### PR TITLE
test(desktop): add coverage for Agent Studio orchestration hooks

### DIFF
--- a/apps/desktop/src/pages/use-agent-session-permission-actions.test.tsx
+++ b/apps/desktop/src/pages/use-agent-session-permission-actions.test.tsx
@@ -1,0 +1,187 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { AgentPermissionRequest } from "@/types/agent-orchestrator";
+import {
+  createDeferred,
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useAgentSessionPermissionActions } from "./use-agent-session-permission-actions";
+
+enableReactActEnvironment();
+
+type HookArgs = Parameters<typeof useAgentSessionPermissionActions>[0];
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentSessionPermissionActions, initialProps);
+
+const createPermissionRequest = (requestId: string): AgentPermissionRequest => ({
+  requestId,
+  permission: "shell",
+  patterns: ["*"],
+});
+
+const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
+  activeSessionId: "session-1",
+  pendingPermissions: [createPermissionRequest("req-1")],
+  agentStudioReady: true,
+  replyAgentPermission: async () => {},
+  ...overrides,
+});
+
+describe("useAgentSessionPermissionActions", () => {
+  test("does nothing when session is missing or studio is not ready", async () => {
+    const replyAgentPermission = mock(async () => {});
+    const base = createBaseArgs({ replyAgentPermission });
+    const harness = createHookHarness({ ...base, activeSessionId: null });
+
+    try {
+      await harness.mount();
+      await harness.run(async (state) => {
+        await state.onReplyPermission("req-1", "once");
+      });
+
+      await harness.update({ ...base, agentStudioReady: false });
+      await harness.run(async (state) => {
+        await state.onReplyPermission("req-1", "always");
+      });
+
+      expect(replyAgentPermission).not.toHaveBeenCalled();
+      expect(harness.getLatest().isSubmittingPermissionByRequestId).toEqual({});
+      expect(harness.getLatest().permissionReplyErrorByRequestId).toEqual({});
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("tracks submitting state while sending a permission reply", async () => {
+    const deferredReply = createDeferred<void>();
+    const replyAgentPermission = mock(async () => deferredReply.promise);
+    const harness = createHookHarness(createBaseArgs({ replyAgentPermission }));
+
+    try {
+      await harness.mount();
+
+      await harness.run((state) => {
+        void state.onReplyPermission("req-1", "once");
+      });
+
+      await harness.waitFor((state) => state.isSubmittingPermissionByRequestId["req-1"] === true);
+      expect(replyAgentPermission).toHaveBeenCalledWith("session-1", "req-1", "once");
+
+      await harness.run(async () => {
+        deferredReply.resolve(undefined);
+        await deferredReply.promise;
+      });
+
+      await harness.waitFor((state) => state.isSubmittingPermissionByRequestId["req-1"] !== true);
+      expect(harness.getLatest().permissionReplyErrorByRequestId["req-1"]).toBeUndefined();
+    } finally {
+      deferredReply.resolve(undefined);
+      await harness.unmount();
+    }
+  });
+
+  test("stores the thrown Error message when replying fails", async () => {
+    const replyAgentPermission = mock(async () => {
+      throw new Error("permission denied");
+    });
+    const harness = createHookHarness(createBaseArgs({ replyAgentPermission }));
+
+    try {
+      await harness.mount();
+      await harness.run(async (state) => {
+        await state.onReplyPermission("req-1", "reject");
+      });
+
+      expect(replyAgentPermission).toHaveBeenCalledWith("session-1", "req-1", "reject");
+      expect(harness.getLatest().permissionReplyErrorByRequestId["req-1"]).toBe(
+        "permission denied",
+      );
+      expect(harness.getLatest().isSubmittingPermissionByRequestId["req-1"]).toBeUndefined();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("uses fallback error text for non-Error failures", async () => {
+    const replyAgentPermission = mock(async () => {
+      throw { code: "E_PERMISSION" };
+    });
+    const harness = createHookHarness(createBaseArgs({ replyAgentPermission }));
+
+    try {
+      await harness.mount();
+      await harness.run(async (state) => {
+        await state.onReplyPermission("req-1", "always");
+      });
+
+      expect(harness.getLatest().permissionReplyErrorByRequestId["req-1"]).toBe(
+        "Failed to reply to permission request.",
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("prunes stale request state when pending permissions change", async () => {
+    const replyAgentPermission = mock(async () => {
+      throw new Error("stale request");
+    });
+    const baseArgs = createBaseArgs({ replyAgentPermission });
+    const harness = createHookHarness(baseArgs);
+
+    try {
+      await harness.mount();
+      await harness.run(async (state) => {
+        await state.onReplyPermission("req-1", "reject");
+      });
+      await harness.waitFor(
+        (state) => typeof state.permissionReplyErrorByRequestId["req-1"] === "string",
+      );
+
+      await harness.update({
+        ...baseArgs,
+        pendingPermissions: [createPermissionRequest("req-2")],
+      });
+
+      await harness.waitFor(
+        (state) => state.permissionReplyErrorByRequestId["req-1"] === undefined,
+      );
+      expect(harness.getLatest().permissionReplyErrorByRequestId["req-2"]).toBeUndefined();
+      expect(harness.getLatest().isSubmittingPermissionByRequestId["req-1"]).toBeUndefined();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("clears request state when the active session changes", async () => {
+    const replyAgentPermission = mock(async () => {
+      throw new Error("session-bound failure");
+    });
+    const baseArgs = createBaseArgs({ replyAgentPermission });
+    const harness = createHookHarness(baseArgs);
+
+    try {
+      await harness.mount();
+      await harness.run(async (state) => {
+        await state.onReplyPermission("req-1", "reject");
+      });
+      await harness.waitFor(
+        (state) => typeof state.permissionReplyErrorByRequestId["req-1"] === "string",
+      );
+
+      await harness.update({
+        ...baseArgs,
+        activeSessionId: "session-2",
+      });
+
+      await harness.waitFor(
+        (state) =>
+          Object.keys(state.permissionReplyErrorByRequestId).length === 0 &&
+          Object.keys(state.isSubmittingPermissionByRequestId).length === 0,
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-documents.test.tsx
@@ -1,0 +1,286 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+type DocumentSectionKey = "spec" | "plan" | "qa";
+
+type TaskDocumentPayload = {
+  markdown: string;
+  updatedAt: string | null;
+};
+
+type TaskDocumentState = {
+  markdown: string;
+  updatedAt: string | null;
+  isLoading: boolean;
+  error: string | null;
+  loaded: boolean;
+};
+
+type TaskDocumentsState = {
+  specDoc: TaskDocumentState;
+  planDoc: TaskDocumentState;
+  qaDoc: TaskDocumentState;
+};
+
+type UseTaskDocumentsReturn = TaskDocumentsState & {
+  ensureDocumentLoaded: (section: DocumentSectionKey) => boolean;
+  reloadDocument: (section: DocumentSectionKey) => boolean;
+  applyDocumentUpdate: (section: DocumentSectionKey, payload: TaskDocumentPayload) => void;
+};
+
+const createDocumentState = (overrides: Partial<TaskDocumentState> = {}): TaskDocumentState => ({
+  markdown: "",
+  updatedAt: null,
+  isLoading: false,
+  error: null,
+  loaded: true,
+  ...overrides,
+});
+
+let taskDocumentsState: TaskDocumentsState = {
+  specDoc: createDocumentState(),
+  planDoc: createDocumentState(),
+  qaDoc: createDocumentState(),
+};
+
+const ensureDocumentLoadedMock = mock((_section: DocumentSectionKey) => true);
+const reloadDocumentMock = mock((_section: DocumentSectionKey) => true);
+const applyDocumentUpdateMock = mock(
+  (_section: DocumentSectionKey, _payload: TaskDocumentPayload) => {},
+);
+
+const setTaskDocumentsState = (overrides: Partial<TaskDocumentsState> = {}): void => {
+  taskDocumentsState = {
+    specDoc: createDocumentState(),
+    planDoc: createDocumentState(),
+    qaDoc: createDocumentState(),
+    ...overrides,
+  };
+};
+
+mock.module("@/components/features/task-details/use-task-documents", () => ({
+  useTaskDocuments: (): UseTaskDocumentsReturn => ({
+    specDoc: taskDocumentsState.specDoc,
+    planDoc: taskDocumentsState.planDoc,
+    qaDoc: taskDocumentsState.qaDoc,
+    ensureDocumentLoaded: ensureDocumentLoadedMock,
+    reloadDocument: reloadDocumentMock,
+    applyDocumentUpdate: applyDocumentUpdateMock,
+  }),
+}));
+
+type UseAgentStudioDocumentsHook =
+  typeof import("./use-agent-studio-documents")["useAgentStudioDocuments"];
+
+let useAgentStudioDocuments: UseAgentStudioDocumentsHook;
+
+type HookArgs = Parameters<UseAgentStudioDocumentsHook>[0];
+type AgentMessage = ReturnType<typeof createAgentSessionFixture>["messages"][number];
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioDocuments, initialProps);
+
+const createBaseArgs = (): HookArgs => ({
+  taskId: "task-1",
+  activeSession: null,
+  selectedTask: createTaskCardFixture({ id: "task-1", updatedAt: "2026-02-22T08:00:00.000Z" }),
+});
+
+const createCompletedToolMessage = ({
+  id = "message-1",
+  tool = "odt_set_spec",
+  input,
+  output,
+  content = "",
+}: {
+  id?: string;
+  tool?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  content?: string;
+} = {}): AgentMessage => ({
+  id,
+  role: "tool",
+  content,
+  timestamp: "2026-02-22T08:10:00.000Z",
+  meta: {
+    kind: "tool",
+    partId: `part-${id}`,
+    callId: `call-${id}`,
+    tool,
+    status: "completed",
+    ...(input !== undefined ? { input } : {}),
+    ...(output !== undefined ? { output } : {}),
+  },
+});
+
+beforeAll(async () => {
+  ({ useAgentStudioDocuments } = await import("./use-agent-studio-documents"));
+});
+
+beforeEach(() => {
+  setTaskDocumentsState();
+  ensureDocumentLoadedMock.mockClear();
+  reloadDocumentMock.mockClear();
+  applyDocumentUpdateMock.mockClear();
+});
+
+describe("useAgentStudioDocuments", () => {
+  test("loads each document section and refreshes when task updatedAt changes", async () => {
+    const baseArgs = createBaseArgs();
+    const harness = createHookHarness(baseArgs);
+
+    try {
+      await harness.mount();
+
+      expect(ensureDocumentLoadedMock).toHaveBeenCalledTimes(3);
+      expect(ensureDocumentLoadedMock).toHaveBeenNthCalledWith(1, "spec");
+      expect(ensureDocumentLoadedMock).toHaveBeenNthCalledWith(2, "plan");
+      expect(ensureDocumentLoadedMock).toHaveBeenNthCalledWith(3, "qa");
+
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(3);
+      expect(reloadDocumentMock).toHaveBeenNthCalledWith(1, "spec");
+      expect(reloadDocumentMock).toHaveBeenNthCalledWith(2, "plan");
+      expect(reloadDocumentMock).toHaveBeenNthCalledWith(3, "qa");
+
+      await harness.update({
+        ...baseArgs,
+        selectedTask: createTaskCardFixture({
+          id: "task-1",
+          updatedAt: "2026-02-22T08:00:00.000Z",
+        }),
+      });
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(3);
+
+      await harness.update({
+        ...baseArgs,
+        selectedTask: createTaskCardFixture({
+          id: "task-1",
+          updatedAt: "2026-02-22T08:30:00.000Z",
+        }),
+      });
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(6);
+      expect(reloadDocumentMock).toHaveBeenNthCalledWith(4, "spec");
+      expect(reloadDocumentMock).toHaveBeenNthCalledWith(5, "plan");
+      expect(reloadDocumentMock).toHaveBeenNthCalledWith(6, "qa");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("applies optimistic updates from completed workflow tool messages", async () => {
+    setTaskDocumentsState({
+      specDoc: createDocumentState({
+        markdown: "# Old spec",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+      }),
+    });
+
+    const activeSession = createAgentSessionFixture({
+      sessionId: "session-1",
+      messages: [
+        createCompletedToolMessage({
+          tool: "odt_set_spec",
+          input: { markdown: "# Updated spec" },
+          output: "completed 2026-02-22T09:00:00.000Z",
+        }),
+      ],
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      selectedTask: null,
+      activeSession,
+    });
+
+    try {
+      await harness.mount();
+
+      expect(applyDocumentUpdateMock).toHaveBeenCalledTimes(1);
+      expect(applyDocumentUpdateMock).toHaveBeenCalledWith("spec", {
+        markdown: "# Updated spec",
+        updatedAt: "2026-02-22T09:00:00.000Z",
+      });
+      expect(reloadDocumentMock).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("reloads section when completion timestamp is unavailable", async () => {
+    setTaskDocumentsState({
+      planDoc: createDocumentState({ markdown: "", updatedAt: null, isLoading: false }),
+    });
+
+    const activeSession = createAgentSessionFixture({
+      sessionId: "session-2",
+      messages: [createCompletedToolMessage({ tool: "odt_set_plan", input: {}, output: "done" })],
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      selectedTask: null,
+      activeSession,
+    });
+
+    try {
+      await harness.mount();
+      expect(applyDocumentUpdateMock).not.toHaveBeenCalled();
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
+      expect(reloadDocumentMock).toHaveBeenCalledWith("plan");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("resets processed tool-event context when switching sessions", async () => {
+    setTaskDocumentsState({
+      specDoc: createDocumentState({
+        markdown: "# Old spec",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+      }),
+    });
+
+    const toolMessage = createCompletedToolMessage({
+      id: "shared-message-id",
+      tool: "odt_set_spec",
+      input: { markdown: "# Session update" },
+      output: "completed 2026-02-22T08:45:00.000Z",
+    });
+
+    const baseArgs = createBaseArgs();
+    const harness = createHookHarness({
+      ...baseArgs,
+      selectedTask: null,
+      activeSession: createAgentSessionFixture({
+        sessionId: "session-A",
+        messages: [toolMessage],
+      }),
+    });
+
+    try {
+      await harness.mount();
+      expect(applyDocumentUpdateMock).toHaveBeenCalledTimes(1);
+
+      await harness.update({
+        ...baseArgs,
+        selectedTask: null,
+        activeSession: createAgentSessionFixture({
+          sessionId: "session-B",
+          messages: [toolMessage],
+        }),
+      });
+
+      expect(applyDocumentUpdateMock).toHaveBeenCalledTimes(2);
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-task-hydration.test.tsx
@@ -110,23 +110,33 @@ describe("useAgentStudioTaskHydration", () => {
 
   test("marks a task hydrated even when loading sessions rejects", async () => {
     const deferred = createDeferred<void>();
-    const loadAgentSessions = mock(async () => {
-      try {
-        await deferred.promise;
-      } catch {}
+    const loadError = new Error("load failed");
+    const loadAgentSessions = mock(() => {
+      const promise = deferred.promise;
+      const originalFinally = promise.finally.bind(promise);
+      promise.finally = ((onFinally) => {
+        const finalPromise = originalFinally(onFinally);
+        void finalPromise.catch(() => undefined);
+        return finalPromise;
+      }) as Promise<void>["finally"];
+      return promise;
     });
 
     const harness = createHookHarness(createBaseArgs({ loadAgentSessions }));
 
     try {
       await harness.mount();
+      const rejectionCapture = deferred.promise.then(
+        () => null,
+        (error: unknown) => error,
+      );
 
-      await harness.run(async () => {
-        deferred.reject(new Error("load failed"));
-        try {
-          await deferred.promise;
-        } catch {}
+      await harness.run(() => {
+        deferred.reject(loadError);
       });
+
+      const capturedError = await rejectionCapture;
+      expect(capturedError).toBe(loadError);
 
       await harness.waitFor((state) => state["/repo-a:task-1"] === true);
       expect(loadAgentSessions).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/pages/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-task-hydration.test.tsx
@@ -1,0 +1,175 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  createDeferred,
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useAgentStudioTaskHydration } from "./use-agent-studio-task-hydration";
+
+enableReactActEnvironment();
+
+type HookArgs = Parameters<typeof useAgentStudioTaskHydration>[0];
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioTaskHydration, initialProps);
+
+const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
+  activeRepo: "/repo-a",
+  activeTaskId: "task-1",
+  tabTaskIds: [],
+  loadAgentSessions: async () => {},
+  ...overrides,
+});
+
+describe("useAgentStudioTaskHydration", () => {
+  test("hydrates the active task once and marks it hydrated", async () => {
+    const deferred = createDeferred<void>();
+    const loadAgentSessions = mock((taskId: string) => {
+      if (taskId !== "task-1") {
+        return Promise.resolve();
+      }
+      return deferred.promise;
+    });
+
+    const args = createBaseArgs({ loadAgentSessions });
+    const harness = createHookHarness(args);
+
+    try {
+      await harness.mount();
+
+      expect(loadAgentSessions).toHaveBeenCalledTimes(1);
+      expect(loadAgentSessions).toHaveBeenCalledWith("task-1");
+      expect(harness.getLatest()["/repo-a:task-1"]).toBeUndefined();
+
+      await harness.run(async () => {
+        deferred.resolve(undefined);
+        await deferred.promise;
+      });
+
+      await harness.waitFor((state) => state["/repo-a:task-1"] === true);
+
+      await harness.update(args);
+      expect(loadAgentSessions).toHaveBeenCalledTimes(1);
+    } finally {
+      deferred.resolve(undefined);
+      await harness.unmount();
+    }
+  });
+
+  test("hydrates tab tasks in the background and skips duplicates/active task", async () => {
+    const deferredByTask = new Map<string, ReturnType<typeof createDeferred<void>>>([
+      ["task-1", createDeferred<void>()],
+      ["task-2", createDeferred<void>()],
+      ["task-3", createDeferred<void>()],
+    ]);
+    const loadAgentSessions = mock((taskId: string) => {
+      const deferred = deferredByTask.get(taskId);
+      if (!deferred) {
+        return Promise.resolve();
+      }
+      return deferred.promise;
+    });
+
+    const args = createBaseArgs({
+      tabTaskIds: ["task-1", "task-2", "task-3", "task-2"],
+      loadAgentSessions,
+    });
+    const harness = createHookHarness(args);
+
+    try {
+      await harness.mount();
+
+      expect(loadAgentSessions).toHaveBeenCalledTimes(3);
+      expect(loadAgentSessions).toHaveBeenCalledWith("task-1");
+      expect(loadAgentSessions).toHaveBeenCalledWith("task-2");
+      expect(loadAgentSessions).toHaveBeenCalledWith("task-3");
+
+      await harness.update(args);
+      expect(loadAgentSessions).toHaveBeenCalledTimes(3);
+
+      await harness.run(async () => {
+        deferredByTask.get("task-1")?.resolve(undefined);
+        deferredByTask.get("task-2")?.resolve(undefined);
+        deferredByTask.get("task-3")?.resolve(undefined);
+        await Promise.all([...deferredByTask.values()].map((entry) => entry.promise));
+      });
+
+      await harness.waitFor(
+        (state) =>
+          state["/repo-a:task-1"] === true &&
+          state["/repo-a:task-2"] === true &&
+          state["/repo-a:task-3"] === true,
+      );
+    } finally {
+      for (const deferred of deferredByTask.values()) {
+        deferred.resolve(undefined);
+      }
+      await harness.unmount();
+    }
+  });
+
+  test("marks a task hydrated even when loading sessions rejects", async () => {
+    const deferred = createDeferred<void>();
+    const loadAgentSessions = mock(async () => {
+      try {
+        await deferred.promise;
+      } catch {}
+    });
+
+    const harness = createHookHarness(createBaseArgs({ loadAgentSessions }));
+
+    try {
+      await harness.mount();
+
+      await harness.run(async () => {
+        deferred.reject(new Error("load failed"));
+        try {
+          await deferred.promise;
+        } catch {}
+      });
+
+      await harness.waitFor((state) => state["/repo-a:task-1"] === true);
+      expect(loadAgentSessions).toHaveBeenCalledTimes(1);
+    } finally {
+      deferred.resolve(undefined);
+      await harness.unmount();
+    }
+  });
+
+  test("clears hydration cache when repo changes and requests hydration again", async () => {
+    const firstLoad = createDeferred<void>();
+    const secondLoad = createDeferred<void>();
+    let loadCount = 0;
+    const loadAgentSessions = mock(() => {
+      loadCount += 1;
+      return loadCount === 1 ? firstLoad.promise : secondLoad.promise;
+    });
+    const harness = createHookHarness(createBaseArgs({ loadAgentSessions }));
+
+    try {
+      await harness.mount();
+
+      await harness.run(async () => {
+        firstLoad.resolve(undefined);
+        await firstLoad.promise;
+      });
+      await harness.waitFor((state) => state["/repo-a:task-1"] === true);
+
+      await harness.update(
+        createBaseArgs({
+          activeRepo: "/repo-b",
+          activeTaskId: "task-1",
+          tabTaskIds: [],
+          loadAgentSessions,
+        }),
+      );
+
+      await harness.waitFor((state) => state["/repo-a:task-1"] === undefined);
+      expect(loadAgentSessions).toHaveBeenCalledTimes(2);
+    } finally {
+      firstLoad.resolve(undefined);
+      secondLoad.resolve(undefined);
+      await harness.unmount();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add direct tests for Agent Studio orchestration hooks that are role/session/permission sensitive
- cover document update orchestration, task hydration transitions, and permission reply state/error flows
- protect deep-link and session-context behavior with targeted edge-case assertions and regression paths

## Testing
- bun test "src/pages/use-agent-studio-documents.test.tsx" "src/pages/use-agent-studio-task-hydration.test.tsx" "src/pages/use-agent-session-permission-actions.test.tsx"
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test