### PR TITLE
fix(security): enforce workspace allowlist for Tauri repo_path operations

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -1,13 +1,11 @@
 use super::{
-    emit_event, spawn_opencode_server, spawn_output_forwarder, terminate_child_process,
-    run_parsed_hook_command_allow_failure, validate_hook_trust, validate_transition,
+    emit_event, run_parsed_hook_command_allow_failure, spawn_opencode_server,
+    spawn_output_forwarder, terminate_child_process, validate_hook_trust, validate_transition,
     wait_for_local_server_with_process, AppService, RunEmitter, RunProcess,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, RunEvent, RunState, RunSummary, TaskStatus};
-use host_infra_system::{
-    build_branch_name, pick_free_port, remove_worktree,
-};
+use host_infra_system::{build_branch_name, pick_free_port, remove_worktree};
 use serde::Deserialize;
 use std::fs;
 use std::path::Path;
@@ -56,6 +54,10 @@ impl AppService {
         task_id: &str,
         emitter: RunEmitter,
     ) -> Result<RunSummary> {
+        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = Self::repo_key(repo_path);
+        let repo_path = repo_path.as_str();
+
         let repo_config = self.config_store.repo_config(repo_path)?;
 
         let worktree_base = repo_config.worktree_base_path.clone().ok_or_else(|| {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -54,8 +54,7 @@ impl AppService {
         task_id: &str,
         emitter: RunEmitter,
     ) -> Result<RunSummary> {
-        self.ensure_repo_initialized(repo_path)?;
-        let repo_path = Self::repo_key(repo_path);
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         let repo_path = repo_path.as_str();
 
         let repo_config = self.config_store.repo_config(repo_path)?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/repo_init.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/repo_init.rs
@@ -8,8 +8,24 @@ impl AppService {
             .to_string()
     }
 
-    pub(super) fn ensure_repo_initialized(&self, repo_path: &str) -> Result<()> {
+    pub(super) fn ensure_repo_authorized(&self, repo_path: &str) -> Result<String> {
         let repo_key = Self::repo_key(repo_path);
+        if !self.enforce_repo_allowlist {
+            return Ok(repo_key);
+        }
+
+        let is_allowed = self.config_store.repo_config_optional(repo_path)?.is_some();
+        if !is_allowed {
+            return Err(anyhow!(
+                "Repository path is not in the configured workspace allowlist: {repo_path}"
+            ));
+        }
+
+        Ok(repo_key)
+    }
+
+    pub(super) fn ensure_repo_initialized(&self, repo_path: &str) -> Result<()> {
+        let repo_key = self.ensure_repo_authorized(repo_path)?;
         {
             let cache = self
                 .initialized_repos

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/repo_init.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/repo_init.rs
@@ -24,7 +24,7 @@ impl AppService {
         Ok(repo_key)
     }
 
-    pub(super) fn ensure_repo_initialized(&self, repo_path: &str) -> Result<()> {
+    pub(super) fn resolve_initialized_repo_path(&self, repo_path: &str) -> Result<String> {
         let repo_key = self.ensure_repo_authorized(repo_path)?;
         {
             let cache = self
@@ -32,20 +32,24 @@ impl AppService {
                 .lock()
                 .map_err(|_| anyhow!("Initialized repo cache lock poisoned"))?;
             if cache.contains(&repo_key) {
-                return Ok(());
+                return Ok(repo_key);
             }
         }
 
         self.task_store
-            .ensure_repo_initialized(Path::new(repo_path))
-            .with_context(|| format!("Failed to initialize task store for {repo_path}"))?;
+            .ensure_repo_initialized(Path::new(&repo_key))
+            .with_context(|| format!("Failed to initialize task store for {}", repo_key))?;
 
         let mut cache = self
             .initialized_repos
             .lock()
             .map_err(|_| anyhow!("Initialized repo cache lock poisoned"))?;
-        cache.insert(repo_key);
+        cache.insert(repo_key.clone());
 
-        Ok(())
+        Ok(repo_key)
+    }
+
+    pub(super) fn ensure_repo_initialized(&self, repo_path: &str) -> Result<()> {
+        self.resolve_initialized_repo_path(repo_path).map(|_| ())
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -4,9 +4,7 @@ use super::{
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary};
-use host_infra_system::{
-    build_branch_name, pick_free_port, remove_worktree, run_command,
-};
+use host_infra_system::{build_branch_name, pick_free_port, remove_worktree, run_command};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
@@ -14,6 +12,9 @@ use uuid::Uuid;
 
 impl AppService {
     pub fn runs_list(&self, repo_path: Option<&str>) -> Result<Vec<RunSummary>> {
+        let repo_key_filter = repo_path
+            .map(|path| self.ensure_repo_authorized(path))
+            .transpose()?;
         let runs = self
             .runs
             .lock()
@@ -22,8 +23,8 @@ impl AppService {
         let mut list = runs
             .values()
             .filter(|run| {
-                if let Some(path) = repo_path {
-                    run.repo_path == path
+                if let Some(path_key) = repo_key_filter.as_deref() {
+                    Self::repo_key(run.repo_path.as_str()) == path_key
                 } else {
                     true
                 }
@@ -39,7 +40,9 @@ impl AppService {
         &self,
         repo_path: Option<&str>,
     ) -> Result<Vec<AgentRuntimeSummary>> {
-        let repo_key_filter = repo_path.map(Self::repo_key);
+        let repo_key_filter = repo_path
+            .map(|path| self.ensure_repo_authorized(path))
+            .transpose()?;
         let mut runtimes = self
             .agent_runtimes
             .lock()

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -94,9 +94,8 @@ impl AppService {
     }
 
     pub fn opencode_repo_runtime_ensure(&self, repo_path: &str) -> Result<AgentRuntimeSummary> {
-        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
-        let repo_path = repo_path.as_str();
-        let repo_key = repo_path.to_string();
+        let repo_key = self.resolve_initialized_repo_path(repo_path)?;
+        let repo_path = repo_key.as_str();
 
         {
             let mut runtimes = self
@@ -240,9 +239,8 @@ impl AppService {
         task_id: &str,
         role: &str,
     ) -> Result<AgentRuntimeSummary> {
-        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
-        let repo_path = repo_path.as_str();
-        let repo_key = repo_path.to_string();
+        let repo_key = self.resolve_initialized_repo_path(repo_path)?;
+        let repo_path = repo_key.as_str();
         if !matches!(role, "spec" | "planner" | "qa") {
             return Err(anyhow!(
                 "Unsupported agent runtime role: {role}. Supported: spec, planner, qa"

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -5,7 +5,7 @@ use super::{
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary};
 use host_infra_system::{build_branch_name, pick_free_port, remove_worktree, run_command};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 use uuid::Uuid;
@@ -15,6 +15,17 @@ impl AppService {
         let repo_key_filter = repo_path
             .map(|path| self.ensure_repo_authorized(path))
             .transpose()?;
+        let allowlisted_repo_keys = if repo_key_filter.is_none() && self.enforce_repo_allowlist {
+            Some(
+                self.config_store
+                    .list_workspaces()?
+                    .into_iter()
+                    .map(|workspace| workspace.path)
+                    .collect::<HashSet<_>>(),
+            )
+        } else {
+            None
+        };
         let runs = self
             .runs
             .lock()
@@ -25,6 +36,9 @@ impl AppService {
             .filter(|run| {
                 if let Some(path_key) = repo_key_filter.as_deref() {
                     Self::repo_key(run.repo_path.as_str()) == path_key
+                } else if let Some(allowlist) = allowlisted_repo_keys.as_ref() {
+                    let run_repo_key = Self::repo_key(run.repo_path.as_str());
+                    allowlist.contains(&run_repo_key)
                 } else {
                     true
                 }
@@ -43,6 +57,17 @@ impl AppService {
         let repo_key_filter = repo_path
             .map(|path| self.ensure_repo_authorized(path))
             .transpose()?;
+        let allowlisted_repo_keys = if repo_key_filter.is_none() && self.enforce_repo_allowlist {
+            Some(
+                self.config_store
+                    .list_workspaces()?
+                    .into_iter()
+                    .map(|workspace| workspace.path)
+                    .collect::<HashSet<_>>(),
+            )
+        } else {
+            None
+        };
         let mut runtimes = self
             .agent_runtimes
             .lock()
@@ -54,6 +79,9 @@ impl AppService {
             .filter(|runtime| {
                 if let Some(path_key) = repo_key_filter.as_deref() {
                     Self::repo_key(runtime.summary.repo_path.as_str()) == path_key
+                } else if let Some(allowlist) = allowlisted_repo_keys.as_ref() {
+                    let runtime_repo_key = Self::repo_key(runtime.summary.repo_path.as_str());
+                    allowlist.contains(&runtime_repo_key)
                 } else {
                     true
                 }
@@ -66,8 +94,9 @@ impl AppService {
     }
 
     pub fn opencode_repo_runtime_ensure(&self, repo_path: &str) -> Result<AgentRuntimeSummary> {
-        self.ensure_repo_initialized(repo_path)?;
-        let repo_key = Self::repo_key(repo_path);
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let repo_path = repo_path.as_str();
+        let repo_key = repo_path.to_string();
 
         {
             let mut runtimes = self
@@ -211,8 +240,9 @@ impl AppService {
         task_id: &str,
         role: &str,
     ) -> Result<AgentRuntimeSummary> {
-        self.ensure_repo_initialized(repo_path)?;
-        let repo_key = Self::repo_key(repo_path);
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let repo_path = repo_path.as_str();
+        let repo_key = repo_path.to_string();
         if !matches!(role, "spec" | "planner" | "qa") {
             return Err(anyhow!(
                 "Unsupported agent runtime role: {role}. Supported: spec, planner, qa"

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
@@ -18,6 +18,7 @@ pub struct AppService {
     pub(super) runtime_check_cache: Arc<Mutex<Option<CachedRuntimeCheck>>>,
     pub(super) startup_cancel_epoch: StartupCancelEpoch,
     pub(super) startup_metrics: Arc<Mutex<OpencodeStartupMetrics>>,
+    pub(super) enforce_repo_allowlist: bool,
 }
 
 pub(crate) struct RunProcess {
@@ -62,6 +63,15 @@ impl AppService {
         config_store: AppConfigStore,
         git_port: Arc<dyn GitPort>,
     ) -> Self {
+        Self::with_git_port_allowlist(task_store, config_store, git_port, true)
+    }
+
+    fn with_git_port_allowlist(
+        task_store: Arc<dyn TaskStore>,
+        config_store: AppConfigStore,
+        git_port: Arc<dyn GitPort>,
+        enforce_repo_allowlist: bool,
+    ) -> Self {
         let opencode_process_registry_path = Self::opencode_process_registry_path(&config_store);
         let instance_pid = std::process::id();
         let service = Self {
@@ -77,6 +87,7 @@ impl AppService {
             runtime_check_cache: Arc::new(Mutex::new(None)),
             startup_cancel_epoch: Arc::new(AtomicU64::new(0)),
             startup_metrics: Arc::new(Mutex::new(OpencodeStartupMetrics::default())),
+            enforce_repo_allowlist,
         };
         if let Err(error) = service.reconcile_opencode_process_registry_on_startup() {
             eprintln!(
@@ -84,5 +95,14 @@ impl AppService {
             );
         }
         service
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_git_port_unrestricted(
+        task_store: Arc<dyn TaskStore>,
+        config_store: AppConfigStore,
+        git_port: Arc<dyn GitPort>,
+    ) -> Self {
+        Self::with_git_port_allowlist(task_store, config_store, git_port, false)
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -196,7 +196,9 @@ impl AppService {
                     ));
                 }
             } else {
-                return Err(anyhow!("Hook trust confirmation requires fingerprint challenge."));
+                return Err(anyhow!(
+                    "Hook trust confirmation requires fingerprint challenge."
+                ));
             }
 
             return self.config_store.set_repo_trust_hooks(
@@ -206,7 +208,8 @@ impl AppService {
             );
         }
 
-        self.config_store.set_repo_trust_hooks(repo_path, false, None)
+        self.config_store
+            .set_repo_trust_hooks(repo_path, false, None)
     }
 
     pub fn get_theme(&self) -> Result<String> {
@@ -218,13 +221,13 @@ impl AppService {
     }
 
     pub fn git_get_branches(&self, repo_path: &str) -> Result<Vec<GitBranch>> {
-        self.ensure_repo_initialized(repo_path)?;
-        self.git_port.get_branches(Path::new(repo_path))
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        self.git_port.get_branches(Path::new(&repo_path))
     }
 
     pub fn git_get_current_branch(&self, repo_path: &str) -> Result<GitCurrentBranch> {
-        self.ensure_repo_initialized(repo_path)?;
-        self.git_port.get_current_branch(Path::new(repo_path))
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        self.git_port.get_current_branch(Path::new(&repo_path))
     }
 
     pub fn git_switch_branch(
@@ -233,9 +236,9 @@ impl AppService {
         branch: &str,
         create: bool,
     ) -> Result<GitCurrentBranch> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         self.git_port
-            .switch_branch(Path::new(repo_path), branch, create)
+            .switch_branch(Path::new(&repo_path), branch, create)
     }
 
     pub fn git_create_worktree(
@@ -245,14 +248,14 @@ impl AppService {
         branch: &str,
         create_branch: bool,
     ) -> Result<GitWorktreeSummary> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         let worktree = worktree_path.trim();
         if worktree.is_empty() {
             return Err(anyhow!("worktree path cannot be empty"));
         }
 
         self.git_port.create_worktree(
-            Path::new(repo_path),
+            Path::new(&repo_path),
             Path::new(worktree),
             branch,
             create_branch,
@@ -270,13 +273,13 @@ impl AppService {
         worktree_path: &str,
         force: bool,
     ) -> Result<bool> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         let worktree = worktree_path.trim();
         if worktree.is_empty() {
             return Err(anyhow!("worktree path cannot be empty"));
         }
         self.git_port
-            .remove_worktree(Path::new(repo_path), Path::new(worktree), force)?;
+            .remove_worktree(Path::new(&repo_path), Path::new(worktree), force)?;
         Ok(true)
     }
 
@@ -288,13 +291,13 @@ impl AppService {
         set_upstream: bool,
         force_with_lease: bool,
     ) -> Result<GitPushSummary> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         let remote = remote
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .unwrap_or("origin");
         self.git_port.push_branch(
-            Path::new(repo_path),
+            Path::new(&repo_path),
             remote,
             branch,
             set_upstream,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
@@ -15,21 +15,21 @@ use std::path::Path;
 
 impl AppService {
     pub fn tasks_list(&self, repo_path: &str) -> Result<Vec<TaskCard>> {
-        self.ensure_repo_initialized(repo_path)?;
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
         Ok(self.enrich_tasks(tasks))
     }
 
     pub fn task_create(&self, repo_path: &str, mut input: CreateTaskInput) -> Result<TaskCard> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         if input.ai_review_enabled.is_none() {
             input.ai_review_enabled = Some(default_qa_required_for_issue_type(&input.issue_type));
         }
 
-        let mut existing = self.task_store.list_tasks(Path::new(repo_path))?;
+        let mut existing = self.task_store.list_tasks(Path::new(&repo_path))?;
         validate_parent_relationships_for_create(&existing, &input)?;
 
-        let created = self.task_store.create_task(Path::new(repo_path), input)?;
+        let created = self.task_store.create_task(Path::new(&repo_path), input)?;
         existing.push(created.clone());
         Ok(self.enrich_task(created, &existing))
     }
@@ -40,14 +40,14 @@ impl AppService {
         task_id: &str,
         patch: UpdateTaskPatch,
     ) -> Result<TaskCard> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         if patch.status.is_some() {
             return Err(anyhow!(
                 "Status cannot be updated directly. Use workflow transitions."
             ));
         }
 
-        let mut existing = self.task_store.list_tasks(Path::new(repo_path))?;
+        let mut existing = self.task_store.list_tasks(Path::new(&repo_path))?;
         let current = existing
             .iter()
             .find(|task| task.id == task_id)
@@ -56,7 +56,7 @@ impl AppService {
 
         let updated = self
             .task_store
-            .update_task(Path::new(repo_path), task_id, patch)?;
+            .update_task(Path::new(&repo_path), task_id, patch)?;
         if let Some(index) = existing.iter().position(|task| task.id == task_id) {
             existing[index] = updated.clone();
         }
@@ -64,8 +64,8 @@ impl AppService {
     }
 
     pub fn task_delete(&self, repo_path: &str, task_id: &str, delete_subtasks: bool) -> Result<()> {
-        self.ensure_repo_initialized(repo_path)?;
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
         let task = tasks
             .iter()
             .find(|entry| entry.id == task_id)
@@ -85,7 +85,7 @@ impl AppService {
         }
 
         self.task_store
-            .delete_task(Path::new(repo_path), task_id, delete_subtasks)
+            .delete_task(Path::new(&repo_path), task_id, delete_subtasks)
             .with_context(|| format!("Failed to delete task {task_id}"))?;
         Ok(())
     }
@@ -97,8 +97,8 @@ impl AppService {
         target_status: TaskStatus,
         _reason: Option<&str>,
     ) -> Result<TaskCard> {
-        self.ensure_repo_initialized(repo_path)?;
-        let mut existing = self.task_store.list_tasks(Path::new(repo_path))?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let mut existing = self.task_store.list_tasks(Path::new(&repo_path))?;
         let task = existing
             .iter()
             .find(|entry| entry.id == task_id)
@@ -112,7 +112,7 @@ impl AppService {
         }
 
         let updated = self.task_store.update_task(
-            Path::new(repo_path),
+            Path::new(&repo_path),
             task_id,
             UpdateTaskPatch {
                 title: None,
@@ -164,8 +164,8 @@ impl AppService {
         task_id: &str,
         _summary: Option<&str>,
     ) -> Result<TaskCard> {
-        self.ensure_repo_initialized(repo_path)?;
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
         let task = tasks
             .iter()
             .find(|entry| entry.id == task_id)
@@ -176,7 +176,12 @@ impl AppService {
             TaskStatus::HumanReview
         };
 
-        self.task_transition(repo_path, task_id, next_status, Some("Builder completed"))
+        self.task_transition(
+            repo_path.as_str(),
+            task_id,
+            next_status,
+            Some("Builder completed"),
+        )
     }
 
     pub fn human_request_changes(
@@ -207,8 +212,8 @@ impl AppService {
         task_id: &str,
         _reason: Option<&str>,
     ) -> Result<TaskCard> {
-        self.ensure_repo_initialized(repo_path)?;
-        let existing = self.task_store.list_tasks(Path::new(repo_path))?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let existing = self.task_store.list_tasks(Path::new(&repo_path))?;
         let task = existing
             .iter()
             .find(|entry| entry.id == task_id)
@@ -223,7 +228,7 @@ impl AppService {
         }
 
         self.task_transition(
-            repo_path,
+            repo_path.as_str(),
             task_id,
             TaskStatus::Deferred,
             Some("Deferred by user"),
@@ -231,8 +236,8 @@ impl AppService {
     }
 
     pub fn task_resume_deferred(&self, repo_path: &str, task_id: &str) -> Result<TaskCard> {
-        self.ensure_repo_initialized(repo_path)?;
-        let existing = self.task_store.list_tasks(Path::new(repo_path))?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let existing = self.task_store.list_tasks(Path::new(&repo_path))?;
         let task = existing
             .iter()
             .find(|entry| entry.id == task_id)
@@ -241,7 +246,7 @@ impl AppService {
             return Err(anyhow!("Task is not deferred: {task_id}"));
         }
         self.task_transition(
-            repo_path,
+            repo_path.as_str(),
             task_id,
             TaskStatus::Open,
             Some("Deferred task resumed"),
@@ -249,9 +254,9 @@ impl AppService {
     }
 
     pub fn task_metadata_get(&self, repo_path: &str, task_id: &str) -> Result<TaskMetadata> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         self.task_store
-            .get_task_metadata(Path::new(repo_path), task_id)
+            .get_task_metadata(Path::new(&repo_path), task_id)
             .with_context(|| format!("Failed to load task metadata for {task_id}"))
     }
 
@@ -260,9 +265,9 @@ impl AppService {
     }
 
     pub fn set_spec(&self, repo_path: &str, task_id: &str, markdown: &str) -> Result<SpecDocument> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         let markdown = normalize_required_markdown(markdown, "spec")?;
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
         let task = tasks
             .iter()
             .find(|entry| entry.id == task_id)
@@ -277,12 +282,12 @@ impl AppService {
 
         let spec = self
             .task_store
-            .set_spec(Path::new(repo_path), task_id, &markdown)
+            .set_spec(Path::new(&repo_path), task_id, &markdown)
             .with_context(|| format!("Failed to persist spec markdown for {task_id}"))?;
 
         if task.status == TaskStatus::Open {
             self.task_transition(
-                repo_path,
+                repo_path.as_str(),
                 task_id,
                 TaskStatus::SpecReady,
                 Some("Spec ready"),
@@ -298,15 +303,15 @@ impl AppService {
         task_id: &str,
         markdown: &str,
     ) -> Result<SpecDocument> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         let markdown = normalize_required_markdown(markdown, "spec")?;
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
         if tasks.iter().all(|entry| entry.id != task_id) {
             return Err(anyhow!("Task not found: {task_id}"));
         }
 
         self.task_store
-            .set_spec(Path::new(repo_path), task_id, &markdown)
+            .set_spec(Path::new(&repo_path), task_id, &markdown)
             .with_context(|| format!("Failed to persist spec markdown for {task_id}"))
     }
 
@@ -321,9 +326,9 @@ impl AppService {
         markdown: &str,
         subtasks: Option<Vec<PlanSubtaskInput>>,
     ) -> Result<SpecDocument> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         let markdown = normalize_required_markdown(markdown, "implementation plan")?;
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
         let task = tasks
             .iter()
             .find(|entry| entry.id == task_id)
@@ -346,11 +351,11 @@ impl AppService {
 
         let plan = self
             .task_store
-            .set_plan(Path::new(repo_path), task_id, &markdown)
+            .set_plan(Path::new(&repo_path), task_id, &markdown)
             .with_context(|| format!("Failed to persist implementation plan for {task_id}"))?;
 
         if issue_type == IssueType::Epic {
-            let mut current_tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+            let mut current_tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
             let refreshed_task = current_tasks
                 .iter()
                 .find(|entry| entry.id == task_id)
@@ -389,7 +394,7 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
 
             for existing_subtask_id in &existing_direct_subtask_ids {
                 self.task_store
-                    .delete_task(Path::new(repo_path), existing_subtask_id, false)
+                    .delete_task(Path::new(&repo_path), existing_subtask_id, false)
                     .with_context(|| {
                         format!("Failed to delete replaced subtask {}", existing_subtask_id)
                     })?;
@@ -412,13 +417,13 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
                 validate_parent_relationships_for_create(&current_tasks, &create_input)?;
                 let created = self
                     .task_store
-                    .create_task(Path::new(repo_path), create_input)?;
+                    .create_task(Path::new(&repo_path), create_input)?;
                 current_tasks.push(created);
             }
         }
 
         self.task_transition(
-            repo_path,
+            repo_path.as_str(),
             task_id,
             TaskStatus::ReadyForDev,
             Some("Implementation plan ready"),
@@ -433,15 +438,15 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
         task_id: &str,
         markdown: &str,
     ) -> Result<SpecDocument> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         let markdown = normalize_required_markdown(markdown, "implementation plan")?;
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
         if tasks.iter().all(|entry| entry.id != task_id) {
             return Err(anyhow!("Task not found: {task_id}"));
         }
 
         self.task_store
-            .set_plan(Path::new(repo_path), task_id, &markdown)
+            .set_plan(Path::new(&repo_path), task_id, &markdown)
             .with_context(|| format!("Failed to persist implementation plan for {task_id}"))
     }
 
@@ -461,8 +466,8 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
     }
 
     pub fn qa_approved(&self, repo_path: &str, task_id: &str, markdown: &str) -> Result<TaskCard> {
-        self.ensure_repo_initialized(repo_path)?;
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
         let task = tasks
             .iter()
             .find(|entry| entry.id == task_id)
@@ -471,11 +476,16 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
         validate_transition(&task, &tasks, &task.status, &TaskStatus::HumanReview)?;
 
         self.task_store
-            .append_qa_report(Path::new(repo_path), task_id, markdown, QaVerdict::Approved)
+            .append_qa_report(
+                Path::new(&repo_path),
+                task_id,
+                markdown,
+                QaVerdict::Approved,
+            )
             .with_context(|| format!("Failed to persist QA report for {task_id}"))?;
 
         self.task_transition(
-            repo_path,
+            repo_path.as_str(),
             task_id,
             TaskStatus::HumanReview,
             Some("QA approved"),
@@ -483,8 +493,8 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
     }
 
     pub fn qa_rejected(&self, repo_path: &str, task_id: &str, markdown: &str) -> Result<TaskCard> {
-        self.ensure_repo_initialized(repo_path)?;
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let tasks = self.task_store.list_tasks(Path::new(&repo_path))?;
         let task = tasks
             .iter()
             .find(|entry| entry.id == task_id)
@@ -493,11 +503,16 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
         validate_transition(&task, &tasks, &task.status, &TaskStatus::InProgress)?;
 
         self.task_store
-            .append_qa_report(Path::new(repo_path), task_id, markdown, QaVerdict::Rejected)
+            .append_qa_report(
+                Path::new(&repo_path),
+                task_id,
+                markdown,
+                QaVerdict::Rejected,
+            )
             .with_context(|| format!("Failed to persist QA report for {task_id}"))?;
 
         self.task_transition(
-            repo_path,
+            repo_path.as_str(),
             task_id,
             TaskStatus::InProgress,
             Some("QA requested changes"),
@@ -518,12 +533,12 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
         task_id: &str,
         mut session: AgentSessionDocument,
     ) -> Result<bool> {
-        self.ensure_repo_initialized(repo_path)?;
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
         if session.task_id != task_id {
             session.task_id = task_id.to_string();
         }
         self.task_store
-            .upsert_agent_session(Path::new(repo_path), task_id, session)
+            .upsert_agent_session(Path::new(&repo_path), task_id, session)
             .with_context(|| format!("Failed to persist agent session for {task_id}"))?;
         Ok(true)
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -445,6 +445,46 @@ pub(crate) fn build_service_with_state(
     )
 }
 
+pub(crate) fn build_service_with_git_state_enforced(
+    tasks: Vec<TaskCard>,
+    branches: Vec<GitBranch>,
+    current_branch: GitCurrentBranch,
+) -> (AppService, Arc<Mutex<TaskStoreState>>, Arc<Mutex<GitState>>) {
+    let task_state = Arc::new(Mutex::new(TaskStoreState {
+        ensure_calls: Vec::new(),
+        ensure_error: None,
+        tasks,
+        list_error: None,
+        delete_calls: Vec::new(),
+        created_inputs: Vec::new(),
+        updated_patches: Vec::new(),
+        spec_get_calls: Vec::new(),
+        spec_set_calls: Vec::new(),
+        plan_get_calls: Vec::new(),
+        plan_set_calls: Vec::new(),
+        metadata_get_calls: Vec::new(),
+        qa_append_calls: Vec::new(),
+        latest_qa_report: None,
+        agent_sessions: Vec::new(),
+        upserted_sessions: Vec::new(),
+    }));
+    let git_state = Arc::new(Mutex::new(GitState {
+        calls: Vec::new(),
+        branches,
+        current_branch,
+        last_push_remote: None,
+    }));
+    let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore {
+        state: task_state.clone(),
+    });
+    let git_port: Arc<dyn GitPort> = Arc::new(FakeGitPort {
+        state: git_state.clone(),
+    });
+    let config_store = AppConfigStore::from_path(unique_temp_path("host-app-config-enforced"));
+    let service = AppService::with_git_port(task_store, config_store, git_port);
+    (service, task_state, git_state)
+}
+
 pub(crate) fn build_service_with_git_state(
     tasks: Vec<TaskCard>,
     branches: Vec<GitBranch>,
@@ -481,7 +521,7 @@ pub(crate) fn build_service_with_git_state(
         state: git_state.clone(),
     });
     let config_store = AppConfigStore::from_path(unique_temp_path("host-app-config"));
-    let service = AppService::with_git_port(task_store, config_store, git_port);
+    let service = AppService::with_git_port_unrestricted(task_store, config_store, git_port);
     (service, task_state, git_state)
 }
 
@@ -885,7 +925,7 @@ pub(crate) fn build_service_with_store(
     let git_port: Arc<dyn GitPort> = Arc::new(FakeGitPort {
         state: git_state.clone(),
     });
-    let service = AppService::with_git_port(task_store, config_store, git_port);
+    let service = AppService::with_git_port_unrestricted(task_store, config_store, git_port);
     (service, task_state, git_state)
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -59,6 +59,7 @@ fn build_start_respond_and_cleanup_success_flow() -> Result<()> {
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
     service.workspace_update_repo_config(
         repo_path.as_str(),
         RepoConfig {
@@ -237,6 +238,7 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
 
     let pre_start_failure_hooks = HookSet {
         pre_start: vec!["sh -lc 'echo pre-fail >&2; exit 1'".to_string()],
@@ -329,6 +331,7 @@ fn build_start_requires_worktree_base_path() -> Result<()> {
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
     service.workspace_update_repo_config(
         repo_path.as_str(),
         RepoConfig {
@@ -372,6 +375,7 @@ fn build_start_rejects_untrusted_hooks_configuration() -> Result<()> {
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
     service.workspace_update_repo_config(
         repo_path.as_str(),
         RepoConfig {
@@ -421,6 +425,7 @@ fn build_start_rejects_existing_worktree_directory() -> Result<()> {
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
     service.workspace_update_repo_config(
         repo_path.as_str(),
         RepoConfig {
@@ -472,6 +477,7 @@ fn build_start_reports_opencode_startup_failure() -> Result<()> {
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
     service.workspace_update_repo_config(
         repo_path.as_str(),
         RepoConfig {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/mod.rs
@@ -1,6 +1,7 @@
 mod build_flows;
 mod git_and_task;
 mod opencode_runtime;
+mod repo_authorization;
 mod runtime_checks;
 mod shutdown_and_helpers;
 mod workflow_docs;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -189,6 +189,7 @@ fn opencode_runtime_start_supports_spec_and_qa_roles() -> Result<()> {
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
     service.workspace_update_repo_config(
         repo_path.as_str(),
         RepoConfig {
@@ -265,6 +266,7 @@ fn opencode_runtime_start_qa_validates_config_and_existing_worktree_path() -> Re
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
 
     service.workspace_update_repo_config(
         repo_path.as_str(),
@@ -345,6 +347,7 @@ fn opencode_runtime_start_surfaces_qa_pre_start_cleanup_failure() -> Result<()> 
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
 
     let pre_start_cleanup_failure_hooks = HookSet {
         pre_start: vec![format!("sh -lc 'rm -rf \"{repo_path}\"; exit 1'")],
@@ -397,6 +400,7 @@ fn opencode_runtime_start_surfaces_cleanup_failure_after_startup_error() -> Resu
         },
         config_store,
     );
+    service.workspace_add(repo_path.as_str())?;
     service.workspace_update_repo_config(
         repo_path.as_str(),
         RepoConfig {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/repo_authorization.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/repo_authorization.rs
@@ -1,11 +1,14 @@
 use anyhow::Result;
-use host_domain::{GitCurrentBranch, RunEvent, TaskStatus};
+use host_domain::{GitCurrentBranch, RunEvent, RunState, RunSummary, TaskStatus};
+use host_infra_system::{HookSet, RepoConfig};
 use std::fs;
 use std::sync::{Arc, Mutex};
 
 use crate::app_service::test_support::{
-    build_service_with_git_state_enforced, make_emitter, make_task, unique_temp_path,
+    build_service_with_git_state_enforced, make_emitter, make_task, spawn_sleep_process,
+    unique_temp_path,
 };
+use crate::app_service::RunProcess;
 
 #[test]
 fn tasks_reject_repo_path_not_in_workspace_allowlist() {
@@ -87,9 +90,10 @@ fn canonical_repo_path_variants_are_authorized() -> Result<()> {
 
     let root = unique_temp_path("repo-auth-canonical");
     let repo = root.join("repo");
-    fs::create_dir_all(&repo)?;
+    fs::create_dir_all(repo.join(".git"))?;
 
     let canonical_repo = fs::canonicalize(&repo)?.to_string_lossy().to_string();
+    service.workspace_add(canonical_repo.as_str())?;
     service.workspace_update_repo_config(canonical_repo.as_str(), Default::default())?;
 
     let repo_variant = format!("{}/.", canonical_repo);
@@ -97,5 +101,87 @@ fn canonical_repo_path_variants_are_authorized() -> Result<()> {
     assert_eq!(tasks.len(), 1);
 
     let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn workspace_update_repo_config_cannot_register_new_allowlist_entries() {
+    let (service, _task_state, _git_state) = build_service_with_git_state_enforced(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+
+    let unknown_repo_path = "/tmp/odt-repo-unauthorized-config";
+    let error = service
+        .workspace_update_repo_config(
+            unknown_repo_path,
+            RepoConfig {
+                worktree_base_path: Some("/tmp/wt".to_string()),
+                branch_prefix: "odt".to_string(),
+                trusted_hooks: false,
+                trusted_hooks_fingerprint: None,
+                hooks: HookSet::default(),
+                agent_defaults: Default::default(),
+            },
+        )
+        .expect_err("updating unknown workspace should fail");
+    assert!(error.to_string().contains("Workspace not found in config"));
+
+    let task_error = service
+        .tasks_list(unknown_repo_path)
+        .expect_err("unknown path must still be blocked");
+    assert!(task_error.to_string().contains("workspace allowlist"));
+}
+
+#[test]
+fn runs_list_without_filter_hides_non_allowlisted_runs() -> Result<()> {
+    let (service, _task_state, _git_state) = build_service_with_git_state_enforced(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+
+    let run_id = "run-outside-allowlist".to_string();
+    service
+        .runs
+        .lock()
+        .expect("run state lock poisoned")
+        .insert(
+            run_id.clone(),
+            RunProcess {
+                summary: RunSummary {
+                    run_id: run_id.clone(),
+                    repo_path: "/tmp/outside-allowlist".to_string(),
+                    task_id: "task-1".to_string(),
+                    branch: "odt/task-1".to_string(),
+                    worktree_path: "/tmp/outside-allowlist".to_string(),
+                    port: 4010,
+                    state: RunState::Running,
+                    last_message: None,
+                    started_at: "2026-02-28T16:00:00Z".to_string(),
+                },
+                child: spawn_sleep_process(30),
+                _opencode_process_guard: None,
+                repo_path: "/tmp/outside-allowlist".to_string(),
+                task_id: "task-1".to_string(),
+                worktree_path: "/tmp/outside-allowlist".to_string(),
+                repo_config: RepoConfig::default(),
+            },
+        );
+
+    let listed = service.runs_list(None)?;
+    assert!(
+        listed.is_empty(),
+        "non-allowlisted runs must be hidden when no filter is provided"
+    );
+
+    let _ = service.shutdown();
     Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/repo_authorization.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/repo_authorization.rs
@@ -1,0 +1,101 @@
+use anyhow::Result;
+use host_domain::{GitCurrentBranch, RunEvent, TaskStatus};
+use std::fs;
+use std::sync::{Arc, Mutex};
+
+use crate::app_service::test_support::{
+    build_service_with_git_state_enforced, make_emitter, make_task, unique_temp_path,
+};
+
+#[test]
+fn tasks_reject_repo_path_not_in_workspace_allowlist() {
+    let (service, task_state, _git_state) = build_service_with_git_state_enforced(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+
+    let error = service
+        .tasks_list("/tmp/odt-repo-unauthorized-task")
+        .expect_err("unconfigured repo path should be rejected");
+
+    assert!(error.to_string().contains("workspace allowlist"));
+    let state = task_state.lock().expect("task state lock poisoned");
+    assert!(state.ensure_calls.is_empty());
+}
+
+#[test]
+fn git_rejects_repo_path_not_in_workspace_allowlist() {
+    let (service, task_state, git_state) = build_service_with_git_state_enforced(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+
+    let error = service
+        .git_get_branches("/tmp/odt-repo-unauthorized-git")
+        .expect_err("unconfigured repo path should be rejected");
+
+    assert!(error.to_string().contains("workspace allowlist"));
+    let task_state = task_state.lock().expect("task state lock poisoned");
+    assert!(task_state.ensure_calls.is_empty());
+    let git_state = git_state.lock().expect("git state lock poisoned");
+    assert!(git_state.calls.is_empty());
+}
+
+#[test]
+fn build_rejects_repo_path_not_in_workspace_allowlist() {
+    let (service, task_state, _git_state) = build_service_with_git_state_enforced(
+        vec![make_task("task-1", "bug", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+
+    let events = Arc::new(Mutex::new(Vec::<RunEvent>::new()));
+    let error = service
+        .build_start(
+            "/tmp/odt-repo-unauthorized-build",
+            "task-1",
+            make_emitter(events),
+        )
+        .expect_err("unconfigured repo path should be rejected");
+
+    assert!(error.to_string().contains("workspace allowlist"));
+    let state = task_state.lock().expect("task state lock poisoned");
+    assert!(state.ensure_calls.is_empty());
+}
+
+#[test]
+fn canonical_repo_path_variants_are_authorized() -> Result<()> {
+    let (service, _task_state, _git_state) = build_service_with_git_state_enforced(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+
+    let root = unique_temp_path("repo-auth-canonical");
+    let repo = root.join("repo");
+    fs::create_dir_all(&repo)?;
+
+    let canonical_repo = fs::canonicalize(&repo)?.to_string_lossy().to_string();
+    service.workspace_update_repo_config(canonical_repo.as_str(), Default::default())?;
+
+    let repo_variant = format!("{}/.", canonical_repo);
+    let tasks = service.tasks_list(repo_variant.as_str())?;
+    assert_eq!(tasks.len(), 1);
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -5,8 +5,8 @@ mod types;
 
 pub use store::AppConfigStore;
 pub use types::{
-    hook_set_fingerprint, AgentDefaults, AgentModelDefault, GlobalConfig, HookSet, OpencodeStartupReadinessConfig,
-    RepoConfig, SchedulerConfig, SoftGuardrails,
+    hook_set_fingerprint, AgentDefaults, AgentModelDefault, GlobalConfig, HookSet,
+    OpencodeStartupReadinessConfig, RepoConfig, SchedulerConfig, SoftGuardrails,
 };
 
 #[cfg(test)]
@@ -219,7 +219,11 @@ mod tests {
         assert!(optional.is_none());
 
         let trust_error = store
-            .set_repo_trust_hooks(missing_repo_str.as_str(), true, Some("fingerprint".to_string()))
+            .set_repo_trust_hooks(
+                missing_repo_str.as_str(),
+                true,
+                Some("fingerprint".to_string()),
+            )
             .expect_err("set trust should fail when repo missing");
         assert!(trust_error
             .to_string()
@@ -233,6 +237,9 @@ mod tests {
         let repo = root.join("repo-main");
         fake_git_workspace(&repo);
         let repo_str = repo.to_string_lossy().to_string();
+        store
+            .add_workspace(repo_str.as_str())
+            .expect("workspace should be added before updating config");
 
         let updated = store
             .update_repo_config(
@@ -274,6 +281,21 @@ mod tests {
     }
 
     #[test]
+    fn update_repo_config_rejects_unknown_workspace() {
+        let (store, root) = test_store("update-repo-config-missing-workspace");
+        let repo = root.join("missing-repo");
+        fake_git_workspace(&repo);
+        let repo_str = repo.to_string_lossy().to_string();
+
+        let error = store
+            .update_repo_config(repo_str.as_str(), RepoConfig::default())
+            .expect_err("unknown workspace should be rejected");
+
+        assert!(error.to_string().contains("Workspace not found in config"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn update_repo_config_normalizes_blank_worktree_path() {
         let (store, root) = test_store("normalize-worktree");
         let repo = root.join("repo");
@@ -311,6 +333,9 @@ mod tests {
         let repo = root.join("repo");
         fake_git_workspace(&repo);
         let repo_str = repo.to_string_lossy().to_string();
+        store
+            .add_workspace(repo_str.as_str())
+            .expect("workspace should be added before updating config");
 
         store
             .update_repo_config(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -1,8 +1,8 @@
 use super::migrate::{canonicalize_workspace_key, migrate_repos_to_canonical_keys};
 use super::normalize::{normalize_global_config, normalize_repo_config};
 use super::types::{
-    default_task_metadata_namespace, hook_set_fingerprint, GlobalConfig,
-    HookSet, OpencodeStartupReadinessConfig, RepoConfig,
+    default_task_metadata_namespace, hook_set_fingerprint, GlobalConfig, HookSet,
+    OpencodeStartupReadinessConfig, RepoConfig,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::WorkspaceRecord;
@@ -204,6 +204,11 @@ impl AppConfigStore {
             canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
 
         let mut config = self.load()?;
+        if !config.repos.contains_key(&canonical_path) {
+            return Err(anyhow!(
+                "Workspace not found in config: {repo_path}. Add/select the workspace before updating configuration."
+            ));
+        }
         config
             .repos
             .insert(canonical_path.clone(), repo_config.clone());
@@ -221,7 +226,11 @@ impl AppConfigStore {
         })
     }
 
-    pub fn update_repo_hooks(&self, repo_path: &str, mut hooks: HookSet) -> Result<WorkspaceRecord> {
+    pub fn update_repo_hooks(
+        &self,
+        repo_path: &str,
+        mut hooks: HookSet,
+    ) -> Result<WorkspaceRecord> {
         let canonical_path =
             canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
         let mut normalized_repo = RepoConfig {
@@ -297,11 +306,7 @@ impl AppConfigStore {
                 .get_mut(&canonical_path)
                 .ok_or_else(|| anyhow!("Repository is not configured"))?;
             repo.trusted_hooks = trusted;
-            repo.trusted_hooks_fingerprint = if trusted {
-                trusted_fingerprint
-            } else {
-                None
-            };
+            repo.trusted_hooks_fingerprint = if trusted { trusted_fingerprint } else { None };
             (
                 has_configured_worktree(repo),
                 repo.worktree_base_path.clone(),


### PR DESCRIPTION
## Summary
- enforce host-side workspace allowlist checks for `repo_path` before task/git/build/runtime operations
- canonicalize authorized repo paths and use canonical paths for downstream operations to avoid path-variant bypasses
- prevent implicit allowlist expansion by requiring workspaces to be registered before `workspace_update_repo_config`
- restrict unfiltered run/runtime listings to allowlisted repositories
- add regression coverage for unauthorized path rejection, escalation prevention, and canonical-path acceptance

## Validation
- `cd apps/desktop/src-tauri && cargo test -p host-infra-system`
- `cd apps/desktop/src-tauri && cargo test -p host-application`

## Commits
- `f77a7e1b` fix(host-application): enforce workspace allowlist for repo_path
- `7578b633` fix(security): harden workspace allowlist enforcement for repo paths
