### PR TITLE
perf(desktop): stabilize external branch probe lifecycle

### DIFF
--- a/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
@@ -302,4 +302,112 @@ describe("use-workspace-operations", () => {
       host.gitGetBranches = original.gitGetBranches;
     }
   });
+
+  test("keeps branch probe interval/listeners mounted while branch loading and switching flags change", async () => {
+    const setActiveRepo = mock(() => {});
+    const addWindowEventListener = mock(() => {});
+    const removeWindowEventListener = mock(() => {});
+    const setIntervalMock = mock(() => 1);
+    const clearIntervalMock = mock(() => {});
+    const addDocumentEventListener = mock(() => {});
+    const removeDocumentEventListener = mock(() => {});
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
+    const fakeWindow = {
+      addEventListener: addWindowEventListener,
+      removeEventListener: removeWindowEventListener,
+      setInterval: setIntervalMock,
+      clearInterval: clearIntervalMock,
+    } as unknown as Window;
+    const fakeDocument = {
+      addEventListener: addDocumentEventListener,
+      removeEventListener: removeDocumentEventListener,
+      visibilityState: "visible" as const,
+    } as unknown as Document;
+
+    const gitGetCurrentBranch = mock(async () => ({
+      name: "main",
+      detached: false,
+    }));
+    const gitGetBranches = mock(async () => [
+      {
+        name: "main",
+        isCurrent: true,
+        isRemote: false,
+      },
+      {
+        name: "feature",
+        isCurrent: false,
+        isRemote: false,
+      },
+    ]);
+    const gitSwitchBranch = mock(async (_repoPath: string, branchName: string) => ({
+      name: branchName,
+      detached: false,
+    }));
+
+    const original = {
+      gitGetCurrentBranch: host.gitGetCurrentBranch,
+      gitGetBranches: host.gitGetBranches,
+      gitSwitchBranch: host.gitSwitchBranch,
+    };
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      writable: true,
+      value: fakeWindow,
+    });
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      writable: true,
+      value: fakeDocument,
+    });
+    host.gitGetCurrentBranch = gitGetCurrentBranch;
+    host.gitGetBranches = gitGetBranches;
+    host.gitSwitchBranch = gitSwitchBranch;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      setActiveRepo,
+      clearTaskData: () => {},
+      clearActiveBeadsCheck: () => {},
+    });
+
+    try {
+      await harness.mount();
+      expect(addWindowEventListener).toHaveBeenCalledTimes(1);
+      expect(addDocumentEventListener).toHaveBeenCalledTimes(1);
+      expect(setIntervalMock).toHaveBeenCalledTimes(1);
+
+      await harness.run(async (value) => {
+        await value.refreshBranches();
+      });
+      await harness.run(async (value) => {
+        await value.switchBranch("feature");
+      });
+
+      expect(addWindowEventListener).toHaveBeenCalledTimes(1);
+      expect(addDocumentEventListener).toHaveBeenCalledTimes(1);
+      expect(setIntervalMock).toHaveBeenCalledTimes(1);
+      expect(removeWindowEventListener).not.toHaveBeenCalled();
+      expect(removeDocumentEventListener).not.toHaveBeenCalled();
+      expect(clearIntervalMock).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+      host.gitGetCurrentBranch = original.gitGetCurrentBranch;
+      host.gitGetBranches = original.gitGetBranches;
+      host.gitSwitchBranch = original.gitSwitchBranch;
+
+      if (windowDescriptor) {
+        Object.defineProperty(globalThis, "window", windowDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "window");
+      }
+      if (documentDescriptor) {
+        Object.defineProperty(globalThis, "document", documentDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "document");
+      }
+    }
+  });
 });

--- a/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
@@ -15,6 +15,47 @@ const flush = async (): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, 0));
 };
 
+const setGlobalProperty = (key: "window" | "document", value: unknown): void => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, key);
+  if (!descriptor || descriptor.configurable) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      writable: true,
+      value,
+    });
+    return;
+  }
+
+  if ("writable" in descriptor && descriptor.writable) {
+    (globalThis as Record<string, unknown>)[key] = value;
+    return;
+  }
+
+  throw new Error(`Cannot override global ${key}`);
+};
+
+const mockBrowserGlobals = (windowValue: Window, documentValue: Document): (() => void) => {
+  const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
+
+  setGlobalProperty("window", windowValue);
+  setGlobalProperty("document", documentValue);
+
+  return () => {
+    if (windowDescriptor) {
+      Object.defineProperty(globalThis, "window", windowDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, "window");
+    }
+
+    if (documentDescriptor) {
+      Object.defineProperty(globalThis, "document", documentDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, "document");
+    }
+  };
+};
+
 const createDeferred = <T,>() => {
   let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
   let reject: ((reason?: unknown) => void) | null = null;
@@ -311,8 +352,6 @@ describe("use-workspace-operations", () => {
     const clearIntervalMock = mock(() => {});
     const addDocumentEventListener = mock(() => {});
     const removeDocumentEventListener = mock(() => {});
-    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
-    const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
     const fakeWindow = {
       addEventListener: addWindowEventListener,
       removeEventListener: removeWindowEventListener,
@@ -324,6 +363,7 @@ describe("use-workspace-operations", () => {
       removeEventListener: removeDocumentEventListener,
       visibilityState: "visible" as const,
     } as unknown as Document;
+    const restoreBrowserGlobals = mockBrowserGlobals(fakeWindow, fakeDocument);
 
     const gitGetCurrentBranch = mock(async () => ({
       name: "main",
@@ -352,16 +392,6 @@ describe("use-workspace-operations", () => {
       gitSwitchBranch: host.gitSwitchBranch,
     };
 
-    Object.defineProperty(globalThis, "window", {
-      configurable: true,
-      writable: true,
-      value: fakeWindow,
-    });
-    Object.defineProperty(globalThis, "document", {
-      configurable: true,
-      writable: true,
-      value: fakeDocument,
-    });
     host.gitGetCurrentBranch = gitGetCurrentBranch;
     host.gitGetBranches = gitGetBranches;
     host.gitSwitchBranch = gitSwitchBranch;
@@ -394,20 +424,14 @@ describe("use-workspace-operations", () => {
       expect(clearIntervalMock).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
+      expect(removeWindowEventListener).toHaveBeenCalledTimes(1);
+      expect(removeDocumentEventListener).toHaveBeenCalledTimes(1);
+      expect(clearIntervalMock).toHaveBeenCalledTimes(1);
+
       host.gitGetCurrentBranch = original.gitGetCurrentBranch;
       host.gitGetBranches = original.gitGetBranches;
       host.gitSwitchBranch = original.gitSwitchBranch;
-
-      if (windowDescriptor) {
-        Object.defineProperty(globalThis, "window", windowDescriptor);
-      } else {
-        Reflect.deleteProperty(globalThis, "window");
-      }
-      if (documentDescriptor) {
-        Object.defineProperty(globalThis, "document", documentDescriptor);
-      } else {
-        Reflect.deleteProperty(globalThis, "document");
-      }
+      restoreBrowserGlobals();
     }
   });
 });

--- a/apps/desktop/src/state/operations/use-workspace-operations.ts
+++ b/apps/desktop/src/state/operations/use-workspace-operations.ts
@@ -52,13 +52,15 @@ export function useWorkspaceOperations({
   const lastKnownBranchNameRef = useRef<string | null>(null);
   const lastKnownDetachedRef = useRef<boolean | null>(null);
   const activeRepoRef = useRef(activeRepo);
-  const isSwitchingWorkspaceRef = useRef(isSwitchingWorkspace);
-  const isLoadingBranchesRef = useRef(isLoadingBranches);
-  const isSwitchingBranchRef = useRef(isSwitchingBranch);
+  const probeGatesRef = useRef({
+    isSwitchingWorkspace,
+    isLoadingBranches,
+    isSwitchingBranch,
+  });
 
-  isSwitchingWorkspaceRef.current = isSwitchingWorkspace;
-  isLoadingBranchesRef.current = isLoadingBranches;
-  isSwitchingBranchRef.current = isSwitchingBranch;
+  probeGatesRef.current.isSwitchingWorkspace = isSwitchingWorkspace;
+  probeGatesRef.current.isLoadingBranches = isLoadingBranches;
+  probeGatesRef.current.isSwitchingBranch = isSwitchingBranch;
 
   useEffect(() => {
     activeRepoRef.current = activeRepo;
@@ -188,9 +190,9 @@ export function useWorkspaceOperations({
     if (
       !shouldProbeExternalBranchChange({
         activeRepo: repoPath,
-        isSwitchingWorkspace: isSwitchingWorkspaceRef.current,
-        isSwitchingBranch: isSwitchingBranchRef.current,
-        isLoadingBranches: isLoadingBranchesRef.current,
+        isSwitchingWorkspace: probeGatesRef.current.isSwitchingWorkspace,
+        isSwitchingBranch: probeGatesRef.current.isSwitchingBranch,
+        isLoadingBranches: probeGatesRef.current.isLoadingBranches,
         isSyncInFlight: branchSyncInFlightRef.current,
       })
     ) {

--- a/apps/desktop/src/state/operations/use-workspace-operations.ts
+++ b/apps/desktop/src/state/operations/use-workspace-operations.ts
@@ -52,6 +52,13 @@ export function useWorkspaceOperations({
   const lastKnownBranchNameRef = useRef<string | null>(null);
   const lastKnownDetachedRef = useRef<boolean | null>(null);
   const activeRepoRef = useRef(activeRepo);
+  const isSwitchingWorkspaceRef = useRef(isSwitchingWorkspace);
+  const isLoadingBranchesRef = useRef(isLoadingBranches);
+  const isSwitchingBranchRef = useRef(isSwitchingBranch);
+
+  isSwitchingWorkspaceRef.current = isSwitchingWorkspace;
+  isLoadingBranchesRef.current = isLoadingBranches;
+  isSwitchingBranchRef.current = isSwitchingBranch;
 
   useEffect(() => {
     activeRepoRef.current = activeRepo;
@@ -181,9 +188,9 @@ export function useWorkspaceOperations({
     if (
       !shouldProbeExternalBranchChange({
         activeRepo: repoPath,
-        isSwitchingWorkspace,
-        isSwitchingBranch,
-        isLoadingBranches,
+        isSwitchingWorkspace: isSwitchingWorkspaceRef.current,
+        isSwitchingBranch: isSwitchingBranchRef.current,
+        isLoadingBranches: isLoadingBranchesRef.current,
         isSyncInFlight: branchSyncInFlightRef.current,
       })
     ) {
@@ -219,7 +226,7 @@ export function useWorkspaceOperations({
     } finally {
       branchSyncInFlightRef.current = false;
     }
-  }, [isLoadingBranches, isSwitchingBranch, isSwitchingWorkspace, refreshBranchesForRepo]);
+  }, [refreshBranchesForRepo]);
 
   useEffect(() => {
     if (!activeRepo) {


### PR DESCRIPTION
## Summary
- stabilize `probeExternalBranchChange` so interval and event listeners are not torn down/remounted during transient branch/workspace loading state changes
- switch probe gating reads to stable ref-backed values to keep callback identity stable while preserving latest state checks
- harden hook tests to verify listener/timer lifecycle behavior and cleanup on unmount
- improve browser-global mocking in tests to use guarded setup/restore utilities

## Why
`probeExternalBranchChange` previously depended on transient flags, causing frequent callback recreation and effect remounts. This introduced avoidable interval/listener churn and risked polling gaps during rapid workspace/branch transitions.

## Validation
- `bun run --filter @openducktor/desktop test ./src/state/operations/use-workspace-operations.test.tsx`
- `bun run --filter @openducktor/desktop test`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
