### PR TITLE
perf(desktop): reduce Kanban card re-renders with memoization

### DIFF
--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -1,7 +1,16 @@
 import type { RunSummary } from "@openducktor/contracts";
 import type { KanbanColumn as KanbanColumnData, KanbanColumnId } from "@openducktor/core";
 import { Inbox } from "lucide-react";
-import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ComponentProps,
+  memo,
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   buildVirtualColumnLayout,
   findVirtualWindowRange,
@@ -20,7 +29,8 @@ const VIRTUAL_CARD_ESTIMATED_HEIGHT_PX = 180;
 const VIRTUAL_CARD_GAP_PX = 12;
 const VIRTUAL_OVERSCAN_PX = 360;
 const INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX = 900;
-const EMPTY_ACTIVE_SESSIONS: AgentSessionState[] = [];
+type RunningTaskSessions = NonNullable<ComponentProps<typeof KanbanTaskCard>["activeSessions"]>;
+const EMPTY_ACTIVE_SESSIONS: RunningTaskSessions = [];
 
 type KanbanColumnProps = {
   column: KanbanColumnData;
@@ -55,7 +65,7 @@ const MeasuredTaskCard = memo(function MeasuredTaskCard({
 }: {
   task: KanbanColumnData["tasks"][number];
   runState: RunSummary["state"] | undefined;
-  activeSessions: AgentSessionState[] | undefined;
+  activeSessions: RunningTaskSessions | undefined;
   onMeasuredHeight: (taskId: string, height: number) => void;
 } & TaskCardHandlers): ReactElement {
   const taskWrapperRef = useRef<HTMLDivElement | null>(null);

--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -20,6 +20,7 @@ const VIRTUAL_CARD_ESTIMATED_HEIGHT_PX = 180;
 const VIRTUAL_CARD_GAP_PX = 12;
 const VIRTUAL_OVERSCAN_PX = 360;
 const INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX = 900;
+const EMPTY_ACTIVE_SESSIONS: AgentSessionState[] = [];
 
 type KanbanColumnProps = {
   column: KanbanColumnData;
@@ -341,7 +342,7 @@ export function KanbanColumn({
                   key={task.id}
                   task={task}
                   runState={runStateByTaskId.get(task.id)}
-                  activeSessions={activeSessionsByTaskId.get(task.id) ?? []}
+                  activeSessions={activeSessionsByTaskId.get(task.id) ?? EMPTY_ACTIVE_SESSIONS}
                   onMeasuredHeight={handleMeasuredHeight}
                   onOpenDetails={onOpenDetails}
                   onDelegate={onDelegate}
@@ -363,7 +364,7 @@ export function KanbanColumn({
                 key={task.id}
                 task={task}
                 runState={runStateByTaskId.get(task.id)}
-                activeSessions={activeSessionsByTaskId.get(task.id) ?? []}
+                activeSessions={activeSessionsByTaskId.get(task.id) ?? EMPTY_ACTIVE_SESSIONS}
                 onOpenDetails={onOpenDetails}
                 onDelegate={onDelegate}
                 onPlan={onPlan}

--- a/apps/desktop/src/components/features/kanban/kanban-task-badges.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-badges.tsx
@@ -9,7 +9,7 @@ import {
   PlayCircle,
   Sparkles,
 } from "lucide-react";
-import type { ReactElement } from "react";
+import { memo, type ReactElement } from "react";
 import { Badge } from "@/components/ui/badge";
 
 const ISSUE_TYPE_STYLES: Record<
@@ -147,7 +147,11 @@ const runStateClassName = (value: RunSummary["state"]): string => {
   return "border-border bg-muted text-foreground";
 };
 
-export function IssueTypeBadge({ issueType }: { issueType: IssueType }): ReactElement {
+export const IssueTypeBadge = memo(function IssueTypeBadge({
+  issueType,
+}: {
+  issueType: IssueType;
+}): ReactElement {
   const style = ISSUE_TYPE_STYLES[issueType] ?? ISSUE_TYPE_STYLES.task;
   const Icon = style.icon;
   return (
@@ -159,9 +163,13 @@ export function IssueTypeBadge({ issueType }: { issueType: IssueType }): ReactEl
       {style.label}
     </Badge>
   );
-}
+});
 
-export function PriorityBadge({ priority }: { priority: number }): ReactElement {
+export const PriorityBadge = memo(function PriorityBadge({
+  priority,
+}: {
+  priority: number;
+}): ReactElement {
   const style = getPriorityStyle(priority);
   return (
     <Badge
@@ -173,9 +181,13 @@ export function PriorityBadge({ priority }: { priority: number }): ReactElement 
       {style.label}
     </Badge>
   );
-}
+});
 
-export function RunStateBadge({ runState }: { runState: RunSummary["state"] }): ReactElement {
+export const RunStateBadge = memo(function RunStateBadge({
+  runState,
+}: {
+  runState: RunSummary["state"];
+}): ReactElement {
   const Icon = runStateIcon(runState);
   return (
     <Badge
@@ -186,4 +198,4 @@ export function RunStateBadge({ runState }: { runState: RunSummary["state"] }): 
       {runStateLabel(runState)}
     </Badge>
   );
-}
+});

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.memo.test.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.memo.test.tsx
@@ -1,0 +1,148 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { createTaskCardFixture, enableReactActEnvironment } from "@/pages/agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+const workflowActionGroupRenderMock = mock((_: unknown) => {});
+const noop = (): void => {};
+
+mock.module("@/components/features/kanban/task-workflow-action-group", () => ({
+  TaskWorkflowActionGroup: (props: unknown): ReactElement | null => {
+    workflowActionGroupRenderMock(props);
+    return null;
+  },
+}));
+
+describe("KanbanTaskCard memoization", () => {
+  beforeEach(() => {
+    workflowActionGroupRenderMock.mockClear();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("skips rerender when task reference changes but compared fields are equivalent", async () => {
+    const { KanbanTaskCard } = await import("./kanban-task-card");
+
+    const task = createTaskCardFixture({
+      id: "TASK-1",
+      title: "Memoized card",
+      status: "in_progress",
+      issueType: "feature",
+      priority: 2,
+      subtaskIds: ["TASK-1.1"],
+      availableActions: ["open_builder", "human_request_changes"],
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const activeSessions = [
+      {
+        sessionId: "session-1",
+        role: "build",
+        scenario: "build_implementation_start",
+        status: "running",
+      } as const,
+    ];
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <MemoryRouter initialEntries={["/kanban"]}>
+          <KanbanTaskCard
+            task={task}
+            runState="running"
+            activeSessions={activeSessions}
+            onOpenDetails={noop}
+            onDelegate={noop}
+            onPlan={noop}
+            onBuild={noop}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(workflowActionGroupRenderMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer.update(
+        <MemoryRouter initialEntries={["/kanban"]}>
+          <KanbanTaskCard
+            task={{ ...task }}
+            runState="running"
+            activeSessions={activeSessions.map((session) => ({ ...session }))}
+            onOpenDetails={noop}
+            onDelegate={noop}
+            onPlan={noop}
+            onBuild={noop}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(workflowActionGroupRenderMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("rerenders when task workflow data changes", async () => {
+    const { KanbanTaskCard } = await import("./kanban-task-card");
+
+    const task = createTaskCardFixture({
+      id: "TASK-2",
+      status: "in_progress",
+      availableActions: ["open_builder"],
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <MemoryRouter initialEntries={["/kanban"]}>
+          <KanbanTaskCard
+            task={task}
+            runState="running"
+            activeSessions={[]}
+            onOpenDetails={noop}
+            onDelegate={noop}
+            onPlan={noop}
+            onBuild={noop}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(workflowActionGroupRenderMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      renderer.update(
+        <MemoryRouter initialEntries={["/kanban"]}>
+          <KanbanTaskCard
+            task={{
+              ...task,
+              availableActions: ["open_builder", "human_request_changes"],
+              updatedAt: "2026-01-01T00:00:01.000Z",
+            }}
+            runState="running"
+            activeSessions={[]}
+            onOpenDetails={noop}
+            onDelegate={noop}
+            onPlan={noop}
+            onBuild={noop}
+          />
+        </MemoryRouter>,
+      );
+    });
+
+    expect(workflowActionGroupRenderMock).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+});

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
@@ -29,6 +29,31 @@ type KanbanTaskCardProps = {
   onHumanRequestChanges?: (taskId: string) => void;
 };
 
+const areStringArraysEqual = (left: string[], right: string[]): boolean => {
+  if (left === right) {
+    return true;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const areTaskCardsEquivalent = (left: TaskCard, right: TaskCard): boolean =>
+  left.id === right.id &&
+  left.updatedAt === right.updatedAt &&
+  left.title === right.title &&
+  left.status === right.status &&
+  left.issueType === right.issueType &&
+  left.priority === right.priority &&
+  areStringArraysEqual(left.subtaskIds, right.subtaskIds) &&
+  areStringArraysEqual(left.availableActions, right.availableActions);
+
 const areRunningTaskSessionsEqual = (
   left: RunningTaskSession[] | undefined,
   right: RunningTaskSession[] | undefined,
@@ -64,7 +89,7 @@ const areKanbanTaskCardPropsEqual = (
   previous: KanbanTaskCardProps,
   next: KanbanTaskCardProps,
 ): boolean =>
-  previous.task === next.task &&
+  areTaskCardsEquivalent(previous.task, next.task) &&
   previous.runState === next.runState &&
   areRunningTaskSessionsEqual(previous.activeSessions, next.activeSessions) &&
   previous.onOpenDetails === next.onOpenDetails &&

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
@@ -1,6 +1,6 @@
 import type { RunSummary, TaskCard } from "@openducktor/contracts";
 import { ExternalLink, PlayCircle } from "lucide-react";
-import type { ReactElement } from "react";
+import { memo, type ReactElement } from "react";
 import { Link } from "react-router-dom";
 import {
   IssueTypeBadge,
@@ -29,6 +29,51 @@ type KanbanTaskCardProps = {
   onHumanRequestChanges?: (taskId: string) => void;
 };
 
+const areRunningTaskSessionsEqual = (
+  left: RunningTaskSession[] | undefined,
+  right: RunningTaskSession[] | undefined,
+): boolean => {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return left === right;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    const leftSession = left[index];
+    const rightSession = right[index];
+    if (!leftSession || !rightSession) {
+      return false;
+    }
+    if (
+      leftSession.sessionId !== rightSession.sessionId ||
+      leftSession.role !== rightSession.role ||
+      leftSession.scenario !== rightSession.scenario ||
+      leftSession.status !== rightSession.status
+    ) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const areKanbanTaskCardPropsEqual = (
+  previous: KanbanTaskCardProps,
+  next: KanbanTaskCardProps,
+): boolean =>
+  previous.task === next.task &&
+  previous.runState === next.runState &&
+  areRunningTaskSessionsEqual(previous.activeSessions, next.activeSessions) &&
+  previous.onOpenDetails === next.onOpenDetails &&
+  previous.onDelegate === next.onDelegate &&
+  previous.onPlan === next.onPlan &&
+  previous.onBuild === next.onBuild &&
+  previous.onHumanApprove === next.onHumanApprove &&
+  previous.onHumanRequestChanges === next.onHumanRequestChanges;
+
 function toSessionHref({
   taskId,
   session,
@@ -46,27 +91,35 @@ function toSessionHref({
   return `/agents?${params.toString()}`;
 }
 
-function ActiveSessionChip({
-  taskId,
-  session,
-}: {
-  taskId: string;
-  session: RunningTaskSession;
-}): ReactElement {
-  const roleLabel = AGENT_ROLE_LABELS[session.role] ?? session.role;
-  const statusLabel = session.status === "starting" ? "Starting" : "Running";
+const ActiveSessionChip = memo(
+  function ActiveSessionChip({
+    taskId,
+    session,
+  }: {
+    taskId: string;
+    session: RunningTaskSession;
+  }): ReactElement {
+    const roleLabel = AGENT_ROLE_LABELS[session.role] ?? session.role;
+    const statusLabel = session.status === "starting" ? "Starting" : "Running";
 
-  return (
-    <Link
-      to={toSessionHref({ taskId, session })}
-      className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-sky-200 dark:border-sky-800 bg-sky-50 dark:bg-sky-950/50 px-2 py-1 text-[11px] font-semibold text-sky-700 dark:text-sky-300 transition hover:border-sky-300 dark:hover:border-sky-700 hover:bg-sky-100/75 dark:hover:bg-sky-900/50"
-    >
-      <PlayCircle className="size-3" />
-      {roleLabel}
-      <span className="text-[10px] font-medium text-primary/90">{statusLabel}</span>
-    </Link>
-  );
-}
+    return (
+      <Link
+        to={toSessionHref({ taskId, session })}
+        className="inline-flex cursor-pointer items-center gap-1 rounded-md border border-sky-200 dark:border-sky-800 bg-sky-50 dark:bg-sky-950/50 px-2 py-1 text-[11px] font-semibold text-sky-700 dark:text-sky-300 transition hover:border-sky-300 dark:hover:border-sky-700 hover:bg-sky-100/75 dark:hover:bg-sky-900/50"
+      >
+        <PlayCircle className="size-3" />
+        {roleLabel}
+        <span className="text-[10px] font-medium text-primary/90">{statusLabel}</span>
+      </Link>
+    );
+  },
+  (previous, next) =>
+    previous.taskId === next.taskId &&
+    previous.session.sessionId === next.session.sessionId &&
+    previous.session.role === next.session.role &&
+    previous.session.scenario === next.session.scenario &&
+    previous.session.status === next.session.status,
+);
 
 function ActiveSessionsLine({
   taskId,
@@ -173,7 +226,7 @@ function TaskActions({
   );
 }
 
-export function KanbanTaskCard({
+export const KanbanTaskCard = memo(function KanbanTaskCard({
   task,
   runState,
   activeSessions = [],
@@ -238,4 +291,4 @@ export function KanbanTaskCard({
       </div>
     </article>
   );
-}
+}, areKanbanTaskCardPropsEqual);

--- a/apps/desktop/src/pages/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban-page.test.tsx
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { isValidElement, type ReactElement, useState } from "react";
+import { isValidElement, type ReactElement, useCallback, useState } from "react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { createTaskCardFixture, enableReactActEnvironment } from "./agent-studio-test-utils";
@@ -100,6 +100,52 @@ mock.module("./use-session-start-modal-state", () => ({
       opencodeAgent: "build-agent",
     });
 
+    const openStartModal = useCallback((nextIntent: Record<string, unknown>) => {
+      setIntent(nextIntent);
+      setSelection({
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "default",
+        opencodeAgent: "build-agent",
+      });
+    }, []);
+
+    const closeStartModal = useCallback(() => {
+      setIntent(null);
+    }, []);
+
+    const handleSelectAgent = useCallback((opencodeAgent: string) => {
+      setSelection((current) => ({
+        ...current,
+        opencodeAgent,
+      }));
+    }, []);
+
+    const handleSelectModel = useCallback((modelKey: string) => {
+      if (modelKey === "anthropic/claude-sonnet") {
+        setSelection((current) => ({
+          ...current,
+          providerId: "anthropic",
+          modelId: "claude-sonnet",
+          variant: "default",
+        }));
+        return;
+      }
+      setSelection((current) => ({
+        ...current,
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "default",
+      }));
+    }, []);
+
+    const handleSelectVariant = useCallback((variant: string) => {
+      setSelection((current) => ({
+        ...current,
+        variant,
+      }));
+    }, []);
+
     return {
       intent,
       isOpen: intent !== null,
@@ -109,47 +155,11 @@ mock.module("./use-session-start-modal-state", () => ({
       modelOptions: [],
       modelGroups: [],
       variantOptions: [],
-      openStartModal: (nextIntent: Record<string, unknown>) => {
-        setIntent(nextIntent);
-        setSelection({
-          providerId: "openai",
-          modelId: "gpt-5",
-          variant: "default",
-          opencodeAgent: "build-agent",
-        });
-      },
-      closeStartModal: () => {
-        setIntent(null);
-      },
-      handleSelectAgent: (opencodeAgent: string) => {
-        setSelection((current) => ({
-          ...current,
-          opencodeAgent,
-        }));
-      },
-      handleSelectModel: (modelKey: string) => {
-        if (modelKey === "anthropic/claude-sonnet") {
-          setSelection((current) => ({
-            ...current,
-            providerId: "anthropic",
-            modelId: "claude-sonnet",
-            variant: "default",
-          }));
-          return;
-        }
-        setSelection((current) => ({
-          ...current,
-          providerId: "openai",
-          modelId: "gpt-5",
-          variant: "default",
-        }));
-      },
-      handleSelectVariant: (variant: string) => {
-        setSelection((current) => ({
-          ...current,
-          variant,
-        }));
-      },
+      openStartModal,
+      closeStartModal,
+      handleSelectAgent,
+      handleSelectModel,
+      handleSelectVariant,
     };
   },
 }));
@@ -415,6 +425,24 @@ describe("KanbanPage session start modal flow", () => {
     expect(startAgentSessionMock).not.toHaveBeenCalled();
     expect(latestLocation).toContain("/agents?task=TASK-123");
     expect(latestLocation).toContain("session=session-spec");
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("keeps human request changes handler stable across modal state re-renders", async () => {
+    const renderer = await renderPage();
+
+    const initialOnHumanRequestChanges = latestKanbanColumnProps?.onHumanRequestChanges;
+    expect(initialOnHumanRequestChanges).toBeDefined();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onDelegate as (taskId: string) => void)("TASK-123");
+    });
+
+    const nextOnHumanRequestChanges = latestKanbanColumnProps?.onHumanRequestChanges;
+    expect(nextOnHumanRequestChanges).toBe(initialOnHumanRequestChanges);
 
     await act(async () => {
       renderer.unmount();

--- a/apps/desktop/src/pages/use-kanban-page-models.tsx
+++ b/apps/desktop/src/pages/use-kanban-page-models.tsx
@@ -39,6 +39,8 @@ export function useKanbanPageModels(): KanbanPageModels {
     sendAgentMessage,
     updateAgentSessionModel,
   });
+  const { sessionStartModal, onDelegate, onPlan, onBuild, openBuildAfterHumanRequestChanges } =
+    sessionStartFlow;
 
   const onRefreshTasks = useCallback((): void => {
     void refreshTasks();
@@ -55,17 +57,17 @@ export function useKanbanPageModels(): KanbanPageModels {
     (taskId: string): void => {
       void (async () => {
         await humanRequestChangesTask(taskId);
-        sessionStartFlow.openBuildAfterHumanRequestChanges(taskId);
+        openBuildAfterHumanRequestChanges(taskId);
       })();
     },
-    [humanRequestChangesTask, sessionStartFlow],
+    [humanRequestChangesTask, openBuildAfterHumanRequestChanges],
   );
 
   const taskDialogs = useKanbanTaskDialogs({
     tasks,
-    onPlan: sessionStartFlow.onPlan,
-    onBuild: sessionStartFlow.onBuild,
-    onDelegate: sessionStartFlow.onDelegate,
+    onPlan,
+    onBuild,
+    onDelegate,
     onDefer: (taskId) => {
       void deferTask(taskId);
     },
@@ -82,9 +84,9 @@ export function useKanbanPageModels(): KanbanPageModels {
     runs,
     sessions,
     onOpenDetails: taskDialogs.onOpenDetails,
-    onDelegate: sessionStartFlow.onDelegate,
-    onPlan: sessionStartFlow.onPlan,
-    onBuild: sessionStartFlow.onBuild,
+    onDelegate,
+    onPlan,
+    onBuild,
     onHumanApprove,
     onHumanRequestChanges,
   });
@@ -99,6 +101,6 @@ export function useKanbanPageModels(): KanbanPageModels {
     content,
     taskComposer: taskDialogs.taskComposer,
     detailsSheet: taskDialogs.detailsSheet,
-    sessionStartModal: sessionStartFlow.sessionStartModal,
+    sessionStartModal,
   };
 }


### PR DESCRIPTION
## Summary
- memoize Kanban card and badge render paths (`KanbanTaskCard`, `IssueTypeBadge`, `PriorityBadge`, `RunStateBadge`, `ActiveSessionChip`)
- harden `KanbanTaskCard` memo comparison to handle semantically equivalent refreshed task objects using stable task fields
- avoid unstable empty-array props in `KanbanColumn` by reusing a shared constant
- stabilize Kanban callback wiring in `use-kanban-page-models` so human-review action handlers remain referentially stable
- add targeted regression tests for memoization behavior and callback stability

## Why
Kanban cards are rendered inside virtualized lanes. Parent re-renders (task/session updates) were still causing avoidable card reconciliation work due to callback and prop instability and reference-only comparisons.

## Validation
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop test`
