### PR TITLE
feat(workflow): support queued tool lifecycle and ready_for_dev replanning

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -28,7 +28,8 @@ pub(crate) use opencode_runtime::{
     terminate_child_process, wait_for_local_server_with_process,
 };
 pub(crate) use workflow_rules::{
-    can_set_plan, can_set_spec_from_status, default_qa_required_for_issue_type,
+    can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
+    default_qa_required_for_issue_type,
     derive_available_actions, normalize_issue_type, normalize_required_markdown,
     normalize_subtask_plan_inputs, normalize_title_key, validate_parent_relationships_for_create,
     validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
@@ -2201,6 +2202,47 @@ echo "bd-fake"
             .iter()
             .any(|(_, patch)| patch.status == Some(TaskStatus::ReadyForDev)));
         Ok(())
+    }
+
+    #[test]
+    fn set_plan_for_epic_rejects_subtask_replacement_when_existing_subtask_is_active() {
+        let repo_path = "/tmp/odt-repo-plan-epic-active-subtask";
+        let epic = make_task("epic-1", "epic", TaskStatus::SpecReady);
+        let mut active_child = make_task("child-1", "task", TaskStatus::InProgress);
+        active_child.parent_id = Some("epic-1".to_string());
+
+        let (service, task_state, _git_state) = build_service_with_state(
+            vec![epic, active_child],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+            },
+        );
+
+        let error = service
+            .set_plan(
+                repo_path,
+                "epic-1",
+                "# Epic Plan",
+                Some(vec![PlanSubtaskInput {
+                    title: "Build API".to_string(),
+                    issue_type: Some("task".to_string()),
+                    priority: Some(2),
+                    description: None,
+                }]),
+            )
+            .expect_err("active direct subtasks must block replacement");
+        assert!(
+            error
+                .to_string()
+                .contains("Cannot replace epic subtasks while active work exists"),
+            "unexpected error: {error}"
+        );
+
+        let task_state = task_state.lock().expect("task lock poisoned");
+        assert!(task_state.delete_calls.is_empty());
+        assert!(task_state.created_inputs.is_empty());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -218,6 +218,7 @@ mod tests {
         spec_set_calls: Vec<(String, String)>,
         plan_get_calls: Vec<String>,
         plan_set_calls: Vec<(String, String)>,
+        metadata_get_calls: Vec<String>,
         qa_append_calls: Vec<(String, String, QaVerdict)>,
         latest_qa_report: Option<QaReportDocument>,
         agent_sessions: Vec<AgentSessionDocument>,
@@ -440,6 +441,10 @@ mod tests {
         }
 
         fn get_task_metadata(&self, _repo_path: &Path, _task_id: &str) -> Result<TaskMetadata> {
+            let mut state = self.state.lock().expect("task store lock poisoned");
+            state.metadata_get_calls.push(_task_id.to_string());
+            let qa_report = state.latest_qa_report.clone();
+            let agent_sessions = state.agent_sessions.clone();
             Ok(TaskMetadata {
                 spec: SpecDocument {
                     markdown: String::new(),
@@ -449,8 +454,8 @@ mod tests {
                     markdown: String::new(),
                     updated_at: None,
                 },
-                qa_report: None,
-                agent_sessions: Vec::new(),
+                qa_report,
+                agent_sessions,
             })
         }
     }
@@ -609,6 +614,7 @@ mod tests {
             spec_set_calls: Vec::new(),
             plan_get_calls: Vec::new(),
             plan_set_calls: Vec::new(),
+            metadata_get_calls: Vec::new(),
             qa_append_calls: Vec::new(),
             latest_qa_report: None,
             agent_sessions: Vec::new(),
@@ -665,6 +671,7 @@ mod tests {
                 spec_set_calls: Vec::new(),
                 plan_get_calls: Vec::new(),
                 plan_set_calls: Vec::new(),
+                metadata_get_calls: Vec::new(),
                 qa_append_calls: Vec::new(),
                 latest_qa_report: None,
                 agent_sessions: Vec::new(),
@@ -999,6 +1006,7 @@ echo "bd-fake"
             spec_set_calls: Vec::new(),
             plan_get_calls: Vec::new(),
             plan_set_calls: Vec::new(),
+            metadata_get_calls: Vec::new(),
             qa_append_calls: Vec::new(),
             latest_qa_report: None,
             agent_sessions: Vec::new(),
@@ -1218,16 +1226,24 @@ echo "bd-fake"
 
         let epic_open = make_task("epic-open", "epic", TaskStatus::Open);
         let epic_spec_ready = make_task("epic-spec", "epic", TaskStatus::SpecReady);
+        let epic_ready_for_dev = make_task("epic-ready", "epic", TaskStatus::ReadyForDev);
         let feature_open = make_task("feature-open", "feature", TaskStatus::Open);
+        let feature_ready_for_dev = make_task("feature-ready", "feature", TaskStatus::ReadyForDev);
         let task_open = make_task("task-open", "task", TaskStatus::Open);
+        let task_ready_for_dev = make_task("task-ready", "task", TaskStatus::ReadyForDev);
         let bug_open = make_task("bug-open", "bug", TaskStatus::Open);
+        let bug_ready_for_dev = make_task("bug-ready", "bug", TaskStatus::ReadyForDev);
         let feature_in_progress = make_task("feature-progress", "feature", TaskStatus::InProgress);
 
         assert!(!can_set_plan(&epic_open));
         assert!(can_set_plan(&epic_spec_ready));
+        assert!(can_set_plan(&epic_ready_for_dev));
         assert!(!can_set_plan(&feature_open));
+        assert!(can_set_plan(&feature_ready_for_dev));
         assert!(can_set_plan(&task_open));
+        assert!(can_set_plan(&task_ready_for_dev));
         assert!(can_set_plan(&bug_open));
+        assert!(can_set_plan(&bug_ready_for_dev));
         assert!(!can_set_plan(&feature_in_progress));
     }
 
@@ -2076,6 +2092,36 @@ echo "bd-fake"
     }
 
     #[test]
+    fn set_plan_allows_feature_from_ready_for_dev_without_status_transition() -> Result<()> {
+        let repo_path = "/tmp/odt-repo-plan-feature-ready";
+        let (service, task_state, _git_state) = build_service_with_state(
+            vec![make_task("task-1", "feature", TaskStatus::ReadyForDev)],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+            },
+        );
+
+        let plan = service.set_plan(repo_path, "task-1", "  # Revised Plan  ", None)?;
+        assert_eq!(plan.markdown, "# Revised Plan");
+
+        let task_state = task_state.lock().expect("task lock poisoned");
+        assert_eq!(
+            task_state.plan_set_calls,
+            vec![("task-1".to_string(), "# Revised Plan".to_string())]
+        );
+        assert!(
+            !task_state
+                .updated_patches
+                .iter()
+                .any(|(_, patch)| patch.status.is_some()),
+            "status update should be skipped when already ready_for_dev"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn set_plan_rejects_invalid_status_for_feature() {
         let repo_path = "/tmp/odt-repo-plan-invalid";
         let (service, _task_state, _git_state) = build_service_with_state(
@@ -2094,7 +2140,7 @@ echo "bd-fake"
     }
 
     #[test]
-    fn set_plan_for_epic_creates_unique_missing_subtasks() -> Result<()> {
+    fn set_plan_for_epic_replaces_existing_subtasks_with_new_plan_proposals() -> Result<()> {
         let repo_path = "/tmp/odt-repo-plan-epic";
         let epic = make_task("epic-1", "epic", TaskStatus::SpecReady);
         let mut existing_child = make_task("child-1", "task", TaskStatus::Open);
@@ -2138,10 +2184,16 @@ echo "bd-fake"
         assert_eq!(plan.markdown, "# Epic Plan");
 
         let task_state = task_state.lock().expect("task lock poisoned");
-        assert_eq!(task_state.created_inputs.len(), 1);
-        assert_eq!(task_state.created_inputs[0].title, "Build UI");
+        assert_eq!(task_state.delete_calls, vec![("child-1".to_string(), false)]);
+        assert_eq!(task_state.created_inputs.len(), 2);
+        assert_eq!(task_state.created_inputs[0].title, "Build API");
         assert_eq!(
             task_state.created_inputs[0].parent_id.as_deref(),
+            Some("epic-1")
+        );
+        assert_eq!(task_state.created_inputs[1].title, "Build UI");
+        assert_eq!(
+            task_state.created_inputs[1].parent_id.as_deref(),
             Some("epic-1")
         );
         assert!(task_state
@@ -2197,7 +2249,7 @@ echo "bd-fake"
     }
 
     #[test]
-    fn spec_get_and_plan_get_delegate_to_task_store() -> Result<()> {
+    fn spec_get_and_plan_get_use_consolidated_metadata_lookup() -> Result<()> {
         let repo_path = "/tmp/odt-repo-docs-read";
         let (service, task_state, _git_state) = build_service_with_state(
             vec![],
@@ -2212,8 +2264,12 @@ echo "bd-fake"
         let _ = service.plan_get(repo_path, "task-1")?;
 
         let state = task_state.lock().expect("task lock poisoned");
-        assert_eq!(state.spec_get_calls, vec!["task-1".to_string()]);
-        assert_eq!(state.plan_get_calls, vec!["task-1".to_string()]);
+        assert!(state.spec_get_calls.is_empty());
+        assert!(state.plan_get_calls.is_empty());
+        assert_eq!(
+            state.metadata_get_calls,
+            vec!["task-1".to_string(), "task-1".to_string()]
+        );
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -2205,6 +2205,35 @@ echo "bd-fake"
     }
 
     #[test]
+    fn set_plan_for_epic_without_subtasks_clears_existing_direct_subtasks() -> Result<()> {
+        let repo_path = "/tmp/odt-repo-plan-epic-clear";
+        let epic = make_task("epic-1", "epic", TaskStatus::SpecReady);
+        let mut existing_child = make_task("child-1", "task", TaskStatus::Open);
+        existing_child.parent_id = Some("epic-1".to_string());
+
+        let (service, task_state, _git_state) = build_service_with_state(
+            vec![epic, existing_child],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+            },
+        );
+
+        let plan = service.set_plan(repo_path, "epic-1", "# Epic Plan", None)?;
+        assert_eq!(plan.markdown, "# Epic Plan");
+
+        let task_state = task_state.lock().expect("task lock poisoned");
+        assert_eq!(task_state.delete_calls, vec![("child-1".to_string(), false)]);
+        assert!(task_state.created_inputs.is_empty());
+        assert!(task_state
+            .updated_patches
+            .iter()
+            .any(|(_, patch)| patch.status == Some(TaskStatus::ReadyForDev)));
+        Ok(())
+    }
+
+    #[test]
     fn set_plan_for_epic_rejects_subtask_replacement_when_existing_subtask_is_active() {
         let repo_path = "/tmp/odt-repo-plan-epic-active-subtask";
         let epic = make_task("epic-1", "epic", TaskStatus::SpecReady);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
@@ -8,7 +8,7 @@ use super::{
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentSessionDocument, CreateTaskInput, PlanSubtaskInput, QaVerdict, SpecDocument, TaskCard,
-    TaskStatus, UpdateTaskPatch,
+    TaskMetadata, TaskStatus, UpdateTaskPatch,
 };
 use std::collections::HashSet;
 use std::path::Path;
@@ -252,9 +252,15 @@ impl AppService {
         )
     }
 
-    pub fn spec_get(&self, repo_path: &str, task_id: &str) -> Result<SpecDocument> {
+    pub fn task_metadata_get(&self, repo_path: &str, task_id: &str) -> Result<TaskMetadata> {
         self.ensure_repo_initialized(repo_path)?;
-        self.task_store.get_spec(Path::new(repo_path), task_id)
+        self.task_store
+            .get_task_metadata(Path::new(repo_path), task_id)
+            .with_context(|| format!("Failed to load task metadata for {task_id}"))
+    }
+
+    pub fn spec_get(&self, repo_path: &str, task_id: &str) -> Result<SpecDocument> {
+        Ok(self.task_metadata_get(repo_path, task_id)?.spec)
     }
 
     pub fn set_spec(&self, repo_path: &str, task_id: &str, markdown: &str) -> Result<SpecDocument> {
@@ -309,8 +315,7 @@ impl AppService {
     }
 
     pub fn plan_get(&self, repo_path: &str, task_id: &str) -> Result<SpecDocument> {
-        self.ensure_repo_initialized(repo_path)?;
-        self.task_store.get_plan(Path::new(repo_path), task_id)
+        Ok(self.task_metadata_get(repo_path, task_id)?.plan)
     }
 
     pub fn set_plan(
@@ -350,15 +355,25 @@ impl AppService {
 
         if issue_type == "epic" && !subtask_creates.is_empty() {
             let mut current_tasks = self.task_store.list_tasks(Path::new(repo_path))?;
-            let mut existing_titles = tasks
+            let existing_direct_subtasks = tasks
                 .iter()
                 .filter(|entry| entry.parent_id.as_deref() == Some(task_id))
-                .map(|entry| normalize_title_key(&entry.title))
-                .collect::<HashSet<_>>();
+                .cloned()
+                .collect::<Vec<_>>();
+            let mut proposal_titles = HashSet::new();
+
+            for existing_subtask in existing_direct_subtasks {
+                self.task_store
+                    .delete_task(Path::new(repo_path), &existing_subtask.id, false)
+                    .with_context(|| {
+                        format!("Failed to delete replaced subtask {}", existing_subtask.id)
+                    })?;
+                current_tasks.retain(|entry| entry.id != existing_subtask.id);
+            }
 
             for mut create_input in subtask_creates {
                 let title_key = normalize_title_key(&create_input.title);
-                if existing_titles.contains(&title_key) {
+                if !proposal_titles.insert(title_key) {
                     continue;
                 }
                 create_input.parent_id = Some(task_id.to_string());
@@ -367,7 +382,6 @@ impl AppService {
                     .task_store
                     .create_task(Path::new(repo_path), create_input)?;
                 current_tasks.push(created);
-                existing_titles.insert(title_key);
             }
         }
 
@@ -400,10 +414,9 @@ impl AppService {
     }
 
     pub fn qa_get_report(&self, repo_path: &str, task_id: &str) -> Result<SpecDocument> {
-        self.ensure_repo_initialized(repo_path)?;
         let report = self
-            .task_store
-            .get_latest_qa_report(Path::new(repo_path), task_id)?
+            .task_metadata_get(repo_path, task_id)?
+            .qa_report
             .map(|entry| SpecDocument {
                 markdown: entry.markdown,
                 updated_at: Some(entry.updated_at),
@@ -464,10 +477,7 @@ impl AppService {
         repo_path: &str,
         task_id: &str,
     ) -> Result<Vec<AgentSessionDocument>> {
-        self.ensure_repo_initialized(repo_path)?;
-        self.task_store
-            .list_agent_sessions(Path::new(repo_path), task_id)
-            .with_context(|| format!("Failed to read persisted agent sessions for {task_id}"))
+        Ok(self.task_metadata_get(repo_path, task_id)?.agent_sessions)
     }
 
     pub fn agent_session_upsert(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
@@ -354,7 +354,7 @@ impl AppService {
             .set_plan(Path::new(repo_path), task_id, &markdown)
             .with_context(|| format!("Failed to persist implementation plan for {task_id}"))?;
 
-        if issue_type == "epic" && !subtask_creates.is_empty() {
+        if issue_type == "epic" {
             let mut current_tasks = self.task_store.list_tasks(Path::new(repo_path))?;
             let refreshed_task = current_tasks
                 .iter()

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
@@ -1,5 +1,6 @@
 use super::{
-    can_set_plan, can_set_spec_from_status, default_qa_required_for_issue_type,
+    can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
+    default_qa_required_for_issue_type,
     normalize_issue_type, normalize_required_markdown, normalize_subtask_plan_inputs,
     normalize_title_key, validate_parent_relationships_for_create,
     validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
@@ -355,20 +356,56 @@ impl AppService {
 
         if issue_type == "epic" && !subtask_creates.is_empty() {
             let mut current_tasks = self.task_store.list_tasks(Path::new(repo_path))?;
-            let existing_direct_subtasks = tasks
+            let refreshed_task = current_tasks
+                .iter()
+                .find(|entry| entry.id == task_id)
+                .cloned()
+                .ok_or_else(|| anyhow!("Task not found: {task_id}"))?;
+            if !can_set_plan(&refreshed_task) {
+                return Err(anyhow!(
+                    "set_plan is not allowed for issue type {} from status {}",
+                    normalize_issue_type(&refreshed_task.issue_type),
+                    refreshed_task.status.as_cli_value()
+                ));
+            }
+
+            let existing_direct_subtasks = current_tasks
                 .iter()
                 .filter(|entry| entry.parent_id.as_deref() == Some(task_id))
                 .cloned()
                 .collect::<Vec<_>>();
+            let blocked_subtasks = existing_direct_subtasks
+                .iter()
+                .filter(|entry| !can_replace_epic_subtask_status(&entry.status))
+                .map(|entry| format!("{} ({})", entry.id, entry.status.as_cli_value()))
+                .collect::<Vec<_>>();
+            if !blocked_subtasks.is_empty() {
+                return Err(anyhow!(
+                    "Cannot replace epic subtasks while active work exists. \
+Move subtasks to open/spec_ready/ready_for_dev first: {}",
+                    blocked_subtasks.join(", ")
+                ));
+            }
+            let existing_direct_subtask_ids = existing_direct_subtasks
+                .iter()
+                .map(|entry| entry.id.clone())
+                .collect::<Vec<_>>();
             let mut proposal_titles = HashSet::new();
 
-            for existing_subtask in existing_direct_subtasks {
+            for existing_subtask_id in &existing_direct_subtask_ids {
                 self.task_store
-                    .delete_task(Path::new(repo_path), &existing_subtask.id, false)
+                    .delete_task(Path::new(repo_path), existing_subtask_id, false)
                     .with_context(|| {
-                        format!("Failed to delete replaced subtask {}", existing_subtask.id)
+                        format!("Failed to delete replaced subtask {}", existing_subtask_id)
                     })?;
-                current_tasks.retain(|entry| entry.id != existing_subtask.id);
+            }
+
+            if !existing_direct_subtask_ids.is_empty() {
+                let removed_ids = existing_direct_subtask_ids
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<HashSet<_>>();
+                current_tasks.retain(|entry| !removed_ids.contains(entry.id.as_str()));
             }
 
             for mut create_input in subtask_creates {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -15,6 +15,7 @@ pub(crate) struct TaskStoreState {
     pub ensure_calls: Vec<String>,
     pub tasks: Vec<TaskCard>,
     pub updated_patches: Vec<(String, UpdateTaskPatch)>,
+    pub latest_qa_report: Option<QaReportDocument>,
     pub agent_sessions: Vec<AgentSessionDocument>,
 }
 
@@ -144,7 +145,8 @@ impl TaskStore for FakeTaskStore {
         _repo_path: &Path,
         _task_id: &str,
     ) -> Result<Option<QaReportDocument>> {
-        Ok(None)
+        let state = self.state.lock().expect("task store lock poisoned");
+        Ok(state.latest_qa_report.clone())
     }
 
     fn append_qa_report(
@@ -191,6 +193,7 @@ impl TaskStore for FakeTaskStore {
     }
 
     fn get_task_metadata(&self, _repo_path: &Path, _task_id: &str) -> Result<TaskMetadata> {
+        let state = self.state.lock().expect("task store lock poisoned");
         Ok(TaskMetadata {
             spec: SpecDocument {
                 markdown: String::new(),
@@ -200,8 +203,8 @@ impl TaskStore for FakeTaskStore {
                 markdown: String::new(),
                 updated_at: None,
             },
-            qa_report: None,
-            agent_sessions: Vec::new(),
+            qa_report: state.latest_qa_report.clone(),
+            agent_sessions: state.agent_sessions.clone(),
         })
     }
 }
@@ -287,6 +290,7 @@ pub(crate) fn build_service_with_state(
         ensure_calls: Vec::new(),
         tasks,
         updated_patches: Vec::new(),
+        latest_qa_report: None,
         agent_sessions: Vec::new(),
     }));
     let git_state = Arc::new(Mutex::new(GitState {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
@@ -214,8 +214,11 @@ pub(crate) fn can_set_spec_from_status(status: &TaskStatus) -> bool {
 pub(crate) fn can_set_plan(task: &TaskCard) -> bool {
     let issue_type = normalize_issue_type(&task.issue_type);
     match issue_type {
-        "epic" | "feature" => matches!(task.status, TaskStatus::SpecReady),
-        "task" | "bug" => matches!(task.status, TaskStatus::Open | TaskStatus::SpecReady),
+        "epic" | "feature" => matches!(task.status, TaskStatus::SpecReady | TaskStatus::ReadyForDev),
+        "task" | "bug" => matches!(
+            task.status,
+            TaskStatus::Open | TaskStatus::SpecReady | TaskStatus::ReadyForDev
+        ),
         _ => false,
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
@@ -223,6 +223,13 @@ pub(crate) fn can_set_plan(task: &TaskCard) -> bool {
     }
 }
 
+pub(crate) fn can_replace_epic_subtask_status(status: &TaskStatus) -> bool {
+    matches!(
+        status,
+        TaskStatus::Open | TaskStatus::SpecReady | TaskStatus::ReadyForDev
+    )
+}
+
 pub(crate) fn derive_available_actions(task: &TaskCard, all_tasks: &[TaskCard]) -> Vec<TaskAction> {
     let mut actions = vec![TaskAction::ViewDetails];
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -416,6 +416,15 @@ async fn spec_get(
 }
 
 #[tauri::command]
+async fn task_metadata_get(
+    state: State<'_, AppState>,
+    repo_path: String,
+    task_id: String,
+) -> Result<host_domain::TaskMetadata, String> {
+    as_error(state.service.task_metadata_get(&repo_path, &task_id))
+}
+
+#[tauri::command]
 async fn set_spec(
     state: State<'_, AppState>,
     repo_path: String,
@@ -758,6 +767,7 @@ pub fn run() -> anyhow::Result<()> {
             task_defer,
             task_resume_deferred,
             spec_get,
+            task_metadata_get,
             set_spec,
             spec_save_document,
             plan_get,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -6,6 +6,7 @@ import {
   formatRawJsonLikeText,
   getAssistantFooterData,
   getToolDuration,
+  getToolLifecyclePhase,
   questionToolDetails,
   roleLabel,
   stripToolPrefix,
@@ -91,9 +92,66 @@ describe("agent-chat-message-card-model", () => {
     expect(details).toEqual([{ prompt: "Choose role", answers: ["planner"] }]);
   });
 
-  test("computes duration using observed timing first then fallback timing", () => {
-    const withObserved = getToolDuration(
+  test("derives lifecycle phases from status, payload and errors", () => {
+    expect(
+      getToolLifecyclePhase(
+        createToolMeta({
+          status: "pending",
+          input: {},
+        }),
+      ),
+    ).toBe("queued");
+
+    expect(
+      getToolLifecyclePhase(
+        createToolMeta({
+          status: "pending",
+          input: { taskId: "fairnest-123" },
+        }),
+      ),
+    ).toBe("executing");
+
+    expect(
+      getToolLifecyclePhase(
+        createToolMeta({
+          status: "running",
+        }),
+      ),
+    ).toBe("executing");
+
+    expect(
+      getToolLifecyclePhase(
+        createToolMeta({
+          status: "completed",
+        }),
+      ),
+    ).toBe("completed");
+
+    expect(
+      getToolLifecyclePhase(
+        createToolMeta({
+          tool: "odt_set_plan",
+          status: "completed",
+          output: "MCP error -32602: Input validation error",
+        }),
+      ),
+    ).toBe("failed");
+
+    expect(
+      getToolLifecyclePhase(
+        createToolMeta({
+          status: "error",
+          error: "Tool call cancelled by user",
+        }),
+      ),
+    ).toBe("cancelled");
+  });
+
+  test("computes duration from input-ready timestamp and ignores queue time", () => {
+    const withInputReady = getToolDuration(
       createToolMeta({
+        status: "completed",
+        inputReadyAtMs: 130,
         observedStartedAtMs: 100,
         observedEndedAtMs: 260,
         startedAtMs: 100,
@@ -101,10 +159,31 @@ describe("agent-chat-message-card-model", () => {
       }),
       "2026-02-22T10:00:00.000Z",
     );
-    expect(withObserved).toBe(160);
+    expect(withInputReady).toBe(130);
+
+    const queued = getToolDuration(
+      createToolMeta({
+        status: "pending",
+        input: {},
+      }),
+      "2026-02-22T10:00:00.000Z",
+    );
+    expect(queued).toBeNull();
+
+    const executing = getToolDuration(
+      createToolMeta({
+        status: "pending",
+        input: { taskId: "fairnest-111" },
+        inputReadyAtMs: 100,
+        observedEndedAtMs: 260,
+      }),
+      "2026-02-22T10:00:00.000Z",
+    );
+    expect(executing).toBeNull();
 
     const withFallback = getToolDuration(
       createToolMeta({
+        status: "completed",
         startedAtMs: 100,
         endedAtMs: 160,
       }),
@@ -139,5 +218,6 @@ describe("agent-chat-message-card-model", () => {
   test("strips tool prefix and status from tool content", () => {
     expect(stripToolPrefix("read_task", "Tool read_task completed: loaded")).toBe("loaded");
     expect(stripToolPrefix("bash", "queued: npm test")).toBe("npm test");
+    expect(stripToolPrefix("bash", "cancelled: interrupted by user")).toBe("interrupted by user");
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.ts
@@ -1,5 +1,5 @@
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
-import { toOdtWorkflowToolDisplayName } from "@openducktor/core";
+import { isOdtWorkflowMutationToolName, toOdtWorkflowToolDisplayName } from "@openducktor/core";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 
 const OUTPUT_IGNORED_TOOL_NAMES = new Set([
@@ -23,6 +23,11 @@ const AGENT_ROLE_LABEL: Record<AgentRole, string> = {
   build: "Builder",
   qa: "QA",
 };
+
+type ToolMeta = Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "tool" }>;
+
+const MCP_TOOL_ERROR_PREFIX = /^\s*mcp\s+error\b/i;
+const TOOL_CANCELLED_PATTERN = /\b(cancel(?:ed|led)|aborted|stopped|interrupted|terminated)\b/i;
 
 export const formatTime = (timestamp: string): string => {
   const value = new Date(timestamp);
@@ -64,7 +69,7 @@ export const stripToolPrefix = (tool: string, value: string): string => {
   const normalized = value.trim();
   return normalized
     .replace(new RegExp(`^Tool\\s+${escaped}\\s*`, "i"), "")
-    .replace(/^(queued|running|completed|failed)\s*[:.-]?\s*/i, "")
+    .replace(/^(queued|running|executing|completed|failed|cancelled|canceled)\s*[:.-]?\s*/i, "")
     .trim();
 };
 
@@ -110,15 +115,75 @@ export const roleLabel = (
   return "System";
 };
 
+const hasMeaningfulInputValue = (value: unknown): boolean => {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasMeaningfulInputValue(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return Object.values(value as Record<string, unknown>).some((entry) =>
+    hasMeaningfulInputValue(entry),
+  );
+};
+
 export const hasNonEmptyInput = (input: Record<string, unknown> | undefined): boolean => {
   if (!input) {
     return false;
   }
-  return Object.keys(input).length > 0;
+  return Object.values(input).some((value) => hasMeaningfulInputValue(value));
 };
 
 export const hasNonEmptyText = (value: unknown): value is string => {
   return typeof value === "string" && value.trim().length > 0;
+};
+
+export const isToolMessageFailure = (meta: ToolMeta): boolean => {
+  if (meta.status === "error") {
+    return true;
+  }
+
+  if (
+    meta.status === "completed" &&
+    isOdtWorkflowMutationToolName(meta.tool) &&
+    hasNonEmptyText(meta.output)
+  ) {
+    return MCP_TOOL_ERROR_PREFIX.test(meta.output);
+  }
+
+  return false;
+};
+
+export const isToolMessageCancelled = (meta: ToolMeta): boolean => {
+  if (meta.status !== "error") {
+    return false;
+  }
+
+  return (
+    (hasNonEmptyText(meta.error) && TOOL_CANCELLED_PATTERN.test(meta.error)) ||
+    (hasNonEmptyText(meta.output) && TOOL_CANCELLED_PATTERN.test(meta.output))
+  );
+};
+
+export type ToolLifecyclePhase = "queued" | "executing" | "completed" | "cancelled" | "failed";
+
+export const getToolLifecyclePhase = (meta: ToolMeta): ToolLifecyclePhase => {
+  if (meta.status === "pending") {
+    return hasNonEmptyInput(meta.input) ? "executing" : "queued";
+  }
+  if (meta.status === "running") {
+    return "executing";
+  }
+  if (meta.status === "completed") {
+    return isToolMessageFailure(meta) ? "failed" : "completed";
+  }
+  return isToolMessageCancelled(meta) ? "cancelled" : "failed";
 };
 
 const readInputString = (
@@ -462,23 +527,24 @@ const countTodosFromOutput = (output: string | undefined): number | null => {
   }
 };
 
-export const buildToolSummary = (
-  meta: Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "tool" }>,
-  content: string,
-): string => {
+export const buildToolSummary = (meta: ToolMeta, content: string): string => {
   const lowerTool = meta.tool.toLowerCase();
   const isTodoTool = isTodoToolName(lowerTool);
+  const lifecyclePhase = getToolLifecyclePhase(meta);
 
   if (isTodoTool) {
     const todoCount = countTodosFromOutput(meta.output) ?? countTodosFromInput(meta.input);
     if (todoCount !== null) {
       return `${todoCount} todo${todoCount === 1 ? "" : "s"}`;
     }
-    if (meta.status === "running" || meta.status === "pending") {
+    if (lifecyclePhase === "queued" || lifecyclePhase === "executing") {
       return "updating todos";
     }
-    if (meta.status === "completed") {
+    if (lifecyclePhase === "completed") {
       return "todos updated";
+    }
+    if (lifecyclePhase === "cancelled") {
+      return "todos update cancelled";
     }
   }
 
@@ -529,18 +595,43 @@ export const buildToolSummary = (
   return "";
 };
 
-export const getToolDuration = (
-  meta: Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "tool" }>,
-  messageTimestamp: string,
-): number | null => {
+export const getToolDuration = (meta: ToolMeta, messageTimestamp: string): number | null => {
+  const lifecyclePhase = getToolLifecyclePhase(meta);
+  if (lifecyclePhase === "queued" || lifecyclePhase === "executing") {
+    return null;
+  }
+
+  const parsedMessageTimestamp = Date.parse(messageTimestamp);
+  const completionAtMs =
+    typeof meta.observedEndedAtMs === "number"
+      ? meta.observedEndedAtMs
+      : typeof meta.endedAtMs === "number"
+        ? meta.endedAtMs
+        : Number.isNaN(parsedMessageTimestamp)
+          ? null
+          : parsedMessageTimestamp;
+  const inputReadyAtMs =
+    typeof meta.inputReadyAtMs === "number"
+      ? meta.inputReadyAtMs
+      : hasNonEmptyInput(meta.input)
+        ? typeof meta.observedStartedAtMs === "number"
+          ? meta.observedStartedAtMs
+          : typeof meta.startedAtMs === "number"
+            ? meta.startedAtMs
+            : null
+        : null;
+  if (completionAtMs !== null && inputReadyAtMs !== null && completionAtMs >= inputReadyAtMs) {
+    return completionAtMs - inputReadyAtMs;
+  }
+
   const observedStartedAtMs =
     typeof meta.observedStartedAtMs === "number" ? meta.observedStartedAtMs : null;
   const observedEndedAtMs =
     typeof meta.observedEndedAtMs === "number"
       ? meta.observedEndedAtMs
-      : meta.status === "running" || meta.status === "pending"
+      : Number.isNaN(parsedMessageTimestamp)
         ? null
-        : Date.parse(messageTimestamp);
+        : parsedMessageTimestamp;
   if (
     observedStartedAtMs !== null &&
     observedEndedAtMs !== null &&
@@ -556,9 +647,9 @@ export const getToolDuration = (
   const endedAtMs =
     typeof meta.endedAtMs === "number"
       ? meta.endedAtMs
-      : meta.status === "running" || meta.status === "pending"
+      : Number.isNaN(parsedMessageTimestamp)
         ? null
-        : Date.parse(messageTimestamp);
+        : parsedMessageTimestamp;
   if (endedAtMs === null || Number.isNaN(endedAtMs) || endedAtMs < meta.startedAtMs) {
     return null;
   }

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
@@ -1,4 +1,4 @@
-import { type AgentRole, isOdtWorkflowMutationToolName } from "@openducktor/core";
+import type { AgentRole } from "@openducktor/core";
 import {
   Bot,
   FileText,
@@ -17,6 +17,7 @@ import {
   buildToolSummary,
   formatRawJsonLikeText,
   getToolDuration,
+  getToolLifecyclePhase,
   hasNonEmptyInput,
   hasNonEmptyText,
   questionToolDetails,
@@ -24,24 +25,6 @@ import {
 } from "./agent-chat-message-card-model";
 import type { ToolMeta } from "./agent-chat-message-card-types";
 import { formatAgentDuration } from "./format-agent-duration";
-
-const MCP_TOOL_ERROR_PREFIX = /^\s*mcp\s+error\b/i;
-
-export const isToolMessageFailure = (meta: ToolMeta): boolean => {
-  if (meta.status === "error") {
-    return true;
-  }
-
-  if (
-    meta.status === "completed" &&
-    isOdtWorkflowMutationToolName(meta.tool) &&
-    hasNonEmptyText(meta.output)
-  ) {
-    return MCP_TOOL_ERROR_PREFIX.test(meta.output);
-  }
-
-  return false;
-};
 
 export const assistantRoleIcon = (role: AgentRole): ReactElement => {
   if (role === "spec") {
@@ -112,9 +95,17 @@ export const WorkflowToolMessage = ({
   const hasInput = hasNonEmptyInput(meta.input);
   const hasOutput = hasNonEmptyText(meta.output);
   const hasError = hasNonEmptyText(meta.error);
-  const isRunning = meta.status === "running" || meta.status === "pending";
-  const isFailure = isToolMessageFailure(meta);
-  const isSuccessfulCompletion = meta.status === "completed" && !isFailure;
+  const lifecyclePhase = getToolLifecyclePhase(meta);
+  const isActive = lifecyclePhase === "queued" || lifecyclePhase === "executing";
+  const isFailure = lifecyclePhase === "failed";
+  const isCancelled = lifecyclePhase === "cancelled";
+  const isSuccessfulCompletion = lifecyclePhase === "completed";
+  const isExecuting = lifecyclePhase === "executing";
+  const statusLabel =
+    lifecyclePhase === "queued" ? "QUEUED" : lifecyclePhase === "executing" ? "RUNNING" : null;
+  const statusClassName = isExecuting
+    ? "border-blue-300/70 bg-blue-100/80 text-blue-800"
+    : "border-violet-300/70 bg-violet-100/80 text-violet-800";
 
   return (
     <div className="space-y-2">
@@ -125,15 +116,29 @@ export const WorkflowToolMessage = ({
             "text-xs font-semibold",
             isFailure
               ? "text-rose-900"
-              : isSuccessfulCompletion
-                ? "text-emerald-900"
-                : "text-amber-900",
+              : isCancelled
+                ? "text-orange-900"
+                : isSuccessfulCompletion
+                  ? "text-emerald-900"
+                  : isExecuting
+                    ? "text-blue-900"
+                    : "text-violet-900",
           )}
         >
           {toolDisplayName(meta.tool)}
         </p>
-        {isRunning ? <LoaderCircle className="ml-auto size-3 animate-spin" /> : null}
-        {!isRunning && durationMs !== null ? (
+        {statusLabel ? (
+          <span
+            className={cn(
+              "ml-auto rounded-full border px-1.5 py-0.5 text-[10px] font-semibold tracking-wide",
+              statusClassName,
+            )}
+          >
+            {statusLabel}
+          </span>
+        ) : null}
+        {isExecuting ? <LoaderCircle className="size-3 animate-spin" /> : null}
+        {!isActive && durationMs !== null ? (
           <span className="ml-auto text-[11px] text-current/75">
             {formatAgentDuration(durationMs)}
           </span>
@@ -186,14 +191,22 @@ export const RegularToolMessage = ({
   messageTimestamp,
   timeLabel,
 }: RegularToolMessageProps): ReactElement => {
+  const lifecyclePhase = getToolLifecyclePhase(meta);
   const summary = buildToolSummary(meta, messageContent);
-  const summaryText = summary.length > 0 ? summary : meta.status === "error" ? "Tool failed" : "";
+  const summaryText =
+    summary.length > 0
+      ? summary
+      : lifecyclePhase === "failed"
+        ? "Tool failed"
+        : lifecyclePhase === "cancelled"
+          ? "Tool cancelled"
+          : "";
   const durationMs = getToolDuration(meta, messageTimestamp);
   const hasInput = hasNonEmptyInput(meta.input);
   const hasOutput = hasNonEmptyText(meta.output);
   const hasError = hasNonEmptyText(meta.error);
   const hasExpandableDetails = hasInput || hasOutput || hasError;
-  const isRunning = meta.status === "running" || meta.status === "pending";
+  const isActive = lifecyclePhase === "queued" || lifecyclePhase === "executing";
   const questionDetails = questionToolDetails(meta);
 
   const summaryRow = (
@@ -201,17 +214,29 @@ export const RegularToolMessage = ({
       className={cn(
         "flex min-h-6 items-center gap-2 text-xs",
         hasExpandableDetails ? "cursor-pointer" : "",
-        meta.status === "error" ? "text-rose-700" : "text-slate-700",
+        lifecyclePhase === "failed"
+          ? "text-rose-700"
+          : lifecyclePhase === "cancelled"
+            ? "text-orange-700"
+            : "text-slate-700",
       )}
     >
-      <span className={cn(meta.status === "error" ? "text-rose-500" : "text-slate-500")}>
+      <span
+        className={cn(
+          lifecyclePhase === "failed"
+            ? "text-rose-500"
+            : lifecyclePhase === "cancelled"
+              ? "text-orange-500"
+              : "text-slate-500",
+        )}
+      >
         {toolIcon(meta.tool)}
       </span>
       <p className="shrink-0 font-medium text-current">{toolDisplayName(meta.tool)}</p>
       {summaryText.length > 0 ? <p className="truncate text-slate-600">{summaryText}</p> : null}
       <span className="ml-auto inline-flex shrink-0 items-center gap-2 text-[11px] text-slate-500">
-        {isRunning ? <LoaderCircle className="size-3 animate-spin" /> : null}
-        {!isRunning && durationMs !== null ? <span>{formatAgentDuration(durationMs)}</span> : null}
+        {isActive ? <LoaderCircle className="size-3 animate-spin" /> : null}
+        {!isActive && durationMs !== null ? <span>{formatAgentDuration(durationMs)}</span> : null}
         {timeLabel ? <span>{timeLabel}</span> : null}
       </span>
     </div>

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
@@ -9,9 +9,9 @@ import { resolveAgentAccentColor } from "../agent-accent-color";
 import {
   assistantRoleFromMessage,
   formatTime,
+  getToolLifecyclePhase,
   SYSTEM_PROMPT_PREFIX,
 } from "./agent-chat-message-card-model";
-import { isToolMessageFailure } from "./agent-chat-message-card-tool-presenters";
 
 export type AgentChatMessageCardViewModelInput = {
   message: AgentChatMessage;
@@ -61,12 +61,8 @@ const toArticleClassName = (
   isSystemPromptMessage: boolean,
 ): string => {
   const meta = message.meta;
-  const workflowToolFailed =
-    isWorkflowToolMessage && meta?.kind === "tool" ? isToolMessageFailure(meta) : false;
-  const workflowToolCompleted =
-    isWorkflowToolMessage && meta?.kind === "tool"
-      ? meta.status === "completed" && !workflowToolFailed
-      : false;
+  const workflowToolPhase =
+    isWorkflowToolMessage && meta?.kind === "tool" ? getToolLifecyclePhase(meta) : null;
 
   return cn(
     "text-sm",
@@ -74,11 +70,15 @@ const toArticleClassName = (
       "ml-auto w-fit max-w-[85%] rounded-2xl rounded-br-sm border border-sky-100 bg-sky-50 px-4 py-3 text-slate-900 shadow-sm",
     isToolMessage
       ? isWorkflowToolMessage
-        ? workflowToolCompleted
+        ? workflowToolPhase === "completed"
           ? "rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-emerald-900"
-          : workflowToolFailed
+          : workflowToolPhase === "failed"
             ? "rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-rose-900"
-            : "rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900"
+            : workflowToolPhase === "cancelled"
+              ? "rounded-md border border-orange-200 bg-orange-50 px-3 py-2 text-orange-900"
+              : workflowToolPhase === "executing"
+                ? "rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-blue-900"
+                : "rounded-md border border-violet-200 bg-violet-50 px-3 py-2 text-violet-900"
         : "border-none bg-transparent px-0 py-0 text-slate-800"
       : isSubtaskMessage
         ? "rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900"

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -4,7 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { AgentChatMessageCard } from "./agent-chat-message-card";
 
 describe("AgentChatMessageCard tool duration", () => {
-  test("prefers observed wall-clock timing over part timing", () => {
+  test("uses completedAt - inputReadyAt for workflow duration display", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {
         message: {
@@ -22,6 +22,7 @@ describe("AgentChatMessageCard tool duration", () => {
             output: "ok",
             startedAtMs: 1_000,
             endedAtMs: 2_500,
+            inputReadyAtMs: Date.parse("2026-02-20T19:00:30.000Z"),
             observedStartedAtMs: Date.parse("2026-02-20T19:00:00.000Z"),
             observedEndedAtMs: Date.parse("2026-02-20T19:01:00.000Z"),
           },
@@ -32,7 +33,7 @@ describe("AgentChatMessageCard tool duration", () => {
       }),
     );
 
-    expect(html).toContain("1m");
+    expect(html).toContain("30s");
     expect(html).not.toContain("1.5s");
   });
 
@@ -95,7 +96,7 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).toContain("fairnest-97f");
   });
 
-  test("renders workflow tool pending state with spinner", () => {
+  test("renders workflow tool executing state with blue styling and running label", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {
         message: {
@@ -120,7 +121,41 @@ describe("AgentChatMessageCard tool duration", () => {
     );
 
     expect(html).toContain("animate-spin");
+    expect(html).toContain("border-blue-200");
+    expect(html).not.toContain("border-violet-200");
+    expect(html).toContain("RUNNING");
     expect(html).toContain("build_completed");
+  });
+
+  test("renders queued workflow tools with purple styling", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-queued",
+          role: "tool",
+          content: "Tool openducktor_odt_set_plan pending",
+          timestamp: "2026-02-22T10:21:10.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-queued",
+            callId: "call-queued",
+            tool: "openducktor_odt_set_plan",
+            status: "pending",
+            input: {},
+            output: "",
+          },
+        },
+        sessionRole: "planner",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).not.toContain("animate-spin");
+    expect(html).toContain("border-violet-200");
+    expect(html).not.toContain("border-blue-200");
+    expect(html).toContain("QUEUED");
+    expect(html).not.toContain("RUNNING");
   });
 
   test("renders workflow MCP validation failures as error styling", () => {
@@ -149,6 +184,35 @@ describe("AgentChatMessageCard tool duration", () => {
 
     expect(html).toContain("border-rose-200");
     expect(html).not.toContain("border-emerald-200");
+  });
+
+  test("renders cancelled workflow tools with orange styling", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-cancelled",
+          role: "tool",
+          content: "Tool odt_set_plan failed",
+          timestamp: "2026-02-22T10:21:40.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-cancelled",
+            callId: "call-cancelled",
+            tool: "odt_set_plan",
+            status: "error",
+            input: { taskId: "fairnest-cancelled" },
+            error: "Request cancelled by user",
+            output: "",
+          },
+        },
+        sessionRole: "planner",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("border-orange-200");
+    expect(html).not.toContain("border-rose-200");
   });
 
   test("renders system prompt as expandable card", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -26,6 +26,140 @@ const buildSession = (overrides: Partial<AgentSessionState> = {}): AgentSessionS
 });
 
 describe("agent-orchestrator-session-events", () => {
+  test("records inputReadyAtMs when tool input first becomes meaningful", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({ role: "planner" }),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+      loadSessionTodos: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "assistant_part",
+      sessionId: "session-1",
+      timestamp: "2026-02-22T08:00:05.000Z",
+      part: {
+        kind: "tool",
+        messageId: "tool-msg-1",
+        partId: "part-1",
+        callId: "call-1",
+        tool: "odt_set_spec",
+        status: "pending",
+        input: {},
+        output: "",
+        error: "",
+      },
+    });
+
+    const queuedMessage = sessionsRef.current["session-1"]?.messages.find(
+      (message) => message.meta?.kind === "tool" && message.meta.callId === "call-1",
+    );
+    if (!queuedMessage || queuedMessage.meta?.kind !== "tool") {
+      throw new Error("Expected queued tool message");
+    }
+    expect(queuedMessage.meta.inputReadyAtMs).toBeUndefined();
+
+    handleEvent({
+      type: "assistant_part",
+      sessionId: "session-1",
+      timestamp: "2026-02-22T08:00:10.000Z",
+      part: {
+        kind: "tool",
+        messageId: "tool-msg-1",
+        partId: "part-1",
+        callId: "call-1",
+        tool: "odt_set_spec",
+        status: "pending",
+        input: {
+          taskId: "fairnest-123",
+          markdown: "# Plan",
+        },
+        output: "",
+        error: "",
+      },
+    });
+
+    const inputReadyMessage = sessionsRef.current["session-1"]?.messages.find(
+      (message) => message.meta?.kind === "tool" && message.meta.callId === "call-1",
+    );
+    if (!inputReadyMessage || inputReadyMessage.meta?.kind !== "tool") {
+      throw new Error("Expected input-ready tool message");
+    }
+    expect(inputReadyMessage.meta.inputReadyAtMs).toBe(Date.parse("2026-02-22T08:00:10.000Z"));
+
+    handleEvent({
+      type: "assistant_part",
+      sessionId: "session-1",
+      timestamp: "2026-02-22T08:00:20.000Z",
+      part: {
+        kind: "tool",
+        messageId: "tool-msg-1",
+        partId: "part-1",
+        callId: "call-1",
+        tool: "odt_set_spec",
+        status: "completed",
+        input: {
+          taskId: "fairnest-123",
+          markdown: "# Plan",
+        },
+        output: "ok",
+        error: "",
+      },
+    });
+
+    const completedMessage = sessionsRef.current["session-1"]?.messages.find(
+      (message) => message.meta?.kind === "tool" && message.meta.callId === "call-1",
+    );
+    if (!completedMessage || completedMessage.meta?.kind !== "tool") {
+      throw new Error("Expected completed tool message");
+    }
+    expect(completedMessage.meta.inputReadyAtMs).toBe(Date.parse("2026-02-22T08:00:10.000Z"));
+  });
+
   test("auto-rejects mutating permissions for read-only roles", async () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const replyPermission = mock(

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -93,6 +93,31 @@ const eventTimestampMs = (timestamp: string): number => {
   return Number.isNaN(parsed) ? Date.now() : parsed;
 };
 
+const hasMeaningfulToolInputValue = (value: unknown): boolean => {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasMeaningfulToolInputValue(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return Object.values(value as Record<string, unknown>).some((entry) =>
+    hasMeaningfulToolInputValue(entry),
+  );
+};
+
+const hasMeaningfulToolInput = (input: Record<string, unknown> | undefined): boolean => {
+  if (!input) {
+    return false;
+  }
+  return Object.values(input).some((value) => hasMeaningfulToolInputValue(value));
+};
+
 const shouldClearTurnFromCurrentState = (current: AgentSessionState): boolean => {
   return (
     current.draftAssistantText.trim().length > 0 &&
@@ -322,6 +347,12 @@ const handleToolPart = (
         resolvedToolStatus === "completed" || resolvedToolStatus === "error"
           ? observedEventTimestampMs
           : undefined;
+      const inputReadyAtMs =
+        typeof existingToolMeta?.inputReadyAtMs === "number"
+          ? existingToolMeta.inputReadyAtMs
+          : hasMeaningfulToolInput(input)
+            ? observedEventTimestampMs
+            : undefined;
       if (
         isOdtWorkflowMutationToolName(part.tool) &&
         resolvedToolStatus === "completed" &&
@@ -364,6 +395,7 @@ const handleToolPart = (
             ...(typeof part.endedAtMs === "number" ? { endedAtMs: part.endedAtMs } : {}),
             ...(typeof observedStartedAtMs === "number" ? { observedStartedAtMs } : {}),
             ...(typeof observedEndedAtMs === "number" ? { observedEndedAtMs } : {}),
+            ...(typeof inputReadyAtMs === "number" ? { inputReadyAtMs } : {}),
           },
         }),
       };

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -27,6 +27,7 @@ export type AgentChatMessageMeta =
       endedAtMs?: number;
       observedStartedAtMs?: number;
       observedEndedAtMs?: number;
+      inputReadyAtMs?: number;
     }
   | {
       kind: "assistant";

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -193,6 +193,48 @@ describe("event-stream", () => {
     ]);
   });
 
+  test("forwards every raw sdk event to logEvent before relevance filtering", async () => {
+    const client = makeClientWithEvents([
+      {
+        type: "todo.updated",
+        properties: {
+          sessionID: "external-other-session",
+          todos: [{ content: "ignored" }],
+        },
+      } as unknown as Event,
+      {
+        type: "todo.updated",
+        properties: {
+          sessionID: "external-session-1",
+          todos: [{ content: "handled" }],
+        },
+      } as unknown as Event,
+    ]);
+    const sessionRecord = makeSessionRecord(client);
+    const logs: Array<{ type: string; relevant: boolean }> = [];
+
+    await subscribeOpencodeEvents({
+      context: {
+        sessionId: "local-session-1",
+        externalSessionId: "external-session-1",
+        input: makeSessionInput(),
+      },
+      client,
+      controller: new AbortController(),
+      now: () => "2026-02-22T12:00:00.000Z",
+      emit: () => undefined,
+      getSession: () => sessionRecord,
+      logEvent: (entry) => {
+        logs.push({ type: entry.event.type, relevant: entry.relevant });
+      },
+    });
+
+    expect(logs).toEqual([
+      { type: "todo.updated", relevant: false },
+      { type: "todo.updated", relevant: true },
+    ]);
+  });
+
   test("applies queued part delta with append semantics", async () => {
     const emitted = await runEventStream([
       {

--- a/packages/adapters-opencode-sdk/src/event-stream.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.ts
@@ -3,7 +3,7 @@ import type { AgentEvent } from "@openducktor/core";
 import { handleMessageEvent } from "./event-stream/message-events";
 import { handleSessionEvent } from "./event-stream/session-events";
 import { isRelevantEvent } from "./event-stream/shared";
-import type { SessionInput, SessionRecord } from "./types";
+import type { OpencodeEventLogger, SessionInput, SessionRecord } from "./types";
 
 type SubscribeOpencodeEventsInput = {
   context: {
@@ -16,6 +16,7 @@ type SubscribeOpencodeEventsInput = {
   now: () => string;
   emit: (sessionId: string, event: AgentEvent) => void;
   getSession: (sessionId: string) => SessionRecord | undefined;
+  logEvent?: OpencodeEventLogger;
 };
 
 export const subscribeOpencodeEvents = async (
@@ -41,7 +42,17 @@ export const subscribeOpencodeEvents = async (
   };
 
   for await (const event of sse.stream) {
-    if (!isRelevantEvent(input.context.externalSessionId, event)) {
+    const relevant = isRelevantEvent(input.context.externalSessionId, event);
+    if (input.logEvent) {
+      input.logEvent({
+        sessionId: input.context.sessionId,
+        externalSessionId: input.context.externalSessionId,
+        relevant,
+        event,
+      });
+    }
+
+    if (!relevant) {
       continue;
     }
 

--- a/packages/adapters-opencode-sdk/src/index.ts
+++ b/packages/adapters-opencode-sdk/src/index.ts
@@ -1,2 +1,7 @@
 export { OpencodeSdkAdapter } from "./opencode-sdk-adapter";
-export type { McpServerStatus, OpencodeSdkAdapterOptions } from "./types";
+export type {
+  McpServerStatus,
+  OpencodeEventLogger,
+  OpencodeSdkAdapterOptions,
+  OpencodeStreamEventLog,
+} from "./types";

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -37,6 +37,7 @@ import { normalizeTodoList } from "./todo-normalizers";
 import type {
   ClientFactory,
   McpServerStatus,
+  OpencodeEventLogger,
   OpencodeSdkAdapterOptions,
   SessionInput,
   SessionRecord,
@@ -49,10 +50,12 @@ export class OpencodeSdkAdapter implements AgentEnginePort {
   private readonly listeners = new Map<string, Set<(event: AgentEvent) => void>>();
   private readonly now: () => string;
   private readonly createClient: ClientFactory;
+  private readonly logEvent: OpencodeEventLogger | undefined;
 
   constructor(options: OpencodeSdkAdapterOptions = {}) {
     this.now = options.now ?? nowIso;
     this.createClient = options.createClient ?? buildDefaultFactory();
+    this.logEvent = options.logEvent;
   }
 
   async startSession(input: StartAgentSessionInput): Promise<AgentSessionSummary> {
@@ -477,6 +480,7 @@ export class OpencodeSdkAdapter implements AgentEnginePort {
       now: this.now,
       emit: this.emit.bind(this),
       getSession: (sessionId) => this.sessions.get(sessionId),
+      ...(this.logEvent ? { logEvent: this.logEvent } : {}),
     }).catch((error: unknown) => {
       const message = error instanceof Error ? error.message : "Event stream failed";
       this.emit(input.sessionId, {

--- a/packages/adapters-opencode-sdk/src/types.test.ts
+++ b/packages/adapters-opencode-sdk/src/types.test.ts
@@ -47,10 +47,12 @@ describe("types", () => {
     const options: OpencodeSdkAdapterOptions = {
       now: () => "2026-02-22T12:00:00.000Z",
       createClient,
+      logEvent: () => undefined,
     };
 
     expect(sessionRecord.input.sessionId).toBe("session-1");
     expect(status.status).toBe("connected");
     expect(typeof options.createClient).toBe("function");
+    expect(typeof options.logEvent).toBe("function");
   });
 });

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -1,4 +1,4 @@
-import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import type { AgentSessionSummary, StartAgentSessionInput } from "@openducktor/core";
 
 /**
@@ -30,9 +30,19 @@ export type ClientFactory = (input: {
   workingDirectory: string;
 }) => OpencodeClient;
 
+export type OpencodeStreamEventLog = {
+  sessionId: string;
+  externalSessionId: string;
+  relevant: boolean;
+  event: Event;
+};
+
+export type OpencodeEventLogger = (entry: OpencodeStreamEventLog) => void;
+
 export type OpencodeSdkAdapterOptions = {
   now?: () => string;
   createClient?: ClientFactory;
+  logEvent?: OpencodeEventLogger;
 };
 
 export type McpServerStatus = {

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -337,25 +337,30 @@ describe("TauriHostClient", () => {
 
   test("agent session history commands use expected IPC routes", async () => {
     const { client, calls } = createClient((command) => {
-      if (command === "agent_sessions_list") {
-        return [
-          {
-            sessionId: "obp-session-1",
-            externalSessionId: "session-opencode-1",
-            taskId: "task-1",
-            role: "spec",
-            scenario: "spec_initial",
-            status: "idle",
-            startedAt: "2026-02-18T17:20:00Z",
-            updatedAt: "2026-02-18T17:21:00Z",
-            endedAt: null,
-            runtimeId: "runtime-1",
-            runId: null,
-            baseUrl: "http://127.0.0.1:4173",
-            workingDirectory: "/repo",
-            selectedModel: null,
-          },
-        ];
+      if (command === "task_metadata_get") {
+        return {
+          spec: { markdown: "", updatedAt: null },
+          plan: { markdown: "", updatedAt: null },
+          qaReport: null,
+          agentSessions: [
+            {
+              sessionId: "obp-session-1",
+              externalSessionId: "session-opencode-1",
+              taskId: "task-1",
+              role: "spec",
+              scenario: "spec_initial",
+              status: "idle",
+              startedAt: "2026-02-18T17:20:00Z",
+              updatedAt: "2026-02-18T17:21:00Z",
+              endedAt: null,
+              runtimeId: "runtime-1",
+              runId: null,
+              baseUrl: "http://127.0.0.1:4173",
+              workingDirectory: "/repo",
+              selectedModel: null,
+            },
+          ],
+        };
       }
       if (command === "agent_session_upsert") {
         return { ok: true };
@@ -372,7 +377,7 @@ describe("TauriHostClient", () => {
 
     expect(history).toHaveLength(1);
     expect(calls.map((entry) => entry.command)).toEqual([
-      "agent_sessions_list",
+      "task_metadata_get",
       "agent_session_upsert",
     ]);
     expect(calls[0].args).toEqual({
@@ -383,57 +388,62 @@ describe("TauriHostClient", () => {
 
   test("agentSessionsList normalizes legacy scenarios and skips invalid rows", async () => {
     const { client } = createClient((command) => {
-      if (command === "agent_sessions_list") {
-        return [
-          {
-            sessionId: "legacy-spec",
-            externalSessionId: "legacy-ext-1",
-            taskId: "task-1",
-            role: "spec",
-            scenario: "spec_revision",
-            status: "idle",
-            startedAt: "2026-02-18T17:20:00Z",
-            updatedAt: "2026-02-18T17:21:00Z",
-            endedAt: null,
-            runtimeId: "runtime-1",
-            runId: null,
-            baseUrl: "http://127.0.0.1:4173",
-            workingDirectory: "/repo",
-            selectedModel: null,
-          },
-          {
-            sessionId: "legacy-planner",
-            externalSessionId: "legacy-ext-2",
-            taskId: "task-1",
-            role: "planner",
-            scenario: "planner_revision",
-            status: "idle",
-            startedAt: "2026-02-18T17:22:00Z",
-            updatedAt: "2026-02-18T17:23:00Z",
-            endedAt: null,
-            runtimeId: "runtime-1",
-            runId: null,
-            baseUrl: "http://127.0.0.1:4173",
-            workingDirectory: "/repo",
-            selectedModel: null,
-          },
-          {
-            sessionId: "bad-entry",
-            externalSessionId: "legacy-ext-3",
-            taskId: "task-1",
-            role: "planner",
-            scenario: "planner_unknown",
-            status: "idle",
-            startedAt: "2026-02-18T17:24:00Z",
-            updatedAt: "2026-02-18T17:25:00Z",
-            endedAt: null,
-            runtimeId: "runtime-1",
-            runId: null,
-            baseUrl: "http://127.0.0.1:4173",
-            workingDirectory: "/repo",
-            selectedModel: null,
-          },
-        ];
+      if (command === "task_metadata_get") {
+        return {
+          spec: { markdown: "", updatedAt: null },
+          plan: { markdown: "", updatedAt: null },
+          qaReport: null,
+          agentSessions: [
+            {
+              sessionId: "legacy-spec",
+              externalSessionId: "legacy-ext-1",
+              taskId: "task-1",
+              role: "spec",
+              scenario: "spec_revision",
+              status: "idle",
+              startedAt: "2026-02-18T17:20:00Z",
+              updatedAt: "2026-02-18T17:21:00Z",
+              endedAt: null,
+              runtimeId: "runtime-1",
+              runId: null,
+              baseUrl: "http://127.0.0.1:4173",
+              workingDirectory: "/repo",
+              selectedModel: null,
+            },
+            {
+              sessionId: "legacy-planner",
+              externalSessionId: "legacy-ext-2",
+              taskId: "task-1",
+              role: "planner",
+              scenario: "planner_revision",
+              status: "idle",
+              startedAt: "2026-02-18T17:22:00Z",
+              updatedAt: "2026-02-18T17:23:00Z",
+              endedAt: null,
+              runtimeId: "runtime-1",
+              runId: null,
+              baseUrl: "http://127.0.0.1:4173",
+              workingDirectory: "/repo",
+              selectedModel: null,
+            },
+            {
+              sessionId: "bad-entry",
+              externalSessionId: "legacy-ext-3",
+              taskId: "task-1",
+              role: "planner",
+              scenario: "planner_unknown",
+              status: "idle",
+              startedAt: "2026-02-18T17:24:00Z",
+              updatedAt: "2026-02-18T17:25:00Z",
+              endedAt: null,
+              runtimeId: "runtime-1",
+              runId: null,
+              baseUrl: "http://127.0.0.1:4173",
+              workingDirectory: "/repo",
+              selectedModel: null,
+            },
+          ],
+        };
       }
       throw new Error(`Unexpected command: ${command}`);
     });
@@ -443,5 +453,62 @@ describe("TauriHostClient", () => {
     expect(sessions).toHaveLength(2);
     expect(sessions[0]?.scenario).toBe("spec_initial");
     expect(sessions[1]?.scenario).toBe("planner_initial");
+  });
+
+  test("spec, plan, qa, and session reads share one metadata IPC call per task", async () => {
+    const { client, calls } = createClient((command) => {
+      if (command === "task_metadata_get") {
+        return {
+          spec: { markdown: "Spec Body", updatedAt: "2026-02-20T09:00:00Z" },
+          plan: { markdown: "Plan Body", updatedAt: "2026-02-20T09:05:00Z" },
+          qaReport: {
+            markdown: "QA Body",
+            verdict: "approved",
+            updatedAt: "2026-02-20T09:10:00Z",
+            revision: 2,
+          },
+          agentSessions: [
+            {
+              sessionId: "session-1",
+              externalSessionId: "external-1",
+              taskId: "task-1",
+              role: "build",
+              scenario: "build_implementation_start",
+              status: "idle",
+              startedAt: "2026-02-18T17:20:00Z",
+              updatedAt: "2026-02-18T17:21:00Z",
+              endedAt: null,
+              runtimeId: "runtime-1",
+              runId: null,
+              baseUrl: "http://127.0.0.1:4173",
+              workingDirectory: "/repo",
+              selectedModel: null,
+            },
+          ],
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const [spec, plan, qa, sessions] = await Promise.all([
+      client.specGet("/repo", "task-1"),
+      client.planGet("/repo", "task-1"),
+      client.qaGetReport("/repo", "task-1"),
+      client.agentSessionsList("/repo", "task-1"),
+    ]);
+
+    expect(spec.markdown).toBe("Spec Body");
+    expect(plan.markdown).toBe("Plan Body");
+    expect(qa.markdown).toBe("QA Body");
+    expect(sessions).toHaveLength(1);
+    expect(calls).toEqual([
+      {
+        command: "task_metadata_get",
+        args: {
+          repoPath: "/repo",
+          taskId: "task-1",
+        },
+      },
+    ]);
   });
 });

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -23,10 +23,12 @@ import {
   systemCheckSchema,
   type TaskCard,
   type TaskCreateInput,
+  type TaskMetadataPayload,
   type TaskStatus,
   type TaskUpdatePatch,
   taskCardSchema,
   taskCreateInputSchema,
+  taskMetadataPayloadSchema,
   taskStatusSchema,
   taskUpdatePatchSchema,
   type WorkspaceRecord,
@@ -66,8 +68,51 @@ const normalizeLegacyAgentSessionScenario = (entry: unknown): unknown => {
   };
 };
 
+type ParsedTaskMetadata = Omit<TaskMetadataPayload, "agentSessions"> & {
+  agentSessions: AgentSessionRecord[];
+};
+
+const parseAgentSessions = (entries: unknown[]): AgentSessionRecord[] => {
+  const sessions: AgentSessionRecord[] = [];
+  for (const entry of entries) {
+    const parsed = agentSessionRecordSchema.safeParse(normalizeLegacyAgentSessionScenario(entry));
+    if (parsed.success) {
+      sessions.push(parsed.data);
+    }
+  }
+  return sessions;
+};
+
 export class TauriHostClient implements PlannerTools {
+  private readonly taskMetadataInFlight = new Map<string, Promise<ParsedTaskMetadata>>();
+
   constructor(private readonly invokeFn: InvokeFn) {}
+
+  private taskMetadataKey(repoPath: string, taskId: string): string {
+    return `${repoPath}::${taskId}`;
+  }
+
+  private async getTaskMetadata(repoPath: string, taskId: string): Promise<ParsedTaskMetadata> {
+    const cacheKey = this.taskMetadataKey(repoPath, taskId);
+    const inFlight = this.taskMetadataInFlight.get(cacheKey);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const next = this.invokeFn<unknown>("task_metadata_get", { repoPath, taskId })
+      .then((payload) => {
+        const parsed = taskMetadataPayloadSchema.parse(payload);
+        return {
+          ...parsed,
+          agentSessions: parseAgentSessions(parsed.agentSessions),
+        };
+      })
+      .finally(() => {
+        this.taskMetadataInFlight.delete(cacheKey);
+      });
+    this.taskMetadataInFlight.set(cacheKey, next);
+    return next;
+  }
 
   async workspaceList(): Promise<WorkspaceRecord[]> {
     const payload = await this.invokeFn<unknown>("workspace_list");
@@ -172,17 +217,10 @@ export class TauriHostClient implements PlannerTools {
     repoPath: string,
     taskId: string,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.invokeFn<{ markdown: string; updatedAt?: string | null }>(
-      "spec_get",
-      {
-        repoPath,
-        taskId,
-      },
-    );
-
+    const payload = await this.getTaskMetadata(repoPath, taskId);
     return {
-      markdown: payload.markdown,
-      updatedAt: payload.updatedAt ?? null,
+      markdown: payload.spec.markdown,
+      updatedAt: payload.spec.updatedAt ?? null,
     };
   }
 
@@ -261,16 +299,10 @@ export class TauriHostClient implements PlannerTools {
     repoPath: string,
     taskId: string,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.invokeFn<{ markdown: string; updatedAt?: string | null }>(
-      "plan_get",
-      {
-        repoPath,
-        taskId,
-      },
-    );
+    const payload = await this.getTaskMetadata(repoPath, taskId);
     return {
-      markdown: payload.markdown,
-      updatedAt: payload.updatedAt ?? null,
+      markdown: payload.plan.markdown,
+      updatedAt: payload.plan.updatedAt ?? null,
     };
   }
 
@@ -278,16 +310,10 @@ export class TauriHostClient implements PlannerTools {
     repoPath: string,
     taskId: string,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.invokeFn<{ markdown: string; updatedAt?: string | null }>(
-      "qa_get_report",
-      {
-        repoPath,
-        taskId,
-      },
-    );
+    const payload = await this.getTaskMetadata(repoPath, taskId);
     return {
-      markdown: payload.markdown,
-      updatedAt: payload.updatedAt ?? null,
+      markdown: payload.qaReport?.markdown ?? "",
+      updatedAt: payload.qaReport?.updatedAt ?? null,
     };
   }
 
@@ -346,22 +372,8 @@ export class TauriHostClient implements PlannerTools {
   }
 
   async agentSessionsList(repoPath: string, taskId: string): Promise<AgentSessionRecord[]> {
-    const payload = await this.invokeFn<unknown>("agent_sessions_list", {
-      repoPath,
-      taskId,
-    });
-    if (!Array.isArray(payload)) {
-      throw new Error("Expected array payload from host command");
-    }
-
-    const sessions: AgentSessionRecord[] = [];
-    for (const entry of payload) {
-      const parsed = agentSessionRecordSchema.safeParse(normalizeLegacyAgentSessionScenario(entry));
-      if (parsed.success) {
-        sessions.push(parsed.data);
-      }
-    }
-    return sessions;
+    const payload = await this.getTaskMetadata(repoPath, taskId);
+    return payload.agentSessions;
   }
 
   async agentSessionUpsert(

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -396,6 +396,31 @@ export const agentSessionRecordSchema = z.object({
 });
 export type AgentSessionRecord = z.infer<typeof agentSessionRecordSchema>;
 
+export const taskMetadataDocumentSchema = z.object({
+  markdown: z.string().default(""),
+  updatedAt: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
+});
+export type TaskMetadataDocument = z.infer<typeof taskMetadataDocumentSchema>;
+
+export const taskMetadataQaReportSchema = z.object({
+  markdown: z.string(),
+  verdict: z.enum(["approved", "rejected"]),
+  updatedAt: z.string(),
+  revision: z.number().int().nonnegative(),
+});
+export type TaskMetadataQaReport = z.infer<typeof taskMetadataQaReportSchema>;
+
+export const taskMetadataPayloadSchema = z.object({
+  spec: taskMetadataDocumentSchema,
+  plan: taskMetadataDocumentSchema,
+  qaReport: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    taskMetadataQaReportSchema.optional(),
+  ),
+  agentSessions: z.array(z.unknown()).default([]),
+});
+export type TaskMetadataPayload = z.infer<typeof taskMetadataPayloadSchema>;
+
 export const runEventSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("run_started"),

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -40,8 +40,8 @@ Workflow constraints you must obey:
 - Feature/epic flow: open -> spec_ready -> ready_for_dev -> in_progress -> ai_review/human_review -> closed.
 - Task/bug may skip planning and go open -> in_progress.
 - odt_set_spec allowed from open/spec_ready only.
-- odt_set_plan for feature/epic allowed from spec_ready only.
-- odt_set_plan for task/bug allowed from open/spec_ready.
+- odt_set_plan for feature/epic allowed from spec_ready/ready_for_dev.
+- odt_set_plan for task/bug allowed from open/spec_ready/ready_for_dev.
 - odt_build_completed from in_progress transitions to ai_review when qaRequired=true, else human_review.
 - odt_qa_rejected transitions ai_review -> in_progress.
 - odt_qa_approved transitions ai_review -> human_review.

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -1126,6 +1126,171 @@ describe("openducktor-mcp lib", () => {
     expect(statusUpdateCalls).toBe(1);
   });
 
+  test("setPlan allows feature tasks to update plan from ready_for_dev", async () => {
+    let status = "ready_for_dev";
+    let statusUpdateCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Feature task",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Feature task",
+              status,
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        status = args[args.indexOf("--status") + 1] ?? status;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    const result = (await store.setPlan({
+      taskId: "task-1",
+      markdown: "# Updated plan",
+    })) as {
+      task: { status: string };
+      document: { markdown: string };
+    };
+
+    expect(result.document.markdown).toBe("# Updated plan");
+    expect(result.task.status).toBe("ready_for_dev");
+    expect(statusUpdateCalls).toBe(0);
+  });
+
+  test("setPlan epic subtasks replace existing direct subtasks", async () => {
+    let status = "spec_ready";
+    const deletedTaskIds: string[] = [];
+    let createCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "epic-1",
+              title: "Epic task",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+            {
+              id: "legacy-subtask",
+              title: "Legacy child",
+              status: "open",
+              issue_type: "task",
+              parent: "epic-1",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "epic-1",
+              title: "Epic task",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "delete") {
+        const taskIdArg = args[args.indexOf("--") + 1] ?? "";
+        deletedTaskIds.push(taskIdArg);
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "create") {
+        createCalls += 1;
+        return { ok: true, stdout: JSON.stringify({ id: `new-subtask-${createCalls}` }) };
+      }
+      if (command === "update" && args.includes("--status")) {
+        status = args[args.indexOf("--status") + 1] ?? status;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    const result = (await store.setPlan({
+      taskId: "epic-1",
+      markdown: "# New epic plan",
+      subtasks: [{ title: "New child task" }],
+    })) as {
+      createdSubtaskIds: string[];
+      task: { status: string };
+    };
+
+    expect(deletedTaskIds).toEqual(["legacy-subtask"]);
+    expect(createCalls).toBe(1);
+    expect(result.createdSubtaskIds).toEqual(["new-subtask-1"]);
+    expect(result.task.status).toBe("ready_for_dev");
+  });
+
   test("buildCompleted revalidates using refreshed task and avoids duplicate list calls", async () => {
     let status = "in_progress";
     let listCalls = 0;

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -1291,6 +1291,100 @@ describe("openducktor-mcp lib", () => {
     expect(result.task.status).toBe("ready_for_dev");
   });
 
+  test("setPlan epic omitting subtasks clears existing direct subtasks", async () => {
+    let status = "spec_ready";
+    const deletedTaskIds: string[] = [];
+    let createCalls = 0;
+    let statusUpdateCalls = 0;
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "epic-1",
+              title: "Epic task",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+            {
+              id: "legacy-subtask",
+              title: "Legacy child",
+              status: "open",
+              issue_type: "task",
+              parent: "epic-1",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "epic-1",
+              title: "Epic task",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "delete") {
+        const taskIdArg = args[args.indexOf("--") + 1] ?? "";
+        deletedTaskIds.push(taskIdArg);
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "create") {
+        createCalls += 1;
+        return { ok: true, stdout: JSON.stringify({ id: `new-subtask-${createCalls}` }) };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        status = args[args.indexOf("--status") + 1] ?? status;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    const result = (await store.setPlan({
+      taskId: "epic-1",
+      markdown: "# New epic plan",
+    })) as {
+      createdSubtaskIds: string[];
+      task: { status: string };
+    };
+
+    expect(deletedTaskIds).toEqual(["legacy-subtask"]);
+    expect(createCalls).toBe(0);
+    expect(result.createdSubtaskIds).toEqual([]);
+    expect(statusUpdateCalls).toBe(1);
+    expect(result.task.status).toBe("ready_for_dev");
+  });
+
   test("setPlan epic subtasks blocks replacement when refreshed subtasks are active", async () => {
     let status = "spec_ready";
     let listCalls = 0;

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -1043,7 +1043,7 @@ describe("openducktor-mcp lib", () => {
     expect(statusUpdateCalls).toBe(0);
   });
 
-  test("setPlan epic subtasks reuses initial snapshot and avoids duplicate list calls", async () => {
+  test("setPlan epic subtasks revalidates against a fresh snapshot before replacement", async () => {
     let status = "spec_ready";
     let listCalls = 0;
     let createCalls = 0;
@@ -1121,7 +1121,7 @@ describe("openducktor-mcp lib", () => {
 
     expect(result.task.status).toBe("ready_for_dev");
     expect(result.createdSubtaskIds).toEqual(["task-1-sub-1"]);
-    expect(listCalls).toBe(1);
+    expect(listCalls).toBe(2);
     expect(createCalls).toBe(1);
     expect(statusUpdateCalls).toBe(1);
   });
@@ -1289,6 +1289,102 @@ describe("openducktor-mcp lib", () => {
     expect(createCalls).toBe(1);
     expect(result.createdSubtaskIds).toEqual(["new-subtask-1"]);
     expect(result.task.status).toBe("ready_for_dev");
+  });
+
+  test("setPlan epic subtasks blocks replacement when refreshed subtasks are active", async () => {
+    let status = "spec_ready";
+    let listCalls = 0;
+    let createCalls = 0;
+    let statusUpdateCalls = 0;
+    const deletedTaskIds: string[] = [];
+
+    const { runProcess } = buildProcessRunner((args) => {
+      const command = args[1];
+      if (command === "where") {
+        return { ok: true, stdout: JSON.stringify({ path: "/beads" }) };
+      }
+      if (command === "config") {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "list") {
+        listCalls += 1;
+        const refreshedSubtaskStatus = listCalls >= 2 ? "in_progress" : "open";
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "epic-1",
+              title: "Epic task",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+            {
+              id: "legacy-subtask",
+              title: "Legacy child",
+              status: refreshedSubtaskStatus,
+              issue_type: "task",
+              parent: "epic-1",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "epic-1",
+              title: "Epic task",
+              status,
+              issue_type: "epic",
+              metadata: {},
+            },
+          ]),
+        };
+      }
+      if (command === "update" && args.includes("--metadata")) {
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "delete") {
+        const taskIdArg = args[args.indexOf("--") + 1] ?? "";
+        deletedTaskIds.push(taskIdArg);
+        return { ok: true, stdout: "{}" };
+      }
+      if (command === "create") {
+        createCalls += 1;
+        return { ok: true, stdout: JSON.stringify({ id: `new-subtask-${createCalls}` }) };
+      }
+      if (command === "update" && args.includes("--status")) {
+        statusUpdateCalls += 1;
+        status = args[args.indexOf("--status") + 1] ?? status;
+        return { ok: true, stdout: "{}" };
+      }
+      throw new Error(`Unexpected bd command: ${args.join(" ")}`);
+    });
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      { runProcess },
+    );
+
+    await expect(
+      store.setPlan({
+        taskId: "epic-1",
+        markdown: "# New epic plan",
+        subtasks: [{ title: "New child task" }],
+      }),
+    ).rejects.toThrow("Cannot replace epic subtasks while active work exists");
+
+    expect(listCalls).toBe(2);
+    expect(deletedTaskIds).toEqual([]);
+    expect(createCalls).toBe(0);
+    expect(statusUpdateCalls).toBe(0);
   });
 
   test("buildCompleted revalidates using refreshed task and avoids duplicate list calls", async () => {

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -285,6 +285,7 @@ import {
 } from "./tool-schemas";
 import {
   assertNoValidationError,
+  canReplaceEpicSubtaskStatus,
   getSetPlanError,
   getSetSpecError,
   validatePlanSubtaskRules,
@@ -751,7 +752,29 @@ export class OdtTaskStore {
 
     const createdSubtaskIds: string[] = [];
     if (task.issueType === "epic" && normalizedSubtasks.length > 0) {
-      const existingDirectSubtasks = tasks.filter((entry) => entry.parentId === task.id);
+      const latestTasks = await this.listTasks();
+      const latestTask = latestTasks.find((entry) => entry.id === task.id);
+      if (!latestTask) {
+        throw new Error(`Task not found: ${task.id}`);
+      }
+
+      assertNoValidationError(getSetPlanError(latestTask));
+      validatePlanSubtaskRules(latestTask, latestTasks, normalizedSubtasks);
+
+      const existingDirectSubtasks = latestTasks.filter((entry) => entry.parentId === task.id);
+      const blockedSubtasks = existingDirectSubtasks.filter(
+        (entry) => !canReplaceEpicSubtaskStatus(entry.status),
+      );
+      if (blockedSubtasks.length > 0) {
+        const blockedSummary = blockedSubtasks
+          .map((entry) => `${entry.id} (${entry.status})`)
+          .join(", ");
+        throw new Error(
+          "Cannot replace epic subtasks while active work exists. " +
+            `Move subtasks to open/spec_ready/ready_for_dev first: ${blockedSummary}`,
+        );
+      }
+
       for (const existingSubtask of existingDirectSubtasks) {
         await this.deleteTask(existingSubtask.id);
       }

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -751,7 +751,7 @@ export class OdtTaskStore {
     await this.writeNamespace(task.id, root, nextNamespace);
 
     const createdSubtaskIds: string[] = [];
-    if (task.issueType === "epic" && normalizedSubtasks.length > 0) {
+    if (task.issueType === "epic") {
       const latestTasks = await this.listTasks();
       const latestTask = latestTasks.find((entry) => entry.id === task.id);
       if (!latestTask) {

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -621,6 +621,16 @@ export class OdtTaskStore {
     return id;
   }
 
+  private async deleteTask(taskId: string, deleteSubtasks = false): Promise<void> {
+    const args = ["delete", "--force", "--reason", "Deleted from OpenDucktor"];
+    if (deleteSubtasks) {
+      args.push("--cascade");
+    }
+    args.push("--", taskId);
+    await this.runBdJson(args);
+    this.invalidateTaskIndex();
+  }
+
   async readTask(rawInput: unknown): Promise<unknown> {
     await this.ensureInitialized();
     const input = ReadTaskInputSchema.parse(rawInput);
@@ -741,21 +751,21 @@ export class OdtTaskStore {
 
     const createdSubtaskIds: string[] = [];
     if (task.issueType === "epic" && normalizedSubtasks.length > 0) {
-      const existingTitleKeys = new Set(
-        tasks
-          .filter((entry) => entry.parentId === task.id)
-          .map((entry) => normalizeTitleKey(entry.title)),
-      );
+      const existingDirectSubtasks = tasks.filter((entry) => entry.parentId === task.id);
+      for (const existingSubtask of existingDirectSubtasks) {
+        await this.deleteTask(existingSubtask.id);
+      }
 
+      const createdTitleKeys = new Set<string>();
       for (const subtask of normalizedSubtasks) {
         const key = normalizeTitleKey(subtask.title);
-        if (existingTitleKeys.has(key)) {
+        if (createdTitleKeys.has(key)) {
           continue;
         }
 
         const createdId = await this.createSubtask(task.id, subtask);
         createdSubtaskIds.push(createdId);
-        existingTitleKeys.add(key);
+        createdTitleKeys.add(key);
       }
     }
 

--- a/packages/openducktor-mcp/src/workflow-policy.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.ts
@@ -56,6 +56,12 @@ const SET_PLAN_ALLOWED_STATUSES: Readonly<Record<IssueType, readonly TaskStatus[
   bug: ["open", "spec_ready", "ready_for_dev"],
 };
 
+const EPIC_SUBTASK_REPLACEMENT_ALLOWED_STATUSES: readonly TaskStatus[] = [
+  "open",
+  "spec_ready",
+  "ready_for_dev",
+];
+
 const isStatusAllowed = (status: TaskStatus, allowed: readonly TaskStatus[]): boolean => {
   return allowed.includes(status);
 };
@@ -99,6 +105,10 @@ const canSetSpecFromStatus = (status: TaskStatus): boolean => {
 
 const canSetPlan = (task: TaskCard): boolean => {
   return isStatusAllowed(task.status, SET_PLAN_ALLOWED_STATUSES[task.issueType]);
+};
+
+export const canReplaceEpicSubtaskStatus = (status: TaskStatus): boolean => {
+  return isStatusAllowed(status, EPIC_SUBTASK_REPLACEMENT_ALLOWED_STATUSES);
 };
 
 export const getSetSpecError = (status: TaskStatus): string | null => {

--- a/packages/openducktor-mcp/src/workflow-policy.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.ts
@@ -50,10 +50,10 @@ const SKIP_SPEC_AND_PLAN_TRANSITION_EXTRAS: Readonly<
 const SET_SPEC_ALLOWED_STATUSES: readonly TaskStatus[] = ["open", "spec_ready"];
 
 const SET_PLAN_ALLOWED_STATUSES: Readonly<Record<IssueType, readonly TaskStatus[]>> = {
-  epic: ["spec_ready"],
-  feature: ["spec_ready"],
-  task: ["open", "spec_ready"],
-  bug: ["open", "spec_ready"],
+  epic: ["spec_ready", "ready_for_dev"],
+  feature: ["spec_ready", "ready_for_dev"],
+  task: ["open", "spec_ready", "ready_for_dev"],
+  bug: ["open", "spec_ready", "ready_for_dev"],
 };
 
 const isStatusAllowed = (status: TaskStatus, allowed: readonly TaskStatus[]): boolean => {


### PR DESCRIPTION
## Summary
- model workflow tool calls as a 3-phase lifecycle (queued, running, completed) and track input-ready timing separately from queue time
- update Agent Chat workflow tool cards to show queued label without spinner (purple), executing state in blue, and cancelled state in orange
- compute displayed workflow duration as completedAt - inputReadyAt when available
- allow set_plan from ready_for_dev for all task types and keep status behavior aligned across MCP + host workflow rules
- when an epic plan provides a new subtask list, replace existing direct subtasks with the new list
- remove temporary OpenCode SDK event console logging

## Testing
- bun run lint
- bun run typecheck
- bun run test
- cd apps/desktop/src-tauri && cargo check
- cd apps/desktop/src-tauri && cargo test