### PR TITLE
perf(host-infra-beads): cache and harden Beads task list refresh

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/constants.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/constants.rs
@@ -1,3 +1,3 @@
 pub(crate) const DEFAULT_METADATA_NAMESPACE: &str = "openducktor";
 pub(crate) const CUSTOM_STATUS_VALUES: &str = "spec_ready,ready_for_dev,ai_review,human_review";
-
+pub(crate) const TASK_LIST_CACHE_TTL_MS: u64 = 2_000;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
@@ -14,7 +14,7 @@ pub use store::BeadsTaskStore;
 #[cfg(test)]
 use command_runner::{CommandRunner, ProcessCommandRunner};
 #[cfg(test)]
-use constants::CUSTOM_STATUS_VALUES;
+use constants::{CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS};
 #[cfg(test)]
 use metadata::{
     metadata_bool_qa_required, metadata_namespace, parse_agent_sessions, parse_markdown_entries,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata_ops.rs
@@ -18,6 +18,7 @@ impl BeadsTaskStore {
             repo_path,
             &["update", "--metadata", payload.as_str(), "--", task_id],
         )?;
+        self.invalidate_task_list_cache(repo_path)?;
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -26,6 +26,13 @@ type MetadataNamespaceResolver = Arc<dyn Fn() -> Result<String> + Send + Sync>;
 struct TaskListCacheEntry {
     tasks: Vec<TaskCard>,
     cached_at: Instant,
+    metadata_namespace: String,
+}
+
+#[derive(Default)]
+struct TaskListCacheState {
+    generation: u64,
+    entry: Option<TaskListCacheEntry>,
 }
 
 pub struct BeadsTaskStore {
@@ -34,7 +41,7 @@ pub struct BeadsTaskStore {
     pub(crate) metadata_namespace_resolver: Option<MetadataNamespaceResolver>,
     pub(crate) init_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
     pub(crate) initialized_repos: Mutex<HashSet<String>>,
-    task_list_cache: Mutex<HashMap<String, TaskListCacheEntry>>,
+    task_list_cache: Mutex<HashMap<String, TaskListCacheState>>,
 }
 
 impl fmt::Debug for BeadsTaskStore {
@@ -163,36 +170,51 @@ impl BeadsTaskStore {
         Duration::from_millis(TASK_LIST_CACHE_TTL_MS)
     }
 
-    fn cached_task_list(&self, repo_key: &str) -> Result<Option<Vec<TaskCard>>> {
+    fn cached_task_list_and_generation(
+        &self,
+        repo_key: &str,
+        metadata_namespace: &str,
+    ) -> Result<(Option<Vec<TaskCard>>, u64)> {
         let mut cache = self
             .task_list_cache
             .lock()
             .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
+        let state = cache.entry(repo_key.to_string()).or_default();
+        let generation = state.generation;
 
-        let Some(entry) = cache.get(repo_key) else {
-            return Ok(None);
-        };
-
-        if entry.cached_at.elapsed() <= Self::task_list_cache_ttl() {
-            return Ok(Some(entry.tasks.clone()));
+        if let Some(entry) = state.entry.as_ref() {
+            let is_fresh = entry.cached_at.elapsed() <= Self::task_list_cache_ttl();
+            let namespace_matches = entry.metadata_namespace == metadata_namespace;
+            if is_fresh && namespace_matches {
+                return Ok((Some(entry.tasks.clone()), generation));
+            }
         }
 
-        cache.remove(repo_key);
-        Ok(None)
+        state.entry = None;
+        Ok((None, generation))
     }
 
-    fn cache_task_list(&self, repo_key: &str, tasks: &[TaskCard]) -> Result<()> {
+    fn cache_task_list_if_generation(
+        &self,
+        repo_key: &str,
+        metadata_namespace: &str,
+        generation: u64,
+        tasks: &[TaskCard],
+    ) -> Result<()> {
         let mut cache = self
             .task_list_cache
             .lock()
             .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
-        cache.insert(
-            repo_key.to_string(),
-            TaskListCacheEntry {
-                tasks: tasks.to_vec(),
-                cached_at: Instant::now(),
-            },
-        );
+        let state = cache.entry(repo_key.to_string()).or_default();
+        if state.generation != generation {
+            return Ok(());
+        }
+
+        state.entry = Some(TaskListCacheEntry {
+            tasks: tasks.to_vec(),
+            cached_at: Instant::now(),
+            metadata_namespace: metadata_namespace.to_string(),
+        });
         Ok(())
     }
 
@@ -202,7 +224,33 @@ impl BeadsTaskStore {
             .task_list_cache
             .lock()
             .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
-        cache.remove(&repo_key);
+        let state = cache.entry(repo_key).or_default();
+        state.generation = state.generation.saturating_add(1);
+        state.entry = None;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn task_list_cache_generation_for_repo(&self, repo_path: &Path) -> Result<u64> {
+        let repo_key = Self::repo_key(repo_path);
+        let mut cache = self
+            .task_list_cache
+            .lock()
+            .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
+        let state = cache.entry(repo_key).or_default();
+        Ok(state.generation)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cache_task_list_for_repo_if_generation(
+        &self,
+        repo_path: &Path,
+        metadata_namespace: &str,
+        generation: u64,
+        tasks: &[TaskCard],
+    ) -> Result<()> {
+        let repo_key = Self::repo_key(repo_path);
+        self.cache_task_list_if_generation(&repo_key, metadata_namespace, generation, tasks)?;
         Ok(())
     }
 }
@@ -270,13 +318,15 @@ impl TaskStore for BeadsTaskStore {
     }
 
     fn list_tasks(&self, repo_path: &Path) -> Result<Vec<TaskCard>> {
+        let metadata_namespace = self.current_metadata_namespace();
         let repo_key = Self::repo_key(repo_path);
-        if let Some(tasks) = self.cached_task_list(&repo_key)? {
+        let (cached_tasks, cache_generation) =
+            self.cached_task_list_and_generation(&repo_key, &metadata_namespace)?;
+        if let Some(tasks) = cached_tasks {
             return Ok(tasks);
         }
 
         let value = self.run_bd_json(repo_path, &["list", "--all", "--limit", "0"])?;
-        let metadata_namespace = self.current_metadata_namespace();
 
         let mut tasks = value
             .as_array()
@@ -310,7 +360,12 @@ impl TaskStore for BeadsTaskStore {
             task.subtask_ids = subtasks;
         }
 
-        self.cache_task_list(&repo_key, &tasks)?;
+        self.cache_task_list_if_generation(
+            &repo_key,
+            &metadata_namespace,
+            cache_generation,
+            &tasks,
+        )?;
         Ok(tasks)
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -9,9 +9,10 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use crate::command_runner::{CommandRunner, ProcessCommandRunner};
-use crate::constants::DEFAULT_METADATA_NAMESPACE;
+use crate::constants::{DEFAULT_METADATA_NAMESPACE, TASK_LIST_CACHE_TTL_MS};
 use crate::metadata::{
     metadata_namespace, parse_agent_sessions, parse_markdown_entries, parse_metadata_root,
     parse_qa_entries,
@@ -21,12 +22,19 @@ use crate::normalize::{normalize_labels, normalize_text_option};
 
 type MetadataNamespaceResolver = Arc<dyn Fn() -> Result<String> + Send + Sync>;
 
+#[derive(Clone)]
+struct TaskListCacheEntry {
+    tasks: Vec<TaskCard>,
+    cached_at: Instant,
+}
+
 pub struct BeadsTaskStore {
     pub(crate) command_runner: Arc<dyn CommandRunner>,
     pub(crate) metadata_namespace: Mutex<String>,
     pub(crate) metadata_namespace_resolver: Option<MetadataNamespaceResolver>,
     pub(crate) init_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
     pub(crate) initialized_repos: Mutex<HashSet<String>>,
+    task_list_cache: Mutex<HashMap<String, TaskListCacheEntry>>,
 }
 
 impl fmt::Debug for BeadsTaskStore {
@@ -75,6 +83,7 @@ impl BeadsTaskStore {
             metadata_namespace_resolver,
             init_locks: Mutex::new(HashMap::new()),
             initialized_repos: Mutex::new(HashSet::new()),
+            task_list_cache: Mutex::new(HashMap::new()),
         }
     }
 
@@ -149,6 +158,53 @@ impl BeadsTaskStore {
         self.refresh_metadata_namespace();
         self.metadata_namespace_snapshot()
     }
+
+    fn task_list_cache_ttl() -> Duration {
+        Duration::from_millis(TASK_LIST_CACHE_TTL_MS)
+    }
+
+    fn cached_task_list(&self, repo_key: &str) -> Result<Option<Vec<TaskCard>>> {
+        let mut cache = self
+            .task_list_cache
+            .lock()
+            .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
+
+        let Some(entry) = cache.get(repo_key) else {
+            return Ok(None);
+        };
+
+        if entry.cached_at.elapsed() <= Self::task_list_cache_ttl() {
+            return Ok(Some(entry.tasks.clone()));
+        }
+
+        cache.remove(repo_key);
+        Ok(None)
+    }
+
+    fn cache_task_list(&self, repo_key: &str, tasks: &[TaskCard]) -> Result<()> {
+        let mut cache = self
+            .task_list_cache
+            .lock()
+            .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
+        cache.insert(
+            repo_key.to_string(),
+            TaskListCacheEntry {
+                tasks: tasks.to_vec(),
+                cached_at: Instant::now(),
+            },
+        );
+        Ok(())
+    }
+
+    pub(crate) fn invalidate_task_list_cache(&self, repo_path: &Path) -> Result<()> {
+        let repo_key = Self::repo_key(repo_path);
+        let mut cache = self
+            .task_list_cache
+            .lock()
+            .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
+        cache.remove(&repo_key);
+        Ok(())
+    }
 }
 
 impl TaskStore for BeadsTaskStore {
@@ -214,6 +270,11 @@ impl TaskStore for BeadsTaskStore {
     }
 
     fn list_tasks(&self, repo_path: &Path) -> Result<Vec<TaskCard>> {
+        let repo_key = Self::repo_key(repo_path);
+        if let Some(tasks) = self.cached_task_list(&repo_key)? {
+            return Ok(tasks);
+        }
+
         let value = self.run_bd_json(repo_path, &["list", "--all", "--limit", "0"])?;
         let metadata_namespace = self.current_metadata_namespace();
 
@@ -249,6 +310,7 @@ impl TaskStore for BeadsTaskStore {
             task.subtask_ids = subtasks;
         }
 
+        self.cache_task_list(&repo_key, &tasks)?;
         Ok(tasks)
     }
 
@@ -285,6 +347,7 @@ impl TaskStore for BeadsTaskStore {
 
         let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
         let value = self.run_bd_json(repo_path, &arg_refs)?;
+        self.invalidate_task_list_cache(repo_path)?;
         let raw: RawIssue =
             serde_json::from_value(value).context("Failed to decode created issue")?;
         let created_id = raw.id.clone();
@@ -374,6 +437,7 @@ impl TaskStore for BeadsTaskStore {
             args.push(task_id.to_string());
             let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
             self.run_bd_json(repo_path, &arg_refs)?;
+            self.invalidate_task_list_cache(repo_path)?;
         }
 
         if let Some(ai_review_enabled) = patch.ai_review_enabled {
@@ -395,6 +459,7 @@ impl TaskStore for BeadsTaskStore {
         args.push(task_id);
 
         self.run_bd(repo_path, &args)?;
+        self.invalidate_task_list_cache(repo_path)?;
         Ok(true)
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -2,7 +2,7 @@ use super::{
     default_ai_review_enabled, metadata_bool_qa_required, metadata_namespace, normalize_issue_type,
     normalize_labels, normalize_text_option, parse_agent_sessions, parse_markdown_entries,
     parse_metadata_root, parse_qa_entries, BeadsTaskStore, CommandRunner, ProcessCommandRunner,
-    CUSTOM_STATUS_VALUES,
+    CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS,
 };
 use anyhow::{anyhow, Result};
 use host_domain::{
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum CallKind {
@@ -799,6 +799,147 @@ fn list_tasks_cache_is_invalidated_after_metadata_mutation() -> Result<()> {
         .filter(|call| call.args.get(1).map(String::as_str) == Some("list"))
         .count();
     assert_eq!(list_calls, 2);
+    Ok(())
+}
+
+#[test]
+fn list_tasks_cache_expires_after_ttl() -> Result<()> {
+    let repo = RepoFixture::new("list-cache-expiry");
+    let initial_list = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let refreshed_list = json!([issue_value(
+        "task-1",
+        "blocked",
+        "task",
+        None,
+        json!([]),
+        None
+    )]);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(initial_list.to_string())),
+        MockStep::WithEnv(Ok(refreshed_list.to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let initial = store.list_tasks(repo.path())?;
+    assert_eq!(initial[0].status, TaskStatus::Open);
+
+    std::thread::sleep(Duration::from_millis(TASK_LIST_CACHE_TTL_MS + 50));
+
+    let refreshed = store.list_tasks(repo.path())?;
+    assert_eq!(refreshed[0].status, TaskStatus::Blocked);
+
+    let calls = runner.take_calls();
+    let list_calls = calls
+        .iter()
+        .filter(|call| call.args.get(1).map(String::as_str) == Some("list"))
+        .count();
+    assert_eq!(list_calls, 2);
+    Ok(())
+}
+
+#[test]
+fn list_tasks_cache_is_invalidated_after_create_mutation() -> Result<()> {
+    let repo = RepoFixture::new("list-cache-invalidate-create");
+    let initial_list = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let created = issue_value("task-2", "open", "task", None, json!([]), None);
+    let shown = issue_value("task-2", "open", "task", None, json!([]), None);
+    let refreshed_list = json!([
+        issue_value("task-1", "open", "task", None, json!([]), None),
+        issue_value("task-2", "open", "task", None, json!([]), None)
+    ]);
+
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(initial_list.to_string())),
+        MockStep::WithEnv(Ok(created.to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+        MockStep::WithEnv(Ok(json!([shown]).to_string())),
+        MockStep::WithEnv(Ok(refreshed_list.to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let initial = store.list_tasks(repo.path())?;
+    assert_eq!(initial.len(), 1);
+
+    let created_task = store.create_task(
+        repo.path(),
+        CreateTaskInput {
+            title: "New task".to_string(),
+            issue_type: "task".to_string(),
+            priority: 2,
+            description: None,
+            acceptance_criteria: None,
+            labels: None,
+            ai_review_enabled: Some(true),
+            parent_id: None,
+        },
+    )?;
+    assert_eq!(created_task.id, "task-2");
+
+    let refreshed = store.list_tasks(repo.path())?;
+    assert_eq!(refreshed.len(), 2);
+    assert!(refreshed.iter().any(|task| task.id == "task-2"));
+
+    let calls = runner.take_calls();
+    let list_calls = calls
+        .iter()
+        .filter(|call| call.args.get(1).map(String::as_str) == Some("list"))
+        .count();
+    assert_eq!(list_calls, 2);
+    Ok(())
+}
+
+#[test]
+fn list_tasks_cache_is_invalidated_after_delete_mutation() -> Result<()> {
+    let repo = RepoFixture::new("list-cache-invalidate-delete");
+    let initial_list = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let refreshed_list = json!([]);
+
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(initial_list.to_string())),
+        MockStep::WithEnv(Ok("done".to_string())),
+        MockStep::WithEnv(Ok(refreshed_list.to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let initial = store.list_tasks(repo.path())?;
+    assert_eq!(initial.len(), 1);
+
+    assert!(store.delete_task(repo.path(), "task-1", false)?);
+
+    let refreshed = store.list_tasks(repo.path())?;
+    assert!(refreshed.is_empty());
+
+    let calls = runner.take_calls();
+    let list_calls = calls
+        .iter()
+        .filter(|call| call.args.get(1).map(String::as_str) == Some("list"))
+        .count();
+    assert_eq!(list_calls, 2);
+    Ok(())
+}
+
+#[test]
+fn stale_generation_cache_writes_are_ignored() -> Result<()> {
+    let repo = RepoFixture::new("list-cache-generation-guard");
+    let payload = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(payload.to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let stale_generation = store.task_list_cache_generation_for_repo(repo.path())?;
+    store.invalidate_task_list_cache(repo.path())?;
+    store.cache_task_list_for_repo_if_generation(
+        repo.path(),
+        "openducktor",
+        stale_generation,
+        &[],
+    )?;
+
+    let tasks = store.list_tasks(repo.path())?;
+    assert_eq!(tasks.len(), 1);
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].args[1], "list");
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -668,6 +668,141 @@ fn list_tasks_filters_events_and_populates_subtask_ids() -> Result<()> {
 }
 
 #[test]
+fn list_tasks_uses_short_lived_repo_cache() -> Result<()> {
+    let repo = RepoFixture::new("list-cache-hit");
+    let payload = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(payload.to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let first = store.list_tasks(repo.path())?;
+    let second = store.list_tasks(repo.path())?;
+    assert_eq!(first.len(), 1);
+    assert_eq!(second.len(), 1);
+    assert_eq!(second[0].id, "task-1");
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].args[1], "list");
+    Ok(())
+}
+
+#[test]
+fn list_tasks_cache_is_invalidated_after_update_mutation() -> Result<()> {
+    let repo = RepoFixture::new("list-cache-invalidate-update");
+    let initial_list = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let updated_show = json!([issue_value(
+        "task-1",
+        "blocked",
+        "task",
+        None,
+        json!([]),
+        None
+    )]);
+    let refreshed_list = json!([issue_value(
+        "task-1",
+        "blocked",
+        "task",
+        None,
+        json!([]),
+        None
+    )]);
+
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(initial_list.to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+        MockStep::WithEnv(Ok(updated_show.to_string())),
+        MockStep::WithEnv(Ok(refreshed_list.to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let initial = store.list_tasks(repo.path())?;
+    assert_eq!(initial[0].status, TaskStatus::Open);
+
+    let updated = store.update_task(
+        repo.path(),
+        "task-1",
+        UpdateTaskPatch {
+            title: None,
+            description: None,
+            acceptance_criteria: None,
+            notes: None,
+            status: Some(TaskStatus::Blocked),
+            priority: None,
+            issue_type: None,
+            ai_review_enabled: None,
+            labels: None,
+            assignee: None,
+            parent_id: None,
+        },
+    )?;
+    assert_eq!(updated.status, TaskStatus::Blocked);
+
+    let refreshed = store.list_tasks(repo.path())?;
+    assert_eq!(refreshed[0].status, TaskStatus::Blocked);
+
+    let calls = runner.take_calls();
+    let list_calls = calls
+        .iter()
+        .filter(|call| call.args.get(1).map(String::as_str) == Some("list"))
+        .count();
+    assert_eq!(list_calls, 2);
+    Ok(())
+}
+
+#[test]
+fn list_tasks_cache_is_invalidated_after_metadata_mutation() -> Result<()> {
+    let repo = RepoFixture::new("list-cache-invalidate-metadata");
+    let initial_list = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let current_issue = issue_value("task-1", "open", "task", None, json!([]), None);
+    let refreshed_list = json!([issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "documents": {
+                    "spec": [
+                        {
+                            "markdown": "# Spec",
+                            "updatedAt": "2026-02-20T12:00:00Z",
+                            "updatedBy": "planner-agent",
+                            "sourceTool": "set_spec",
+                            "revision": 1
+                        }
+                    ]
+                }
+            }
+        })),
+    )]);
+
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(initial_list.to_string())),
+        MockStep::WithEnv(Ok(json!([current_issue]).to_string())),
+        MockStep::WithEnv(Ok("{}".to_string())),
+        MockStep::WithEnv(Ok(refreshed_list.to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let initial = store.list_tasks(repo.path())?;
+    assert!(!initial[0].document_summary.spec.has);
+
+    store.set_spec(repo.path(), "task-1", "# Spec")?;
+
+    let refreshed = store.list_tasks(repo.path())?;
+    assert!(refreshed[0].document_summary.spec.has);
+
+    let calls = runner.take_calls();
+    let list_calls = calls
+        .iter()
+        .filter(|call| call.args.get(1).map(String::as_str) == Some("list"))
+        .count();
+    assert_eq!(list_calls, 2);
+    Ok(())
+}
+
+#[test]
 fn create_task_normalizes_payload_and_persists_qa_flag() -> Result<()> {
     let repo = RepoFixture::new("create-task");
     let created = issue_value("task-1", "open", "feature", None, json!([]), None);
@@ -1402,20 +1537,25 @@ fn get_task_metadata_fetches_all_fields_in_single_call() -> Result<()> {
         })),
     );
 
-    let runner = MockCommandRunner::with_steps(vec![
-        MockStep::WithEnv(Ok(json!([issue]).to_string())),
-    ]);
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([issue]).to_string()))]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     let metadata = store.get_task_metadata(repo.path(), "task-1")?;
 
     // Verify spec
     assert_eq!(metadata.spec.markdown, "# Spec content");
-    assert_eq!(metadata.spec.updated_at.as_deref(), Some("2026-02-20T10:00:00Z"));
+    assert_eq!(
+        metadata.spec.updated_at.as_deref(),
+        Some("2026-02-20T10:00:00Z")
+    );
 
     // Verify plan
     assert_eq!(metadata.plan.markdown, "# Plan content");
-    assert_eq!(metadata.plan.updated_at.as_deref(), Some("2026-02-20T11:00:00Z"));
+    assert_eq!(
+        metadata.plan.updated_at.as_deref(),
+        Some("2026-02-20T11:00:00Z")
+    );
 
     // Verify QA report
     let qa = metadata.qa_report.expect("qa_report should be present");
@@ -1442,9 +1582,8 @@ fn get_task_metadata_handles_empty_metadata() -> Result<()> {
     let repo = RepoFixture::new("get-task-metadata-empty");
     let issue = issue_value("task-1", "open", "task", None, json!([]), None);
 
-    let runner = MockCommandRunner::with_steps(vec![
-        MockStep::WithEnv(Ok(json!([issue]).to_string())),
-    ]);
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([issue]).to_string()))]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner);
 
     let metadata = store.get_task_metadata(repo.path(), "task-1")?;


### PR DESCRIPTION
## Summary
- add a short-lived host-side cache for `BeadsTaskStore::list_tasks` to avoid repeated full `bd list --all --limit 0` calls on frequent board refreshes
- invalidate task-list cache on all task mutations (`create`, `update`, `delete`) and metadata writes
- harden cache consistency with:
  - generation-based write guards (prevents stale reinsert after invalidation under overlapping calls)
  - metadata-namespace-aware cache entries
  - namespace refresh before cache lookup

## Testing
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test`
- `cd apps/desktop/src-tauri && cargo test -p host-infra-beads`
- `bun run typecheck`
- `bun run test`

## Scope
Only touched:
- `apps/desktop/src-tauri/crates/host-infra-beads/src/constants.rs`
- `apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs`
- `apps/desktop/src-tauri/crates/host-infra-beads/src/metadata_ops.rs`
- `apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs`
- `apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs`
