### PR TITLE
perf(mcp): optimize and harden task identifier resolution

### DIFF
--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -552,6 +552,89 @@ describe("openducktor-mcp lib", () => {
     expect(calls.filter((entry) => entry.args[1] === "list")).toHaveLength(2);
   });
 
+  test("readTask refreshes index on ambiguous cache miss and resolves uniquely", async () => {
+    let listCalls = 0;
+
+    const { runProcess, calls } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        listCalls += 1;
+        const issues =
+          listCalls === 1
+            ? [
+                {
+                  id: "fairnest-wsp",
+                  title: "Task A",
+                  status: "open",
+                  issue_type: "task",
+                  metadata: {},
+                },
+                {
+                  id: "delta-wsp",
+                  title: "Task B",
+                  status: "open",
+                  issue_type: "task",
+                  metadata: {},
+                },
+              ]
+            : [
+                {
+                  id: "fairnest-wsp",
+                  title: "Task A",
+                  status: "in_progress",
+                  issue_type: "task",
+                  metadata: {},
+                },
+              ];
+
+        return { ok: true, stdout: JSON.stringify(issues) };
+      }
+      if (command === "show") {
+        const id = args[2];
+        if (id !== "fairnest-wsp") {
+          return { ok: true, stdout: JSON.stringify([]) };
+        }
+
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "fairnest-wsp",
+              title: "Task A",
+              status: "in_progress",
+              issue_type: "task",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    const result = (await store.readTask({ taskId: "wsp" })) as {
+      task: { id: string; status: string };
+    };
+
+    expect(result.task.id).toBe("fairnest-wsp");
+    expect(result.task.status).toBe("in_progress");
+    expect(calls.filter((entry) => entry.args[1] === "list")).toHaveLength(2);
+  });
+
   test("buildResumed allows task issues to skip spec/planning from open", async () => {
     let status = "open";
     let statusTransition: string | null = null;

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -260,6 +260,93 @@ describe("openducktor-mcp lib", () => {
     expect(statusTargetTaskId).toBe("fairnest-wsp");
   });
 
+  test("setSpec resolves short task id suffix to canonical task id", async () => {
+    let metadataTargetTaskId: string | null = null;
+    let statusTargetTaskId: string | null = null;
+    let status = "open";
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "fairnest-wsp",
+              title: "Add Facebook OAuth Login",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+            {
+              id: "fairnest-abc",
+              title: "Improve UI spacing",
+              status: "open",
+              issue_type: "task",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        const id = args[2];
+        if (id !== "fairnest-wsp") {
+          return { ok: true, stdout: JSON.stringify([]) };
+        }
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "fairnest-wsp",
+              title: "Add Facebook OAuth Login",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        metadataTargetTaskId = args[2] ?? null;
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusTargetTaskId = args[2] ?? null;
+        status = args[args.indexOf("--status") + 1] ?? status;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      {
+        runProcess,
+        now: () => "2026-02-19T12:00:00.000Z",
+      },
+    );
+
+    const result = (await store.setSpec({
+      taskId: "wsp",
+      markdown: "# Spec",
+    })) as { task: { id: string; status: string } };
+
+    expect(result.task.id).toBe("fairnest-wsp");
+    expect(result.task.status).toBe("spec_ready");
+    expect(metadataTargetTaskId).toBe("fairnest-wsp");
+    expect(statusTargetTaskId).toBe("fairnest-wsp");
+  });
+
   test("setSpec fails with explicit candidates when task identifier is ambiguous", async () => {
     const { runProcess } = buildProcessRunner((args) => {
       const command = args[1];
@@ -310,7 +397,7 @@ describe("openducktor-mcp lib", () => {
     ).rejects.toThrow('Task identifier "facebook-oauth" is ambiguous');
   });
 
-  test("OdtTaskStore initialization is cached across concurrent calls", async () => {
+  test("OdtTaskStore initialization and task index build are cached across concurrent calls", async () => {
     const { runProcess, calls } = buildProcessRunner((args) => {
       const command = args[1];
       if (command === "where") {
@@ -370,12 +457,99 @@ describe("openducktor-mcp lib", () => {
 
     expect(calls.filter((entry) => entry.args[1] === "init")).toHaveLength(1);
     expect(calls.filter((entry) => entry.args[1] === "config")).toHaveLength(1);
-    expect(calls.filter((entry) => entry.args[1] === "list")).toHaveLength(3);
+    expect(calls.filter((entry) => entry.args[1] === "list")).toHaveLength(1);
     expect(calls.filter((entry) => entry.args[1] === "show")).toHaveLength(3);
     for (const call of calls) {
       expect(call.command).toBe("bd");
       expect(call.env.BEADS_DIR).toBe("/beads");
     }
+  });
+
+  test("readTask refreshes index on not-found cache miss and resolves newly added task", async () => {
+    let listCalls = 0;
+
+    const { runProcess, calls } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        listCalls += 1;
+        const issues =
+          listCalls === 1
+            ? [
+                {
+                  id: "task-1",
+                  title: "Task 1",
+                  status: "open",
+                  issue_type: "task",
+                  metadata: {},
+                },
+              ]
+            : [
+                {
+                  id: "task-1",
+                  title: "Task 1",
+                  status: "open",
+                  issue_type: "task",
+                  metadata: {},
+                },
+                {
+                  id: "task-2",
+                  title: "Task 2",
+                  status: "in_progress",
+                  issue_type: "task",
+                  metadata: {},
+                },
+              ];
+
+        return {
+          ok: true,
+          stdout: JSON.stringify(issues),
+        };
+      }
+      if (command === "show") {
+        const id = args[2];
+        if (id !== "task-1" && id !== "task-2") {
+          return { ok: true, stdout: JSON.stringify([]) };
+        }
+
+        const issue = {
+          id,
+          title: id === "task-2" ? "Task 2" : "Task 1",
+          status: id === "task-2" ? "in_progress" : "open",
+          issue_type: "task",
+          metadata: {},
+        };
+
+        return {
+          ok: true,
+          stdout: JSON.stringify([issue]),
+        };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    await store.readTask({ taskId: "task-1" });
+    const result = (await store.readTask({ taskId: "task-2" })) as {
+      task: { id: string; status: string };
+    };
+
+    expect(result.task.id).toBe("task-2");
+    expect(result.task.status).toBe("in_progress");
+    expect(calls.filter((entry) => entry.args[1] === "list")).toHaveLength(2);
   });
 
   test("buildResumed allows task issues to skip spec/planning from open", async () => {

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -24,6 +24,42 @@ interface TaskIndexEntry {
   titleSlug: string;
 }
 
+const MAX_TASK_CANDIDATES = 5;
+
+const formatTaskRef = (task: TaskCard): string => `${task.id} (${task.title})`;
+
+class TaskResolutionAmbiguousError extends Error {
+  readonly requestedTaskId: string;
+  readonly candidates: string[];
+
+  constructor(requestedTaskId: string, candidates: string[]) {
+    super(
+      `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
+    );
+    this.name = "TaskResolutionAmbiguousError";
+    this.requestedTaskId = requestedTaskId;
+    this.candidates = candidates;
+  }
+}
+
+class TaskResolutionNotFoundError extends Error {
+  readonly requestedTaskId: string;
+  readonly candidates: string[];
+
+  constructor(requestedTaskId: string, candidates: string[]) {
+    const hintSuffix = candidates.length > 0 ? ` Candidate task ids: ${candidates.join(", ")}` : "";
+    super(`Task not found: ${requestedTaskId}.${hintSuffix}`);
+    this.name = "TaskResolutionNotFoundError";
+    this.requestedTaskId = requestedTaskId;
+    this.candidates = candidates;
+  }
+}
+
+function throwAmbiguousTaskIdentifier(requestedTaskId: string, matches: TaskCard[]): never {
+  const candidates = matches.slice(0, MAX_TASK_CANDIDATES).map(formatTaskRef);
+  throw new TaskResolutionAmbiguousError(requestedTaskId, candidates);
+}
+
 /**
  * Build normalized lookup maps from tasks array.
  * O(n) build time, enables O(1) lookups.
@@ -120,10 +156,7 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
       return byCaseInsensitiveId[0];
     }
     if (byCaseInsensitiveId.length > 1) {
-      const candidates = byCaseInsensitiveId.slice(0, 5).map((t) => `${t.id} (${t.title})`);
-      throw new Error(
-        `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-      );
+      throwAmbiguousTaskIdentifier(requestedTaskId, byCaseInsensitiveId);
     }
   }
 
@@ -135,10 +168,7 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
       return byIdSuffix[0];
     }
     if (byIdSuffix && byIdSuffix.length > 1) {
-      const candidates = byIdSuffix.slice(0, 5).map((t) => `${t.id} (${t.title})`);
-      throw new Error(
-        `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-      );
+      throwAmbiguousTaskIdentifier(requestedTaskId, byIdSuffix);
     }
   }
 
@@ -149,10 +179,7 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
       return byTitleExact[0];
     }
     if (byTitleExact.length > 1) {
-      const candidates = byTitleExact.slice(0, 5).map((t) => `${t.id} (${t.title})`);
-      throw new Error(
-        `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-      );
+      throwAmbiguousTaskIdentifier(requestedTaskId, byTitleExact);
     }
   }
 
@@ -164,10 +191,7 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
         return byTitleSlugExact[0];
       }
       if (byTitleSlugExact.length > 1) {
-        const candidates = byTitleSlugExact.slice(0, 5).map((t) => `${t.id} (${t.title})`);
-        throw new Error(
-          `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-        );
+        throwAmbiguousTaskIdentifier(requestedTaskId, byTitleSlugExact);
       }
     }
   }
@@ -181,7 +205,7 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
 
       if (matchesLower || matchesSlug) {
         byTitleContains.push(entry.task);
-        if (byTitleContains.length > 5) {
+        if (byTitleContains.length > MAX_TASK_CANDIDATES) {
           break; // Only need 6+ to detect ambiguity
         }
       }
@@ -192,10 +216,7 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
     return byTitleContains[0];
   }
   if (byTitleContains.length > 1) {
-    const candidates = byTitleContains.slice(0, 5).map((t) => `${t.id} (${t.title})`);
-    throw new Error(
-      `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-    );
+    throwAmbiguousTaskIdentifier(requestedTaskId, byTitleContains);
   }
 
   // 7. Fallback hints (partial ID/title match) - single pass O(n)
@@ -210,18 +231,17 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
 
       if (matchesIdLower || matchesTitleLower || matchesIdSlug || matchesTitleSlug) {
         hints.push(entry.task);
-        if (hints.length >= 5) {
+        if (hints.length >= MAX_TASK_CANDIDATES) {
           break;
         }
       }
     }
   }
 
-  const fallback = (hints.length > 0 ? hints : index.tasks.slice(0, 5)).map(
-    (t) => `${t.id} (${t.title})`,
+  const fallback = (hints.length > 0 ? hints : index.tasks.slice(0, MAX_TASK_CANDIDATES)).map(
+    formatTaskRef,
   );
-  const hintSuffix = fallback.length > 0 ? ` Candidate task ids: ${fallback.join(", ")}` : "";
-  throw new Error(`Task not found: ${requestedTaskId}.${hintSuffix}`);
+  throw new TaskResolutionNotFoundError(requestedTaskId, fallback);
 }
 
 import { basename } from "node:path";
@@ -459,10 +479,6 @@ export class OdtTaskStore {
     this.taskIndexBuildPromise = null;
   }
 
-  private formatTaskRef(task: TaskCard): string {
-    return `${task.id} (${task.title})`;
-  }
-
   private async resolveTaskContext(taskId: string): Promise<TaskContext> {
     const tasks = await this.listTasks();
     const task = resolveTaskFromIndex(buildTaskIndex(tasks), taskId);
@@ -614,8 +630,10 @@ export class OdtTaskStore {
     try {
       task = resolveTaskFromIndex(index, input.taskId);
     } catch (error) {
-      const isNotFoundError = error instanceof Error && error.message.startsWith("Task not found:");
-      if (!isNotFoundError) {
+      const shouldRefreshIndex =
+        error instanceof TaskResolutionNotFoundError ||
+        error instanceof TaskResolutionAmbiguousError;
+      if (!shouldRefreshIndex) {
         throw error;
       }
 

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -116,17 +116,24 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
     }
   }
 
-  // 3. ID slug prefix match - O(1) for map lookup + O(k) for suffix check where k is matches
+  // 3. ID slug suffix match - scan for IDs ending with requestedSlug
   if (requestedSlug.length > 0) {
-    const byIdSuffix = index.idLower.get(requestedSlug);
-    const byIdSuffixEnds = index.idLower.get(`-${requestedSlug}`);
-    const combined = [...(byIdSuffix ?? []), ...(byIdSuffixEnds ?? [])];
-
-    if (combined.length === 1 && combined[0]) {
-      return combined[0];
+    const byIdSuffix: TaskCard[] = [];
+    for (const task of index.tasks) {
+      const idLower = normalizeTitleKey(task.id);
+      if (idLower === requestedSlug || idLower.endsWith(`-${requestedSlug}`)) {
+        byIdSuffix.push(task);
+        if (byIdSuffix.length > 5) {
+          break;
+        }
+      }
     }
-    if (combined.length > 1) {
-      const candidates = combined.slice(0, 5).map((t) => `${t.id} (${t.title})`);
+
+    if (byIdSuffix.length === 1 && byIdSuffix[0]) {
+      return byIdSuffix[0];
+    }
+    if (byIdSuffix.length > 1) {
+      const candidates = byIdSuffix.slice(0, 5).map((t) => `${t.id} (${t.title})`);
       throw new Error(
         `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
       );

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -1,3 +1,226 @@
+/**
+ * Indexed lookup maps for O(1) task resolution.
+ * Built once per tasks load, enables single-pass matching.
+ */
+interface TaskIndex {
+  /** All tasks array (for fallback hints) */
+  tasks: TaskCard[];
+  /** Exact ID lookup (case-sensitive) */
+  idExact: Map<string, TaskCard>;
+  /** Case-insensitive ID lookup */
+  idLower: Map<string, TaskCard[]>;
+  /** Slug-prefixed ID lookup (e.g., "abc" matches "abc-1", "abc-xyz-2") */
+  idSlugPrefix: Map<string, TaskCard[]>;
+  /** Exact title lookup (lowercase) */
+  titleExact: Map<string, TaskCard[]>;
+  /** Title slug lookup (sanitized) */
+  titleSlug: Map<string, TaskCard[]>;
+}
+
+/**
+ * Build normalized lookup maps from tasks array.
+ * O(n) build time, enables O(1) lookups.
+ */
+function buildTaskIndex(tasks: TaskCard[]): TaskIndex {
+  const idExact = new Map<string, TaskCard>();
+  const idLower = new Map<string, TaskCard[]>();
+  const idSlugPrefix = new Map<string, TaskCard[]>();
+  const titleExact = new Map<string, TaskCard[]>();
+  const titleSlug = new Map<string, TaskCard[]>();
+
+  for (const task of tasks) {
+    // Exact ID (case-sensitive)
+    idExact.set(task.id, task);
+
+    // Case-insensitive ID
+    const idL = normalizeTitleKey(task.id);
+    const existingLower = idLower.get(idL);
+    if (existingLower) {
+      existingLower.push(task);
+    } else {
+      idLower.set(idL, [task]);
+    }
+
+    // Slug-prefixed ID (for suffix matching like "abc" -> "abc-1", "abc-xyz-2")
+    const idSlug = toSearchSlug(task.id);
+    if (idSlug.length > 0) {
+      const existingSlug = idSlugPrefix.get(idSlug);
+      if (existingSlug) {
+        existingSlug.push(task);
+      } else {
+        idSlugPrefix.set(idSlug, [task]);
+      }
+    }
+
+    // Exact title (lowercase)
+    const titleL = normalizeTitleKey(task.title);
+    const existingTitle = titleExact.get(titleL);
+    if (existingTitle) {
+      existingTitle.push(task);
+    } else {
+      titleExact.set(titleL, [task]);
+    }
+
+    // Title slug
+    const titleS = toSearchSlug(task.title);
+    if (titleS.length > 0) {
+      const existingTitleSlug = titleSlug.get(titleS);
+      if (existingTitleSlug) {
+        existingTitleSlug.push(task);
+      } else {
+        titleSlug.set(titleS, [task]);
+      }
+    }
+  }
+
+  return {
+    tasks,
+    idExact,
+    idLower,
+    idSlugPrefix,
+    titleExact,
+    titleSlug,
+  };
+}
+
+/**
+ * Resolve task using indexed lookup.
+ * Single-pass for contains/hints, O(1) for exact matches.
+ */
+function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCard {
+  const requestedLiteral = requestedTaskId.trim();
+  if (requestedLiteral.length === 0) {
+    throw new Error("Missing taskId.");
+  }
+
+  const requestedLower = normalizeTitleKey(requestedLiteral);
+  const requestedSlug = toSearchSlug(requestedLiteral);
+
+  // 1. Exact ID (case-sensitive) - O(1)
+  const exact = index.idExact.get(requestedLiteral);
+  if (exact) {
+    return exact;
+  }
+
+  // 2. Case-insensitive ID - O(1)
+  const byCaseInsensitiveId = index.idLower.get(requestedLower);
+  if (byCaseInsensitiveId) {
+    if (byCaseInsensitiveId.length === 1 && byCaseInsensitiveId[0]) {
+      return byCaseInsensitiveId[0];
+    }
+    if (byCaseInsensitiveId.length > 1) {
+      const candidates = byCaseInsensitiveId.slice(0, 5).map((t) => `${t.id} (${t.title})`);
+      throw new Error(
+        `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
+      );
+    }
+  }
+
+  // 3. ID slug prefix match - O(1) for map lookup + O(k) for suffix check where k is matches
+  if (requestedSlug.length > 0) {
+    const byIdSuffix = index.idLower.get(requestedSlug);
+    const byIdSuffixEnds = index.idLower.get(`-${requestedSlug}`);
+    const combined = [...(byIdSuffix ?? []), ...(byIdSuffixEnds ?? [])];
+
+    if (combined.length === 1 && combined[0]) {
+      return combined[0];
+    }
+    if (combined.length > 1) {
+      const candidates = combined.slice(0, 5).map((t) => `${t.id} (${t.title})`);
+      throw new Error(
+        `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
+      );
+    }
+  }
+
+  // 4. Exact title (lowercase) - O(1)
+  const byTitleExact = index.titleExact.get(requestedLower);
+  if (byTitleExact) {
+    if (byTitleExact.length === 1 && byTitleExact[0]) {
+      return byTitleExact[0];
+    }
+    if (byTitleExact.length > 1) {
+      const candidates = byTitleExact.slice(0, 5).map((t) => `${t.id} (${t.title})`);
+      throw new Error(
+        `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
+      );
+    }
+  }
+
+  // 5. Title slug exact match - O(1)
+  if (requestedSlug.length > 0) {
+    const byTitleSlugExact = index.titleSlug.get(requestedSlug);
+    if (byTitleSlugExact) {
+      if (byTitleSlugExact.length === 1 && byTitleSlugExact[0]) {
+        return byTitleSlugExact[0];
+      }
+      if (byTitleSlugExact.length > 1) {
+        const candidates = byTitleSlugExact.slice(0, 5).map((t) => `${t.id} (${t.title})`);
+        throw new Error(
+          `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
+        );
+      }
+    }
+  }
+
+  // 6. Contains search (title contains) - single pass O(n)
+  const byTitleContains: TaskCard[] = [];
+  if (requestedLower.length > 0 || requestedSlug.length > 0) {
+    for (const task of index.tasks) {
+      const titleLower = normalizeTitleKey(task.title);
+      const titleSlug = toSearchSlug(task.title);
+
+      const matchesLower = requestedLower.length > 0 && titleLower.includes(requestedLower);
+      const matchesSlug = requestedSlug.length > 0 && titleSlug.includes(requestedSlug);
+
+      if (matchesLower || matchesSlug) {
+        byTitleContains.push(task);
+        if (byTitleContains.length > 5) {
+          break; // Only need 6+ to detect ambiguity
+        }
+      }
+    }
+  }
+
+  if (byTitleContains.length === 1 && byTitleContains[0]) {
+    return byTitleContains[0];
+  }
+  if (byTitleContains.length > 1) {
+    const candidates = byTitleContains.slice(0, 5).map((t) => `${t.id} (${t.title})`);
+    throw new Error(
+      `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
+    );
+  }
+
+  // 7. Fallback hints (partial ID/title match) - single pass O(n)
+  const hints: TaskCard[] = [];
+  if (requestedLower.length > 0 || requestedSlug.length > 0) {
+    for (const task of index.tasks) {
+      const idLower = normalizeTitleKey(task.id);
+      const titleLower = normalizeTitleKey(task.title);
+      const titleSlug = toSearchSlug(task.title);
+
+      const matchesIdLower = requestedLower.length > 0 && idLower.includes(requestedLower);
+      const matchesTitleLower = requestedLower.length > 0 && titleLower.includes(requestedLower);
+      const matchesIdSlug = requestedSlug.length > 0 && idLower.includes(requestedSlug);
+      const matchesTitleSlug = requestedSlug.length > 0 && titleSlug.includes(requestedSlug);
+
+      if (matchesIdLower || matchesTitleLower || matchesIdSlug || matchesTitleSlug) {
+        hints.push(task);
+        if (hints.length >= 5) {
+          break;
+        }
+      }
+    }
+  }
+
+  const fallback = (hints.length > 0 ? hints : index.tasks.slice(0, 5)).map(
+    (t) => `${t.id} (${t.title})`,
+  );
+  const hintSuffix = fallback.length > 0 ? ` Candidate task ids: ${fallback.join(", ")}` : "";
+  throw new Error(`Task not found: ${requestedTaskId}.${hintSuffix}`);
+}
+
 import { basename } from "node:path";
 import {
   type BeadsDirResolver,
@@ -74,6 +297,7 @@ export class OdtTaskStore {
   private readonly now: TimeProvider;
   private initialized: boolean;
   private initializationPromise: Promise<void> | null;
+  private taskIndex: TaskIndex | null;
 
   constructor(options: OdtStoreOptions, deps: OdtTaskStoreDeps = {}) {
     this.repoPath = options.repoPath;
@@ -84,6 +308,7 @@ export class OdtTaskStore {
     this.now = deps.now ?? nowIso;
     this.initialized = false;
     this.initializationPromise = null;
+    this.taskIndex = null;
   }
 
   private async ensureBeadsDir(): Promise<string> {
@@ -195,123 +420,31 @@ export class OdtTaskStore {
       .map((entry) => issueToTaskCard(entry as RawIssue, this.metadataNamespace));
   }
 
+  /**
+   * Get or build cached task index for O(1) lookups.
+   * Rebuilds index when tasks change.
+   */
+  private async getOrBuildTaskIndex(): Promise<TaskIndex> {
+    if (this.taskIndex) {
+      return this.taskIndex;
+    }
+    const tasks = await this.listTasks();
+    this.taskIndex = buildTaskIndex(tasks);
+    return this.taskIndex;
+  }
+
+  /** Invalidate task index after mutations */
+  private invalidateTaskIndex(): void {
+    this.taskIndex = null;
+  }
+
   private formatTaskRef(task: TaskCard): string {
     return `${task.id} (${task.title})`;
   }
 
-  private resolveTaskFromTasks(tasks: TaskCard[], requestedTaskId: string): TaskCard {
-    const requestedLiteral = requestedTaskId.trim();
-    if (requestedLiteral.length === 0) {
-      throw new Error("Missing taskId.");
-    }
-
-    const requestedLower = normalizeTitleKey(requestedLiteral);
-    const requestedSlug = toSearchSlug(requestedLiteral);
-
-    const exact = tasks.find((entry) => entry.id === requestedLiteral);
-    if (exact) {
-      return exact;
-    }
-
-    const byCaseInsensitiveId = tasks.filter(
-      (entry) => normalizeTitleKey(entry.id) === requestedLower,
-    );
-    const caseInsensitiveMatch = byCaseInsensitiveId.at(0);
-    if (byCaseInsensitiveId.length === 1 && caseInsensitiveMatch) {
-      return caseInsensitiveMatch;
-    }
-    if (byCaseInsensitiveId.length > 1) {
-      const candidates = byCaseInsensitiveId.slice(0, 5).map((entry) => this.formatTaskRef(entry));
-      throw new Error(
-        `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-      );
-    }
-
-    if (requestedSlug.length > 0) {
-      const byIdSuffix = tasks.filter((entry) => {
-        const idLower = normalizeTitleKey(entry.id);
-        return idLower === requestedSlug || idLower.endsWith(`-${requestedSlug}`);
-      });
-      const idSuffixMatch = byIdSuffix.at(0);
-      if (byIdSuffix.length === 1 && idSuffixMatch) {
-        return idSuffixMatch;
-      }
-      if (byIdSuffix.length > 1) {
-        const candidates = byIdSuffix.slice(0, 5).map((entry) => this.formatTaskRef(entry));
-        throw new Error(
-          `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-        );
-      }
-    }
-
-    const byTitleExact = tasks.filter((entry) => normalizeTitleKey(entry.title) === requestedLower);
-    const titleExactMatch = byTitleExact.at(0);
-    if (byTitleExact.length === 1 && titleExactMatch) {
-      return titleExactMatch;
-    }
-    if (byTitleExact.length > 1) {
-      const candidates = byTitleExact.slice(0, 5).map((entry) => this.formatTaskRef(entry));
-      throw new Error(
-        `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-      );
-    }
-
-    if (requestedSlug.length > 0) {
-      const byTitleSlugExact = tasks.filter((entry) => toSearchSlug(entry.title) === requestedSlug);
-      const titleSlugMatch = byTitleSlugExact.at(0);
-      if (byTitleSlugExact.length === 1 && titleSlugMatch) {
-        return titleSlugMatch;
-      }
-      if (byTitleSlugExact.length > 1) {
-        const candidates = byTitleSlugExact.slice(0, 5).map((entry) => this.formatTaskRef(entry));
-        throw new Error(
-          `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-        );
-      }
-    }
-
-    const byTitleContains = tasks.filter((entry) => {
-      const titleLower = normalizeTitleKey(entry.title);
-      const titleSlug = toSearchSlug(entry.title);
-      return (
-        (requestedLower.length > 0 && titleLower.includes(requestedLower)) ||
-        (requestedSlug.length > 0 && titleSlug.includes(requestedSlug))
-      );
-    });
-    const titleContainsMatch = byTitleContains.at(0);
-    if (byTitleContains.length === 1 && titleContainsMatch) {
-      return titleContainsMatch;
-    }
-    if (byTitleContains.length > 1) {
-      const candidates = byTitleContains.slice(0, 5).map((entry) => this.formatTaskRef(entry));
-      throw new Error(
-        `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
-      );
-    }
-
-    const hints = tasks
-      .filter((entry) => {
-        const idLower = normalizeTitleKey(entry.id);
-        const titleLower = normalizeTitleKey(entry.title);
-        const titleSlug = toSearchSlug(entry.title);
-        return (
-          (requestedLower.length > 0 &&
-            (idLower.includes(requestedLower) || titleLower.includes(requestedLower))) ||
-          (requestedSlug.length > 0 &&
-            (idLower.includes(requestedSlug) || titleSlug.includes(requestedSlug)))
-        );
-      })
-      .slice(0, 5);
-    const fallback = (hints.length > 0 ? hints : tasks.slice(0, 5)).map((entry) =>
-      this.formatTaskRef(entry),
-    );
-    const hintSuffix = fallback.length > 0 ? ` Candidate task ids: ${fallback.join(", ")}` : "";
-    throw new Error(`Task not found: ${requestedTaskId}.${hintSuffix}`);
-  }
-
   private async resolveTaskContext(taskId: string): Promise<TaskContext> {
     const tasks = await this.listTasks();
-    const task = this.resolveTaskFromTasks(tasks, taskId);
+    const task = resolveTaskFromIndex(buildTaskIndex(tasks), taskId);
     return { task, tasks };
   }
 
@@ -344,6 +477,7 @@ export class OdtTaskStore {
     }
 
     const refreshed = await this.showRawIssue(task.id);
+    this.invalidateTaskIndex();
     return issueToTaskCard(refreshed, this.metadataNamespace);
   }
 
@@ -446,14 +580,15 @@ export class OdtTaskStore {
       throw new Error("Failed to resolve created subtask id");
     }
 
+    this.invalidateTaskIndex();
     return id;
   }
 
   async readTask(rawInput: unknown): Promise<unknown> {
     await this.ensureInitialized();
     const input = ReadTaskInputSchema.parse(rawInput);
-    const tasks = await this.listTasks();
-    const task = this.resolveTaskFromTasks(tasks, input.taskId);
+    const index = await this.getOrBuildTaskIndex();
+    const task = resolveTaskFromIndex(index, input.taskId);
     const issue = await this.showRawIssue(task.id);
     const taskCard = issueToTaskCard(issue, this.metadataNamespace);
     const docs = this.parseDocs(issue);

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -5,16 +5,23 @@
 interface TaskIndex {
   /** All tasks array (for fallback hints) */
   tasks: TaskCard[];
+  entries: TaskIndexEntry[];
   /** Exact ID lookup (case-sensitive) */
   idExact: Map<string, TaskCard>;
   /** Case-insensitive ID lookup */
   idLower: Map<string, TaskCard[]>;
-  /** Slug-prefixed ID lookup (e.g., "abc" matches "abc-1", "abc-xyz-2") */
-  idSlugPrefix: Map<string, TaskCard[]>;
+  idSuffix: Map<string, TaskCard[]>;
   /** Exact title lookup (lowercase) */
   titleExact: Map<string, TaskCard[]>;
   /** Title slug lookup (sanitized) */
   titleSlug: Map<string, TaskCard[]>;
+}
+
+interface TaskIndexEntry {
+  task: TaskCard;
+  idLower: string;
+  titleLower: string;
+  titleSlug: string;
 }
 
 /**
@@ -24,60 +31,64 @@ interface TaskIndex {
 function buildTaskIndex(tasks: TaskCard[]): TaskIndex {
   const idExact = new Map<string, TaskCard>();
   const idLower = new Map<string, TaskCard[]>();
-  const idSlugPrefix = new Map<string, TaskCard[]>();
+  const idSuffix = new Map<string, TaskCard[]>();
   const titleExact = new Map<string, TaskCard[]>();
   const titleSlug = new Map<string, TaskCard[]>();
+  const entries: TaskIndexEntry[] = [];
+
+  const addTaskToBucket = (map: Map<string, TaskCard[]>, key: string, task: TaskCard): void => {
+    const existing = map.get(key);
+    if (existing) {
+      existing.push(task);
+    } else {
+      map.set(key, [task]);
+    }
+  };
 
   for (const task of tasks) {
+    const normalizedId = normalizeTitleKey(task.id);
+    const normalizedTitle = normalizeTitleKey(task.title);
+    const normalizedTitleSlug = toSearchSlug(task.title);
+
     // Exact ID (case-sensitive)
     idExact.set(task.id, task);
 
     // Case-insensitive ID
-    const idL = normalizeTitleKey(task.id);
-    const existingLower = idLower.get(idL);
-    if (existingLower) {
-      existingLower.push(task);
-    } else {
-      idLower.set(idL, [task]);
-    }
+    addTaskToBucket(idLower, normalizedId, task);
 
-    // Slug-prefixed ID (for suffix matching like "abc" -> "abc-1", "abc-xyz-2")
-    const idSlug = toSearchSlug(task.id);
-    if (idSlug.length > 0) {
-      const existingSlug = idSlugPrefix.get(idSlug);
-      if (existingSlug) {
-        existingSlug.push(task);
-      } else {
-        idSlugPrefix.set(idSlug, [task]);
+    addTaskToBucket(idSuffix, normalizedId, task);
+    for (let i = 0; i < normalizedId.length; i += 1) {
+      if (normalizedId[i] !== "-") {
+        continue;
+      }
+      const suffix = normalizedId.slice(i + 1);
+      if (suffix.length > 0) {
+        addTaskToBucket(idSuffix, suffix, task);
       }
     }
 
     // Exact title (lowercase)
-    const titleL = normalizeTitleKey(task.title);
-    const existingTitle = titleExact.get(titleL);
-    if (existingTitle) {
-      existingTitle.push(task);
-    } else {
-      titleExact.set(titleL, [task]);
-    }
+    addTaskToBucket(titleExact, normalizedTitle, task);
 
     // Title slug
-    const titleS = toSearchSlug(task.title);
-    if (titleS.length > 0) {
-      const existingTitleSlug = titleSlug.get(titleS);
-      if (existingTitleSlug) {
-        existingTitleSlug.push(task);
-      } else {
-        titleSlug.set(titleS, [task]);
-      }
+    if (normalizedTitleSlug.length > 0) {
+      addTaskToBucket(titleSlug, normalizedTitleSlug, task);
     }
+
+    entries.push({
+      task,
+      idLower: normalizedId,
+      titleLower: normalizedTitle,
+      titleSlug: normalizedTitleSlug,
+    });
   }
 
   return {
     tasks,
+    entries,
     idExact,
     idLower,
-    idSlugPrefix,
+    idSuffix,
     titleExact,
     titleSlug,
   };
@@ -118,21 +129,12 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
 
   // 3. ID slug suffix match - scan for IDs ending with requestedSlug
   if (requestedSlug.length > 0) {
-    const byIdSuffix: TaskCard[] = [];
-    for (const task of index.tasks) {
-      const idLower = normalizeTitleKey(task.id);
-      if (idLower === requestedSlug || idLower.endsWith(`-${requestedSlug}`)) {
-        byIdSuffix.push(task);
-        if (byIdSuffix.length > 5) {
-          break;
-        }
-      }
-    }
+    const byIdSuffix = index.idSuffix.get(requestedSlug);
 
-    if (byIdSuffix.length === 1 && byIdSuffix[0]) {
+    if (byIdSuffix?.length === 1 && byIdSuffix[0]) {
       return byIdSuffix[0];
     }
-    if (byIdSuffix.length > 1) {
+    if (byIdSuffix && byIdSuffix.length > 1) {
       const candidates = byIdSuffix.slice(0, 5).map((t) => `${t.id} (${t.title})`);
       throw new Error(
         `Task identifier "${requestedTaskId}" is ambiguous. Use exact task id. Candidates: ${candidates.join(", ")}`,
@@ -173,15 +175,12 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
   // 6. Contains search (title contains) - single pass O(n)
   const byTitleContains: TaskCard[] = [];
   if (requestedLower.length > 0 || requestedSlug.length > 0) {
-    for (const task of index.tasks) {
-      const titleLower = normalizeTitleKey(task.title);
-      const titleSlug = toSearchSlug(task.title);
-
-      const matchesLower = requestedLower.length > 0 && titleLower.includes(requestedLower);
-      const matchesSlug = requestedSlug.length > 0 && titleSlug.includes(requestedSlug);
+    for (const entry of index.entries) {
+      const matchesLower = requestedLower.length > 0 && entry.titleLower.includes(requestedLower);
+      const matchesSlug = requestedSlug.length > 0 && entry.titleSlug.includes(requestedSlug);
 
       if (matchesLower || matchesSlug) {
-        byTitleContains.push(task);
+        byTitleContains.push(entry.task);
         if (byTitleContains.length > 5) {
           break; // Only need 6+ to detect ambiguity
         }
@@ -202,18 +201,15 @@ function resolveTaskFromIndex(index: TaskIndex, requestedTaskId: string): TaskCa
   // 7. Fallback hints (partial ID/title match) - single pass O(n)
   const hints: TaskCard[] = [];
   if (requestedLower.length > 0 || requestedSlug.length > 0) {
-    for (const task of index.tasks) {
-      const idLower = normalizeTitleKey(task.id);
-      const titleLower = normalizeTitleKey(task.title);
-      const titleSlug = toSearchSlug(task.title);
-
-      const matchesIdLower = requestedLower.length > 0 && idLower.includes(requestedLower);
-      const matchesTitleLower = requestedLower.length > 0 && titleLower.includes(requestedLower);
-      const matchesIdSlug = requestedSlug.length > 0 && idLower.includes(requestedSlug);
-      const matchesTitleSlug = requestedSlug.length > 0 && titleSlug.includes(requestedSlug);
+    for (const entry of index.entries) {
+      const matchesIdLower = requestedLower.length > 0 && entry.idLower.includes(requestedLower);
+      const matchesTitleLower =
+        requestedLower.length > 0 && entry.titleLower.includes(requestedLower);
+      const matchesIdSlug = requestedSlug.length > 0 && entry.idLower.includes(requestedSlug);
+      const matchesTitleSlug = requestedSlug.length > 0 && entry.titleSlug.includes(requestedSlug);
 
       if (matchesIdLower || matchesTitleLower || matchesIdSlug || matchesTitleSlug) {
-        hints.push(task);
+        hints.push(entry.task);
         if (hints.length >= 5) {
           break;
         }
@@ -305,6 +301,7 @@ export class OdtTaskStore {
   private initialized: boolean;
   private initializationPromise: Promise<void> | null;
   private taskIndex: TaskIndex | null;
+  private taskIndexBuildPromise: Promise<TaskIndex> | null;
 
   constructor(options: OdtStoreOptions, deps: OdtTaskStoreDeps = {}) {
     this.repoPath = options.repoPath;
@@ -316,6 +313,7 @@ export class OdtTaskStore {
     this.initialized = false;
     this.initializationPromise = null;
     this.taskIndex = null;
+    this.taskIndexBuildPromise = null;
   }
 
   private async ensureBeadsDir(): Promise<string> {
@@ -427,6 +425,13 @@ export class OdtTaskStore {
       .map((entry) => issueToTaskCard(entry as RawIssue, this.metadataNamespace));
   }
 
+  private async refreshTaskIndex(): Promise<TaskIndex> {
+    const tasks = await this.listTasks();
+    const next = buildTaskIndex(tasks);
+    this.taskIndex = next;
+    return next;
+  }
+
   /**
    * Get or build cached task index for O(1) lookups.
    * Rebuilds index when tasks change.
@@ -435,14 +440,23 @@ export class OdtTaskStore {
     if (this.taskIndex) {
       return this.taskIndex;
     }
-    const tasks = await this.listTasks();
-    this.taskIndex = buildTaskIndex(tasks);
-    return this.taskIndex;
+
+    if (this.taskIndexBuildPromise) {
+      return this.taskIndexBuildPromise;
+    }
+
+    this.taskIndexBuildPromise = this.refreshTaskIndex();
+    try {
+      return await this.taskIndexBuildPromise;
+    } finally {
+      this.taskIndexBuildPromise = null;
+    }
   }
 
   /** Invalidate task index after mutations */
   private invalidateTaskIndex(): void {
     this.taskIndex = null;
+    this.taskIndexBuildPromise = null;
   }
 
   private formatTaskRef(task: TaskCard): string {
@@ -595,7 +609,20 @@ export class OdtTaskStore {
     await this.ensureInitialized();
     const input = ReadTaskInputSchema.parse(rawInput);
     const index = await this.getOrBuildTaskIndex();
-    const task = resolveTaskFromIndex(index, input.taskId);
+
+    let task: TaskCard;
+    try {
+      task = resolveTaskFromIndex(index, input.taskId);
+    } catch (error) {
+      const isNotFoundError = error instanceof Error && error.message.startsWith("Task not found:");
+      if (!isNotFoundError) {
+        throw error;
+      }
+
+      const refreshedIndex = await this.refreshTaskIndex();
+      task = resolveTaskFromIndex(refreshedIndex, input.taskId);
+    }
+
     const issue = await this.showRawIssue(task.id);
     const taskCard = issueToTaskCard(issue, this.metadataNamespace);
     const docs = this.parseDocs(issue);


### PR DESCRIPTION
## Summary
- Replace multi-pass task matching with indexed lookup maps and pre-normalized search entries to reduce per-lookup CPU work.
- Harden identifier resolution with deterministic ID suffix indexing and preserve strict ambiguity errors.
- Improve cache correctness and concurrency by deduplicating in-flight index builds and refreshing index on read-time not-found cache misses.
- Add regression coverage for short ID suffix resolution, concurrent index build caching, and stale-cache refresh behavior.

## Validation
- `bun run --filter @openducktor/openducktor-mcp typecheck`
- `bun run --filter @openducktor/openducktor-mcp test`