### PR TITLE
refactor: replace duplicated workspace guard literals with shared constant

### DIFF
--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -8,6 +8,7 @@ import type {
 import { buildAgentSystemPrompt } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
+import { requireActiveRepo } from "../../task-operations-model";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import {
   captureOrchestratorFallback,
@@ -19,7 +20,6 @@ import {
   kickoffPrompt,
   throwIfRepoStale,
 } from "../support/utils";
-import { requireActiveRepo } from "../../task-operations-model";
 
 export type StartAgentSessionInput = {
   taskId: string;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -19,6 +19,7 @@ import {
   kickoffPrompt,
   throwIfRepoStale,
 } from "../support/utils";
+import { requireActiveRepo } from "../../task-operations-model";
 
 export type StartAgentSessionInput = {
   taskId: string;
@@ -110,11 +111,7 @@ export const createStartAgentSession = ({
     sendKickoff = false,
     startMode = "reuse_latest",
   }: StartAgentSessionInput): Promise<string> => {
-    if (!activeRepo) {
-      throw new Error("Select a workspace first.");
-    }
-
-    const repoPath = activeRepo;
+    const repoPath = requireActiveRepo(activeRepo);
     const inFlightKey = `${repoPath}::${taskId}::${role}::${startMode}`;
     const existingInFlight = inFlightStartsByRepoTaskRef.current.get(inFlightKey);
     if (existingInFlight) {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -1,6 +1,7 @@
 import type { TaskCard } from "@openducktor/contracts";
 import { type AgentEnginePort, buildAgentSystemPrompt } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { requireActiveRepo } from "../../task-operations-model";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import {
   captureOrchestratorFallback,
@@ -11,7 +12,6 @@ import {
   shouldReattachListenerForAttachedSession,
   throwIfRepoStale,
 } from "../support/utils";
-import { requireActiveRepo } from "../../task-operations-model";
 
 type EnsureSessionReadyDependencies = {
   activeRepo: string | null;

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -11,6 +11,7 @@ import {
   shouldReattachListenerForAttachedSession,
   throwIfRepoStale,
 } from "../support/utils";
+import { requireActiveRepo } from "../../task-operations-model";
 
 type EnsureSessionReadyDependencies = {
   activeRepo: string | null;
@@ -63,11 +64,7 @@ export const createEnsureSessionReady = ({
   loadSessionModelCatalog,
 }: EnsureSessionReadyDependencies) => {
   return async (sessionId: string): Promise<void> => {
-    if (!activeRepo) {
-      throw new Error("Select a workspace first.");
-    }
-
-    const repoPath = activeRepo;
+    const repoPath = requireActiveRepo(activeRepo);
     const isStaleRepoOperation = createRepoStaleGuard({
       repoPath,
       repoEpochRef,

--- a/apps/desktop/src/state/operations/use-delegation-operations.ts
+++ b/apps/desktop/src/state/operations/use-delegation-operations.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { host } from "./host";
+import { requireActiveRepo } from "./task-operations-model";
 
 type UseDelegationOperationsArgs = {
   activeRepo: string | null;
@@ -23,12 +24,10 @@ export function useDelegationOperations({
 }: UseDelegationOperationsArgs): UseDelegationOperationsResult {
   const delegateTask = useCallback(
     async (taskId: string): Promise<void> => {
-      if (!activeRepo) {
-        throw new Error("Select a workspace first.");
-      }
+      const repo = requireActiveRepo(activeRepo);
 
-      await host.buildStart(activeRepo, taskId);
-      await refreshTaskData(activeRepo);
+      await host.buildStart(repo, taskId);
+      await refreshTaskData(repo);
     },
     [activeRepo, refreshTaskData],
   );

--- a/apps/desktop/src/state/operations/use-repo-settings-operations.ts
+++ b/apps/desktop/src/state/operations/use-repo-settings-operations.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import { host } from "./host";
+import { requireActiveRepo } from "./task-operations-model";
 
 type UseRepoSettingsOperationsArgs = {
   activeRepo: string | null;
@@ -65,11 +66,9 @@ export function useRepoSettingsOperations({
   );
 
   const loadRepoSettings = useCallback(async (): Promise<RepoSettingsInput> => {
-    if (!activeRepo) {
-      throw new Error("Select a workspace first.");
-    }
+    const repo = requireActiveRepo(activeRepo);
 
-    const config = await host.workspaceGetRepoConfig(activeRepo);
+    const config = await host.workspaceGetRepoConfig(repo);
     return {
       worktreeBasePath: config.worktreeBasePath ?? "",
       branchPrefix: config.branchPrefix,
@@ -87,9 +86,7 @@ export function useRepoSettingsOperations({
 
   const saveRepoSettings = useCallback(
     async (input: RepoSettingsInput) => {
-      if (!activeRepo) {
-        throw new Error("Select a workspace first.");
-      }
+      const repo = requireActiveRepo(activeRepo);
 
       const specDefault = toConfigDefault(input.agentDefaults.spec);
       const plannerDefault = toConfigDefault(input.agentDefaults.planner);
@@ -98,7 +95,7 @@ export function useRepoSettingsOperations({
       const normalizedWorktreeBasePath = input.worktreeBasePath.trim();
       const normalizedBranchPrefix = input.branchPrefix.trim();
 
-      await host.workspaceUpdateRepoConfig(activeRepo, {
+      await host.workspaceUpdateRepoConfig(repo, {
         worktreeBasePath: normalizedWorktreeBasePath,
         branchPrefix: normalizedBranchPrefix,
         trustedHooks: input.trustedHooks,

--- a/apps/desktop/src/state/operations/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/use-spec-operations.ts
@@ -1,6 +1,7 @@
 import { defaultSpecTemplateMarkdown, validateSpecMarkdown } from "@openducktor/contracts";
 import { useCallback } from "react";
 import { host } from "./host";
+import { requireActiveRepo } from "./task-operations-model";
 
 type UseSpecOperationsArgs = {
   activeRepo: string | null;
@@ -19,10 +20,8 @@ type UseSpecOperationsResult = {
 export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpecOperationsResult {
   const loadSpecDocument = useCallback(
     async (taskId: string): Promise<{ markdown: string; updatedAt: string | null }> => {
-      if (!activeRepo) {
-        throw new Error("Select a workspace first.");
-      }
-      const spec = await host.specGet(activeRepo, taskId);
+      const repo = requireActiveRepo(activeRepo);
+      const spec = await host.specGet(repo, taskId);
       return {
         markdown: spec.markdown,
         updatedAt: spec.updatedAt,
@@ -33,10 +32,8 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
 
   const loadPlanDocument = useCallback(
     async (taskId: string): Promise<{ markdown: string; updatedAt: string | null }> => {
-      if (!activeRepo) {
-        throw new Error("Select a workspace first.");
-      }
-      const plan = await host.planGet(activeRepo, taskId);
+      const repo = requireActiveRepo(activeRepo);
+      const plan = await host.planGet(repo, taskId);
       return {
         markdown: plan.markdown,
         updatedAt: plan.updatedAt,
@@ -47,10 +44,8 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
 
   const loadQaReportDocument = useCallback(
     async (taskId: string): Promise<{ markdown: string; updatedAt: string | null }> => {
-      if (!activeRepo) {
-        throw new Error("Select a workspace first.");
-      }
-      const report = await host.qaGetReport(activeRepo, taskId);
+      const repo = requireActiveRepo(activeRepo);
+      const report = await host.qaGetReport(repo, taskId);
       return {
         markdown: report.markdown,
         updatedAt: report.updatedAt,
@@ -69,16 +64,14 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
 
   const saveSpec = useCallback(
     async (taskId: string, markdown: string): Promise<{ updatedAt: string }> => {
-      if (!activeRepo) {
-        throw new Error("Select a workspace first.");
-      }
+      const repo = requireActiveRepo(activeRepo);
 
       const validation = validateSpecMarkdown(markdown);
       if (!validation.valid) {
         throw new Error(`Missing required sections: ${validation.missing.join(", ")}`);
       }
 
-      const saved = await host.setSpec({ repoPath: activeRepo, taskId, markdown });
+      const saved = await host.setSpec({ repoPath: repo, taskId, markdown });
       return saved;
     },
     [activeRepo],
@@ -86,20 +79,16 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
 
   const saveSpecDocument = useCallback(
     async (taskId: string, markdown: string): Promise<{ updatedAt: string }> => {
-      if (!activeRepo) {
-        throw new Error("Select a workspace first.");
-      }
-      return host.saveSpecDocument(activeRepo, taskId, markdown);
+      const repo = requireActiveRepo(activeRepo);
+      return host.saveSpecDocument(repo, taskId, markdown);
     },
     [activeRepo],
   );
 
   const savePlanDocument = useCallback(
     async (taskId: string, markdown: string): Promise<{ updatedAt: string }> => {
-      if (!activeRepo) {
-        throw new Error("Select a workspace first.");
-      }
-      return host.savePlanDocument(activeRepo, taskId, markdown);
+      const repo = requireActiveRepo(activeRepo);
+      return host.savePlanDocument(repo, taskId, markdown);
     },
     [activeRepo],
   );


### PR DESCRIPTION
## Summary

- Replace 11 hardcoded "Select a workspace first." error messages across 5 operation modules with the centralized `requireActiveRepo` helper from `task-operations-model.ts`
- Ensures consistent UX messaging and reduces string duplication
- Centralizes workspace guard behavior for easier maintenance

## Changes

| File | Replacements |
|------|-------------|
| use-spec-operations.ts | 6 |
| use-repo-settings-operations.ts | 2 |
| use-delegation-operations.ts | 1 |
| ensure-ready.ts | 1 |
| start-session.ts | 1 |

## Testing

- Typecheck passes: `bun run --filter @openducktor/desktop typecheck`
