### PR TITLE
refactor(host-application): extract and harden QA worktree setup

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -21,6 +21,7 @@ mod events;
 mod hook_security;
 mod opencode_runtime;
 mod process_registry;
+mod qa_worktree;
 mod repo_init;
 mod runtime_orchestrator;
 mod service_core;
@@ -47,6 +48,7 @@ pub(crate) use process_registry::{
     with_locked_opencode_process_registry, OpencodeProcessRegistryInstance,
     TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
+pub(crate) use qa_worktree::prepare_qa_worktree;
 pub(crate) use service_core::{AgentRuntimeProcess, CachedRuntimeCheck, RunProcess};
 pub use service_core::{AppService, RunEmitter};
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -48,7 +48,6 @@ pub(crate) use process_registry::{
     with_locked_opencode_process_registry, OpencodeProcessRegistryInstance,
     TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
-pub(crate) use qa_worktree::prepare_qa_worktree;
 pub(crate) use service_core::{AgentRuntimeProcess, CachedRuntimeCheck, RunProcess};
 pub use service_core::{AppService, RunEmitter};
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/qa_worktree.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/qa_worktree.rs
@@ -139,6 +139,11 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
+    fn register_workspace(config_store: &AppConfigStore, repo_path: &str) -> Result<()> {
+        config_store.add_workspace(repo_path)?;
+        Ok(())
+    }
+
     #[test]
     fn prepare_qa_worktree_returns_setup_for_valid_config() -> Result<()> {
         let root = unique_temp_path("qa-worktree-setup-success");
@@ -147,6 +152,7 @@ mod tests {
         let config_store = AppConfigStore::from_path(root.join("config.json"));
         let repo_path = repo.to_string_lossy().to_string();
         let worktree_base = root.join("qa-worktrees");
+        register_workspace(&config_store, repo_path.as_str())?;
 
         config_store.update_repo_config(
             repo_path.as_str(),
@@ -177,6 +183,7 @@ mod tests {
         init_git_repo(&repo)?;
         let config_store = AppConfigStore::from_path(root.join("config.json"));
         let repo_path = repo.to_string_lossy().to_string();
+        register_workspace(&config_store, repo_path.as_str())?;
 
         config_store.update_repo_config(
             repo_path.as_str(),
@@ -210,6 +217,7 @@ mod tests {
             pre_start: vec!["sh -lc 'exit 1'".to_string()],
             post_complete: Vec::new(),
         };
+        register_workspace(&config_store, repo_path.as_str())?;
 
         config_store.update_repo_config(
             repo_path.as_str(),
@@ -244,6 +252,7 @@ mod tests {
         let config_store = AppConfigStore::from_path(root.join("config.json"));
         let repo_path = repo.to_string_lossy().to_string();
         let worktree_base = root.join("qa-worktrees");
+        register_workspace(&config_store, repo_path.as_str())?;
 
         config_store.update_repo_config(
             repo_path.as_str(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/qa_worktree.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/qa_worktree.rs
@@ -1,0 +1,97 @@
+use super::{run_parsed_hook_command_allow_failure, validate_hook_trust};
+use anyhow::{anyhow, Context, Result};
+use host_infra_system::{build_branch_name, remove_worktree, run_command, AppConfigStore};
+use std::fs;
+use std::path::Path;
+
+pub(crate) struct QaWorktreeSetup {
+    pub(crate) working_directory: String,
+    pub(crate) cleanup_repo_path: String,
+    pub(crate) cleanup_worktree_path: String,
+}
+
+pub(crate) fn prepare_qa_worktree(
+    repo_path: &str,
+    task_id: &str,
+    task_title: &str,
+    config_store: &AppConfigStore,
+) -> Result<QaWorktreeSetup> {
+    let repo_config = config_store.repo_config(repo_path)?;
+    let worktree_base = repo_config.worktree_base_path.clone().ok_or_else(|| {
+        anyhow!(
+            "QA blocked: configure repos.{repo_path}.worktreeBasePath in {}",
+            config_store.path().display()
+        )
+    })?;
+
+    validate_hook_trust(repo_path, &repo_config)?;
+
+    let worktree_base_path = Path::new(&worktree_base);
+    fs::create_dir_all(worktree_base_path).with_context(|| {
+        format!(
+            "Failed creating QA worktree base directory {}",
+            worktree_base_path.display()
+        )
+    })?;
+
+    let qa_worktree = worktree_base_path.join(format!("qa-{task_id}"));
+    if qa_worktree.exists() {
+        return Err(anyhow!(
+            "QA worktree path already exists for task {}: {}",
+            task_id,
+            qa_worktree.display()
+        ));
+    }
+
+    let repo_path_ref = Path::new(repo_path);
+    let branch = build_branch_name(&repo_config.branch_prefix, task_id, task_title);
+    let qa_worktree_str = qa_worktree
+        .to_str()
+        .ok_or_else(|| anyhow!("Invalid QA worktree path"))?;
+    let checkout_existing = run_command(
+        "git",
+        &["worktree", "add", qa_worktree_str, &branch],
+        Some(repo_path_ref),
+    );
+    if let Err(existing_error) = checkout_existing {
+        run_command(
+            "git",
+            &["worktree", "add", qa_worktree_str, "-b", &branch],
+            Some(repo_path_ref),
+        )
+        .with_context(|| {
+            format!("Failed to create or checkout QA branch {branch}: {existing_error}")
+        })?;
+    }
+
+    for hook in &repo_config.hooks.pre_start {
+        let (ok, _stdout, stderr) =
+            run_parsed_hook_command_allow_failure(hook, qa_worktree.as_path());
+        if !ok {
+            if let Err(cleanup_error) =
+                remove_runtime_worktree(repo_path_ref, qa_worktree.as_path())
+            {
+                return Err(anyhow!(
+                    "QA pre-start hook failed: {hook}\n{stderr}\nAlso failed to remove QA worktree: {cleanup_error}"
+                ));
+            }
+            return Err(anyhow!("QA pre-start hook failed: {hook}\n{stderr}"));
+        }
+    }
+
+    let qa_worktree_path = qa_worktree_str.to_string();
+    Ok(QaWorktreeSetup {
+        working_directory: qa_worktree_path.clone(),
+        cleanup_repo_path: repo_path.to_string(),
+        cleanup_worktree_path: qa_worktree_path,
+    })
+}
+
+fn remove_runtime_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
+    remove_worktree(repo_path, worktree_path).with_context(|| {
+        format!(
+            "Failed removing QA worktree runtime {}",
+            worktree_path.display()
+        )
+    })
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/qa_worktree.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/qa_worktree.rs
@@ -2,13 +2,12 @@ use super::{run_parsed_hook_command_allow_failure, validate_hook_trust};
 use anyhow::{anyhow, Context, Result};
 use host_infra_system::{build_branch_name, remove_worktree, run_command, AppConfigStore};
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path};
 
 #[derive(Debug)]
 pub(super) struct QaWorktreeSetup {
-    pub(super) working_directory: String,
-    pub(super) cleanup_repo_path: String,
-    pub(super) cleanup_worktree_path: String,
+    pub(super) repo_path: String,
+    pub(super) worktree_path: String,
 }
 
 pub(super) fn prepare_qa_worktree(
@@ -17,6 +16,8 @@ pub(super) fn prepare_qa_worktree(
     task_title: &str,
     config_store: &AppConfigStore,
 ) -> Result<QaWorktreeSetup> {
+    validate_task_id_for_worktree(task_id)?;
+
     let repo_config = config_store.repo_config(repo_path)?;
     let worktree_base = repo_config.worktree_base_path.clone().ok_or_else(|| {
         anyhow!(
@@ -82,9 +83,8 @@ pub(super) fn prepare_qa_worktree(
 
     let qa_worktree_path = qa_worktree_str.to_string();
     Ok(QaWorktreeSetup {
-        working_directory: qa_worktree_path.clone(),
-        cleanup_repo_path: repo_path.to_string(),
-        cleanup_worktree_path: qa_worktree_path,
+        repo_path: repo_path.to_string(),
+        worktree_path: qa_worktree_path,
     })
 }
 
@@ -95,6 +95,39 @@ pub(super) fn remove_runtime_worktree(repo_path: &Path, worktree_path: &Path) ->
             worktree_path.display()
         )
     })
+}
+
+fn validate_task_id_for_worktree(task_id: &str) -> Result<()> {
+    let trimmed = task_id.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("Invalid task id for QA worktree: value is empty"));
+    }
+
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    {
+        return Err(anyhow!(
+            "Invalid task id for QA worktree: only ASCII letters, numbers, '-' and '_' are allowed"
+        ));
+    }
+
+    // Defense in depth: reject anything that could be interpreted as path traversal.
+    let path = Path::new(trimmed);
+    if path.is_absolute() {
+        return Err(anyhow!(
+            "Invalid task id for QA worktree: absolute paths are not allowed"
+        ));
+    }
+    if !matches!(path.components().next(), Some(Component::Normal(_)))
+        || path.components().count() != 1
+    {
+        return Err(anyhow!(
+            "Invalid task id for QA worktree: path separators or traversal segments are not allowed"
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -128,12 +161,11 @@ mod tests {
         )?;
 
         let setup = prepare_qa_worktree(repo_path.as_str(), "task-1", "Task 1", &config_store)?;
-        let qa_path = Path::new(setup.working_directory.as_str());
+        let qa_path = Path::new(setup.worktree_path.as_str());
         assert!(qa_path.exists());
-        assert_eq!(setup.cleanup_repo_path, repo_path);
-        assert_eq!(setup.cleanup_worktree_path, setup.working_directory);
+        assert_eq!(setup.repo_path, repo_path);
 
-        remove_runtime_worktree(Path::new(setup.cleanup_repo_path.as_str()), qa_path)?;
+        remove_runtime_worktree(Path::new(setup.repo_path.as_str()), qa_path)?;
         let _ = fs::remove_dir_all(root);
         Ok(())
     }
@@ -199,6 +231,37 @@ mod tests {
             !qa_worktree_path.exists(),
             "qa worktree should be removed when pre-start hook fails"
         );
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn prepare_qa_worktree_rejects_invalid_task_id() -> Result<()> {
+        let root = unique_temp_path("qa-worktree-invalid-task-id");
+        let repo = root.join("repo");
+        init_git_repo(&repo)?;
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let repo_path = repo.to_string_lossy().to_string();
+        let worktree_base = root.join("qa-worktrees");
+
+        config_store.update_repo_config(
+            repo_path.as_str(),
+            RepoConfig {
+                worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+                branch_prefix: "odt".to_string(),
+                trusted_hooks: true,
+                trusted_hooks_fingerprint: None,
+                hooks: HookSet::default(),
+                agent_defaults: Default::default(),
+            },
+        )?;
+
+        let error = prepare_qa_worktree(repo_path.as_str(), "../../tmp", "Task 1", &config_store)
+            .expect_err("task id with traversal markers should fail");
+        assert!(error
+            .to_string()
+            .contains("Invalid task id for QA worktree"));
 
         let _ = fs::remove_dir_all(root);
         Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/qa_worktree.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/qa_worktree.rs
@@ -4,13 +4,14 @@ use host_infra_system::{build_branch_name, remove_worktree, run_command, AppConf
 use std::fs;
 use std::path::Path;
 
-pub(crate) struct QaWorktreeSetup {
-    pub(crate) working_directory: String,
-    pub(crate) cleanup_repo_path: String,
-    pub(crate) cleanup_worktree_path: String,
+#[derive(Debug)]
+pub(super) struct QaWorktreeSetup {
+    pub(super) working_directory: String,
+    pub(super) cleanup_repo_path: String,
+    pub(super) cleanup_worktree_path: String,
 }
 
-pub(crate) fn prepare_qa_worktree(
+pub(super) fn prepare_qa_worktree(
     repo_path: &str,
     task_id: &str,
     task_title: &str,
@@ -87,11 +88,119 @@ pub(crate) fn prepare_qa_worktree(
     })
 }
 
-fn remove_runtime_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
+pub(super) fn remove_runtime_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
     remove_worktree(repo_path, worktree_path).with_context(|| {
         format!(
             "Failed removing QA worktree runtime {}",
             worktree_path.display()
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{prepare_qa_worktree, remove_runtime_worktree};
+    use crate::app_service::test_support::{init_git_repo, unique_temp_path};
+    use anyhow::Result;
+    use host_infra_system::{hook_set_fingerprint, AppConfigStore, HookSet, RepoConfig};
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn prepare_qa_worktree_returns_setup_for_valid_config() -> Result<()> {
+        let root = unique_temp_path("qa-worktree-setup-success");
+        let repo = root.join("repo");
+        init_git_repo(&repo)?;
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let repo_path = repo.to_string_lossy().to_string();
+        let worktree_base = root.join("qa-worktrees");
+
+        config_store.update_repo_config(
+            repo_path.as_str(),
+            RepoConfig {
+                worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+                branch_prefix: "odt".to_string(),
+                trusted_hooks: true,
+                trusted_hooks_fingerprint: None,
+                hooks: HookSet::default(),
+                agent_defaults: Default::default(),
+            },
+        )?;
+
+        let setup = prepare_qa_worktree(repo_path.as_str(), "task-1", "Task 1", &config_store)?;
+        let qa_path = Path::new(setup.working_directory.as_str());
+        assert!(qa_path.exists());
+        assert_eq!(setup.cleanup_repo_path, repo_path);
+        assert_eq!(setup.cleanup_worktree_path, setup.working_directory);
+
+        remove_runtime_worktree(Path::new(setup.cleanup_repo_path.as_str()), qa_path)?;
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn prepare_qa_worktree_requires_worktree_base_path() -> Result<()> {
+        let root = unique_temp_path("qa-worktree-missing-base");
+        let repo = root.join("repo");
+        init_git_repo(&repo)?;
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let repo_path = repo.to_string_lossy().to_string();
+
+        config_store.update_repo_config(
+            repo_path.as_str(),
+            RepoConfig {
+                worktree_base_path: None,
+                branch_prefix: "odt".to_string(),
+                trusted_hooks: true,
+                trusted_hooks_fingerprint: None,
+                hooks: HookSet::default(),
+                agent_defaults: Default::default(),
+            },
+        )?;
+
+        let error = prepare_qa_worktree(repo_path.as_str(), "task-1", "Task 1", &config_store)
+            .expect_err("missing worktree base path should fail");
+        assert!(error.to_string().contains("QA blocked: configure repos."));
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn prepare_qa_worktree_removes_worktree_when_pre_start_hook_fails() -> Result<()> {
+        let root = unique_temp_path("qa-worktree-hook-failure");
+        let repo = root.join("repo");
+        init_git_repo(&repo)?;
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let repo_path = repo.to_string_lossy().to_string();
+        let worktree_base = root.join("qa-worktrees");
+        let hooks = HookSet {
+            pre_start: vec!["sh -lc 'exit 1'".to_string()],
+            post_complete: Vec::new(),
+        };
+
+        config_store.update_repo_config(
+            repo_path.as_str(),
+            RepoConfig {
+                worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+                branch_prefix: "odt".to_string(),
+                trusted_hooks: true,
+                trusted_hooks_fingerprint: Some(hook_set_fingerprint(&hooks)),
+                hooks,
+                agent_defaults: Default::default(),
+            },
+        )?;
+
+        let qa_worktree_path = worktree_base.join("qa-task-1");
+        let error = prepare_qa_worktree(repo_path.as_str(), "task-1", "Task 1", &config_store)
+            .expect_err("failing pre-start hook should fail setup");
+        assert!(error.to_string().contains("QA pre-start hook failed"));
+        assert!(
+            !qa_worktree_path.exists(),
+            "qa worktree should be removed when pre-start hook fails"
+        );
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -1,11 +1,11 @@
 use super::{
-    prepare_qa_worktree, spawn_opencode_server, terminate_child_process,
-    wait_for_local_server_with_process, AgentRuntimeProcess, AppService,
-    StartupEventCorrelation, StartupEventPayload,
+    qa_worktree::{prepare_qa_worktree, remove_runtime_worktree},
+    spawn_opencode_server, terminate_child_process, wait_for_local_server_with_process,
+    AgentRuntimeProcess, AppService, StartupEventCorrelation, StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary};
-use host_infra_system::{pick_free_port, remove_worktree};
+use host_infra_system::pick_free_port;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use uuid::Uuid;
@@ -345,7 +345,7 @@ impl AppService {
                     cleanup_worktree_path.as_deref(),
                 ) {
                     if let Err(cleanup_error) =
-                        Self::remove_runtime_worktree(Path::new(repo), Path::new(worktree))
+                        remove_runtime_worktree(Path::new(repo), Path::new(worktree))
                     {
                         return Err(anyhow!(
                             "{startup_context}\nAlso failed to remove QA worktree: {cleanup_error}"
@@ -409,7 +409,7 @@ impl AppService {
             runtime.cleanup_repo_path.as_deref(),
             runtime.cleanup_worktree_path.as_deref(),
         ) {
-            Self::remove_runtime_worktree(Path::new(repo_path), Path::new(worktree_path))?;
+            remove_runtime_worktree(Path::new(repo_path), Path::new(worktree_path))?;
         }
         Ok(true)
     }
@@ -441,10 +441,9 @@ impl AppService {
                         runtime.cleanup_repo_path.as_deref(),
                         runtime.cleanup_worktree_path.as_deref(),
                     ) {
-                        if let Err(error) = Self::remove_runtime_worktree(
-                            Path::new(repo_path),
-                            Path::new(worktree_path),
-                        ) {
+                        if let Err(error) =
+                            remove_runtime_worktree(Path::new(repo_path), Path::new(worktree_path))
+                        {
                             cleanup_errors.push(format!(
                                 "Failed shutting down runtime {}: {}",
                                 runtime.summary.runtime_id, error
@@ -461,15 +460,6 @@ impl AppService {
         } else {
             Err(anyhow!(cleanup_errors.join("\n")))
         }
-    }
-
-    fn remove_runtime_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
-        remove_worktree(repo_path, worktree_path).with_context(|| {
-            format!(
-                "Failed removing QA worktree runtime {}",
-                worktree_path.display()
-            )
-        })
     }
 
     pub(crate) fn prune_stale_runtimes(
@@ -494,10 +484,9 @@ impl AppService {
                     runtime.cleanup_repo_path.as_deref(),
                     runtime.cleanup_worktree_path.as_deref(),
                 ) {
-                    if let Err(error) = Self::remove_runtime_worktree(
-                        Path::new(repo_path),
-                        Path::new(worktree_path),
-                    ) {
+                    if let Err(error) =
+                        remove_runtime_worktree(Path::new(repo_path), Path::new(worktree_path))
+                    {
                         cleanup_errors.push(format!(
                             "Failed pruning stale runtime {runtime_id}: {error}"
                         ));

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -1,13 +1,12 @@
 use super::{
-    run_parsed_hook_command_allow_failure, spawn_opencode_server, terminate_child_process,
-    validate_hook_trust, wait_for_local_server_with_process, AgentRuntimeProcess, AppService,
+    prepare_qa_worktree, spawn_opencode_server, terminate_child_process,
+    wait_for_local_server_with_process, AgentRuntimeProcess, AppService,
     StartupEventCorrelation, StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary};
-use host_infra_system::{build_branch_name, pick_free_port, remove_worktree, run_command};
+use host_infra_system::{pick_free_port, remove_worktree};
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::path::Path;
 use uuid::Uuid;
 
@@ -271,77 +270,17 @@ impl AppService {
             }
         }
 
-        let mut cleanup_repo_path: Option<String> = None;
-        let mut cleanup_worktree_path: Option<String> = None;
-        let runtime_working_directory = if role == "qa" {
-            let repo_config = self.config_store.repo_config(repo_path)?;
-            let worktree_base = repo_config.worktree_base_path.clone().ok_or_else(|| {
-                anyhow!(
-                    "QA blocked: configure repos.{repo_path}.worktreeBasePath in {}",
-                    self.config_store.path().display()
-                )
-            })?;
-
-            validate_hook_trust(repo_path, &repo_config)?;
-
-            let worktree_base_path = Path::new(&worktree_base);
-            fs::create_dir_all(worktree_base_path).with_context(|| {
-                format!(
-                    "Failed creating QA worktree base directory {}",
-                    worktree_base_path.display()
-                )
-            })?;
-
-            let qa_worktree = worktree_base_path.join(format!("qa-{task_id}"));
-            if qa_worktree.exists() {
-                return Err(anyhow!(
-                    "QA worktree path already exists for task {}: {}",
-                    task_id,
-                    qa_worktree.display()
-                ));
-            }
-
-            let repo_path_ref = Path::new(repo_path);
-            let branch = build_branch_name(&repo_config.branch_prefix, task_id, &task.title);
-            let qa_worktree_str = qa_worktree
-                .to_str()
-                .ok_or_else(|| anyhow!("Invalid QA worktree path"))?;
-            let checkout_existing = run_command(
-                "git",
-                &["worktree", "add", qa_worktree_str, &branch],
-                Some(repo_path_ref),
-            );
-            if let Err(existing_error) = checkout_existing {
-                run_command(
-                    "git",
-                    &["worktree", "add", qa_worktree_str, "-b", &branch],
-                    Some(repo_path_ref),
-                )
-                .with_context(|| {
-                    format!("Failed to create or checkout QA branch {branch}: {existing_error}")
-                })?;
-            }
-
-            for hook in &repo_config.hooks.pre_start {
-                let (ok, _stdout, stderr) =
-                    run_parsed_hook_command_allow_failure(hook, qa_worktree.as_path());
-                if !ok {
-                    if let Err(cleanup_error) =
-                        Self::remove_runtime_worktree(repo_path_ref, qa_worktree.as_path())
-                    {
-                        return Err(anyhow!(
-                            "QA pre-start hook failed: {hook}\n{stderr}\nAlso failed to remove QA worktree: {cleanup_error}"
-                        ));
-                    }
-                    return Err(anyhow!("QA pre-start hook failed: {hook}\n{stderr}"));
-                }
-            }
-
-            cleanup_repo_path = Some(repo_path.to_string());
-            cleanup_worktree_path = Some(qa_worktree_str.to_string());
-            qa_worktree_str.to_string()
+        let (runtime_working_directory, cleanup_repo_path, cleanup_worktree_path) = if role == "qa"
+        {
+            let setup =
+                prepare_qa_worktree(repo_path, task_id, task.title.as_str(), &self.config_store)?;
+            (
+                setup.working_directory,
+                Some(setup.cleanup_repo_path),
+                Some(setup.cleanup_worktree_path),
+            )
         } else {
-            repo_path.to_string()
+            (repo_path.to_string(), None, None)
         };
 
         let port = pick_free_port()?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -275,9 +275,9 @@ impl AppService {
             let setup =
                 prepare_qa_worktree(repo_path, task_id, task.title.as_str(), &self.config_store)?;
             (
-                setup.working_directory,
-                Some(setup.cleanup_repo_path),
-                Some(setup.cleanup_worktree_path),
+                setup.worktree_path.clone(),
+                Some(setup.repo_path),
+                Some(setup.worktree_path),
             )
         } else {
             (repo_path.to_string(), None, None)


### PR DESCRIPTION
## Summary
- extract QA worktree preparation out of `opencode_runtime_start` into a dedicated helper module (`qa_worktree.rs`)
- keep runtime startup orchestration focused on process/network concerns while preserving existing QA setup behavior and error handling
- centralize QA worktree cleanup in a shared helper and remove duplicated cleanup logic across runtime paths
- narrow helper visibility boundaries and remove broad crate-level re-export
- add focused tests for QA worktree helper behavior (success path, missing config, pre-start hook failure cleanup)

## Files Changed
- `apps/desktop/src-tauri/crates/host-application/src/app_service/qa_worktree.rs`
- `apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs`
- `apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs`

## Validation
- `cd apps/desktop/src-tauri && cargo test -p host-application`
- `cd apps/desktop/src-tauri && cargo clippy -p host-application -- -D warnings`
