### PR TITLE
perf(desktop): lazy-load inactive Prism theme in MarkdownSyntaxBlock

### DIFF
--- a/apps/desktop/src/components/ui/markdown-syntax-block.test.tsx
+++ b/apps/desktop/src/components/ui/markdown-syntax-block.test.tsx
@@ -95,16 +95,14 @@ describe("MarkdownSyntaxBlock", () => {
     expect(renderer.root.findAllByType("pre")).toHaveLength(1);
     expect(findSyntaxNodes(renderer)).toHaveLength(0);
 
-    await act(async () => {
-      await flushMicrotasks();
-    });
+    await act(flushMicrotasks);
 
     const nodes = findSyntaxNodes(renderer);
     expect(nodes).toHaveLength(1);
     expect(nodes[0]?.props.style).toBe(DARK_THEME);
     expect(darkThemeModuleLoadMock).toHaveBeenCalledTimes(1);
 
-    await act(async () => {
+    act(() => {
       renderer.unmount();
     });
   });
@@ -121,7 +119,7 @@ describe("MarkdownSyntaxBlock", () => {
     expect(renderer.root.findAllByType("pre")).toHaveLength(0);
     expect(darkThemeModuleLoadMock).not.toHaveBeenCalled();
 
-    await act(async () => {
+    act(() => {
       renderer.unmount();
     });
   });
@@ -135,7 +133,7 @@ describe("MarkdownSyntaxBlock", () => {
     expect(renderer.root.findAllByType("pre")).toHaveLength(1);
     expect(findSyntaxNodes(renderer)).toHaveLength(0);
 
-    await act(async () => {
+    act(() => {
       renderer.unmount();
     });
   });
@@ -153,16 +151,14 @@ describe("MarkdownSyntaxBlock", () => {
       );
     });
 
-    await act(async () => {
-      await flushMicrotasks();
-    });
+    await act(flushMicrotasks);
 
     const nodes = findSyntaxNodes(renderer);
     expect(nodes).toHaveLength(2);
     expect(nodes[0]?.props.style).toBe(DARK_THEME);
     expect(nodes[1]?.props.style).toBe(DARK_THEME);
 
-    await act(async () => {
+    act(() => {
       renderer.unmount();
     });
   });

--- a/apps/desktop/src/components/ui/markdown-syntax-block.test.tsx
+++ b/apps/desktop/src/components/ui/markdown-syntax-block.test.tsx
@@ -1,0 +1,169 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+const reactActEnvironment = globalThis as {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+
+type Theme = "dark" | "light";
+
+const LIGHT_THEME = { themeName: "light" };
+const DARK_THEME = { themeName: "dark" };
+
+let currentTheme: Theme = "light";
+const registerLanguageMock = mock((_language: string, _grammar: unknown) => {});
+const syntaxHighlighterRenderMock = mock((_props: Record<string, unknown>) => {});
+const darkThemeModuleLoadMock = mock(() => DARK_THEME);
+
+mock.module("@/components/theme-provider", () => ({
+  useTheme: () => ({
+    theme: currentTheme,
+    setTheme: (_theme: Theme) => {},
+  }),
+}));
+
+mock.module("react-syntax-highlighter", () => {
+  const PrismLight = ({
+    children,
+    ...props
+  }: Record<string, unknown> & { children?: ReactElement | string }): ReactElement => {
+    syntaxHighlighterRenderMock(props);
+    return createElement("mock-syntax-highlighter", props, children);
+  };
+
+  PrismLight.registerLanguage = (language: string, grammar: unknown): void => {
+    registerLanguageMock(language, grammar);
+  };
+
+  return { PrismLight };
+});
+
+mock.module("react-syntax-highlighter/dist/esm/languages/prism/javascript", () => ({
+  default: { grammar: "javascript" },
+}));
+
+mock.module("react-syntax-highlighter/dist/esm/languages/prism/json", () => ({
+  default: { grammar: "json" },
+}));
+
+mock.module("react-syntax-highlighter/dist/esm/styles/prism/one-light", () => ({
+  default: LIGHT_THEME,
+}));
+
+mock.module("react-syntax-highlighter/dist/esm/styles/prism/one-dark", () => ({
+  default: darkThemeModuleLoadMock(),
+}));
+
+type MarkdownSyntaxBlockComponent = typeof import("./markdown-syntax-block").default;
+let MarkdownSyntaxBlock: MarkdownSyntaxBlockComponent;
+
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const findSyntaxNodes = (renderer: ReactTestRenderer) =>
+  renderer.root.findAll((node) => (node.type as unknown) === "mock-syntax-highlighter");
+
+beforeAll(async () => {
+  ({ default: MarkdownSyntaxBlock } = await import("./markdown-syntax-block"));
+});
+
+beforeEach(() => {
+  currentTheme = "light";
+  syntaxHighlighterRenderMock.mockClear();
+  darkThemeModuleLoadMock.mockClear();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("MarkdownSyntaxBlock", () => {
+  test("renders plain code first in dark theme, then upgrades to dark syntax theme", async () => {
+    currentTheme = "dark";
+
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <MarkdownSyntaxBlock language="javascript" code={"const x = 1;\nconsole.log(x);"} />,
+      );
+    });
+
+    expect(renderer.root.findAllByType("pre")).toHaveLength(1);
+    expect(findSyntaxNodes(renderer)).toHaveLength(0);
+
+    await act(async () => {
+      await flushMicrotasks();
+    });
+
+    const nodes = findSyntaxNodes(renderer);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.props.style).toBe(DARK_THEME);
+    expect(darkThemeModuleLoadMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("renders light syntax theme immediately when theme is light", async () => {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<MarkdownSyntaxBlock language="javascript" code="const answer = 42;" />);
+    });
+
+    const nodes = findSyntaxNodes(renderer);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.props.style).toBe(LIGHT_THEME);
+    expect(renderer.root.findAllByType("pre")).toHaveLength(0);
+    expect(darkThemeModuleLoadMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("keeps plain code fallback for unsupported languages", async () => {
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(<MarkdownSyntaxBlock language="elixir" code="IO.puts(:hello)" />);
+    });
+
+    expect(renderer.root.findAllByType("pre")).toHaveLength(1);
+    expect(findSyntaxNodes(renderer)).toHaveLength(0);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("upgrades multiple dark blocks from plain code to dark syntax highlighting", async () => {
+    currentTheme = "dark";
+
+    let renderer!: ReactTestRenderer;
+    act(() => {
+      renderer = create(
+        <div>
+          <MarkdownSyntaxBlock language="javascript" code="const a = 1;" />
+          <MarkdownSyntaxBlock language="json" code='{"a":1}' />
+        </div>,
+      );
+    });
+
+    await act(async () => {
+      await flushMicrotasks();
+    });
+
+    const nodes = findSyntaxNodes(renderer);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]?.props.style).toBe(DARK_THEME);
+    expect(nodes[1]?.props.style).toBe(DARK_THEME);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+});

--- a/apps/desktop/src/components/ui/markdown-syntax-block.tsx
+++ b/apps/desktop/src/components/ui/markdown-syntax-block.tsx
@@ -2,7 +2,7 @@ import { type CSSProperties, type ReactElement, useEffect, useState } from "reac
 import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";
 import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
-import oneDark from "react-syntax-highlighter/dist/esm/styles/prism/one-dark";
+import oneLight from "react-syntax-highlighter/dist/esm/styles/prism/one-light";
 import { useTheme } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
 import { createMarkdownSyntaxLanguageRegistry } from "./markdown-syntax-language-registry";
@@ -58,34 +58,34 @@ const SYNTAX_CODE_TAG_STYLE: CSSProperties = {
   fontFamily: '"IBM Plex Mono", "SF Mono", Menlo, Monaco, Consolas, monospace',
 };
 
-type PrismTheme = typeof oneDark;
+type PrismTheme = typeof oneLight;
 
-let cachedOneLightTheme: PrismTheme | null = null;
-let oneLightThemePromise: Promise<PrismTheme | null> | null = null;
+let cachedOneDarkTheme: PrismTheme | null = null;
+let oneDarkThemePromise: Promise<PrismTheme | null> | null = null;
 
-const loadOneLightTheme = async (): Promise<PrismTheme | null> => {
-  if (cachedOneLightTheme) {
-    return cachedOneLightTheme;
+const loadOneDarkTheme = async (): Promise<PrismTheme | null> => {
+  if (cachedOneDarkTheme) {
+    return cachedOneDarkTheme;
   }
 
-  if (oneLightThemePromise) {
-    return oneLightThemePromise;
+  if (oneDarkThemePromise) {
+    return oneDarkThemePromise;
   }
 
-  oneLightThemePromise = import("react-syntax-highlighter/dist/esm/styles/prism/one-light")
+  oneDarkThemePromise = import("react-syntax-highlighter/dist/esm/styles/prism/one-dark")
     .then((module) => {
-      cachedOneLightTheme = module.default;
+      cachedOneDarkTheme = module.default;
       return module.default;
     })
     .catch((error) => {
-      console.error("Failed to lazy-load Prism light theme:", error);
+      console.error("Failed to lazy-load Prism dark theme:", error);
       return null;
     })
     .finally(() => {
-      oneLightThemePromise = null;
+      oneDarkThemePromise = null;
     });
 
-  return oneLightThemePromise;
+  return oneDarkThemePromise;
 };
 
 const useResolvedDark = (): boolean => {
@@ -101,7 +101,7 @@ export default function MarkdownSyntaxBlock({
   className,
 }: MarkdownSyntaxBlockProps): ReactElement {
   const [, setLanguageRegistrationVersion] = useState(0);
-  const [oneLightTheme, setOneLightTheme] = useState<PrismTheme | null>(() => cachedOneLightTheme);
+  const [oneDarkTheme, setOneDarkTheme] = useState<PrismTheme | null>(() => cachedOneDarkTheme);
   const normalizedLanguage = markdownSyntaxLanguageRegistry.normalizeLanguage(language);
   const isSupportedLanguage =
     markdownSyntaxLanguageRegistry.isLanguageSupported(normalizedLanguage);
@@ -110,24 +110,24 @@ export default function MarkdownSyntaxBlock({
   const isDark = useResolvedDark();
 
   useEffect(() => {
-    if (isDark || oneLightTheme) {
+    if (!isDark || oneDarkTheme) {
       return;
     }
 
     let isActive = true;
 
-    void loadOneLightTheme().then((theme) => {
+    void loadOneDarkTheme().then((theme) => {
       if (!isActive || !theme) {
         return;
       }
 
-      setOneLightTheme(theme);
+      setOneDarkTheme(theme);
     });
 
     return () => {
       isActive = false;
     };
-  }, [isDark, oneLightTheme]);
+  }, [isDark, oneDarkTheme]);
 
   useEffect(() => {
     const shouldRegisterLanguage =
@@ -172,7 +172,7 @@ export default function MarkdownSyntaxBlock({
     <div className={cn("overflow-x-auto rounded-xl border border-border bg-muted/30", className)}>
       <SyntaxHighlighter
         language={normalizedLanguage}
-        style={isDark ? oneDark : (oneLightTheme ?? oneDark)}
+        style={isDark ? (oneDarkTheme ?? oneLight) : oneLight}
         customStyle={SYNTAX_PRE_STYLE}
         codeTagProps={{ style: SYNTAX_CODE_TAG_STYLE }}
         PreTag="div"

--- a/apps/desktop/src/components/ui/markdown-syntax-block.tsx
+++ b/apps/desktop/src/components/ui/markdown-syntax-block.tsx
@@ -164,11 +164,10 @@ export default function MarkdownSyntaxBlock({
     return renderPlainCodeBlock();
   }
 
-  if (isDark && !oneDarkTheme) {
+  const syntaxTheme = isDark ? oneDarkTheme : oneLight;
+  if (!syntaxTheme) {
     return renderPlainCodeBlock();
   }
-
-  const syntaxTheme: PrismTheme = isDark ? (oneDarkTheme as PrismTheme) : oneLight;
 
   return (
     <div className={cn("overflow-x-auto rounded-xl border border-border bg-muted/30", className)}>

--- a/apps/desktop/src/components/ui/markdown-syntax-block.tsx
+++ b/apps/desktop/src/components/ui/markdown-syntax-block.tsx
@@ -2,7 +2,7 @@ import { type CSSProperties, type ReactElement, useEffect, useState } from "reac
 import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";
 import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
-import { oneDark, oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
+import oneDark from "react-syntax-highlighter/dist/esm/styles/prism/one-dark";
 import { useTheme } from "@/components/theme-provider";
 import { cn } from "@/lib/utils";
 import { createMarkdownSyntaxLanguageRegistry } from "./markdown-syntax-language-registry";
@@ -58,6 +58,36 @@ const SYNTAX_CODE_TAG_STYLE: CSSProperties = {
   fontFamily: '"IBM Plex Mono", "SF Mono", Menlo, Monaco, Consolas, monospace',
 };
 
+type PrismTheme = typeof oneDark;
+
+let cachedOneLightTheme: PrismTheme | null = null;
+let oneLightThemePromise: Promise<PrismTheme | null> | null = null;
+
+const loadOneLightTheme = async (): Promise<PrismTheme | null> => {
+  if (cachedOneLightTheme) {
+    return cachedOneLightTheme;
+  }
+
+  if (oneLightThemePromise) {
+    return oneLightThemePromise;
+  }
+
+  oneLightThemePromise = import("react-syntax-highlighter/dist/esm/styles/prism/one-light")
+    .then((module) => {
+      cachedOneLightTheme = module.default;
+      return module.default;
+    })
+    .catch((error) => {
+      console.error("Failed to lazy-load Prism light theme:", error);
+      return null;
+    })
+    .finally(() => {
+      oneLightThemePromise = null;
+    });
+
+  return oneLightThemePromise;
+};
+
 const useResolvedDark = (): boolean => {
   const { theme } = useTheme();
   if (theme === "dark") return true;
@@ -71,12 +101,33 @@ export default function MarkdownSyntaxBlock({
   className,
 }: MarkdownSyntaxBlockProps): ReactElement {
   const [, setLanguageRegistrationVersion] = useState(0);
+  const [oneLightTheme, setOneLightTheme] = useState<PrismTheme | null>(() => cachedOneLightTheme);
   const normalizedLanguage = markdownSyntaxLanguageRegistry.normalizeLanguage(language);
   const isSupportedLanguage =
     markdownSyntaxLanguageRegistry.isLanguageSupported(normalizedLanguage);
   const isLanguageRegistered =
     markdownSyntaxLanguageRegistry.isLanguageRegistered(normalizedLanguage);
   const isDark = useResolvedDark();
+
+  useEffect(() => {
+    if (isDark || oneLightTheme) {
+      return;
+    }
+
+    let isActive = true;
+
+    void loadOneLightTheme().then((theme) => {
+      if (!isActive || !theme) {
+        return;
+      }
+
+      setOneLightTheme(theme);
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [isDark, oneLightTheme]);
 
   useEffect(() => {
     const shouldRegisterLanguage =
@@ -121,7 +172,7 @@ export default function MarkdownSyntaxBlock({
     <div className={cn("overflow-x-auto rounded-xl border border-border bg-muted/30", className)}>
       <SyntaxHighlighter
         language={normalizedLanguage}
-        style={isDark ? oneDark : oneLight}
+        style={isDark ? oneDark : (oneLightTheme ?? oneDark)}
         customStyle={SYNTAX_PRE_STYLE}
         codeTagProps={{ style: SYNTAX_CODE_TAG_STYLE }}
         PreTag="div"

--- a/apps/desktop/src/components/ui/markdown-syntax-block.tsx
+++ b/apps/desktop/src/components/ui/markdown-syntax-block.tsx
@@ -88,18 +88,12 @@ const loadOneDarkTheme = async (): Promise<PrismTheme | null> => {
   return oneDarkThemePromise;
 };
 
-const useResolvedDark = (): boolean => {
-  const { theme } = useTheme();
-  if (theme === "dark") return true;
-  if (theme === "light") return false;
-  return window.matchMedia("(prefers-color-scheme: dark)").matches;
-};
-
 export default function MarkdownSyntaxBlock({
   language,
   code,
   className,
 }: MarkdownSyntaxBlockProps): ReactElement {
+  const { theme } = useTheme();
   const [, setLanguageRegistrationVersion] = useState(0);
   const [oneDarkTheme, setOneDarkTheme] = useState<PrismTheme | null>(() => cachedOneDarkTheme);
   const normalizedLanguage = markdownSyntaxLanguageRegistry.normalizeLanguage(language);
@@ -107,7 +101,18 @@ export default function MarkdownSyntaxBlock({
     markdownSyntaxLanguageRegistry.isLanguageSupported(normalizedLanguage);
   const isLanguageRegistered =
     markdownSyntaxLanguageRegistry.isLanguageRegistered(normalizedLanguage);
-  const isDark = useResolvedDark();
+  const isDark = theme === "dark";
+
+  const renderPlainCodeBlock = (): ReactElement => (
+    <pre
+      className={cn(
+        "overflow-x-auto rounded-xl border border-border bg-muted/30 p-3.5 font-mono text-xs leading-relaxed text-foreground",
+        className,
+      )}
+    >
+      <code>{code}</code>
+    </pre>
+  );
 
   useEffect(() => {
     if (!isDark || oneDarkTheme) {
@@ -156,23 +161,20 @@ export default function MarkdownSyntaxBlock({
   }, [normalizedLanguage]);
 
   if (!isSupportedLanguage || !isLanguageRegistered) {
-    return (
-      <pre
-        className={cn(
-          "overflow-x-auto rounded-xl border border-border bg-muted/30 p-3.5 font-mono text-xs leading-relaxed text-foreground",
-          className,
-        )}
-      >
-        <code>{code}</code>
-      </pre>
-    );
+    return renderPlainCodeBlock();
   }
+
+  if (isDark && !oneDarkTheme) {
+    return renderPlainCodeBlock();
+  }
+
+  const syntaxTheme: PrismTheme = isDark ? (oneDarkTheme as PrismTheme) : oneLight;
 
   return (
     <div className={cn("overflow-x-auto rounded-xl border border-border bg-muted/30", className)}>
       <SyntaxHighlighter
         language={normalizedLanguage}
-        style={isDark ? (oneDarkTheme ?? oneLight) : oneLight}
+        style={syntaxTheme}
         customStyle={SYNTAX_PRE_STYLE}
         codeTagProps={{ style: SYNTAX_CODE_TAG_STYLE }}
         PreTag="div"


### PR DESCRIPTION
## Summary
- change `MarkdownSyntaxBlock` Prism theme loading to avoid eagerly bundling both themes
- default syntax highlighting to light theme (matching app default)
- lazy-load dark Prism theme and render plain code in dark mode until the theme chunk is ready to avoid wrong-theme flash
- simplify dark-mode detection to use `theme === "dark"` from `ThemeProvider`
- add focused tests for light/dark theme behavior, fallback rendering, and async upgrade path

## Files
- `apps/desktop/src/components/ui/markdown-syntax-block.tsx`
- `apps/desktop/src/components/ui/markdown-syntax-block.test.tsx`

## Validation
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop test`
