### PR TITLE
refactor(desktop): add barrel exports for feature and state boundaries

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,22 +2,14 @@ import { lazy, type ReactElement, Suspense } from "react";
 import { Navigate, Outlet, Route, Routes } from "react-router-dom";
 import { AppShell } from "@/components/layout/app-shell";
 import { Toaster } from "@/components/ui/sonner";
+import { loadAgentsPage, loadKanbanPage, loadNotFoundPage } from "@/pages";
 import { AppStateProvider, useWorkspaceState } from "@/state";
 
-const AgentsPage = lazy(async () => {
-  const module = await import("@/pages/agents-page");
-  return { default: module.AgentsPage };
-});
+const AgentsPage = lazy(loadAgentsPage);
 
-const KanbanPage = lazy(async () => {
-  const module = await import("@/pages/kanban-page");
-  return { default: module.KanbanPage };
-});
+const KanbanPage = lazy(loadKanbanPage);
 
-const NotFoundPage = lazy(async () => {
-  const module = await import("@/pages/not-found-page");
-  return { default: module.NotFoundPage };
-});
+const NotFoundPage = lazy(loadNotFoundPage);
 
 function RouteFallback(): ReactElement {
   return (

--- a/apps/desktop/src/components/features/agents/index.ts
+++ b/apps/desktop/src/components/features/agents/index.ts
@@ -1,0 +1,32 @@
+export { resolveAgentAccentColor } from "./agent-accent-color";
+export type {
+  AgentChatComposerModel,
+  AgentChatModel,
+  AgentChatThreadModel,
+  AgentRoleOption,
+} from "./agent-chat";
+export {
+  AgentChat,
+  CHAT_AUTOSCROLL_THRESHOLD_PX,
+  COMPOSER_TEXTAREA_MAX_HEIGHT_PX,
+  COMPOSER_TEXTAREA_MIN_HEIGHT_PX,
+  computeComposerTextareaLayout,
+  computeTodoPanelBottomOffset,
+  isNearBottom,
+  useAgentChatLayout,
+} from "./agent-chat";
+export type { AgentStudioHeaderModel } from "./agent-studio-header";
+export { AgentStudioHeader } from "./agent-studio-header";
+export type {
+  AgentStudioTaskTab,
+  AgentStudioTaskTabStatus,
+  AgentStudioTaskTabsModel,
+} from "./agent-studio-task-tabs";
+export { AgentStudioTaskTabs } from "./agent-studio-task-tabs";
+export type { AgentStudioWorkspaceSidebarModel } from "./agent-studio-workspace-sidebar";
+export { AgentStudioWorkspaceSidebar } from "./agent-studio-workspace-sidebar";
+export {
+  toModelGroupsByProvider,
+  toModelOptions,
+  toPrimaryAgentOptions,
+} from "./catalog-select-options";

--- a/apps/desktop/src/components/features/settings-modal.tsx
+++ b/apps/desktop/src/components/features/settings-modal.tsx
@@ -6,7 +6,7 @@ import {
   toModelGroupsByProvider,
   toModelOptions,
   toPrimaryAgentOptions,
-} from "@/components/features/agents/catalog-select-options";
+} from "@/components/features/agents";
 import {
   clearRoleDefault,
   DEFAULT_BRANCH_PREFIX,
@@ -39,7 +39,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { errorMessage } from "@/lib/errors";
 import { cn } from "@/lib/utils";
 import { useWorkspaceState } from "@/state";
-import { loadRepoOpencodeCatalog } from "@/state/operations/opencode-catalog";
+import { loadRepoOpencodeCatalog } from "@/state/operations";
 
 type SettingsModalProps = {
   triggerClassName?: string;

--- a/apps/desktop/src/components/features/task-create-modal.tsx
+++ b/apps/desktop/src/components/features/task-create-modal.tsx
@@ -8,8 +8,10 @@ import {
   TaskDocumentEditor,
   TaskEditSectionSwitcher,
 } from "@/components/features/task-composer";
-import { TaskCreateDiscardDialog } from "@/components/features/task-create/task-create-discard-dialog";
-import { useTaskCreateModalController } from "@/components/features/task-create/use-task-create-modal-controller";
+import {
+  TaskCreateDiscardDialog,
+  useTaskCreateModalController,
+} from "@/components/features/task-create";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,

--- a/apps/desktop/src/components/features/task-create/index.ts
+++ b/apps/desktop/src/components/features/task-create/index.ts
@@ -1,0 +1,3 @@
+export { TaskCreateDiscardDialog } from "./task-create-discard-dialog";
+export type { PendingDiscardIntent } from "./use-task-create-modal-controller";
+export { useTaskCreateModalController } from "./use-task-create-modal-controller";

--- a/apps/desktop/src/pages/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents-page-session-tabs.ts
@@ -1,6 +1,6 @@
 import type { TaskAction, TaskCard } from "@openducktor/contracts";
 import type { AgentRole, AgentScenario } from "@openducktor/core";
-import type { AgentStudioTaskTab } from "@/components/features/agents/agent-studio-task-tabs";
+import type { AgentStudioTaskTab } from "@/components/features/agents";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentWorkflowStepState } from "@/types/agent-workflow";

--- a/apps/desktop/src/pages/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents-page-view-model.ts
@@ -1,10 +1,13 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
 import type { RefObject, UIEvent } from "react";
-import type { AgentChatModel, AgentRoleOption } from "@/components/features/agents/agent-chat";
-import type { AgentStudioHeaderModel } from "@/components/features/agents/agent-studio-header";
-import type { AgentStudioTaskTabsModel } from "@/components/features/agents/agent-studio-task-tabs";
-import type { AgentStudioWorkspaceSidebarModel } from "@/components/features/agents/agent-studio-workspace-sidebar";
+import type {
+  AgentChatModel,
+  AgentRoleOption,
+  AgentStudioHeaderModel,
+  AgentStudioTaskTabsModel,
+  AgentStudioWorkspaceSidebarModel,
+} from "@/components/features/agents";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { AgentPermissionRequest, AgentSessionState } from "@/types/agent-orchestrator";

--- a/apps/desktop/src/pages/agents-page.tsx
+++ b/apps/desktop/src/pages/agents-page.tsx
@@ -1,10 +1,12 @@
 import type { AgentRole, AgentScenario } from "@openducktor/core";
 import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { AgentChat } from "@/components/features/agents/agent-chat";
-import { AgentStudioHeader } from "@/components/features/agents/agent-studio-header";
-import { AgentStudioTaskTabs } from "@/components/features/agents/agent-studio-task-tabs";
-import { AgentStudioWorkspaceSidebar } from "@/components/features/agents/agent-studio-workspace-sidebar";
+import {
+  AgentChat,
+  AgentStudioHeader,
+  AgentStudioTaskTabs,
+  AgentStudioWorkspaceSidebar,
+} from "@/components/features/agents";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { useAgentState, useChecksState, useTasksState, useWorkspaceState } from "@/state";
 import { firstScenario, isRole, isScenario, SCENARIOS_BY_ROLE } from "./agents-page-constants";

--- a/apps/desktop/src/pages/index.ts
+++ b/apps/desktop/src/pages/index.ts
@@ -1,0 +1,14 @@
+export const loadAgentsPage = async () => {
+  const module = await import("./agents-page");
+  return { default: module.AgentsPage };
+};
+
+export const loadKanbanPage = async () => {
+  const module = await import("./kanban-page");
+  return { default: module.KanbanPage };
+};
+
+export const loadNotFoundPage = async () => {
+  const module = await import("./not-found-page");
+  return { default: module.NotFoundPage };
+};

--- a/apps/desktop/src/pages/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/use-agent-studio-model-selection.ts
@@ -1,13 +1,13 @@
 import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { resolveAgentAccentColor } from "@/components/features/agents/agent-accent-color";
 import {
+  resolveAgentAccentColor,
   toModelGroupsByProvider,
   toModelOptions,
   toPrimaryAgentOptions,
-} from "@/components/features/agents/catalog-select-options";
+} from "@/components/features/agents";
 import type { ComboboxOption } from "@/components/ui/combobox";
-import { loadRepoOpencodeCatalog } from "@/state/operations/opencode-catalog";
+import { loadRepoOpencodeCatalog } from "@/state/operations";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {

--- a/apps/desktop/src/pages/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/use-agent-studio-page-models.ts
@@ -1,8 +1,11 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
 import { type UIEvent, useCallback, useMemo, useState } from "react";
-import { isNearBottom, useAgentChatLayout } from "@/components/features/agents/agent-chat";
-import type { AgentStudioTaskTabsModel } from "@/components/features/agents/agent-studio-task-tabs";
+import {
+  type AgentStudioTaskTabsModel,
+  isNearBottom,
+  useAgentChatLayout,
+} from "@/components/features/agents";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { AgentSessionState } from "@/types/agent-orchestrator";

--- a/apps/desktop/src/pages/use-agent-studio-task-tabs.ts
+++ b/apps/desktop/src/pages/use-agent-studio-task-tabs.ts
@@ -1,6 +1,6 @@
 import type { TaskCard } from "@openducktor/contracts";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { AgentStudioTaskTabsModel } from "@/components/features/agents/agent-studio-task-tabs";
+import type { AgentStudioTaskTabsModel } from "@/components/features/agents";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import {
   buildTaskTabs,

--- a/apps/desktop/src/state/app-state-provider.tsx
+++ b/apps/desktop/src/state/app-state-provider.tsx
@@ -27,13 +27,15 @@ import {
   findActiveWorkspace,
 } from "./app-state-context-values";
 import { useAppLifecycle } from "./lifecycle/use-app-lifecycle";
-import { useAgentOrchestratorOperations } from "./operations/use-agent-orchestrator-operations";
-import { useChecks } from "./operations/use-checks";
-import { useDelegationOperations } from "./operations/use-delegation-operations";
-import { useRepoSettingsOperations } from "./operations/use-repo-settings-operations";
-import { useSpecOperations } from "./operations/use-spec-operations";
-import { useTaskOperations } from "./operations/use-task-operations";
-import { useWorkspaceOperations } from "./operations/use-workspace-operations";
+import {
+  useAgentOrchestratorOperations,
+  useChecks,
+  useDelegationOperations,
+  useRepoSettingsOperations,
+  useSpecOperations,
+  useTaskOperations,
+  useWorkspaceOperations,
+} from "./operations";
 
 const WorkspaceStateContext = createContext<WorkspaceStateContextValue | null>(null);
 const ChecksStateContext = createContext<ChecksStateContextValue | null>(null);

--- a/apps/desktop/src/state/operations/index.ts
+++ b/apps/desktop/src/state/operations/index.ts
@@ -1,0 +1,8 @@
+export { checkRepoOpencodeHealth, loadRepoOpencodeCatalog } from "./opencode-catalog";
+export { useAgentOrchestratorOperations } from "./use-agent-orchestrator-operations";
+export { useChecks } from "./use-checks";
+export { useDelegationOperations } from "./use-delegation-operations";
+export { useRepoSettingsOperations } from "./use-repo-settings-operations";
+export { useSpecOperations } from "./use-spec-operations";
+export { useTaskOperations } from "./use-task-operations";
+export { useWorkspaceOperations } from "./use-workspace-operations";


### PR DESCRIPTION
## Summary
- add directory-level barrel exports for `pages`, `state/operations`, `components/features/agents`, and `components/features/task-create`
- migrate desktop consumers from deep internal imports to these public entry points
- keep page-level lazy loading behavior by exposing async page loaders from `pages/index.ts`

## What Changed
- added `index.ts` entry points at feature/state boundaries to define public APIs
- updated imports in agent studio pages, settings modal, task-create modal, app state provider, and app lazy route wiring
- reduced coupling to internal file structure while preserving existing behavior

## Validation
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop test`
- `bun run --filter @openducktor/desktop build`