### PR TITLE
refactor(adapters-opencode-sdk): reduce stream-part-mapper complexity

### DIFF
--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -58,7 +58,7 @@ const createToolPart = ({
 };
 
 describe("stream-part-mapper", () => {
-  test("maps completed MCP tool output with isError as tool error part", () => {
+  test("maps completed MCP tool output with isError as tool error part and omits title", () => {
     const part = createToolPart({
       id: "tool-1",
       tool: "openducktor_odt_set_spec",
@@ -71,6 +71,7 @@ describe("stream-part-mapper", () => {
       metadata: {
         scope: "mcp",
       },
+      title: "Spec write",
       time: {
         start: 100,
         end: 130,

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -67,6 +67,83 @@ describe("stream-part-mapper", () => {
     });
   });
 
+  test("maps started tool without end timing as running and keeps title", () => {
+    const part = {
+      id: "tool-3",
+      sessionID: "session-1",
+      messageID: "assistant-3",
+      callID: "call-3",
+      type: "tool",
+      tool: "todowrite",
+      state: {
+        status: "started",
+        input: {},
+        title: "Working",
+        time: {
+          start: 25,
+        },
+      },
+    } as unknown as Part;
+
+    const mapped = mapPartToAgentStreamPart(part);
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      status: "running",
+      title: "Working",
+      startedAtMs: 25,
+    });
+  });
+
+  test("maps failed tool status as error", () => {
+    const part = {
+      id: "tool-4",
+      sessionID: "session-1",
+      messageID: "assistant-4",
+      callID: "call-4",
+      type: "tool",
+      tool: "todowrite",
+      state: {
+        status: "failed",
+        input: {},
+        error: "Execution failed",
+      },
+    } as unknown as Part;
+
+    const mapped = mapPartToAgentStreamPart(part);
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      status: "error",
+      error: "Execution failed",
+    });
+  });
+
+  test("maps unknown tool status with end timing as completed", () => {
+    const part = {
+      id: "tool-5",
+      sessionID: "session-1",
+      messageID: "assistant-5",
+      callID: "call-5",
+      type: "tool",
+      tool: "todowrite",
+      state: {
+        status: "unknown",
+        input: {},
+        time: {
+          start: 10,
+          end: 12,
+        },
+      },
+    } as unknown as Part;
+
+    const mapped = mapPartToAgentStreamPart(part);
+    expect(mapped).toMatchObject({
+      kind: "tool",
+      status: "completed",
+      startedAtMs: 10,
+      endedAtMs: 12,
+    });
+  });
+
   test("returns null for unsupported part type", () => {
     const part = {
       id: "unknown-1",

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -2,146 +2,211 @@ import { describe, expect, test } from "bun:test";
 import type { Part } from "@opencode-ai/sdk/v2/client";
 import { mapPartToAgentStreamPart } from "./stream-part-mapper";
 
+const createToolPart = ({
+  id,
+  status,
+  input = {},
+  output,
+  error,
+  title,
+  metadata,
+  time,
+  tool = "todowrite",
+}: {
+  id: string;
+  status?: string;
+  input?: Record<string, unknown>;
+  output?: unknown;
+  error?: unknown;
+  title?: unknown;
+  metadata?: Record<string, unknown>;
+  time?: { start?: number; end?: number };
+  tool?: string;
+}): Part => {
+  const state: Record<string, unknown> = {
+    input,
+  };
+
+  if (status !== undefined) {
+    state.status = status;
+  }
+  if (output !== undefined) {
+    state.output = output;
+  }
+  if (error !== undefined) {
+    state.error = error;
+  }
+  if (title !== undefined) {
+    state.title = title;
+  }
+  if (metadata !== undefined) {
+    state.metadata = metadata;
+  }
+  if (time !== undefined) {
+    state.time = time;
+  }
+
+  return {
+    id,
+    sessionID: "session-1",
+    messageID: `assistant-${id}`,
+    callID: `call-${id}`,
+    type: "tool",
+    tool,
+    state,
+  } as unknown as Part;
+};
+
 describe("stream-part-mapper", () => {
   test("maps completed MCP tool output with isError as tool error part", () => {
-    const part = {
+    const part = createToolPart({
       id: "tool-1",
-      sessionID: "session-1",
-      messageID: "assistant-1",
-      callID: "call-1",
-      type: "tool",
       tool: "openducktor_odt_set_spec",
-      state: {
-        status: "completed",
-        input: { taskId: "task-1" },
-        output: {
-          content: [{ type: "text", text: "Task not found" }],
-          isError: true,
-        },
-        metadata: {
-          scope: "mcp",
-        },
-        time: {
-          start: 100,
-          end: 130,
-        },
+      status: "completed",
+      input: { taskId: "task-1" },
+      output: {
+        content: [{ type: "text", text: "Task not found" }],
+        isError: true,
       },
-    } as unknown as Part;
+      metadata: {
+        scope: "mcp",
+      },
+      time: {
+        start: 100,
+        end: 130,
+      },
+    });
 
     const mapped = mapPartToAgentStreamPart(part);
-    expect(mapped).toMatchObject({
+    expect(mapped).toEqual({
       kind: "tool",
+      messageId: "assistant-tool-1",
+      partId: "tool-1",
+      callId: "call-tool-1",
+      tool: "openducktor_odt_set_spec",
       status: "error",
+      input: { taskId: "task-1" },
       error: "Task not found",
+      metadata: {
+        scope: "mcp",
+      },
       startedAtMs: 100,
       endedAtMs: 130,
     });
   });
 
   test("maps pending tool with end timing as completed", () => {
-    const part = {
+    const part = createToolPart({
       id: "tool-2",
-      sessionID: "session-1",
-      messageID: "assistant-2",
-      callID: "call-2",
-      type: "tool",
-      tool: "todowrite",
-      state: {
-        status: "pending",
-        input: {
-          todos: [{ id: "todo-1", content: "A" }],
-        },
-        time: {
-          start: 1,
-          end: 2,
-        },
+      status: "pending",
+      input: {
+        todos: [{ id: "todo-1", content: "A" }],
       },
-    } as unknown as Part;
+      time: {
+        start: 1,
+        end: 2,
+      },
+    });
 
     const mapped = mapPartToAgentStreamPart(part);
-    expect(mapped).toMatchObject({
+    expect(mapped).toEqual({
       kind: "tool",
+      messageId: "assistant-tool-2",
+      partId: "tool-2",
+      callId: "call-tool-2",
+      tool: "todowrite",
       status: "completed",
+      input: {
+        todos: [{ id: "todo-1", content: "A" }],
+      },
       startedAtMs: 1,
       endedAtMs: 2,
     });
   });
 
   test("maps started tool without end timing as running and keeps title", () => {
-    const part = {
+    const part = createToolPart({
       id: "tool-3",
-      sessionID: "session-1",
-      messageID: "assistant-3",
-      callID: "call-3",
-      type: "tool",
-      tool: "todowrite",
-      state: {
-        status: "started",
-        input: {},
-        title: "Working",
-        time: {
-          start: 25,
-        },
+      status: "started",
+      input: {},
+      title: "Working",
+      time: {
+        start: 25,
       },
-    } as unknown as Part;
+    });
 
     const mapped = mapPartToAgentStreamPart(part);
-    expect(mapped).toMatchObject({
+    expect(mapped).toEqual({
       kind: "tool",
+      messageId: "assistant-tool-3",
+      partId: "tool-3",
+      callId: "call-tool-3",
+      tool: "todowrite",
       status: "running",
+      input: {},
       title: "Working",
       startedAtMs: 25,
     });
   });
 
-  test("maps failed tool status as error", () => {
-    const part = {
+  test("maps failed tool status as error without title field", () => {
+    const part = createToolPart({
       id: "tool-4",
-      sessionID: "session-1",
-      messageID: "assistant-4",
-      callID: "call-4",
-      type: "tool",
-      tool: "todowrite",
-      state: {
-        status: "failed",
-        input: {},
-        error: "Execution failed",
-      },
-    } as unknown as Part;
+      status: "failed",
+      input: {},
+      title: "Failure title",
+      error: "Execution failed",
+    });
 
     const mapped = mapPartToAgentStreamPart(part);
-    expect(mapped).toMatchObject({
+    expect(mapped).toEqual({
       kind: "tool",
+      messageId: "assistant-tool-4",
+      partId: "tool-4",
+      callId: "call-tool-4",
+      tool: "todowrite",
       status: "error",
+      input: {},
       error: "Execution failed",
     });
   });
 
-  test("maps unknown tool status with end timing as completed", () => {
-    const part = {
-      id: "tool-5",
-      sessionID: "session-1",
-      messageID: "assistant-5",
-      callID: "call-5",
-      type: "tool",
-      tool: "todowrite",
-      state: {
-        status: "unknown",
-        input: {},
-        time: {
-          start: 10,
-          end: 12,
-        },
-      },
-    } as unknown as Part;
+  test("normalizes tool statuses across known and fallback values", () => {
+    const scenarios = [
+      { rawStatus: "completed", hasEndedTiming: false, expectedStatus: "completed" },
+      { rawStatus: "completed", hasEndedTiming: true, expectedStatus: "completed" },
+      { rawStatus: "error", hasEndedTiming: false, expectedStatus: "error" },
+      { rawStatus: "failed", hasEndedTiming: false, expectedStatus: "error" },
+      { rawStatus: "pending", hasEndedTiming: false, expectedStatus: "pending" },
+      { rawStatus: "pending", hasEndedTiming: true, expectedStatus: "completed" },
+      { rawStatus: "running", hasEndedTiming: false, expectedStatus: "running" },
+      { rawStatus: "running", hasEndedTiming: true, expectedStatus: "completed" },
+      { rawStatus: "started", hasEndedTiming: false, expectedStatus: "running" },
+      { rawStatus: "started", hasEndedTiming: true, expectedStatus: "completed" },
+      { rawStatus: "unknown", hasEndedTiming: false, expectedStatus: "running" },
+      { rawStatus: "unknown", hasEndedTiming: true, expectedStatus: "completed" },
+      { rawStatus: "", hasEndedTiming: false, expectedStatus: "running" },
+      { rawStatus: "", hasEndedTiming: true, expectedStatus: "completed" },
+      { rawStatus: undefined, hasEndedTiming: false, expectedStatus: "running" },
+      { rawStatus: undefined, hasEndedTiming: true, expectedStatus: "completed" },
+      { rawStatus: "   ", hasEndedTiming: false, expectedStatus: "running" },
+      { rawStatus: "   ", hasEndedTiming: true, expectedStatus: "completed" },
+    ] as const;
 
-    const mapped = mapPartToAgentStreamPart(part);
-    expect(mapped).toMatchObject({
-      kind: "tool",
-      status: "completed",
-      startedAtMs: 10,
-      endedAtMs: 12,
-    });
+    for (const [index, scenario] of scenarios.entries()) {
+      const part = createToolPart({
+        id: `status-${index}`,
+        status: scenario.rawStatus,
+        time: scenario.hasEndedTiming ? { start: 1, end: 2 } : { start: 1 },
+      });
+      const mapped = mapPartToAgentStreamPart(part);
+
+      expect(mapped).toBeTruthy();
+      if (!mapped || mapped.kind !== "tool") {
+        throw new Error("Expected mapped tool part.");
+      }
+      expect(mapped.status).toBe(scenario.expectedStatus);
+    }
   });
 
   test("returns null for unsupported part type", () => {

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -92,6 +92,83 @@ const extractPartTiming = (
   };
 };
 
+type ToolPart = Extract<Part, { type: "tool" }>;
+type ToolStreamPart = Extract<AgentStreamPart, { kind: "tool" }>;
+type ToolStatus = ToolStreamPart["status"];
+
+const normalizeToolStatus = (rawStatus: string, hasEndedTiming: boolean): ToolStatus => {
+  const normalized = rawStatus.trim().toLowerCase();
+  if (normalized === "completed") {
+    return "completed";
+  }
+  if (normalized === "error" || normalized === "failed") {
+    return "error";
+  }
+  if (normalized === "pending") {
+    return hasEndedTiming ? "completed" : "pending";
+  }
+  if (normalized === "running" || normalized === "started") {
+    return hasEndedTiming ? "completed" : "running";
+  }
+  return hasEndedTiming ? "completed" : "running";
+};
+
+const buildToolStreamPart = (
+  part: ToolPart,
+  normalizedStatus: ToolStatus,
+  timing: ReturnType<typeof extractPartTiming>,
+  metadata: Record<string, unknown> | undefined,
+): ToolStreamPart => {
+  const toolState = part.state as Record<string, unknown>;
+  const title = toDisplayText(toolState.title);
+  const titleField = title ? { title } : {};
+  const base: ToolStreamPart = {
+    kind: "tool",
+    messageId: part.messageID,
+    partId: part.id,
+    callId: part.callID,
+    tool: part.tool,
+    status: normalizedStatus,
+    input: part.state.input,
+    ...(metadata ? { metadata } : {}),
+    ...timing,
+  };
+
+  if (normalizedStatus === "pending") {
+    return base;
+  }
+  if (normalizedStatus === "running") {
+    return {
+      ...base,
+      ...titleField,
+    };
+  }
+
+  const error = toDisplayText(toolState.error);
+  if (normalizedStatus === "error") {
+    return {
+      ...base,
+      ...(error ? { error } : {}),
+    };
+  }
+
+  const output = readToolOutputText(toolState.output);
+  if (isToolOutputError(toolState.output) || (error && error.trim().length > 0)) {
+    return {
+      ...base,
+      status: "error",
+      error: output ?? error ?? "Tool failed",
+      ...titleField,
+    };
+  }
+
+  return {
+    ...base,
+    ...(output ? { output } : {}),
+    ...titleField,
+  };
+};
+
 export const mapPartToAgentStreamPart = (part: Part): AgentStreamPart | null => {
   switch (part.type) {
     case "text":
@@ -112,105 +189,15 @@ export const mapPartToAgentStreamPart = (part: Part): AgentStreamPart | null => 
         completed: Boolean(part.time?.end),
       };
     case "tool": {
-      const toolState = part.state as Record<string, unknown>;
       const timing = extractPartTiming(part);
       const metadata = normalizeMetadata(
         (part as { state?: { metadata?: unknown } }).state?.metadata,
       );
-      const rawStatus =
-        typeof part.state.status === "string" ? part.state.status.trim().toLowerCase() : "";
-      const hasEndedTiming = typeof timing.endedAtMs === "number";
-      const normalizedStatus: "pending" | "running" | "completed" | "error" = (() => {
-        if (rawStatus === "completed") {
-          return "completed";
-        }
-        if (rawStatus === "error" || rawStatus === "failed") {
-          return "error";
-        }
-        if (rawStatus === "pending") {
-          return hasEndedTiming ? "completed" : "pending";
-        }
-        if (rawStatus === "running" || rawStatus === "started") {
-          return hasEndedTiming ? "completed" : "running";
-        }
-        return hasEndedTiming ? "completed" : "running";
-      })();
-
-      if (normalizedStatus === "pending") {
-        return {
-          kind: "tool",
-          messageId: part.messageID,
-          partId: part.id,
-          callId: part.callID,
-          tool: part.tool,
-          status: "pending",
-          input: part.state.input,
-          ...(metadata ? { metadata } : {}),
-          ...timing,
-        };
-      }
-      if (normalizedStatus === "running") {
-        const title = toDisplayText(toolState.title);
-        return {
-          kind: "tool",
-          messageId: part.messageID,
-          partId: part.id,
-          callId: part.callID,
-          tool: part.tool,
-          status: "running",
-          input: part.state.input,
-          ...(title ? { title } : {}),
-          ...(metadata ? { metadata } : {}),
-          ...timing,
-        };
-      }
-      if (normalizedStatus === "completed") {
-        const output = readToolOutputText(toolState.output);
-        const error = toDisplayText(toolState.error);
-        const title = toDisplayText(toolState.title);
-        if (isToolOutputError(toolState.output) || (error && error.trim().length > 0)) {
-          const errorText = output ?? error ?? "Tool failed";
-          return {
-            kind: "tool",
-            messageId: part.messageID,
-            partId: part.id,
-            callId: part.callID,
-            tool: part.tool,
-            status: "error",
-            input: part.state.input,
-            error: errorText,
-            ...(title ? { title } : {}),
-            ...(metadata ? { metadata } : {}),
-            ...timing,
-          };
-        }
-        return {
-          kind: "tool",
-          messageId: part.messageID,
-          partId: part.id,
-          callId: part.callID,
-          tool: part.tool,
-          status: "completed",
-          input: part.state.input,
-          ...(output ? { output } : {}),
-          ...(title ? { title } : {}),
-          ...(metadata ? { metadata } : {}),
-          ...timing,
-        };
-      }
-      const error = toDisplayText(toolState.error);
-      return {
-        kind: "tool",
-        messageId: part.messageID,
-        partId: part.id,
-        callId: part.callID,
-        tool: part.tool,
-        status: "error",
-        input: part.state.input,
-        ...(error ? { error } : {}),
-        ...(metadata ? { metadata } : {}),
-        ...timing,
-      };
+      const normalizedStatus = normalizeToolStatus(
+        typeof part.state.status === "string" ? part.state.status : "",
+        typeof timing.endedAtMs === "number",
+      );
+      return buildToolStreamPart(part, normalizedStatus, timing, metadata);
     }
     case "step-start":
       return {

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -120,8 +120,6 @@ const buildToolStreamPart = (
   metadata: Record<string, unknown> | undefined,
 ): ToolStreamPart => {
   const toolState = part.state as Record<string, unknown>;
-  const title = toDisplayText(toolState.title);
-  const titleField = title ? { title } : {};
   const base: ToolStreamPart = {
     kind: "tool",
     messageId: part.messageID,
@@ -138,9 +136,10 @@ const buildToolStreamPart = (
     return base;
   }
   if (normalizedStatus === "running") {
+    const title = toDisplayText(toolState.title);
     return {
       ...base,
-      ...titleField,
+      ...(title ? { title } : {}),
     };
   }
 
@@ -153,6 +152,8 @@ const buildToolStreamPart = (
   }
 
   const output = readToolOutputText(toolState.output);
+  const title = toDisplayText(toolState.title);
+  const titleField = title ? { title } : {};
   if (isToolOutputError(toolState.output) || (error && error.trim().length > 0)) {
     return {
       ...base,

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -152,17 +152,16 @@ const buildToolStreamPart = (
   }
 
   const output = readToolOutputText(toolState.output);
-  const title = toDisplayText(toolState.title);
-  const titleField = title ? { title } : {};
   if (isToolOutputError(toolState.output) || (error && error.trim().length > 0)) {
     return {
       ...base,
       status: "error",
       error: output ?? error ?? "Tool failed",
-      ...titleField,
     };
   }
 
+  const title = toDisplayText(toolState.title);
+  const titleField = title ? { title } : {};
   return {
     ...base,
     ...(output ? { output } : {}),


### PR DESCRIPTION
## Summary
- extract tool status normalization into `normalizeToolStatus` and tool payload assembly into `buildToolStreamPart`
- simplify `mapPartToAgentStreamPart` tool branch to focused delegation
- tighten mapper tests with strict tool payload assertions, add status normalization matrix coverage, and verify failed status does not emit title

## Validation
- bun run --filter @openducktor/adapters-opencode-sdk lint
- bun run --filter @openducktor/adapters-opencode-sdk typecheck
- bun run --filter @openducktor/adapters-opencode-sdk test
