### PR TITLE
refactor(desktop): decompose OpenCode health check routine

### DIFF
--- a/apps/desktop/src/state/operations/opencode-catalog.test.ts
+++ b/apps/desktop/src/state/operations/opencode-catalog.test.ts
@@ -218,6 +218,53 @@ describe("opencode-catalog", () => {
     expect(result.availableToolIds).toEqual(["odt_read_task", "odt_set_plan"]);
   });
 
+  test("keeps restarted runtime details when config-invalid retry still fails", async () => {
+    const restartedRuntime: RuntimeSummary = {
+      ...runtimeFixture,
+      runtimeId: "runtime-2",
+      port: 5555,
+    };
+    const ensureRuntime = mock(async (repoPath: string) => {
+      if (repoPath !== "/tmp/repo") {
+        throw new Error("unexpected repo path");
+      }
+      return ensureRuntime.mock.calls.length === 1 ? runtimeFixture : restartedRuntime;
+    });
+    const stopRuntime = mock(async () => ({ ok: true }));
+    const getMcpStatus = mock(async (_input: { baseUrl: string; workingDirectory: string }) => {
+      if (getMcpStatus.mock.calls.length === 1) {
+        throw new Error("ConfigInvalidError: invalid option loglevel");
+      }
+      throw new Error("status still unavailable");
+    });
+
+    const operations = createOpencodeCatalogOperations(
+      createDeps({
+        ensureRuntime,
+        stopRuntime,
+        getMcpStatus,
+      }),
+    );
+
+    const result = await operations.checkRepoOpencodeHealth("/tmp/repo");
+
+    expect(ensureRuntime).toHaveBeenCalledTimes(2);
+    expect(stopRuntime).toHaveBeenCalledWith("runtime-1");
+    expect(getMcpStatus).toHaveBeenCalledTimes(2);
+    expect(getMcpStatus.mock.calls[1]?.[0]).toEqual({
+      baseUrl: "http://127.0.0.1:5555",
+      workingDirectory: "/tmp/repo/worktree",
+    });
+    expect(result.runtimeOk).toBe(true);
+    expect(result.runtime).toEqual(restartedRuntime);
+    expect(result.mcpOk).toBe(false);
+    expect(result.mcpError).toBe("Failed to query OpenCode MCP status: status still unavailable");
+    expect(result.errors).toEqual([
+      "Failed to query OpenCode MCP status: status still unavailable",
+    ]);
+    expect(result.availableToolIds).toEqual([]);
+  });
+
   test("reconnects MCP when disconnected and falls back on tool-id lookup errors", async () => {
     const getMcpStatus = mock(async (_input: { baseUrl: string; workingDirectory: string }) => {
       if (getMcpStatus.mock.calls.length === 1) {

--- a/apps/desktop/src/state/operations/opencode-catalog.ts
+++ b/apps/desktop/src/state/operations/opencode-catalog.ts
@@ -192,9 +192,10 @@ export const createOpencodeCatalogOperations = (deps: OpencodeCatalogDependencie
         };
       }
 
+      let restartedRuntime: AgentRuntimeSummary | null = null;
       try {
         await deps.stopRuntime(runtimeProbe.runtime.runtimeId);
-        const restartedRuntime = await deps.ensureRuntime(repoPath);
+        restartedRuntime = await deps.ensureRuntime(repoPath);
         const restartedRuntimeInput = toRuntimeInput(restartedRuntime);
         const statusByServer = await deps.getMcpStatus(restartedRuntimeInput);
         return {
@@ -207,7 +208,7 @@ export const createOpencodeCatalogOperations = (deps: OpencodeCatalogDependencie
         return {
           ok: false,
           result: toMcpStatusFailedHealthCheck(
-            runtimeProbe.runtime,
+            restartedRuntime ?? runtimeProbe.runtime,
             `Failed to query OpenCode MCP status: ${errorMessage(retryError)}`,
             checkedAt,
           ),

--- a/apps/desktop/src/state/operations/opencode-catalog.ts
+++ b/apps/desktop/src/state/operations/opencode-catalog.ts
@@ -19,11 +19,115 @@ type OpencodeCatalogDependencies = {
   connectMcpServer: (input: ListCatalogInput & { name: string }) => Promise<void>;
 };
 
+type RuntimeProbeResult =
+  | {
+      ok: true;
+      runtime: AgentRuntimeSummary;
+      runtimeInput: ListCatalogInput;
+    }
+  | {
+      ok: false;
+      result: RepoOpencodeHealthCheck;
+    };
+
+type McpProbeResult =
+  | {
+      ok: true;
+      runtime: AgentRuntimeSummary;
+      runtimeInput: ListCatalogInput;
+      statusByServer: Record<string, McpServerStatus>;
+    }
+  | {
+      ok: false;
+      result: RepoOpencodeHealthCheck;
+    };
+
+type NormalizedMcpStatus = {
+  mcpServerStatus: string | null;
+  mcpServerError: string | null;
+};
+
 const ODT_MCP_SERVER_NAME = "openducktor";
 const toBaseUrl = (port: number): string => `http://127.0.0.1:${port}`;
 const toNowIso = (): string => new Date().toISOString();
+const toRuntimeInput = (runtime: AgentRuntimeSummary): ListCatalogInput => ({
+  baseUrl: toBaseUrl(runtime.port),
+  workingDirectory: runtime.workingDirectory,
+});
 const isOpencodeConfigInvalidError = (message: string): boolean =>
   /configinvaliderror|opencode_config_content|loglevel|invalid option/i.test(message);
+const shouldReconnectMcp = (status: string | null): boolean => {
+  return status !== null && status !== "connected";
+};
+
+const toRuntimeUnavailableHealthCheck = (
+  runtimeError: string,
+  checkedAt: string,
+): RepoOpencodeHealthCheck => {
+  const unavailableMessage = "OpenCode runtime is unavailable, so MCP cannot be verified.";
+  return {
+    runtimeOk: false,
+    runtimeError,
+    runtime: null,
+    mcpOk: false,
+    mcpError: unavailableMessage,
+    mcpServerName: ODT_MCP_SERVER_NAME,
+    mcpServerStatus: null,
+    mcpServerError: unavailableMessage,
+    availableToolIds: [],
+    checkedAt,
+    errors: [runtimeError, unavailableMessage],
+  };
+};
+
+const toMcpStatusFailedHealthCheck = (
+  runtime: AgentRuntimeSummary,
+  mcpError: string,
+  checkedAt: string,
+): RepoOpencodeHealthCheck => {
+  return {
+    runtimeOk: true,
+    runtimeError: null,
+    runtime,
+    mcpOk: false,
+    mcpError,
+    mcpServerName: ODT_MCP_SERVER_NAME,
+    mcpServerStatus: null,
+    mcpServerError: mcpError,
+    availableToolIds: [],
+    checkedAt,
+    errors: [mcpError],
+  };
+};
+
+const toRepoOpencodeHealthCheck = ({
+  runtime,
+  availableToolIds,
+  mcpServerStatus,
+  mcpServerError,
+  checkedAt,
+}: {
+  runtime: AgentRuntimeSummary;
+  availableToolIds: string[];
+  checkedAt: string;
+} & NormalizedMcpStatus): RepoOpencodeHealthCheck => {
+  const mcpOk = mcpServerStatus === "connected";
+  const mcpError = mcpOk ? null : (mcpServerError ?? "OpenDucktor MCP is unavailable.");
+
+  return {
+    runtimeOk: true,
+    runtimeError: null,
+    runtime,
+    mcpOk,
+    mcpError,
+    mcpServerName: ODT_MCP_SERVER_NAME,
+    mcpServerStatus,
+    mcpServerError: mcpServerError ?? null,
+    availableToolIds,
+    checkedAt,
+    errors: mcpError ? [mcpError] : [],
+  };
+};
 
 const resolveMcpStatusError = (
   statusByServer: Record<string, McpServerStatus>,
@@ -45,6 +149,103 @@ const resolveMcpStatusError = (
 };
 
 export const createOpencodeCatalogOperations = (deps: OpencodeCatalogDependencies) => {
+  const probeRuntime = async (repoPath: string, checkedAt: string): Promise<RuntimeProbeResult> => {
+    try {
+      const runtime = await deps.ensureRuntime(repoPath);
+      return {
+        ok: true,
+        runtime,
+        runtimeInput: toRuntimeInput(runtime),
+      };
+    } catch (error) {
+      const runtimeError = errorMessage(error);
+      return {
+        ok: false,
+        result: toRuntimeUnavailableHealthCheck(runtimeError, checkedAt),
+      };
+    }
+  };
+
+  const probeMcpStatusWithRetryStrategy = async (
+    repoPath: string,
+    runtimeProbe: Extract<RuntimeProbeResult, { ok: true }>,
+    checkedAt: string,
+  ): Promise<McpProbeResult> => {
+    try {
+      const statusByServer = await deps.getMcpStatus(runtimeProbe.runtimeInput);
+      return {
+        ok: true,
+        runtime: runtimeProbe.runtime,
+        runtimeInput: runtimeProbe.runtimeInput,
+        statusByServer,
+      };
+    } catch (error) {
+      const rawMessage = errorMessage(error);
+      if (!isOpencodeConfigInvalidError(rawMessage)) {
+        return {
+          ok: false,
+          result: toMcpStatusFailedHealthCheck(
+            runtimeProbe.runtime,
+            `Failed to query OpenCode MCP status: ${rawMessage}`,
+            checkedAt,
+          ),
+        };
+      }
+
+      try {
+        await deps.stopRuntime(runtimeProbe.runtime.runtimeId);
+        const restartedRuntime = await deps.ensureRuntime(repoPath);
+        const restartedRuntimeInput = toRuntimeInput(restartedRuntime);
+        const statusByServer = await deps.getMcpStatus(restartedRuntimeInput);
+        return {
+          ok: true,
+          runtime: restartedRuntime,
+          runtimeInput: restartedRuntimeInput,
+          statusByServer,
+        };
+      } catch (retryError) {
+        return {
+          ok: false,
+          result: toMcpStatusFailedHealthCheck(
+            runtimeProbe.runtime,
+            `Failed to query OpenCode MCP status: ${errorMessage(retryError)}`,
+            checkedAt,
+          ),
+        };
+      }
+    }
+  };
+
+  const normalizeMcpStatus = async (
+    runtimeInput: ListCatalogInput,
+    statusByServer: Record<string, McpServerStatus>,
+  ): Promise<NormalizedMcpStatus> => {
+    let { status: mcpServerStatus, error: mcpServerError } = resolveMcpStatusError(statusByServer);
+
+    if (shouldReconnectMcp(mcpServerStatus)) {
+      try {
+        await deps.connectMcpServer({
+          ...runtimeInput,
+          name: ODT_MCP_SERVER_NAME,
+        });
+        const refreshedStatusByServer = await deps.getMcpStatus(runtimeInput);
+        const refreshedStatus = resolveMcpStatusError(refreshedStatusByServer);
+        mcpServerStatus = refreshedStatus.status;
+        mcpServerError = refreshedStatus.error;
+      } catch (error) {
+        const reconnectError = errorMessage(error);
+        mcpServerError = mcpServerError
+          ? `${mcpServerError} (reconnect failed: ${reconnectError})`
+          : `Failed to reconnect MCP server '${ODT_MCP_SERVER_NAME}': ${reconnectError}`;
+      }
+    }
+
+    return {
+      mcpServerStatus,
+      mcpServerError,
+    };
+  };
+
   const loadRepoOpencodeCatalog = async (repoPath: string): Promise<AgentModelCatalog> => {
     const runtime = await deps.ensureRuntime(repoPath);
     return deps.listAvailableModels({
@@ -55,123 +256,32 @@ export const createOpencodeCatalogOperations = (deps: OpencodeCatalogDependencie
 
   const checkRepoOpencodeHealth = async (repoPath: string): Promise<RepoOpencodeHealthCheck> => {
     const checkedAt = toNowIso();
-    let runtime: AgentRuntimeSummary | null = null;
-
-    try {
-      runtime = await deps.ensureRuntime(repoPath);
-    } catch (error) {
-      const runtimeError = errorMessage(error);
-      const unavailableMessage = "OpenCode runtime is unavailable, so MCP cannot be verified.";
-      return {
-        runtimeOk: false,
-        runtimeError,
-        runtime: null,
-        mcpOk: false,
-        mcpError: unavailableMessage,
-        mcpServerName: ODT_MCP_SERVER_NAME,
-        mcpServerStatus: null,
-        mcpServerError: unavailableMessage,
-        availableToolIds: [],
-        checkedAt,
-        errors: [runtimeError, unavailableMessage],
-      };
+    const runtimeProbe = await probeRuntime(repoPath, checkedAt);
+    if (!runtimeProbe.ok) {
+      return runtimeProbe.result;
     }
 
-    let runtimeInput = {
-      baseUrl: toBaseUrl(runtime.port),
-      workingDirectory: runtime.workingDirectory,
-    };
-
-    let statusByServer: Record<string, McpServerStatus>;
-    try {
-      statusByServer = await deps.getMcpStatus(runtimeInput);
-    } catch (error) {
-      const rawMessage = errorMessage(error);
-      if (runtime && isOpencodeConfigInvalidError(rawMessage)) {
-        try {
-          await deps.stopRuntime(runtime.runtimeId);
-          runtime = await deps.ensureRuntime(repoPath);
-          runtimeInput = {
-            baseUrl: toBaseUrl(runtime.port),
-            workingDirectory: runtime.workingDirectory,
-          };
-          statusByServer = await deps.getMcpStatus(runtimeInput);
-        } catch (retryError) {
-          const mcpError = `Failed to query OpenCode MCP status: ${errorMessage(retryError)}`;
-          return {
-            runtimeOk: true,
-            runtimeError: null,
-            runtime,
-            mcpOk: false,
-            mcpError,
-            mcpServerName: ODT_MCP_SERVER_NAME,
-            mcpServerStatus: null,
-            mcpServerError: mcpError,
-            availableToolIds: [],
-            checkedAt,
-            errors: [mcpError],
-          };
-        }
-      } else {
-        const mcpError = `Failed to query OpenCode MCP status: ${rawMessage}`;
-        return {
-          runtimeOk: true,
-          runtimeError: null,
-          runtime,
-          mcpOk: false,
-          mcpError,
-          mcpServerName: ODT_MCP_SERVER_NAME,
-          mcpServerStatus: null,
-          mcpServerError: mcpError,
-          availableToolIds: [],
-          checkedAt,
-          errors: [mcpError],
-        };
-      }
+    const mcpProbe = await probeMcpStatusWithRetryStrategy(repoPath, runtimeProbe, checkedAt);
+    if (!mcpProbe.ok) {
+      return mcpProbe.result;
     }
 
     const availableToolIdsPromise = deps
-      .listAvailableToolIds(runtimeInput)
+      .listAvailableToolIds(mcpProbe.runtimeInput)
       .catch(() => [] as string[]);
 
-    let { status: mcpServerStatus, error: mcpServerError } = resolveMcpStatusError(statusByServer);
-
-    if (mcpServerStatus !== null && mcpServerStatus !== "connected") {
-      try {
-        await deps.connectMcpServer({
-          ...runtimeInput,
-          name: ODT_MCP_SERVER_NAME,
-        });
-        statusByServer = await deps.getMcpStatus(runtimeInput);
-        const resolved = resolveMcpStatusError(statusByServer);
-        mcpServerStatus = resolved.status;
-        mcpServerError = resolved.error;
-      } catch (error) {
-        const reconnectError = errorMessage(error);
-        mcpServerError = mcpServerError
-          ? `${mcpServerError} (reconnect failed: ${reconnectError})`
-          : `Failed to reconnect MCP server '${ODT_MCP_SERVER_NAME}': ${reconnectError}`;
-      }
-    }
-
+    const normalizedMcpStatus = await normalizeMcpStatus(
+      mcpProbe.runtimeInput,
+      mcpProbe.statusByServer,
+    );
     const availableToolIds = await availableToolIdsPromise;
 
-    const mcpOk = mcpServerStatus === "connected";
-    const mcpError = mcpOk ? null : (mcpServerError ?? "OpenDucktor MCP is unavailable.");
-
-    return {
-      runtimeOk: true,
-      runtimeError: null,
-      runtime,
-      mcpOk,
-      mcpError,
-      mcpServerName: ODT_MCP_SERVER_NAME,
-      mcpServerStatus,
-      mcpServerError: mcpServerError ?? null,
+    return toRepoOpencodeHealthCheck({
+      runtime: mcpProbe.runtime,
       availableToolIds,
       checkedAt,
-      errors: mcpError ? [mcpError] : [],
-    };
+      ...normalizedMcpStatus,
+    });
   };
 
   return {


### PR DESCRIPTION
## Summary
- Extract `checkRepoOpencodeHealth` into explicit helper steps for runtime probe, MCP status probe/retry, reconnect normalization, and final response mapping.
- Preserve existing diagnostics and fallback behavior while reducing method size and single-function responsibility.
- Keep tool-id lookup resilient by retaining fallback-to-empty behavior when tool list calls fail.

## Validation
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop test`
- `bun run --filter @openducktor/desktop build`
