### PR TITLE
perf(openducktor-mcp): reuse fetched task snapshot in setPlan

### DIFF
--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -740,12 +740,9 @@ export class OdtTaskStore {
     await this.writeNamespace(task.id, root, nextNamespace);
 
     const createdSubtaskIds: string[] = [];
-    let transitionContext: TaskContext = context;
     if (task.issueType === "epic" && normalizedSubtasks.length > 0) {
-      const existingTaskSnapshot = transitionContext;
-      transitionContext = existingTaskSnapshot;
       const existingTitleKeys = new Set(
-        existingTaskSnapshot.tasks
+        tasks
           .filter((entry) => entry.parentId === task.id)
           .map((entry) => normalizeTitleKey(entry.title)),
       );
@@ -762,7 +759,7 @@ export class OdtTaskStore {
       }
     }
 
-    const refreshedTransitionContext = await this.refreshTaskContext(task.id, transitionContext);
+    const refreshedTransitionContext = await this.refreshTaskContext(task.id, context);
     const nextTask = await this.transitionTask(
       task.id,
       "ready_for_dev",


### PR DESCRIPTION
## Summary
- reuse the existing in-memory `tasks` snapshot in `setPlan` when deriving existing epic subtasks
- remove redundant transition context aliasing in the plan subtask suggestion flow
- keep transition refresh logic intact while avoiding an extra Beads list roundtrip

## Validation
- bun run --filter @openducktor/openducktor-mcp typecheck
- bun run --filter @openducktor/openducktor-mcp test
- bun run typecheck
- bun run test
- cd apps/desktop/src-tauri && cargo check
- cd apps/desktop/src-tauri && cargo test