### PR TITLE
test: enforce cross-layer workflow contract parity

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
@@ -431,11 +431,33 @@ pub(crate) fn normalize_subtask_plan_inputs(
 #[cfg(test)]
 mod tests {
     use super::{
+        allows_transition, can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
         derive_agent_workflows, derive_available_actions, normalize_subtask_plan_inputs,
         normalize_title_key,
     };
     use crate::app_service::test_support::make_task;
     use host_domain::{PlanSubtaskInput, QaWorkflowVerdict, TaskAction, TaskStatus};
+    use serde::Deserialize;
+    use std::collections::BTreeMap;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct WorkflowContractFixture {
+        statuses: Vec<String>,
+        transitions: BTreeMap<String, BTreeMap<String, Vec<String>>>,
+        set_spec_allowed_statuses: Vec<String>,
+        set_plan_allowed_statuses: BTreeMap<String, Vec<String>>,
+        epic_subtask_replacement_allowed_statuses: Vec<String>,
+    }
+
+    fn load_workflow_contract_fixture() -> WorkflowContractFixture {
+        let raw = include_str!("../../../../../../../docs/contracts/workflow-contract-fixture.json");
+        serde_json::from_str(raw).expect("workflow contract fixture must parse")
+    }
+
+    fn parse_status(value: &str) -> TaskStatus {
+        TaskStatus::from_cli_value(value).unwrap_or_else(|| panic!("unknown fixture status: {value}"))
+    }
 
     #[test]
     fn module_normalize_title_key_is_case_insensitive_and_trimmed() {
@@ -590,5 +612,95 @@ mod tests {
         assert!(reopened.planner.available);
         assert!(reopened.builder.available);
         assert!(reopened.qa.available);
+    }
+
+    #[test]
+    fn workflow_contract_transitions_match_fixture() {
+        let fixture = load_workflow_contract_fixture();
+        for issue_type in ["epic", "feature", "task", "bug"] {
+            let issue_transitions = fixture
+                .transitions
+                .get(issue_type)
+                .unwrap_or_else(|| panic!("missing transitions for issue type: {issue_type}"));
+            for from in &fixture.statuses {
+                let from_status = parse_status(from);
+                let task = make_task("fixture-task", issue_type, from_status.clone());
+                let expected_targets = issue_transitions
+                    .get(from)
+                    .unwrap_or_else(|| panic!("missing transitions for status: {from}"));
+
+                for to in &fixture.statuses {
+                    let to_status = parse_status(to);
+                    let expected_allowed = from == to || expected_targets.contains(to);
+                    let actual_allowed = allows_transition(&task, &from_status, &to_status);
+                    assert_eq!(
+                        actual_allowed, expected_allowed,
+                        "transition mismatch for issue_type={issue_type} {from}->{to}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn workflow_contract_set_spec_statuses_match_fixture() {
+        let fixture = load_workflow_contract_fixture();
+        let expected = fixture
+            .set_spec_allowed_statuses
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+
+        for status in &fixture.statuses {
+            let parsed = parse_status(status);
+            let actual_allowed = can_set_spec_from_status(&parsed);
+            let expected_allowed = expected.contains(&status.as_str());
+            assert_eq!(
+                actual_allowed, expected_allowed,
+                "set_spec mismatch for status={status}"
+            );
+        }
+    }
+
+    #[test]
+    fn workflow_contract_set_plan_statuses_match_fixture() {
+        let fixture = load_workflow_contract_fixture();
+        for issue_type in ["epic", "feature", "task", "bug"] {
+            let expected_statuses = fixture
+                .set_plan_allowed_statuses
+                .get(issue_type)
+                .unwrap_or_else(|| panic!("missing set_plan statuses for issue_type={issue_type}"));
+
+            for status in &fixture.statuses {
+                let parsed_status = parse_status(status);
+                let task = make_task("fixture-task", issue_type, parsed_status);
+                let actual_allowed = can_set_plan(&task);
+                let expected_allowed = expected_statuses.contains(status);
+                assert_eq!(
+                    actual_allowed, expected_allowed,
+                    "set_plan mismatch for issue_type={issue_type} status={status}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn workflow_contract_epic_subtask_replacement_statuses_match_fixture() {
+        let fixture = load_workflow_contract_fixture();
+        let expected = fixture
+            .epic_subtask_replacement_allowed_statuses
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+
+        for status in &fixture.statuses {
+            let parsed = parse_status(status);
+            let actual_allowed = can_replace_epic_subtask_status(&parsed);
+            let expected_allowed = expected.contains(&status.as_str());
+            assert_eq!(
+                actual_allowed, expected_allowed,
+                "epic subtask replacement mismatch for status={status}"
+            );
+        }
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -876,6 +876,7 @@ mod tests {
     use super::*;
     use anyhow::anyhow;
     use host_domain::RuntimeCheck;
+    use serde_json::json;
 
     #[test]
     fn namespace_with_startup_warning_uses_configured_namespace() {
@@ -941,5 +942,47 @@ mod tests {
         ));
         let error = result.expect_err("panic in worker should map to join failure");
         assert!(error.to_string().contains("test-join worker join failure"));
+    }
+
+    #[test]
+    fn task_create_payload_deserialization_surfaces_missing_required_fields() {
+        let payload = json!({
+            "issueType": "task",
+            "priority": 2
+        });
+
+        let error = serde_json::from_value::<TaskCreatePayload>(payload)
+            .expect_err("missing title should fail deserialization");
+        assert!(
+            error.to_string().contains("title"),
+            "deserialization error should mention missing title: {error}"
+        );
+    }
+
+    #[test]
+    fn plan_payload_deserialization_rejects_non_array_subtasks() {
+        let payload = json!({
+            "markdown": "## Plan",
+            "subtasks": {
+                "title": "Not an array payload"
+            }
+        });
+
+        let error = serde_json::from_value::<PlanPayload>(payload)
+            .expect_err("non-array subtasks should fail deserialization");
+        assert!(
+            error.to_string().contains("expected a sequence"),
+            "deserialization error should preserve serde type detail: {error}"
+        );
+    }
+
+    #[test]
+    fn task_status_deserialization_rejects_unknown_status() {
+        let error = serde_json::from_value::<TaskStatus>(json!("backlog"))
+            .expect_err("unknown status should fail deserialization");
+        assert!(
+            error.to_string().contains("unknown variant"),
+            "status parse error should include variant details: {error}"
+        );
     }
 }

--- a/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
@@ -196,7 +196,7 @@ describe("AgentStudioHeader", () => {
       }),
     );
 
-    expect(html).toContain("ring-3 ring-offset-3 ring-blue-400");
+    expect(html).toContain("ring-2 ring-offset-2 ring-emerald-400");
     expect(html).toContain("border-emerald-300");
     expect(html).toContain("bg-emerald-50");
     expect(html).toContain("text-emerald-700");

--- a/apps/desktop/src/components/features/agents/agent-studio-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.tsx
@@ -102,7 +102,8 @@ const workflowConnectorClassName = (state: AgentWorkflowStep["state"] | "blocked
 const workflowSelectionClassName = (
   isSelected: boolean,
   state: AgentWorkflowStep["state"],
-): string => (isSelected ? (WORKFLOW_SELECTION_CLASSES[state] ?? WORKFLOW_SELECTION_CLASSES.blocked) : "");
+): string =>
+  isSelected ? (WORKFLOW_SELECTION_CLASSES[state] ?? WORKFLOW_SELECTION_CLASSES.blocked) : "";
 
 const workflowStepHint = (entry: AgentWorkflowStep): string => {
   if (entry.sessionId) {

--- a/docs/contracts/workflow-contract-fixture.json
+++ b/docs/contracts/workflow-contract-fixture.json
@@ -1,0 +1,233 @@
+{
+  "roles": {
+    "spec": [
+      "odt_read_task",
+      "odt_set_spec"
+    ],
+    "planner": [
+      "odt_read_task",
+      "odt_set_plan"
+    ],
+    "build": [
+      "odt_read_task",
+      "odt_build_blocked",
+      "odt_build_resumed",
+      "odt_build_completed"
+    ],
+    "qa": [
+      "odt_read_task",
+      "odt_qa_approved",
+      "odt_qa_rejected"
+    ]
+  },
+  "tools": [
+    "odt_read_task",
+    "odt_set_spec",
+    "odt_set_plan",
+    "odt_build_blocked",
+    "odt_build_resumed",
+    "odt_build_completed",
+    "odt_qa_approved",
+    "odt_qa_rejected"
+  ],
+  "statuses": [
+    "open",
+    "spec_ready",
+    "ready_for_dev",
+    "in_progress",
+    "blocked",
+    "ai_review",
+    "human_review",
+    "deferred",
+    "closed"
+  ],
+  "transitions": {
+    "feature": {
+      "open": [
+        "spec_ready",
+        "deferred"
+      ],
+      "spec_ready": [
+        "ready_for_dev",
+        "deferred"
+      ],
+      "ready_for_dev": [
+        "in_progress",
+        "deferred"
+      ],
+      "in_progress": [
+        "blocked",
+        "ai_review",
+        "human_review",
+        "deferred"
+      ],
+      "blocked": [
+        "in_progress",
+        "deferred"
+      ],
+      "ai_review": [
+        "in_progress",
+        "human_review",
+        "deferred"
+      ],
+      "human_review": [
+        "in_progress",
+        "closed",
+        "deferred"
+      ],
+      "deferred": [
+        "open"
+      ],
+      "closed": []
+    },
+    "epic": {
+      "open": [
+        "spec_ready",
+        "deferred"
+      ],
+      "spec_ready": [
+        "ready_for_dev",
+        "deferred"
+      ],
+      "ready_for_dev": [
+        "in_progress",
+        "deferred"
+      ],
+      "in_progress": [
+        "blocked",
+        "ai_review",
+        "human_review",
+        "deferred"
+      ],
+      "blocked": [
+        "in_progress",
+        "deferred"
+      ],
+      "ai_review": [
+        "in_progress",
+        "human_review",
+        "deferred"
+      ],
+      "human_review": [
+        "in_progress",
+        "closed",
+        "deferred"
+      ],
+      "deferred": [
+        "open"
+      ],
+      "closed": []
+    },
+    "task": {
+      "open": [
+        "spec_ready",
+        "ready_for_dev",
+        "in_progress",
+        "deferred"
+      ],
+      "spec_ready": [
+        "ready_for_dev",
+        "in_progress",
+        "deferred"
+      ],
+      "ready_for_dev": [
+        "in_progress",
+        "deferred"
+      ],
+      "in_progress": [
+        "blocked",
+        "ai_review",
+        "human_review",
+        "deferred"
+      ],
+      "blocked": [
+        "in_progress",
+        "deferred"
+      ],
+      "ai_review": [
+        "in_progress",
+        "human_review",
+        "deferred"
+      ],
+      "human_review": [
+        "in_progress",
+        "closed",
+        "deferred"
+      ],
+      "deferred": [
+        "open"
+      ],
+      "closed": []
+    },
+    "bug": {
+      "open": [
+        "spec_ready",
+        "ready_for_dev",
+        "in_progress",
+        "deferred"
+      ],
+      "spec_ready": [
+        "ready_for_dev",
+        "in_progress",
+        "deferred"
+      ],
+      "ready_for_dev": [
+        "in_progress",
+        "deferred"
+      ],
+      "in_progress": [
+        "blocked",
+        "ai_review",
+        "human_review",
+        "deferred"
+      ],
+      "blocked": [
+        "in_progress",
+        "deferred"
+      ],
+      "ai_review": [
+        "in_progress",
+        "human_review",
+        "deferred"
+      ],
+      "human_review": [
+        "in_progress",
+        "closed",
+        "deferred"
+      ],
+      "deferred": [
+        "open"
+      ],
+      "closed": []
+    }
+  },
+  "setSpecAllowedStatuses": [
+    "open",
+    "spec_ready"
+  ],
+  "setPlanAllowedStatuses": {
+    "epic": [
+      "spec_ready",
+      "ready_for_dev"
+    ],
+    "feature": [
+      "spec_ready",
+      "ready_for_dev"
+    ],
+    "task": [
+      "open",
+      "spec_ready",
+      "ready_for_dev"
+    ],
+    "bug": [
+      "open",
+      "spec_ready",
+      "ready_for_dev"
+    ]
+  },
+  "epicSubtaskReplacementAllowedStatuses": [
+    "open",
+    "spec_ready",
+    "ready_for_dev"
+  ]
+}

--- a/docs/plans/hexagonal-architecture-compliance-and-tests-plan.md
+++ b/docs/plans/hexagonal-architecture-compliance-and-tests-plan.md
@@ -1,0 +1,135 @@
+# Hexagonal Architecture Compliance and Test Hardening Plan (Verified)
+
+## Objective
+Align workflow policy/runtime behavior across layers and harden contract tests so policy drift and boundary regressions fail fast.
+
+## Scope
+- Core role/tool policy and tool normalization.
+- MCP workflow schemas, registrations, and transition policy.
+- Rust host workflow rules and command boundary behavior.
+- Adapter boundary contracts (`adapters-tauri-host`, `adapters-opencode-sdk`).
+- Documentation/runtime parity for workflow contracts.
+
+This plan does **not** change business rules. It enforces existing rules consistently.
+
+## Verification Snapshot (2026-02-27)
+- `bun run --filter @openducktor/core test`: pass (15/15)
+- `bun run --filter @openducktor/openducktor-mcp test`: pass (27/27)
+- `bun run --filter @openducktor/adapters-tauri-host test`: pass (15/15)
+- `bun run --filter @openducktor/adapters-opencode-sdk test`: pass (53/53)
+- `cd apps/desktop/src-tauri && cargo test -p host-application`: pass (116/116)
+
+## Corrected Findings
+1. Previous status checkboxes were inaccurate:
+   - `packages/core/src/services/workflow-contract-fixture.json` is not present.
+   - `packages/core/src/types/agent-orchestrator.contract.test.ts` is not present.
+   - `packages/openducktor-mcp/src/workflow-policy.contract.test.ts` is not present.
+2. Source-of-truth references were partly wrong:
+   - Role/tool allowlist is canonical in `packages/core/src/types/agent-orchestrator.ts`.
+   - MCP tool registration is defined in `packages/openducktor-mcp/src/index.ts` (not `lib.ts`).
+   - Transition rules are implemented in `packages/openducktor-mcp/src/workflow-policy.ts` and `apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs`.
+   - `packages/core/src/services/odt-workflow-tools.ts` is tool normalization/selection logic, not transition rules.
+3. Existing tests are good but still fragmented:
+   - Strong behavior tests exist in MCP store tests, host app service tests, and adapter tests.
+   - No single cross-layer invariant fixture currently proves policy/transition parity across TS and Rust.
+4. Docs/runtime drift exists and should be treated as contract risk:
+   - `docs/task-workflow-transition-matrix.md` omits currently supported `set_plan` from `ready_for_dev`.
+   - The same doc uses non-`odt_*` tool names while runtime contracts are `odt_*`.
+
+## Planned Work (Priority Order)
+
+### P1 — Introduce a canonical workflow contract fixture
+- Add a single fixture that captures:
+  - role -> allowed tools
+  - tool list (canonical `odt_*`)
+  - transition matrix (including task/bug skip paths)
+  - `set_spec` and `set_plan` allowed statuses
+  - epic-subtask replacement allowed statuses
+- Place it in a location consumable by TS tests and Rust tests (JSON is preferred).
+
+Deliverables:
+- One canonical, test-owned fixture used by all parity tests.
+
+### P2 — Add cross-layer role/tool parity tests
+- Add `packages/core/src/types/agent-orchestrator.contract.test.ts`:
+  - assert `AGENT_ROLE_TOOL_POLICY` equals canonical fixture.
+- Add MCP parity tests (recommended in `packages/openducktor-mcp/src/index.test.js`):
+  - assert tool registration list in `index.ts` exactly matches `ODT_TOOL_SCHEMAS` keys.
+  - assert schema keys and canonical fixture tool list are identical.
+
+Deliverables:
+- Fail-fast on tool rename/removal/allowlist drift across core and MCP.
+
+### P3 — Add cross-layer transition parity tests
+- Add `packages/openducktor-mcp/src/workflow-policy.contract.test.ts`:
+  - assert transition acceptance/rejection parity against canonical fixture.
+  - assert set_spec/set_plan and epic-subtask guards parity with fixture.
+- Add Rust parity tests under `apps/desktop/src-tauri/crates/host-application`:
+  - compare `allows_transition`, `can_set_spec_from_status`, `can_set_plan`, and `can_replace_epic_subtask_status` against the same fixture.
+
+Deliverables:
+- TS and Rust transition policy cannot diverge silently.
+
+### P4 — Harden boundary and guardrail tests where coverage is still weak
+- Extend existing test files instead of introducing parallel duplicate suites:
+  - `packages/adapters-tauri-host/src/index.test.ts`
+  - `packages/adapters-opencode-sdk/src/index.test.ts`
+  - `apps/desktop/src-tauri/src/lib.rs` tests
+- Focus additions:
+  - explicit host command deserialization failures -> stable error envelope
+  - MCP registration coverage for every schema tool
+  - alias normalization rejection edge cases (malformed prefixed tool IDs)
+
+Deliverables:
+- Better boundary guarantees with less test duplication.
+
+### P5 — Add docs/runtime contract parity checks (new)
+- Update:
+  - `docs/task-workflow-transition-matrix.md`
+  - `docs/task-workflow-actions.md` (if needed for naming consistency)
+- Align docs to current runtime behavior:
+  - `set_plan` allowed from `ready_for_dev` for all supported issue types
+  - canonical `odt_*` workflow tool names (or explicit alias section)
+- Add a lightweight check/test that validates documented statuses/tools against the canonical fixture.
+
+Deliverables:
+- Documentation cannot drift away from runtime contracts unnoticed.
+
+### P6 — Validation matrix and CI alignment
+- Required non-frontend checks from AGENTS for this work:
+  - `bun run typecheck`
+  - `bun run test`
+  - `cd apps/desktop/src-tauri && cargo check`
+  - `cd apps/desktop/src-tauri && cargo test`
+- Keep package-focused runs for faster iteration:
+  - `bun run --filter @openducktor/core test`
+  - `bun run --filter @openducktor/openducktor-mcp test`
+  - `bun run --filter @openducktor/adapters-tauri-host test`
+  - `bun run --filter @openducktor/adapters-opencode-sdk test`
+  - `cd apps/desktop/src-tauri && cargo test -p host-application`
+
+Deliverables:
+- Test evidence captured in PR checklist with command output summary.
+
+## Acceptance Criteria
+- Any policy/transition drift across core, MCP, and host fails tests immediately.
+- MCP tool registration and schema keys are guaranteed to match canonical fixture.
+- Adapter boundary tests cover both success and error-path mapping.
+- Docs and runtime contract are kept in sync by automated checks.
+- Required AGENTS validation commands pass.
+
+## Implementation Status (Verified 2026-02-27)
+- [x] Baseline focused suites currently pass (core, MCP, adapters, host-application).
+- [x] Canonical shared fixture implemented and consumed by TS + Rust tests.
+- [x] Cross-layer role/tool parity tests implemented.
+- [x] Cross-layer transition parity tests implemented.
+- [x] Docs/runtime parity checks implemented.
+- [x] AGENTS validation matrix executed successfully (`bun run typecheck`, `bun run test`, `cargo check`, `cargo test`).
+
+## Risks and Mitigations
+- Risk: brittle tests from overspecified fixtures.
+  - Mitigation: fixture should encode behaviorally relevant policy only.
+- Risk: duplicate constants continue to drift.
+  - Mitigation: all policy assertions must consume one fixture.
+- Risk: TS/Rust serialization differences for fixture ingestion.
+  - Mitigation: use behavior-based assertions and normalize parsed values.

--- a/docs/task-workflow-actions.md
+++ b/docs/task-workflow-actions.md
@@ -37,8 +37,8 @@ The backend is the single source of truth for which actions are currently allowe
 ### `set_plan`
 - Purpose: author or revise implementation plan markdown.
 - Transition:
-  - `feature/epic`: `spec_ready -> ready_for_dev`
-  - `task/bug`: `open/spec_ready -> ready_for_dev`
+  - `feature/epic`: allowed from `spec_ready` and `ready_for_dev` (`ready_for_dev` remains `ready_for_dev`).
+  - `task/bug`: allowed from `open`, `spec_ready`, and `ready_for_dev` (`ready_for_dev` remains `ready_for_dev`).
 
 ### `build_start`
 - Purpose: start build execution for this task.

--- a/docs/task-workflow-status-model.md
+++ b/docs/task-workflow-status-model.md
@@ -54,7 +54,7 @@ Removed from OpenDucktor UI scope:
 ## Type-Specific Flow Rules
 - `feature` and `epic` follow the standard path:
   `open -> spec_ready -> ready_for_dev -> in_progress -> ai_review/human_review -> closed`
-- `feature` and `epic` cannot start planning directly from `open`; `set_plan` is allowed only from `spec_ready`.
+- `feature` and `epic` cannot start planning directly from `open`; `set_plan` is allowed from `spec_ready` and `ready_for_dev`.
 - `task` and `bug` may skip spec/planning:
   `open -> in_progress`
 
@@ -102,7 +102,7 @@ Root namespace key is configurable and defaults to `openducktor`.
           "markdown": "## Spec",
           "updatedAt": "2026-02-17T12:34:56Z",
           "updatedBy": "planner-agent",
-          "sourceTool": "set_spec",
+          "sourceTool": "odt_set_spec",
           "revision": 1
         }
       ],
@@ -111,7 +111,7 @@ Root namespace key is configurable and defaults to `openducktor`.
           "markdown": "## Plan",
           "updatedAt": "2026-02-17T12:40:10Z",
           "updatedBy": "planner-agent",
-          "sourceTool": "set_plan",
+          "sourceTool": "odt_set_plan",
           "revision": 1
         }
       ],
@@ -121,7 +121,7 @@ Root namespace key is configurable and defaults to `openducktor`.
           "verdict": "approved",
           "updatedAt": "2026-02-17T13:02:00Z",
           "updatedBy": "qa-agent",
-          "sourceTool": "qa_approved",
+          "sourceTool": "odt_qa_approved",
           "revision": 1
         }
       ]

--- a/docs/task-workflow-transition-matrix.md
+++ b/docs/task-workflow-transition-matrix.md
@@ -10,25 +10,21 @@ including trigger tools/actions and guardrails.
 - Auto-transitions are triggered only by explicit workflow tools/actions.
 
 ## Tool Naming (Canonical)
-Planner tools:
-- `set_spec(taskId, markdown)`
-- `set_plan(taskId, markdown, subtasks?)` (epic only for `subtasks`, one level max)
+MCP workflow tools:
+- `odt_read_task(taskId)`
+- `odt_set_spec(taskId, markdown)`
+- `odt_set_plan(taskId, markdown, subtasks?)` (epic only for `subtasks`, one level max)
+- `odt_build_blocked(taskId, reason)`
+- `odt_build_resumed(taskId)`
+- `odt_build_completed(taskId, summary?)`
+- `odt_qa_approved(taskId, reportMarkdown)`
+- `odt_qa_rejected(taskId, reportMarkdown)`
 
 `subtasks` payload (optional):
 - `title` (required)
 - `issueType` (`task` | `feature` | `bug`, defaults to `task`)
 - `priority` (0..4, defaults to `2`)
 - `description` (optional)
-
-Builder tools:
-- `build_start(taskId)`
-- `build_blocked(taskId, reason)`
-- `build_resumed(taskId)`
-- `build_completed(taskId, summary)`
-
-QA tools:
-- `qa_approved(taskId, reportMarkdown)`
-- `qa_rejected(taskId, reportMarkdown)`
 
 Human actions:
 - `human_request_changes(taskId, note)`
@@ -40,18 +36,17 @@ Human actions:
 | Trigger | From | Guards | To |
 |---|---|---|---|
 | `task_create` | n/a | always | `open` |
-| `set_spec` | `open`, `spec_ready` | non-empty markdown | `spec_ready` |
-| `set_plan` (feature/epic) | `spec_ready` | non-empty markdown | `ready_for_dev` |
-| `set_plan` (task/bug) | `open`, `spec_ready` | non-empty markdown | `ready_for_dev` |
-| `set_plan` (epic) | `spec_ready` | plan includes subtask proposals | `ready_for_dev` |
-| `build_start` | `ready_for_dev` | feature/epic standard flow | `in_progress` |
-| `build_start` | `open`, `spec_ready`, `ready_for_dev` | task/bug optional flow | `in_progress` |
-| `build_blocked` | `in_progress` | reason required | `blocked` |
-| `build_resumed` | `blocked` | resume requested | `in_progress` |
-| `build_completed` | `in_progress` | `qaRequired=true` | `ai_review` |
-| `build_completed` | `in_progress` | `qaRequired=false` | `human_review` |
-| `qa_rejected` | `ai_review` | report markdown required | `in_progress` |
-| `qa_approved` | `ai_review` | report markdown required | `human_review` |
+| `odt_set_spec` | `open`, `spec_ready` | non-empty markdown | `spec_ready` |
+| `odt_set_plan` (feature/epic) | `spec_ready`, `ready_for_dev` | non-empty markdown | `ready_for_dev` |
+| `odt_set_plan` (task/bug) | `open`, `spec_ready`, `ready_for_dev` | non-empty markdown | `ready_for_dev` |
+| `odt_set_plan` (epic with subtasks) | `spec_ready`, `ready_for_dev` | plan includes subtask proposals | `ready_for_dev` |
+| `odt_build_resumed` | `ready_for_dev` | feature/epic standard flow | `in_progress` |
+| `odt_build_resumed` | `open`, `spec_ready`, `ready_for_dev`, `blocked` | task/bug optional flow + blocked resume | `in_progress` |
+| `odt_build_blocked` | `in_progress` | reason required | `blocked` |
+| `odt_build_completed` | `in_progress` | `qaRequired=true` | `ai_review` |
+| `odt_build_completed` | `in_progress` | `qaRequired=false` | `human_review` |
+| `odt_qa_rejected` | `ai_review` | report markdown required | `in_progress` |
+| `odt_qa_approved` | `ai_review` | report markdown required | `human_review` |
 | `human_request_changes` | `human_review` | note optional | `in_progress` |
 | `human_approve` | `human_review` | epic completion guard passes | `closed` |
 | `defer_issue` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | not subtask | `deferred` |

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
@@ -47,7 +47,11 @@ describe("workflow-tool-selection", () => {
   test("ignores malformed runtime aliases and keeps canonical role policy", async () => {
     const selection = await resolveWorkflowToolSelection({
       client: makeClient({
-        toolIds: ["customprefix_odt_set_spec_extra", "customprefix_odt_", "customprefix_odt_set_plan"],
+        toolIds: [
+          "customprefix_odt_set_spec_extra",
+          "customprefix_odt_",
+          "customprefix_odt_set_plan",
+        ],
       }),
       role: "spec",
       workingDirectory: "/repo",

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
@@ -43,4 +43,19 @@ describe("workflow-tool-selection", () => {
     expect(selection.odt_qa_approved).toBe(true);
     expect(selection.odt_set_spec).toBe(false);
   });
+
+  test("ignores malformed runtime aliases and keeps canonical role policy", async () => {
+    const selection = await resolveWorkflowToolSelection({
+      client: makeClient({
+        toolIds: ["customprefix_odt_set_spec_extra", "customprefix_odt_", "customprefix_odt_set_plan"],
+      }),
+      role: "spec",
+      workingDirectory: "/repo",
+    });
+
+    expect(selection.odt_read_task).toBe(true);
+    expect(selection.odt_set_spec).toBe(true);
+    expect(selection.customprefix_odt_set_spec_extra).toBeUndefined();
+    expect(selection.customprefix_odt_set_plan).toBe(false);
+  });
 });

--- a/packages/adapters-tauri-host/src/bun-test.d.ts
+++ b/packages/adapters-tauri-host/src/bun-test.d.ts
@@ -4,7 +4,7 @@ type RejectMatchers = {
   toThrow(message?: string | RegExp): Promise<void>;
 };
 
-type Matchers<T> = {
+type Matchers<_T> = {
   toBe(expected: unknown): void;
   toEqual(expected: unknown): void;
   toHaveLength(expected: number): void;

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -150,6 +150,23 @@ describe("TauriHostClient", () => {
     });
   });
 
+  test("setPlan preserves host error details for invalid command payloads", async () => {
+    const { client } = createClient((command) => {
+      if (command === "set_plan") {
+        throw new Error("invalid args: input.markdown is required");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(
+      client.setPlan({
+        repoPath: "/repo",
+        taskId: "epic-1",
+        markdown: "## Plan",
+      }),
+    ).rejects.toThrow("invalid args: input.markdown is required");
+  });
+
   test("runtimeCheck forwards force flag to IPC command", async () => {
     const { client, calls } = createClient((command) => {
       if (command === "runtime_check") {

--- a/packages/core/src/services/odt-workflow-tools.test.ts
+++ b/packages/core/src/services/odt-workflow-tools.test.ts
@@ -12,6 +12,10 @@ describe("odt workflow tools", () => {
     expect(normalizeOdtWorkflowToolName("odt_set_spec")).toBe("odt_set_spec");
     expect(normalizeOdtWorkflowToolName("OpenDucktor_ODT_SET_SPEC")).toBe("odt_set_spec");
     expect(normalizeOdtWorkflowToolName("  openducktor_odt_qa_rejected  ")).toBe("odt_qa_rejected");
+    expect(normalizeOdtWorkflowToolName("customprefix_odt_set_plan")).toBe("odt_set_plan");
+    expect(normalizeOdtWorkflowToolName("customprefix_odt_")).toBeNull();
+    expect(normalizeOdtWorkflowToolName("customprefix_odt_set_plan_extra")).toBeNull();
+    expect(normalizeOdtWorkflowToolName("ODT_")).toBeNull();
     expect(normalizeOdtWorkflowToolName("read")).toBeNull();
     expect(normalizeOdtWorkflowToolName("openducktor_odt_set_spec_extra")).toBeNull();
   });

--- a/packages/core/src/types/agent-orchestrator.contract.test.ts
+++ b/packages/core/src/types/agent-orchestrator.contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { AGENT_ROLE_TOOL_POLICY } from "./agent-orchestrator";
+
+type WorkflowContractFixture = {
+  roles: Record<string, string[]>;
+};
+
+const loadFixture = (): WorkflowContractFixture => {
+  const fixturePath = join(import.meta.dir, "../../../../docs/contracts/workflow-contract-fixture.json");
+  const raw = readFileSync(fixturePath, "utf8");
+  return JSON.parse(raw) as WorkflowContractFixture;
+};
+
+describe("agent orchestrator role policy contract", () => {
+  test("matches canonical workflow fixture", () => {
+    const fixture = loadFixture();
+    expect(AGENT_ROLE_TOOL_POLICY).toEqual(fixture.roles);
+  });
+});

--- a/packages/core/src/types/agent-orchestrator.contract.test.ts
+++ b/packages/core/src/types/agent-orchestrator.contract.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
 import { AGENT_ROLE_TOOL_POLICY } from "./agent-orchestrator";
 
 type WorkflowContractFixture = {
@@ -8,7 +8,10 @@ type WorkflowContractFixture = {
 };
 
 const loadFixture = (): WorkflowContractFixture => {
-  const fixturePath = join(import.meta.dir, "../../../../docs/contracts/workflow-contract-fixture.json");
+  const fixturePath = join(
+    import.meta.dir,
+    "../../../../docs/contracts/workflow-contract-fixture.json",
+  );
   const raw = readFileSync(fixturePath, "utf8");
   return JSON.parse(raw) as WorkflowContractFixture;
 };

--- a/packages/core/src/types/workflow-docs.contract.test.ts
+++ b/packages/core/src/types/workflow-docs.contract.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
 
 type WorkflowContractFixture = {
   tools: string[];
@@ -8,14 +8,20 @@ type WorkflowContractFixture = {
 };
 
 const loadFixture = (): WorkflowContractFixture => {
-  const fixturePath = join(import.meta.dir, "../../../../docs/contracts/workflow-contract-fixture.json");
+  const fixturePath = join(
+    import.meta.dir,
+    "../../../../docs/contracts/workflow-contract-fixture.json",
+  );
   return JSON.parse(readFileSync(fixturePath, "utf8")) as WorkflowContractFixture;
 };
 
 describe("workflow docs contract", () => {
   test("transition matrix references canonical mutation tools and statuses", () => {
     const fixture = loadFixture();
-    const transitionDocPath = join(import.meta.dir, "../../../../docs/task-workflow-transition-matrix.md");
+    const transitionDocPath = join(
+      import.meta.dir,
+      "../../../../docs/task-workflow-transition-matrix.md",
+    );
     const transitionDoc = readFileSync(transitionDocPath, "utf8");
 
     for (const status of fixture.statuses) {

--- a/packages/core/src/types/workflow-docs.contract.test.ts
+++ b/packages/core/src/types/workflow-docs.contract.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+type WorkflowContractFixture = {
+  tools: string[];
+  statuses: string[];
+};
+
+const loadFixture = (): WorkflowContractFixture => {
+  const fixturePath = join(import.meta.dir, "../../../../docs/contracts/workflow-contract-fixture.json");
+  return JSON.parse(readFileSync(fixturePath, "utf8")) as WorkflowContractFixture;
+};
+
+describe("workflow docs contract", () => {
+  test("transition matrix references canonical mutation tools and statuses", () => {
+    const fixture = loadFixture();
+    const transitionDocPath = join(import.meta.dir, "../../../../docs/task-workflow-transition-matrix.md");
+    const transitionDoc = readFileSync(transitionDocPath, "utf8");
+
+    for (const status of fixture.statuses) {
+      expect(transitionDoc).toContain(`\`${status}\``);
+    }
+
+    const mutationTools = fixture.tools.filter((tool) => tool !== "odt_read_task");
+    for (const tool of mutationTools) {
+      expect(transitionDoc).toContain(`\`${tool}\``);
+    }
+
+    expect(transitionDoc).toMatch(
+      /\| `odt_set_plan` \(feature\/epic\) \| `spec_ready`, `ready_for_dev` \|/,
+    );
+    expect(transitionDoc).toMatch(
+      /\| `odt_set_plan` \(task\/bug\) \| `open`, `spec_ready`, `ready_for_dev` \|/,
+    );
+  });
+
+  test("status model examples use canonical odt sourceTool names", () => {
+    const statusModelPath = join(import.meta.dir, "../../../../docs/task-workflow-status-model.md");
+    const statusModelDoc = readFileSync(statusModelPath, "utf8");
+
+    expect(statusModelDoc).toContain('"sourceTool": "odt_set_spec"');
+    expect(statusModelDoc).toContain('"sourceTool": "odt_set_plan"');
+    expect(statusModelDoc).toContain('"sourceTool": "odt_qa_approved"');
+  });
+});

--- a/packages/openducktor-mcp/src/index.test.js
+++ b/packages/openducktor-mcp/src/index.test.js
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { registerOdtTool } from "./index";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { ODT_TOOL_SCHEMAS } from "./lib";
+import { ODT_REGISTERED_TOOL_NAMES, registerOdtTool } from "./index";
+
+const loadWorkflowFixture = () => {
+  const fixturePath = join(import.meta.dir, "../../../docs/contracts/workflow-contract-fixture.json");
+  return JSON.parse(readFileSync(fixturePath, "utf8"));
+};
 
 describe("registerOdtTool", () => {
   test("binds registerTool to server context", () => {
@@ -27,5 +35,15 @@ describe("registerOdtTool", () => {
 
     expect(capturedName).toBe("odt_read_task");
     expect(fakeServer._registeredTools).toEqual(["odt_read_task"]);
+  });
+
+  test("keeps registered tools in sync with MCP schema keys", () => {
+    const schemaToolNames = Object.keys(ODT_TOOL_SCHEMAS);
+    expect(ODT_REGISTERED_TOOL_NAMES).toEqual(schemaToolNames);
+  });
+
+  test("matches canonical workflow fixture tool list", () => {
+    const fixture = loadWorkflowFixture();
+    expect(ODT_REGISTERED_TOOL_NAMES).toEqual(fixture.tools);
   });
 });

--- a/packages/openducktor-mcp/src/index.test.js
+++ b/packages/openducktor-mcp/src/index.test.js
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { ODT_TOOL_SCHEMAS } from "./lib";
 import { ODT_REGISTERED_TOOL_NAMES, registerOdtTool } from "./index";
+import { ODT_TOOL_SCHEMAS } from "./lib";
 
 const loadWorkflowFixture = () => {
-  const fixturePath = join(import.meta.dir, "../../../docs/contracts/workflow-contract-fixture.json");
+  const fixturePath = join(
+    import.meta.dir,
+    "../../../docs/contracts/workflow-contract-fixture.json",
+  );
   return JSON.parse(readFileSync(fixturePath, "utf8"));
 };
 

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -127,16 +127,15 @@ export const registerOdtTool = (
   );
 };
 
-export const ODT_REGISTERED_TOOL_SPECS: Readonly<
-  Record<RegisteredToolName, RegisteredToolSpec>
-> = {
+export const ODT_REGISTERED_TOOL_SPECS: Readonly<Record<RegisteredToolName, RegisteredToolSpec>> = {
   odt_read_task: {
     description:
       "Read one OpenDucktor task with its current status and agent documents (spec/plan/latest QA).",
     execute: (store, input) => store.readTask(input),
   },
   odt_set_spec: {
-    description: "Persist specification markdown for a task and transition open->spec_ready when needed.",
+    description:
+      "Persist specification markdown for a task and transition open->spec_ready when needed.",
     execute: (store, input) => store.setSpec(input),
   },
   odt_set_plan: {

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -78,6 +78,13 @@ type RegisteredTool = {
   execute: (store: OdtTaskStore, input: unknown) => Promise<unknown>;
 };
 
+type RegisteredToolName = keyof typeof ODT_TOOL_SCHEMAS;
+
+type RegisteredToolSpec = {
+  description: string;
+  execute: (store: OdtTaskStore, input: unknown) => Promise<unknown>;
+};
+
 type ToolInputSchema = {
   shape: Record<string, unknown>;
   parse: (input: unknown) => unknown;
@@ -120,54 +127,57 @@ export const registerOdtTool = (
   );
 };
 
-const registerTools = (server: McpServer, store: OdtTaskStore): void => {
-  const tools: RegisteredTool[] = [
-    {
-      name: "odt_read_task",
-      description:
-        "Read one OpenDucktor task with its current status and agent documents (spec/plan/latest QA).",
-      execute: (currentStore, input) => currentStore.readTask(input),
-    },
-    {
-      name: "odt_set_spec",
-      description:
-        "Persist specification markdown for a task and transition open->spec_ready when needed.",
-      execute: (currentStore, input) => currentStore.setSpec(input),
-    },
-    {
-      name: "odt_set_plan",
-      description:
-        "Persist implementation plan markdown and transition task to ready_for_dev (with optional epic subtask proposals).",
-      execute: (currentStore, input) => currentStore.setPlan(input),
-    },
-    {
-      name: "odt_build_blocked",
-      description: "Transition task to blocked with explicit reason.",
-      execute: (currentStore, input) => currentStore.buildBlocked(input),
-    },
-    {
-      name: "odt_build_resumed",
-      description: "Transition blocked task back to in_progress.",
-      execute: (currentStore, input) => currentStore.buildResumed(input),
-    },
-    {
-      name: "odt_build_completed",
-      description: "Transition in_progress task to ai_review/human_review according to qaRequired.",
-      execute: (currentStore, input) => currentStore.buildCompleted(input),
-    },
-    {
-      name: "odt_qa_approved",
-      description: "Append approved QA report and transition ai_review->human_review.",
-      execute: (currentStore, input) => currentStore.qaApproved(input),
-    },
-    {
-      name: "odt_qa_rejected",
-      description: "Append rejected QA report and transition ai_review->in_progress.",
-      execute: (currentStore, input) => currentStore.qaRejected(input),
-    },
-  ];
+export const ODT_REGISTERED_TOOL_SPECS: Readonly<
+  Record<RegisteredToolName, RegisteredToolSpec>
+> = {
+  odt_read_task: {
+    description:
+      "Read one OpenDucktor task with its current status and agent documents (spec/plan/latest QA).",
+    execute: (store, input) => store.readTask(input),
+  },
+  odt_set_spec: {
+    description: "Persist specification markdown for a task and transition open->spec_ready when needed.",
+    execute: (store, input) => store.setSpec(input),
+  },
+  odt_set_plan: {
+    description:
+      "Persist implementation plan markdown and transition task to ready_for_dev (with optional epic subtask proposals).",
+    execute: (store, input) => store.setPlan(input),
+  },
+  odt_build_blocked: {
+    description: "Transition task to blocked with explicit reason.",
+    execute: (store, input) => store.buildBlocked(input),
+  },
+  odt_build_resumed: {
+    description: "Transition blocked task back to in_progress.",
+    execute: (store, input) => store.buildResumed(input),
+  },
+  odt_build_completed: {
+    description: "Transition in_progress task to ai_review/human_review according to qaRequired.",
+    execute: (store, input) => store.buildCompleted(input),
+  },
+  odt_qa_approved: {
+    description: "Append approved QA report and transition ai_review->human_review.",
+    execute: (store, input) => store.qaApproved(input),
+  },
+  odt_qa_rejected: {
+    description: "Append rejected QA report and transition ai_review->in_progress.",
+    execute: (store, input) => store.qaRejected(input),
+  },
+};
 
-  for (const tool of tools) {
+export const ODT_REGISTERED_TOOL_NAMES = Object.keys(
+  ODT_REGISTERED_TOOL_SPECS,
+) as RegisteredToolName[];
+
+const registerTools = (server: McpServer, store: OdtTaskStore): void => {
+  for (const toolName of ODT_REGISTERED_TOOL_NAMES) {
+    const spec = ODT_REGISTERED_TOOL_SPECS[toolName];
+    const tool: RegisteredTool = {
+      name: toolName,
+      description: spec.description,
+      execute: spec.execute,
+    };
     registerOdtTool(server, store, tool);
   }
 };

--- a/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
@@ -62,6 +62,19 @@ describe("workflow policy contract", () => {
     }
   });
 
+  test("epic completion is blocked when a direct subtask is still active", () => {
+    const epic = makeTask("epic", "human_review");
+    epic.id = "epic-1";
+
+    const activeSubtask = makeTask("task", "open");
+    activeSubtask.id = "task-1";
+    activeSubtask.parentId = epic.id;
+
+    const error = getTransitionError(epic, [epic, activeSubtask], "human_review", "closed");
+    expect(error).not.toBeNull();
+    expect(error).toContain("still active");
+  });
+
   test("set_spec allowed statuses match canonical fixture", () => {
     const fixture = loadFixture();
     const expected = new Set(fixture.setSpecAllowedStatuses);

--- a/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
@@ -1,6 +1,6 @@
+import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, test } from "bun:test";
 import type { IssueType, TaskCard, TaskStatus } from "./contracts";
 import {
   canReplaceEpicSubtaskStatus,
@@ -20,7 +20,10 @@ type WorkflowContractFixture = {
 const ISSUE_TYPES: IssueType[] = ["epic", "feature", "task", "bug"];
 
 const loadFixture = (): WorkflowContractFixture => {
-  const fixturePath = join(import.meta.dir, "../../../docs/contracts/workflow-contract-fixture.json");
+  const fixturePath = join(
+    import.meta.dir,
+    "../../../docs/contracts/workflow-contract-fixture.json",
+  );
   const raw = readFileSync(fixturePath, "utf8");
   return JSON.parse(raw) as WorkflowContractFixture;
 };

--- a/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import type { IssueType, TaskCard, TaskStatus } from "./contracts";
+import {
+  canReplaceEpicSubtaskStatus,
+  getSetPlanError,
+  getSetSpecError,
+  getTransitionError,
+} from "./workflow-policy";
+
+type WorkflowContractFixture = {
+  statuses: string[];
+  transitions: Record<string, Record<string, string[]>>;
+  setSpecAllowedStatuses: string[];
+  setPlanAllowedStatuses: Record<string, string[]>;
+  epicSubtaskReplacementAllowedStatuses: string[];
+};
+
+const ISSUE_TYPES: IssueType[] = ["epic", "feature", "task", "bug"];
+
+const loadFixture = (): WorkflowContractFixture => {
+  const fixturePath = join(import.meta.dir, "../../../docs/contracts/workflow-contract-fixture.json");
+  const raw = readFileSync(fixturePath, "utf8");
+  return JSON.parse(raw) as WorkflowContractFixture;
+};
+
+const makeTask = (issueType: IssueType, status: TaskStatus): TaskCard => {
+  return {
+    id: `${issueType}-${status}`,
+    title: "Contract fixture task",
+    issueType,
+    status,
+    aiReviewEnabled: true,
+    parentId: null,
+  };
+};
+
+describe("workflow policy contract", () => {
+  test("transition matrix matches canonical fixture for every issue type", () => {
+    const fixture = loadFixture();
+
+    for (const issueType of ISSUE_TYPES) {
+      const issueTransitions = fixture.transitions[issueType];
+      expect(issueTransitions).toBeDefined();
+
+      for (const from of fixture.statuses) {
+        const task = makeTask(issueType, from as TaskStatus);
+        const expectedTargets = new Set(issueTransitions[from] ?? []);
+
+        for (const to of fixture.statuses) {
+          const expectedAllowed = from === to || expectedTargets.has(to);
+          const actualAllowed =
+            getTransitionError(task, [task], from as TaskStatus, to as TaskStatus) === null;
+
+          expect(actualAllowed).toBe(expectedAllowed);
+        }
+      }
+    }
+  });
+
+  test("set_spec allowed statuses match canonical fixture", () => {
+    const fixture = loadFixture();
+    const expected = new Set(fixture.setSpecAllowedStatuses);
+
+    for (const status of fixture.statuses) {
+      const actualAllowed = getSetSpecError(status as TaskStatus) === null;
+      expect(actualAllowed).toBe(expected.has(status));
+    }
+  });
+
+  test("set_plan allowed statuses match canonical fixture", () => {
+    const fixture = loadFixture();
+
+    for (const issueType of ISSUE_TYPES) {
+      const expectedStatuses = new Set(fixture.setPlanAllowedStatuses[issueType] ?? []);
+      for (const status of fixture.statuses) {
+        const task = makeTask(issueType, status as TaskStatus);
+        const actualAllowed = getSetPlanError(task) === null;
+        expect(actualAllowed).toBe(expectedStatuses.has(status));
+      }
+    }
+  });
+
+  test("epic subtask replacement statuses match canonical fixture", () => {
+    const fixture = loadFixture();
+    const expected = new Set(fixture.epicSubtaskReplacementAllowedStatuses);
+
+    for (const status of fixture.statuses) {
+      const actualAllowed = canReplaceEpicSubtaskStatus(status as TaskStatus);
+      expect(actualAllowed).toBe(expected.has(status));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a canonical workflow contract fixture shared across docs/tests
- add cross-layer parity tests for role/tool policy (core + MCP) and workflow transitions (MCP + Rust host)
- refactor MCP tool registration to an exported canonical spec map and assert schema/registration parity
- harden adapter/host error-path tests and workflow alias normalization edge cases
- align workflow docs with runtime behavior/tool naming and update the implementation plan status
- fix a failing desktop header style assertion so workspace tests are green

## Validation
- bun run typecheck
- bun run test
- cd apps/desktop/src-tauri && cargo check
- cd apps/desktop/src-tauri && cargo test