### PR TITLE
fix(host-application): surface runtime worktree cleanup failures

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -804,6 +804,46 @@ exit 1
         write_executable_script(path, script)
     }
 
+    fn create_failing_opencode_with_worktree_cleanup(path: &Path) -> Result<()> {
+        let script = r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "opencode-fake 0.0.1"
+  exit 0
+fi
+
+if [ "$1" = "serve" ]; then
+  REPO_PATH=$(python3 - <<'PY'
+import json
+import os
+
+raw = os.environ.get("OPENCODE_CONFIG_CONTENT", "{}")
+try:
+    config = json.loads(raw)
+except Exception:
+    print("")
+    raise SystemExit(0)
+
+environment = (
+    config.get("mcp", {})
+    .get("openducktor", {})
+    .get("environment", {})
+)
+print(environment.get("ODT_REPO_PATH", ""))
+PY
+)
+  if [ -n "$REPO_PATH" ]; then
+    rm -rf "$REPO_PATH"
+  fi
+  echo "simulated startup failure after deleting repo path" >&2
+  exit 42
+fi
+
+echo "unsupported opencode invocation" >&2
+exit 1
+"#;
+        write_executable_script(path, script)
+    }
+
     fn create_fake_bd(path: &Path) -> Result<()> {
         let script = r#"#!/bin/sh
 echo "bd-fake"
@@ -2553,6 +2593,95 @@ echo "bd-fake"
     }
 
     #[test]
+    fn opencode_runtime_start_surfaces_qa_pre_start_cleanup_failure() -> Result<()> {
+        let root = unique_temp_path("runtime-pre-start-cleanup-failure");
+        let repo = root.join("repo");
+        init_git_repo(&repo)?;
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let repo_path = repo.to_string_lossy().to_string();
+        let worktree_base = root.join("qa-worktrees");
+        let (service, _task_state, _git_state) = build_service_with_store(
+            vec![make_task("task-1", "task", TaskStatus::Open)],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+            },
+            config_store,
+        );
+
+        service.workspace_update_repo_config(
+            repo_path.as_str(),
+            RepoConfig {
+                worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+                branch_prefix: "odt".to_string(),
+                trusted_hooks: true,
+                hooks: HookSet {
+                    pre_start: vec![format!("rm -rf \"{repo_path}\"; exit 1")],
+                    post_complete: Vec::new(),
+                },
+                agent_defaults: Default::default(),
+            },
+        )?;
+
+        let error = service
+            .opencode_runtime_start(repo_path.as_str(), "task-1", "qa")
+            .expect_err("cleanup failure should be surfaced when pre-start hook fails");
+        let message = error.to_string();
+        assert!(message.contains("QA pre-start hook failed"));
+        assert!(message.contains("Failed removing QA worktree runtime"));
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn opencode_runtime_start_surfaces_cleanup_failure_after_startup_error() -> Result<()> {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("runtime-startup-cleanup-failure");
+        let repo = root.join("repo");
+        init_git_repo(&repo)?;
+        let failing_opencode = root.join("opencode");
+        create_failing_opencode_with_worktree_cleanup(&failing_opencode)?;
+        let _opencode_guard = set_env_var(
+            "OPENDUCKTOR_OPENCODE_BINARY",
+            failing_opencode.to_string_lossy().as_ref(),
+        );
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let repo_path = repo.to_string_lossy().to_string();
+        let worktree_base = root.join("qa-worktrees");
+        let (service, _task_state, _git_state) = build_service_with_store(
+            vec![make_task("task-1", "task", TaskStatus::Open)],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+            },
+            config_store,
+        );
+        service.workspace_update_repo_config(
+            repo_path.as_str(),
+            RepoConfig {
+                worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+                branch_prefix: "odt".to_string(),
+                trusted_hooks: true,
+                hooks: HookSet::default(),
+                agent_defaults: Default::default(),
+            },
+        )?;
+
+        let error = service
+            .opencode_runtime_start(repo_path.as_str(), "task-1", "qa")
+            .expect_err("startup cleanup failure should be surfaced");
+        let message = error.to_string();
+        assert!(message.contains("OpenCode runtime failed to start for task task-1"));
+        assert!(message.contains("Failed removing QA worktree runtime"));
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
     fn opencode_runtime_start_reuses_existing_runtime_for_same_task_and_role() -> Result<()> {
         let _env_lock = lock_env();
         let root = unique_temp_path("runtime-reuse");
@@ -2682,6 +2811,72 @@ echo "bd-fake"
         std::thread::sleep(Duration::from_millis(50));
         let listed = service.opencode_runtime_list(None)?;
         assert!(listed.is_empty());
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn opencode_runtime_list_surfaces_stale_cleanup_failure() -> Result<()> {
+        let root = unique_temp_path("runtime-prune-cleanup-failure");
+        let repo = root.join("repo");
+        init_git_repo(&repo)?;
+
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let (service, _task_state, _git_state) = build_service_with_store(
+            vec![],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+            },
+            config_store,
+        );
+
+        let stale_child = Command::new("/bin/sh")
+            .arg("-lc")
+            .arg("exit 0")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn stale child");
+        let summary = AgentRuntimeSummary {
+            runtime_id: "runtime-stale-cleanup-error".to_string(),
+            repo_path: repo.to_string_lossy().to_string(),
+            task_id: "task-1".to_string(),
+            role: "qa".to_string(),
+            working_directory: repo.to_string_lossy().to_string(),
+            port: 1,
+            started_at: "2026-02-20T12:00:00Z".to_string(),
+        };
+        service
+            .agent_runtimes
+            .lock()
+            .expect("runtime lock poisoned")
+            .insert(
+                summary.runtime_id.clone(),
+                super::AgentRuntimeProcess {
+                    summary,
+                    child: stale_child,
+                    cleanup_repo_path: Some("/tmp/non-existent-repo-for-prune".to_string()),
+                    cleanup_worktree_path: Some(
+                        "/tmp/non-existent-worktree-for-prune".to_string(),
+                    ),
+                },
+            );
+
+        std::thread::sleep(Duration::from_millis(50));
+        let error = service
+            .opencode_runtime_list(None)
+            .expect_err("stale runtime cleanup failure should be surfaced");
+        let message = error.to_string();
+        assert!(message.contains("Failed pruning stale agent runtimes"));
+        assert!(message.contains("Failed removing QA worktree runtime"));
+        assert!(service
+            .agent_runtimes
+            .lock()
+            .expect("runtime lock poisoned")
+            .is_empty());
 
         let _ = fs::remove_dir_all(root);
         Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -168,7 +168,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
     use std::sync::{Arc, LazyLock, Mutex};
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     fn make_task(id: &str, issue_type: &str, status: TaskStatus) -> TaskCard {
         TaskCard {
@@ -749,12 +749,28 @@ if [ "$1" = "serve" ]; then
   echo "permission requested: git push"
   echo "tool execution heartbeat" >&2
   exec python3 - "$HOST" "$PORT" <<'PY'
+import os
 import signal
 import socket
 import sys
+import time
 
 host = sys.argv[1]
 port = int(sys.argv[2])
+delay_ms = int(os.environ.get("OPENDUCKTOR_TEST_STARTUP_DELAY_MS", "0") or "0")
+pid_file = os.environ.get("OPENDUCKTOR_TEST_PID_FILE", "")
+termination_file = os.environ.get("OPENDUCKTOR_TEST_TERM_FILE", "")
+
+if pid_file:
+    try:
+        with open(pid_file, "w", encoding="utf-8") as file:
+            file.write(str(os.getpid()))
+    except Exception:
+        pass
+
+if delay_ms > 0:
+    time.sleep(delay_ms / 1000.0)
+
 server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 server.bind((host, port))
@@ -762,6 +778,12 @@ server.listen(16)
 
 def _stop(*_):
     try:
+        if termination_file:
+            try:
+                with open(termination_file, "w", encoding="utf-8") as file:
+                    file.write("terminated")
+            except Exception:
+                pass
         server.close()
     finally:
         raise SystemExit(0)
@@ -896,6 +918,39 @@ echo "bd-fake"
             key: "PATH".to_string(),
             previous,
         }
+    }
+
+    fn wait_for_path_exists(path: &Path, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if path.exists() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        path.exists()
+    }
+
+    fn process_is_alive(pid: i32) -> bool {
+        Command::new("/bin/sh")
+            .arg("-lc")
+            .arg(format!("kill -0 {pid}"))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    fn wait_for_process_exit(pid: i32, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if !process_is_alive(pid) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        !process_is_alive(pid)
     }
 
     fn build_service_with_store(
@@ -2428,6 +2483,93 @@ echo "bd-fake"
         assert!(service
             .opencode_runtime_list(Some(repo_path.as_str()))?
             .is_empty());
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn opencode_workspace_runtime_ensure_stops_spawned_child_when_post_start_prune_fails(
+    ) -> Result<()> {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("runtime-workspace-prune-failure");
+        let repo = root.join("repo");
+        init_git_repo(&repo)?;
+        let fake_opencode = root.join("opencode");
+        create_fake_opencode(&fake_opencode)?;
+        let pid_file = root.join("spawned-runtime.pid");
+        let _opencode_guard = set_env_var(
+            "OPENDUCKTOR_OPENCODE_BINARY",
+            fake_opencode.to_string_lossy().as_ref(),
+        );
+        let _delay_guard = set_env_var("OPENDUCKTOR_TEST_STARTUP_DELAY_MS", "600");
+        let _pid_guard = set_env_var(
+            "OPENDUCKTOR_TEST_PID_FILE",
+            pid_file.to_string_lossy().as_ref(),
+        );
+
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let (service, _task_state, _git_state) = build_service_with_store(
+            vec![],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+            },
+            config_store,
+        );
+        let stale_child = Command::new("/bin/sh")
+            .arg("-lc")
+            .arg("sleep 0.2")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn stale child");
+        service
+            .agent_runtimes
+            .lock()
+            .expect("runtime lock poisoned")
+            .insert(
+                "runtime-stale-prune-failure-window".to_string(),
+                super::AgentRuntimeProcess {
+                    summary: AgentRuntimeSummary {
+                        runtime_id: "runtime-stale-prune-failure-window".to_string(),
+                        repo_path: "/tmp/other-repo-for-prune".to_string(),
+                        task_id: "task-1".to_string(),
+                        role: "spec".to_string(),
+                        working_directory: "/tmp/other-repo-for-prune".to_string(),
+                        port: 1,
+                        started_at: "2026-02-20T12:00:00Z".to_string(),
+                    },
+                    child: stale_child,
+                    cleanup_repo_path: Some(
+                        "/tmp/non-existent-repo-for-ensure-post-start-prune".to_string(),
+                    ),
+                    cleanup_worktree_path: Some(
+                        "/tmp/non-existent-worktree-for-ensure-post-start-prune".to_string(),
+                    ),
+                },
+            );
+
+        let repo_path = repo.to_string_lossy().to_string();
+        let error = service
+            .opencode_repo_runtime_ensure(repo_path.as_str())
+            .expect_err("post-start prune failure should bubble up");
+        let message = error.to_string();
+        assert!(message.contains(
+            "Failed pruning stale runtimes while finalizing workspace runtime"
+        ));
+        assert!(wait_for_path_exists(pid_file.as_path(), Duration::from_secs(2)));
+        let spawned_pid = fs::read_to_string(pid_file.as_path())?
+            .trim()
+            .parse::<i32>()
+            .expect("spawned runtime pid should parse as i32");
+        assert!(wait_for_process_exit(spawned_pid, Duration::from_secs(2)));
+        assert!(service
+            .agent_runtimes
+            .lock()
+            .expect("runtime lock poisoned")
+            .is_empty());
+
         let _ = fs::remove_dir_all(root);
         Ok(())
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -45,7 +45,7 @@ impl AppService {
             .agent_runtimes
             .lock()
             .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
-        Self::prune_stale_runtimes(&mut runtimes);
+        Self::prune_stale_runtimes(&mut runtimes)?;
 
         let mut list = runtimes
             .values()
@@ -72,7 +72,7 @@ impl AppService {
                 .agent_runtimes
                 .lock()
                 .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
-            Self::prune_stale_runtimes(&mut runtimes);
+            Self::prune_stale_runtimes(&mut runtimes)?;
 
             if let Some(existing) = runtimes.values().find(|runtime| {
                 Self::repo_key(runtime.summary.repo_path.as_str()) == repo_key
@@ -115,7 +115,7 @@ impl AppService {
                 .agent_runtimes
                 .lock()
                 .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
-            Self::prune_stale_runtimes(&mut runtimes);
+            Self::prune_stale_runtimes(&mut runtimes)?;
 
             if let Some(existing) = runtimes.values().find(|runtime| {
                 Self::repo_key(runtime.summary.repo_path.as_str()) == repo_key
@@ -165,7 +165,7 @@ impl AppService {
                 .agent_runtimes
                 .lock()
                 .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
-            Self::prune_stale_runtimes(&mut runtimes);
+            Self::prune_stale_runtimes(&mut runtimes)?;
 
             if let Some(existing) = runtimes.values().find(|runtime| {
                 Self::repo_key(runtime.summary.repo_path.as_str()) == repo_key
@@ -238,7 +238,13 @@ impl AppService {
                 let (ok, _stdout, stderr) =
                     run_command_allow_failure("sh", &["-lc", hook], Some(qa_worktree.as_path()))?;
                 if !ok {
-                    let _ = remove_worktree(repo_path_ref, qa_worktree.as_path());
+                    if let Err(cleanup_error) =
+                        Self::remove_runtime_worktree(repo_path_ref, qa_worktree.as_path())
+                    {
+                        return Err(anyhow!(
+                            "QA pre-start hook failed: {hook}\n{stderr}\nAlso failed to remove QA worktree: {cleanup_error}"
+                        ));
+                    }
                     return Err(anyhow!("QA pre-start hook failed: {hook}\n{stderr}"));
                 }
             }
@@ -262,14 +268,20 @@ impl AppService {
             wait_for_local_server_with_process(&mut child, port, Duration::from_secs(8))
         {
             terminate_child_process(&mut child);
+            let startup_context = format!("OpenCode runtime failed to start for task {task_id}");
             if let (Some(repo), Some(worktree)) = (
                 cleanup_repo_path.as_deref(),
                 cleanup_worktree_path.as_deref(),
             ) {
-                let _ = remove_worktree(Path::new(repo), Path::new(worktree));
+                if let Err(cleanup_error) =
+                    Self::remove_runtime_worktree(Path::new(repo), Path::new(worktree))
+                {
+                    return Err(anyhow!(
+                        "{startup_context}\nAlso failed to remove QA worktree: {cleanup_error}"
+                    ));
+                }
             }
-            return Err(error)
-                .with_context(|| format!("OpenCode runtime failed to start for task {task_id}"));
+            return Err(error).with_context(|| startup_context);
         }
 
         let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
@@ -312,8 +324,7 @@ impl AppService {
             runtime.cleanup_repo_path.as_deref(),
             runtime.cleanup_worktree_path.as_deref(),
         ) {
-            remove_worktree(Path::new(repo_path), Path::new(worktree_path))
-                .with_context(|| format!("Failed removing QA worktree runtime {worktree_path}"))?;
+            Self::remove_runtime_worktree(Path::new(repo_path), Path::new(worktree_path))?;
         }
         Ok(true)
     }
@@ -341,12 +352,13 @@ impl AppService {
                     runtime.cleanup_repo_path.as_deref(),
                     runtime.cleanup_worktree_path.as_deref(),
                 ) {
-                    if let Err(error) =
-                        remove_worktree(Path::new(repo_path), Path::new(worktree_path))
-                    {
+                    if let Err(error) = Self::remove_runtime_worktree(
+                        Path::new(repo_path),
+                        Path::new(worktree_path),
+                    ) {
                         cleanup_errors.push(format!(
-                            "Failed removing QA worktree runtime {}: {}",
-                            worktree_path, error
+                            "Failed shutting down runtime {}: {}",
+                            runtime.summary.runtime_id, error
                         ));
                     }
                 }
@@ -360,7 +372,18 @@ impl AppService {
         }
     }
 
-    pub(crate) fn prune_stale_runtimes(runtimes: &mut HashMap<String, AgentRuntimeProcess>) {
+    fn remove_runtime_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
+        remove_worktree(repo_path, worktree_path).with_context(|| {
+            format!(
+                "Failed removing QA worktree runtime {}",
+                worktree_path.display()
+            )
+        })
+    }
+
+    pub(crate) fn prune_stale_runtimes(
+        runtimes: &mut HashMap<String, AgentRuntimeProcess>,
+    ) -> Result<()> {
         let stale_runtime_ids = runtimes
             .iter_mut()
             .filter_map(|(runtime_id, runtime)| {
@@ -372,6 +395,7 @@ impl AppService {
                     .map(|_| runtime_id.clone())
             })
             .collect::<Vec<_>>();
+        let mut cleanup_errors = Vec::new();
         for runtime_id in stale_runtime_ids {
             if let Some(mut runtime) = runtimes.remove(&runtime_id) {
                 terminate_child_process(&mut runtime.child);
@@ -379,9 +403,25 @@ impl AppService {
                     runtime.cleanup_repo_path.as_deref(),
                     runtime.cleanup_worktree_path.as_deref(),
                 ) {
-                    let _ = remove_worktree(Path::new(repo_path), Path::new(worktree_path));
+                    if let Err(error) = Self::remove_runtime_worktree(
+                        Path::new(repo_path),
+                        Path::new(worktree_path),
+                    ) {
+                        cleanup_errors.push(format!(
+                            "Failed pruning stale runtime {runtime_id}: {error}"
+                        ));
+                    }
                 }
             }
+        }
+
+        if cleanup_errors.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "Failed pruning stale agent runtimes:\n{}",
+                cleanup_errors.join("\n")
+            ))
         }
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -115,7 +115,14 @@ impl AppService {
                 .agent_runtimes
                 .lock()
                 .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
-            Self::prune_stale_runtimes(&mut runtimes)?;
+            if let Err(error) = Self::prune_stale_runtimes(&mut runtimes) {
+                terminate_child_process(&mut child);
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed pruning stale runtimes while finalizing workspace runtime for {repo_path}"
+                    )
+                });
+            }
 
             if let Some(existing) = runtimes.values().find(|runtime| {
                 Self::repo_key(runtime.summary.repo_path.as_str()) == repo_key


### PR DESCRIPTION
## Summary
- make QA runtime worktree cleanup failures observable instead of silently ignored
- centralize runtime cleanup error context in runtime_orchestrator
- add regression tests for QA pre-start cleanup failure, startup cleanup failure, and stale runtime prune cleanup failure

## Validation
- cd apps/desktop/src-tauri && cargo fmt --check
- cd apps/desktop/src-tauri && cargo check
- cd apps/desktop/src-tauri && cargo test -p host-application
- cd apps/desktop/src-tauri && cargo test
- bun run typecheck
- bun run test
