### PR TITLE
fix(desktop): replace Agent Studio hardcoded gray chrome styles with semantic tokens

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-right-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-right-panel.tsx
@@ -38,7 +38,7 @@ export function AgentStudioRightPanelToggleButton({
       type="button"
       size="icon"
       variant="ghost"
-      className="h-10 w-10 rounded-md border border-transparent bg-transparent text-gray-50 hover:border-white/30 hover:bg-card/10"
+      className="h-10 w-10 rounded-md border border-transparent bg-transparent text-studio-chrome-foreground hover:border-studio-chrome-foreground/30 hover:bg-studio-chrome-foreground/10"
       onClick={model.onToggle}
       aria-label={model.isOpen ? `Hide ${panelLabel} panel` : `Show ${panelLabel} panel`}
       title={model.isOpen ? `Hide ${panelLabel} panel` : `Show ${panelLabel} panel`}

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -51,7 +51,7 @@ describe("AgentStudioTaskTabs", () => {
     expect(html).not.toContain("overflow-y-visible");
     expect(html).not.toContain("rounded-full border");
     expect(html).not.toContain("bg-card/80");
-    expect(html).toContain("bg-gray-700/70");
+    expect(html).toContain("bg-studio-chrome");
     expect(html).toContain("size-[1.4rem]");
 
     const lastTabCloseIndex = html.lastIndexOf("Close tab for Ship QA checklist");

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -103,7 +103,7 @@ export function AgentStudioTaskTabs({
   const hasAnyTab = useMemo(() => tabs.length > 0, [tabs]);
 
   return (
-    <div className="bg-gray-700/70 px-2 pt-1.5 pb-0">
+    <div className="bg-studio-chrome px-2 pt-1.5 pb-0">
       <div className="flex min-w-0 items-center gap-1">
         <div className="min-w-0 flex-1 overflow-x-auto">
           <div className="inline-flex h-10 min-w-max items-center gap-1 px-2">
@@ -174,7 +174,7 @@ export function AgentStudioTaskTabs({
               size="icon"
               variant="ghost"
               aria-label="Open new task tab"
-              className="h-10 w-10 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-gray-50 shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+              className="h-10 w-10 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
               disabled={!canOpenCreateDialog}
               onClick={() => setIsCreateDialogOpen(true)}
             >

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -53,6 +53,10 @@
   --sidebar-primary: oklch(0.588 0.158 241.966);
   --sidebar-primary-foreground: oklch(1 0 0);
   --sidebar-ring: oklch(0.588 0.158 241.966);
+
+  /* agent studio chrome */
+  --studio-chrome: oklch(0.446 0.043 257.281); /* ~slate-600 */
+  --studio-chrome-foreground: oklch(0.968 0.007 247.896); /* ~slate-50 */
 }
 
 .dark {
@@ -94,6 +98,9 @@
   --sidebar-primary: oklch(0.631 0.158 241.966);
   --sidebar-primary-foreground: oklch(0.145 0.017 265.755);
   --sidebar-ring: oklch(0.631 0.158 241.966);
+
+  --studio-chrome: oklch(0.332 0.038 260.912); /* ~slate-700 */
+  --studio-chrome-foreground: oklch(0.968 0.007 247.896);
 }
 
 /* Expose CSS variables as Tailwind v4 color utilities (bg-*, text-*, etc.) */
@@ -126,6 +133,8 @@
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-studio-chrome: var(--studio-chrome);
+  --color-studio-chrome-foreground: var(--studio-chrome-foreground);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -100,7 +100,7 @@
   --sidebar-ring: oklch(0.631 0.158 241.966);
 
   --studio-chrome: oklch(0.332 0.038 260.912); /* ~slate-700 */
-  --studio-chrome-foreground: oklch(0.968 0.007 247.896);
+  --studio-chrome-foreground: oklch(0.968 0.007 247.896); /* ~slate-50 */
 }
 
 /* Expose CSS variables as Tailwind v4 color utilities (bg-*, text-*, etc.) */


### PR DESCRIPTION
## Summary
- replace hardcoded bg-gray-700/70 in Agent Studio task tab chrome with semantic bg-studio-chrome
- replace hardcoded text-gray-50 usages in Agent Studio tab/new-tab and right-panel toggle with text-studio-chrome-foreground
- add dedicated Agent Studio chrome tokens in apps/desktop/src/styles.css and map them in Tailwind v4 @theme inline
- update Agent Studio tab test assertion for the new semantic class

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test