### PR TITLE
fix(desktop): add aria-label to create session icon button

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.tsx
@@ -200,6 +200,7 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
                 className="h-9 w-9 rounded-md"
                 disabled={!agentStudioReady || createSessionDisabled}
                 title="Create session"
+                aria-label="Create session"
               >
                 {isCreatingSession ? (
                   <LoaderCircle className="size-4 animate-spin" />


### PR DESCRIPTION
## Summary
- add an explicit accessible name to the icon-only Create session button in Agent Studio header
- keep existing tooltip title behavior unchanged

## Why
- title alone is not a reliable accessible name for icon-only controls across assistive tech
- fixes WCAG 4.1.2 Name, Role, Value issue raised by static analysis

## Validation
- bun run --filter @openducktor/desktop typecheck