### PR TITLE
fix(desktop): replace settings checkbox with shadcn switch

### DIFF
--- a/apps/desktop/src/components/features/settings-modal.tsx
+++ b/apps/desktop/src/components/features/settings-modal.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { errorMessage } from "@/lib/errors";
 import { cn } from "@/lib/utils";
@@ -377,15 +378,17 @@ export function SettingsModal({
             })}
           </div>
 
-          <label className="flex items-center gap-2 text-sm text-foreground">
-            <input
-              type="checkbox"
+          <div className="flex items-center gap-2">
+            <Switch
+              id="trusted-hooks"
               checked={trustedHooks}
               disabled={isLoadingConfig || isSaving}
-              onChange={(event) => setTrustedHooks(event.currentTarget.checked)}
+              onCheckedChange={setTrustedHooks}
             />
-            Trust hooks for this workspace
-          </label>
+            <Label htmlFor="trusted-hooks" className="text-sm text-foreground">
+              Trust hooks for this workspace
+            </Label>
+          </div>
         </div>
 
         <DialogFooter className="mt-0 shrink-0 items-center justify-between border-t border-border px-6 pb-6 pt-4">

--- a/apps/desktop/src/components/features/settings-modal.tsx
+++ b/apps/desktop/src/components/features/settings-modal.tsx
@@ -378,17 +378,18 @@ export function SettingsModal({
             })}
           </div>
 
-          <div className="flex items-center gap-2">
+          <Label
+            htmlFor="trusted-hooks"
+            className="flex items-center gap-2 text-sm text-foreground"
+          >
             <Switch
               id="trusted-hooks"
               checked={trustedHooks}
               disabled={isLoadingConfig || isSaving}
               onCheckedChange={setTrustedHooks}
             />
-            <Label htmlFor="trusted-hooks" className="text-sm text-foreground">
-              Trust hooks for this workspace
-            </Label>
-          </div>
+            Trust hooks for this workspace
+          </Label>
         </div>
 
         <DialogFooter className="mt-0 shrink-0 items-center justify-between border-t border-border px-6 pb-6 pt-4">


### PR DESCRIPTION
## Summary
- replace native `<input type="checkbox">` in Settings modal with shadcn `Switch`
- keep existing trusted hooks state wiring and disabled behavior during loading/saving
- align Settings UI control styling with project shadcn component standards

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test