### PR TITLE
perf(desktop): lazy-load markdown rendering in agent chat

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-markdown-hints.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-markdown-hints.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { hasMarkdownSyntaxHint } from "./agent-chat-markdown-hints";
+
+describe("agent-chat-markdown-hints", () => {
+  test("detects common inline markdown emphasis", () => {
+    expect(hasMarkdownSyntaxHint("Use **bold** and *italic* text.")).toBe(true);
+    expect(hasMarkdownSyntaxHint("Use __bold__ and _italic_ text.")).toBe(true);
+  });
+
+  test("detects bare autolink urls", () => {
+    expect(hasMarkdownSyntaxHint("See https://example.com/docs for details.")).toBe(true);
+  });
+
+  test("detects horizontal rules", () => {
+    expect(hasMarkdownSyntaxHint("Before\n---\nAfter")).toBe(true);
+    expect(hasMarkdownSyntaxHint("Before\n***\nAfter")).toBe(true);
+    expect(hasMarkdownSyntaxHint("Before\n___\nAfter")).toBe(true);
+  });
+
+  test("detects existing block markdown syntax", () => {
+    expect(hasMarkdownSyntaxHint("# Heading")).toBe(true);
+    expect(hasMarkdownSyntaxHint("| col |\n| --- |")).toBe(true);
+  });
+
+  test("does not mark plain text without markdown hints", () => {
+    expect(hasMarkdownSyntaxHint("This is plain text with no markdown semantics.")).toBe(false);
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-markdown-hints.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-markdown-hints.ts
@@ -1,0 +1,6 @@
+const MARKDOWN_SYNTAX_HINT_PATTERN =
+  /(?:^|\n)\s{0,3}(?:#{1,6}\s+|>\s+|[-*+]\s+|\d+\.\s+|```|~~~|(?:-{3,}|\*{3,}|_{3,})\s*$)|`[^`\n]+`|!\[[^\]]*\]\([^)]+\)|\[[^\]]+\]\([^)]+\)|~~[^~\n]+~~|\*\*[^*\n]+\*\*|__[^_\n]+__|\*[^*\n]+\*|_[^_\n]+_|(?:^|\n)\|.*\||\bhttps?:\/\/[^\s<]+/m;
+
+export const hasMarkdownSyntaxHint = (value: string): boolean => {
+  return MARKDOWN_SYNTAX_HINT_PATTERN.test(value);
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -4,8 +4,8 @@ import {
   isOdtWorkflowMutationToolName,
 } from "@openducktor/core";
 import { Brain, Hammer, MessageSquareQuote } from "lucide-react";
-import type { ReactElement } from "react";
-import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
+import { lazy, type ReactElement, Suspense } from "react";
+import type { MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
 import { cn } from "@/lib/utils";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import {
@@ -19,6 +19,58 @@ import {
   RegularToolMessage,
   WorkflowToolMessage,
 } from "./agent-chat-message-card-tool-presenters";
+
+const LazyMarkdownRenderer = lazy(async () => {
+  const module = await import("@/components/ui/markdown-renderer");
+  return { default: module.MarkdownRenderer };
+});
+
+const MARKDOWN_SYNTAX_HINT_PATTERN =
+  /(?:^|\n)\s{0,3}(?:#{1,6}\s+|>\s+|[-*+]\s+|\d+\.\s+|```)|`[^`\n]+`|!\[[^\]]*\]\([^)]+\)|\[[^\]]+\]\([^)]+\)|~~[^~]+~~|(?:^|\n)\|.*\|/m;
+
+const PLAIN_TEXT_CLASSES: Record<MarkdownRendererVariant, string> = {
+  compact: "whitespace-pre-wrap text-[13px] leading-relaxed text-slate-600",
+  document: "whitespace-pre-wrap leading-6 text-slate-700",
+};
+
+const hasMarkdownSyntaxHint = (value: string): boolean => MARKDOWN_SYNTAX_HINT_PATTERN.test(value);
+
+type PlainTextMarkdownFallbackProps = {
+  content: string;
+  variant: MarkdownRendererVariant;
+};
+
+const PlainTextMarkdownFallback = ({
+  content,
+  variant,
+}: PlainTextMarkdownFallbackProps): ReactElement => {
+  return <p className={PLAIN_TEXT_CLASSES[variant]}>{content}</p>;
+};
+
+type DeferredMarkdownRendererProps = {
+  markdown: string;
+  variant?: MarkdownRendererVariant;
+};
+
+const DeferredMarkdownRenderer = ({
+  markdown,
+  variant = "document",
+}: DeferredMarkdownRendererProps): ReactElement | null => {
+  const content = markdown.trim();
+  if (!content) {
+    return null;
+  }
+
+  if (!hasMarkdownSyntaxHint(content)) {
+    return <PlainTextMarkdownFallback content={content} variant={variant} />;
+  }
+
+  return (
+    <Suspense fallback={<PlainTextMarkdownFallback content={content} variant={variant} />}>
+      <LazyMarkdownRenderer markdown={content} variant={variant} />
+    </Suspense>
+  );
+};
 
 export type MessageHeaderProps = {
   message: AgentChatMessage;
@@ -85,7 +137,7 @@ const ReasoningMessage = ({
           ) : null}
         </summary>
         <div className="pl-6 pt-2">
-          <MarkdownRenderer markdown={content || "Reasoning complete"} variant="compact" />
+          <DeferredMarkdownRenderer markdown={content || "Reasoning complete"} variant="compact" />
         </div>
       </details>
     );
@@ -100,7 +152,7 @@ const ReasoningMessage = ({
           <span className="ml-auto shrink-0 text-[11px] text-slate-500">{timeLabel}</span>
         ) : null}
       </div>
-      <MarkdownRenderer markdown={content || "Thinking..."} variant="compact" />
+      <DeferredMarkdownRenderer markdown={content || "Thinking..."} variant="compact" />
     </div>
   );
 };
@@ -119,7 +171,7 @@ const AssistantMessage = ({
   const footer = getAssistantFooterData(message, sessionSelectedModel);
   return (
     <div className="space-y-2">
-      <MarkdownRenderer markdown={message.content} variant="document" />
+      <DeferredMarkdownRenderer markdown={message.content} variant="document" />
       {footer.infoParts.length > 0 ? (
         <div className="flex items-center gap-2 text-xs text-slate-500">
           <span
@@ -194,7 +246,7 @@ export const MessageBody = ({
           Show system prompt
         </summary>
         <div className="border-t border-slate-200 px-2 py-2">
-          <MarkdownRenderer markdown={systemPromptBody} variant="compact" />
+          <DeferredMarkdownRenderer markdown={systemPromptBody} variant="compact" />
         </div>
       </details>
     );
@@ -225,5 +277,5 @@ export const MessageBody = ({
     );
   }
 
-  return <MarkdownRenderer markdown={message.content} variant="document" />;
+  return <DeferredMarkdownRenderer markdown={message.content} variant="document" />;
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -8,6 +8,7 @@ import { lazy, type ReactElement, Suspense } from "react";
 import type { MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
 import { cn } from "@/lib/utils";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
+import { hasMarkdownSyntaxHint } from "./agent-chat-markdown-hints";
 import {
   getAssistantFooterData,
   roleLabel,
@@ -25,15 +26,10 @@ const LazyMarkdownRenderer = lazy(async () => {
   return { default: module.MarkdownRenderer };
 });
 
-const MARKDOWN_SYNTAX_HINT_PATTERN =
-  /(?:^|\n)\s{0,3}(?:#{1,6}\s+|>\s+|[-*+]\s+|\d+\.\s+|```)|`[^`\n]+`|!\[[^\]]*\]\([^)]+\)|\[[^\]]+\]\([^)]+\)|~~[^~]+~~|(?:^|\n)\|.*\|/m;
-
 const PLAIN_TEXT_CLASSES: Record<MarkdownRendererVariant, string> = {
   compact: "whitespace-pre-wrap text-[13px] leading-relaxed text-slate-600",
   document: "whitespace-pre-wrap leading-6 text-slate-700",
 };
-
-const hasMarkdownSyntaxHint = (value: string): boolean => MARKDOWN_SYNTAX_HINT_PATTERN.test(value);
 
 type PlainTextMarkdownFallbackProps = {
   content: string;


### PR DESCRIPTION
## Summary
- code-split markdown rendering in agent chat message content
- defer loading `MarkdownRenderer` behind `React.lazy` + `Suspense`
- keep plain-text messages on a fast path with a markdown syntax heuristic

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop build
