### PR TITLE
refactor(host-application): simplify and harden build cleanup orchestration

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -47,12 +47,9 @@ impl CleanupMode {
     }
 }
 
-enum CleanupStatusTransition {
-    Blocked {
-        reason: &'static str,
-        mark_run_failed: bool,
-    },
-    ReviewReady,
+struct ReviewTransition {
+    status: TaskStatus,
+    label: &'static str,
 }
 
 enum CleanupEvent<'a> {
@@ -375,32 +372,75 @@ impl AppService {
         mode: CleanupMode,
         emitter: RunEmitter,
     ) -> Result<bool> {
-        let mut runs = self
-            .runs
-            .lock()
-            .map_err(|_| anyhow!("Run state lock poisoned"))?;
-        let mut run = runs
-            .remove(run_id)
-            .ok_or_else(|| anyhow!("Run not found: {run_id}"))?;
+        let mut run = self.take_run_for_cleanup(run_id)?;
 
         terminate_child_process(&mut run.child);
 
-        if matches!(mode, CleanupMode::Failure) {
-            self.apply_task_status_transition(
-                &mut run,
-                CleanupStatusTransition::Blocked {
-                    reason: "Run failed; worktree retained",
-                    mark_run_failed: true,
-                },
-            )?;
-            self.emit_cleanup_events(&emitter, run_id, CleanupEvent::RunFailed);
-            return Ok(true);
+        match mode {
+            CleanupMode::Failure => self.cleanup_failed_run(run_id, &mut run, &emitter),
+            CleanupMode::Success => self.cleanup_success_run(run_id, &mut run, &emitter),
+        }
+    }
+
+    fn take_run_for_cleanup(&self, run_id: &str) -> Result<RunProcess> {
+        self.runs
+            .lock()
+            .map_err(|_| anyhow!("Run state lock poisoned"))?
+            .remove(run_id)
+            .ok_or_else(|| anyhow!("Run not found: {run_id}"))
+    }
+
+    fn cleanup_failed_run(
+        &self,
+        run_id: &str,
+        run: &mut RunProcess,
+        emitter: &RunEmitter,
+    ) -> Result<bool> {
+        self.apply_blocked_transition(run, "Run failed; worktree retained", true)?;
+        self.emit_cleanup_events(emitter, run_id, CleanupEvent::RunFailed);
+        Ok(true)
+    }
+
+    fn cleanup_success_run(
+        &self,
+        run_id: &str,
+        run: &mut RunProcess,
+        emitter: &RunEmitter,
+    ) -> Result<bool> {
+        if !self.run_post_complete_hooks(run_id, run, emitter)? {
+            return Ok(false);
         }
 
+        let review_transition = self.determine_review_transition(run)?;
+        self.emit_cleanup_events(
+            emitter,
+            run_id,
+            CleanupEvent::ReadyForReview {
+                review_label: review_transition.label,
+            },
+        );
+        self.apply_review_transition(run, &review_transition)?;
+        self.cleanup_worktree(run)?;
+        self.emit_cleanup_events(
+            emitter,
+            run_id,
+            CleanupEvent::RunCompleted {
+                review_label: review_transition.label,
+            },
+        );
+        Ok(true)
+    }
+
+    fn run_post_complete_hooks(
+        &self,
+        run_id: &str,
+        run: &mut RunProcess,
+        emitter: &RunEmitter,
+    ) -> Result<bool> {
         let post_complete_hooks = run.repo_config.hooks.post_complete.clone();
         for hook in post_complete_hooks {
             self.emit_cleanup_events(
-                &emitter,
+                emitter,
                 run_id,
                 CleanupEvent::PostHookStarted {
                     hook: hook.as_str(),
@@ -411,92 +451,76 @@ impl AppService {
                 run_parsed_hook_command_allow_failure(hook.as_str(), Path::new(&run.worktree_path));
 
             if !ok {
-                self.apply_task_status_transition(
-                    &mut run,
-                    CleanupStatusTransition::Blocked {
-                        reason: "Post-complete hook failed",
-                        mark_run_failed: false,
-                    },
-                )?;
+                self.apply_blocked_transition(run, "Post-complete hook failed", false)?;
                 self.emit_cleanup_events(
-                    &emitter,
+                    emitter,
                     run_id,
                     CleanupEvent::PostHookFailed {
                         hook: hook.as_str(),
                         stderr: stderr.as_str(),
                     },
                 );
-
                 return Ok(false);
             }
         }
-
-        let review_label = self
-            .apply_task_status_transition(&mut run, CleanupStatusTransition::ReviewReady)?
-            .ok_or_else(|| anyhow!("Cleanup review transition did not return a review label"))?;
-        self.emit_cleanup_events(
-            &emitter,
-            run_id,
-            CleanupEvent::ReadyForReview { review_label },
-        );
-        self.cleanup_worktree_and_branches(&run)?;
-        self.emit_cleanup_events(
-            &emitter,
-            run_id,
-            CleanupEvent::RunCompleted { review_label },
-        );
-
         Ok(true)
     }
 
-    fn cleanup_worktree_and_branches(&self, run: &RunProcess) -> Result<()> {
+    fn cleanup_worktree(&self, run: &RunProcess) -> Result<()> {
         remove_worktree(Path::new(&run.repo_path), Path::new(&run.worktree_path))
     }
 
-    fn apply_task_status_transition(
+    fn apply_blocked_transition(
         &self,
         run: &mut RunProcess,
-        transition: CleanupStatusTransition,
-    ) -> Result<Option<&'static str>> {
-        match transition {
-            CleanupStatusTransition::Blocked {
-                reason,
-                mark_run_failed,
-            } => {
-                self.task_transition(
-                    &run.repo_path,
-                    &run.task_id,
-                    TaskStatus::Blocked,
-                    Some(reason),
-                )?;
-                if mark_run_failed {
-                    run.summary.state = RunState::Failed;
-                }
-                Ok(None)
-            }
-            CleanupStatusTransition::ReviewReady => {
-                let current_task = self
-                    .task_store
-                    .list_tasks(Path::new(&run.repo_path))?
-                    .into_iter()
-                    .find(|task| task.id == run.task_id)
-                    .ok_or_else(|| anyhow!("Task not found: {}", run.task_id))?;
-
-                let (review_status, review_label) = if current_task.ai_review_enabled {
-                    (TaskStatus::AiReview, "AI review")
-                } else {
-                    (TaskStatus::HumanReview, "Human review")
-                };
-
-                self.task_transition(
-                    &run.repo_path,
-                    &run.task_id,
-                    review_status,
-                    Some("Builder completed"),
-                )?;
-                Ok(Some(review_label))
-            }
+        reason: &'static str,
+        mark_run_failed: bool,
+    ) -> Result<()> {
+        self.task_transition(
+            &run.repo_path,
+            &run.task_id,
+            TaskStatus::Blocked,
+            Some(reason),
+        )?;
+        if mark_run_failed {
+            run.summary.state = RunState::Failed;
         }
+        Ok(())
+    }
+
+    fn determine_review_transition(&self, run: &RunProcess) -> Result<ReviewTransition> {
+        let current_task = self
+            .task_store
+            .list_tasks(Path::new(&run.repo_path))?
+            .into_iter()
+            .find(|task| task.id == run.task_id)
+            .ok_or_else(|| anyhow!("Task not found: {}", run.task_id))?;
+
+        if current_task.ai_review_enabled {
+            Ok(ReviewTransition {
+                status: TaskStatus::AiReview,
+                label: "AI review",
+            })
+        } else {
+            Ok(ReviewTransition {
+                status: TaskStatus::HumanReview,
+                label: "Human review",
+            })
+        }
+    }
+
+    fn apply_review_transition(
+        &self,
+        run: &RunProcess,
+        review_transition: &ReviewTransition,
+    ) -> Result<()> {
+        self.task_transition(
+            &run.repo_path,
+            &run.task_id,
+            review_transition.status.clone(),
+            Some("Builder completed"),
+        )?;
+        Ok(())
     }
 
     fn emit_cleanup_events(&self, emitter: &RunEmitter, run_id: &str, event: CleanupEvent<'_>) {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -496,17 +496,17 @@ impl AppService {
             .find(|task| task.id == run.task_id)
             .ok_or_else(|| anyhow!("Task not found: {}", run.task_id))?;
 
-        if current_task.ai_review_enabled {
-            Ok(ReviewTransition {
+        Ok(if current_task.ai_review_enabled {
+            ReviewTransition {
                 status: TaskStatus::AiReview,
                 label: "AI review",
-            })
+            }
         } else {
-            Ok(ReviewTransition {
+            ReviewTransition {
                 status: TaskStatus::HumanReview,
                 label: "Human review",
-            })
-        }
+            }
+        })
     }
 
     fn apply_review_transition(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -47,6 +47,22 @@ impl CleanupMode {
     }
 }
 
+enum CleanupStatusTransition {
+    Blocked {
+        reason: &'static str,
+        mark_run_failed: bool,
+    },
+    ReviewReady,
+}
+
+enum CleanupEvent<'a> {
+    RunFailed,
+    PostHookStarted { hook: &'a str },
+    PostHookFailed { hook: &'a str, stderr: &'a str },
+    ReadyForReview { review_label: &'a str },
+    RunCompleted { review_label: &'a str },
+}
+
 impl AppService {
     pub fn build_start(
         &self,
@@ -369,57 +385,45 @@ impl AppService {
 
         terminate_child_process(&mut run.child);
 
-        match mode {
-            CleanupMode::Failure => {
-                self.task_transition(
-                    &run.repo_path,
-                    &run.task_id,
-                    TaskStatus::Blocked,
-                    Some("Run failed; worktree retained"),
-                )?;
-
-                run.summary.state = RunState::Failed;
-                emit_event(
-                    &emitter,
-                    RunEvent::RunFinished {
-                        run_id: run_id.to_string(),
-                        message: "Run marked as failed; worktree retained".to_string(),
-                        timestamp: now_rfc3339(),
-                        success: false,
-                    },
-                );
-                return Ok(true);
-            }
-            CleanupMode::Success => {}
+        if matches!(mode, CleanupMode::Failure) {
+            self.apply_task_status_transition(
+                &mut run,
+                CleanupStatusTransition::Blocked {
+                    reason: "Run failed; worktree retained",
+                    mark_run_failed: true,
+                },
+            )?;
+            self.emit_cleanup_events(&emitter, run_id, CleanupEvent::RunFailed);
+            return Ok(true);
         }
 
-        for hook in &run.repo_config.hooks.post_complete {
-            emit_event(
+        let post_complete_hooks = run.repo_config.hooks.post_complete.clone();
+        for hook in post_complete_hooks {
+            self.emit_cleanup_events(
                 &emitter,
-                RunEvent::PostHookStarted {
-                    run_id: run_id.to_string(),
-                    message: format!("Running post-complete hook: {hook}"),
-                    timestamp: now_rfc3339(),
+                run_id,
+                CleanupEvent::PostHookStarted {
+                    hook: hook.as_str(),
                 },
             );
 
             let (ok, _stdout, stderr) =
-                run_parsed_hook_command_allow_failure(hook, Path::new(&run.worktree_path));
+                run_parsed_hook_command_allow_failure(hook.as_str(), Path::new(&run.worktree_path));
 
             if !ok {
-                self.task_transition(
-                    &run.repo_path,
-                    &run.task_id,
-                    TaskStatus::Blocked,
-                    Some("Post-complete hook failed"),
+                self.apply_task_status_transition(
+                    &mut run,
+                    CleanupStatusTransition::Blocked {
+                        reason: "Post-complete hook failed",
+                        mark_run_failed: false,
+                    },
                 )?;
-
-                emit_event(
+                self.emit_cleanup_events(
                     &emitter,
-                    RunEvent::PostHookFailed {
-                        run_id: run_id.to_string(),
-                        message: format!("Post-complete hook failed: {hook}\n{stderr}"),
-                        timestamp: now_rfc3339(),
+                    run_id,
+                    CleanupEvent::PostHookFailed {
+                        hook: hook.as_str(),
+                        stderr: stderr.as_str(),
                     },
                 );
 
@@ -427,54 +431,109 @@ impl AppService {
             }
         }
 
-        let current_task = self
-            .task_store
-            .list_tasks(Path::new(&run.repo_path))?
-            .into_iter()
-            .find(|task| task.id == run.task_id)
-            .ok_or_else(|| anyhow!("Task not found: {}", run.task_id))?;
-
-        let review_status = if current_task.ai_review_enabled {
-            TaskStatus::AiReview
-        } else {
-            TaskStatus::HumanReview
-        };
-
-        let review_label = if current_task.ai_review_enabled {
-            "AI review"
-        } else {
-            "Human review"
-        };
-
-        emit_event(
+        let review_label = self
+            .apply_task_status_transition(&mut run, CleanupStatusTransition::ReviewReady)?
+            .ok_or_else(|| anyhow!("Cleanup review transition did not return a review label"))?;
+        self.emit_cleanup_events(
             &emitter,
-            RunEvent::ReadyForManualDoneConfirmation {
-                run_id: run_id.to_string(),
-                message: format!("Post-complete hooks passed. Transitioning to {review_label}."),
-                timestamp: now_rfc3339(),
-            },
+            run_id,
+            CleanupEvent::ReadyForReview { review_label },
+        );
+        self.cleanup_worktree_and_branches(&run)?;
+        self.emit_cleanup_events(
+            &emitter,
+            run_id,
+            CleanupEvent::RunCompleted { review_label },
         );
 
-        self.task_transition(
-            &run.repo_path,
-            &run.task_id,
-            review_status,
-            Some("Builder completed"),
-        )?;
+        Ok(true)
+    }
 
-        remove_worktree(Path::new(&run.repo_path), Path::new(&run.worktree_path))?;
+    fn cleanup_worktree_and_branches(&self, run: &RunProcess) -> Result<()> {
+        remove_worktree(Path::new(&run.repo_path), Path::new(&run.worktree_path))
+    }
 
-        emit_event(
-            &emitter,
-            RunEvent::RunFinished {
+    fn apply_task_status_transition(
+        &self,
+        run: &mut RunProcess,
+        transition: CleanupStatusTransition,
+    ) -> Result<Option<&'static str>> {
+        match transition {
+            CleanupStatusTransition::Blocked {
+                reason,
+                mark_run_failed,
+            } => {
+                self.task_transition(
+                    &run.repo_path,
+                    &run.task_id,
+                    TaskStatus::Blocked,
+                    Some(reason),
+                )?;
+                if mark_run_failed {
+                    run.summary.state = RunState::Failed;
+                }
+                Ok(None)
+            }
+            CleanupStatusTransition::ReviewReady => {
+                let current_task = self
+                    .task_store
+                    .list_tasks(Path::new(&run.repo_path))?
+                    .into_iter()
+                    .find(|task| task.id == run.task_id)
+                    .ok_or_else(|| anyhow!("Task not found: {}", run.task_id))?;
+
+                let (review_status, review_label) = if current_task.ai_review_enabled {
+                    (TaskStatus::AiReview, "AI review")
+                } else {
+                    (TaskStatus::HumanReview, "Human review")
+                };
+
+                self.task_transition(
+                    &run.repo_path,
+                    &run.task_id,
+                    review_status,
+                    Some("Builder completed"),
+                )?;
+                Ok(Some(review_label))
+            }
+        }
+    }
+
+    fn emit_cleanup_events(&self, emitter: &RunEmitter, run_id: &str, event: CleanupEvent<'_>) {
+        let event = match event {
+            CleanupEvent::RunFailed => RunEvent::RunFinished {
+                run_id: run_id.to_string(),
+                message: "Run marked as failed; worktree retained".to_string(),
+                timestamp: now_rfc3339(),
+                success: false,
+            },
+            CleanupEvent::PostHookStarted { hook } => RunEvent::PostHookStarted {
+                run_id: run_id.to_string(),
+                message: format!("Running post-complete hook: {hook}"),
+                timestamp: now_rfc3339(),
+            },
+            CleanupEvent::PostHookFailed { hook, stderr } => RunEvent::PostHookFailed {
+                run_id: run_id.to_string(),
+                message: format!("Post-complete hook failed: {hook}\n{stderr}"),
+                timestamp: now_rfc3339(),
+            },
+            CleanupEvent::ReadyForReview { review_label } => {
+                RunEvent::ReadyForManualDoneConfirmation {
+                    run_id: run_id.to_string(),
+                    message: format!(
+                        "Post-complete hooks passed. Transitioning to {review_label}."
+                    ),
+                    timestamp: now_rfc3339(),
+                }
+            }
+            CleanupEvent::RunCompleted { review_label } => RunEvent::RunFinished {
                 run_id: run_id.to_string(),
                 message: format!("Run completed; moved to {review_label}; worktree removed"),
                 timestamp: now_rfc3339(),
                 success: true,
             },
-        );
-
-        Ok(true)
+        };
+        emit_event(emitter, event);
     }
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -125,6 +125,18 @@ fn build_start_respond_and_cleanup_success_flow() -> Result<()> {
     assert!(emitted
         .iter()
         .any(|event| matches!(event, RunEvent::RunFinished { success: true, .. })));
+    let ready_for_review_index = emitted
+        .iter()
+        .position(|event| matches!(event, RunEvent::ReadyForManualDoneConfirmation { .. }))
+        .expect("ready-for-review event should be emitted");
+    let run_finished_index = emitted
+        .iter()
+        .position(|event| matches!(event, RunEvent::RunFinished { success: true, .. }))
+        .expect("successful run-finished event should be emitted");
+    assert!(
+        ready_for_review_index < run_finished_index,
+        "ready-for-review event should be emitted before run-finished"
+    );
     drop(emitted);
 
     let _ = fs::remove_dir_all(root);
@@ -309,6 +321,18 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
     assert!(emitted
         .iter()
         .any(|event| matches!(event, RunEvent::PostHookFailed { .. })));
+    let post_hook_started_index = emitted
+        .iter()
+        .position(|event| matches!(event, RunEvent::PostHookStarted { .. }))
+        .expect("post-hook-started event should be emitted");
+    let post_hook_failed_index = emitted
+        .iter()
+        .position(|event| matches!(event, RunEvent::PostHookFailed { .. }))
+        .expect("post-hook-failed event should be emitted");
+    assert!(
+        post_hook_started_index < post_hook_failed_index,
+        "post-hook-started event should be emitted before post-hook-failed"
+    );
     drop(emitted);
 
     let _ = fs::remove_dir_all(root);


### PR DESCRIPTION
## Summary
- refactor `build_cleanup` into a small dispatcher with focused helpers for run lookup, failure cleanup, success cleanup, hook execution, status transitions, and worktree cleanup
- restore and lock cleanup event sequencing by emitting `ReadyForManualDoneConfirmation` before review transition and by validating post-hook event order
- tighten transition typing by replacing the prior optional return path with explicit blocked/review transition helpers
- add integration assertions for cleanup event ordering in success and hook-failure flows

## Testing
- `cd apps/desktop/src-tauri && cargo test -p host-application app_service::tests::integration::build_flows::`
- `cd apps/desktop/src-tauri && cargo test -p host-application`
