### PR TITLE
refactor(openducktor-mcp): reduce OdtTaskStore.setPlan complexity

### DIFF
--- a/packages/openducktor-mcp/src/epic-subtasks.ts
+++ b/packages/openducktor-mcp/src/epic-subtasks.ts
@@ -8,6 +8,7 @@ export async function createSubtask(
 ): Promise<string> {
   const args = [
     "create",
+    "--title",
     subtask.title,
     "--type",
     subtask.issueType ?? "task",

--- a/packages/openducktor-mcp/src/odt-task-store.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.test.ts
@@ -162,7 +162,9 @@ class OdtStoreHarness {
         break;
       }
       case "create": {
-        const title = args[2] ?? "Untitled";
+        const titleIndex = args.indexOf("--title");
+        const title =
+          titleIndex >= 0 ? (args[titleIndex + 1] ?? "Untitled") : (args[2] ?? "Untitled");
         const typeIndex = args.indexOf("--type");
         const parentIndex = args.indexOf("--parent");
         const issueType = typeIndex >= 0 ? (args[typeIndex + 1] ?? "task") : "task";
@@ -588,6 +590,9 @@ describe("OdtTaskStore workflow mutation paths", () => {
     expect(result.createdSubtaskIds).toEqual(["epic-1-sub-1", "epic-1-sub-2"]);
     expect(harness.getCommandCalls("delete")).toHaveLength(2);
     expect(harness.getCommandCalls("create")).toHaveLength(2);
+    for (const createCall of harness.getCommandCalls("create")) {
+      expect(createCall.args).toContain("--title");
+    }
     expect(harness.getStatusUpdateCalls()).toHaveLength(1);
     expect(harness.getStatusUpdateCalls()[0]?.args).toContain("ready_for_dev");
     const metadataUpdateIndex = harness.calls.findIndex(

--- a/packages/openducktor-mcp/src/odt-task-store.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.test.ts
@@ -467,6 +467,64 @@ describe("OdtTaskStore workflow mutation paths", () => {
     expect(harness.getMetadataUpdateCalls()).toHaveLength(0);
   });
 
+  test("setPlan epic rules use fresh snapshot when context is stale", async () => {
+    const harness = new OdtStoreHarness({
+      issues: [
+        makeIssue({
+          id: "epic-1",
+          title: "Epic task",
+          status: "spec_ready",
+          issueType: "epic",
+          metadata: {},
+        }),
+      ],
+      listSnapshots: [
+        [
+          makeIssue({
+            id: "epic-1",
+            title: "Epic task",
+            status: "spec_ready",
+            issueType: "epic",
+            metadata: {},
+          }),
+        ],
+        [
+          makeIssue({
+            id: "epic-1",
+            title: "Epic task",
+            status: "spec_ready",
+            issueType: "epic",
+            metadata: {},
+          }),
+          makeIssue({
+            id: "legacy-subtask",
+            title: "Legacy subtask",
+            status: "open",
+            issueType: "task",
+            parentId: "epic-1",
+            metadata: {},
+          }),
+        ],
+      ],
+    });
+    const store = harness.createStore();
+
+    const result = (await store.setPlan({
+      taskId: "epic-1",
+      markdown: "# Plan without proposed subtasks",
+    })) as {
+      task: { status: string };
+      createdSubtaskIds: string[];
+    };
+
+    expect(result.task.status).toBe("ready_for_dev");
+    expect(result.createdSubtaskIds).toEqual([]);
+    expect(harness.getCommandCalls("list")).toHaveLength(2);
+    expect(harness.getCommandCalls("delete")).toHaveLength(1);
+    expect(harness.getCommandCalls("create")).toHaveLength(0);
+    expect(harness.getMetadataUpdateCalls()).toHaveLength(1);
+  });
+
   test("setPlan replaces epic subtasks, deduplicates by title key, and stores latest-only plan", async () => {
     const harness = new OdtStoreHarness({
       issues: [
@@ -532,6 +590,14 @@ describe("OdtTaskStore workflow mutation paths", () => {
     expect(harness.getCommandCalls("create")).toHaveLength(2);
     expect(harness.getStatusUpdateCalls()).toHaveLength(1);
     expect(harness.getStatusUpdateCalls()[0]?.args).toContain("ready_for_dev");
+    const metadataUpdateIndex = harness.calls.findIndex(
+      (call) => call.args[1] === "update" && call.args.includes("--metadata"),
+    );
+    const firstDeleteIndex = harness.calls.findIndex((call) => call.args[1] === "delete");
+    const firstCreateIndex = harness.calls.findIndex((call) => call.args[1] === "create");
+    expect(metadataUpdateIndex).toBeGreaterThanOrEqual(0);
+    expect(firstDeleteIndex).toBeGreaterThan(metadataUpdateIndex);
+    expect(firstCreateIndex).toBeGreaterThan(metadataUpdateIndex);
 
     const documents = getNamespaceDocuments(harness.getIssue("epic-1"));
     const implementationPlan = Array.isArray(documents.implementationPlan)

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -225,6 +225,56 @@ export class OdtTaskStore {
     );
   }
 
+  private async applyEpicSubtaskReplacement(
+    task: TaskCard,
+    normalizedSubtasks: PlanSubtaskInput[],
+    persistPlanDocument: () => Promise<{ updatedAt: string; revision: number }>,
+  ): Promise<{ createdSubtaskIds: string[]; document: { updatedAt: string; revision: number } }> {
+    const latestTasks = await this.listTasks();
+    const latestTask = latestTasks.find((entry) => entry.id === task.id);
+    if (!latestTask) {
+      throw new Error(`Task not found: ${task.id}`);
+    }
+
+    assertNoValidationError(getSetPlanError(latestTask));
+    validatePlanSubtaskRules(latestTask, latestTasks, normalizedSubtasks);
+
+    const existingDirectSubtasks = latestTasks.filter((entry) => entry.parentId === task.id);
+    const blockedSubtasks = existingDirectSubtasks.filter(
+      (entry) => !canReplaceEpicSubtaskStatus(entry.status),
+    );
+    if (blockedSubtasks.length > 0) {
+      const blockedSummary = blockedSubtasks
+        .map((entry) => `${entry.id} (${entry.status})`)
+        .join(", ");
+      throw new Error(
+        "Cannot replace epic subtasks while active work exists. " +
+          `Move subtasks to open/spec_ready/ready_for_dev first: ${blockedSummary}`,
+      );
+    }
+
+    const document = await persistPlanDocument();
+
+    for (const existingSubtask of existingDirectSubtasks) {
+      await this.deleteTask(existingSubtask.id);
+    }
+
+    const createdSubtaskIds: string[] = [];
+    const createdTitleKeys = new Set<string>();
+    for (const subtask of normalizedSubtasks) {
+      const key = normalizeTitleKey(subtask.title);
+      if (createdTitleKeys.has(key)) {
+        continue;
+      }
+
+      const createdId = await this.createSubtask(task.id, subtask);
+      createdSubtaskIds.push(createdId);
+      createdTitleKeys.add(key);
+    }
+
+    return { createdSubtaskIds, document };
+  }
+
   async readTask(rawInput: unknown): Promise<unknown> {
     await this.ensureInitialized();
     const input = ReadTaskInputSchema.parse(rawInput);
@@ -315,77 +365,51 @@ export class OdtTaskStore {
     assertNoValidationError(getSetPlanError(task));
 
     const normalizedSubtasks = normalizePlanSubtasks(input.subtasks ?? []);
-    validatePlanSubtaskRules(task, tasks, normalizedSubtasks);
+    const persistPlanDocument = async (): Promise<{ updatedAt: string; revision: number }> => {
+      const issue = await this.showRawIssue(task.id);
+      const { root, namespace, documents } = this.getNamespaceData(issue);
+      const nextRevision =
+        (parseMarkdownEntries(documents.implementationPlan).at(-1)?.revision ?? 0) + 1;
 
-    let existingDirectSubtasks: TaskCard[] = [];
+      const updatedAt = this.now();
+      const entry: MarkdownEntry = {
+        markdown,
+        updatedAt,
+        updatedBy: "planner-agent",
+        sourceTool: "odt_set_plan",
+        revision: nextRevision,
+      };
+
+      const nextDocuments = {
+        ...documents,
+        implementationPlan: [entry],
+      };
+
+      const nextNamespace = {
+        ...namespace,
+        documents: nextDocuments,
+      };
+
+      await this.writeNamespace(task.id, root, nextNamespace);
+      return {
+        updatedAt,
+        revision: nextRevision,
+      };
+    };
+
+    let persistedDocument: { updatedAt: string; revision: number };
+    let createdSubtaskIds: string[] = [];
     if (task.issueType === "epic") {
-      const latestTasks = await this.listTasks();
-      const latestTask = latestTasks.find((entry) => entry.id === task.id);
-      if (!latestTask) {
-        throw new Error(`Task not found: ${task.id}`);
-      }
-
-      assertNoValidationError(getSetPlanError(latestTask));
-      validatePlanSubtaskRules(latestTask, latestTasks, normalizedSubtasks);
-
-      existingDirectSubtasks = latestTasks.filter((entry) => entry.parentId === task.id);
-      const blockedSubtasks = existingDirectSubtasks.filter(
-        (entry) => !canReplaceEpicSubtaskStatus(entry.status),
+      const epicReplacement = await this.applyEpicSubtaskReplacement(
+        task,
+        normalizedSubtasks,
+        persistPlanDocument,
       );
-      if (blockedSubtasks.length > 0) {
-        const blockedSummary = blockedSubtasks
-          .map((entry) => `${entry.id} (${entry.status})`)
-          .join(", ");
-        throw new Error(
-          "Cannot replace epic subtasks while active work exists. " +
-            `Move subtasks to open/spec_ready/ready_for_dev first: ${blockedSummary}`,
-        );
-      }
-    }
-
-    const issue = await this.showRawIssue(task.id);
-    const { root, namespace, documents } = this.getNamespaceData(issue);
-    const nextRevision =
-      (parseMarkdownEntries(documents.implementationPlan).at(-1)?.revision ?? 0) + 1;
-
-    const updatedAt = this.now();
-    const entry: MarkdownEntry = {
-      markdown,
-      updatedAt,
-      updatedBy: "planner-agent",
-      sourceTool: "odt_set_plan",
-      revision: nextRevision,
-    };
-
-    const nextDocuments = {
-      ...documents,
-      implementationPlan: [entry],
-    };
-
-    const nextNamespace = {
-      ...namespace,
-      documents: nextDocuments,
-    };
-
-    await this.writeNamespace(task.id, root, nextNamespace);
-
-    const createdSubtaskIds: string[] = [];
-    if (task.issueType === "epic") {
-      for (const existingSubtask of existingDirectSubtasks) {
-        await this.deleteTask(existingSubtask.id);
-      }
-
-      const createdTitleKeys = new Set<string>();
-      for (const subtask of normalizedSubtasks) {
-        const key = normalizeTitleKey(subtask.title);
-        if (createdTitleKeys.has(key)) {
-          continue;
-        }
-
-        const createdId = await this.createSubtask(task.id, subtask);
-        createdSubtaskIds.push(createdId);
-        createdTitleKeys.add(key);
-      }
+      createdSubtaskIds = epicReplacement.createdSubtaskIds;
+      persistedDocument = epicReplacement.document;
+    } else {
+      validatePlanSubtaskRules(task, tasks, normalizedSubtasks);
+      persistedDocument = await persistPlanDocument();
     }
 
     const refreshedTransitionContext = await this.refreshTaskContext(task.id, context);
@@ -399,8 +423,8 @@ export class OdtTaskStore {
       task: nextTask,
       document: {
         markdown,
-        updatedAt,
-        revision: nextRevision,
+        updatedAt: persistedDocument.updatedAt,
+        revision: persistedDocument.revision,
       },
       createdSubtaskIds,
     };

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -225,11 +225,10 @@ export class OdtTaskStore {
     );
   }
 
-  private async applyEpicSubtaskReplacement(
+  private async prepareEpicSubtaskReplacement(
     task: TaskCard,
     normalizedSubtasks: PlanSubtaskInput[],
-    persistPlanDocument: () => Promise<{ updatedAt: string; revision: number }>,
-  ): Promise<{ createdSubtaskIds: string[]; document: { updatedAt: string; revision: number } }> {
+  ): Promise<{ latestTask: TaskCard; existingDirectSubtasks: TaskCard[] }> {
     const latestTasks = await this.listTasks();
     const latestTask = latestTasks.find((entry) => entry.id === task.id);
     if (!latestTask) {
@@ -253,8 +252,14 @@ export class OdtTaskStore {
       );
     }
 
-    const document = await persistPlanDocument();
+    return { latestTask, existingDirectSubtasks };
+  }
 
+  private async applyEpicSubtaskReplacement(
+    task: TaskCard,
+    existingDirectSubtasks: TaskCard[],
+    normalizedSubtasks: PlanSubtaskInput[],
+  ): Promise<string[]> {
     for (const existingSubtask of existingDirectSubtasks) {
       await this.deleteTask(existingSubtask.id);
     }
@@ -272,7 +277,42 @@ export class OdtTaskStore {
       createdTitleKeys.add(key);
     }
 
-    return { createdSubtaskIds, document };
+    return createdSubtaskIds;
+  }
+
+  private async persistImplementationPlan(
+    taskId: string,
+    markdown: string,
+  ): Promise<{ updatedAt: string; revision: number }> {
+    const issue = await this.showRawIssue(taskId);
+    const { root, namespace, documents } = this.getNamespaceData(issue);
+    const nextRevision =
+      (parseMarkdownEntries(documents.implementationPlan).at(-1)?.revision ?? 0) + 1;
+
+    const updatedAt = this.now();
+    const entry: MarkdownEntry = {
+      markdown,
+      updatedAt,
+      updatedBy: "planner-agent",
+      sourceTool: "odt_set_plan",
+      revision: nextRevision,
+    };
+
+    const nextDocuments = {
+      ...documents,
+      implementationPlan: [entry],
+    };
+
+    const nextNamespace = {
+      ...namespace,
+      documents: nextDocuments,
+    };
+
+    await this.writeNamespace(taskId, root, nextNamespace);
+    return {
+      updatedAt,
+      revision: nextRevision,
+    };
   }
 
   async readTask(rawInput: unknown): Promise<unknown> {
@@ -365,51 +405,20 @@ export class OdtTaskStore {
     assertNoValidationError(getSetPlanError(task));
 
     const normalizedSubtasks = normalizePlanSubtasks(input.subtasks ?? []);
-    const persistPlanDocument = async (): Promise<{ updatedAt: string; revision: number }> => {
-      const issue = await this.showRawIssue(task.id);
-      const { root, namespace, documents } = this.getNamespaceData(issue);
-      const nextRevision =
-        (parseMarkdownEntries(documents.implementationPlan).at(-1)?.revision ?? 0) + 1;
-
-      const updatedAt = this.now();
-      const entry: MarkdownEntry = {
-        markdown,
-        updatedAt,
-        updatedBy: "planner-agent",
-        sourceTool: "odt_set_plan",
-        revision: nextRevision,
-      };
-
-      const nextDocuments = {
-        ...documents,
-        implementationPlan: [entry],
-      };
-
-      const nextNamespace = {
-        ...namespace,
-        documents: nextDocuments,
-      };
-
-      await this.writeNamespace(task.id, root, nextNamespace);
-      return {
-        updatedAt,
-        revision: nextRevision,
-      };
-    };
-
     let persistedDocument: { updatedAt: string; revision: number };
     let createdSubtaskIds: string[] = [];
     if (task.issueType === "epic") {
-      const epicReplacement = await this.applyEpicSubtaskReplacement(
-        task,
+      // Epic subtask replacement must validate against a fresh snapshot, not the initial context.
+      const epicReplacement = await this.prepareEpicSubtaskReplacement(task, normalizedSubtasks);
+      persistedDocument = await this.persistImplementationPlan(task.id, markdown);
+      createdSubtaskIds = await this.applyEpicSubtaskReplacement(
+        epicReplacement.latestTask,
+        epicReplacement.existingDirectSubtasks,
         normalizedSubtasks,
-        persistPlanDocument,
       );
-      createdSubtaskIds = epicReplacement.createdSubtaskIds;
-      persistedDocument = epicReplacement.document;
     } else {
       validatePlanSubtaskRules(task, tasks, normalizedSubtasks);
-      persistedDocument = await persistPlanDocument();
+      persistedDocument = await this.persistImplementationPlan(task.id, markdown);
     }
 
     const refreshedTransitionContext = await this.refreshTaskContext(task.id, context);

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -402,7 +402,6 @@ export class OdtTaskStore {
 
     const context = await this.resolveTaskContext(input.taskId);
     const { task, tasks } = context;
-    assertNoValidationError(getSetPlanError(task));
 
     const normalizedSubtasks = normalizePlanSubtasks(input.subtasks ?? []);
     let persistedDocument: { updatedAt: string; revision: number };
@@ -417,6 +416,7 @@ export class OdtTaskStore {
         normalizedSubtasks,
       );
     } else {
+      assertNoValidationError(getSetPlanError(task));
       validatePlanSubtaskRules(task, tasks, normalizedSubtasks);
       persistedDocument = await this.persistImplementationPlan(task.id, markdown);
     }


### PR DESCRIPTION
## Summary
- extract epic subtask orchestration out of OdtTaskStore.setPlan
- split epic flow into explicit phases: fresh snapshot preflight, implementation plan persistence, and subtask replacement
- add persistImplementationPlan to isolate document write logic
- strengthen MCP store tests for fresh-snapshot precedence and side-effect ordering (metadata update before delete/create)

## Validation
- bun run --filter @openducktor/openducktor-mcp typecheck
- bun run --filter @openducktor/openducktor-mcp lint
- bun run --filter @openducktor/openducktor-mcp test
