### PR TITLE
refactor(desktop): reduce start-session parameter bloat and harden coverage

### DIFF
--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -203,24 +203,34 @@ export const createAgentSessionActions = ({
   };
 
   const startAgentSession = createStartAgentSession({
-    activeRepo,
-    adapter,
-    setSessionsById,
-    sessionsRef,
-    taskRef,
-    repoEpochRef,
-    previousRepoRef,
-    inFlightStartsByRepoTaskRef,
-    attachSessionListener,
-    ensureRuntime,
-    loadTaskDocuments,
-    loadRepoDefaultModel,
-    loadSessionTodos,
-    loadSessionModelCatalog,
-    loadAgentSessions,
-    refreshTaskData,
-    persistSessionSnapshot,
-    sendAgentMessage,
+    repo: {
+      activeRepo,
+      repoEpochRef,
+      previousRepoRef,
+    },
+    session: {
+      setSessionsById,
+      sessionsRef,
+      inFlightStartsByRepoTaskRef,
+      loadAgentSessions,
+      persistSessionSnapshot,
+      attachSessionListener,
+    },
+    runtime: {
+      adapter,
+      ensureRuntime,
+    },
+    task: {
+      taskRef,
+      loadTaskDocuments,
+      refreshTaskData,
+      sendAgentMessage,
+    },
+    model: {
+      loadRepoDefaultModel,
+      loadSessionTodos,
+      loadSessionModelCatalog,
+    },
   });
 
   const stopAgentSession = async (sessionId: string): Promise<void> => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test-helpers.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test-helpers.ts
@@ -1,0 +1,42 @@
+import type { StartSessionDependencies } from "./start-session";
+
+export type FlatStartSessionDependencies = StartSessionDependencies["repo"] &
+  StartSessionDependencies["session"] &
+  StartSessionDependencies["runtime"] &
+  StartSessionDependencies["task"] &
+  StartSessionDependencies["model"];
+
+export const toStartSessionDependencies = (
+  deps: FlatStartSessionDependencies,
+): StartSessionDependencies => {
+  return {
+    repo: {
+      activeRepo: deps.activeRepo,
+      repoEpochRef: deps.repoEpochRef,
+      previousRepoRef: deps.previousRepoRef,
+    },
+    session: {
+      setSessionsById: deps.setSessionsById,
+      sessionsRef: deps.sessionsRef,
+      inFlightStartsByRepoTaskRef: deps.inFlightStartsByRepoTaskRef,
+      loadAgentSessions: deps.loadAgentSessions,
+      persistSessionSnapshot: deps.persistSessionSnapshot,
+      attachSessionListener: deps.attachSessionListener,
+    },
+    runtime: {
+      adapter: deps.adapter,
+      ensureRuntime: deps.ensureRuntime,
+    },
+    task: {
+      taskRef: deps.taskRef,
+      loadTaskDocuments: deps.loadTaskDocuments,
+      refreshTaskData: deps.refreshTaskData,
+      sendAgentMessage: deps.sendAgentMessage,
+    },
+    model: {
+      loadRepoDefaultModel: deps.loadRepoDefaultModel,
+      loadSessionTodos: deps.loadSessionTodos,
+      loadSessionModelCatalog: deps.loadSessionModelCatalog,
+    },
+  };
+};

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -1,78 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
-import type { TaskCard } from "@openducktor/contracts";
-import type { AgentEnginePort, AgentModelSelection, AgentRole } from "@openducktor/core";
-import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentModelSelection } from "@openducktor/core";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
-import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import { createDeferred, createTaskCardFixture, withTimeout } from "../test-utils";
 import { createStartAgentSession } from "./start-session";
-
-type FlatStartSessionDependencies = {
-  activeRepo: string | null;
-  adapter: AgentEnginePort;
-  setSessionsById: (
-    updater:
-      | Record<string, AgentSessionState>
-      | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
-  ) => void;
-  sessionsRef: { current: Record<string, AgentSessionState> };
-  taskRef: { current: TaskCard[] };
-  repoEpochRef: { current: number };
-  previousRepoRef: { current: string | null };
-  inFlightStartsByRepoTaskRef: { current: Map<string, Promise<string>> };
-  attachSessionListener: (repoPath: string, sessionId: string) => void;
-  ensureRuntime: (repoPath: string, taskId: string, role: AgentRole) => Promise<RuntimeInfo>;
-  loadTaskDocuments: (repoPath: string, taskId: string) => Promise<TaskDocuments>;
-  loadRepoDefaultModel: (repoPath: string, role: AgentRole) => Promise<AgentModelSelection | null>;
-  loadSessionTodos: (
-    sessionId: string,
-    baseUrl: string,
-    workingDirectory: string,
-    externalSessionId: string,
-  ) => Promise<void>;
-  loadSessionModelCatalog: (
-    sessionId: string,
-    baseUrl: string,
-    workingDirectory: string,
-  ) => Promise<void>;
-  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
-  refreshTaskData: (repoPath: string) => Promise<void>;
-  persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;
-  sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
-};
+import {
+  type FlatStartSessionDependencies,
+  toStartSessionDependencies,
+} from "./start-session.test-helpers";
 
 const createStartAgentSessionWithFlatDeps = (deps: FlatStartSessionDependencies) => {
-  return createStartAgentSession({
-    repo: {
-      activeRepo: deps.activeRepo,
-      repoEpochRef: deps.repoEpochRef,
-      previousRepoRef: deps.previousRepoRef,
-    },
-    session: {
-      setSessionsById: deps.setSessionsById,
-      sessionsRef: deps.sessionsRef,
-      inFlightStartsByRepoTaskRef: deps.inFlightStartsByRepoTaskRef,
-      loadAgentSessions: deps.loadAgentSessions,
-      persistSessionSnapshot: deps.persistSessionSnapshot,
-      attachSessionListener: deps.attachSessionListener,
-    },
-    runtime: {
-      adapter: deps.adapter,
-      ensureRuntime: deps.ensureRuntime,
-    },
-    task: {
-      taskRef: deps.taskRef,
-      loadTaskDocuments: deps.loadTaskDocuments,
-      refreshTaskData: deps.refreshTaskData,
-      sendAgentMessage: deps.sendAgentMessage,
-    },
-    model: {
-      loadRepoDefaultModel: deps.loadRepoDefaultModel,
-      loadSessionTodos: deps.loadSessionTodos,
-      loadSessionModelCatalog: deps.loadSessionModelCatalog,
-    },
-  });
+  return createStartAgentSession(toStartSessionDependencies(deps));
 };
 
 const taskFixture = createTaskCardFixture({
@@ -772,6 +711,70 @@ describe("agent-orchestrator/handlers/start-session", () => {
     }
   });
 
+  test("rolls back started remote session when workspace becomes stale after listener attach", async () => {
+    const previousRepoRef = { current: "/tmp/repo" as string | null };
+    let stopCalls = 0;
+
+    const adapter = new OpencodeSdkAdapter();
+    const originalStartSession = adapter.startSession;
+    const originalStopSession = adapter.stopSession;
+    adapter.startSession = async () => {
+      return {
+        sessionId: "session-created",
+        externalSessionId: "external-created",
+        startedAt: "2026-02-22T08:00:10.000Z",
+        role: "build",
+        scenario: "build_implementation_start",
+        status: "idle",
+      };
+    };
+    adapter.stopSession = async () => {
+      stopCalls += 1;
+    };
+
+    const originalAgentSessionsList = host.agentSessionsList;
+    host.agentSessionsList = async () => [];
+
+    const start = createStartAgentSessionWithFlatDeps({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef: { current: {} },
+      taskRef: { current: [taskFixture] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef,
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      attachSessionListener: () => {
+        previousRepoRef.current = "/tmp/other";
+      },
+      ensureRuntime: async () => ({
+        runtimeId: null,
+        runId: "run-1",
+        baseUrl: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadAgentSessions: async () => {},
+      refreshTaskData: async () => {},
+      persistSessionSnapshot: async () => {},
+      sendAgentMessage: async () => {},
+    });
+
+    try {
+      await expect(start({ taskId: "task-1", role: "build" })).rejects.toThrow(
+        "Workspace changed while starting session.",
+      );
+      expect(stopCalls).toBe(1);
+    } finally {
+      adapter.startSession = originalStartSession;
+      adapter.stopSession = originalStopSession;
+      host.agentSessionsList = originalAgentSessionsList;
+    }
+  });
+
   test("creates a fresh session and triggers kickoff flow", async () => {
     let attachCalls = 0;
     let persistCalls = 0;
@@ -991,6 +994,139 @@ describe("agent-orchestrator/handlers/start-session", () => {
       await expect(startPromise).resolves.toBe("session-created");
     } finally {
       refreshDeferred.resolve();
+      adapter.startSession = originalStartSession;
+      host.agentSessionsList = originalAgentSessionsList;
+    }
+  });
+
+  test("requireModelReady waits for and applies resolved default model before completion", async () => {
+    const defaultModelDeferred = createDeferred<AgentModelSelection | null>();
+    const resolvedModel: AgentModelSelection = {
+      providerId: "openai",
+      modelId: "gpt-5",
+    };
+    let sessionsState: Record<string, AgentSessionState> = {};
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      sessionsState = typeof updater === "function" ? updater(sessionsState) : updater;
+    };
+
+    const adapter = new OpencodeSdkAdapter();
+    const originalStartSession = adapter.startSession;
+    adapter.startSession = async () => ({
+      sessionId: "session-created",
+      externalSessionId: "external-created",
+      startedAt: "2026-02-22T08:00:10.000Z",
+      role: "build",
+      scenario: "build_implementation_start",
+      status: "idle",
+    });
+
+    const originalAgentSessionsList = host.agentSessionsList;
+    host.agentSessionsList = async () => [];
+
+    const start = createStartAgentSessionWithFlatDeps({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById,
+      sessionsRef: { current: {} },
+      taskRef: { current: [taskFixture] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        runtimeId: null,
+        runId: "run-1",
+        baseUrl: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => defaultModelDeferred.promise,
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadAgentSessions: async () => {},
+      refreshTaskData: async () => {},
+      persistSessionSnapshot: async () => {},
+      sendAgentMessage: async () => {},
+    });
+
+    try {
+      const startPromise = start({ taskId: "task-1", role: "build", requireModelReady: true });
+      const beforeModelReady = await withTimeout(startPromise, 20);
+      expect(beforeModelReady).toBe("timeout");
+
+      defaultModelDeferred.resolve(resolvedModel);
+      await expect(startPromise).resolves.toBe("session-created");
+      expect(sessionsState["session-created"]?.selectedModel).toEqual(resolvedModel);
+    } finally {
+      defaultModelDeferred.resolve(null);
+      adapter.startSession = originalStartSession;
+      host.agentSessionsList = originalAgentSessionsList;
+    }
+  });
+
+  test("requireModelReady falls back to null model when default-model loading fails", async () => {
+    const defaultModelDeferred = createDeferred<AgentModelSelection | null>();
+    let sessionsState: Record<string, AgentSessionState> = {};
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      sessionsState = typeof updater === "function" ? updater(sessionsState) : updater;
+    };
+
+    const adapter = new OpencodeSdkAdapter();
+    const originalStartSession = adapter.startSession;
+    adapter.startSession = async () => ({
+      sessionId: "session-created",
+      externalSessionId: "external-created",
+      startedAt: "2026-02-22T08:00:10.000Z",
+      role: "build",
+      scenario: "build_implementation_start",
+      status: "idle",
+    });
+
+    const originalAgentSessionsList = host.agentSessionsList;
+    host.agentSessionsList = async () => [];
+
+    const start = createStartAgentSessionWithFlatDeps({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById,
+      sessionsRef: { current: {} },
+      taskRef: { current: [taskFixture] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        runtimeId: null,
+        runId: "run-1",
+        baseUrl: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => defaultModelDeferred.promise,
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadAgentSessions: async () => {},
+      refreshTaskData: async () => {},
+      persistSessionSnapshot: async () => {},
+      sendAgentMessage: async () => {},
+    });
+
+    try {
+      const startPromise = start({ taskId: "task-1", role: "build", requireModelReady: true });
+      defaultModelDeferred.reject(new Error("catalog unavailable"));
+      await expect(startPromise).resolves.toBe("session-created");
+      expect(sessionsState["session-created"]?.selectedModel).toBeNull();
+    } finally {
+      defaultModelDeferred.resolve(null);
       adapter.startSession = originalStartSession;
       host.agentSessionsList = originalAgentSessionsList;
     }

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -1,9 +1,79 @@
 import { describe, expect, test } from "bun:test";
 import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { TaskCard } from "@openducktor/contracts";
+import type { AgentEnginePort, AgentModelSelection, AgentRole } from "@openducktor/core";
+import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
+import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import { createDeferred, createTaskCardFixture, withTimeout } from "../test-utils";
 import { createStartAgentSession } from "./start-session";
+
+type FlatStartSessionDependencies = {
+  activeRepo: string | null;
+  adapter: AgentEnginePort;
+  setSessionsById: (
+    updater:
+      | Record<string, AgentSessionState>
+      | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+  ) => void;
+  sessionsRef: { current: Record<string, AgentSessionState> };
+  taskRef: { current: TaskCard[] };
+  repoEpochRef: { current: number };
+  previousRepoRef: { current: string | null };
+  inFlightStartsByRepoTaskRef: { current: Map<string, Promise<string>> };
+  attachSessionListener: (repoPath: string, sessionId: string) => void;
+  ensureRuntime: (repoPath: string, taskId: string, role: AgentRole) => Promise<RuntimeInfo>;
+  loadTaskDocuments: (repoPath: string, taskId: string) => Promise<TaskDocuments>;
+  loadRepoDefaultModel: (repoPath: string, role: AgentRole) => Promise<AgentModelSelection | null>;
+  loadSessionTodos: (
+    sessionId: string,
+    baseUrl: string,
+    workingDirectory: string,
+    externalSessionId: string,
+  ) => Promise<void>;
+  loadSessionModelCatalog: (
+    sessionId: string,
+    baseUrl: string,
+    workingDirectory: string,
+  ) => Promise<void>;
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
+  refreshTaskData: (repoPath: string) => Promise<void>;
+  persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;
+  sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
+};
+
+const createStartAgentSessionWithFlatDeps = (deps: FlatStartSessionDependencies) => {
+  return createStartAgentSession({
+    repo: {
+      activeRepo: deps.activeRepo,
+      repoEpochRef: deps.repoEpochRef,
+      previousRepoRef: deps.previousRepoRef,
+    },
+    session: {
+      setSessionsById: deps.setSessionsById,
+      sessionsRef: deps.sessionsRef,
+      inFlightStartsByRepoTaskRef: deps.inFlightStartsByRepoTaskRef,
+      loadAgentSessions: deps.loadAgentSessions,
+      persistSessionSnapshot: deps.persistSessionSnapshot,
+      attachSessionListener: deps.attachSessionListener,
+    },
+    runtime: {
+      adapter: deps.adapter,
+      ensureRuntime: deps.ensureRuntime,
+    },
+    task: {
+      taskRef: deps.taskRef,
+      loadTaskDocuments: deps.loadTaskDocuments,
+      refreshTaskData: deps.refreshTaskData,
+      sendAgentMessage: deps.sendAgentMessage,
+    },
+    model: {
+      loadRepoDefaultModel: deps.loadRepoDefaultModel,
+      loadSessionTodos: deps.loadSessionTodos,
+      loadSessionModelCatalog: deps.loadSessionModelCatalog,
+    },
+  });
+};
 
 const taskFixture = createTaskCardFixture({
   title: "Implement feature",
@@ -15,7 +85,7 @@ const taskFixture = createTaskCardFixture({
 
 describe("agent-orchestrator/handlers/start-session", () => {
   test("throws when no active repo is selected", () => {
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: null,
       adapter: new OpencodeSdkAdapter(),
       setSessionsById: () => {},
@@ -49,7 +119,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     const inFlightMap = new Map<string, Promise<string>>([
       ["/tmp/repo::task-1::build::reuse_latest", inFlight],
     ]);
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter: new OpencodeSdkAdapter(),
       setSessionsById: () => {},
@@ -107,7 +177,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     const originalAgentSessionsList = host.agentSessionsList;
     host.agentSessionsList = async () => [];
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter,
       setSessionsById: () => {},
@@ -161,7 +231,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       return [];
     };
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter: new OpencodeSdkAdapter(),
       setSessionsById: () => {},
@@ -258,7 +328,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       ];
     };
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter,
       setSessionsById: () => {},
@@ -366,7 +436,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       },
     };
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter,
       setSessionsById: () => {},
@@ -451,7 +521,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       },
     ];
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter: new OpencodeSdkAdapter(),
       setSessionsById: () => {},
@@ -499,7 +569,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       return originalStartSession(input);
     };
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter,
       setSessionsById: () => {},
@@ -542,7 +612,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     const originalAgentSessionsList = host.agentSessionsList;
     host.agentSessionsList = async () => [];
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter: new OpencodeSdkAdapter(),
       setSessionsById: () => {},
@@ -603,7 +673,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       return [];
     };
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter: new OpencodeSdkAdapter(),
       setSessionsById: () => {},
@@ -664,7 +734,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     const originalAgentSessionsList = host.agentSessionsList;
     host.agentSessionsList = async () => [];
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter,
       setSessionsById: () => {},
@@ -738,7 +808,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     host.agentSessionsList = async () => [];
 
     const sessionsRef = { current: {} as Record<string, never> };
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter,
       setSessionsById,
@@ -816,7 +886,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     const originalAgentSessionsList = host.agentSessionsList;
     host.agentSessionsList = async () => [];
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter,
       setSessionsById: () => {},
@@ -882,7 +952,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     const originalAgentSessionsList = host.agentSessionsList;
     host.agentSessionsList = async () => [];
 
-    const start = createStartAgentSession({
+    const start = createStartAgentSessionWithFlatDeps({
       activeRepo: "/tmp/repo",
       adapter,
       setSessionsById: () => {},

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -648,6 +648,71 @@ describe("agent-orchestrator/handlers/start-session", () => {
     }
   });
 
+  test("does not diverge ref/state when workspace becomes stale during initial session commit", async () => {
+    const previousRepoRef = { current: "/tmp/repo" as string | null };
+    let sessionsState: Record<string, AgentSessionState> = {};
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      previousRepoRef.current = "/tmp/other";
+      sessionsState = typeof updater === "function" ? updater(sessionsState) : updater;
+    };
+
+    const adapter = new OpencodeSdkAdapter();
+    const originalStartSession = adapter.startSession;
+    adapter.startSession = async () => ({
+      sessionId: "session-created",
+      externalSessionId: "external-created",
+      startedAt: "2026-02-22T08:00:10.000Z",
+      role: "build",
+      scenario: "build_implementation_start",
+      status: "idle",
+    });
+
+    const originalAgentSessionsList = host.agentSessionsList;
+    host.agentSessionsList = async () => [];
+
+    const start = createStartAgentSessionWithFlatDeps({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById,
+      sessionsRef,
+      taskRef: { current: [taskFixture] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef,
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        runtimeId: null,
+        runId: "run-1",
+        baseUrl: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadAgentSessions: async () => {},
+      refreshTaskData: async () => {},
+      persistSessionSnapshot: async () => {},
+      sendAgentMessage: async () => {},
+    });
+
+    try {
+      await expect(start({ taskId: "task-1", role: "build" })).rejects.toThrow(
+        "Workspace changed while starting session.",
+      );
+      expect(sessionsRef.current).toEqual({});
+      expect(sessionsState).toEqual({});
+    } finally {
+      adapter.startSession = originalStartSession;
+      host.agentSessionsList = originalAgentSessionsList;
+    }
+  });
+
   test("rolls back started remote session when workspace becomes stale after start", async () => {
     const previousRepoRef = { current: "/tmp/repo" as string | null };
     let stopCalls = 0;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -32,22 +32,31 @@ export type StartAgentSessionInput = {
   requireModelReady?: boolean;
 };
 
-type StartSessionDependencies = {
-  activeRepo: string | null;
-  adapter: AgentEnginePort;
-  setSessionsById: (
-    updater:
-      | Record<string, AgentSessionState>
-      | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
-  ) => void;
-  sessionsRef: { current: Record<string, AgentSessionState> };
-  taskRef: { current: TaskCard[] };
-  repoEpochRef: { current: number };
-  previousRepoRef: { current: string | null };
+type SessionStateById = Record<string, AgentSessionState>;
+type SessionStateUpdater = SessionStateById | ((current: SessionStateById) => SessionStateById);
+
+type SessionDependencies = {
+  setSessionsById: (updater: SessionStateUpdater) => void;
+  sessionsRef: { current: SessionStateById };
   inFlightStartsByRepoTaskRef: { current: Map<string, Promise<string>> };
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
+  persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;
   attachSessionListener: (repoPath: string, sessionId: string) => void;
+};
+
+type RuntimeDependencies = {
+  adapter: AgentEnginePort;
   ensureRuntime: (repoPath: string, taskId: string, role: AgentRole) => Promise<RuntimeInfo>;
+};
+
+type TaskDependencies = {
+  taskRef: { current: TaskCard[] };
   loadTaskDocuments: (repoPath: string, taskId: string) => Promise<TaskDocuments>;
+  refreshTaskData: (repoPath: string) => Promise<void>;
+  sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
+};
+
+type ModelDependencies = {
   loadRepoDefaultModel: (repoPath: string, role: AgentRole) => Promise<AgentModelSelection | null>;
   loadSessionTodos: (
     sessionId: string,
@@ -60,13 +69,55 @@ type StartSessionDependencies = {
     baseUrl: string,
     workingDirectory: string,
   ) => Promise<void>;
-  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
-  refreshTaskData: (repoPath: string) => Promise<void>;
-  persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;
-  sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
+};
+
+type RepoDependencies = {
+  activeRepo: string | null;
+  repoEpochRef: { current: number };
+  previousRepoRef: { current: string | null };
+};
+
+type StartSessionDependencies = {
+  repo: RepoDependencies;
+  session: SessionDependencies;
+  runtime: RuntimeDependencies;
+  task: TaskDependencies;
+  model: ModelDependencies;
 };
 
 const STALE_START_ERROR = "Workspace changed while starting session.";
+type RepoStaleGuard = () => boolean;
+type SessionStartSummary = Awaited<ReturnType<AgentEnginePort["startSession"]>>;
+
+type SessionStartTags = {
+  repoPath: string;
+  taskId: string;
+  role: AgentRole;
+  scenario: AgentScenario;
+  sessionId: string;
+};
+
+type ResolvedRuntimeAndModel = {
+  task: TaskCard;
+  runtime: RuntimeInfo;
+  resolvedScenario: AgentScenario;
+  systemPrompt: string;
+  defaultModelSelectionPromise: Promise<AgentModelSelection | null>;
+};
+
+type StartOrReuseResult =
+  | {
+      kind: "reused";
+      sessionId: string;
+    }
+  | {
+      kind: "started";
+      task: TaskCard;
+      runtime: RuntimeInfo;
+      summary: SessionStartSummary;
+      resolvedScenario: AgentScenario;
+      defaultModelSelectionPromise: Promise<AgentModelSelection | null>;
+    };
 
 const compareBySessionRecency = (
   a: { startedAt: string; sessionId: string },
@@ -87,25 +138,555 @@ const pickLatestSession = <T extends { startedAt: string; sessionId: string }>(
   return [...sessions].sort(compareBySessionRecency)[0];
 };
 
+const createSessionStartTags = ({
+  repoPath,
+  taskId,
+  role,
+  scenario,
+  sessionId,
+}: SessionStartTags): SessionStartTags => ({
+  repoPath,
+  taskId,
+  role,
+  scenario,
+  sessionId,
+});
+
+const stopSessionOnStaleAndThrow = async ({
+  reason,
+  runtime,
+  tags,
+}: {
+  reason: string;
+  runtime: RuntimeDependencies;
+  tags: SessionStartTags;
+}): Promise<never> => {
+  await captureOrchestratorFallback(
+    reason,
+    async () => runtime.adapter.stopSession(tags.sessionId),
+    {
+      tags,
+      fallback: () => undefined,
+    },
+  );
+  throw new Error(STALE_START_ERROR);
+};
+
+const resolveStartTask = ({
+  taskId,
+  role,
+  task,
+}: {
+  taskId: string;
+  role: AgentRole;
+  task: TaskDependencies;
+}): TaskCard => {
+  const resolvedTask = task.taskRef.current.find((entry) => entry.id === taskId);
+  if (!resolvedTask) {
+    throw new Error(`Task not found: ${taskId}`);
+  }
+  if (!isRoleAvailableForTask(resolvedTask, role)) {
+    throw new Error(unavailableRoleErrorMessage(resolvedTask, role));
+  }
+  return resolvedTask;
+};
+
+const resolveRuntimeAndModel = async ({
+  repoPath,
+  taskId,
+  role,
+  scenario,
+  taskCard,
+  runtime,
+  task,
+  model,
+  isStaleRepoOperation,
+}: {
+  repoPath: string;
+  taskId: string;
+  role: AgentRole;
+  scenario: AgentScenario | undefined;
+  taskCard: TaskCard;
+  runtime: RuntimeDependencies;
+  task: TaskDependencies;
+  model: ModelDependencies;
+  isStaleRepoOperation: RepoStaleGuard;
+}): Promise<ResolvedRuntimeAndModel> => {
+  const docsPromise = task.loadTaskDocuments(repoPath, taskId);
+  const runtimePromise = runtime.ensureRuntime(repoPath, taskId, role);
+  const defaultModelSelectionPromise = model.loadRepoDefaultModel(repoPath, role);
+
+  const [docs, runtimeInfo] = await Promise.all([docsPromise, runtimePromise]);
+  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+
+  const resolvedScenario = scenario ?? inferScenario(role, taskCard, docs);
+  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+
+  const systemPrompt = buildAgentSystemPrompt({
+    role,
+    scenario: resolvedScenario,
+    task: {
+      taskId: taskCard.id,
+      title: taskCard.title,
+      issueType: taskCard.issueType,
+      status: taskCard.status,
+      qaRequired: taskCard.aiReviewEnabled,
+      description: taskCard.description,
+      acceptanceCriteria: taskCard.acceptanceCriteria,
+      specMarkdown: docs.specMarkdown,
+      planMarkdown: docs.planMarkdown,
+      latestQaReportMarkdown: docs.qaMarkdown,
+    },
+  });
+
+  return {
+    task: taskCard,
+    runtime: runtimeInfo,
+    resolvedScenario,
+    systemPrompt,
+    defaultModelSelectionPromise,
+  };
+};
+
+const buildInitialSession = ({
+  taskId,
+  role,
+  resolvedScenario,
+  selectedModel,
+  runtime,
+  summary,
+  systemPrompt,
+}: {
+  taskId: string;
+  role: AgentRole;
+  resolvedScenario: AgentScenario;
+  selectedModel: AgentModelSelection | null;
+  runtime: RuntimeInfo;
+  summary: SessionStartSummary;
+  systemPrompt: string;
+}): AgentSessionState => ({
+  sessionId: summary.sessionId,
+  externalSessionId: summary.externalSessionId,
+  taskId,
+  role,
+  scenario: resolvedScenario,
+  status: "idle",
+  startedAt: summary.startedAt,
+  runtimeId: runtime.runtimeId,
+  runId: runtime.runId,
+  baseUrl: runtime.baseUrl,
+  workingDirectory: runtime.workingDirectory,
+  messages: [
+    {
+      id: crypto.randomUUID(),
+      role: "system",
+      content: `Session started (${role} - ${resolvedScenario})`,
+      timestamp: summary.startedAt,
+    },
+    {
+      id: crypto.randomUUID(),
+      role: "system",
+      content: `System prompt:\n\n${systemPrompt}`,
+      timestamp: summary.startedAt,
+    },
+  ],
+  draftAssistantText: "",
+  pendingPermissions: [],
+  pendingQuestions: [],
+  todos: [],
+  modelCatalog: null,
+  selectedModel,
+  isLoadingModelCatalog: true,
+});
+
+const persistInitialSession = ({
+  initialSession,
+  session,
+  tags,
+}: {
+  initialSession: AgentSessionState;
+  session: SessionDependencies;
+  tags: SessionStartTags;
+}): void => {
+  runOrchestratorSideEffect(
+    "start-session-persist-initial-session",
+    session.persistSessionSnapshot(initialSession),
+    { tags },
+  );
+};
+
+const createOrReuseSession = async ({
+  repoPath,
+  taskId,
+  role,
+  scenario,
+  selectedModel,
+  startMode,
+  session,
+  runtime,
+  task,
+  model,
+  isStaleRepoOperation,
+}: {
+  repoPath: string;
+  taskId: string;
+  role: AgentRole;
+  scenario: AgentScenario | undefined;
+  selectedModel: AgentModelSelection | null;
+  startMode: "reuse_latest" | "fresh";
+  session: SessionDependencies;
+  runtime: RuntimeDependencies;
+  task: TaskDependencies;
+  model: ModelDependencies;
+  isStaleRepoOperation: RepoStaleGuard;
+}): Promise<StartOrReuseResult> => {
+  if (startMode === "reuse_latest") {
+    const existingSession = pickLatestSession(
+      Object.values(session.sessionsRef.current).filter(
+        (entry) => entry.taskId === taskId && entry.role === role,
+      ),
+    );
+    if (existingSession) {
+      return {
+        kind: "reused",
+        sessionId: existingSession.sessionId,
+      };
+    }
+
+    const persistedSessions = await host.agentSessionsList(repoPath, taskId);
+    throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+    const latestPersistedSession = pickLatestSession(
+      persistedSessions.filter((entry) => entry.role === role),
+    );
+    if (latestPersistedSession) {
+      if (!session.sessionsRef.current[latestPersistedSession.sessionId]) {
+        await session.loadAgentSessions(taskId, {
+          hydrateHistoryForSessionId: latestPersistedSession.sessionId,
+        });
+        throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+      }
+      return {
+        kind: "reused",
+        sessionId: latestPersistedSession.sessionId,
+      };
+    }
+  }
+
+  const taskCard = resolveStartTask({ taskId, role, task });
+  const resolved = await resolveRuntimeAndModel({
+    repoPath,
+    taskId,
+    role,
+    scenario,
+    taskCard,
+    runtime,
+    task,
+    model,
+    isStaleRepoOperation,
+  });
+
+  const summary = await runtime.adapter.startSession({
+    repoPath,
+    workingDirectory: resolved.runtime.workingDirectory,
+    taskId,
+    role,
+    scenario: resolved.resolvedScenario,
+    systemPrompt: resolved.systemPrompt,
+    baseUrl: resolved.runtime.baseUrl,
+  });
+
+  const sessionTags = createSessionStartTags({
+    repoPath,
+    taskId,
+    role,
+    scenario: resolved.resolvedScenario,
+    sessionId: summary.sessionId,
+  });
+
+  if (isStaleRepoOperation()) {
+    await stopSessionOnStaleAndThrow({
+      reason: "start-session-stop-on-stale-after-start",
+      runtime,
+      tags: sessionTags,
+    });
+  }
+
+  const initialSession = buildInitialSession({
+    taskId,
+    role,
+    resolvedScenario: resolved.resolvedScenario,
+    selectedModel,
+    runtime: resolved.runtime,
+    summary,
+    systemPrompt: resolved.systemPrompt,
+  });
+
+  session.sessionsRef.current = {
+    ...session.sessionsRef.current,
+    [summary.sessionId]: initialSession,
+  };
+  session.setSessionsById((current) => {
+    if (isStaleRepoOperation()) {
+      return current;
+    }
+    return {
+      ...current,
+      [summary.sessionId]: initialSession,
+    };
+  });
+  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+
+  persistInitialSession({
+    initialSession,
+    session,
+    tags: sessionTags,
+  });
+
+  return {
+    kind: "started",
+    task: resolved.task,
+    runtime: resolved.runtime,
+    summary,
+    resolvedScenario: resolved.resolvedScenario,
+    defaultModelSelectionPromise: resolved.defaultModelSelectionPromise,
+  };
+};
+
+const attachSessionListenerAndGuard = async ({
+  repoPath,
+  taskId,
+  role,
+  resolvedScenario,
+  summary,
+  session,
+  runtime,
+  isStaleRepoOperation,
+}: {
+  repoPath: string;
+  taskId: string;
+  role: AgentRole;
+  resolvedScenario: AgentScenario;
+  summary: SessionStartSummary;
+  session: SessionDependencies;
+  runtime: RuntimeDependencies;
+  isStaleRepoOperation: RepoStaleGuard;
+}): Promise<void> => {
+  session.attachSessionListener(repoPath, summary.sessionId);
+
+  if (!isStaleRepoOperation()) {
+    return;
+  }
+
+  await stopSessionOnStaleAndThrow({
+    reason: "start-session-stop-on-stale-after-listener-attach",
+    runtime,
+    tags: createSessionStartTags({
+      repoPath,
+      taskId,
+      role,
+      scenario: resolvedScenario,
+      sessionId: summary.sessionId,
+    }),
+  });
+};
+
+const warmSessionData = ({
+  taskId,
+  role,
+  repoPath,
+  resolvedScenario,
+  runtime,
+  summary,
+  model,
+}: {
+  taskId: string;
+  role: AgentRole;
+  repoPath: string;
+  resolvedScenario: AgentScenario;
+  runtime: RuntimeInfo;
+  summary: SessionStartSummary;
+  model: ModelDependencies;
+}): void => {
+  const tags = createSessionStartTags({
+    repoPath,
+    taskId,
+    role,
+    scenario: resolvedScenario,
+    sessionId: summary.sessionId,
+  });
+
+  runOrchestratorSideEffect(
+    "start-session-warm-session-todos",
+    model.loadSessionTodos(
+      summary.sessionId,
+      runtime.baseUrl,
+      runtime.workingDirectory,
+      summary.externalSessionId,
+    ),
+    {
+      tags: {
+        ...tags,
+        externalSessionId: summary.externalSessionId,
+      },
+    },
+  );
+
+  runOrchestratorSideEffect(
+    "start-session-warm-session-model-catalog",
+    model.loadSessionModelCatalog(summary.sessionId, runtime.baseUrl, runtime.workingDirectory),
+    { tags },
+  );
+};
+
+const applyResolvedModelSelection = ({
+  resolvedModel,
+  summary,
+  session,
+  isStaleRepoOperation,
+}: {
+  resolvedModel: AgentModelSelection | null;
+  summary: SessionStartSummary;
+  session: SessionDependencies;
+  isStaleRepoOperation: RepoStaleGuard;
+}): void => {
+  if (isStaleRepoOperation() || !resolvedModel) {
+    return;
+  }
+
+  session.setSessionsById((current) => {
+    const currentSession = current[summary.sessionId];
+    if (!currentSession || currentSession.selectedModel) {
+      return current;
+    }
+
+    const nextSession: AgentSessionState = {
+      ...currentSession,
+      selectedModel: resolvedModel,
+    };
+    const nextSessions = {
+      ...current,
+      [summary.sessionId]: nextSession,
+    };
+    session.sessionsRef.current = nextSessions;
+    return nextSessions;
+  });
+};
+
+const maybeApplyDefaultModelSelection = async ({
+  selectedModel,
+  requireModelReady,
+  defaultModelSelectionPromise,
+  repoPath,
+  taskId,
+  role,
+  resolvedScenario,
+  summary,
+  session,
+  isStaleRepoOperation,
+}: {
+  selectedModel: AgentModelSelection | null;
+  requireModelReady: boolean;
+  defaultModelSelectionPromise: Promise<AgentModelSelection | null>;
+  repoPath: string;
+  taskId: string;
+  role: AgentRole;
+  resolvedScenario: AgentScenario;
+  summary: SessionStartSummary;
+  session: SessionDependencies;
+  isStaleRepoOperation: RepoStaleGuard;
+}): Promise<void> => {
+  if (selectedModel) {
+    return;
+  }
+
+  const tags = createSessionStartTags({
+    repoPath,
+    taskId,
+    role,
+    scenario: resolvedScenario,
+    sessionId: summary.sessionId,
+  });
+
+  if (requireModelReady) {
+    const resolvedModel = await captureOrchestratorFallback<AgentModelSelection | null>(
+      "start-session-await-default-model-selection",
+      async () => defaultModelSelectionPromise,
+      {
+        tags,
+        fallback: () => null,
+      },
+    );
+    throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+    applyResolvedModelSelection({
+      resolvedModel,
+      summary,
+      session,
+      isStaleRepoOperation,
+    });
+    return;
+  }
+
+  runOrchestratorSideEffect(
+    "start-session-apply-default-model-selection",
+    defaultModelSelectionPromise.then((defaultModelSelection) => {
+      applyResolvedModelSelection({
+        resolvedModel: defaultModelSelection,
+        summary,
+        session,
+        isStaleRepoOperation,
+      });
+    }),
+    { tags },
+  );
+};
+
+const maybeSendKickoff = async ({
+  sendKickoff,
+  repoPath,
+  taskId,
+  role,
+  resolvedScenario,
+  summary,
+  task,
+  isStaleRepoOperation,
+}: {
+  sendKickoff: boolean;
+  repoPath: string;
+  taskId: string;
+  role: AgentRole;
+  resolvedScenario: AgentScenario;
+  summary: SessionStartSummary;
+  task: TaskDependencies;
+  isStaleRepoOperation: RepoStaleGuard;
+}): Promise<void> => {
+  if (!sendKickoff) {
+    return;
+  }
+
+  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+  await task.sendAgentMessage(summary.sessionId, kickoffPrompt(role, resolvedScenario, taskId));
+  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+  runOrchestratorSideEffect(
+    "start-session-refresh-task-data-after-kickoff",
+    task.refreshTaskData(repoPath),
+    {
+      tags: createSessionStartTags({
+        repoPath,
+        taskId,
+        role,
+        scenario: resolvedScenario,
+        sessionId: summary.sessionId,
+      }),
+    },
+  );
+};
+
 export const createStartAgentSession = ({
-  activeRepo,
-  adapter,
-  setSessionsById,
-  sessionsRef,
-  taskRef,
-  repoEpochRef,
-  previousRepoRef,
-  inFlightStartsByRepoTaskRef,
-  attachSessionListener,
-  ensureRuntime,
-  loadTaskDocuments,
-  loadRepoDefaultModel,
-  loadSessionTodos,
-  loadSessionModelCatalog,
-  loadAgentSessions,
-  refreshTaskData,
-  persistSessionSnapshot,
-  sendAgentMessage,
+  repo,
+  session,
+  runtime,
+  task,
+  model,
 }: StartSessionDependencies) => {
   return async ({
     taskId,
@@ -116,9 +697,9 @@ export const createStartAgentSession = ({
     startMode = "reuse_latest",
     requireModelReady = false,
   }: StartAgentSessionInput): Promise<string> => {
-    const repoPath = requireActiveRepo(activeRepo);
+    const repoPath = requireActiveRepo(repo.activeRepo);
     const inFlightKey = `${repoPath}::${taskId}::${role}::${startMode}`;
-    const existingInFlight = inFlightStartsByRepoTaskRef.current.get(inFlightKey);
+    const existingInFlight = session.inFlightStartsByRepoTaskRef.current.get(inFlightKey);
     if (existingInFlight) {
       return existingInFlight;
     }
@@ -126,307 +707,83 @@ export const createStartAgentSession = ({
     const startPromise = (async (): Promise<string> => {
       const isStaleRepoOperation = createRepoStaleGuard({
         repoPath,
-        repoEpochRef,
-        previousRepoRef,
+        repoEpochRef: repo.repoEpochRef,
+        previousRepoRef: repo.previousRepoRef,
       });
       throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
 
-      if (startMode === "reuse_latest") {
-        const existingSession = pickLatestSession(
-          Object.values(sessionsRef.current).filter(
-            (entry) => entry.taskId === taskId && entry.role === role,
-          ),
-        );
-        if (existingSession) {
-          return existingSession.sessionId;
-        }
-
-        const persistedSessions = await host.agentSessionsList(repoPath, taskId);
-        throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-        const latestPersistedSession = pickLatestSession(
-          persistedSessions.filter((entry) => entry.role === role),
-        );
-        if (latestPersistedSession) {
-          if (!sessionsRef.current[latestPersistedSession.sessionId]) {
-            await loadAgentSessions(taskId, {
-              hydrateHistoryForSessionId: latestPersistedSession.sessionId,
-            });
-            throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-          }
-          return latestPersistedSession.sessionId;
-        }
-      }
-
-      const task = taskRef.current.find((entry) => entry.id === taskId);
-      if (!task) {
-        throw new Error(`Task not found: ${taskId}`);
-      }
-      if (!isRoleAvailableForTask(task, role)) {
-        throw new Error(unavailableRoleErrorMessage(task, role));
-      }
-
-      const docsPromise = loadTaskDocuments(repoPath, taskId);
-      const runtimePromise = ensureRuntime(repoPath, taskId, role);
-      const defaultModelSelectionPromise = loadRepoDefaultModel(repoPath, role);
-
-      const [docs, runtime] = await Promise.all([docsPromise, runtimePromise]);
-      throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-      const resolvedScenario = scenario ?? inferScenario(role, task, docs);
-      throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-      const systemPrompt = buildAgentSystemPrompt({
-        role,
-        scenario: resolvedScenario,
-        task: {
-          taskId: task.id,
-          title: task.title,
-          issueType: task.issueType,
-          status: task.status,
-          qaRequired: task.aiReviewEnabled,
-          description: task.description,
-          acceptanceCriteria: task.acceptanceCriteria,
-          specMarkdown: docs.specMarkdown,
-          planMarkdown: docs.planMarkdown,
-          latestQaReportMarkdown: docs.qaMarkdown,
-        },
-      });
-
-      const summary = await adapter.startSession({
+      const startResult = await createOrReuseSession({
         repoPath,
-        workingDirectory: runtime.workingDirectory,
         taskId,
         role,
-        scenario: resolvedScenario,
-        systemPrompt,
-        baseUrl: runtime.baseUrl,
-      });
-      if (isStaleRepoOperation()) {
-        await captureOrchestratorFallback(
-          "start-session-stop-on-stale-after-start",
-          async () => adapter.stopSession(summary.sessionId),
-          {
-            tags: {
-              repoPath,
-              taskId,
-              role,
-              scenario: resolvedScenario,
-              sessionId: summary.sessionId,
-            },
-            fallback: () => undefined,
-          },
-        );
-        throw new Error(STALE_START_ERROR);
-      }
-
-      const initialSession: AgentSessionState = {
-        sessionId: summary.sessionId,
-        externalSessionId: summary.externalSessionId,
-        taskId,
-        role,
-        scenario: resolvedScenario,
-        status: "idle",
-        startedAt: summary.startedAt,
-        runtimeId: runtime.runtimeId,
-        runId: runtime.runId,
-        baseUrl: runtime.baseUrl,
-        workingDirectory: runtime.workingDirectory,
-        messages: [
-          {
-            id: crypto.randomUUID(),
-            role: "system",
-            content: `Session started (${role} - ${resolvedScenario})`,
-            timestamp: summary.startedAt,
-          },
-          {
-            id: crypto.randomUUID(),
-            role: "system",
-            content: `System prompt:\n\n${systemPrompt}`,
-            timestamp: summary.startedAt,
-          },
-        ],
-        draftAssistantText: "",
-        pendingPermissions: [],
-        pendingQuestions: [],
-        todos: [],
-        modelCatalog: null,
+        scenario,
         selectedModel,
-        isLoadingModelCatalog: true,
-      };
-
-      sessionsRef.current = {
-        ...sessionsRef.current,
-        [summary.sessionId]: initialSession,
-      };
-
-      setSessionsById((current) => {
-        if (isStaleRepoOperation()) {
-          return current;
-        }
-        return {
-          ...current,
-          [summary.sessionId]: initialSession,
-        };
+        startMode,
+        session,
+        runtime,
+        task,
+        model,
+        isStaleRepoOperation,
       });
-      throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-      runOrchestratorSideEffect(
-        "start-session-persist-initial-session",
-        persistSessionSnapshot(initialSession),
-        {
-          tags: {
-            repoPath,
-            taskId,
-            role,
-            scenario: resolvedScenario,
-            sessionId: summary.sessionId,
-          },
-        },
-      );
-
-      attachSessionListener(repoPath, summary.sessionId);
-
-      if (isStaleRepoOperation()) {
-        await captureOrchestratorFallback(
-          "start-session-stop-on-stale-after-listener-attach",
-          async () => adapter.stopSession(summary.sessionId),
-          {
-            tags: {
-              repoPath,
-              taskId,
-              role,
-              scenario: resolvedScenario,
-              sessionId: summary.sessionId,
-            },
-            fallback: () => undefined,
-          },
-        );
-        throw new Error(STALE_START_ERROR);
+      if (startResult.kind === "reused") {
+        return startResult.sessionId;
       }
 
-      const warmSessionData = (): void => {
-        runOrchestratorSideEffect(
-          "start-session-warm-session-todos",
-          loadSessionTodos(
-            summary.sessionId,
-            runtime.baseUrl,
-            runtime.workingDirectory,
-            summary.externalSessionId,
-          ),
-          {
-            tags: {
-              repoPath,
-              taskId,
-              role,
-              scenario: resolvedScenario,
-              sessionId: summary.sessionId,
-              externalSessionId: summary.externalSessionId,
-            },
-          },
-        );
-        runOrchestratorSideEffect(
-          "start-session-warm-session-model-catalog",
-          loadSessionModelCatalog(summary.sessionId, runtime.baseUrl, runtime.workingDirectory),
-          {
-            tags: {
-              repoPath,
-              taskId,
-              role,
-              scenario: resolvedScenario,
-              sessionId: summary.sessionId,
-            },
-          },
-        );
-      };
-      warmSessionData();
+      await attachSessionListenerAndGuard({
+        repoPath,
+        taskId,
+        role,
+        resolvedScenario: startResult.resolvedScenario,
+        summary: startResult.summary,
+        session,
+        runtime,
+        isStaleRepoOperation,
+      });
 
-      const applyResolvedModelSelection = (resolvedModel: AgentModelSelection | null): void => {
-        if (isStaleRepoOperation() || !resolvedModel) {
-          return;
-        }
+      warmSessionData({
+        taskId,
+        role,
+        repoPath,
+        resolvedScenario: startResult.resolvedScenario,
+        runtime: startResult.runtime,
+        summary: startResult.summary,
+        model,
+      });
 
-        setSessionsById((current) => {
-          const currentSession = current[summary.sessionId];
-          if (!currentSession || currentSession.selectedModel) {
-            return current;
-          }
+      await maybeApplyDefaultModelSelection({
+        selectedModel,
+        requireModelReady,
+        defaultModelSelectionPromise: startResult.defaultModelSelectionPromise,
+        repoPath,
+        taskId,
+        role,
+        resolvedScenario: startResult.resolvedScenario,
+        summary: startResult.summary,
+        session,
+        isStaleRepoOperation,
+      });
 
-          const nextSession: AgentSessionState = {
-            ...currentSession,
-            selectedModel: resolvedModel,
-          };
-          const nextSessions = {
-            ...current,
-            [summary.sessionId]: nextSession,
-          };
-          sessionsRef.current = nextSessions;
-          return nextSessions;
-        });
-      };
+      await maybeSendKickoff({
+        sendKickoff,
+        repoPath,
+        taskId: startResult.task.id,
+        role,
+        resolvedScenario: startResult.resolvedScenario,
+        summary: startResult.summary,
+        task,
+        isStaleRepoOperation,
+      });
 
-      if (!selectedModel) {
-        if (requireModelReady) {
-          const resolvedModel = await captureOrchestratorFallback<AgentModelSelection | null>(
-            "start-session-await-default-model-selection",
-            async () => defaultModelSelectionPromise,
-            {
-              tags: {
-                repoPath,
-                taskId,
-                role,
-                scenario: resolvedScenario,
-                sessionId: summary.sessionId,
-              },
-              fallback: () => null,
-            },
-          );
-          throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-          applyResolvedModelSelection(resolvedModel);
-        } else {
-          runOrchestratorSideEffect(
-            "start-session-apply-default-model-selection",
-            defaultModelSelectionPromise.then((defaultModelSelection) => {
-              applyResolvedModelSelection(defaultModelSelection);
-            }),
-            {
-              tags: {
-                repoPath,
-                taskId,
-                role,
-                scenario: resolvedScenario,
-                sessionId: summary.sessionId,
-              },
-            },
-          );
-        }
-      }
-
-      if (sendKickoff) {
-        throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-        await sendAgentMessage(summary.sessionId, kickoffPrompt(role, resolvedScenario, task.id));
-        throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-        runOrchestratorSideEffect(
-          "start-session-refresh-task-data-after-kickoff",
-          refreshTaskData(repoPath),
-          {
-            tags: {
-              repoPath,
-              taskId,
-              role,
-              scenario: resolvedScenario,
-              sessionId: summary.sessionId,
-            },
-          },
-        );
-      }
-
-      return summary.sessionId;
+      return startResult.summary.sessionId;
     })();
 
-    inFlightStartsByRepoTaskRef.current.set(inFlightKey, startPromise);
+    session.inFlightStartsByRepoTaskRef.current.set(inFlightKey, startPromise);
     try {
       return await startPromise;
     } finally {
-      const currentInFlight = inFlightStartsByRepoTaskRef.current.get(inFlightKey);
+      const currentInFlight = session.inFlightStartsByRepoTaskRef.current.get(inFlightKey);
       if (currentInFlight === startPromise) {
-        inFlightStartsByRepoTaskRef.current.delete(inFlightKey);
+        session.inFlightStartsByRepoTaskRef.current.delete(inFlightKey);
       }
     }
   };

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -77,7 +77,7 @@ type RepoDependencies = {
   previousRepoRef: { current: string | null };
 };
 
-type StartSessionDependencies = {
+export type StartSessionDependencies = {
   repo: RepoDependencies;
   session: SessionDependencies;
   runtime: RuntimeDependencies;
@@ -97,8 +97,31 @@ type SessionStartTags = {
   sessionId: string;
 };
 
+type StartSessionContext = {
+  repoPath: string;
+  taskId: string;
+  role: AgentRole;
+  isStaleRepoOperation: RepoStaleGuard;
+};
+
+type StartedSessionContext = StartSessionContext & {
+  summary: SessionStartSummary;
+  resolvedScenario: AgentScenario;
+};
+
+type StartSessionExecutionDependencies = Pick<
+  StartSessionDependencies,
+  "session" | "runtime" | "task" | "model"
+>;
+
+type StartSessionCreationInput = {
+  scenario: AgentScenario | undefined;
+  selectedModel: AgentModelSelection | null;
+  startMode: "reuse_latest" | "fresh";
+};
+
 type ResolvedRuntimeAndModel = {
-  task: TaskCard;
+  taskCard: TaskCard;
   runtime: RuntimeInfo;
   resolvedScenario: AgentScenario;
   systemPrompt: string;
@@ -112,10 +135,8 @@ type StartOrReuseResult =
     }
   | {
       kind: "started";
-      task: TaskCard;
-      runtime: RuntimeInfo;
-      summary: SessionStartSummary;
-      resolvedScenario: AgentScenario;
+      runtimeInfo: RuntimeInfo;
+      ctx: StartedSessionContext;
       defaultModelSelectionPromise: Promise<AgentModelSelection | null>;
     };
 
@@ -142,25 +163,26 @@ const createSessionStartTags = ({
   repoPath,
   taskId,
   role,
-  scenario,
-  sessionId,
-}: SessionStartTags): SessionStartTags => ({
+  resolvedScenario,
+  summary,
+}: StartedSessionContext): SessionStartTags => ({
   repoPath,
   taskId,
   role,
-  scenario,
-  sessionId,
+  scenario: resolvedScenario,
+  sessionId: summary.sessionId,
 });
 
 const stopSessionOnStaleAndThrow = async ({
   reason,
   runtime,
-  tags,
+  startedCtx,
 }: {
   reason: string;
   runtime: RuntimeDependencies;
-  tags: SessionStartTags;
+  startedCtx: StartedSessionContext;
 }): Promise<never> => {
+  const tags = createSessionStartTags(startedCtx);
   await captureOrchestratorFallback(
     reason,
     async () => runtime.adapter.stopSession(tags.sessionId),
@@ -173,57 +195,45 @@ const stopSessionOnStaleAndThrow = async ({
 };
 
 const resolveStartTask = ({
-  taskId,
-  role,
+  ctx,
   task,
 }: {
-  taskId: string;
-  role: AgentRole;
+  ctx: StartSessionContext;
   task: TaskDependencies;
 }): TaskCard => {
-  const resolvedTask = task.taskRef.current.find((entry) => entry.id === taskId);
+  const resolvedTask = task.taskRef.current.find((entry) => entry.id === ctx.taskId);
   if (!resolvedTask) {
-    throw new Error(`Task not found: ${taskId}`);
+    throw new Error(`Task not found: ${ctx.taskId}`);
   }
-  if (!isRoleAvailableForTask(resolvedTask, role)) {
-    throw new Error(unavailableRoleErrorMessage(resolvedTask, role));
+  if (!isRoleAvailableForTask(resolvedTask, ctx.role)) {
+    throw new Error(unavailableRoleErrorMessage(resolvedTask, ctx.role));
   }
   return resolvedTask;
 };
 
 const resolveRuntimeAndModel = async ({
-  repoPath,
-  taskId,
-  role,
+  ctx,
   scenario,
   taskCard,
-  runtime,
-  task,
-  model,
-  isStaleRepoOperation,
+  deps,
 }: {
-  repoPath: string;
-  taskId: string;
-  role: AgentRole;
+  ctx: StartSessionContext;
   scenario: AgentScenario | undefined;
   taskCard: TaskCard;
-  runtime: RuntimeDependencies;
-  task: TaskDependencies;
-  model: ModelDependencies;
-  isStaleRepoOperation: RepoStaleGuard;
+  deps: Pick<StartSessionExecutionDependencies, "runtime" | "task" | "model">;
 }): Promise<ResolvedRuntimeAndModel> => {
-  const docsPromise = task.loadTaskDocuments(repoPath, taskId);
-  const runtimePromise = runtime.ensureRuntime(repoPath, taskId, role);
-  const defaultModelSelectionPromise = model.loadRepoDefaultModel(repoPath, role);
+  const docsPromise = deps.task.loadTaskDocuments(ctx.repoPath, ctx.taskId);
+  const runtimePromise = deps.runtime.ensureRuntime(ctx.repoPath, ctx.taskId, ctx.role);
+  const defaultModelSelectionPromise = deps.model.loadRepoDefaultModel(ctx.repoPath, ctx.role);
 
   const [docs, runtimeInfo] = await Promise.all([docsPromise, runtimePromise]);
-  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+  throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
 
-  const resolvedScenario = scenario ?? inferScenario(role, taskCard, docs);
-  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+  const resolvedScenario = scenario ?? inferScenario(ctx.role, taskCard, docs);
+  throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
 
   const systemPrompt = buildAgentSystemPrompt({
-    role,
+    role: ctx.role,
     scenario: resolvedScenario,
     task: {
       taskId: taskCard.id,
@@ -240,7 +250,7 @@ const resolveRuntimeAndModel = async ({
   });
 
   return {
-    task: taskCard,
+    taskCard,
     runtime: runtimeInfo,
     resolvedScenario,
     systemPrompt,
@@ -249,29 +259,23 @@ const resolveRuntimeAndModel = async ({
 };
 
 const buildInitialSession = ({
-  taskId,
-  role,
-  resolvedScenario,
+  startedCtx,
   selectedModel,
   runtime,
-  summary,
   systemPrompt,
 }: {
-  taskId: string;
-  role: AgentRole;
-  resolvedScenario: AgentScenario;
+  startedCtx: StartedSessionContext;
   selectedModel: AgentModelSelection | null;
   runtime: RuntimeInfo;
-  summary: SessionStartSummary;
   systemPrompt: string;
 }): AgentSessionState => ({
-  sessionId: summary.sessionId,
-  externalSessionId: summary.externalSessionId,
-  taskId,
-  role,
-  scenario: resolvedScenario,
+  sessionId: startedCtx.summary.sessionId,
+  externalSessionId: startedCtx.summary.externalSessionId,
+  taskId: startedCtx.taskId,
+  role: startedCtx.role,
+  scenario: startedCtx.resolvedScenario,
   status: "idle",
-  startedAt: summary.startedAt,
+  startedAt: startedCtx.summary.startedAt,
   runtimeId: runtime.runtimeId,
   runId: runtime.runId,
   baseUrl: runtime.baseUrl,
@@ -280,14 +284,14 @@ const buildInitialSession = ({
     {
       id: crypto.randomUUID(),
       role: "system",
-      content: `Session started (${role} - ${resolvedScenario})`,
-      timestamp: summary.startedAt,
+      content: `Session started (${startedCtx.role} - ${startedCtx.resolvedScenario})`,
+      timestamp: startedCtx.summary.startedAt,
     },
     {
       id: crypto.randomUUID(),
       role: "system",
       content: `System prompt:\n\n${systemPrompt}`,
-      timestamp: summary.startedAt,
+      timestamp: startedCtx.summary.startedAt,
     },
   ],
   draftAssistantText: "",
@@ -316,34 +320,18 @@ const persistInitialSession = ({
 };
 
 const createOrReuseSession = async ({
-  repoPath,
-  taskId,
-  role,
-  scenario,
-  selectedModel,
-  startMode,
-  session,
-  runtime,
-  task,
-  model,
-  isStaleRepoOperation,
+  ctx,
+  input,
+  deps,
 }: {
-  repoPath: string;
-  taskId: string;
-  role: AgentRole;
-  scenario: AgentScenario | undefined;
-  selectedModel: AgentModelSelection | null;
-  startMode: "reuse_latest" | "fresh";
-  session: SessionDependencies;
-  runtime: RuntimeDependencies;
-  task: TaskDependencies;
-  model: ModelDependencies;
-  isStaleRepoOperation: RepoStaleGuard;
+  ctx: StartSessionContext;
+  input: StartSessionCreationInput;
+  deps: StartSessionExecutionDependencies;
 }): Promise<StartOrReuseResult> => {
-  if (startMode === "reuse_latest") {
+  if (input.startMode === "reuse_latest") {
     const existingSession = pickLatestSession(
-      Object.values(session.sessionsRef.current).filter(
-        (entry) => entry.taskId === taskId && entry.role === role,
+      Object.values(deps.session.sessionsRef.current).filter(
+        (entry) => entry.taskId === ctx.taskId && entry.role === ctx.role,
       ),
     );
     if (existingSession) {
@@ -353,17 +341,17 @@ const createOrReuseSession = async ({
       };
     }
 
-    const persistedSessions = await host.agentSessionsList(repoPath, taskId);
-    throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+    const persistedSessions = await host.agentSessionsList(ctx.repoPath, ctx.taskId);
+    throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
     const latestPersistedSession = pickLatestSession(
-      persistedSessions.filter((entry) => entry.role === role),
+      persistedSessions.filter((entry) => entry.role === ctx.role),
     );
     if (latestPersistedSession) {
-      if (!session.sessionsRef.current[latestPersistedSession.sessionId]) {
-        await session.loadAgentSessions(taskId, {
+      if (!deps.session.sessionsRef.current[latestPersistedSession.sessionId]) {
+        await deps.session.loadAgentSessions(ctx.taskId, {
           hydrateHistoryForSessionId: latestPersistedSession.sessionId,
         });
-        throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+        throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
       }
       return {
         kind: "reused",
@@ -372,61 +360,51 @@ const createOrReuseSession = async ({
     }
   }
 
-  const taskCard = resolveStartTask({ taskId, role, task });
+  const taskCard = resolveStartTask({ ctx, task: deps.task });
   const resolved = await resolveRuntimeAndModel({
-    repoPath,
-    taskId,
-    role,
-    scenario,
+    ctx,
+    scenario: input.scenario,
     taskCard,
-    runtime,
-    task,
-    model,
-    isStaleRepoOperation,
+    deps,
   });
 
-  const summary = await runtime.adapter.startSession({
-    repoPath,
+  const summary = await deps.runtime.adapter.startSession({
+    repoPath: ctx.repoPath,
     workingDirectory: resolved.runtime.workingDirectory,
-    taskId,
-    role,
+    taskId: ctx.taskId,
+    role: ctx.role,
     scenario: resolved.resolvedScenario,
     systemPrompt: resolved.systemPrompt,
     baseUrl: resolved.runtime.baseUrl,
   });
 
-  const sessionTags = createSessionStartTags({
-    repoPath,
-    taskId,
-    role,
-    scenario: resolved.resolvedScenario,
-    sessionId: summary.sessionId,
-  });
+  const startedCtx: StartedSessionContext = {
+    ...ctx,
+    resolvedScenario: resolved.resolvedScenario,
+    summary,
+  };
 
-  if (isStaleRepoOperation()) {
+  if (ctx.isStaleRepoOperation()) {
     await stopSessionOnStaleAndThrow({
       reason: "start-session-stop-on-stale-after-start",
-      runtime,
-      tags: sessionTags,
+      runtime: deps.runtime,
+      startedCtx,
     });
   }
 
   const initialSession = buildInitialSession({
-    taskId,
-    role,
-    resolvedScenario: resolved.resolvedScenario,
-    selectedModel,
+    startedCtx,
+    selectedModel: input.selectedModel,
     runtime: resolved.runtime,
-    summary,
     systemPrompt: resolved.systemPrompt,
   });
 
-  session.sessionsRef.current = {
-    ...session.sessionsRef.current,
+  deps.session.sessionsRef.current = {
+    ...deps.session.sessionsRef.current,
     [summary.sessionId]: initialSession,
   };
-  session.setSessionsById((current) => {
-    if (isStaleRepoOperation()) {
+  deps.session.setSessionsById((current) => {
+    if (ctx.isStaleRepoOperation()) {
       return current;
     }
     return {
@@ -434,127 +412,97 @@ const createOrReuseSession = async ({
       [summary.sessionId]: initialSession,
     };
   });
-  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+  throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
 
   persistInitialSession({
     initialSession,
-    session,
-    tags: sessionTags,
+    session: deps.session,
+    tags: createSessionStartTags(startedCtx),
   });
 
   return {
     kind: "started",
-    task: resolved.task,
-    runtime: resolved.runtime,
-    summary,
-    resolvedScenario: resolved.resolvedScenario,
+    runtimeInfo: resolved.runtime,
+    ctx: startedCtx,
     defaultModelSelectionPromise: resolved.defaultModelSelectionPromise,
   };
 };
 
 const attachSessionListenerAndGuard = async ({
-  repoPath,
-  taskId,
-  role,
-  resolvedScenario,
-  summary,
+  startedCtx,
   session,
   runtime,
-  isStaleRepoOperation,
 }: {
-  repoPath: string;
-  taskId: string;
-  role: AgentRole;
-  resolvedScenario: AgentScenario;
-  summary: SessionStartSummary;
+  startedCtx: StartedSessionContext;
   session: SessionDependencies;
   runtime: RuntimeDependencies;
-  isStaleRepoOperation: RepoStaleGuard;
 }): Promise<void> => {
-  session.attachSessionListener(repoPath, summary.sessionId);
+  session.attachSessionListener(startedCtx.repoPath, startedCtx.summary.sessionId);
 
-  if (!isStaleRepoOperation()) {
+  if (!startedCtx.isStaleRepoOperation()) {
     return;
   }
 
   await stopSessionOnStaleAndThrow({
     reason: "start-session-stop-on-stale-after-listener-attach",
     runtime,
-    tags: createSessionStartTags({
-      repoPath,
-      taskId,
-      role,
-      scenario: resolvedScenario,
-      sessionId: summary.sessionId,
-    }),
+    startedCtx,
   });
 };
 
 const warmSessionData = ({
-  taskId,
-  role,
-  repoPath,
-  resolvedScenario,
-  runtime,
-  summary,
+  startedCtx,
+  runtimeInfo,
   model,
 }: {
-  taskId: string;
-  role: AgentRole;
-  repoPath: string;
-  resolvedScenario: AgentScenario;
-  runtime: RuntimeInfo;
-  summary: SessionStartSummary;
+  startedCtx: StartedSessionContext;
+  runtimeInfo: RuntimeInfo;
   model: ModelDependencies;
 }): void => {
-  const tags = createSessionStartTags({
-    repoPath,
-    taskId,
-    role,
-    scenario: resolvedScenario,
-    sessionId: summary.sessionId,
-  });
+  const tags = createSessionStartTags(startedCtx);
 
   runOrchestratorSideEffect(
     "start-session-warm-session-todos",
     model.loadSessionTodos(
-      summary.sessionId,
-      runtime.baseUrl,
-      runtime.workingDirectory,
-      summary.externalSessionId,
+      startedCtx.summary.sessionId,
+      runtimeInfo.baseUrl,
+      runtimeInfo.workingDirectory,
+      startedCtx.summary.externalSessionId,
     ),
     {
       tags: {
         ...tags,
-        externalSessionId: summary.externalSessionId,
+        externalSessionId: startedCtx.summary.externalSessionId,
       },
     },
   );
 
   runOrchestratorSideEffect(
     "start-session-warm-session-model-catalog",
-    model.loadSessionModelCatalog(summary.sessionId, runtime.baseUrl, runtime.workingDirectory),
+    model.loadSessionModelCatalog(
+      startedCtx.summary.sessionId,
+      runtimeInfo.baseUrl,
+      runtimeInfo.workingDirectory,
+    ),
     { tags },
   );
 };
 
 const applyResolvedModelSelection = ({
   resolvedModel,
-  summary,
+  startedCtx,
   session,
-  isStaleRepoOperation,
 }: {
   resolvedModel: AgentModelSelection | null;
-  summary: SessionStartSummary;
+  startedCtx: StartedSessionContext;
   session: SessionDependencies;
-  isStaleRepoOperation: RepoStaleGuard;
 }): void => {
-  if (isStaleRepoOperation() || !resolvedModel) {
+  if (startedCtx.isStaleRepoOperation() || !resolvedModel) {
     return;
   }
 
   session.setSessionsById((current) => {
-    const currentSession = current[summary.sessionId];
+    const currentSession = current[startedCtx.summary.sessionId];
     if (!currentSession || currentSession.selectedModel) {
       return current;
     }
@@ -565,7 +513,7 @@ const applyResolvedModelSelection = ({
     };
     const nextSessions = {
       ...current,
-      [summary.sessionId]: nextSession,
+      [startedCtx.summary.sessionId]: nextSession,
     };
     session.sessionsRef.current = nextSessions;
     return nextSessions;
@@ -576,36 +524,20 @@ const maybeApplyDefaultModelSelection = async ({
   selectedModel,
   requireModelReady,
   defaultModelSelectionPromise,
-  repoPath,
-  taskId,
-  role,
-  resolvedScenario,
-  summary,
+  startedCtx,
   session,
-  isStaleRepoOperation,
 }: {
   selectedModel: AgentModelSelection | null;
   requireModelReady: boolean;
   defaultModelSelectionPromise: Promise<AgentModelSelection | null>;
-  repoPath: string;
-  taskId: string;
-  role: AgentRole;
-  resolvedScenario: AgentScenario;
-  summary: SessionStartSummary;
+  startedCtx: StartedSessionContext;
   session: SessionDependencies;
-  isStaleRepoOperation: RepoStaleGuard;
 }): Promise<void> => {
   if (selectedModel) {
     return;
   }
 
-  const tags = createSessionStartTags({
-    repoPath,
-    taskId,
-    role,
-    scenario: resolvedScenario,
-    sessionId: summary.sessionId,
-  });
+  const tags = createSessionStartTags(startedCtx);
 
   if (requireModelReady) {
     const resolvedModel = await captureOrchestratorFallback<AgentModelSelection | null>(
@@ -616,12 +548,11 @@ const maybeApplyDefaultModelSelection = async ({
         fallback: () => null,
       },
     );
-    throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+    throwIfRepoStale(startedCtx.isStaleRepoOperation, STALE_START_ERROR);
     applyResolvedModelSelection({
       resolvedModel,
-      summary,
+      startedCtx,
       session,
-      isStaleRepoOperation,
     });
     return;
   }
@@ -631,9 +562,8 @@ const maybeApplyDefaultModelSelection = async ({
     defaultModelSelectionPromise.then((defaultModelSelection) => {
       applyResolvedModelSelection({
         resolvedModel: defaultModelSelection,
-        summary,
+        startedCtx,
         session,
-        isStaleRepoOperation,
       });
     }),
     { tags },
@@ -642,41 +572,28 @@ const maybeApplyDefaultModelSelection = async ({
 
 const maybeSendKickoff = async ({
   sendKickoff,
-  repoPath,
-  taskId,
-  role,
-  resolvedScenario,
-  summary,
+  startedCtx,
   task,
-  isStaleRepoOperation,
 }: {
   sendKickoff: boolean;
-  repoPath: string;
-  taskId: string;
-  role: AgentRole;
-  resolvedScenario: AgentScenario;
-  summary: SessionStartSummary;
+  startedCtx: StartedSessionContext;
   task: TaskDependencies;
-  isStaleRepoOperation: RepoStaleGuard;
 }): Promise<void> => {
   if (!sendKickoff) {
     return;
   }
 
-  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
-  await task.sendAgentMessage(summary.sessionId, kickoffPrompt(role, resolvedScenario, taskId));
-  throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
+  throwIfRepoStale(startedCtx.isStaleRepoOperation, STALE_START_ERROR);
+  await task.sendAgentMessage(
+    startedCtx.summary.sessionId,
+    kickoffPrompt(startedCtx.role, startedCtx.resolvedScenario, startedCtx.taskId),
+  );
+  throwIfRepoStale(startedCtx.isStaleRepoOperation, STALE_START_ERROR);
   runOrchestratorSideEffect(
     "start-session-refresh-task-data-after-kickoff",
-    task.refreshTaskData(repoPath),
+    task.refreshTaskData(startedCtx.repoPath),
     {
-      tags: createSessionStartTags({
-        repoPath,
-        taskId,
-        role,
-        scenario: resolvedScenario,
-        sessionId: summary.sessionId,
-      }),
+      tags: createSessionStartTags(startedCtx),
     },
   );
 };
@@ -712,41 +629,40 @@ export const createStartAgentSession = ({
       });
       throwIfRepoStale(isStaleRepoOperation, STALE_START_ERROR);
 
-      const startResult = await createOrReuseSession({
+      const startCtx: StartSessionContext = {
         repoPath,
         taskId,
         role,
-        scenario,
-        selectedModel,
-        startMode,
-        session,
-        runtime,
-        task,
-        model,
         isStaleRepoOperation,
+      };
+
+      const startResult = await createOrReuseSession({
+        ctx: startCtx,
+        input: {
+          scenario,
+          selectedModel,
+          startMode,
+        },
+        deps: {
+          session,
+          runtime,
+          task,
+          model,
+        },
       });
       if (startResult.kind === "reused") {
         return startResult.sessionId;
       }
 
       await attachSessionListenerAndGuard({
-        repoPath,
-        taskId,
-        role,
-        resolvedScenario: startResult.resolvedScenario,
-        summary: startResult.summary,
+        startedCtx: startResult.ctx,
         session,
         runtime,
-        isStaleRepoOperation,
       });
 
       warmSessionData({
-        taskId,
-        role,
-        repoPath,
-        resolvedScenario: startResult.resolvedScenario,
-        runtime: startResult.runtime,
-        summary: startResult.summary,
+        startedCtx: startResult.ctx,
+        runtimeInfo: startResult.runtimeInfo,
         model,
       });
 
@@ -754,27 +670,17 @@ export const createStartAgentSession = ({
         selectedModel,
         requireModelReady,
         defaultModelSelectionPromise: startResult.defaultModelSelectionPromise,
-        repoPath,
-        taskId,
-        role,
-        resolvedScenario: startResult.resolvedScenario,
-        summary: startResult.summary,
+        startedCtx: startResult.ctx,
         session,
-        isStaleRepoOperation,
       });
 
       await maybeSendKickoff({
         sendKickoff,
-        repoPath,
-        taskId: startResult.task.id,
-        role,
-        resolvedScenario: startResult.resolvedScenario,
-        summary: startResult.summary,
+        startedCtx: startResult.ctx,
         task,
-        isStaleRepoOperation,
       });
 
-      return startResult.summary.sessionId;
+      return startResult.ctx.summary.sessionId;
     })();
 
     session.inFlightStartsByRepoTaskRef.current.set(inFlightKey, startPromise);

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -399,18 +399,22 @@ const createOrReuseSession = async ({
     systemPrompt: resolved.systemPrompt,
   });
 
-  deps.session.sessionsRef.current = {
+  const optimisticSessions = {
     ...deps.session.sessionsRef.current,
     [summary.sessionId]: initialSession,
   };
+  deps.session.sessionsRef.current = optimisticSessions;
   deps.session.setSessionsById((current) => {
     if (ctx.isStaleRepoOperation()) {
+      deps.session.sessionsRef.current = current;
       return current;
     }
-    return {
+    const nextSessions = {
       ...current,
       [summary.sessionId]: initialSession,
     };
+    deps.session.sessionsRef.current = nextSessions;
+    return nextSessions;
   });
   throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
 


### PR DESCRIPTION
## Summary
- reduce `createStartAgentSession` dependency and helper parameter bloat by introducing grouped deps and execution contexts
- split start-session workflow into focused phases while preserving stale-repo guards and side-effect ordering
- add targeted regression tests for stale-after-listener rollback and `requireModelReady` success/fallback behavior
- extract shared start-session test dependency mapping into `start-session.test-helpers.ts`

## Validation
- `bun run --filter @openducktor/desktop test -- src/state/operations/agent-orchestrator/handlers/start-session.test.ts`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop test`

## Commits
- `becf6ec` refactor(desktop): split start-session deps into grouped phases
- `73bbef8` refactor(desktop): simplify start-session phases and harden regression tests
