### PR TITLE
fix(desktop): add aria-label for kanban task details button

### DIFF
--- a/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
@@ -208,6 +208,7 @@ export function KanbanTaskCard({
       <div className="kanban-active-session-content flex min-w-0 flex-col space-y-2.5 p-3.5">
         <button
           type="button"
+          aria-label={`Open details for ${task.title}`}
           className="flex w-full min-w-0 cursor-pointer items-start justify-between gap-2 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
           onClick={() => onOpenDetails(task.id)}
         >


### PR DESCRIPTION
## Summary
- add an explicit aria-label to the Kanban task card details button
- make the button announcement clearer for screen readers versus concatenated child text

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test