### PR TITLE
refactor(openducktor-mcp): simplify workflow transition control complexity

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/index.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/index.ts
@@ -6,6 +6,11 @@ export type {
   AgentRoleOption,
 } from "./agent-chat.types";
 export {
+  CHAT_AUTOSCROLL_THRESHOLD_PX,
+  COMPOSER_TEXTAREA_MAX_HEIGHT_PX,
+  COMPOSER_TEXTAREA_MIN_HEIGHT_PX,
+  computeComposerTextareaLayout,
+  computeTodoPanelBottomOffset,
   isNearBottom,
   useAgentChatLayout,
 } from "./use-agent-chat-layout";

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -633,4 +633,354 @@ describe("openducktor-mcp lib", () => {
       updatedAt: "2026-02-19T12:00:00.000Z",
     });
   });
+
+  test("setSpec revalidates transition after metadata write and avoids stale status updates", async () => {
+    let status = "open";
+    let metadataUpdateCalls = 0;
+    let statusUpdateCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        metadataUpdateCalls += 1;
+        status = "in_progress";
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    await expect(
+      store.setSpec({
+        taskId: "task-1",
+        markdown: "# Spec",
+      }),
+    ).rejects.toThrow("Transition not allowed");
+
+    expect(metadataUpdateCalls).toBe(1);
+    expect(statusUpdateCalls).toBe(0);
+  });
+
+  test("setPlan revalidates transition after side effects and avoids stale status updates", async () => {
+    let status = "spec_ready";
+    let metadataUpdateCalls = 0;
+    let statusUpdateCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        metadataUpdateCalls += 1;
+        status = "in_progress";
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    await expect(
+      store.setPlan({
+        taskId: "task-1",
+        markdown: "# Plan",
+      }),
+    ).rejects.toThrow("Transition not allowed");
+
+    expect(metadataUpdateCalls).toBe(1);
+    expect(statusUpdateCalls).toBe(0);
+  });
+
+  test("buildCompleted revalidates transition from fresh task context", async () => {
+    let status = "in_progress";
+    let listCalls = 0;
+    let statusUpdateCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        listCalls += 1;
+        const currentStatus = status;
+        if (listCalls === 1) {
+          status = "blocked";
+        }
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status: currentStatus,
+              issue_type: "feature",
+              ai_review_enabled: false,
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    await expect(
+      store.buildCompleted({
+        taskId: "task-1",
+      }),
+    ).rejects.toThrow("Transition not allowed");
+
+    expect(statusUpdateCalls).toBe(0);
+  });
+
+  test("qaApproved revalidates transition after report append and avoids stale status updates", async () => {
+    let status = "ai_review";
+    let metadataUpdateCalls = 0;
+    let statusUpdateCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        metadataUpdateCalls += 1;
+        status = "closed";
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    await expect(
+      store.qaApproved({
+        taskId: "task-1",
+        reportMarkdown: "## QA",
+      }),
+    ).rejects.toThrow("Transition not allowed");
+
+    expect(metadataUpdateCalls).toBe(1);
+    expect(statusUpdateCalls).toBe(0);
+  });
+
+  test("qaRejected revalidates transition after report append and avoids stale status updates", async () => {
+    let status = "human_review";
+    let metadataUpdateCalls = 0;
+    let statusUpdateCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        metadataUpdateCalls += 1;
+        status = "closed";
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    await expect(
+      store.qaRejected({
+        taskId: "task-1",
+        reportMarkdown: "## QA",
+      }),
+    ).rejects.toThrow("Transition not allowed");
+
+    expect(metadataUpdateCalls).toBe(1);
+    expect(statusUpdateCalls).toBe(0);
+  });
 });

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -378,6 +378,121 @@ describe("openducktor-mcp lib", () => {
     }
   });
 
+  test("buildResumed allows task issues to skip spec/planning from open", async () => {
+    let status = "open";
+    let statusTransition: string | null = null;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "task",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "task",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--status")) {
+        status = args[args.indexOf("--status") + 1] ?? status;
+        statusTransition = status;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    const result = (await store.buildResumed({
+      taskId: "task-1",
+    })) as { task: { status: string } };
+
+    expect(result.task.status).toBe("in_progress");
+    expect(statusTransition).toBe("in_progress");
+  });
+
+  test("buildResumed rejects feature issues from open and does not update status", async () => {
+    let statusUpdateCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status: "open",
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    await expect(
+      store.buildResumed({
+        taskId: "task-1",
+      }),
+    ).rejects.toThrow("Transition not allowed");
+
+    expect(statusUpdateCalls).toBe(0);
+  });
+
   test("qaApproved fails fast when transition is not allowed and does not write metadata", async () => {
     let metadataUpdateCalls = 0;
     const { runProcess } = buildProcessRunner((args) => {
@@ -500,10 +615,12 @@ describe("openducktor-mcp lib", () => {
     expect(result.task.status).toBe("human_review");
     expect(statusTransition).toBe("human_review");
 
-    const namespace = ((metadataPayload as Record<string, unknown>)?.openducktor ?? {}) as Record<
-      string,
-      unknown
-    >;
+    const metadataRoot = (metadataPayload ?? {}) as Record<string, unknown>;
+    const namespaceValue = metadataRoot.openducktor;
+    const namespace =
+      typeof namespaceValue === "object" && namespaceValue !== null
+        ? (namespaceValue as Record<string, unknown>)
+        : {};
     const documents = (namespace.documents ?? {}) as Record<string, unknown>;
     const qaReports = (documents.qaReports ?? []) as Array<Record<string, unknown>>;
     expect(qaReports).toHaveLength(1);

--- a/packages/openducktor-mcp/src/lib.ts
+++ b/packages/openducktor-mcp/src/lib.ts
@@ -964,7 +964,7 @@ export class OdtTaskStore {
     const input = SetSpecInputSchema.parse(rawInput);
     const markdown = input.markdown.trim();
 
-    const { task, tasks } = await this.resolveTaskContext(input.taskId);
+    const { task } = await this.resolveTaskContext(input.taskId);
     assertNoValidationError(getSetSpecError(task.status));
 
     const issue = await this.showRawIssue(task.id);
@@ -994,8 +994,7 @@ export class OdtTaskStore {
 
     let nextTask: TaskCard = task;
     if (task.status === "open") {
-      this.assertTransitionAllowed(task, tasks, "spec_ready");
-      nextTask = await this.applyTransition(task, "spec_ready");
+      nextTask = await this.transitionTask(task.id, "spec_ready");
     }
 
     return {
@@ -1066,8 +1065,7 @@ export class OdtTaskStore {
       }
     }
 
-    this.assertTransitionAllowed(task, tasks, "ready_for_dev");
-    const nextTask = await this.applyTransition(task, "ready_for_dev");
+    const nextTask = await this.transitionTask(task.id, "ready_for_dev");
 
     return {
       task: nextTask,
@@ -1101,11 +1099,10 @@ export class OdtTaskStore {
     await this.ensureInitialized();
     const input = BuildCompletedInputSchema.parse(rawInput);
 
-    const { task, tasks } = await this.resolveTaskContext(input.taskId);
+    const { task } = await this.resolveTaskContext(input.taskId);
 
     const nextStatus: TaskStatus = task.aiReviewEnabled ? "ai_review" : "human_review";
-    this.assertTransitionAllowed(task, tasks, nextStatus);
-    const updated = await this.applyTransition(task, nextStatus);
+    const updated = await this.transitionTask(task.id, nextStatus);
     return {
       task: updated,
       ...(input.summary ? { summary: input.summary } : {}),
@@ -1150,7 +1147,7 @@ export class OdtTaskStore {
     const { task, tasks } = await this.resolveTaskContext(input.taskId);
     this.assertTransitionAllowed(task, tasks, "human_review");
     await this.appendQaReport(task.id, input.reportMarkdown.trim(), "approved");
-    const updated = await this.applyTransition(task, "human_review");
+    const updated = await this.transitionTask(task.id, "human_review");
     return { task: updated };
   }
 
@@ -1160,7 +1157,7 @@ export class OdtTaskStore {
     const { task, tasks } = await this.resolveTaskContext(input.taskId);
     this.assertTransitionAllowed(task, tasks, "in_progress");
     await this.appendQaReport(task.id, input.reportMarkdown.trim(), "rejected");
-    const updated = await this.applyTransition(task, "in_progress");
+    const updated = await this.transitionTask(task.id, "in_progress");
     return { task: updated };
   }
 }

--- a/packages/openducktor-mcp/src/lib.ts
+++ b/packages/openducktor-mcp/src/lib.ts
@@ -313,76 +313,125 @@ const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): TaskCard =
   };
 };
 
+const TASK_STATUS_VALUES: readonly TaskStatus[] = [
+  "open",
+  "spec_ready",
+  "ready_for_dev",
+  "in_progress",
+  "blocked",
+  "ai_review",
+  "human_review",
+  "deferred",
+  "closed",
+];
+
+const TASK_STATUS_SET = new Set<TaskStatus>(TASK_STATUS_VALUES);
+
+const isTaskStatus = (value: string): value is TaskStatus =>
+  TASK_STATUS_SET.has(value as TaskStatus);
+
 const toTaskStatus = (value: unknown): TaskStatus => {
-  const normalized = typeof value === "string" ? value : "open";
-  if (
-    normalized === "open" ||
-    normalized === "spec_ready" ||
-    normalized === "ready_for_dev" ||
-    normalized === "in_progress" ||
-    normalized === "blocked" ||
-    normalized === "ai_review" ||
-    normalized === "human_review" ||
-    normalized === "deferred" ||
-    normalized === "closed"
-  ) {
-    return normalized;
+  if (typeof value !== "string") {
+    return "open";
   }
-  return "open";
+  return isTaskStatus(value) ? value : "open";
 };
 
 const canSkipSpecAndPlanning = (task: TaskCard): boolean => {
   return task.issueType === "task" || task.issueType === "bug";
 };
 
-const allowsTransition = (task: TaskCard, from: TaskStatus, to: TaskStatus): boolean => {
+const BASE_TRANSITION_RULES: Readonly<Record<TaskStatus, readonly TaskStatus[]>> = {
+  open: ["spec_ready", "deferred"],
+  spec_ready: ["ready_for_dev", "deferred"],
+  ready_for_dev: ["in_progress", "deferred"],
+  in_progress: ["blocked", "ai_review", "human_review", "deferred"],
+  blocked: ["in_progress", "deferred"],
+  ai_review: ["in_progress", "human_review", "deferred"],
+  human_review: ["in_progress", "closed", "deferred"],
+  deferred: ["open"],
+  closed: [],
+};
+
+const SKIP_SPEC_AND_PLAN_TRANSITION_EXTRAS: Readonly<
+  Partial<Record<TaskStatus, readonly TaskStatus[]>>
+> = {
+  open: ["ready_for_dev", "in_progress"],
+  spec_ready: ["in_progress"],
+};
+
+const SET_SPEC_ALLOWED_STATUSES: readonly TaskStatus[] = ["open", "spec_ready"];
+
+const SET_PLAN_ALLOWED_STATUSES: Readonly<Record<IssueType, readonly TaskStatus[]>> = {
+  epic: ["spec_ready"],
+  feature: ["spec_ready"],
+  task: ["open", "spec_ready"],
+  bug: ["open", "spec_ready"],
+};
+
+const isStatusAllowed = (status: TaskStatus, allowed: readonly TaskStatus[]): boolean => {
+  return allowed.includes(status);
+};
+
+const getTransitionError = (
+  task: TaskCard,
+  allTasks: TaskCard[],
+  from: TaskStatus,
+  to: TaskStatus,
+): string | null => {
   if (from === to) {
-    return true;
+    return null;
   }
 
-  switch (from) {
-    case "open": {
-      if (canSkipSpecAndPlanning(task)) {
-        return (
-          to === "spec_ready" || to === "ready_for_dev" || to === "in_progress" || to === "deferred"
-        );
-      }
-      return to === "spec_ready" || to === "deferred";
-    }
-    case "spec_ready": {
-      if (canSkipSpecAndPlanning(task)) {
-        return to === "ready_for_dev" || to === "in_progress" || to === "deferred";
-      }
-      return to === "ready_for_dev" || to === "deferred";
-    }
-    case "ready_for_dev":
-      return to === "in_progress" || to === "deferred";
-    case "in_progress":
-      return to === "blocked" || to === "ai_review" || to === "human_review" || to === "deferred";
-    case "blocked":
-      return to === "in_progress" || to === "deferred";
-    case "ai_review":
-      return to === "in_progress" || to === "human_review" || to === "deferred";
-    case "human_review":
-      return to === "in_progress" || to === "closed" || to === "deferred";
-    case "deferred":
-      return to === "open";
-    case "closed":
-      return false;
-    default:
-      return false;
+  const baseAllowed = BASE_TRANSITION_RULES[from] ?? [];
+  const extraAllowed = canSkipSpecAndPlanning(task)
+    ? (SKIP_SPEC_AND_PLAN_TRANSITION_EXTRAS[from] ?? [])
+    : [];
+
+  if (!isStatusAllowed(to, baseAllowed) && !isStatusAllowed(to, extraAllowed)) {
+    return `Transition not allowed for ${task.id} (${task.issueType}): ${from} -> ${to}`;
   }
+
+  if (to === "closed" && task.issueType === "epic") {
+    const blockingSubtask = allTasks.find(
+      (entry) =>
+        entry.parentId === task.id && entry.status !== "closed" && entry.status !== "deferred",
+    );
+
+    if (blockingSubtask) {
+      return `Epic cannot be completed while direct subtask ${blockingSubtask.id} is still active.`;
+    }
+  }
+
+  return null;
 };
 
 const canSetSpecFromStatus = (status: TaskStatus): boolean => {
-  return status === "open" || status === "spec_ready";
+  return isStatusAllowed(status, SET_SPEC_ALLOWED_STATUSES);
 };
 
 const canSetPlan = (task: TaskCard): boolean => {
-  if (task.issueType === "epic" || task.issueType === "feature") {
-    return task.status === "spec_ready";
+  return isStatusAllowed(task.status, SET_PLAN_ALLOWED_STATUSES[task.issueType]);
+};
+
+const getSetSpecError = (status: TaskStatus): string | null => {
+  if (canSetSpecFromStatus(status)) {
+    return null;
   }
-  return task.status === "open" || task.status === "spec_ready";
+  return `set_spec is only allowed from open/spec_ready (current: ${status})`;
+};
+
+const getSetPlanError = (task: TaskCard): string | null => {
+  if (canSetPlan(task)) {
+    return null;
+  }
+  return `set_plan is not allowed for issue type ${task.issueType} from status ${task.status}`;
+};
+
+const assertNoValidationError = (error: string | null): void => {
+  if (error) {
+    throw new Error(error);
+  }
 };
 
 const normalizeTitleKey = (value: string): string => value.trim().toLowerCase();
@@ -445,22 +494,7 @@ const validateTransition = (
   from: TaskStatus,
   to: TaskStatus,
 ): void => {
-  if (!allowsTransition(task, from, to)) {
-    throw new Error(`Transition not allowed for ${task.id} (${task.issueType}): ${from} -> ${to}`);
-  }
-
-  if (to === "closed" && task.issueType === "epic") {
-    const blockingSubtask = allTasks.find(
-      (entry) =>
-        entry.parentId === task.id && entry.status !== "closed" && entry.status !== "deferred",
-    );
-
-    if (blockingSubtask) {
-      throw new Error(
-        `Epic cannot be completed while direct subtask ${blockingSubtask.id} is still active.`,
-      );
-    }
-  }
+  assertNoValidationError(getTransitionError(task, allTasks, from, to));
 };
 
 type ProcessResult = { ok: boolean; stdout: string; stderr: string };
@@ -793,18 +827,29 @@ export class OdtTaskStore {
     throw new Error(`Task not found: ${requestedTaskId}.${hintSuffix}`);
   }
 
-  private async transitionTask(taskId: string, next: TaskStatus): Promise<TaskCard> {
+  private async resolveTaskContext(taskId: string): Promise<{ task: TaskCard; tasks: TaskCard[] }> {
     const tasks = await this.listTasks();
     const task = this.resolveTaskFromTasks(tasks, taskId);
+    return { task, tasks };
+  }
 
-    validateTransition(task, tasks, task.status, next);
+  private assertTransitionAllowed(task: TaskCard, tasks: TaskCard[], nextStatus: TaskStatus): void {
+    validateTransition(task, tasks, task.status, nextStatus);
+  }
 
-    if (task.status !== next) {
-      await this.runBdJson(["update", task.id, "--status", next]);
+  private async applyTransition(task: TaskCard, nextStatus: TaskStatus): Promise<TaskCard> {
+    if (task.status !== nextStatus) {
+      await this.runBdJson(["update", task.id, "--status", nextStatus]);
     }
 
     const refreshed = await this.showRawIssue(task.id);
     return issueToTaskCard(refreshed, this.metadataNamespace);
+  }
+
+  private async transitionTask(taskId: string, next: TaskStatus): Promise<TaskCard> {
+    const { task, tasks } = await this.resolveTaskContext(taskId);
+    this.assertTransitionAllowed(task, tasks, next);
+    return this.applyTransition(task, next);
   }
 
   private getNamespaceData(issue: RawIssue): {
@@ -919,12 +964,8 @@ export class OdtTaskStore {
     const input = SetSpecInputSchema.parse(rawInput);
     const markdown = input.markdown.trim();
 
-    const tasks = await this.listTasks();
-    const task = this.resolveTaskFromTasks(tasks, input.taskId);
-
-    if (!canSetSpecFromStatus(task.status)) {
-      throw new Error(`set_spec is only allowed from open/spec_ready (current: ${task.status})`);
-    }
+    const { task, tasks } = await this.resolveTaskContext(input.taskId);
+    assertNoValidationError(getSetSpecError(task.status));
 
     const issue = await this.showRawIssue(task.id);
     const { root, namespace, documents } = this.getNamespaceData(issue);
@@ -951,8 +992,11 @@ export class OdtTaskStore {
 
     await this.writeNamespace(task.id, root, nextNamespace);
 
-    const nextTask =
-      task.status === "open" ? await this.transitionTask(task.id, "spec_ready") : task;
+    let nextTask: TaskCard = task;
+    if (task.status === "open") {
+      this.assertTransitionAllowed(task, tasks, "spec_ready");
+      nextTask = await this.applyTransition(task, "spec_ready");
+    }
 
     return {
       task: nextTask,
@@ -969,14 +1013,8 @@ export class OdtTaskStore {
     const input = SetPlanInputSchema.parse(rawInput);
     const markdown = input.markdown.trim();
 
-    const tasks = await this.listTasks();
-    const task = this.resolveTaskFromTasks(tasks, input.taskId);
-
-    if (!canSetPlan(task)) {
-      throw new Error(
-        `set_plan is not allowed for issue type ${task.issueType} from status ${task.status}`,
-      );
-    }
+    const { task, tasks } = await this.resolveTaskContext(input.taskId);
+    assertNoValidationError(getSetPlanError(task));
 
     const normalizedSubtasks = normalizePlanSubtasks(input.subtasks ?? []);
     validatePlanSubtaskRules(task, tasks, normalizedSubtasks);
@@ -1028,7 +1066,8 @@ export class OdtTaskStore {
       }
     }
 
-    const nextTask = await this.transitionTask(task.id, "ready_for_dev");
+    this.assertTransitionAllowed(task, tasks, "ready_for_dev");
+    const nextTask = await this.applyTransition(task, "ready_for_dev");
 
     return {
       task: nextTask,
@@ -1062,11 +1101,11 @@ export class OdtTaskStore {
     await this.ensureInitialized();
     const input = BuildCompletedInputSchema.parse(rawInput);
 
-    const tasks = await this.listTasks();
-    const task = this.resolveTaskFromTasks(tasks, input.taskId);
+    const { task, tasks } = await this.resolveTaskContext(input.taskId);
 
     const nextStatus: TaskStatus = task.aiReviewEnabled ? "ai_review" : "human_review";
-    const updated = await this.transitionTask(task.id, nextStatus);
+    this.assertTransitionAllowed(task, tasks, nextStatus);
+    const updated = await this.applyTransition(task, nextStatus);
     return {
       task: updated,
       ...(input.summary ? { summary: input.summary } : {}),
@@ -1105,32 +1144,23 @@ export class OdtTaskStore {
     await this.writeNamespace(taskId, root, nextNamespace);
   }
 
-  private async ensureQaTransitionAllowed(
-    taskId: string,
-    nextStatus: TaskStatus,
-  ): Promise<TaskCard> {
-    const tasks = await this.listTasks();
-    const task = this.resolveTaskFromTasks(tasks, taskId);
-
-    validateTransition(task, tasks, task.status, nextStatus);
-    return task;
-  }
-
   async qaApproved(rawInput: unknown): Promise<unknown> {
     await this.ensureInitialized();
     const input = QaApprovedInputSchema.parse(rawInput);
-    const task = await this.ensureQaTransitionAllowed(input.taskId, "human_review");
+    const { task, tasks } = await this.resolveTaskContext(input.taskId);
+    this.assertTransitionAllowed(task, tasks, "human_review");
     await this.appendQaReport(task.id, input.reportMarkdown.trim(), "approved");
-    const updated = await this.transitionTask(task.id, "human_review");
+    const updated = await this.applyTransition(task, "human_review");
     return { task: updated };
   }
 
   async qaRejected(rawInput: unknown): Promise<unknown> {
     await this.ensureInitialized();
     const input = QaRejectedInputSchema.parse(rawInput);
-    const task = await this.ensureQaTransitionAllowed(input.taskId, "in_progress");
+    const { task, tasks } = await this.resolveTaskContext(input.taskId);
+    this.assertTransitionAllowed(task, tasks, "in_progress");
     await this.appendQaReport(task.id, input.reportMarkdown.trim(), "rejected");
-    const updated = await this.transitionTask(task.id, "in_progress");
+    const updated = await this.applyTransition(task, "in_progress");
     return { task: updated };
   }
 }


### PR DESCRIPTION
## Summary
- Refactor MCP workflow transition policy into explicit rule tables and pure validation helpers.
- Simplify `OdtTaskStore` command handlers by sharing task-context resolution and transition application paths.
- Add regression tests for `buildResumed` skip behavior and transition rejection safety.

## Verification
- `bun run --filter @openducktor/openducktor-mcp typecheck`
- `bun run --filter @openducktor/openducktor-mcp lint`
- `bun run --filter @openducktor/openducktor-mcp test`
- `bun run --filter @openducktor/openducktor-mcp build`