### PR TITLE
perf(desktop): prevent AgentChat thread rerenders on composer input

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, Bot, Brain, LoaderCircle, RefreshCcw, Sparkles } from "lucide-react";
-import { Fragment, type ReactElement, type ReactNode } from "react";
+import { Fragment, type ReactElement } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { AgentChatThreadModel } from "./agent-chat.types";
@@ -9,13 +9,7 @@ import { AgentSessionQuestionCard } from "./agent-session-question-card";
 import { AgentSessionTodoPanel } from "./agent-session-todo-panel";
 import { AgentTurnDurationSeparator } from "./agent-turn-duration-separator";
 
-export function AgentChatThread({
-  model,
-  children,
-}: {
-  model: AgentChatThreadModel;
-  children?: ReactNode;
-}): ReactElement {
+export function AgentChatThread({ model }: { model: AgentChatThreadModel }): ReactElement {
   const {
     session,
     roleOptions,
@@ -47,7 +41,7 @@ export function AgentChatThread({
   const StreamingRoleIcon = streamingRoleDisplay?.icon ?? Bot;
 
   return (
-    <div className="relative flex h-full min-h-0 flex-col">
+    <div className="relative flex min-h-0 flex-1 flex-col">
       {!agentStudioReady ? (
         <div className="mx-4 mt-4 flex items-start justify-between gap-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
           <div className="flex min-w-0 items-start gap-2">
@@ -184,7 +178,6 @@ export function AgentChatThread({
           />
         </div>
       ) : null}
-      {children}
     </div>
   );
 }

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.tsx
@@ -1,7 +1,9 @@
-import type { ReactElement, ReactNode } from "react";
+import { memo, type ReactElement, type ReactNode } from "react";
 import type { AgentChatModel } from "./agent-chat.types";
 import { AgentChatComposer } from "./agent-chat-composer";
 import { AgentChatThread } from "./agent-chat-thread";
+
+const MemoizedAgentChatThread = memo(AgentChatThread);
 
 export function AgentChat({
   model,
@@ -14,9 +16,10 @@ export function AgentChat({
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
       {header}
       <div className="min-h-0 flex-1 bg-slate-50/50">
-        <AgentChatThread model={model.thread}>
+        <div className="flex h-full min-h-0 flex-col">
+          <MemoizedAgentChatThread model={model.thread} />
           <AgentChatComposer model={model.composer} />
-        </AgentChatThread>
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
@@ -41,8 +41,8 @@ describe("use-agent-chat-layout helpers", () => {
     });
   });
 
-  test("computes todo panel bottom offset from composer height with minimum", () => {
-    expect(computeTodoPanelBottomOffset(40)).toBe(120);
-    expect(computeTodoPanelBottomOffset(180)).toBe(192);
+  test("anchors todo panel with a fixed offset from the thread bottom", () => {
+    expect(computeTodoPanelBottomOffset(40)).toBe(12);
+    expect(computeTodoPanelBottomOffset(180)).toBe(12);
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -29,8 +29,8 @@ export const computeComposerTextareaLayout = (
   };
 };
 
-export const computeTodoPanelBottomOffset = (composerFormHeight: number): number => {
-  return Math.max(composerFormHeight + 12, 120);
+export const computeTodoPanelBottomOffset = (_composerFormHeight: number): number => {
+  return 12;
 };
 
 type UseAgentChatLayoutInput = {

--- a/apps/desktop/src/pages/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents-page-view-model.ts
@@ -2,7 +2,9 @@ import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
 import type { RefObject, UIEvent } from "react";
 import type {
+  AgentChatComposerModel,
   AgentChatModel,
+  AgentChatThreadModel,
   AgentRoleOption,
   AgentStudioHeaderModel,
   AgentStudioTaskTabsModel,
@@ -103,7 +105,7 @@ export const buildAgentStudioWorkspaceSidebarModel = (args: {
   activeDocument: args.activeDocument,
 });
 
-export const buildAgentChatModel = (args: {
+type AgentChatThreadModelArgs = {
   activeSession: AgentSessionState | null;
   roleOptions: AgentRoleOption[];
   agentStudioReady: boolean;
@@ -127,9 +129,16 @@ export const buildAgentChatModel = (args: {
   todoPanelBottomOffset: number;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
   onMessagesScroll: (event: UIEvent<HTMLDivElement>) => void;
+};
+
+type AgentChatComposerModelArgs = {
+  taskId: string;
+  agentStudioReady: boolean;
   input: string;
   onInputChange: (value: string) => void;
   onSend: () => void;
+  isSending: boolean;
+  isStarting: boolean;
   isSessionWorking: boolean;
   selectedModelSelection: AgentModelSelection | null;
   isSelectionCatalogLoading: boolean;
@@ -146,55 +155,67 @@ export const buildAgentChatModel = (args: {
   composerFormRef: RefObject<HTMLFormElement | null>;
   composerTextareaRef: RefObject<HTMLTextAreaElement | null>;
   onComposerTextareaInput: () => void;
-}): AgentChatModel => ({
-  thread: {
-    session: args.activeSession,
-    roleOptions: args.roleOptions,
-    agentStudioReady: args.agentStudioReady,
-    blockedReason: args.agentStudioBlockedReason,
-    isLoadingChecks: args.isLoadingChecks,
-    onRefreshChecks: args.onRefreshChecks,
-    taskSelected: Boolean(args.taskId),
-    canKickoffNewSession: args.canKickoffNewSession,
-    kickoffLabel: args.kickoffLabel,
-    onKickoff: args.onKickoff,
-    isStarting: args.isStarting,
-    isSending: args.isSending,
-    sessionAgentColors: args.activeSessionAgentColors,
-    isSubmittingQuestionByRequestId: args.isSubmittingQuestionByRequestId,
-    onSubmitQuestionAnswers: args.onSubmitQuestionAnswers,
-    isSubmittingPermissionByRequestId: args.isSubmittingPermissionByRequestId,
-    permissionReplyErrorByRequestId: args.permissionReplyErrorByRequestId,
-    onReplyPermission: args.onReplyPermission,
-    todoPanelCollapsed: args.todoPanelCollapsed,
-    onToggleTodoPanel: args.onToggleTodoPanel,
-    todoPanelBottomOffset: args.todoPanelBottomOffset,
-    messagesContainerRef: args.messagesContainerRef,
-    onMessagesScroll: args.onMessagesScroll,
-  },
-  composer: {
-    taskId: args.taskId,
-    agentStudioReady: args.agentStudioReady,
-    input: args.input,
-    onInputChange: args.onInputChange,
-    onSend: args.onSend,
-    isSending: args.isSending,
-    isStarting: args.isStarting,
-    isSessionWorking: args.isSessionWorking,
-    selectedModelSelection: args.selectedModelSelection,
-    isSelectionCatalogLoading: args.isSelectionCatalogLoading,
-    agentOptions: args.agentOptions,
-    modelOptions: args.modelOptions,
-    modelGroups: args.modelGroups,
-    variantOptions: args.variantOptions,
-    onSelectAgent: args.onSelectAgent,
-    onSelectModel: args.onSelectModel,
-    onSelectVariant: args.onSelectVariant,
-    contextUsage: args.contextUsage,
-    canStopSession: args.canStopSession,
-    onStopSession: args.onStopSession,
-    composerFormRef: args.composerFormRef,
-    composerTextareaRef: args.composerTextareaRef,
-    onComposerTextareaInput: args.onComposerTextareaInput,
-  },
+};
+
+export const buildAgentChatThreadModel = (
+  args: AgentChatThreadModelArgs,
+): AgentChatThreadModel => ({
+  session: args.activeSession,
+  roleOptions: args.roleOptions,
+  agentStudioReady: args.agentStudioReady,
+  blockedReason: args.agentStudioBlockedReason,
+  isLoadingChecks: args.isLoadingChecks,
+  onRefreshChecks: args.onRefreshChecks,
+  taskSelected: Boolean(args.taskId),
+  canKickoffNewSession: args.canKickoffNewSession,
+  kickoffLabel: args.kickoffLabel,
+  onKickoff: args.onKickoff,
+  isStarting: args.isStarting,
+  isSending: args.isSending,
+  sessionAgentColors: args.activeSessionAgentColors,
+  isSubmittingQuestionByRequestId: args.isSubmittingQuestionByRequestId,
+  onSubmitQuestionAnswers: args.onSubmitQuestionAnswers,
+  isSubmittingPermissionByRequestId: args.isSubmittingPermissionByRequestId,
+  permissionReplyErrorByRequestId: args.permissionReplyErrorByRequestId,
+  onReplyPermission: args.onReplyPermission,
+  todoPanelCollapsed: args.todoPanelCollapsed,
+  onToggleTodoPanel: args.onToggleTodoPanel,
+  todoPanelBottomOffset: args.todoPanelBottomOffset,
+  messagesContainerRef: args.messagesContainerRef,
+  onMessagesScroll: args.onMessagesScroll,
+});
+
+export const buildAgentChatComposerModel = (
+  args: AgentChatComposerModelArgs,
+): AgentChatComposerModel => ({
+  taskId: args.taskId,
+  agentStudioReady: args.agentStudioReady,
+  input: args.input,
+  onInputChange: args.onInputChange,
+  onSend: args.onSend,
+  isSending: args.isSending,
+  isStarting: args.isStarting,
+  isSessionWorking: args.isSessionWorking,
+  selectedModelSelection: args.selectedModelSelection,
+  isSelectionCatalogLoading: args.isSelectionCatalogLoading,
+  agentOptions: args.agentOptions,
+  modelOptions: args.modelOptions,
+  modelGroups: args.modelGroups,
+  variantOptions: args.variantOptions,
+  onSelectAgent: args.onSelectAgent,
+  onSelectModel: args.onSelectModel,
+  onSelectVariant: args.onSelectVariant,
+  contextUsage: args.contextUsage,
+  canStopSession: args.canStopSession,
+  onStopSession: args.onStopSession,
+  composerFormRef: args.composerFormRef,
+  composerTextareaRef: args.composerTextareaRef,
+  onComposerTextareaInput: args.onComposerTextareaInput,
+});
+
+export const buildAgentChatModel = (
+  args: AgentChatThreadModelArgs & AgentChatComposerModelArgs,
+): AgentChatModel => ({
+  thread: buildAgentChatThreadModel(args),
+  composer: buildAgentChatComposerModel(args),
 });

--- a/apps/desktop/src/pages/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-page-models.test.tsx
@@ -363,4 +363,31 @@ describe("useAgentStudioPageModels", () => {
 
     await harness.unmount();
   });
+
+  test("keeps thread model stable for input-only composer updates", async () => {
+    const session = createSession("session-1", "external-1");
+    const baseProps = createHookArgs({
+      activeSession: session,
+      sessionsForTask: [session],
+      input: "",
+    });
+    const harness = createHookHarness(baseProps);
+
+    await harness.mount();
+    const initialState = harness.getLatest();
+    const initialThreadModel = initialState.agentChatModel.thread;
+    const initialComposerModel = initialState.agentChatModel.composer;
+
+    await harness.update({
+      ...baseProps,
+      input: "draft update",
+    });
+
+    const nextState = harness.getLatest();
+    expect(nextState.agentChatModel.thread).toBe(initialThreadModel);
+    expect(nextState.agentChatModel.composer).not.toBe(initialComposerModel);
+    expect(nextState.agentChatModel.composer.input).toBe("draft update");
+
+    await harness.unmount();
+  });
 });

--- a/apps/desktop/src/pages/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/use-agent-studio-page-models.ts
@@ -2,6 +2,7 @@ import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
 import { type UIEvent, useCallback, useMemo, useState } from "react";
 import {
+  type AgentChatModel,
   type AgentStudioTaskTabsModel,
   isNearBottom,
   useAgentChatLayout,
@@ -19,7 +20,8 @@ import {
   type SessionCreateOption,
 } from "./agents-page-session-tabs";
 import {
-  buildAgentChatModel,
+  buildAgentChatComposerModel,
+  buildAgentChatThreadModel,
   buildAgentStudioHeaderModel,
   buildAgentStudioTaskTabsModel,
   buildAgentStudioWorkspaceSidebarModel,
@@ -135,7 +137,7 @@ export function useAgentStudioPageModels({
   agentStudioTaskTabsModel: AgentStudioTaskTabsModel;
   agentStudioHeaderModel: ReturnType<typeof buildAgentStudioHeaderModel>;
   agentStudioWorkspaceSidebarModel: ReturnType<typeof buildAgentStudioWorkspaceSidebarModel>;
-  agentChatModel: ReturnType<typeof buildAgentChatModel>;
+  agentChatModel: AgentChatModel;
 } {
   const [todoPanelCollapsedBySession, setTodoPanelCollapsedBySession] = useState<
     Record<string, boolean>
@@ -375,9 +377,9 @@ export function useAgentStudioPageModels({
     void stopAgentSession(activeSession.sessionId);
   }, [activeSession, stopAgentSession]);
 
-  const agentChatModel = useMemo(
+  const agentChatThreadModel = useMemo(
     () =>
-      buildAgentChatModel({
+      buildAgentChatThreadModel({
         activeSession,
         roleOptions: ROLE_OPTIONS,
         agentStudioReady,
@@ -401,9 +403,43 @@ export function useAgentStudioPageModels({
         todoPanelBottomOffset,
         messagesContainerRef,
         onMessagesScroll: handleMessagesScroll,
+      }),
+    [
+      activeSession,
+      activeSessionAgentColors,
+      activeTodoPanelCollapsed,
+      agentStudioBlockedReason,
+      agentStudioReady,
+      canKickoffNewSession,
+      handleKickoff,
+      handleMessagesScroll,
+      handleRefreshChecks,
+      handleToggleTodoPanel,
+      isLoadingChecks,
+      isSending,
+      isStarting,
+      isSubmittingQuestionByRequestId,
+      isSubmittingPermissionByRequestId,
+      handlePermissionReply,
+      kickoffLabel,
+      permissionReplyErrorByRequestId,
+      messagesContainerRef,
+      onSubmitQuestionAnswers,
+      taskId,
+      todoPanelBottomOffset,
+    ],
+  );
+
+  const agentChatComposerModel = useMemo(
+    () =>
+      buildAgentChatComposerModel({
+        taskId,
+        agentStudioReady,
         input,
         onInputChange: setInput,
         onSend: handleSend,
+        isSending,
+        isStarting,
         isSessionWorking,
         selectedModelSelection,
         isSelectionCatalogLoading,
@@ -422,48 +458,38 @@ export function useAgentStudioPageModels({
         onComposerTextareaInput: resizeComposerTextarea,
       }),
     [
-      activeSession,
-      activeSessionAgentColors,
-      activeTodoPanelCollapsed,
       agentOptions,
-      agentStudioBlockedReason,
       agentStudioReady,
-      canKickoffNewSession,
       canStopSession,
       chatContextUsage,
       composerFormRef,
       composerTextareaRef,
-      handleKickoff,
-      handleMessagesScroll,
-      handleRefreshChecks,
-      onSelectAgent,
-      onSelectModel,
-      onSelectVariant,
       handleSend,
       handleStopSession,
-      handleToggleTodoPanel,
       input,
-      isLoadingChecks,
       isSelectionCatalogLoading,
       isSending,
       isSessionWorking,
       isStarting,
-      isSubmittingQuestionByRequestId,
-      isSubmittingPermissionByRequestId,
-      handlePermissionReply,
-      kickoffLabel,
-      permissionReplyErrorByRequestId,
-      messagesContainerRef,
       modelGroups,
       modelOptions,
-      onSubmitQuestionAnswers,
+      onSelectAgent,
+      onSelectModel,
+      onSelectVariant,
       resizeComposerTextarea,
       selectedModelSelection,
       setInput,
       taskId,
-      todoPanelBottomOffset,
       variantOptions,
     ],
+  );
+
+  const agentChatModel = useMemo(
+    () => ({
+      thread: agentChatThreadModel,
+      composer: agentChatComposerModel,
+    }),
+    [agentChatComposerModel, agentChatThreadModel],
   );
 
   return {


### PR DESCRIPTION
## Summary
- split Agent Chat view models into independent memo boundaries for thread and composer data
- memoize AgentChatThread rendering path and decouple it from composer child composition
- add a regression test ensuring input-only updates keep the thread model reference stable

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test