### PR TITLE
perf(desktop): virtualize Kanban task cards for high-volume columns

### DIFF
--- a/apps/desktop/src/components/features/kanban/kanban-column-virtualization.test.ts
+++ b/apps/desktop/src/components/features/kanban/kanban-column-virtualization.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildVirtualColumnLayout,
+  findVirtualWindowRange,
+  getVirtualWindowEdgeOffsets,
+} from "@/components/features/kanban/kanban-column-virtualization";
+
+describe("kanban-column virtualization helpers", () => {
+  test("buildVirtualColumnLayout tracks offsets with inter-card gaps", () => {
+    const layout = buildVirtualColumnLayout([100, 120, 140], 12);
+
+    expect(layout.itemOffsets).toEqual([0, 112, 244]);
+    expect(layout.totalHeight).toBe(384);
+  });
+
+  test("findVirtualWindowRange returns only intersecting items", () => {
+    const itemHeights = [80, 90, 100, 110];
+    const layout = buildVirtualColumnLayout(itemHeights, 12);
+
+    const range = findVirtualWindowRange({
+      itemOffsets: layout.itemOffsets,
+      itemHeights,
+      totalHeight: layout.totalHeight,
+      viewportStart: 90,
+      viewportEnd: 250,
+    });
+
+    expect(range).toEqual({ startIndex: 1, endIndex: 2 });
+  });
+
+  test("findVirtualWindowRange returns empty when viewport is outside the column", () => {
+    const itemHeights = [80, 90, 100];
+    const layout = buildVirtualColumnLayout(itemHeights, 12);
+
+    const range = findVirtualWindowRange({
+      itemOffsets: layout.itemOffsets,
+      itemHeights,
+      totalHeight: layout.totalHeight,
+      viewportStart: -600,
+      viewportEnd: -200,
+    });
+
+    expect(range).toEqual({ startIndex: 0, endIndex: -1 });
+  });
+
+  test("getVirtualWindowEdgeOffsets returns spacer heights around visible range", () => {
+    const itemHeights = [100, 110, 120, 130];
+    const layout = buildVirtualColumnLayout(itemHeights, 12);
+
+    const offsets = getVirtualWindowEdgeOffsets({
+      range: { startIndex: 1, endIndex: 2 },
+      itemOffsets: layout.itemOffsets,
+      itemHeights,
+      totalHeight: layout.totalHeight,
+    });
+
+    expect(offsets).toEqual({
+      topSpacerHeight: 112,
+      bottomSpacerHeight: 142,
+    });
+  });
+});

--- a/apps/desktop/src/components/features/kanban/kanban-column-virtualization.ts
+++ b/apps/desktop/src/components/features/kanban/kanban-column-virtualization.ts
@@ -1,0 +1,131 @@
+export type VirtualWindowRange = {
+  startIndex: number;
+  endIndex: number;
+};
+
+type FindVirtualWindowRangeArgs = {
+  itemOffsets: number[];
+  itemHeights: number[];
+  totalHeight: number;
+  viewportStart: number;
+  viewportEnd: number;
+};
+
+type VirtualWindowEdgeOffsetsArgs = {
+  range: VirtualWindowRange;
+  itemOffsets: number[];
+  itemHeights: number[];
+  totalHeight: number;
+};
+
+const EMPTY_RANGE: VirtualWindowRange = { startIndex: 0, endIndex: -1 };
+
+export function buildVirtualColumnLayout(
+  itemHeights: number[],
+  gapPx: number,
+): { itemOffsets: number[]; totalHeight: number } {
+  const safeGapPx = Math.max(0, gapPx);
+  const itemOffsets = new Array<number>(itemHeights.length);
+  let nextOffset = 0;
+
+  for (let index = 0; index < itemHeights.length; index += 1) {
+    itemOffsets[index] = nextOffset;
+    const safeHeight = Math.max(0, itemHeights[index] ?? 0);
+    nextOffset += safeHeight;
+    if (index < itemHeights.length - 1) {
+      nextOffset += safeGapPx;
+    }
+  }
+
+  return { itemOffsets, totalHeight: nextOffset };
+}
+
+export function findVirtualWindowRange({
+  itemOffsets,
+  itemHeights,
+  totalHeight,
+  viewportStart,
+  viewportEnd,
+}: FindVirtualWindowRangeArgs): VirtualWindowRange {
+  if (itemHeights.length === 0) {
+    return EMPTY_RANGE;
+  }
+
+  const minViewport = Math.min(viewportStart, viewportEnd);
+  const maxViewport = Math.max(viewportStart, viewportEnd);
+
+  if (maxViewport < 0 || minViewport > totalHeight) {
+    return EMPTY_RANGE;
+  }
+
+  const start = Math.max(0, minViewport);
+  const end = Math.max(0, maxViewport);
+  const firstIndex = findFirstIndexWithEndAfterStart(itemOffsets, itemHeights, start);
+  const lastIndex = findLastIndexWithStartBeforeEnd(itemOffsets, end);
+
+  if (firstIndex < 0 || lastIndex < firstIndex) {
+    return EMPTY_RANGE;
+  }
+
+  return { startIndex: firstIndex, endIndex: lastIndex };
+}
+
+export function getVirtualWindowEdgeOffsets({
+  range,
+  itemOffsets,
+  itemHeights,
+  totalHeight,
+}: VirtualWindowEdgeOffsetsArgs): { topSpacerHeight: number; bottomSpacerHeight: number } {
+  if (range.endIndex < range.startIndex || itemHeights.length === 0) {
+    return { topSpacerHeight: 0, bottomSpacerHeight: totalHeight };
+  }
+
+  const topSpacerHeight = itemOffsets[range.startIndex] ?? 0;
+  const visibleWindowEnd =
+    (itemOffsets[range.endIndex] ?? 0) + (itemHeights[range.endIndex] ?? 0);
+  const bottomSpacerHeight = Math.max(0, totalHeight - visibleWindowEnd);
+
+  return { topSpacerHeight, bottomSpacerHeight };
+}
+
+function findFirstIndexWithEndAfterStart(
+  itemOffsets: number[],
+  itemHeights: number[],
+  start: number,
+): number {
+  let low = 0;
+  let high = itemOffsets.length - 1;
+  let candidate = -1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const itemEnd = (itemOffsets[mid] ?? 0) + (itemHeights[mid] ?? 0);
+    if (itemEnd >= start) {
+      candidate = mid;
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  return candidate;
+}
+
+function findLastIndexWithStartBeforeEnd(itemOffsets: number[], end: number): number {
+  let low = 0;
+  let high = itemOffsets.length - 1;
+  let candidate = -1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const itemStart = itemOffsets[mid] ?? 0;
+    if (itemStart <= end) {
+      candidate = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return candidate;
+}

--- a/apps/desktop/src/components/features/kanban/kanban-column-virtualization.ts
+++ b/apps/desktop/src/components/features/kanban/kanban-column-virtualization.ts
@@ -81,8 +81,7 @@ export function getVirtualWindowEdgeOffsets({
   }
 
   const topSpacerHeight = itemOffsets[range.startIndex] ?? 0;
-  const visibleWindowEnd =
-    (itemOffsets[range.endIndex] ?? 0) + (itemHeights[range.endIndex] ?? 0);
+  const visibleWindowEnd = (itemOffsets[range.endIndex] ?? 0) + (itemHeights[range.endIndex] ?? 0);
   const bottomSpacerHeight = Math.max(0, totalHeight - visibleWindowEnd);
 
   return { topSpacerHeight, bottomSpacerHeight };

--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -1,11 +1,28 @@
 import type { RunSummary } from "@openducktor/contracts";
 import type { KanbanColumn as KanbanColumnData, KanbanColumnId } from "@openducktor/core";
 import { Inbox } from "lucide-react";
-import type { ReactElement } from "react";
+import {
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  buildVirtualColumnLayout,
+  findVirtualWindowRange,
+  getVirtualWindowEdgeOffsets,
+} from "@/components/features/kanban/kanban-column-virtualization";
 import { KanbanTaskCard } from "@/components/features/kanban/kanban-task-card";
 import { laneTheme } from "@/components/features/kanban/kanban-theme";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+
+const VIRTUALIZATION_MIN_TASK_COUNT = 30;
+const VIRTUAL_CARD_ESTIMATED_HEIGHT_PX = 180;
+const VIRTUAL_CARD_GAP_PX = 12;
+const VIRTUAL_OVERSCAN_PX = 360;
 
 type KanbanColumnProps = {
   column: KanbanColumnData;
@@ -19,6 +36,78 @@ type KanbanColumnProps = {
 };
 
 const laneCountLabel = (count: number): string => (count === 1 ? "1 task" : `${count} tasks`);
+
+type TaskCardHandlers = Pick<
+  KanbanColumnProps,
+  | "onOpenDetails"
+  | "onDelegate"
+  | "onPlan"
+  | "onBuild"
+  | "onHumanApprove"
+  | "onHumanRequestChanges"
+>;
+
+function MeasuredTaskCard({
+  task,
+  runState,
+  onMeasuredHeight,
+  onOpenDetails,
+  onDelegate,
+  onPlan,
+  onBuild,
+  onHumanApprove,
+  onHumanRequestChanges,
+}: {
+  task: KanbanColumnData["tasks"][number];
+  runState: RunSummary["state"] | undefined;
+  onMeasuredHeight: (taskId: string, height: number) => void;
+} & TaskCardHandlers): ReactElement {
+  const taskWrapperRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const element = taskWrapperRef.current;
+    if (!element) {
+      return;
+    }
+
+    const reportHeight = (): void => {
+      const nextHeight = Math.ceil(element.getBoundingClientRect().height);
+      if (nextHeight > 0) {
+        onMeasuredHeight(task.id, nextHeight);
+      }
+    };
+
+    reportHeight();
+
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      reportHeight();
+    });
+
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, [onMeasuredHeight, task.id]);
+
+  return (
+    <div ref={taskWrapperRef}>
+      <KanbanTaskCard
+        task={task}
+        runState={runState}
+        onOpenDetails={onOpenDetails}
+        onDelegate={onDelegate}
+        onPlan={onPlan}
+        onBuild={onBuild}
+        {...(onHumanApprove ? { onHumanApprove } : {})}
+        {...(onHumanRequestChanges ? { onHumanRequestChanges } : {})}
+      />
+    </div>
+  );
+}
 
 function LaneHeader({
   id,
@@ -77,6 +166,147 @@ export function KanbanColumn({
   onHumanRequestChanges,
 }: KanbanColumnProps): ReactElement {
   const theme = laneTheme(column.id);
+  const cardsViewportRef = useRef<HTMLDivElement | null>(null);
+  const shouldVirtualize = column.tasks.length >= VIRTUALIZATION_MIN_TASK_COUNT;
+  const [measuredCardHeightsById, setMeasuredCardHeightsById] = useState<Record<string, number>>({});
+  const [viewport, setViewport] = useState<{ start: number; end: number }>({
+    start: -VIRTUAL_OVERSCAN_PX,
+    end: VIRTUAL_OVERSCAN_PX,
+  });
+
+  const taskHeights = useMemo(
+    () =>
+      column.tasks.map(
+        (task) => measuredCardHeightsById[task.id] ?? VIRTUAL_CARD_ESTIMATED_HEIGHT_PX,
+      ),
+    [column.tasks, measuredCardHeightsById],
+  );
+
+  const virtualLayout = useMemo(
+    () => buildVirtualColumnLayout(taskHeights, VIRTUAL_CARD_GAP_PX),
+    [taskHeights],
+  );
+
+  const visibleRange = useMemo(
+    () =>
+      findVirtualWindowRange({
+        itemOffsets: virtualLayout.itemOffsets,
+        itemHeights: taskHeights,
+        totalHeight: virtualLayout.totalHeight,
+        viewportStart: viewport.start - VIRTUAL_OVERSCAN_PX,
+        viewportEnd: viewport.end + VIRTUAL_OVERSCAN_PX,
+      }),
+    [taskHeights, viewport.end, viewport.start, virtualLayout.itemOffsets, virtualLayout.totalHeight],
+  );
+
+  const { topSpacerHeight, bottomSpacerHeight } = useMemo(
+    () =>
+      getVirtualWindowEdgeOffsets({
+        range: visibleRange,
+        itemOffsets: virtualLayout.itemOffsets,
+        itemHeights: taskHeights,
+        totalHeight: virtualLayout.totalHeight,
+      }),
+    [taskHeights, virtualLayout.itemOffsets, virtualLayout.totalHeight, visibleRange],
+  );
+
+  const syncViewport = useCallback((): void => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const viewportElement = cardsViewportRef.current;
+    if (!viewportElement) {
+      return;
+    }
+
+    const rect = viewportElement.getBoundingClientRect();
+    const nextStart = -rect.top;
+    const nextEnd = nextStart + window.innerHeight;
+
+    setViewport((current) => {
+      if (current.start === nextStart && current.end === nextEnd) {
+        return current;
+      }
+      return { start: nextStart, end: nextEnd };
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!shouldVirtualize || typeof window === "undefined") {
+      return;
+    }
+
+    const rafRef: { current: number | null } = { current: null };
+
+    const scheduleViewportSync = (): void => {
+      if (rafRef.current !== null) {
+        return;
+      }
+      rafRef.current = window.requestAnimationFrame(() => {
+        rafRef.current = null;
+        syncViewport();
+      });
+    };
+
+    scheduleViewportSync();
+    window.addEventListener("scroll", scheduleViewportSync, { passive: true });
+    window.addEventListener("resize", scheduleViewportSync);
+
+    const viewportElement = cardsViewportRef.current;
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            scheduleViewportSync();
+          });
+
+    if (resizeObserver && viewportElement) {
+      resizeObserver.observe(viewportElement);
+    }
+
+    return () => {
+      window.removeEventListener("scroll", scheduleViewportSync);
+      window.removeEventListener("resize", scheduleViewportSync);
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, [shouldVirtualize, syncViewport]);
+
+  useEffect(() => {
+    if (!shouldVirtualize) {
+      return;
+    }
+    const taskIds = new Set(column.tasks.map((task) => task.id));
+    setMeasuredCardHeightsById((current) => {
+      let changed = false;
+      const next: Record<string, number> = {};
+      for (const [taskId, measuredHeight] of Object.entries(current)) {
+        if (taskIds.has(taskId)) {
+          next[taskId] = measuredHeight;
+          continue;
+        }
+        changed = true;
+      }
+      return changed ? next : current;
+    });
+  }, [column.tasks, shouldVirtualize]);
+
+  const handleMeasuredHeight = useCallback((taskId: string, nextHeight: number): void => {
+    setMeasuredCardHeightsById((current) => {
+      if (current[taskId] === nextHeight) {
+        return current;
+      }
+      return { ...current, [taskId]: nextHeight };
+    });
+  }, []);
+
+  const visibleTasks = !shouldVirtualize
+    ? column.tasks
+    : visibleRange.endIndex >= visibleRange.startIndex
+      ? column.tasks.slice(visibleRange.startIndex, visibleRange.endIndex + 1)
+      : [];
 
   return (
     <section
@@ -86,22 +316,49 @@ export function KanbanColumn({
       )}
     >
       <LaneHeader id={column.id} title={column.title} count={column.tasks.length} />
-      <div className="flex-1 space-y-3 p-3">
+      <div ref={cardsViewportRef} className="flex-1 p-3">
         {column.tasks.length === 0 ? <LaneEmptyState id={column.id} /> : null}
 
-        {column.tasks.map((task) => (
-          <KanbanTaskCard
-            key={task.id}
-            task={task}
-            runState={runStateByTaskId.get(task.id)}
-            onOpenDetails={onOpenDetails}
-            onDelegate={onDelegate}
-            onPlan={onPlan}
-            onBuild={onBuild}
-            {...(onHumanApprove ? { onHumanApprove } : {})}
-            {...(onHumanRequestChanges ? { onHumanRequestChanges } : {})}
-          />
-        ))}
+        {column.tasks.length > 0 && shouldVirtualize ? (
+          <>
+            {topSpacerHeight > 0 ? <div style={{ height: topSpacerHeight }} /> : null}
+            <div className="space-y-3">
+              {visibleTasks.map((task) => (
+                <MeasuredTaskCard
+                  key={task.id}
+                  task={task}
+                  runState={runStateByTaskId.get(task.id)}
+                  onMeasuredHeight={handleMeasuredHeight}
+                  onOpenDetails={onOpenDetails}
+                  onDelegate={onDelegate}
+                  onPlan={onPlan}
+                  onBuild={onBuild}
+                  {...(onHumanApprove ? { onHumanApprove } : {})}
+                  {...(onHumanRequestChanges ? { onHumanRequestChanges } : {})}
+                />
+              ))}
+            </div>
+            {bottomSpacerHeight > 0 ? <div style={{ height: bottomSpacerHeight }} /> : null}
+          </>
+        ) : null}
+
+        {column.tasks.length > 0 && !shouldVirtualize ? (
+          <div className="space-y-3">
+            {column.tasks.map((task) => (
+              <KanbanTaskCard
+                key={task.id}
+                task={task}
+                runState={runStateByTaskId.get(task.id)}
+                onOpenDetails={onOpenDetails}
+                onDelegate={onDelegate}
+                onPlan={onPlan}
+                onBuild={onBuild}
+                {...(onHumanApprove ? { onHumanApprove } : {})}
+                {...(onHumanRequestChanges ? { onHumanRequestChanges } : {})}
+              />
+            ))}
+          </div>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -1,18 +1,12 @@
 import type { RunSummary } from "@openducktor/contracts";
 import type { KanbanColumn as KanbanColumnData, KanbanColumnId } from "@openducktor/core";
 import { Inbox } from "lucide-react";
-import {
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   buildVirtualColumnLayout,
   findVirtualWindowRange,
   getVirtualWindowEdgeOffsets,
+  type VirtualWindowRange,
 } from "@/components/features/kanban/kanban-column-virtualization";
 import { KanbanTaskCard } from "@/components/features/kanban/kanban-task-card";
 import { laneTheme } from "@/components/features/kanban/kanban-theme";
@@ -23,6 +17,7 @@ const VIRTUALIZATION_MIN_TASK_COUNT = 30;
 const VIRTUAL_CARD_ESTIMATED_HEIGHT_PX = 180;
 const VIRTUAL_CARD_GAP_PX = 12;
 const VIRTUAL_OVERSCAN_PX = 360;
+const INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX = 900;
 
 type KanbanColumnProps = {
   column: KanbanColumnData;
@@ -39,15 +34,10 @@ const laneCountLabel = (count: number): string => (count === 1 ? "1 task" : `${c
 
 type TaskCardHandlers = Pick<
   KanbanColumnProps,
-  | "onOpenDetails"
-  | "onDelegate"
-  | "onPlan"
-  | "onBuild"
-  | "onHumanApprove"
-  | "onHumanRequestChanges"
+  "onOpenDetails" | "onDelegate" | "onPlan" | "onBuild" | "onHumanApprove" | "onHumanRequestChanges"
 >;
 
-function MeasuredTaskCard({
+const MeasuredTaskCard = memo(function MeasuredTaskCard({
   task,
   runState,
   onMeasuredHeight,
@@ -107,7 +97,7 @@ function MeasuredTaskCard({
       />
     </div>
   );
-}
+});
 
 function LaneHeader({
   id,
@@ -168,11 +158,9 @@ export function KanbanColumn({
   const theme = laneTheme(column.id);
   const cardsViewportRef = useRef<HTMLDivElement | null>(null);
   const shouldVirtualize = column.tasks.length >= VIRTUALIZATION_MIN_TASK_COUNT;
-  const [measuredCardHeightsById, setMeasuredCardHeightsById] = useState<Record<string, number>>({});
-  const [viewport, setViewport] = useState<{ start: number; end: number }>({
-    start: -VIRTUAL_OVERSCAN_PX,
-    end: VIRTUAL_OVERSCAN_PX,
-  });
+  const [measuredCardHeightsById, setMeasuredCardHeightsById] = useState<Record<string, number>>(
+    {},
+  );
 
   const taskHeights = useMemo(
     () =>
@@ -187,27 +175,16 @@ export function KanbanColumn({
     [taskHeights],
   );
 
-  const visibleRange = useMemo(
-    () =>
-      findVirtualWindowRange({
-        itemOffsets: virtualLayout.itemOffsets,
-        itemHeights: taskHeights,
-        totalHeight: virtualLayout.totalHeight,
-        viewportStart: viewport.start - VIRTUAL_OVERSCAN_PX,
-        viewportEnd: viewport.end + VIRTUAL_OVERSCAN_PX,
-      }),
-    [taskHeights, viewport.end, viewport.start, virtualLayout.itemOffsets, virtualLayout.totalHeight],
-  );
-
-  const { topSpacerHeight, bottomSpacerHeight } = useMemo(
-    () =>
-      getVirtualWindowEdgeOffsets({
-        range: visibleRange,
-        itemOffsets: virtualLayout.itemOffsets,
-        itemHeights: taskHeights,
-        totalHeight: virtualLayout.totalHeight,
-      }),
-    [taskHeights, virtualLayout.itemOffsets, virtualLayout.totalHeight, visibleRange],
+  const [visibleRange, setVisibleRange] = useState<VirtualWindowRange>(() =>
+    findVirtualWindowRange({
+      itemOffsets: virtualLayout.itemOffsets,
+      itemHeights: taskHeights,
+      totalHeight: virtualLayout.totalHeight,
+      viewportStart: -VIRTUAL_OVERSCAN_PX,
+      viewportEnd:
+        (typeof window === "undefined" ? INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX : window.innerHeight) +
+        VIRTUAL_OVERSCAN_PX,
+    }),
   );
 
   const syncViewport = useCallback((): void => {
@@ -222,14 +199,32 @@ export function KanbanColumn({
     const rect = viewportElement.getBoundingClientRect();
     const nextStart = -rect.top;
     const nextEnd = nextStart + window.innerHeight;
+    const nextRange = findVirtualWindowRange({
+      itemOffsets: virtualLayout.itemOffsets,
+      itemHeights: taskHeights,
+      totalHeight: virtualLayout.totalHeight,
+      viewportStart: nextStart - VIRTUAL_OVERSCAN_PX,
+      viewportEnd: nextEnd + VIRTUAL_OVERSCAN_PX,
+    });
 
-    setViewport((current) => {
-      if (current.start === nextStart && current.end === nextEnd) {
+    setVisibleRange((current) => {
+      if (current.startIndex === nextRange.startIndex && current.endIndex === nextRange.endIndex) {
         return current;
       }
-      return { start: nextStart, end: nextEnd };
+      return nextRange;
     });
-  }, []);
+  }, [taskHeights, virtualLayout.itemOffsets, virtualLayout.totalHeight]);
+
+  const { topSpacerHeight, bottomSpacerHeight } = useMemo(
+    () =>
+      getVirtualWindowEdgeOffsets({
+        range: visibleRange,
+        itemOffsets: virtualLayout.itemOffsets,
+        itemHeights: taskHeights,
+        totalHeight: virtualLayout.totalHeight,
+      }),
+    [taskHeights, virtualLayout.itemOffsets, virtualLayout.totalHeight, visibleRange],
+  );
 
   useEffect(() => {
     if (!shouldVirtualize || typeof window === "undefined") {


### PR DESCRIPTION
## Summary
- add windowed rendering for Kanban columns to avoid mounting every card in large lanes
- measure card heights and compute virtual offsets/ranges with spacer blocks to preserve scroll/layout behavior
- keep full rendering path for smaller columns and add deterministic virtualization helper tests

## Testing
- bun run --filter @openducktor/desktop test
- bun test apps/desktop/src/components/features/kanban/kanban-column-virtualization.test.ts
