### PR TITLE
refactor(host-application): type and harden OpenCode startup event emission

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -1,7 +1,7 @@
 use super::{
     emit_event, run_parsed_hook_command_allow_failure, spawn_opencode_server,
     spawn_output_forwarder, terminate_child_process, validate_hook_trust, validate_transition,
-    wait_for_local_server_with_process, AppService, RunEmitter, RunProcess,
+    wait_for_local_server_with_process, AppService, RunEmitter, RunProcess, StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, RunEvent, RunState, RunSummary, TaskStatus};
@@ -164,19 +164,18 @@ impl AppService {
         let startup_policy = self.opencode_startup_readiness_policy();
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
-        self.emit_opencode_startup_event(
-            "startup_wait_begin",
-            "build_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload {
+            event_name: "startup_wait_begin",
+            runtime_type: "build_runtime",
             repo_path,
-            Some(task_id),
-            "build",
+            task_id: Some(task_id),
+            role: "build",
             port,
-            Some("run_id"),
-            Some(run_id.as_str()),
-            Some(startup_policy),
-            None,
-            None,
-        );
+            extra: Some(("run_id", run_id.as_str())),
+            policy: Some(startup_policy),
+            report: None,
+            failure_reason: None,
+        });
         let startup_report = match wait_for_local_server_with_process(
             &mut child,
             port,
@@ -186,38 +185,36 @@ impl AppService {
         ) {
             Ok(report) => report,
             Err(error) => {
-                self.emit_opencode_startup_event(
-                    "startup_failed",
-                    "build_runtime",
+                self.emit_opencode_startup_event(StartupEventPayload {
+                    event_name: "startup_failed",
+                    runtime_type: "build_runtime",
                     repo_path,
-                    Some(task_id),
-                    "build",
+                    task_id: Some(task_id),
+                    role: "build",
                     port,
-                    Some("run_id"),
-                    Some(run_id.as_str()),
-                    Some(startup_policy),
-                    Some(error.report),
-                    Some(error.reason),
-                );
+                    extra: Some(("run_id", run_id.as_str())),
+                    policy: Some(startup_policy),
+                    report: Some(error.report),
+                    failure_reason: Some(error.reason),
+                });
                 terminate_child_process(&mut child);
                 return Err(anyhow!(error)).with_context(|| {
                     format!("OpenCode build runtime failed to start for task {task_id}")
                 });
             }
         };
-        self.emit_opencode_startup_event(
-            "startup_ready",
-            "build_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload {
+            event_name: "startup_ready",
+            runtime_type: "build_runtime",
             repo_path,
-            Some(task_id),
-            "build",
+            task_id: Some(task_id),
+            role: "build",
             port,
-            Some("run_id"),
-            Some(run_id.as_str()),
-            Some(startup_policy),
-            Some(startup_report),
-            None,
-        );
+            extra: Some(("run_id", run_id.as_str())),
+            policy: Some(startup_policy),
+            report: Some(startup_report),
+            failure_reason: None,
+        });
 
         self.task_transition(
             repo_path,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -1,7 +1,8 @@
 use super::{
     emit_event, run_parsed_hook_command_allow_failure, spawn_opencode_server,
     spawn_output_forwarder, terminate_child_process, validate_hook_trust, validate_transition,
-    wait_for_local_server_with_process, AppService, RunEmitter, RunProcess, StartupEventPayload,
+    wait_for_local_server_with_process, AppService, RunEmitter, RunProcess,
+    StartupEventCorrelation, StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, RunEvent, RunState, RunSummary, TaskStatus};
@@ -164,18 +165,15 @@ impl AppService {
         let startup_policy = self.opencode_startup_readiness_policy();
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
-        self.emit_opencode_startup_event(StartupEventPayload {
-            event_name: "startup_wait_begin",
-            runtime_type: "build_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
+            "build_runtime",
             repo_path,
-            task_id: Some(task_id),
-            role: "build",
+            Some(task_id),
+            "build",
             port,
-            extra: Some(("run_id", run_id.as_str())),
-            policy: Some(startup_policy),
-            report: None,
-            failure_reason: None,
-        });
+            Some(StartupEventCorrelation::new("run_id", run_id.as_str())),
+            Some(startup_policy),
+        ));
         let startup_report = match wait_for_local_server_with_process(
             &mut child,
             port,
@@ -185,36 +183,33 @@ impl AppService {
         ) {
             Ok(report) => report,
             Err(error) => {
-                self.emit_opencode_startup_event(StartupEventPayload {
-                    event_name: "startup_failed",
-                    runtime_type: "build_runtime",
+                self.emit_opencode_startup_event(StartupEventPayload::failed(
+                    "build_runtime",
                     repo_path,
-                    task_id: Some(task_id),
-                    role: "build",
+                    Some(task_id),
+                    "build",
                     port,
-                    extra: Some(("run_id", run_id.as_str())),
-                    policy: Some(startup_policy),
-                    report: Some(error.report),
-                    failure_reason: Some(error.reason),
-                });
+                    Some(StartupEventCorrelation::new("run_id", run_id.as_str())),
+                    Some(startup_policy),
+                    error.report,
+                    error.reason,
+                ));
                 terminate_child_process(&mut child);
                 return Err(anyhow!(error)).with_context(|| {
                     format!("OpenCode build runtime failed to start for task {task_id}")
                 });
             }
         };
-        self.emit_opencode_startup_event(StartupEventPayload {
-            event_name: "startup_ready",
-            runtime_type: "build_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload::ready(
+            "build_runtime",
             repo_path,
-            task_id: Some(task_id),
-            role: "build",
+            Some(task_id),
+            "build",
             port,
-            extra: Some(("run_id", run_id.as_str())),
-            policy: Some(startup_policy),
-            report: Some(startup_report),
-            failure_reason: None,
-        });
+            Some(StartupEventCorrelation::new("run_id", run_id.as_str())),
+            Some(startup_policy),
+            startup_report,
+        ));
 
         self.task_transition(
             repo_path,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -49,6 +49,7 @@ pub(crate) use process_registry::{
 };
 pub(crate) use service_core::{AgentRuntimeProcess, CachedRuntimeCheck, RunProcess};
 pub use service_core::{AppService, RunEmitter};
+pub(crate) use startup_metrics::StartupEventPayload;
 #[cfg(test)]
 pub(crate) use startup_metrics::{
     build_opencode_startup_event_payload, OpencodeStartupMetricsSnapshot,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -49,11 +49,11 @@ pub(crate) use process_registry::{
 };
 pub(crate) use service_core::{AgentRuntimeProcess, CachedRuntimeCheck, RunProcess};
 pub use service_core::{AppService, RunEmitter};
-pub(crate) use startup_metrics::StartupEventPayload;
 #[cfg(test)]
 pub(crate) use startup_metrics::{
     build_opencode_startup_event_payload, OpencodeStartupMetricsSnapshot,
 };
+pub(crate) use startup_metrics::{StartupEventCorrelation, StartupEventPayload};
 pub(crate) use workflow_rules::{
     can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
     default_qa_required_for_issue_type, derive_agent_workflows, derive_available_actions,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -1,7 +1,7 @@
 use super::{
     run_parsed_hook_command_allow_failure, spawn_opencode_server, terminate_child_process,
     validate_hook_trust, wait_for_local_server_with_process, AgentRuntimeProcess, AppService,
-    StartupEventPayload,
+    StartupEventCorrelation, StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary};
@@ -132,18 +132,18 @@ impl AppService {
         let startup_policy = self.opencode_startup_readiness_policy();
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
-        self.emit_opencode_startup_event(StartupEventPayload {
-            event_name: "startup_wait_begin",
-            runtime_type: "workspace_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
+            "workspace_runtime",
             repo_path,
-            task_id: Some(Self::WORKSPACE_RUNTIME_TASK_ID),
-            role: Self::WORKSPACE_RUNTIME_ROLE,
+            Some(Self::WORKSPACE_RUNTIME_TASK_ID),
+            Self::WORKSPACE_RUNTIME_ROLE,
             port,
-            extra: Some(("runtime_id", runtime_id.as_str())),
-            policy: Some(startup_policy),
-            report: None,
-            failure_reason: None,
-        });
+            Some(StartupEventCorrelation::new(
+                "runtime_id",
+                runtime_id.as_str(),
+            )),
+            Some(startup_policy),
+        ));
         let startup_report = match wait_for_local_server_with_process(
             &mut child,
             port,
@@ -153,36 +153,39 @@ impl AppService {
         ) {
             Ok(report) => report,
             Err(error) => {
-                self.emit_opencode_startup_event(StartupEventPayload {
-                    event_name: "startup_failed",
-                    runtime_type: "workspace_runtime",
+                self.emit_opencode_startup_event(StartupEventPayload::failed(
+                    "workspace_runtime",
                     repo_path,
-                    task_id: Some(Self::WORKSPACE_RUNTIME_TASK_ID),
-                    role: Self::WORKSPACE_RUNTIME_ROLE,
+                    Some(Self::WORKSPACE_RUNTIME_TASK_ID),
+                    Self::WORKSPACE_RUNTIME_ROLE,
                     port,
-                    extra: Some(("runtime_id", runtime_id.as_str())),
-                    policy: Some(startup_policy),
-                    report: Some(error.report),
-                    failure_reason: Some(error.reason),
-                });
+                    Some(StartupEventCorrelation::new(
+                        "runtime_id",
+                        runtime_id.as_str(),
+                    )),
+                    Some(startup_policy),
+                    error.report,
+                    error.reason,
+                ));
                 terminate_child_process(&mut child);
                 return Err(anyhow!(error)).with_context(|| {
                     format!("OpenCode workspace runtime failed to start for {repo_path}")
                 });
             }
         };
-        self.emit_opencode_startup_event(StartupEventPayload {
-            event_name: "startup_ready",
-            runtime_type: "workspace_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload::ready(
+            "workspace_runtime",
             repo_path,
-            task_id: Some(Self::WORKSPACE_RUNTIME_TASK_ID),
-            role: Self::WORKSPACE_RUNTIME_ROLE,
+            Some(Self::WORKSPACE_RUNTIME_TASK_ID),
+            Self::WORKSPACE_RUNTIME_ROLE,
             port,
-            extra: Some(("runtime_id", runtime_id.as_str())),
-            policy: Some(startup_policy),
-            report: Some(startup_report),
-            failure_reason: None,
-        });
+            Some(StartupEventCorrelation::new(
+                "runtime_id",
+                runtime_id.as_str(),
+            )),
+            Some(startup_policy),
+            startup_report,
+        ));
 
         let summary = AgentRuntimeSummary {
             runtime_id: runtime_id.clone(),
@@ -360,18 +363,18 @@ impl AppService {
         let startup_policy = self.opencode_startup_readiness_policy();
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
-        self.emit_opencode_startup_event(StartupEventPayload {
-            event_name: "startup_wait_begin",
-            runtime_type: "agent_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
+            "agent_runtime",
             repo_path,
-            task_id: Some(task_id),
+            Some(task_id),
             role,
             port,
-            extra: Some(("runtime_id", runtime_id.as_str())),
-            policy: Some(startup_policy),
-            report: None,
-            failure_reason: None,
-        });
+            Some(StartupEventCorrelation::new(
+                "runtime_id",
+                runtime_id.as_str(),
+            )),
+            Some(startup_policy),
+        ));
         let startup_report = match wait_for_local_server_with_process(
             &mut child,
             port,
@@ -381,18 +384,20 @@ impl AppService {
         ) {
             Ok(report) => report,
             Err(error) => {
-                self.emit_opencode_startup_event(StartupEventPayload {
-                    event_name: "startup_failed",
-                    runtime_type: "agent_runtime",
+                self.emit_opencode_startup_event(StartupEventPayload::failed(
+                    "agent_runtime",
                     repo_path,
-                    task_id: Some(task_id),
+                    Some(task_id),
                     role,
                     port,
-                    extra: Some(("runtime_id", runtime_id.as_str())),
-                    policy: Some(startup_policy),
-                    report: Some(error.report),
-                    failure_reason: Some(error.reason),
-                });
+                    Some(StartupEventCorrelation::new(
+                        "runtime_id",
+                        runtime_id.as_str(),
+                    )),
+                    Some(startup_policy),
+                    error.report,
+                    error.reason,
+                ));
                 terminate_child_process(&mut child);
                 let startup_context =
                     format!("OpenCode runtime failed to start for task {task_id}");
@@ -411,18 +416,19 @@ impl AppService {
                 return Err(anyhow!(error)).with_context(|| startup_context);
             }
         };
-        self.emit_opencode_startup_event(StartupEventPayload {
-            event_name: "startup_ready",
-            runtime_type: "agent_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload::ready(
+            "agent_runtime",
             repo_path,
-            task_id: Some(task_id),
+            Some(task_id),
             role,
             port,
-            extra: Some(("runtime_id", runtime_id.as_str())),
-            policy: Some(startup_policy),
-            report: Some(startup_report),
-            failure_reason: None,
-        });
+            Some(StartupEventCorrelation::new(
+                "runtime_id",
+                runtime_id.as_str(),
+            )),
+            Some(startup_policy),
+            startup_report,
+        ));
 
         let summary = AgentRuntimeSummary {
             runtime_id: runtime_id.clone(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -1,6 +1,7 @@
 use super::{
     run_parsed_hook_command_allow_failure, spawn_opencode_server, terminate_child_process,
     validate_hook_trust, wait_for_local_server_with_process, AgentRuntimeProcess, AppService,
+    StartupEventPayload,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary};
@@ -131,19 +132,18 @@ impl AppService {
         let startup_policy = self.opencode_startup_readiness_policy();
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
-        self.emit_opencode_startup_event(
-            "startup_wait_begin",
-            "workspace_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload {
+            event_name: "startup_wait_begin",
+            runtime_type: "workspace_runtime",
             repo_path,
-            Some(Self::WORKSPACE_RUNTIME_TASK_ID),
-            Self::WORKSPACE_RUNTIME_ROLE,
+            task_id: Some(Self::WORKSPACE_RUNTIME_TASK_ID),
+            role: Self::WORKSPACE_RUNTIME_ROLE,
             port,
-            Some("runtime_id"),
-            Some(runtime_id.as_str()),
-            Some(startup_policy),
-            None,
-            None,
-        );
+            extra: Some(("runtime_id", runtime_id.as_str())),
+            policy: Some(startup_policy),
+            report: None,
+            failure_reason: None,
+        });
         let startup_report = match wait_for_local_server_with_process(
             &mut child,
             port,
@@ -153,38 +153,36 @@ impl AppService {
         ) {
             Ok(report) => report,
             Err(error) => {
-                self.emit_opencode_startup_event(
-                    "startup_failed",
-                    "workspace_runtime",
+                self.emit_opencode_startup_event(StartupEventPayload {
+                    event_name: "startup_failed",
+                    runtime_type: "workspace_runtime",
                     repo_path,
-                    Some(Self::WORKSPACE_RUNTIME_TASK_ID),
-                    Self::WORKSPACE_RUNTIME_ROLE,
+                    task_id: Some(Self::WORKSPACE_RUNTIME_TASK_ID),
+                    role: Self::WORKSPACE_RUNTIME_ROLE,
                     port,
-                    Some("runtime_id"),
-                    Some(runtime_id.as_str()),
-                    Some(startup_policy),
-                    Some(error.report),
-                    Some(error.reason),
-                );
+                    extra: Some(("runtime_id", runtime_id.as_str())),
+                    policy: Some(startup_policy),
+                    report: Some(error.report),
+                    failure_reason: Some(error.reason),
+                });
                 terminate_child_process(&mut child);
                 return Err(anyhow!(error)).with_context(|| {
                     format!("OpenCode workspace runtime failed to start for {repo_path}")
                 });
             }
         };
-        self.emit_opencode_startup_event(
-            "startup_ready",
-            "workspace_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload {
+            event_name: "startup_ready",
+            runtime_type: "workspace_runtime",
             repo_path,
-            Some(Self::WORKSPACE_RUNTIME_TASK_ID),
-            Self::WORKSPACE_RUNTIME_ROLE,
+            task_id: Some(Self::WORKSPACE_RUNTIME_TASK_ID),
+            role: Self::WORKSPACE_RUNTIME_ROLE,
             port,
-            Some("runtime_id"),
-            Some(runtime_id.as_str()),
-            Some(startup_policy),
-            Some(startup_report),
-            None,
-        );
+            extra: Some(("runtime_id", runtime_id.as_str())),
+            policy: Some(startup_policy),
+            report: Some(startup_report),
+            failure_reason: None,
+        });
 
         let summary = AgentRuntimeSummary {
             runtime_id: runtime_id.clone(),
@@ -362,19 +360,18 @@ impl AppService {
         let startup_policy = self.opencode_startup_readiness_policy();
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
-        self.emit_opencode_startup_event(
-            "startup_wait_begin",
-            "agent_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload {
+            event_name: "startup_wait_begin",
+            runtime_type: "agent_runtime",
             repo_path,
-            Some(task_id),
+            task_id: Some(task_id),
             role,
             port,
-            Some("runtime_id"),
-            Some(runtime_id.as_str()),
-            Some(startup_policy),
-            None,
-            None,
-        );
+            extra: Some(("runtime_id", runtime_id.as_str())),
+            policy: Some(startup_policy),
+            report: None,
+            failure_reason: None,
+        });
         let startup_report = match wait_for_local_server_with_process(
             &mut child,
             port,
@@ -384,19 +381,18 @@ impl AppService {
         ) {
             Ok(report) => report,
             Err(error) => {
-                self.emit_opencode_startup_event(
-                    "startup_failed",
-                    "agent_runtime",
+                self.emit_opencode_startup_event(StartupEventPayload {
+                    event_name: "startup_failed",
+                    runtime_type: "agent_runtime",
                     repo_path,
-                    Some(task_id),
+                    task_id: Some(task_id),
                     role,
                     port,
-                    Some("runtime_id"),
-                    Some(runtime_id.as_str()),
-                    Some(startup_policy),
-                    Some(error.report),
-                    Some(error.reason),
-                );
+                    extra: Some(("runtime_id", runtime_id.as_str())),
+                    policy: Some(startup_policy),
+                    report: Some(error.report),
+                    failure_reason: Some(error.reason),
+                });
                 terminate_child_process(&mut child);
                 let startup_context =
                     format!("OpenCode runtime failed to start for task {task_id}");
@@ -415,19 +411,18 @@ impl AppService {
                 return Err(anyhow!(error)).with_context(|| startup_context);
             }
         };
-        self.emit_opencode_startup_event(
-            "startup_ready",
-            "agent_runtime",
+        self.emit_opencode_startup_event(StartupEventPayload {
+            event_name: "startup_ready",
+            runtime_type: "agent_runtime",
             repo_path,
-            Some(task_id),
+            task_id: Some(task_id),
             role,
             port,
-            Some("runtime_id"),
-            Some(runtime_id.as_str()),
-            Some(startup_policy),
-            Some(startup_report),
-            None,
-        );
+            extra: Some(("runtime_id", runtime_id.as_str())),
+            policy: Some(startup_policy),
+            report: Some(startup_report),
+            failure_reason: None,
+        });
 
         let summary = AgentRuntimeSummary {
             runtime_id: runtime_id.clone(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
@@ -57,17 +57,143 @@ pub(crate) struct OpencodeStartupEventPayload {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub(crate) struct StartupEventCorrelation<'a> {
+    correlation_type: &'a str,
+    correlation_id: &'a str,
+}
+
+impl<'a> StartupEventCorrelation<'a> {
+    pub(crate) const fn new(correlation_type: &'a str, correlation_id: &'a str) -> Self {
+        Self {
+            correlation_type,
+            correlation_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum StartupEventKind {
+    WaitBegin,
+    Ready(OpencodeStartupWaitReport),
+    Failed {
+        report: OpencodeStartupWaitReport,
+        failure_reason: &'static str,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct StartupEventPayload<'a> {
-    pub(crate) event_name: &'a str,
-    pub(crate) runtime_type: &'a str,
-    pub(crate) repo_path: &'a str,
-    pub(crate) task_id: Option<&'a str>,
-    pub(crate) role: &'a str,
-    pub(crate) port: u16,
-    pub(crate) extra: Option<(&'a str, &'a str)>,
-    pub(crate) policy: Option<OpencodeStartupReadinessPolicy>,
-    pub(crate) report: Option<OpencodeStartupWaitReport>,
-    pub(crate) failure_reason: Option<&'a str>,
+    runtime_type: &'a str,
+    repo_path: &'a str,
+    task_id: Option<&'a str>,
+    role: &'a str,
+    port: u16,
+    correlation: Option<StartupEventCorrelation<'a>>,
+    policy: Option<OpencodeStartupReadinessPolicy>,
+    kind: StartupEventKind,
+}
+
+impl<'a> StartupEventPayload<'a> {
+    pub(crate) fn wait_begin(
+        runtime_type: &'a str,
+        repo_path: &'a str,
+        task_id: Option<&'a str>,
+        role: &'a str,
+        port: u16,
+        correlation: Option<StartupEventCorrelation<'a>>,
+        policy: Option<OpencodeStartupReadinessPolicy>,
+    ) -> Self {
+        Self {
+            runtime_type,
+            repo_path,
+            task_id,
+            role,
+            port,
+            correlation,
+            policy,
+            kind: StartupEventKind::WaitBegin,
+        }
+    }
+
+    pub(crate) fn ready(
+        runtime_type: &'a str,
+        repo_path: &'a str,
+        task_id: Option<&'a str>,
+        role: &'a str,
+        port: u16,
+        correlation: Option<StartupEventCorrelation<'a>>,
+        policy: Option<OpencodeStartupReadinessPolicy>,
+        report: OpencodeStartupWaitReport,
+    ) -> Self {
+        Self {
+            runtime_type,
+            repo_path,
+            task_id,
+            role,
+            port,
+            correlation,
+            policy,
+            kind: StartupEventKind::Ready(report),
+        }
+    }
+
+    pub(crate) fn failed(
+        runtime_type: &'a str,
+        repo_path: &'a str,
+        task_id: Option<&'a str>,
+        role: &'a str,
+        port: u16,
+        correlation: Option<StartupEventCorrelation<'a>>,
+        policy: Option<OpencodeStartupReadinessPolicy>,
+        report: OpencodeStartupWaitReport,
+        failure_reason: &'static str,
+    ) -> Self {
+        Self {
+            runtime_type,
+            repo_path,
+            task_id,
+            role,
+            port,
+            correlation,
+            policy,
+            kind: StartupEventKind::Failed {
+                report,
+                failure_reason,
+            },
+        }
+    }
+
+    fn event_name(self) -> &'static str {
+        match self.kind {
+            StartupEventKind::WaitBegin => "startup_wait_begin",
+            StartupEventKind::Ready(_) => "startup_ready",
+            StartupEventKind::Failed { .. } => "startup_failed",
+        }
+    }
+
+    fn report(self) -> Option<OpencodeStartupWaitReport> {
+        match self.kind {
+            StartupEventKind::WaitBegin => None,
+            StartupEventKind::Ready(report) => Some(report),
+            StartupEventKind::Failed { report, .. } => Some(report),
+        }
+    }
+
+    fn failure_reason(self) -> Option<&'static str> {
+        match self.kind {
+            StartupEventKind::WaitBegin | StartupEventKind::Ready(_) => None,
+            StartupEventKind::Failed { failure_reason, .. } => Some(failure_reason),
+        }
+    }
+
+    fn correlation_parts(self) -> (Option<&'a str>, Option<&'a str>) {
+        self.correlation.map_or((None, None), |correlation| {
+            (
+                Some(correlation.correlation_type),
+                Some(correlation.correlation_id),
+            )
+        })
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -290,20 +416,16 @@ impl AppService {
     }
 
     pub(crate) fn emit_opencode_startup_event(&self, event: StartupEventPayload<'_>) {
-        let StartupEventPayload {
-            event_name,
-            runtime_type,
-            repo_path,
-            task_id,
-            role,
-            port,
-            extra,
-            policy,
-            report,
-            failure_reason,
-        } = event;
-        let (correlation_type, correlation_id) =
-            extra.map_or((None, None), |(key, value)| (Some(key), Some(value)));
+        let event_name = event.event_name();
+        let runtime_type = event.runtime_type;
+        let repo_path = event.repo_path;
+        let task_id = event.task_id;
+        let role = event.role;
+        let port = event.port;
+        let policy = event.policy;
+        let report = event.report();
+        let failure_reason = event.failure_reason();
+        let (correlation_type, correlation_id) = event.correlation_parts();
 
         let (metrics, alerts) = match report {
             Some(report) if matches!(event_name, "startup_ready" | "startup_failed") => {
@@ -376,5 +498,72 @@ impl AppService {
                 "OpenCode startup threshold exceeded"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn test_startup_policy() -> OpencodeStartupReadinessPolicy {
+        OpencodeStartupReadinessPolicy {
+            timeout: Duration::from_millis(8_000),
+            connect_timeout: Duration::from_millis(250),
+            initial_retry_delay: Duration::from_millis(25),
+            max_retry_delay: Duration::from_millis(250),
+            child_state_check_interval: Duration::from_millis(100),
+        }
+    }
+
+    fn test_startup_report() -> OpencodeStartupWaitReport {
+        OpencodeStartupWaitReport::from_parts(5, Duration::from_millis(420))
+    }
+
+    #[test]
+    fn startup_event_payload_wait_begin_has_no_terminal_fields() {
+        let event = StartupEventPayload::wait_begin(
+            "agent_runtime",
+            "/tmp/repo",
+            Some("task-42"),
+            "qa",
+            4242,
+            Some(StartupEventCorrelation::new("runtime_id", "runtime-abc")),
+            Some(test_startup_policy()),
+        );
+
+        assert_eq!(event.event_name(), "startup_wait_begin");
+        assert!(event.report().is_none());
+        assert_eq!(event.failure_reason(), None);
+        assert_eq!(
+            event.correlation_parts(),
+            (Some("runtime_id"), Some("runtime-abc"))
+        );
+    }
+
+    #[test]
+    fn startup_event_payload_failed_requires_reason_with_report() {
+        let report = test_startup_report();
+        let event = StartupEventPayload::failed(
+            "agent_runtime",
+            "/tmp/repo",
+            Some("task-42"),
+            "qa",
+            4242,
+            Some(StartupEventCorrelation::new("runtime_id", "runtime-abc")),
+            Some(test_startup_policy()),
+            report,
+            "timeout",
+        );
+
+        assert_eq!(event.event_name(), "startup_failed");
+        let emitted_report = event.report().expect("failed event should carry report");
+        assert_eq!(emitted_report.startup_ms(), report.startup_ms());
+        assert_eq!(emitted_report.attempts(), report.attempts());
+        assert_eq!(event.failure_reason(), Some("timeout"));
+        assert_eq!(
+            event.correlation_parts(),
+            (Some("runtime_id"), Some("runtime-abc"))
+        );
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
@@ -56,6 +56,20 @@ pub(crate) struct OpencodeStartupEventPayload {
     alerts: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StartupEventPayload<'a> {
+    pub(crate) event_name: &'a str,
+    pub(crate) runtime_type: &'a str,
+    pub(crate) repo_path: &'a str,
+    pub(crate) task_id: Option<&'a str>,
+    pub(crate) role: &'a str,
+    pub(crate) port: u16,
+    pub(crate) extra: Option<(&'a str, &'a str)>,
+    pub(crate) policy: Option<OpencodeStartupReadinessPolicy>,
+    pub(crate) report: Option<OpencodeStartupWaitReport>,
+    pub(crate) failure_reason: Option<&'a str>,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct OpencodeStartupMetrics {
     total: u64,
@@ -275,29 +289,31 @@ impl AppService {
         self.startup_cancel_epoch.load(Ordering::SeqCst)
     }
 
-    pub(crate) fn emit_opencode_startup_event(
-        &self,
-        event: &str,
-        scope: &str,
-        repo_path: &str,
-        task_id: Option<&str>,
-        role: &str,
-        port: u16,
-        correlation_type: Option<&str>,
-        correlation_id: Option<&str>,
-        policy: Option<OpencodeStartupReadinessPolicy>,
-        report: Option<OpencodeStartupWaitReport>,
-        reason: Option<&str>,
-    ) {
+    pub(crate) fn emit_opencode_startup_event(&self, event: StartupEventPayload<'_>) {
+        let StartupEventPayload {
+            event_name,
+            runtime_type,
+            repo_path,
+            task_id,
+            role,
+            port,
+            extra,
+            policy,
+            report,
+            failure_reason,
+        } = event;
+        let (correlation_type, correlation_id) =
+            extra.map_or((None, None), |(key, value)| (Some(key), Some(value)));
+
         let (metrics, alerts) = match report {
-            Some(report) if matches!(event, "startup_ready" | "startup_failed") => {
+            Some(report) if matches!(event_name, "startup_ready" | "startup_failed") => {
                 match self.startup_metrics.lock() {
-                    Ok(mut metrics) => metrics.record_terminal(event, report, reason),
+                    Ok(mut metrics) => metrics.record_terminal(event_name, report, failure_reason),
                     Err(_) => {
                         tracing::warn!(
                             target: "openducktor.opencode.startup",
-                            event,
-                            scope,
+                            event = event_name,
+                            scope = runtime_type,
                             repo_path,
                             "OpenCode startup metrics lock poisoned; continuing without metrics"
                         );
@@ -307,10 +323,10 @@ impl AppService {
             }
             _ => (OpencodeStartupMetricsSnapshot::default(), Vec::new()),
         };
-        let include_metrics = matches!(event, "startup_ready" | "startup_failed");
+        let include_metrics = matches!(event_name, "startup_ready" | "startup_failed");
         let payload = build_opencode_startup_event_payload(
-            event,
-            scope,
+            event_name,
+            runtime_type,
             repo_path,
             task_id,
             role,
@@ -319,7 +335,7 @@ impl AppService {
             correlation_id,
             policy,
             report,
-            reason,
+            failure_reason,
             include_metrics.then_some(metrics),
             alerts.clone(),
         );
@@ -329,15 +345,15 @@ impl AppService {
         let attempts = report.map(|entry| entry.attempts()).unwrap_or_default();
         tracing::info!(
             target: "openducktor.opencode.startup",
-            event,
-            scope,
+            event = event_name,
+            scope = runtime_type,
             repo_path,
             task_id = task_id.unwrap_or(""),
             role,
             port,
             correlation_type = correlation_type.unwrap_or(""),
             correlation_id = correlation_id.unwrap_or(""),
-            reason = reason.unwrap_or(""),
+            reason = failure_reason.unwrap_or(""),
             startup_ms,
             attempts,
             payload = %payload_json,
@@ -346,15 +362,15 @@ impl AppService {
             tracing::warn!(
                 target: "openducktor.opencode.startup.alert",
                 alert = %alert,
-                event,
-                scope,
+                event = event_name,
+                scope = runtime_type,
                 repo_path,
                 task_id = task_id.unwrap_or(""),
                 role,
                 port,
                 correlation_type = correlation_type.unwrap_or(""),
                 correlation_id = correlation_id.unwrap_or(""),
-                reason = reason.unwrap_or(""),
+                reason = failure_reason.unwrap_or(""),
                 startup_ms,
                 attempts,
                 "OpenCode startup threshold exceeded"

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
@@ -163,7 +163,7 @@ impl<'a> StartupEventPayload<'a> {
         }
     }
 
-    fn event_name(self) -> &'static str {
+    fn event_name(&self) -> &'static str {
         match self.kind {
             StartupEventKind::WaitBegin => "startup_wait_begin",
             StartupEventKind::Ready(_) => "startup_ready",
@@ -171,7 +171,7 @@ impl<'a> StartupEventPayload<'a> {
         }
     }
 
-    fn report(self) -> Option<OpencodeStartupWaitReport> {
+    fn report(&self) -> Option<OpencodeStartupWaitReport> {
         match self.kind {
             StartupEventKind::WaitBegin => None,
             StartupEventKind::Ready(report) => Some(report),
@@ -179,14 +179,14 @@ impl<'a> StartupEventPayload<'a> {
         }
     }
 
-    fn failure_reason(self) -> Option<&'static str> {
+    fn failure_reason(&self) -> Option<&'static str> {
         match self.kind {
             StartupEventKind::WaitBegin | StartupEventKind::Ready(_) => None,
             StartupEventKind::Failed { failure_reason, .. } => Some(failure_reason),
         }
     }
 
-    fn correlation_parts(self) -> (Option<&'a str>, Option<&'a str>) {
+    fn correlation_parts(&self) -> (Option<&'a str>, Option<&'a str>) {
         self.correlation.map_or((None, None), |correlation| {
             (
                 Some(correlation.correlation_type),


### PR DESCRIPTION
## Summary
- replace positional startup event argument lists with a typed `StartupEventPayload` API
- enforce valid startup event states with constructor-based invariants (`wait_begin`, `ready`, `failed`)
- replace tuple correlation metadata with named `StartupEventCorrelation`
- migrate runtime/build orchestrators to the new typed constructors
- add focused startup-event invariant tests in `startup_metrics.rs`

## Why
This removes primitive obsession in startup event emission and prevents invalid event payload combinations from compiling, reducing regression risk as startup telemetry evolves.

## Verification
- `cd apps/desktop/src-tauri && cargo test -p host-application`
