### PR TITLE
refactor(openducktor-mcp)!: extract generic metadata parser and enforce strict revisions

### DIFF
--- a/packages/openducktor-mcp/src/task-mapping.test.ts
+++ b/packages/openducktor-mcp/src/task-mapping.test.ts
@@ -72,6 +72,92 @@ describe("task mapping entry parsers", () => {
     ]);
   });
 
+  test("rejects invalid revision values", () => {
+    const parsedMarkdown = parseMarkdownEntries([
+      {
+        markdown: "valid",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 1,
+      },
+      {
+        markdown: "nan",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: Number.NaN,
+      },
+      {
+        markdown: "infinity",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: Infinity,
+      },
+      {
+        markdown: "float",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 1.5,
+      },
+      {
+        markdown: "negative",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: -1,
+      },
+      {
+        markdown: "zero",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 0,
+      },
+    ]);
+
+    const parsedQa = parseQaEntries([
+      {
+        markdown: "valid qa",
+        verdict: "approved",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "qa-agent",
+        sourceTool: "odt_qa_approved",
+        revision: 2,
+      },
+      {
+        markdown: "bad revision qa",
+        verdict: "rejected",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "qa-agent",
+        sourceTool: "odt_qa_rejected",
+        revision: Number.NaN,
+      },
+    ]);
+
+    expect(parsedMarkdown).toEqual([
+      {
+        markdown: "valid",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 1,
+      },
+    ]);
+    expect(parsedQa).toEqual([
+      {
+        markdown: "valid qa",
+        verdict: "approved",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "qa-agent",
+        sourceTool: "odt_qa_approved",
+        revision: 2,
+      },
+    ]);
+  });
+
   test("returns an empty array for non-array metadata values", () => {
     expect(parseMarkdownEntries(undefined)).toEqual([]);
     expect(parseMarkdownEntries({})).toEqual([]);

--- a/packages/openducktor-mcp/src/task-mapping.test.ts
+++ b/packages/openducktor-mcp/src/task-mapping.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { parseMarkdownEntries, parseQaEntries } from "./task-mapping";
+
+describe("task mapping entry parsers", () => {
+  test("parseMarkdownEntries returns only valid markdown metadata entries", () => {
+    const parsed = parseMarkdownEntries([
+      {
+        markdown: "# Spec",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 1,
+        ignoredField: "ignored",
+      },
+      {
+        markdown: "# Missing revision",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+      },
+      null,
+      "invalid",
+    ]);
+
+    expect(parsed).toEqual([
+      {
+        markdown: "# Spec",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 1,
+      },
+    ]);
+  });
+
+  test("parseQaEntries enforces verdict and required fields", () => {
+    const parsed = parseQaEntries([
+      {
+        markdown: "QA report",
+        verdict: "approved",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "qa-agent",
+        sourceTool: "odt_qa_approved",
+        revision: 2,
+      },
+      {
+        markdown: "Invalid verdict",
+        verdict: "not_reviewed",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "qa-agent",
+        sourceTool: "odt_qa_approved",
+        revision: 3,
+      },
+      {
+        markdown: "Missing source tool",
+        verdict: "rejected",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "qa-agent",
+        revision: 4,
+      },
+    ]);
+
+    expect(parsed).toEqual([
+      {
+        markdown: "QA report",
+        verdict: "approved",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "qa-agent",
+        sourceTool: "odt_qa_approved",
+        revision: 2,
+      },
+    ]);
+  });
+
+  test("returns an empty array for non-array metadata values", () => {
+    expect(parseMarkdownEntries(undefined)).toEqual([]);
+    expect(parseMarkdownEntries({})).toEqual([]);
+    expect(parseQaEntries(null)).toEqual([]);
+    expect(parseQaEntries("invalid")).toEqual([]);
+  });
+});

--- a/packages/openducktor-mcp/src/task-mapping.test.ts
+++ b/packages/openducktor-mcp/src/task-mapping.test.ts
@@ -158,6 +158,85 @@ describe("task mapping entry parsers", () => {
     ]);
   });
 
+  test("rejects invalid updatedAt values", () => {
+    const parsedMarkdown = parseMarkdownEntries([
+      {
+        markdown: "valid zulu",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 1,
+      },
+      {
+        markdown: "valid offset",
+        updatedAt: "2026-02-28T00:00:00+01:00",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 2,
+      },
+      {
+        markdown: "date only",
+        updatedAt: "2026-02-28",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 3,
+      },
+      {
+        markdown: "invalid date",
+        updatedAt: "not-a-date",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 4,
+      },
+    ]);
+
+    const parsedQa = parseQaEntries([
+      {
+        markdown: "valid qa",
+        verdict: "approved",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "qa-agent",
+        sourceTool: "odt_qa_approved",
+        revision: 1,
+      },
+      {
+        markdown: "invalid qa date",
+        verdict: "rejected",
+        updatedAt: "2026-02-28",
+        updatedBy: "qa-agent",
+        sourceTool: "odt_qa_rejected",
+        revision: 2,
+      },
+    ]);
+
+    expect(parsedMarkdown).toEqual([
+      {
+        markdown: "valid zulu",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 1,
+      },
+      {
+        markdown: "valid offset",
+        updatedAt: "2026-02-28T00:00:00+01:00",
+        updatedBy: "agent",
+        sourceTool: "odt_set_spec",
+        revision: 2,
+      },
+    ]);
+    expect(parsedQa).toEqual([
+      {
+        markdown: "valid qa",
+        verdict: "approved",
+        updatedAt: "2026-02-28T00:00:00Z",
+        updatedBy: "qa-agent",
+        sourceTool: "odt_qa_approved",
+        revision: 1,
+      },
+    ]);
+  });
+
   test("returns an empty array for non-array metadata values", () => {
     expect(parseMarkdownEntries(undefined)).toEqual([]);
     expect(parseMarkdownEntries({})).toEqual([]);

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type {
   IssueType,
   JsonObject,
@@ -31,69 +32,41 @@ export const ensureObject = (value: unknown): JsonObject => {
   return { ...(value as JsonObject) };
 };
 
-export const parseMarkdownEntries = (value: unknown): MarkdownEntry[] => {
+const MarkdownEntrySchema = z.object({
+  markdown: z.string(),
+  updatedAt: z.string(),
+  updatedBy: z.string(),
+  sourceTool: z.string(),
+  revision: z.number(),
+});
+
+const QaEntrySchema = MarkdownEntrySchema.extend({
+  verdict: z.enum(["approved", "rejected"]),
+});
+
+const parseTypedEntries = <T>(schema: z.ZodType<T>, value: unknown): T[] => {
   if (!Array.isArray(value)) {
     return [];
   }
 
-  const entries: MarkdownEntry[] = [];
+  const entries: T[] = [];
   for (const entry of value) {
-    if (!entry || typeof entry !== "object") {
+    const parsed = schema.safeParse(entry);
+    if (!parsed.success) {
       continue;
     }
-    const record = entry as Record<string, unknown>;
-    if (
-      typeof record.markdown !== "string" ||
-      typeof record.updatedAt !== "string" ||
-      typeof record.updatedBy !== "string" ||
-      typeof record.sourceTool !== "string" ||
-      typeof record.revision !== "number"
-    ) {
-      continue;
-    }
-    entries.push({
-      markdown: record.markdown,
-      updatedAt: record.updatedAt,
-      updatedBy: record.updatedBy,
-      sourceTool: record.sourceTool,
-      revision: record.revision,
-    });
+    entries.push(parsed.data);
   }
+
   return entries;
 };
 
+export const parseMarkdownEntries = (value: unknown): MarkdownEntry[] => {
+  return parseTypedEntries(MarkdownEntrySchema, value);
+};
+
 export const parseQaEntries = (value: unknown): QaEntry[] => {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  const entries: QaEntry[] = [];
-  for (const entry of value) {
-    if (!entry || typeof entry !== "object") {
-      continue;
-    }
-    const record = entry as Record<string, unknown>;
-    if (
-      typeof record.markdown !== "string" ||
-      (record.verdict !== "approved" && record.verdict !== "rejected") ||
-      typeof record.updatedAt !== "string" ||
-      typeof record.updatedBy !== "string" ||
-      typeof record.sourceTool !== "string" ||
-      typeof record.revision !== "number"
-    ) {
-      continue;
-    }
-
-    entries.push({
-      markdown: record.markdown,
-      verdict: record.verdict,
-      updatedAt: record.updatedAt,
-      updatedBy: record.updatedBy,
-      sourceTool: record.sourceTool,
-      revision: record.revision,
-    });
-  }
-  return entries;
+  return parseTypedEntries(QaEntrySchema, value);
 };
 
 const normalizeParentId = (issue: RawIssue): string | null => {

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -32,12 +32,14 @@ export const ensureObject = (value: unknown): JsonObject => {
   return { ...(value as JsonObject) };
 };
 
+const RevisionSchema = z.number().int().positive();
+
 const MarkdownEntrySchema = z.object({
   markdown: z.string(),
   updatedAt: z.string(),
   updatedBy: z.string(),
   sourceTool: z.string(),
-  revision: z.number(),
+  revision: RevisionSchema,
 });
 
 const QaEntrySchema = MarkdownEntrySchema.extend({

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -33,10 +33,11 @@ export const ensureObject = (value: unknown): JsonObject => {
 };
 
 const RevisionSchema = z.number().int().positive();
+const UpdatedAtSchema = z.string().datetime({ offset: true });
 
 const MarkdownEntrySchema = z.object({
   markdown: z.string(),
-  updatedAt: z.string(),
+  updatedAt: UpdatedAtSchema,
   updatedBy: z.string(),
   sourceTool: z.string(),
   revision: RevisionSchema,


### PR DESCRIPTION
## Summary
- extract a generic Zod-based metadata entry parser (`parseTypedEntries`) in MCP task mapping
- replace duplicated `parseMarkdownEntries` / `parseQaEntries` manual validation logic with schemas
- enforce strict `revision` validation as a positive integer
- add parser regression tests including invalid revision cases (`NaN`, `Infinity`, float, zero, negative)

## Validation
- `bun run --filter @openducktor/openducktor-mcp typecheck`
- `bun run --filter @openducktor/openducktor-mcp lint`
- `bun run --filter @openducktor/openducktor-mcp test`

## Breaking Change
This intentionally drops backward compatibility during development:
- metadata entries with non-positive, non-integer, or non-finite `revision` values are now rejected
