### PR TITLE
fix(desktop): resolve agent chat color and selector loading mismatch

### DIFF
--- a/apps/desktop/src/pages/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-model-selection.test.tsx
@@ -3,6 +3,7 @@ import type { AgentModelCatalog } from "@openducktor/core";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
   createAgentSessionFixture,
+  createDeferred,
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
@@ -48,6 +49,7 @@ const CATALOG: AgentModelCatalog = {
       name: "spec-agent",
       mode: "primary",
       hidden: false,
+      color: "#f59e0b",
     },
     {
       name: "build-agent",
@@ -198,6 +200,58 @@ describe("useAgentStudioModelSelection", () => {
       variant: "high",
       opencodeAgent: "spec-agent",
     });
+
+    await harness.unmount();
+  });
+
+  test("falls back to composer catalog colors and loading state when session catalog is unavailable", async () => {
+    const loadCatalog = mock(async () => CATALOG);
+    const activeSession = createActiveSession({
+      modelCatalog: null,
+      isLoadingModelCatalog: true,
+    });
+
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession,
+        loadCatalog,
+      }),
+    );
+
+    await harness.mount();
+    await harness.waitFor((state) => state.agentOptions.length > 0);
+
+    const state = harness.getLatest();
+    expect(state.isSelectionCatalogLoading).toBe(false);
+    expect(state.activeSessionAgentColors).toMatchObject({
+      "spec-agent": "#f59e0b",
+    });
+
+    await harness.unmount();
+  });
+
+  test("keeps loading while no catalog source is available for an active session", async () => {
+    const deferredCatalog = createDeferred<AgentModelCatalog>();
+    const activeSession = createActiveSession({
+      modelCatalog: null,
+      isLoadingModelCatalog: true,
+    });
+
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession,
+        loadCatalog: async () => deferredCatalog.promise,
+      }),
+    );
+
+    await harness.mount();
+    expect(harness.getLatest().isSelectionCatalogLoading).toBe(true);
+
+    await harness.run(async () => {
+      deferredCatalog.resolve(CATALOG);
+      await deferredCatalog.promise;
+    });
+    await harness.waitFor((state) => state.isSelectionCatalogLoading === false);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/pages/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-model-selection.test.tsx
@@ -247,9 +247,8 @@ describe("useAgentStudioModelSelection", () => {
     await harness.mount();
     expect(harness.getLatest().isSelectionCatalogLoading).toBe(true);
 
-    await harness.run(async () => {
+    await harness.run(() => {
       deferredCatalog.resolve(CATALOG);
-      await deferredCatalog.promise;
     });
     await harness.waitFor((state) => state.isSelectionCatalogLoading === false);
 

--- a/apps/desktop/src/pages/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/use-agent-studio-model-selection.ts
@@ -145,7 +145,7 @@ export function useAgentStudioModelSelection({
   const draftSelection = draftSelectionByRole[role];
   const selectionCatalog = activeSession?.modelCatalog ?? composerCatalog;
   const isSelectionCatalogLoading = activeSession
-    ? activeSession.isLoadingModelCatalog
+    ? activeSession.isLoadingModelCatalog && !activeSession.modelCatalog && !composerCatalog
     : isLoadingComposerCatalog;
   const fallbackCatalogSelection = useMemo(
     () => pickDefaultSelectionForCatalog(selectionCatalog),
@@ -258,11 +258,15 @@ export function useAgentStudioModelSelection({
   }, [selectedModelEntry, selectedModelSelection?.variant]);
 
   const activeSessionAgentColors = useMemo<Record<string, string>>(() => {
-    if (!activeSession?.modelCatalog) {
+    if (!activeSession) {
+      return {};
+    }
+    const catalog = activeSession.modelCatalog ?? composerCatalog;
+    if (!catalog) {
       return {};
     }
     const map: Record<string, string> = {};
-    for (const descriptor of activeSession.modelCatalog.agents) {
+    for (const descriptor of catalog.agents) {
       if (!descriptor.name) {
         continue;
       }
@@ -272,7 +276,7 @@ export function useAgentStudioModelSelection({
       }
     }
     return map;
-  }, [activeSession?.modelCatalog]);
+  }, [activeSession, composerCatalog]);
 
   const activeSessionContextUsage = useMemo<AgentStudioContextUsage>(() => {
     if (!activeSession) {


### PR DESCRIPTION
## Summary
- fix Agent chat accent color resolution to use the same catalog fallback path as the model and agent selectors
- prevent agent and model selects from staying disabled when an active session is still loading its catalog but a fallback catalog is already available
- add regression tests for fallback color mapping and loading-state behavior in use-agent-studio-model-selection

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test

## Context
This addresses the planner Start Planner or Start Plan flow where selectors could remain disabled after work finished, and cases where chat colors diverged from selector colors.