### PR TITLE
fix(security): remediate vulnerable hono transitive dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Dependency vulnerability guard (hono)
+        run: bun run deps:audit:hono
+
       - name: Lint workspaces
         run: bun run lint
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ bun run typecheck
 bun run build
 bun run test
 bun run deps:check
+bun run deps:audit:hono
 bun run deps:unused
 bun run deps:outdated
 
@@ -114,11 +115,13 @@ cd apps/desktop/src-tauri && cargo check
 ## Dependency Hygiene
 
 - Blocking unused dependency check: `bun run deps:check`
+- Blocking targeted vulnerability check (Hono GHSA-`xh87-mx6m-69f3`): `bun run deps:audit:hono`
 - Non-blocking unused export report: `bun run deps:unused`
 - Outdated dependency report: `bun run deps:outdated`
 - Automated update PRs: `.github/dependabot.yml`
 - CI automation: `.github/workflows/dependency-hygiene.yml`
 - Review and upgrade cadence: `docs/dependency-hygiene.md`
+- MCP runtime transport and threat assumptions: `docs/mcp-runtime-security.md`
 
 ## IPC Commands (Implemented)
 

--- a/bun.lock
+++ b/bun.lock
@@ -92,10 +92,13 @@
       "name": "@openducktor/openducktor-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.5",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "zod": "^4.3.6",
       },
     },
+  },
+  "overrides": {
+    "hono": "^4.12.2",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -752,7 +755,7 @@
 
     "highlightjs-vue": ["highlightjs-vue@1.0.0", "", {}, "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="],
 
-    "hono": ["hono@4.12.0", "", {}, "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA=="],
+    "hono": ["hono@4.12.3", "", {}, "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 

--- a/docs/dependency-hygiene.md
+++ b/docs/dependency-hygiene.md
@@ -49,10 +49,21 @@ Implementation notes:
 
 - Dedicated report workflow: `.github/workflows/dependency-hygiene-report.yml`
 
+## 4) Targeted Vulnerability Gate (Hono)
+
+- Command: `bun run deps:audit:hono`
+- Backed by: `bun audit --json`
+- Scope: blocks GHSA-`xh87-mx6m-69f3` reintroduction (`hono` must resolve to `>=4.12.2`)
+
+Implementation notes:
+
+- Included in `.github/workflows/ci.yml` Bun quality job.
+- Included in `deps:check`, which runs in `.github/workflows/dependency-hygiene.yml`.
+
 ## Cadence
 
 - Weekly (automated): Dependabot creates update PRs, and report CI publishes `bun run deps:unused:exports` plus `bun run deps:outdated` outputs.
-- Per PR (automated): CI runs `bun run deps:check` to catch new dependency drift.
+- Per PR (automated): CI runs `bun run deps:check` to catch dependency drift and the targeted Hono regression.
 - Monthly (manual): open a dependency refresh PR for safe patch/minor updates.
 - Urgent security advisories: process outside cadence and patch immediately.
 

--- a/docs/mcp-runtime-security.md
+++ b/docs/mcp-runtime-security.md
@@ -1,0 +1,31 @@
+# MCP Runtime Security Assumptions
+
+This document defines allowed runtime transports and threat assumptions for `@openducktor/openducktor-mcp`.
+
+## Allowed Transports (V1)
+
+- Allowed: MCP `stdio` transport only.
+- Not allowed: network transports (`streamable-http`, SSE, WebSocket, Lambda adapters, reverse-proxied HTTP endpoints).
+
+Current implementation uses `StdioServerTransport` in
+`packages/openducktor-mcp/src/index.ts`.
+
+## Threat Assumptions (V1)
+
+- The MCP server is launched as a local child process by a trusted OpenDucktor runtime.
+- Transport channel is process-local stdio, not internet-reachable.
+- Request metadata from external network boundaries (for example `x-forwarded-for`) is not part of auth decisions in V1.
+
+## Supply-Chain Guardrails
+
+- `hono` is pinned via root `package.json` override to `^4.12.2` or later.
+- CI runs `bun run deps:audit:hono`, which wraps `bun audit --json` and fails on GHSA-`xh87-mx6m-69f3` regression.
+
+## Change Control for Future Transport Expansion
+
+Before enabling any network-facing transport:
+
+1. Complete a security design review for authn/authz and proxy trust boundaries.
+2. Reassess dependency advisories for transport framework code paths.
+3. Add integration tests that verify spoofed client-IP headers cannot bypass authentication.
+4. Update this document and `docs/dependency-hygiene.md` in the same change.

--- a/package.json
+++ b/package.json
@@ -16,8 +16,12 @@
     "deps:unused:deps": "knip --workspace @openducktor/* --include dependencies",
     "deps:unused:exports": "knip --workspace @openducktor/* --include exports --no-exit-code",
     "deps:unused": "bun run deps:unused:deps && bun run deps:unused:exports",
+    "deps:audit:hono": "bun run scripts/audit-hono-guard.ts",
     "deps:outdated": "bun outdated",
-    "deps:check": "bun run deps:unused:deps"
+    "deps:check": "bun run deps:audit:hono && bun run deps:unused:deps"
+  },
+  "overrides": {
+    "hono": "^4.12.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",

--- a/packages/openducktor-mcp/package.json
+++ b/packages/openducktor-mcp/package.json
@@ -12,7 +12,7 @@
     "lint": "biome check src"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.5",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "zod": "^4.3.6"
   }
 }

--- a/scripts/audit-hono-guard.ts
+++ b/scripts/audit-hono-guard.ts
@@ -1,0 +1,62 @@
+const HONO_ADVISORY_ID = "GHSA-xh87-mx6m-69f3";
+const HONO_MIN_SAFE_VERSION = "4.12.2";
+
+type AuditAdvisory = {
+  url?: string;
+};
+
+type AuditResult = Record<string, AuditAdvisory[]>;
+
+const decode = (buffer: Uint8Array): string => new TextDecoder().decode(buffer);
+
+const audit = Bun.spawnSync(["bun", "audit", "--json"], {
+  stdout: "pipe",
+  stderr: "pipe",
+});
+
+const stdout = decode(audit.stdout);
+const stderr = decode(audit.stderr);
+const jsonLine = stdout
+  .split(/\r?\n/u)
+  .map((line) => line.trim())
+  .find((line) => line.startsWith("{") && line.endsWith("}"));
+
+if (!jsonLine) {
+  console.error("[deps:audit:hono] Unable to parse `bun audit --json` output.");
+  if (stdout.trim().length > 0) {
+    console.error(stdout.trim());
+  }
+  if (stderr.trim().length > 0) {
+    console.error(stderr.trim());
+  }
+  process.exit(2);
+}
+
+let parsed: AuditResult;
+try {
+  parsed = JSON.parse(jsonLine) as AuditResult;
+} catch (error) {
+  console.error("[deps:audit:hono] Invalid JSON from `bun audit --json`.");
+  console.error(error);
+  process.exit(2);
+}
+
+const honoAdvisories = Array.isArray(parsed.hono) ? parsed.hono : [];
+const hasVulnerableHono = honoAdvisories.some((advisory) => {
+  return advisory.url?.includes(HONO_ADVISORY_ID);
+});
+
+if (hasVulnerableHono) {
+  console.error(
+    `[deps:audit:hono] ${HONO_ADVISORY_ID} detected for hono. Lockfile must resolve hono >=${HONO_MIN_SAFE_VERSION}.`,
+  );
+  process.exit(1);
+}
+
+console.log(`[deps:audit:hono] No ${HONO_ADVISORY_ID} advisory detected for hono.`);
+
+if ((audit.exitCode ?? 1) !== 0) {
+  console.warn(
+    "[deps:audit:hono] `bun audit` reported additional advisories outside this targeted gate.",
+  );
+}

--- a/scripts/audit-hono-guard.ts
+++ b/scripts/audit-hono-guard.ts
@@ -8,6 +8,55 @@ type AuditAdvisory = {
 type AuditResult = Record<string, AuditAdvisory[]>;
 
 const decode = (buffer: Uint8Array): string => new TextDecoder().decode(buffer);
+const extractFirstJsonObject = (value: string): string | null => {
+  const start = value.indexOf("{");
+  if (start === -1) {
+    return null;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < value.length; index += 1) {
+    const char = value[index];
+    if (!char) {
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return value.slice(start, index + 1);
+      }
+    }
+  }
+
+  return null;
+};
 
 const audit = Bun.spawnSync(["bun", "audit", "--json"], {
   stdout: "pipe",
@@ -16,12 +65,9 @@ const audit = Bun.spawnSync(["bun", "audit", "--json"], {
 
 const stdout = decode(audit.stdout);
 const stderr = decode(audit.stderr);
-const jsonLine = stdout
-  .split(/\r?\n/u)
-  .map((line) => line.trim())
-  .find((line) => line.startsWith("{") && line.endsWith("}"));
+const jsonPayload = extractFirstJsonObject(stdout);
 
-if (!jsonLine) {
+if (!jsonPayload) {
   console.error("[deps:audit:hono] Unable to parse `bun audit --json` output.");
   if (stdout.trim().length > 0) {
     console.error(stdout.trim());
@@ -34,7 +80,7 @@ if (!jsonLine) {
 
 let parsed: AuditResult;
 try {
-  parsed = JSON.parse(jsonLine) as AuditResult;
+  parsed = JSON.parse(jsonPayload) as AuditResult;
 } catch (error) {
   console.error("[deps:audit:hono] Invalid JSON from `bun audit --json`.");
   console.error(error);


### PR DESCRIPTION
## Summary
- force `hono` to a safe version via Bun override (`^4.12.2`) and regenerate lockfile
- bump `@modelcontextprotocol/sdk` range in `@openducktor/openducktor-mcp`
- add targeted `bun audit --json` guard script to fail on GHSA-xh87-mx6m-69f3 regressions
- wire audit guard into CI and dependency hygiene checks
- document MCP transport security assumptions (stdio-only) and threat model constraints

## Why
`bun audit --json` reported GHSA-xh87-mx6m-69f3 (`hono >=4.12.0 <4.12.2`), an authentication bypass by IP spoofing issue in AWS Lambda ALB conninfo handling. Even though MCP currently runs over stdio, we should not keep known high-severity vulnerabilities in the dependency graph.

## Validation
- bun run deps:audit:hono
- bun run deps:check
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- cd apps/desktop/src-tauri && cargo check
- cd apps/desktop/src-tauri && cargo test

## Notes
- `bun audit` still reports an unrelated `rollup` advisory (GHSA-mw96-cpmx-2vgc).
