### PR TITLE
fix(desktop): remove panic-prone Tauri bootstrap expects

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/execution.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/execution.rs
@@ -61,6 +61,7 @@ impl BeadsTaskStore {
 
     pub(crate) fn show_task(&self, repo_path: &Path, task_id: &str) -> Result<TaskCard> {
         let raw = self.show_raw_issue(repo_path, task_id)?;
-        self.parse_task_card(raw)
+        let metadata_namespace = self.current_metadata_namespace();
+        self.parse_task_card(raw, &metadata_namespace)
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata_ops.rs
@@ -25,12 +25,13 @@ impl BeadsTaskStore {
         &self,
         repo_path: &Path,
         task_id: &str,
-    ) -> Result<(RawIssue, Map<String, Value>, Map<String, Value>)> {
+    ) -> Result<(RawIssue, Map<String, Value>, String, Map<String, Value>)> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let mut root = parse_metadata_root(issue.metadata.clone());
+        let namespace_key = self.current_metadata_namespace();
 
         let namespace = root
-            .entry(self.metadata_namespace.clone())
+            .entry(namespace_key.clone())
             .or_insert_with(|| Value::Object(Map::new()));
         if !namespace.is_object() {
             *namespace = Value::Object(Map::new());
@@ -41,20 +42,18 @@ impl BeadsTaskStore {
             .cloned()
             .ok_or_else(|| anyhow!("Invalid metadata namespace payload"))?;
 
-        Ok((issue, root, namespace_map))
+        Ok((issue, root, namespace_key, namespace_map))
     }
 
     pub(crate) fn persist_namespace(
         &self,
         repo_path: &Path,
         task_id: &str,
+        namespace_key: &str,
         root: &mut Map<String, Value>,
         namespace_map: Map<String, Value>,
     ) -> Result<()> {
-        root.insert(
-            self.metadata_namespace.clone(),
-            Value::Object(namespace_map),
-        );
+        root.insert(namespace_key.to_string(), Value::Object(namespace_map));
         self.write_metadata(repo_path, task_id, root)
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/parsing.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/parsing.rs
@@ -9,12 +9,16 @@ use crate::normalize::{default_ai_review_enabled, normalize_issue_type, normaliz
 use crate::store::BeadsTaskStore;
 
 impl BeadsTaskStore {
-    pub(crate) fn parse_task_card(&self, issue: RawIssue) -> Result<TaskCard> {
+    pub(crate) fn parse_task_card(
+        &self,
+        issue: RawIssue,
+        metadata_namespace_key: &str,
+    ) -> Result<TaskCard> {
         let status = TaskStatus::from_cli_value(&issue.status)
             .ok_or_else(|| anyhow!("Unknown task status from bd: {}", issue.status))?;
 
         let metadata_root = parse_metadata_root(issue.metadata);
-        let namespace = metadata_namespace(&metadata_root, &self.metadata_namespace);
+        let namespace = metadata_namespace(&metadata_root, metadata_namespace_key);
         let ai_review_enabled = namespace
             .and_then(metadata_bool_qa_required)
             .unwrap_or_else(|| default_ai_review_enabled(&issue.issue_type));

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -3,7 +3,7 @@ use host_domain::{
     now_rfc3339, AgentSessionDocument, CreateTaskInput, QaReportDocument, QaVerdict, SpecDocument,
     TaskCard, TaskStore, UpdateTaskPatch,
 };
-use host_infra_system::{compute_repo_slug, resolve_central_beads_dir};
+use host_infra_system::{compute_repo_slug, resolve_central_beads_dir, AppConfigStore};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -19,9 +19,12 @@ use crate::metadata::{
 use crate::model::{MarkdownEntry, QaEntry, RawIssue};
 use crate::normalize::{normalize_labels, normalize_text_option};
 
+type MetadataNamespaceResolver = Arc<dyn Fn() -> Result<String> + Send + Sync>;
+
 pub struct BeadsTaskStore {
     pub(crate) command_runner: Arc<dyn CommandRunner>,
-    pub(crate) metadata_namespace: String,
+    pub(crate) metadata_namespace: Mutex<String>,
+    pub(crate) metadata_namespace_resolver: Option<MetadataNamespaceResolver>,
     pub(crate) init_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
     pub(crate) initialized_repos: Mutex<HashSet<String>>,
 }
@@ -29,7 +32,11 @@ pub struct BeadsTaskStore {
 impl fmt::Debug for BeadsTaskStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BeadsTaskStore")
-            .field("metadata_namespace", &self.metadata_namespace)
+            .field("metadata_namespace", &self.metadata_namespace_snapshot())
+            .field(
+                "has_metadata_namespace_resolver",
+                &self.metadata_namespace_resolver.is_some(),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -45,27 +52,27 @@ impl BeadsTaskStore {
         Self::with_metadata_namespace_and_runner(
             DEFAULT_METADATA_NAMESPACE,
             Arc::new(ProcessCommandRunner),
+            Some(Self::default_metadata_namespace_resolver()),
         )
     }
 
     pub fn with_metadata_namespace(namespace: &str) -> Self {
-        Self::with_metadata_namespace_and_runner(namespace, Arc::new(ProcessCommandRunner))
+        Self::with_metadata_namespace_and_runner(
+            namespace,
+            Arc::new(ProcessCommandRunner),
+            Some(Self::default_metadata_namespace_resolver()),
+        )
     }
 
     fn with_metadata_namespace_and_runner(
         namespace: &str,
         command_runner: Arc<dyn CommandRunner>,
+        metadata_namespace_resolver: Option<MetadataNamespaceResolver>,
     ) -> Self {
-        let trimmed = namespace.trim();
-        let metadata_namespace = if trimmed.is_empty() {
-            DEFAULT_METADATA_NAMESPACE.to_string()
-        } else {
-            trimmed.to_string()
-        };
-
         Self {
             command_runner,
-            metadata_namespace,
+            metadata_namespace: Mutex::new(Self::normalize_metadata_namespace(namespace)),
+            metadata_namespace_resolver,
             init_locks: Mutex::new(HashMap::new()),
             initialized_repos: Mutex::new(HashSet::new()),
         }
@@ -76,7 +83,71 @@ impl BeadsTaskStore {
         namespace: &str,
         command_runner: Arc<dyn CommandRunner>,
     ) -> Self {
-        Self::with_metadata_namespace_and_runner(namespace, command_runner)
+        Self::with_metadata_namespace_and_runner(namespace, command_runner, None)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_test_runner_and_namespace_resolver(
+        namespace: &str,
+        command_runner: Arc<dyn CommandRunner>,
+        metadata_namespace_resolver: Arc<dyn Fn() -> Result<String> + Send + Sync>,
+    ) -> Self {
+        Self::with_metadata_namespace_and_runner(
+            namespace,
+            command_runner,
+            Some(metadata_namespace_resolver),
+        )
+    }
+
+    fn default_metadata_namespace_resolver() -> MetadataNamespaceResolver {
+        Arc::new(|| {
+            let config_store = AppConfigStore::new()?;
+            config_store.task_metadata_namespace()
+        })
+    }
+
+    fn normalize_metadata_namespace(namespace: &str) -> String {
+        let trimmed = namespace.trim();
+        if trimmed.is_empty() {
+            DEFAULT_METADATA_NAMESPACE.to_string()
+        } else {
+            trimmed.to_string()
+        }
+    }
+
+    fn metadata_namespace_snapshot(&self) -> String {
+        match self.metadata_namespace.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+
+    fn set_metadata_namespace(&self, namespace: &str) {
+        let normalized = Self::normalize_metadata_namespace(namespace);
+        match self.metadata_namespace.lock() {
+            Ok(mut guard) => *guard = normalized,
+            Err(poisoned) => {
+                let mut guard = poisoned.into_inner();
+                *guard = normalized;
+            }
+        }
+    }
+
+    fn refresh_metadata_namespace(&self) {
+        let Some(resolve_namespace) = &self.metadata_namespace_resolver else {
+            return;
+        };
+
+        let Ok(namespace) = resolve_namespace() else {
+            return;
+        };
+
+        self.set_metadata_namespace(&namespace);
+    }
+
+    pub(crate) fn current_metadata_namespace(&self) -> String {
+        self.refresh_metadata_namespace();
+        self.metadata_namespace_snapshot()
     }
 }
 
@@ -144,6 +215,7 @@ impl TaskStore for BeadsTaskStore {
 
     fn list_tasks(&self, repo_path: &Path) -> Result<Vec<TaskCard>> {
         let value = self.run_bd_json(repo_path, &["list", "--all", "--limit", "0"])?;
+        let metadata_namespace = self.current_metadata_namespace();
 
         let mut tasks = value
             .as_array()
@@ -152,7 +224,7 @@ impl TaskStore for BeadsTaskStore {
             .map(|entry| {
                 let issue: RawIssue = serde_json::from_value(entry.clone())
                     .context("Failed to decode task from bd list")?;
-                self.parse_task_card(issue)
+                self.parse_task_card(issue, &metadata_namespace)
             })
             .collect::<Result<Vec<TaskCard>>>()?;
 
@@ -218,7 +290,8 @@ impl TaskStore for BeadsTaskStore {
         let created_id = raw.id.clone();
 
         let mut metadata_root = parse_metadata_root(raw.metadata);
-        let mut namespace_map = metadata_namespace(&metadata_root, &self.metadata_namespace)
+        let namespace_key = self.current_metadata_namespace();
+        let mut namespace_map = metadata_namespace(&metadata_root, &namespace_key)
             .cloned()
             .unwrap_or_default();
 
@@ -227,7 +300,13 @@ impl TaskStore for BeadsTaskStore {
             Value::Bool(input.ai_review_enabled.unwrap_or(true)),
         );
 
-        self.persist_namespace(repo_path, &created_id, &mut metadata_root, namespace_map)?;
+        self.persist_namespace(
+            repo_path,
+            &created_id,
+            &namespace_key,
+            &mut metadata_root,
+            namespace_map,
+        )?;
 
         self.show_task(repo_path, &created_id)
     }
@@ -298,9 +377,10 @@ impl TaskStore for BeadsTaskStore {
         }
 
         if let Some(ai_review_enabled) = patch.ai_review_enabled {
-            let (_issue, mut root, mut namespace_map) = self.load_namespace(repo_path, task_id)?;
+            let (_issue, mut root, namespace_key, mut namespace_map) =
+                self.load_namespace(repo_path, task_id)?;
             namespace_map.insert("qaRequired".to_string(), Value::Bool(ai_review_enabled));
-            self.persist_namespace(repo_path, task_id, &mut root, namespace_map)?;
+            self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
         }
 
         self.show_task(repo_path, task_id)
@@ -321,7 +401,8 @@ impl TaskStore for BeadsTaskStore {
     fn get_spec(&self, repo_path: &Path, task_id: &str) -> Result<SpecDocument> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata.clone());
-        let entries = metadata_namespace(&metadata_root, &self.metadata_namespace)
+        let namespace_key = self.current_metadata_namespace();
+        let entries = metadata_namespace(&metadata_root, &namespace_key)
             .and_then(|ns| ns.get("documents"))
             .and_then(|docs| docs.get("spec"))
             .and_then(parse_markdown_entries);
@@ -336,7 +417,8 @@ impl TaskStore for BeadsTaskStore {
     }
 
     fn set_spec(&self, repo_path: &Path, task_id: &str, markdown: &str) -> Result<SpecDocument> {
-        let (_issue, mut root, mut namespace_map) = self.load_namespace(repo_path, task_id)?;
+        let (_issue, mut root, namespace_key, mut namespace_map) =
+            self.load_namespace(repo_path, task_id)?;
         let mut documents_map = namespace_map
             .get("documents")
             .and_then(Value::as_object)
@@ -364,7 +446,7 @@ impl TaskStore for BeadsTaskStore {
         );
         namespace_map.insert("documents".to_string(), Value::Object(documents_map));
 
-        self.persist_namespace(repo_path, task_id, &mut root, namespace_map)?;
+        self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
 
         Ok(SpecDocument {
             markdown: entry.markdown,
@@ -375,7 +457,8 @@ impl TaskStore for BeadsTaskStore {
     fn get_plan(&self, repo_path: &Path, task_id: &str) -> Result<SpecDocument> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata.clone());
-        let entries = metadata_namespace(&metadata_root, &self.metadata_namespace)
+        let namespace_key = self.current_metadata_namespace();
+        let entries = metadata_namespace(&metadata_root, &namespace_key)
             .and_then(|ns| ns.get("documents"))
             .and_then(|docs| docs.get("implementationPlan"))
             .and_then(parse_markdown_entries);
@@ -390,7 +473,8 @@ impl TaskStore for BeadsTaskStore {
     }
 
     fn set_plan(&self, repo_path: &Path, task_id: &str, markdown: &str) -> Result<SpecDocument> {
-        let (_issue, mut root, mut namespace_map) = self.load_namespace(repo_path, task_id)?;
+        let (_issue, mut root, namespace_key, mut namespace_map) =
+            self.load_namespace(repo_path, task_id)?;
         let mut documents_map = namespace_map
             .get("documents")
             .and_then(Value::as_object)
@@ -418,7 +502,7 @@ impl TaskStore for BeadsTaskStore {
         );
         namespace_map.insert("documents".to_string(), Value::Object(documents_map));
 
-        self.persist_namespace(repo_path, task_id, &mut root, namespace_map)?;
+        self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
 
         Ok(SpecDocument {
             markdown: entry.markdown,
@@ -433,7 +517,8 @@ impl TaskStore for BeadsTaskStore {
     ) -> Result<Option<QaReportDocument>> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata);
-        let namespace = metadata_namespace(&metadata_root, &self.metadata_namespace);
+        let namespace_key = self.current_metadata_namespace();
+        let namespace = metadata_namespace(&metadata_root, &namespace_key);
         let Some(entries) = namespace
             .and_then(|ns| ns.get("documents"))
             .and_then(|docs| docs.get("qaReports"))
@@ -457,7 +542,8 @@ impl TaskStore for BeadsTaskStore {
         markdown: &str,
         verdict: QaVerdict,
     ) -> Result<QaReportDocument> {
-        let (_issue, mut root, mut namespace_map) = self.load_namespace(repo_path, task_id)?;
+        let (_issue, mut root, namespace_key, mut namespace_map) =
+            self.load_namespace(repo_path, task_id)?;
         let mut documents_map = namespace_map
             .get("documents")
             .and_then(Value::as_object)
@@ -495,7 +581,7 @@ impl TaskStore for BeadsTaskStore {
         );
         namespace_map.insert("documents".to_string(), Value::Object(documents_map));
 
-        self.persist_namespace(repo_path, task_id, &mut root, namespace_map)?;
+        self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
         Ok(QaReportDocument {
             markdown: entry.markdown,
             verdict: entry.verdict,
@@ -511,7 +597,8 @@ impl TaskStore for BeadsTaskStore {
     ) -> Result<Vec<AgentSessionDocument>> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata);
-        let mut entries = metadata_namespace(&metadata_root, &self.metadata_namespace)
+        let namespace_key = self.current_metadata_namespace();
+        let mut entries = metadata_namespace(&metadata_root, &namespace_key)
             .and_then(|ns| ns.get("agentSessions"))
             .and_then(parse_agent_sessions)
             .unwrap_or_default();
@@ -526,7 +613,8 @@ impl TaskStore for BeadsTaskStore {
         task_id: &str,
         session: AgentSessionDocument,
     ) -> Result<()> {
-        let (_issue, mut root, mut namespace_map) = self.load_namespace(repo_path, task_id)?;
+        let (_issue, mut root, namespace_key, mut namespace_map) =
+            self.load_namespace(repo_path, task_id)?;
         let mut sessions = namespace_map
             .get("agentSessions")
             .and_then(parse_agent_sessions)
@@ -554,7 +642,7 @@ impl TaskStore for BeadsTaskStore {
             ),
         );
 
-        self.persist_namespace(repo_path, task_id, &mut root, namespace_map)?;
+        self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
         Ok(())
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1016,6 +1016,54 @@ fn set_spec_trims_markdown_and_increments_revision() -> Result<()> {
 }
 
 #[test]
+fn set_spec_switches_namespace_after_config_recovers() -> Result<()> {
+    let repo = RepoFixture::new("set-spec-namespace-resync");
+    let current = issue_value("task-1", "open", "task", None, json!([]), None);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([current.clone()]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+        MockStep::WithEnv(Ok(json!([current]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+    ]);
+
+    let namespace_results = Arc::new(Mutex::new(VecDeque::from(vec![
+        Err(anyhow!("config temporarily unreadable")),
+        Ok("custom-ns".to_string()),
+    ])));
+    let namespace_results_for_resolver = Arc::clone(&namespace_results);
+    let resolver: Arc<dyn Fn() -> Result<String> + Send + Sync> = Arc::new(move || {
+        let mut guard = namespace_results_for_resolver
+            .lock()
+            .map_err(|_| anyhow!("namespace resolver lock poisoned"))?;
+        guard
+            .pop_front()
+            .unwrap_or_else(|| Ok("custom-ns".to_string()))
+    });
+
+    let store = BeadsTaskStore::with_test_runner_and_namespace_resolver(
+        "openducktor",
+        runner.clone(),
+        resolver,
+    );
+
+    store.set_spec(repo.path(), "task-1", "First write")?;
+    store.set_spec(repo.path(), "task-1", "Second write")?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 4);
+
+    let first_metadata_root = metadata_from_call(&calls[1]);
+    assert!(first_metadata_root.get("openducktor").is_some());
+    assert!(first_metadata_root.get("custom-ns").is_none());
+
+    let second_metadata_root = metadata_from_call(&calls[3]);
+    assert!(second_metadata_root.get("custom-ns").is_some());
+    assert!(second_metadata_root.get("openducktor").is_none());
+
+    Ok(())
+}
+
+#[test]
 fn get_and_set_plan_use_implementation_plan_metadata() -> Result<()> {
     let repo = RepoFixture::new("plan-docs");
     let current_with_plan = issue_value(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use host_application::{AppService, RunEmitter};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, PlanSubtaskInput, RunEvent,
@@ -11,7 +12,10 @@ use tauri::{AppHandle, Emitter, RunEvent as TauriRunEvent, State};
 
 struct AppState {
     service: Arc<AppService>,
+    startup_errors: Vec<String>,
 }
+
+const FALLBACK_TASK_METADATA_NAMESPACE: &str = "openducktor";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -89,7 +93,9 @@ async fn system_check(
 
 #[tauri::command]
 async fn runtime_check(state: State<'_, AppState>) -> Result<host_domain::RuntimeCheck, String> {
-    as_error(state.service.runtime_check())
+    let mut check = as_error(state.service.runtime_check())?;
+    check.errors.extend(state.startup_errors.iter().cloned());
+    Ok(check)
 }
 
 #[tauri::command]
@@ -669,19 +675,39 @@ async fn agent_session_upsert(
     )
 }
 
-pub fn run() {
-    let config_store = AppConfigStore::new().expect("failed to initialize config store");
-    let metadata_namespace = config_store
-        .task_metadata_namespace()
-        .expect("failed to read task metadata namespace from config");
+fn bootstrap_service() -> anyhow::Result<(Arc<AppService>, Vec<String>)> {
+    let config_store = AppConfigStore::new().context("failed to initialize config store")?;
+    let mut startup_errors = Vec::new();
+    let metadata_namespace = match config_store.task_metadata_namespace() {
+        Ok(namespace) => namespace,
+        Err(error) => {
+            let message = format!(
+                "Failed to read task metadata namespace from config; using fallback namespace '{}': {error:#}",
+                FALLBACK_TASK_METADATA_NAMESPACE
+            );
+            eprintln!("OpenDucktor startup warning: {message}");
+            startup_errors.push(message);
+            FALLBACK_TASK_METADATA_NAMESPACE.to_string()
+        }
+    };
+
     let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(&metadata_namespace));
     let service = Arc::new(AppService::new(task_store, config_store));
+
+    Ok((service, startup_errors))
+}
+
+pub fn run() -> anyhow::Result<()> {
+    let (service, startup_errors) = bootstrap_service()?;
 
     let app_service = service.clone();
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
-        .manage(AppState { service })
+        .manage(AppState {
+            service,
+            startup_errors,
+        })
         .invoke_handler(tauri::generate_handler![
             system_check,
             runtime_check,
@@ -732,7 +758,7 @@ pub fn run() {
             agent_session_upsert
         ])
         .build(tauri::generate_context!())
-        .expect("error while building openducktor")
+        .context("error while building openducktor")?
         .run(move |_handle, event| {
             if matches!(
                 event,
@@ -741,4 +767,6 @@ pub fn run() {
                 let _ = app_service.shutdown();
             }
         });
+
+    Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -77,6 +77,29 @@ fn as_error<T>(result: anyhow::Result<T>) -> Result<T, String> {
     result.map_err(|error| format!("{error:#}"))
 }
 
+fn extend_runtime_errors_with_startup(
+    mut check: host_domain::RuntimeCheck,
+    startup_errors: &[String],
+) -> host_domain::RuntimeCheck {
+    check.errors.extend(startup_errors.iter().cloned());
+    check
+}
+
+fn namespace_with_startup_warning(
+    namespace_result: anyhow::Result<String>,
+) -> (String, Option<String>) {
+    match namespace_result {
+        Ok(namespace) => (namespace, None),
+        Err(error) => (
+            FALLBACK_TASK_METADATA_NAMESPACE.to_string(),
+            Some(format!(
+                "Failed to read task metadata namespace from config; using fallback namespace '{}': {error:#}",
+                FALLBACK_TASK_METADATA_NAMESPACE
+            )),
+        ),
+    }
+}
+
 fn run_emitter(app: AppHandle) -> RunEmitter {
     Arc::new(move |event: RunEvent| {
         let _ = app.emit("openducktor://run-event", event);
@@ -93,9 +116,11 @@ async fn system_check(
 
 #[tauri::command]
 async fn runtime_check(state: State<'_, AppState>) -> Result<host_domain::RuntimeCheck, String> {
-    let mut check = as_error(state.service.runtime_check())?;
-    check.errors.extend(state.startup_errors.iter().cloned());
-    Ok(check)
+    let check = as_error(state.service.runtime_check())?;
+    Ok(extend_runtime_errors_with_startup(
+        check,
+        &state.startup_errors,
+    ))
 }
 
 #[tauri::command]
@@ -678,18 +703,12 @@ async fn agent_session_upsert(
 fn bootstrap_service() -> anyhow::Result<(Arc<AppService>, Vec<String>)> {
     let config_store = AppConfigStore::new().context("failed to initialize config store")?;
     let mut startup_errors = Vec::new();
-    let metadata_namespace = match config_store.task_metadata_namespace() {
-        Ok(namespace) => namespace,
-        Err(error) => {
-            let message = format!(
-                "Failed to read task metadata namespace from config; using fallback namespace '{}': {error:#}",
-                FALLBACK_TASK_METADATA_NAMESPACE
-            );
-            eprintln!("OpenDucktor startup warning: {message}");
-            startup_errors.push(message);
-            FALLBACK_TASK_METADATA_NAMESPACE.to_string()
-        }
-    };
+    let (metadata_namespace, startup_warning) =
+        namespace_with_startup_warning(config_store.task_metadata_namespace());
+    if let Some(message) = startup_warning {
+        eprintln!("OpenDucktor startup warning: {message}");
+        startup_errors.push(message);
+    }
 
     let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(&metadata_namespace));
     let service = Arc::new(AppService::new(task_store, config_store));
@@ -769,4 +788,57 @@ pub fn run() -> anyhow::Result<()> {
         });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+    use host_domain::RuntimeCheck;
+
+    #[test]
+    fn namespace_with_startup_warning_uses_configured_namespace() {
+        let (namespace, warning) =
+            namespace_with_startup_warning(Ok("custom-namespace".to_string()));
+
+        assert_eq!(namespace, "custom-namespace");
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn namespace_with_startup_warning_falls_back_and_reports_error_context() {
+        let (namespace, warning) =
+            namespace_with_startup_warning(Err(anyhow!("config parse failure")));
+
+        assert_eq!(namespace, FALLBACK_TASK_METADATA_NAMESPACE);
+
+        let warning = warning.expect("expected startup warning for fallback namespace");
+        assert!(
+            warning.contains("using fallback namespace 'openducktor'"),
+            "warning should mention fallback namespace: {warning}"
+        );
+        assert!(
+            warning.contains("config parse failure"),
+            "warning should include original error context: {warning}"
+        );
+    }
+
+    #[test]
+    fn extend_runtime_errors_with_startup_appends_startup_messages() {
+        let runtime = RuntimeCheck {
+            git_ok: true,
+            git_version: Some("git version 2.0.0".to_string()),
+            opencode_ok: true,
+            opencode_version: Some("1.0.0".to_string()),
+            errors: vec!["runtime issue".to_string()],
+        };
+
+        let startup_errors = vec!["startup warning".to_string()];
+        let updated = extend_runtime_errors_with_startup(runtime, &startup_errors);
+
+        assert_eq!(
+            updated.errors,
+            vec!["runtime issue".to_string(), "startup warning".to_string()]
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1,3 +1,6 @@
 fn main() {
-    openducktor_desktop_lib::run();
+    if let Err(error) = openducktor_desktop_lib::run() {
+        eprintln!("OpenDucktor failed to start: {error:#}");
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
## Summary
- replace panic-prone startup `expect(...)` calls in Tauri bootstrap with contextual `Result` propagation
- add fallback handling for metadata namespace initialization and surface startup warnings through `runtime_check.errors` for diagnostics visibility
- add regression tests around namespace fallback warning generation and startup warning propagation into runtime diagnostics

## Verification
- `cd apps/desktop/src-tauri && cargo check && cargo test`
- `bun run typecheck && bun run test`