### PR TITLE
refactor(desktop): split AgentsPage composition root into focused controller slices

### DIFF
--- a/apps/desktop/src/pages/agents-page.tsx
+++ b/apps/desktop/src/pages/agents-page.tsx
@@ -4,7 +4,6 @@ import {
   startTransition,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -19,35 +18,17 @@ import {
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { useAgentState, useChecksState, useTasksState, useWorkspaceState } from "@/state";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
-import { firstScenario, SCENARIO_LABELS, SCENARIOS_BY_ROLE } from "./agents-page-constants";
-import { resolveAgentStudioActiveSession, resolveAgentStudioTaskId } from "./agents-page-selection";
-import { useAgentSessionPermissionActions } from "./use-agent-session-permission-actions";
-import { useAgentStudioDocuments } from "./use-agent-studio-documents";
-import { useAgentStudioModelSelection } from "./use-agent-studio-model-selection";
-import { useAgentStudioPageModels } from "./use-agent-studio-page-models";
+import { SCENARIO_LABELS } from "./agents-page-constants";
+import { useAgentStudioOrchestrationController } from "./use-agent-studio-orchestration-controller";
+import { useAgentStudioQuerySessionSync } from "./use-agent-studio-query-session-sync";
 import { useAgentStudioQuerySync } from "./use-agent-studio-query-sync";
-import { useAgentStudioRepoSettings } from "./use-agent-studio-repo-settings";
-import { useAgentStudioRightPanel } from "./use-agent-studio-right-panel";
-import {
-  type NewSessionStartDecision,
-  type NewSessionStartRequest,
-  useAgentStudioSessionActions,
+import { useAgentStudioSelectionController } from "./use-agent-studio-selection-controller";
+import type {
+  NewSessionStartDecision,
+  NewSessionStartRequest,
 } from "./use-agent-studio-session-actions";
-import { useAgentStudioTaskHydration } from "./use-agent-studio-task-hydration";
-import { useAgentStudioTaskTabs } from "./use-agent-studio-task-tabs";
 import { useSessionStartModalState } from "./use-session-start-modal-state";
-
-const compareSessionsByRecency = (left: AgentSessionState, right: AgentSessionState): number => {
-  if (left.startedAt !== right.startedAt) {
-    return left.startedAt > right.startedAt ? -1 : 1;
-  }
-  if (left.sessionId === right.sessionId) {
-    return 0;
-  }
-  return left.sessionId > right.sessionId ? -1 : 1;
-};
 
 const ROLE_LABEL_BY_ROLE: Record<AgentRole, string> = {
   spec: "Spec",
@@ -242,60 +223,46 @@ export function AgentsPage(): ReactElement {
     [updateQuery],
   );
 
-  const tasksById = useMemo(() => {
-    return new Map(tasks.map((task) => [task.id, task]));
-  }, [tasks]);
+  const clearComposerInput = useCallback((): void => {
+    setInput("");
+  }, []);
 
-  const sessionsById = useMemo(() => {
-    return new Map(sessions.map((session) => [session.sessionId, session]));
-  }, [sessions]);
+  const signalContextSwitchIntent = useCallback((): void => {
+    setContextSwitchVersion((current) => current + 1);
+  }, []);
 
-  const sessionsByTaskId = useMemo(() => {
-    const grouped = new Map<string, AgentSessionState[]>();
-    for (const session of sessions) {
-      const current = grouped.get(session.taskId);
-      if (current) {
-        current.push(session);
-      } else {
-        grouped.set(session.taskId, [session]);
-      }
-    }
-    for (const group of grouped.values()) {
-      group.sort(compareSessionsByRecency);
-    }
-    return grouped;
-  }, [sessions]);
-
-  const selectedSessionById = useMemo(
-    () => (sessionParam ? (sessionsById.get(sessionParam) ?? null) : null),
-    [sessionParam, sessionsById],
-  );
-
-  const taskId = resolveAgentStudioTaskId({
+  const selection = useAgentStudioSelectionController({
+    activeRepo,
+    tasks,
+    isLoadingTasks,
+    sessions,
     taskIdParam,
-    selectedSessionById,
+    sessionParam,
+    hasExplicitRoleParam,
+    roleFromQuery,
+    scenarioFromQuery,
+    sessionStartPreference,
+    updateQuery,
+    loadAgentSessions,
+    clearComposerInput,
+    onContextSwitchIntent: signalContextSwitchIntent,
   });
-  const selectedTask = useMemo(
-    () => (taskId ? (tasksById.get(taskId) ?? null) : null),
-    [taskId, tasksById],
-  );
 
-  const sessionsForTask = useMemo(() => {
-    if (!taskId) {
-      return [];
-    }
-    return sessionsByTaskId.get(taskId) ?? [];
-  }, [sessionsByTaskId, taskId]);
-
-  const activeSession = useMemo(() => {
-    return resolveAgentStudioActiveSession({
-      sessionsForTask,
-      sessionParam,
-      hasExplicitRoleParam,
-      roleFromQuery,
-      sessionStartPreference,
-    });
-  }, [hasExplicitRoleParam, roleFromQuery, sessionStartPreference, sessionParam, sessionsForTask]);
+  useAgentStudioQuerySessionSync({
+    isLoadingTasks,
+    tasks,
+    taskIdParam,
+    sessionParam,
+    selectedSessionById: selection.selectedSessionById,
+    taskId: selection.taskId,
+    activeSession: selection.activeSession,
+    autostart,
+    roleFromQuery,
+    scenarioFromQuery,
+    sessionStartPreference,
+    isActiveTaskHydrated: selection.isActiveTaskHydrated,
+    scheduleQueryUpdate,
+  });
 
   const agentStudioReady = Boolean(
     activeRepo && opencodeHealth?.runtimeOk && opencodeHealth?.mcpOk,
@@ -310,392 +277,68 @@ export function AgentsPage(): ReactElement {
           ? "Checking OpenCode and OpenDucktor MCP health..."
           : "OpenCode runtime or OpenDucktor MCP is not ready.";
 
-  const sessionByTaskId = useMemo(() => {
-    const latestByTask = new Map<string, AgentSessionState>();
-    for (const [taskKey, taskSessions] of sessionsByTaskId) {
-      const latestSession = taskSessions[0];
-      if (latestSession) {
-        latestByTask.set(taskKey, latestSession);
-      }
-    }
-    return latestByTask;
-  }, [sessionsByTaskId]);
-
-  const clearComposerInput = useCallback((): void => {
-    setInput("");
-  }, []);
-
-  const signalContextSwitchIntent = useCallback((): void => {
-    setContextSwitchVersion((current) => current + 1);
-  }, []);
-
-  const {
-    activeTaskTabId,
-    availableTabTasks,
-    taskTabs,
-    handleSelectTab,
-    handleCreateTab,
-    handleCloseTab,
-  } = useAgentStudioTaskTabs({
-    activeRepo,
-    taskId,
-    selectedTask,
-    tasks,
-    isLoadingTasks,
-    latestSessionByTaskId: sessionByTaskId,
-    updateQuery,
-    clearComposerInput,
-    onContextSwitchIntent: signalContextSwitchIntent,
-  });
-
-  const viewTaskId = activeTaskTabId || taskId;
-  const viewSelectedTask = useMemo(
-    () => (viewTaskId ? (tasksById.get(viewTaskId) ?? null) : null),
-    [tasksById, viewTaskId],
-  );
-  const viewSessionsForTask = useMemo(() => {
-    if (!viewTaskId) {
-      return [];
-    }
-    return sessionsByTaskId.get(viewTaskId) ?? [];
-  }, [sessionsByTaskId, viewTaskId]);
-
-  const viewSessionParam = useMemo(() => {
-    if (!sessionParam) {
-      return null;
-    }
-
-    const belongsToViewTask = viewSessionsForTask.some(
-      (session) => session.sessionId === sessionParam,
-    );
-    return belongsToViewTask ? sessionParam : null;
-  }, [sessionParam, viewSessionsForTask]);
-
-  const isViewTaskDetachedFromQuery = Boolean(viewTaskId && taskId && viewTaskId !== taskId);
-
-  const hasViewRoleSelection = hasExplicitRoleParam && !isViewTaskDetachedFromQuery;
-
-  const normalizedSessionStartPreference = sessionStartPreference ?? null;
-  const viewSessionStartPreference = isViewTaskDetachedFromQuery
-    ? null
-    : normalizedSessionStartPreference;
-
-  const viewActiveSession = useMemo(() => {
-    return resolveAgentStudioActiveSession({
-      sessionsForTask: viewSessionsForTask,
-      sessionParam: viewSessionParam,
-      hasExplicitRoleParam: hasViewRoleSelection,
-      roleFromQuery,
-      sessionStartPreference: viewSessionStartPreference,
-    });
-  }, [
-    hasViewRoleSelection,
-    roleFromQuery,
-    viewSessionStartPreference,
-    viewSessionParam,
-    viewSessionsForTask,
-  ]);
-
-  const viewRole: AgentRole = hasViewRoleSelection
-    ? roleFromQuery
-    : (viewActiveSession?.role ??
-      viewSessionsForTask[0]?.role ??
-      (isViewTaskDetachedFromQuery ? "spec" : roleFromQuery));
-  const viewScenarios = SCENARIOS_BY_ROLE[viewRole];
-  const viewScenario = hasViewRoleSelection
-    ? scenarioFromQuery && viewScenarios.includes(scenarioFromQuery)
-      ? scenarioFromQuery
-      : firstScenario(viewRole)
-    : viewActiveSession?.scenario && viewScenarios.includes(viewActiveSession.scenario)
-      ? viewActiveSession.scenario
-      : firstScenario(viewRole);
-
-  const hydratedTasksByRepoAndTask = useAgentStudioTaskHydration({
-    activeRepo,
-    activeTaskId: viewTaskId,
-    activeSessionId: viewActiveSession?.sessionId ?? null,
-    loadAgentSessions,
-  });
-
-  const taskHydrationKey = activeRepo && viewTaskId ? `${activeRepo}:${viewTaskId}` : "";
-  const isActiveTaskHydrated = taskHydrationKey
-    ? (hydratedTasksByRepoAndTask[taskHydrationKey] ?? false)
-    : false;
-
-  useEffect(() => {
-    if (isLoadingTasks) {
-      return;
-    }
-    if (!taskIdParam || selectedSessionById) {
-      return;
-    }
-    if (tasks.some((entry) => entry.id === taskIdParam)) {
-      return;
-    }
-    scheduleQueryUpdate({
-      task: undefined,
-      session: undefined,
-      agent: undefined,
-      scenario: undefined,
-      autostart: undefined,
-      start: undefined,
-    });
-  }, [isLoadingTasks, scheduleQueryUpdate, selectedSessionById, taskIdParam, tasks]);
-
-  useEffect(() => {
-    if (!selectedSessionById || taskIdParam) {
-      return;
-    }
-    scheduleQueryUpdate({ task: selectedSessionById.taskId });
-  }, [scheduleQueryUpdate, selectedSessionById, taskIdParam]);
-
-  useEffect(() => {
-    if (!sessionParam) {
-      return;
-    }
-    if (selectedSessionById && taskId && selectedSessionById.taskId !== taskId) {
-      scheduleQueryUpdate({ session: undefined });
-      return;
-    }
-    if (!taskId || !isActiveTaskHydrated) {
-      return;
-    }
-    if (selectedSessionById && selectedSessionById.taskId === taskId) {
-      return;
-    }
-    scheduleQueryUpdate({ session: undefined });
-  }, [isActiveTaskHydrated, scheduleQueryUpdate, selectedSessionById, sessionParam, taskId]);
-
-  useEffect(() => {
-    if (!activeSession) {
-      return;
-    }
-
-    const updates: Record<string, string | undefined> = {};
-    if (taskIdParam !== activeSession.taskId) {
-      updates.task = activeSession.taskId;
-    }
-    if (sessionParam !== activeSession.sessionId) {
-      updates.session = activeSession.sessionId;
-    }
-    if (roleFromQuery !== activeSession.role) {
-      updates.agent = activeSession.role;
-    }
-    if (scenarioFromQuery !== activeSession.scenario) {
-      updates.scenario = activeSession.scenario;
-    }
-    if (autostart) {
-      updates.autostart = undefined;
-    }
-    if (sessionStartPreference) {
-      updates.start = undefined;
-    }
-
-    if (Object.keys(updates).length === 0) {
-      return;
-    }
-    scheduleQueryUpdate(updates);
-  }, [
-    activeSession,
-    autostart,
-    roleFromQuery,
-    scheduleQueryUpdate,
-    scenarioFromQuery,
-    sessionParam,
-    sessionStartPreference,
-    taskIdParam,
-  ]);
-
-  const { repoSettings } = useAgentStudioRepoSettings({
+  const orchestration = useAgentStudioOrchestrationController({
     activeRepo,
     loadRepoSettings,
-  });
-
-  const { specDoc, planDoc, qaDoc } = useAgentStudioDocuments({
-    activeRepo,
-    taskId: viewTaskId,
-    activeSession: viewActiveSession,
-    selectedTask: viewSelectedTask,
-  });
-
-  const {
-    selectionForNewSession,
-    selectedModelSelection,
-    isSelectionCatalogLoading,
-    agentOptions,
-    modelOptions,
-    modelGroups,
-    variantOptions,
-    activeSessionAgentColors,
-    activeSessionContextUsage,
-    handleSelectAgent,
-    handleSelectModel,
-    handleSelectVariant,
-  } = useAgentStudioModelSelection({
-    activeRepo,
-    activeSession: viewActiveSession,
-    role: viewRole,
-    repoSettings,
-    updateAgentSessionModel,
-  });
-
-  const {
-    isStarting,
-    isSending,
-    isSubmittingQuestionByRequestId,
-    isSessionWorking,
-    canKickoffNewSession,
-    kickoffLabel,
-    canStopSession,
-    startScenarioKickoff,
-    onSend,
-    onSubmitQuestionAnswers,
-    handleWorkflowStepSelect,
-    handleSessionSelectionChange,
-    handleCreateSession,
-  } = useAgentStudioSessionActions({
-    activeRepo,
-    taskId: viewTaskId,
-    role: viewRole,
-    scenario: viewScenario,
-    autostart: false,
-    sessionStartPreference: null,
-    activeSession: viewActiveSession,
-    sessionsForTask: viewSessionsForTask,
-    selectedTask: viewSelectedTask,
+    viewTaskId: selection.viewTaskId,
+    viewRole: selection.viewRole,
+    viewScenario: selection.viewScenario,
+    viewSelectedTask: selection.viewSelectedTask,
+    viewSessionsForTask: selection.viewSessionsForTask,
+    viewActiveSession: selection.viewActiveSession,
+    activeTaskTabId: selection.activeTaskTabId,
+    taskTabs: selection.taskTabs,
+    availableTabTasks: selection.availableTabTasks,
+    contextSwitchVersion,
+    isLoadingTasks,
+    isActiveTaskHydrated: selection.isActiveTaskHydrated,
     agentStudioReady,
-    isActiveTaskHydrated,
-    selectionForNewSession,
+    agentStudioBlockedReason,
+    isLoadingChecks,
+    refreshChecks,
     input,
     setInput,
-    startAgentSession,
-    sendAgentMessage,
-    updateAgentSessionModel,
-    answerAgentQuestion,
     updateQuery,
     onContextSwitchIntent: signalContextSwitchIntent,
+    onCreateTab: selection.handleCreateTab,
+    onCloseTab: selection.handleCloseTab,
+    startAgentSession,
+    sendAgentMessage,
+    stopAgentSession,
+    updateAgentSessionModel,
+    replyAgentPermission,
+    answerAgentQuestion,
     requestNewSessionStart,
-  });
-
-  const { isSubmittingPermissionByRequestId, permissionReplyErrorByRequestId, onReplyPermission } =
-    useAgentSessionPermissionActions({
-      activeSessionId: viewActiveSession?.sessionId ?? null,
-      pendingPermissions: viewActiveSession?.pendingPermissions ?? [],
-      agentStudioReady,
-      replyAgentPermission,
-    });
-
-  const {
-    activeTabValue,
-    agentStudioTaskTabsModel,
-    agentStudioHeaderModel,
-    agentStudioWorkspaceSidebarModel,
-    agentChatModel,
-  } = useAgentStudioPageModels({
-    core: {
-      activeTabValue: activeTaskTabId || viewTaskId || "__agent_studio_empty__",
-      taskId: viewTaskId,
-      role: viewRole,
-      selectedTask: viewSelectedTask,
-      sessionsForTask: viewSessionsForTask,
-      contextSessionsLength: viewSessionsForTask.length,
-      activeSession: viewActiveSession,
-      isTaskHydrating: Boolean(viewTaskId && !isActiveTaskHydrated),
-      contextSwitchVersion,
-    },
-    taskTabs: {
-      taskTabs,
-      availableTabTasks,
-      isLoadingTasks,
-      onCreateTab: handleCreateTab,
-      onCloseTab: handleCloseTab,
-    },
-    documents: {
-      specDoc,
-      planDoc,
-      qaDoc,
-    },
-    readiness: {
-      agentStudioReady,
-      agentStudioBlockedReason,
-      isLoadingChecks,
-      refreshChecks,
-    },
-    sessionActions: {
-      handleWorkflowStepSelect,
-      handleSessionSelectionChange,
-      handleCreateSession,
-      isStarting,
-      isSending,
-      isSessionWorking,
-      canKickoffNewSession,
-      kickoffLabel,
-      canStopSession,
-      startScenarioKickoff,
-      onSend,
-      onSubmitQuestionAnswers,
-      isSubmittingQuestionByRequestId,
-      stopAgentSession,
-    },
-    modelSelection: {
-      selectedModelSelection,
-      isSelectionCatalogLoading,
-      agentOptions,
-      modelOptions,
-      modelGroups,
-      variantOptions,
-      onSelectAgent: handleSelectAgent,
-      onSelectModel: handleSelectModel,
-      onSelectVariant: handleSelectVariant,
-      activeSessionAgentColors,
-      activeSessionContextUsage,
-    },
-    permissions: {
-      isSubmittingPermissionByRequestId,
-      permissionReplyErrorByRequestId,
-      onReplyPermission,
-    },
-    composer: {
-      input,
-      setInput,
-    },
-  });
-
-  const rightPanel = useAgentStudioRightPanel({
-    role: viewRole,
-    hasTaskContext: Boolean(viewTaskId),
-    hasDocumentPanel: Boolean(agentStudioWorkspaceSidebarModel.activeDocument),
-    hasDiffPanel: false,
   });
 
   return (
     <Tabs
-      value={activeTabValue}
-      onValueChange={handleSelectTab}
+      value={orchestration.activeTabValue}
+      onValueChange={selection.handleSelectTab}
       className="h-full min-h-0 max-h-full gap-0 overflow-hidden bg-card"
     >
       <AgentStudioTaskTabs
-        model={agentStudioTaskTabsModel}
-        rightPanelToggleModel={rightPanel.rightPanelToggleModel}
+        model={orchestration.agentStudioTaskTabsModel}
+        rightPanelToggleModel={orchestration.rightPanel.rightPanelToggleModel}
       />
 
-      <TabsContent value={activeTabValue} className="m-0 min-h-0 flex-1 bg-card p-0">
-        {viewTaskId ? (
+      <TabsContent value={orchestration.activeTabValue} className="m-0 min-h-0 flex-1 bg-card p-0">
+        {selection.viewTaskId ? (
           <ResizablePanelGroup direction="horizontal" className="h-full min-h-0 overflow-hidden">
             <ResizablePanel defaultSize={63} minSize={35}>
               <AgentChat
-                header={<AgentStudioHeader model={agentStudioHeaderModel} />}
-                model={agentChatModel}
+                header={<AgentStudioHeader model={orchestration.agentStudioHeaderModel} />}
+                model={orchestration.agentChatModel}
               />
             </ResizablePanel>
-            {rightPanel.panelKind && rightPanel.isPanelOpen ? (
+            {orchestration.rightPanel.panelKind && orchestration.rightPanel.isPanelOpen ? (
               <>
                 <ResizableHandle withHandle />
                 <ResizablePanel defaultSize={37} minSize={30}>
                   <AgentStudioRightPanel
                     model={{
-                      kind: rightPanel.panelKind,
-                      documentsModel: agentStudioWorkspaceSidebarModel,
+                      kind: orchestration.rightPanel.panelKind,
+                      documentsModel: orchestration.agentStudioWorkspaceSidebarModel,
                     }}
                   />
                 </ResizablePanel>
@@ -712,7 +355,7 @@ export function AgentsPage(): ReactElement {
         <AgentStudioSessionStartModal
           request={pendingSessionStartRequest}
           activeRepo={activeRepo}
-          repoSettings={repoSettings}
+          repoSettings={orchestration.repoSettings}
           onCancel={() => resolvePendingSessionStart(null)}
           onConfirm={resolvePendingSessionStart}
         />

--- a/apps/desktop/src/pages/agents-page.tsx
+++ b/apps/desktop/src/pages/agents-page.tsx
@@ -20,7 +20,14 @@ import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { useAgentState, useChecksState, useTasksState, useWorkspaceState } from "@/state";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import { SCENARIO_LABELS } from "./agents-page-constants";
-import { useAgentStudioOrchestrationController } from "./use-agent-studio-orchestration-controller";
+import {
+  type AgentStudioOrchestrationActionsContext,
+  type AgentStudioOrchestrationComposerContext,
+  type AgentStudioOrchestrationReadinessContext,
+  type AgentStudioOrchestrationSelectionContext,
+  type AgentStudioOrchestrationWorkspaceContext,
+  useAgentStudioOrchestrationController,
+} from "./use-agent-studio-orchestration-controller";
 import { useAgentStudioQuerySessionSync } from "./use-agent-studio-query-session-sync";
 import { useAgentStudioQuerySync } from "./use-agent-studio-query-sync";
 import { useAgentStudioSelectionController } from "./use-agent-studio-selection-controller";
@@ -28,6 +35,7 @@ import type {
   NewSessionStartDecision,
   NewSessionStartRequest,
 } from "./use-agent-studio-session-actions";
+import { useAgentStudioSessionStartRequest } from "./use-agent-studio-session-start-request";
 import { useSessionStartModalState } from "./use-session-start-modal-state";
 
 const ROLE_LABEL_BY_ROLE: Record<AgentRole, string> = {
@@ -168,36 +176,8 @@ export function AgentsPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const [input, setInput] = useState("");
   const [contextSwitchVersion, setContextSwitchVersion] = useState(0);
-  const [pendingSessionStartRequest, setPendingSessionStartRequest] =
-    useState<NewSessionStartRequest | null>(null);
-  const pendingSessionStartResolverRef = useRef<
-    ((decision: NewSessionStartDecision) => void) | null
-  >(null);
-
-  const resolvePendingSessionStart = useCallback((decision: NewSessionStartDecision): void => {
-    const resolver = pendingSessionStartResolverRef.current;
-    pendingSessionStartResolverRef.current = null;
-    setPendingSessionStartRequest(null);
-    resolver?.(decision);
-  }, []);
-
-  const requestNewSessionStart = useCallback(
-    (request: NewSessionStartRequest): Promise<NewSessionStartDecision> => {
-      pendingSessionStartResolverRef.current?.(null);
-      return new Promise((resolve) => {
-        pendingSessionStartResolverRef.current = resolve;
-        setPendingSessionStartRequest(request);
-      });
-    },
-    [],
-  );
-
-  useEffect(() => {
-    return () => {
-      pendingSessionStartResolverRef.current?.(null);
-      pendingSessionStartResolverRef.current = null;
-    };
-  }, []);
+  const { pendingSessionStartRequest, requestNewSessionStart, resolvePendingSessionStart } =
+    useAgentStudioSessionStartRequest();
 
   const {
     taskIdParam,
@@ -277,9 +257,12 @@ export function AgentsPage(): ReactElement {
           ? "Checking OpenCode and OpenDucktor MCP health..."
           : "OpenCode runtime or OpenDucktor MCP is not ready.";
 
-  const orchestration = useAgentStudioOrchestrationController({
+  const orchestrationWorkspace = {
     activeRepo,
     loadRepoSettings,
+  } satisfies AgentStudioOrchestrationWorkspaceContext;
+
+  const orchestrationSelection = {
     viewTaskId: selection.viewTaskId,
     viewRole: selection.viewRole,
     viewScenario: selection.viewScenario,
@@ -292,16 +275,25 @@ export function AgentsPage(): ReactElement {
     contextSwitchVersion,
     isLoadingTasks,
     isActiveTaskHydrated: selection.isActiveTaskHydrated,
+    onCreateTab: selection.handleCreateTab,
+    onCloseTab: selection.handleCloseTab,
+  } satisfies AgentStudioOrchestrationSelectionContext;
+
+  const orchestrationReadiness = {
     agentStudioReady,
     agentStudioBlockedReason,
     isLoadingChecks,
     refreshChecks,
+  } satisfies AgentStudioOrchestrationReadinessContext;
+
+  const orchestrationComposer = {
     input,
     setInput,
+  } satisfies AgentStudioOrchestrationComposerContext;
+
+  const orchestrationActions = {
     updateQuery,
     onContextSwitchIntent: signalContextSwitchIntent,
-    onCreateTab: selection.handleCreateTab,
-    onCloseTab: selection.handleCloseTab,
     startAgentSession,
     sendAgentMessage,
     stopAgentSession,
@@ -309,6 +301,14 @@ export function AgentsPage(): ReactElement {
     replyAgentPermission,
     answerAgentQuestion,
     requestNewSessionStart,
+  } satisfies AgentStudioOrchestrationActionsContext;
+
+  const orchestration = useAgentStudioOrchestrationController({
+    workspace: orchestrationWorkspace,
+    selection: orchestrationSelection,
+    readiness: orchestrationReadiness,
+    composer: orchestrationComposer,
+    actions: orchestrationActions,
   });
 
   return (

--- a/apps/desktop/src/pages/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/use-agent-studio-orchestration-controller.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { createAgentSessionFixture, createTaskCardFixture } from "./agent-studio-test-utils";
+import { buildAgentStudioPageModelsArgs } from "./use-agent-studio-orchestration-controller";
+
+const taskDocument = {
+  markdown: "# doc",
+  updatedAt: "2026-02-22T10:00:00.000Z",
+  isLoading: false,
+  error: null,
+  loaded: true,
+};
+
+describe("buildAgentStudioPageModelsArgs", () => {
+  test("maps grouped orchestration context into page-model contracts", () => {
+    const task = createTaskCardFixture({ id: "task-1", title: "Task 1" });
+    const session = createAgentSessionFixture({
+      sessionId: "session-1",
+      taskId: "task-1",
+      role: "planner",
+      scenario: "planner_initial",
+    });
+
+    const onCreateTab = () => {};
+    const onCloseTab = () => {};
+    const onSelectAgent = () => {};
+    const onSelectModel = () => {};
+    const onSelectVariant = () => {};
+
+    const mapped = buildAgentStudioPageModelsArgs({
+      viewTaskId: "task-1",
+      viewRole: "planner",
+      viewSelectedTask: task,
+      viewSessionsForTask: [session],
+      viewActiveSession: session,
+      activeTaskTabId: "task-1",
+      taskTabs: [],
+      availableTabTasks: [task],
+      onCreateTab,
+      onCloseTab,
+      contextSwitchVersion: 4,
+      isLoadingTasks: false,
+      isActiveTaskHydrated: true,
+      specDoc: taskDocument,
+      planDoc: taskDocument,
+      qaDoc: taskDocument,
+      readiness: {
+        agentStudioReady: true,
+        agentStudioBlockedReason: "",
+        isLoadingChecks: false,
+        refreshChecks: async () => {},
+      },
+      sessionActions: {
+        handleWorkflowStepSelect: () => {},
+        handleSessionSelectionChange: () => {},
+        handleCreateSession: () => {},
+        isStarting: false,
+        isSending: false,
+        isSessionWorking: false,
+        canKickoffNewSession: false,
+        kickoffLabel: "Kickoff",
+        canStopSession: false,
+        startScenarioKickoff: async () => {},
+        onSend: async () => {},
+        onSubmitQuestionAnswers: async () => {},
+        isSubmittingQuestionByRequestId: {},
+        stopAgentSession: async () => {},
+      },
+      modelSelection: {
+        selectedModelSelection: null,
+        isSelectionCatalogLoading: false,
+        agentOptions: [],
+        modelOptions: [],
+        modelGroups: [],
+        variantOptions: [],
+        onSelectAgent,
+        onSelectModel,
+        onSelectVariant,
+        activeSessionAgentColors: {},
+        activeSessionContextUsage: null,
+      },
+      permissions: {
+        isSubmittingPermissionByRequestId: {},
+        permissionReplyErrorByRequestId: {},
+        onReplyPermission: async () => {},
+      },
+      composer: {
+        input: "hello",
+        setInput: () => {},
+      },
+    });
+
+    expect(mapped.core.role).toBe("planner");
+    expect(mapped.core.contextSwitchVersion).toBe(4);
+    expect(mapped.taskTabs.onCreateTab).toBe(onCreateTab);
+    expect(mapped.taskTabs.onCloseTab).toBe(onCloseTab);
+    expect(mapped.documents.planDoc.markdown).toBe("# doc");
+    expect(mapped.modelSelection.onSelectAgent).toBe(onSelectAgent);
+    expect(mapped.modelSelection.onSelectModel).toBe(onSelectModel);
+    expect(mapped.modelSelection.onSelectVariant).toBe(onSelectVariant);
+    expect(mapped.composer.input).toBe("hello");
+  });
+});

--- a/apps/desktop/src/pages/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/use-agent-studio-orchestration-controller.ts
@@ -14,9 +14,12 @@ import type { RequestNewSessionStart } from "./use-agent-studio-session-start-ty
 
 type QueryUpdate = Record<string, string | undefined>;
 
-type UseAgentStudioOrchestrationControllerArgs = {
+export type AgentStudioOrchestrationWorkspaceContext = {
   activeRepo: string | null;
   loadRepoSettings: () => Promise<RepoSettingsInput>;
+};
+
+export type AgentStudioOrchestrationSelectionContext = {
   viewTaskId: string;
   viewRole: AgentRole;
   viewScenario: AgentScenario;
@@ -29,16 +32,25 @@ type UseAgentStudioOrchestrationControllerArgs = {
   contextSwitchVersion: number;
   isLoadingTasks: boolean;
   isActiveTaskHydrated: boolean;
+  onCreateTab: (taskId: string) => void;
+  onCloseTab: (taskId: string) => void;
+};
+
+export type AgentStudioOrchestrationReadinessContext = {
   agentStudioReady: boolean;
   agentStudioBlockedReason: string;
   isLoadingChecks: boolean;
   refreshChecks: () => Promise<void>;
+};
+
+export type AgentStudioOrchestrationComposerContext = {
   input: string;
   setInput: (value: string) => void;
+};
+
+export type AgentStudioOrchestrationActionsContext = {
   updateQuery: (updates: QueryUpdate) => void;
   onContextSwitchIntent: () => void;
-  onCreateTab: (taskId: string) => void;
-  onCloseTab: (taskId: string) => void;
   startAgentSession: AgentStateContextValue["startAgentSession"];
   sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
   stopAgentSession: AgentStateContextValue["stopAgentSession"];
@@ -46,6 +58,14 @@ type UseAgentStudioOrchestrationControllerArgs = {
   replyAgentPermission: AgentStateContextValue["replyAgentPermission"];
   answerAgentQuestion: AgentStateContextValue["answerAgentQuestion"];
   requestNewSessionStart?: RequestNewSessionStart;
+};
+
+type UseAgentStudioOrchestrationControllerArgs = {
+  workspace: AgentStudioOrchestrationWorkspaceContext;
+  selection: AgentStudioOrchestrationSelectionContext;
+  readiness: AgentStudioOrchestrationReadinessContext;
+  composer: AgentStudioOrchestrationComposerContext;
+  actions: AgentStudioOrchestrationActionsContext;
 };
 
 type UseAgentStudioOrchestrationControllerResult = {
@@ -60,39 +80,143 @@ type UseAgentStudioOrchestrationControllerResult = {
   rightPanel: ReturnType<typeof useAgentStudioRightPanel>;
 };
 
-export function useAgentStudioOrchestrationController({
-  activeRepo,
-  loadRepoSettings,
+type BuildAgentStudioPageModelsArgsInput = {
+  viewTaskId: string;
+  viewRole: AgentRole;
+  viewSelectedTask: TaskCard | null;
+  viewSessionsForTask: AgentSessionState[];
+  viewActiveSession: AgentSessionState | null;
+  activeTaskTabId: string;
+  taskTabs: AgentStudioTaskTabsModel["tabs"];
+  availableTabTasks: TaskCard[];
+  onCreateTab: (taskId: string) => void;
+  onCloseTab: (taskId: string) => void;
+  contextSwitchVersion: number;
+  isLoadingTasks: boolean;
+  isActiveTaskHydrated: boolean;
+  specDoc: ReturnType<typeof useAgentStudioDocuments>["specDoc"];
+  planDoc: ReturnType<typeof useAgentStudioDocuments>["planDoc"];
+  qaDoc: ReturnType<typeof useAgentStudioDocuments>["qaDoc"];
+  readiness: AgentStudioOrchestrationReadinessContext;
+  sessionActions: ReturnType<typeof useAgentStudioSessionActions> & {
+    stopAgentSession: AgentStateContextValue["stopAgentSession"];
+  };
+  modelSelection: {
+    selectedModelSelection: ReturnType<
+      typeof useAgentStudioModelSelection
+    >["selectedModelSelection"];
+    isSelectionCatalogLoading: ReturnType<
+      typeof useAgentStudioModelSelection
+    >["isSelectionCatalogLoading"];
+    agentOptions: ReturnType<typeof useAgentStudioModelSelection>["agentOptions"];
+    modelOptions: ReturnType<typeof useAgentStudioModelSelection>["modelOptions"];
+    modelGroups: ReturnType<typeof useAgentStudioModelSelection>["modelGroups"];
+    variantOptions: ReturnType<typeof useAgentStudioModelSelection>["variantOptions"];
+    onSelectAgent: ReturnType<typeof useAgentStudioModelSelection>["handleSelectAgent"];
+    onSelectModel: ReturnType<typeof useAgentStudioModelSelection>["handleSelectModel"];
+    onSelectVariant: ReturnType<typeof useAgentStudioModelSelection>["handleSelectVariant"];
+    activeSessionAgentColors: ReturnType<
+      typeof useAgentStudioModelSelection
+    >["activeSessionAgentColors"];
+    activeSessionContextUsage: ReturnType<
+      typeof useAgentStudioModelSelection
+    >["activeSessionContextUsage"];
+  };
+  permissions: ReturnType<typeof useAgentSessionPermissionActions>;
+  composer: AgentStudioOrchestrationComposerContext;
+};
+
+export const buildAgentStudioPageModelsArgs = ({
   viewTaskId,
   viewRole,
-  viewScenario,
   viewSelectedTask,
   viewSessionsForTask,
   viewActiveSession,
   activeTaskTabId,
   taskTabs,
   availableTabTasks,
+  onCreateTab,
+  onCloseTab,
   contextSwitchVersion,
   isLoadingTasks,
   isActiveTaskHydrated,
-  agentStudioReady,
-  agentStudioBlockedReason,
-  isLoadingChecks,
-  refreshChecks,
-  input,
-  setInput,
-  updateQuery,
-  onContextSwitchIntent,
-  onCreateTab,
-  onCloseTab,
-  startAgentSession,
-  sendAgentMessage,
-  stopAgentSession,
-  updateAgentSessionModel,
-  replyAgentPermission,
-  answerAgentQuestion,
-  requestNewSessionStart,
+  specDoc,
+  planDoc,
+  qaDoc,
+  readiness,
+  sessionActions,
+  modelSelection,
+  permissions,
+  composer,
+}: BuildAgentStudioPageModelsArgsInput): Parameters<typeof useAgentStudioPageModels>[0] => ({
+  core: {
+    activeTabValue: activeTaskTabId || viewTaskId || "__agent_studio_empty__",
+    taskId: viewTaskId,
+    role: viewRole,
+    selectedTask: viewSelectedTask,
+    sessionsForTask: viewSessionsForTask,
+    contextSessionsLength: viewSessionsForTask.length,
+    activeSession: viewActiveSession,
+    isTaskHydrating: Boolean(viewTaskId && !isActiveTaskHydrated),
+    contextSwitchVersion,
+  },
+  taskTabs: {
+    taskTabs,
+    availableTabTasks,
+    isLoadingTasks,
+    onCreateTab,
+    onCloseTab,
+  },
+  documents: {
+    specDoc,
+    planDoc,
+    qaDoc,
+  },
+  readiness,
+  sessionActions,
+  modelSelection,
+  permissions,
+  composer,
+});
+
+export function useAgentStudioOrchestrationController({
+  workspace,
+  selection,
+  readiness,
+  composer,
+  actions,
 }: UseAgentStudioOrchestrationControllerArgs): UseAgentStudioOrchestrationControllerResult {
+  const { activeRepo, loadRepoSettings } = workspace;
+  const {
+    viewTaskId,
+    viewRole,
+    viewScenario,
+    viewSelectedTask,
+    viewSessionsForTask,
+    viewActiveSession,
+    activeTaskTabId,
+    taskTabs,
+    availableTabTasks,
+    contextSwitchVersion,
+    isLoadingTasks,
+    isActiveTaskHydrated,
+    onCreateTab,
+    onCloseTab,
+  } = selection;
+  const { agentStudioReady } = readiness;
+  const { input, setInput } = composer;
+  const {
+    updateQuery,
+    onContextSwitchIntent,
+    startAgentSession,
+    sendAgentMessage,
+    stopAgentSession,
+    updateAgentSessionModel,
+    replyAgentPermission,
+    answerAgentQuestion,
+    requestNewSessionStart,
+  } = actions;
+
   const { repoSettings } = useAgentStudioRepoSettings({
     activeRepo,
     loadRepoSettings,
@@ -172,48 +296,28 @@ export function useAgentStudioOrchestrationController({
       replyAgentPermission,
     });
 
-  const {
-    activeTabValue,
-    agentStudioTaskTabsModel,
-    agentStudioHeaderModel,
-    agentStudioWorkspaceSidebarModel,
-    agentChatModel,
-  } = useAgentStudioPageModels({
-    core: {
-      activeTabValue: activeTaskTabId || viewTaskId || "__agent_studio_empty__",
-      taskId: viewTaskId,
-      role: viewRole,
-      selectedTask: viewSelectedTask,
-      sessionsForTask: viewSessionsForTask,
-      contextSessionsLength: viewSessionsForTask.length,
-      activeSession: viewActiveSession,
-      isTaskHydrating: Boolean(viewTaskId && !isActiveTaskHydrated),
-      contextSwitchVersion,
-    },
-    taskTabs: {
-      taskTabs,
-      availableTabTasks,
-      isLoadingTasks,
-      onCreateTab,
-      onCloseTab,
-    },
-    documents: {
-      specDoc,
-      planDoc,
-      qaDoc,
-    },
-    readiness: {
-      agentStudioReady,
-      agentStudioBlockedReason,
-      isLoadingChecks,
-      refreshChecks,
-    },
+  const pageModelsArgs = buildAgentStudioPageModelsArgs({
+    viewTaskId,
+    viewRole,
+    viewSelectedTask,
+    viewSessionsForTask,
+    viewActiveSession,
+    activeTaskTabId,
+    taskTabs,
+    availableTabTasks,
+    onCreateTab,
+    onCloseTab,
+    contextSwitchVersion,
+    isLoadingTasks,
+    isActiveTaskHydrated,
+    specDoc,
+    planDoc,
+    qaDoc,
+    readiness,
     sessionActions: {
-      handleWorkflowStepSelect,
-      handleSessionSelectionChange,
-      handleCreateSession,
       isStarting,
       isSending,
+      isSubmittingQuestionByRequestId,
       isSessionWorking,
       canKickoffNewSession,
       kickoffLabel,
@@ -221,7 +325,9 @@ export function useAgentStudioOrchestrationController({
       startScenarioKickoff,
       onSend,
       onSubmitQuestionAnswers,
-      isSubmittingQuestionByRequestId,
+      handleWorkflowStepSelect,
+      handleSessionSelectionChange,
+      handleCreateSession,
       stopAgentSession,
     },
     modelSelection: {
@@ -231,22 +337,27 @@ export function useAgentStudioOrchestrationController({
       modelOptions,
       modelGroups,
       variantOptions,
+      activeSessionAgentColors,
+      activeSessionContextUsage,
       onSelectAgent: handleSelectAgent,
       onSelectModel: handleSelectModel,
       onSelectVariant: handleSelectVariant,
-      activeSessionAgentColors,
-      activeSessionContextUsage,
     },
     permissions: {
       isSubmittingPermissionByRequestId,
       permissionReplyErrorByRequestId,
       onReplyPermission,
     },
-    composer: {
-      input,
-      setInput,
-    },
+    composer,
   });
+
+  const {
+    activeTabValue,
+    agentStudioTaskTabsModel,
+    agentStudioHeaderModel,
+    agentStudioWorkspaceSidebarModel,
+    agentChatModel,
+  } = useAgentStudioPageModels(pageModelsArgs);
 
   const rightPanel = useAgentStudioRightPanel({
     role: viewRole,

--- a/apps/desktop/src/pages/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/use-agent-studio-orchestration-controller.ts
@@ -1,0 +1,267 @@
+import type { TaskCard } from "@openducktor/contracts";
+import type { AgentRole, AgentScenario } from "@openducktor/core";
+import type { AgentStudioTaskTabsModel } from "@/components/features/agents";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentStateContextValue, RepoSettingsInput } from "@/types/state-slices";
+import { useAgentSessionPermissionActions } from "./use-agent-session-permission-actions";
+import { useAgentStudioDocuments } from "./use-agent-studio-documents";
+import { useAgentStudioModelSelection } from "./use-agent-studio-model-selection";
+import { useAgentStudioPageModels } from "./use-agent-studio-page-models";
+import { useAgentStudioRepoSettings } from "./use-agent-studio-repo-settings";
+import { useAgentStudioRightPanel } from "./use-agent-studio-right-panel";
+import { useAgentStudioSessionActions } from "./use-agent-studio-session-actions";
+import type { RequestNewSessionStart } from "./use-agent-studio-session-start-types";
+
+type QueryUpdate = Record<string, string | undefined>;
+
+type UseAgentStudioOrchestrationControllerArgs = {
+  activeRepo: string | null;
+  loadRepoSettings: () => Promise<RepoSettingsInput>;
+  viewTaskId: string;
+  viewRole: AgentRole;
+  viewScenario: AgentScenario;
+  viewSelectedTask: TaskCard | null;
+  viewSessionsForTask: AgentSessionState[];
+  viewActiveSession: AgentSessionState | null;
+  activeTaskTabId: string;
+  taskTabs: AgentStudioTaskTabsModel["tabs"];
+  availableTabTasks: TaskCard[];
+  contextSwitchVersion: number;
+  isLoadingTasks: boolean;
+  isActiveTaskHydrated: boolean;
+  agentStudioReady: boolean;
+  agentStudioBlockedReason: string;
+  isLoadingChecks: boolean;
+  refreshChecks: () => Promise<void>;
+  input: string;
+  setInput: (value: string) => void;
+  updateQuery: (updates: QueryUpdate) => void;
+  onContextSwitchIntent: () => void;
+  onCreateTab: (taskId: string) => void;
+  onCloseTab: (taskId: string) => void;
+  startAgentSession: AgentStateContextValue["startAgentSession"];
+  sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
+  stopAgentSession: AgentStateContextValue["stopAgentSession"];
+  updateAgentSessionModel: AgentStateContextValue["updateAgentSessionModel"];
+  replyAgentPermission: AgentStateContextValue["replyAgentPermission"];
+  answerAgentQuestion: AgentStateContextValue["answerAgentQuestion"];
+  requestNewSessionStart?: RequestNewSessionStart;
+};
+
+type UseAgentStudioOrchestrationControllerResult = {
+  repoSettings: RepoSettingsInput | null;
+  activeTabValue: string;
+  agentStudioTaskTabsModel: AgentStudioTaskTabsModel;
+  agentStudioHeaderModel: ReturnType<typeof useAgentStudioPageModels>["agentStudioHeaderModel"];
+  agentStudioWorkspaceSidebarModel: ReturnType<
+    typeof useAgentStudioPageModels
+  >["agentStudioWorkspaceSidebarModel"];
+  agentChatModel: ReturnType<typeof useAgentStudioPageModels>["agentChatModel"];
+  rightPanel: ReturnType<typeof useAgentStudioRightPanel>;
+};
+
+export function useAgentStudioOrchestrationController({
+  activeRepo,
+  loadRepoSettings,
+  viewTaskId,
+  viewRole,
+  viewScenario,
+  viewSelectedTask,
+  viewSessionsForTask,
+  viewActiveSession,
+  activeTaskTabId,
+  taskTabs,
+  availableTabTasks,
+  contextSwitchVersion,
+  isLoadingTasks,
+  isActiveTaskHydrated,
+  agentStudioReady,
+  agentStudioBlockedReason,
+  isLoadingChecks,
+  refreshChecks,
+  input,
+  setInput,
+  updateQuery,
+  onContextSwitchIntent,
+  onCreateTab,
+  onCloseTab,
+  startAgentSession,
+  sendAgentMessage,
+  stopAgentSession,
+  updateAgentSessionModel,
+  replyAgentPermission,
+  answerAgentQuestion,
+  requestNewSessionStart,
+}: UseAgentStudioOrchestrationControllerArgs): UseAgentStudioOrchestrationControllerResult {
+  const { repoSettings } = useAgentStudioRepoSettings({
+    activeRepo,
+    loadRepoSettings,
+  });
+
+  const { specDoc, planDoc, qaDoc } = useAgentStudioDocuments({
+    activeRepo,
+    taskId: viewTaskId,
+    activeSession: viewActiveSession,
+    selectedTask: viewSelectedTask,
+  });
+
+  const {
+    selectionForNewSession,
+    selectedModelSelection,
+    isSelectionCatalogLoading,
+    agentOptions,
+    modelOptions,
+    modelGroups,
+    variantOptions,
+    activeSessionAgentColors,
+    activeSessionContextUsage,
+    handleSelectAgent,
+    handleSelectModel,
+    handleSelectVariant,
+  } = useAgentStudioModelSelection({
+    activeRepo,
+    activeSession: viewActiveSession,
+    role: viewRole,
+    repoSettings,
+    updateAgentSessionModel,
+  });
+
+  const {
+    isStarting,
+    isSending,
+    isSubmittingQuestionByRequestId,
+    isSessionWorking,
+    canKickoffNewSession,
+    kickoffLabel,
+    canStopSession,
+    startScenarioKickoff,
+    onSend,
+    onSubmitQuestionAnswers,
+    handleWorkflowStepSelect,
+    handleSessionSelectionChange,
+    handleCreateSession,
+  } = useAgentStudioSessionActions({
+    activeRepo,
+    taskId: viewTaskId,
+    role: viewRole,
+    scenario: viewScenario,
+    autostart: false,
+    sessionStartPreference: null,
+    activeSession: viewActiveSession,
+    sessionsForTask: viewSessionsForTask,
+    selectedTask: viewSelectedTask,
+    agentStudioReady,
+    isActiveTaskHydrated,
+    selectionForNewSession,
+    input,
+    setInput,
+    startAgentSession,
+    sendAgentMessage,
+    updateAgentSessionModel,
+    answerAgentQuestion,
+    updateQuery,
+    onContextSwitchIntent,
+    ...(requestNewSessionStart ? { requestNewSessionStart } : {}),
+  });
+
+  const { isSubmittingPermissionByRequestId, permissionReplyErrorByRequestId, onReplyPermission } =
+    useAgentSessionPermissionActions({
+      activeSessionId: viewActiveSession?.sessionId ?? null,
+      pendingPermissions: viewActiveSession?.pendingPermissions ?? [],
+      agentStudioReady,
+      replyAgentPermission,
+    });
+
+  const {
+    activeTabValue,
+    agentStudioTaskTabsModel,
+    agentStudioHeaderModel,
+    agentStudioWorkspaceSidebarModel,
+    agentChatModel,
+  } = useAgentStudioPageModels({
+    core: {
+      activeTabValue: activeTaskTabId || viewTaskId || "__agent_studio_empty__",
+      taskId: viewTaskId,
+      role: viewRole,
+      selectedTask: viewSelectedTask,
+      sessionsForTask: viewSessionsForTask,
+      contextSessionsLength: viewSessionsForTask.length,
+      activeSession: viewActiveSession,
+      isTaskHydrating: Boolean(viewTaskId && !isActiveTaskHydrated),
+      contextSwitchVersion,
+    },
+    taskTabs: {
+      taskTabs,
+      availableTabTasks,
+      isLoadingTasks,
+      onCreateTab,
+      onCloseTab,
+    },
+    documents: {
+      specDoc,
+      planDoc,
+      qaDoc,
+    },
+    readiness: {
+      agentStudioReady,
+      agentStudioBlockedReason,
+      isLoadingChecks,
+      refreshChecks,
+    },
+    sessionActions: {
+      handleWorkflowStepSelect,
+      handleSessionSelectionChange,
+      handleCreateSession,
+      isStarting,
+      isSending,
+      isSessionWorking,
+      canKickoffNewSession,
+      kickoffLabel,
+      canStopSession,
+      startScenarioKickoff,
+      onSend,
+      onSubmitQuestionAnswers,
+      isSubmittingQuestionByRequestId,
+      stopAgentSession,
+    },
+    modelSelection: {
+      selectedModelSelection,
+      isSelectionCatalogLoading,
+      agentOptions,
+      modelOptions,
+      modelGroups,
+      variantOptions,
+      onSelectAgent: handleSelectAgent,
+      onSelectModel: handleSelectModel,
+      onSelectVariant: handleSelectVariant,
+      activeSessionAgentColors,
+      activeSessionContextUsage,
+    },
+    permissions: {
+      isSubmittingPermissionByRequestId,
+      permissionReplyErrorByRequestId,
+      onReplyPermission,
+    },
+    composer: {
+      input,
+      setInput,
+    },
+  });
+
+  const rightPanel = useAgentStudioRightPanel({
+    role: viewRole,
+    hasTaskContext: Boolean(viewTaskId),
+    hasDocumentPanel: Boolean(agentStudioWorkspaceSidebarModel.activeDocument),
+    hasDiffPanel: false,
+  });
+
+  return {
+    repoSettings,
+    activeTabValue,
+    agentStudioTaskTabsModel,
+    agentStudioHeaderModel,
+    agentStudioWorkspaceSidebarModel,
+    agentChatModel,
+    rightPanel,
+  };
+}

--- a/apps/desktop/src/pages/use-agent-studio-query-session-sync.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-query-session-sync.test.tsx
@@ -1,0 +1,167 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useAgentStudioQuerySessionSync } from "./use-agent-studio-query-session-sync";
+
+enableReactActEnvironment();
+
+type HookArgs = Parameters<typeof useAgentStudioQuerySessionSync>[0];
+
+const createTask = (id: string) => createTaskCardFixture({ id, title: id });
+
+const createSession = (taskId: string, sessionId: string) =>
+  createAgentSessionFixture({
+    sessionId,
+    externalSessionId: `ext-${sessionId}`,
+    taskId,
+  });
+
+const useHookHarness = (props: HookArgs) => {
+  useAgentStudioQuerySessionSync(props);
+  return { ready: true };
+};
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useHookHarness, initialProps);
+
+const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
+  isLoadingTasks: false,
+  tasks: [createTask("task-1")],
+  taskIdParam: "task-1",
+  sessionParam: null,
+  selectedSessionById: null,
+  taskId: "task-1",
+  activeSession: null,
+  autostart: false,
+  roleFromQuery: "spec",
+  scenarioFromQuery: "spec_initial",
+  sessionStartPreference: null,
+  isActiveTaskHydrated: true,
+  scheduleQueryUpdate: () => {},
+  ...overrides,
+});
+
+describe("useAgentStudioQuerySessionSync", () => {
+  test("clears query when URL task no longer exists", async () => {
+    const scheduleQueryUpdate = mock((_updates: Record<string, string | undefined>) => {});
+    const harness = createHookHarness(
+      createBaseArgs({
+        tasks: [createTask("task-1")],
+        taskIdParam: "missing-task",
+        taskId: "missing-task",
+        scheduleQueryUpdate,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(scheduleQueryUpdate).toHaveBeenCalledTimes(1);
+      expect(scheduleQueryUpdate.mock.calls[0]).toEqual([
+        {
+          task: undefined,
+          session: undefined,
+          agent: undefined,
+          scenario: undefined,
+          autostart: undefined,
+          start: undefined,
+        },
+      ]);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("backfills missing task param from selected session", async () => {
+    const scheduleQueryUpdate = mock((_updates: Record<string, string | undefined>) => {});
+    const selectedSession = createSession("task-2", "session-2");
+    const harness = createHookHarness(
+      createBaseArgs({
+        tasks: [createTask("task-1"), createTask("task-2")],
+        taskIdParam: "",
+        sessionParam: "session-2",
+        selectedSessionById: selectedSession,
+        taskId: "task-2",
+        scheduleQueryUpdate,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(scheduleQueryUpdate).toHaveBeenCalledTimes(1);
+      expect(scheduleQueryUpdate.mock.calls[0]).toEqual([{ task: "task-2" }]);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("clears stale session param when selected session belongs to another task", async () => {
+    const scheduleQueryUpdate = mock((_updates: Record<string, string | undefined>) => {});
+    const selectedSession = createSession("task-2", "session-2");
+    const harness = createHookHarness(
+      createBaseArgs({
+        tasks: [createTask("task-1"), createTask("task-2")],
+        taskIdParam: "task-1",
+        sessionParam: "session-2",
+        selectedSessionById: selectedSession,
+        taskId: "task-1",
+        scheduleQueryUpdate,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(scheduleQueryUpdate).toHaveBeenCalledTimes(1);
+      expect(scheduleQueryUpdate.mock.calls[0]).toEqual([{ session: undefined }]);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("aligns query params with resolved active session", async () => {
+    const scheduleQueryUpdate = mock((_updates: Record<string, string | undefined>) => {});
+    const activeSession = createAgentSessionFixture({
+      sessionId: "session-1",
+      externalSessionId: "ext-session-1",
+      taskId: "task-1",
+      role: "planner",
+      scenario: "planner_initial",
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        taskIdParam: "task-1",
+        sessionParam: null,
+        taskId: "task-1",
+        activeSession,
+        autostart: true,
+        roleFromQuery: "spec",
+        scenarioFromQuery: "spec_initial",
+        sessionStartPreference: "continue",
+        scheduleQueryUpdate,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(scheduleQueryUpdate).toHaveBeenCalledTimes(1);
+      expect(scheduleQueryUpdate.mock.calls[0]).toEqual([
+        {
+          session: "session-1",
+          agent: "planner",
+          scenario: "planner_initial",
+          autostart: undefined,
+          start: undefined,
+        },
+      ]);
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/use-agent-studio-query-session-sync.ts
+++ b/apps/desktop/src/pages/use-agent-studio-query-session-sync.ts
@@ -1,0 +1,120 @@
+import type { TaskCard } from "@openducktor/contracts";
+import type { AgentRole, AgentScenario } from "@openducktor/core";
+import { useEffect } from "react";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+
+type UseAgentStudioQuerySessionSyncArgs = {
+  isLoadingTasks: boolean;
+  tasks: TaskCard[];
+  taskIdParam: string;
+  sessionParam: string | null;
+  selectedSessionById: AgentSessionState | null;
+  taskId: string;
+  activeSession: AgentSessionState | null;
+  autostart: boolean;
+  roleFromQuery: AgentRole;
+  scenarioFromQuery: AgentScenario | undefined;
+  sessionStartPreference: "fresh" | "continue" | null;
+  isActiveTaskHydrated: boolean;
+  scheduleQueryUpdate: (updates: Record<string, string | undefined>) => void;
+};
+
+export function useAgentStudioQuerySessionSync({
+  isLoadingTasks,
+  tasks,
+  taskIdParam,
+  sessionParam,
+  selectedSessionById,
+  taskId,
+  activeSession,
+  autostart,
+  roleFromQuery,
+  scenarioFromQuery,
+  sessionStartPreference,
+  isActiveTaskHydrated,
+  scheduleQueryUpdate,
+}: UseAgentStudioQuerySessionSyncArgs): void {
+  useEffect(() => {
+    if (isLoadingTasks) {
+      return;
+    }
+    if (!taskIdParam || selectedSessionById) {
+      return;
+    }
+    if (tasks.some((entry) => entry.id === taskIdParam)) {
+      return;
+    }
+    scheduleQueryUpdate({
+      task: undefined,
+      session: undefined,
+      agent: undefined,
+      scenario: undefined,
+      autostart: undefined,
+      start: undefined,
+    });
+  }, [isLoadingTasks, scheduleQueryUpdate, selectedSessionById, taskIdParam, tasks]);
+
+  useEffect(() => {
+    if (!selectedSessionById || taskIdParam) {
+      return;
+    }
+    scheduleQueryUpdate({ task: selectedSessionById.taskId });
+  }, [scheduleQueryUpdate, selectedSessionById, taskIdParam]);
+
+  useEffect(() => {
+    if (!sessionParam) {
+      return;
+    }
+    if (selectedSessionById && taskId && selectedSessionById.taskId !== taskId) {
+      scheduleQueryUpdate({ session: undefined });
+      return;
+    }
+    if (!taskId || !isActiveTaskHydrated) {
+      return;
+    }
+    if (selectedSessionById && selectedSessionById.taskId === taskId) {
+      return;
+    }
+    scheduleQueryUpdate({ session: undefined });
+  }, [isActiveTaskHydrated, scheduleQueryUpdate, selectedSessionById, sessionParam, taskId]);
+
+  useEffect(() => {
+    if (!activeSession) {
+      return;
+    }
+
+    const updates: Record<string, string | undefined> = {};
+    if (taskIdParam !== activeSession.taskId) {
+      updates.task = activeSession.taskId;
+    }
+    if (sessionParam !== activeSession.sessionId) {
+      updates.session = activeSession.sessionId;
+    }
+    if (roleFromQuery !== activeSession.role) {
+      updates.agent = activeSession.role;
+    }
+    if (scenarioFromQuery !== activeSession.scenario) {
+      updates.scenario = activeSession.scenario;
+    }
+    if (autostart) {
+      updates.autostart = undefined;
+    }
+    if (sessionStartPreference) {
+      updates.start = undefined;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return;
+    }
+    scheduleQueryUpdate(updates);
+  }, [
+    activeSession,
+    autostart,
+    roleFromQuery,
+    scheduleQueryUpdate,
+    scenarioFromQuery,
+    sessionParam,
+    sessionStartPreference,
+    taskIdParam,
+  ]);
+}

--- a/apps/desktop/src/pages/use-agent-studio-selection-controller.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-selection-controller.test.tsx
@@ -1,0 +1,142 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useAgentStudioSelectionController } from "./use-agent-studio-selection-controller";
+
+enableReactActEnvironment();
+
+type HookArgs = Parameters<typeof useAgentStudioSelectionController>[0];
+
+const createTask = (id: string) => createTaskCardFixture({ id, title: id });
+
+const createSession = (
+  taskId: string,
+  sessionId: string,
+  overrides: Partial<ReturnType<typeof createAgentSessionFixture>> = {},
+) =>
+  createAgentSessionFixture({
+    sessionId,
+    externalSessionId: `ext-${sessionId}`,
+    taskId,
+    ...overrides,
+  });
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioSelectionController, initialProps);
+
+const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
+  activeRepo: null,
+  tasks: [createTask("task-1"), createTask("task-2")],
+  isLoadingTasks: false,
+  sessions: [],
+  taskIdParam: "task-1",
+  sessionParam: null,
+  hasExplicitRoleParam: false,
+  roleFromQuery: "spec",
+  scenarioFromQuery: "spec_initial",
+  sessionStartPreference: null,
+  updateQuery: () => {},
+  loadAgentSessions: async () => {},
+  clearComposerInput: () => {},
+  ...overrides,
+});
+
+describe("useAgentStudioSelectionController", () => {
+  test("resolves task context from selected session when task param is missing", async () => {
+    const session = createSession("task-2", "session-2");
+    const harness = createHookHarness(
+      createBaseArgs({
+        sessions: [session],
+        taskIdParam: "",
+        sessionParam: "session-2",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      const latest = harness.getLatest();
+      expect(latest.taskId).toBe("task-2");
+      expect(latest.selectedTask?.id).toBe("task-2");
+      expect(latest.activeSession?.sessionId).toBe("session-2");
+      expect(latest.viewTaskId).toBe("task-2");
+      expect(latest.viewActiveSession?.sessionId).toBe("session-2");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("uses detached tab context instead of query role selection", async () => {
+    const updateQuery = mock(() => {});
+    const clearComposerInput = mock(() => {});
+    const harness = createHookHarness(
+      createBaseArgs({
+        taskIdParam: "task-1",
+        hasExplicitRoleParam: true,
+        roleFromQuery: "build",
+        scenarioFromQuery: "build_implementation_start",
+        updateQuery,
+        clearComposerInput,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run((state) => {
+        state.handleSelectTab("task-2");
+      });
+
+      const latest = harness.getLatest();
+      expect(latest.viewTaskId).toBe("task-2");
+      expect(latest.viewRole).toBe("spec");
+      expect(latest.viewScenario).toBe("spec_initial");
+      expect(clearComposerInput).toHaveBeenCalledTimes(1);
+      expect(updateQuery).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("resolves view session from the UI-active task tab", async () => {
+    const sessionTaskOne = createSession("task-1", "session-1", {
+      role: "planner",
+      scenario: "planner_initial",
+      startedAt: "2026-02-22T12:00:00.000Z",
+    });
+    const sessionTaskTwo = createSession("task-2", "session-2", {
+      role: "qa",
+      scenario: "qa_review",
+      startedAt: "2026-02-22T13:00:00.000Z",
+    });
+
+    const harness = createHookHarness(
+      createBaseArgs({
+        sessions: [sessionTaskOne, sessionTaskTwo],
+        taskIdParam: "task-1",
+        hasExplicitRoleParam: false,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().viewActiveSession?.sessionId).toBe("session-1");
+
+      await harness.run((state) => {
+        state.handleSelectTab("task-2");
+      });
+
+      const latest = harness.getLatest();
+      expect(latest.viewTaskId).toBe("task-2");
+      expect(latest.viewActiveSession?.sessionId).toBe("session-2");
+      expect(latest.viewRole).toBe("qa");
+      expect(latest.viewScenario).toBe("qa_review");
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/use-agent-studio-selection-controller.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-selection-controller.test.tsx
@@ -96,6 +96,26 @@ describe("useAgentStudioSelectionController", () => {
     ]);
   });
 
+  test("keeps cache signature stable when task sessions arrive in a different order", () => {
+    const sessionOld = createSession("task-1", "session-old", {
+      startedAt: "2026-02-22T10:00:00.000Z",
+    });
+    const sessionNew = createSession("task-1", "session-new", {
+      startedAt: "2026-02-22T11:00:00.000Z",
+    });
+
+    const first = buildSessionsByTaskIdWithCache([sessionOld, sessionNew], new Map());
+    const second = buildSessionsByTaskIdWithCache([sessionNew, sessionOld], first.nextCache);
+
+    expect(second.nextCache.get("task-1")?.inputSignature).toBe(
+      first.nextCache.get("task-1")?.inputSignature,
+    );
+    expect(second.sessionsByTaskId.get("task-1")?.map((session) => session.sessionId)).toEqual([
+      "session-new",
+      "session-old",
+    ]);
+  });
+
   test("resolves task context from selected session when task param is missing", async () => {
     const session = createSession("task-2", "session-2");
     const harness = createHookHarness(

--- a/apps/desktop/src/pages/use-agent-studio-selection-controller.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-selection-controller.test.tsx
@@ -5,7 +5,10 @@ import {
   createTaskCardFixture,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
-import { useAgentStudioSelectionController } from "./use-agent-studio-selection-controller";
+import {
+  buildSessionsByTaskIdWithCache,
+  useAgentStudioSelectionController,
+} from "./use-agent-studio-selection-controller";
 
 enableReactActEnvironment();
 
@@ -46,6 +49,53 @@ const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
 });
 
 describe("useAgentStudioSelectionController", () => {
+  test("reuses cached task ordering metadata for unchanged task signatures", () => {
+    const firstTaskOneOld = createSession("task-1", "session-old", {
+      startedAt: "2026-02-22T10:00:00.000Z",
+    });
+    const firstTaskOneNew = createSession("task-1", "session-new", {
+      startedAt: "2026-02-22T11:00:00.000Z",
+    });
+    const firstTaskTwo = createSession("task-2", "session-2-old", {
+      startedAt: "2026-02-22T09:00:00.000Z",
+    });
+
+    const first = buildSessionsByTaskIdWithCache(
+      [firstTaskOneOld, firstTaskOneNew, firstTaskTwo],
+      new Map(),
+    );
+
+    expect(first.sessionsByTaskId.get("task-1")?.map((session) => session.sessionId)).toEqual([
+      "session-new",
+      "session-old",
+    ]);
+
+    const secondTaskOneOld = createSession("task-1", "session-old", {
+      startedAt: "2026-02-22T10:00:00.000Z",
+      status: "running",
+    });
+    const secondTaskOneNew = createSession("task-1", "session-new", {
+      startedAt: "2026-02-22T11:00:00.000Z",
+      status: "stopped",
+    });
+    const secondTaskTwoNew = createSession("task-2", "session-2-new", {
+      startedAt: "2026-02-22T12:00:00.000Z",
+    });
+
+    const second = buildSessionsByTaskIdWithCache(
+      [secondTaskOneOld, secondTaskOneNew, secondTaskTwoNew],
+      first.nextCache,
+    );
+
+    expect(second.sessionsByTaskId.get("task-1")?.map((session) => session.sessionId)).toEqual([
+      "session-new",
+      "session-old",
+    ]);
+    expect(second.sessionsByTaskId.get("task-2")?.map((session) => session.sessionId)).toEqual([
+      "session-2-new",
+    ]);
+  });
+
   test("resolves task context from selected session when task param is missing", async () => {
     const session = createSession("task-2", "session-2");
     const harness = createHookHarness(

--- a/apps/desktop/src/pages/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/use-agent-studio-selection-controller.ts
@@ -1,0 +1,255 @@
+import type { TaskCard } from "@openducktor/contracts";
+import type { AgentRole, AgentScenario } from "@openducktor/core";
+import { useMemo } from "react";
+import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
+import { firstScenario, SCENARIOS_BY_ROLE } from "./agents-page-constants";
+import { resolveAgentStudioActiveSession, resolveAgentStudioTaskId } from "./agents-page-selection";
+import { useAgentStudioTaskHydration } from "./use-agent-studio-task-hydration";
+import { useAgentStudioTaskTabs } from "./use-agent-studio-task-tabs";
+
+type QueryUpdate = Record<string, string | undefined>;
+
+type UseAgentStudioSelectionControllerArgs = {
+  activeRepo: string | null;
+  tasks: TaskCard[];
+  isLoadingTasks: boolean;
+  sessions: AgentSessionState[];
+  taskIdParam: string;
+  sessionParam: string | null;
+  hasExplicitRoleParam: boolean;
+  roleFromQuery: AgentRole;
+  scenarioFromQuery: AgentScenario | undefined;
+  sessionStartPreference: "fresh" | "continue" | null;
+  updateQuery: (updates: QueryUpdate) => void;
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
+  clearComposerInput: () => void;
+  onContextSwitchIntent?: () => void;
+};
+
+type UseAgentStudioSelectionControllerResult = {
+  selectedSessionById: AgentSessionState | null;
+  taskId: string;
+  selectedTask: TaskCard | null;
+  sessionsForTask: AgentSessionState[];
+  activeSession: AgentSessionState | null;
+  activeTaskTabId: string;
+  availableTabTasks: TaskCard[];
+  taskTabs: ReturnType<typeof useAgentStudioTaskTabs>["taskTabs"];
+  handleSelectTab: (nextTaskId: string) => void;
+  handleCreateTab: (nextTaskId: string) => void;
+  handleCloseTab: (taskIdToClose: string) => void;
+  viewTaskId: string;
+  viewSelectedTask: TaskCard | null;
+  viewSessionsForTask: AgentSessionState[];
+  viewActiveSession: AgentSessionState | null;
+  viewRole: AgentRole;
+  viewScenario: AgentScenario;
+  isActiveTaskHydrated: boolean;
+};
+
+const compareSessionsByRecency = (left: AgentSessionState, right: AgentSessionState): number => {
+  if (left.startedAt !== right.startedAt) {
+    return left.startedAt > right.startedAt ? -1 : 1;
+  }
+  if (left.sessionId === right.sessionId) {
+    return 0;
+  }
+  return left.sessionId > right.sessionId ? -1 : 1;
+};
+
+export function useAgentStudioSelectionController({
+  activeRepo,
+  tasks,
+  isLoadingTasks,
+  sessions,
+  taskIdParam,
+  sessionParam,
+  hasExplicitRoleParam,
+  roleFromQuery,
+  scenarioFromQuery,
+  sessionStartPreference,
+  updateQuery,
+  loadAgentSessions,
+  clearComposerInput,
+  onContextSwitchIntent,
+}: UseAgentStudioSelectionControllerArgs): UseAgentStudioSelectionControllerResult {
+  const tasksById = useMemo(() => {
+    return new Map(tasks.map((task) => [task.id, task]));
+  }, [tasks]);
+
+  const sessionsById = useMemo(() => {
+    return new Map(sessions.map((session) => [session.sessionId, session]));
+  }, [sessions]);
+
+  const sessionsByTaskId = useMemo(() => {
+    const grouped = new Map<string, AgentSessionState[]>();
+    for (const session of sessions) {
+      const current = grouped.get(session.taskId);
+      if (current) {
+        current.push(session);
+      } else {
+        grouped.set(session.taskId, [session]);
+      }
+    }
+    for (const group of grouped.values()) {
+      group.sort(compareSessionsByRecency);
+    }
+    return grouped;
+  }, [sessions]);
+
+  const selectedSessionById = useMemo(
+    () => (sessionParam ? (sessionsById.get(sessionParam) ?? null) : null),
+    [sessionParam, sessionsById],
+  );
+
+  const taskId = resolveAgentStudioTaskId({
+    taskIdParam,
+    selectedSessionById,
+  });
+
+  const selectedTask = useMemo(
+    () => (taskId ? (tasksById.get(taskId) ?? null) : null),
+    [taskId, tasksById],
+  );
+
+  const sessionsForTask = useMemo(() => {
+    if (!taskId) {
+      return [];
+    }
+    return sessionsByTaskId.get(taskId) ?? [];
+  }, [sessionsByTaskId, taskId]);
+
+  const activeSession = useMemo(() => {
+    return resolveAgentStudioActiveSession({
+      sessionsForTask,
+      sessionParam,
+      hasExplicitRoleParam,
+      roleFromQuery,
+      sessionStartPreference,
+    });
+  }, [hasExplicitRoleParam, roleFromQuery, sessionStartPreference, sessionParam, sessionsForTask]);
+
+  const latestSessionByTaskId = useMemo(() => {
+    const latestByTask = new Map<string, AgentSessionState>();
+    for (const [taskKey, taskSessions] of sessionsByTaskId) {
+      const latestSession = taskSessions[0];
+      if (latestSession) {
+        latestByTask.set(taskKey, latestSession);
+      }
+    }
+    return latestByTask;
+  }, [sessionsByTaskId]);
+
+  const {
+    activeTaskTabId,
+    availableTabTasks,
+    taskTabs,
+    handleSelectTab,
+    handleCreateTab,
+    handleCloseTab,
+  } = useAgentStudioTaskTabs({
+    activeRepo,
+    taskId,
+    selectedTask,
+    tasks,
+    isLoadingTasks,
+    latestSessionByTaskId,
+    updateQuery,
+    clearComposerInput,
+    ...(onContextSwitchIntent ? { onContextSwitchIntent } : {}),
+  });
+
+  const viewTaskId = activeTaskTabId || taskId;
+
+  const viewSelectedTask = useMemo(
+    () => (viewTaskId ? (tasksById.get(viewTaskId) ?? null) : null),
+    [tasksById, viewTaskId],
+  );
+
+  const viewSessionsForTask = useMemo(() => {
+    if (!viewTaskId) {
+      return [];
+    }
+    return sessionsByTaskId.get(viewTaskId) ?? [];
+  }, [sessionsByTaskId, viewTaskId]);
+
+  const viewSessionParam = useMemo(() => {
+    if (!sessionParam) {
+      return null;
+    }
+
+    const belongsToViewTask = viewSessionsForTask.some(
+      (session) => session.sessionId === sessionParam,
+    );
+    return belongsToViewTask ? sessionParam : null;
+  }, [sessionParam, viewSessionsForTask]);
+
+  const isViewTaskDetachedFromQuery = Boolean(viewTaskId && taskId && viewTaskId !== taskId);
+  const hasViewRoleSelection = hasExplicitRoleParam && !isViewTaskDetachedFromQuery;
+  const viewSessionStartPreference = isViewTaskDetachedFromQuery ? null : sessionStartPreference;
+
+  const viewActiveSession = useMemo(() => {
+    return resolveAgentStudioActiveSession({
+      sessionsForTask: viewSessionsForTask,
+      sessionParam: viewSessionParam,
+      hasExplicitRoleParam: hasViewRoleSelection,
+      roleFromQuery,
+      sessionStartPreference: viewSessionStartPreference,
+    });
+  }, [
+    hasViewRoleSelection,
+    roleFromQuery,
+    viewSessionStartPreference,
+    viewSessionParam,
+    viewSessionsForTask,
+  ]);
+
+  const viewRole: AgentRole = hasViewRoleSelection
+    ? roleFromQuery
+    : (viewActiveSession?.role ??
+      viewSessionsForTask[0]?.role ??
+      (isViewTaskDetachedFromQuery ? "spec" : roleFromQuery));
+
+  const viewScenarios = SCENARIOS_BY_ROLE[viewRole];
+
+  const viewScenario: AgentScenario = hasViewRoleSelection
+    ? scenarioFromQuery && viewScenarios.includes(scenarioFromQuery)
+      ? scenarioFromQuery
+      : firstScenario(viewRole)
+    : viewActiveSession?.scenario && viewScenarios.includes(viewActiveSession.scenario)
+      ? viewActiveSession.scenario
+      : firstScenario(viewRole);
+
+  const hydratedTasksByRepoAndTask = useAgentStudioTaskHydration({
+    activeRepo,
+    activeTaskId: viewTaskId,
+    activeSessionId: viewActiveSession?.sessionId ?? null,
+    loadAgentSessions,
+  });
+
+  const taskHydrationKey = activeRepo && viewTaskId ? `${activeRepo}:${viewTaskId}` : "";
+  const isActiveTaskHydrated = taskHydrationKey
+    ? (hydratedTasksByRepoAndTask[taskHydrationKey] ?? false)
+    : false;
+
+  return {
+    selectedSessionById,
+    taskId,
+    selectedTask,
+    sessionsForTask,
+    activeSession,
+    activeTaskTabId,
+    availableTabTasks,
+    taskTabs,
+    handleSelectTab,
+    handleCreateTab,
+    handleCloseTab,
+    viewTaskId,
+    viewSelectedTask,
+    viewSessionsForTask,
+    viewActiveSession,
+    viewRole,
+    viewScenario,
+    isActiveTaskHydrated,
+  };
+}

--- a/apps/desktop/src/pages/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/use-agent-studio-selection-controller.ts
@@ -65,7 +65,10 @@ type SessionsByTaskSortCacheEntry = {
 type SessionsByTaskSortCache = Map<string, SessionsByTaskSortCacheEntry>;
 
 const toTaskInputSignature = (taskSessions: AgentSessionState[]): string =>
-  taskSessions.map((session) => `${session.sessionId}:${session.startedAt}`).join("|");
+  taskSessions
+    .map((session) => `${session.sessionId}:${session.startedAt}`)
+    .sort()
+    .join("|");
 
 export const buildSessionsByTaskIdWithCache = (
   sessions: AgentSessionState[],

--- a/apps/desktop/src/pages/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/use-agent-studio-selection-controller.ts
@@ -1,6 +1,6 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentRole, AgentScenario } from "@openducktor/core";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import { firstScenario, SCENARIOS_BY_ROLE } from "./agents-page-constants";
 import { resolveAgentStudioActiveSession, resolveAgentStudioTaskId } from "./agents-page-selection";
@@ -57,6 +57,62 @@ const compareSessionsByRecency = (left: AgentSessionState, right: AgentSessionSt
   return left.sessionId > right.sessionId ? -1 : 1;
 };
 
+type SessionsByTaskSortCacheEntry = {
+  inputSignature: string;
+  sortedSessionIds: string[];
+};
+
+type SessionsByTaskSortCache = Map<string, SessionsByTaskSortCacheEntry>;
+
+const toTaskInputSignature = (taskSessions: AgentSessionState[]): string =>
+  taskSessions.map((session) => `${session.sessionId}:${session.startedAt}`).join("|");
+
+export const buildSessionsByTaskIdWithCache = (
+  sessions: AgentSessionState[],
+  previousCache: SessionsByTaskSortCache,
+): { sessionsByTaskId: Map<string, AgentSessionState[]>; nextCache: SessionsByTaskSortCache } => {
+  const grouped = new Map<string, AgentSessionState[]>();
+  for (const session of sessions) {
+    const current = grouped.get(session.taskId);
+    if (current) {
+      current.push(session);
+    } else {
+      grouped.set(session.taskId, [session]);
+    }
+  }
+
+  const nextCache: SessionsByTaskSortCache = new Map();
+  for (const [taskId, taskSessions] of grouped) {
+    const inputSignature = toTaskInputSignature(taskSessions);
+    const previous = previousCache.get(taskId);
+    const sessionsById = new Map(taskSessions.map((session) => [session.sessionId, session]));
+
+    let sortedSessions: AgentSessionState[];
+    if (previous && previous.inputSignature === inputSignature) {
+      sortedSessions = previous.sortedSessionIds
+        .map((sessionId) => sessionsById.get(sessionId))
+        .filter((session): session is AgentSessionState => session !== undefined);
+
+      if (sortedSessions.length !== taskSessions.length) {
+        sortedSessions = [...taskSessions].sort(compareSessionsByRecency);
+      }
+    } else {
+      sortedSessions = [...taskSessions].sort(compareSessionsByRecency);
+    }
+
+    grouped.set(taskId, sortedSessions);
+    nextCache.set(taskId, {
+      inputSignature,
+      sortedSessionIds: sortedSessions.map((session) => session.sessionId),
+    });
+  }
+
+  return {
+    sessionsByTaskId: grouped,
+    nextCache,
+  };
+};
+
 export function useAgentStudioSelectionController({
   activeRepo,
   tasks,
@@ -73,6 +129,8 @@ export function useAgentStudioSelectionController({
   clearComposerInput,
   onContextSwitchIntent,
 }: UseAgentStudioSelectionControllerArgs): UseAgentStudioSelectionControllerResult {
+  const sessionsByTaskSortCacheRef = useRef<SessionsByTaskSortCache>(new Map());
+
   const tasksById = useMemo(() => {
     return new Map(tasks.map((task) => [task.id, task]));
   }, [tasks]);
@@ -82,18 +140,11 @@ export function useAgentStudioSelectionController({
   }, [sessions]);
 
   const sessionsByTaskId = useMemo(() => {
-    const grouped = new Map<string, AgentSessionState[]>();
-    for (const session of sessions) {
-      const current = grouped.get(session.taskId);
-      if (current) {
-        current.push(session);
-      } else {
-        grouped.set(session.taskId, [session]);
-      }
-    }
-    for (const group of grouped.values()) {
-      group.sort(compareSessionsByRecency);
-    }
+    const { sessionsByTaskId: grouped, nextCache } = buildSessionsByTaskIdWithCache(
+      sessions,
+      sessionsByTaskSortCacheRef.current,
+    );
+    sessionsByTaskSortCacheRef.current = nextCache;
     return grouped;
   }, [sessions]);
 

--- a/apps/desktop/src/pages/use-agent-studio-session-start-request.test.tsx
+++ b/apps/desktop/src/pages/use-agent-studio-session-start-request.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useAgentStudioSessionStartRequest } from "./use-agent-studio-session-start-request";
+
+enableReactActEnvironment();
+
+const createHookHarness = () =>
+  createSharedHookHarness(useAgentStudioSessionStartRequest, undefined);
+
+const createRequest = () => ({
+  taskId: "task-1",
+  role: "build" as const,
+  scenario: "build_implementation_start" as const,
+  startMode: "fresh" as const,
+  reason: "scenario_kickoff" as const,
+  selectedModel: null,
+});
+
+describe("useAgentStudioSessionStartRequest", () => {
+  test("stores pending request and resolves it on confirm", async () => {
+    const harness = createHookHarness();
+
+    try {
+      await harness.mount();
+
+      let decision: unknown;
+      await harness.run((state) => {
+        void state.requestNewSessionStart(createRequest()).then((result) => {
+          decision = result;
+        });
+      });
+
+      expect(harness.getLatest().pendingSessionStartRequest?.taskId).toBe("task-1");
+
+      await harness.run((state) => {
+        state.resolvePendingSessionStart({ selectedModel: null });
+      });
+
+      await harness.waitFor(() => decision !== undefined);
+      expect(decision).toEqual({ selectedModel: null });
+      expect(harness.getLatest().pendingSessionStartRequest).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("cancels previous pending request when a new request arrives", async () => {
+    const harness = createHookHarness();
+
+    try {
+      await harness.mount();
+
+      const firstRequest = createRequest();
+      const secondRequest = { ...createRequest(), taskId: "task-2" };
+      let firstDecision: unknown;
+
+      await harness.run((state) => {
+        void state.requestNewSessionStart(firstRequest).then((result) => {
+          firstDecision = result;
+        });
+      });
+
+      await harness.run((state) => {
+        void state.requestNewSessionStart(secondRequest);
+      });
+
+      await harness.waitFor(() => firstDecision !== undefined);
+      expect(firstDecision).toBeNull();
+      expect(harness.getLatest().pendingSessionStartRequest?.taskId).toBe("task-2");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("resolves pending request with null on unmount cleanup", async () => {
+    const harness = createHookHarness();
+
+    let decision: unknown;
+    await harness.mount();
+    await harness.run((state) => {
+      void state.requestNewSessionStart(createRequest()).then((result) => {
+        decision = result;
+      });
+    });
+
+    await harness.unmount();
+
+    expect(decision).toBeNull();
+  });
+});

--- a/apps/desktop/src/pages/use-agent-studio-session-start-request.ts
+++ b/apps/desktop/src/pages/use-agent-studio-session-start-request.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  NewSessionStartDecision,
+  NewSessionStartRequest,
+} from "./use-agent-studio-session-actions";
+
+export function useAgentStudioSessionStartRequest(): {
+  pendingSessionStartRequest: NewSessionStartRequest | null;
+  requestNewSessionStart: (request: NewSessionStartRequest) => Promise<NewSessionStartDecision>;
+  resolvePendingSessionStart: (decision: NewSessionStartDecision) => void;
+} {
+  const [pendingSessionStartRequest, setPendingSessionStartRequest] =
+    useState<NewSessionStartRequest | null>(null);
+  const pendingSessionStartResolverRef = useRef<
+    ((decision: NewSessionStartDecision) => void) | null
+  >(null);
+
+  const resolvePendingSessionStart = useCallback((decision: NewSessionStartDecision): void => {
+    const resolver = pendingSessionStartResolverRef.current;
+    pendingSessionStartResolverRef.current = null;
+    setPendingSessionStartRequest(null);
+    resolver?.(decision);
+  }, []);
+
+  const requestNewSessionStart = useCallback(
+    (request: NewSessionStartRequest): Promise<NewSessionStartDecision> => {
+      pendingSessionStartResolverRef.current?.(null);
+      return new Promise((resolve) => {
+        pendingSessionStartResolverRef.current = resolve;
+        setPendingSessionStartRequest(request);
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      pendingSessionStartResolverRef.current?.(null);
+      pendingSessionStartResolverRef.current = null;
+    };
+  }, []);
+
+  return {
+    pendingSessionStartRequest,
+    requestNewSessionStart,
+    resolvePendingSessionStart,
+  };
+}


### PR DESCRIPTION
## Summary
- split `AgentsPage` responsibilities into focused controller hooks instead of keeping orchestration/query/session logic in a single large page file
- introduce `useAgentStudioOrchestrationController` grouped context contracts (`workspace`, `selection`, `readiness`, `composer`, `actions`) to keep `agents-page.tsx` as a composition root
- extract query/session synchronization into `use-agent-studio-query-session-sync.ts`
- extract session start request lifecycle into `use-agent-studio-session-start-request.ts`
- add selection-controller sorting cache reuse to avoid unnecessary per-task re-sorts when task session signatures are unchanged

## Main Changes
- `apps/desktop/src/pages/agents-page.tsx`
  - now focuses on composing hooks/models and layout
  - passes typed grouped contexts to orchestration controller via `satisfies`
- `apps/desktop/src/pages/use-agent-studio-orchestration-controller.ts`
  - central orchestration wiring + page model arg builder
  - exported context types for narrow contracts
- `apps/desktop/src/pages/use-agent-studio-query-session-sync.ts`
  - URL query/session synchronization behavior extracted from page
- `apps/desktop/src/pages/use-agent-studio-selection-controller.ts`
  - selection/task/session resolution logic extracted and optimized with task-session sort cache
- `apps/desktop/src/pages/use-agent-studio-session-start-request.ts`
  - isolated pending session-start request + resolver lifecycle

## Tests
- added:
  - `apps/desktop/src/pages/use-agent-studio-query-session-sync.test.tsx`
  - `apps/desktop/src/pages/use-agent-studio-selection-controller.test.tsx`
  - `apps/desktop/src/pages/use-agent-studio-orchestration-controller.test.ts`
  - `apps/desktop/src/pages/use-agent-studio-session-start-request.test.tsx`
- validated locally:
  - `bun run --filter @openducktor/desktop lint`
  - `bun run --filter @openducktor/desktop typecheck`
  - `bun run --filter @openducktor/desktop test`
  - `bun run --filter @openducktor/desktop build`
