### PR TITLE
refactor(desktop): remove unused agent chat and kanban exports

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.ts
@@ -17,7 +17,7 @@ const REGULAR_TOOL_SUMMARY_FROM_OUTPUT_TOOL_NAMES = new Set(["task", "subtask", 
 
 export const SYSTEM_PROMPT_PREFIX = "System prompt:\n\n";
 
-export const AGENT_ROLE_LABEL: Record<AgentRole, string> = {
+const AGENT_ROLE_LABEL: Record<AgentRole, string> = {
   spec: "Spec",
   planner: "Planner",
   build: "Builder",

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-test-fixtures.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-test-fixtures.ts
@@ -163,5 +163,3 @@ export const buildTodoItem = (
   priority: "medium",
   ...overrides,
 });
-
-export const buildRole = (role: AgentRole): AgentRole => role;

--- a/apps/desktop/src/components/features/agents/agent-chat/index.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/index.ts
@@ -6,11 +6,6 @@ export type {
   AgentRoleOption,
 } from "./agent-chat.types";
 export {
-  CHAT_AUTOSCROLL_THRESHOLD_PX,
-  COMPOSER_TEXTAREA_MAX_HEIGHT_PX,
-  COMPOSER_TEXTAREA_MIN_HEIGHT_PX,
-  computeComposerTextareaLayout,
-  computeTodoPanelBottomOffset,
   isNearBottom,
   useAgentChatLayout,
 } from "./use-agent-chat-layout";

--- a/apps/desktop/src/components/features/kanban/index.ts
+++ b/apps/desktop/src/components/features/kanban/index.ts
@@ -1,3 +1,2 @@
 export { KanbanColumn } from "./kanban-column";
 export { KanbanSummaryCards } from "./kanban-summary-cards";
-export { KanbanTaskCard } from "./kanban-task-card";

--- a/apps/desktop/src/pages/agent-studio-test-utils.tsx
+++ b/apps/desktop/src/pages/agent-studio-test-utils.tsx
@@ -16,7 +16,7 @@ export const enableReactActEnvironment = (): void => {
   (globalThis as ReactActEnvironment).IS_REACT_ACT_ENVIRONMENT = true;
 };
 
-export const flushMicrotasks = async (): Promise<void> => {
+const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve();
   await Promise.resolve();
 };


### PR DESCRIPTION
## Summary
- remove dead public exports in agent chat and kanban feature barrels identified by static usage analysis
- make internal-only helpers non-exported (`AGENT_ROLE_LABEL`, `flushMicrotasks`) and remove unused fixture helper `buildRole`
- reduce surface area without behavior changes to keep module intent clearer

## Testing
- Not run in this PR flow (changes are export-surface only)