### PR TITLE
refactor(workspace-git): remove misspelled branch aliases

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -192,14 +192,6 @@ async fn git_get_branches(
 }
 
 #[tauri::command]
-async fn git_get_branchs(
-    state: State<'_, AppState>,
-    repo_path: String,
-) -> Result<Vec<host_domain::GitBranch>, String> {
-    as_error(state.service.git_get_branches(&repo_path))
-}
-
-#[tauri::command]
 async fn git_get_current_branch(
     state: State<'_, AppState>,
     repo_path: String,
@@ -701,7 +693,6 @@ pub fn run() {
             workspace_get_repo_config,
             workspace_set_trusted_hooks,
             git_get_branches,
-            git_get_branchs,
             git_get_current_branch,
             git_switch_branch,
             git_create_worktree,

--- a/packages/adapters-tauri-host/src/bun-test.d.ts
+++ b/packages/adapters-tauri-host/src/bun-test.d.ts
@@ -1,0 +1,19 @@
+export {};
+
+type RejectMatchers = {
+  toThrow(message?: string | RegExp): Promise<void>;
+};
+
+type Matchers<T> = {
+  toBe(expected: unknown): void;
+  toEqual(expected: unknown): void;
+  toHaveLength(expected: number): void;
+  toThrow(message?: string | RegExp): void;
+  rejects: RejectMatchers;
+};
+
+declare global {
+  const describe: (name: string, fn: () => void | Promise<void>) => void;
+  const test: (name: string, fn: () => void | Promise<void>) => void;
+  function expect<T>(actual: T): Matchers<T>;
+}

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import type {} from "./bun-test";
 import { TauriHostClient } from "./index";
 
 type InvokeCall = {
@@ -148,7 +148,7 @@ describe("TauriHostClient", () => {
 
   test("git commands use expected IPC routes and payloads", async () => {
     const { client, calls } = createClient((command) => {
-      if (command === "git_get_branches" || command === "git_get_branchs") {
+      if (command === "git_get_branches") {
         return [{ name: "main", isCurrent: true, isRemote: false }];
       }
       if (command === "git_get_current_branch" || command === "git_switch_branch") {
@@ -167,7 +167,6 @@ describe("TauriHostClient", () => {
     });
 
     const branches = await client.gitGetBranches("/repo");
-    const branchs = await client.gitGetBranchs("/repo");
     const current = await client.gitGetCurrentBranch("/repo");
     const switched = await client.gitSwitchBranch("/repo", "feature/task-1", { create: true });
     const worktree = await client.gitCreateWorktree("/repo", "/tmp/wt/task-1", "feature/task-1", {
@@ -181,7 +180,6 @@ describe("TauriHostClient", () => {
     });
 
     expect(branches).toHaveLength(1);
-    expect(branchs).toHaveLength(1);
     expect(current.detached).toBe(false);
     expect(switched.name).toBe("main");
     expect(worktree.worktreePath).toBe("/tmp/wt/task-1");
@@ -190,25 +188,24 @@ describe("TauriHostClient", () => {
 
     expect(calls.map((entry) => entry.command)).toEqual([
       "git_get_branches",
-      "git_get_branchs",
       "git_get_current_branch",
       "git_switch_branch",
       "git_create_worktree",
       "git_remove_worktree",
       "git_push_branch",
     ]);
-    expect(calls[3].args).toEqual({
+    expect(calls[2].args).toEqual({
       repoPath: "/repo",
       branch: "feature/task-1",
       create: true,
     });
-    expect(calls[4].args).toEqual({
+    expect(calls[3].args).toEqual({
       repoPath: "/repo",
       worktreePath: "/tmp/wt/task-1",
       branch: "feature/task-1",
       createBranch: true,
     });
-    expect(calls[6].args).toEqual({
+    expect(calls[5].args).toEqual({
       repoPath: "/repo",
       branch: "feature/task-1",
       remote: "origin",

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -416,11 +416,6 @@ export class TauriHostClient implements PlannerTools {
     return parseArray(gitBranchSchema, payload);
   }
 
-  async gitGetBranchs(repoPath: string): Promise<GitBranch[]> {
-    const payload = await this.invokeFn<unknown>("git_get_branchs", { repoPath });
-    return parseArray(gitBranchSchema, payload);
-  }
-
   async gitGetCurrentBranch(repoPath: string): Promise<GitCurrentBranch> {
     const payload = await this.invokeFn<unknown>("git_get_current_branch", { repoPath });
     return gitCurrentBranchSchema.parse(payload);


### PR DESCRIPTION
## Summary
- remove misspelled branch API aliases (`gitGetBranchs` / `git_get_branchs`) and keep canonical branch listing names
- align Tauri command registration and TS adapter surface to the single canonical `gitGetBranches`/`git_get_branches` path
- update adapter tests and local bun test typings to validate canonical command routing only

## Validation
- bun run --workspaces typecheck
- bun run --workspaces test
- bun run --workspaces build
- cargo check
- cargo test