### PR TITLE
fix(host-application): harden opencode runtime startup orchestration

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/hook_security.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/hook_security.rs
@@ -65,7 +65,8 @@ mod tests {
 
     #[test]
     fn run_parsed_hook_command_allow_failure_reports_empty_hook() {
-        let (ok, _stdout, stderr) = run_parsed_hook_command_allow_failure("  ", std::path::Path::new("."));
+        let (ok, _stdout, stderr) =
+            run_parsed_hook_command_allow_failure("  ", std::path::Path::new("."));
         assert!(!ok);
         assert!(stderr.contains("Hook command is empty"));
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -10,6 +10,31 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use uuid::Uuid;
 
+#[derive(Clone, Copy)]
+struct RuntimeExistingLookup<'a> {
+    repo_key: &'a str,
+    role: &'a str,
+    task_id: Option<&'a str>,
+}
+
+struct RuntimePostStartPolicy<'a> {
+    existing_lookup: RuntimeExistingLookup<'a>,
+    prune_error_context: String,
+}
+
+struct RuntimeStartInput<'a> {
+    startup_scope: &'a str,
+    repo_path: &'a str,
+    task_id: &'a str,
+    role: &'a str,
+    working_directory: String,
+    cleanup_repo_path: Option<String>,
+    cleanup_worktree_path: Option<String>,
+    tracking_error_context: &'static str,
+    startup_error_context: String,
+    post_start_policy: Option<RuntimePostStartPolicy<'a>>,
+}
+
 impl AppService {
     pub fn runs_list(&self, repo_path: Option<&str>) -> Result<Vec<RunSummary>> {
         let repo_key_filter = repo_path
@@ -104,133 +129,39 @@ impl AppService {
                 .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
             Self::prune_stale_runtimes(&mut runtimes)?;
 
-            if let Some(existing) = runtimes.values().find(|runtime| {
-                Self::repo_key(runtime.summary.repo_path.as_str()) == repo_key
-                    && runtime.summary.role == Self::WORKSPACE_RUNTIME_ROLE
-            }) {
-                return Ok(existing.summary.clone());
-            }
-        }
-
-        let port = pick_free_port()?;
-        let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
-        let metadata_namespace = self.config_store.task_metadata_namespace()?;
-        let mut child = spawn_opencode_server(
-            Path::new(repo_path),
-            Path::new(repo_path),
-            metadata_namespace.as_str(),
-            port,
-        )?;
-        let opencode_process_guard = match self.track_pending_opencode_process(child.id()) {
-            Ok(guard) => guard,
-            Err(error) => {
-                terminate_child_process(&mut child);
-                return Err(error).context("Failed tracking spawned OpenCode workspace runtime");
-            }
-        };
-        let startup_policy = self.opencode_startup_readiness_policy();
-        let startup_cancel_epoch = self.startup_cancel_epoch();
-        let startup_cancel_snapshot = self.startup_cancel_snapshot();
-        self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
-            "workspace_runtime",
-            repo_path,
-            Some(Self::WORKSPACE_RUNTIME_TASK_ID),
-            Self::WORKSPACE_RUNTIME_ROLE,
-            port,
-            Some(StartupEventCorrelation::new(
-                "runtime_id",
-                runtime_id.as_str(),
-            )),
-            Some(startup_policy),
-        ));
-        let startup_report = match wait_for_local_server_with_process(
-            &mut child,
-            port,
-            startup_policy,
-            &startup_cancel_epoch,
-            startup_cancel_snapshot,
-        ) {
-            Ok(report) => report,
-            Err(error) => {
-                self.emit_opencode_startup_event(StartupEventPayload::failed(
-                    "workspace_runtime",
-                    repo_path,
-                    Some(Self::WORKSPACE_RUNTIME_TASK_ID),
-                    Self::WORKSPACE_RUNTIME_ROLE,
-                    port,
-                    Some(StartupEventCorrelation::new(
-                        "runtime_id",
-                        runtime_id.as_str(),
-                    )),
-                    Some(startup_policy),
-                    error.report,
-                    error.reason,
-                ));
-                terminate_child_process(&mut child);
-                return Err(anyhow!(error)).with_context(|| {
-                    format!("OpenCode workspace runtime failed to start for {repo_path}")
-                });
-            }
-        };
-        self.emit_opencode_startup_event(StartupEventPayload::ready(
-            "workspace_runtime",
-            repo_path,
-            Some(Self::WORKSPACE_RUNTIME_TASK_ID),
-            Self::WORKSPACE_RUNTIME_ROLE,
-            port,
-            Some(StartupEventCorrelation::new(
-                "runtime_id",
-                runtime_id.as_str(),
-            )),
-            Some(startup_policy),
-            startup_report,
-        ));
-
-        let summary = AgentRuntimeSummary {
-            runtime_id: runtime_id.clone(),
-            repo_path: repo_key.clone(),
-            task_id: Self::WORKSPACE_RUNTIME_TASK_ID.to_string(),
-            role: Self::WORKSPACE_RUNTIME_ROLE.to_string(),
-            working_directory: repo_key.clone(),
-            port,
-            started_at: now_rfc3339(),
-        };
-
-        {
-            let mut runtimes = self
-                .agent_runtimes
-                .lock()
-                .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
-            if let Err(error) = Self::prune_stale_runtimes(&mut runtimes) {
-                terminate_child_process(&mut child);
-                return Err(error).with_context(|| {
-                    format!(
-                        "Failed pruning stale runtimes while finalizing workspace runtime for {repo_path}"
-                    )
-                });
-            }
-
-            if let Some(existing) = runtimes.values().find(|runtime| {
-                Self::repo_key(runtime.summary.repo_path.as_str()) == repo_key
-                    && runtime.summary.role == Self::WORKSPACE_RUNTIME_ROLE
-            }) {
-                terminate_child_process(&mut child);
-                return Ok(existing.summary.clone());
-            }
-
-            runtimes.insert(
-                runtime_id,
-                AgentRuntimeProcess {
-                    summary: summary.clone(),
-                    child,
-                    _opencode_process_guard: Some(opencode_process_guard),
-                    cleanup_repo_path: None,
-                    cleanup_worktree_path: None,
+            if let Some(existing) = Self::find_existing_runtime(
+                &runtimes,
+                RuntimeExistingLookup {
+                    repo_key: repo_key.as_str(),
+                    role: Self::WORKSPACE_RUNTIME_ROLE,
+                    task_id: None,
                 },
-            );
+            ) {
+                return Ok(existing);
+            }
         }
 
-        Ok(summary)
+        self.spawn_and_register_runtime(RuntimeStartInput {
+            startup_scope: "workspace_runtime",
+            repo_path,
+            task_id: Self::WORKSPACE_RUNTIME_TASK_ID,
+            role: Self::WORKSPACE_RUNTIME_ROLE,
+            working_directory: repo_key.clone(),
+            cleanup_repo_path: None,
+            cleanup_worktree_path: None,
+            tracking_error_context: "Failed tracking spawned OpenCode workspace runtime",
+            startup_error_context: format!("OpenCode workspace runtime failed to start for {repo_path}"),
+            post_start_policy: Some(RuntimePostStartPolicy {
+                existing_lookup: RuntimeExistingLookup {
+                    repo_key: repo_key.as_str(),
+                    role: Self::WORKSPACE_RUNTIME_ROLE,
+                    task_id: None,
+                },
+                prune_error_context: format!(
+                    "Failed pruning stale runtimes while finalizing workspace runtime for {repo_path}"
+                ),
+            }),
+        })
     }
 
     pub fn opencode_runtime_start(
@@ -261,12 +192,15 @@ impl AppService {
                 .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
             Self::prune_stale_runtimes(&mut runtimes)?;
 
-            if let Some(existing) = runtimes.values().find(|runtime| {
-                Self::repo_key(runtime.summary.repo_path.as_str()) == repo_key
-                    && runtime.summary.task_id == task_id
-                    && runtime.summary.role == role
-            }) {
-                return Ok(existing.summary.clone());
+            if let Some(existing) = Self::find_existing_runtime(
+                &runtimes,
+                RuntimeExistingLookup {
+                    repo_key: repo_key.as_str(),
+                    role,
+                    task_id: Some(task_id),
+                },
+            ) {
+                return Ok(existing);
             }
         }
 
@@ -283,11 +217,42 @@ impl AppService {
             (repo_path.to_string(), None, None)
         };
 
+        self.spawn_and_register_runtime(RuntimeStartInput {
+            startup_scope: "agent_runtime",
+            repo_path,
+            task_id,
+            role,
+            working_directory: runtime_working_directory,
+            cleanup_repo_path,
+            cleanup_worktree_path,
+            tracking_error_context: "Failed tracking spawned OpenCode agent runtime",
+            startup_error_context: format!("OpenCode runtime failed to start for task {task_id}"),
+            post_start_policy: None,
+        })
+    }
+
+    fn spawn_and_register_runtime(
+        &self,
+        input: RuntimeStartInput<'_>,
+    ) -> Result<AgentRuntimeSummary> {
+        let RuntimeStartInput {
+            startup_scope,
+            repo_path,
+            task_id,
+            role,
+            working_directory,
+            cleanup_repo_path,
+            cleanup_worktree_path,
+            tracking_error_context,
+            startup_error_context,
+            post_start_policy,
+        } = input;
+
         let port = pick_free_port()?;
         let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
         let metadata_namespace = self.config_store.task_metadata_namespace()?;
         let mut child = spawn_opencode_server(
-            Path::new(&runtime_working_directory),
+            Path::new(working_directory.as_str()),
             Path::new(repo_path),
             metadata_namespace.as_str(),
             port,
@@ -296,14 +261,14 @@ impl AppService {
             Ok(guard) => guard,
             Err(error) => {
                 terminate_child_process(&mut child);
-                return Err(error).context("Failed tracking spawned OpenCode agent runtime");
+                return Err(error).context(tracking_error_context);
             }
         };
         let startup_policy = self.opencode_startup_readiness_policy();
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
         self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
-            "agent_runtime",
+            startup_scope,
             repo_path,
             Some(task_id),
             role,
@@ -324,7 +289,7 @@ impl AppService {
             Ok(report) => report,
             Err(error) => {
                 self.emit_opencode_startup_event(StartupEventPayload::failed(
-                    "agent_runtime",
+                    startup_scope,
                     repo_path,
                     Some(task_id),
                     role,
@@ -338,25 +303,19 @@ impl AppService {
                     error.reason,
                 ));
                 terminate_child_process(&mut child);
-                let startup_context =
-                    format!("OpenCode runtime failed to start for task {task_id}");
-                if let (Some(repo), Some(worktree)) = (
+                if let Err(cleanup_error) = Self::cleanup_runtime_worktree_if_needed(
                     cleanup_repo_path.as_deref(),
                     cleanup_worktree_path.as_deref(),
                 ) {
-                    if let Err(cleanup_error) =
-                        remove_runtime_worktree(Path::new(repo), Path::new(worktree))
-                    {
-                        return Err(anyhow!(
-                            "{startup_context}\nAlso failed to remove QA worktree: {cleanup_error}"
-                        ));
-                    }
+                    return Err(anyhow!(
+                        "{startup_error_context}\nAlso failed to remove QA worktree: {cleanup_error}"
+                    ));
                 }
-                return Err(anyhow!(error)).with_context(|| startup_context);
+                return Err(anyhow!(error)).with_context(|| startup_error_context);
             }
         };
         self.emit_opencode_startup_event(StartupEventPayload::ready(
-            "agent_runtime",
+            startup_scope,
             repo_path,
             Some(task_id),
             role,
@@ -371,29 +330,69 @@ impl AppService {
 
         let summary = AgentRuntimeSummary {
             runtime_id: runtime_id.clone(),
-            repo_path: repo_key,
+            repo_path: repo_path.to_string(),
             task_id: task_id.to_string(),
             role: role.to_string(),
-            working_directory: runtime_working_directory,
+            working_directory,
             port,
             started_at: now_rfc3339(),
         };
 
-        self.agent_runtimes
+        let mut runtimes = self
+            .agent_runtimes
             .lock()
-            .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?
-            .insert(
-                runtime_id,
-                AgentRuntimeProcess {
-                    summary: summary.clone(),
-                    child,
-                    _opencode_process_guard: Some(opencode_process_guard),
-                    cleanup_repo_path,
-                    cleanup_worktree_path,
-                },
-            );
+            .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
+        if let Some(post_start_policy) = post_start_policy {
+            if let Err(error) = Self::prune_stale_runtimes(&mut runtimes) {
+                terminate_child_process(&mut child);
+                return Err(error).with_context(|| post_start_policy.prune_error_context);
+            }
+            if let Some(existing) =
+                Self::find_existing_runtime(&runtimes, post_start_policy.existing_lookup)
+            {
+                terminate_child_process(&mut child);
+                return Ok(existing);
+            }
+        }
+
+        runtimes.insert(
+            runtime_id,
+            AgentRuntimeProcess {
+                summary: summary.clone(),
+                child,
+                _opencode_process_guard: Some(opencode_process_guard),
+                cleanup_repo_path,
+                cleanup_worktree_path,
+            },
+        );
 
         Ok(summary)
+    }
+
+    fn find_existing_runtime(
+        runtimes: &HashMap<String, AgentRuntimeProcess>,
+        lookup: RuntimeExistingLookup<'_>,
+    ) -> Option<AgentRuntimeSummary> {
+        runtimes
+            .values()
+            .find(|runtime| {
+                Self::repo_key(runtime.summary.repo_path.as_str()) == lookup.repo_key
+                    && runtime.summary.role == lookup.role
+                    && lookup
+                        .task_id
+                        .map_or(true, |task_id| runtime.summary.task_id == task_id)
+            })
+            .map(|runtime| runtime.summary.clone())
+    }
+
+    fn cleanup_runtime_worktree_if_needed(
+        cleanup_repo_path: Option<&str>,
+        cleanup_worktree_path: Option<&str>,
+    ) -> Result<()> {
+        if let (Some(repo_path), Some(worktree_path)) = (cleanup_repo_path, cleanup_worktree_path) {
+            remove_runtime_worktree(Path::new(repo_path), Path::new(worktree_path))?;
+        }
+        Ok(())
     }
 
     pub fn opencode_runtime_stop(&self, runtime_id: &str) -> Result<bool> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -8,6 +8,7 @@ use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary};
 use host_infra_system::pick_free_port;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::process::Child;
 use uuid::Uuid;
 
 #[derive(Clone, Copy)]
@@ -25,6 +26,7 @@ struct RuntimePostStartPolicy<'a> {
 struct RuntimeStartInput<'a> {
     startup_scope: &'a str,
     repo_path: &'a str,
+    repo_key: String,
     task_id: &'a str,
     role: &'a str,
     working_directory: String,
@@ -144,6 +146,7 @@ impl AppService {
         self.spawn_and_register_runtime(RuntimeStartInput {
             startup_scope: "workspace_runtime",
             repo_path,
+            repo_key: repo_key.clone(),
             task_id: Self::WORKSPACE_RUNTIME_TASK_ID,
             role: Self::WORKSPACE_RUNTIME_ROLE,
             working_directory: repo_key.clone(),
@@ -220,6 +223,7 @@ impl AppService {
         self.spawn_and_register_runtime(RuntimeStartInput {
             startup_scope: "agent_runtime",
             repo_path,
+            repo_key: repo_key.clone(),
             task_id,
             role,
             working_directory: runtime_working_directory,
@@ -227,7 +231,16 @@ impl AppService {
             cleanup_worktree_path,
             tracking_error_context: "Failed tracking spawned OpenCode agent runtime",
             startup_error_context: format!("OpenCode runtime failed to start for task {task_id}"),
-            post_start_policy: None,
+            post_start_policy: Some(RuntimePostStartPolicy {
+                existing_lookup: RuntimeExistingLookup {
+                    repo_key: repo_key.as_str(),
+                    role,
+                    task_id: Some(task_id),
+                },
+                prune_error_context: format!(
+                    "Failed pruning stale runtimes while finalizing OpenCode runtime for task {task_id}"
+                ),
+            }),
         })
     }
 
@@ -238,6 +251,7 @@ impl AppService {
         let RuntimeStartInput {
             startup_scope,
             repo_path,
+            repo_key,
             task_id,
             role,
             working_directory,
@@ -302,16 +316,15 @@ impl AppService {
                     error.report,
                     error.reason,
                 ));
-                terminate_child_process(&mut child);
-                if let Err(cleanup_error) = Self::cleanup_runtime_worktree_if_needed(
+                let startup_error = anyhow!(error).context(startup_error_context.clone());
+                if let Err(cleanup_error) = Self::cleanup_started_runtime(
+                    &mut child,
                     cleanup_repo_path.as_deref(),
                     cleanup_worktree_path.as_deref(),
                 ) {
-                    return Err(anyhow!(
-                        "{startup_error_context}\nAlso failed to remove QA worktree: {cleanup_error}"
-                    ));
+                    return Err(Self::append_cleanup_error(startup_error, cleanup_error));
                 }
-                return Err(anyhow!(error)).with_context(|| startup_error_context);
+                return Err(startup_error);
             }
         };
         self.emit_opencode_startup_event(StartupEventPayload::ready(
@@ -330,7 +343,7 @@ impl AppService {
 
         let summary = AgentRuntimeSummary {
             runtime_id: runtime_id.clone(),
-            repo_path: repo_path.to_string(),
+            repo_path: repo_key,
             task_id: task_id.to_string(),
             role: role.to_string(),
             working_directory,
@@ -338,19 +351,45 @@ impl AppService {
             started_at: now_rfc3339(),
         };
 
-        let mut runtimes = self
-            .agent_runtimes
-            .lock()
-            .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
+        let mut runtimes = match self.agent_runtimes.lock() {
+            Ok(runtimes) => runtimes,
+            Err(_) => {
+                let lock_error = anyhow!("Agent runtime state lock poisoned");
+                if let Err(cleanup_error) = Self::cleanup_started_runtime(
+                    &mut child,
+                    cleanup_repo_path.as_deref(),
+                    cleanup_worktree_path.as_deref(),
+                ) {
+                    return Err(Self::append_cleanup_error(lock_error, cleanup_error));
+                }
+                return Err(lock_error);
+            }
+        };
         if let Some(post_start_policy) = post_start_policy {
             if let Err(error) = Self::prune_stale_runtimes(&mut runtimes) {
-                terminate_child_process(&mut child);
-                return Err(error).with_context(|| post_start_policy.prune_error_context);
+                let prune_error = error.context(post_start_policy.prune_error_context);
+                if let Err(cleanup_error) = Self::cleanup_started_runtime(
+                    &mut child,
+                    cleanup_repo_path.as_deref(),
+                    cleanup_worktree_path.as_deref(),
+                ) {
+                    return Err(Self::append_cleanup_error(prune_error, cleanup_error));
+                }
+                return Err(prune_error);
             }
             if let Some(existing) =
                 Self::find_existing_runtime(&runtimes, post_start_policy.existing_lookup)
             {
-                terminate_child_process(&mut child);
+                if let Err(cleanup_error) = Self::cleanup_started_runtime(
+                    &mut child,
+                    cleanup_repo_path.as_deref(),
+                    cleanup_worktree_path.as_deref(),
+                ) {
+                    return Err(anyhow!(
+                        "Found existing runtime {} while finalizing {startup_scope} startup\nAlso failed to remove QA worktree: {cleanup_error}",
+                        existing.runtime_id
+                    ));
+                }
                 return Ok(existing);
             }
         }
@@ -393,6 +432,22 @@ impl AppService {
             remove_runtime_worktree(Path::new(repo_path), Path::new(worktree_path))?;
         }
         Ok(())
+    }
+
+    fn cleanup_started_runtime(
+        child: &mut Child,
+        cleanup_repo_path: Option<&str>,
+        cleanup_worktree_path: Option<&str>,
+    ) -> Result<()> {
+        terminate_child_process(child);
+        Self::cleanup_runtime_worktree_if_needed(cleanup_repo_path, cleanup_worktree_path)
+    }
+
+    fn append_cleanup_error(
+        base_error: anyhow::Error,
+        cleanup_error: anyhow::Error,
+    ) -> anyhow::Error {
+        anyhow!("{base_error}\nAlso failed to remove QA worktree: {cleanup_error}")
     }
 
     pub fn opencode_runtime_stop(&self, runtime_id: &str) -> Result<bool> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -415,7 +415,7 @@ impl AppService {
         runtimes
             .values()
             .find(|runtime| {
-                Self::repo_key(runtime.summary.repo_path.as_str()) == lookup.repo_key
+                runtime.summary.repo_path == lookup.repo_key
                     && runtime.summary.role == lookup.role
                     && lookup
                         .task_id

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
@@ -219,6 +220,41 @@ fn opencode_runtime_start_supports_spec_and_qa_roles() -> Result<()> {
     assert!(bad_role
         .to_string()
         .contains("Unsupported agent runtime role"));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn opencode_runtime_start_persists_canonical_repo_path_in_summary() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("runtime-canonical-repo-path");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    let fake_opencode = root.join("opencode");
+    create_fake_opencode(&fake_opencode)?;
+    let _opencode_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        fake_opencode.to_string_lossy().as_ref(),
+    );
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+        config_store,
+    );
+    let repo_path_with_suffix = format!("{}/.", repo.to_string_lossy());
+    let runtime =
+        service.opencode_runtime_start(repo_path_with_suffix.as_str(), "task-1", "spec")?;
+
+    let expected_repo_key = fs::canonicalize(&repo)?.to_string_lossy().to_string();
+    assert_eq!(runtime.repo_path, expected_repo_key);
+    assert!(service.opencode_runtime_stop(runtime.runtime_id.as_str())?);
 
     let _ = fs::remove_dir_all(root);
     Ok(())
@@ -452,6 +488,131 @@ fn opencode_runtime_start_reuses_existing_runtime_for_same_task_and_role() -> Re
     let second = service.opencode_runtime_start(repo_path.as_str(), "task-1", "spec")?;
     assert_eq!(first.runtime_id, second.runtime_id);
     assert!(service.opencode_runtime_stop(first.runtime_id.as_str())?);
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn opencode_runtime_start_deduplicates_concurrent_same_task_and_role() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("runtime-concurrent-dedup");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    let fake_opencode = root.join("opencode");
+    create_fake_opencode(&fake_opencode)?;
+    let _opencode_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        fake_opencode.to_string_lossy().as_ref(),
+    );
+    let _delay_guard = set_env_var("OPENDUCKTOR_TEST_STARTUP_DELAY_MS", "700");
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+        config_store,
+    );
+    let repo_path = repo.to_string_lossy().to_string();
+
+    let (first, second) = thread::scope(|scope| {
+        let first_start =
+            scope.spawn(|| service.opencode_runtime_start(repo_path.as_str(), "task-1", "spec"));
+        let second_start =
+            scope.spawn(|| service.opencode_runtime_start(repo_path.as_str(), "task-1", "spec"));
+        (
+            first_start
+                .join()
+                .expect("first runtime start thread should join"),
+            second_start
+                .join()
+                .expect("second runtime start thread should join"),
+        )
+    });
+    let first = first?;
+    let second = second?;
+    assert_eq!(first.runtime_id, second.runtime_id);
+    assert_eq!(
+        service
+            .agent_runtimes
+            .lock()
+            .expect("runtime lock poisoned")
+            .len(),
+        1
+    );
+    assert!(service.opencode_runtime_stop(first.runtime_id.as_str())?);
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn opencode_workspace_runtime_ensure_cleans_up_spawned_child_when_runtime_lock_is_poisoned(
+) -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("runtime-workspace-lock-poison");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    let fake_opencode = root.join("opencode");
+    create_fake_opencode(&fake_opencode)?;
+    let pid_file = root.join("spawned-runtime.pid");
+    let _opencode_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        fake_opencode.to_string_lossy().as_ref(),
+    );
+    let _delay_guard = set_env_var("OPENDUCKTOR_TEST_STARTUP_DELAY_MS", "800");
+    let _pid_guard = set_env_var(
+        "OPENDUCKTOR_TEST_PID_FILE",
+        pid_file.to_string_lossy().as_ref(),
+    );
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+        config_store,
+    );
+
+    let repo_path = repo.to_string_lossy().to_string();
+    let ensure_error = thread::scope(|scope| -> Result<anyhow::Error> {
+        let ensure_handle =
+            scope.spawn(|| service.opencode_repo_runtime_ensure(repo_path.as_str()));
+
+        assert!(wait_for_path_exists(
+            pid_file.as_path(),
+            Duration::from_secs(2)
+        ));
+        let spawned_pid = fs::read_to_string(pid_file.as_path())?
+            .trim()
+            .parse::<i32>()
+            .expect("spawned runtime pid should parse as i32");
+
+        let poison_handle = scope.spawn(|| {
+            let _lock = service
+                .agent_runtimes
+                .lock()
+                .expect("runtime lock should be available for poisoning");
+            panic!("poison runtime lock");
+        });
+        assert!(poison_handle.join().is_err());
+
+        let ensure_error = ensure_handle
+            .join()
+            .expect("workspace ensure thread should join")
+            .expect_err("workspace ensure should fail when runtime lock is poisoned");
+        assert!(wait_for_process_exit(spawned_pid, Duration::from_secs(2)));
+        Ok(ensure_error)
+    })?;
+    assert!(ensure_error
+        .to_string()
+        .contains("Agent runtime state lock poisoned"));
+
     let _ = fs::remove_dir_all(root);
     Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
@@ -1,7 +1,6 @@
 use super::types::{
     default_branch_prefix, default_task_metadata_namespace, hook_set_fingerprint,
-    AgentModelDefault, GlobalConfig,
-    OpencodeStartupReadinessConfig, RepoConfig,
+    AgentModelDefault, GlobalConfig, OpencodeStartupReadinessConfig, RepoConfig,
 };
 
 fn normalize_optional_non_empty(value: Option<String>) -> Option<String> {


### PR DESCRIPTION
## Summary
- refactor `runtime_orchestrator` to deduplicate the runtime spawn/wait/register startup sequence between workspace ensure and agent runtime start
- harden post-start finalization paths so spawned runtimes are cleaned up on lock/prune/dedup failures
- add post-start deduplication for concurrent `opencode_runtime_start` calls and persist canonical repo keys in runtime summaries
- add integration regressions for concurrent dedup, canonical repo path persistence, and lock-poison cleanup behavior

## Validation
- `cd apps/desktop/src-tauri && cargo test -p host-application opencode_runtime_`
- `cd apps/desktop/src-tauri && cargo test -p host-application opencode_workspace_runtime_ensure`
- `cd apps/desktop/src-tauri && cargo test -p host-application`
