### PR TITLE
perf(desktop): cache tauri core module import in host client

### DIFF
--- a/apps/desktop/src/lib/host-client.ts
+++ b/apps/desktop/src/lib/host-client.ts
@@ -1,6 +1,15 @@
 import { TauriHostClient } from "@openducktor/adapters-tauri-host";
 import { isTauriRuntime } from "@/lib/runtime";
 
+let tauriCoreModulePromise: Promise<typeof import("@tauri-apps/api/core")> | null = null;
+
+const getTauriCoreModule = (): Promise<typeof import("@tauri-apps/api/core")> => {
+  if (!tauriCoreModulePromise) {
+    tauriCoreModulePromise = import("@tauri-apps/api/core");
+  }
+  return tauriCoreModulePromise;
+};
+
 const notAvailable = async <T>(): Promise<T> => {
   throw new Error("Tauri runtime not available. Run inside the desktop shell.");
 };
@@ -11,7 +20,7 @@ export const createHostClient = (): TauriHostClient => {
   }
 
   return new TauriHostClient(async <T>(command: string, args?: Record<string, unknown>) => {
-    const api = await import("@tauri-apps/api/core");
+    const api = await getTauriCoreModule();
     return api.invoke<T>(command, args);
   });
 };


### PR DESCRIPTION
## Summary
- memoize the dynamic import of `@tauri-apps/api/core` in the desktop host client
- reuse the cached module for all `invoke` calls instead of resolving import per command
- keep non-Tauri fallback behavior unchanged

## Validation
- `bun test --pass-with-no-tests` (apps/desktop)
