### PR TITLE
perf(tauri): async OpenCode startup readiness with startup telemetry

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -1824,6 +1825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +1955,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -2232,6 +2251,8 @@ dependencies = [
  "tauri-plugin-shell",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -3125,6 +3146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,6 +3795,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3993,7 +4032,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
 ]
 
 [[package]]
@@ -4003,6 +4054,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4152,6 +4246,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,6 +22,8 @@ tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "process", "sync", "macros", "time"] }
 thiserror = "2"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 ctrlc = "3"
 

--- a/apps/desktop/src-tauri/crates/host-application/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-application/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 fs2 = "0.4"
 tokio = { version = "1", features = ["net", "rt-multi-thread", "sync", "time"] }
+tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/apps/desktop/src-tauri/crates/host-application/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-application/Cargo.toml
@@ -11,7 +11,7 @@ host-infra-system = { path = "../host-infra-system" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 fs2 = "0.4"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["net", "rt-multi-thread", "sync", "time"] }
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -10,7 +10,6 @@ use host_infra_system::{
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;
-use std::time::Duration;
 use uuid::Uuid;
 
 /// Action responded by user during build/run (for approve/deny/message flow).
@@ -152,14 +151,57 @@ impl AppService {
                 return Err(error).context("Failed tracking spawned OpenCode build process");
             }
         };
-        if let Err(error) =
-            wait_for_local_server_with_process(&mut child, port, Duration::from_secs(8))
-        {
-            terminate_child_process(&mut child);
-            return Err(error).with_context(|| {
-                format!("OpenCode build runtime failed to start for task {task_id}")
-            });
-        }
+        let startup_policy = self.opencode_startup_readiness_policy();
+        let startup_cancel_epoch = self.startup_cancel_epoch();
+        let startup_cancel_snapshot = self.startup_cancel_snapshot();
+        self.emit_opencode_startup_event(
+            "startup_wait_begin",
+            "build_runtime",
+            repo_path,
+            Some(task_id),
+            "build",
+            port,
+            Some(startup_policy),
+            None,
+            None,
+        );
+        let startup_report = match wait_for_local_server_with_process(
+            &mut child,
+            port,
+            startup_policy,
+            &startup_cancel_epoch,
+            startup_cancel_snapshot,
+        ) {
+            Ok(report) => report,
+            Err(error) => {
+                self.emit_opencode_startup_event(
+                    "startup_failed",
+                    "build_runtime",
+                    repo_path,
+                    Some(task_id),
+                    "build",
+                    port,
+                    Some(startup_policy),
+                    Some(error.report),
+                    Some(error.reason),
+                );
+                terminate_child_process(&mut child);
+                return Err(anyhow!(error)).with_context(|| {
+                    format!("OpenCode build runtime failed to start for task {task_id}")
+                });
+            }
+        };
+        self.emit_opencode_startup_event(
+            "startup_ready",
+            "build_runtime",
+            repo_path,
+            Some(task_id),
+            "build",
+            port,
+            Some(startup_policy),
+            Some(startup_report),
+            None,
+        );
 
         self.task_transition(
             repo_path,
@@ -310,7 +352,12 @@ impl AppService {
         Ok(true)
     }
 
-    pub fn build_cleanup(&self, run_id: &str, mode: CleanupMode, emitter: RunEmitter) -> Result<bool> {
+    pub fn build_cleanup(
+        &self,
+        run_id: &str,
+        mode: CleanupMode,
+        emitter: RunEmitter,
+    ) -> Result<bool> {
         let mut runs = self
             .runs
             .lock()
@@ -435,8 +482,8 @@ impl AppService {
 
 #[cfg(test)]
 mod tests {
-    use crate::app_service::test_support::{build_service_with_state, make_emitter};
     use crate::app_service::build_orchestrator::BuildResponseAction;
+    use crate::app_service::test_support::{build_service_with_state, make_emitter};
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -457,7 +504,12 @@ mod tests {
         let events = Arc::new(Mutex::new(Vec::new()));
 
         let error = service
-            .build_respond("missing-run", BuildResponseAction::Approve, None, make_emitter(events))
+            .build_respond(
+                "missing-run",
+                BuildResponseAction::Approve,
+                None,
+                make_emitter(events),
+            )
             .expect_err("responding to unknown run should fail");
 
         assert!(error.to_string().contains("Run not found: missing-run"));

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -135,6 +135,7 @@ impl AppService {
             }
         }
 
+        let run_id = format!("run-{}", Uuid::new_v4().simple());
         let port = pick_free_port()?;
         let metadata_namespace = self.config_store.task_metadata_namespace()?;
 
@@ -161,6 +162,8 @@ impl AppService {
             Some(task_id),
             "build",
             port,
+            Some("run_id"),
+            Some(run_id.as_str()),
             Some(startup_policy),
             None,
             None,
@@ -181,6 +184,8 @@ impl AppService {
                     Some(task_id),
                     "build",
                     port,
+                    Some("run_id"),
+                    Some(run_id.as_str()),
                     Some(startup_policy),
                     Some(error.report),
                     Some(error.reason),
@@ -198,6 +203,8 @@ impl AppService {
             Some(task_id),
             "build",
             port,
+            Some("run_id"),
+            Some(run_id.as_str()),
             Some(startup_policy),
             Some(startup_report),
             None,
@@ -209,8 +216,6 @@ impl AppService {
             TaskStatus::InProgress,
             Some("Builder delegated"),
         )?;
-
-        let run_id = format!("run-{}", Uuid::new_v4().simple());
 
         let summary = RunSummary {
             run_id: run_id.clone(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -11,6 +11,7 @@ use std::fs::{self, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::Child;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -29,21 +30,21 @@ pub(crate) use events::{emit_event, spawn_output_forwarder};
 pub(crate) use opencode_runtime::{
     opencode_server_parent_pid, process_exists, read_opencode_version,
     resolve_opencode_binary_path, spawn_opencode_server, terminate_child_process,
-    terminate_process_by_pid, wait_for_local_server_with_process,
+    terminate_process_by_pid, wait_for_local_server_with_process, OpencodeStartupReadinessPolicy,
+    OpencodeStartupWaitReport, StartupCancelEpoch,
 };
 pub(crate) use workflow_rules::{
     can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
-    default_qa_required_for_issue_type,
-    derive_available_actions, normalize_issue_type, normalize_required_markdown,
-    normalize_subtask_plan_inputs, normalize_title_key, validate_parent_relationships_for_create,
-    validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
+    default_qa_required_for_issue_type, derive_available_actions, normalize_issue_type,
+    normalize_required_markdown, normalize_subtask_plan_inputs, normalize_title_key,
+    validate_parent_relationships_for_create, validate_parent_relationships_for_update,
+    validate_plan_subtask_rules, validate_transition,
 };
 
 #[cfg(test)]
 pub(crate) use opencode_runtime::{
-    build_opencode_config_content, default_mcp_workspace_root,
-    is_orphaned_opencode_server_process, parse_mcp_command_json, resolve_mcp_command,
-    wait_for_local_server,
+    build_opencode_config_content, default_mcp_workspace_root, is_orphaned_opencode_server_process,
+    parse_mcp_command_json, resolve_mcp_command, wait_for_local_server,
 };
 #[cfg(test)]
 pub(crate) use workflow_rules::allows_transition;
@@ -62,6 +63,7 @@ pub struct AppService {
     instance_pid: u32,
     initialized_repos: Arc<Mutex<HashSet<String>>>,
     runtime_check_cache: Arc<Mutex<Option<CachedRuntimeCheck>>>,
+    startup_cancel_epoch: StartupCancelEpoch,
 }
 
 pub(crate) struct TrackedOpencodeProcessGuard {
@@ -156,7 +158,9 @@ struct OpencodeProcessRegistryFile {
     instances: Vec<OpencodeProcessRegistryInstance>,
 }
 
-fn normalize_opencode_process_registry_instances(instances: &mut Vec<OpencodeProcessRegistryInstance>) {
+fn normalize_opencode_process_registry_instances(
+    instances: &mut Vec<OpencodeProcessRegistryInstance>,
+) {
     for instance in instances.iter_mut() {
         instance.child_pids.sort_unstable();
         instance.child_pids.dedup();
@@ -201,7 +205,12 @@ fn with_locked_opencode_process_registry<T>(
         .read(true)
         .write(true)
         .open(path)
-        .with_context(|| format!("Failed opening OpenCode process registry {}", path.display()))?;
+        .with_context(|| {
+            format!(
+                "Failed opening OpenCode process registry {}",
+                path.display()
+            )
+        })?;
     file.lock_exclusive().with_context(|| {
         format!(
             "Failed acquiring lock for OpenCode process registry {}",
@@ -210,8 +219,12 @@ fn with_locked_opencode_process_registry<T>(
     })?;
 
     let mut data = String::new();
-    file.read_to_string(&mut data)
-        .with_context(|| format!("Failed reading OpenCode process registry {}", path.display()))?;
+    file.read_to_string(&mut data).with_context(|| {
+        format!(
+            "Failed reading OpenCode process registry {}",
+            path.display()
+        )
+    })?;
 
     let mut parsed = if data.trim().is_empty() {
         OpencodeProcessRegistryFile::default()
@@ -230,14 +243,30 @@ fn with_locked_opencode_process_registry<T>(
 
     let payload = serde_json::to_string_pretty(&parsed)
         .context("Failed serializing OpenCode process registry payload")?;
-    file.set_len(0)
-        .with_context(|| format!("Failed truncating OpenCode process registry {}", path.display()))?;
-    file.seek(SeekFrom::Start(0))
-        .with_context(|| format!("Failed seeking OpenCode process registry {}", path.display()))?;
-    file.write_all(payload.as_bytes())
-        .with_context(|| format!("Failed writing OpenCode process registry {}", path.display()))?;
-    file.flush()
-        .with_context(|| format!("Failed flushing OpenCode process registry {}", path.display()))?;
+    file.set_len(0).with_context(|| {
+        format!(
+            "Failed truncating OpenCode process registry {}",
+            path.display()
+        )
+    })?;
+    file.seek(SeekFrom::Start(0)).with_context(|| {
+        format!(
+            "Failed seeking OpenCode process registry {}",
+            path.display()
+        )
+    })?;
+    file.write_all(payload.as_bytes()).with_context(|| {
+        format!(
+            "Failed writing OpenCode process registry {}",
+            path.display()
+        )
+    })?;
+    file.flush().with_context(|| {
+        format!(
+            "Failed flushing OpenCode process registry {}",
+            path.display()
+        )
+    })?;
 
     Ok(output)
 }
@@ -266,8 +295,7 @@ impl AppService {
         config_store: AppConfigStore,
         git_port: Arc<dyn GitPort>,
     ) -> Self {
-        let opencode_process_registry_path =
-            Self::opencode_process_registry_path(&config_store);
+        let opencode_process_registry_path = Self::opencode_process_registry_path(&config_store);
         let instance_pid = std::process::id();
         let service = Self {
             task_store,
@@ -280,6 +308,7 @@ impl AppService {
             instance_pid,
             initialized_repos: Arc::new(Mutex::new(HashSet::new())),
             runtime_check_cache: Arc::new(Mutex::new(None)),
+            startup_cancel_epoch: Arc::new(AtomicU64::new(0)),
         };
         if let Err(error) = service.reconcile_opencode_process_registry_on_startup() {
             eprintln!(
@@ -319,6 +348,67 @@ impl AppService {
         cache.insert(repo_key);
 
         Ok(())
+    }
+
+    pub(crate) fn opencode_startup_readiness_policy(&self) -> OpencodeStartupReadinessPolicy {
+        match self.config_store.opencode_startup_readiness() {
+            Ok(config) => OpencodeStartupReadinessPolicy::from_config(config),
+            Err(error) => {
+                eprintln!(
+                    "OpenDucktor warning: failed loading OpenCode startup readiness config; using defaults: {error:#}"
+                );
+                OpencodeStartupReadinessPolicy::default()
+            }
+        }
+    }
+
+    pub(crate) fn startup_cancel_epoch(&self) -> StartupCancelEpoch {
+        Arc::clone(&self.startup_cancel_epoch)
+    }
+
+    pub(crate) fn startup_cancel_snapshot(&self) -> u64 {
+        self.startup_cancel_epoch.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn emit_opencode_startup_event(
+        &self,
+        event: &str,
+        scope: &str,
+        repo_path: &str,
+        task_id: Option<&str>,
+        role: &str,
+        port: u16,
+        policy: Option<OpencodeStartupReadinessPolicy>,
+        report: Option<OpencodeStartupWaitReport>,
+        reason: Option<&str>,
+    ) {
+        let policy_payload = policy.map(|entry| {
+            serde_json::json!({
+                "timeoutMs": entry.timeout_ms(),
+                "connectTimeoutMs": entry.connect_timeout_ms(),
+                "initialRetryDelayMs": entry.initial_retry_delay_ms(),
+                "maxRetryDelayMs": entry.max_retry_delay_ms(),
+                "childCheckIntervalMs": entry.child_state_check_interval_ms(),
+            })
+        });
+        let report_payload = report.map(|entry| {
+            serde_json::json!({
+                "startupMs": entry.startup_ms(),
+                "attempts": entry.attempts(),
+            })
+        });
+        let payload = serde_json::json!({
+            "event": event,
+            "scope": scope,
+            "repoPath": repo_path,
+            "taskId": task_id,
+            "role": role,
+            "port": port,
+            "policy": policy_payload,
+            "report": report_payload,
+            "reason": reason,
+        });
+        eprintln!("OpenDucktor opencode-startup {payload}");
     }
 
     fn enrich_task(&self, task: TaskCard, all_tasks: &[TaskCard]) -> TaskCard {
@@ -494,23 +584,23 @@ impl AppService {
 
 #[cfg(test)]
 mod tests {
+    use super::build_orchestrator::{BuildResponseAction, CleanupMode};
     use super::{
         allows_transition, build_opencode_config_content, can_set_plan, can_set_spec_from_status,
-        default_mcp_workspace_root, derive_available_actions, normalize_required_markdown,
-        is_orphaned_opencode_server_process, normalize_subtask_plan_inputs,
-        parse_mcp_command_json, read_opencode_version, resolve_mcp_command,
-        resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
+        default_mcp_workspace_root, derive_available_actions, is_orphaned_opencode_server_process,
+        normalize_required_markdown, normalize_subtask_plan_inputs, parse_mcp_command_json,
+        read_opencode_version, resolve_mcp_command, resolve_opencode_binary_path,
+        terminate_child_process, terminate_process_by_pid, OpencodeStartupReadinessPolicy,
         validate_parent_relationships_for_create, validate_parent_relationships_for_update,
         validate_plan_subtask_rules, validate_transition, wait_for_local_server,
         wait_for_local_server_with_process, AppService,
     };
-    use super::build_orchestrator::{BuildResponseAction, CleanupMode};
     use anyhow::{anyhow, Context, Result};
     use host_domain::{
         AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
         GitPort, GitPushSummary, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState,
-        RunSummary, SpecDocument, TaskAction, TaskCard, TaskDocumentSummary, TaskMetadata, TaskStatus,
-        TaskStore, UpdateTaskPatch,
+        RunSummary, SpecDocument, TaskAction, TaskCard, TaskDocumentSummary, TaskMetadata,
+        TaskStatus, TaskStore, UpdateTaskPatch,
     };
     use host_infra_system::{AppConfigStore, HookSet, RepoConfig};
     use serde_json::Value;
@@ -520,6 +610,7 @@ mod tests {
     use std::net::{TcpListener, TcpStream};
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, LazyLock, Mutex};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -1723,6 +1814,16 @@ echo "bd-fake"
         assert!(result.is_err());
     }
 
+    fn test_startup_policy(timeout: Duration) -> OpencodeStartupReadinessPolicy {
+        OpencodeStartupReadinessPolicy {
+            timeout,
+            connect_timeout: Duration::from_millis(50),
+            initial_retry_delay: Duration::from_millis(10),
+            max_retry_delay: Duration::from_millis(50),
+            child_state_check_interval: Duration::from_millis(25),
+        }
+    }
+
     #[test]
     fn terminate_child_process_stops_background_process() {
         let mut child = Command::new("/bin/sh")
@@ -1748,9 +1849,71 @@ echo "bd-fake"
             .stderr(std::process::Stdio::piped())
             .spawn()
             .expect("spawn failing process");
-        let error = wait_for_local_server_with_process(&mut child, port, Duration::from_secs(2))
-            .expect_err("should report early process exit");
+        let cancel_epoch = Arc::new(AtomicU64::new(0));
+        let error = wait_for_local_server_with_process(
+            &mut child,
+            port,
+            test_startup_policy(Duration::from_secs(2)),
+            &cancel_epoch,
+            0,
+        )
+        .expect_err("should report early process exit");
         assert!(error.to_string().contains("startup failed"));
+        assert_eq!(error.reason, "child_exited");
+    }
+
+    #[test]
+    fn wait_for_local_server_with_process_times_out_when_child_stays_alive() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let port = listener.local_addr().expect("addr").port();
+        drop(listener);
+
+        let mut child = Command::new("/bin/sh")
+            .arg("-lc")
+            .arg("sleep 5")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn sleeping process");
+        let cancel_epoch = Arc::new(AtomicU64::new(0));
+        let error = wait_for_local_server_with_process(
+            &mut child,
+            port,
+            test_startup_policy(Duration::from_millis(250)),
+            &cancel_epoch,
+            0,
+        )
+        .expect_err("should time out when child remains alive and port stays closed");
+        terminate_child_process(&mut child);
+        assert_eq!(error.reason, "timeout");
+    }
+
+    #[test]
+    fn wait_for_local_server_with_process_honors_cancellation_epoch() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let port = listener.local_addr().expect("addr").port();
+        drop(listener);
+
+        let mut child = Command::new("/bin/sh")
+            .arg("-lc")
+            .arg("sleep 5")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn sleeping process");
+        let cancel_epoch = Arc::new(AtomicU64::new(1));
+        let snapshot = cancel_epoch.load(Ordering::SeqCst);
+        cancel_epoch.fetch_add(1, Ordering::SeqCst);
+        let error = wait_for_local_server_with_process(
+            &mut child,
+            port,
+            test_startup_policy(Duration::from_secs(2)),
+            &cancel_epoch,
+            snapshot,
+        )
+        .expect_err("should stop waiting when cancellation epoch changes");
+        terminate_child_process(&mut child);
+        assert_eq!(error.reason, "cancelled");
     }
 
     #[test]
@@ -2554,7 +2717,10 @@ echo "bd-fake"
         assert_eq!(plan.markdown, "# Epic Plan");
 
         let task_state = task_state.lock().expect("task lock poisoned");
-        assert_eq!(task_state.delete_calls, vec![("child-1".to_string(), false)]);
+        assert_eq!(
+            task_state.delete_calls,
+            vec![("child-1".to_string(), false)]
+        );
         assert_eq!(task_state.created_inputs.len(), 2);
         assert_eq!(task_state.created_inputs[0].title, "Build API");
         assert_eq!(
@@ -2593,7 +2759,10 @@ echo "bd-fake"
         assert_eq!(plan.markdown, "# Epic Plan");
 
         let task_state = task_state.lock().expect("task lock poisoned");
-        assert_eq!(task_state.delete_calls, vec![("child-1".to_string(), false)]);
+        assert_eq!(
+            task_state.delete_calls,
+            vec![("child-1".to_string(), false)]
+        );
         assert!(task_state.created_inputs.is_empty());
         assert!(task_state
             .updated_patches
@@ -3080,10 +3249,13 @@ echo "bd-fake"
             .opencode_repo_runtime_ensure(repo_path.as_str())
             .expect_err("post-start prune failure should bubble up");
         let message = error.to_string();
-        assert!(message.contains(
-            "Failed pruning stale runtimes while finalizing workspace runtime"
+        assert!(
+            message.contains("Failed pruning stale runtimes while finalizing workspace runtime")
+        );
+        assert!(wait_for_path_exists(
+            pid_file.as_path(),
+            Duration::from_secs(2)
         ));
-        assert!(wait_for_path_exists(pid_file.as_path(), Duration::from_secs(2)));
         let spawned_pid = fs::read_to_string(pid_file.as_path())?
             .trim()
             .parse::<i32>()
@@ -3530,9 +3702,7 @@ echo "bd-fake"
                     child: stale_child,
                     _opencode_process_guard: None,
                     cleanup_repo_path: Some("/tmp/non-existent-repo-for-prune".to_string()),
-                    cleanup_worktree_path: Some(
-                        "/tmp/non-existent-worktree-for-prune".to_string(),
-                    ),
+                    cleanup_worktree_path: Some("/tmp/non-existent-worktree-for-prune".to_string()),
                 },
             );
 
@@ -3603,7 +3773,11 @@ echo "bd-fake"
             emitter.clone()
         )?);
 
-        assert!(service.build_cleanup(run.run_id.as_str(), CleanupMode::Success, emitter.clone())?);
+        assert!(service.build_cleanup(
+            run.run_id.as_str(),
+            CleanupMode::Success,
+            emitter.clone()
+        )?);
         assert!(service.runs_list(Some(repo_path.as_str()))?.is_empty());
 
         let state = task_state.lock().expect("task lock poisoned");
@@ -3692,7 +3866,12 @@ echo "bd-fake"
             Some("note"),
             emitter.clone()
         )?);
-        assert!(service.build_respond(run_id.as_str(), BuildResponseAction::Deny, None, emitter.clone())?);
+        assert!(service.build_respond(
+            run_id.as_str(),
+            BuildResponseAction::Deny,
+            None,
+            emitter.clone()
+        )?);
 
         assert!(service.build_stop(run_id.as_str(), emitter.clone())?);
         assert!(service.build_cleanup(run_id.as_str(), CleanupMode::Failure, emitter.clone())?);
@@ -3780,7 +3959,8 @@ echo "bd-fake"
         let events = Arc::new(Mutex::new(Vec::<RunEvent>::new()));
         let emitter = make_emitter(events.clone());
         let run = service.build_start(repo_path.as_str(), "task-2", emitter.clone())?;
-        let cleaned = service.build_cleanup(run.run_id.as_str(), CleanupMode::Success, emitter.clone())?;
+        let cleaned =
+            service.build_cleanup(run.run_id.as_str(), CleanupMode::Success, emitter.clone())?;
         assert!(!cleaned, "post-hook failure should report false");
 
         let invalid_mode = service
@@ -4332,7 +4512,10 @@ echo "bd-fake"
             config_store,
         );
 
-        assert!(wait_for_process_exit(orphan_pid as i32, Duration::from_secs(2)));
+        assert!(wait_for_process_exit(
+            orphan_pid as i32,
+            Duration::from_secs(2)
+        ));
         assert!(super::read_opencode_process_registry(registry_path.as_path())?.is_empty());
 
         let _ = fs::remove_dir_all(root);
@@ -4357,7 +4540,10 @@ echo "bd-fake"
             .stderr(Stdio::null())
             .spawn()?;
 
-        assert!(wait_for_path_exists(pid_file.as_path(), Duration::from_secs(2)));
+        assert!(wait_for_path_exists(
+            pid_file.as_path(),
+            Duration::from_secs(2)
+        ));
         let pids = fs::read_to_string(pid_file.as_path())?;
         let mut parts = pids.split_whitespace();
         let live_parent_pid = parts

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -6,7 +6,7 @@ use host_domain::{
 use host_infra_system::{AppConfigStore, GitCliPort, RepoConfig};
 use serde::{Deserialize, Serialize};
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -64,6 +64,7 @@ pub struct AppService {
     initialized_repos: Arc<Mutex<HashSet<String>>>,
     runtime_check_cache: Arc<Mutex<Option<CachedRuntimeCheck>>>,
     startup_cancel_epoch: StartupCancelEpoch,
+    startup_metrics: Arc<Mutex<OpencodeStartupMetrics>>,
 }
 
 pub(crate) struct TrackedOpencodeProcessGuard {
@@ -151,6 +152,263 @@ pub(crate) struct CachedRuntimeCheck {
 }
 
 const OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH: &str = "runtime/opencode-processes.json";
+const STARTUP_DURATION_WARN_MS: u64 = 5_000;
+const STARTUP_ATTEMPTS_WARN: u32 = 20;
+const STARTUP_FAILURE_RATE_WARN_MIN_SAMPLES: u64 = 10;
+const STARTUP_FAILURE_RATE_WARN_PCT: u64 = 30;
+const STARTUP_MS_BUCKETS: [&str; 7] = [
+    "<=100",
+    "<=250",
+    "<=500",
+    "<=1000",
+    "<=2000",
+    "<=5000",
+    ">5000",
+];
+const STARTUP_ATTEMPTS_BUCKETS: [&str; 6] = ["<=1", "<=3", "<=5", "<=10", "<=20", ">20"];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OpencodeStartupPolicyPayload {
+    timeout_ms: u64,
+    connect_timeout_ms: u64,
+    initial_retry_delay_ms: u64,
+    max_retry_delay_ms: u64,
+    child_check_interval_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OpencodeStartupReportPayload {
+    startup_ms: u64,
+    attempts: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OpencodeStartupMetricsSnapshot {
+    total: u64,
+    ready: u64,
+    failed: u64,
+    failed_by_reason: BTreeMap<String, u64>,
+    startup_ms_histogram: BTreeMap<String, u64>,
+    attempts_histogram: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct OpencodeStartupEventPayload {
+    event: String,
+    scope: String,
+    repo_path: String,
+    task_id: Option<String>,
+    role: String,
+    port: u16,
+    correlation_type: Option<String>,
+    correlation_id: Option<String>,
+    policy: Option<OpencodeStartupPolicyPayload>,
+    report: Option<OpencodeStartupReportPayload>,
+    reason: Option<String>,
+    metrics: Option<OpencodeStartupMetricsSnapshot>,
+    #[serde(default)]
+    alerts: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct OpencodeStartupMetrics {
+    total: u64,
+    ready: u64,
+    failed: u64,
+    failed_by_reason: BTreeMap<String, u64>,
+    startup_ms_histogram: BTreeMap<String, u64>,
+    attempts_histogram: BTreeMap<String, u64>,
+}
+
+impl OpencodeStartupMetrics {
+    fn default_histogram(buckets: &[&str]) -> BTreeMap<String, u64> {
+        buckets
+            .iter()
+            .map(|bucket| ((*bucket).to_string(), 0))
+            .collect()
+    }
+
+    fn startup_ms_bucket(startup_ms: u64) -> &'static str {
+        if startup_ms <= 100 {
+            "<=100"
+        } else if startup_ms <= 250 {
+            "<=250"
+        } else if startup_ms <= 500 {
+            "<=500"
+        } else if startup_ms <= 1_000 {
+            "<=1000"
+        } else if startup_ms <= 2_000 {
+            "<=2000"
+        } else if startup_ms <= 5_000 {
+            "<=5000"
+        } else {
+            ">5000"
+        }
+    }
+
+    fn attempts_bucket(attempts: u32) -> &'static str {
+        if attempts <= 1 {
+            "<=1"
+        } else if attempts <= 3 {
+            "<=3"
+        } else if attempts <= 5 {
+            "<=5"
+        } else if attempts <= 10 {
+            "<=10"
+        } else if attempts <= 20 {
+            "<=20"
+        } else {
+            ">20"
+        }
+    }
+
+    fn snapshot(&self) -> OpencodeStartupMetricsSnapshot {
+        OpencodeStartupMetricsSnapshot {
+            total: self.total,
+            ready: self.ready,
+            failed: self.failed,
+            failed_by_reason: self.failed_by_reason.clone(),
+            startup_ms_histogram: self.startup_ms_histogram.clone(),
+            attempts_histogram: self.attempts_histogram.clone(),
+        }
+    }
+
+    fn failure_rate_percent(&self) -> u64 {
+        if self.total == 0 {
+            return 0;
+        }
+        ((self.failed * 100) / self.total).min(100)
+    }
+
+    fn ensure_histograms_initialized(&mut self) {
+        if self.startup_ms_histogram.is_empty() {
+            self.startup_ms_histogram = Self::default_histogram(&STARTUP_MS_BUCKETS);
+        }
+        if self.attempts_histogram.is_empty() {
+            self.attempts_histogram = Self::default_histogram(&STARTUP_ATTEMPTS_BUCKETS);
+        }
+    }
+
+    fn record_terminal(
+        &mut self,
+        event: &str,
+        report: OpencodeStartupWaitReport,
+        reason: Option<&str>,
+    ) -> (OpencodeStartupMetricsSnapshot, Vec<String>) {
+        self.ensure_histograms_initialized();
+        self.total += 1;
+        if event == "startup_ready" {
+            self.ready += 1;
+        } else if event == "startup_failed" {
+            self.failed += 1;
+            let reason_key = reason.unwrap_or("unknown").to_string();
+            *self.failed_by_reason.entry(reason_key).or_insert(0) += 1;
+        }
+
+        let startup_bucket = Self::startup_ms_bucket(report.startup_ms()).to_string();
+        if let Some(entry) = self.startup_ms_histogram.get_mut(&startup_bucket) {
+            *entry += 1;
+        }
+        let attempts_bucket = Self::attempts_bucket(report.attempts()).to_string();
+        if let Some(entry) = self.attempts_histogram.get_mut(&attempts_bucket) {
+            *entry += 1;
+        }
+
+        let mut alerts = Vec::new();
+        if report.startup_ms() >= STARTUP_DURATION_WARN_MS {
+            alerts.push(format!("startup_duration_high:{}", report.startup_ms()));
+        }
+        if report.attempts() >= STARTUP_ATTEMPTS_WARN {
+            alerts.push(format!("startup_attempts_high:{}", report.attempts()));
+        }
+        let failure_rate_pct = self.failure_rate_percent();
+        if self.total >= STARTUP_FAILURE_RATE_WARN_MIN_SAMPLES
+            && failure_rate_pct >= STARTUP_FAILURE_RATE_WARN_PCT
+        {
+            alerts.push(format!("startup_failure_rate_high:{failure_rate_pct}"));
+        }
+
+        (self.snapshot(), alerts)
+    }
+}
+
+impl Default for OpencodeStartupMetricsSnapshot {
+    fn default() -> Self {
+        Self {
+            total: 0,
+            ready: 0,
+            failed: 0,
+            failed_by_reason: BTreeMap::new(),
+            startup_ms_histogram: OpencodeStartupMetrics::default_histogram(&STARTUP_MS_BUCKETS),
+            attempts_histogram: OpencodeStartupMetrics::default_histogram(
+                &STARTUP_ATTEMPTS_BUCKETS,
+            ),
+        }
+    }
+}
+
+impl Default for OpencodeStartupMetrics {
+    fn default() -> Self {
+        Self {
+            total: 0,
+            ready: 0,
+            failed: 0,
+            failed_by_reason: BTreeMap::new(),
+            startup_ms_histogram: OpencodeStartupMetrics::default_histogram(&STARTUP_MS_BUCKETS),
+            attempts_histogram: OpencodeStartupMetrics::default_histogram(
+                &STARTUP_ATTEMPTS_BUCKETS,
+            ),
+        }
+    }
+}
+
+fn build_opencode_startup_event_payload(
+    event: &str,
+    scope: &str,
+    repo_path: &str,
+    task_id: Option<&str>,
+    role: &str,
+    port: u16,
+    correlation_type: Option<&str>,
+    correlation_id: Option<&str>,
+    policy: Option<OpencodeStartupReadinessPolicy>,
+    report: Option<OpencodeStartupWaitReport>,
+    reason: Option<&str>,
+    metrics: Option<OpencodeStartupMetricsSnapshot>,
+    alerts: Vec<String>,
+) -> OpencodeStartupEventPayload {
+    let policy_payload = policy.map(|entry| OpencodeStartupPolicyPayload {
+        timeout_ms: entry.timeout_ms(),
+        connect_timeout_ms: entry.connect_timeout_ms(),
+        initial_retry_delay_ms: entry.initial_retry_delay_ms(),
+        max_retry_delay_ms: entry.max_retry_delay_ms(),
+        child_check_interval_ms: entry.child_state_check_interval_ms(),
+    });
+    let report_payload = report.map(|entry| OpencodeStartupReportPayload {
+        startup_ms: entry.startup_ms(),
+        attempts: entry.attempts(),
+    });
+
+    OpencodeStartupEventPayload {
+        event: event.to_string(),
+        scope: scope.to_string(),
+        repo_path: repo_path.to_string(),
+        task_id: task_id.map(str::to_string),
+        role: role.to_string(),
+        port,
+        correlation_type: correlation_type.map(str::to_string),
+        correlation_id: correlation_id.map(str::to_string),
+        policy: policy_payload,
+        report: report_payload,
+        reason: reason.map(str::to_string),
+        metrics,
+        alerts,
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct OpencodeProcessRegistryFile {
@@ -309,6 +567,7 @@ impl AppService {
             initialized_repos: Arc::new(Mutex::new(HashSet::new())),
             runtime_check_cache: Arc::new(Mutex::new(None)),
             startup_cancel_epoch: Arc::new(AtomicU64::new(0)),
+            startup_metrics: Arc::new(Mutex::new(OpencodeStartupMetrics::default())),
         };
         if let Err(error) = service.reconcile_opencode_process_registry_on_startup() {
             eprintln!(
@@ -354,8 +613,10 @@ impl AppService {
         match self.config_store.opencode_startup_readiness() {
             Ok(config) => OpencodeStartupReadinessPolicy::from_config(config),
             Err(error) => {
-                eprintln!(
-                    "OpenDucktor warning: failed loading OpenCode startup readiness config; using defaults: {error:#}"
+                tracing::warn!(
+                    target: "openducktor.opencode.startup",
+                    error = %format!("{error:#}"),
+                    "Failed loading OpenCode startup readiness config; using defaults"
                 );
                 OpencodeStartupReadinessPolicy::default()
             }
@@ -378,37 +639,83 @@ impl AppService {
         task_id: Option<&str>,
         role: &str,
         port: u16,
+        correlation_type: Option<&str>,
+        correlation_id: Option<&str>,
         policy: Option<OpencodeStartupReadinessPolicy>,
         report: Option<OpencodeStartupWaitReport>,
         reason: Option<&str>,
     ) {
-        let policy_payload = policy.map(|entry| {
-            serde_json::json!({
-                "timeoutMs": entry.timeout_ms(),
-                "connectTimeoutMs": entry.connect_timeout_ms(),
-                "initialRetryDelayMs": entry.initial_retry_delay_ms(),
-                "maxRetryDelayMs": entry.max_retry_delay_ms(),
-                "childCheckIntervalMs": entry.child_state_check_interval_ms(),
-            })
-        });
-        let report_payload = report.map(|entry| {
-            serde_json::json!({
-                "startupMs": entry.startup_ms(),
-                "attempts": entry.attempts(),
-            })
-        });
-        let payload = serde_json::json!({
-            "event": event,
-            "scope": scope,
-            "repoPath": repo_path,
-            "taskId": task_id,
-            "role": role,
-            "port": port,
-            "policy": policy_payload,
-            "report": report_payload,
-            "reason": reason,
-        });
-        eprintln!("OpenDucktor opencode-startup {payload}");
+        let (metrics, alerts) = match report {
+            Some(report) if matches!(event, "startup_ready" | "startup_failed") => {
+                match self.startup_metrics.lock() {
+                    Ok(mut metrics) => metrics.record_terminal(event, report, reason),
+                    Err(_) => {
+                        tracing::warn!(
+                            target: "openducktor.opencode.startup",
+                            event,
+                            scope,
+                            repo_path,
+                            "OpenCode startup metrics lock poisoned; continuing without metrics"
+                        );
+                        (OpencodeStartupMetricsSnapshot::default(), Vec::new())
+                    }
+                }
+            }
+            _ => (OpencodeStartupMetricsSnapshot::default(), Vec::new()),
+        };
+        let include_metrics = matches!(event, "startup_ready" | "startup_failed");
+        let payload = build_opencode_startup_event_payload(
+            event,
+            scope,
+            repo_path,
+            task_id,
+            role,
+            port,
+            correlation_type,
+            correlation_id,
+            policy,
+            report,
+            reason,
+            include_metrics.then_some(metrics),
+            alerts.clone(),
+        );
+        let payload_json = serde_json::to_string(&payload)
+            .unwrap_or_else(|_| "{\"serializationError\":\"startup-event\"}".to_string());
+        let startup_ms = report.map(|entry| entry.startup_ms()).unwrap_or_default();
+        let attempts = report.map(|entry| entry.attempts()).unwrap_or_default();
+        tracing::info!(
+            target: "openducktor.opencode.startup",
+            event,
+            scope,
+            repo_path,
+            task_id = task_id.unwrap_or(""),
+            role,
+            port,
+            correlation_type = correlation_type.unwrap_or(""),
+            correlation_id = correlation_id.unwrap_or(""),
+            reason = reason.unwrap_or(""),
+            startup_ms,
+            attempts,
+            payload = %payload_json,
+        );
+        for alert in alerts {
+            tracing::warn!(
+                target: "openducktor.opencode.startup.alert",
+                alert = %alert,
+                event,
+                scope,
+                repo_path,
+                task_id = task_id.unwrap_or(""),
+                role,
+                port,
+                correlation_type = correlation_type.unwrap_or(""),
+                correlation_id = correlation_id.unwrap_or(""),
+                reason = reason.unwrap_or(""),
+                startup_ms,
+                attempts,
+                "OpenCode startup threshold exceeded"
+            );
+        }
     }
 
     fn enrich_task(&self, task: TaskCard, all_tasks: &[TaskCard]) -> TaskCard {
@@ -586,14 +893,15 @@ impl AppService {
 mod tests {
     use super::build_orchestrator::{BuildResponseAction, CleanupMode};
     use super::{
-        allows_transition, build_opencode_config_content, can_set_plan, can_set_spec_from_status,
-        default_mcp_workspace_root, derive_available_actions, is_orphaned_opencode_server_process,
-        normalize_required_markdown, normalize_subtask_plan_inputs, parse_mcp_command_json,
-        read_opencode_version, resolve_mcp_command, resolve_opencode_binary_path,
-        terminate_child_process, terminate_process_by_pid, OpencodeStartupReadinessPolicy,
-        validate_parent_relationships_for_create, validate_parent_relationships_for_update,
-        validate_plan_subtask_rules, validate_transition, wait_for_local_server,
-        wait_for_local_server_with_process, AppService,
+        allows_transition, build_opencode_config_content, build_opencode_startup_event_payload,
+        can_set_plan, can_set_spec_from_status, default_mcp_workspace_root,
+        derive_available_actions, is_orphaned_opencode_server_process, normalize_required_markdown,
+        normalize_subtask_plan_inputs, parse_mcp_command_json, read_opencode_version,
+        resolve_mcp_command, resolve_opencode_binary_path, terminate_child_process,
+        terminate_process_by_pid, validate_parent_relationships_for_create,
+        validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
+        wait_for_local_server, wait_for_local_server_with_process, AppService,
+        OpencodeStartupMetricsSnapshot, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
     };
     use anyhow::{anyhow, Context, Result};
     use host_domain::{
@@ -602,7 +910,9 @@ mod tests {
         RunSummary, SpecDocument, TaskAction, TaskCard, TaskDocumentSummary, TaskMetadata,
         TaskStatus, TaskStore, UpdateTaskPatch,
     };
-    use host_infra_system::{AppConfigStore, HookSet, RepoConfig};
+    use host_infra_system::{
+        AppConfigStore, GlobalConfig, HookSet, OpencodeStartupReadinessConfig, RepoConfig,
+    };
     use serde_json::Value;
     use std::ffi::OsString;
     use std::fs;
@@ -1822,6 +2132,87 @@ echo "bd-fake"
             max_retry_delay: Duration::from_millis(50),
             child_state_check_interval: Duration::from_millis(25),
         }
+    }
+
+    #[test]
+    fn opencode_startup_event_payload_contract_includes_correlation_and_metrics() {
+        let policy = test_startup_policy(Duration::from_millis(8_000));
+        let report = OpencodeStartupWaitReport::from_parts(7, Duration::from_millis(321));
+        let mut metrics = OpencodeStartupMetricsSnapshot::default();
+        metrics.total = 4;
+        metrics.ready = 3;
+        metrics.failed = 1;
+        metrics.failed_by_reason.insert("timeout".to_string(), 1);
+        if let Some(bucket) = metrics.startup_ms_histogram.get_mut("<=500") {
+            *bucket = 4;
+        }
+        if let Some(bucket) = metrics.attempts_histogram.get_mut("<=10") {
+            *bucket = 4;
+        }
+
+        let payload = build_opencode_startup_event_payload(
+            "startup_ready",
+            "agent_runtime",
+            "/tmp/repo",
+            Some("task-42"),
+            "qa",
+            4242,
+            Some("runtime_id"),
+            Some("runtime-abc"),
+            Some(policy),
+            Some(report),
+            None,
+            Some(metrics),
+            vec!["startup_duration_high:321".to_string()],
+        );
+        let payload_json = serde_json::to_value(payload).expect("payload should serialize");
+
+        assert_eq!(payload_json["event"], "startup_ready");
+        assert_eq!(payload_json["scope"], "agent_runtime");
+        assert_eq!(payload_json["repoPath"], "/tmp/repo");
+        assert_eq!(payload_json["taskId"], "task-42");
+        assert_eq!(payload_json["role"], "qa");
+        assert_eq!(payload_json["port"], 4242);
+        assert_eq!(payload_json["correlationType"], "runtime_id");
+        assert_eq!(payload_json["correlationId"], "runtime-abc");
+        assert_eq!(payload_json["policy"]["timeoutMs"], 8_000);
+        assert_eq!(payload_json["report"]["startupMs"], 321);
+        assert_eq!(payload_json["report"]["attempts"], 7);
+        assert_eq!(payload_json["metrics"]["total"], 4);
+        assert_eq!(payload_json["metrics"]["ready"], 3);
+        assert_eq!(payload_json["metrics"]["failed"], 1);
+        assert_eq!(payload_json["alerts"][0], "startup_duration_high:321");
+    }
+
+    #[test]
+    fn opencode_startup_readiness_policy_uses_config_overrides() -> Result<()> {
+        let root = unique_temp_path("startup-policy-config");
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let config = GlobalConfig {
+            opencode_startup: OpencodeStartupReadinessConfig {
+                timeout_ms: 12_345,
+                connect_timeout_ms: 456,
+                initial_retry_delay_ms: 33,
+                max_retry_delay_ms: 99,
+                child_check_interval_ms: 77,
+            },
+            ..GlobalConfig::default()
+        };
+        config_store.save(&config)?;
+
+        let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore {
+            state: Arc::new(Mutex::new(TaskStoreState::default())),
+        });
+        let service = AppService::new(task_store, config_store);
+        let policy = service.opencode_startup_readiness_policy();
+        assert_eq!(policy.timeout, Duration::from_millis(12_345));
+        assert_eq!(policy.connect_timeout, Duration::from_millis(456));
+        assert_eq!(policy.initial_retry_delay, Duration::from_millis(33));
+        assert_eq!(policy.max_retry_delay, Duration::from_millis(99));
+        assert_eq!(policy.child_state_check_interval, Duration::from_millis(77));
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -309,12 +309,12 @@ impl OpencodeStartupMetrics {
             *self.failed_by_reason.entry(reason_key).or_insert(0) += 1;
         }
 
-        let startup_bucket = Self::startup_ms_bucket(report.startup_ms()).to_string();
-        if let Some(entry) = self.startup_ms_histogram.get_mut(&startup_bucket) {
+        let startup_bucket = Self::startup_ms_bucket(report.startup_ms());
+        if let Some(entry) = self.startup_ms_histogram.get_mut(startup_bucket) {
             *entry += 1;
         }
-        let attempts_bucket = Self::attempts_bucket(report.attempts()).to_string();
-        if let Some(entry) = self.attempts_histogram.get_mut(&attempts_bucket) {
+        let attempts_bucket = Self::attempts_bucket(report.attempts());
+        if let Some(entry) = self.attempts_histogram.get_mut(attempts_bucket) {
             *entry += 1;
         }
 
@@ -2277,6 +2277,45 @@ echo "bd-fake"
         .expect_err("should time out when child remains alive and port stays closed");
         terminate_child_process(&mut child);
         assert_eq!(error.reason, "timeout");
+    }
+
+    #[test]
+    fn wait_for_local_server_with_process_honors_total_timeout_budget_when_connect_timeout_is_large()
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let port = listener.local_addr().expect("addr").port();
+        drop(listener);
+
+        let mut child = Command::new("/bin/sh")
+            .arg("-lc")
+            .arg("sleep 5")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn sleeping process");
+        let cancel_epoch = Arc::new(AtomicU64::new(0));
+        let started_at = Instant::now();
+        let error = wait_for_local_server_with_process(
+            &mut child,
+            port,
+            OpencodeStartupReadinessPolicy {
+                timeout: Duration::from_millis(250),
+                connect_timeout: Duration::from_secs(10),
+                initial_retry_delay: Duration::from_millis(10),
+                max_retry_delay: Duration::from_millis(50),
+                child_state_check_interval: Duration::from_millis(25),
+            },
+            &cancel_epoch,
+            0,
+        )
+        .expect_err("total timeout budget should cap each connect attempt");
+        let elapsed = started_at.elapsed();
+        terminate_child_process(&mut child);
+        assert_eq!(error.reason, "timeout");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "startup wait should not exceed total budget window, elapsed={elapsed:?}"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -354,6 +354,10 @@ pub(crate) struct OpencodeStartupReadinessPolicy {
 }
 
 impl OpencodeStartupReadinessPolicy {
+    fn duration_ms(duration: Duration) -> u64 {
+        duration.as_millis().min(u64::MAX as u128) as u64
+    }
+
     pub(crate) fn from_config(config: OpencodeStartupReadinessConfig) -> Self {
         Self {
             timeout: Duration::from_millis(config.timeout_ms),
@@ -364,24 +368,24 @@ impl OpencodeStartupReadinessPolicy {
         }
     }
 
-    pub(crate) fn timeout_ms(self) -> u128 {
-        self.timeout.as_millis()
+    pub(crate) fn timeout_ms(self) -> u64 {
+        Self::duration_ms(self.timeout)
     }
 
-    pub(crate) fn connect_timeout_ms(self) -> u128 {
-        self.connect_timeout.as_millis()
+    pub(crate) fn connect_timeout_ms(self) -> u64 {
+        Self::duration_ms(self.connect_timeout)
     }
 
-    pub(crate) fn initial_retry_delay_ms(self) -> u128 {
-        self.initial_retry_delay.as_millis()
+    pub(crate) fn initial_retry_delay_ms(self) -> u64 {
+        Self::duration_ms(self.initial_retry_delay)
     }
 
-    pub(crate) fn max_retry_delay_ms(self) -> u128 {
-        self.max_retry_delay.as_millis()
+    pub(crate) fn max_retry_delay_ms(self) -> u64 {
+        Self::duration_ms(self.max_retry_delay)
     }
 
-    pub(crate) fn child_state_check_interval_ms(self) -> u128 {
-        self.child_state_check_interval.as_millis()
+    pub(crate) fn child_state_check_interval_ms(self) -> u64 {
+        Self::duration_ms(self.child_state_check_interval)
     }
 }
 
@@ -402,8 +406,13 @@ impl OpencodeStartupWaitReport {
         self.attempts
     }
 
-    pub(crate) fn startup_ms(self) -> u128 {
-        self.elapsed.as_millis()
+    pub(crate) fn startup_ms(self) -> u64 {
+        self.elapsed.as_millis().min(u64::MAX as u128) as u64
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_parts(attempts: u32, elapsed: Duration) -> Self {
+        Self { attempts, elapsed }
     }
 }
 
@@ -447,6 +456,8 @@ struct LocalServerProbeEvent {
 struct LocalServerProbe {
     receiver: mpsc::Receiver<LocalServerProbeEvent>,
     attempts: Arc<AtomicU32>,
+    cancelled: Arc<AtomicBool>,
+    task: tokio::task::JoinHandle<()>,
 }
 
 impl LocalServerProbe {
@@ -459,18 +470,26 @@ impl LocalServerProbe {
         let (sender, receiver) = mpsc::channel();
         let attempts = Arc::new(AtomicU32::new(0));
         let attempts_for_probe = Arc::clone(&attempts);
-        startup_probe_runtime().spawn(async move {
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancelled_for_probe = Arc::clone(&cancelled);
+        let task = startup_probe_runtime().spawn(async move {
             let event = probe_local_server_async(
                 address,
                 policy,
                 cancel_epoch,
                 cancel_snapshot,
                 attempts_for_probe,
+                cancelled_for_probe,
             )
             .await;
             let _ = sender.send(event);
         });
-        Self { receiver, attempts }
+        Self {
+            receiver,
+            attempts,
+            cancelled,
+            task,
+        }
     }
 
     fn recv_timeout(
@@ -482,6 +501,13 @@ impl LocalServerProbe {
 
     fn attempts(&self) -> u32 {
         self.attempts.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for LocalServerProbe {
+    fn drop(&mut self) {
+        self.cancelled.store(true, Ordering::Release);
+        self.task.abort();
     }
 }
 
@@ -530,12 +556,20 @@ async fn probe_local_server_async(
     cancel_epoch: StartupCancelEpoch,
     cancel_snapshot: u64,
     attempts: Arc<AtomicU32>,
+    cancelled: Arc<AtomicBool>,
 ) -> LocalServerProbeEvent {
     let started_at = Instant::now();
     let deadline = started_at + policy.timeout;
     let mut retry_delay = policy.initial_retry_delay;
 
     loop {
+        if cancelled.load(Ordering::Acquire) {
+            return LocalServerProbeEvent {
+                state: LocalServerProbeState::Cancelled,
+                report: startup_wait_report(started_at, current_attempts(&attempts)),
+            };
+        }
+
         if cancel_epoch.load(Ordering::SeqCst) != cancel_snapshot {
             return LocalServerProbeEvent {
                 state: LocalServerProbeState::Cancelled,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
@@ -577,9 +577,26 @@ async fn probe_local_server_async(
             };
         }
 
+        let now = Instant::now();
+        if now >= deadline {
+            return LocalServerProbeEvent {
+                state: LocalServerProbeState::TimedOut,
+                report: startup_wait_report(started_at, current_attempts(&attempts)),
+            };
+        }
+
+        let remaining_budget = deadline.saturating_duration_since(now);
+        let connect_timeout = policy.connect_timeout.min(remaining_budget);
+        if connect_timeout.is_zero() {
+            return LocalServerProbeEvent {
+                state: LocalServerProbeState::TimedOut,
+                report: startup_wait_report(started_at, current_attempts(&attempts)),
+            };
+        }
+
         attempts.fetch_add(1, Ordering::Relaxed);
         let connected = tokio::time::timeout(
-            policy.connect_timeout,
+            connect_timeout,
             tokio::net::TcpStream::connect(address),
         )
         .await
@@ -593,15 +610,17 @@ async fn probe_local_server_async(
             };
         }
 
-        let now = Instant::now();
-        if now >= deadline {
+        let now_after_connect = Instant::now();
+        if now_after_connect >= deadline {
             return LocalServerProbeEvent {
                 state: LocalServerProbeState::TimedOut,
                 report: startup_wait_report(started_at, current_attempts(&attempts)),
             };
         }
 
-        let sleep_for = deadline.saturating_duration_since(now).min(retry_delay);
+        let sleep_for = deadline
+            .saturating_duration_since(now_after_connect)
+            .min(retry_delay);
         tokio::time::sleep(sleep_for).await;
         retry_delay = retry_delay
             .checked_mul(2)

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
@@ -5,6 +5,8 @@ use std::io::Read;
 use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
 
 pub(crate) fn parse_mcp_command_json(raw: &str) -> Result<Vec<String>> {
@@ -338,24 +340,90 @@ pub(crate) fn spawn_opencode_server(
     Ok(child)
 }
 
+const LOCAL_SERVER_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
+const LOCAL_SERVER_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(25);
+const LOCAL_SERVER_MAX_RETRY_DELAY: Duration = Duration::from_millis(250);
+const CHILD_STATE_CHECK_INTERVAL: Duration = Duration::from_millis(75);
+
+enum LocalServerProbeEvent {
+    Ready,
+    TimedOut,
+}
+
+struct LocalServerProbe {
+    receiver: mpsc::Receiver<LocalServerProbeEvent>,
+    cancel: Arc<AtomicBool>,
+}
+
+impl LocalServerProbe {
+    fn spawn(address: SocketAddr, timeout: Duration) -> Self {
+        let (sender, receiver) = mpsc::channel();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_signal = Arc::clone(&cancel);
+
+        std::thread::spawn(move || {
+            let deadline = Instant::now() + timeout;
+            let mut retry_delay = LOCAL_SERVER_INITIAL_RETRY_DELAY;
+            loop {
+                if cancel_signal.load(Ordering::Relaxed) {
+                    return;
+                }
+
+                if TcpStream::connect_timeout(&address, LOCAL_SERVER_CONNECT_TIMEOUT).is_ok() {
+                    let _ = sender.send(LocalServerProbeEvent::Ready);
+                    return;
+                }
+
+                let now = Instant::now();
+                if now >= deadline {
+                    let _ = sender.send(LocalServerProbeEvent::TimedOut);
+                    return;
+                }
+
+                let sleep_for = deadline.saturating_duration_since(now).min(retry_delay);
+                std::thread::sleep(sleep_for);
+                retry_delay = retry_delay
+                    .saturating_mul(2)
+                    .min(LOCAL_SERVER_MAX_RETRY_DELAY);
+            }
+        });
+
+        Self { receiver, cancel }
+    }
+
+    fn recv_timeout(
+        &self,
+        timeout: Duration,
+    ) -> std::result::Result<LocalServerProbeEvent, mpsc::RecvTimeoutError> {
+        self.receiver.recv_timeout(timeout)
+    }
+}
+
+impl Drop for LocalServerProbe {
+    fn drop(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn wait_for_local_server(port: u16, timeout: Duration) -> Result<()> {
-    let deadline = Instant::now() + timeout;
     let address: SocketAddr = format!("127.0.0.1:{port}")
         .parse()
         .context("Invalid localhost address")?;
+    let probe = LocalServerProbe::spawn(address, timeout);
+    let wait_budget = timeout
+        .saturating_add(LOCAL_SERVER_CONNECT_TIMEOUT)
+        .saturating_add(LOCAL_SERVER_MAX_RETRY_DELAY);
 
-    while Instant::now() < deadline {
-        if TcpStream::connect_timeout(&address, Duration::from_millis(250)).is_ok() {
-            return Ok(());
-        }
-        std::thread::sleep(Duration::from_millis(150));
+    match probe.recv_timeout(wait_budget) {
+        Ok(LocalServerProbeEvent::Ready) => Ok(()),
+        Ok(LocalServerProbeEvent::TimedOut)
+        | Err(mpsc::RecvTimeoutError::Timeout)
+        | Err(mpsc::RecvTimeoutError::Disconnected) => Err(anyhow!(
+            "Timed out waiting for OpenCode runtime on 127.0.0.1:{}",
+            port
+        )),
     }
-
-    Err(anyhow!(
-        "Timed out waiting for OpenCode runtime on 127.0.0.1:{}",
-        port
-    ))
 }
 
 fn read_child_pipe(pipe: &mut Option<impl Read>) -> String {
@@ -376,10 +444,21 @@ pub(crate) fn wait_for_local_server_with_process(
     let address: SocketAddr = format!("127.0.0.1:{port}")
         .parse()
         .context("Invalid localhost address")?;
+    let probe = LocalServerProbe::spawn(address, timeout);
 
     while Instant::now() < deadline {
-        if TcpStream::connect_timeout(&address, Duration::from_millis(250)).is_ok() {
-            return Ok(());
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let wait_for = remaining.min(CHILD_STATE_CHECK_INTERVAL);
+        if wait_for.is_zero() {
+            break;
+        }
+
+        match probe.recv_timeout(wait_for) {
+            Ok(LocalServerProbeEvent::Ready) => return Ok(()),
+            Ok(LocalServerProbeEvent::TimedOut) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                break;
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
         }
 
         if let Some(status) = child
@@ -399,8 +478,24 @@ pub(crate) fn wait_for_local_server_with_process(
                 "OpenCode process exited before runtime became reachable: {details}"
             ));
         }
+    }
 
-        std::thread::sleep(Duration::from_millis(150));
+    if let Some(status) = child
+        .try_wait()
+        .context("Failed checking OpenCode process state")?
+    {
+        let stderr = read_child_pipe(&mut child.stderr);
+        let stdout = read_child_pipe(&mut child.stdout);
+        let details = if !stderr.is_empty() {
+            stderr
+        } else if !stdout.is_empty() {
+            stdout
+        } else {
+            format!("process exited with status {status}")
+        };
+        return Err(anyhow!(
+            "OpenCode process exited before runtime became reachable: {details}"
+        ));
     }
 
     Err(anyhow!(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
@@ -1,12 +1,14 @@
 use anyhow::{anyhow, Context, Result};
-use host_infra_system::{command_exists, command_path, resolve_central_beads_dir};
+use host_infra_system::{
+    command_exists, command_path, resolve_central_beads_dir, OpencodeStartupReadinessConfig,
+};
 use serde_json::json;
 use std::io::Read;
-use std::net::{SocketAddr, TcpStream};
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{mpsc, Arc};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::{mpsc, Arc, OnceLock};
 use std::time::{Duration, Instant};
 
 pub(crate) fn parse_mcp_command_json(raw: &str) -> Result<Vec<String>> {
@@ -340,55 +342,135 @@ pub(crate) fn spawn_opencode_server(
     Ok(child)
 }
 
-const LOCAL_SERVER_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
-const LOCAL_SERVER_INITIAL_RETRY_DELAY: Duration = Duration::from_millis(25);
-const LOCAL_SERVER_MAX_RETRY_DELAY: Duration = Duration::from_millis(250);
-const CHILD_STATE_CHECK_INTERVAL: Duration = Duration::from_millis(75);
+pub(crate) type StartupCancelEpoch = Arc<AtomicU64>;
 
-enum LocalServerProbeEvent {
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OpencodeStartupReadinessPolicy {
+    pub timeout: Duration,
+    pub connect_timeout: Duration,
+    pub initial_retry_delay: Duration,
+    pub max_retry_delay: Duration,
+    pub child_state_check_interval: Duration,
+}
+
+impl OpencodeStartupReadinessPolicy {
+    pub(crate) fn from_config(config: OpencodeStartupReadinessConfig) -> Self {
+        Self {
+            timeout: Duration::from_millis(config.timeout_ms),
+            connect_timeout: Duration::from_millis(config.connect_timeout_ms),
+            initial_retry_delay: Duration::from_millis(config.initial_retry_delay_ms),
+            max_retry_delay: Duration::from_millis(config.max_retry_delay_ms),
+            child_state_check_interval: Duration::from_millis(config.child_check_interval_ms),
+        }
+    }
+
+    pub(crate) fn timeout_ms(self) -> u128 {
+        self.timeout.as_millis()
+    }
+
+    pub(crate) fn connect_timeout_ms(self) -> u128 {
+        self.connect_timeout.as_millis()
+    }
+
+    pub(crate) fn initial_retry_delay_ms(self) -> u128 {
+        self.initial_retry_delay.as_millis()
+    }
+
+    pub(crate) fn max_retry_delay_ms(self) -> u128 {
+        self.max_retry_delay.as_millis()
+    }
+
+    pub(crate) fn child_state_check_interval_ms(self) -> u128 {
+        self.child_state_check_interval.as_millis()
+    }
+}
+
+impl Default for OpencodeStartupReadinessPolicy {
+    fn default() -> Self {
+        Self::from_config(OpencodeStartupReadinessConfig::default())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct OpencodeStartupWaitReport {
+    attempts: u32,
+    elapsed: Duration,
+}
+
+impl OpencodeStartupWaitReport {
+    pub(crate) fn attempts(self) -> u32 {
+        self.attempts
+    }
+
+    pub(crate) fn startup_ms(self) -> u128 {
+        self.elapsed.as_millis()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OpencodeStartupWaitFailure {
+    pub port: u16,
+    pub reason: &'static str,
+    pub details: String,
+    pub report: OpencodeStartupWaitReport,
+}
+
+impl std::fmt::Display for OpencodeStartupWaitFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "OpenCode startup probe failed reason={} port={} startupMs={} attempts={} details={}",
+            self.reason,
+            self.port,
+            self.report.startup_ms(),
+            self.report.attempts(),
+            self.details.replace('\n', "\\n")
+        )
+    }
+}
+
+impl std::error::Error for OpencodeStartupWaitFailure {}
+
+#[derive(Debug, Clone, Copy)]
+enum LocalServerProbeState {
     Ready,
     TimedOut,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LocalServerProbeEvent {
+    state: LocalServerProbeState,
+    report: OpencodeStartupWaitReport,
 }
 
 struct LocalServerProbe {
     receiver: mpsc::Receiver<LocalServerProbeEvent>,
-    cancel: Arc<AtomicBool>,
+    attempts: Arc<AtomicU32>,
 }
 
 impl LocalServerProbe {
-    fn spawn(address: SocketAddr, timeout: Duration) -> Self {
+    fn spawn(
+        address: SocketAddr,
+        policy: OpencodeStartupReadinessPolicy,
+        cancel_epoch: StartupCancelEpoch,
+        cancel_snapshot: u64,
+    ) -> Self {
         let (sender, receiver) = mpsc::channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        let cancel_signal = Arc::clone(&cancel);
-
-        std::thread::spawn(move || {
-            let deadline = Instant::now() + timeout;
-            let mut retry_delay = LOCAL_SERVER_INITIAL_RETRY_DELAY;
-            loop {
-                if cancel_signal.load(Ordering::Relaxed) {
-                    return;
-                }
-
-                if TcpStream::connect_timeout(&address, LOCAL_SERVER_CONNECT_TIMEOUT).is_ok() {
-                    let _ = sender.send(LocalServerProbeEvent::Ready);
-                    return;
-                }
-
-                let now = Instant::now();
-                if now >= deadline {
-                    let _ = sender.send(LocalServerProbeEvent::TimedOut);
-                    return;
-                }
-
-                let sleep_for = deadline.saturating_duration_since(now).min(retry_delay);
-                std::thread::sleep(sleep_for);
-                retry_delay = retry_delay
-                    .saturating_mul(2)
-                    .min(LOCAL_SERVER_MAX_RETRY_DELAY);
-            }
+        let attempts = Arc::new(AtomicU32::new(0));
+        let attempts_for_probe = Arc::clone(&attempts);
+        startup_probe_runtime().spawn(async move {
+            let event = probe_local_server_async(
+                address,
+                policy,
+                cancel_epoch,
+                cancel_snapshot,
+                attempts_for_probe,
+            )
+            .await;
+            let _ = sender.send(event);
         });
-
-        Self { receiver, cancel }
+        Self { receiver, attempts }
     }
 
     fn recv_timeout(
@@ -397,32 +479,100 @@ impl LocalServerProbe {
     ) -> std::result::Result<LocalServerProbeEvent, mpsc::RecvTimeoutError> {
         self.receiver.recv_timeout(timeout)
     }
-}
 
-impl Drop for LocalServerProbe {
-    fn drop(&mut self) {
-        self.cancel.store(true, Ordering::Relaxed);
+    fn attempts(&self) -> u32 {
+        self.attempts.load(Ordering::Relaxed)
     }
 }
 
-#[cfg(test)]
-pub(crate) fn wait_for_local_server(port: u16, timeout: Duration) -> Result<()> {
-    let address: SocketAddr = format!("127.0.0.1:{port}")
-        .parse()
-        .context("Invalid localhost address")?;
-    let probe = LocalServerProbe::spawn(address, timeout);
-    let wait_budget = timeout
-        .saturating_add(LOCAL_SERVER_CONNECT_TIMEOUT)
-        .saturating_add(LOCAL_SERVER_MAX_RETRY_DELAY);
+static STARTUP_PROBE_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
-    match probe.recv_timeout(wait_budget) {
-        Ok(LocalServerProbeEvent::Ready) => Ok(()),
-        Ok(LocalServerProbeEvent::TimedOut)
-        | Err(mpsc::RecvTimeoutError::Timeout)
-        | Err(mpsc::RecvTimeoutError::Disconnected) => Err(anyhow!(
-            "Timed out waiting for OpenCode runtime on 127.0.0.1:{}",
-            port
-        )),
+fn startup_probe_runtime() -> &'static tokio::runtime::Runtime {
+    STARTUP_PROBE_RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name("odt-opencode-startup")
+            .enable_io()
+            .enable_time()
+            .build()
+            .expect("failed to build OpenCode startup probe runtime")
+    })
+}
+
+fn startup_wait_report(started_at: Instant, attempts: u32) -> OpencodeStartupWaitReport {
+    OpencodeStartupWaitReport {
+        attempts,
+        elapsed: started_at.elapsed(),
+    }
+}
+
+fn startup_wait_failure(
+    reason: &'static str,
+    port: u16,
+    details: String,
+    report: OpencodeStartupWaitReport,
+) -> OpencodeStartupWaitFailure {
+    OpencodeStartupWaitFailure {
+        port,
+        reason,
+        details,
+        report,
+    }
+}
+
+fn current_attempts(attempts: &Arc<AtomicU32>) -> u32 {
+    attempts.load(Ordering::Relaxed)
+}
+
+async fn probe_local_server_async(
+    address: SocketAddr,
+    policy: OpencodeStartupReadinessPolicy,
+    cancel_epoch: StartupCancelEpoch,
+    cancel_snapshot: u64,
+    attempts: Arc<AtomicU32>,
+) -> LocalServerProbeEvent {
+    let started_at = Instant::now();
+    let deadline = started_at + policy.timeout;
+    let mut retry_delay = policy.initial_retry_delay;
+
+    loop {
+        if cancel_epoch.load(Ordering::SeqCst) != cancel_snapshot {
+            return LocalServerProbeEvent {
+                state: LocalServerProbeState::Cancelled,
+                report: startup_wait_report(started_at, current_attempts(&attempts)),
+            };
+        }
+
+        attempts.fetch_add(1, Ordering::Relaxed);
+        let connected = tokio::time::timeout(
+            policy.connect_timeout,
+            tokio::net::TcpStream::connect(address),
+        )
+        .await
+        .ok()
+        .and_then(|result| result.ok())
+        .is_some();
+        if connected {
+            return LocalServerProbeEvent {
+                state: LocalServerProbeState::Ready,
+                report: startup_wait_report(started_at, current_attempts(&attempts)),
+            };
+        }
+
+        let now = Instant::now();
+        if now >= deadline {
+            return LocalServerProbeEvent {
+                state: LocalServerProbeState::TimedOut,
+                report: startup_wait_report(started_at, current_attempts(&attempts)),
+            };
+        }
+
+        let sleep_for = deadline.saturating_duration_since(now).min(retry_delay);
+        tokio::time::sleep(sleep_for).await;
+        retry_delay = retry_delay
+            .checked_mul(2)
+            .unwrap_or(policy.max_retry_delay)
+            .min(policy.max_retry_delay);
     }
 }
 
@@ -435,36 +585,79 @@ fn read_child_pipe(pipe: &mut Option<impl Read>) -> String {
     output.trim().to_string()
 }
 
-pub(crate) fn wait_for_local_server_with_process(
-    child: &mut Child,
-    port: u16,
-    timeout: Duration,
-) -> Result<()> {
-    let deadline = Instant::now() + timeout;
+#[cfg(test)]
+pub(crate) fn wait_for_local_server(port: u16, timeout: Duration) -> Result<()> {
+    let policy = OpencodeStartupReadinessPolicy {
+        timeout,
+        ..OpencodeStartupReadinessPolicy::default()
+    };
     let address: SocketAddr = format!("127.0.0.1:{port}")
         .parse()
         .context("Invalid localhost address")?;
-    let probe = LocalServerProbe::spawn(address, timeout);
+    let cancel_epoch = Arc::new(AtomicU64::new(0));
+    let probe = LocalServerProbe::spawn(address, policy, cancel_epoch, 0);
+    let wait_budget = timeout
+        .saturating_add(policy.connect_timeout)
+        .saturating_add(policy.max_retry_delay)
+        .saturating_add(policy.child_state_check_interval);
 
-    while Instant::now() < deadline {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        let wait_for = remaining.min(CHILD_STATE_CHECK_INTERVAL);
-        if wait_for.is_zero() {
-            break;
+    match probe.recv_timeout(wait_budget) {
+        Ok(LocalServerProbeEvent {
+            state: LocalServerProbeState::Ready,
+            ..
+        }) => Ok(()),
+        Ok(LocalServerProbeEvent { state, report }) => Err(anyhow!(
+            "{}",
+            startup_wait_failure(
+                match state {
+                    LocalServerProbeState::TimedOut => "timeout",
+                    LocalServerProbeState::Cancelled => "cancelled",
+                    LocalServerProbeState::Ready => "ready",
+                },
+                port,
+                format!("OpenCode runtime did not become reachable on 127.0.0.1:{port}"),
+                report,
+            )
+        )),
+        Err(mpsc::RecvTimeoutError::Timeout) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+            Err(anyhow!(
+                "OpenCode startup probe failed reason=probe_disconnected port={} startupMs={} attempts={} details={}",
+                port,
+                timeout.as_millis(),
+                probe.attempts(),
+                "Probe channel disconnected before startup completion"
+            ))
         }
+    }
+}
 
-        match probe.recv_timeout(wait_for) {
-            Ok(LocalServerProbeEvent::Ready) => return Ok(()),
-            Ok(LocalServerProbeEvent::TimedOut) | Err(mpsc::RecvTimeoutError::Disconnected) => {
-                break;
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {}
-        }
+pub(crate) fn wait_for_local_server_with_process(
+    child: &mut Child,
+    port: u16,
+    policy: OpencodeStartupReadinessPolicy,
+    cancel_epoch: &StartupCancelEpoch,
+    cancel_snapshot: u64,
+) -> std::result::Result<OpencodeStartupWaitReport, OpencodeStartupWaitFailure> {
+    let started_at = Instant::now();
+    let address: SocketAddr = format!("127.0.0.1:{port}").parse().map_err(|error| {
+        startup_wait_failure(
+            "invalid_address",
+            port,
+            format!("Invalid localhost address: {error}"),
+            startup_wait_report(started_at, 0),
+        )
+    })?;
+    let probe = LocalServerProbe::spawn(address, policy, Arc::clone(cancel_epoch), cancel_snapshot);
 
-        if let Some(status) = child
-            .try_wait()
-            .context("Failed checking OpenCode process state")?
-        {
+    loop {
+        if let Some(status) = child.try_wait().map_err(|error| {
+            startup_wait_failure(
+                "child_state_check_failed",
+                port,
+                format!("Failed checking OpenCode process state: {error}"),
+                startup_wait_report(started_at, probe.attempts()),
+            )
+        })? {
             let stderr = read_child_pipe(&mut child.stderr);
             let stdout = read_child_pipe(&mut child.stdout);
             let details = if !stderr.is_empty() {
@@ -474,32 +667,50 @@ pub(crate) fn wait_for_local_server_with_process(
             } else {
                 format!("process exited with status {status}")
             };
-            return Err(anyhow!(
-                "OpenCode process exited before runtime became reachable: {details}"
+            return Err(startup_wait_failure(
+                "child_exited",
+                port,
+                format!("OpenCode process exited before runtime became reachable: {details}"),
+                startup_wait_report(started_at, probe.attempts()),
             ));
         }
-    }
 
-    if let Some(status) = child
-        .try_wait()
-        .context("Failed checking OpenCode process state")?
-    {
-        let stderr = read_child_pipe(&mut child.stderr);
-        let stdout = read_child_pipe(&mut child.stdout);
-        let details = if !stderr.is_empty() {
-            stderr
-        } else if !stdout.is_empty() {
-            stdout
-        } else {
-            format!("process exited with status {status}")
-        };
-        return Err(anyhow!(
-            "OpenCode process exited before runtime became reachable: {details}"
-        ));
+        match probe.recv_timeout(policy.child_state_check_interval) {
+            Ok(LocalServerProbeEvent {
+                state: LocalServerProbeState::Ready,
+                report,
+            }) => return Ok(report),
+            Ok(LocalServerProbeEvent {
+                state: LocalServerProbeState::TimedOut,
+                report,
+            }) => {
+                return Err(startup_wait_failure(
+                    "timeout",
+                    port,
+                    format!("Timed out waiting for OpenCode runtime on 127.0.0.1:{port}"),
+                    report,
+                ))
+            }
+            Ok(LocalServerProbeEvent {
+                state: LocalServerProbeState::Cancelled,
+                report,
+            }) => {
+                return Err(startup_wait_failure(
+                    "cancelled",
+                    port,
+                    "Startup cancelled while waiting for OpenCode runtime readiness".to_string(),
+                    report,
+                ))
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(startup_wait_failure(
+                    "probe_disconnected",
+                    port,
+                    "Startup probe channel disconnected before readiness result".to_string(),
+                    startup_wait_report(started_at, probe.attempts()),
+                ))
+            }
+        }
     }
-
-    Err(anyhow!(
-        "Timed out waiting for OpenCode runtime on 127.0.0.1:{}",
-        port
-    ))
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -82,6 +82,7 @@ impl AppService {
         }
 
         let port = pick_free_port()?;
+        let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
         let metadata_namespace = self.config_store.task_metadata_namespace()?;
         let mut child = spawn_opencode_server(
             Path::new(repo_path),
@@ -106,6 +107,8 @@ impl AppService {
             Some(Self::WORKSPACE_RUNTIME_TASK_ID),
             Self::WORKSPACE_RUNTIME_ROLE,
             port,
+            Some("runtime_id"),
+            Some(runtime_id.as_str()),
             Some(startup_policy),
             None,
             None,
@@ -126,6 +129,8 @@ impl AppService {
                     Some(Self::WORKSPACE_RUNTIME_TASK_ID),
                     Self::WORKSPACE_RUNTIME_ROLE,
                     port,
+                    Some("runtime_id"),
+                    Some(runtime_id.as_str()),
                     Some(startup_policy),
                     Some(error.report),
                     Some(error.reason),
@@ -143,12 +148,13 @@ impl AppService {
             Some(Self::WORKSPACE_RUNTIME_TASK_ID),
             Self::WORKSPACE_RUNTIME_ROLE,
             port,
+            Some("runtime_id"),
+            Some(runtime_id.as_str()),
             Some(startup_policy),
             Some(startup_report),
             None,
         );
 
-        let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
         let summary = AgentRuntimeSummary {
             runtime_id: runtime_id.clone(),
             repo_path: repo_key.clone(),
@@ -314,6 +320,7 @@ impl AppService {
         };
 
         let port = pick_free_port()?;
+        let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
         let metadata_namespace = self.config_store.task_metadata_namespace()?;
         let mut child = spawn_opencode_server(
             Path::new(&runtime_working_directory),
@@ -338,6 +345,8 @@ impl AppService {
             Some(task_id),
             role,
             port,
+            Some("runtime_id"),
+            Some(runtime_id.as_str()),
             Some(startup_policy),
             None,
             None,
@@ -358,6 +367,8 @@ impl AppService {
                     Some(task_id),
                     role,
                     port,
+                    Some("runtime_id"),
+                    Some(runtime_id.as_str()),
                     Some(startup_policy),
                     Some(error.report),
                     Some(error.reason),
@@ -387,12 +398,13 @@ impl AppService {
             Some(task_id),
             role,
             port,
+            Some("runtime_id"),
+            Some(runtime_id.as_str()),
             Some(startup_policy),
             Some(startup_report),
             None,
         );
 
-        let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
         let summary = AgentRuntimeSummary {
             runtime_id: runtime_id.clone(),
             repo_path: repo_key,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -10,7 +10,6 @@ use host_infra_system::{
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::time::Duration;
 use uuid::Uuid;
 
 impl AppService {
@@ -97,14 +96,57 @@ impl AppService {
                 return Err(error).context("Failed tracking spawned OpenCode workspace runtime");
             }
         };
-        if let Err(error) =
-            wait_for_local_server_with_process(&mut child, port, Duration::from_secs(8))
-        {
-            terminate_child_process(&mut child);
-            return Err(error).with_context(|| {
-                format!("OpenCode workspace runtime failed to start for {repo_path}")
-            });
-        }
+        let startup_policy = self.opencode_startup_readiness_policy();
+        let startup_cancel_epoch = self.startup_cancel_epoch();
+        let startup_cancel_snapshot = self.startup_cancel_snapshot();
+        self.emit_opencode_startup_event(
+            "startup_wait_begin",
+            "workspace_runtime",
+            repo_path,
+            Some(Self::WORKSPACE_RUNTIME_TASK_ID),
+            Self::WORKSPACE_RUNTIME_ROLE,
+            port,
+            Some(startup_policy),
+            None,
+            None,
+        );
+        let startup_report = match wait_for_local_server_with_process(
+            &mut child,
+            port,
+            startup_policy,
+            &startup_cancel_epoch,
+            startup_cancel_snapshot,
+        ) {
+            Ok(report) => report,
+            Err(error) => {
+                self.emit_opencode_startup_event(
+                    "startup_failed",
+                    "workspace_runtime",
+                    repo_path,
+                    Some(Self::WORKSPACE_RUNTIME_TASK_ID),
+                    Self::WORKSPACE_RUNTIME_ROLE,
+                    port,
+                    Some(startup_policy),
+                    Some(error.report),
+                    Some(error.reason),
+                );
+                terminate_child_process(&mut child);
+                return Err(anyhow!(error)).with_context(|| {
+                    format!("OpenCode workspace runtime failed to start for {repo_path}")
+                });
+            }
+        };
+        self.emit_opencode_startup_event(
+            "startup_ready",
+            "workspace_runtime",
+            repo_path,
+            Some(Self::WORKSPACE_RUNTIME_TASK_ID),
+            Self::WORKSPACE_RUNTIME_ROLE,
+            port,
+            Some(startup_policy),
+            Some(startup_report),
+            None,
+        );
 
         let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
         let summary = AgentRuntimeSummary {
@@ -286,25 +328,69 @@ impl AppService {
                 return Err(error).context("Failed tracking spawned OpenCode agent runtime");
             }
         };
-        if let Err(error) =
-            wait_for_local_server_with_process(&mut child, port, Duration::from_secs(8))
-        {
-            terminate_child_process(&mut child);
-            let startup_context = format!("OpenCode runtime failed to start for task {task_id}");
-            if let (Some(repo), Some(worktree)) = (
-                cleanup_repo_path.as_deref(),
-                cleanup_worktree_path.as_deref(),
-            ) {
-                if let Err(cleanup_error) =
-                    Self::remove_runtime_worktree(Path::new(repo), Path::new(worktree))
-                {
-                    return Err(anyhow!(
-                        "{startup_context}\nAlso failed to remove QA worktree: {cleanup_error}"
-                    ));
+        let startup_policy = self.opencode_startup_readiness_policy();
+        let startup_cancel_epoch = self.startup_cancel_epoch();
+        let startup_cancel_snapshot = self.startup_cancel_snapshot();
+        self.emit_opencode_startup_event(
+            "startup_wait_begin",
+            "agent_runtime",
+            repo_path,
+            Some(task_id),
+            role,
+            port,
+            Some(startup_policy),
+            None,
+            None,
+        );
+        let startup_report = match wait_for_local_server_with_process(
+            &mut child,
+            port,
+            startup_policy,
+            &startup_cancel_epoch,
+            startup_cancel_snapshot,
+        ) {
+            Ok(report) => report,
+            Err(error) => {
+                self.emit_opencode_startup_event(
+                    "startup_failed",
+                    "agent_runtime",
+                    repo_path,
+                    Some(task_id),
+                    role,
+                    port,
+                    Some(startup_policy),
+                    Some(error.report),
+                    Some(error.reason),
+                );
+                terminate_child_process(&mut child);
+                let startup_context =
+                    format!("OpenCode runtime failed to start for task {task_id}");
+                if let (Some(repo), Some(worktree)) = (
+                    cleanup_repo_path.as_deref(),
+                    cleanup_worktree_path.as_deref(),
+                ) {
+                    if let Err(cleanup_error) =
+                        Self::remove_runtime_worktree(Path::new(repo), Path::new(worktree))
+                    {
+                        return Err(anyhow!(
+                            "{startup_context}\nAlso failed to remove QA worktree: {cleanup_error}"
+                        ));
+                    }
                 }
+                return Err(anyhow!(error)).with_context(|| startup_context);
             }
-            return Err(error).with_context(|| startup_context);
-        }
+        };
+        self.emit_opencode_startup_event(
+            "startup_ready",
+            "agent_runtime",
+            repo_path,
+            Some(task_id),
+            role,
+            port,
+            Some(startup_policy),
+            Some(startup_report),
+            None,
+        );
 
         let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
         let summary = AgentRuntimeSummary {
@@ -353,6 +439,8 @@ impl AppService {
     }
 
     pub fn shutdown(&self) -> Result<()> {
+        self.startup_cancel_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let mut cleanup_errors = Vec::new();
         if let Err(error) = self.terminate_pending_opencode_processes() {
             cleanup_errors.push(format!(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config.rs
@@ -132,6 +132,7 @@ fn normalize_global_config(config: &mut GlobalConfig) {
     } else {
         namespace.to_string()
     };
+    normalize_opencode_startup_readiness_config(&mut config.opencode_startup);
     for repo in config.repos.values_mut() {
         normalize_repo_config(repo);
     }
@@ -169,10 +170,8 @@ fn migrate_repos_to_canonical_keys(
     let mut from_active_repo: HashMap<String, bool> = HashMap::new();
 
     // Collect all entries first to avoid borrowing issues
-    let entries: Vec<(String, RepoConfig)> = repos
-        .iter()
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
+    let entries: Vec<(String, RepoConfig)> =
+        repos.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
     // Sort entries lexicographically for deterministic processing
     let mut entries: Vec<(String, RepoConfig)> = entries;
@@ -185,8 +184,10 @@ fn migrate_repos_to_canonical_keys(
                 // 1. If this canonical key doesn't exist, insert it
                 // 2. If it exists, prefer the entry that matches active_repo
                 // 3. Otherwise prefer the entry where original_key == canonical_key (the "true" entry)
-                let is_from_active = active_repo.as_ref().map_or(false, |active| **active == original_key);
-                
+                let is_from_active = active_repo
+                    .as_ref()
+                    .map_or(false, |active| **active == original_key);
+
                 let should_insert = match canonical_repos.get(&canonical_key) {
                     None => true,
                     Some(_) => {
@@ -200,9 +201,9 @@ fn migrate_repos_to_canonical_keys(
                             // Neither is from active_repo, prefer canonical form
                             original_key == canonical_key
                         }
-                    },
+                    }
                 };
-                
+
                 if should_insert {
                     canonical_repos.insert(canonical_key.clone(), repo_config);
                     from_active_repo.insert(canonical_key, is_from_active);
@@ -211,7 +212,12 @@ fn migrate_repos_to_canonical_keys(
             Err(_) => {
                 // If canonicalization fails, keep the original key
                 canonical_repos.insert(original_key.clone(), repo_config);
-                from_active_repo.insert(original_key.clone(), active_repo.as_ref().map_or(false, |active| **active == original_key));
+                from_active_repo.insert(
+                    original_key.clone(),
+                    active_repo
+                        .as_ref()
+                        .map_or(false, |active| **active == original_key),
+                );
             }
         }
     }
@@ -275,11 +281,67 @@ pub struct SchedulerConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct OpencodeStartupReadinessConfig {
+    #[serde(default = "default_opencode_startup_timeout_ms")]
+    pub timeout_ms: u64,
+    #[serde(default = "default_opencode_startup_connect_timeout_ms")]
+    pub connect_timeout_ms: u64,
+    #[serde(default = "default_opencode_startup_initial_retry_delay_ms")]
+    pub initial_retry_delay_ms: u64,
+    #[serde(default = "default_opencode_startup_max_retry_delay_ms")]
+    pub max_retry_delay_ms: u64,
+    #[serde(default = "default_opencode_startup_child_check_interval_ms")]
+    pub child_check_interval_ms: u64,
+}
+
+const fn default_opencode_startup_timeout_ms() -> u64 {
+    8_000
+}
+const fn default_opencode_startup_connect_timeout_ms() -> u64 {
+    250
+}
+const fn default_opencode_startup_initial_retry_delay_ms() -> u64 {
+    25
+}
+const fn default_opencode_startup_max_retry_delay_ms() -> u64 {
+    250
+}
+const fn default_opencode_startup_child_check_interval_ms() -> u64 {
+    75
+}
+
+fn normalize_opencode_startup_readiness_config(config: &mut OpencodeStartupReadinessConfig) {
+    config.timeout_ms = config.timeout_ms.clamp(250, 120_000);
+    config.connect_timeout_ms = config.connect_timeout_ms.clamp(25, 10_000);
+    config.initial_retry_delay_ms = config.initial_retry_delay_ms.clamp(5, 5_000);
+    config.max_retry_delay_ms = config.max_retry_delay_ms.clamp(10, 10_000);
+    config.child_check_interval_ms = config.child_check_interval_ms.clamp(10, 2_000);
+    if config.max_retry_delay_ms < config.initial_retry_delay_ms {
+        config.max_retry_delay_ms = config.initial_retry_delay_ms;
+    }
+}
+
+impl Default for OpencodeStartupReadinessConfig {
+    fn default() -> Self {
+        Self {
+            timeout_ms: default_opencode_startup_timeout_ms(),
+            connect_timeout_ms: default_opencode_startup_connect_timeout_ms(),
+            initial_retry_delay_ms: default_opencode_startup_initial_retry_delay_ms(),
+            max_retry_delay_ms: default_opencode_startup_max_retry_delay_ms(),
+            child_check_interval_ms: default_opencode_startup_child_check_interval_ms(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GlobalConfig {
     pub version: u8,
     pub active_repo: Option<String>,
     #[serde(default = "default_task_metadata_namespace")]
     pub task_metadata_namespace: String,
+    #[serde(default)]
+    pub opencode_startup: OpencodeStartupReadinessConfig,
     #[serde(default)]
     pub repos: HashMap<String, RepoConfig>,
     #[serde(default)]
@@ -294,6 +356,7 @@ impl Default for GlobalConfig {
             version: 1,
             active_repo: None,
             task_metadata_namespace: default_task_metadata_namespace(),
+            opencode_startup: OpencodeStartupReadinessConfig::default(),
             repos: HashMap::new(),
             recent_repos: Vec::new(),
             scheduler: SchedulerConfig::default(),
@@ -341,7 +404,8 @@ impl AppConfigStore {
 
         // Migrate repo keys to canonical form
         // Pass active_repo to prefer the user's current configuration on collision
-        let canonical_repos = migrate_repos_to_canonical_keys(&mut parsed.repos, parsed.active_repo.as_ref());
+        let canonical_repos =
+            migrate_repos_to_canonical_keys(&mut parsed.repos, parsed.active_repo.as_ref());
         parsed.repos = canonical_repos;
 
         // Also migrate active_repo to canonical key if it exists
@@ -386,6 +450,10 @@ impl AppConfigStore {
         } else {
             Ok(trimmed.to_string())
         }
+    }
+
+    pub fn opencode_startup_readiness(&self) -> Result<OpencodeStartupReadinessConfig> {
+        Ok(self.load()?.opencode_startup)
     }
 
     pub fn save(&self, config: &GlobalConfig) -> Result<()> {
@@ -457,8 +525,9 @@ impl AppConfigStore {
 
     pub fn select_workspace(&self, repo_path: &str) -> Result<WorkspaceRecord> {
         // Canonicalize the path for consistent key lookup
-        let canonical_path = canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
-        
+        let canonical_path =
+            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
+
         let mut config = self.load()?;
         if !config.repos.contains_key(&canonical_path) {
             return Err(anyhow!("Workspace not found in config: {repo_path}"));
@@ -487,8 +556,9 @@ impl AppConfigStore {
         normalize_repo_config(&mut repo_config);
 
         // Canonicalize the path for consistent key lookup
-        let canonical_path = canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
-        
+        let canonical_path =
+            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
+
         let mut config = self.load()?;
         config
             .repos
@@ -509,8 +579,9 @@ impl AppConfigStore {
 
     pub fn repo_config(&self, repo_path: &str) -> Result<RepoConfig> {
         // Canonicalize the path for consistent key lookup
-        let canonical_path = canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
-        
+        let canonical_path =
+            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
+
         let config = self.load()?;
         config
             .repos
@@ -521,16 +592,18 @@ impl AppConfigStore {
 
     pub fn repo_config_optional(&self, repo_path: &str) -> Result<Option<RepoConfig>> {
         // Canonicalize the path for consistent key lookup
-        let canonical_path = canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
-        
+        let canonical_path =
+            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
+
         let config = self.load()?;
         Ok(config.repos.get(&canonical_path).cloned())
     }
 
     pub fn set_repo_trust_hooks(&self, repo_path: &str, trusted: bool) -> Result<WorkspaceRecord> {
         // Canonicalize the path for consistent key lookup
-        let canonical_path = canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
-        
+        let canonical_path =
+            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
+
         let mut config = self.load()?;
         let (has_config, configured_worktree_base_path) = {
             let repo = config
@@ -562,7 +635,9 @@ fn touch_recent(recent: &mut Vec<String>, repo_path: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::{touch_recent, AppConfigStore, GlobalConfig, RepoConfig};
+    use super::{
+        touch_recent, AppConfigStore, GlobalConfig, OpencodeStartupReadinessConfig, RepoConfig,
+    };
     use serde_json::json;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -592,6 +667,8 @@ mod tests {
         let config = store.load().expect("load default");
         assert_eq!(config.version, 1);
         assert_eq!(config.task_metadata_namespace, "openducktor");
+        assert_eq!(config.opencode_startup.timeout_ms, 8_000);
+        assert_eq!(config.opencode_startup.connect_timeout_ms, 250);
         assert!(config.repos.is_empty());
         let _ = fs::remove_dir_all(root);
     }
@@ -625,6 +702,33 @@ mod tests {
     }
 
     #[test]
+    fn opencode_startup_readiness_defaults_and_normalizes() {
+        let (store, root) = test_store("opencode-startup-readiness");
+        let config = GlobalConfig {
+            opencode_startup: OpencodeStartupReadinessConfig {
+                timeout_ms: 10,
+                connect_timeout_ms: 0,
+                initial_retry_delay_ms: 3_000,
+                max_retry_delay_ms: 20,
+                child_check_interval_ms: 1,
+            },
+            ..GlobalConfig::default()
+        };
+        store.save(&config).expect("save config");
+
+        let readiness = store
+            .opencode_startup_readiness()
+            .expect("readiness policy should load");
+        assert_eq!(readiness.timeout_ms, 250);
+        assert_eq!(readiness.connect_timeout_ms, 25);
+        assert_eq!(readiness.initial_retry_delay_ms, 3_000);
+        assert_eq!(readiness.max_retry_delay_ms, 3_000);
+        assert_eq!(readiness.child_check_interval_ms, 10);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn workspace_add_select_and_update_persist_state() {
         let (store, root) = test_store("workspace-flow");
         let repo_a = root.join("repo-a");
@@ -635,7 +739,10 @@ mod tests {
         let repo_a_str = repo_a.to_string_lossy().to_string();
         let repo_b_str = repo_b.to_string_lossy().to_string();
         // Canonical form (resolved absolute path)
-        let repo_a_canonical = fs::canonicalize(&repo_a).unwrap().to_string_lossy().to_string();
+        let repo_a_canonical = fs::canonicalize(&repo_a)
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
 
         let added = store.add_workspace(&repo_a_str).expect("add workspace");
         assert!(added.is_active);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -6,8 +6,8 @@ mod worktree;
 
 pub use beads::{compute_repo_id, compute_repo_slug, resolve_central_beads_dir};
 pub use config::{
-    AgentDefaults, AgentModelDefault, AppConfigStore, GlobalConfig, HookSet, RepoConfig,
-    SchedulerConfig, SoftGuardrails,
+    AgentDefaults, AgentModelDefault, AppConfigStore, GlobalConfig, HookSet,
+    OpencodeStartupReadinessConfig, RepoConfig, SchedulerConfig, SoftGuardrails,
 };
 pub use git::GitCliPort;
 pub use process::{

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -78,6 +78,16 @@ fn as_error<T>(result: anyhow::Result<T>) -> Result<T, String> {
     result.map_err(|error| format!("{error:#}"))
 }
 
+async fn run_service_blocking<T, F>(operation_name: &'static str, operation: F) -> anyhow::Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> anyhow::Result<T> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(operation)
+        .await
+        .map_err(|error| anyhow!("{operation_name} worker join failure: {error}"))?
+}
+
 fn extend_runtime_errors_with_startup(
     mut check: host_domain::RuntimeCheck,
     startup_errors: &[String],
@@ -532,12 +542,10 @@ async fn build_start(
 ) -> Result<RunSummary, String> {
     let service = state.service.clone();
     let emitter = run_emitter(app);
-    let result = tauri::async_runtime::spawn_blocking(move || {
+    let result = run_service_blocking("build_start", move || {
         service.build_start(&repo_path, &task_id, emitter)
     })
-    .await
-    .map_err(|error| anyhow!("build_start worker join failure: {error}"))
-    .and_then(|output| output);
+    .await;
     as_error(result)
 }
 
@@ -670,12 +678,10 @@ async fn opencode_runtime_start(
     role: String,
 ) -> Result<AgentRuntimeSummary, String> {
     let service = state.service.clone();
-    let result = tauri::async_runtime::spawn_blocking(move || {
+    let result = run_service_blocking("opencode_runtime_start", move || {
         service.opencode_runtime_start(&repo_path, &task_id, &role)
     })
-    .await
-    .map_err(|error| anyhow!("opencode_runtime_start worker join failure: {error}"))
-    .and_then(|output| output);
+    .await;
     as_error(result)
 }
 
@@ -698,12 +704,10 @@ async fn opencode_repo_runtime_ensure(
     repo_path: String,
 ) -> Result<AgentRuntimeSummary, String> {
     let service = state.service.clone();
-    let result = tauri::async_runtime::spawn_blocking(move || {
+    let result = run_service_blocking("opencode_repo_runtime_ensure", move || {
         service.opencode_repo_runtime_ensure(&repo_path)
     })
-    .await
-    .map_err(|error| anyhow!("opencode_repo_runtime_ensure worker join failure: {error}"))
-    .and_then(|output| output);
+    .await;
     as_error(result)
 }
 
@@ -890,5 +894,25 @@ mod tests {
             updated.errors,
             vec!["runtime issue".to_string(), "startup warning".to_string()]
         );
+    }
+
+    #[test]
+    fn run_service_blocking_propagates_operation_error() {
+        let result = tauri::async_runtime::block_on(run_service_blocking(
+            "test-op",
+            || -> anyhow::Result<()> { Err(anyhow!("service failure")) },
+        ));
+        let error = result.expect_err("service error should propagate");
+        assert!(error.to_string().contains("service failure"));
+    }
+
+    #[test]
+    fn run_service_blocking_maps_join_failures() {
+        let result = tauri::async_runtime::block_on(run_service_blocking(
+            "test-join",
+            || -> anyhow::Result<()> { panic!("simulated join panic") },
+        ));
+        let error = result.expect_err("panic in worker should map to join failure");
+        assert!(error.to_string().contains("test-join worker join failure"));
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
-use anyhow::Context;
-use host_application::{BuildResponseAction, CleanupMode, AppService, RunEmitter};
+use anyhow::{anyhow, Context};
+use host_application::{AppService, BuildResponseAction, CleanupMode, RunEmitter};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, PlanSubtaskInput, RunEvent,
     RunSummary, TaskCard, TaskStatus, UpdateTaskPatch,
@@ -7,8 +7,8 @@ use host_domain::{
 use host_infra_beads::BeadsTaskStore;
 use host_infra_system::{AppConfigStore, RepoConfig};
 use serde::Deserialize;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter, RunEvent as TauriRunEvent, State};
 
 struct AppState {
@@ -530,11 +530,15 @@ async fn build_start(
     repo_path: String,
     task_id: String,
 ) -> Result<RunSummary, String> {
-    as_error(
-        state
-            .service
-            .build_start(&repo_path, &task_id, run_emitter(app)),
-    )
+    let service = state.service.clone();
+    let emitter = run_emitter(app);
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        service.build_start(&repo_path, &task_id, emitter)
+    })
+    .await
+    .map_err(|error| anyhow!("build_start worker join failure: {error}"))
+    .and_then(|output| output);
+    as_error(result)
 }
 
 #[tauri::command]
@@ -665,11 +669,14 @@ async fn opencode_runtime_start(
     task_id: String,
     role: String,
 ) -> Result<AgentRuntimeSummary, String> {
-    as_error(
-        state
-            .service
-            .opencode_runtime_start(&repo_path, &task_id, &role),
-    )
+    let service = state.service.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        service.opencode_runtime_start(&repo_path, &task_id, &role)
+    })
+    .await
+    .map_err(|error| anyhow!("opencode_runtime_start worker join failure: {error}"))
+    .and_then(|output| output);
+    as_error(result)
 }
 
 #[tauri::command]
@@ -690,7 +697,14 @@ async fn opencode_repo_runtime_ensure(
     state: State<'_, AppState>,
     repo_path: String,
 ) -> Result<AgentRuntimeSummary, String> {
-    as_error(state.service.opencode_repo_runtime_ensure(&repo_path))
+    let service = state.service.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        service.opencode_repo_runtime_ensure(&repo_path)
+    })
+    .await
+    .map_err(|error| anyhow!("opencode_repo_runtime_ensure worker join failure: {error}"))
+    .and_then(|output| output);
+    as_error(result)
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use host_infra_beads::BeadsTaskStore;
 use host_infra_system::{AppConfigStore, RepoConfig};
 use serde::Deserialize;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tauri::{AppHandle, Emitter, RunEvent as TauriRunEvent, State};
 
 struct AppState {
@@ -17,6 +17,26 @@ struct AppState {
 }
 
 const FALLBACK_TASK_METADATA_NAMESPACE: &str = "openducktor";
+static TRACING_INITIALIZED: OnceLock<()> = OnceLock::new();
+
+fn init_tracing_subscriber() {
+    TRACING_INITIALIZED.get_or_init(|| {
+        let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_target(true)
+            .with_ansi(false)
+            .json()
+            .flatten_event(true)
+            .with_current_span(false)
+            .with_span_list(false)
+            .finish();
+        if let Err(error) = tracing::subscriber::set_global_default(subscriber) {
+            eprintln!("OpenDucktor warning: failed to initialize tracing subscriber: {error:#}");
+        }
+    });
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -741,7 +761,11 @@ fn bootstrap_service() -> anyhow::Result<(Arc<AppService>, Vec<String>)> {
     let (metadata_namespace, startup_warning) =
         namespace_with_startup_warning(config_store.task_metadata_namespace());
     if let Some(message) = startup_warning {
-        eprintln!("OpenDucktor startup warning: {message}");
+        tracing::warn!(
+            target: "openducktor.startup",
+            warning = %message,
+            "OpenDucktor startup warning"
+        );
         startup_errors.push(message);
     }
 
@@ -762,13 +786,16 @@ fn install_shutdown_signal_handler(service: Arc<AppService>) {
         let _ = shutdown_service.shutdown();
         std::process::exit(0);
     }) {
-        eprintln!(
-            "OpenDucktor warning: failed to install process signal handler; cleanup on SIGTERM/SIGINT may be incomplete: {error:#}"
+        tracing::warn!(
+            target: "openducktor.startup",
+            error = %format!("{error:#}"),
+            "Failed to install process signal handler; cleanup on SIGTERM/SIGINT may be incomplete"
         );
     }
 }
 
 pub fn run() -> anyhow::Result<()> {
+    init_tracing_subscriber();
     let (service, startup_errors) = bootstrap_service()?;
     install_shutdown_signal_handler(service.clone());
 


### PR DESCRIPTION
## Summary
- replace synchronous OpenCode startup polling with async probe-based readiness checks
- add per-probe cancellation/abort guards to stop probe tasks immediately on early returns
- add structured startup telemetry with correlation IDs (run_id/runtime_id), startup duration/attempt reporting, and threshold alerts
- add startup readiness policy config support/normalization and wire it through runtime/build startup paths
- initialize JSON tracing subscriber in the Tauri host for consistent structured logs

## Testing
- cd apps/desktop/src-tauri && cargo check
- cd apps/desktop/src-tauri && cargo test
- cd apps/desktop/src-tauri && cargo test -p host-application
- cd apps/desktop/src-tauri && cargo clippy -p host-application --all-targets -- -D warnings
- bun run typecheck
- bun run test
