### PR TITLE
refactor(adapters-opencode-sdk): validate SSE payload handling and guard regressions

### DIFF
--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
@@ -1,5 +1,6 @@
 import type { AgentModelCatalog } from "@openducktor/core";
 import { unwrapData } from "./data-utils";
+import { asUnknownRecord, readStringProp } from "./guards";
 import { mapProviderListToCatalog, toToolIdList } from "./payload-mappers";
 import type { ClientFactory, McpServerStatus } from "./types";
 
@@ -90,22 +91,19 @@ export const getMcpStatus = async (
     directory: input.workingDirectory,
   });
   const payload = unwrapData(response, "get mcp status");
-  if (!payload || typeof payload !== "object") {
+  const statusPayload = asUnknownRecord(payload);
+  if (!statusPayload) {
     return {};
   }
 
   const statusByServer: Record<string, McpServerStatus> = {};
-  for (const [name, rawStatus] of Object.entries(payload as Record<string, unknown>)) {
-    if (!rawStatus || typeof rawStatus !== "object") {
+  for (const [name, rawStatus] of Object.entries(statusPayload)) {
+    const status = readStringProp(rawStatus, ["status"]);
+    if (!status || status.trim().length === 0) {
       continue;
     }
-    const status = (rawStatus as { status?: unknown }).status;
-    if (typeof status !== "string" || status.trim().length === 0) {
-      continue;
-    }
-    const error = (rawStatus as { error?: unknown }).error;
-    statusByServer[name] =
-      typeof error === "string" && error.trim().length > 0 ? { status, error } : { status };
+    const error = readStringProp(rawStatus, ["error"]);
+    statusByServer[name] = error && error.trim().length > 0 ? { status, error } : { status };
   }
 
   return statusByServer;

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -446,6 +446,35 @@ describe("event-stream", () => {
     });
   });
 
+  test("normalizes unknown session.status types as retry payload", async () => {
+    const emitted = await runEventStream([
+      {
+        type: "session.status",
+        properties: {
+          sessionID: "external-session-1",
+          status: {
+            type: "reconnect",
+            attempt: 3,
+            message: "Reconnecting",
+            next: 500,
+          },
+        },
+      } as unknown as Event,
+    ]);
+
+    const statusEvents = emitted.filter((event) => event.type === "session_status");
+    expect(statusEvents).toHaveLength(1);
+    if (statusEvents[0]?.type !== "session_status") {
+      throw new Error("Expected session_status event");
+    }
+    expect(statusEvents[0].status).toEqual({
+      type: "retry",
+      attempt: 3,
+      message: "Reconnecting",
+      nextEpochMs: 500,
+    });
+  });
+
   test("forwards permission and question events", async () => {
     const emitted = await runEventStream([
       {

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -1,12 +1,25 @@
 import type { Event, Part } from "@opencode-ai/sdk/v2/client";
 import {
+  asUnknownRecord,
+  readArrayProp,
+  readStringProp,
+  readUnknownProp,
+  type UnknownRecord,
+} from "../guards";
+import {
   extractMessageTotalTokens,
   readTextFromParts,
   sanitizeAssistantMessage,
 } from "../message-normalizers";
 import { mapPartToAgentStreamPart } from "../stream-part-mapper";
+import {
+  readEventInfo,
+  readEventPart,
+  readEventProperties,
+  readMessageCompletedAt,
+} from "./schemas";
 import type { EventStreamRuntime } from "./shared";
-import { applyDeltaToPart, readStringProp } from "./shared";
+import { applyDeltaToPart } from "./shared";
 
 const emitAssistantPart = (runtime: EventStreamRuntime, part: Part, roleHint?: string): boolean => {
   const mapped = mapPartToAgentStreamPart(part);
@@ -45,19 +58,16 @@ const applyPendingDeltas = (runtime: EventStreamRuntime, partId: string, basePar
   return nextPart;
 };
 
-const readRawMessageParts = (
-  properties: Record<string, unknown>,
-  info: Record<string, unknown> | undefined,
-): unknown[] => {
-  if (Array.isArray(properties.parts)) {
-    return properties.parts as unknown[];
+const readRawMessageParts = (properties: unknown, info: unknown): unknown[] => {
+  const directParts = readArrayProp(properties, "parts");
+  if (directParts) {
+    return directParts;
   }
-  const nestedParts = info?.parts;
-  return Array.isArray(nestedParts) ? (nestedParts as unknown[]) : [];
+  return readArrayProp(info, "parts") ?? [];
 };
 
 const normalizeMessagePart = (
-  rawPartRecord: Record<string, unknown>,
+  rawPartRecord: UnknownRecord,
   messageId: string,
   externalSessionId: string,
 ): Part => {
@@ -77,10 +87,11 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     return false;
   }
 
-  const properties = event.properties as Record<string, unknown>;
-  const info = properties.info;
-  const infoRecord =
-    info && typeof info === "object" ? (info as Record<string, unknown>) : undefined;
+  const properties = readEventProperties(event);
+  if (!properties) {
+    return true;
+  }
+  const infoRecord = readEventInfo(properties);
 
   const messageId = infoRecord
     ? readStringProp(infoRecord, ["id", "messageID", "messageId", "message_id"])
@@ -94,10 +105,11 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
   const rawParts = readRawMessageParts(properties, infoRecord);
   if (messageId && rawParts.length > 0) {
     for (const rawPart of rawParts) {
-      if (!rawPart || typeof rawPart !== "object") {
+      const rawPartRecord = asUnknownRecord(rawPart);
+      if (!rawPartRecord) {
         continue;
       }
-      const rawPartRecord = rawPart as Record<string, unknown>;
+
       const rawPartId = readStringProp(rawPartRecord, ["id"]);
       if (!rawPartId) {
         continue;
@@ -116,15 +128,13 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     }
   }
 
-  const completedAt = infoRecord
-    ? ((infoRecord as { time?: { completed?: unknown } }).time?.completed ?? null)
-    : null;
+  const completedAt = infoRecord ? readMessageCompletedAt(infoRecord) : undefined;
   const finish = infoRecord ? readStringProp(infoRecord, ["finish"]) : undefined;
   const shouldEmitCompletedMessage =
     messageId !== undefined &&
     role === "assistant" &&
     normalizedParts.length > 0 &&
-    (typeof completedAt === "number" || finish === "stop");
+    (completedAt !== undefined || finish === "stop");
   if (!shouldEmitCompletedMessage || !messageId) {
     return true;
   }
@@ -158,11 +168,15 @@ const handleMessagePartDeltaEvent = (event: Event, runtime: EventStreamRuntime):
     return false;
   }
 
-  const deltaEvent = event.properties as Record<string, unknown>;
+  const deltaEvent = readEventProperties(event);
+  if (!deltaEvent) {
+    return true;
+  }
   const partId = readStringProp(deltaEvent, ["partID", "partId", "part_id"]) ?? "";
   const messageId = readStringProp(deltaEvent, ["messageID", "messageId", "message_id"]);
   const field = readStringProp(deltaEvent, ["field"]) ?? "";
-  const delta = typeof deltaEvent.delta === "string" ? deltaEvent.delta : "";
+  const deltaValue = readUnknownProp(deltaEvent, "delta");
+  const delta = typeof deltaValue === "string" ? deltaValue : "";
 
   const knownPart = partId ? runtime.partsById.get(partId) : undefined;
   if (knownPart && field.length > 0) {
@@ -205,14 +219,20 @@ const handleMessagePartUpdatedEvent = (event: Event, runtime: EventStreamRuntime
     return false;
   }
 
-  const rawPart = (event.properties as { part?: unknown }).part;
-  if (!rawPart || typeof rawPart !== "object") {
+  const properties = readEventProperties(event);
+  const rawPartRecord = properties ? readEventPart(properties) : undefined;
+  if (!rawPartRecord) {
     return true;
   }
 
-  const current = rawPart as Part;
-  const nextPart = applyPendingDeltas(runtime, current.id, current);
-  runtime.partsById.set(nextPart.id, nextPart);
+  const partId = readStringProp(rawPartRecord, ["id"]);
+  if (!partId) {
+    return true;
+  }
+
+  const current = rawPartRecord as Part;
+  const nextPart = applyPendingDeltas(runtime, partId, current);
+  runtime.partsById.set(partId, nextPart);
   emitAssistantPart(runtime, nextPart);
   return true;
 };
@@ -222,11 +242,10 @@ const handleMessagePartRemovedEvent = (event: Event, runtime: EventStreamRuntime
     return false;
   }
 
-  const removedPartId = readStringProp(event.properties as Record<string, unknown>, [
-    "partID",
-    "partId",
-    "part_id",
-  ]);
+  const properties = readEventProperties(event);
+  const removedPartId = properties
+    ? readStringProp(properties, ["partID", "partId", "part_id"])
+    : undefined;
   if (!removedPartId) {
     return true;
   }

--- a/packages/adapters-opencode-sdk/src/event-stream/schemas.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/schemas.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+  parsePermissionAsked,
+  parseQuestionAsked,
+  parseSessionStatus,
+  readSessionErrorMessage,
+} from "./schemas";
+
+describe("event-stream schemas", () => {
+  test("parseSessionStatus maps unknown type to retry payload", () => {
+    expect(
+      parseSessionStatus({
+        status: {
+          type: "reconnect",
+          attempt: 4,
+          message: "Backoff",
+          next: 900,
+        },
+      }),
+    ).toEqual({
+      type: "retry",
+      attempt: 4,
+      message: "Backoff",
+      nextEpochMs: 900,
+    });
+  });
+
+  test("parseSessionStatus maps missing type to retry defaults", () => {
+    expect(parseSessionStatus({ status: {} })).toEqual({
+      type: "retry",
+      attempt: 0,
+      message: "Retrying session",
+      nextEpochMs: 0,
+    });
+  });
+
+  test("parsePermissionAsked normalizes invalid patterns as empty list", () => {
+    expect(
+      parsePermissionAsked({
+        id: "perm-1",
+        permission: "write",
+        patterns: ["src/**", 12],
+      }),
+    ).toEqual({
+      requestId: "perm-1",
+      permission: "write",
+      patterns: [],
+    });
+  });
+
+  test("parseQuestionAsked filters malformed questions and options", () => {
+    expect(
+      parseQuestionAsked({
+        id: "q-1",
+        questions: [
+          {
+            header: "Pick one",
+            question: "Select",
+            options: [{ label: "A", description: "Option A" }, { label: "B" }],
+          },
+          {
+            header: "Missing options",
+            question: "Broken",
+          },
+        ],
+      }),
+    ).toEqual({
+      requestId: "q-1",
+      questions: [
+        {
+          header: "Pick one",
+          question: "Select",
+          options: [{ label: "A", description: "Option A" }],
+        },
+        {
+          header: "Missing options",
+          question: "Broken",
+          options: [],
+        },
+      ],
+    });
+  });
+
+  test("readSessionErrorMessage falls back when nested message is absent", () => {
+    expect(readSessionErrorMessage({ error: { data: {} } })).toBe("Unknown session error");
+  });
+});

--- a/packages/adapters-opencode-sdk/src/event-stream/schemas.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/schemas.ts
@@ -114,17 +114,13 @@ export const parseSessionStatus = (properties: unknown): ParsedSessionStatus | u
   if (!status) {
     return undefined;
   }
+
   const type = readStringProp(status, ["type"]);
-  if (!type) {
-    return undefined;
-  }
   if (type === "busy" || type === "idle") {
     return { type };
   }
-  if (type !== "retry") {
-    return undefined;
-  }
 
+  // Keep unknown/missing status types forward-compatible by normalizing to retry.
   return {
     type: "retry",
     attempt: readNumberProp(status, ["attempt"]) ?? 0,

--- a/packages/adapters-opencode-sdk/src/event-stream/schemas.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/schemas.ts
@@ -1,0 +1,177 @@
+import type { Event } from "@opencode-ai/sdk/v2/client";
+import {
+  asUnknownRecord,
+  readArrayProp,
+  readBooleanProp,
+  readNumberProp,
+  readRecordProp,
+  readStringArrayProp,
+  readStringProp,
+  readUnknownProp,
+  type UnknownRecord,
+} from "../guards";
+
+type BusyStatus = {
+  type: "busy";
+};
+
+type IdleStatus = {
+  type: "idle";
+};
+
+type RetryStatus = {
+  type: "retry";
+  attempt: number;
+  message: string;
+  nextEpochMs: number;
+};
+
+export type ParsedSessionStatus = BusyStatus | IdleStatus | RetryStatus;
+
+export type ParsedPermissionAsked = {
+  requestId: string;
+  permission: string;
+  patterns: string[];
+  metadata?: UnknownRecord;
+};
+
+type ParsedQuestionOption = {
+  label: string;
+  description: string;
+};
+
+type ParsedQuestion = {
+  header: string;
+  question: string;
+  options: ParsedQuestionOption[];
+  multiple?: boolean;
+  custom?: boolean;
+};
+
+export type ParsedQuestionAsked = {
+  requestId: string;
+  questions: ParsedQuestion[];
+};
+
+export const readEventProperties = (event: Event): UnknownRecord | undefined => {
+  return asUnknownRecord(event.properties);
+};
+
+export const readEventInfo = (properties: unknown): UnknownRecord | undefined => {
+  return readRecordProp(properties, "info");
+};
+
+export const readEventPart = (properties: unknown): UnknownRecord | undefined => {
+  return readRecordProp(properties, "part");
+};
+
+export const readMessageCompletedAt = (info: unknown): number | undefined => {
+  return readNumberProp(readRecordProp(info, "time"), ["completed"]);
+};
+
+const parseQuestionOption = (value: unknown): ParsedQuestionOption | null => {
+  const record = asUnknownRecord(value);
+  if (!record) {
+    return null;
+  }
+  const label = readStringProp(record, ["label"]);
+  const description = readStringProp(record, ["description"]);
+  if (!label || !description) {
+    return null;
+  }
+  return { label, description };
+};
+
+const parseQuestion = (value: unknown): ParsedQuestion | null => {
+  const record = asUnknownRecord(value);
+  if (!record) {
+    return null;
+  }
+  const header = readStringProp(record, ["header"]);
+  const question = readStringProp(record, ["question"]);
+  if (!header || !question) {
+    return null;
+  }
+
+  const options = (readArrayProp(record, "options") ?? [])
+    .map(parseQuestionOption)
+    .filter((entry): entry is ParsedQuestionOption => entry !== null);
+
+  const multiple = readBooleanProp(record, ["multiple"]);
+  const custom = readBooleanProp(record, ["custom"]);
+
+  return {
+    header,
+    question,
+    options,
+    ...(multiple !== undefined ? { multiple } : {}),
+    ...(custom !== undefined ? { custom } : {}),
+  };
+};
+
+export const parseSessionStatus = (properties: unknown): ParsedSessionStatus | undefined => {
+  const status = readRecordProp(properties, "status");
+  if (!status) {
+    return undefined;
+  }
+  const type = readStringProp(status, ["type"]);
+  if (!type) {
+    return undefined;
+  }
+  if (type === "busy" || type === "idle") {
+    return { type };
+  }
+  if (type !== "retry") {
+    return undefined;
+  }
+
+  return {
+    type: "retry",
+    attempt: readNumberProp(status, ["attempt"]) ?? 0,
+    message: readStringProp(status, ["message"]) ?? "Retrying session",
+    nextEpochMs: readNumberProp(status, ["next"]) ?? 0,
+  };
+};
+
+export const parsePermissionAsked = (properties: unknown): ParsedPermissionAsked | undefined => {
+  const requestId = readStringProp(properties, ["id"]);
+  const permission = readStringProp(properties, ["permission"]);
+  if (!requestId || !permission) {
+    return undefined;
+  }
+
+  const patterns = readStringArrayProp(properties, "patterns") ?? [];
+  const metadata = readRecordProp(properties, "metadata");
+  return {
+    requestId,
+    permission,
+    patterns,
+    ...(metadata ? { metadata } : {}),
+  };
+};
+
+export const parseQuestionAsked = (properties: unknown): ParsedQuestionAsked | undefined => {
+  const requestId = readStringProp(properties, ["id"]);
+  if (!requestId) {
+    return undefined;
+  }
+
+  const questions = (readArrayProp(properties, "questions") ?? [])
+    .map(parseQuestion)
+    .filter((entry): entry is ParsedQuestion => entry !== null);
+  return {
+    requestId,
+    questions,
+  };
+};
+
+export const readSessionErrorMessage = (properties: unknown): string => {
+  const message = readStringProp(readRecordProp(readRecordProp(properties, "error"), "data"), [
+    "message",
+  ]);
+  return message ?? "Unknown session error";
+};
+
+export const readTodoPayload = (properties: unknown): unknown => {
+  return readUnknownProp(properties, "todos");
+};

--- a/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
@@ -1,5 +1,13 @@
 import type { Event } from "@opencode-ai/sdk/v2/client";
 import { normalizeTodoList } from "../todo-normalizers";
+import {
+  parsePermissionAsked,
+  parseQuestionAsked,
+  parseSessionStatus,
+  readEventProperties,
+  readSessionErrorMessage,
+  readTodoPayload,
+} from "./schemas";
 import type { EventStreamRuntime } from "./shared";
 
 const handleSessionStatusEvent = (event: Event, runtime: EventStreamRuntime): boolean => {
@@ -7,11 +15,12 @@ const handleSessionStatusEvent = (event: Event, runtime: EventStreamRuntime): bo
     return false;
   }
 
-  const status = (
-    event.properties as {
-      status: { type: string; attempt?: number; message?: string; next?: number };
-    }
-  ).status;
+  const properties = readEventProperties(event);
+  const status = properties ? parseSessionStatus(properties) : undefined;
+  if (!status) {
+    return true;
+  }
+
   if (status.type === "busy" || status.type === "idle") {
     runtime.emit(runtime.sessionId, {
       type: "session_status",
@@ -28,12 +37,9 @@ const handleSessionStatusEvent = (event: Event, runtime: EventStreamRuntime): bo
     timestamp: runtime.now(),
     status: {
       type: "retry",
-      attempt: typeof status.attempt === "number" ? status.attempt : 0,
-      message:
-        typeof status.message === "string" && status.message.length > 0
-          ? status.message
-          : "Retrying session",
-      nextEpochMs: typeof status.next === "number" ? status.next : 0,
+      attempt: status.attempt,
+      message: status.message,
+      nextEpochMs: status.nextEpochMs,
     },
   });
   return true;
@@ -44,20 +50,19 @@ const handlePermissionAskedEvent = (event: Event, runtime: EventStreamRuntime): 
     return false;
   }
 
-  const properties = event.properties as {
-    id: string;
-    permission: string;
-    patterns: string[];
-    metadata?: Record<string, unknown>;
-  };
+  const properties = readEventProperties(event);
+  const parsed = properties ? parsePermissionAsked(properties) : undefined;
+  if (!parsed) {
+    return true;
+  }
   runtime.emit(runtime.sessionId, {
     type: "permission_required",
     sessionId: runtime.sessionId,
     timestamp: runtime.now(),
-    requestId: properties.id,
-    permission: properties.permission,
-    patterns: properties.patterns,
-    ...(properties.metadata ? { metadata: properties.metadata } : {}),
+    requestId: parsed.requestId,
+    permission: parsed.permission,
+    patterns: parsed.patterns,
+    ...(parsed.metadata ? { metadata: parsed.metadata } : {}),
   });
   return true;
 };
@@ -67,23 +72,18 @@ const handleQuestionAskedEvent = (event: Event, runtime: EventStreamRuntime): bo
     return false;
   }
 
-  const properties = event.properties as {
-    id: string;
-    questions: Array<{
-      header: string;
-      question: string;
-      options: Array<{ label: string; description: string }>;
-      multiple?: boolean;
-      custom?: boolean;
-    }>;
-  };
+  const properties = readEventProperties(event);
+  const parsed = properties ? parseQuestionAsked(properties) : undefined;
+  if (!parsed) {
+    return true;
+  }
 
   runtime.emit(runtime.sessionId, {
     type: "question_required",
     sessionId: runtime.sessionId,
     timestamp: runtime.now(),
-    requestId: properties.id,
-    questions: properties.questions.map((question) => ({
+    requestId: parsed.requestId,
+    questions: parsed.questions.map((question) => ({
       header: question.header,
       question: question.question,
       options: question.options,
@@ -99,13 +99,12 @@ const handleSessionErrorEvent = (event: Event, runtime: EventStreamRuntime): boo
     return false;
   }
 
-  const maybeMessage = (event.properties as { error?: { data?: { message?: unknown } } }).error
-    ?.data?.message;
+  const properties = readEventProperties(event);
   runtime.emit(runtime.sessionId, {
     type: "session_error",
     sessionId: runtime.sessionId,
     timestamp: runtime.now(),
-    message: typeof maybeMessage === "string" ? maybeMessage : "Unknown session error",
+    message: properties ? readSessionErrorMessage(properties) : "Unknown session error",
   });
   return true;
 };
@@ -128,8 +127,8 @@ const handleTodoUpdatedEvent = (event: Event, runtime: EventStreamRuntime): bool
     return false;
   }
 
-  const props = event.properties as Record<string, unknown>;
-  const todos = normalizeTodoList(props.todos);
+  const properties = readEventProperties(event);
+  const todos = normalizeTodoList(readTodoPayload(properties));
   runtime.emit(runtime.sessionId, {
     type: "session_todos_updated",
     sessionId: runtime.sessionId,

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -1,6 +1,8 @@
 import type { Event, Part } from "@opencode-ai/sdk/v2/client";
 import type { AgentEvent } from "@openducktor/core";
+import { asUnknownRecord, readRecordProp, readStringProp } from "../guards";
 import type { SessionInput, SessionRecord } from "../types";
+import { readEventProperties } from "./schemas";
 
 export type PendingPartDelta = {
   field: string;
@@ -24,19 +26,6 @@ export type EventStreamState = {
 
 export type EventStreamRuntime = EventStreamContext & EventStreamState;
 
-export const readStringProp = (
-  payload: Record<string, unknown>,
-  keys: string[],
-): string | undefined => {
-  for (const key of keys) {
-    const value = payload[key];
-    if (typeof value === "string" && value.length > 0) {
-      return value;
-    }
-  }
-  return undefined;
-};
-
 const normalizePartDeltaField = (field: string): string => {
   if (
     field === "reasoning_content" ||
@@ -51,20 +40,24 @@ const normalizePartDeltaField = (field: string): string => {
 
 export const applyDeltaToPart = (part: Part, field: string, delta: string): Part | null => {
   const normalizedField = normalizePartDeltaField(field);
-  const partRecord = part as Record<string, unknown>;
-  const existing = partRecord[normalizedField];
+  const partRecord = asUnknownRecord(part);
+  const existing = partRecord?.[normalizedField];
   if (existing !== undefined && typeof existing !== "string") {
     return null;
   }
 
   return {
-    ...partRecord,
+    ...part,
     [normalizedField]: `${typeof existing === "string" ? existing : ""}${delta}`,
   } as Part;
 };
 
 export const isRelevantEvent = (externalSessionId: string, event: Event): boolean => {
-  const properties = event.properties as Record<string, unknown>;
+  const properties = readEventProperties(event);
+  if (!properties) {
+    return false;
+  }
+
   const directSessionId = readStringProp(properties, [
     "sessionID",
     "sessionId",
@@ -75,23 +68,19 @@ export const isRelevantEvent = (externalSessionId: string, event: Event): boolea
     return directSessionId === externalSessionId;
   }
 
-  if ("part" in properties) {
-    const part = properties.part as Record<string, unknown> | undefined;
-    if (part && typeof part === "object") {
-      const partSessionId = readStringProp(part, ["sessionID", "sessionId", "session_id"]);
-      if (partSessionId) {
-        return partSessionId === externalSessionId;
-      }
+  const part = readRecordProp(properties, "part");
+  if (part) {
+    const partSessionId = readStringProp(part, ["sessionID", "sessionId", "session_id"]);
+    if (partSessionId) {
+      return partSessionId === externalSessionId;
     }
   }
 
-  if ("info" in properties) {
-    const info = properties.info as Record<string, unknown> | undefined;
-    if (info && typeof info === "object") {
-      const infoSessionId = readStringProp(info, ["sessionID", "sessionId", "session_id"]);
-      if (infoSessionId) {
-        return infoSessionId === externalSessionId;
-      }
+  const info = readRecordProp(properties, "info");
+  if (info) {
+    const infoSessionId = readStringProp(info, ["sessionID", "sessionId", "session_id"]);
+    if (infoSessionId) {
+      return infoSessionId === externalSessionId;
     }
   }
 

--- a/packages/adapters-opencode-sdk/src/guards.test.ts
+++ b/packages/adapters-opencode-sdk/src/guards.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { readStringArrayProp } from "./guards";
+
+describe("guards", () => {
+  test("readStringArrayProp returns a copied string array for valid input", () => {
+    const source = {
+      patterns: ["src/**", "docs/**"],
+    };
+
+    const result = readStringArrayProp(source, "patterns");
+    expect(result).toEqual(["src/**", "docs/**"]);
+    expect(result).not.toBe(source.patterns);
+  });
+
+  test("readStringArrayProp returns undefined when any entry is non-string", () => {
+    const result = readStringArrayProp({ patterns: ["src/**", 42] }, "patterns");
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/adapters-opencode-sdk/src/guards.ts
+++ b/packages/adapters-opencode-sdk/src/guards.ts
@@ -1,0 +1,91 @@
+export type UnknownRecord = Record<string, unknown>;
+
+export const isUnknownRecord = (value: unknown): value is UnknownRecord => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+export const asUnknownRecord = (value: unknown): UnknownRecord | undefined => {
+  return isUnknownRecord(value) ? value : undefined;
+};
+
+export const safeProp = <T>(
+  source: unknown,
+  key: string,
+  guard: (value: unknown) => value is T,
+): T | undefined => {
+  const record = asUnknownRecord(source);
+  if (!record) {
+    return undefined;
+  }
+  const value = record[key];
+  return guard(value) ? value : undefined;
+};
+
+export const readUnknownProp = (source: unknown, key: string): unknown => {
+  const record = asUnknownRecord(source);
+  return record?.[key];
+};
+
+export const readRecordProp = (source: unknown, key: string): UnknownRecord | undefined => {
+  return safeProp(source, key, isUnknownRecord);
+};
+
+export const readArrayProp = (source: unknown, key: string): unknown[] | undefined => {
+  return safeProp(source, key, Array.isArray);
+};
+
+export const readStringProp = (source: unknown, keys: string[]): string | undefined => {
+  const record = asUnknownRecord(source);
+  if (!record) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+export const readNumberProp = (source: unknown, keys: string[]): number | undefined => {
+  const record = asUnknownRecord(source);
+  if (!record) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value) && !Number.isNaN(value)) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+export const readBooleanProp = (source: unknown, keys: string[]): boolean | undefined => {
+  const record = asUnknownRecord(source);
+  if (!record) {
+    return undefined;
+  }
+
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+export const readStringArrayProp = (source: unknown, key: string): string[] | undefined => {
+  const values = readArrayProp(source, key);
+  if (!values) {
+    return undefined;
+  }
+  if (!values.every((entry) => typeof entry === "string")) {
+    return undefined;
+  }
+  return values;
+};

--- a/packages/adapters-opencode-sdk/src/guards.ts
+++ b/packages/adapters-opencode-sdk/src/guards.ts
@@ -84,8 +84,13 @@ export const readStringArrayProp = (source: unknown, key: string): string[] | un
   if (!values) {
     return undefined;
   }
-  if (!values.every((entry) => typeof entry === "string")) {
-    return undefined;
+
+  const stringArray: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+    stringArray.push(value);
   }
-  return values;
+  return stringArray;
 };

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -1,4 +1,5 @@
 import type { Part } from "@opencode-ai/sdk/v2/client";
+import { asUnknownRecord, readRecordProp, readUnknownProp } from "./guards";
 
 export const readTextFromParts = (parts: Part[]): string => {
   return parts
@@ -9,16 +10,15 @@ export const readTextFromParts = (parts: Part[]): string => {
 };
 
 export const readTextFromMessageInfo = (info: unknown): string => {
-  if (!info || typeof info !== "object") {
+  const record = asUnknownRecord(info);
+  if (!record) {
     return "";
   }
-  const record = info as Record<string, unknown>;
+
   const direct =
-    record.text ??
-    record.content ??
-    (record.message && typeof record.message === "object"
-      ? (record.message as Record<string, unknown>).text
-      : undefined);
+    readUnknownProp(record, "text") ??
+    readUnknownProp(record, "content") ??
+    readUnknownProp(readRecordProp(record, "message"), "text");
   return typeof direct === "string" ? direct.trim() : "";
 };
 
@@ -71,20 +71,14 @@ export const extractMessageTotalTokens = (
   info: unknown,
   parts: Array<Part | Record<string, unknown>>,
 ): number | undefined => {
-  const infoTokens =
-    info && typeof info === "object"
-      ? toTokenTotal((info as { tokens?: unknown }).tokens)
-      : undefined;
+  const infoTokens = toTokenTotal(readUnknownProp(info, "tokens"));
   if (typeof infoTokens === "number" && infoTokens > 0) {
     return infoTokens;
   }
 
   let maxPartTokens = 0;
   for (const part of parts) {
-    if (!part || typeof part !== "object") {
-      continue;
-    }
-    const partTokens = toTokenTotal((part as { tokens?: unknown }).tokens);
+    const partTokens = toTokenTotal(readUnknownProp(part, "tokens"));
     if (typeof partTokens === "number" && partTokens > maxPartTokens) {
       maxPartTokens = partTokens;
     }

--- a/packages/adapters-opencode-sdk/src/payload-mappers.ts
+++ b/packages/adapters-opencode-sdk/src/payload-mappers.ts
@@ -1,4 +1,5 @@
 import type { AgentModelCatalog, AgentModelSelection } from "@openducktor/core";
+import { asUnknownRecord, readArrayProp, readRecordProp, readUnknownProp } from "./guards";
 
 const toFiniteNumber = (value: unknown): number | null => {
   if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
@@ -29,23 +30,25 @@ export const normalizeModelInput = (
 };
 
 export const resolveAssistantResponseMessageId = (payload: unknown): string | null => {
-  if (!payload || typeof payload !== "object") {
+  const payloadRecord = asUnknownRecord(payload);
+  if (!payloadRecord) {
     return null;
   }
-  const infoId = ((payload as { info?: { id?: unknown } }).info?.id ?? null) as unknown;
+  const infoId = readUnknownProp(readRecordProp(payloadRecord, "info"), "id");
   if (typeof infoId === "string" && infoId.trim().length > 0) {
     return infoId.trim();
   }
 
-  const parts = (payload as { parts?: unknown }).parts;
-  if (!Array.isArray(parts)) {
+  const parts = readArrayProp(payloadRecord, "parts");
+  if (!parts) {
     return null;
   }
   for (const part of parts) {
-    if (!part || typeof part !== "object") {
+    const partRecord = asUnknownRecord(part);
+    if (!partRecord) {
       continue;
     }
-    const messageId = (part as { messageID?: unknown }).messageID;
+    const messageId = readUnknownProp(partRecord, "messageID");
     if (typeof messageId === "string" && messageId.trim().length > 0) {
       return messageId.trim();
     }
@@ -64,55 +67,48 @@ export const toToolIdList = (payload: unknown): string[] => {
 };
 
 export const mapProviderListToCatalog = (payload: unknown): AgentModelCatalog => {
-  if (!payload || typeof payload !== "object") {
+  const payloadRecord = asUnknownRecord(payload);
+  if (!payloadRecord) {
     return { models: [], defaultModelsByProvider: {}, agents: [] };
   }
 
-  const providers = Array.isArray((payload as { providers?: unknown }).providers)
-    ? ((payload as { providers: Array<unknown> }).providers as Array<unknown>)
-    : [];
-  const defaults =
-    typeof (payload as { default?: unknown }).default === "object" &&
-    (payload as { default?: unknown }).default !== null
-      ? ((payload as { default: Record<string, string> }).default ?? {})
-      : {};
+  const providers = readArrayProp(payloadRecord, "providers") ?? [];
+  const defaultsRaw = readRecordProp(payloadRecord, "default");
+  const defaults: Record<string, string> = {};
+  if (defaultsRaw) {
+    for (const [providerId, modelId] of Object.entries(defaultsRaw)) {
+      if (typeof modelId === "string") {
+        defaults[providerId] = modelId;
+      }
+    }
+  }
 
   const models = providers.flatMap((provider) => {
-    if (!provider || typeof provider !== "object") {
+    const providerRecord = asUnknownRecord(provider);
+    if (!providerRecord) {
       return [];
     }
-    const providerId = (provider as { id?: unknown }).id;
-    const providerName = (provider as { name?: unknown }).name;
-    const rawModels = (provider as { models?: unknown }).models;
-    if (
-      typeof providerId !== "string" ||
-      typeof providerName !== "string" ||
-      !rawModels ||
-      typeof rawModels !== "object"
-    ) {
+    const providerId = readUnknownProp(providerRecord, "id");
+    const providerName = readUnknownProp(providerRecord, "name");
+    const rawModels = readRecordProp(providerRecord, "models");
+    if (typeof providerId !== "string" || typeof providerName !== "string" || !rawModels) {
       return [];
     }
 
-    return Object.entries(rawModels as Record<string, unknown>)
+    return Object.entries(rawModels)
       .map(([modelId, rawModel]) => {
-        if (!rawModel || typeof rawModel !== "object") {
+        const modelRecord = asUnknownRecord(rawModel);
+        if (!modelRecord) {
           return null;
         }
-        const modelName = (rawModel as { name?: unknown }).name;
-        const variantsRaw = (rawModel as { variants?: unknown }).variants;
-        const limitRaw = (rawModel as { limit?: unknown }).limit;
-        const contextWindow =
-          limitRaw && typeof limitRaw === "object"
-            ? (toFiniteNumber((limitRaw as { context?: unknown }).context) ?? undefined)
-            : undefined;
-        const outputLimit =
-          limitRaw && typeof limitRaw === "object"
-            ? (toFiniteNumber((limitRaw as { output?: unknown }).output) ?? undefined)
-            : undefined;
-        const variants =
-          variantsRaw && typeof variantsRaw === "object"
-            ? Object.keys(variantsRaw as Record<string, unknown>)
-            : [];
+        const modelName = readUnknownProp(modelRecord, "name");
+        const variantsRaw = readRecordProp(modelRecord, "variants");
+        const limitRaw = readRecordProp(modelRecord, "limit");
+        const contextRaw = readUnknownProp(limitRaw, "context");
+        const outputRaw = readUnknownProp(limitRaw, "output");
+        const contextWindow = limitRaw ? (toFiniteNumber(contextRaw) ?? undefined) : undefined;
+        const outputLimit = limitRaw ? (toFiniteNumber(outputRaw) ?? undefined) : undefined;
+        const variants = variantsRaw ? Object.keys(variantsRaw) : [];
 
         return {
           id: `${providerId}/${modelId}`,

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -125,6 +125,37 @@ describe("stream-part-mapper", () => {
     });
   });
 
+  test("falls back to state timing when direct timing fields are non-numeric", () => {
+    const part = {
+      ...createToolPart({
+        id: "tool-2b",
+        status: "completed",
+        input: {},
+        time: {
+          start: 111,
+          end: 222,
+        },
+      }),
+      time: {
+        start: "invalid",
+        end: "invalid",
+      },
+    } as unknown as Part;
+
+    const mapped = mapPartToAgentStreamPart(part);
+    expect(mapped).toEqual({
+      kind: "tool",
+      messageId: "assistant-tool-2b",
+      partId: "tool-2b",
+      callId: "call-tool-2b",
+      tool: "todowrite",
+      status: "completed",
+      input: {},
+      startedAtMs: 111,
+      endedAtMs: 222,
+    });
+  });
+
   test("maps started tool without end timing as running and keeps title", () => {
     const part = createToolPart({
       id: "tool-3",

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -1,5 +1,6 @@
 import type { Part } from "@opencode-ai/sdk/v2/client";
 import type { AgentStreamPart } from "@openducktor/core";
+import { asUnknownRecord, readRecordProp, readStringProp, readUnknownProp } from "./guards";
 
 const toDisplayText = (value: unknown): string | undefined => {
   if (typeof value === "string") {
@@ -15,7 +16,8 @@ const toDisplayText = (value: unknown): string | undefined => {
   if (Array.isArray(value) && value.length === 0) {
     return undefined;
   }
-  if (typeof value === "object" && Object.keys(value as Record<string, unknown>).length === 0) {
+  const valueRecord = asUnknownRecord(value);
+  if (valueRecord && Object.keys(valueRecord).length === 0) {
     return undefined;
   }
   try {
@@ -26,20 +28,18 @@ const toDisplayText = (value: unknown): string | undefined => {
 };
 
 const outputTextFromMcpPayload = (value: unknown): string | undefined => {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const content = (value as { content?: unknown }).content;
+  const content = readUnknownProp(value, "content");
   if (!Array.isArray(content)) {
     return undefined;
   }
 
   const textChunks = content
     .map((entry) => {
-      if (!entry || typeof entry !== "object") {
+      const entryRecord = asUnknownRecord(entry);
+      if (!entryRecord) {
         return null;
       }
-      const text = (entry as { text?: unknown }).text;
+      const text = readUnknownProp(entryRecord, "text");
       return typeof text === "string" ? text.trim() : null;
     })
     .filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
@@ -54,18 +54,15 @@ const readToolOutputText = (value: unknown): string | undefined => {
 };
 
 const isToolOutputError = (value: unknown): boolean => {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const isError = (value as { isError?: unknown }).isError;
+  const isError = readUnknownProp(value, "isError");
   return isError === true;
 };
 
 const normalizeMetadata = (value: unknown): Record<string, unknown> | undefined => {
-  if (!value || typeof value !== "object") {
+  const normalized = asUnknownRecord(value);
+  if (!normalized) {
     return undefined;
   }
-  const normalized = value as Record<string, unknown>;
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 };
 
@@ -75,13 +72,13 @@ const extractPartTiming = (
   startedAtMs?: number;
   endedAtMs?: number;
 } => {
-  const direct = (part as { time?: { start?: unknown; end?: unknown } }).time;
-  const fromDirectStart = typeof direct?.start === "number" ? direct.start : undefined;
-  const fromDirectEnd = typeof direct?.end === "number" ? direct.end : undefined;
+  const directTime = readRecordProp(part, "time");
+  const fromDirectStart = readUnknownProp(directTime, "start");
+  const fromDirectEnd = readUnknownProp(directTime, "end");
 
-  const stateTime = (part as { state?: { time?: { start?: unknown; end?: unknown } } }).state?.time;
-  const fromStateStart = typeof stateTime?.start === "number" ? stateTime.start : undefined;
-  const fromStateEnd = typeof stateTime?.end === "number" ? stateTime.end : undefined;
+  const stateTime = readRecordProp(readRecordProp(part, "state"), "time");
+  const fromStateStart = readUnknownProp(stateTime, "start");
+  const fromStateEnd = readUnknownProp(stateTime, "end");
 
   const startedAtMs = fromDirectStart ?? fromStateStart;
   const endedAtMs = fromDirectEnd ?? fromStateEnd;
@@ -115,11 +112,11 @@ const normalizeToolStatus = (rawStatus: string, hasEndedTiming: boolean): ToolSt
 
 const buildToolStreamPart = (
   part: ToolPart,
+  toolState: Record<string, unknown>,
   normalizedStatus: ToolStatus,
   timing: ReturnType<typeof extractPartTiming>,
   metadata: Record<string, unknown> | undefined,
 ): ToolStreamPart => {
-  const toolState = part.state as Record<string, unknown>;
   const base: ToolStreamPart = {
     kind: "tool",
     messageId: part.messageID,
@@ -136,14 +133,14 @@ const buildToolStreamPart = (
     return base;
   }
   if (normalizedStatus === "running") {
-    const title = toDisplayText(toolState.title);
+    const title = toDisplayText(readUnknownProp(toolState, "title"));
     return {
       ...base,
       ...(title ? { title } : {}),
     };
   }
 
-  const error = toDisplayText(toolState.error);
+  const error = toDisplayText(readUnknownProp(toolState, "error"));
   if (normalizedStatus === "error") {
     return {
       ...base,
@@ -151,8 +148,9 @@ const buildToolStreamPart = (
     };
   }
 
-  const output = readToolOutputText(toolState.output);
-  if (isToolOutputError(toolState.output) || (error && error.trim().length > 0)) {
+  const outputValue = readUnknownProp(toolState, "output");
+  const output = readToolOutputText(outputValue);
+  if (isToolOutputError(outputValue) || (error && error.trim().length > 0)) {
     return {
       ...base,
       status: "error",
@@ -160,7 +158,7 @@ const buildToolStreamPart = (
     };
   }
 
-  const title = toDisplayText(toolState.title);
+  const title = toDisplayText(readUnknownProp(toolState, "title"));
   const titleField = title ? { title } : {};
   return {
     ...base,
@@ -189,15 +187,14 @@ export const mapPartToAgentStreamPart = (part: Part): AgentStreamPart | null => 
         completed: Boolean(part.time?.end),
       };
     case "tool": {
+      const toolState = asUnknownRecord(part.state) ?? {};
       const timing = extractPartTiming(part);
-      const metadata = normalizeMetadata(
-        (part as { state?: { metadata?: unknown } }).state?.metadata,
-      );
+      const metadata = normalizeMetadata(readUnknownProp(toolState, "metadata"));
       const normalizedStatus = normalizeToolStatus(
-        typeof part.state.status === "string" ? part.state.status : "",
+        readStringProp(toolState, ["status"]) ?? "",
         typeof timing.endedAtMs === "number",
       );
-      return buildToolStreamPart(part, normalizedStatus, timing, metadata);
+      return buildToolStreamPart(part, toolState, normalizedStatus, timing, metadata);
     }
     case "step-start":
       return {

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -1,6 +1,12 @@
 import type { Part } from "@opencode-ai/sdk/v2/client";
 import type { AgentStreamPart } from "@openducktor/core";
-import { asUnknownRecord, readRecordProp, readStringProp, readUnknownProp } from "./guards";
+import {
+  asUnknownRecord,
+  readNumberProp,
+  readRecordProp,
+  readStringProp,
+  readUnknownProp,
+} from "./guards";
 
 const toDisplayText = (value: unknown): string | undefined => {
   if (typeof value === "string") {
@@ -73,12 +79,12 @@ const extractPartTiming = (
   endedAtMs?: number;
 } => {
   const directTime = readRecordProp(part, "time");
-  const fromDirectStart = readUnknownProp(directTime, "start");
-  const fromDirectEnd = readUnknownProp(directTime, "end");
+  const fromDirectStart = readNumberProp(directTime, ["start"]);
+  const fromDirectEnd = readNumberProp(directTime, ["end"]);
 
   const stateTime = readRecordProp(readRecordProp(part, "state"), "time");
-  const fromStateStart = readUnknownProp(stateTime, "start");
-  const fromStateEnd = readUnknownProp(stateTime, "end");
+  const fromStateStart = readNumberProp(stateTime, ["start"]);
+  const fromStateEnd = readNumberProp(stateTime, ["end"]);
 
   const startedAtMs = fromDirectStart ?? fromStateStart;
   const endedAtMs = fromDirectEnd ?? fromStateEnd;


### PR DESCRIPTION
## Summary
- replace pervasive `as Record<string, unknown>` casts in the opencode SDK adapter with validated runtime guard helpers
- introduce shared event-stream parsers for dynamic SSE payload shapes (`session.status`, permission/question payloads, message info/part reads)
- harden adapter mappers (`stream-part-mapper`, `payload-mappers`, `catalog-and-mcp`, `message-normalizers`) to read from unknown safely

## Follow-up Fixes
- restore `state.time` fallback when `part.time` fields are present but non-numeric
- keep `session.status` forward-compatible by normalizing unknown/missing status types to retry payloads
- add focused regression tests for timing fallback and schema normalization

## Testing
- `bun run --filter @openducktor/adapters-opencode-sdk lint`
- `bun run --filter @openducktor/adapters-opencode-sdk test`
- `bun run --filter @openducktor/adapters-opencode-sdk typecheck`
