### PR TITLE
perf(host-infra-beads): reduce metadata parsing allocation overhead

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
@@ -2,6 +2,7 @@ use host_domain::{
     AgentSessionDocument, QaVerdict, QaWorkflowVerdict, TaskDocumentPresence, TaskDocumentSummary,
     TaskQaDocumentPresence,
 };
+use serde::Deserialize;
 use serde_json::{Map, Value};
 
 use crate::model::{MarkdownEntry, QaEntry};
@@ -90,7 +91,7 @@ pub(crate) fn parse_markdown_entries(value: &Value) -> Option<Vec<MarkdownEntry>
     let entries = value
         .as_array()?
         .iter()
-        .filter_map(|entry| serde_json::from_value::<MarkdownEntry>(entry.clone()).ok())
+        .filter_map(|entry| MarkdownEntry::deserialize(entry).ok())
         .collect::<Vec<_>>();
     Some(entries)
 }
@@ -99,7 +100,7 @@ pub(crate) fn parse_qa_entries(value: &Value) -> Option<Vec<QaEntry>> {
     let entries = value
         .as_array()?
         .iter()
-        .filter_map(|entry| serde_json::from_value::<QaEntry>(entry.clone()).ok())
+        .filter_map(|entry| QaEntry::deserialize(entry).ok())
         .collect::<Vec<_>>();
     Some(entries)
 }
@@ -108,7 +109,7 @@ pub(crate) fn parse_agent_sessions(value: &Value) -> Option<Vec<AgentSessionDocu
     let entries = value
         .as_array()?
         .iter()
-        .filter_map(|entry| serde_json::from_value::<AgentSessionDocument>(entry.clone()).ok())
+        .filter_map(|entry| AgentSessionDocument::deserialize(entry).ok())
         .collect::<Vec<_>>();
     Some(entries)
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata_ops.rs
@@ -3,7 +3,6 @@ use serde_json::{Map, Value};
 use std::path::Path;
 
 use crate::metadata::parse_metadata_root;
-use crate::model::RawIssue;
 use crate::store::BeadsTaskStore;
 
 impl BeadsTaskStore {
@@ -26,9 +25,9 @@ impl BeadsTaskStore {
         &self,
         repo_path: &Path,
         task_id: &str,
-    ) -> Result<(RawIssue, Map<String, Value>, String, Map<String, Value>)> {
+    ) -> Result<(Map<String, Value>, String, Map<String, Value>)> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
-        let mut root = parse_metadata_root(issue.metadata.clone());
+        let mut root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();
 
         let namespace = root
@@ -43,7 +42,7 @@ impl BeadsTaskStore {
             .cloned()
             .ok_or_else(|| anyhow!("Invalid metadata namespace payload"))?;
 
-        Ok((issue, root, namespace_key, namespace_map))
+        Ok((root, namespace_key, namespace_map))
     }
 
     pub(crate) fn persist_namespace(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
@@ -25,7 +25,7 @@ impl BeadsTaskStore {
         task_id: &str,
         markdown: &str,
     ) -> Result<SpecDocument> {
-        let (_issue, mut root, namespace_key, mut namespace_map) =
+        let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
         let mut documents_map = namespace_map
             .get("documents")
@@ -86,7 +86,7 @@ impl BeadsTaskStore {
         task_id: &str,
         markdown: &str,
     ) -> Result<SpecDocument> {
-        let (_issue, mut root, namespace_key, mut namespace_map) =
+        let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
         let mut documents_map = namespace_map
             .get("documents")
@@ -155,7 +155,7 @@ impl BeadsTaskStore {
         markdown: &str,
         verdict: QaVerdict,
     ) -> Result<QaReportDocument> {
-        let (_issue, mut root, namespace_key, mut namespace_map) =
+        let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
         let mut documents_map = namespace_map
             .get("documents")

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
@@ -3,7 +3,7 @@ use super::*;
 impl BeadsTaskStore {
     pub(super) fn get_spec_impl(&self, repo_path: &Path, task_id: &str) -> Result<SpecDocument> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
-        let metadata_root = parse_metadata_root(issue.metadata.clone());
+        let metadata_root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();
         let entries = metadata_namespace(&metadata_root, &namespace_key)
             .and_then(|ns| ns.get("documents"))
@@ -64,7 +64,7 @@ impl BeadsTaskStore {
 
     pub(super) fn get_plan_impl(&self, repo_path: &Path, task_id: &str) -> Result<SpecDocument> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
-        let metadata_root = parse_metadata_root(issue.metadata.clone());
+        let metadata_root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();
         let entries = metadata_namespace(&metadata_root, &namespace_key)
             .and_then(|ns| ns.get("documents"))

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -24,7 +24,7 @@ impl BeadsTaskStore {
         task_id: &str,
         session: AgentSessionDocument,
     ) -> Result<()> {
-        let (_issue, mut root, namespace_key, mut namespace_map) =
+        let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
         let mut sessions = namespace_map
             .get("agentSessions")

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde::Deserialize;
 
 impl BeadsTaskStore {
     pub(super) fn ensure_repo_initialized_impl(&self, repo_path: &Path) -> Result<()> {
@@ -78,8 +79,8 @@ impl BeadsTaskStore {
             .as_array()
             .ok_or_else(|| anyhow!("bd list did not return an array"))?
         {
-            let issue: RawIssue = serde_json::from_value(entry.clone())
-                .context("Failed to decode task from bd list")?;
+            let issue: RawIssue =
+                RawIssue::deserialize(entry).context("Failed to decode task from bd list")?;
             if issue.issue_type == "event" || issue.issue_type == "gate" {
                 continue;
             }
@@ -242,7 +243,7 @@ impl BeadsTaskStore {
         }
 
         if let Some(ai_review_enabled) = patch.ai_review_enabled {
-            let (_issue, mut root, namespace_key, mut namespace_map) =
+            let (mut root, namespace_key, mut namespace_map) =
                 self.load_namespace(repo_path, task_id)?;
             namespace_map.insert("qaRequired".to_string(), Value::Bool(ai_review_enabled));
             self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -15,7 +15,7 @@ use std::collections::VecDeque;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum CallKind {
@@ -449,6 +449,83 @@ fn markdown_and_qa_entry_parsers_filter_invalid_entries() {
     assert_eq!(sessions.len(), 1);
     assert_eq!(sessions[0].session_id, "obp-session-1");
     assert_eq!(sessions[0].external_session_id, "session-opencode-1");
+}
+
+#[test]
+#[ignore = "manual benchmark scaffold; run with cargo test -p host-infra-beads metadata_parsing_benchmark_scaffold -- --ignored --nocapture"]
+fn metadata_parsing_benchmark_scaffold() {
+    let markdown_payload = Value::Array(
+        (0..200)
+            .map(|index| {
+                json!({
+                    "markdown": format!("# Spec {index}\n\n{}", "detail ".repeat(32)),
+                    "updatedAt": "2026-02-17T12:34:56Z",
+                    "updatedBy": "planner-agent",
+                    "sourceTool": "set_spec",
+                    "revision": index + 1
+                })
+            })
+            .collect(),
+    );
+    let qa_payload = Value::Array(
+        (0..200)
+            .map(|index| {
+                json!({
+                    "markdown": format!("# QA {index}\n\n{}", "report ".repeat(48)),
+                    "verdict": if index % 2 == 0 { "approved" } else { "rejected" },
+                    "updatedAt": "2026-02-17T13:10:00Z",
+                    "updatedBy": "qa-agent",
+                    "sourceTool": if index % 2 == 0 { "qa_approved" } else { "qa_rejected" },
+                    "revision": index + 1
+                })
+            })
+            .collect(),
+    );
+    let session_payload = Value::Array(
+        (0..200)
+            .map(|index| {
+                json!({
+                    "sessionId": format!("obp-session-{index}"),
+                    "externalSessionId": format!("session-opencode-{index}"),
+                    "taskId": "task-1",
+                    "role": "build",
+                    "scenario": "build_default",
+                    "status": "running",
+                    "startedAt": "2026-02-18T17:20:00Z",
+                    "updatedAt": "2026-02-18T17:21:00Z",
+                    "endedAt": null,
+                    "runtimeId": "runtime-1",
+                    "runId": null,
+                    "baseUrl": "http://127.0.0.1:4173",
+                    "workingDirectory": "/repo",
+                    "selectedModel": null
+                })
+            })
+            .collect(),
+    );
+
+    let iterations = 200;
+    let started = Instant::now();
+    let mut parsed_entries = 0usize;
+
+    for _ in 0..iterations {
+        parsed_entries += parse_markdown_entries(&markdown_payload)
+            .expect("expected markdown entries")
+            .len();
+        parsed_entries += parse_qa_entries(&qa_payload)
+            .expect("expected qa entries")
+            .len();
+        parsed_entries += parse_agent_sessions(&session_payload)
+            .expect("expected session entries")
+            .len();
+    }
+
+    let expected_entries = iterations * 600;
+    assert_eq!(parsed_entries, expected_entries);
+    eprintln!(
+        "metadata parsing benchmark scaffold: parsed {parsed_entries} entries in {:?}",
+        started.elapsed()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace `serde_json::from_value(entry.clone())` with borrowed deserialization in metadata entry parsers
- eliminate remaining `issue.metadata.clone()` usage in namespace-loading/write paths by consuming metadata ownership
- remove task-list decode cloning in `list_tasks_impl` and add a manual ignored benchmark scaffold for metadata parsing

## Testing
- `cd apps/desktop/src-tauri && cargo test -p host-infra-beads`
- `cd apps/desktop/src-tauri && cargo test -p host-infra-beads metadata_parsing_benchmark_scaffold -- --ignored --nocapture`
