### PR TITLE
refactor(desktop): decompose agent question card and harden draft state updates

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-card.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-card.test.tsx
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import type { AgentQuestionRequest } from "@/types/agent-orchestrator";
+import { AgentSessionQuestionCard } from "./agent-session-question-card";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const TEST_RENDERER_DEPRECATION_WARNING = "react-test-renderer is deprecated";
+const originalConsoleError = console.error;
+
+type CardProps = React.ComponentProps<typeof AgentSessionQuestionCard>;
+
+const buildRequest = (overrides: Partial<AgentQuestionRequest> = {}): AgentQuestionRequest => ({
+  requestId: "request-1",
+  questions: [
+    {
+      header: "Scope",
+      question: "Which area should we prioritize?",
+      options: [
+        { label: "Frontend", description: "UI and interaction work" },
+        { label: "Backend", description: "Services and persistence" },
+      ],
+      multiple: false,
+    },
+  ],
+  ...overrides,
+});
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const nodeText = (node: TestRenderer.ReactTestInstance): string => {
+  return node.children
+    .map((child) => {
+      if (typeof child === "string") {
+        return child;
+      }
+      return nodeText(child);
+    })
+    .join("");
+};
+
+const createCardHarness = (props: CardProps) => {
+  let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+  const mount = async (): Promise<void> => {
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(AgentSessionQuestionCard, props));
+      await flush();
+    });
+  };
+
+  const unmount = async (): Promise<void> => {
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  };
+
+  const clickButtonByText = async (label: string, index = 0): Promise<void> => {
+    if (!renderer) {
+      throw new Error("Renderer not mounted");
+    }
+    const button = renderer.root.findAll(
+      (node) =>
+        node.type === "button" &&
+        typeof node.props.onClick === "function" &&
+        nodeText(node).includes(label),
+    )[index];
+    if (!button) {
+      throw new Error(`No button found for label '${label}' at index ${index}`);
+    }
+    await act(async () => {
+      button.props.onClick();
+      await flush();
+    });
+  };
+
+  const getButtonDisabled = (label: string): boolean => {
+    if (!renderer) {
+      throw new Error("Renderer not mounted");
+    }
+    const button = renderer.root.find(
+      (node) =>
+        node.type === "button" &&
+        typeof node.props.onClick === "function" &&
+        nodeText(node).includes(label),
+    );
+    return Boolean(button.props.disabled);
+  };
+
+  const asText = (): string => {
+    if (!renderer) {
+      throw new Error("Renderer not mounted");
+    }
+    return JSON.stringify(renderer.toJSON());
+  };
+
+  return { mount, unmount, clickButtonByText, getButtonDisabled, asText };
+};
+
+describe("AgentSessionQuestionCard", () => {
+  beforeEach(() => {
+    console.error = (...args: unknown[]): void => {
+      if (typeof args[0] === "string" && args[0].includes(TEST_RENDERER_DEPRECATION_WARNING)) {
+        return;
+      }
+      originalConsoleError(...args);
+    };
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  test("navigates from summary to a selected question tab", async () => {
+    const harness = createCardHarness({
+      request: buildRequest({
+        questions: [
+          {
+            header: "Architecture",
+            question: "What architecture should we follow?",
+            options: [{ label: "Hexagonal", description: "Ports and adapters" }],
+            multiple: false,
+          },
+          {
+            header: "Validation",
+            question: "How should we validate this change?",
+            options: [{ label: "Integration tests", description: "Exercise full card flow" }],
+            multiple: false,
+          },
+        ],
+      }),
+      onSubmit: async () => {},
+    });
+    await harness.mount();
+
+    await harness.clickButtonByText("Summary");
+    expect(harness.asText()).toContain("No answer yet");
+
+    await harness.clickButtonByText("Validation", 1);
+    expect(harness.asText()).toContain("How should we validate this change?");
+    expect(harness.asText()).not.toContain("No answer yet");
+
+    await harness.unmount();
+  });
+
+  test("enables submit after completion and sends normalized answers", async () => {
+    const onSubmit = mock(async () => {});
+    const harness = createCardHarness({
+      request: buildRequest(),
+      onSubmit,
+    });
+    await harness.mount();
+
+    expect(harness.getButtonDisabled("Confirm Answers")).toBe(true);
+
+    await harness.clickButtonByText("Frontend");
+    expect(harness.getButtonDisabled("Confirm Answers")).toBe(false);
+
+    await harness.clickButtonByText("Confirm Answers");
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("request-1", [["Frontend"]]);
+
+    await harness.unmount();
+  });
+
+  test("reset clears draft answers and disables submit again", async () => {
+    const harness = createCardHarness({
+      request: buildRequest(),
+      onSubmit: async () => {},
+    });
+    await harness.mount();
+
+    await harness.clickButtonByText("Backend");
+    expect(harness.getButtonDisabled("Confirm Answers")).toBe(false);
+    expect(harness.asText()).toContain("All questions answered.");
+
+    await harness.clickButtonByText("Reset");
+    expect(harness.getButtonDisabled("Confirm Answers")).toBe(true);
+    expect(harness.asText()).toContain("Answer all questions to confirm.");
+
+    await harness.unmount();
+  });
+
+  test("shows submit errors and clears them after user edits", async () => {
+    const harness = createCardHarness({
+      request: buildRequest(),
+      onSubmit: async () => {
+        throw new Error("Submission exploded");
+      },
+    });
+    await harness.mount();
+
+    await harness.clickButtonByText("Frontend");
+    await harness.clickButtonByText("Confirm Answers");
+    expect(harness.asText()).toContain("Submission exploded");
+
+    await harness.clickButtonByText("Frontend");
+    expect(harness.asText()).not.toContain("Submission exploded");
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-card.tsx
@@ -1,31 +1,13 @@
-import {
-  CheckCircle2,
-  CheckSquare,
-  Circle,
-  CircleDotDashed,
-  ListChecks,
-  LoaderCircle,
-  MessageSquarePlus,
-  Sparkles,
-  Square,
-} from "lucide-react";
-import { type ReactElement, useEffect, useMemo, useState } from "react";
-import { flushSync } from "react-dom";
+import { CheckCircle2, Circle, CircleDotDashed, ListChecks } from "lucide-react";
+import type { ReactElement } from "react";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import type { AgentQuestionRequest } from "@/types/agent-orchestrator";
-import {
-  type AgentQuestionDraftEntry,
-  buildAgentQuestionAnswers,
-  createAgentQuestionDraft,
-  isAgentQuestionAnswered,
-  isAgentQuestionRequestComplete,
-  normalizeAgentQuestionDraft,
-  toggleAgentQuestionOption,
-} from "./agent-session-question-draft";
-
-const SUMMARY_TAB_ID = "__summary__";
+import { isAgentQuestionAnswered } from "./agent-session-question-draft";
+import { QuestionSubmitFooter } from "./agent-session-question-submit-footer";
+import { QuestionSummaryTab } from "./agent-session-question-summary-tab";
+import { QuestionTab } from "./agent-session-question-tab";
+import { QUESTION_SUMMARY_TAB_ID, useQuestionDraft } from "./use-agent-session-question-draft";
 
 type AgentSessionQuestionCardProps = {
   request: AgentQuestionRequest;
@@ -34,62 +16,33 @@ type AgentSessionQuestionCardProps = {
   onSubmit: (requestId: string, answers: string[][]) => Promise<void>;
 };
 
-const answerPreviewForQuestion = (
-  question: AgentQuestionRequest["questions"][number],
-  entry: AgentQuestionDraftEntry | undefined,
-): string => {
-  const selection = entry?.selectedOptionLabels ?? [];
-  const freeText = entry?.useFreeText ? (entry.freeText ?? "").trim() : "";
-  if (!question.multiple) {
-    if (freeText.length > 0) {
-      return freeText;
-    }
-    return selection[0] ?? "No answer yet";
-  }
-  const answers = [...selection, ...(freeText.length > 0 ? [freeText] : [])];
-  return answers.length > 0 ? answers.join(", ") : "No answer yet";
-};
-
 export function AgentSessionQuestionCard({
   request,
   disabled = false,
   isSubmitting = false,
   onSubmit,
 }: AgentSessionQuestionCardProps): ReactElement | null {
-  const [activeTabId, setActiveTabId] = useState<string>("0");
-  const [draft, setDraft] = useState<AgentQuestionDraftEntry[]>(() =>
-    createAgentQuestionDraft(request),
-  );
-  const [submitError, setSubmitError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setActiveTabId("0");
-    setDraft(createAgentQuestionDraft(request));
-    setSubmitError(null);
-  }, [request]);
-
-  const normalizedDraft = useMemo(
-    () => normalizeAgentQuestionDraft(request, draft),
-    [request, draft],
-  );
-  const answeredCount = useMemo(
-    () =>
-      request.questions.filter((question, index) =>
-        isAgentQuestionAnswered(question, normalizedDraft[index]),
-      ).length,
-    [normalizedDraft, request.questions],
-  );
-  const requiredCount = request.questions.length;
-  const isComplete = useMemo(
-    () => isAgentQuestionRequestComplete(request, normalizedDraft),
-    [normalizedDraft, request],
-  );
-  const hasMultipleQuestions = request.questions.length > 1;
-  const isSummaryTab = hasMultipleQuestions && activeTabId === SUMMARY_TAB_ID;
-  const activeQuestionIndex = isSummaryTab ? -1 : Math.max(0, Number(activeTabId) || 0);
-  const activeQuestion =
-    activeQuestionIndex >= 0 ? request.questions[activeQuestionIndex] : undefined;
-  const activeEntry = activeQuestionIndex >= 0 ? normalizedDraft[activeQuestionIndex] : undefined;
+  const {
+    activeTabId,
+    setActiveTabId,
+    submitError,
+    clearSubmitError,
+    setSubmitError,
+    normalizedDraft,
+    answeredCount,
+    requiredCount,
+    isComplete,
+    hasMultipleQuestions,
+    isSummaryTab,
+    activeQuestion,
+    activeQuestionIndex,
+    activeEntry,
+    selectOption,
+    toggleFreeText,
+    updateFreeText,
+    resetDraft,
+    buildAnswers,
+  } = useQuestionDraft({ request });
 
   if (request.questions.length === 0) {
     return null;
@@ -157,7 +110,7 @@ export function AgentSessionQuestionCard({
                   ? "bg-sidebar-accent text-white hover:bg-sidebar-accent/90"
                   : "bg-card text-foreground hover:bg-muted",
               )}
-              onClick={() => setActiveTabId(SUMMARY_TAB_ID)}
+              onClick={() => setActiveTabId(QUESTION_SUMMARY_TAB_ID)}
             >
               <ListChecks className="size-3.5" />
               Summary
@@ -166,269 +119,47 @@ export function AgentSessionQuestionCard({
         ) : null}
 
         {isSummaryTab ? (
-          <div className="space-y-1.5 rounded-lg border border-input bg-card p-1.5">
-            {request.questions.map((question, index) => {
-              const answered = isAgentQuestionAnswered(question, normalizedDraft[index]);
-              return (
-                <button
-                  key={`${request.requestId}:summary:${question.header}:${index}`}
-                  type="button"
-                  className="w-full cursor-pointer rounded-md px-2 py-1 text-left hover:bg-accent"
-                  onClick={() => setActiveTabId(String(index))}
-                >
-                  <p className="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    {answered ? (
-                      <CheckCircle2 className="size-3 text-emerald-500" />
-                    ) : (
-                      <Circle className="size-3 text-muted-foreground" />
-                    )}
-                    {question.header?.trim() || `Question ${index + 1}`}
-                  </p>
-                  <p
-                    className={cn(
-                      "mt-0.5 text-xs",
-                      answered ? "text-foreground" : "italic text-muted-foreground",
-                    )}
-                  >
-                    {answerPreviewForQuestion(question, normalizedDraft[index])}
-                  </p>
-                </button>
-              );
-            })}
-          </div>
+          <QuestionSummaryTab
+            request={request}
+            draft={normalizedDraft}
+            onSelectQuestion={(index) => setActiveTabId(String(index))}
+          />
         ) : activeQuestion ? (
-          <div className="space-y-2">
-            <div className="space-y-1">
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                  {activeQuestion.header?.trim() || `Question ${activeQuestionIndex + 1}`}
-                </p>
-                <p className="text-[13px] font-medium text-foreground">{activeQuestion.question}</p>
-              </div>
-              {activeQuestion.multiple ? (
-                <p className="inline-flex items-center gap-1 rounded-full border border-input bg-secondary px-1.5 py-0 text-[10px] font-semibold text-foreground">
-                  <CheckSquare className="size-3" />
-                  Multiple choice - select one or more answers
-                </p>
-              ) : null}
-            </div>
-
-            {activeQuestion.options.length > 0 ? (
-              <div className="space-y-1">
-                {activeQuestion.options.map((option) => {
-                  const isSelected = Boolean(
-                    activeEntry?.selectedOptionLabels.includes(option.label),
-                  );
-                  return (
-                    <button
-                      key={`${request.requestId}:option:${activeQuestionIndex}:${option.label}`}
-                      type="button"
-                      disabled={disabled || isSubmitting}
-                      className={cn(
-                        "w-full cursor-pointer rounded-md border px-2 py-1 text-left transition-colors",
-                        isSelected
-                          ? "border-muted-foreground bg-secondary text-foreground"
-                          : "border-border bg-card text-foreground hover:border-input hover:bg-accent",
-                        (disabled || isSubmitting) && "cursor-not-allowed opacity-70",
-                      )}
-                      onClick={() => {
-                        setSubmitError(null);
-                        let shouldAdvance = false;
-                        flushSync(() => {
-                          setDraft((current) => {
-                            const next = normalizeAgentQuestionDraft(request, current);
-                            const target = next[activeQuestionIndex] ?? {
-                              selectedOptionLabels: [],
-                              freeText: "",
-                              useFreeText: false,
-                            };
-                            const wasSelected = target.selectedOptionLabels.includes(option.label);
-                            const nextEntry = toggleAgentQuestionOption(
-                              activeQuestion,
-                              target,
-                              option.label,
-                            );
-                            next[activeQuestionIndex] =
-                              !activeQuestion.multiple && nextEntry.selectedOptionLabels.length > 0
-                                ? {
-                                    ...nextEntry,
-                                    useFreeText: false,
-                                  }
-                                : nextEntry;
-                            shouldAdvance =
-                              !activeQuestion.multiple &&
-                              !wasSelected &&
-                              nextEntry.selectedOptionLabels.length > 0;
-                            return next;
-                          });
-                        });
-                        if (shouldAdvance && hasMultipleQuestions) {
-                          const nextQuestionIndex = activeQuestionIndex + 1;
-                          setActiveTabId(
-                            nextQuestionIndex < request.questions.length
-                              ? String(nextQuestionIndex)
-                              : SUMMARY_TAB_ID,
-                          );
-                        }
-                      }}
-                    >
-                      <div className="flex items-start gap-1.5">
-                        <span className="inline-flex size-4 shrink-0 items-center justify-center pt-0.5">
-                          {activeQuestion.multiple ? (
-                            isSelected ? (
-                              <CheckSquare className="size-3.5 text-foreground" />
-                            ) : (
-                              <Square className="size-3.5 text-muted-foreground" />
-                            )
-                          ) : isSelected ? (
-                            <CheckCircle2 className="size-3.5 text-foreground" />
-                          ) : (
-                            <Circle className="size-3.5 text-muted-foreground" />
-                          )}
-                        </span>
-                        <span className="min-w-0">
-                          <span className="block text-[12px] font-medium leading-4">
-                            {option.label}
-                          </span>
-                          <span className="block text-[10px] leading-4 text-muted-foreground">
-                            {option.description}
-                          </span>
-                        </span>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            ) : null}
-
-            {activeQuestion.options.length > 0 ? (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className={cn(
-                  "h-6 cursor-pointer border-input px-2 text-[11px]",
-                  activeEntry?.useFreeText
-                    ? "bg-primary text-primary-foreground hover:bg-primary/90"
-                    : "bg-card text-foreground hover:bg-accent",
-                )}
-                disabled={disabled || isSubmitting}
-                onClick={() => {
-                  setSubmitError(null);
-                  setDraft((current) => {
-                    const next = normalizeAgentQuestionDraft(request, current);
-                    const target = next[activeQuestionIndex] ?? {
-                      selectedOptionLabels: [],
-                      freeText: "",
-                      useFreeText: false,
-                    };
-                    next[activeQuestionIndex] = {
-                      ...target,
-                      useFreeText: !target.useFreeText,
-                      selectedOptionLabels:
-                        !target.useFreeText && !activeQuestion.multiple
-                          ? []
-                          : target.selectedOptionLabels,
-                    };
-                    return next;
-                  });
-                }}
-              >
-                <MessageSquarePlus className="size-3.5" />
-                Other answer
-              </Button>
-            ) : null}
-
-            {activeQuestion.options.length === 0 || activeEntry?.useFreeText ? (
-              <div className="space-y-1">
-                <p className="text-[11px] text-muted-foreground">Free text answer</p>
-                <Textarea
-                  value={activeEntry?.freeText ?? ""}
-                  disabled={disabled || isSubmitting}
-                  className="min-h-16 bg-card text-sm"
-                  placeholder="Write your answer..."
-                  onChange={(event) => {
-                    setSubmitError(null);
-                    const value = event.currentTarget.value;
-                    setDraft((current) => {
-                      const next = normalizeAgentQuestionDraft(request, current);
-                      const target = next[activeQuestionIndex] ?? {
-                        selectedOptionLabels: [],
-                        freeText: "",
-                        useFreeText: true,
-                      };
-                      next[activeQuestionIndex] = {
-                        ...target,
-                        freeText: value,
-                        useFreeText: true,
-                        selectedOptionLabels: activeQuestion.multiple
-                          ? target.selectedOptionLabels
-                          : [],
-                      };
-                      return next;
-                    });
-                  }}
-                />
-              </div>
-            ) : null}
-          </div>
+          <QuestionTab
+            requestId={request.requestId}
+            question={activeQuestion}
+            questionIndex={activeQuestionIndex}
+            entry={activeEntry}
+            disabled={disabled || isSubmitting}
+            onSelectOption={(optionLabel) => selectOption(activeQuestionIndex, optionLabel)}
+            onToggleFreeText={() => toggleFreeText(activeQuestionIndex)}
+            onChangeFreeText={(value) => updateFreeText(activeQuestionIndex, value)}
+          />
         ) : null}
 
         {submitError ? (
-          <p className="rounded-md border border-rose-200 dark:border-rose-800 bg-rose-50 dark:bg-rose-950/50 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
+          <p className="rounded-md border border-rose-200 bg-rose-50 px-2 py-1.5 text-xs text-rose-700 dark:border-rose-800 dark:bg-rose-950/50 dark:text-rose-300">
             {submitError}
           </p>
         ) : null}
 
-        <footer className="flex items-center justify-between gap-2 border-t border-input pt-1.5">
-          <p className="text-[11px] text-muted-foreground">
-            {isComplete ? "All questions answered." : "Answer all questions to confirm."}
-          </p>
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="h-7"
-              disabled={disabled || isSubmitting}
-              onClick={() => {
-                setSubmitError(null);
-                setDraft(createAgentQuestionDraft(request));
-              }}
-            >
-              Reset
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              className="h-7"
-              disabled={disabled || isSubmitting || !isComplete}
-              onClick={() => {
-                setSubmitError(null);
-                const answers = buildAgentQuestionAnswers(request, normalizedDraft);
-                void onSubmit(request.requestId, answers).catch((error) => {
-                  const description =
-                    error instanceof Error && error.message.trim().length > 0
-                      ? error.message
-                      : "Failed to submit answers.";
-                  setSubmitError(description);
-                });
-              }}
-            >
-              {isSubmitting ? (
-                <>
-                  <LoaderCircle className="size-3.5 animate-spin" />
-                  Submitting...
-                </>
-              ) : (
-                <>
-                  <Sparkles className="size-3.5" />
-                  Confirm Answers
-                </>
-              )}
-            </Button>
-          </div>
-        </footer>
+        <QuestionSubmitFooter
+          disabled={disabled}
+          isSubmitting={isSubmitting}
+          isComplete={isComplete}
+          onReset={resetDraft}
+          onSubmit={() => {
+            clearSubmitError();
+            const answers = buildAnswers();
+            void onSubmit(request.requestId, answers).catch((error) => {
+              const description =
+                error instanceof Error && error.message.trim().length > 0
+                  ? error.message
+                  : "Failed to submit answers.";
+              setSubmitError(description);
+            });
+          }}
+        />
       </div>
     </section>
   );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-submit-footer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-submit-footer.tsx
@@ -1,0 +1,58 @@
+import { LoaderCircle, Sparkles } from "lucide-react";
+import type { ReactElement } from "react";
+import { Button } from "@/components/ui/button";
+
+type QuestionSubmitFooterProps = {
+  disabled: boolean;
+  isSubmitting: boolean;
+  isComplete: boolean;
+  onReset: () => void;
+  onSubmit: () => void;
+};
+
+export const QuestionSubmitFooter = ({
+  disabled,
+  isSubmitting,
+  isComplete,
+  onReset,
+  onSubmit,
+}: QuestionSubmitFooterProps): ReactElement => {
+  return (
+    <footer className="flex items-center justify-between gap-2 border-t border-input pt-1.5">
+      <p className="text-[11px] text-muted-foreground">
+        {isComplete ? "All questions answered." : "Answer all questions to confirm."}
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-7"
+          disabled={disabled || isSubmitting}
+          onClick={onReset}
+        >
+          Reset
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          className="h-7"
+          disabled={disabled || isSubmitting || !isComplete}
+          onClick={onSubmit}
+        >
+          {isSubmitting ? (
+            <>
+              <LoaderCircle className="size-3.5 animate-spin" />
+              Submitting...
+            </>
+          ) : (
+            <>
+              <Sparkles className="size-3.5" />
+              Confirm Answers
+            </>
+          )}
+        </Button>
+      </div>
+    </footer>
+  );
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-summary-tab.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-summary-tab.tsx
@@ -1,0 +1,69 @@
+import { CheckCircle2, Circle } from "lucide-react";
+import type { ReactElement } from "react";
+import { cn } from "@/lib/utils";
+import type { AgentQuestionRequest } from "@/types/agent-orchestrator";
+import {
+  type AgentQuestionDraftEntry,
+  isAgentQuestionAnswered,
+} from "./agent-session-question-draft";
+
+type QuestionSummaryTabProps = {
+  request: AgentQuestionRequest;
+  draft: AgentQuestionDraftEntry[];
+  onSelectQuestion: (index: number) => void;
+};
+
+const answerPreviewForQuestion = (
+  question: AgentQuestionRequest["questions"][number],
+  entry: AgentQuestionDraftEntry | undefined,
+): string => {
+  const selection = entry?.selectedOptionLabels ?? [];
+  const freeText = entry?.useFreeText ? (entry.freeText ?? "").trim() : "";
+  if (!question.multiple) {
+    if (freeText.length > 0) {
+      return freeText;
+    }
+    return selection[0] ?? "No answer yet";
+  }
+  const answers = [...selection, ...(freeText.length > 0 ? [freeText] : [])];
+  return answers.length > 0 ? answers.join(", ") : "No answer yet";
+};
+
+export const QuestionSummaryTab = ({
+  request,
+  draft,
+  onSelectQuestion,
+}: QuestionSummaryTabProps): ReactElement => {
+  return (
+    <div className="space-y-1.5 rounded-lg border border-input bg-card p-1.5">
+      {request.questions.map((question, index) => {
+        const answered = isAgentQuestionAnswered(question, draft[index]);
+        return (
+          <button
+            key={`${request.requestId}:summary:${question.header}:${index}`}
+            type="button"
+            className="w-full cursor-pointer rounded-md px-2 py-1 text-left hover:bg-accent"
+            onClick={() => onSelectQuestion(index)}
+          >
+            <p className="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              {answered ? (
+                <CheckCircle2 className="size-3 text-emerald-500" />
+              ) : (
+                <Circle className="size-3 text-muted-foreground" />
+              )}
+              {question.header?.trim() || `Question ${index + 1}`}
+            </p>
+            <p
+              className={cn(
+                "mt-0.5 text-xs",
+                answered ? "text-foreground" : "italic text-muted-foreground",
+              )}
+            >
+              {answerPreviewForQuestion(question, draft[index])}
+            </p>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-tab.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-question-tab.tsx
@@ -1,0 +1,125 @@
+import { CheckCircle2, CheckSquare, Circle, MessageSquarePlus, Square } from "lucide-react";
+import type { ReactElement } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import type { AgentQuestionRequest } from "@/types/agent-orchestrator";
+import type { AgentQuestionDraftEntry } from "./agent-session-question-draft";
+
+type QuestionTabProps = {
+  requestId: string;
+  question: AgentQuestionRequest["questions"][number];
+  questionIndex: number;
+  entry: AgentQuestionDraftEntry | undefined;
+  disabled: boolean;
+  onSelectOption: (optionLabel: string) => void;
+  onToggleFreeText: () => void;
+  onChangeFreeText: (value: string) => void;
+};
+
+export const QuestionTab = ({
+  requestId,
+  question,
+  questionIndex,
+  entry,
+  disabled,
+  onSelectOption,
+  onToggleFreeText,
+  onChangeFreeText,
+}: QuestionTabProps): ReactElement => {
+  return (
+    <div className="space-y-2">
+      <div className="space-y-1">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            {question.header?.trim() || `Question ${questionIndex + 1}`}
+          </p>
+          <p className="text-[13px] font-medium text-foreground">{question.question}</p>
+        </div>
+        {question.multiple ? (
+          <p className="inline-flex items-center gap-1 rounded-full border border-input bg-secondary px-1.5 py-0 text-[10px] font-semibold text-foreground">
+            <CheckSquare className="size-3" />
+            Multiple choice - select one or more answers
+          </p>
+        ) : null}
+      </div>
+
+      {question.options.length > 0 ? (
+        <div className="space-y-1">
+          {question.options.map((option) => {
+            const isSelected = Boolean(entry?.selectedOptionLabels.includes(option.label));
+            return (
+              <button
+                key={`${requestId}:option:${questionIndex}:${option.label}`}
+                type="button"
+                disabled={disabled}
+                className={cn(
+                  "w-full cursor-pointer rounded-md border px-2 py-1 text-left transition-colors",
+                  isSelected
+                    ? "border-muted-foreground bg-secondary text-foreground"
+                    : "border-border bg-card text-foreground hover:border-input hover:bg-accent",
+                  disabled && "cursor-not-allowed opacity-70",
+                )}
+                onClick={() => onSelectOption(option.label)}
+              >
+                <div className="flex items-start gap-1.5">
+                  <span className="inline-flex size-4 shrink-0 items-center justify-center pt-0.5">
+                    {question.multiple ? (
+                      isSelected ? (
+                        <CheckSquare className="size-3.5 text-foreground" />
+                      ) : (
+                        <Square className="size-3.5 text-muted-foreground" />
+                      )
+                    ) : isSelected ? (
+                      <CheckCircle2 className="size-3.5 text-foreground" />
+                    ) : (
+                      <Circle className="size-3.5 text-muted-foreground" />
+                    )}
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block text-[12px] font-medium leading-4">{option.label}</span>
+                    <span className="block text-[10px] leading-4 text-muted-foreground">
+                      {option.description}
+                    </span>
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {question.options.length > 0 ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className={cn(
+            "h-6 cursor-pointer border-input px-2 text-[11px]",
+            entry?.useFreeText
+              ? "bg-primary text-primary-foreground hover:bg-primary/90"
+              : "bg-card text-foreground hover:bg-accent",
+          )}
+          disabled={disabled}
+          onClick={onToggleFreeText}
+        >
+          <MessageSquarePlus className="size-3.5" />
+          Other answer
+        </Button>
+      ) : null}
+
+      {question.options.length === 0 || entry?.useFreeText ? (
+        <div className="space-y-1">
+          <p className="text-[11px] text-muted-foreground">Free text answer</p>
+          <Textarea
+            value={entry?.freeText ?? ""}
+            disabled={disabled}
+            className="min-h-16 bg-card text-sm"
+            placeholder="Write your answer..."
+            onChange={(event) => onChangeFreeText(event.currentTarget.value)}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.test.tsx
@@ -267,4 +267,22 @@ describe("useQuestionDraft", () => {
 
     await harness.unmount();
   });
+
+  test("clears submit error when switching tabs", async () => {
+    const request = buildRequest({
+      questions: [baseQuestion({ header: "Question 1" }), baseQuestion({ header: "Question 2" })],
+    });
+    const harness = createHookHarness(request);
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.setSubmitError("Submission failed");
+      state.setActiveTabId("1");
+    });
+
+    expect(harness.getLatest().activeTabId).toBe("1");
+    expect(harness.getLatest().submitError).toBeNull();
+
+    await harness.unmount();
+  });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.test.tsx
@@ -181,6 +181,62 @@ describe("useQuestionDraft", () => {
     await harness.unmount();
   });
 
+  test("preserves free-text changes when option selection is batched in same update", async () => {
+    const harness = createHookHarness(
+      buildRequest({
+        questions: [
+          baseQuestion({
+            multiple: true,
+            options: [
+              { label: "A", description: "first" },
+              { label: "B", description: "second" },
+            ],
+          }),
+        ],
+      }),
+    );
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.toggleFreeText(0);
+      state.updateFreeText(0, "Keep this note");
+      state.selectOption(0, "A");
+    });
+
+    const latest = harness.getLatest();
+    expect(latest.normalizedDraft[0]?.freeText).toBe("Keep this note");
+    expect(latest.normalizedDraft[0]?.selectedOptionLabels).toEqual(["A"]);
+    expect(latest.buildAnswers()).toEqual([["A", "Keep this note"]]);
+
+    await harness.unmount();
+  });
+
+  test("merges multi-select options when selections happen in one batch", async () => {
+    const harness = createHookHarness(
+      buildRequest({
+        questions: [
+          baseQuestion({
+            multiple: true,
+            options: [
+              { label: "A", description: "first" },
+              { label: "B", description: "second" },
+            ],
+          }),
+        ],
+      }),
+    );
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.selectOption(0, "A");
+      state.selectOption(0, "B");
+    });
+
+    expect(harness.getLatest().normalizedDraft[0]?.selectedOptionLabels).toEqual(["A", "B"]);
+
+    await harness.unmount();
+  });
+
   test("resets active tab, draft, and submit error when request changes", async () => {
     const requestOne = buildRequest({
       requestId: "request-1",

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.test.tsx
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createElement, type ReactElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import type { AgentQuestionRequest } from "@/types/agent-orchestrator";
+import { QUESTION_SUMMARY_TAB_ID, useQuestionDraft } from "./use-agent-session-question-draft";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const TEST_RENDERER_DEPRECATION_WARNING = "react-test-renderer is deprecated";
+const originalConsoleError = console.error;
+
+type HookState = ReturnType<typeof useQuestionDraft>;
+
+type QuestionOverride = Partial<AgentQuestionRequest["questions"][number]>;
+
+const baseQuestion = (
+  overrides: QuestionOverride = {},
+): AgentQuestionRequest["questions"][number] => ({
+  header: "Primary question",
+  question: "Pick one option",
+  options: [
+    { label: "Frontend", description: "UI work" },
+    { label: "Backend", description: "API work" },
+  ],
+  multiple: false,
+  custom: true,
+  ...overrides,
+});
+
+const buildRequest = (overrides: Partial<AgentQuestionRequest> = {}): AgentQuestionRequest => ({
+  requestId: "request-1",
+  questions: [baseQuestion()],
+  ...overrides,
+});
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createHookHarness = (initialRequest: AgentQuestionRequest) => {
+  let latest: HookState | null = null;
+  let currentRequest = initialRequest;
+
+  const Harness = ({ request }: { request: AgentQuestionRequest }): ReactElement | null => {
+    latest = useQuestionDraft({ request });
+    return null;
+  };
+
+  let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+  const mount = async (): Promise<void> => {
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness, { request: currentRequest }));
+      await flush();
+    });
+  };
+
+  const update = async (request: AgentQuestionRequest): Promise<void> => {
+    currentRequest = request;
+    await act(async () => {
+      renderer?.update(createElement(Harness, { request }));
+      await flush();
+    });
+  };
+
+  const run = async (fn: (state: HookState) => void | Promise<void>): Promise<void> => {
+    await act(async () => {
+      const state = latest;
+      if (!state) {
+        throw new Error("Hook state unavailable");
+      }
+      await fn(state);
+      await flush();
+    });
+  };
+
+  const getLatest = (): HookState => {
+    if (!latest) {
+      throw new Error("Hook state unavailable");
+    }
+    return latest;
+  };
+
+  const unmount = async (): Promise<void> => {
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  };
+
+  return { mount, update, run, getLatest, unmount };
+};
+
+describe("useQuestionDraft", () => {
+  beforeEach(() => {
+    console.error = (...args: unknown[]): void => {
+      if (typeof args[0] === "string" && args[0].includes(TEST_RENDERER_DEPRECATION_WARNING)) {
+        return;
+      }
+      originalConsoleError(...args);
+    };
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  test("tracks completion and builds answers for selected options", async () => {
+    const harness = createHookHarness(buildRequest());
+    await harness.mount();
+
+    expect(harness.getLatest().answeredCount).toBe(0);
+    expect(harness.getLatest().isComplete).toBe(false);
+
+    await harness.run((state) => {
+      state.selectOption(0, "Frontend");
+    });
+
+    const latest = harness.getLatest();
+    expect(latest.answeredCount).toBe(1);
+    expect(latest.isComplete).toBe(true);
+    expect(latest.buildAnswers()).toEqual([["Frontend"]]);
+
+    await harness.unmount();
+  });
+
+  test("auto advances single-choice flow to summary for multi-question requests", async () => {
+    const request = buildRequest({
+      questions: [
+        baseQuestion({
+          header: "Question 1",
+          options: [{ label: "One", description: "first" }],
+        }),
+        baseQuestion({
+          header: "Question 2",
+          options: [{ label: "Two", description: "second" }],
+        }),
+      ],
+    });
+    const harness = createHookHarness(request);
+    await harness.mount();
+
+    expect(harness.getLatest().activeTabId).toBe("0");
+
+    await harness.run((state) => {
+      state.selectOption(0, "One");
+    });
+    expect(harness.getLatest().activeTabId).toBe("1");
+
+    await harness.run((state) => {
+      state.selectOption(1, "Two");
+    });
+    expect(harness.getLatest().activeTabId).toBe(QUESTION_SUMMARY_TAB_ID);
+
+    await harness.unmount();
+  });
+
+  test("free-text mode overrides single-choice selection", async () => {
+    const harness = createHookHarness(buildRequest());
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.selectOption(0, "Frontend");
+    });
+
+    await harness.run((state) => {
+      state.toggleFreeText(0);
+      state.updateFreeText(0, "Design system updates");
+    });
+
+    const latest = harness.getLatest();
+    expect(latest.normalizedDraft[0]?.selectedOptionLabels).toEqual([]);
+    expect(latest.normalizedDraft[0]?.useFreeText).toBe(true);
+    expect(latest.buildAnswers()).toEqual([["Design system updates"]]);
+
+    await harness.unmount();
+  });
+
+  test("resets active tab, draft, and submit error when request changes", async () => {
+    const requestOne = buildRequest({
+      requestId: "request-1",
+      questions: [baseQuestion(), baseQuestion({ header: "Question 2" })],
+    });
+    const requestTwo = buildRequest({
+      requestId: "request-2",
+      questions: [baseQuestion({ header: "Fresh question", options: [] })],
+    });
+
+    const harness = createHookHarness(requestOne);
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.selectOption(0, "Frontend");
+      state.setSubmitError("Submission failed");
+    });
+    expect(harness.getLatest().activeTabId).toBe("1");
+    expect(harness.getLatest().submitError).toBe("Submission failed");
+
+    await harness.update(requestTwo);
+
+    const latest = harness.getLatest();
+    expect(latest.activeTabId).toBe("0");
+    expect(latest.submitError).toBeNull();
+    expect(latest.answeredCount).toBe(0);
+    expect(latest.normalizedDraft[0]?.freeText).toBe("");
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.ts
@@ -12,6 +12,11 @@ import {
 
 export const QUESTION_SUMMARY_TAB_ID = "__summary__";
 
+type QuestionDraftUiState = {
+  activeTabId: string;
+  draft: AgentQuestionDraftEntry[];
+};
+
 type UseQuestionDraftArgs = {
   request: AgentQuestionRequest;
 };
@@ -45,21 +50,23 @@ const EMPTY_DRAFT_ENTRY: AgentQuestionDraftEntry = {
 };
 
 export const useQuestionDraft = ({ request }: UseQuestionDraftArgs): UseQuestionDraftState => {
-  const [activeTabId, setActiveTabId] = useState<string>("0");
-  const [draft, setDraft] = useState<AgentQuestionDraftEntry[]>(() =>
-    createAgentQuestionDraft(request),
-  );
+  const [uiState, setUiState] = useState<QuestionDraftUiState>(() => ({
+    activeTabId: "0",
+    draft: createAgentQuestionDraft(request),
+  }));
   const [submitError, setSubmitErrorState] = useState<string | null>(null);
 
   useEffect(() => {
-    setActiveTabId("0");
-    setDraft(createAgentQuestionDraft(request));
+    setUiState({
+      activeTabId: "0",
+      draft: createAgentQuestionDraft(request),
+    });
     setSubmitErrorState(null);
   }, [request]);
 
   const normalizedDraft = useMemo(
-    () => normalizeAgentQuestionDraft(request, draft),
-    [request, draft],
+    () => normalizeAgentQuestionDraft(request, uiState.draft),
+    [request, uiState.draft],
   );
 
   const answeredCount = useMemo(
@@ -77,6 +84,7 @@ export const useQuestionDraft = ({ request }: UseQuestionDraftArgs): UseQuestion
   );
 
   const hasMultipleQuestions = request.questions.length > 1;
+  const activeTabId = uiState.activeTabId;
   const isSummaryTab = hasMultipleQuestions && activeTabId === QUESTION_SUMMARY_TAB_ID;
   const activeQuestionIndex = isSummaryTab ? -1 : Math.max(0, Number(activeTabId) || 0);
   const activeQuestion =
@@ -91,6 +99,13 @@ export const useQuestionDraft = ({ request }: UseQuestionDraftArgs): UseQuestion
     setSubmitErrorState(null);
   }, []);
 
+  const setActiveTabId = useCallback((tabId: string) => {
+    setUiState((current) => ({
+      ...current,
+      activeTabId: tabId,
+    }));
+  }, []);
+
   const selectOption = useCallback(
     (questionIndex: number, optionLabel: string): void => {
       const question = request.questions[questionIndex];
@@ -100,32 +115,40 @@ export const useQuestionDraft = ({ request }: UseQuestionDraftArgs): UseQuestion
 
       clearSubmitError();
 
-      const next = normalizeAgentQuestionDraft(request, normalizedDraft);
-      const target = next[questionIndex] ?? EMPTY_DRAFT_ENTRY;
-      const wasSelected = target.selectedOptionLabels.includes(optionLabel);
-      const nextEntry = toggleAgentQuestionOption(question, target, optionLabel);
-      const shouldAdvance =
-        !question.multiple && !wasSelected && nextEntry.selectedOptionLabels.length > 0;
+      setUiState((current) => {
+        const nextDraft = normalizeAgentQuestionDraft(request, current.draft);
+        const target = nextDraft[questionIndex] ?? EMPTY_DRAFT_ENTRY;
+        const wasSelected = target.selectedOptionLabels.includes(optionLabel);
+        const nextEntry = toggleAgentQuestionOption(question, target, optionLabel);
+        const shouldAdvance =
+          !question.multiple && !wasSelected && nextEntry.selectedOptionLabels.length > 0;
 
-      next[questionIndex] =
-        !question.multiple && nextEntry.selectedOptionLabels.length > 0
-          ? {
-              ...nextEntry,
-              useFreeText: false,
-            }
-          : nextEntry;
-      setDraft(next);
+        nextDraft[questionIndex] =
+          !question.multiple && nextEntry.selectedOptionLabels.length > 0
+            ? {
+                ...nextEntry,
+                useFreeText: false,
+              }
+            : nextEntry;
 
-      if (shouldAdvance && hasMultipleQuestions) {
+        if (!shouldAdvance || !hasMultipleQuestions) {
+          return {
+            ...current,
+            draft: nextDraft,
+          };
+        }
+
         const nextQuestionIndex = questionIndex + 1;
-        setActiveTabId(
-          nextQuestionIndex < request.questions.length
-            ? String(nextQuestionIndex)
-            : QUESTION_SUMMARY_TAB_ID,
-        );
-      }
+        return {
+          activeTabId:
+            nextQuestionIndex < request.questions.length
+              ? String(nextQuestionIndex)
+              : QUESTION_SUMMARY_TAB_ID,
+          draft: nextDraft,
+        };
+      });
     },
-    [request, normalizedDraft, hasMultipleQuestions, clearSubmitError],
+    [request, hasMultipleQuestions, clearSubmitError],
   );
 
   const toggleFreeText = useCallback(
@@ -137,16 +160,19 @@ export const useQuestionDraft = ({ request }: UseQuestionDraftArgs): UseQuestion
 
       clearSubmitError();
 
-      setDraft((current) => {
-        const next = normalizeAgentQuestionDraft(request, current);
-        const target = next[questionIndex] ?? EMPTY_DRAFT_ENTRY;
-        next[questionIndex] = {
+      setUiState((current) => {
+        const nextDraft = normalizeAgentQuestionDraft(request, current.draft);
+        const target = nextDraft[questionIndex] ?? EMPTY_DRAFT_ENTRY;
+        nextDraft[questionIndex] = {
           ...target,
           useFreeText: !target.useFreeText,
           selectedOptionLabels:
             !target.useFreeText && !question.multiple ? [] : target.selectedOptionLabels,
         };
-        return next;
+        return {
+          ...current,
+          draft: nextDraft,
+        };
       });
     },
     [request, clearSubmitError],
@@ -161,19 +187,22 @@ export const useQuestionDraft = ({ request }: UseQuestionDraftArgs): UseQuestion
 
       clearSubmitError();
 
-      setDraft((current) => {
-        const next = normalizeAgentQuestionDraft(request, current);
-        const target = next[questionIndex] ?? {
+      setUiState((current) => {
+        const nextDraft = normalizeAgentQuestionDraft(request, current.draft);
+        const target = nextDraft[questionIndex] ?? {
           ...EMPTY_DRAFT_ENTRY,
           useFreeText: true,
         };
-        next[questionIndex] = {
+        nextDraft[questionIndex] = {
           ...target,
           freeText: value,
           useFreeText: true,
           selectedOptionLabels: question.multiple ? target.selectedOptionLabels : [],
         };
-        return next;
+        return {
+          ...current,
+          draft: nextDraft,
+        };
       });
     },
     [request, clearSubmitError],
@@ -181,7 +210,10 @@ export const useQuestionDraft = ({ request }: UseQuestionDraftArgs): UseQuestion
 
   const resetDraft = useCallback(() => {
     clearSubmitError();
-    setDraft(createAgentQuestionDraft(request));
+    setUiState((current) => ({
+      ...current,
+      draft: createAgentQuestionDraft(request),
+    }));
   }, [request, clearSubmitError]);
 
   const buildAnswers = useCallback(

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.ts
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { AgentQuestionRequest } from "@/types/agent-orchestrator";
+import {
+  type AgentQuestionDraftEntry,
+  buildAgentQuestionAnswers,
+  createAgentQuestionDraft,
+  isAgentQuestionAnswered,
+  isAgentQuestionRequestComplete,
+  normalizeAgentQuestionDraft,
+  toggleAgentQuestionOption,
+} from "./agent-session-question-draft";
+
+export const QUESTION_SUMMARY_TAB_ID = "__summary__";
+
+type UseQuestionDraftArgs = {
+  request: AgentQuestionRequest;
+};
+
+type UseQuestionDraftState = {
+  activeTabId: string;
+  setActiveTabId: (tabId: string) => void;
+  submitError: string | null;
+  setSubmitError: (message: string | null) => void;
+  clearSubmitError: () => void;
+  normalizedDraft: AgentQuestionDraftEntry[];
+  answeredCount: number;
+  requiredCount: number;
+  isComplete: boolean;
+  hasMultipleQuestions: boolean;
+  isSummaryTab: boolean;
+  activeQuestionIndex: number;
+  activeQuestion: AgentQuestionRequest["questions"][number] | undefined;
+  activeEntry: AgentQuestionDraftEntry | undefined;
+  selectOption: (questionIndex: number, optionLabel: string) => void;
+  toggleFreeText: (questionIndex: number) => void;
+  updateFreeText: (questionIndex: number, value: string) => void;
+  resetDraft: () => void;
+  buildAnswers: () => string[][];
+};
+
+const EMPTY_DRAFT_ENTRY: AgentQuestionDraftEntry = {
+  selectedOptionLabels: [],
+  freeText: "",
+  useFreeText: false,
+};
+
+export const useQuestionDraft = ({ request }: UseQuestionDraftArgs): UseQuestionDraftState => {
+  const [activeTabId, setActiveTabId] = useState<string>("0");
+  const [draft, setDraft] = useState<AgentQuestionDraftEntry[]>(() =>
+    createAgentQuestionDraft(request),
+  );
+  const [submitError, setSubmitErrorState] = useState<string | null>(null);
+
+  useEffect(() => {
+    setActiveTabId("0");
+    setDraft(createAgentQuestionDraft(request));
+    setSubmitErrorState(null);
+  }, [request]);
+
+  const normalizedDraft = useMemo(
+    () => normalizeAgentQuestionDraft(request, draft),
+    [request, draft],
+  );
+
+  const answeredCount = useMemo(
+    () =>
+      request.questions.filter((question, index) =>
+        isAgentQuestionAnswered(question, normalizedDraft[index]),
+      ).length,
+    [request.questions, normalizedDraft],
+  );
+
+  const requiredCount = request.questions.length;
+  const isComplete = useMemo(
+    () => isAgentQuestionRequestComplete(request, normalizedDraft),
+    [request, normalizedDraft],
+  );
+
+  const hasMultipleQuestions = request.questions.length > 1;
+  const isSummaryTab = hasMultipleQuestions && activeTabId === QUESTION_SUMMARY_TAB_ID;
+  const activeQuestionIndex = isSummaryTab ? -1 : Math.max(0, Number(activeTabId) || 0);
+  const activeQuestion =
+    activeQuestionIndex >= 0 ? request.questions[activeQuestionIndex] : undefined;
+  const activeEntry = activeQuestionIndex >= 0 ? normalizedDraft[activeQuestionIndex] : undefined;
+
+  const setSubmitError = useCallback((message: string | null) => {
+    setSubmitErrorState(message);
+  }, []);
+
+  const clearSubmitError = useCallback(() => {
+    setSubmitErrorState(null);
+  }, []);
+
+  const selectOption = useCallback(
+    (questionIndex: number, optionLabel: string): void => {
+      const question = request.questions[questionIndex];
+      if (!question) {
+        return;
+      }
+
+      clearSubmitError();
+
+      const next = normalizeAgentQuestionDraft(request, normalizedDraft);
+      const target = next[questionIndex] ?? EMPTY_DRAFT_ENTRY;
+      const wasSelected = target.selectedOptionLabels.includes(optionLabel);
+      const nextEntry = toggleAgentQuestionOption(question, target, optionLabel);
+      const shouldAdvance =
+        !question.multiple && !wasSelected && nextEntry.selectedOptionLabels.length > 0;
+
+      next[questionIndex] =
+        !question.multiple && nextEntry.selectedOptionLabels.length > 0
+          ? {
+              ...nextEntry,
+              useFreeText: false,
+            }
+          : nextEntry;
+      setDraft(next);
+
+      if (shouldAdvance && hasMultipleQuestions) {
+        const nextQuestionIndex = questionIndex + 1;
+        setActiveTabId(
+          nextQuestionIndex < request.questions.length
+            ? String(nextQuestionIndex)
+            : QUESTION_SUMMARY_TAB_ID,
+        );
+      }
+    },
+    [request, normalizedDraft, hasMultipleQuestions, clearSubmitError],
+  );
+
+  const toggleFreeText = useCallback(
+    (questionIndex: number): void => {
+      const question = request.questions[questionIndex];
+      if (!question) {
+        return;
+      }
+
+      clearSubmitError();
+
+      setDraft((current) => {
+        const next = normalizeAgentQuestionDraft(request, current);
+        const target = next[questionIndex] ?? EMPTY_DRAFT_ENTRY;
+        next[questionIndex] = {
+          ...target,
+          useFreeText: !target.useFreeText,
+          selectedOptionLabels:
+            !target.useFreeText && !question.multiple ? [] : target.selectedOptionLabels,
+        };
+        return next;
+      });
+    },
+    [request, clearSubmitError],
+  );
+
+  const updateFreeText = useCallback(
+    (questionIndex: number, value: string): void => {
+      const question = request.questions[questionIndex];
+      if (!question) {
+        return;
+      }
+
+      clearSubmitError();
+
+      setDraft((current) => {
+        const next = normalizeAgentQuestionDraft(request, current);
+        const target = next[questionIndex] ?? {
+          ...EMPTY_DRAFT_ENTRY,
+          useFreeText: true,
+        };
+        next[questionIndex] = {
+          ...target,
+          freeText: value,
+          useFreeText: true,
+          selectedOptionLabels: question.multiple ? target.selectedOptionLabels : [],
+        };
+        return next;
+      });
+    },
+    [request, clearSubmitError],
+  );
+
+  const resetDraft = useCallback(() => {
+    clearSubmitError();
+    setDraft(createAgentQuestionDraft(request));
+  }, [request, clearSubmitError]);
+
+  const buildAnswers = useCallback(
+    () => buildAgentQuestionAnswers(request, normalizedDraft),
+    [request, normalizedDraft],
+  );
+
+  return {
+    activeTabId,
+    setActiveTabId,
+    submitError,
+    setSubmitError,
+    clearSubmitError,
+    normalizedDraft,
+    answeredCount,
+    requiredCount,
+    isComplete,
+    hasMultipleQuestions,
+    isSummaryTab,
+    activeQuestionIndex,
+    activeQuestion,
+    activeEntry,
+    selectOption,
+    toggleFreeText,
+    updateFreeText,
+    resetDraft,
+    buildAnswers,
+  };
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-session-question-draft.ts
@@ -99,12 +99,16 @@ export const useQuestionDraft = ({ request }: UseQuestionDraftArgs): UseQuestion
     setSubmitErrorState(null);
   }, []);
 
-  const setActiveTabId = useCallback((tabId: string) => {
-    setUiState((current) => ({
-      ...current,
-      activeTabId: tabId,
-    }));
-  }, []);
+  const setActiveTabId = useCallback(
+    (tabId: string) => {
+      clearSubmitError();
+      setUiState((current) => ({
+        ...current,
+        activeTabId: tabId,
+      }));
+    },
+    [clearSubmitError],
+  );
 
   const selectOption = useCallback(
     (questionIndex: number, optionLabel: string): void => {


### PR DESCRIPTION
## Summary
- decompose `AgentSessionQuestionCard` into a composition shell plus focused subcomponents (`QuestionTab`, `QuestionSummaryTab`, `QuestionSubmitFooter`)
- extract draft/tab/submit state logic into `useQuestionDraft`
- fix batched update correctness by making draft and tab updates atomic in the hook
- add regression coverage for batched state updates and integration coverage for card-level wiring

## Why
- reduce component complexity and improve maintainability/testability
- eliminate stale-state overwrite risk during batched React updates

## Validation
- `bun run --filter @openducktor/desktop test -- src/components/features/agents/agent-chat/use-agent-session-question-draft.test.tsx src/components/features/agents/agent-chat/agent-session-question-card.test.tsx src/components/features/agents/agent-chat/agent-chat-thread.test.ts`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
