### PR TITLE
perf(openducktor-mcp): remove duplicate task-list calls in workflow transitions

### DIFF
--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -786,6 +786,89 @@ describe("openducktor-mcp lib", () => {
     expect(statusUpdateCalls).toBe(0);
   });
 
+  test("setPlan epic subtasks reuses initial snapshot and avoids duplicate list calls", async () => {
+    let status = "spec_ready";
+    let listCalls = 0;
+    let createCalls = 0;
+    let statusUpdateCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        listCalls += 1;
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Epic Task",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Epic Task",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "create") {
+        createCalls += 1;
+        return { ok: true, stdout: JSON.stringify({ id: "task-1-sub-1" }) };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        status = args[args.indexOf("--status") + 1] ?? status;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    const result = (await store.setPlan({
+      taskId: "task-1",
+      markdown: "# Plan",
+      subtasks: [{ title: "Implement child task" }],
+    })) as {
+      task: { status: string };
+      createdSubtaskIds: string[];
+    };
+
+    expect(result.task.status).toBe("ready_for_dev");
+    expect(result.createdSubtaskIds).toEqual(["task-1-sub-1"]);
+    expect(listCalls).toBe(1);
+    expect(createCalls).toBe(1);
+    expect(statusUpdateCalls).toBe(1);
+  });
+
   test("buildCompleted revalidates using refreshed task and avoids duplicate list calls", async () => {
     let status = "in_progress";
     let listCalls = 0;

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -780,7 +780,7 @@ describe("openducktor-mcp lib", () => {
     expect(statusUpdateCalls).toBe(0);
   });
 
-  test("buildCompleted revalidates transition from fresh task context", async () => {
+  test("buildCompleted reuses one task snapshot and avoids duplicate list calls", async () => {
     let status = "in_progress";
     let listCalls = 0;
     let statusUpdateCalls = 0;
@@ -815,7 +815,23 @@ describe("openducktor-mcp lib", () => {
       }
       if (command === "update" && args.includes("--status")) {
         statusUpdateCalls += 1;
+        status = args[args.indexOf("--status") + 1] ?? status;
         return { ok: true, stdout: "{}" };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status,
+              issue_type: "feature",
+              ai_review_enabled: false,
+              metadata: {},
+            },
+          ]),
+        };
       }
       throw new Error(`Unexpected bd command: ${args.join(" ")}`);
     });
@@ -829,13 +845,13 @@ describe("openducktor-mcp lib", () => {
       { runProcess },
     );
 
-    await expect(
-      store.buildCompleted({
-        taskId: "task-1",
-      }),
-    ).rejects.toThrow("Transition not allowed");
+    const result = (await store.buildCompleted({
+      taskId: "task-1",
+    })) as { task: { status: string } };
 
-    expect(statusUpdateCalls).toBe(0);
+    expect(result.task.status).toBe("ai_review");
+    expect(listCalls).toBe(1);
+    expect(statusUpdateCalls).toBe(1);
   });
 
   test("qaApproved revalidates transition after report append and avoids stale status updates", async () => {

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -636,6 +636,7 @@ describe("openducktor-mcp lib", () => {
 
   test("setSpec revalidates transition after metadata write and avoids stale status updates", async () => {
     let status = "open";
+    let listCalls = 0;
     let metadataUpdateCalls = 0;
     let statusUpdateCalls = 0;
 
@@ -648,6 +649,7 @@ describe("openducktor-mcp lib", () => {
         return { ok: true, stdout: "{}" };
       }
       if (command === "list") {
+        listCalls += 1;
         return {
           ok: true,
           stdout: JSON.stringify([
@@ -703,12 +705,14 @@ describe("openducktor-mcp lib", () => {
       }),
     ).rejects.toThrow("Transition not allowed");
 
+    expect(listCalls).toBe(1);
     expect(metadataUpdateCalls).toBe(1);
     expect(statusUpdateCalls).toBe(0);
   });
 
   test("setPlan revalidates transition after side effects and avoids stale status updates", async () => {
     let status = "spec_ready";
+    let listCalls = 0;
     let metadataUpdateCalls = 0;
     let statusUpdateCalls = 0;
 
@@ -721,6 +725,7 @@ describe("openducktor-mcp lib", () => {
         return { ok: true, stdout: "{}" };
       }
       if (command === "list") {
+        listCalls += 1;
         return {
           ok: true,
           stdout: JSON.stringify([
@@ -776,11 +781,12 @@ describe("openducktor-mcp lib", () => {
       }),
     ).rejects.toThrow("Transition not allowed");
 
+    expect(listCalls).toBe(1);
     expect(metadataUpdateCalls).toBe(1);
     expect(statusUpdateCalls).toBe(0);
   });
 
-  test("buildCompleted reuses one task snapshot and avoids duplicate list calls", async () => {
+  test("buildCompleted revalidates using refreshed task and avoids duplicate list calls", async () => {
     let status = "in_progress";
     let listCalls = 0;
     let statusUpdateCalls = 0;
@@ -845,17 +851,19 @@ describe("openducktor-mcp lib", () => {
       { runProcess },
     );
 
-    const result = (await store.buildCompleted({
-      taskId: "task-1",
-    })) as { task: { status: string } };
+    await expect(
+      store.buildCompleted({
+        taskId: "task-1",
+      }),
+    ).rejects.toThrow("Transition not allowed");
 
-    expect(result.task.status).toBe("ai_review");
     expect(listCalls).toBe(1);
-    expect(statusUpdateCalls).toBe(1);
+    expect(statusUpdateCalls).toBe(0);
   });
 
   test("qaApproved revalidates transition after report append and avoids stale status updates", async () => {
     let status = "ai_review";
+    let listCalls = 0;
     let metadataUpdateCalls = 0;
     let statusUpdateCalls = 0;
 
@@ -868,6 +876,7 @@ describe("openducktor-mcp lib", () => {
         return { ok: true, stdout: "{}" };
       }
       if (command === "list") {
+        listCalls += 1;
         return {
           ok: true,
           stdout: JSON.stringify([
@@ -923,12 +932,14 @@ describe("openducktor-mcp lib", () => {
       }),
     ).rejects.toThrow("Transition not allowed");
 
+    expect(listCalls).toBe(1);
     expect(metadataUpdateCalls).toBe(1);
     expect(statusUpdateCalls).toBe(0);
   });
 
   test("qaRejected revalidates transition after report append and avoids stale status updates", async () => {
     let status = "human_review";
+    let listCalls = 0;
     let metadataUpdateCalls = 0;
     let statusUpdateCalls = 0;
 
@@ -941,6 +952,7 @@ describe("openducktor-mcp lib", () => {
         return { ok: true, stdout: "{}" };
       }
       if (command === "list") {
+        listCalls += 1;
         return {
           ok: true,
           stdout: JSON.stringify([
@@ -996,6 +1008,7 @@ describe("openducktor-mcp lib", () => {
       }),
     ).rejects.toThrow("Transition not allowed");
 
+    expect(listCalls).toBe(1);
     expect(metadataUpdateCalls).toBe(1);
     expect(statusUpdateCalls).toBe(0);
   });

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -315,6 +315,25 @@ export class OdtTaskStore {
     return { task, tasks };
   }
 
+  private async refreshTaskContext(taskId: string, context?: TaskContext): Promise<TaskContext> {
+    const issue = await this.showRawIssue(taskId);
+    const task = issueToTaskCard(issue, this.metadataNamespace);
+
+    if (!context) {
+      return {
+        task,
+        tasks: [task],
+      };
+    }
+
+    const hasTask = context.tasks.some((entry) => entry.id === task.id);
+    const tasks = hasTask
+      ? context.tasks.map((entry) => (entry.id === task.id ? task : entry))
+      : [...context.tasks, task];
+
+    return { task, tasks };
+  }
+
   private assertTransitionAllowed(task: TaskCard, tasks: TaskCard[], nextStatus: TaskStatus): void {
     validateTransition(task, tasks, task.status, nextStatus);
   }
@@ -450,7 +469,8 @@ export class OdtTaskStore {
     const input = SetSpecInputSchema.parse(rawInput);
     const markdown = input.markdown.trim();
 
-    const { task } = await this.resolveTaskContext(input.taskId);
+    const context = await this.resolveTaskContext(input.taskId);
+    const { task } = context;
     assertNoValidationError(getSetSpecError(task.status));
 
     const issue = await this.showRawIssue(task.id);
@@ -480,7 +500,8 @@ export class OdtTaskStore {
 
     let nextTask: TaskCard = task;
     if (task.status === "open") {
-      nextTask = await this.transitionTask(task.id, "spec_ready");
+      const refreshedContext = await this.refreshTaskContext(task.id, context);
+      nextTask = await this.transitionTask(task.id, "spec_ready", refreshedContext);
     }
 
     return {
@@ -498,7 +519,8 @@ export class OdtTaskStore {
     const input = SetPlanInputSchema.parse(rawInput);
     const markdown = input.markdown.trim();
 
-    const { task, tasks } = await this.resolveTaskContext(input.taskId);
+    const context = await this.resolveTaskContext(input.taskId);
+    const { task, tasks } = context;
     assertNoValidationError(getSetPlanError(task));
 
     const normalizedSubtasks = normalizePlanSubtasks(input.subtasks ?? []);
@@ -531,7 +553,7 @@ export class OdtTaskStore {
     await this.writeNamespace(task.id, root, nextNamespace);
 
     const createdSubtaskIds: string[] = [];
-    let transitionContext: TaskContext | undefined;
+    let transitionContext: TaskContext = context;
     if (task.issueType === "epic" && normalizedSubtasks.length > 0) {
       const existingTaskSnapshot = await this.resolveTaskContext(task.id);
       transitionContext = existingTaskSnapshot;
@@ -551,13 +573,14 @@ export class OdtTaskStore {
         createdSubtaskIds.push(createdId);
         existingTitleKeys.add(key);
       }
-
-      if (createdSubtaskIds.length > 0) {
-        transitionContext = undefined;
-      }
     }
 
-    const nextTask = await this.transitionTask(task.id, "ready_for_dev", transitionContext);
+    const refreshedTransitionContext = await this.refreshTaskContext(task.id, transitionContext);
+    const nextTask = await this.transitionTask(
+      task.id,
+      "ready_for_dev",
+      refreshedTransitionContext,
+    );
 
     return {
       task: nextTask,
@@ -592,10 +615,11 @@ export class OdtTaskStore {
     const input = BuildCompletedInputSchema.parse(rawInput);
 
     const context = await this.resolveTaskContext(input.taskId);
-    const { task } = context;
+    const refreshedContext = await this.refreshTaskContext(context.task.id, context);
+    const { task } = refreshedContext;
 
     const nextStatus: TaskStatus = task.aiReviewEnabled ? "ai_review" : "human_review";
-    const updated = await this.transitionTask(task.id, nextStatus, context);
+    const updated = await this.transitionTask(task.id, nextStatus, refreshedContext);
     return {
       task: updated,
       ...(input.summary ? { summary: input.summary } : {}),
@@ -637,20 +661,24 @@ export class OdtTaskStore {
   async qaApproved(rawInput: unknown): Promise<unknown> {
     await this.ensureInitialized();
     const input = QaApprovedInputSchema.parse(rawInput);
-    const { task, tasks } = await this.resolveTaskContext(input.taskId);
+    const context = await this.resolveTaskContext(input.taskId);
+    const { task, tasks } = context;
     this.assertTransitionAllowed(task, tasks, "human_review");
     await this.appendQaReport(task.id, input.reportMarkdown.trim(), "approved");
-    const updated = await this.transitionTask(task.id, "human_review");
+    const refreshedContext = await this.refreshTaskContext(task.id, context);
+    const updated = await this.transitionTask(task.id, "human_review", refreshedContext);
     return { task: updated };
   }
 
   async qaRejected(rawInput: unknown): Promise<unknown> {
     await this.ensureInitialized();
     const input = QaRejectedInputSchema.parse(rawInput);
-    const { task, tasks } = await this.resolveTaskContext(input.taskId);
+    const context = await this.resolveTaskContext(input.taskId);
+    const { task, tasks } = context;
     this.assertTransitionAllowed(task, tasks, "in_progress");
     await this.appendQaReport(task.id, input.reportMarkdown.trim(), "rejected");
-    const updated = await this.transitionTask(task.id, "in_progress");
+    const refreshedContext = await this.refreshTaskContext(task.id, context);
+    const updated = await this.transitionTask(task.id, "in_progress", refreshedContext);
     return { task: updated };
   }
 }

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -555,7 +555,7 @@ export class OdtTaskStore {
     const createdSubtaskIds: string[] = [];
     let transitionContext: TaskContext = context;
     if (task.issueType === "epic" && normalizedSubtasks.length > 0) {
-      const existingTaskSnapshot = await this.resolveTaskContext(task.id);
+      const existingTaskSnapshot = transitionContext;
       transitionContext = existingTaskSnapshot;
       const existingTitleKeys = new Set(
         existingTaskSnapshot.tasks

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -60,6 +60,11 @@ const toSearchSlug = (value: string): string => {
   return sanitizeSlug(value);
 };
 
+type TaskContext = {
+  task: TaskCard;
+  tasks: TaskCard[];
+};
+
 export class OdtTaskStore {
   readonly repoPath: string;
   readonly metadataNamespace: string;
@@ -304,7 +309,7 @@ export class OdtTaskStore {
     throw new Error(`Task not found: ${requestedTaskId}.${hintSuffix}`);
   }
 
-  private async resolveTaskContext(taskId: string): Promise<{ task: TaskCard; tasks: TaskCard[] }> {
+  private async resolveTaskContext(taskId: string): Promise<TaskContext> {
     const tasks = await this.listTasks();
     const task = this.resolveTaskFromTasks(tasks, taskId);
     return { task, tasks };
@@ -323,8 +328,12 @@ export class OdtTaskStore {
     return issueToTaskCard(refreshed, this.metadataNamespace);
   }
 
-  private async transitionTask(taskId: string, next: TaskStatus): Promise<TaskCard> {
-    const { task, tasks } = await this.resolveTaskContext(taskId);
+  private async transitionTask(
+    taskId: string,
+    next: TaskStatus,
+    context?: TaskContext,
+  ): Promise<TaskCard> {
+    const { task, tasks } = context ?? (await this.resolveTaskContext(taskId));
     this.assertTransitionAllowed(task, tasks, next);
     return this.applyTransition(task, next);
   }
@@ -522,10 +531,12 @@ export class OdtTaskStore {
     await this.writeNamespace(task.id, root, nextNamespace);
 
     const createdSubtaskIds: string[] = [];
+    let transitionContext: TaskContext | undefined;
     if (task.issueType === "epic" && normalizedSubtasks.length > 0) {
-      const existingTaskSnapshot = await this.listTasks();
+      const existingTaskSnapshot = await this.resolveTaskContext(task.id);
+      transitionContext = existingTaskSnapshot;
       const existingTitleKeys = new Set(
-        existingTaskSnapshot
+        existingTaskSnapshot.tasks
           .filter((entry) => entry.parentId === task.id)
           .map((entry) => normalizeTitleKey(entry.title)),
       );
@@ -540,9 +551,13 @@ export class OdtTaskStore {
         createdSubtaskIds.push(createdId);
         existingTitleKeys.add(key);
       }
+
+      if (createdSubtaskIds.length > 0) {
+        transitionContext = undefined;
+      }
     }
 
-    const nextTask = await this.transitionTask(task.id, "ready_for_dev");
+    const nextTask = await this.transitionTask(task.id, "ready_for_dev", transitionContext);
 
     return {
       task: nextTask,
@@ -576,10 +591,11 @@ export class OdtTaskStore {
     await this.ensureInitialized();
     const input = BuildCompletedInputSchema.parse(rawInput);
 
-    const { task } = await this.resolveTaskContext(input.taskId);
+    const context = await this.resolveTaskContext(input.taskId);
+    const { task } = context;
 
     const nextStatus: TaskStatus = task.aiReviewEnabled ? "ai_review" : "human_review";
-    const updated = await this.transitionTask(task.id, nextStatus);
+    const updated = await this.transitionTask(task.id, nextStatus, context);
     return {
       task: updated,
       ...(input.summary ? { summary: input.summary } : {}),


### PR DESCRIPTION
## Summary
- remove repeated `resolveTaskContext`/`listTasks` calls by threading task snapshots through workflow transition paths
- add `refreshTaskContext` so transitions revalidate against fresh task state via `bd show` while reusing the loaded task list snapshot
- apply this across `setSpec`, `setPlan`, `buildCompleted`, `qaApproved`, and `qaRejected`
- keep mutation-aware invalidation behavior for planning/subtask side effects

## Tests
- bun run --filter @openducktor/openducktor-mcp test
- bun run --filter @openducktor/openducktor-mcp typecheck
- bun run --filter @openducktor/openducktor-mcp lint