### PR TITLE
refactor(contracts,core,mcp): consolidate canonical workflow schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
+        "@openducktor/contracts": "workspace:*",
         "zod": "^4.3.6",
       },
     },

--- a/packages/contracts/src/agent-workflow-schemas.ts
+++ b/packages/contracts/src/agent-workflow-schemas.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const agentRoleValues = ["spec", "planner", "build", "qa"] as const;
+export const agentScenarioValues = [
+  "spec_initial",
+  "planner_initial",
+  "build_implementation_start",
+  "build_after_qa_rejected",
+  "build_after_human_request_changes",
+  "qa_review",
+] as const;
+export const agentToolNameValues = [
+  "odt_read_task",
+  "odt_set_spec",
+  "odt_set_plan",
+  "odt_build_blocked",
+  "odt_build_resumed",
+  "odt_build_completed",
+  "odt_qa_approved",
+  "odt_qa_rejected",
+] as const;
+
+export const agentRoleSchema = z.enum(agentRoleValues);
+export type AgentRole = z.infer<typeof agentRoleSchema>;
+
+export const agentScenarioSchema = z.enum(agentScenarioValues);
+export type AgentScenario = z.infer<typeof agentScenarioSchema>;
+
+export const agentToolNameSchema = z.enum(agentToolNameValues);
+export type AgentToolName = z.infer<typeof agentToolNameSchema>;

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -47,8 +47,13 @@ import type {
 import * as contracts from "./index";
 
 const EXPECTED_RUNTIME_EXPORTS = [
+  "agentRoleSchema",
+  "agentRoleValues",
+  "agentScenarioSchema",
+  "agentScenarioValues",
   "agentModelDefaultSchema",
   "agentToolNameSchema",
+  "agentToolNameValues",
   "agentRuntimeSummarySchema",
   "agentSessionModelSelectionSchema",
   "agentSessionRecordSchema",

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import type {
   AgentModelDefault,
+  AgentRole,
   AgentRuntimeSummary,
+  AgentScenario,
   AgentSessionModelSelection,
   AgentSessionRecord,
   AgentSessionRole,
   AgentSessionScenario,
   AgentSessionStatus,
   AgentSessionTodoPayloadRecord,
+  AgentToolName,
   AgentWorkflowState,
   AgentWorkflows,
   BeadsCheck,
@@ -45,6 +48,7 @@ import * as contracts from "./index";
 
 const EXPECTED_RUNTIME_EXPORTS = [
   "agentModelDefaultSchema",
+  "agentToolNameSchema",
   "agentRuntimeSummarySchema",
   "agentSessionModelSelectionSchema",
   "agentSessionRecordSchema",
@@ -87,7 +91,9 @@ const EXPECTED_RUNTIME_EXPORTS = [
 ] as const;
 
 type ExportedTypeContract = {
+  AgentRole: AgentRole;
   AgentModelDefault: AgentModelDefault;
+  AgentScenario: AgentScenario;
   AgentRuntimeSummary: AgentRuntimeSummary;
   AgentSessionModelSelection: AgentSessionModelSelection;
   AgentSessionTodoPayloadRecord: AgentSessionTodoPayloadRecord;
@@ -95,6 +101,7 @@ type ExportedTypeContract = {
   AgentSessionRole: AgentSessionRole;
   AgentSessionScenario: AgentSessionScenario;
   AgentSessionStatus: AgentSessionStatus;
+  AgentToolName: AgentToolName;
   AgentWorkflowState: AgentWorkflowState;
   AgentWorkflows: AgentWorkflows;
   BeadsCheck: BeadsCheck;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./agent-workflow-schemas";
 export * from "./config-schemas";
 export * from "./git-schemas";
 export * from "./metadata-schemas";

--- a/packages/contracts/src/session-schemas.ts
+++ b/packages/contracts/src/session-schemas.ts
@@ -1,20 +1,38 @@
 import { z } from "zod";
 
-export const agentSessionStatusSchema = z.enum(["starting", "running", "idle", "error", "stopped"]);
-export type AgentSessionStatus = z.infer<typeof agentSessionStatusSchema>;
-
-export const agentSessionRoleSchema = z.enum(["spec", "planner", "build", "qa"]);
-export type AgentSessionRole = z.infer<typeof agentSessionRoleSchema>;
-
-export const agentSessionScenarioSchema = z.enum([
+const AGENT_SESSION_ROLE_VALUES = ["spec", "planner", "build", "qa"] as const;
+const AGENT_SESSION_SCENARIO_VALUES = [
   "spec_initial",
   "planner_initial",
   "build_implementation_start",
   "build_after_qa_rejected",
   "build_after_human_request_changes",
   "qa_review",
-]);
+] as const;
+const AGENT_TOOL_NAME_VALUES = [
+  "odt_read_task",
+  "odt_set_spec",
+  "odt_set_plan",
+  "odt_build_blocked",
+  "odt_build_resumed",
+  "odt_build_completed",
+  "odt_qa_approved",
+  "odt_qa_rejected",
+] as const;
+
+export const agentSessionStatusSchema = z.enum(["starting", "running", "idle", "error", "stopped"]);
+export type AgentSessionStatus = z.infer<typeof agentSessionStatusSchema>;
+
+export const agentSessionRoleSchema = z.enum(AGENT_SESSION_ROLE_VALUES);
+export type AgentSessionRole = z.infer<typeof agentSessionRoleSchema>;
+export type AgentRole = AgentSessionRole;
+
+export const agentSessionScenarioSchema = z.enum(AGENT_SESSION_SCENARIO_VALUES);
 export type AgentSessionScenario = z.infer<typeof agentSessionScenarioSchema>;
+export type AgentScenario = AgentSessionScenario;
+
+export const agentToolNameSchema = z.enum(AGENT_TOOL_NAME_VALUES);
+export type AgentToolName = z.infer<typeof agentToolNameSchema>;
 
 export const agentSessionModelSelectionSchema = z.object({
   providerId: z.string(),

--- a/packages/contracts/src/session-schemas.ts
+++ b/packages/contracts/src/session-schemas.ts
@@ -1,38 +1,14 @@
 import { z } from "zod";
-
-const AGENT_SESSION_ROLE_VALUES = ["spec", "planner", "build", "qa"] as const;
-const AGENT_SESSION_SCENARIO_VALUES = [
-  "spec_initial",
-  "planner_initial",
-  "build_implementation_start",
-  "build_after_qa_rejected",
-  "build_after_human_request_changes",
-  "qa_review",
-] as const;
-const AGENT_TOOL_NAME_VALUES = [
-  "odt_read_task",
-  "odt_set_spec",
-  "odt_set_plan",
-  "odt_build_blocked",
-  "odt_build_resumed",
-  "odt_build_completed",
-  "odt_qa_approved",
-  "odt_qa_rejected",
-] as const;
+import { agentRoleSchema, agentScenarioSchema } from "./agent-workflow-schemas";
 
 export const agentSessionStatusSchema = z.enum(["starting", "running", "idle", "error", "stopped"]);
 export type AgentSessionStatus = z.infer<typeof agentSessionStatusSchema>;
 
-export const agentSessionRoleSchema = z.enum(AGENT_SESSION_ROLE_VALUES);
+export const agentSessionRoleSchema = agentRoleSchema;
 export type AgentSessionRole = z.infer<typeof agentSessionRoleSchema>;
-export type AgentRole = AgentSessionRole;
 
-export const agentSessionScenarioSchema = z.enum(AGENT_SESSION_SCENARIO_VALUES);
+export const agentSessionScenarioSchema = agentScenarioSchema;
 export type AgentSessionScenario = z.infer<typeof agentSessionScenarioSchema>;
-export type AgentScenario = AgentSessionScenario;
-
-export const agentToolNameSchema = z.enum(AGENT_TOOL_NAME_VALUES);
-export type AgentToolName = z.infer<typeof agentToolNameSchema>;
 
 export const agentSessionModelSelectionSchema = z.object({
   providerId: z.string(),

--- a/packages/core/src/services/odt-workflow-tools.ts
+++ b/packages/core/src/services/odt-workflow-tools.ts
@@ -1,19 +1,12 @@
+import { agentToolNameSchema } from "@openducktor/contracts";
 import {
   AGENT_ROLE_TOOL_POLICY,
   type AgentRole,
   type AgentToolName,
 } from "../types/agent-orchestrator";
 
-export const ODT_WORKFLOW_TOOL_NAMES = [
-  "odt_read_task",
-  "odt_set_spec",
-  "odt_set_plan",
-  "odt_build_blocked",
-  "odt_build_resumed",
-  "odt_build_completed",
-  "odt_qa_approved",
-  "odt_qa_rejected",
-] as const satisfies readonly AgentToolName[];
+export const ODT_WORKFLOW_TOOL_NAMES =
+  agentToolNameSchema.options satisfies readonly AgentToolName[];
 
 const ODT_WORKFLOW_TOOL_SET = new Set<AgentToolName>(ODT_WORKFLOW_TOOL_NAMES);
 export const ODT_WORKFLOW_MUTATION_TOOL_NAMES = ODT_WORKFLOW_TOOL_NAMES.filter(

--- a/packages/core/src/services/odt-workflow-tools.ts
+++ b/packages/core/src/services/odt-workflow-tools.ts
@@ -1,12 +1,11 @@
-import { agentToolNameSchema } from "@openducktor/contracts";
+import { agentToolNameValues } from "@openducktor/contracts";
 import {
   AGENT_ROLE_TOOL_POLICY,
   type AgentRole,
   type AgentToolName,
 } from "../types/agent-orchestrator";
 
-export const ODT_WORKFLOW_TOOL_NAMES =
-  agentToolNameSchema.options satisfies readonly AgentToolName[];
+export const ODT_WORKFLOW_TOOL_NAMES = agentToolNameValues satisfies readonly AgentToolName[];
 
 const ODT_WORKFLOW_TOOL_SET = new Set<AgentToolName>(ODT_WORKFLOW_TOOL_NAMES);
 export const ODT_WORKFLOW_MUTATION_TOOL_NAMES = ODT_WORKFLOW_TOOL_NAMES.filter(

--- a/packages/core/src/types/agent-orchestrator.ts
+++ b/packages/core/src/types/agent-orchestrator.ts
@@ -1,24 +1,13 @@
-import type { TaskPriority } from "@openducktor/contracts";
+import type {
+  AgentRole as ContractsAgentRole,
+  AgentScenario as ContractsAgentScenario,
+  AgentToolName as ContractsAgentToolName,
+  TaskPriority,
+} from "@openducktor/contracts";
 
-export type AgentRole = "spec" | "planner" | "build" | "qa";
-
-export type AgentScenario =
-  | "spec_initial"
-  | "planner_initial"
-  | "build_implementation_start"
-  | "build_after_qa_rejected"
-  | "build_after_human_request_changes"
-  | "qa_review";
-
-export type AgentToolName =
-  | "odt_read_task"
-  | "odt_set_spec"
-  | "odt_set_plan"
-  | "odt_build_blocked"
-  | "odt_build_resumed"
-  | "odt_build_completed"
-  | "odt_qa_approved"
-  | "odt_qa_rejected";
+export type AgentRole = ContractsAgentRole;
+export type AgentScenario = ContractsAgentScenario;
+export type AgentToolName = ContractsAgentToolName;
 
 export type AgentModelSelection = {
   providerId: string;

--- a/packages/openducktor-mcp/package.json
+++ b/packages/openducktor-mcp/package.json
@@ -12,6 +12,7 @@
     "lint": "biome check src"
   },
   "dependencies": {
+    "@openducktor/contracts": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "zod": "^4.3.6"
   }

--- a/packages/openducktor-mcp/src/contracts.ts
+++ b/packages/openducktor-mcp/src/contracts.ts
@@ -11,8 +11,10 @@ export type PlanSubtaskInput = {
 
 export type TaskCard = Pick<
   CanonicalTaskCard,
-  "id" | "title" | "status" | "issueType" | "aiReviewEnabled" | "parentId"
->;
+  "id" | "title" | "status" | "issueType" | "aiReviewEnabled"
+> & {
+  parentId?: string;
+};
 
 export type RawIssue = {
   id: string;

--- a/packages/openducktor-mcp/src/contracts.ts
+++ b/packages/openducktor-mcp/src/contracts.ts
@@ -1,31 +1,18 @@
-export type TaskStatus =
-  | "open"
-  | "spec_ready"
-  | "ready_for_dev"
-  | "in_progress"
-  | "blocked"
-  | "ai_review"
-  | "human_review"
-  | "deferred"
-  | "closed";
+import type { TaskCard as CanonicalTaskCard, IssueType, TaskStatus } from "@openducktor/contracts";
 
-export type IssueType = "epic" | "feature" | "task" | "bug";
+export type { IssueType, TaskStatus };
 
 export type PlanSubtaskInput = {
   title: string;
-  issueType?: "task" | "feature" | "bug" | undefined;
+  issueType?: Exclude<IssueType, "epic"> | undefined;
   priority?: number | undefined;
   description?: string | undefined;
 };
 
-export type TaskCard = {
-  id: string;
-  title: string;
-  status: TaskStatus;
-  issueType: IssueType;
-  aiReviewEnabled: boolean;
-  parentId: string | null;
-};
+export type TaskCard = Pick<
+  CanonicalTaskCard,
+  "id" | "title" | "status" | "issueType" | "aiReviewEnabled" | "parentId"
+>;
 
 export type RawIssue = {
   id: string;

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -119,6 +119,6 @@ export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): Tas
     status: toTaskStatus(issue.status),
     issueType: normalizeIssueType(issue.issue_type),
     aiReviewEnabled: qaRequired,
-    parentId,
+    ...(parentId ? { parentId } : {}),
   };
 };

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -72,13 +72,13 @@ export const parseQaEntries = (value: unknown): QaEntry[] => {
   return parseTypedEntries(QaEntrySchema, value);
 };
 
-const normalizeParentId = (issue: RawIssue): string | null => {
+const normalizeParentId = (issue: RawIssue): string | undefined => {
   if (typeof issue.parent === "string" && issue.parent.trim().length > 0) {
     return issue.parent;
   }
 
   if (!Array.isArray(issue.dependencies)) {
-    return null;
+    return undefined;
   }
 
   for (const dependency of issue.dependencies) {
@@ -100,7 +100,7 @@ const normalizeParentId = (issue: RawIssue): string | null => {
     }
   }
 
-  return null;
+  return undefined;
 };
 
 export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): TaskCard => {
@@ -111,12 +111,14 @@ export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): Tas
       ? namespace.qaRequired
       : defaultQaRequiredForIssueType(normalizeIssueType(issue.issue_type));
 
+  const parentId = normalizeParentId(issue);
+
   return {
     id: issue.id,
     title: issue.title,
     status: toTaskStatus(issue.status),
     issueType: normalizeIssueType(issue.issue_type),
     aiReviewEnabled: qaRequired,
-    parentId: normalizeParentId(issue),
+    parentId,
   };
 };

--- a/packages/openducktor-mcp/src/tool-schemas.ts
+++ b/packages/openducktor-mcp/src/tool-schemas.ts
@@ -1,3 +1,4 @@
+import type { AgentToolName } from "@openducktor/contracts";
 import { z } from "zod";
 
 const PLAN_SUBTASK_PRIORITY_VALUES = [0, 1, 2, 3, 4] as const;
@@ -75,4 +76,4 @@ export const ODT_TOOL_SCHEMAS = {
   odt_build_completed: BuildCompletedInputSchema,
   odt_qa_approved: QaApprovedInputSchema,
   odt_qa_rejected: QaRejectedInputSchema,
-} as const;
+} as const satisfies Record<AgentToolName, z.ZodTypeAny>;

--- a/packages/openducktor-mcp/src/tool-schemas.ts
+++ b/packages/openducktor-mcp/src/tool-schemas.ts
@@ -1,4 +1,4 @@
-import type { AgentToolName } from "@openducktor/contracts";
+import { type AgentToolName, issueTypeSchema } from "@openducktor/contracts";
 import { z } from "zod";
 
 const PLAN_SUBTASK_PRIORITY_VALUES = [0, 1, 2, 3, 4] as const;
@@ -14,7 +14,9 @@ const PlanSubtaskPrioritySchema = z
 
 const PlanSubtaskSchema = z.object({
   title: z.string().trim().min(1),
-  issueType: z.enum(["task", "feature", "bug"]).optional(),
+  issueType: issueTypeSchema
+    .refine((value) => value !== "epic", "Epic subtasks are not allowed.")
+    .optional(),
   priority: PlanSubtaskPrioritySchema.optional(),
   description: z.string().optional(),
 });

--- a/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
@@ -35,7 +35,6 @@ const makeTask = (issueType: IssueType, status: TaskStatus): TaskCard => {
     issueType,
     status,
     aiReviewEnabled: true,
-    parentId: undefined,
   };
 };
 

--- a/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.contract.test.ts
@@ -35,7 +35,7 @@ const makeTask = (issueType: IssueType, status: TaskStatus): TaskCard => {
     issueType,
     status,
     aiReviewEnabled: true,
-    parentId: null,
+    parentId: undefined,
   };
 };
 

--- a/packages/openducktor-mcp/src/workflow-policy.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.ts
@@ -1,21 +1,9 @@
+import { taskStatusSchema } from "@openducktor/contracts";
 import type { IssueType, PlanSubtaskInput, TaskCard, TaskStatus } from "./contracts";
 
-const TASK_STATUS_VALUES: readonly TaskStatus[] = [
-  "open",
-  "spec_ready",
-  "ready_for_dev",
-  "in_progress",
-  "blocked",
-  "ai_review",
-  "human_review",
-  "deferred",
-  "closed",
-];
+const TASK_STATUS_SET = new Set<string>(taskStatusSchema.options);
 
-const TASK_STATUS_SET = new Set<TaskStatus>(TASK_STATUS_VALUES);
-
-const isTaskStatus = (value: string): value is TaskStatus =>
-  TASK_STATUS_SET.has(value as TaskStatus);
+const isTaskStatus = (value: string): value is TaskStatus => TASK_STATUS_SET.has(value);
 
 export const toTaskStatus = (value: unknown): TaskStatus => {
   if (typeof value !== "string") {
@@ -104,7 +92,7 @@ const canSetSpecFromStatus = (status: TaskStatus): boolean => {
 };
 
 const canSetPlan = (task: TaskCard): boolean => {
-  return isStatusAllowed(task.status, SET_PLAN_ALLOWED_STATUSES[task.issueType]);
+  return isStatusAllowed(task.status, SET_PLAN_ALLOWED_STATUSES[task.issueType] ?? []);
 };
 
 export const canReplaceEpicSubtaskStatus = (status: TaskStatus): boolean => {


### PR DESCRIPTION
## Summary
Consolidates duplicated workflow/domain type definitions across `packages/contracts`, `packages/core`, and `packages/openducktor-mcp` so role/scenario/tool/status definitions come from canonical contracts sources.

## Changes
- Added canonical workflow enums/schemas/constants in `@openducktor/contracts` (`agent-workflow-schemas.ts`) and exported them via the barrel.
- Updated session schemas to reuse canonical workflow schemas instead of redefining literals.
- Replaced `core` local unions for `AgentRole` / `AgentScenario` / `AgentToolName` with contract-derived types.
- Updated `core` workflow tool normalization to use canonical tool name values.
- Refactored MCP local contracts to derive `TaskStatus` / `IssueType` from contracts and simplify `TaskCard` typing.
- Replaced MCP status literal set with canonical `taskStatusSchema` source.
- Bound MCP tool schema map keys to canonical `AgentToolName` and reused canonical `issueTypeSchema` for plan subtasks (excluding `epic`).
- Updated export/policy contract tests to reflect the canonical API surface.

## Validation
- `bun run --filter @openducktor/contracts typecheck`
- `bun run --filter @openducktor/contracts test`
- `bun run --filter @openducktor/contracts lint`
- `bun run --filter @openducktor/core typecheck`
- `bun run --filter @openducktor/core test`
- `bun run --filter @openducktor/core lint`
- `bun run --filter @openducktor/openducktor-mcp typecheck`
- `bun run --filter @openducktor/openducktor-mcp test`
- `bun run --filter @openducktor/openducktor-mcp lint`
