### PR TITLE
refactor(tauri): type issueType across domain and host boundaries

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -41,14 +41,14 @@ pub(crate) use opencode_runtime::{
     OpencodeStartupWaitReport, StartupCancelEpoch,
 };
 #[cfg(test)]
+pub(crate) use process_registry::read_opencode_process_registry;
+#[cfg(test)]
 pub(crate) use process_registry::{
     with_locked_opencode_process_registry, OpencodeProcessRegistryInstance,
     TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
-#[cfg(test)]
-pub(crate) use process_registry::read_opencode_process_registry;
-pub use service_core::{AppService, RunEmitter};
 pub(crate) use service_core::{AgentRuntimeProcess, CachedRuntimeCheck, RunProcess};
+pub use service_core::{AppService, RunEmitter};
 #[cfg(test)]
 pub(crate) use startup_metrics::{
     build_opencode_startup_event_payload, OpencodeStartupMetricsSnapshot,
@@ -57,8 +57,8 @@ pub(crate) use workflow_rules::{
     can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
     default_qa_required_for_issue_type, derive_agent_workflows, derive_available_actions,
     normalize_required_markdown, normalize_subtask_plan_inputs, normalize_title_key,
-    validate_parent_relationships_for_create,
-    validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
+    validate_parent_relationships_for_create, validate_parent_relationships_for_update,
+    validate_plan_subtask_rules, validate_transition,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -56,8 +56,8 @@ pub(crate) use startup_metrics::{
 pub(crate) use workflow_rules::{
     can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
     default_qa_required_for_issue_type, derive_agent_workflows, derive_available_actions,
-    normalize_issue_type, normalize_required_markdown, normalize_subtask_plan_inputs,
-    normalize_title_key, validate_parent_relationships_for_create,
+    normalize_required_markdown, normalize_subtask_plan_inputs, normalize_title_key,
+    validate_parent_relationships_for_create,
     validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
 };
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
@@ -595,14 +595,12 @@ async fn probe_local_server_async(
         }
 
         attempts.fetch_add(1, Ordering::Relaxed);
-        let connected = tokio::time::timeout(
-            connect_timeout,
-            tokio::net::TcpStream::connect(address),
-        )
-        .await
-        .ok()
-        .and_then(|result| result.ok())
-        .is_some();
+        let connected =
+            tokio::time::timeout(connect_timeout, tokio::net::TcpStream::connect(address))
+                .await
+                .ok()
+                .and_then(|result| result.ok())
+                .is_some();
         if connected {
             return LocalServerProbeEvent {
                 state: LocalServerProbeState::Ready,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/process_registry.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/process_registry.rs
@@ -69,7 +69,9 @@ struct OpencodeProcessRegistryFile {
     instances: Vec<OpencodeProcessRegistryInstance>,
 }
 
-fn normalize_opencode_process_registry_instances(instances: &mut Vec<OpencodeProcessRegistryInstance>) {
+fn normalize_opencode_process_registry_instances(
+    instances: &mut Vec<OpencodeProcessRegistryInstance>,
+) {
     for instance in instances.iter_mut() {
         instance.child_pids.sort_unstable();
         instance.child_pids.dedup();
@@ -114,7 +116,12 @@ pub(crate) fn with_locked_opencode_process_registry<T>(
         .read(true)
         .write(true)
         .open(path)
-        .with_context(|| format!("Failed opening OpenCode process registry {}", path.display()))?;
+        .with_context(|| {
+            format!(
+                "Failed opening OpenCode process registry {}",
+                path.display()
+            )
+        })?;
     file.lock_exclusive().with_context(|| {
         format!(
             "Failed acquiring lock for OpenCode process registry {}",
@@ -123,8 +130,12 @@ pub(crate) fn with_locked_opencode_process_registry<T>(
     })?;
 
     let mut data = String::new();
-    file.read_to_string(&mut data)
-        .with_context(|| format!("Failed reading OpenCode process registry {}", path.display()))?;
+    file.read_to_string(&mut data).with_context(|| {
+        format!(
+            "Failed reading OpenCode process registry {}",
+            path.display()
+        )
+    })?;
 
     let mut parsed = if data.trim().is_empty() {
         OpencodeProcessRegistryFile::default()
@@ -143,14 +154,30 @@ pub(crate) fn with_locked_opencode_process_registry<T>(
 
     let payload = serde_json::to_string_pretty(&parsed)
         .context("Failed serializing OpenCode process registry payload")?;
-    file.set_len(0)
-        .with_context(|| format!("Failed truncating OpenCode process registry {}", path.display()))?;
-    file.seek(SeekFrom::Start(0))
-        .with_context(|| format!("Failed seeking OpenCode process registry {}", path.display()))?;
-    file.write_all(payload.as_bytes())
-        .with_context(|| format!("Failed writing OpenCode process registry {}", path.display()))?;
-    file.flush()
-        .with_context(|| format!("Failed flushing OpenCode process registry {}", path.display()))?;
+    file.set_len(0).with_context(|| {
+        format!(
+            "Failed truncating OpenCode process registry {}",
+            path.display()
+        )
+    })?;
+    file.seek(SeekFrom::Start(0)).with_context(|| {
+        format!(
+            "Failed seeking OpenCode process registry {}",
+            path.display()
+        )
+    })?;
+    file.write_all(payload.as_bytes()).with_context(|| {
+        format!(
+            "Failed writing OpenCode process registry {}",
+            path.display()
+        )
+    })?;
+    file.flush().with_context(|| {
+        format!(
+            "Failed flushing OpenCode process registry {}",
+            path.display()
+        )
+    })?;
 
     Ok(output)
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
@@ -5,13 +5,7 @@ const STARTUP_ATTEMPTS_WARN: u32 = 20;
 const STARTUP_FAILURE_RATE_WARN_MIN_SAMPLES: u64 = 10;
 const STARTUP_FAILURE_RATE_WARN_PCT: u64 = 30;
 const STARTUP_MS_BUCKETS: [&str; 7] = [
-    "<=100",
-    "<=250",
-    "<=500",
-    "<=1000",
-    "<=2000",
-    "<=5000",
-    ">5000",
+    "<=100", "<=250", "<=500", "<=1000", "<=2000", "<=5000", ">5000",
 ];
 const STARTUP_ATTEMPTS_BUCKETS: [&str; 6] = ["<=1", "<=3", "<=5", "<=10", "<=20", ">20"];
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -73,12 +73,9 @@ impl AppService {
     }
 
     fn update_runtime_check_cache(&self, check: RuntimeCheck) -> Result<()> {
-        let mut cache = self
-            .runtime_check_cache
-            .lock()
-            .map_err(|_| {
-                anyhow!("Runtime check cache lock poisoned in `update_runtime_check_cache`")
-            })?;
+        let mut cache = self.runtime_check_cache.lock().map_err(|_| {
+            anyhow!("Runtime check cache lock poisoned in `update_runtime_check_cache`")
+        })?;
         *cache = Some(CachedRuntimeCheck {
             checked_at: Instant::now(),
             value: check,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
@@ -1,7 +1,6 @@
 use super::{
     can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
-    default_qa_required_for_issue_type,
-    normalize_issue_type, normalize_required_markdown, normalize_subtask_plan_inputs,
+    default_qa_required_for_issue_type, normalize_required_markdown, normalize_subtask_plan_inputs,
     normalize_title_key, validate_parent_relationships_for_create,
     validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
     AppService,
@@ -39,16 +38,13 @@ impl AppService {
         &self,
         repo_path: &str,
         task_id: &str,
-        mut patch: UpdateTaskPatch,
+        patch: UpdateTaskPatch,
     ) -> Result<TaskCard> {
         self.ensure_repo_initialized(repo_path)?;
         if patch.status.is_some() {
             return Err(anyhow!(
                 "Status cannot be updated directly. Use workflow transitions."
             ));
-        }
-        if let Some(issue_type) = patch.issue_type.as_ref() {
-            patch.issue_type = Some(normalize_issue_type(issue_type).as_cli_value().to_string());
         }
 
         let mut existing = self.task_store.list_tasks(Path::new(repo_path))?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
@@ -8,8 +8,8 @@ use super::{
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentSessionDocument, CreateTaskInput, PlanSubtaskInput, QaVerdict, SpecDocument, TaskCard,
-    TaskMetadata, TaskStatus, UpdateTaskPatch,
+    AgentSessionDocument, CreateTaskInput, IssueType, PlanSubtaskInput, QaVerdict, SpecDocument,
+    TaskCard, TaskMetadata, TaskStatus, UpdateTaskPatch,
 };
 use std::collections::HashSet;
 use std::path::Path;
@@ -23,7 +23,6 @@ impl AppService {
 
     pub fn task_create(&self, repo_path: &str, mut input: CreateTaskInput) -> Result<TaskCard> {
         self.ensure_repo_initialized(repo_path)?;
-        input.issue_type = normalize_issue_type(&input.issue_type).to_string();
         if input.ai_review_enabled.is_none() {
             input.ai_review_enabled = Some(default_qa_required_for_issue_type(&input.issue_type));
         }
@@ -49,7 +48,7 @@ impl AppService {
             ));
         }
         if let Some(issue_type) = patch.issue_type.as_ref() {
-            patch.issue_type = Some(normalize_issue_type(issue_type).to_string());
+            patch.issue_type = Some(normalize_issue_type(issue_type).as_cli_value().to_string());
         }
 
         let mut existing = self.task_store.list_tasks(Path::new(repo_path))?;
@@ -337,15 +336,15 @@ impl AppService {
         if !can_set_plan(&task) {
             return Err(anyhow!(
                 "set_plan is not allowed for issue type {} from status {}",
-                normalize_issue_type(&task.issue_type),
+                task.issue_type.as_cli_value(),
                 task.status.as_cli_value()
             ));
         }
 
-        let issue_type = normalize_issue_type(&task.issue_type);
+        let issue_type = task.issue_type.clone();
         let mut subtask_creates = normalize_subtask_plan_inputs(subtasks.unwrap_or_default())?;
         validate_plan_subtask_rules(&task, &tasks, &subtask_creates)?;
-        if issue_type != "epic" {
+        if issue_type != IssueType::Epic {
             subtask_creates.clear();
         }
 
@@ -354,7 +353,7 @@ impl AppService {
             .set_plan(Path::new(repo_path), task_id, &markdown)
             .with_context(|| format!("Failed to persist implementation plan for {task_id}"))?;
 
-        if issue_type == "epic" {
+        if issue_type == IssueType::Epic {
             let mut current_tasks = self.task_store.list_tasks(Path::new(repo_path))?;
             let refreshed_task = current_tasks
                 .iter()
@@ -364,7 +363,7 @@ impl AppService {
             if !can_set_plan(&refreshed_task) {
                 return Err(anyhow!(
                     "set_plan is not allowed for issue type {} from status {}",
-                    normalize_issue_type(&refreshed_task.issue_type),
+                    refreshed_task.issue_type.as_cli_value(),
                     refreshed_task.status.as_cli_value()
                 ));
             }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -18,9 +18,9 @@ use super::{
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, AgentWorkflows, CreateTaskInput, GitBranch,
-    GitCurrentBranch, GitPort, GitPushSummary, PlanSubtaskInput, QaReportDocument, QaVerdict,
-    RunEvent, RunState, RunSummary, SpecDocument, TaskAction, TaskCard, TaskDocumentSummary,
-    TaskMetadata, TaskStatus, TaskStore, UpdateTaskPatch,
+    GitCurrentBranch, GitPort, GitPushSummary, IssueType, PlanSubtaskInput, QaReportDocument,
+    QaVerdict, RunEvent, RunState, RunSummary, SpecDocument, TaskAction, TaskCard,
+    TaskDocumentSummary, TaskMetadata, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{
     AppConfigStore, GlobalConfig, HookSet, OpencodeStartupReadinessConfig, RepoConfig,
@@ -45,7 +45,7 @@ pub(crate) fn make_task(id: &str, issue_type: &str, status: TaskStatus) -> TaskC
         notes: String::new(),
         status,
         priority: 2,
-        issue_type: issue_type.to_string(),
+        issue_type: IssueType::from_cli_value(issue_type).unwrap_or(IssueType::Task),
         ai_review_enabled: true,
         available_actions: Vec::new(),
         labels: Vec::new(),
@@ -155,7 +155,8 @@ impl TaskStore for FakeTaskStore {
             updated.status = status;
         }
         if let Some(issue_type) = patch.issue_type {
-            updated.issue_type = issue_type;
+            updated.issue_type =
+                IssueType::from_cli_value(&issue_type).unwrap_or(IssueType::Task);
         }
         if let Some(ai_review_enabled) = patch.ai_review_enabled {
             updated.ai_review_enabled = ai_review_enabled;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -155,8 +155,7 @@ impl TaskStore for FakeTaskStore {
             updated.status = status;
         }
         if let Some(issue_type) = patch.issue_type {
-            updated.issue_type =
-                IssueType::from_cli_value(&issue_type).unwrap_or(IssueType::Task);
+            updated.issue_type = issue_type;
         }
         if let Some(ai_review_enabled) = patch.ai_review_enabled {
             updated.ai_review_enabled = ai_review_enabled;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -889,7 +889,9 @@ pub(crate) fn build_service_with_store(
     (service, task_state, git_state)
 }
 
-pub(crate) fn make_emitter(events: Arc<Mutex<Vec<RunEvent>>>) -> Arc<dyn Fn(RunEvent) + Send + Sync> {
+pub(crate) fn make_emitter(
+    events: Arc<Mutex<Vec<RunEvent>>>,
+) -> Arc<dyn Fn(RunEvent) + Send + Sync> {
     Arc::new(move |event| {
         events.lock().expect("events lock poisoned").push(event);
     })

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -3,8 +3,8 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
-    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, TaskAction, TaskStatus,
-    TaskStore, UpdateTaskPatch,
+    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{hook_set_fingerprint, AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -17,22 +17,21 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
-use crate::app_service::{
-    build_opencode_config_content, can_set_plan, default_mcp_workspace_root, parse_mcp_command_json,
-    read_opencode_process_registry, read_opencode_version, resolve_mcp_command,
-    resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
-    validate_parent_relationships_for_update, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
-    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
-    with_locked_opencode_process_registry,
-};
 use crate::app_service::test_support::{
-    FakeTaskStore, GitCall, TaskStoreState, build_service_with_git_state, build_service_with_store,
-    create_fake_bd, create_fake_opencode, create_failing_opencode,
-    create_failing_opencode_with_worktree_cleanup, create_orphanable_opencode, empty_patch,
-    init_git_repo, lock_env, make_emitter, make_session, make_task, prepend_path,
-    process_is_alive, remove_env_var, set_env_var, spawn_sleep_process, unique_temp_path,
-    wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
-    write_executable_script,
+    build_service_with_git_state, build_service_with_store, create_failing_opencode,
+    create_failing_opencode_with_worktree_cleanup, create_fake_bd, create_fake_opencode,
+    create_orphanable_opencode, empty_patch, init_git_repo, lock_env, make_emitter, make_session,
+    make_task, prepend_path, process_is_alive, remove_env_var, set_env_var, spawn_sleep_process,
+    unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
+    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+};
+use crate::app_service::{
+    build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
+    parse_mcp_command_json, read_opencode_process_registry, read_opencode_version,
+    resolve_mcp_command, resolve_opencode_binary_path, terminate_child_process,
+    terminate_process_by_pid, validate_parent_relationships_for_update,
+    with_locked_opencode_process_registry, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
+    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
@@ -3,8 +3,8 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
-    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, TaskAction, TaskStatus,
-    TaskStore, UpdateTaskPatch,
+    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -17,22 +17,21 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
-use crate::app_service::{
-    build_opencode_config_content, can_set_plan, default_mcp_workspace_root, parse_mcp_command_json,
-    read_opencode_process_registry, read_opencode_version, resolve_mcp_command,
-    resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
-    validate_parent_relationships_for_update, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
-    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
-    with_locked_opencode_process_registry,
-};
 use crate::app_service::test_support::{
-    FakeTaskStore, GitCall, TaskStoreState, build_service_with_git_state, build_service_with_store,
-    create_fake_bd, create_fake_opencode, create_failing_opencode,
-    create_failing_opencode_with_worktree_cleanup, create_orphanable_opencode, empty_patch,
-    init_git_repo, lock_env, make_emitter, make_session, make_task, prepend_path,
-    process_is_alive, remove_env_var, set_env_var, spawn_sleep_process, unique_temp_path,
-    wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
-    write_executable_script,
+    build_service_with_git_state, build_service_with_store, create_failing_opencode,
+    create_failing_opencode_with_worktree_cleanup, create_fake_bd, create_fake_opencode,
+    create_orphanable_opencode, empty_patch, init_git_repo, lock_env, make_emitter, make_session,
+    make_task, prepend_path, process_is_alive, remove_env_var, set_env_var, spawn_sleep_process,
+    unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
+    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+};
+use crate::app_service::{
+    build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
+    parse_mcp_command_json, read_opencode_process_registry, read_opencode_version,
+    resolve_mcp_command, resolve_opencode_binary_path, terminate_child_process,
+    terminate_process_by_pid, validate_parent_relationships_for_update,
+    with_locked_opencode_process_registry, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
+    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 
 #[test]
@@ -214,4 +213,3 @@ fn git_push_branch_defaults_remote_to_origin() -> Result<()> {
     }));
     Ok(())
 }
-

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -3,8 +3,8 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
-    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, TaskAction, TaskStatus,
-    TaskStore, UpdateTaskPatch,
+    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{hook_set_fingerprint, AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -17,22 +17,21 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
-use crate::app_service::{
-    build_opencode_config_content, can_set_plan, default_mcp_workspace_root, parse_mcp_command_json,
-    read_opencode_process_registry, read_opencode_version, resolve_mcp_command,
-    resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
-    validate_parent_relationships_for_update, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
-    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
-    with_locked_opencode_process_registry,
-};
 use crate::app_service::test_support::{
-    FakeTaskStore, GitCall, TaskStoreState, build_service_with_git_state, build_service_with_store,
-    create_fake_bd, create_fake_opencode, create_failing_opencode,
-    create_failing_opencode_with_worktree_cleanup, create_orphanable_opencode, empty_patch,
-    init_git_repo, lock_env, make_emitter, make_session, make_task, prepend_path,
-    process_is_alive, remove_env_var, set_env_var, spawn_sleep_process, unique_temp_path,
-    wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
-    write_executable_script,
+    build_service_with_git_state, build_service_with_store, create_failing_opencode,
+    create_failing_opencode_with_worktree_cleanup, create_fake_bd, create_fake_opencode,
+    create_orphanable_opencode, empty_patch, init_git_repo, lock_env, make_emitter, make_session,
+    make_task, prepend_path, process_is_alive, remove_env_var, set_env_var, spawn_sleep_process,
+    unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
+    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+};
+use crate::app_service::{
+    build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
+    parse_mcp_command_json, read_opencode_process_registry, read_opencode_version,
+    resolve_mcp_command, resolve_opencode_binary_path, terminate_child_process,
+    terminate_process_by_pid, validate_parent_relationships_for_update,
+    with_locked_opencode_process_registry, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
+    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
@@ -3,8 +3,8 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
-    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, TaskAction, TaskStatus,
-    TaskStore, UpdateTaskPatch,
+    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -17,22 +17,21 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
-use crate::app_service::{
-    build_opencode_config_content, can_set_plan, default_mcp_workspace_root, parse_mcp_command_json,
-    read_opencode_process_registry, read_opencode_version, resolve_mcp_command,
-    resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
-    validate_parent_relationships_for_update, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
-    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
-    with_locked_opencode_process_registry,
-};
 use crate::app_service::test_support::{
-    FakeTaskStore, GitCall, TaskStoreState, build_service_with_git_state, build_service_with_store,
-    create_fake_bd, create_fake_opencode, create_failing_opencode,
-    create_failing_opencode_with_worktree_cleanup, create_orphanable_opencode, empty_patch,
-    init_git_repo, lock_env, make_emitter, make_session, make_task, prepend_path,
-    process_is_alive, remove_env_var, set_env_var, spawn_sleep_process, unique_temp_path,
-    wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
-    write_executable_script,
+    build_service_with_git_state, build_service_with_store, create_failing_opencode,
+    create_failing_opencode_with_worktree_cleanup, create_fake_bd, create_fake_opencode,
+    create_orphanable_opencode, empty_patch, init_git_repo, lock_env, make_emitter, make_session,
+    make_task, prepend_path, process_is_alive, remove_env_var, set_env_var, spawn_sleep_process,
+    unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
+    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+};
+use crate::app_service::{
+    build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
+    parse_mcp_command_json, read_opencode_process_registry, read_opencode_version,
+    resolve_mcp_command, resolve_opencode_binary_path, terminate_child_process,
+    terminate_process_by_pid, validate_parent_relationships_for_update,
+    with_locked_opencode_process_registry, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
+    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -3,8 +3,8 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
-    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, TaskAction, TaskStatus,
-    TaskStore, UpdateTaskPatch,
+    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -17,22 +17,21 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
-use crate::app_service::{
-    build_opencode_config_content, can_set_plan, default_mcp_workspace_root, parse_mcp_command_json,
-    read_opencode_process_registry, read_opencode_version, resolve_mcp_command,
-    resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
-    validate_parent_relationships_for_update, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
-    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
-    with_locked_opencode_process_registry,
-};
 use crate::app_service::test_support::{
-    FakeTaskStore, GitCall, TaskStoreState, build_service_with_git_state, build_service_with_store,
-    create_fake_bd, create_fake_opencode, create_failing_opencode,
-    create_failing_opencode_with_worktree_cleanup, create_orphanable_opencode, empty_patch,
-    init_git_repo, lock_env, make_emitter, make_session, make_task, prepend_path,
-    process_is_alive, remove_env_var, set_env_var, spawn_sleep_process, unique_temp_path,
-    wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
-    write_executable_script,
+    build_service_with_git_state, build_service_with_store, create_failing_opencode,
+    create_failing_opencode_with_worktree_cleanup, create_fake_bd, create_fake_opencode,
+    create_orphanable_opencode, empty_patch, init_git_repo, lock_env, make_emitter, make_session,
+    make_task, prepend_path, process_is_alive, remove_env_var, set_env_var, spawn_sleep_process,
+    unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
+    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+};
+use crate::app_service::{
+    build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
+    parse_mcp_command_json, read_opencode_process_registry, read_opencode_version,
+    resolve_mcp_command, resolve_opencode_binary_path, terminate_child_process,
+    terminate_process_by_pid, validate_parent_relationships_for_update,
+    with_locked_opencode_process_registry, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
+    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 
 #[test]
@@ -153,7 +152,9 @@ fn shutdown_terminates_pending_opencode_processes() -> Result<()> {
         wait_for_process_exit(pending_pid as i32, Duration::from_secs(2)),
         "pending OpenCode process should have exited during shutdown"
     );
-    let _ = pending_child.wait().context("failed waiting pending OpenCode process")?;
+    let _ = pending_child
+        .wait()
+        .context("failed waiting pending OpenCode process")?;
     assert!(service
         .tracked_opencode_processes
         .lock()

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -107,7 +107,7 @@ fn validate_parent_relationships_for_update_enforces_hierarchy_constraints() {
         .contains("Tasks with subtasks cannot become subtasks."));
 
     let mut non_epic_patch = empty_patch();
-    non_epic_patch.issue_type = Some("feature".to_string());
+    non_epic_patch.issue_type = Some(IssueType::Feature);
     let type_error = validate_parent_relationships_for_update(&tasks, &current, &non_epic_patch)
         .expect_err("task with direct subtasks must remain epic");
     assert!(type_error

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -17,22 +17,21 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
-use crate::app_service::{
-    build_opencode_config_content, can_set_plan, default_mcp_workspace_root, parse_mcp_command_json,
-    read_opencode_process_registry, read_opencode_version, resolve_mcp_command,
-    resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
-    validate_parent_relationships_for_update, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
-    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
-    with_locked_opencode_process_registry,
-};
 use crate::app_service::test_support::{
-    FakeTaskStore, GitCall, TaskStoreState, build_service_with_git_state, build_service_with_store,
-    create_fake_bd, create_fake_opencode, create_failing_opencode,
-    create_failing_opencode_with_worktree_cleanup, create_orphanable_opencode, empty_patch,
-    init_git_repo, lock_env, make_emitter, make_session, make_task, prepend_path,
-    process_is_alive, remove_env_var, set_env_var, spawn_sleep_process, unique_temp_path,
-    wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
-    write_executable_script,
+    build_service_with_git_state, build_service_with_store, create_failing_opencode,
+    create_failing_opencode_with_worktree_cleanup, create_fake_bd, create_fake_opencode,
+    create_orphanable_opencode, empty_patch, init_git_repo, lock_env, make_emitter, make_session,
+    make_task, prepend_path, process_is_alive, remove_env_var, set_env_var, spawn_sleep_process,
+    unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
+    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+};
+use crate::app_service::{
+    build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
+    parse_mcp_command_json, read_opencode_process_registry, read_opencode_version,
+    resolve_mcp_command, resolve_opencode_binary_path, terminate_child_process,
+    terminate_process_by_pid, validate_parent_relationships_for_update,
+    with_locked_opencode_process_registry, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
+    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -3,8 +3,8 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
-    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, TaskAction, TaskStatus,
-    TaskStore, UpdateTaskPatch,
+    GitPort, IssueType, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState,
+    RunSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -298,7 +298,7 @@ fn tasks_list_enriches_available_actions() -> Result<()> {
 }
 
 #[test]
-fn task_create_normalizes_issue_type_and_defaults_ai_review() -> Result<()> {
+fn task_create_defaults_ai_review_for_typed_issue_type() -> Result<()> {
     let repo_path = "/tmp/odt-repo-create";
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![],
@@ -313,7 +313,7 @@ fn task_create_normalizes_issue_type_and_defaults_ai_review() -> Result<()> {
         repo_path,
         CreateTaskInput {
             title: "New task".to_string(),
-            issue_type: "something-unknown".to_string(),
+            issue_type: IssueType::Task,
             priority: 2,
             description: None,
             acceptance_criteria: None,
@@ -322,12 +322,12 @@ fn task_create_normalizes_issue_type_and_defaults_ai_review() -> Result<()> {
             parent_id: None,
         },
     )?;
-    assert_eq!(created.issue_type, "task");
+    assert_eq!(created.issue_type, IssueType::Task);
     assert!(created.ai_review_enabled);
 
     let task_state = task_state.lock().expect("task lock poisoned");
     assert_eq!(task_state.created_inputs.len(), 1);
-    assert_eq!(task_state.created_inputs[0].issue_type, "task");
+    assert_eq!(task_state.created_inputs[0].issue_type, IssueType::Task);
     assert_eq!(task_state.created_inputs[0].ai_review_enabled, Some(true));
     Ok(())
 }
@@ -632,19 +632,19 @@ fn set_plan_for_epic_replaces_existing_subtasks_with_new_plan_proposals() -> Res
         Some(vec![
             PlanSubtaskInput {
                 title: "Build API".to_string(),
-                issue_type: Some("task".to_string()),
+                issue_type: Some(IssueType::Task),
                 priority: Some(2),
                 description: None,
             },
             PlanSubtaskInput {
                 title: "Build UI".to_string(),
-                issue_type: Some("feature".to_string()),
+                issue_type: Some(IssueType::Feature),
                 priority: Some(2),
                 description: Some("Add interface".to_string()),
             },
             PlanSubtaskInput {
                 title: "Build UI".to_string(),
-                issue_type: Some("feature".to_string()),
+                issue_type: Some(IssueType::Feature),
                 priority: Some(2),
                 description: Some("Duplicate".to_string()),
             },
@@ -730,7 +730,7 @@ fn set_plan_for_epic_rejects_subtask_replacement_when_existing_subtask_is_active
             "# Epic Plan",
             Some(vec![PlanSubtaskInput {
                 title: "Build API".to_string(),
-                issue_type: Some("task".to_string()),
+                issue_type: Some(IssueType::Task),
                 priority: Some(2),
                 description: None,
             }]),
@@ -913,4 +913,3 @@ fn agent_sessions_list_and_upsert_flow_through_store() -> Result<()> {
     assert_eq!(task_state.upserted_sessions[0].1.task_id, "task-1");
     Ok(())
 }
-

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use host_domain::{
-    CreateTaskInput, PlanSubtaskInput, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    CreateTaskInput, IssueType, PlanSubtaskInput, TaskAction, TaskStatus, TaskStore,
+    UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, OpencodeStartupReadinessConfig};
 use std::fs;
@@ -127,7 +128,7 @@ fn only_epics_can_have_subtasks_and_depth_is_one_level() {
 
     let invalid_non_epic_parent = CreateTaskInput {
         title: "child".to_string(),
-        issue_type: "task".to_string(),
+        issue_type: IssueType::Task,
         priority: 2,
         description: None,
         acceptance_criteria: None,
@@ -139,7 +140,7 @@ fn only_epics_can_have_subtasks_and_depth_is_one_level() {
 
     let invalid_depth_two = CreateTaskInput {
         title: "child".to_string(),
-        issue_type: "task".to_string(),
+        issue_type: IssueType::Task,
         priority: 2,
         description: None,
         acceptance_criteria: None,
@@ -179,7 +180,7 @@ fn markdown_documents_require_non_empty_content() {
 fn subtask_plan_inputs_are_normalized_and_validated() {
     let normalized = normalize_subtask_plan_inputs(vec![PlanSubtaskInput {
         title: "  Build API  ".to_string(),
-        issue_type: Some("feature".to_string()),
+        issue_type: Some(IssueType::Feature),
         priority: Some(99),
         description: Some("  add endpoint ".to_string()),
     }])
@@ -188,7 +189,7 @@ fn subtask_plan_inputs_are_normalized_and_validated() {
     assert_eq!(normalized.len(), 1);
     let first = &normalized[0];
     assert_eq!(first.title, "Build API");
-    assert_eq!(first.issue_type, "feature");
+    assert_eq!(first.issue_type, IssueType::Feature);
     assert_eq!(first.priority, 4);
     assert_eq!(first.description.as_deref(), Some("add endpoint"));
 }
@@ -197,7 +198,7 @@ fn subtask_plan_inputs_are_normalized_and_validated() {
 fn subtask_plan_inputs_reject_epic_issue_type() {
     let result = normalize_subtask_plan_inputs(vec![PlanSubtaskInput {
         title: "Do work".to_string(),
-        issue_type: Some("epic".to_string()),
+        issue_type: Some(IssueType::Epic),
         priority: Some(2),
         description: None,
     }]);
@@ -242,7 +243,7 @@ fn epic_plan_requires_existing_or_proposed_direct_subtasks() {
 
     let proposals = vec![CreateTaskInput {
         title: "Subtask".to_string(),
-        issue_type: "task".to_string(),
+        issue_type: IssueType::Task,
         priority: 2,
         description: None,
         acceptance_criteria: None,
@@ -258,7 +259,7 @@ fn non_epic_plan_cannot_accept_subtask_proposals() {
     let task = make_task("task-1", "task", TaskStatus::Open);
     let proposals = vec![CreateTaskInput {
         title: "Child".to_string(),
-        issue_type: "bug".to_string(),
+        issue_type: IssueType::Bug,
         priority: 2,
         description: None,
         acceptance_criteria: None,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -11,15 +11,18 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use crate::app_service::{
-    allows_transition, build_opencode_startup_event_payload, can_set_plan, can_set_spec_from_status,
-    derive_available_actions, normalize_required_markdown, normalize_subtask_plan_inputs,
-    terminate_child_process, validate_parent_relationships_for_create,
-    validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
-    wait_for_local_server, wait_for_local_server_with_process, AppService,
-    OpencodeStartupMetricsSnapshot, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
+use crate::app_service::test_support::{
+    make_task, unique_temp_path, FakeTaskStore, TaskStoreState,
 };
-use crate::app_service::test_support::{FakeTaskStore, TaskStoreState, make_task, unique_temp_path};
+use crate::app_service::{
+    allows_transition, build_opencode_startup_event_payload, can_set_plan,
+    can_set_spec_from_status, derive_available_actions, normalize_required_markdown,
+    normalize_subtask_plan_inputs, terminate_child_process,
+    validate_parent_relationships_for_create, validate_parent_relationships_for_update,
+    validate_plan_subtask_rules, validate_transition, wait_for_local_server,
+    wait_for_local_server_with_process, AppService, OpencodeStartupMetricsSnapshot,
+    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
+};
 
 #[test]
 fn app_service_new_constructor_is_callable() -> Result<()> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
@@ -1,22 +1,17 @@
 use anyhow::{anyhow, Result};
 use host_domain::{
-    AgentWorkflowState, AgentWorkflows, CreateTaskInput, PlanSubtaskInput, QaWorkflowVerdict,
-    TaskAction, TaskCard, TaskStatus, UpdateTaskPatch,
+    AgentWorkflowState, AgentWorkflows, CreateTaskInput, IssueType, PlanSubtaskInput,
+    QaWorkflowVerdict, TaskAction, TaskCard, TaskStatus, UpdateTaskPatch,
 };
 
-pub(crate) fn normalize_issue_type(issue_type: &str) -> &'static str {
-    match issue_type {
-        "epic" => "epic",
-        "feature" => "feature",
-        "bug" => "bug",
-        _ => "task",
-    }
+pub(crate) fn normalize_issue_type(issue_type: &str) -> IssueType {
+    IssueType::from_cli_value(issue_type).unwrap_or(IssueType::Task)
 }
 
-pub(crate) fn default_qa_required_for_issue_type(issue_type: &str) -> bool {
+pub(crate) fn default_qa_required_for_issue_type(issue_type: &IssueType) -> bool {
     matches!(
-        normalize_issue_type(issue_type),
-        "epic" | "feature" | "task" | "bug"
+        issue_type,
+        IssueType::Epic | IssueType::Feature | IssueType::Task | IssueType::Bug
     )
 }
 
@@ -25,13 +20,12 @@ pub(crate) fn is_open_state(status: &TaskStatus) -> bool {
 }
 
 fn can_skip_spec_and_planning(task: &TaskCard) -> bool {
-    matches!(normalize_issue_type(&task.issue_type), "task" | "bug")
+    matches!(task.issue_type, IssueType::Task | IssueType::Bug)
 }
 
 pub(crate) fn derive_agent_workflows(task: &TaskCard) -> AgentWorkflows {
-    let issue_type = normalize_issue_type(&task.issue_type);
-    let is_feature_epic = matches!(issue_type, "feature" | "epic");
-    let is_task_bug = matches!(issue_type, "task" | "bug");
+    let is_feature_epic = matches!(task.issue_type, IssueType::Feature | IssueType::Epic);
+    let is_task_bug = matches!(task.issue_type, IssueType::Task | IssueType::Bug);
     let qa_required = task.ai_review_enabled;
     let is_closed = task.status == TaskStatus::Closed;
     let is_ready_for_dev_or_later = matches!(
@@ -174,13 +168,13 @@ pub(crate) fn validate_transition(
         return Err(anyhow!(
             "Transition not allowed for {} ({}): {} -> {}",
             task.id,
-            task.issue_type,
+            task.issue_type.as_cli_value(),
             from.as_cli_value(),
             to.as_cli_value()
         ));
     }
 
-    if *to == TaskStatus::Closed && normalize_issue_type(&task.issue_type) == "epic" {
+    if *to == TaskStatus::Closed && task.issue_type == IssueType::Epic {
         let blocking_subtasks = all_tasks.iter().filter(|candidate| {
             candidate.parent_id.as_deref() == Some(task.id.as_str())
                 && !matches!(candidate.status, TaskStatus::Closed | TaskStatus::Deferred)
@@ -208,20 +202,19 @@ pub(crate) fn validate_parent_relationships_for_create(
     tasks: &[TaskCard],
     input: &CreateTaskInput,
 ) -> Result<()> {
-    let issue_type = normalize_issue_type(&input.issue_type);
     let parent_id = input
         .parent_id
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
 
-    if issue_type == "epic" && parent_id.is_some() {
+    if input.issue_type == IssueType::Epic && parent_id.is_some() {
         return Err(anyhow!("Epics cannot be created as subtasks."));
     }
 
     if let Some(parent_id) = parent_id {
         let parent = find_task(tasks, parent_id)?;
-        if normalize_issue_type(&parent.issue_type) != "epic" {
+        if parent.issue_type != IssueType::Epic {
             return Err(anyhow!("Only epics can have subtasks."));
         }
         if parent.parent_id.is_some() {
@@ -241,7 +234,7 @@ pub(crate) fn validate_parent_relationships_for_update(
         .issue_type
         .as_deref()
         .map(normalize_issue_type)
-        .unwrap_or_else(|| normalize_issue_type(&current.issue_type));
+        .unwrap_or_else(|| current.issue_type.clone());
 
     let next_parent_id = match patch.parent_id.as_deref() {
         Some(value) => {
@@ -255,7 +248,7 @@ pub(crate) fn validate_parent_relationships_for_update(
         None => current.parent_id.as_deref(),
     };
 
-    if next_issue_type == "epic" && next_parent_id.is_some() {
+    if next_issue_type == IssueType::Epic && next_parent_id.is_some() {
         return Err(anyhow!("Epics cannot be converted to subtasks."));
     }
 
@@ -266,13 +259,13 @@ pub(crate) fn validate_parent_relationships_for_update(
         return Err(anyhow!("Tasks with subtasks cannot become subtasks."));
     }
 
-    if has_direct_subtasks && next_issue_type != "epic" {
+    if has_direct_subtasks && next_issue_type != IssueType::Epic {
         return Err(anyhow!("Only epics can have subtasks."));
     }
 
     if let Some(parent_id) = next_parent_id {
         let parent = find_task(tasks, parent_id)?;
-        if normalize_issue_type(&parent.issue_type) != "epic" {
+        if parent.issue_type != IssueType::Epic {
             return Err(anyhow!("Only epics can be selected as parents."));
         }
         if parent.parent_id.is_some() {
@@ -296,14 +289,14 @@ pub(crate) fn can_set_spec_from_status(status: &TaskStatus) -> bool {
 }
 
 pub(crate) fn can_set_plan(task: &TaskCard) -> bool {
-    let issue_type = normalize_issue_type(&task.issue_type);
-    match issue_type {
-        "epic" | "feature" => matches!(task.status, TaskStatus::SpecReady | TaskStatus::ReadyForDev),
-        "task" | "bug" => matches!(
+    match task.issue_type {
+        IssueType::Epic | IssueType::Feature => {
+            matches!(task.status, TaskStatus::SpecReady | TaskStatus::ReadyForDev)
+        }
+        IssueType::Task | IssueType::Bug => matches!(
             task.status,
             TaskStatus::Open | TaskStatus::SpecReady | TaskStatus::ReadyForDev
         ),
-        _ => false,
     }
 }
 
@@ -360,8 +353,7 @@ pub(crate) fn validate_plan_subtask_rules(
     all_tasks: &[TaskCard],
     plan_subtasks: &[CreateTaskInput],
 ) -> Result<()> {
-    let issue_type = normalize_issue_type(&task.issue_type);
-    if issue_type != "epic" {
+    if task.issue_type != IssueType::Epic {
         if !plan_subtasks.is_empty() {
             return Err(anyhow!(
                 "Only epics can receive subtask proposals during planning."
@@ -396,9 +388,8 @@ pub(crate) fn normalize_subtask_plan_inputs(
             return Err(anyhow!("Subtask proposals require a non-empty title."));
         }
 
-        let issue_type =
-            normalize_issue_type(entry.issue_type.as_deref().unwrap_or("task")).to_string();
-        if issue_type == "epic" {
+        let issue_type = entry.issue_type.unwrap_or(IssueType::Task);
+        if issue_type == IssueType::Epic {
             return Err(anyhow!(
                 "Epic subtasks are not allowed. Subtask hierarchy depth is limited to one level."
             ));

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
@@ -4,10 +4,6 @@ use host_domain::{
     QaWorkflowVerdict, TaskAction, TaskCard, TaskStatus, UpdateTaskPatch,
 };
 
-pub(crate) fn normalize_issue_type(issue_type: &str) -> IssueType {
-    IssueType::from_cli_value(issue_type).unwrap_or(IssueType::Task)
-}
-
 pub(crate) fn default_qa_required_for_issue_type(issue_type: &IssueType) -> bool {
     matches!(
         issue_type,
@@ -232,8 +228,7 @@ pub(crate) fn validate_parent_relationships_for_update(
 ) -> Result<()> {
     let next_issue_type = patch
         .issue_type
-        .as_deref()
-        .map(normalize_issue_type)
+        .clone()
         .unwrap_or_else(|| current.issue_type.clone());
 
     let next_parent_id = match patch.parent_id.as_deref() {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs
@@ -32,7 +32,8 @@ pub(crate) fn derive_agent_workflows(task: &TaskCard) -> AgentWorkflows {
             | TaskStatus::AiReview
             | TaskStatus::HumanReview
     );
-    let is_planner_feature_epic_status = task.status == TaskStatus::SpecReady || is_ready_for_dev_or_later;
+    let is_planner_feature_epic_status =
+        task.status == TaskStatus::SpecReady || is_ready_for_dev_or_later;
 
     let spec_required = is_feature_epic;
     let spec_can_skip = !spec_required;
@@ -437,12 +438,14 @@ mod tests {
     }
 
     fn load_workflow_contract_fixture() -> WorkflowContractFixture {
-        let raw = include_str!("../../../../../../../docs/contracts/workflow-contract-fixture.json");
+        let raw =
+            include_str!("../../../../../../../docs/contracts/workflow-contract-fixture.json");
         serde_json::from_str(raw).expect("workflow contract fixture must parse")
     }
 
     fn parse_status(value: &str) -> TaskStatus {
-        TaskStatus::from_cli_value(value).unwrap_or_else(|| panic!("unknown fixture status: {value}"))
+        TaskStatus::from_cli_value(value)
+            .unwrap_or_else(|| panic!("unknown fixture status: {value}"))
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/lib.rs
@@ -1,4 +1,4 @@
 mod app_service;
 
-pub use app_service::{AppService, RunEmitter};
 pub use app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
+pub use app_service::{AppService, RunEmitter};

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -240,7 +240,7 @@ pub struct UpdateTaskPatch {
     pub notes: Option<String>,
     pub status: Option<TaskStatus>,
     pub priority: Option<i32>,
-    pub issue_type: Option<String>,
+    pub issue_type: Option<IssueType>,
     pub ai_review_enabled: Option<bool>,
     pub labels: Option<Vec<String>>,
     pub assignee: Option<String>,

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -336,8 +336,11 @@ pub trait TaskStore: Send + Sync {
         markdown: &str,
         verdict: QaVerdict,
     ) -> Result<QaReportDocument>;
-    fn list_agent_sessions(&self, repo_path: &Path, task_id: &str)
-        -> Result<Vec<AgentSessionDocument>>;
+    fn list_agent_sessions(
+        &self,
+        repo_path: &Path,
+        task_id: &str,
+    ) -> Result<Vec<AgentSessionDocument>>;
     fn upsert_agent_session(
         &self,
         repo_path: &Path,
@@ -423,8 +426,12 @@ pub struct GitPushSummary {
 pub trait GitPort: Send + Sync {
     fn get_branches(&self, repo_path: &Path) -> Result<Vec<GitBranch>>;
     fn get_current_branch(&self, repo_path: &Path) -> Result<GitCurrentBranch>;
-    fn switch_branch(&self, repo_path: &Path, branch: &str, create: bool)
-    -> Result<GitCurrentBranch>;
+    fn switch_branch(
+        &self,
+        repo_path: &Path,
+        branch: &str,
+        create: bool,
+    ) -> Result<GitCurrentBranch>;
     fn create_worktree(
         &self,
         repo_path: &Path,

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -16,6 +16,44 @@ pub enum TaskStatus {
     Closed,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IssueType {
+    Task,
+    Feature,
+    Bug,
+    Epic,
+}
+
+impl IssueType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            IssueType::Task => "task",
+            IssueType::Feature => "feature",
+            IssueType::Bug => "bug",
+            IssueType::Epic => "epic",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "task" => Some(IssueType::Task),
+            "feature" => Some(IssueType::Feature),
+            "bug" => Some(IssueType::Bug),
+            "epic" => Some(IssueType::Epic),
+            _ => None,
+        }
+    }
+
+    pub fn as_cli_value(&self) -> &'static str {
+        self.as_str()
+    }
+
+    pub fn from_cli_value(value: &str) -> Option<Self> {
+        Self::from_str(value)
+    }
+}
+
 impl TaskStatus {
     pub fn as_cli_value(&self) -> &'static str {
         match self {
@@ -158,7 +196,7 @@ pub struct TaskCard {
     pub notes: String,
     pub status: TaskStatus,
     pub priority: i32,
-    pub issue_type: String,
+    pub issue_type: IssueType,
     pub ai_review_enabled: bool,
     pub available_actions: Vec<TaskAction>,
     pub labels: Vec<String>,
@@ -175,7 +213,7 @@ pub struct TaskCard {
 #[serde(rename_all = "camelCase")]
 pub struct CreateTaskInput {
     pub title: String,
-    pub issue_type: String,
+    pub issue_type: IssueType,
     pub priority: i32,
     pub description: Option<String>,
     pub acceptance_criteria: Option<String>,
@@ -188,7 +226,7 @@ pub struct CreateTaskInput {
 #[serde(rename_all = "camelCase")]
 pub struct PlanSubtaskInput {
     pub title: String,
-    pub issue_type: Option<String>,
+    pub issue_type: Option<IssueType>,
     pub priority: Option<i32>,
     pub description: Option<String>,
 }
@@ -502,7 +540,7 @@ pub fn now_rfc3339() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{now_rfc3339, TaskStatus};
+    use super::{now_rfc3339, IssueType, TaskStatus};
 
     #[test]
     fn task_status_cli_roundtrip() {
@@ -529,6 +567,28 @@ mod tests {
     fn task_status_rejects_unknown_value() {
         assert!(TaskStatus::from_cli_value("backlog").is_none());
         assert!(TaskStatus::from_cli_value("").is_none());
+    }
+
+    #[test]
+    fn issue_type_cli_roundtrip() {
+        let issue_types = [
+            IssueType::Task,
+            IssueType::Feature,
+            IssueType::Bug,
+            IssueType::Epic,
+        ];
+
+        for issue_type in issue_types {
+            let raw = issue_type.as_cli_value();
+            let parsed = IssueType::from_cli_value(raw).expect("issue type should parse");
+            assert_eq!(parsed, issue_type);
+        }
+    }
+
+    #[test]
+    fn issue_type_rejects_unknown_value() {
+        assert!(IssueType::from_cli_value("event").is_none());
+        assert!(IssueType::from_cli_value("").is_none());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/normalize.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/normalize.rs
@@ -1,3 +1,5 @@
+use host_domain::IssueType;
+
 pub(crate) fn normalize_labels(labels: Vec<String>) -> Vec<String> {
     let mut normalized: Vec<String> = labels
         .into_iter()
@@ -20,19 +22,13 @@ pub(crate) fn normalize_text_option(value: Option<String>) -> Option<String> {
     })
 }
 
-pub(crate) fn normalize_issue_type(issue_type: &str) -> &'static str {
-    match issue_type {
-        "epic" => "epic",
-        "feature" => "feature",
-        "bug" => "bug",
-        _ => "task",
-    }
+pub(crate) fn normalize_issue_type(issue_type: &str) -> IssueType {
+    IssueType::from_cli_value(issue_type).unwrap_or(IssueType::Task)
 }
 
 pub(crate) fn default_ai_review_enabled(issue_type: &str) -> bool {
     matches!(
         normalize_issue_type(issue_type),
-        "epic" | "feature" | "task" | "bug"
+        IssueType::Epic | IssueType::Feature | IssueType::Task | IssueType::Bug
     )
 }
-

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/parsing.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/parsing.rs
@@ -24,11 +24,7 @@ impl BeadsTaskStore {
             .unwrap_or_else(|| default_ai_review_enabled(&issue.issue_type));
         let document_summary = metadata_document_summary(namespace);
 
-        let normalized_issue_type = if issue.issue_type == "event" || issue.issue_type == "gate" {
-            issue.issue_type.clone()
-        } else {
-            normalize_issue_type(&issue.issue_type).to_string()
-        };
+        let normalized_issue_type = normalize_issue_type(&issue.issue_type);
 
         let parent_id = issue.parent.or_else(|| {
             issue.dependencies.iter().find_map(|dependency| {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    now_rfc3339, AgentSessionDocument, CreateTaskInput, QaReportDocument, QaVerdict,
-    SpecDocument, TaskCard, TaskMetadata, TaskStore, UpdateTaskPatch,
+    now_rfc3339, AgentSessionDocument, CreateTaskInput, QaReportDocument, QaVerdict, SpecDocument,
+    TaskCard, TaskMetadata, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{compute_repo_slug, resolve_central_beads_dir, AppConfigStore};
 use serde_json::Value;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -57,7 +57,11 @@ impl BeadsTaskStore {
         Ok(())
     }
 
-    pub(super) fn get_task_metadata_impl(&self, repo_path: &Path, task_id: &str) -> Result<TaskMetadata> {
+    pub(super) fn get_task_metadata_impl(
+        &self,
+        repo_path: &Path,
+        task_id: &str,
+    ) -> Result<TaskMetadata> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let metadata_root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -72,21 +72,18 @@ impl BeadsTaskStore {
 
         let value = self.run_bd_json(repo_path, &["list", "--all", "--limit", "0"])?;
 
-        let mut tasks = value
+        let mut tasks = Vec::new();
+        for entry in value
             .as_array()
             .ok_or_else(|| anyhow!("bd list did not return an array"))?
-            .iter()
-            .map(|entry| {
-                let issue: RawIssue = serde_json::from_value(entry.clone())
-                    .context("Failed to decode task from bd list")?;
-                self.parse_task_card(issue, &metadata_namespace)
-            })
-            .collect::<Result<Vec<TaskCard>>>()?;
-
-        tasks = tasks
-            .into_iter()
-            .filter(|task| task.issue_type != "event" && task.issue_type != "gate")
-            .collect::<Vec<_>>();
+        {
+            let issue: RawIssue =
+                serde_json::from_value(entry.clone()).context("Failed to decode task from bd list")?;
+            if issue.issue_type == "event" || issue.issue_type == "gate" {
+                continue;
+            }
+            tasks.push(self.parse_task_card(issue, &metadata_namespace)?);
+        }
 
         let mut subtasks_by_parent: HashMap<String, Vec<String>> = HashMap::new();
         for task in &tasks {
@@ -113,7 +110,7 @@ impl BeadsTaskStore {
             "create".to_string(),
             input.title,
             "--type".to_string(),
-            input.issue_type,
+            input.issue_type.as_cli_value().to_string(),
             "--priority".to_string(),
             input.priority.to_string(),
         ];

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -46,7 +46,8 @@ impl BeadsTaskStore {
                 ));
             }
 
-            let (is_ready_after, reason_after) = self.verify_repo_initialized(repo_path, &beads_dir)?;
+            let (is_ready_after, reason_after) =
+                self.verify_repo_initialized(repo_path, &beads_dir)?;
             if !is_ready_after {
                 return Err(anyhow!(
                     "Beads init completed but store is not ready at {}: {}",
@@ -77,8 +78,8 @@ impl BeadsTaskStore {
             .as_array()
             .ok_or_else(|| anyhow!("bd list did not return an array"))?
         {
-            let issue: RawIssue =
-                serde_json::from_value(entry.clone()).context("Failed to decode task from bd list")?;
+            let issue: RawIssue = serde_json::from_value(entry.clone())
+                .context("Failed to decode task from bd list")?;
             if issue.issue_type == "event" || issue.issue_type == "gate" {
                 continue;
             }
@@ -101,11 +102,20 @@ impl BeadsTaskStore {
             task.subtask_ids = subtasks;
         }
 
-        self.cache_task_list_if_generation(&repo_key, &metadata_namespace, cache_generation, &tasks)?;
+        self.cache_task_list_if_generation(
+            &repo_key,
+            &metadata_namespace,
+            cache_generation,
+            &tasks,
+        )?;
         Ok(tasks)
     }
 
-    pub(super) fn create_task_impl(&self, repo_path: &Path, input: CreateTaskInput) -> Result<TaskCard> {
+    pub(super) fn create_task_impl(
+        &self,
+        repo_path: &Path,
+        input: CreateTaskInput,
+    ) -> Result<TaskCard> {
         let mut args = vec![
             "create".to_string(),
             input.title,
@@ -139,7 +149,8 @@ impl BeadsTaskStore {
         let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
         let value = self.run_bd_json(repo_path, &arg_refs)?;
         self.invalidate_task_list_cache(repo_path)?;
-        let raw: RawIssue = serde_json::from_value(value).context("Failed to decode created issue")?;
+        let raw: RawIssue =
+            serde_json::from_value(value).context("Failed to decode created issue")?;
         let created_id = raw.id.clone();
 
         let mut metadata_root = parse_metadata_root(raw.metadata);

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -204,7 +204,7 @@ impl BeadsTaskStore {
 
         if let Some(issue_type) = patch.issue_type {
             args.push("--type".to_string());
-            args.push(issue_type);
+            args.push(issue_type.as_cli_value().to_string());
         }
 
         if let Some(assignee) = patch.assignee {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -6,7 +6,8 @@ use super::{
 };
 use anyhow::{anyhow, Result};
 use host_domain::{
-    AgentSessionDocument, CreateTaskInput, QaVerdict, TaskStatus, TaskStore, UpdateTaskPatch,
+    AgentSessionDocument, CreateTaskInput, IssueType, QaVerdict, TaskStatus, TaskStore,
+    UpdateTaskPatch,
 };
 use host_infra_system::{compute_repo_slug, resolve_central_beads_dir};
 use serde_json::{json, Value};
@@ -377,8 +378,8 @@ fn show_task_uses_id_flag_when_loading_issue() -> Result<()> {
 
 #[test]
 fn issue_type_and_ai_review_defaults_are_normalized() {
-    assert_eq!(normalize_issue_type("feature"), "feature");
-    assert_eq!(normalize_issue_type("unknown-type"), "task");
+    assert_eq!(normalize_issue_type("feature"), IssueType::Feature);
+    assert_eq!(normalize_issue_type("unknown-type"), IssueType::Task);
     assert!(default_ai_review_enabled("epic"));
     assert!(default_ai_review_enabled("unknown-type"));
 }
@@ -864,7 +865,7 @@ fn list_tasks_cache_is_invalidated_after_create_mutation() -> Result<()> {
         repo.path(),
         CreateTaskInput {
             title: "New task".to_string(),
-            issue_type: "task".to_string(),
+            issue_type: IssueType::Task,
             priority: 2,
             description: None,
             acceptance_criteria: None,
@@ -966,7 +967,7 @@ fn create_task_normalizes_payload_and_persists_qa_flag() -> Result<()> {
         repo.path(),
         CreateTaskInput {
             title: "Build API".to_string(),
-            issue_type: "feature".to_string(),
+            issue_type: IssueType::Feature,
             priority: 3,
             description: Some("  expose endpoint ".to_string()),
             acceptance_criteria: Some("  green tests ".to_string()),

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1064,7 +1064,7 @@ fn update_task_updates_cli_fields_and_qa_metadata() -> Result<()> {
             notes: Some("Updated notes".to_string()),
             status: Some(TaskStatus::Blocked),
             priority: Some(1),
-            issue_type: Some("feature".to_string()),
+            issue_type: Some(IssueType::Feature),
             ai_review_enabled: Some(false),
             labels: Some(vec![
                 "backend".to_string(),

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -116,8 +116,8 @@ mod tests {
 
     #[test]
     fn central_beads_dir_uses_expected_layout_suffix() {
-        let resolved = resolve_central_beads_dir(Path::new("/tmp/openducktor-test/repo"))
-            .expect("beads dir");
+        let resolved =
+            resolve_central_beads_dir(Path::new("/tmp/openducktor-test/repo")).expect("beads dir");
         let as_string = resolved.to_string_lossy();
         assert!(as_string.contains(".openducktor/beads/"));
         assert!(as_string.ends_with("/.beads"));

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/migrate.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/migrate.rs
@@ -16,8 +16,8 @@ pub(super) fn canonicalize_workspace_key(repo_path: &str) -> Result<String> {
         return Ok(repo_path.to_string());
     }
     // Canonicalize resolves symlinks and normalizes the path.
-    let canonical =
-        fs::canonicalize(path).with_context(|| format!("Failed to canonicalize path: {}", repo_path))?;
+    let canonical = fs::canonicalize(path)
+        .with_context(|| format!("Failed to canonicalize path: {}", repo_path))?;
     Ok(canonical.to_string_lossy().to_string())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
@@ -71,7 +71,9 @@ pub(super) fn normalize_repo_config(repo: &mut RepoConfig) {
     normalize_agent_model_default(&mut repo.agent_defaults.qa);
 }
 
-pub(super) fn normalize_opencode_startup_readiness_config(config: &mut OpencodeStartupReadinessConfig) {
+pub(super) fn normalize_opencode_startup_readiness_config(
+    config: &mut OpencodeStartupReadinessConfig,
+) {
     config.timeout_ms = config.timeout_ms.clamp(250, 120_000);
     config.connect_timeout_ms = config.connect_timeout_ms.clamp(25, 10_000);
     config.initial_retry_delay_ms = config.initial_retry_delay_ms.clamp(5, 5_000);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -105,8 +105,9 @@ impl AppConfigStore {
 
     pub fn save(&self, config: &GlobalConfig) -> Result<()> {
         if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("Failed creating config directory {}", parent.display()))?;
+            fs::create_dir_all(parent).with_context(|| {
+                format!("Failed creating config directory {}", parent.display())
+            })?;
         }
         let mut normalized = config.clone();
         normalize_global_config(&mut normalized);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git.rs
@@ -102,7 +102,13 @@ impl GitPort for GitCliPort {
         if create_branch {
             self.run_git(
                 repo_path,
-                &["worktree", "add", "-b", branch.as_str(), worktree_path.as_str()],
+                &[
+                    "worktree",
+                    "add",
+                    "-b",
+                    branch.as_str(),
+                    worktree_path.as_str(),
+                ],
             )?;
         } else {
             self.run_git(
@@ -295,7 +301,10 @@ mod tests {
     fn setup_repo(prefix: &str) -> TempPath {
         let repo = TempPath::new(prefix);
         run_git_ok(&repo.path, &["init"]);
-        run_git_ok(&repo.path, &["config", "user.email", "tests@openducktor.local"]);
+        run_git_ok(
+            &repo.path,
+            &["config", "user.email", "tests@openducktor.local"],
+        );
         run_git_ok(&repo.path, &["config", "user.name", "OpenDucktor Tests"]);
         fs::write(repo.path.join("README.md"), "# OpenDucktor\n").expect("seed file should write");
         run_git_ok(&repo.path, &["add", "README.md"]);
@@ -382,7 +391,10 @@ mod tests {
         let repo = setup_repo("branches");
         let remote = setup_bare_remote("branches-remote");
         let remote_path = remote.path.to_string_lossy().to_string();
-        run_git_ok(&repo.path, &["remote", "add", "origin", remote_path.as_str()]);
+        run_git_ok(
+            &repo.path,
+            &["remote", "add", "origin", remote_path.as_str()],
+        );
         run_git_ok(&repo.path, &["push", "-u", "origin", "main"]);
         run_git_ok(&repo.path, &["switch", "-c", "feature/list"]);
         fs::write(repo.path.join("feature.txt"), "feature\n").expect("feature file should write");
@@ -400,17 +412,15 @@ mod tests {
         assert_eq!(branches[0].name, "main");
         assert!(branches[0].is_current);
         assert!(!branches[0].is_remote);
-        assert!(branches.iter().any(|entry| entry.name == "feature/list" && !entry.is_remote));
-        assert!(
-            branches
-                .iter()
-                .any(|entry| entry.name == "origin/main" && entry.is_remote)
-        );
-        assert!(
-            !branches
-                .iter()
-                .any(|entry| entry.name == "origin/HEAD" && entry.is_remote)
-        );
+        assert!(branches
+            .iter()
+            .any(|entry| entry.name == "feature/list" && !entry.is_remote));
+        assert!(branches
+            .iter()
+            .any(|entry| entry.name == "origin/main" && entry.is_remote));
+        assert!(!branches
+            .iter()
+            .any(|entry| entry.name == "origin/HEAD" && entry.is_remote));
     }
 
     #[test]
@@ -483,7 +493,10 @@ mod tests {
             .expect("dirty file should write");
 
         let no_force = git.remove_worktree(&repo.path, &worktree.path, false);
-        assert!(no_force.is_err(), "dirty worktree removal without force should fail");
+        assert!(
+            no_force.is_err(),
+            "dirty worktree removal without force should fail"
+        );
 
         git.remove_worktree(&repo.path, &worktree.path, true)
             .expect("dirty worktree removal with force should succeed");
@@ -498,7 +511,10 @@ mod tests {
         let repo = setup_repo("push");
         let remote = setup_bare_remote("push-remote");
         let remote_path = remote.path.to_string_lossy().to_string();
-        run_git_ok(&repo.path, &["remote", "add", "origin", remote_path.as_str()]);
+        run_git_ok(
+            &repo.path,
+            &["remote", "add", "origin", remote_path.as_str()],
+        );
         let git = GitCliPort::new();
 
         git.switch_branch(&repo.path, "feature/push", true)
@@ -513,7 +529,10 @@ mod tests {
         assert_eq!(summary.remote, "origin");
         assert_eq!(summary.branch, "feature/push");
 
-        let ls_remote = run_git_ok(&repo.path, &["ls-remote", "--heads", "origin", "feature/push"]);
+        let ls_remote = run_git_ok(
+            &repo.path,
+            &["ls-remote", "--heads", "origin", "feature/push"],
+        );
         assert!(
             ls_remote.contains("refs/heads/feature/push"),
             "remote should contain pushed branch"
@@ -532,8 +551,14 @@ mod tests {
 
         assert!(git.get_branches(&non_repo.path).is_err());
         assert!(git.switch_branch(&repo.path, "   ", false).is_err());
-        assert!(git.create_worktree(&repo.path, &TempPath::new("w").path, " ", true).is_err());
-        assert!(git.push_branch(&repo.path, "", "main", false, false).is_err());
-        assert!(git.push_branch(&repo.path, "origin", " ", false, false).is_err());
+        assert!(git
+            .create_worktree(&repo.path, &TempPath::new("w").path, " ", true)
+            .is_err());
+        assert!(git
+            .push_branch(&repo.path, "", "main", false, false)
+            .is_err());
+        assert!(git
+            .push_branch(&repo.path, "origin", " ", false, false)
+            .is_err());
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
@@ -177,9 +177,7 @@ mod tests {
 
         let error = remove_worktree(&repo, &missing_worktree).expect_err("removal should fail");
         assert!(
-            error
-                .to_string()
-                .contains("git worktree remove failed for"),
+            error.to_string().contains("git worktree remove failed for"),
             "unexpected remove_worktree error: {error}"
         );
         let _ = fs::remove_dir_all(root);

--- a/apps/desktop/src-tauri/src/commands/documents.rs
+++ b/apps/desktop/src-tauri/src/commands/documents.rs
@@ -1,6 +1,46 @@
-use crate::{as_error, AppState, MarkdownPayload, PlanPayload};
-use host_domain::{SpecDocument, TaskCard, TaskMetadata};
+use crate::{as_error, AppState, MarkdownPayload, PlanPayload, PlanSubtaskPayload};
+use host_domain::{IssueType, PlanSubtaskInput, SpecDocument, TaskCard, TaskMetadata};
 use tauri::State;
+
+fn parse_issue_type(value: &str, field_name: &str) -> Result<IssueType, String> {
+    IssueType::from_cli_value(value).ok_or_else(|| {
+        format!("Invalid {field_name}: '{value}'. Allowed values: task, feature, bug, epic.")
+    })
+}
+
+fn map_plan_subtask_payload(
+    subtask: PlanSubtaskPayload,
+    index: usize,
+) -> Result<PlanSubtaskInput, String> {
+    let issue_type = match subtask.issue_type {
+        Some(issue_type) => Some(parse_issue_type(
+            &issue_type,
+            &format!("subtasks[{index}].issueType"),
+        )?),
+        None => None,
+    };
+
+    Ok(PlanSubtaskInput {
+        title: subtask.title,
+        issue_type,
+        priority: subtask.priority,
+        description: subtask.description,
+    })
+}
+
+fn map_plan_subtasks(
+    subtasks: Option<Vec<PlanSubtaskPayload>>,
+) -> Result<Option<Vec<PlanSubtaskInput>>, String> {
+    subtasks
+        .map(|items| {
+            items
+                .into_iter()
+                .enumerate()
+                .map(|(index, item)| map_plan_subtask_payload(item, index))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()
+}
 
 #[tauri::command]
 pub async fn spec_get(
@@ -60,10 +100,11 @@ pub async fn set_plan(
     task_id: String,
     input: PlanPayload,
 ) -> Result<SpecDocument, String> {
+    let mapped_subtasks = map_plan_subtasks(input.subtasks)?;
     as_error(
         state
             .service
-            .set_plan(&repo_path, &task_id, &input.markdown, input.subtasks),
+            .set_plan(&repo_path, &task_id, &input.markdown, mapped_subtasks),
     )
 }
 
@@ -116,4 +157,39 @@ pub async fn qa_rejected(
             .service
             .qa_rejected(&repo_path, &task_id, &input.markdown),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_plan_subtasks;
+    use crate::PlanSubtaskPayload;
+    use host_domain::IssueType;
+
+    #[test]
+    fn map_plan_subtasks_rejects_unknown_issue_type_with_field_path() {
+        let error = map_plan_subtasks(Some(vec![PlanSubtaskPayload {
+            title: "Build UI".to_string(),
+            issue_type: Some("featur".to_string()),
+            priority: Some(2),
+            description: None,
+        }]))
+        .expect_err("unknown issue type should fail");
+
+        assert!(error.contains("subtasks[0].issueType"));
+        assert!(error.contains("task, feature, bug, epic"));
+    }
+
+    #[test]
+    fn map_plan_subtasks_parses_valid_issue_type() {
+        let subtasks = map_plan_subtasks(Some(vec![PlanSubtaskPayload {
+            title: "Build API".to_string(),
+            issue_type: Some("bug".to_string()),
+            priority: Some(1),
+            description: Some("Fix bug".to_string()),
+        }]))
+        .expect("valid issue type should parse")
+        .expect("subtasks should be present");
+
+        assert_eq!(subtasks[0].issue_type, Some(IssueType::Bug));
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/documents.rs
+++ b/apps/desktop/src-tauri/src/commands/documents.rs
@@ -1,12 +1,7 @@
+use super::issue_type::parse_issue_type;
 use crate::{as_error, AppState, MarkdownPayload, PlanPayload, PlanSubtaskPayload};
-use host_domain::{IssueType, PlanSubtaskInput, SpecDocument, TaskCard, TaskMetadata};
+use host_domain::{PlanSubtaskInput, SpecDocument, TaskCard, TaskMetadata};
 use tauri::State;
-
-fn parse_issue_type(value: &str, field_name: &str) -> Result<IssueType, String> {
-    IssueType::from_cli_value(value).ok_or_else(|| {
-        format!("Invalid {field_name}: '{value}'. Allowed values: task, feature, bug, epic.")
-    })
-}
 
 fn map_plan_subtask_payload(
     subtask: PlanSubtaskPayload,

--- a/apps/desktop/src-tauri/src/commands/issue_type.rs
+++ b/apps/desktop/src-tauri/src/commands/issue_type.rs
@@ -1,0 +1,7 @@
+use host_domain::IssueType;
+
+pub(crate) fn parse_issue_type(value: &str, field_name: &str) -> Result<IssueType, String> {
+    IssueType::from_cli_value(value).ok_or_else(|| {
+        format!("Invalid {field_name}: '{value}'. Allowed values: task, feature, bug, epic.")
+    })
+}

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod agent_sessions;
 pub mod build;
 pub mod documents;
 pub mod git;
+pub(crate) mod issue_type;
 pub mod runtime;
 pub mod tasks;
 pub mod workspace;

--- a/apps/desktop/src-tauri/src/commands/tasks.rs
+++ b/apps/desktop/src-tauri/src/commands/tasks.rs
@@ -2,6 +2,46 @@ use crate::{as_error, AppState, TaskCreatePayload, TaskUpdatePayload};
 use host_domain::{CreateTaskInput, IssueType, TaskCard, TaskStatus, UpdateTaskPatch};
 use tauri::State;
 
+fn parse_issue_type(value: &str, field_name: &str) -> Result<IssueType, String> {
+    IssueType::from_cli_value(value).ok_or_else(|| {
+        format!("Invalid {field_name}: '{value}'. Allowed values: task, feature, bug, epic.")
+    })
+}
+
+fn map_task_create_payload(input: TaskCreatePayload) -> Result<CreateTaskInput, String> {
+    Ok(CreateTaskInput {
+        title: input.title,
+        issue_type: parse_issue_type(&input.issue_type, "issueType")?,
+        priority: input.priority,
+        description: input.description,
+        acceptance_criteria: input.acceptance_criteria,
+        labels: input.labels,
+        ai_review_enabled: input.ai_review_enabled,
+        parent_id: input.parent_id,
+    })
+}
+
+fn map_task_update_payload(patch: TaskUpdatePayload) -> Result<UpdateTaskPatch, String> {
+    let issue_type = match patch.issue_type {
+        Some(issue_type) => Some(parse_issue_type(&issue_type, "issueType")?),
+        None => None,
+    };
+
+    Ok(UpdateTaskPatch {
+        title: patch.title,
+        description: patch.description,
+        acceptance_criteria: patch.acceptance_criteria,
+        notes: None,
+        status: None,
+        priority: patch.priority,
+        issue_type,
+        ai_review_enabled: patch.ai_review_enabled,
+        labels: patch.labels,
+        assignee: patch.assignee,
+        parent_id: patch.parent_id,
+    })
+}
+
 #[tauri::command]
 pub async fn tasks_list(
     state: State<'_, AppState>,
@@ -16,16 +56,7 @@ pub async fn task_create(
     repo_path: String,
     input: TaskCreatePayload,
 ) -> Result<TaskCard, String> {
-    let create = CreateTaskInput {
-        title: input.title,
-        issue_type: IssueType::from_cli_value(&input.issue_type).unwrap_or(IssueType::Task),
-        priority: input.priority,
-        description: input.description,
-        acceptance_criteria: input.acceptance_criteria,
-        labels: input.labels,
-        ai_review_enabled: input.ai_review_enabled,
-        parent_id: input.parent_id,
-    };
+    let create = map_task_create_payload(input)?;
     as_error(state.service.task_create(&repo_path, create))
 }
 
@@ -36,23 +67,8 @@ pub async fn task_update(
     task_id: String,
     patch: TaskUpdatePayload,
 ) -> Result<TaskCard, String> {
-    as_error(state.service.task_update(
-        &repo_path,
-        &task_id,
-        UpdateTaskPatch {
-            title: patch.title,
-            description: patch.description,
-            acceptance_criteria: patch.acceptance_criteria,
-            notes: None,
-            status: None,
-            priority: patch.priority,
-            issue_type: patch.issue_type,
-            ai_review_enabled: patch.ai_review_enabled,
-            labels: patch.labels,
-            assignee: patch.assignee,
-            parent_id: patch.parent_id,
-        },
-    ))
+    let mapped = map_task_update_payload(patch)?;
+    as_error(state.service.task_update(&repo_path, &task_id, mapped))
 }
 
 #[tauri::command]
@@ -106,4 +122,65 @@ pub async fn task_resume_deferred(
     task_id: String,
 ) -> Result<TaskCard, String> {
     as_error(state.service.task_resume_deferred(&repo_path, &task_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{map_task_create_payload, map_task_update_payload};
+    use crate::{TaskCreatePayload, TaskUpdatePayload};
+    use host_domain::IssueType;
+
+    #[test]
+    fn map_task_create_payload_rejects_unknown_issue_type() {
+        let error = map_task_create_payload(TaskCreatePayload {
+            title: "Task".to_string(),
+            issue_type: "epik".to_string(),
+            priority: 2,
+            description: None,
+            acceptance_criteria: None,
+            labels: None,
+            ai_review_enabled: None,
+            parent_id: None,
+        })
+        .expect_err("unknown issue type should fail");
+
+        assert!(error.contains("Invalid issueType"));
+        assert!(error.contains("task, feature, bug, epic"));
+    }
+
+    #[test]
+    fn map_task_update_payload_rejects_unknown_issue_type() {
+        let error = map_task_update_payload(TaskUpdatePayload {
+            title: None,
+            description: None,
+            acceptance_criteria: None,
+            priority: None,
+            issue_type: Some("bugg".to_string()),
+            ai_review_enabled: None,
+            labels: None,
+            assignee: None,
+            parent_id: None,
+        })
+        .expect_err("unknown issue type should fail");
+
+        assert!(error.contains("Invalid issueType"));
+    }
+
+    #[test]
+    fn map_task_update_payload_parses_valid_issue_type() {
+        let patch = map_task_update_payload(TaskUpdatePayload {
+            title: None,
+            description: None,
+            acceptance_criteria: None,
+            priority: None,
+            issue_type: Some("feature".to_string()),
+            ai_review_enabled: None,
+            labels: None,
+            assignee: None,
+            parent_id: None,
+        })
+        .expect("feature should parse");
+
+        assert_eq!(patch.issue_type, Some(IssueType::Feature));
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/tasks.rs
+++ b/apps/desktop/src-tauri/src/commands/tasks.rs
@@ -1,12 +1,7 @@
+use super::issue_type::parse_issue_type;
 use crate::{as_error, AppState, TaskCreatePayload, TaskUpdatePayload};
-use host_domain::{CreateTaskInput, IssueType, TaskCard, TaskStatus, UpdateTaskPatch};
+use host_domain::{CreateTaskInput, TaskCard, TaskStatus, UpdateTaskPatch};
 use tauri::State;
-
-fn parse_issue_type(value: &str, field_name: &str) -> Result<IssueType, String> {
-    IssueType::from_cli_value(value).ok_or_else(|| {
-        format!("Invalid {field_name}: '{value}'. Allowed values: task, feature, bug, epic.")
-    })
-}
 
 fn map_task_create_payload(input: TaskCreatePayload) -> Result<CreateTaskInput, String> {
     Ok(CreateTaskInput {

--- a/apps/desktop/src-tauri/src/commands/tasks.rs
+++ b/apps/desktop/src-tauri/src/commands/tasks.rs
@@ -1,5 +1,5 @@
 use crate::{as_error, AppState, TaskCreatePayload, TaskUpdatePayload};
-use host_domain::{CreateTaskInput, TaskCard, TaskStatus, UpdateTaskPatch};
+use host_domain::{CreateTaskInput, IssueType, TaskCard, TaskStatus, UpdateTaskPatch};
 use tauri::State;
 
 #[tauri::command]
@@ -18,7 +18,7 @@ pub async fn task_create(
 ) -> Result<TaskCard, String> {
     let create = CreateTaskInput {
         title: input.title,
-        issue_type: input.issue_type,
+        issue_type: IssueType::from_cli_value(&input.issue_type).unwrap_or(IssueType::Task),
         priority: input.priority,
         description: input.description,
         acceptance_criteria: input.acceptance_criteria,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Context};
 use host_application::{AppService, RunEmitter};
+use host_domain::RunEvent;
 #[cfg(test)]
 use host_domain::TaskStatus;
-use host_domain::{PlanSubtaskInput, RunEvent};
 use host_infra_beads::BeadsTaskStore;
 use host_infra_system::AppConfigStore;
 use serde::Deserialize;
@@ -95,7 +95,16 @@ struct MarkdownPayload {
 #[serde(rename_all = "camelCase")]
 struct PlanPayload {
     markdown: String,
-    subtasks: Option<Vec<PlanSubtaskInput>>,
+    subtasks: Option<Vec<PlanSubtaskPayload>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PlanSubtaskPayload {
+    title: String,
+    issue_type: Option<String>,
+    priority: Option<i32>,
+    description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary
- replace raw `issue_type` strings in Rust host domain models with a typed `IssueType` enum
- migrate workflow rule evaluation and task workflow branching from string comparisons to enum matches
- enforce strict `issueType` parsing at Tauri command boundaries (`tasks` and `documents`) with explicit validation errors
- update Beads normalization/parsing/store paths to use typed issue kinds end-to-end
- refresh unit/integration tests to cover typed transitions and invalid `issueType` payloads

## Why
This removes primitive obsession around task issue kinds, prevents typo-driven runtime bugs, and gives compile-time exhaustiveness checks when workflow behavior depends on issue type.

## Validation
- updated Rust unit/integration tests in touched crates
