### PR TITLE
refactor(desktop): invert opencode adapter dependency in state operations

### DIFF
--- a/apps/desktop/src/state/app-state-provider.tsx
+++ b/apps/desktop/src/state/app-state-provider.tsx
@@ -1,3 +1,4 @@
+import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { RunEvent } from "@openducktor/contracts";
 import {
   type Context,
@@ -5,6 +6,7 @@ import {
   type PropsWithChildren,
   type ReactElement,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -28,6 +30,8 @@ import {
 } from "./app-state-context-values";
 import { useAppLifecycle } from "./lifecycle/use-app-lifecycle";
 import {
+  configureOpencodeCatalogOperations,
+  createHostOpencodeCatalogOperations,
   useAgentOrchestratorOperations,
   useChecks,
   useDelegationOperations,
@@ -55,6 +59,15 @@ const useRequiredContext = <T,>(context: Context<T | null>, name: string): T => 
 export function AppStateProvider({ children }: PropsWithChildren): ReactElement {
   const [activeRepo, setActiveRepo] = useState<string | null>(null);
   const [events, setEvents] = useState<RunEvent[]>([]);
+  const agentEngine = useMemo(() => new OpencodeSdkAdapter(), []);
+  const opencodeCatalogOperations = useMemo(
+    () => createHostOpencodeCatalogOperations(agentEngine),
+    [agentEngine],
+  );
+
+  useEffect(() => {
+    configureOpencodeCatalogOperations(opencodeCatalogOperations);
+  }, [opencodeCatalogOperations]);
 
   const {
     runtimeCheck,
@@ -73,6 +86,7 @@ export function AppStateProvider({ children }: PropsWithChildren): ReactElement 
     clearActiveRepoOpencodeHealth,
   } = useChecks({
     activeRepo,
+    checkRepoOpencodeHealth: opencodeCatalogOperations.checkRepoOpencodeHealth,
   });
 
   const {
@@ -127,6 +141,7 @@ export function AppStateProvider({ children }: PropsWithChildren): ReactElement 
     tasks,
     runs,
     refreshTaskData,
+    agentEngine,
   });
 
   const {

--- a/apps/desktop/src/state/app-state-provider.tsx
+++ b/apps/desktop/src/state/app-state-provider.tsx
@@ -6,7 +6,6 @@ import {
   type PropsWithChildren,
   type ReactElement,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -60,14 +59,11 @@ export function AppStateProvider({ children }: PropsWithChildren): ReactElement 
   const [activeRepo, setActiveRepo] = useState<string | null>(null);
   const [events, setEvents] = useState<RunEvent[]>([]);
   const agentEngine = useMemo(() => new OpencodeSdkAdapter(), []);
-  const opencodeCatalogOperations = useMemo(
-    () => createHostOpencodeCatalogOperations(agentEngine),
-    [agentEngine],
-  );
-
-  useEffect(() => {
-    configureOpencodeCatalogOperations(opencodeCatalogOperations);
-  }, [opencodeCatalogOperations]);
+  const opencodeCatalogOperations = useMemo(() => {
+    const ops = createHostOpencodeCatalogOperations(agentEngine);
+    configureOpencodeCatalogOperations(ops);
+    return ops;
+  }, [agentEngine]);
 
   const {
     runtimeCheck,

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -1,5 +1,4 @@
-import type { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
-import { isOdtWorkflowMutationToolName } from "@openducktor/core";
+import { type AgentEnginePort, isOdtWorkflowMutationToolName } from "@openducktor/core";
 import type { MutableRefObject } from "react";
 import { errorMessage } from "@/lib/errors";
 import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
@@ -39,7 +38,7 @@ type ResolveTurnDuration = (
   messages?: AgentChatMessage[],
 ) => number | undefined;
 
-export type SessionEventAdapter = Pick<OpencodeSdkAdapter, "subscribeEvents" | "replyPermission">;
+export type SessionEventAdapter = Pick<AgentEnginePort, "subscribeEvents" | "replyPermission">;
 
 type SessionEvent = Parameters<Parameters<SessionEventAdapter["subscribeEvents"]>[1]>[0];
 type SessionPartEvent = Extract<SessionEvent, { type: "assistant_part" }>;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -1,6 +1,5 @@
-import type { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { TaskCard } from "@openducktor/contracts";
-import type { AgentModelSelection, AgentRole } from "@openducktor/core";
+import type { AgentEnginePort, AgentModelSelection, AgentRole } from "@openducktor/core";
 import { errorMessage } from "@/lib/errors";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { createEnsureSessionReady } from "../lifecycle/ensure-ready";
@@ -11,7 +10,7 @@ import { createStartAgentSession } from "./start-session";
 
 type SessionActionsDependencies = {
   activeRepo: string | null;
-  adapter: OpencodeSdkAdapter;
+  adapter: AgentEnginePort;
   setSessionsById: (
     updater:
       | Record<string, AgentSessionState>

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -1,6 +1,10 @@
-import type { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { TaskCard } from "@openducktor/contracts";
-import type { AgentModelSelection, AgentRole, AgentScenario } from "@openducktor/core";
+import type {
+  AgentEnginePort,
+  AgentModelSelection,
+  AgentRole,
+  AgentScenario,
+} from "@openducktor/core";
 import { buildAgentSystemPrompt } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
@@ -26,7 +30,7 @@ export type StartAgentSessionInput = {
 
 type StartSessionDependencies = {
   activeRepo: string | null;
-  adapter: OpencodeSdkAdapter;
+  adapter: AgentEnginePort;
   setSessionsById: (
     updater:
       | Record<string, AgentSessionState>

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -1,6 +1,5 @@
-import type { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { TaskCard } from "@openducktor/contracts";
-import { buildAgentSystemPrompt } from "@openducktor/core";
+import { type AgentEnginePort, buildAgentSystemPrompt } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import {
@@ -15,7 +14,7 @@ import {
 
 type EnsureSessionReadyDependencies = {
   activeRepo: string | null;
-  adapter: OpencodeSdkAdapter;
+  adapter: AgentEnginePort;
   repoEpochRef: { current: number };
   previousRepoRef: { current: string | null };
   sessionsRef: { current: Record<string, AgentSessionState> };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -1,6 +1,5 @@
-import type { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { TaskCard } from "@openducktor/contracts";
-import { buildAgentSystemPrompt } from "@openducktor/core";
+import { type AgentEnginePort, buildAgentSystemPrompt } from "@openducktor/core";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
@@ -24,7 +23,7 @@ type UpdateSession = (
   options?: { persist?: boolean },
 ) => void;
 
-type SessionHistoryAdapter = Pick<OpencodeSdkAdapter, "loadSessionHistory">;
+type SessionHistoryAdapter = Pick<AgentEnginePort, "loadSessionHistory">;
 type SessionHistoryLoadResult =
   | {
       ok: true;

--- a/apps/desktop/src/state/operations/index.ts
+++ b/apps/desktop/src/state/operations/index.ts
@@ -1,4 +1,9 @@
-export { checkRepoOpencodeHealth, loadRepoOpencodeCatalog } from "./opencode-catalog";
+export {
+  checkRepoOpencodeHealth,
+  configureOpencodeCatalogOperations,
+  createHostOpencodeCatalogOperations,
+  loadRepoOpencodeCatalog,
+} from "./opencode-catalog";
 export { useAgentOrchestratorOperations } from "./use-agent-orchestrator-operations";
 export { useChecks } from "./use-checks";
 export { useDelegationOperations } from "./use-delegation-operations";

--- a/apps/desktop/src/state/operations/opencode-catalog.ts
+++ b/apps/desktop/src/state/operations/opencode-catalog.ts
@@ -1,6 +1,6 @@
-import { type McpServerStatus, OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
+import type { McpServerStatus } from "@openducktor/adapters-opencode-sdk";
 import type { AgentRuntimeSummary } from "@openducktor/contracts";
-import type { AgentModelCatalog } from "@openducktor/core";
+import type { AgentEnginePort, AgentModelCatalog } from "@openducktor/core";
 import { errorMessage } from "@/lib/errors";
 import type { RepoOpencodeHealthCheck } from "@/types/diagnostics";
 import { host } from "./host";
@@ -8,6 +8,12 @@ import { host } from "./host";
 type ListCatalogInput = {
   baseUrl: string;
   workingDirectory: string;
+};
+
+export type OpencodeCatalogAdapter = Pick<AgentEnginePort, "listAvailableModels"> & {
+  listAvailableToolIds: (input: ListCatalogInput) => Promise<string[]>;
+  getMcpStatus: (input: ListCatalogInput) => Promise<Record<string, McpServerStatus>>;
+  connectMcpServer: (input: ListCatalogInput & { name: string }) => Promise<void>;
 };
 
 type OpencodeCatalogDependencies = {
@@ -291,16 +297,39 @@ export const createOpencodeCatalogOperations = (deps: OpencodeCatalogDependencie
   };
 };
 
-const adapter = new OpencodeSdkAdapter();
+export type OpencodeCatalogOperations = ReturnType<typeof createOpencodeCatalogOperations>;
 
-const opencodeCatalogOperations = createOpencodeCatalogOperations({
-  ensureRuntime: (repoPath) => host.opencodeRepoRuntimeEnsure(repoPath),
-  stopRuntime: (runtimeId) => host.opencodeRuntimeStop(runtimeId),
-  listAvailableModels: (input) => adapter.listAvailableModels(input),
-  listAvailableToolIds: (input) => adapter.listAvailableToolIds(input),
-  getMcpStatus: (input) => adapter.getMcpStatus(input),
-  connectMcpServer: (input) => adapter.connectMcpServer(input),
-});
+export const createHostOpencodeCatalogOperations = (
+  adapter: OpencodeCatalogAdapter,
+): OpencodeCatalogOperations =>
+  createOpencodeCatalogOperations({
+    ensureRuntime: (repoPath) => host.opencodeRepoRuntimeEnsure(repoPath),
+    stopRuntime: (runtimeId) => host.opencodeRuntimeStop(runtimeId),
+    listAvailableModels: (input) => adapter.listAvailableModels(input),
+    listAvailableToolIds: (input) => adapter.listAvailableToolIds(input),
+    getMcpStatus: (input) => adapter.getMcpStatus(input),
+    connectMcpServer: (input) => adapter.connectMcpServer(input),
+  });
 
-export const loadRepoOpencodeCatalog = opencodeCatalogOperations.loadRepoOpencodeCatalog;
-export const checkRepoOpencodeHealth = opencodeCatalogOperations.checkRepoOpencodeHealth;
+let configuredOpencodeCatalogOperations: OpencodeCatalogOperations | null = null;
+
+export const configureOpencodeCatalogOperations = (operations: OpencodeCatalogOperations): void => {
+  configuredOpencodeCatalogOperations = operations;
+};
+
+const getConfiguredOpencodeCatalogOperations = (): OpencodeCatalogOperations => {
+  if (!configuredOpencodeCatalogOperations) {
+    throw new Error(
+      "OpenCode catalog operations are not configured. Initialize them from AppStateProvider before use.",
+    );
+  }
+  return configuredOpencodeCatalogOperations;
+};
+
+export const loadRepoOpencodeCatalog = (repoPath: string): Promise<AgentModelCatalog> => {
+  return getConfiguredOpencodeCatalogOperations().loadRepoOpencodeCatalog(repoPath);
+};
+
+export const checkRepoOpencodeHealth = (repoPath: string): Promise<RepoOpencodeHealthCheck> => {
+  return getConfiguredOpencodeCatalogOperations().checkRepoOpencodeHealth(repoPath);
+};

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
@@ -103,10 +103,14 @@ const createHookHarness = (args: {
   tasks: TaskCard[];
   runs: RunSummary[];
   refreshTaskData: (repoPath: string) => Promise<void>;
+  agentEngine?: OpencodeSdkAdapter;
 }) => {
   let latest: ReturnType<typeof useAgentOrchestratorOperations> | null = null;
   let renderer: TestRenderer.ReactTestRenderer | null = null;
-  let currentArgs = args;
+  let currentArgs = {
+    ...args,
+    agentEngine: args.agentEngine ?? new OpencodeSdkAdapter(),
+  };
 
   const Harness = () => {
     latest = useAgentOrchestratorOperations(currentArgs);
@@ -136,6 +140,7 @@ const createHookHarness = (args: {
       tasks: TaskCard[];
       runs: RunSummary[];
       refreshTaskData: (repoPath: string) => Promise<void>;
+      agentEngine: OpencodeSdkAdapter;
     }>,
   ) => {
     currentArgs = {

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
@@ -1,6 +1,10 @@
-import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { RunSummary, TaskCard } from "@openducktor/contracts";
-import type { AgentModelSelection, AgentRole, AgentScenario } from "@openducktor/core";
+import type {
+  AgentEnginePort,
+  AgentModelSelection,
+  AgentRole,
+  AgentScenario,
+} from "@openducktor/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
@@ -27,6 +31,7 @@ type UseAgentOrchestratorOperationsArgs = {
   tasks: TaskCard[];
   runs: RunSummary[];
   refreshTaskData: (repoPath: string) => Promise<void>;
+  agentEngine: AgentEnginePort;
 };
 
 type UseAgentOrchestratorOperationsResult = {
@@ -56,6 +61,7 @@ export function useAgentOrchestratorOperations({
   tasks,
   runs,
   refreshTaskData,
+  agentEngine,
 }: UseAgentOrchestratorOperationsArgs): UseAgentOrchestratorOperationsResult {
   const [sessionsById, setSessionsById] = useState<Record<string, AgentSessionState>>({});
   const sessionsRef = useRef<Record<string, AgentSessionState>>({});
@@ -100,8 +106,6 @@ export function useAgentOrchestratorOperations({
     sessionsRef.current = {};
     setSessionsById({});
   }, [activeRepo]);
-
-  const adapter = useMemo(() => new OpencodeSdkAdapter(), []);
 
   const persistSessionSnapshot = useCallback(
     async (session: AgentSessionState): Promise<void> => {
@@ -198,7 +202,7 @@ export function useAgentOrchestratorOperations({
       );
 
       try {
-        const catalog = await adapter.listAvailableModels({
+        const catalog = await agentEngine.listAvailableModels({
           baseUrl,
           workingDirectory,
         });
@@ -231,7 +235,7 @@ export function useAgentOrchestratorOperations({
         );
       }
     },
-    [adapter, updateSession],
+    [agentEngine, updateSession],
   );
 
   const loadSessionTodos = useCallback(
@@ -241,7 +245,7 @@ export function useAgentOrchestratorOperations({
       workingDirectory: string,
       externalSessionId: string,
     ): Promise<void> => {
-      const todos = await adapter.loadSessionTodos({
+      const todos = await agentEngine.loadSessionTodos({
         baseUrl,
         workingDirectory,
         externalSessionId,
@@ -255,14 +259,14 @@ export function useAgentOrchestratorOperations({
         { persist: false },
       );
     },
-    [adapter, updateSession],
+    [agentEngine, updateSession],
   );
 
   const loadAgentSessions = useMemo(
     () =>
       createLoadAgentSessions({
         activeRepo,
-        adapter,
+        adapter: agentEngine,
         repoEpochRef,
         previousRepoRef,
         sessionsRef,
@@ -272,13 +276,13 @@ export function useAgentOrchestratorOperations({
         loadSessionTodos,
         loadSessionModelCatalog,
       }),
-    [activeRepo, adapter, loadSessionModelCatalog, loadSessionTodos, updateSession],
+    [activeRepo, agentEngine, loadSessionModelCatalog, loadSessionTodos, updateSession],
   );
 
   const attachSessionListener = useCallback(
     (repoPath: string, sessionId: string): void => {
       const unsubscribe = attachAgentSessionListener({
-        adapter,
+        adapter: agentEngine,
         repoPath,
         sessionId,
         sessionsRef,
@@ -295,7 +299,7 @@ export function useAgentOrchestratorOperations({
       unsubscribersRef.current.set(sessionId, unsubscribe);
     },
     [
-      adapter,
+      agentEngine,
       clearTurnDuration,
       loadSessionTodos,
       refreshTaskData,
@@ -317,7 +321,7 @@ export function useAgentOrchestratorOperations({
     () =>
       createAgentSessionActions({
         activeRepo,
-        adapter,
+        adapter: agentEngine,
         setSessionsById,
         sessionsRef,
         taskRef,
@@ -340,7 +344,7 @@ export function useAgentOrchestratorOperations({
       }),
     [
       activeRepo,
-      adapter,
+      agentEngine,
       attachSessionListener,
       clearTurnDuration,
       ensureRuntime,

--- a/apps/desktop/src/state/operations/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/use-checks.test.tsx
@@ -59,19 +59,23 @@ mock.module("sonner", () => ({
   },
 }));
 
-mock.module("./opencode-catalog", () => ({
-  checkRepoOpencodeHealth: (repoPath: string) => checkRepoOpencodeHealthMock(repoPath),
-}));
-
 type UseChecksHook = typeof import("./use-checks")["useChecks"];
 type HookArgs = Parameters<UseChecksHook>[0];
 type HookResult = ReturnType<UseChecksHook>;
+type HookHarnessArgs = Omit<HookArgs, "checkRepoOpencodeHealth"> & {
+  checkRepoOpencodeHealth?: HookArgs["checkRepoOpencodeHealth"];
+};
 
 let useChecks: UseChecksHook;
 
-const createHookHarness = (initialArgs: HookArgs) => {
+const createHookHarness = (initialArgs: HookHarnessArgs) => {
   let latest: HookResult | null = null;
-  let currentArgs = initialArgs;
+  let currentArgs: HookArgs = {
+    ...initialArgs,
+    checkRepoOpencodeHealth:
+      initialArgs.checkRepoOpencodeHealth ??
+      ((repoPath: string) => checkRepoOpencodeHealthMock(repoPath)),
+  };
 
   const Harness = ({ args }: { args: HookArgs }) => {
     latest = useChecks(args);
@@ -87,8 +91,13 @@ const createHookHarness = (initialArgs: HookArgs) => {
       });
       await flush();
     },
-    updateArgs: async (nextArgs: HookArgs) => {
-      currentArgs = nextArgs;
+    updateArgs: async (nextArgs: Partial<HookHarnessArgs>) => {
+      currentArgs = {
+        ...currentArgs,
+        ...nextArgs,
+        checkRepoOpencodeHealth:
+          nextArgs.checkRepoOpencodeHealth ?? currentArgs.checkRepoOpencodeHealth,
+      };
       await act(async () => {
         renderer?.update(createElement(Harness, { args: currentArgs }));
       });

--- a/apps/desktop/src/state/operations/use-checks.ts
+++ b/apps/desktop/src/state/operations/use-checks.ts
@@ -4,10 +4,10 @@ import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import type { RepoOpencodeHealthCheck } from "@/types/diagnostics";
 import { host } from "./host";
-import { checkRepoOpencodeHealth } from "./opencode-catalog";
 
 type UseChecksArgs = {
   activeRepo: string | null;
+  checkRepoOpencodeHealth: (repoPath: string) => Promise<RepoOpencodeHealthCheck>;
 };
 
 type UseChecksResult = {
@@ -30,7 +30,7 @@ type UseChecksResult = {
   clearActiveRepoOpencodeHealth: () => void;
 };
 
-export function useChecks({ activeRepo }: UseChecksArgs): UseChecksResult {
+export function useChecks({ activeRepo, checkRepoOpencodeHealth }: UseChecksArgs): UseChecksResult {
   const [runtimeCheck, setRuntimeCheck] = useState<RuntimeCheck | null>(null);
   const [activeBeadsCheck, setActiveBeadsCheck] = useState<BeadsCheck | null>(null);
   const [activeRepoOpencodeHealth, setActiveRepoOpencodeHealth] =
@@ -86,7 +86,7 @@ export function useChecks({ activeRepo }: UseChecksArgs): UseChecksResult {
 
       return check;
     },
-    [activeRepo],
+    [activeRepo, checkRepoOpencodeHealth],
   );
 
   const refreshChecks = useCallback(async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- inject AgentEnginePort into agent orchestrator state operations instead of constructing OpencodeSdkAdapter in module scope
- move opencode catalog operation wiring to AppStateProvider composition root and configure shared catalog operations there
- update checks/orchestrator hooks and related tests to consume injected dependencies and preserve existing behavior

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test