### PR TITLE
perf(desktop): lazy-load Prism languages for markdown code blocks

### DIFF
--- a/apps/desktop/src/components/ui/markdown-syntax-block.tsx
+++ b/apps/desktop/src/components/ui/markdown-syntax-block.tsx
@@ -70,7 +70,11 @@ export default function MarkdownSyntaxBlock({
     markdownSyntaxLanguageRegistry.isLanguageRegistered(normalizedLanguage);
 
   useEffect(() => {
-    if (!isSupportedLanguage || isLanguageRegistered) {
+    const shouldRegisterLanguage =
+      markdownSyntaxLanguageRegistry.isLanguageSupported(normalizedLanguage) &&
+      !markdownSyntaxLanguageRegistry.isLanguageRegistered(normalizedLanguage);
+
+    if (!shouldRegisterLanguage) {
       return;
     }
 
@@ -84,15 +88,12 @@ export default function MarkdownSyntaxBlock({
         }
 
         setLanguageRegistrationVersion((version) => version + 1);
-      })
-      .catch(() => {
-        // Keep rendering fallback <pre> when dynamic language registration fails.
       });
 
     return () => {
       isActive = false;
     };
-  }, [isLanguageRegistered, isSupportedLanguage, normalizedLanguage]);
+  }, [normalizedLanguage]);
 
   if (!isSupportedLanguage || !isLanguageRegistered) {
     return (

--- a/apps/desktop/src/components/ui/markdown-syntax-block.tsx
+++ b/apps/desktop/src/components/ui/markdown-syntax-block.tsx
@@ -1,17 +1,10 @@
-import type { CSSProperties, ReactElement } from "react";
+import { type CSSProperties, type ReactElement, useEffect, useState } from "react";
 import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
-import bash from "react-syntax-highlighter/dist/esm/languages/prism/bash";
-import diff from "react-syntax-highlighter/dist/esm/languages/prism/diff";
 import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";
 import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
-import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
-import markdown from "react-syntax-highlighter/dist/esm/languages/prism/markdown";
-import rust from "react-syntax-highlighter/dist/esm/languages/prism/rust";
-import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
-import typescript from "react-syntax-highlighter/dist/esm/languages/prism/typescript";
-import yaml from "react-syntax-highlighter/dist/esm/languages/prism/yaml";
 import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { cn } from "@/lib/utils";
+import { createMarkdownSyntaxLanguageRegistry } from "./markdown-syntax-language-registry";
 
 type MarkdownSyntaxBlockProps = {
   language: string;
@@ -31,29 +24,26 @@ const LANGUAGE_ALIASES: Record<string, string> = {
   yml: "yaml",
 };
 
-const SUPPORTED_LANGUAGES = new Set([
-  "bash",
-  "diff",
-  "javascript",
-  "json",
-  "jsx",
-  "markdown",
-  "rust",
-  "tsx",
-  "typescript",
-  "yaml",
-]);
-
-SyntaxHighlighter.registerLanguage("bash", bash);
-SyntaxHighlighter.registerLanguage("diff", diff);
-SyntaxHighlighter.registerLanguage("javascript", javascript);
-SyntaxHighlighter.registerLanguage("json", json);
-SyntaxHighlighter.registerLanguage("jsx", jsx);
-SyntaxHighlighter.registerLanguage("markdown", markdown);
-SyntaxHighlighter.registerLanguage("rust", rust);
-SyntaxHighlighter.registerLanguage("tsx", tsx);
-SyntaxHighlighter.registerLanguage("typescript", typescript);
-SyntaxHighlighter.registerLanguage("yaml", yaml);
+const markdownSyntaxLanguageRegistry = createMarkdownSyntaxLanguageRegistry({
+  languageAliases: LANGUAGE_ALIASES,
+  defaultLanguages: {
+    javascript,
+    json,
+  },
+  lazyLanguageLoaders: {
+    bash: () => import("react-syntax-highlighter/dist/esm/languages/prism/bash"),
+    diff: () => import("react-syntax-highlighter/dist/esm/languages/prism/diff"),
+    jsx: () => import("react-syntax-highlighter/dist/esm/languages/prism/jsx"),
+    markdown: () => import("react-syntax-highlighter/dist/esm/languages/prism/markdown"),
+    rust: () => import("react-syntax-highlighter/dist/esm/languages/prism/rust"),
+    tsx: () => import("react-syntax-highlighter/dist/esm/languages/prism/tsx"),
+    typescript: () => import("react-syntax-highlighter/dist/esm/languages/prism/typescript"),
+    yaml: () => import("react-syntax-highlighter/dist/esm/languages/prism/yaml"),
+  },
+  registerLanguage: (language, grammar) => {
+    SyntaxHighlighter.registerLanguage(language, grammar);
+  },
+});
 
 const SYNTAX_PRE_STYLE: CSSProperties = {
   margin: 0,
@@ -67,20 +57,44 @@ const SYNTAX_CODE_TAG_STYLE: CSSProperties = {
   fontFamily: '"IBM Plex Mono", "SF Mono", Menlo, Monaco, Consolas, monospace',
 };
 
-function normalizeLanguage(language: string): string {
-  const normalized = language.trim().toLowerCase();
-  return LANGUAGE_ALIASES[normalized] ?? normalized;
-}
-
 export default function MarkdownSyntaxBlock({
   language,
   code,
   className,
 }: MarkdownSyntaxBlockProps): ReactElement {
-  const normalizedLanguage = normalizeLanguage(language);
-  const isSupportedLanguage = SUPPORTED_LANGUAGES.has(normalizedLanguage);
+  const [, setLanguageRegistrationVersion] = useState(0);
+  const normalizedLanguage = markdownSyntaxLanguageRegistry.normalizeLanguage(language);
+  const isSupportedLanguage =
+    markdownSyntaxLanguageRegistry.isLanguageSupported(normalizedLanguage);
+  const isLanguageRegistered =
+    markdownSyntaxLanguageRegistry.isLanguageRegistered(normalizedLanguage);
 
-  if (!isSupportedLanguage) {
+  useEffect(() => {
+    if (!isSupportedLanguage || isLanguageRegistered) {
+      return;
+    }
+
+    let isActive = true;
+
+    void markdownSyntaxLanguageRegistry
+      .ensureLanguageRegistered(normalizedLanguage)
+      .then((didRegister) => {
+        if (!isActive || !didRegister) {
+          return;
+        }
+
+        setLanguageRegistrationVersion((version) => version + 1);
+      })
+      .catch(() => {
+        // Keep rendering fallback <pre> when dynamic language registration fails.
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [isLanguageRegistered, isSupportedLanguage, normalizedLanguage]);
+
+  if (!isSupportedLanguage || !isLanguageRegistered) {
     return (
       <pre
         className={cn(

--- a/apps/desktop/src/components/ui/markdown-syntax-language-registry.test.ts
+++ b/apps/desktop/src/components/ui/markdown-syntax-language-registry.test.ts
@@ -51,26 +51,35 @@ describe("createMarkdownSyntaxLanguageRegistry", () => {
   });
 
   test("returns false for unsupported languages and failed lazy loaders", async () => {
+    const originalConsoleError = console.error;
+    const consoleError = mock((_message: string, _error?: unknown) => {});
     const registerLanguage = mock((_language: string, _grammar: unknown) => {});
     const loadYamlLanguage = mock(async () => {
       throw new Error("bad grammar module");
     });
 
-    const registry = createMarkdownSyntaxLanguageRegistry({
-      languageAliases: {},
-      defaultLanguages: {},
-      lazyLanguageLoaders: {
-        yaml: loadYamlLanguage,
-      },
-      registerLanguage,
-    });
+    console.error = consoleError as typeof console.error;
+    try {
+      const registry = createMarkdownSyntaxLanguageRegistry({
+        languageAliases: {},
+        defaultLanguages: {},
+        lazyLanguageLoaders: {
+          yaml: loadYamlLanguage,
+        },
+        registerLanguage,
+      });
 
-    const unsupportedResult = await registry.ensureLanguageRegistered("rust");
-    const failedResult = await registry.ensureLanguageRegistered("yaml");
+      const unsupportedResult = await registry.ensureLanguageRegistered("rust");
+      const failedResult = await registry.ensureLanguageRegistered("yaml");
 
-    expect(unsupportedResult).toBe(false);
-    expect(failedResult).toBe(false);
-    expect(loadYamlLanguage).toHaveBeenCalledTimes(1);
-    expect(registerLanguage).not.toHaveBeenCalled();
+      expect(unsupportedResult).toBe(false);
+      expect(failedResult).toBe(false);
+      expect(loadYamlLanguage).toHaveBeenCalledTimes(1);
+      expect(registerLanguage).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError.mock.calls[0]?.[0]).toContain("yaml");
+    } finally {
+      console.error = originalConsoleError;
+    }
   });
 });

--- a/apps/desktop/src/components/ui/markdown-syntax-language-registry.test.ts
+++ b/apps/desktop/src/components/ui/markdown-syntax-language-registry.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createMarkdownSyntaxLanguageRegistry } from "./markdown-syntax-language-registry";
+
+describe("createMarkdownSyntaxLanguageRegistry", () => {
+  test("normalizes aliases and registers default languages at initialization", () => {
+    const registerLanguage = mock((_language: string, _grammar: unknown) => {});
+
+    const registry = createMarkdownSyntaxLanguageRegistry({
+      languageAliases: { js: "javascript" },
+      defaultLanguages: {
+        javascript: { name: "javascript" },
+      },
+      lazyLanguageLoaders: {},
+      registerLanguage,
+    });
+
+    expect(registerLanguage).toHaveBeenCalledTimes(1);
+    expect(registerLanguage.mock.calls[0]).toEqual(["javascript", { name: "javascript" }]);
+    expect(registry.normalizeLanguage(" JS ")).toBe("javascript");
+    expect(registry.isLanguageSupported("js")).toBe(true);
+    expect(registry.isLanguageRegistered("js")).toBe(true);
+  });
+
+  test("loads and registers a lazy language once even with concurrent requests", async () => {
+    const registerLanguage = mock((_language: string, _grammar: unknown) => {});
+    const loadYamlLanguage = mock(async () => ({ default: { name: "yaml" } }));
+
+    const registry = createMarkdownSyntaxLanguageRegistry({
+      languageAliases: { yml: "yaml" },
+      defaultLanguages: {},
+      lazyLanguageLoaders: {
+        yaml: loadYamlLanguage,
+      },
+      registerLanguage,
+    });
+
+    const [firstResult, secondResult] = await Promise.all([
+      registry.ensureLanguageRegistered("yaml"),
+      registry.ensureLanguageRegistered("yml"),
+    ]);
+
+    expect(firstResult).toBe(true);
+    expect(secondResult).toBe(true);
+    expect(loadYamlLanguage).toHaveBeenCalledTimes(1);
+    expect(registerLanguage).toHaveBeenCalledTimes(1);
+    expect(registerLanguage.mock.calls[0]).toEqual(["yaml", { name: "yaml" }]);
+
+    const repeatedResult = await registry.ensureLanguageRegistered("yaml");
+    expect(repeatedResult).toBe(true);
+    expect(loadYamlLanguage).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns false for unsupported languages and failed lazy loaders", async () => {
+    const registerLanguage = mock((_language: string, _grammar: unknown) => {});
+    const loadYamlLanguage = mock(async () => {
+      throw new Error("bad grammar module");
+    });
+
+    const registry = createMarkdownSyntaxLanguageRegistry({
+      languageAliases: {},
+      defaultLanguages: {},
+      lazyLanguageLoaders: {
+        yaml: loadYamlLanguage,
+      },
+      registerLanguage,
+    });
+
+    const unsupportedResult = await registry.ensureLanguageRegistered("rust");
+    const failedResult = await registry.ensureLanguageRegistered("yaml");
+
+    expect(unsupportedResult).toBe(false);
+    expect(failedResult).toBe(false);
+    expect(loadYamlLanguage).toHaveBeenCalledTimes(1);
+    expect(registerLanguage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/components/ui/markdown-syntax-language-registry.ts
+++ b/apps/desktop/src/components/ui/markdown-syntax-language-registry.ts
@@ -74,7 +74,10 @@ export function createMarkdownSyntaxLanguageRegistry({
         registerNormalizedLanguage(normalizedLanguage, module.default);
         return true;
       })
-      .catch(() => false)
+      .catch((error) => {
+        console.error(`Failed to lazy-load language grammar for '${normalizedLanguage}':`, error);
+        return false;
+      })
       .finally(() => {
         pendingLanguageRegistrations.delete(normalizedLanguage);
       });

--- a/apps/desktop/src/components/ui/markdown-syntax-language-registry.ts
+++ b/apps/desktop/src/components/ui/markdown-syntax-language-registry.ts
@@ -1,0 +1,92 @@
+export type PrismLanguageLoader = () => Promise<{ default: unknown }>;
+
+type CreateMarkdownSyntaxLanguageRegistryArgs = {
+  languageAliases: Record<string, string>;
+  defaultLanguages: Record<string, unknown>;
+  lazyLanguageLoaders: Record<string, PrismLanguageLoader>;
+  registerLanguage: (language: string, grammar: unknown) => void;
+};
+
+export type MarkdownSyntaxLanguageRegistry = ReturnType<
+  typeof createMarkdownSyntaxLanguageRegistry
+>;
+
+export function createMarkdownSyntaxLanguageRegistry({
+  languageAliases,
+  defaultLanguages,
+  lazyLanguageLoaders,
+  registerLanguage,
+}: CreateMarkdownSyntaxLanguageRegistryArgs) {
+  const registeredLanguages = new Set<string>();
+  const pendingLanguageRegistrations = new Map<string, Promise<boolean>>();
+  const supportedLanguages = new Set([
+    ...Object.keys(defaultLanguages),
+    ...Object.keys(lazyLanguageLoaders),
+  ]);
+
+  const normalizeLanguage = (language: string): string => {
+    const normalized = language.trim().toLowerCase();
+    return languageAliases[normalized] ?? normalized;
+  };
+
+  const registerNormalizedLanguage = (language: string, grammar: unknown): void => {
+    if (registeredLanguages.has(language)) {
+      return;
+    }
+
+    registerLanguage(language, grammar);
+    registeredLanguages.add(language);
+  };
+
+  for (const [language, grammar] of Object.entries(defaultLanguages)) {
+    registerNormalizedLanguage(language, grammar);
+  }
+
+  const isLanguageSupported = (language: string): boolean =>
+    supportedLanguages.has(normalizeLanguage(language));
+
+  const isLanguageRegistered = (language: string): boolean =>
+    registeredLanguages.has(normalizeLanguage(language));
+
+  const ensureLanguageRegistered = async (language: string): Promise<boolean> => {
+    const normalizedLanguage = normalizeLanguage(language);
+
+    if (!supportedLanguages.has(normalizedLanguage)) {
+      return false;
+    }
+
+    if (registeredLanguages.has(normalizedLanguage)) {
+      return true;
+    }
+
+    const existingRegistration = pendingLanguageRegistrations.get(normalizedLanguage);
+    if (existingRegistration) {
+      return existingRegistration;
+    }
+
+    const languageLoader = lazyLanguageLoaders[normalizedLanguage];
+    if (!languageLoader) {
+      return false;
+    }
+
+    const registration = languageLoader()
+      .then((module) => {
+        registerNormalizedLanguage(normalizedLanguage, module.default);
+        return true;
+      })
+      .catch(() => false)
+      .finally(() => {
+        pendingLanguageRegistrations.delete(normalizedLanguage);
+      });
+
+    pendingLanguageRegistrations.set(normalizedLanguage, registration);
+    return registration;
+  };
+
+  return {
+    ensureLanguageRegistered,
+    isLanguageRegistered,
+    isLanguageSupported,
+    normalizeLanguage,
+  };
+}

--- a/apps/desktop/src/state/operations/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/use-checks.test.tsx
@@ -49,6 +49,7 @@ const makeRepoHealth = (
 });
 
 const toastError = mock((_message: string, _options?: { description?: string }) => {});
+const toastSuccess = mock((_message: string, _options?: { description?: string }) => {});
 let repoHealthHandler = async (_repoPath: string): Promise<RepoOpencodeHealthCheck> =>
   makeRepoHealth();
 const checkRepoOpencodeHealthMock = mock((repoPath: string) => repoHealthHandler(repoPath));
@@ -56,6 +57,8 @@ const checkRepoOpencodeHealthMock = mock((repoPath: string) => repoHealthHandler
 mock.module("sonner", () => ({
   toast: {
     error: (message: string, options?: { description?: string }) => toastError(message, options),
+    success: (message: string, options?: { description?: string }) =>
+      toastSuccess(message, options),
   },
 }));
 
@@ -133,6 +136,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   toastError.mockClear();
+  toastSuccess.mockClear();
   checkRepoOpencodeHealthMock.mockClear();
   repoHealthHandler = async () => makeRepoHealth();
 });


### PR DESCRIPTION
## Summary
- lazy-load Prism language definitions in `markdown-syntax-block` instead of importing all supported languages eagerly
- keep only a minimal default eager language set and register additional languages on demand with cached in-flight registration
- add unit tests for alias normalization, concurrent lazy registration deduplication, and loader failure fallback in the language registry helper

## Testing
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop build
