### PR TITLE
perf(desktop): optimize Google Fonts loading path

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -3,6 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
+    />
     <title>OpenDucktor</title>
   </head>
   <body>

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -6,9 +6,22 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      rel="stylesheet"
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
     />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      media="print"
+      onload="this.media='all'"
+    />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
+      />
+    </noscript>
     <title>OpenDucktor</title>
   </head>
   <body>

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap");
 @import "tailwindcss";
 @custom-variant dark (&:where(.dark, .dark *));
 @plugin "@tailwindcss/typography";


### PR DESCRIPTION
## Summary
- remove Google Fonts `@import` from `apps/desktop/src/styles.css`
- move font loading into `apps/desktop/index.html` with `preconnect` hints
- make font stylesheet non-blocking via `preload` + deferred stylesheet (`media="print"` / `onload`) + `noscript` fallback

## Why
- avoid CSS `@import` render-blocking chain
- reduce initial paint delay on cold start

## Validation
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop build`
