### PR TITLE
perf(diagnostics): cache runtime probes and support forced recheck

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, Context, Result};
-use host_domain::{AgentRuntimeSummary, GitPort, RunEvent, RunSummary, TaskCard, TaskStore};
+use host_domain::{
+    AgentRuntimeSummary, GitPort, RunEvent, RunSummary, RuntimeCheck, TaskCard, TaskStore,
+};
 use host_infra_system::{AppConfigStore, GitCliPort, RepoConfig};
 
 use std::collections::{HashMap, HashSet};
@@ -7,6 +9,7 @@ use std::fs;
 use std::path::Path;
 use std::process::Child;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 pub mod build_orchestrator;
 
@@ -49,6 +52,7 @@ pub struct AppService {
     runs: Arc<Mutex<HashMap<String, RunProcess>>>,
     agent_runtimes: Arc<Mutex<HashMap<String, AgentRuntimeProcess>>>,
     initialized_repos: Arc<Mutex<HashSet<String>>>,
+    runtime_check_cache: Arc<Mutex<Option<CachedRuntimeCheck>>>,
 }
 
 pub(crate) struct RunProcess {
@@ -65,6 +69,11 @@ pub(crate) struct AgentRuntimeProcess {
     child: Child,
     cleanup_repo_path: Option<String>,
     cleanup_worktree_path: Option<String>,
+}
+
+pub(crate) struct CachedRuntimeCheck {
+    checked_at: Instant,
+    value: RuntimeCheck,
 }
 
 impl Drop for AppService {
@@ -93,6 +102,7 @@ impl AppService {
             runs: Arc::new(Mutex::new(HashMap::new())),
             agent_runtimes: Arc::new(Mutex::new(HashMap::new())),
             initialized_repos: Arc::new(Mutex::new(HashSet::new())),
+            runtime_check_cache: Arc::new(Mutex::new(None)),
         }
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -59,7 +59,7 @@ impl AppService {
         let mut cache = self
             .runtime_check_cache
             .lock()
-            .map_err(|_| anyhow!("Runtime check cache lock poisoned"))?;
+            .map_err(|_| anyhow!("Runtime check cache lock poisoned in `cached_runtime_check`"))?;
         if let Some(entry) = cache.as_ref() {
             if entry.checked_at.elapsed() <= RUNTIME_CHECK_CACHE_TTL {
                 return Ok(Some(entry.value.clone()));
@@ -73,7 +73,9 @@ impl AppService {
         let mut cache = self
             .runtime_check_cache
             .lock()
-            .map_err(|_| anyhow!("Runtime check cache lock poisoned"))?;
+            .map_err(|_| {
+                anyhow!("Runtime check cache lock poisoned in `update_runtime_check_cache`")
+            })?;
         *cache = Some(CachedRuntimeCheck {
             checked_at: Instant::now(),
             value: check,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -1,4 +1,4 @@
-use super::{read_opencode_version, resolve_opencode_binary_path, AppService};
+use super::{read_opencode_version, resolve_opencode_binary_path, AppService, CachedRuntimeCheck};
 use anyhow::{anyhow, Result};
 use host_domain::{
     BeadsCheck, GitBranch, GitCurrentBranch, GitPushSummary, GitWorktreeSummary, RuntimeCheck,
@@ -6,9 +6,28 @@ use host_domain::{
 };
 use host_infra_system::{command_exists, resolve_central_beads_dir, version_command, RepoConfig};
 use std::path::Path;
+use std::time::{Duration, Instant};
+
+const RUNTIME_CHECK_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 
 impl AppService {
     pub fn runtime_check(&self) -> Result<RuntimeCheck> {
+        self.runtime_check_with_refresh(false)
+    }
+
+    pub fn runtime_check_with_refresh(&self, force_refresh: bool) -> Result<RuntimeCheck> {
+        if !force_refresh {
+            if let Some(cached) = self.cached_runtime_check()? {
+                return Ok(cached);
+            }
+        }
+
+        let runtime = Self::probe_runtime_check();
+        self.update_runtime_check_cache(runtime.clone())?;
+        Ok(runtime)
+    }
+
+    fn probe_runtime_check() -> RuntimeCheck {
         let git_ok = command_exists("git");
         let opencode_binary = resolve_opencode_binary_path();
         let opencode_ok = opencode_binary.is_some();
@@ -21,7 +40,7 @@ impl AppService {
             errors.push("opencode not found in PATH".to_string());
         }
 
-        Ok(RuntimeCheck {
+        RuntimeCheck {
             git_ok,
             git_version: version_command("git", &["--version"]),
             opencode_ok,
@@ -33,7 +52,33 @@ impl AppService {
                 }
             }),
             errors,
-        })
+        }
+    }
+
+    fn cached_runtime_check(&self) -> Result<Option<RuntimeCheck>> {
+        let mut cache = self
+            .runtime_check_cache
+            .lock()
+            .map_err(|_| anyhow!("Runtime check cache lock poisoned"))?;
+        if let Some(entry) = cache.as_ref() {
+            if entry.checked_at.elapsed() <= RUNTIME_CHECK_CACHE_TTL {
+                return Ok(Some(entry.value.clone()));
+            }
+        }
+        *cache = None;
+        Ok(None)
+    }
+
+    fn update_runtime_check_cache(&self, check: RuntimeCheck) -> Result<()> {
+        let mut cache = self
+            .runtime_check_cache
+            .lock()
+            .map_err(|_| anyhow!("Runtime check cache lock poisoned"))?;
+        *cache = Some(CachedRuntimeCheck {
+            checked_at: Instant::now(),
+            value: check,
+        });
+        Ok(())
     }
 
     pub fn beads_check(&self, repo_path: &str) -> Result<BeadsCheck> {
@@ -221,7 +266,11 @@ impl AppService {
 
 #[cfg(test)]
 mod tests {
+    use super::super::CachedRuntimeCheck;
+    use super::RUNTIME_CHECK_CACHE_TTL;
     use crate::app_service::test_support::build_service_with_state;
+    use host_domain::RuntimeCheck;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn module_git_create_worktree_rejects_empty_path() {
@@ -251,5 +300,98 @@ mod tests {
         assert_eq!(summary.remote, "origin");
         let state = git_state.lock().expect("git state lock poisoned");
         assert_eq!(state.last_push_remote.as_deref(), Some("origin"));
+    }
+
+    #[test]
+    fn module_runtime_check_returns_cached_value_when_fresh() {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let cached = RuntimeCheck {
+            git_ok: false,
+            git_version: Some("cached-git-sentinel".to_string()),
+            opencode_ok: false,
+            opencode_version: Some("cached-opencode-sentinel".to_string()),
+            errors: vec!["cached-runtime-sentinel".to_string()],
+        };
+        {
+            let mut cache = service
+                .runtime_check_cache
+                .lock()
+                .expect("runtime cache lock poisoned");
+            *cache = Some(CachedRuntimeCheck {
+                checked_at: Instant::now(),
+                value: cached.clone(),
+            });
+        }
+
+        let runtime = service
+            .runtime_check()
+            .expect("runtime check should use cached entry");
+        assert_eq!(runtime.git_version, cached.git_version);
+        assert_eq!(runtime.opencode_version, cached.opencode_version);
+        assert_eq!(runtime.errors, cached.errors);
+    }
+
+    #[test]
+    fn module_runtime_check_force_refresh_bypasses_cache() {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let sentinel_error = "cached-runtime-sentinel".to_string();
+        {
+            let mut cache = service
+                .runtime_check_cache
+                .lock()
+                .expect("runtime cache lock poisoned");
+            *cache = Some(CachedRuntimeCheck {
+                checked_at: Instant::now(),
+                value: RuntimeCheck {
+                    git_ok: false,
+                    git_version: Some("cached-git-sentinel".to_string()),
+                    opencode_ok: false,
+                    opencode_version: Some("cached-opencode-sentinel".to_string()),
+                    errors: vec![sentinel_error.clone()],
+                },
+            });
+        }
+
+        let runtime = service
+            .runtime_check_with_refresh(true)
+            .expect("runtime check should bypass cache when forced");
+        assert!(!runtime.errors.contains(&sentinel_error));
+        assert_ne!(runtime.git_version.as_deref(), Some("cached-git-sentinel"));
+        assert_ne!(
+            runtime.opencode_version.as_deref(),
+            Some("cached-opencode-sentinel")
+        );
+    }
+
+    #[test]
+    fn module_runtime_check_refreshes_when_cache_is_stale() {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let sentinel_error = "cached-runtime-sentinel".to_string();
+        {
+            let mut cache = service
+                .runtime_check_cache
+                .lock()
+                .expect("runtime cache lock poisoned");
+            *cache = Some(CachedRuntimeCheck {
+                checked_at: Instant::now() - (RUNTIME_CHECK_CACHE_TTL + Duration::from_secs(1)),
+                value: RuntimeCheck {
+                    git_ok: false,
+                    git_version: Some("cached-git-sentinel".to_string()),
+                    opencode_ok: false,
+                    opencode_version: Some("cached-opencode-sentinel".to_string()),
+                    errors: vec![sentinel_error.clone()],
+                },
+            });
+        }
+
+        let runtime = service
+            .runtime_check()
+            .expect("runtime check should refresh stale cache entries");
+        assert!(!runtime.errors.contains(&sentinel_error));
+        assert_ne!(runtime.git_version.as_deref(), Some("cached-git-sentinel"));
+        assert_ne!(
+            runtime.opencode_version.as_deref(),
+            Some("cached-opencode-sentinel")
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -115,8 +115,15 @@ async fn system_check(
 }
 
 #[tauri::command]
-async fn runtime_check(state: State<'_, AppState>) -> Result<host_domain::RuntimeCheck, String> {
-    let check = as_error(state.service.runtime_check())?;
+async fn runtime_check(
+    state: State<'_, AppState>,
+    force: Option<bool>,
+) -> Result<host_domain::RuntimeCheck, String> {
+    let check = as_error(
+        state
+            .service
+            .runtime_check_with_refresh(force.unwrap_or(false)),
+    )?;
     Ok(extend_runtime_errors_with_startup(
         check,
         &state.startup_errors,

--- a/apps/desktop/src/state/operations/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/use-checks.test.tsx
@@ -139,7 +139,9 @@ beforeEach(() => {
 
 describe("use-checks", () => {
   test("refreshChecks is a no-op when no active repo is selected", async () => {
-    const runtimeCheck = mock(async (): Promise<RuntimeCheck> => makeRuntimeCheck());
+    const runtimeCheck = mock(
+      async (_force?: boolean): Promise<RuntimeCheck> => makeRuntimeCheck(),
+    );
     const beadsCheck = mock(async (): Promise<BeadsCheck> => makeBeadsCheck());
 
     const original = {
@@ -170,7 +172,9 @@ describe("use-checks", () => {
   });
 
   test("refreshRuntimeCheck caches and supports force retries", async () => {
-    const runtimeCheck = mock(async (): Promise<RuntimeCheck> => makeRuntimeCheck());
+    const runtimeCheck = mock(
+      async (_force?: boolean): Promise<RuntimeCheck> => makeRuntimeCheck(),
+    );
 
     const original = {
       runtimeCheck: host.runtimeCheck,
@@ -188,6 +192,8 @@ describe("use-checks", () => {
       });
 
       expect(runtimeCheck).toHaveBeenCalledTimes(2);
+      expect(runtimeCheck.mock.calls[0]).toEqual([false]);
+      expect(runtimeCheck.mock.calls[1]).toEqual([true]);
       expect(harness.getLatest().hasRuntimeCheck()).toBe(true);
     } finally {
       await harness.unmount();
@@ -241,7 +247,7 @@ describe("use-checks", () => {
 
   test("refreshChecks reports unhealthy diagnostics details", async () => {
     const runtimeCheck = mock(
-      async (): Promise<RuntimeCheck> =>
+      async (_force?: boolean): Promise<RuntimeCheck> =>
         makeRuntimeCheck({ gitOk: false, errors: ["git unavailable"] }),
     );
     const beadsCheck = mock(
@@ -280,7 +286,7 @@ describe("use-checks", () => {
   test("refreshChecks forces a fresh runtime check and surfaces errors", async () => {
     let callCount = 0;
     const runtimeCheck = mock(
-      async (): Promise<RuntimeCheck> =>
+      async (_force?: boolean): Promise<RuntimeCheck> =>
         new Promise((resolve, reject) => {
           callCount += 1;
           if (callCount === 1) {
@@ -308,6 +314,8 @@ describe("use-checks", () => {
       });
 
       expect(runtimeCheck).toHaveBeenCalledTimes(2);
+      expect(runtimeCheck.mock.calls[0]).toEqual([false]);
+      expect(runtimeCheck.mock.calls[1]).toEqual([true]);
       expect(toastError).toHaveBeenCalledWith("Diagnostics check unavailable", {
         description: "runtime down",
       });

--- a/apps/desktop/src/state/operations/use-checks.ts
+++ b/apps/desktop/src/state/operations/use-checks.ts
@@ -45,7 +45,7 @@ export function useChecks({ activeRepo, checkRepoOpencodeHealth }: UseChecksArgs
       return runtimeCheckRef.current;
     }
 
-    const check = await host.runtimeCheck();
+    const check = await host.runtimeCheck(force);
     runtimeCheckRef.current = check;
     setRuntimeCheck(check);
     return check;

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -115,6 +115,35 @@ describe("TauriHostClient", () => {
     });
   });
 
+  test("runtimeCheck forwards force flag to IPC command", async () => {
+    const { client, calls } = createClient((command) => {
+      if (command === "runtime_check") {
+        return {
+          gitOk: true,
+          gitVersion: "2.45.0",
+          opencodeOk: true,
+          opencodeVersion: "0.12.0",
+          errors: [],
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await client.runtimeCheck();
+    await client.runtimeCheck(true);
+
+    expect(calls).toEqual([
+      {
+        command: "runtime_check",
+        args: { force: false },
+      },
+      {
+        command: "runtime_check",
+        args: { force: true },
+      },
+    ]);
+  });
+
   test("taskTransition validates status before invoking host", async () => {
     const { client, calls } = createClient(() => makeTaskCardPayload());
 

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -89,8 +89,8 @@ export class TauriHostClient implements PlannerTools {
     return systemCheckSchema.parse(payload);
   }
 
-  async runtimeCheck(): Promise<RuntimeCheck> {
-    const payload = await this.invokeFn<unknown>("runtime_check");
+  async runtimeCheck(force = false): Promise<RuntimeCheck> {
+    const payload = await this.invokeFn<unknown>("runtime_check", { force });
     return runtimeCheckSchema.parse(payload);
   }
 


### PR DESCRIPTION
## Summary
- cache runtime diagnostics probe results in host application
- add explicit force-refresh path for runtime checks from frontend to tauri to host service
- increase backend runtime check cache TTL to 5 minutes

## Validation
- cd apps/desktop/src-tauri && cargo check
- cd apps/desktop/src-tauri && cargo test -p host-application
