### PR TITLE
test(desktop): consolidate duplicated agent-studio/orchestrator fixtures

### DIFF
--- a/apps/desktop/src/pages/agent-studio-test-utils.tsx
+++ b/apps/desktop/src/pages/agent-studio-test-utils.tsx
@@ -1,3 +1,8 @@
+import {
+  createAgentSessionFixture as createSharedAgentSessionFixture,
+  createDeferred as createSharedDeferred,
+  createTaskCardFixture as createSharedTaskCardFixture,
+} from "@/test-utils/shared-test-fixtures";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { TaskCard } from "@openducktor/contracts";
 import { type ReactElement, createElement } from "react";
@@ -16,70 +21,26 @@ export const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve();
 };
 
-export const createDeferred = <T,>() => {
-  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
-  let reject: ((reason?: unknown) => void) | null = null;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {
-    promise,
-    resolve: (value: T) => resolve?.(value),
-    reject: (reason?: unknown) => reject?.(reason),
-  };
-};
-
-export const createTaskCardFixture = (overrides: Partial<TaskCard> = {}): TaskCard => ({
-  id: "task-1",
+const PAGE_TASK_CARD_DEFAULTS: Partial<TaskCard> = {
   title: "Task 1",
-  description: "",
-  acceptanceCriteria: "",
-  notes: "",
-  status: "open",
-  priority: 2,
-  issueType: "task",
-  aiReviewEnabled: true,
-  availableActions: [],
-  labels: [],
-  parentId: undefined,
-  subtaskIds: [],
-  assignee: undefined,
-  documentSummary: {
-    spec: { has: false },
-    plan: { has: false },
-    qaReport: { has: false },
-  },
   updatedAt: "2026-02-22T12:00:00.000Z",
   createdAt: "2026-02-22T12:00:00.000Z",
-  ...overrides,
-});
+};
+
+const PAGE_SESSION_DEFAULTS: Partial<AgentSessionState> = {
+  startedAt: "2026-02-22T10:00:00.000Z",
+  baseUrl: "http://localhost:4000",
+  workingDirectory: "/repo",
+};
+
+export const createDeferred = createSharedDeferred;
+
+export const createTaskCardFixture = (overrides: Partial<TaskCard> = {}): TaskCard =>
+  createSharedTaskCardFixture(PAGE_TASK_CARD_DEFAULTS, overrides);
 
 export const createAgentSessionFixture = (
   overrides: Partial<AgentSessionState> = {},
-): AgentSessionState => ({
-  sessionId: "session-1",
-  externalSessionId: "external-1",
-  taskId: "task-1",
-  role: "spec",
-  scenario: "spec_initial",
-  status: "idle",
-  startedAt: "2026-02-22T10:00:00.000Z",
-  runtimeId: null,
-  runId: null,
-  baseUrl: "http://localhost:4000",
-  workingDirectory: "/repo",
-  messages: [],
-  draftAssistantText: "",
-  pendingPermissions: [],
-  pendingQuestions: [],
-  todos: [],
-  modelCatalog: null,
-  selectedModel: null,
-  isLoadingModelCatalog: false,
-  ...overrides,
-});
+): AgentSessionState => createSharedAgentSessionFixture(PAGE_SESSION_DEFAULTS, overrides);
 
 type HookRunner<State> = (state: State) => void | Promise<void>;
 

--- a/apps/desktop/src/pages/agent-studio-test-utils.tsx
+++ b/apps/desktop/src/pages/agent-studio-test-utils.tsx
@@ -1,0 +1,160 @@
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { TaskCard } from "@openducktor/contracts";
+import { type ReactElement, createElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+
+type ReactActEnvironment = typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+export const enableReactActEnvironment = (): void => {
+  (globalThis as ReactActEnvironment).IS_REACT_ACT_ENVIRONMENT = true;
+};
+
+export const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+export const createDeferred = <T,>() => {
+  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
+  let reject: ((reason?: unknown) => void) | null = null;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve: (value: T) => resolve?.(value),
+    reject: (reason?: unknown) => reject?.(reason),
+  };
+};
+
+export const createTaskCardFixture = (overrides: Partial<TaskCard> = {}): TaskCard => ({
+  id: "task-1",
+  title: "Task 1",
+  description: "",
+  acceptanceCriteria: "",
+  notes: "",
+  status: "open",
+  priority: 2,
+  issueType: "task",
+  aiReviewEnabled: true,
+  availableActions: [],
+  labels: [],
+  parentId: undefined,
+  subtaskIds: [],
+  assignee: undefined,
+  documentSummary: {
+    spec: { has: false },
+    plan: { has: false },
+    qaReport: { has: false },
+  },
+  updatedAt: "2026-02-22T12:00:00.000Z",
+  createdAt: "2026-02-22T12:00:00.000Z",
+  ...overrides,
+});
+
+export const createAgentSessionFixture = (
+  overrides: Partial<AgentSessionState> = {},
+): AgentSessionState => ({
+  sessionId: "session-1",
+  externalSessionId: "external-1",
+  taskId: "task-1",
+  role: "spec",
+  scenario: "spec_initial",
+  status: "idle",
+  startedAt: "2026-02-22T10:00:00.000Z",
+  runtimeId: null,
+  runId: null,
+  baseUrl: "http://localhost:4000",
+  workingDirectory: "/repo",
+  messages: [],
+  draftAssistantText: "",
+  pendingPermissions: [],
+  pendingQuestions: [],
+  todos: [],
+  modelCatalog: null,
+  selectedModel: null,
+  isLoadingModelCatalog: false,
+  ...overrides,
+});
+
+type HookRunner<State> = (state: State) => void | Promise<void>;
+
+export const createHookHarness = <Props, State>(
+  useHook: (props: Props) => State,
+  initialProps: Props,
+) => {
+  let latest: State | null = null;
+  let currentProps = initialProps;
+
+  const Harness = ({ hookProps }: { hookProps: Props }): ReactElement | null => {
+    latest = useHook(hookProps);
+    return null;
+  };
+
+  let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+  const mount = async (): Promise<void> => {
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness, { hookProps: currentProps }));
+      await flushMicrotasks();
+    });
+  };
+
+  const update = async (nextProps: Props): Promise<void> => {
+    currentProps = nextProps;
+    await act(async () => {
+      renderer?.update(createElement(Harness, { hookProps: currentProps }));
+      await flushMicrotasks();
+    });
+  };
+
+  const run = async (fn: HookRunner<State>): Promise<void> => {
+    await act(async () => {
+      if (!latest) {
+        throw new Error("Hook state unavailable");
+      }
+      await fn(latest);
+      await flushMicrotasks();
+    });
+  };
+
+  const getLatest = (): State => {
+    if (!latest) {
+      throw new Error("Hook state unavailable");
+    }
+    return latest;
+  };
+
+  const waitFor = async (
+    predicate: (state: State) => boolean,
+    timeoutMs = 500,
+    intervalMs = 5,
+  ): Promise<void> => {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+      if (latest && predicate(latest)) {
+        return;
+      }
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+        await flushMicrotasks();
+      });
+    }
+
+    throw new Error("Timed out waiting for hook state");
+  };
+
+  const unmount = async (): Promise<void> => {
+    await act(async () => {
+      renderer?.unmount();
+      await flushMicrotasks();
+    });
+  };
+
+  return { mount, update, run, getLatest, waitFor, unmount };
+};

--- a/apps/desktop/src/pages/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-model-selection.test.tsx
@@ -1,18 +1,17 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import type { AgentModelCatalog } from "@openducktor/core";
-import { type ReactElement, createElement } from "react";
-import TestRenderer, { act } from "react-test-renderer";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
 import {
   type AgentStudioModelSelectionState,
   useAgentStudioModelSelection,
 } from "./use-agent-studio-model-selection";
 
-const reactActEnvironment = globalThis as typeof globalThis & {
-  IS_REACT_ACT_ENVIRONMENT?: boolean;
-};
-reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+enableReactActEnvironment();
 
 const TEST_RENDERER_DEPRECATION_WARNING = "react-test-renderer is deprecated";
 const originalConsoleError = console.error;
@@ -74,101 +73,20 @@ const createRepoSettings = (
   },
 });
 
-const createActiveSession = (overrides: Partial<AgentSessionState> = {}): AgentSessionState => ({
-  sessionId: "session-1",
-  externalSessionId: "external-1",
-  taskId: "task-1",
-  role: "spec",
-  scenario: "spec_initial",
-  status: "idle",
-  startedAt: "2026-02-22T10:00:00.000Z",
-  runtimeId: null,
-  runId: null,
-  baseUrl: "http://localhost:4000",
-  workingDirectory: "/repo",
-  messages: [],
-  draftAssistantText: "",
-  pendingPermissions: [],
-  pendingQuestions: [],
-  todos: [],
-  modelCatalog: CATALOG,
-  selectedModel: {
-    providerId: "openai",
-    modelId: "gpt-5",
-    variant: "default",
-    opencodeAgent: "spec-agent",
-  },
-  isLoadingModelCatalog: false,
-  ...overrides,
-});
+const createActiveSession = (overrides = {}) =>
+  createAgentSessionFixture({
+    modelCatalog: CATALOG,
+    selectedModel: {
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+      opencodeAgent: "spec-agent",
+    },
+    ...overrides,
+  });
 
-const flush = async (): Promise<void> => {
-  await Promise.resolve();
-  await Promise.resolve();
-};
-
-const createHookHarness = (initialProps: HookArgs) => {
-  let latest: HookState | null = null;
-
-  const Harness = (props: HookArgs): ReactElement | null => {
-    latest = useAgentStudioModelSelection(props);
-    return null;
-  };
-
-  let renderer: TestRenderer.ReactTestRenderer | null = null;
-
-  const mount = async (): Promise<void> => {
-    await act(async () => {
-      renderer = TestRenderer.create(createElement(Harness, initialProps));
-      await flush();
-    });
-  };
-
-  const run = async (fn: () => Promise<void> | void): Promise<void> => {
-    await act(async () => {
-      await fn();
-      await flush();
-    });
-  };
-
-  const getLatest = (): HookState => {
-    if (!latest) {
-      throw new Error("Hook state unavailable");
-    }
-    return latest;
-  };
-
-  const waitFor = async (
-    predicate: (state: HookState) => boolean,
-    timeoutMs = 500,
-  ): Promise<void> => {
-    const startTime = Date.now();
-    while (Date.now() - startTime < timeoutMs) {
-      const current = latest;
-      if (current && predicate(current)) {
-        return;
-      }
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 5));
-        await flush();
-      });
-    }
-
-    throw new Error("Timed out waiting for hook state");
-  };
-
-  const unmount = async (): Promise<void> => {
-    if (!renderer) {
-      return;
-    }
-    await act(async () => {
-      renderer?.unmount();
-      await flush();
-    });
-  };
-
-  return { mount, run, getLatest, waitFor, unmount };
-};
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioModelSelection, initialProps);
 
 const createBaseProps = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   activeRepo: "/repo",

--- a/apps/desktop/src/pages/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-page-models.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
-import { act } from "react-test-renderer";
 import {
   createAgentSessionFixture,
   createHookHarness as createSharedHookHarness,
@@ -184,8 +183,8 @@ describe("useAgentStudioPageModels", () => {
     await harness.mount();
     expect(harness.getLatest().agentChatModel.thread.todoPanelCollapsed).toBe(false);
 
-    await act(async () => {
-      harness.getLatest().agentChatModel.thread.onToggleTodoPanel();
+    await harness.run((state) => {
+      state.agentChatModel.thread.onToggleTodoPanel();
     });
     expect(harness.getLatest().agentChatModel.thread.todoPanelCollapsed).toBe(true);
 
@@ -196,8 +195,8 @@ describe("useAgentStudioPageModels", () => {
     });
     expect(harness.getLatest().agentChatModel.thread.todoPanelCollapsed).toBe(false);
 
-    await act(async () => {
-      harness.getLatest().agentChatModel.thread.onToggleTodoPanel();
+    await harness.run((state) => {
+      state.agentChatModel.thread.onToggleTodoPanel();
     });
     expect(harness.getLatest().agentChatModel.thread.todoPanelCollapsed).toBe(true);
 

--- a/apps/desktop/src/pages/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-page-models.test.tsx
@@ -1,67 +1,34 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
-import type { TaskCard } from "@openducktor/contracts";
-import { type ReactElement, createElement } from "react";
-import TestRenderer, { act } from "react-test-renderer";
+import { act } from "react-test-renderer";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
 import { useAgentStudioPageModels } from "./use-agent-studio-page-models";
 
-const reactActEnvironment = globalThis as typeof globalThis & {
-  IS_REACT_ACT_ENVIRONMENT?: boolean;
-};
-reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioPageModels>[0];
 type HookState = ReturnType<typeof useAgentStudioPageModels>;
 
-const createTask = (): TaskCard => ({
-  id: "task-1",
-  title: "Task 1",
-  description: "",
-  acceptanceCriteria: "",
-  notes: "",
-  status: "open",
-  priority: 2,
-  issueType: "task",
-  aiReviewEnabled: true,
-  availableActions: [],
-  labels: [],
-  parentId: undefined,
-  subtaskIds: [],
-  assignee: undefined,
-  documentSummary: {
-    spec: { has: true },
-    plan: { has: false },
-    qaReport: { has: false },
-  },
-  updatedAt: "2026-02-22T12:00:00.000Z",
-  createdAt: "2026-02-22T12:00:00.000Z",
-});
+const createTask = () =>
+  createTaskCardFixture({
+    documentSummary: {
+      spec: { has: true },
+      plan: { has: false },
+      qaReport: { has: false },
+    },
+  });
 
-const createSession = (
-  sessionId = "session-1",
-  externalSessionId = "external-1",
-): AgentSessionState => ({
-  sessionId,
-  externalSessionId,
-  taskId: "task-1",
-  role: "spec",
-  scenario: "spec_initial",
-  status: "running",
-  startedAt: "2026-02-22T10:00:00.000Z",
-  runtimeId: null,
-  runId: null,
-  baseUrl: "http://localhost:4000",
-  workingDirectory: "/repo",
-  messages: [],
-  draftAssistantText: "",
-  pendingPermissions: [],
-  pendingQuestions: [],
-  todos: [],
-  modelCatalog: null,
-  selectedModel: null,
-  isLoadingModelCatalog: false,
-});
+const createSession = (sessionId = "session-1", externalSessionId = "external-1") =>
+  createAgentSessionFixture({
+    sessionId,
+    externalSessionId,
+    status: "running",
+  });
 
 const createDocumentState = (markdown: string): TaskDocumentState => ({
   markdown,
@@ -71,53 +38,8 @@ const createDocumentState = (markdown: string): TaskDocumentState => ({
   loaded: true,
 });
 
-const flush = async (): Promise<void> => {
-  await Promise.resolve();
-  await Promise.resolve();
-};
-
-const createHookHarness = (initialProps: HookArgs) => {
-  let latest: HookState | null = null;
-  let currentProps = initialProps;
-
-  const Harness = (props: HookArgs): ReactElement | null => {
-    latest = useAgentStudioPageModels(props);
-    return null;
-  };
-
-  let renderer: TestRenderer.ReactTestRenderer | null = null;
-
-  const mount = async (): Promise<void> => {
-    await act(async () => {
-      renderer = TestRenderer.create(createElement(Harness, currentProps));
-      await flush();
-    });
-  };
-
-  const update = async (nextProps: HookArgs): Promise<void> => {
-    currentProps = nextProps;
-    await act(async () => {
-      renderer?.update(createElement(Harness, currentProps));
-      await flush();
-    });
-  };
-
-  const getLatest = (): HookState => {
-    if (!latest) {
-      throw new Error("Hook state unavailable");
-    }
-    return latest;
-  };
-
-  const unmount = async (): Promise<void> => {
-    await act(async () => {
-      renderer?.unmount();
-      await flush();
-    });
-  };
-
-  return { mount, update, getLatest, unmount };
-};
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioPageModels, initialProps);
 
 describe("useAgentStudioPageModels", () => {
   test("builds page models and forwards wrapper callbacks", async () => {
@@ -264,7 +186,6 @@ describe("useAgentStudioPageModels", () => {
 
     await act(async () => {
       harness.getLatest().agentChatModel.thread.onToggleTodoPanel();
-      await flush();
     });
     expect(harness.getLatest().agentChatModel.thread.todoPanelCollapsed).toBe(true);
 
@@ -277,7 +198,6 @@ describe("useAgentStudioPageModels", () => {
 
     await act(async () => {
       harness.getLatest().agentChatModel.thread.onToggleTodoPanel();
-      await flush();
     });
     expect(harness.getLatest().agentChatModel.thread.todoPanelCollapsed).toBe(true);
 

--- a/apps/desktop/src/pages/use-agent-studio-query-sync.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-query-sync.test.tsx
@@ -1,110 +1,26 @@
 import { describe, expect, test } from "bun:test";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
-import type { TaskCard } from "@openducktor/contracts";
-import { type ReactElement, createElement } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
-import TestRenderer, { act } from "react-test-renderer";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
 import { useAgentStudioQuerySync } from "./use-agent-studio-query-sync";
 
-const reactActEnvironment = globalThis as typeof globalThis & {
-  IS_REACT_ACT_ENVIRONMENT?: boolean;
-};
-reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioQuerySync>[0];
 type HookState = ReturnType<typeof useAgentStudioQuerySync>;
 
 type SearchParamsCall = Parameters<SetURLSearchParams>;
 
-const createSession = (overrides: Partial<AgentSessionState> = {}): AgentSessionState => ({
-  sessionId: "session-1",
-  externalSessionId: "external-1",
-  taskId: "task-1",
-  role: "spec",
-  scenario: "spec_initial",
-  status: "idle",
-  startedAt: "2026-02-22T10:00:00.000Z",
-  runtimeId: null,
-  runId: null,
-  baseUrl: "http://localhost:4000",
-  workingDirectory: "/repo",
-  messages: [],
-  draftAssistantText: "",
-  pendingPermissions: [],
-  pendingQuestions: [],
-  todos: [],
-  modelCatalog: null,
-  selectedModel: null,
-  isLoadingModelCatalog: false,
-  ...overrides,
-});
+const createSession = (overrides = {}) => createAgentSessionFixture(overrides);
 
-const createTask = (id: string): TaskCard => ({
-  id,
-  title: id,
-  description: "",
-  acceptanceCriteria: "",
-  notes: "",
-  status: "open",
-  priority: 2,
-  issueType: "task",
-  aiReviewEnabled: true,
-  availableActions: [],
-  labels: [],
-  parentId: undefined,
-  subtaskIds: [],
-  assignee: undefined,
-  documentSummary: {
-    spec: { has: false },
-    plan: { has: false },
-    qaReport: { has: false },
-  },
-  updatedAt: "2026-02-22T12:00:00.000Z",
-  createdAt: "2026-02-22T12:00:00.000Z",
-});
+const createTask = (id: string) => createTaskCardFixture({ id, title: id });
 
-const flush = async (): Promise<void> => {
-  await Promise.resolve();
-  await Promise.resolve();
-};
-
-const createHookHarness = (initialProps: HookArgs) => {
-  let latest: HookState | null = null;
-  const currentProps = initialProps;
-
-  const Harness = (props: HookArgs): ReactElement | null => {
-    latest = useAgentStudioQuerySync(props);
-    return null;
-  };
-
-  let renderer: TestRenderer.ReactTestRenderer | null = null;
-
-  const mount = async (): Promise<void> => {
-    await act(async () => {
-      renderer = TestRenderer.create(createElement(Harness, currentProps));
-      await flush();
-    });
-  };
-
-  const run = async (fn: (state: HookState) => void | Promise<void>): Promise<void> => {
-    await act(async () => {
-      if (!latest) {
-        throw new Error("Hook state unavailable");
-      }
-      await fn(latest);
-      await flush();
-    });
-  };
-
-  const unmount = async (): Promise<void> => {
-    await act(async () => {
-      renderer?.unmount();
-      await flush();
-    });
-  };
-
-  return { mount, run, unmount };
-};
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioQuerySync, initialProps);
 
 describe("useAgentStudioQuerySync", () => {
   test("updateQuery writes search params when values change", async () => {

--- a/apps/desktop/src/pages/use-agent-studio-repo-settings.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-repo-settings.test.tsx
@@ -1,13 +1,12 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { RepoSettingsInput } from "@/types/state-slices";
-import { type ReactElement, createElement } from "react";
-import TestRenderer, { act } from "react-test-renderer";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
 import { useAgentStudioRepoSettings } from "./use-agent-studio-repo-settings";
 
-const reactActEnvironment = globalThis as typeof globalThis & {
-  IS_REACT_ACT_ENVIRONMENT?: boolean;
-};
-reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioRepoSettings>[0];
 type HookState = ReturnType<typeof useAgentStudioRepoSettings>;
@@ -26,53 +25,8 @@ const createSettings = (): RepoSettingsInput => ({
   },
 });
 
-const flush = async (): Promise<void> => {
-  await Promise.resolve();
-  await Promise.resolve();
-};
-
-const createHookHarness = (initialProps: HookArgs) => {
-  let latest: HookState | null = null;
-  let currentProps = initialProps;
-
-  const Harness = (props: HookArgs): ReactElement | null => {
-    latest = useAgentStudioRepoSettings(props);
-    return null;
-  };
-
-  let renderer: TestRenderer.ReactTestRenderer | null = null;
-
-  const mount = async (): Promise<void> => {
-    await act(async () => {
-      renderer = TestRenderer.create(createElement(Harness, currentProps));
-      await flush();
-    });
-  };
-
-  const update = async (next: HookArgs): Promise<void> => {
-    currentProps = next;
-    await act(async () => {
-      renderer?.update(createElement(Harness, currentProps));
-      await flush();
-    });
-  };
-
-  const getLatest = (): HookState => {
-    if (!latest) {
-      throw new Error("Hook state unavailable");
-    }
-    return latest;
-  };
-
-  const unmount = async (): Promise<void> => {
-    await act(async () => {
-      renderer?.unmount();
-      await flush();
-    });
-  };
-
-  return { mount, update, getLatest, unmount };
-};
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioRepoSettings, initialProps);
 
 describe("useAgentStudioRepoSettings", () => {
   test("loads repo settings when repository is active", async () => {

--- a/apps/desktop/src/pages/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-session-actions.test.tsx
@@ -1,131 +1,25 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
-import type { TaskCard } from "@openducktor/contracts";
-import { type ReactElement, createElement } from "react";
-import TestRenderer, { act } from "react-test-renderer";
+import {
+  createAgentSessionFixture,
+  createDeferred,
+  createHookHarness as createSharedHookHarness,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
 import { kickoffPromptForScenario } from "./agents-page-constants";
 import { useAgentStudioSessionActions } from "./use-agent-studio-session-actions";
 
-const reactActEnvironment = globalThis as typeof globalThis & {
-  IS_REACT_ACT_ENVIRONMENT?: boolean;
-};
-reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioSessionActions>[0];
 type HookState = ReturnType<typeof useAgentStudioSessionActions>;
 
-const createTask = (overrides: Partial<TaskCard> = {}): TaskCard => ({
-  id: "task-1",
-  title: "Task 1",
-  description: "",
-  acceptanceCriteria: "",
-  notes: "",
-  status: "open",
-  priority: 2,
-  issueType: "task",
-  aiReviewEnabled: true,
-  availableActions: [],
-  labels: [],
-  parentId: undefined,
-  subtaskIds: [],
-  assignee: undefined,
-  documentSummary: {
-    spec: { has: false },
-    plan: { has: false },
-    qaReport: { has: false },
-  },
-  updatedAt: "2026-02-22T12:00:00.000Z",
-  createdAt: "2026-02-22T12:00:00.000Z",
-  ...overrides,
-});
+const createTask = (overrides = {}) => createTaskCardFixture(overrides);
 
-const createSession = (overrides: Partial<AgentSessionState> = {}): AgentSessionState => ({
-  sessionId: "session-1",
-  externalSessionId: "external-1",
-  taskId: "task-1",
-  role: "spec",
-  scenario: "spec_initial",
-  status: "idle",
-  startedAt: "2026-02-22T10:00:00.000Z",
-  runtimeId: null,
-  runId: null,
-  baseUrl: "http://localhost:4000",
-  workingDirectory: "/repo",
-  messages: [],
-  draftAssistantText: "",
-  pendingPermissions: [],
-  pendingQuestions: [],
-  todos: [],
-  modelCatalog: null,
-  selectedModel: null,
-  isLoadingModelCatalog: false,
-  ...overrides,
-});
+const createSession = (overrides = {}) => createAgentSessionFixture(overrides);
 
-const flush = async (): Promise<void> => {
-  await Promise.resolve();
-  await Promise.resolve();
-};
-
-const createDeferred = <T,>() => {
-  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
-  let reject: ((reason?: unknown) => void) | null = null;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {
-    promise,
-    resolve: (value: T) => resolve?.(value),
-    reject: (reason?: unknown) => reject?.(reason),
-  };
-};
-
-const createHookHarness = (initialProps: HookArgs) => {
-  let latest: HookState | null = null;
-  const currentProps = initialProps;
-
-  const Harness = (props: HookArgs): ReactElement | null => {
-    latest = useAgentStudioSessionActions(props);
-    return null;
-  };
-
-  let renderer: TestRenderer.ReactTestRenderer | null = null;
-
-  const mount = async (): Promise<void> => {
-    await act(async () => {
-      renderer = TestRenderer.create(createElement(Harness, currentProps));
-      await flush();
-    });
-  };
-
-  const run = async (fn: (state: HookState) => void | Promise<void>): Promise<void> => {
-    await act(async () => {
-      if (!latest) {
-        throw new Error("Hook state unavailable");
-      }
-      await fn(latest);
-      await flush();
-    });
-  };
-
-  const getLatest = (): HookState => {
-    if (!latest) {
-      throw new Error("Hook state unavailable");
-    }
-    return latest;
-  };
-
-  const unmount = async (): Promise<void> => {
-    await act(async () => {
-      renderer?.unmount();
-      await flush();
-    });
-  };
-
-  return { mount, run, getLatest, unmount };
-};
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioSessionActions, initialProps);
 
 const createBaseArgs = (): HookArgs => {
   return {

--- a/apps/desktop/src/pages/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-task-tabs.test.tsx
@@ -1,16 +1,15 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
-import type { TaskCard } from "@openducktor/contracts";
-import { type ReactElement, createElement } from "react";
-import TestRenderer, { act } from "react-test-renderer";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
 import { toPersistedTaskTabs } from "./agents-page-session-tabs";
 import { toTabsStorageKey } from "./agents-page-utils";
 import { useAgentStudioTaskTabs } from "./use-agent-studio-task-tabs";
 
-const reactActEnvironment = globalThis as typeof globalThis & {
-  IS_REACT_ACT_ENVIRONMENT?: boolean;
-};
-reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioTaskTabs>[0];
 type HookState = ReturnType<typeof useAgentStudioTaskTabs>;
@@ -39,101 +38,17 @@ const createMemoryStorage = (): StorageLike => {
   };
 };
 
-const createTask = (id: string): TaskCard => ({
-  id,
-  title: id,
-  description: "",
-  acceptanceCriteria: "",
-  notes: "",
-  status: "open",
-  priority: 2,
-  issueType: "task",
-  aiReviewEnabled: true,
-  availableActions: [],
-  labels: [],
-  parentId: undefined,
-  subtaskIds: [],
-  assignee: undefined,
-  documentSummary: {
-    spec: { has: false },
-    plan: { has: false },
-    qaReport: { has: false },
-  },
-  updatedAt: "2026-02-22T12:00:00.000Z",
-  createdAt: "2026-02-22T12:00:00.000Z",
-});
+const createTask = (id: string) => createTaskCardFixture({ id, title: id });
 
-const createSession = (taskId: string, sessionId: string): AgentSessionState => ({
-  sessionId,
-  externalSessionId: `ext-${sessionId}`,
-  taskId,
-  role: "spec",
-  scenario: "spec_initial",
-  status: "idle",
-  startedAt: "2026-02-22T10:00:00.000Z",
-  runtimeId: null,
-  runId: null,
-  baseUrl: "http://localhost:4000",
-  workingDirectory: "/repo",
-  messages: [],
-  draftAssistantText: "",
-  pendingPermissions: [],
-  pendingQuestions: [],
-  todos: [],
-  modelCatalog: null,
-  selectedModel: null,
-  isLoadingModelCatalog: false,
-});
+const createSession = (taskId: string, sessionId: string) =>
+  createAgentSessionFixture({
+    sessionId,
+    externalSessionId: `ext-${sessionId}`,
+    taskId,
+  });
 
-const flush = async (): Promise<void> => {
-  await Promise.resolve();
-  await Promise.resolve();
-};
-
-const createHookHarness = (initialProps: HookArgs) => {
-  let latest: HookState | null = null;
-  const currentProps = initialProps;
-
-  const Harness = (props: HookArgs): ReactElement | null => {
-    latest = useAgentStudioTaskTabs(props);
-    return null;
-  };
-
-  let renderer: TestRenderer.ReactTestRenderer | null = null;
-
-  const mount = async (): Promise<void> => {
-    await act(async () => {
-      renderer = TestRenderer.create(createElement(Harness, currentProps));
-      await flush();
-    });
-  };
-
-  const run = async (fn: (state: HookState) => void | Promise<void>): Promise<void> => {
-    await act(async () => {
-      if (!latest) {
-        throw new Error("Hook state unavailable");
-      }
-      await fn(latest);
-      await flush();
-    });
-  };
-
-  const getLatest = (): HookState => {
-    if (!latest) {
-      throw new Error("Hook state unavailable");
-    }
-    return latest;
-  };
-
-  const unmount = async (): Promise<void> => {
-    await act(async () => {
-      renderer?.unmount();
-      await flush();
-    });
-  };
-
-  return { mount, run, getLatest, unmount };
-};
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioTaskTabs, initialProps);
 
 describe("useAgentStudioTaskTabs", () => {
   test("hydrates persisted task tabs from localStorage", async () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -1,55 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
-import type { TaskCard } from "@openducktor/contracts";
 import { host } from "../../host";
+import {
+  createAgentSessionFixture,
+  createDeferred,
+  createTaskCardFixture,
+  withTimeout,
+} from "../test-utils";
 import { createStartAgentSession } from "./start-session";
 
-const taskFixture: TaskCard = {
-  id: "task-1",
+const taskFixture = createTaskCardFixture({
   title: "Implement feature",
   description: "desc",
   acceptanceCriteria: "ac",
-  notes: "",
   status: "in_progress",
   priority: 1,
-  issueType: "task",
-  aiReviewEnabled: true,
-  availableActions: [],
-  labels: [],
-  subtaskIds: [],
-  documentSummary: {
-    spec: { has: false },
-    plan: { has: false },
-    qaReport: { has: false },
-  },
-  updatedAt: "2026-02-22T08:00:00.000Z",
-  createdAt: "2026-02-22T08:00:00.000Z",
-};
-
-const createDeferred = <T>() => {
-  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
-  let reject: ((reason?: unknown) => void) | null = null;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {
-    promise,
-    resolve: (value: T) => resolve?.(value),
-    reject: (reason?: unknown) => reject?.(reason),
-  };
-};
-
-const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T | "timeout"> => {
-  return Promise.race([
-    promise,
-    new Promise<"timeout">((resolve) => {
-      setTimeout(() => resolve("timeout"), timeoutMs);
-    }),
-  ]);
-};
+});
 
 describe("agent-orchestrator/handlers/start-session", () => {
   test("throws when no active repo is selected", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -1,48 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import type { AgentSessionRecord, TaskCard } from "@openducktor/contracts";
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import { createDeferred, createTaskCardFixture } from "../test-utils";
 import { createLoadAgentSessions } from "./load-sessions";
 
 type SessionHistory = Awaited<
   ReturnType<Parameters<typeof createLoadAgentSessions>[0]["adapter"]["loadSessionHistory"]>
 >;
 
-const taskFixture: TaskCard = {
-  id: "task-1",
-  title: "Task",
-  description: "",
-  acceptanceCriteria: "",
-  notes: "",
-  status: "open",
-  priority: 2,
-  issueType: "task",
-  aiReviewEnabled: true,
-  availableActions: [],
-  labels: [],
-  subtaskIds: [],
-  documentSummary: {
-    spec: { has: false },
-    plan: { has: false },
-    qaReport: { has: false },
-  },
-  updatedAt: "2026-02-22T08:00:00.000Z",
-  createdAt: "2026-02-22T08:00:00.000Z",
-};
-
-const createDeferred = <T>() => {
-  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
-  let reject: ((reason?: unknown) => void) | null = null;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {
-    promise,
-    resolve: (value: T) => resolve?.(value),
-    reject: (reason?: unknown) => reject?.(reason),
-  };
-};
+const taskFixture = createTaskCardFixture({ title: "Task" });
 
 describe("agent-orchestrator-load-sessions", () => {
   test("no-ops when active repo is missing", async () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { RunSummary } from "@openducktor/contracts";
 import { host } from "../../host";
+import { createDeferred, withTimeout } from "../test-utils";
 import { createEnsureRuntime, loadRepoDefaultModel, loadTaskDocuments } from "./runtime";
 
 const runningRunFixture: RunSummary = {
@@ -13,30 +14,6 @@ const runningRunFixture: RunSummary = {
   state: "running",
   lastMessage: null,
   startedAt: "2026-02-22T08:00:00.000Z",
-};
-
-const createDeferred = <T>() => {
-  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
-  let reject: ((reason?: unknown) => void) | null = null;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {
-    promise,
-    resolve: (value: T) => resolve?.(value),
-    reject: (reason?: unknown) => reject?.(reason),
-  };
-};
-
-const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T | "timeout"> => {
-  return Promise.race([
-    promise,
-    new Promise<"timeout">((resolve) => {
-      setTimeout(() => resolve("timeout"), timeoutMs);
-    }),
-  ]);
 };
 
 describe("agent-orchestrator-runtime", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/test-utils.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/test-utils.ts
@@ -1,0 +1,79 @@
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { TaskCard } from "@openducktor/contracts";
+
+export const createDeferred = <T>() => {
+  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
+  let reject: ((reason?: unknown) => void) | null = null;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve: (value: T) => resolve?.(value),
+    reject: (reason?: unknown) => reject?.(reason),
+  };
+};
+
+export const withTimeout = async <T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T | "timeout"> => {
+  return Promise.race([
+    promise,
+    new Promise<"timeout">((resolve) => {
+      setTimeout(() => resolve("timeout"), timeoutMs);
+    }),
+  ]);
+};
+
+export const createTaskCardFixture = (overrides: Partial<TaskCard> = {}): TaskCard => ({
+  id: "task-1",
+  title: "Task",
+  description: "",
+  acceptanceCriteria: "",
+  notes: "",
+  status: "open",
+  priority: 2,
+  issueType: "task",
+  aiReviewEnabled: true,
+  availableActions: [],
+  labels: [],
+  parentId: undefined,
+  subtaskIds: [],
+  assignee: undefined,
+  documentSummary: {
+    spec: { has: false },
+    plan: { has: false },
+    qaReport: { has: false },
+  },
+  updatedAt: "2026-02-22T08:00:00.000Z",
+  createdAt: "2026-02-22T08:00:00.000Z",
+  ...overrides,
+});
+
+export const createAgentSessionFixture = (
+  overrides: Partial<AgentSessionState> = {},
+): AgentSessionState => ({
+  sessionId: "session-1",
+  externalSessionId: "external-1",
+  taskId: "task-1",
+  role: "spec",
+  scenario: "spec_initial",
+  status: "idle",
+  startedAt: "2026-02-22T08:00:00.000Z",
+  runtimeId: null,
+  runId: null,
+  baseUrl: "http://127.0.0.1:4444",
+  workingDirectory: "/tmp/repo/worktree",
+  messages: [],
+  draftAssistantText: "",
+  pendingPermissions: [],
+  pendingQuestions: [],
+  todos: [],
+  modelCatalog: null,
+  selectedModel: null,
+  isLoadingModelCatalog: false,
+  ...overrides,
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/test-utils.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/test-utils.ts
@@ -1,20 +1,24 @@
+import {
+  createAgentSessionFixture as createSharedAgentSessionFixture,
+  createDeferred as createSharedDeferred,
+  createTaskCardFixture as createSharedTaskCardFixture,
+} from "@/test-utils/shared-test-fixtures";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { TaskCard } from "@openducktor/contracts";
 
-export const createDeferred = <T>() => {
-  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
-  let reject: ((reason?: unknown) => void) | null = null;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return {
-    promise,
-    resolve: (value: T) => resolve?.(value),
-    reject: (reason?: unknown) => reject?.(reason),
-  };
+const ORCHESTRATOR_TASK_CARD_DEFAULTS: Partial<TaskCard> = {
+  title: "Task",
+  updatedAt: "2026-02-22T08:00:00.000Z",
+  createdAt: "2026-02-22T08:00:00.000Z",
 };
+
+const ORCHESTRATOR_SESSION_DEFAULTS: Partial<AgentSessionState> = {
+  startedAt: "2026-02-22T08:00:00.000Z",
+  baseUrl: "http://127.0.0.1:4444",
+  workingDirectory: "/tmp/repo/worktree",
+};
+
+export const createDeferred = createSharedDeferred;
 
 export const withTimeout = async <T>(
   promise: Promise<T>,
@@ -28,52 +32,9 @@ export const withTimeout = async <T>(
   ]);
 };
 
-export const createTaskCardFixture = (overrides: Partial<TaskCard> = {}): TaskCard => ({
-  id: "task-1",
-  title: "Task",
-  description: "",
-  acceptanceCriteria: "",
-  notes: "",
-  status: "open",
-  priority: 2,
-  issueType: "task",
-  aiReviewEnabled: true,
-  availableActions: [],
-  labels: [],
-  parentId: undefined,
-  subtaskIds: [],
-  assignee: undefined,
-  documentSummary: {
-    spec: { has: false },
-    plan: { has: false },
-    qaReport: { has: false },
-  },
-  updatedAt: "2026-02-22T08:00:00.000Z",
-  createdAt: "2026-02-22T08:00:00.000Z",
-  ...overrides,
-});
+export const createTaskCardFixture = (overrides: Partial<TaskCard> = {}): TaskCard =>
+  createSharedTaskCardFixture(ORCHESTRATOR_TASK_CARD_DEFAULTS, overrides);
 
 export const createAgentSessionFixture = (
   overrides: Partial<AgentSessionState> = {},
-): AgentSessionState => ({
-  sessionId: "session-1",
-  externalSessionId: "external-1",
-  taskId: "task-1",
-  role: "spec",
-  scenario: "spec_initial",
-  status: "idle",
-  startedAt: "2026-02-22T08:00:00.000Z",
-  runtimeId: null,
-  runId: null,
-  baseUrl: "http://127.0.0.1:4444",
-  workingDirectory: "/tmp/repo/worktree",
-  messages: [],
-  draftAssistantText: "",
-  pendingPermissions: [],
-  pendingQuestions: [],
-  todos: [],
-  modelCatalog: null,
-  selectedModel: null,
-  isLoadingModelCatalog: false,
-  ...overrides,
-});
+): AgentSessionState => createSharedAgentSessionFixture(ORCHESTRATOR_SESSION_DEFAULTS, overrides);

--- a/apps/desktop/src/test-utils/shared-test-fixtures.ts
+++ b/apps/desktop/src/test-utils/shared-test-fixtures.ts
@@ -1,0 +1,81 @@
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { TaskCard } from "@openducktor/contracts";
+
+const BASE_TASK_CARD_FIXTURE: TaskCard = {
+  id: "task-1",
+  title: "Task",
+  description: "",
+  acceptanceCriteria: "",
+  notes: "",
+  status: "open",
+  priority: 2,
+  issueType: "task",
+  aiReviewEnabled: true,
+  availableActions: [],
+  labels: [],
+  parentId: undefined,
+  subtaskIds: [],
+  assignee: undefined,
+  documentSummary: {
+    spec: { has: false },
+    plan: { has: false },
+    qaReport: { has: false },
+  },
+  updatedAt: "2026-02-22T08:00:00.000Z",
+  createdAt: "2026-02-22T08:00:00.000Z",
+};
+
+const BASE_AGENT_SESSION_FIXTURE: AgentSessionState = {
+  sessionId: "session-1",
+  externalSessionId: "external-1",
+  taskId: "task-1",
+  role: "spec",
+  scenario: "spec_initial",
+  status: "idle",
+  startedAt: "2026-02-22T08:00:00.000Z",
+  runtimeId: null,
+  runId: null,
+  baseUrl: "http://127.0.0.1:4444",
+  workingDirectory: "/tmp/repo/worktree",
+  messages: [],
+  draftAssistantText: "",
+  pendingPermissions: [],
+  pendingQuestions: [],
+  todos: [],
+  modelCatalog: null,
+  selectedModel: null,
+  isLoadingModelCatalog: false,
+};
+
+export const createDeferred = <T>() => {
+  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
+  let reject: ((reason?: unknown) => void) | null = null;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve: (value: T) => resolve?.(value),
+    reject: (reason?: unknown) => reject?.(reason),
+  };
+};
+
+export const createTaskCardFixture = (
+  defaults: Partial<TaskCard> = {},
+  overrides: Partial<TaskCard> = {},
+): TaskCard => ({
+  ...BASE_TASK_CARD_FIXTURE,
+  ...defaults,
+  ...overrides,
+});
+
+export const createAgentSessionFixture = (
+  defaults: Partial<AgentSessionState> = {},
+  overrides: Partial<AgentSessionState> = {},
+): AgentSessionState => ({
+  ...BASE_AGENT_SESSION_FIXTURE,
+  ...defaults,
+  ...overrides,
+});


### PR DESCRIPTION
## Summary
- extract shared Agent Studio page test utilities for deferred promises, fixtures, React act env setup, and generic hook harness plumbing
- extract shared orchestrator test utilities for deferred/timeout helpers and common task/session fixtures
- refactor Agent Studio and orchestrator test suites to use shared helpers while keeping test behavior and assertions unchanged

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test