### PR TITLE
fix(desktop): improve agent orchestrator async failure visibility

### DIFF
--- a/apps/desktop/src/pages/use-agent-studio-session-actions.ts
+++ b/apps/desktop/src/pages/use-agent-studio-session-actions.ts
@@ -3,6 +3,10 @@ import type { AgentModelSelection, AgentRole, AgentScenario } from "@openducktor
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentStateContextValue } from "@/types/state-slices";
+import {
+  captureOrchestratorFallback,
+  runOrchestratorSideEffect,
+} from "../state/operations/agent-orchestrator/support/async-side-effects";
 import { firstScenario, kickoffPromptForScenario, SCENARIO_LABELS } from "./agents-page-constants";
 import { buildRoleEnabledMapForTask, type SessionCreateOption } from "./agents-page-session-tabs";
 
@@ -419,13 +423,29 @@ export function useAgentStudioSessionActions({
       const startPromise = (async (): Promise<string | undefined> => {
         try {
           setIsStarting(true);
-          const sessionId = await startAgentSession({
-            taskId,
-            role: nextRole,
-            scenario: nextScenario,
-            sendKickoff: false,
-            startMode: "fresh",
-          });
+          const sessionId = await captureOrchestratorFallback<string | undefined>(
+            "agent-studio-start-fresh-session",
+            async () =>
+              startAgentSession({
+                taskId,
+                role: nextRole,
+                scenario: nextScenario,
+                sendKickoff: false,
+                startMode: "fresh",
+              }),
+            {
+              tags: {
+                repoPath: activeRepo,
+                taskId,
+                role: nextRole,
+                scenario: nextScenario,
+              },
+              fallback: () => {
+                updateQuery(previousSelection);
+                return undefined;
+              },
+            },
+          );
           if (!sessionId) {
             updateQuery(previousSelection);
             return undefined;
@@ -437,14 +457,20 @@ export function useAgentStudioSessionActions({
             scenario: nextScenario,
             autostart: undefined,
           });
-          void sendAgentMessage(
-            sessionId,
-            kickoffPromptForScenario(nextRole, nextScenario, taskId),
-          ).catch(() => undefined);
+          runOrchestratorSideEffect(
+            "agent-studio-send-kickoff-message",
+            sendAgentMessage(sessionId, kickoffPromptForScenario(nextRole, nextScenario, taskId)),
+            {
+              tags: {
+                repoPath: activeRepo,
+                taskId,
+                role: nextRole,
+                scenario: nextScenario,
+                sessionId,
+              },
+            },
+          );
           return sessionId;
-        } catch {
-          updateQuery(previousSelection);
-          return undefined;
         } finally {
           setIsStarting(false);
         }
@@ -465,6 +491,7 @@ export function useAgentStudioSessionActions({
       selectedTask,
       role,
       scenario,
+      activeRepo,
       sendAgentMessage,
       sessionsForTask,
       startAgentSession,

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -9,6 +9,7 @@ import {
   settleDanglingTodoToolMessages,
 } from "../../agent-tool-messages";
 import { isMutatingPermission } from "../../permission-policy";
+import { runOrchestratorSideEffect } from "../support/async-side-effects";
 import {
   finalizeDraftAssistantMessage,
   isDuplicateAssistantMessage,
@@ -151,14 +152,24 @@ const refreshTodosFromSessionRef = (context: SessionEventContext): void => {
   if (!session) {
     return;
   }
-  void context
-    .loadSessionTodos(
+  runOrchestratorSideEffect(
+    "session-events-refresh-todos",
+    context.loadSessionTodos(
       context.sessionId,
       session.baseUrl,
       session.workingDirectory,
       session.externalSessionId,
-    )
-    .catch(() => undefined);
+    ),
+    {
+      tags: {
+        repoPath: context.repoPath,
+        sessionId: context.sessionId,
+        taskId: session.taskId,
+        role: session.role,
+        externalSessionId: session.externalSessionId,
+      },
+    },
+  );
 };
 
 const handleSessionStarted = (
@@ -362,7 +373,17 @@ const handleToolPart = (
   );
 
   if (shouldRefreshTaskData) {
-    void context.refreshTaskData(context.repoPath).catch(() => undefined);
+    runOrchestratorSideEffect(
+      "session-events-refresh-task-data",
+      context.refreshTaskData(context.repoPath),
+      {
+        tags: {
+          repoPath: context.repoPath,
+          sessionId: context.sessionId,
+          tool: part.tool,
+        },
+      },
+    );
   }
   if (shouldRefreshSessionTodos) {
     refreshTodosFromSessionRef(context);

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -6,6 +6,10 @@ import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import {
+  captureOrchestratorFallback,
+  runOrchestratorSideEffect,
+} from "../support/async-side-effects";
+import {
   createRepoStaleGuard,
   inferScenario,
   kickoffPrompt,
@@ -188,7 +192,20 @@ export const createStartAgentSession = ({
         baseUrl: runtime.baseUrl,
       });
       if (isStaleRepoOperation()) {
-        await adapter.stopSession(summary.sessionId).catch(() => undefined);
+        await captureOrchestratorFallback(
+          "start-session-stop-on-stale-after-start",
+          async () => adapter.stopSession(summary.sessionId),
+          {
+            tags: {
+              repoPath,
+              taskId,
+              role,
+              scenario: resolvedScenario,
+              sessionId: summary.sessionId,
+            },
+            fallback: () => undefined,
+          },
+        );
         throw new Error(STALE_START_ERROR);
       }
 
@@ -242,27 +259,73 @@ export const createStartAgentSession = ({
         };
       });
       throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-      void persistSessionSnapshot(initialSession).catch(() => undefined);
+      runOrchestratorSideEffect(
+        "start-session-persist-initial-session",
+        persistSessionSnapshot(initialSession),
+        {
+          tags: {
+            repoPath,
+            taskId,
+            role,
+            scenario: resolvedScenario,
+            sessionId: summary.sessionId,
+          },
+        },
+      );
 
       attachSessionListener(repoPath, summary.sessionId);
 
       if (isStaleRepoOperation()) {
-        await adapter.stopSession(summary.sessionId).catch(() => undefined);
+        await captureOrchestratorFallback(
+          "start-session-stop-on-stale-after-listener-attach",
+          async () => adapter.stopSession(summary.sessionId),
+          {
+            tags: {
+              repoPath,
+              taskId,
+              role,
+              scenario: resolvedScenario,
+              sessionId: summary.sessionId,
+            },
+            fallback: () => undefined,
+          },
+        );
         throw new Error(STALE_START_ERROR);
       }
 
       const warmSessionData = (): void => {
-        void loadSessionTodos(
-          summary.sessionId,
-          runtime.baseUrl,
-          runtime.workingDirectory,
-          summary.externalSessionId,
-        ).catch(() => undefined);
-        void loadSessionModelCatalog(
-          summary.sessionId,
-          runtime.baseUrl,
-          runtime.workingDirectory,
-        ).catch(() => undefined);
+        runOrchestratorSideEffect(
+          "start-session-warm-session-todos",
+          loadSessionTodos(
+            summary.sessionId,
+            runtime.baseUrl,
+            runtime.workingDirectory,
+            summary.externalSessionId,
+          ),
+          {
+            tags: {
+              repoPath,
+              taskId,
+              role,
+              scenario: resolvedScenario,
+              sessionId: summary.sessionId,
+              externalSessionId: summary.externalSessionId,
+            },
+          },
+        );
+        runOrchestratorSideEffect(
+          "start-session-warm-session-model-catalog",
+          loadSessionModelCatalog(summary.sessionId, runtime.baseUrl, runtime.workingDirectory),
+          {
+            tags: {
+              repoPath,
+              taskId,
+              role,
+              scenario: resolvedScenario,
+              sessionId: summary.sessionId,
+            },
+          },
+        );
       };
       warmSessionData();
 
@@ -270,7 +333,19 @@ export const createStartAgentSession = ({
         throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
         await sendAgentMessage(summary.sessionId, kickoffPrompt(role, resolvedScenario, task.id));
         throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-        void refreshTaskData(repoPath).catch(() => undefined);
+        runOrchestratorSideEffect(
+          "start-session-refresh-task-data-after-kickoff",
+          refreshTaskData(repoPath),
+          {
+            tags: {
+              repoPath,
+              taskId,
+              role,
+              scenario: resolvedScenario,
+              sessionId: summary.sessionId,
+            },
+          },
+        );
       }
 
       return summary.sessionId;

--- a/apps/desktop/src/state/operations/agent-orchestrator/index.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/index.ts
@@ -3,6 +3,10 @@ export { createAgentSessionActions } from "./handlers/session-actions";
 export { createLoadAgentSessions } from "./lifecycle/load-sessions";
 export { createEnsureRuntime, loadRepoDefaultModel, loadTaskDocuments } from "./runtime/runtime";
 export {
+  captureOrchestratorFallback,
+  runOrchestratorSideEffect,
+} from "./support/async-side-effects";
+export {
   mergeTodoListPreservingOrder,
   normalizeSelectionForCatalog,
   now,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -4,6 +4,10 @@ import { buildAgentSystemPrompt } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import {
+  captureOrchestratorFallback,
+  runOrchestratorSideEffect,
+} from "../support/async-side-effects";
+import {
   createRepoStaleGuard,
   shouldReattachListenerForAttachedSession,
   throwIfRepoStale,
@@ -97,7 +101,14 @@ export const createEnsureSessionReady = ({
         existingUnsubscriber();
         unsubscribersRef.current.delete(sessionId);
       }
-      await adapter.stopSession(sessionId).catch(() => undefined);
+      await captureOrchestratorFallback(
+        "ensure-ready-stop-attached-error-session",
+        async () => adapter.stopSession(sessionId),
+        {
+          tags: { repoPath, sessionId, taskId: session.taskId, role: session.role },
+          fallback: () => undefined,
+        },
+      );
       assertNotStale();
     }
 
@@ -140,7 +151,14 @@ export const createEnsureSessionReady = ({
     });
 
     if (isStaleRepoOperation()) {
-      await adapter.stopSession(sessionId).catch(() => undefined);
+      await captureOrchestratorFallback(
+        "ensure-ready-stop-session-after-stale-resume",
+        async () => adapter.stopSession(sessionId),
+        {
+          tags: { repoPath, sessionId, taskId: session.taskId, role: session.role },
+          fallback: () => undefined,
+        },
+      );
       throw new Error(STALE_PREPARE_ERROR);
     }
 
@@ -167,15 +185,36 @@ export const createEnsureSessionReady = ({
 
     const activeSession = sessionsRef.current[sessionId];
     const warmSessionData = (targetSession: AgentSessionState): void => {
-      void loadSessionTodos(
-        sessionId,
-        runtime.baseUrl,
-        runtime.workingDirectory,
-        targetSession.externalSessionId,
-      ).catch(() => undefined);
+      runOrchestratorSideEffect(
+        "ensure-ready-warm-session-todos",
+        loadSessionTodos(
+          sessionId,
+          runtime.baseUrl,
+          runtime.workingDirectory,
+          targetSession.externalSessionId,
+        ),
+        {
+          tags: {
+            repoPath,
+            sessionId,
+            taskId: targetSession.taskId,
+            role: targetSession.role,
+            externalSessionId: targetSession.externalSessionId,
+          },
+        },
+      );
       if (!targetSession.modelCatalog && !targetSession.isLoadingModelCatalog) {
-        void loadSessionModelCatalog(sessionId, runtime.baseUrl, runtime.workingDirectory).catch(
-          () => undefined,
+        runOrchestratorSideEffect(
+          "ensure-ready-warm-session-model-catalog",
+          loadSessionModelCatalog(sessionId, runtime.baseUrl, runtime.workingDirectory),
+          {
+            tags: {
+              repoPath,
+              sessionId,
+              taskId: targetSession.taskId,
+              role: targetSession.role,
+            },
+          },
         );
       }
     };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -5,11 +5,16 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
 import {
+  captureOrchestratorFallback,
+  runOrchestratorSideEffect,
+} from "../support/async-side-effects";
+import {
   createRepoStaleGuard,
   fromPersistedSessionRecord,
   historyToChatMessages,
   normalizePersistedSelection,
   toBaseUrl,
+  upsertMessage,
 } from "../support/utils";
 
 type UpdateSession = (
@@ -19,6 +24,15 @@ type UpdateSession = (
 ) => void;
 
 type SessionHistoryAdapter = Pick<OpencodeSdkAdapter, "loadSessionHistory">;
+type SessionHistoryLoadResult =
+  | {
+      ok: true;
+      history: Awaited<ReturnType<SessionHistoryAdapter["loadSessionHistory"]>>;
+    }
+  | {
+      ok: false;
+      reason: string;
+    };
 
 type CreateLoadAgentSessionsArgs = {
   activeRepo: string | null;
@@ -75,11 +89,26 @@ export const createLoadAgentSessions = ({
       workingDirectory: string,
       externalSessionId: string,
     ): void => {
-      void loadSessionTodos(targetSessionId, baseUrl, workingDirectory, externalSessionId).catch(
-        () => undefined,
+      runOrchestratorSideEffect(
+        "load-sessions-warm-session-todos",
+        loadSessionTodos(targetSessionId, baseUrl, workingDirectory, externalSessionId),
+        {
+          tags: {
+            repoPath,
+            sessionId: targetSessionId,
+            externalSessionId,
+          },
+        },
       );
-      void loadSessionModelCatalog(targetSessionId, baseUrl, workingDirectory).catch(
-        () => undefined,
+      runOrchestratorSideEffect(
+        "load-sessions-warm-session-model-catalog",
+        loadSessionModelCatalog(targetSessionId, baseUrl, workingDirectory),
+        {
+          tags: {
+            repoPath,
+            sessionId: targetSessionId,
+          },
+        },
       );
     };
 
@@ -101,20 +130,56 @@ export const createLoadAgentSessions = ({
       }
 
       const docs = await Promise.all([
-        host
-          .specGet(repoPath, record.taskId)
-          .then((doc) => doc.markdown)
-          .catch(() => ""),
-        host
-          .planGet(repoPath, record.taskId)
-          .then((doc) => doc.markdown)
-          .catch(() => ""),
-        host
-          .qaGetReport(repoPath, record.taskId)
-          .then((doc) => doc.markdown)
-          .catch(() => ""),
-      ]).catch(() => null);
-      if (!docs || isStaleRepoOperation()) {
+        captureOrchestratorFallback(
+          "load-sessions-load-prelude-document",
+          async () => {
+            const spec = await host.specGet(repoPath, record.taskId);
+            return spec.markdown;
+          },
+          {
+            tags: {
+              repoPath,
+              taskId: record.taskId,
+              sessionId: record.sessionId,
+              document: "spec",
+            },
+            fallback: () => "",
+          },
+        ),
+        captureOrchestratorFallback(
+          "load-sessions-load-prelude-document",
+          async () => {
+            const plan = await host.planGet(repoPath, record.taskId);
+            return plan.markdown;
+          },
+          {
+            tags: {
+              repoPath,
+              taskId: record.taskId,
+              sessionId: record.sessionId,
+              document: "plan",
+            },
+            fallback: () => "",
+          },
+        ),
+        captureOrchestratorFallback(
+          "load-sessions-load-prelude-document",
+          async () => {
+            const qa = await host.qaGetReport(repoPath, record.taskId);
+            return qa.markdown;
+          },
+          {
+            tags: {
+              repoPath,
+              taskId: record.taskId,
+              sessionId: record.sessionId,
+              document: "qa",
+            },
+            fallback: () => "",
+          },
+        ),
+      ]);
+      if (isStaleRepoOperation()) {
         return preludeMessages;
       }
 
@@ -194,7 +259,14 @@ export const createLoadAgentSessions = ({
       (record) => record.role === "spec" || record.role === "planner",
     );
     const workspaceRuntime = requiresWorkspaceRuntime
-      ? await host.opencodeRepoRuntimeEnsure(repoPath).catch(() => null)
+      ? await captureOrchestratorFallback(
+          "load-sessions-ensure-workspace-runtime",
+          async () => host.opencodeRepoRuntimeEnsure(repoPath),
+          {
+            tags: { repoPath, taskId },
+            fallback: () => null,
+          },
+        )
       : null;
     if (isStaleRepoOperation()) {
       return;
@@ -231,15 +303,30 @@ export const createLoadAgentSessions = ({
           return;
         }
 
-        const historyPromise = adapter
-          .loadSessionHistory({
-            baseUrl,
-            workingDirectory,
-            externalSessionId: record.externalSessionId,
-            limit: 2000,
-          })
-          .then((history) => ({ ok: true as const, history }))
-          .catch(() => ({ ok: false as const }));
+        const historyPromise = captureOrchestratorFallback<SessionHistoryLoadResult>(
+          "load-sessions-load-history",
+          async () => {
+            const history = await adapter.loadSessionHistory({
+              baseUrl,
+              workingDirectory,
+              externalSessionId: record.externalSessionId,
+              limit: 2000,
+            });
+            return { ok: true as const, history };
+          },
+          {
+            tags: {
+              repoPath,
+              taskId: record.taskId,
+              sessionId: record.sessionId,
+              externalSessionId: record.externalSessionId,
+            },
+            fallback: (failure): SessionHistoryLoadResult => ({
+              ok: false,
+              reason: failure.reason,
+            }),
+          },
+        );
 
         const preludeMessages = await buildPreludeMessages(record);
         if (isStaleRepoOperation()) {
@@ -252,6 +339,19 @@ export const createLoadAgentSessions = ({
         }
 
         if (!historyResult.ok) {
+          updateSession(
+            record.sessionId,
+            (current) => ({
+              ...current,
+              messages: upsertMessage(current.messages, {
+                id: `history-unavailable:${record.sessionId}`,
+                role: "system",
+                content: `Session history unavailable: ${historyResult.reason}`,
+                timestamp: new Date().toISOString(),
+              }),
+            }),
+            { persist: false },
+          );
           warmSessionData(record.sessionId, baseUrl, workingDirectory, record.externalSessionId);
           return;
         }

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -143,6 +143,7 @@ export const createLoadAgentSessions = ({
               sessionId: record.sessionId,
               document: "spec",
             },
+            logLevel: "warn",
             fallback: () => "",
           },
         ),
@@ -159,6 +160,7 @@ export const createLoadAgentSessions = ({
               sessionId: record.sessionId,
               document: "plan",
             },
+            logLevel: "warn",
             fallback: () => "",
           },
         ),
@@ -175,6 +177,7 @@ export const createLoadAgentSessions = ({
               sessionId: record.sessionId,
               document: "qa",
             },
+            logLevel: "warn",
             fallback: () => "",
           },
         ),
@@ -264,6 +267,7 @@ export const createLoadAgentSessions = ({
           async () => host.opencodeRepoRuntimeEnsure(repoPath),
           {
             tags: { repoPath, taskId },
+            logLevel: "warn",
             fallback: () => null,
           },
         )
@@ -321,6 +325,7 @@ export const createLoadAgentSessions = ({
               sessionId: record.sessionId,
               externalSessionId: record.externalSessionId,
             },
+            logLevel: "warn",
             fallback: (failure): SessionHistoryLoadResult => ({
               ok: false,
               reason: failure.reason,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -13,6 +13,7 @@ import {
   fromPersistedSessionRecord,
   historyToChatMessages,
   normalizePersistedSelection,
+  now,
   toBaseUrl,
   upsertMessage,
 } from "../support/utils";
@@ -352,7 +353,7 @@ export const createLoadAgentSessions = ({
                 id: `history-unavailable:${record.sessionId}`,
                 role: "system",
                 content: `Session history unavailable: ${historyResult.reason}`,
-                timestamp: new Date().toISOString(),
+                timestamp: now(),
               }),
             }),
             { persist: false },

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -38,6 +38,7 @@ export const loadTaskDocuments = async (
       },
       {
         tags: { repoPath, taskId, document: "spec" },
+        logLevel: "warn",
         fallback: () => "",
       },
     ),
@@ -49,6 +50,7 @@ export const loadTaskDocuments = async (
       },
       {
         tags: { repoPath, taskId, document: "plan" },
+        logLevel: "warn",
         fallback: () => "",
       },
     ),
@@ -60,6 +62,7 @@ export const loadTaskDocuments = async (
       },
       {
         tags: { repoPath, taskId, document: "qa" },
+        logLevel: "warn",
         fallback: () => "",
       },
     ),
@@ -81,6 +84,7 @@ export const loadRepoDefaultModel = async (
     async () => host.workspaceGetRepoConfig(repoPath),
     {
       tags: { repoPath, role },
+      logLevel: "warn",
       fallback: () => null,
     },
   );

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -1,6 +1,10 @@
 import type { RunSummary } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
 import { host } from "../../host";
+import {
+  captureOrchestratorFallback,
+  runOrchestratorSideEffect,
+} from "../support/async-side-effects";
 import { runningStates, toBaseUrl } from "../support/utils";
 
 export type RuntimeInfo = {
@@ -26,18 +30,39 @@ export const loadTaskDocuments = async (
   taskId: string,
 ): Promise<TaskDocuments> => {
   const [spec, plan, qa] = await Promise.all([
-    host
-      .specGet(repoPath, taskId)
-      .then((doc) => doc.markdown)
-      .catch(() => ""),
-    host
-      .planGet(repoPath, taskId)
-      .then((doc) => doc.markdown)
-      .catch(() => ""),
-    host
-      .qaGetReport(repoPath, taskId)
-      .then((doc) => doc.markdown)
-      .catch(() => ""),
+    captureOrchestratorFallback(
+      "runtime-load-task-document",
+      async () => {
+        const spec = await host.specGet(repoPath, taskId);
+        return spec.markdown;
+      },
+      {
+        tags: { repoPath, taskId, document: "spec" },
+        fallback: () => "",
+      },
+    ),
+    captureOrchestratorFallback(
+      "runtime-load-task-document",
+      async () => {
+        const plan = await host.planGet(repoPath, taskId);
+        return plan.markdown;
+      },
+      {
+        tags: { repoPath, taskId, document: "plan" },
+        fallback: () => "",
+      },
+    ),
+    captureOrchestratorFallback(
+      "runtime-load-task-document",
+      async () => {
+        const qa = await host.qaGetReport(repoPath, taskId);
+        return qa.markdown;
+      },
+      {
+        tags: { repoPath, taskId, document: "qa" },
+        fallback: () => "",
+      },
+    ),
   ]);
 
   return {
@@ -51,7 +76,14 @@ export const loadRepoDefaultModel = async (
   repoPath: string,
   role: AgentRole,
 ): Promise<AgentModelSelection | null> => {
-  const config = await host.workspaceGetRepoConfig(repoPath).catch(() => null);
+  const config = await captureOrchestratorFallback(
+    "runtime-load-repo-config",
+    async () => host.workspaceGetRepoConfig(repoPath),
+    {
+      tags: { repoPath, role },
+      fallback: () => null,
+    },
+  );
   const roleDefault = config?.agentDefaults?.[role];
   if (!roleDefault) {
     return null;
@@ -74,7 +106,13 @@ export const createEnsureRuntime = ({ runsRef, refreshTaskData }: EnsureRuntimeD
       );
       if (!run) {
         run = await host.buildStart(repoPath, taskId);
-        void refreshTaskData(repoPath).catch(() => undefined);
+        runOrchestratorSideEffect(
+          "runtime-refresh-task-data-after-build-start",
+          refreshTaskData(repoPath),
+          {
+            tags: { repoPath, taskId, role },
+          },
+        );
       }
       return {
         runtimeId: null,

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/async-side-effects.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/async-side-effects.test.ts
@@ -11,14 +11,14 @@ describe("agent-orchestrator/support/async-side-effects", () => {
 
     let observedReason = "";
     try {
-      runOrchestratorSideEffect("side-effect-default", Promise.reject(new Error("boom")), {
-        onFailure: (failure) => {
-          observedReason = failure.reason;
-        },
+      await new Promise<void>((resolve) => {
+        runOrchestratorSideEffect("side-effect-default", Promise.reject(new Error("boom")), {
+          onFailure: (failure) => {
+            observedReason = failure.reason;
+            resolve();
+          },
+        });
       });
-
-      await Promise.resolve();
-      await Promise.resolve();
     } finally {
       console.error = originalError;
     }

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/async-side-effects.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/async-side-effects.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { captureOrchestratorFallback, runOrchestratorSideEffect } from "./async-side-effects";
+
+describe("agent-orchestrator/support/async-side-effects", () => {
+  test("logs side-effect failures as errors by default", async () => {
+    const originalError = console.error;
+    const calls: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      calls.push(args);
+    };
+
+    let observedReason = "";
+    try {
+      runOrchestratorSideEffect("side-effect-default", Promise.reject(new Error("boom")), {
+        onFailure: (failure) => {
+          observedReason = failure.reason;
+        },
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(observedReason).toBe("boom");
+    expect(calls.length).toBe(1);
+    expect(String(calls[0]?.[1] ?? "")).toBe("side-effect-default");
+  });
+
+  test("uses warn level for expected fallback paths", async () => {
+    const originalError = console.error;
+    const originalWarn = console.warn;
+    const errorCalls: unknown[][] = [];
+    const warnCalls: unknown[][] = [];
+
+    console.error = (...args: unknown[]) => {
+      errorCalls.push(args);
+    };
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args);
+    };
+
+    try {
+      const result = await captureOrchestratorFallback(
+        "fallback-warn",
+        async () => {
+          throw new Error("recoverable");
+        },
+        {
+          logLevel: "warn",
+          fallback: () => "fallback-value",
+        },
+      );
+
+      expect(result).toBe("fallback-value");
+    } finally {
+      console.error = originalError;
+      console.warn = originalWarn;
+    }
+
+    expect(errorCalls.length).toBe(0);
+    expect(warnCalls.length).toBe(1);
+    expect(String(warnCalls[0]?.[1] ?? "")).toBe("fallback-warn");
+  });
+
+  test("supports no-log fallback mode", async () => {
+    const originalError = console.error;
+    const originalWarn = console.warn;
+    const errorCalls: unknown[][] = [];
+    const warnCalls: unknown[][] = [];
+
+    console.error = (...args: unknown[]) => {
+      errorCalls.push(args);
+    };
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args);
+    };
+
+    try {
+      const result = await captureOrchestratorFallback(
+        "fallback-none",
+        async () => {
+          throw new Error("hidden");
+        },
+        {
+          logLevel: "none",
+          fallback: () => "ok",
+        },
+      );
+
+      expect(result).toBe("ok");
+    } finally {
+      console.error = originalError;
+      console.warn = originalWarn;
+    }
+
+    expect(errorCalls.length).toBe(0);
+    expect(warnCalls.length).toBe(0);
+  });
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/async-side-effects.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/async-side-effects.ts
@@ -1,0 +1,71 @@
+import { errorMessage } from "@/lib/errors";
+
+type AsyncTagValue = string | number | boolean | null | undefined;
+
+export type OrchestratorAsyncTags = Record<string, AsyncTagValue>;
+
+export type OrchestratorAsyncFailure = {
+  operation: string;
+  reason: string;
+  tags: OrchestratorAsyncTags;
+  error: unknown;
+};
+
+type AsyncFailureOptions = {
+  tags?: OrchestratorAsyncTags;
+  onFailure?: (failure: OrchestratorAsyncFailure) => void;
+};
+
+type AsyncFallbackOptions<T> = AsyncFailureOptions & {
+  fallback: (failure: OrchestratorAsyncFailure) => T;
+};
+
+const ORCHESTRATOR_ERROR_PREFIX = "[agent-orchestrator]";
+
+const createOrchestratorAsyncFailure = (
+  operation: string,
+  error: unknown,
+  tags?: OrchestratorAsyncTags,
+): OrchestratorAsyncFailure => {
+  return {
+    operation,
+    reason: errorMessage(error),
+    tags: tags ?? {},
+    error,
+  };
+};
+
+const logOrchestratorAsyncFailure = (failure: OrchestratorAsyncFailure): void => {
+  console.error(ORCHESTRATOR_ERROR_PREFIX, failure.operation, {
+    reason: failure.reason,
+    tags: failure.tags,
+    error: failure.error,
+  });
+};
+
+export const runOrchestratorSideEffect = (
+  operation: string,
+  effect: Promise<unknown>,
+  options?: AsyncFailureOptions,
+): void => {
+  void effect.catch((error) => {
+    const failure = createOrchestratorAsyncFailure(operation, error, options?.tags);
+    logOrchestratorAsyncFailure(failure);
+    options?.onFailure?.(failure);
+  });
+};
+
+export const captureOrchestratorFallback = async <T>(
+  operation: string,
+  effect: () => Promise<T>,
+  options: AsyncFallbackOptions<T>,
+): Promise<T> => {
+  try {
+    return await effect();
+  } catch (error) {
+    const failure = createOrchestratorAsyncFailure(operation, error, options.tags);
+    logOrchestratorAsyncFailure(failure);
+    options.onFailure?.(failure);
+    return options.fallback(failure);
+  }
+};

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/async-side-effects.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/async-side-effects.ts
@@ -11,9 +11,12 @@ export type OrchestratorAsyncFailure = {
   error: unknown;
 };
 
+export type OrchestratorAsyncLogLevel = "error" | "warn" | "none";
+
 type AsyncFailureOptions = {
   tags?: OrchestratorAsyncTags;
   onFailure?: (failure: OrchestratorAsyncFailure) => void;
+  logLevel?: OrchestratorAsyncLogLevel;
 };
 
 type AsyncFallbackOptions<T> = AsyncFailureOptions & {
@@ -35,12 +38,26 @@ const createOrchestratorAsyncFailure = (
   };
 };
 
-const logOrchestratorAsyncFailure = (failure: OrchestratorAsyncFailure): void => {
-  console.error(ORCHESTRATOR_ERROR_PREFIX, failure.operation, {
+const logOrchestratorAsyncFailure = (
+  failure: OrchestratorAsyncFailure,
+  logLevel: OrchestratorAsyncLogLevel,
+): void => {
+  if (logLevel === "none") {
+    return;
+  }
+
+  const details = {
     reason: failure.reason,
     tags: failure.tags,
     error: failure.error,
-  });
+  };
+
+  if (logLevel === "warn") {
+    console.warn(ORCHESTRATOR_ERROR_PREFIX, failure.operation, details);
+    return;
+  }
+
+  console.error(ORCHESTRATOR_ERROR_PREFIX, failure.operation, details);
 };
 
 export const runOrchestratorSideEffect = (
@@ -50,7 +67,7 @@ export const runOrchestratorSideEffect = (
 ): void => {
   void effect.catch((error) => {
     const failure = createOrchestratorAsyncFailure(operation, error, options?.tags);
-    logOrchestratorAsyncFailure(failure);
+    logOrchestratorAsyncFailure(failure, options?.logLevel ?? "error");
     options?.onFailure?.(failure);
   });
 };
@@ -64,7 +81,7 @@ export const captureOrchestratorFallback = async <T>(
     return await effect();
   } catch (error) {
     const failure = createOrchestratorAsyncFailure(operation, error, options.tags);
-    logOrchestratorAsyncFailure(failure);
+    logOrchestratorAsyncFailure(failure, options.logLevel ?? "error");
     options.onFailure?.(failure);
     return options.fallback(failure);
   }

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
@@ -16,6 +16,7 @@ import {
   normalizeSelectionForCatalog,
   now,
   pickDefaultModel,
+  runOrchestratorSideEffect,
   toPersistedSessionRecord,
   upsertMessage,
 } from "./agent-orchestrator";
@@ -137,10 +138,21 @@ export function useAgentOrchestratorOperations({
       setSessionsById(nextSessions);
 
       if (options?.persist !== false) {
-        void persistSessionSnapshot(nextSession).catch(() => undefined);
+        runOrchestratorSideEffect(
+          "operations-persist-session-snapshot",
+          persistSessionSnapshot(nextSession),
+          {
+            tags: {
+              repoPath: activeRepo,
+              sessionId,
+              taskId: nextSession.taskId,
+              role: nextSession.role,
+            },
+          },
+        );
       }
     },
-    [persistSessionSnapshot],
+    [activeRepo, persistSessionSnapshot],
   );
 
   const resolveTurnDurationMs = useCallback(


### PR DESCRIPTION
## Summary
- replace silent async fallback suppression in agent orchestrator/session flows with shared tagged failure handling
- preserve non-blocking behavior while making startup, runtime, history, and document-load failure paths observable
- reduce noise by using warn-level logging for expected fallback paths and add utility regression tests for log-level behavior

## Testing
- bun test apps/desktop/src/state/operations/agent-orchestrator/support/async-side-effects.test.ts apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
- bun run --filter @openducktor/desktop typecheck