### PR TITLE
feat(desktop): improve agent studio session and active-task UX

### DIFF
--- a/apps/desktop/src/components/features/agents/index.ts
+++ b/apps/desktop/src/components/features/agents/index.ts
@@ -42,3 +42,5 @@ export {
   toModelOptions,
   toPrimaryAgentOptions,
 } from "./catalog-select-options";
+export type { SessionStartModalModel } from "./session-start-modal";
+export { SessionStartModal } from "./session-start-modal";

--- a/apps/desktop/src/components/features/agents/session-start-modal.tsx
+++ b/apps/desktop/src/components/features/agents/session-start-modal.tsx
@@ -1,0 +1,166 @@
+import type { AgentModelSelection } from "@openducktor/core";
+import { LoaderCircle } from "lucide-react";
+import type { ReactElement } from "react";
+import { Button } from "@/components/ui/button";
+import { Combobox, type ComboboxGroup, type ComboboxOption } from "@/components/ui/combobox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export type SessionStartModalModel = {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  backgroundConfirmLabel?: string;
+  cancelLabel?: string;
+  selectedModelSelection: AgentModelSelection | null;
+  isSelectionCatalogLoading: boolean;
+  agentOptions: ComboboxOption[];
+  modelOptions: ComboboxOption[];
+  modelGroups: ComboboxGroup[];
+  variantOptions: ComboboxOption[];
+  onSelectAgent: (agent: string) => void;
+  onSelectModel: (model: string) => void;
+  onSelectVariant: (variant: string) => void;
+  allowRunInBackground?: boolean;
+  isStarting: boolean;
+  onOpenChange: (nextOpen: boolean) => void;
+  onConfirm: (runInBackground: boolean) => void;
+};
+
+export function SessionStartModal({ model }: { model: SessionStartModalModel }): ReactElement {
+  const {
+    open,
+    title,
+    description,
+    confirmLabel,
+    backgroundConfirmLabel = "Run in background",
+    cancelLabel = "Cancel",
+    selectedModelSelection,
+    isSelectionCatalogLoading,
+    agentOptions,
+    modelOptions,
+    modelGroups,
+    variantOptions,
+    onSelectAgent,
+    onSelectModel,
+    onSelectVariant,
+    allowRunInBackground = false,
+    isStarting,
+    onOpenChange,
+    onConfirm,
+  } = model;
+
+  const selectedAgent = selectedModelSelection?.opencodeAgent ?? "";
+  const selectedModel = selectedModelSelection
+    ? `${selectedModelSelection.providerId}/${selectedModelSelection.modelId}`
+    : "";
+  const selectedVariant = selectedModelSelection?.variant ?? "";
+  const confirmDisabled = isStarting || isSelectionCatalogLoading || !selectedModelSelection;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (isStarting) {
+          return;
+        }
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (confirmDisabled) {
+              return;
+            }
+            onConfirm(false);
+          }}
+        >
+          <fieldset className="space-y-4" disabled={isStarting}>
+            <div className="grid gap-1.5">
+              <label className="text-sm font-medium text-slate-700" htmlFor="session-start-agent">
+                Agent
+              </label>
+              <Combobox
+                value={selectedAgent}
+                options={agentOptions}
+                placeholder="Select agent"
+                disabled={isSelectionCatalogLoading}
+                onValueChange={onSelectAgent}
+              />
+            </div>
+
+            <div className="grid gap-1.5">
+              <label className="text-sm font-medium text-slate-700" htmlFor="session-start-model">
+                Model
+              </label>
+              <Combobox
+                value={selectedModel}
+                options={modelOptions}
+                groups={modelGroups}
+                placeholder={isSelectionCatalogLoading ? "Loading models..." : "Select model"}
+                disabled={isSelectionCatalogLoading}
+                onValueChange={onSelectModel}
+              />
+            </div>
+
+            <div className="grid gap-1.5">
+              <label className="text-sm font-medium text-slate-700" htmlFor="session-start-variant">
+                Variant
+              </label>
+              <Combobox
+                value={selectedVariant}
+                options={variantOptions}
+                placeholder="Select variant"
+                disabled={isSelectionCatalogLoading || !selectedModelSelection}
+                onValueChange={onSelectVariant}
+              />
+            </div>
+          </fieldset>
+
+          <DialogFooter className="mt-5 flex w-full items-center justify-between sm:justify-between">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isStarting}
+            >
+              {cancelLabel}
+            </Button>
+
+            <div className="flex items-center gap-2">
+              {allowRunInBackground ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={confirmDisabled}
+                  onClick={() => onConfirm(true)}
+                >
+                  {isStarting ? <LoaderCircle className="size-4 animate-spin" /> : null}
+                  {backgroundConfirmLabel}
+                </Button>
+              ) : null}
+              <Button type="submit" disabled={confirmDisabled}>
+                {isStarting ? <LoaderCircle className="size-4 animate-spin" /> : null}
+                {confirmLabel}
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -13,6 +13,7 @@ import { KanbanTaskCard } from "@/components/features/kanban/kanban-task-card";
 import { laneTheme } from "@/components/features/kanban/kanban-theme";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
 
 const VIRTUALIZATION_MIN_TASK_COUNT = 30;
 const VIRTUAL_CARD_ESTIMATED_HEIGHT_PX = 180;
@@ -23,6 +24,7 @@ const INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX = 900;
 type KanbanColumnProps = {
   column: KanbanColumnData;
   runStateByTaskId: Map<string, RunSummary["state"]>;
+  activeSessionsByTaskId: Map<string, AgentSessionState[]>;
   onOpenDetails: (taskId: string) => void;
   onDelegate: (taskId: string) => void;
   onPlan: (taskId: string, action: "set_spec" | "set_plan") => void;
@@ -41,6 +43,7 @@ type TaskCardHandlers = Pick<
 const MeasuredTaskCard = memo(function MeasuredTaskCard({
   task,
   runState,
+  activeSessions,
   onMeasuredHeight,
   onOpenDetails,
   onDelegate,
@@ -51,6 +54,7 @@ const MeasuredTaskCard = memo(function MeasuredTaskCard({
 }: {
   task: KanbanColumnData["tasks"][number];
   runState: RunSummary["state"] | undefined;
+  activeSessions: AgentSessionState[] | undefined;
   onMeasuredHeight: (taskId: string, height: number) => void;
 } & TaskCardHandlers): ReactElement {
   const taskWrapperRef = useRef<HTMLDivElement | null>(null);
@@ -89,6 +93,7 @@ const MeasuredTaskCard = memo(function MeasuredTaskCard({
       <KanbanTaskCard
         task={task}
         runState={runState}
+        activeSessions={activeSessions}
         onOpenDetails={onOpenDetails}
         onDelegate={onDelegate}
         onPlan={onPlan}
@@ -149,6 +154,7 @@ function LaneEmptyState({ id }: { id: KanbanColumnId }): ReactElement {
 export function KanbanColumn({
   column,
   runStateByTaskId,
+  activeSessionsByTaskId,
   onOpenDetails,
   onDelegate,
   onPlan,
@@ -338,6 +344,7 @@ export function KanbanColumn({
                   key={task.id}
                   task={task}
                   runState={runStateByTaskId.get(task.id)}
+                  activeSessions={activeSessionsByTaskId.get(task.id) ?? []}
                   onMeasuredHeight={handleMeasuredHeight}
                   onOpenDetails={onOpenDetails}
                   onDelegate={onDelegate}
@@ -359,6 +366,7 @@ export function KanbanColumn({
                 key={task.id}
                 task={task}
                 runState={runStateByTaskId.get(task.id)}
+                activeSessions={activeSessionsByTaskId.get(task.id) ?? []}
                 onOpenDetails={onOpenDetails}
                 onDelegate={onDelegate}
                 onPlan={onPlan}

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.test.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { createTaskCardFixture } from "@/pages/agent-studio-test-utils";
+import { KanbanTaskCard } from "./kanban-task-card";
+
+const noop = (): void => {};
+
+describe("KanbanTaskCard active sessions", () => {
+  test("renders animated active state and session links", () => {
+    const task = createTaskCardFixture({ id: "TASK-1", title: "Build payment flow" });
+
+    const html = renderToStaticMarkup(
+      createElement(
+        MemoryRouter,
+        { initialEntries: ["/kanban"] },
+        createElement(KanbanTaskCard, {
+          task,
+          activeSessions: [
+            {
+              sessionId: "session-build",
+              role: "build",
+              scenario: "build_implementation_start",
+              status: "running",
+            },
+            {
+              sessionId: "session-qa",
+              role: "qa",
+              scenario: "qa_review",
+              status: "starting",
+            },
+          ],
+          onOpenDetails: noop,
+          onDelegate: noop,
+          onPlan: noop,
+          onBuild: noop,
+        }),
+      ),
+    );
+
+    expect(html).toContain("kanban-active-session-card");
+    expect(html).toContain("kanban-active-session-ray");
+    expect(html).toContain("Active sessions");
+    expect(html).toContain("Build");
+    expect(html).toContain("Running");
+    expect(html).toContain("QA");
+    expect(html).toContain("Starting");
+    expect(html).not.toContain("Active agent session");
+    expect(html).toContain(
+      'href="/agents?task=TASK-1&amp;session=session-build&amp;agent=build&amp;scenario=build_implementation_start"',
+    );
+    expect(html).toContain(
+      'href="/agents?task=TASK-1&amp;session=session-qa&amp;agent=qa&amp;scenario=qa_review"',
+    );
+  });
+
+  test("does not render active sessions section when none are active", () => {
+    const task = createTaskCardFixture({ id: "TASK-2", title: "Write specs" });
+
+    const html = renderToStaticMarkup(
+      createElement(
+        MemoryRouter,
+        { initialEntries: ["/kanban"] },
+        createElement(KanbanTaskCard, {
+          task,
+          activeSessions: [],
+          onOpenDetails: noop,
+          onDelegate: noop,
+          onPlan: noop,
+          onBuild: noop,
+        }),
+      ),
+    );
+
+    expect(html).not.toContain("kanban-active-session-card");
+    expect(html).not.toContain("Active sessions");
+    expect(html).not.toContain("Active agent session");
+  });
+});

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
@@ -1,6 +1,7 @@
 import type { RunSummary, TaskCard } from "@openducktor/contracts";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, PlayCircle } from "lucide-react";
 import type { ReactElement } from "react";
+import { Link } from "react-router-dom";
 import {
   IssueTypeBadge,
   PriorityBadge,
@@ -9,10 +10,23 @@ import {
 import type { TaskWorkflowAction } from "@/components/features/kanban/kanban-task-workflow";
 import { TaskWorkflowActionGroup } from "@/components/features/kanban/task-workflow-action-group";
 import { Badge } from "@/components/ui/badge";
+import { BorderRay } from "@/components/ui/border-ray";
+import { cn } from "@/lib/utils";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+
+type RunningTaskSession = Pick<AgentSessionState, "sessionId" | "role" | "scenario" | "status">;
+
+const ACTIVE_SESSION_ROLE_LABEL: Record<RunningTaskSession["role"], string> = {
+  spec: "Spec",
+  planner: "Planner",
+  build: "Build",
+  qa: "QA",
+};
 
 type KanbanTaskCardProps = {
   task: TaskCard;
   runState?: RunSummary["state"] | undefined;
+  activeSessions?: RunningTaskSession[] | undefined;
   onOpenDetails: (taskId: string) => void;
   onDelegate: (taskId: string) => void;
   onPlan: (taskId: string, action: "set_spec" | "set_plan") => void;
@@ -20,6 +34,66 @@ type KanbanTaskCardProps = {
   onHumanApprove?: (taskId: string) => void;
   onHumanRequestChanges?: (taskId: string) => void;
 };
+
+function toSessionHref({
+  taskId,
+  session,
+}: {
+  taskId: string;
+  session: RunningTaskSession;
+}): string {
+  const params = new URLSearchParams({
+    task: taskId,
+    session: session.sessionId,
+    agent: session.role,
+    scenario: session.scenario,
+  });
+
+  return `/agents?${params.toString()}`;
+}
+
+function ActiveSessionChip({
+  taskId,
+  session,
+}: {
+  taskId: string;
+  session: RunningTaskSession;
+}): ReactElement {
+  const roleLabel = ACTIVE_SESSION_ROLE_LABEL[session.role] ?? session.role;
+  const statusLabel = session.status === "starting" ? "Starting" : "Running";
+
+  return (
+    <Link
+      to={toSessionHref({ taskId, session })}
+      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-sky-200 bg-sky-50 px-2 py-1 text-[11px] font-semibold text-sky-700 transition hover:border-sky-300 hover:bg-sky-100/75"
+    >
+      <PlayCircle className="size-3" />
+      {roleLabel}
+      <span className="text-[10px] font-medium text-sky-600/90">{statusLabel}</span>
+    </Link>
+  );
+}
+
+function ActiveSessionsLine({
+  taskId,
+  activeSessions,
+}: {
+  taskId: string;
+  activeSessions: RunningTaskSession[];
+}): ReactElement {
+  return (
+    <div className="space-y-1 border-t border-sky-100/80 pt-2">
+      <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">
+        Active sessions
+      </p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {activeSessions.map((session) => (
+          <ActiveSessionChip key={session.sessionId} taskId={taskId} session={session} />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 function TaskMeta({
   task,
@@ -108,6 +182,7 @@ function TaskActions({
 export function KanbanTaskCard({
   task,
   runState,
+  activeSessions = [],
   onOpenDetails,
   onDelegate,
   onPlan,
@@ -115,38 +190,57 @@ export function KanbanTaskCard({
   onHumanApprove,
   onHumanRequestChanges,
 }: KanbanTaskCardProps): ReactElement {
+  const hasActiveSessions = activeSessions.length > 0;
+
   return (
-    <article className="group flex min-w-0 cursor-pointer flex-col space-y-2.5 overflow-hidden rounded-xl border border-slate-200/90 bg-white/95 p-3.5 shadow-sm transition duration-150 hover:border-sky-200 hover:shadow-md">
-      <button
-        type="button"
-        className="flex w-full min-w-0 cursor-pointer items-start justify-between gap-2 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-sky-500/40"
-        onClick={() => onOpenDetails(task.id)}
-      >
-        <div className="min-w-0 space-y-1">
-          <p
-            className="line-clamp-2 break-words text-sm font-semibold leading-tight text-slate-900"
-            title={task.title}
-          >
-            {task.title}
-          </p>
-          <p className="truncate font-mono text-[11px] text-slate-500">{task.id}</p>
-        </div>
-        <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] text-slate-400 transition group-hover:border-slate-200 group-hover:bg-slate-50 group-hover:text-slate-600">
-          <ExternalLink className="size-3" />
-          Open
-        </span>
-      </button>
+    <article
+      className={cn(
+        "group min-w-0 rounded-xl border border-slate-200/90 bg-white/95 shadow-sm transition duration-150 hover:border-sky-200 hover:shadow-md",
+        hasActiveSessions
+          ? "kanban-active-session-card border-sky-300/80 shadow-sky-200/50"
+          : undefined,
+      )}
+    >
+      {hasActiveSessions ? (
+        <BorderRay turnDurationMs={2500} className="kanban-active-session-ray" />
+      ) : null}
 
-      <TaskMeta task={task} runState={runState} />
+      <div className="kanban-active-session-content flex min-w-0 flex-col space-y-2.5 p-3.5">
+        <button
+          type="button"
+          className="flex w-full min-w-0 cursor-pointer items-start justify-between gap-2 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-sky-500/40"
+          onClick={() => onOpenDetails(task.id)}
+        >
+          <div className="min-w-0 space-y-1">
+            <p
+              className="line-clamp-2 break-words text-sm font-semibold leading-tight text-slate-900"
+              title={task.title}
+            >
+              {task.title}
+            </p>
+            <p className="truncate font-mono text-[11px] text-slate-500">{task.id}</p>
+          </div>
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] text-slate-400 transition group-hover:border-slate-200 group-hover:bg-slate-50 group-hover:text-slate-600">
+            <ExternalLink className="size-3" />
+            Open
+          </span>
+        </button>
 
-      <TaskActions
-        task={task}
-        onPlan={onPlan}
-        onBuild={onBuild}
-        onDelegate={onDelegate}
-        {...(onHumanApprove ? { onHumanApprove } : {})}
-        {...(onHumanRequestChanges ? { onHumanRequestChanges } : {})}
-      />
+        <TaskMeta task={task} runState={runState} />
+
+        {hasActiveSessions ? (
+          <ActiveSessionsLine taskId={task.id} activeSessions={activeSessions} />
+        ) : null}
+
+        <TaskActions
+          task={task}
+          onPlan={onPlan}
+          onBuild={onBuild}
+          onDelegate={onDelegate}
+          {...(onHumanApprove ? { onHumanApprove } : {})}
+          {...(onHumanRequestChanges ? { onHumanRequestChanges } : {})}
+        />
+      </div>
     </article>
   );
 }

--- a/apps/desktop/src/components/features/kanban/kanban-task-workflow.test.ts
+++ b/apps/desktop/src/components/features/kanban/kanban-task-workflow.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { createTaskCardFixture } from "@/pages/agent-studio-test-utils";
+import { resolveTaskCardActions } from "./kanban-task-workflow";
+
+describe("resolveTaskCardActions", () => {
+  test("prioritizes planner action over continue spec when task is spec_ready", () => {
+    const task = createTaskCardFixture({
+      status: "spec_ready",
+      issueType: "epic",
+      availableActions: ["set_spec", "set_plan"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("set_plan");
+    expect(result.secondaryActions).toContain("set_spec");
+  });
+
+  test("keeps spec action priority before planner when task is not spec_ready", () => {
+    const task = createTaskCardFixture({
+      status: "open",
+      issueType: "epic",
+      availableActions: ["set_spec", "set_plan"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("set_spec");
+  });
+
+  test("keeps build-first priority for bug workflow actions", () => {
+    const task = createTaskCardFixture({
+      status: "open",
+      issueType: "bug",
+      availableActions: ["set_plan", "build_start"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("build_start");
+  });
+
+  test("uses build_start as primary for feature-ready-for-dev tasks", () => {
+    const task = createTaskCardFixture({
+      status: "ready_for_dev",
+      issueType: "feature",
+      availableActions: ["set_spec", "set_plan", "build_start"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("build_start");
+  });
+
+  test("uses build_start as primary for epic-ready-for-dev tasks", () => {
+    const task = createTaskCardFixture({
+      status: "ready_for_dev",
+      issueType: "epic",
+      availableActions: ["set_spec", "set_plan", "build_start"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("build_start");
+  });
+
+  test("uses build_start as primary for task-ready-for-dev tasks", () => {
+    const task = createTaskCardFixture({
+      status: "ready_for_dev",
+      issueType: "task",
+      availableActions: ["set_spec", "set_plan", "build_start"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("build_start");
+  });
+
+  test("uses open_builder for in-progress tasks when resume is not available", () => {
+    const task = createTaskCardFixture({
+      status: "in_progress",
+      issueType: "epic",
+      availableActions: ["set_plan", "build_start", "open_builder"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("open_builder");
+  });
+
+  test("uses human_approve as primary during human review", () => {
+    const task = createTaskCardFixture({
+      status: "human_review",
+      issueType: "epic",
+      availableActions: ["open_builder", "human_request_changes", "human_approve"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("human_approve");
+  });
+
+  test("uses resume as primary for deferred tasks", () => {
+    const task = createTaskCardFixture({
+      status: "deferred",
+      issueType: "epic",
+      availableActions: ["set_plan", "build_start", "resume_deferred", "defer_issue"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("resume_deferred");
+  });
+});

--- a/apps/desktop/src/components/features/kanban/kanban-task-workflow.ts
+++ b/apps/desktop/src/components/features/kanban/kanban-task-workflow.ts
@@ -61,6 +61,48 @@ const isWorkflowAction = (action: TaskAction): action is TaskWorkflowAction =>
 const dedupeActions = (actions: TaskWorkflowAction[]): TaskWorkflowAction[] =>
   Array.from(new Set(actions));
 
+const prioritize = (
+  actionPriority: readonly TaskWorkflowAction[],
+  prioritizeAhead: readonly TaskWorkflowAction[],
+): TaskWorkflowAction[] => {
+  const uniqueAhead = dedupeActions(Array.from(prioritizeAhead));
+  const seen = new Set(uniqueAhead);
+  return [...uniqueAhead, ...actionPriority.filter((action) => !seen.has(action))];
+};
+
+const resolvePriorityForTask = (task: TaskCard): TaskWorkflowAction[] => {
+  const basePriority =
+    ACTION_PRIORITY_BY_ISSUE_TYPE[task.issueType] ?? ACTION_PRIORITY_BY_ISSUE_TYPE.task;
+
+  switch (task.status) {
+    case "spec_ready": {
+      return prioritize(basePriority, ["set_plan", "set_spec"]);
+    }
+    case "ready_for_dev": {
+      return prioritize(basePriority, ["build_start"]);
+    }
+    case "deferred": {
+      return prioritize(basePriority, ["resume_deferred"]);
+    }
+    case "in_progress":
+    case "blocked":
+    case "ai_review": {
+      return prioritize(basePriority, ["open_builder", "build_start"]);
+    }
+    case "human_review": {
+      return prioritize(basePriority, [
+        "human_approve",
+        "human_request_changes",
+        "open_builder",
+        "build_start",
+      ]);
+    }
+    default: {
+      return basePriority;
+    }
+  }
+};
+
 export const resolveTaskCardActions = (
   task: TaskCard,
   options: ResolveTaskCardActionsOptions = {},
@@ -72,8 +114,7 @@ export const resolveTaskCardActions = (
       .filter((action) => (includeSet ? includeSet.has(action) : true)),
   );
 
-  const priority =
-    ACTION_PRIORITY_BY_ISSUE_TYPE[task.issueType] ?? ACTION_PRIORITY_BY_ISSUE_TYPE.task;
+  const priority = resolvePriorityForTask(task);
   const primaryAction = priority.find((action) => enabled.includes(action)) ?? enabled[0] ?? null;
 
   return {

--- a/apps/desktop/src/components/features/settings-modal.tsx
+++ b/apps/desktop/src/components/features/settings-modal.tsx
@@ -38,6 +38,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { errorMessage } from "@/lib/errors";
 import { cn } from "@/lib/utils";
+import { REPO_SETTINGS_UPDATED_EVENT } from "@/pages/use-agent-studio-repo-settings";
 import { useWorkspaceState } from "@/state";
 import { loadRepoOpencodeCatalog } from "@/state/operations";
 
@@ -170,6 +171,14 @@ export function SettingsModal({
         postCompleteHooks: parseHookLines(postCompleteHooks),
         agentDefaults,
       });
+
+      if (typeof window !== "undefined" && activeRepo) {
+        window.dispatchEvent(
+          new CustomEvent(REPO_SETTINGS_UPDATED_EVENT, {
+            detail: { repoPath: activeRepo },
+          }),
+        );
+      }
 
       setOpen(false);
     } catch (error: unknown) {

--- a/apps/desktop/src/components/ui/border-ray-model.test.ts
+++ b/apps/desktop/src/components/ui/border-ray-model.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  BORDER_RAY_DEFAULT_LENGTH,
+  BORDER_RAY_DEFAULT_LENGTH_MAX,
+  BORDER_RAY_DEFAULT_LENGTH_MIN,
+  BORDER_RAY_DEFAULT_LENGTH_RATIO,
+  BORDER_RAY_DEFAULT_PERIMETER,
+  BORDER_RAY_DEFAULT_TURN_DURATION_MS,
+  computeBorderRayLength,
+  DEFAULT_BORDER_RAY_PATH_METRICS,
+} from "@/components/ui/border-ray-model";
+
+describe("border-ray-model", () => {
+  test("uses the requested 15% default ratio", () => {
+    expect(BORDER_RAY_DEFAULT_LENGTH_RATIO).toBe(0.15);
+  });
+
+  test("clamps computed length with default bounds", () => {
+    expect(computeBorderRayLength(100)).toBe(BORDER_RAY_DEFAULT_LENGTH_MIN);
+    expect(computeBorderRayLength(2000)).toBe(300);
+    expect(computeBorderRayLength(4000)).toBe(BORDER_RAY_DEFAULT_LENGTH_MAX);
+  });
+
+  test("keeps default path metrics in sync with model constants", () => {
+    expect(DEFAULT_BORDER_RAY_PATH_METRICS.perimeter).toBe(BORDER_RAY_DEFAULT_PERIMETER);
+    expect(DEFAULT_BORDER_RAY_PATH_METRICS.rayLength).toBe(BORDER_RAY_DEFAULT_LENGTH);
+  });
+
+  test("keeps CSS fallbacks aligned with model constants", () => {
+    const stylesPath = resolve(import.meta.dir, "../../styles.css");
+    const styles = readFileSync(stylesPath, "utf8");
+
+    const durationMatch = styles.match(/--odt-border-ray-turn-duration:\s*([\d.]+)ms\s*;/);
+    const perimeterMatch = styles.match(/--odt-border-ray-perimeter:\s*([\d.]+)\s*;/);
+    const lengthMatch = styles.match(/--odt-border-ray-length:\s*([\d.]+)\s*;/);
+
+    expect(durationMatch).not.toBeNull();
+    expect(perimeterMatch).not.toBeNull();
+    expect(lengthMatch).not.toBeNull();
+
+    expect(Number(durationMatch?.[1])).toBe(BORDER_RAY_DEFAULT_TURN_DURATION_MS);
+    expect(Number(perimeterMatch?.[1])).toBe(BORDER_RAY_DEFAULT_PERIMETER);
+    expect(Number(lengthMatch?.[1])).toBe(BORDER_RAY_DEFAULT_LENGTH);
+    expect(styles).not.toContain("--kanban-ray-");
+  });
+});

--- a/apps/desktop/src/components/ui/border-ray-model.ts
+++ b/apps/desktop/src/components/ui/border-ray-model.ts
@@ -1,0 +1,34 @@
+export type BorderRaySize = {
+  width: number;
+  height: number;
+  radius: number;
+  borderWidth: number;
+};
+
+export const BORDER_RAY_DEFAULT_PERIMETER = 1000;
+export const BORDER_RAY_DEFAULT_LENGTH = 190;
+export const BORDER_RAY_DEFAULT_LENGTH_RATIO = 0.15;
+export const BORDER_RAY_DEFAULT_LENGTH_MIN = 50;
+export const BORDER_RAY_DEFAULT_LENGTH_MAX = 320;
+export const BORDER_RAY_DEFAULT_TURN_DURATION_MS = 3000;
+
+export const DEFAULT_BORDER_RAY_SIZE: BorderRaySize = {
+  width: 680,
+  height: 460,
+  radius: 12,
+  borderWidth: 1,
+};
+
+export const DEFAULT_BORDER_RAY_PATH_METRICS = {
+  perimeter: BORDER_RAY_DEFAULT_PERIMETER,
+  rayLength: BORDER_RAY_DEFAULT_LENGTH,
+};
+
+export function computeBorderRayLength(
+  perimeter: number,
+  ratio = BORDER_RAY_DEFAULT_LENGTH_RATIO,
+  min = BORDER_RAY_DEFAULT_LENGTH_MIN,
+  max = BORDER_RAY_DEFAULT_LENGTH_MAX,
+): number {
+  return Math.min(Math.max(perimeter * ratio, min), max);
+}

--- a/apps/desktop/src/components/ui/border-ray.test.tsx
+++ b/apps/desktop/src/components/ui/border-ray.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BorderRay } from "@/components/ui/border-ray";
+import {
+  BORDER_RAY_DEFAULT_LENGTH,
+  BORDER_RAY_DEFAULT_PERIMETER,
+  BORDER_RAY_DEFAULT_TURN_DURATION_MS,
+} from "@/components/ui/border-ray-model";
+
+describe("BorderRay", () => {
+  test("renders with default fallback CSS variables", () => {
+    const html = renderToStaticMarkup(createElement(BorderRay));
+
+    expect(html).toContain(
+      `--odt-border-ray-turn-duration:${BORDER_RAY_DEFAULT_TURN_DURATION_MS}ms`,
+    );
+    expect(html).toContain(`--odt-border-ray-perimeter:${BORDER_RAY_DEFAULT_PERIMETER}`);
+    expect(html).toContain(`--odt-border-ray-length:${BORDER_RAY_DEFAULT_LENGTH}`);
+    expect(html).not.toContain("--kanban-ray-");
+  });
+
+  test("accepts custom turn duration", () => {
+    const html = renderToStaticMarkup(createElement(BorderRay, { turnDurationMs: 4200 }));
+
+    expect(html).toContain("--odt-border-ray-turn-duration:4200ms");
+  });
+
+  test("renders expected ray layers and merges className", () => {
+    const html = renderToStaticMarkup(createElement(BorderRay, { className: "custom-ray" }));
+
+    expect(html).toContain('class="odt-border-ray custom-ray"');
+    expect(html).toContain('class="odt-border-ray-segment-halo"');
+    expect(html).toContain('class="odt-border-ray-segment-glow"');
+    expect(html).toContain('class="odt-border-ray-segment"');
+  });
+});

--- a/apps/desktop/src/components/ui/border-ray.tsx
+++ b/apps/desktop/src/components/ui/border-ray.tsx
@@ -1,0 +1,257 @@
+import { type CSSProperties, type ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import {
+  BORDER_RAY_DEFAULT_LENGTH_MAX,
+  BORDER_RAY_DEFAULT_LENGTH_MIN,
+  BORDER_RAY_DEFAULT_LENGTH_RATIO,
+  BORDER_RAY_DEFAULT_TURN_DURATION_MS,
+  type BorderRaySize,
+  computeBorderRayLength,
+  DEFAULT_BORDER_RAY_PATH_METRICS,
+  DEFAULT_BORDER_RAY_SIZE,
+} from "@/components/ui/border-ray-model";
+import { cn } from "@/lib/utils";
+
+type BorderRayProps = {
+  className?: string;
+  insetOffset?: number;
+  turnDurationMs?: number;
+  rayLengthRatio?: number;
+  rayLengthMin?: number;
+  rayLengthMax?: number;
+};
+
+function parseCssLength(
+  rawValue: string,
+  host: HTMLElement,
+  containerWidth: number,
+  containerHeight: number,
+  fallback: number,
+): number {
+  const token = rawValue.split(/\s|\//).find((part) => part.length > 0) ?? rawValue;
+  const numeric = Number.parseFloat(token);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  if (token.endsWith("rem")) {
+    const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+    return numeric * (Number.isFinite(rootFontSize) ? rootFontSize : 16);
+  }
+
+  if (token.endsWith("em")) {
+    const elementFontSize = Number.parseFloat(getComputedStyle(host).fontSize);
+    return numeric * (Number.isFinite(elementFontSize) ? elementFontSize : 16);
+  }
+
+  if (token.endsWith("%")) {
+    return (Math.min(containerWidth, containerHeight) * numeric) / 100;
+  }
+
+  return numeric;
+}
+
+export function BorderRay({
+  className,
+  insetOffset = -1,
+  turnDurationMs = BORDER_RAY_DEFAULT_TURN_DURATION_MS,
+  rayLengthRatio = BORDER_RAY_DEFAULT_LENGTH_RATIO,
+  rayLengthMin = BORDER_RAY_DEFAULT_LENGTH_MIN,
+  rayLengthMax = BORDER_RAY_DEFAULT_LENGTH_MAX,
+}: BorderRayProps): ReactElement {
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const pathRef = useRef<SVGPathElement | null>(null);
+  const [size, setSize] = useState<BorderRaySize>(DEFAULT_BORDER_RAY_SIZE);
+  const [pathMetrics, setPathMetrics] = useState(DEFAULT_BORDER_RAY_PATH_METRICS);
+
+  useEffect(() => {
+    const node = svgRef.current;
+    if (!node) {
+      return;
+    }
+
+    const host = node.parentElement;
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+
+    const updateFromRect = (
+      nextWidth: number,
+      nextHeight: number,
+      nextRadius: number,
+      nextBorderWidth: number,
+    ): void => {
+      const safeWidth = Math.max(nextWidth, 1);
+      const safeHeight = Math.max(nextHeight, 1);
+      const safeRadius = Math.max(nextRadius, 0);
+      const safeBorderWidth = Math.max(nextBorderWidth, 0);
+      setSize((current) => {
+        if (
+          Math.abs(current.width - safeWidth) < 0.25 &&
+          Math.abs(current.height - safeHeight) < 0.25 &&
+          Math.abs(current.radius - safeRadius) < 0.25 &&
+          Math.abs(current.borderWidth - safeBorderWidth) < 0.1
+        ) {
+          return current;
+        }
+        return {
+          width: safeWidth,
+          height: safeHeight,
+          radius: safeRadius,
+          borderWidth: safeBorderWidth,
+        };
+      });
+    };
+
+    const readRadius = (containerWidth: number, containerHeight: number): number => {
+      return parseCssLength(
+        getComputedStyle(host).borderTopLeftRadius,
+        host,
+        containerWidth,
+        containerHeight,
+        12,
+      );
+    };
+
+    const readBorderWidth = (containerWidth: number, containerHeight: number): number => {
+      return parseCssLength(
+        getComputedStyle(host).borderTopWidth,
+        host,
+        containerWidth,
+        containerHeight,
+        1,
+      );
+    };
+
+    const syncRect = (): void => {
+      const rect = host.getBoundingClientRect();
+      updateFromRect(
+        rect.width,
+        rect.height,
+        readRadius(rect.width, rect.height),
+        readBorderWidth(rect.width, rect.height),
+      );
+    };
+
+    syncRect();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", syncRect);
+      return () => {
+        window.removeEventListener("resize", syncRect);
+      };
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+      updateFromRect(
+        entry.contentRect.width,
+        entry.contentRect.height,
+        readRadius(entry.contentRect.width, entry.contentRect.height),
+        readBorderWidth(entry.contentRect.width, entry.contentRect.height),
+      );
+    });
+    observer.observe(host);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  const rayGeometry = useMemo(() => {
+    const inset = Math.max(size.borderWidth / 2, 0.5) + insetOffset;
+    const width = Math.max(size.width, 1);
+    const height = Math.max(size.height, 1);
+    const drawWidth = Math.max(width - inset * 2, 1);
+    const drawHeight = Math.max(height - inset * 2, 1);
+    const radius = Math.max(0, Math.min(size.radius - inset, drawWidth / 2, drawHeight / 2));
+
+    const left = inset;
+    const top = inset;
+    const right = left + drawWidth;
+    const bottom = top + drawHeight;
+
+    const path = [
+      `M ${left + radius} ${top}`,
+      `H ${right - radius}`,
+      `A ${radius} ${radius} 0 0 1 ${right} ${top + radius}`,
+      `V ${bottom - radius}`,
+      `A ${radius} ${radius} 0 0 1 ${right - radius} ${bottom}`,
+      `H ${left + radius}`,
+      `A ${radius} ${radius} 0 0 1 ${left} ${bottom - radius}`,
+      `V ${top + radius}`,
+      `A ${radius} ${radius} 0 0 1 ${left + radius} ${top}`,
+      "Z",
+    ].join(" ");
+
+    return {
+      path,
+      width,
+      height,
+    };
+  }, [insetOffset, size.borderWidth, size.height, size.radius, size.width]);
+
+  useEffect(() => {
+    if (rayGeometry.path.length === 0) {
+      return;
+    }
+
+    const pathNode = pathRef.current;
+    if (!pathNode) {
+      return;
+    }
+
+    let perimeter = 0;
+    try {
+      perimeter = pathNode.getTotalLength();
+    } catch {
+      return;
+    }
+
+    if (!Number.isFinite(perimeter) || perimeter <= 0) {
+      return;
+    }
+
+    const rayLength = computeBorderRayLength(perimeter, rayLengthRatio, rayLengthMin, rayLengthMax);
+    setPathMetrics((current) => {
+      if (
+        Math.abs(current.perimeter - perimeter) < 0.1 &&
+        Math.abs(current.rayLength - rayLength) < 0.1
+      ) {
+        return current;
+      }
+      return {
+        perimeter,
+        rayLength,
+      };
+    });
+  }, [rayGeometry.path, rayLengthMax, rayLengthMin, rayLengthRatio]);
+
+  const rayStyle: CSSProperties = {
+    position: "absolute",
+    inset: 0,
+    width: "100%",
+    height: "100%",
+    pointerEvents: "none",
+    zIndex: 2,
+    ["--odt-border-ray-turn-duration" as string]: `${Math.max(turnDurationMs, 1)}ms`,
+    ["--odt-border-ray-perimeter" as string]: `${pathMetrics.perimeter}`,
+    ["--odt-border-ray-length" as string]: `${pathMetrics.rayLength}`,
+  };
+
+  return (
+    <svg
+      ref={svgRef}
+      aria-hidden="true"
+      className={cn("odt-border-ray", className)}
+      viewBox={`0 0 ${rayGeometry.width} ${rayGeometry.height}`}
+      preserveAspectRatio="none"
+      style={rayStyle}
+    >
+      <path className="odt-border-ray-segment-halo" d={rayGeometry.path} />
+      <path className="odt-border-ray-segment-glow" d={rayGeometry.path} />
+      <path ref={pathRef} className="odt-border-ray-segment" d={rayGeometry.path} />
+    </svg>
+  );
+}

--- a/apps/desktop/src/pages/agents-page.tsx
+++ b/apps/desktop/src/pages/agents-page.tsx
@@ -117,6 +117,7 @@ function AgentStudioSessionStartModal({
       role: request.role,
       scenario: request.scenario,
       startMode: request.startMode,
+      selectedModel: request.selectedModel,
       postStartAction:
         request.reason === "composer_send"
           ? "send_message"

--- a/apps/desktop/src/pages/agents-page.tsx
+++ b/apps/desktop/src/pages/agents-page.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -13,12 +14,14 @@ import {
   AgentStudioHeader,
   AgentStudioRightPanel,
   AgentStudioTaskTabs,
+  SessionStartModal,
 } from "@/components/features/agents";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { useAgentState, useChecksState, useTasksState, useWorkspaceState } from "@/state";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { firstScenario, SCENARIOS_BY_ROLE } from "./agents-page-constants";
+import type { RepoSettingsInput } from "@/types/state-slices";
+import { firstScenario, SCENARIO_LABELS, SCENARIOS_BY_ROLE } from "./agents-page-constants";
 import { resolveAgentStudioActiveSession, resolveAgentStudioTaskId } from "./agents-page-selection";
 import { useAgentSessionPermissionActions } from "./use-agent-session-permission-actions";
 import { useAgentStudioDocuments } from "./use-agent-studio-documents";
@@ -27,9 +30,14 @@ import { useAgentStudioPageModels } from "./use-agent-studio-page-models";
 import { useAgentStudioQuerySync } from "./use-agent-studio-query-sync";
 import { useAgentStudioRepoSettings } from "./use-agent-studio-repo-settings";
 import { useAgentStudioRightPanel } from "./use-agent-studio-right-panel";
-import { useAgentStudioSessionActions } from "./use-agent-studio-session-actions";
+import {
+  type NewSessionStartDecision,
+  type NewSessionStartRequest,
+  useAgentStudioSessionActions,
+} from "./use-agent-studio-session-actions";
 import { useAgentStudioTaskHydration } from "./use-agent-studio-task-hydration";
 import { useAgentStudioTaskTabs } from "./use-agent-studio-task-tabs";
+import { useSessionStartModalState } from "./use-session-start-modal-state";
 
 const compareSessionsByRecency = (left: AgentSessionState, right: AgentSessionState): number => {
   if (left.startedAt !== right.startedAt) {
@@ -40,6 +48,125 @@ const compareSessionsByRecency = (left: AgentSessionState, right: AgentSessionSt
   }
   return left.sessionId > right.sessionId ? -1 : 1;
 };
+
+const ROLE_LABEL_BY_ROLE: Record<AgentRole, string> = {
+  spec: "Spec",
+  planner: "Planner",
+  build: "Build",
+  qa: "QA",
+};
+
+type AgentStudioSessionStartModalProps = {
+  request: NewSessionStartRequest;
+  activeRepo: string | null;
+  repoSettings: RepoSettingsInput | null;
+  onCancel: () => void;
+  onConfirm: (decision: NonNullable<NewSessionStartDecision>) => void;
+};
+
+function AgentStudioSessionStartModal({
+  request,
+  activeRepo,
+  repoSettings,
+  onCancel,
+  onConfirm,
+}: AgentStudioSessionStartModalProps): ReactElement {
+  const initializedRequestKeyRef = useRef<string | null>(null);
+  const {
+    intent,
+    isOpen,
+    selection,
+    isCatalogLoading,
+    agentOptions,
+    modelOptions,
+    modelGroups,
+    variantOptions,
+    openStartModal,
+    closeStartModal,
+    handleSelectAgent,
+    handleSelectModel,
+    handleSelectVariant,
+  } = useSessionStartModalState({
+    activeRepo,
+    repoSettings,
+  });
+
+  useEffect(() => {
+    const requestKey = [
+      request.taskId,
+      request.role,
+      request.scenario,
+      request.startMode,
+      request.reason,
+    ].join(":");
+    if (initializedRequestKeyRef.current === requestKey) {
+      return;
+    }
+    initializedRequestKeyRef.current = requestKey;
+
+    const roleLabel = ROLE_LABEL_BY_ROLE[request.role] ?? request.role.toUpperCase();
+    const scenarioLabel = SCENARIO_LABELS[request.scenario] ?? request.scenario;
+    const startModeLabel =
+      request.startMode === "fresh"
+        ? "Start a fresh session"
+        : "Continue latest or start a new session";
+
+    openStartModal({
+      source: "agent_studio",
+      taskId: request.taskId,
+      role: request.role,
+      scenario: request.scenario,
+      startMode: request.startMode,
+      postStartAction:
+        request.reason === "composer_send"
+          ? "send_message"
+          : request.reason === "scenario_kickoff"
+            ? "kickoff"
+            : "none",
+      title: `Start ${roleLabel} Session`,
+      description: `${startModeLabel} for ${scenarioLabel}.`,
+    });
+  }, [openStartModal, request]);
+
+  const fallbackRoleLabel = ROLE_LABEL_BY_ROLE[request.role] ?? request.role.toUpperCase();
+  const fallbackScenarioLabel = SCENARIO_LABELS[request.scenario] ?? request.scenario;
+  const fallbackStartModeLabel =
+    request.startMode === "fresh"
+      ? "Start a fresh session"
+      : "Continue latest or start a new session";
+
+  return (
+    <SessionStartModal
+      model={{
+        open: isOpen,
+        title: intent?.title ?? `Start ${fallbackRoleLabel} Session`,
+        description:
+          intent?.description ?? `${fallbackStartModeLabel} for ${fallbackScenarioLabel}.`,
+        confirmLabel: "Start session",
+        selectedModelSelection: selection,
+        isSelectionCatalogLoading: isCatalogLoading,
+        agentOptions,
+        modelOptions,
+        modelGroups,
+        variantOptions,
+        onSelectAgent: handleSelectAgent,
+        onSelectModel: handleSelectModel,
+        onSelectVariant: handleSelectVariant,
+        allowRunInBackground: false,
+        isStarting: false,
+        onOpenChange: (nextOpen) => {
+          if (!nextOpen) {
+            closeStartModal();
+            onCancel();
+          }
+        },
+        onConfirm: (_runInBackground) => {
+          onConfirm({ selectedModel: selection ?? null });
+        },
+      }}
+    />
+  );
+}
 
 export function AgentsPage(): ReactElement {
   const { activeRepo, loadRepoSettings } = useWorkspaceState();
@@ -59,6 +186,36 @@ export function AgentsPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const [input, setInput] = useState("");
   const [contextSwitchVersion, setContextSwitchVersion] = useState(0);
+  const [pendingSessionStartRequest, setPendingSessionStartRequest] =
+    useState<NewSessionStartRequest | null>(null);
+  const pendingSessionStartResolverRef = useRef<
+    ((decision: NewSessionStartDecision) => void) | null
+  >(null);
+
+  const resolvePendingSessionStart = useCallback((decision: NewSessionStartDecision): void => {
+    const resolver = pendingSessionStartResolverRef.current;
+    pendingSessionStartResolverRef.current = null;
+    setPendingSessionStartRequest(null);
+    resolver?.(decision);
+  }, []);
+
+  const requestNewSessionStart = useCallback(
+    (request: NewSessionStartRequest): Promise<NewSessionStartDecision> => {
+      pendingSessionStartResolverRef.current?.(null);
+      return new Promise((resolve) => {
+        pendingSessionStartResolverRef.current = resolve;
+        setPendingSessionStartRequest(request);
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      pendingSessionStartResolverRef.current?.(null);
+      pendingSessionStartResolverRef.current = null;
+    };
+  }, []);
 
   const {
     taskIdParam,
@@ -401,8 +558,8 @@ export function AgentsPage(): ReactElement {
     taskId: viewTaskId,
     role: viewRole,
     scenario: viewScenario,
-    autostart,
-    sessionStartPreference,
+    autostart: false,
+    sessionStartPreference: null,
     activeSession: viewActiveSession,
     sessionsForTask: viewSessionsForTask,
     selectedTask: viewSelectedTask,
@@ -417,6 +574,7 @@ export function AgentsPage(): ReactElement {
     answerAgentQuestion,
     updateQuery,
     onContextSwitchIntent: signalContextSwitchIntent,
+    requestNewSessionStart,
   });
 
   const { isSubmittingPermissionByRequestId, permissionReplyErrorByRequestId, onReplyPermission } =
@@ -534,6 +692,15 @@ export function AgentsPage(): ReactElement {
           </div>
         )}
       </TabsContent>
+      {pendingSessionStartRequest ? (
+        <AgentStudioSessionStartModal
+          request={pendingSessionStartRequest}
+          activeRepo={activeRepo}
+          repoSettings={repoSettings}
+          onCancel={() => resolvePendingSessionStart(null)}
+          onConfirm={resolvePendingSessionStart}
+        />
+      ) : null}
     </Tabs>
   );
 }

--- a/apps/desktop/src/pages/agents-page.tsx
+++ b/apps/desktop/src/pages/agents-page.tsx
@@ -329,7 +329,6 @@ export function AgentsPage(): ReactElement {
   }, []);
 
   const {
-    tabTaskIds,
     activeTaskTabId,
     availableTabTasks,
     taskTabs,
@@ -413,7 +412,7 @@ export function AgentsPage(): ReactElement {
   const hydratedTasksByRepoAndTask = useAgentStudioTaskHydration({
     activeRepo,
     activeTaskId: viewTaskId,
-    tabTaskIds,
+    activeSessionId: viewActiveSession?.sessionId ?? null,
     loadAgentSessions,
   });
 

--- a/apps/desktop/src/pages/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban-page.test.tsx
@@ -91,6 +91,7 @@ mock.module("@/state", () => ({
 }));
 
 mock.module("./use-agent-studio-repo-settings", () => ({
+  REPO_SETTINGS_UPDATED_EVENT: "odt:repo-settings-updated",
   useAgentStudioRepoSettings: () => ({ repoSettings: null }),
 }));
 

--- a/apps/desktop/src/pages/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban-page.test.tsx
@@ -1,0 +1,474 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { isValidElement, type ReactElement, useState } from "react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { createTaskCardFixture, enableReactActEnvironment } from "./agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+const startAgentSessionMock = mock(async () => "session-1");
+const sendAgentMessageMock = mock(async () => {});
+const updateAgentSessionModelMock = mock(() => {});
+const humanApproveTaskMock = mock(async () => {});
+const humanRequestChangesTaskMock = mock(async () => {});
+const deleteTaskMock = mock(async () => {});
+const deferTaskMock = mock(async () => {});
+const resumeDeferredTaskMock = mock(async () => {});
+const toastSuccessMock = mock(() => {});
+const toastErrorMock = mock(() => {});
+
+let latestKanbanColumnProps: Record<string, unknown> | null = null;
+let latestSessionStartModalModel: Record<string, unknown> | null = null;
+let latestLocation = "/";
+
+let currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "open" });
+
+mock.module("sonner", () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+  },
+}));
+
+mock.module("@/components/features/kanban", () => ({
+  KanbanColumn: (props: Record<string, unknown>): ReactElement | null => {
+    latestKanbanColumnProps = props;
+    return null;
+  },
+  TaskComposerDialog: (): ReactElement | null => null,
+  TaskDetailsSheet: (): ReactElement | null => null,
+}));
+
+mock.module("@/components/features/agents", () => ({
+  SessionStartModal: ({ model }: { model: Record<string, unknown> }): ReactElement | null => {
+    latestSessionStartModalModel = model;
+    return null;
+  },
+}));
+
+mock.module("@/state", () => ({
+  AppStateProvider: ({ children }: { children: ReactElement }): ReactElement => children,
+  useWorkspaceState: () => ({
+    activeRepo: "/repo",
+    isSwitchingWorkspace: false,
+    loadRepoSettings: async () => null,
+  }),
+  useAgentState: () => ({
+    sessions: [
+      {
+        sessionId: "session-spec",
+        taskId: "TASK-123",
+        role: "spec",
+        scenario: "spec_initial",
+        status: "running",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        pendingPermissions: 0,
+        pendingQuestions: 0,
+      },
+    ],
+    startAgentSession: startAgentSessionMock,
+    sendAgentMessage: sendAgentMessageMock,
+    updateAgentSessionModel: updateAgentSessionModelMock,
+  }),
+  useTasksState: () => ({
+    tasks: [currentTaskFixture],
+    runs: [],
+    isLoadingTasks: false,
+    runningTaskSessionByTaskId: {},
+    createTask: async () => {},
+    updateTaskStatus: async () => {},
+    refreshTasks: async () => {},
+    deleteTask: deleteTaskMock,
+    deferTask: deferTaskMock,
+    resumeDeferredTask: resumeDeferredTaskMock,
+    humanApproveTask: humanApproveTaskMock,
+    humanRequestChangesTask: humanRequestChangesTaskMock,
+  }),
+  useChecksState: () => ({}),
+  useDelegationState: () => ({}),
+  useSpecState: () => ({}),
+}));
+
+mock.module("./use-agent-studio-repo-settings", () => ({
+  useAgentStudioRepoSettings: () => ({ repoSettings: null }),
+}));
+
+mock.module("./use-session-start-modal-state", () => ({
+  useSessionStartModalState: () => {
+    const [intent, setIntent] = useState<Record<string, unknown> | null>(null);
+    const [selection, setSelection] = useState({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+      opencodeAgent: "build-agent",
+    });
+
+    return {
+      intent,
+      isOpen: intent !== null,
+      selection,
+      isCatalogLoading: false,
+      agentOptions: [],
+      modelOptions: [],
+      modelGroups: [],
+      variantOptions: [],
+      openStartModal: (nextIntent: Record<string, unknown>) => {
+        setIntent(nextIntent);
+        setSelection({
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "default",
+          opencodeAgent: "build-agent",
+        });
+      },
+      closeStartModal: () => {
+        setIntent(null);
+      },
+      handleSelectAgent: (opencodeAgent: string) => {
+        setSelection((current) => ({
+          ...current,
+          opencodeAgent,
+        }));
+      },
+      handleSelectModel: (modelKey: string) => {
+        if (modelKey === "anthropic/claude-sonnet") {
+          setSelection((current) => ({
+            ...current,
+            providerId: "anthropic",
+            modelId: "claude-sonnet",
+            variant: "default",
+          }));
+          return;
+        }
+        setSelection((current) => ({
+          ...current,
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "default",
+        }));
+      },
+      handleSelectVariant: (variant: string) => {
+        setSelection((current) => ({
+          ...current,
+          variant,
+        }));
+      },
+    };
+  },
+}));
+
+const renderPage = async (): Promise<ReactTestRenderer> => {
+  const { KanbanPage } = await import("./kanban-page");
+  const LocationProbe = (): ReactElement | null => {
+    const location = useLocation();
+    latestLocation = `${location.pathname}${location.search}`;
+    return null;
+  };
+
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(
+      <MemoryRouter initialEntries={["/"]}>
+        <LocationProbe />
+        <KanbanPage />
+      </MemoryRouter>,
+    );
+  });
+  return renderer;
+};
+
+describe("KanbanPage session start modal flow", () => {
+  beforeEach(() => {
+    currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "open" });
+    latestKanbanColumnProps = null;
+    latestSessionStartModalModel = null;
+    latestLocation = "/";
+    startAgentSessionMock.mockClear();
+    sendAgentMessageMock.mockClear();
+    updateAgentSessionModelMock.mockClear();
+    humanApproveTaskMock.mockClear();
+    humanRequestChangesTaskMock.mockClear();
+    deleteTaskMock.mockClear();
+    deferTaskMock.mockClear();
+    resumeDeferredTaskMock.mockClear();
+    toastSuccessMock.mockClear();
+    toastErrorMock.mockClear();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("delegate action opens modal and foreground confirm navigates to Agent Studio", async () => {
+    const renderer = await renderPage();
+
+    expect(latestKanbanColumnProps).toBeTruthy();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onDelegate as (taskId: string) => void)("TASK-123");
+    });
+
+    expect(latestSessionStartModalModel?.open).toBe(true);
+
+    await act(async () => {
+      (latestSessionStartModalModel?.onConfirm as () => void)();
+      await Promise.resolve();
+    });
+
+    expect(startAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "TASK-123",
+        role: "build",
+        scenario: "build_implementation_start",
+        requireModelReady: true,
+      }),
+    );
+    expect(updateAgentSessionModelMock).toHaveBeenCalledWith("session-1", {
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+      opencodeAgent: "build-agent",
+    });
+    expect(latestLocation).toContain("/agents?task=TASK-123");
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("background confirm keeps user on Kanban and shows background success toast", async () => {
+    const renderer = await renderPage();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onDelegate as (taskId: string) => void)("TASK-123");
+    });
+
+    await act(async () => {
+      (latestSessionStartModalModel?.onConfirm as (runInBackground: boolean) => void)(true);
+      await Promise.resolve();
+    });
+
+    expect(startAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(updateAgentSessionModelMock).toHaveBeenCalledTimes(1);
+    expect(sendAgentMessageMock).toHaveBeenCalledTimes(1);
+    expect(latestLocation).toBe("/");
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Started Build session in background for TASK-123.",
+      expect.objectContaining({
+        duration: 10000,
+      }),
+    );
+    const toastCall = toastSuccessMock.mock.calls.at(0) as
+      | [string, { description?: unknown }?]
+      | undefined;
+    const toastDescription = toastCall?.[1]?.description;
+    expect(isValidElement(toastDescription)).toBe(true);
+    if (isValidElement<{ className?: string }>(toastDescription)) {
+      expect(toastDescription.props.className).toContain("cursor-pointer");
+    }
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("background kickoff pending does not keep modal in loading state on next open", async () => {
+    let resolveKickoff: (() => void) | null = null;
+    sendAgentMessageMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveKickoff = resolve;
+        }),
+    );
+
+    const renderer = await renderPage();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onDelegate as (taskId: string) => void)("TASK-123");
+    });
+
+    await act(async () => {
+      (latestSessionStartModalModel?.onConfirm as (runInBackground: boolean) => void)(true);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onDelegate as (taskId: string) => void)("TASK-123");
+    });
+
+    expect(latestSessionStartModalModel?.isStarting).toBe(false);
+
+    if (resolveKickoff) {
+      await act(async () => {
+        resolveKickoff?.();
+        await Promise.resolve();
+      });
+    }
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("foreground kickoff failure still navigates and reports kickoff error", async () => {
+    sendAgentMessageMock.mockImplementationOnce(async () => {
+      throw new Error("kickoff failed");
+    });
+
+    const renderer = await renderPage();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onDelegate as (taskId: string) => void)("TASK-123");
+    });
+
+    await act(async () => {
+      (latestSessionStartModalModel?.onConfirm as () => void)();
+      await Promise.resolve();
+    });
+
+    expect(startAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(latestLocation).toContain("/agents?task=TASK-123");
+    expect(toastErrorMock).toHaveBeenCalledWith("Session started, but kickoff message failed.");
+    expect(toastErrorMock).not.toHaveBeenCalledWith("Failed to start the session.");
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("modal model edits are propagated to session start payload", async () => {
+    const renderer = await renderPage();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onDelegate as (taskId: string) => void)("TASK-123");
+    });
+
+    await act(async () => {
+      (latestSessionStartModalModel?.onSelectModel as (value: string) => void)(
+        "anthropic/claude-sonnet",
+      );
+      (latestSessionStartModalModel?.onSelectAgent as (value: string) => void)("build-agent");
+      (latestSessionStartModalModel?.onSelectVariant as (value: string) => void)("default");
+    });
+
+    await act(async () => {
+      (latestSessionStartModalModel?.onConfirm as () => void)();
+      await Promise.resolve();
+    });
+
+    expect(startAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedModel: {
+          providerId: "anthropic",
+          modelId: "claude-sonnet",
+          variant: "default",
+          opencodeAgent: "build-agent",
+        },
+      }),
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("plan action opens modal and starts planner session", async () => {
+    const renderer = await renderPage();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onPlan as (taskId: string, action: string) => void)(
+        "TASK-123",
+        "set_plan",
+      );
+    });
+
+    expect(latestSessionStartModalModel?.open).toBe(true);
+
+    await act(async () => {
+      (latestSessionStartModalModel?.onConfirm as () => void)();
+      await Promise.resolve();
+    });
+
+    expect(startAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "TASK-123",
+        role: "planner",
+        scenario: "planner_initial",
+        startMode: "fresh",
+      }),
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("continue spec action navigates to latest spec session without opening modal", async () => {
+    currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "spec_ready" });
+    const renderer = await renderPage();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onPlan as (taskId: string, action: string) => void)(
+        "TASK-123",
+        "set_spec",
+      );
+    });
+
+    expect(latestSessionStartModalModel).toBeNull();
+    expect(startAgentSessionMock).not.toHaveBeenCalled();
+    expect(latestLocation).toContain("/agents?task=TASK-123");
+    expect(latestLocation).toContain("session=session-spec");
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("human request changes action opens modal with build follow-up scenario", async () => {
+    const renderer = await renderPage();
+
+    await act(async () => {
+      await (latestKanbanColumnProps?.onHumanRequestChanges as (taskId: string) => Promise<void>)(
+        "TASK-123",
+      );
+    });
+
+    expect(humanRequestChangesTaskMock).toHaveBeenCalledWith("TASK-123");
+    expect(latestSessionStartModalModel?.open).toBe(true);
+
+    await act(async () => {
+      (latestSessionStartModalModel?.onConfirm as () => void)();
+      await Promise.resolve();
+    });
+
+    expect(startAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "TASK-123",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        startMode: "reuse_latest",
+      }),
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("build action bypasses modal and navigates directly", async () => {
+    const renderer = await renderPage();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onBuild as (taskId: string) => void)("TASK-123");
+    });
+
+    expect(latestSessionStartModalModel).toBeNull();
+    expect(startAgentSessionMock).not.toHaveBeenCalled();
+    expect(latestLocation).toContain("/agents?task=TASK-123");
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+});

--- a/apps/desktop/src/pages/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban-page.test.tsx
@@ -90,11 +90,6 @@ mock.module("@/state", () => ({
   useSpecState: () => ({}),
 }));
 
-mock.module("./use-agent-studio-repo-settings", () => ({
-  REPO_SETTINGS_UPDATED_EVENT: "odt:repo-settings-updated",
-  useAgentStudioRepoSettings: () => ({ repoSettings: null }),
-}));
-
 mock.module("./use-session-start-modal-state", () => ({
   useSessionStartModalState: () => {
     const [intent, setIntent] = useState<Record<string, unknown> | null>(null);

--- a/apps/desktop/src/pages/kanban-page.tsx
+++ b/apps/desktop/src/pages/kanban-page.tsx
@@ -1,15 +1,37 @@
-import { mapToKanbanColumns } from "@openducktor/core";
+import { type AgentRole, type AgentScenario, mapToKanbanColumns } from "@openducktor/core";
 import { Loader2, Plus, RefreshCcw } from "lucide-react";
 import { type ReactElement, useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { SessionStartModal } from "@/components/features/agents";
 import { KanbanColumn } from "@/components/features/kanban";
 import { TaskCreateModal } from "@/components/features/task-create-modal";
 import { TaskDetailsSheet } from "@/components/features/task-details-sheet";
 import { Button } from "@/components/ui/button";
-import { useTasksState, useWorkspaceState } from "@/state";
+import { useAgentState, useTasksState, useWorkspaceState } from "@/state";
+import { firstScenario, kickoffPromptForScenario, SCENARIO_LABELS } from "./agents-page-constants";
+import { useAgentStudioRepoSettings } from "./use-agent-studio-repo-settings";
+import { useSessionStartModalState } from "./use-session-start-modal-state";
+
+type KanbanSessionStartIntent = {
+  taskId: string;
+  role: AgentRole;
+  scenario: AgentScenario;
+  startMode: "fresh" | "reuse_latest";
+  sendKickoff: boolean;
+};
+
+const ROLE_LABEL_BY_ROLE: Record<AgentRole, string> = {
+  spec: "Spec",
+  planner: "Planner",
+  build: "Build",
+  qa: "QA",
+};
 
 export function KanbanPage(): ReactElement {
-  const { isSwitchingWorkspace } = useWorkspaceState();
+  const { activeRepo, isSwitchingWorkspace, loadRepoSettings } = useWorkspaceState();
+  const { sessions, startAgentSession, sendAgentMessage, updateAgentSessionModel } =
+    useAgentState();
   const {
     tasks,
     runs,
@@ -25,6 +47,31 @@ export function KanbanPage(): ReactElement {
   const [isTaskComposerOpen, setTaskComposerOpen] = useState(false);
   const [composerTaskId, setComposerTaskId] = useState<string | null>(null);
   const [detailsTaskId, setDetailsTaskId] = useState<string | null>(null);
+  const [isStartingSession, setIsStartingSession] = useState(false);
+
+  const { repoSettings } = useAgentStudioRepoSettings({
+    activeRepo,
+    loadRepoSettings,
+  });
+
+  const {
+    intent: sessionStartIntent,
+    isOpen: isSessionStartModalOpen,
+    selection: sessionStartSelection,
+    isCatalogLoading,
+    agentOptions,
+    modelOptions,
+    modelGroups,
+    variantOptions,
+    openStartModal,
+    closeStartModal,
+    handleSelectAgent,
+    handleSelectModel,
+    handleSelectVariant,
+  } = useSessionStartModalState({
+    activeRepo,
+    repoSettings,
+  });
 
   const columns = useMemo(() => mapToKanbanColumns(tasks), [tasks]);
   const runStateByTaskId = useMemo(
@@ -41,31 +88,160 @@ export function KanbanPage(): ReactElement {
   );
 
   const openAgents = useCallback(
-    (
-      taskId: string,
-      agent: "spec" | "planner" | "build" | "qa",
-      options?: {
-        scenario?: string;
-        autostart?: boolean;
-        start?: "fresh" | "continue";
-      },
-    ) => {
+    (taskId: string, agent: "spec" | "planner" | "build" | "qa", scenario?: string) => {
       const params = new URLSearchParams({
         task: taskId,
         agent,
       });
-      if (options?.scenario) {
-        params.set("scenario", options.scenario);
-      }
-      if (options?.autostart) {
-        params.set("autostart", "1");
-      }
-      if (options?.start) {
-        params.set("start", options.start);
+      if (scenario) {
+        params.set("scenario", scenario);
       }
       navigate(`/agents?${params.toString()}`);
     },
     [navigate],
+  );
+
+  const openSessionInAgentStudio = useCallback(
+    (intent: KanbanSessionStartIntent, sessionId: string): void => {
+      const params = new URLSearchParams({
+        task: intent.taskId,
+        session: sessionId,
+        agent: intent.role,
+        scenario: intent.scenario,
+      });
+      navigate(`/agents?${params.toString()}`);
+    },
+    [navigate],
+  );
+
+  const openSessionStartModal = useCallback(
+    (intent: KanbanSessionStartIntent): void => {
+      const roleLabel = ROLE_LABEL_BY_ROLE[intent.role] ?? intent.role.toUpperCase();
+      const scenarioLabel = SCENARIO_LABELS[intent.scenario] ?? intent.scenario;
+      const startModeLabel =
+        intent.startMode === "fresh"
+          ? "Start a fresh session"
+          : "Continue latest or start a new session";
+
+      openStartModal({
+        source: "kanban",
+        taskId: intent.taskId,
+        role: intent.role,
+        scenario: intent.scenario,
+        startMode: intent.startMode,
+        postStartAction: intent.sendKickoff ? "kickoff" : "none",
+        title: `Start ${roleLabel} Session`,
+        description: `${startModeLabel} for ${scenarioLabel}.`,
+      });
+    },
+    [openStartModal],
+  );
+
+  const closeSessionStartModal = useCallback((): void => {
+    if (isStartingSession) {
+      return;
+    }
+    closeStartModal();
+  }, [closeStartModal, isStartingSession]);
+
+  const confirmSessionStart = useCallback(
+    (startInBackground = false): void => {
+      if (!sessionStartIntent) {
+        return;
+      }
+
+      const intent: KanbanSessionStartIntent = {
+        taskId: sessionStartIntent.taskId,
+        role: sessionStartIntent.role,
+        scenario: sessionStartIntent.scenario,
+        startMode: sessionStartIntent.startMode,
+        sendKickoff: sessionStartIntent.postStartAction === "kickoff",
+      };
+      const selection = sessionStartSelection;
+      void (async () => {
+        setIsStartingSession(true);
+        try {
+          const sessionId = await startAgentSession({
+            taskId: intent.taskId,
+            role: intent.role,
+            scenario: intent.scenario,
+            selectedModel: selection,
+            sendKickoff: false,
+            startMode: intent.startMode,
+            requireModelReady: true,
+          });
+
+          if (selection) {
+            updateAgentSessionModel(sessionId, selection);
+          }
+
+          closeStartModal();
+
+          if (startInBackground) {
+            const roleLabel = ROLE_LABEL_BY_ROLE[intent.role] ?? intent.role.toUpperCase();
+            toast.success(`Started ${roleLabel} session in background for ${intent.taskId}.`, {
+              duration: 10000,
+              description: (
+                <button
+                  type="button"
+                  className="w-fit cursor-pointer p-0 text-sm font-medium text-slate-700 underline underline-offset-2"
+                  onClick={() => openSessionInAgentStudio(intent, sessionId)}
+                >
+                  Open in Agent Studio
+                </button>
+              ),
+            });
+          } else {
+            openSessionInAgentStudio(intent, sessionId);
+          }
+
+          if (startInBackground || intent.sendKickoff) {
+            const kickoffPromise = sendAgentMessage(
+              sessionId,
+              kickoffPromptForScenario(intent.role, intent.scenario, intent.taskId),
+            );
+
+            if (startInBackground) {
+              void kickoffPromise.catch(() => {
+                toast.error("Session started, but kickoff message failed.");
+              });
+            } else {
+              try {
+                await kickoffPromise;
+              } catch {
+                toast.error("Session started, but kickoff message failed.");
+              }
+            }
+          }
+        } catch {
+          toast.error("Failed to start the session.");
+        } finally {
+          setIsStartingSession(false);
+        }
+      })();
+    },
+    [
+      closeStartModal,
+      openSessionInAgentStudio,
+      sendAgentMessage,
+      sessionStartIntent,
+      sessionStartSelection,
+      startAgentSession,
+      updateAgentSessionModel,
+    ],
+  );
+
+  const handleDelegate = useCallback(
+    (taskId: string): void => {
+      openSessionStartModal({
+        taskId,
+        role: "build",
+        scenario: "build_implementation_start",
+        startMode: "reuse_latest",
+        sendKickoff: true,
+      });
+    },
+    [openSessionStartModal],
   );
 
   const getPlanningStartPreference = useCallback(
@@ -77,6 +253,76 @@ export function KanbanPage(): ReactElement {
       return task?.status === "spec_ready" ? "continue" : "fresh";
     },
     [tasks],
+  );
+
+  const handlePlan = useCallback(
+    (taskId: string, action: "set_spec" | "set_plan"): void => {
+      const role = action === "set_spec" ? "spec" : "planner";
+      const startPreference = getPlanningStartPreference(taskId, action);
+
+      if (action === "set_spec" && startPreference === "continue") {
+        const latestSpecSession =
+          sessions
+            .filter((session) => session.taskId === taskId && session.role === "spec")
+            .sort((a, b) =>
+              a.startedAt > b.startedAt ? -1 : a.startedAt < b.startedAt ? 1 : 0,
+            )[0] ?? null;
+
+        if (latestSpecSession) {
+          openSessionInAgentStudio(
+            {
+              taskId,
+              role: "spec",
+              scenario: firstScenario("spec"),
+              startMode: "reuse_latest",
+              sendKickoff: false,
+            },
+            latestSpecSession.sessionId,
+          );
+        } else {
+          openAgents(taskId, "spec", firstScenario("spec"));
+        }
+        return;
+      }
+
+      openSessionStartModal({
+        taskId,
+        role,
+        scenario: firstScenario(role),
+        startMode: startPreference === "fresh" ? "fresh" : "reuse_latest",
+        sendKickoff: startPreference === "fresh",
+      });
+    },
+    [
+      getPlanningStartPreference,
+      openAgents,
+      openSessionInAgentStudio,
+      openSessionStartModal,
+      sessions,
+    ],
+  );
+
+  const handleBuild = useCallback(
+    (taskId: string): void => {
+      openAgents(taskId, "build");
+    },
+    [openAgents],
+  );
+
+  const handleHumanRequestChanges = useCallback(
+    (taskId: string): void => {
+      void (async () => {
+        await humanRequestChangesTask(taskId);
+        openSessionStartModal({
+          taskId,
+          role: "build",
+          scenario: "build_after_human_request_changes",
+          startMode: "reuse_latest",
+          sendKickoff: true,
+        });
+      })();
+    },
+    [humanRequestChangesTask, openSessionStartModal],
   );
 
   return (
@@ -123,32 +369,11 @@ export function KanbanPage(): ReactElement {
                 column={column}
                 runStateByTaskId={runStateByTaskId}
                 onOpenDetails={(taskId) => setDetailsTaskId(taskId)}
-                onDelegate={(taskId) =>
-                  openAgents(taskId, "build", {
-                    scenario: "build_implementation_start",
-                    autostart: true,
-                  })
-                }
-                onPlan={(taskId, action) => {
-                  const startPreference = getPlanningStartPreference(taskId, action);
-                  openAgents(taskId, action === "set_spec" ? "spec" : "planner", {
-                    autostart: startPreference === "fresh",
-                    start: startPreference,
-                  });
-                }}
-                onBuild={(taskId) => {
-                  openAgents(taskId, "build");
-                }}
+                onDelegate={handleDelegate}
+                onPlan={handlePlan}
+                onBuild={handleBuild}
                 onHumanApprove={(taskId) => void humanApproveTask(taskId)}
-                onHumanRequestChanges={(taskId) => {
-                  void (async () => {
-                    await humanRequestChangesTask(taskId);
-                    openAgents(taskId, "build", {
-                      scenario: "build_after_human_request_changes",
-                      autostart: true,
-                    });
-                  })();
-                }}
+                onHumanRequestChanges={handleHumanRequestChanges}
               />
             ))}
           </div>
@@ -175,22 +400,9 @@ export function KanbanPage(): ReactElement {
             setDetailsTaskId(null);
           }
         }}
-        onPlan={(taskId, action) => {
-          const startPreference = getPlanningStartPreference(taskId, action);
-          openAgents(taskId, action === "set_spec" ? "spec" : "planner", {
-            autostart: startPreference === "fresh",
-            start: startPreference,
-          });
-        }}
-        onBuild={(taskId) => {
-          openAgents(taskId, "build");
-        }}
-        onDelegate={(taskId) => {
-          openAgents(taskId, "build", {
-            scenario: "build_implementation_start",
-            autostart: true,
-          });
-        }}
+        onPlan={handlePlan}
+        onBuild={handleBuild}
+        onDelegate={handleDelegate}
         onEdit={(taskId) => {
           setDetailsTaskId(null);
           setComposerTaskId(taskId);
@@ -199,17 +411,39 @@ export function KanbanPage(): ReactElement {
         onDefer={(taskId) => void deferTask(taskId)}
         onResumeDeferred={(taskId) => void resumeDeferredTask(taskId)}
         onHumanApprove={(taskId) => void humanApproveTask(taskId)}
-        onHumanRequestChanges={(taskId) => {
-          void (async () => {
-            await humanRequestChangesTask(taskId);
-            openAgents(taskId, "build", {
-              scenario: "build_after_human_request_changes",
-              autostart: true,
-            });
-          })();
-        }}
+        onHumanRequestChanges={handleHumanRequestChanges}
         onDelete={(taskId, options) => deleteTask(taskId, options.deleteSubtasks)}
       />
+      {sessionStartIntent ? (
+        <SessionStartModal
+          model={{
+            open: isSessionStartModalOpen,
+            title: sessionStartIntent.title,
+            description:
+              sessionStartIntent.description ??
+              "Choose agent, model, and variant before starting this session.",
+            confirmLabel: "Start session",
+            selectedModelSelection: sessionStartSelection,
+            isSelectionCatalogLoading: isCatalogLoading,
+            agentOptions,
+            modelOptions,
+            modelGroups,
+            variantOptions,
+            onSelectAgent: handleSelectAgent,
+            onSelectModel: handleSelectModel,
+            onSelectVariant: handleSelectVariant,
+            allowRunInBackground: true,
+            backgroundConfirmLabel: "Run in background",
+            isStarting: isStartingSession,
+            onOpenChange: (nextOpen) => {
+              if (!nextOpen) {
+                closeSessionStartModal();
+              }
+            },
+            onConfirm: confirmSessionStart,
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/pages/kanban-page.tsx
+++ b/apps/desktop/src/pages/kanban-page.tsx
@@ -9,6 +9,7 @@ import { TaskCreateModal } from "@/components/features/task-create-modal";
 import { TaskDetailsSheet } from "@/components/features/task-details-sheet";
 import { Button } from "@/components/ui/button";
 import { useAgentState, useTasksState, useWorkspaceState } from "@/state";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { firstScenario, kickoffPromptForScenario, SCENARIO_LABELS } from "./agents-page-constants";
 import { useAgentStudioRepoSettings } from "./use-agent-studio-repo-settings";
 import { useSessionStartModalState } from "./use-session-start-modal-state";
@@ -27,6 +28,8 @@ const ROLE_LABEL_BY_ROLE: Record<AgentRole, string> = {
   build: "Build",
   qa: "QA",
 };
+
+const ACTIVE_SESSION_STATUS = new Set<AgentSessionState["status"]>(["starting", "running"]);
 
 export function KanbanPage(): ReactElement {
   const { activeRepo, isSwitchingWorkspace, loadRepoSettings } = useWorkspaceState();
@@ -78,6 +81,32 @@ export function KanbanPage(): ReactElement {
     () => new Map(runs.map((run) => [run.taskId, run.state])),
     [runs],
   );
+  const activeSessionsByTaskId = useMemo(() => {
+    const sessionsByTaskId = new Map<string, AgentSessionState[]>();
+    for (const session of sessions) {
+      if (!ACTIVE_SESSION_STATUS.has(session.status)) {
+        continue;
+      }
+
+      const existing = sessionsByTaskId.get(session.taskId);
+      if (existing) {
+        existing.push(session);
+      } else {
+        sessionsByTaskId.set(session.taskId, [session]);
+      }
+    }
+
+    for (const taskSessions of sessionsByTaskId.values()) {
+      taskSessions.sort((left, right) => {
+        if (left.status !== right.status) {
+          return left.status === "running" ? -1 : 1;
+        }
+        return right.startedAt.localeCompare(left.startedAt);
+      });
+    }
+
+    return sessionsByTaskId;
+  }, [sessions]);
   const detailsTask = useMemo(
     () => tasks.find((task) => task.id === detailsTaskId) ?? null,
     [detailsTaskId, tasks],
@@ -368,6 +397,7 @@ export function KanbanPage(): ReactElement {
                 key={column.id}
                 column={column}
                 runStateByTaskId={runStateByTaskId}
+                activeSessionsByTaskId={activeSessionsByTaskId}
                 onOpenDetails={(taskId) => setDetailsTaskId(taskId)}
                 onDelegate={handleDelegate}
                 onPlan={handlePlan}

--- a/apps/desktop/src/pages/use-agent-studio-repo-settings.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-repo-settings.test.tsx
@@ -4,7 +4,10 @@ import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
-import { useAgentStudioRepoSettings } from "./use-agent-studio-repo-settings";
+import {
+  REPO_SETTINGS_UPDATED_EVENT,
+  useAgentStudioRepoSettings,
+} from "./use-agent-studio-repo-settings";
 
 enableReactActEnvironment();
 
@@ -61,5 +64,60 @@ describe("useAgentStudioRepoSettings", () => {
     expect(harness.getLatest().repoSettings).toBeNull();
 
     await harness.unmount();
+  });
+
+  test("reloads settings when repo settings update event is dispatched", async () => {
+    const globalWithWindow = globalThis as typeof globalThis & {
+      window?: EventTarget;
+    };
+    const originalWindow = globalWithWindow.window;
+    const eventWindow = new EventTarget();
+    Object.defineProperty(globalWithWindow, "window", {
+      configurable: true,
+      value: eventWindow,
+    });
+
+    const firstSettings = createSettings();
+    const secondSettings: RepoSettingsInput = {
+      ...createSettings(),
+      branchPrefix: "feature/",
+    };
+
+    let loadCount = 0;
+    const loadRepoSettings = mock(async (): Promise<RepoSettingsInput> => {
+      loadCount += 1;
+      return loadCount === 1 ? firstSettings : secondSettings;
+    });
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      loadRepoSettings,
+    });
+
+    await harness.mount();
+    expect(harness.getLatest().repoSettings).toEqual(firstSettings);
+
+    await harness.run(() => {
+      eventWindow.dispatchEvent(
+        new CustomEvent(REPO_SETTINGS_UPDATED_EVENT, {
+          detail: { repoPath: "/repo" },
+        }),
+      );
+    });
+
+    await harness.waitFor((state) => state.repoSettings?.branchPrefix === "feature/");
+    expect(loadRepoSettings).toHaveBeenCalledTimes(2);
+    expect(harness.getLatest().repoSettings).toEqual(secondSettings);
+
+    await harness.unmount();
+
+    if (typeof originalWindow === "undefined") {
+      Reflect.deleteProperty(globalWithWindow, "window");
+    } else {
+      Object.defineProperty(globalWithWindow, "window", {
+        configurable: true,
+        value: originalWindow,
+      });
+    }
   });
 });

--- a/apps/desktop/src/pages/use-agent-studio-repo-settings.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-repo-settings.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
+  createDeferred,
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
@@ -118,6 +119,75 @@ describe("useAgentStudioRepoSettings", () => {
         configurable: true,
         value: originalWindow,
       });
+    }
+  });
+
+  test("keeps the latest event reload result when concurrent loads resolve out of order", async () => {
+    const globalWithWindow = globalThis as typeof globalThis & {
+      window?: EventTarget;
+    };
+    const originalWindow = globalWithWindow.window;
+    const eventWindow = new EventTarget();
+    Object.defineProperty(globalWithWindow, "window", {
+      configurable: true,
+      value: eventWindow,
+    });
+
+    const firstSettings = createSettings();
+    const secondSettings: RepoSettingsInput = {
+      ...createSettings(),
+      branchPrefix: "feature/latest",
+    };
+    const firstLoad = createDeferred<RepoSettingsInput>();
+    const secondLoad = createDeferred<RepoSettingsInput>();
+    let loadCount = 0;
+    const loadRepoSettings = mock((): Promise<RepoSettingsInput> => {
+      loadCount += 1;
+      return loadCount === 1 ? firstLoad.promise : secondLoad.promise;
+    });
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      loadRepoSettings,
+    });
+
+    try {
+      await harness.mount();
+
+      await harness.run(() => {
+        eventWindow.dispatchEvent(
+          new CustomEvent(REPO_SETTINGS_UPDATED_EVENT, {
+            detail: { repoPath: "/repo" },
+          }),
+        );
+      });
+
+      await harness.run(async () => {
+        secondLoad.resolve(secondSettings);
+        await secondLoad.promise;
+      });
+      await harness.waitFor((state) => state.repoSettings?.branchPrefix === "feature/latest");
+
+      await harness.run(async () => {
+        firstLoad.resolve(firstSettings);
+        await firstLoad.promise;
+      });
+
+      expect(loadRepoSettings).toHaveBeenCalledTimes(2);
+      expect(harness.getLatest().repoSettings).toEqual(secondSettings);
+    } finally {
+      firstLoad.resolve(firstSettings);
+      secondLoad.resolve(secondSettings);
+      await harness.unmount();
+
+      if (typeof originalWindow === "undefined") {
+        Reflect.deleteProperty(globalWithWindow, "window");
+      } else {
+        Object.defineProperty(globalWithWindow, "window", {
+          configurable: true,
+          value: originalWindow,
+        });
+      }
     }
   });
 });

--- a/apps/desktop/src/pages/use-agent-studio-repo-settings.ts
+++ b/apps/desktop/src/pages/use-agent-studio-repo-settings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { RepoSettingsInput } from "@/types/state-slices";
 
 export const REPO_SETTINGS_UPDATED_EVENT = "odt:repo-settings-updated";
@@ -15,22 +15,26 @@ export function useAgentStudioRepoSettings(args: {
 } {
   const { activeRepo, loadRepoSettings } = args;
   const [repoSettings, setRepoSettings] = useState<RepoSettingsInput | null>(null);
+  const latestReloadIdRef = useRef(0);
 
   const reloadRepoSettings = useCallback(() => {
     if (!activeRepo) {
+      latestReloadIdRef.current += 1;
       setRepoSettings(null);
       return () => {};
     }
 
+    const reloadId = latestReloadIdRef.current + 1;
+    latestReloadIdRef.current = reloadId;
     let cancelled = false;
     void loadRepoSettings()
       .then((settings) => {
-        if (!cancelled) {
+        if (!cancelled && reloadId === latestReloadIdRef.current) {
           setRepoSettings(settings);
         }
       })
       .catch(() => {
-        if (!cancelled) {
+        if (!cancelled && reloadId === latestReloadIdRef.current) {
           setRepoSettings(null);
         }
       });

--- a/apps/desktop/src/pages/use-agent-studio-repo-settings.ts
+++ b/apps/desktop/src/pages/use-agent-studio-repo-settings.ts
@@ -1,5 +1,11 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { RepoSettingsInput } from "@/types/state-slices";
+
+export const REPO_SETTINGS_UPDATED_EVENT = "odt:repo-settings-updated";
+
+type RepoSettingsUpdatedEventDetail = {
+  repoPath: string;
+};
 
 export function useAgentStudioRepoSettings(args: {
   activeRepo: string | null;
@@ -10,10 +16,10 @@ export function useAgentStudioRepoSettings(args: {
   const { activeRepo, loadRepoSettings } = args;
   const [repoSettings, setRepoSettings] = useState<RepoSettingsInput | null>(null);
 
-  useEffect(() => {
+  const reloadRepoSettings = useCallback(() => {
     if (!activeRepo) {
       setRepoSettings(null);
-      return;
+      return () => {};
     }
 
     let cancelled = false;
@@ -33,6 +39,31 @@ export function useAgentStudioRepoSettings(args: {
       cancelled = true;
     };
   }, [activeRepo, loadRepoSettings]);
+
+  useEffect(() => {
+    return reloadRepoSettings();
+  }, [reloadRepoSettings]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleRepoSettingsUpdated = (event: Event) => {
+      const customEvent = event as CustomEvent<RepoSettingsUpdatedEventDetail>;
+      const repoPath = customEvent.detail?.repoPath;
+      if (!repoPath || !activeRepo || repoPath !== activeRepo) {
+        return;
+      }
+
+      reloadRepoSettings();
+    };
+
+    window.addEventListener(REPO_SETTINGS_UPDATED_EVENT, handleRepoSettingsUpdated);
+    return () => {
+      window.removeEventListener(REPO_SETTINGS_UPDATED_EVENT, handleRepoSettingsUpdated);
+    };
+  }, [activeRepo, reloadRepoSettings]);
 
   return {
     repoSettings,

--- a/apps/desktop/src/pages/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-session-actions.test.tsx
@@ -407,6 +407,7 @@ describe("useAgentStudioSessionActions", () => {
         agent: "planner",
         scenario: "planner_initial",
         autostart: undefined,
+        start: "fresh",
       });
       expect(startAgentSession).toHaveBeenCalledWith({
         taskId: "task-1",
@@ -434,6 +435,7 @@ describe("useAgentStudioSessionActions", () => {
         agent: "planner",
         scenario: "planner_initial",
         autostart: undefined,
+        start: undefined,
       });
       expect(sendAgentMessage).toHaveBeenCalledWith(
         "session-plan",
@@ -441,6 +443,52 @@ describe("useAgentStudioSessionActions", () => {
       );
     } finally {
       deferredStart.resolve("session-plan");
+      await harness.unmount();
+    }
+  });
+
+  test("handleCreateSession sets fresh-start query when creating another session for same role", async () => {
+    const deferredStart = createDeferred<string>();
+    const startAgentSession = mock(async () => deferredStart.promise);
+    const sendAgentMessage = mock(async () => {});
+    const updateCalls: Array<Record<string, string | undefined>> = [];
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      role: "spec",
+      scenario: "spec_initial",
+      activeSession: createSession({ sessionId: "session-spec", role: "spec" }),
+      selectedTask: createTask(),
+      startAgentSession,
+      sendAgentMessage,
+      updateQuery: (updates) => {
+        updateCalls.push(updates);
+      },
+    });
+
+    try {
+      await harness.mount();
+      await harness.run((state) => {
+        state.handleCreateSession({
+          id: "spec:spec_initial:fresh",
+          role: "spec",
+          scenario: "spec_initial",
+          label: "Spec · Start Spec",
+          description: "Create a new spec session from scratch",
+          disabled: false,
+        });
+      });
+
+      expect(updateCalls[0]).toEqual({
+        task: "task-1",
+        session: undefined,
+        agent: "spec",
+        scenario: "spec_initial",
+        autostart: undefined,
+        start: "fresh",
+      });
+    } finally {
+      deferredStart.resolve("session-spec-fresh");
       await harness.unmount();
     }
   });
@@ -612,6 +660,7 @@ describe("useAgentStudioSessionActions", () => {
         agent: "planner",
         scenario: "planner_initial",
         autostart: undefined,
+        start: "fresh",
       });
       expect(updateCalls).toContainEqual({
         task: "task-1",
@@ -619,6 +668,7 @@ describe("useAgentStudioSessionActions", () => {
         agent: "spec",
         scenario: "spec_initial",
         autostart: undefined,
+        start: undefined,
       });
       expect(sendAgentMessage).not.toHaveBeenCalled();
     } finally {

--- a/apps/desktop/src/pages/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-session-actions.test.tsx
@@ -135,6 +135,80 @@ describe("useAgentStudioSessionActions", () => {
     await harness.unmount();
   });
 
+  test("onSend requests model selection before creating a new session", async () => {
+    const requestedSelection = {
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4",
+      variant: "thinking",
+      opencodeAgent: "spec",
+    } as const;
+    const requestNewSessionStart = mock(async () => ({ selectedModel: requestedSelection }));
+    const startAgentSession = mock(async () => "session-new");
+    const sendAgentMessage = mock(async () => {});
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      requestNewSessionStart,
+      startAgentSession,
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await state.onSend();
+    });
+
+    expect(requestNewSessionStart).toHaveBeenCalledWith({
+      taskId: "task-1",
+      role: "spec",
+      scenario: "spec_initial",
+      startMode: "reuse_latest",
+      reason: "composer_send",
+      selectedModel: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "default",
+        opencodeAgent: "spec",
+      },
+    });
+    expect(startAgentSession).toHaveBeenCalledWith({
+      taskId: "task-1",
+      role: "spec",
+      scenario: "spec_initial",
+      selectedModel: requestedSelection,
+      sendKickoff: false,
+      startMode: "reuse_latest",
+      requireModelReady: true,
+    });
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-new", "hello world");
+
+    await harness.unmount();
+  });
+
+  test("onSend aborts when session creation request is cancelled", async () => {
+    const requestNewSessionStart = mock(async () => null);
+    const startAgentSession = mock(async () => "session-new");
+    const sendAgentMessage = mock(async () => {});
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      requestNewSessionStart,
+      startAgentSession,
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await state.onSend();
+    });
+
+    expect(requestNewSessionStart).toHaveBeenCalledTimes(1);
+    expect(startAgentSession).not.toHaveBeenCalled();
+    expect(sendAgentMessage).not.toHaveBeenCalled();
+
+    await harness.unmount();
+  });
+
   test("onSend ignores active session when fresh preference is selected", async () => {
     const startAgentSession = mock(async () => "session-fresh");
     const sendAgentMessage = mock(async () => {});
@@ -338,6 +412,12 @@ describe("useAgentStudioSessionActions", () => {
         taskId: "task-1",
         role: "planner",
         scenario: "planner_initial",
+        selectedModel: {
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "default",
+          opencodeAgent: "spec",
+        },
         sendKickoff: false,
         startMode: "fresh",
         requireModelReady: true,
@@ -363,6 +443,123 @@ describe("useAgentStudioSessionActions", () => {
       deferredStart.resolve("session-plan");
       await harness.unmount();
     }
+  });
+
+  test("handleCreateSession requests model selection with create_session reason", async () => {
+    const requestNewSessionStart = mock(async () => ({
+      selectedModel: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet-4",
+        variant: "thinking",
+        opencodeAgent: "planner",
+      },
+    }));
+    const startAgentSession = mock(async () => "session-plan");
+    const sendAgentMessage = mock(async () => {});
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      role: "spec",
+      scenario: "spec_initial",
+      activeSession: createSession({ sessionId: "session-spec", role: "spec" }),
+      selectedTask: createTask({
+        agentWorkflows: {
+          spec: { required: true, canSkip: false, available: true, completed: true },
+          planner: { required: true, canSkip: false, available: true, completed: false },
+          builder: { required: true, canSkip: false, available: true, completed: false },
+          qa: { required: true, canSkip: false, available: false, completed: false },
+        },
+      }),
+      requestNewSessionStart,
+      startAgentSession,
+      sendAgentMessage,
+      updateQuery: () => {},
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      state.handleCreateSession({
+        id: "planner:planner_initial:fresh",
+        role: "planner",
+        scenario: "planner_initial",
+        label: "Planner · Start Planner",
+        description: "Create a new planner session from scratch",
+        disabled: false,
+      });
+      await Promise.resolve();
+    });
+
+    expect(requestNewSessionStart).toHaveBeenCalledWith({
+      taskId: "task-1",
+      role: "planner",
+      scenario: "planner_initial",
+      startMode: "fresh",
+      reason: "create_session",
+      selectedModel: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "default",
+        opencodeAgent: "spec",
+      },
+    });
+    expect(startAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: "planner",
+        scenario: "planner_initial",
+        selectedModel: {
+          providerId: "anthropic",
+          modelId: "claude-sonnet-4",
+          variant: "thinking",
+          opencodeAgent: "planner",
+        },
+      }),
+    );
+
+    await harness.unmount();
+  });
+
+  test("handleCreateSession aborts when create-session request is cancelled", async () => {
+    const requestNewSessionStart = mock(async () => null);
+    const startAgentSession = mock(async () => "session-plan");
+    const sendAgentMessage = mock(async () => {});
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      role: "spec",
+      scenario: "spec_initial",
+      activeSession: createSession({ sessionId: "session-spec", role: "spec" }),
+      selectedTask: createTask({
+        agentWorkflows: {
+          spec: { required: true, canSkip: false, available: true, completed: true },
+          planner: { required: true, canSkip: false, available: true, completed: false },
+          builder: { required: true, canSkip: false, available: true, completed: false },
+          qa: { required: true, canSkip: false, available: false, completed: false },
+        },
+      }),
+      requestNewSessionStart,
+      startAgentSession,
+      sendAgentMessage,
+      updateQuery: () => {},
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      state.handleCreateSession({
+        id: "planner:planner_initial:fresh",
+        role: "planner",
+        scenario: "planner_initial",
+        label: "Planner · Start Planner",
+        description: "Create a new planner session from scratch",
+        disabled: false,
+      });
+      await Promise.resolve();
+    });
+
+    expect(requestNewSessionStart).toHaveBeenCalledTimes(1);
+    expect(startAgentSession).not.toHaveBeenCalled();
+    expect(sendAgentMessage).not.toHaveBeenCalled();
+
+    await harness.unmount();
   });
 
   test("handleCreateSession restores previous query selection on start failure", async () => {
@@ -487,6 +684,95 @@ describe("useAgentStudioSessionActions", () => {
       deferredKickoff.resolve();
       await harness.unmount();
     }
+  });
+
+  test("startScenarioKickoff requests session selection with kickoff reason", async () => {
+    const requestNewSessionStart = mock(async () => ({
+      selectedModel: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "default",
+        opencodeAgent: "spec",
+      },
+    }));
+    const startAgentSession = mock(async () => "session-spec");
+    const sendAgentMessage = mock(async () => {});
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      requestNewSessionStart,
+      startAgentSession,
+      sendAgentMessage,
+      input: "",
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await state.startScenarioKickoff();
+    });
+
+    expect(requestNewSessionStart).toHaveBeenCalledWith({
+      taskId: "task-1",
+      role: "spec",
+      scenario: "spec_initial",
+      startMode: "reuse_latest",
+      reason: "scenario_kickoff",
+      selectedModel: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "default",
+        opencodeAgent: "spec",
+      },
+    });
+    expect(sendAgentMessage).toHaveBeenCalledWith(
+      "session-spec",
+      kickoffPromptForScenario("spec", "spec_initial", "task-1"),
+    );
+
+    await harness.unmount();
+  });
+
+  test("autostart flow requests modal selection with scenario_kickoff reason", async () => {
+    const requestNewSessionStart = mock(async () => ({
+      selectedModel: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "default",
+        opencodeAgent: "spec",
+      },
+    }));
+    const startAgentSession = mock(async () => "session-autostart");
+    const sendAgentMessage = mock(async () => {});
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      autostart: true,
+      requestNewSessionStart,
+      startAgentSession,
+      sendAgentMessage,
+      input: "",
+    });
+
+    await harness.mount();
+    await harness.waitFor(() => requestNewSessionStart.mock.calls.length > 0);
+
+    expect(requestNewSessionStart).toHaveBeenCalledWith({
+      taskId: "task-1",
+      role: "spec",
+      scenario: "spec_initial",
+      startMode: "reuse_latest",
+      reason: "scenario_kickoff",
+      selectedModel: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "default",
+        opencodeAgent: "spec",
+      },
+    });
+    expect(startAgentSession).toHaveBeenCalledTimes(1);
+    expect(sendAgentMessage).toHaveBeenCalledTimes(1);
+
+    await harness.unmount();
   });
 
   test("marks autostart flow as initializing before task hydration completes", async () => {

--- a/apps/desktop/src/pages/use-agent-studio-session-actions.ts
+++ b/apps/desktop/src/pages/use-agent-studio-session-actions.ts
@@ -13,6 +13,21 @@ import { buildRoleEnabledMapForTask, type SessionCreateOption } from "./agents-p
 
 type QueryUpdate = Record<string, string | undefined>;
 
+export type SessionStartRequestReason = "create_session" | "composer_send" | "scenario_kickoff";
+
+export type NewSessionStartRequest = {
+  taskId: string;
+  role: AgentRole;
+  scenario: AgentScenario;
+  startMode: "fresh" | "reuse_latest";
+  reason: SessionStartRequestReason;
+  selectedModel: AgentModelSelection | null;
+};
+
+export type NewSessionStartDecision = {
+  selectedModel: AgentModelSelection | null;
+} | null;
+
 type UseAgentStudioSessionActionsArgs = {
   activeRepo: string | null;
   taskId: string;
@@ -34,6 +49,7 @@ type UseAgentStudioSessionActionsArgs = {
   answerAgentQuestion: AgentStateContextValue["answerAgentQuestion"];
   updateQuery: (updates: QueryUpdate) => void;
   onContextSwitchIntent?: () => void;
+  requestNewSessionStart?: (request: NewSessionStartRequest) => Promise<NewSessionStartDecision>;
 };
 
 export function useAgentStudioSessionActions({
@@ -57,6 +73,7 @@ export function useAgentStudioSessionActions({
   answerAgentQuestion,
   updateQuery,
   onContextSwitchIntent,
+  requestNewSessionStart,
 }: UseAgentStudioSessionActionsArgs): {
   isStarting: boolean;
   isSending: boolean;
@@ -91,93 +108,127 @@ export function useAgentStudioSessionActions({
     startingSessionByTaskRef.current.clear();
   }, [activeRepo]);
 
-  const startSession = useCallback(async (): Promise<string | undefined> => {
-    if (!taskId || !agentStudioReady || !isActiveTaskHydrated) {
-      return undefined;
-    }
-    if (selectedTask && !isRoleAvailableForTask(selectedTask, role)) {
-      return undefined;
-    }
-
-    const isFreshStartRequested = sessionStartPreference === "fresh";
-
-    if (activeSession && !isFreshStartRequested) {
-      updateQuery({
-        task: activeSession.taskId,
-        session: activeSession.sessionId,
-        agent: activeSession.role,
-        scenario: activeSession.scenario,
-        autostart: undefined,
-        start: undefined,
+  const resolveRequestedSelection = useCallback(
+    async (
+      request: Omit<NewSessionStartRequest, "selectedModel">,
+    ): Promise<AgentModelSelection | null | undefined> => {
+      if (!requestNewSessionStart) {
+        return selectionForNewSession ?? null;
+      }
+      const decision = await requestNewSessionStart({
+        ...request,
+        selectedModel: selectionForNewSession ?? null,
       });
-      return activeSession.sessionId;
-    }
-
-    if (sessionStartPreference === "continue") {
-      const latestSessionForRole = sessionsForTask.find((entry) => entry.role === role);
-      if (latestSessionForRole) {
-        updateQuery({
-          task: latestSessionForRole.taskId,
-          session: latestSessionForRole.sessionId,
-          agent: latestSessionForRole.role,
-          scenario: latestSessionForRole.scenario,
-          autostart: undefined,
-        });
-        return latestSessionForRole.sessionId;
+      if (!decision) {
+        return undefined;
       }
-    }
+      return decision.selectedModel;
+    },
+    [requestNewSessionStart, selectionForNewSession],
+  );
 
-    const inFlightSessionStart = startingSessionByTaskRef.current.get(taskId);
-    if (inFlightSessionStart) {
-      return inFlightSessionStart;
-    }
+  const startSession = useCallback(
+    async (reason: SessionStartRequestReason): Promise<string | undefined> => {
+      if (!taskId || !agentStudioReady || !isActiveTaskHydrated) {
+        return undefined;
+      }
+      if (selectedTask && !isRoleAvailableForTask(selectedTask, role)) {
+        return undefined;
+      }
 
-    const startPromise = (async (): Promise<string | undefined> => {
-      setIsStarting(true);
-      try {
-        const sessionId = await startAgentSession({
-          taskId,
-          role,
-          scenario,
-          selectedModel: selectionForNewSession ?? null,
-          sendKickoff: false,
-          startMode: sessionStartPreference === "fresh" ? "fresh" : "reuse_latest",
-          requireModelReady: true,
+      const isFreshStartRequested = sessionStartPreference === "fresh";
+
+      if (activeSession && !isFreshStartRequested) {
+        updateQuery({
+          task: activeSession.taskId,
+          session: activeSession.sessionId,
+          agent: activeSession.role,
+          scenario: activeSession.scenario,
+          autostart: undefined,
+          start: undefined,
         });
-        if (selectionForNewSession) {
-          updateAgentSessionModel(sessionId, selectionForNewSession);
+        return activeSession.sessionId;
+      }
+
+      if (sessionStartPreference === "continue") {
+        const latestSessionForRole = sessionsForTask.find((entry) => entry.role === role);
+        if (latestSessionForRole) {
+          updateQuery({
+            task: latestSessionForRole.taskId,
+            session: latestSessionForRole.sessionId,
+            agent: latestSessionForRole.role,
+            scenario: latestSessionForRole.scenario,
+            autostart: undefined,
+          });
+          return latestSessionForRole.sessionId;
         }
-        updateQuery({
-          task: taskId,
-          agent: role,
-          scenario,
-          session: sessionId,
-          autostart: undefined,
-        });
-        return sessionId;
-      } finally {
-        startingSessionByTaskRef.current.delete(taskId);
-        setIsStarting(false);
       }
-    })();
 
-    startingSessionByTaskRef.current.set(taskId, startPromise);
-    return startPromise;
-  }, [
-    activeSession,
-    agentStudioReady,
-    isActiveTaskHydrated,
-    role,
-    scenario,
-    sessionStartPreference,
-    sessionsForTask,
-    selectedTask,
-    selectionForNewSession,
-    startAgentSession,
-    taskId,
-    updateAgentSessionModel,
-    updateQuery,
-  ]);
+      const inFlightSessionStart = startingSessionByTaskRef.current.get(taskId);
+      if (inFlightSessionStart) {
+        return inFlightSessionStart;
+      }
+
+      const startPromise = (async (): Promise<string | undefined> => {
+        setIsStarting(true);
+        try {
+          const startMode = sessionStartPreference === "fresh" ? "fresh" : "reuse_latest";
+          const selectedModel = await resolveRequestedSelection({
+            taskId,
+            role,
+            scenario,
+            startMode,
+            reason,
+          });
+          if (selectedModel === undefined) {
+            return undefined;
+          }
+
+          const sessionId = await startAgentSession({
+            taskId,
+            role,
+            scenario,
+            selectedModel,
+            sendKickoff: false,
+            startMode,
+            requireModelReady: true,
+          });
+          if (selectedModel) {
+            updateAgentSessionModel(sessionId, selectedModel);
+          }
+          updateQuery({
+            task: taskId,
+            agent: role,
+            scenario,
+            session: sessionId,
+            autostart: undefined,
+          });
+          return sessionId;
+        } finally {
+          startingSessionByTaskRef.current.delete(taskId);
+          setIsStarting(false);
+        }
+      })();
+
+      startingSessionByTaskRef.current.set(taskId, startPromise);
+      return startPromise;
+    },
+    [
+      activeSession,
+      agentStudioReady,
+      isActiveTaskHydrated,
+      resolveRequestedSelection,
+      role,
+      scenario,
+      sessionStartPreference,
+      sessionsForTask,
+      selectedTask,
+      startAgentSession,
+      taskId,
+      updateAgentSessionModel,
+      updateQuery,
+    ],
+  );
 
   const startScenarioKickoff = useCallback(async (): Promise<void> => {
     if (!taskId || !agentStudioReady) {
@@ -186,7 +237,7 @@ export function useAgentStudioSessionActions({
     if (selectedTask && !isRoleAvailableForTask(selectedTask, role)) {
       return;
     }
-    const sessionId = await startSession();
+    const sessionId = await startSession("scenario_kickoff");
     if (!sessionId) {
       updateQuery({ autostart: undefined });
       return;
@@ -265,7 +316,7 @@ export function useAgentStudioSessionActions({
 
     let targetSessionId = sessionStartPreference === "fresh" ? undefined : activeSession?.sessionId;
     if (!targetSessionId) {
-      targetSessionId = await startSession();
+      targetSessionId = await startSession("composer_send");
     }
 
     if (!targetSessionId) {
@@ -470,24 +521,35 @@ export function useAgentStudioSessionActions({
         autostart: undefined,
       };
 
-      if (
-        (activeSession?.sessionId ?? null) !== null ||
-        (activeSession?.role ?? role) !== nextRole
-      ) {
-        onContextSwitchIntent?.();
-      }
-
-      updateQuery({
-        task: taskId,
-        session: undefined,
-        agent: nextRole,
-        scenario: nextScenario,
-        autostart: undefined,
-      });
-
       const startPromise = (async (): Promise<string | undefined> => {
         try {
           setIsStarting(true);
+          const selectedModel = await resolveRequestedSelection({
+            taskId,
+            role: nextRole,
+            scenario: nextScenario,
+            startMode: "fresh",
+            reason: "create_session",
+          });
+          if (selectedModel === undefined) {
+            return undefined;
+          }
+
+          if (
+            (activeSession?.sessionId ?? null) !== null ||
+            (activeSession?.role ?? role) !== nextRole
+          ) {
+            onContextSwitchIntent?.();
+          }
+
+          updateQuery({
+            task: taskId,
+            session: undefined,
+            agent: nextRole,
+            scenario: nextScenario,
+            autostart: undefined,
+          });
+
           const sessionId = await captureOrchestratorFallback<string | undefined>(
             "agent-studio-start-fresh-session",
             async () =>
@@ -495,6 +557,7 @@ export function useAgentStudioSessionActions({
                 taskId,
                 role: nextRole,
                 scenario: nextScenario,
+                selectedModel,
                 sendKickoff: false,
                 startMode: "fresh",
                 requireModelReady: true,
@@ -555,6 +618,7 @@ export function useAgentStudioSessionActions({
       isActiveTaskHydrated,
       isSessionWorking,
       selectedTask,
+      resolveRequestedSelection,
       role,
       scenario,
       activeRepo,

--- a/apps/desktop/src/pages/use-agent-studio-session-actions.ts
+++ b/apps/desktop/src/pages/use-agent-studio-session-actions.ts
@@ -519,6 +519,7 @@ export function useAgentStudioSessionActions({
         agent: role,
         scenario,
         autostart: undefined,
+        start: undefined,
       };
 
       const startPromise = (async (): Promise<string | undefined> => {
@@ -548,6 +549,7 @@ export function useAgentStudioSessionActions({
             agent: nextRole,
             scenario: nextScenario,
             autostart: undefined,
+            start: "fresh",
           });
 
           const sessionId = await captureOrchestratorFallback<string | undefined>(
@@ -585,6 +587,7 @@ export function useAgentStudioSessionActions({
             agent: nextRole,
             scenario: nextScenario,
             autostart: undefined,
+            start: undefined,
           });
           runOrchestratorSideEffect(
             "agent-studio-send-kickoff-message",

--- a/apps/desktop/src/pages/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-task-hydration.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
+import type { AgentSessionLoadOptions } from "@/types/agent-orchestrator";
 import {
   createDeferred,
   createHookHarness as createSharedHookHarness,
@@ -16,7 +17,7 @@ const createHookHarness = (initialProps: HookArgs) =>
 const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   activeRepo: "/repo-a",
   activeTaskId: "task-1",
-  tabTaskIds: [],
+  activeSessionId: null,
   loadAgentSessions: async () => {},
   ...overrides,
 });
@@ -56,54 +57,48 @@ describe("useAgentStudioTaskHydration", () => {
     }
   });
 
-  test("hydrates tab tasks in the background and skips duplicates/active task", async () => {
-    const deferredByTask = new Map<string, ReturnType<typeof createDeferred<void>>>([
-      ["task-1", createDeferred<void>()],
-      ["task-2", createDeferred<void>()],
-      ["task-3", createDeferred<void>()],
-    ]);
-    const loadAgentSessions = mock((taskId: string) => {
-      const deferred = deferredByTask.get(taskId);
-      if (!deferred) {
-        return Promise.resolve();
-      }
-      return deferred.promise;
-    });
-
-    const args = createBaseArgs({
-      tabTaskIds: ["task-1", "task-2", "task-3", "task-2"],
-      loadAgentSessions,
-    });
-    const harness = createHookHarness(args);
+  test("loads message history only for the active session", async () => {
+    const loadAgentSessions = mock(
+      async (_taskId: string, _options?: AgentSessionLoadOptions): Promise<void> => {},
+    );
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeSessionId: "session-1",
+        loadAgentSessions,
+      }),
+    );
 
     try {
       await harness.mount();
 
-      expect(loadAgentSessions).toHaveBeenCalledTimes(3);
-      expect(loadAgentSessions).toHaveBeenCalledWith("task-1");
-      expect(loadAgentSessions).toHaveBeenCalledWith("task-2");
-      expect(loadAgentSessions).toHaveBeenCalledWith("task-3");
+      expect(loadAgentSessions).toHaveBeenCalledTimes(2);
+      expect(loadAgentSessions.mock.calls[0]).toEqual(["task-1"]);
+      expect(loadAgentSessions.mock.calls[1]).toEqual([
+        "task-1",
+        { hydrateHistoryForSessionId: "session-1" },
+      ]);
 
-      await harness.update(args);
-      expect(loadAgentSessions).toHaveBeenCalledTimes(3);
-
-      await harness.run(async () => {
-        deferredByTask.get("task-1")?.resolve(undefined);
-        deferredByTask.get("task-2")?.resolve(undefined);
-        deferredByTask.get("task-3")?.resolve(undefined);
-        await Promise.all([...deferredByTask.values()].map((entry) => entry.promise));
-      });
-
-      await harness.waitFor(
-        (state) =>
-          state["/repo-a:task-1"] === true &&
-          state["/repo-a:task-2"] === true &&
-          state["/repo-a:task-3"] === true,
+      await harness.update(
+        createBaseArgs({
+          activeSessionId: "session-1",
+          loadAgentSessions,
+        }),
       );
+      expect(loadAgentSessions).toHaveBeenCalledTimes(2);
+
+      await harness.update(
+        createBaseArgs({
+          activeSessionId: "session-2",
+          loadAgentSessions,
+        }),
+      );
+
+      expect(loadAgentSessions).toHaveBeenCalledTimes(3);
+      expect(loadAgentSessions.mock.calls[2]).toEqual([
+        "task-1",
+        { hydrateHistoryForSessionId: "session-2" },
+      ]);
     } finally {
-      for (const deferred of deferredByTask.values()) {
-        deferred.resolve(undefined);
-      }
       await harness.unmount();
     }
   });
@@ -169,7 +164,7 @@ describe("useAgentStudioTaskHydration", () => {
         createBaseArgs({
           activeRepo: "/repo-b",
           activeTaskId: "task-1",
-          tabTaskIds: [],
+          activeSessionId: null,
           loadAgentSessions,
         }),
       );

--- a/apps/desktop/src/pages/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/use-agent-studio-task-hydration.ts
@@ -1,19 +1,22 @@
 import { useEffect, useRef, useState } from "react";
+import type { AgentSessionLoadOptions } from "@/types/agent-orchestrator";
 
 type UseAgentStudioTaskHydrationParams = {
   activeRepo: string | null;
   activeTaskId: string;
-  tabTaskIds: string[];
-  loadAgentSessions: (taskId: string) => Promise<void>;
+  activeSessionId: string | null;
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
 };
 
 export function useAgentStudioTaskHydration({
   activeRepo,
   activeTaskId,
-  tabTaskIds,
+  activeSessionId,
   loadAgentSessions,
 }: UseAgentStudioTaskHydrationParams): Record<string, boolean> {
-  const hydratingTaskTabsByRepoRef = useRef(new Set<string>());
+  const hydratingTasksByRepoRef = useRef(new Set<string>());
+  const hydratingSessionHistoriesByRepoRef = useRef(new Set<string>());
+  const hydratedSessionHistoriesByRepoRef = useRef(new Set<string>());
   const previousRepoRef = useRef<string | null>(activeRepo);
   const [hydratedTasksByRepoAndTask, setHydratedTasksByRepoAndTask] = useState<
     Record<string, boolean>
@@ -24,7 +27,9 @@ export function useAgentStudioTaskHydration({
       return;
     }
     previousRepoRef.current = activeRepo;
-    hydratingTaskTabsByRepoRef.current.clear();
+    hydratingTasksByRepoRef.current.clear();
+    hydratingSessionHistoriesByRepoRef.current.clear();
+    hydratedSessionHistoriesByRepoRef.current.clear();
     setHydratedTasksByRepoAndTask({});
   }, [activeRepo]);
 
@@ -37,14 +42,14 @@ export function useAgentStudioTaskHydration({
     if (hydratedTasksByRepoAndTask[hydrationKey]) {
       return;
     }
-    if (hydratingTaskTabsByRepoRef.current.has(hydrationKey)) {
+    if (hydratingTasksByRepoRef.current.has(hydrationKey)) {
       return;
     }
 
-    hydratingTaskTabsByRepoRef.current.add(hydrationKey);
+    hydratingTasksByRepoRef.current.add(hydrationKey);
     let cancelled = false;
     void loadAgentSessions(activeTaskId).finally(() => {
-      hydratingTaskTabsByRepoRef.current.delete(hydrationKey);
+      hydratingTasksByRepoRef.current.delete(hydrationKey);
       if (cancelled) {
         return;
       }
@@ -65,53 +70,34 @@ export function useAgentStudioTaskHydration({
   }, [activeRepo, activeTaskId, hydratedTasksByRepoAndTask, loadAgentSessions]);
 
   useEffect(() => {
-    if (!activeRepo || tabTaskIds.length === 0) {
+    if (!activeRepo || !activeTaskId || !activeSessionId) {
       return;
     }
 
+    const sessionHydrationKey = `${activeRepo}:${activeTaskId}:${activeSessionId}`;
+    if (hydratedSessionHistoriesByRepoRef.current.has(sessionHydrationKey)) {
+      return;
+    }
+    if (hydratingSessionHistoriesByRepoRef.current.has(sessionHydrationKey)) {
+      return;
+    }
+
+    hydratingSessionHistoriesByRepoRef.current.add(sessionHydrationKey);
     let cancelled = false;
-    const pendingTaskIds = tabTaskIds.filter((taskId) => {
-      if (!taskId || taskId === activeTaskId) {
-        return false;
+    void loadAgentSessions(activeTaskId, {
+      hydrateHistoryForSessionId: activeSessionId,
+    }).finally(() => {
+      hydratingSessionHistoriesByRepoRef.current.delete(sessionHydrationKey);
+      if (cancelled) {
+        return;
       }
-      const hydrationKey = `${activeRepo}:${taskId}`;
-      if (hydratedTasksByRepoAndTask[hydrationKey]) {
-        return false;
-      }
-      if (hydratingTaskTabsByRepoRef.current.has(hydrationKey)) {
-        return false;
-      }
-      hydratingTaskTabsByRepoRef.current.add(hydrationKey);
-      return true;
+      hydratedSessionHistoriesByRepoRef.current.add(sessionHydrationKey);
     });
-
-    if (pendingTaskIds.length === 0) {
-      return;
-    }
-
-    for (const taskId of pendingTaskIds) {
-      const hydrationKey = `${activeRepo}:${taskId}`;
-      void loadAgentSessions(taskId).finally(() => {
-        hydratingTaskTabsByRepoRef.current.delete(hydrationKey);
-        if (cancelled) {
-          return;
-        }
-        setHydratedTasksByRepoAndTask((current) => {
-          if (current[hydrationKey] === true) {
-            return current;
-          }
-          return {
-            ...current,
-            [hydrationKey]: true,
-          };
-        });
-      });
-    }
 
     return () => {
       cancelled = true;
     };
-  }, [activeRepo, activeTaskId, hydratedTasksByRepoAndTask, loadAgentSessions, tabTaskIds]);
+  }, [activeRepo, activeSessionId, activeTaskId, loadAgentSessions]);
 
   return hydratedTasksByRepoAndTask;
 }

--- a/apps/desktop/src/pages/use-session-start-modal-state.test.tsx
+++ b/apps/desktop/src/pages/use-session-start-modal-state.test.tsx
@@ -254,4 +254,39 @@ describe("useSessionStartModalState", () => {
 
     await harness.unmount();
   });
+
+  test("preserves caller-selected model when opening modal", async () => {
+    const harness = createHookHarness(createBaseProps());
+
+    await harness.mount();
+    await harness.waitFor((state) => state.isCatalogLoading === false);
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "agent_studio",
+        taskId: "TASK-5",
+        role: "spec",
+        scenario: "spec_initial",
+        startMode: "fresh",
+        postStartAction: "none",
+        selectedModel: {
+          providerId: "anthropic",
+          modelId: "claude-sonnet",
+          variant: "default",
+          opencodeAgent: "build-agent",
+        },
+        title: "Start Spec Session",
+      });
+    });
+
+    await harness.waitFor((state) => state.selection?.modelId === "claude-sonnet");
+    expect(harness.getLatest().selection).toEqual({
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      variant: "default",
+      opencodeAgent: "build-agent",
+    });
+
+    await harness.unmount();
+  });
 });

--- a/apps/desktop/src/pages/use-session-start-modal-state.test.tsx
+++ b/apps/desktop/src/pages/use-session-start-modal-state.test.tsx
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { AgentModelCatalog } from "@openducktor/core";
+import type { RepoSettingsInput } from "@/types/state-slices";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useSessionStartModalState } from "./use-session-start-modal-state";
+
+enableReactActEnvironment();
+
+const TEST_RENDERER_DEPRECATION_WARNING = "react-test-renderer is deprecated";
+const originalConsoleError = console.error;
+
+type HookArgs = Parameters<typeof useSessionStartModalState>[0];
+
+const CATALOG: AgentModelCatalog = {
+  models: [
+    {
+      id: "openai/gpt-5",
+      providerId: "openai",
+      providerName: "OpenAI",
+      modelId: "gpt-5",
+      modelName: "GPT-5",
+      variants: ["default", "high"],
+      contextWindow: 200_000,
+      outputLimit: 8_192,
+    },
+    {
+      id: "anthropic/claude-sonnet",
+      providerId: "anthropic",
+      providerName: "Anthropic",
+      modelId: "claude-sonnet",
+      modelName: "Claude Sonnet",
+      variants: ["default"],
+    },
+  ],
+  defaultModelsByProvider: {
+    openai: "gpt-5",
+  },
+  agents: [
+    {
+      name: "spec-agent",
+      mode: "primary",
+      hidden: false,
+      color: "#f59e0b",
+    },
+    {
+      name: "build-agent",
+      mode: "primary",
+      hidden: false,
+    },
+  ],
+};
+
+const createRepoSettings = (
+  overrides: Partial<RepoSettingsInput["agentDefaults"]> = {},
+): RepoSettingsInput => ({
+  worktreeBasePath: "",
+  branchPrefix: "codex/",
+  trustedHooks: false,
+  preStartHooks: [],
+  postCompleteHooks: [],
+  agentDefaults: {
+    spec: {
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      opencodeAgent: "spec-agent",
+    },
+    planner: null,
+    build: {
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      variant: "default",
+      opencodeAgent: "build-agent",
+    },
+    qa: null,
+    ...overrides,
+  },
+});
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useSessionStartModalState, initialProps);
+
+const createBaseProps = (overrides: Partial<HookArgs> = {}): HookArgs => ({
+  activeRepo: "/repo",
+  repoSettings: createRepoSettings(),
+  loadCatalog: async () => CATALOG,
+  ...overrides,
+});
+
+describe("useSessionStartModalState", () => {
+  beforeEach(() => {
+    console.error = (...args: unknown[]): void => {
+      if (typeof args[0] === "string" && args[0].includes(TEST_RENDERER_DEPRECATION_WARNING)) {
+        return;
+      }
+      originalConsoleError(...args);
+    };
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  test("initializes selection from repo role defaults", async () => {
+    const harness = createHookHarness(createBaseProps());
+
+    await harness.mount();
+    await harness.waitFor((state) => state.isCatalogLoading === false);
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "agent_studio",
+        taskId: "TASK-1",
+        role: "build",
+        scenario: "build_implementation_start",
+        startMode: "fresh",
+        postStartAction: "kickoff",
+        title: "Start Build Session",
+      });
+    });
+
+    await harness.waitFor((state) => state.selection?.modelId === "claude-sonnet");
+    expect(harness.getLatest().selection).toEqual({
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      variant: "default",
+      opencodeAgent: "build-agent",
+    });
+
+    await harness.unmount();
+  });
+
+  test("normalizes stale defaults against the loaded catalog", async () => {
+    const harness = createHookHarness(
+      createBaseProps({
+        repoSettings: createRepoSettings({
+          spec: {
+            providerId: "openai",
+            modelId: "does-not-exist",
+            variant: "legacy",
+            opencodeAgent: "spec-agent",
+          },
+        }),
+      }),
+    );
+
+    await harness.mount();
+    await harness.waitFor((state) => state.isCatalogLoading === false);
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-2",
+        role: "spec",
+        scenario: "spec_initial",
+        startMode: "fresh",
+        postStartAction: "kickoff",
+        title: "Start Spec Session",
+      });
+    });
+
+    await harness.waitFor((state) => state.selection?.modelId === "gpt-5");
+    expect(harness.getLatest().selection).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+      opencodeAgent: "spec-agent",
+    });
+
+    await harness.unmount();
+  });
+
+  test("resets draft selection on close", async () => {
+    const harness = createHookHarness(createBaseProps());
+
+    await harness.mount();
+    await harness.waitFor((state) => state.isCatalogLoading === false);
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-3",
+        role: "spec",
+        scenario: "spec_initial",
+        startMode: "fresh",
+        postStartAction: "kickoff",
+        title: "Start Spec Session",
+      });
+    });
+
+    await harness.waitFor((state) => state.selection?.modelId === "gpt-5");
+
+    await harness.run(() => {
+      const state = harness.getLatest();
+      state.handleSelectModel("anthropic/claude-sonnet");
+    });
+    await harness.waitFor((state) => state.selection?.modelId === "claude-sonnet");
+
+    await harness.run(() => {
+      harness.getLatest().closeStartModal();
+    });
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-3",
+        role: "spec",
+        scenario: "spec_initial",
+        startMode: "fresh",
+        postStartAction: "kickoff",
+        title: "Start Spec Session",
+      });
+    });
+
+    await harness.waitFor((state) => state.selection?.modelId === "gpt-5");
+    expect(harness.getLatest().selection).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      opencodeAgent: "spec-agent",
+    });
+
+    await harness.unmount();
+  });
+
+  test("uses role defaults for modal initialization", async () => {
+    const harness = createHookHarness(createBaseProps());
+
+    await harness.mount();
+    await harness.waitFor((state) => state.isCatalogLoading === false);
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "agent_studio",
+        taskId: "TASK-4",
+        role: "spec",
+        scenario: "spec_initial",
+        startMode: "reuse_latest",
+        postStartAction: "none",
+        title: "Start Spec Session",
+      });
+    });
+
+    await harness.waitFor((state) => state.selection?.modelId === "gpt-5");
+    expect(harness.getLatest().selection).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      opencodeAgent: "spec-agent",
+    });
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/pages/use-session-start-modal-state.ts
+++ b/apps/desktop/src/pages/use-session-start-modal-state.ts
@@ -1,0 +1,296 @@
+import type {
+  AgentModelCatalog,
+  AgentModelSelection,
+  AgentRole,
+  AgentScenario,
+} from "@openducktor/core";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  resolveAgentAccentColor,
+  toModelGroupsByProvider,
+  toModelOptions,
+  toPrimaryAgentOptions,
+} from "@/components/features/agents";
+import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
+import { loadRepoOpencodeCatalog } from "@/state/operations";
+import type { RepoSettingsInput } from "@/types/state-slices";
+import {
+  isSameSelection,
+  normalizeSelectionForCatalog,
+  pickDefaultSelectionForCatalog,
+} from "./agents-page-utils";
+
+export type SessionStartModalSource = "agent_studio" | "kanban";
+export type SessionStartPostAction = "none" | "kickoff" | "send_message";
+
+export type SessionStartModalIntent = {
+  source: SessionStartModalSource;
+  taskId: string;
+  role: AgentRole;
+  scenario: AgentScenario;
+  startMode: "fresh" | "reuse_latest";
+  postStartAction: SessionStartPostAction;
+  message?: string;
+  title: string;
+  description?: string;
+};
+
+type UseSessionStartModalStateArgs = {
+  activeRepo: string | null;
+  repoSettings: RepoSettingsInput | null;
+  loadCatalog?: (repoPath: string) => Promise<AgentModelCatalog>;
+};
+
+type UseSessionStartModalStateResult = {
+  intent: SessionStartModalIntent | null;
+  isOpen: boolean;
+  selection: AgentModelSelection | null;
+  isCatalogLoading: boolean;
+  agentOptions: ComboboxOption[];
+  modelOptions: ComboboxOption[];
+  modelGroups: ComboboxGroup[];
+  variantOptions: ComboboxOption[];
+  openStartModal: (nextIntent: SessionStartModalIntent) => void;
+  closeStartModal: () => void;
+  handleSelectAgent: (opencodeAgent: string) => void;
+  handleSelectModel: (modelKey: string) => void;
+  handleSelectVariant: (variant: string) => void;
+};
+
+const roleDefaultSelectionFor = (
+  repoSettings: RepoSettingsInput | null,
+  role: AgentRole,
+): AgentModelSelection | null => {
+  const roleDefault = repoSettings?.agentDefaults[role];
+  if (!roleDefault || !roleDefault.providerId || !roleDefault.modelId) {
+    return null;
+  }
+
+  return {
+    providerId: roleDefault.providerId,
+    modelId: roleDefault.modelId,
+    ...(roleDefault.variant ? { variant: roleDefault.variant } : {}),
+    ...(roleDefault.opencodeAgent ? { opencodeAgent: roleDefault.opencodeAgent } : {}),
+  };
+};
+
+const resolveInitialSelection = (
+  repoSettings: RepoSettingsInput | null,
+  role: AgentRole,
+  catalog: AgentModelCatalog | null,
+): AgentModelSelection | null => {
+  const roleDefault = roleDefaultSelectionFor(repoSettings, role);
+  return (
+    normalizeSelectionForCatalog(catalog, roleDefault) ??
+    pickDefaultSelectionForCatalog(catalog) ??
+    roleDefault
+  );
+};
+
+export function useSessionStartModalState({
+  activeRepo,
+  repoSettings,
+  loadCatalog = loadRepoOpencodeCatalog,
+}: UseSessionStartModalStateArgs): UseSessionStartModalStateResult {
+  const [intent, setIntent] = useState<SessionStartModalIntent | null>(null);
+  const [selection, setSelection] = useState<AgentModelSelection | null>(null);
+  const [catalog, setCatalog] = useState<AgentModelCatalog | null>(null);
+  const [isCatalogLoading, setIsCatalogLoading] = useState(false);
+
+  useEffect(() => {
+    if (!activeRepo) {
+      setCatalog(null);
+      setIsCatalogLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setCatalog(null);
+    setIsCatalogLoading(true);
+    void loadCatalog(activeRepo)
+      .then((nextCatalog) => {
+        if (!cancelled) {
+          setCatalog(nextCatalog);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCatalog(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsCatalogLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeRepo, loadCatalog]);
+
+  const closeStartModal = useCallback(() => {
+    setIntent(null);
+    setSelection(null);
+  }, []);
+
+  const openStartModal = useCallback(
+    (nextIntent: SessionStartModalIntent) => {
+      setIntent(nextIntent);
+      setSelection(resolveInitialSelection(repoSettings, nextIntent.role, catalog));
+    },
+    [catalog, repoSettings],
+  );
+
+  const activeRole = intent?.role ?? null;
+
+  useEffect(() => {
+    if (!activeRole) {
+      return;
+    }
+
+    setSelection((current) => {
+      const normalizedCurrent = normalizeSelectionForCatalog(catalog, current);
+      const fallback = resolveInitialSelection(repoSettings, activeRole, catalog);
+      const next = normalizedCurrent ?? fallback;
+      return isSameSelection(current, next) ? current : next;
+    });
+  }, [activeRole, catalog, repoSettings]);
+
+  const selectedModelEntry = useMemo(() => {
+    if (!catalog || !selection) {
+      return null;
+    }
+    return (
+      catalog.models.find(
+        (entry) => entry.providerId === selection.providerId && entry.modelId === selection.modelId,
+      ) ?? null
+    );
+  }, [catalog, selection]);
+
+  const agentOptions = useMemo<ComboboxOption[]>(() => {
+    const options = toPrimaryAgentOptions(catalog);
+    if (options.length > 0) {
+      return options;
+    }
+
+    const fallbackAgent = selection?.opencodeAgent;
+    if (!fallbackAgent) {
+      return [];
+    }
+    const accentColor = resolveAgentAccentColor(fallbackAgent);
+    return [
+      {
+        value: fallbackAgent,
+        label: fallbackAgent,
+        description: "Current default agent",
+        ...(accentColor ? { accentColor } : {}),
+      },
+    ];
+  }, [catalog, selection?.opencodeAgent]);
+
+  const modelOptions = useMemo<ComboboxOption[]>(() => {
+    const options = toModelOptions(catalog);
+    if (options.length > 0) {
+      return options;
+    }
+
+    if (!selection?.providerId || !selection.modelId) {
+      return [];
+    }
+
+    return [
+      {
+        value: `${selection.providerId}/${selection.modelId}`,
+        label: selection.modelId,
+        description: `${selection.providerId} (saved default model)`,
+      },
+    ];
+  }, [catalog, selection]);
+
+  const modelGroups = useMemo<ComboboxGroup[]>(() => {
+    return toModelGroupsByProvider(catalog);
+  }, [catalog]);
+
+  const variantOptions = useMemo<ComboboxOption[]>(() => {
+    if (selectedModelEntry) {
+      return selectedModelEntry.variants.map((variant) => ({
+        value: variant,
+        label: variant,
+      }));
+    }
+
+    if (!selection?.variant) {
+      return [];
+    }
+
+    return [{ value: selection.variant, label: selection.variant }];
+  }, [selectedModelEntry, selection?.variant]);
+
+  const handleSelectAgent = useCallback(
+    (opencodeAgent: string): void => {
+      const baseSelection =
+        selection ??
+        (activeRole ? resolveInitialSelection(repoSettings, activeRole, catalog) : null) ??
+        pickDefaultSelectionForCatalog(catalog);
+      if (!baseSelection) {
+        return;
+      }
+
+      setSelection({
+        ...baseSelection,
+        opencodeAgent,
+      });
+    },
+    [activeRole, catalog, repoSettings, selection],
+  );
+
+  const handleSelectModel = useCallback(
+    (modelKey: string): void => {
+      if (!catalog) {
+        return;
+      }
+
+      const model = catalog.models.find((entry) => entry.id === modelKey);
+      if (!model) {
+        return;
+      }
+
+      setSelection((current) => ({
+        providerId: model.providerId,
+        modelId: model.modelId,
+        ...(model.variants[0] ? { variant: model.variants[0] } : {}),
+        ...(current?.opencodeAgent ? { opencodeAgent: current.opencodeAgent } : {}),
+      }));
+    },
+    [catalog],
+  );
+
+  const handleSelectVariant = useCallback((variant: string): void => {
+    setSelection((current) => {
+      if (!current) {
+        return current;
+      }
+      return {
+        ...current,
+        variant,
+      };
+    });
+  }, []);
+
+  return {
+    intent,
+    isOpen: intent !== null,
+    selection,
+    isCatalogLoading,
+    agentOptions,
+    modelOptions,
+    modelGroups,
+    variantOptions,
+    openStartModal,
+    closeStartModal,
+    handleSelectAgent,
+    handleSelectModel,
+    handleSelectVariant,
+  };
+}

--- a/apps/desktop/src/pages/use-session-start-modal-state.ts
+++ b/apps/desktop/src/pages/use-session-start-modal-state.ts
@@ -31,6 +31,7 @@ export type SessionStartModalIntent = {
   startMode: "fresh" | "reuse_latest";
   postStartAction: SessionStartPostAction;
   message?: string;
+  selectedModel?: AgentModelSelection | null;
   title: string;
   description?: string;
 };
@@ -78,11 +79,15 @@ const resolveInitialSelection = (
   repoSettings: RepoSettingsInput | null,
   role: AgentRole,
   catalog: AgentModelCatalog | null,
+  selectedModel: AgentModelSelection | null,
 ): AgentModelSelection | null => {
+  const requestedSelection = normalizeSelectionForCatalog(catalog, selectedModel);
   const roleDefault = roleDefaultSelectionFor(repoSettings, role);
   return (
+    requestedSelection ??
     normalizeSelectionForCatalog(catalog, roleDefault) ??
     pickDefaultSelectionForCatalog(catalog) ??
+    selectedModel ??
     roleDefault
   );
 };
@@ -137,7 +142,14 @@ export function useSessionStartModalState({
   const openStartModal = useCallback(
     (nextIntent: SessionStartModalIntent) => {
       setIntent(nextIntent);
-      setSelection(resolveInitialSelection(repoSettings, nextIntent.role, catalog));
+      setSelection(
+        resolveInitialSelection(
+          repoSettings,
+          nextIntent.role,
+          catalog,
+          nextIntent.selectedModel ?? null,
+        ),
+      );
     },
     [catalog, repoSettings],
   );
@@ -151,11 +163,16 @@ export function useSessionStartModalState({
 
     setSelection((current) => {
       const normalizedCurrent = normalizeSelectionForCatalog(catalog, current);
-      const fallback = resolveInitialSelection(repoSettings, activeRole, catalog);
+      const fallback = resolveInitialSelection(
+        repoSettings,
+        activeRole,
+        catalog,
+        intent?.selectedModel ?? null,
+      );
       const next = normalizedCurrent ?? fallback;
       return isSameSelection(current, next) ? current : next;
     });
-  }, [activeRole, catalog, repoSettings]);
+  }, [activeRole, catalog, intent?.selectedModel, repoSettings]);
 
   const selectedModelEntry = useMemo(() => {
     if (!catalog || !selection) {
@@ -231,7 +248,14 @@ export function useSessionStartModalState({
     (opencodeAgent: string): void => {
       const baseSelection =
         selection ??
-        (activeRole ? resolveInitialSelection(repoSettings, activeRole, catalog) : null) ??
+        (activeRole
+          ? resolveInitialSelection(
+              repoSettings,
+              activeRole,
+              catalog,
+              intent?.selectedModel ?? null,
+            )
+          : null) ??
         pickDefaultSelectionForCatalog(catalog);
       if (!baseSelection) {
         return;
@@ -242,7 +266,7 @@ export function useSessionStartModalState({
         opencodeAgent,
       });
     },
-    [activeRole, catalog, repoSettings, selection],
+    [activeRole, catalog, intent?.selectedModel, repoSettings, selection],
   );
 
   const handleSelectModel = useCallback(

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -2,7 +2,7 @@ import type { TaskCard } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentModelSelection, AgentRole } from "@openducktor/core";
 import { errorMessage } from "@/lib/errors";
 import { isRoleAvailableForTask, unavailableRoleErrorMessage } from "@/lib/task-agent-workflows";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import { createEnsureSessionReady } from "../lifecycle/ensure-ready";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import { annotateQuestionToolMessage } from "../support/question-messages";
@@ -44,7 +44,7 @@ type SessionActionsDependencies = {
     baseUrl: string,
     workingDirectory: string,
   ) => Promise<void>;
-  loadAgentSessions: (taskId: string) => Promise<void>;
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
   clearTurnDuration: (sessionId: string) => void;
   refreshTaskData: (repoPath: string) => Promise<void>;
   persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -7,7 +7,7 @@ import type {
 } from "@openducktor/core";
 import { buildAgentSystemPrompt } from "@openducktor/core";
 import { isRoleAvailableForTask, unavailableRoleErrorMessage } from "@/lib/task-agent-workflows";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
 import { requireActiveRepo } from "../../task-operations-model";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
@@ -60,7 +60,7 @@ type StartSessionDependencies = {
     baseUrl: string,
     workingDirectory: string,
   ) => Promise<void>;
-  loadAgentSessions: (taskId: string) => Promise<void>;
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
   refreshTaskData: (repoPath: string) => Promise<void>;
   persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;
   sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
@@ -148,7 +148,9 @@ export const createStartAgentSession = ({
         );
         if (latestPersistedSession) {
           if (!sessionsRef.current[latestPersistedSession.sessionId]) {
-            await loadAgentSessions(taskId);
+            await loadAgentSessions(taskId, {
+              hydrateHistoryForSessionId: latestPersistedSession.sessionId,
+            });
             throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
           }
           return latestPersistedSession.sessionId;

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -110,6 +110,67 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(state["session-1"]?.status).toBe("stopped");
   });
 
+  test("does not eagerly hydrate session history without an explicit target session", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    let historyLoads = 0;
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: {
+        loadSessionHistory: async () => {
+          historyLoads += 1;
+          return [];
+        },
+      },
+      repoEpochRef: { current: 2 },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession: () => {},
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+    });
+
+    const hostModule = await import("../../host");
+    const originalList = hostModule.host.agentSessionsList;
+    hostModule.host.agentSessionsList = async () => [
+      {
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        taskId: "task-1",
+        role: "build",
+        scenario: "build_implementation_start",
+        status: "running",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+        runtimeId: "runtime-1",
+        runId: "run-1",
+        baseUrl: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo",
+      },
+    ];
+
+    try {
+      await loadAgentSessions("task-1");
+    } finally {
+      hostModule.host.agentSessionsList = originalList;
+    }
+
+    expect(Object.keys(state)).toContain("session-1");
+    expect(historyLoads).toBe(0);
+    expect(state["session-1"]?.messages).toEqual([]);
+  });
+
   test("rehydrates persisted sessions that exist in memory with empty message history", async () => {
     const existingSession: AgentSessionState = {
       sessionId: "session-1",
@@ -201,7 +262,7 @@ describe("agent-orchestrator-load-sessions", () => {
     ];
 
     try {
-      await loadAgentSessions("task-1");
+      await loadAgentSessions("task-1", { hydrateHistoryForSessionId: "session-1" });
     } finally {
       hostModule.host.agentSessionsList = originalList;
     }
@@ -377,7 +438,7 @@ describe("agent-orchestrator-load-sessions", () => {
     };
 
     try {
-      await loadAgentSessions("task-1");
+      await loadAgentSessions("task-1", { hydrateHistoryForSessionId: "session-1" });
     } finally {
       hostModule.host.agentSessionsList = originalList;
       hostModule.host.specGet = originalSpecGet;

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -1,7 +1,7 @@
 import type { TaskCard } from "@openducktor/contracts";
 import { type AgentEnginePort, buildAgentSystemPrompt } from "@openducktor/core";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
 import {
   captureOrchestratorFallback,
@@ -70,8 +70,11 @@ export const createLoadAgentSessions = ({
   updateSession,
   loadSessionTodos,
   loadSessionModelCatalog,
-}: CreateLoadAgentSessionsArgs): ((taskId: string) => Promise<void>) => {
-  return async (taskId: string): Promise<void> => {
+}: CreateLoadAgentSessionsArgs): ((
+  taskId: string,
+  options?: AgentSessionLoadOptions,
+) => Promise<void>) => {
+  return async (taskId: string, options?: AgentSessionLoadOptions): Promise<void> => {
     if (!activeRepo || taskId.trim().length === 0) {
       return;
     }
@@ -119,6 +122,9 @@ export const createLoadAgentSessions = ({
     if (isStaleRepoOperation()) {
       return;
     }
+
+    const requestedSessionId = options?.hydrateHistoryForSessionId?.trim() || null;
+    const shouldHydrateRequestedSession = requestedSessionId !== null;
     setSessionsById((current) => {
       if (isStaleRepoOperation()) {
         return current;
@@ -139,23 +145,37 @@ export const createLoadAgentSessions = ({
     }
 
     const recordsToHydrate = persisted.filter((record) => {
+      if (shouldHydrateRequestedSession && record.sessionId !== requestedSessionId) {
+        return false;
+      }
+      if (!shouldHydrateRequestedSession) {
+        return false;
+      }
       const existingSession = sessionsRef.current[record.sessionId];
       return !existingSession || existingSession.messages.length === 0;
     });
 
     if (recordsToHydrate.length === 0) {
-      const existingSessions = Object.values(sessionsRef.current).filter(
-        (entry) => entry.taskId === taskId && !entry.modelCatalog && !entry.isLoadingModelCatalog,
-      );
-      for (const session of existingSessions) {
-        if (!session.baseUrl || !session.workingDirectory) {
-          continue;
-        }
+      if (!shouldHydrateRequestedSession) {
+        return;
+      }
+
+      const requestedSession = requestedSessionId
+        ? sessionsRef.current[requestedSessionId]
+        : undefined;
+      if (
+        requestedSession &&
+        requestedSession.taskId === taskId &&
+        !requestedSession.modelCatalog &&
+        !requestedSession.isLoadingModelCatalog &&
+        requestedSession.baseUrl &&
+        requestedSession.workingDirectory
+      ) {
         warmSessionData(
-          session.sessionId,
-          session.baseUrl,
-          session.workingDirectory,
-          session.externalSessionId,
+          requestedSession.sessionId,
+          requestedSession.baseUrl,
+          requestedSession.workingDirectory,
+          requestedSession.externalSessionId,
         );
       }
       return;

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
@@ -8,7 +8,11 @@ import type {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
-import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
+import type {
+  AgentChatMessage,
+  AgentSessionLoadOptions,
+  AgentSessionState,
+} from "@/types/agent-orchestrator";
 import {
   attachAgentSessionListener,
   createAgentSessionActions,
@@ -36,7 +40,7 @@ type UseAgentOrchestratorOperationsArgs = {
 
 type UseAgentOrchestratorOperationsResult = {
   sessions: AgentSessionState[];
-  loadAgentSessions: (taskId: string) => Promise<void>;
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
   startAgentSession: (input: {
     taskId: string;
     role: AgentRole;
@@ -396,9 +400,9 @@ export function useAgentOrchestratorOperations({
 
   return {
     sessions,
-    loadAgentSessions: async (taskId) => {
+    loadAgentSessions: async (taskId, options) => {
       try {
-        await loadAgentSessions(taskId);
+        await loadAgentSessions(taskId, options);
       } catch (error) {
         toast.error("Failed to load agent sessions", {
           description: errorMessage(error),

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -83,3 +83,82 @@ pre {
 .markdown-body pre code::after {
   content: none;
 }
+
+@keyframes odt-border-ray-run {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: calc(var(--odt-border-ray-perimeter) * -1);
+  }
+}
+
+.kanban-active-session-card {
+  position: relative;
+  isolation: isolate;
+  border-color: rgba(14, 165, 233, 0.58);
+  box-shadow: 0 0 9px rgba(14, 165, 233, 0.22);
+}
+
+.kanban-active-session-ray,
+.odt-border-ray {
+  overflow: visible;
+  --odt-border-ray-turn-duration: 3000ms;
+  --odt-border-ray-perimeter: 1000;
+  --odt-border-ray-length: 190;
+}
+
+.odt-border-ray-segment-halo,
+.odt-border-ray-segment-glow,
+.odt-border-ray-segment,
+.kanban-active-session-ray-segment-halo,
+.kanban-active-session-ray-segment-glow,
+.kanban-active-session-ray-segment {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+  shape-rendering: geometricPrecision;
+  stroke-dasharray: var(--odt-border-ray-length)
+    calc(var(--odt-border-ray-perimeter) - var(--odt-border-ray-length));
+  animation: odt-border-ray-run var(--odt-border-ray-turn-duration) linear infinite;
+}
+
+.odt-border-ray-segment-halo,
+.kanban-active-session-ray-segment-halo {
+  stroke: rgba(56, 189, 248, 0.44);
+  stroke-width: 14;
+  opacity: 0.42;
+  filter: blur(7px);
+}
+
+.odt-border-ray-segment-glow,
+.kanban-active-session-ray-segment-glow {
+  stroke: rgba(125, 211, 252, 0.9);
+  stroke-width: 9.8;
+  opacity: 0.58;
+  filter: blur(3.3px) drop-shadow(0 0 8px rgba(56, 189, 248, 0.62));
+}
+
+.odt-border-ray-segment,
+.kanban-active-session-ray-segment {
+  stroke: rgba(56, 189, 248, 1);
+  stroke-width: 4.4;
+  filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.9));
+}
+
+.kanban-active-session-content {
+  position: relative;
+  z-index: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .odt-border-ray-segment-halo,
+  .odt-border-ray-segment-glow,
+  .odt-border-ray-segment,
+  .kanban-active-session-ray-segment-halo,
+  .kanban-active-session-ray-segment-glow,
+  .kanban-active-session-ray-segment {
+    animation: none;
+  }
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -110,10 +110,7 @@ pre {
 
 .odt-border-ray-segment-halo,
 .odt-border-ray-segment-glow,
-.odt-border-ray-segment,
-.kanban-active-session-ray-segment-halo,
-.kanban-active-session-ray-segment-glow,
-.kanban-active-session-ray-segment {
+.odt-border-ray-segment {
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
@@ -124,24 +121,21 @@ pre {
   animation: odt-border-ray-run var(--odt-border-ray-turn-duration) linear infinite;
 }
 
-.odt-border-ray-segment-halo,
-.kanban-active-session-ray-segment-halo {
+.odt-border-ray-segment-halo {
   stroke: rgba(56, 189, 248, 0.44);
   stroke-width: 14;
   opacity: 0.42;
   filter: blur(7px);
 }
 
-.odt-border-ray-segment-glow,
-.kanban-active-session-ray-segment-glow {
+.odt-border-ray-segment-glow {
   stroke: rgba(125, 211, 252, 0.9);
   stroke-width: 9.8;
   opacity: 0.58;
   filter: blur(3.3px) drop-shadow(0 0 8px rgba(56, 189, 248, 0.62));
 }
 
-.odt-border-ray-segment,
-.kanban-active-session-ray-segment {
+.odt-border-ray-segment {
   stroke: rgba(56, 189, 248, 1);
   stroke-width: 4.4;
   filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.9));
@@ -155,10 +149,7 @@ pre {
 @media (prefers-reduced-motion: reduce) {
   .odt-border-ray-segment-halo,
   .odt-border-ray-segment-glow,
-  .odt-border-ray-segment,
-  .kanban-active-session-ray-segment-halo,
-  .kanban-active-session-ray-segment-glow,
-  .kanban-active-session-ray-segment {
+  .odt-border-ray-segment {
     animation: none;
   }
 }

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -110,3 +110,7 @@ export type AgentSessionState = {
   selectedModel: AgentModelSelection | null;
   isLoadingModelCatalog: boolean;
 };
+
+export type AgentSessionLoadOptions = {
+  hydrateHistoryForSessionId?: string | null;
+};

--- a/apps/desktop/src/types/state-slices.ts
+++ b/apps/desktop/src/types/state-slices.ts
@@ -12,7 +12,7 @@ import type {
   WorkspaceRecord,
 } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole, AgentScenario } from "@openducktor/core";
-import type { AgentSessionState } from "./agent-orchestrator";
+import type { AgentSessionLoadOptions, AgentSessionState } from "./agent-orchestrator";
 import type { RepoOpencodeHealthCheck } from "./diagnostics";
 
 export type RepoAgentDefaultInput = {
@@ -100,7 +100,7 @@ export type SpecStateContextValue = {
 
 export type AgentStateContextValue = {
   sessions: AgentSessionState[];
-  loadAgentSessions: (taskId: string) => Promise<void>;
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
   startAgentSession: (input: {
     taskId: string;
     role: AgentRole;


### PR DESCRIPTION
## Summary
- add explicit Agent Studio session-start confirmation and preselection flow for role/scenario kickoff
- add reusable BorderRay active-session highlighting in Kanban task cards plus related workflow UI updates
- fix Agent Studio new-session flicker and stop eager loading all session histories by hydrating only the active session

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test