### PR TITLE
fix(desktop): add dark mode variants to kanban summary cards

### DIFF
--- a/apps/desktop/src/components/features/kanban/kanban-summary-cards.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-summary-cards.tsx
@@ -17,7 +17,7 @@ export function KanbanSummaryCards({
 }: KanbanSummaryCardsProps): ReactElement {
   return (
     <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-      <Card className="animate-rise-in border-sky-200 bg-sky-50">
+      <Card className="animate-rise-in border-sky-200 dark:border-sky-800 bg-sky-50 dark:bg-sky-950/50">
         <CardHeader className="pb-2">
           <CardTitle className="text-sm text-foreground">Total Tasks</CardTitle>
           <CardDescription>All lanes</CardDescription>
@@ -27,10 +27,10 @@ export function KanbanSummaryCards({
         </CardContent>
       </Card>
 
-      <Card className="animate-rise-in border-amber-200 bg-amber-50">
+      <Card className="animate-rise-in border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/50">
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-sm text-foreground">
-            <Clock3 className="size-4 text-amber-600" />
+            <Clock3 className="size-4 text-amber-600 dark:text-amber-300" />
             Active Runs
           </CardTitle>
           <CardDescription>Builder execution in-flight</CardDescription>
@@ -40,10 +40,10 @@ export function KanbanSummaryCards({
         </CardContent>
       </Card>
 
-      <Card className="animate-rise-in border-rose-200 bg-rose-50">
+      <Card className="animate-rise-in border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/50">
         <CardHeader className="pb-2">
           <CardTitle className="flex items-center gap-2 text-sm text-foreground">
-            <ShieldAlert className="size-4 text-rose-600" />
+            <ShieldAlert className="size-4 text-rose-600 dark:text-rose-300" />
             Blocked
           </CardTitle>
           <CardDescription>Needs human decision</CardDescription>
@@ -53,7 +53,7 @@ export function KanbanSummaryCards({
         </CardContent>
       </Card>
 
-      <Card className="animate-rise-in border-emerald-200 bg-emerald-50">
+      <Card className="animate-rise-in border-emerald-200 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950/50">
         <CardHeader className="pb-2">
           <CardTitle className="text-sm text-foreground">Done</CardTitle>
           <CardDescription>Closed successfully</CardDescription>


### PR DESCRIPTION
## Summary
- add dark-mode border/background variants to Kanban summary cards for sky/amber/rose/emerald status cards
- add dark-mode icon color variants for amber and rose status icons to preserve contrast
- align styling with existing status card patterns used in Kanban and Agent Studio

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint