### PR TITLE
refactor(host-application): split build_start phases and harden startup cleanup

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -10,7 +10,7 @@ use host_infra_system::{build_branch_name, pick_free_port, remove_worktree, Repo
 use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Child;
+use std::process::{Child, ChildStderr, ChildStdout};
 use uuid::Uuid;
 
 /// Action responded by user during build/run (for approve/deny/message flow).
@@ -177,9 +177,25 @@ impl AppService {
             Some(repo_path_ref),
         )?;
 
+        self.run_pre_start_hooks(
+            prerequisites,
+            repo_path_ref,
+            worktree_dir.as_path(),
+            task_id,
+        )?;
+
+        Ok(PreparedBuildWorktree { worktree_dir })
+    }
+
+    fn run_pre_start_hooks(
+        &self,
+        prerequisites: &BuildPrerequisites,
+        repo_path_ref: &Path,
+        worktree_dir: &Path,
+        task_id: &str,
+    ) -> Result<()> {
         for hook in &prerequisites.repo_config.hooks.pre_start {
-            let (ok, _stdout, stderr) =
-                run_parsed_hook_command_allow_failure(hook, worktree_dir.as_path());
+            let (ok, _stdout, stderr) = run_parsed_hook_command_allow_failure(hook, worktree_dir);
             if !ok {
                 let _ = self.task_transition(
                     prerequisites.repo_path.as_str(),
@@ -187,7 +203,7 @@ impl AppService {
                     TaskStatus::Blocked,
                     Some("Pre-start hook failed"),
                 );
-                let cleanup_error = remove_worktree(repo_path_ref, worktree_dir.as_path())
+                let cleanup_error = remove_worktree(repo_path_ref, worktree_dir)
                     .err()
                     .map(|error| error.to_string());
                 return Err(anyhow!(
@@ -198,8 +214,7 @@ impl AppService {
                 ));
             }
         }
-
-        Ok(PreparedBuildWorktree { worktree_dir })
+        Ok(())
     }
 
     fn spawn_and_wait_for_agent(
@@ -208,6 +223,24 @@ impl AppService {
         prepared_worktree: &PreparedBuildWorktree,
         task_id: &str,
         run_id: &str,
+    ) -> Result<SpawnedBuildAgent> {
+        let mut spawned_agent = self.spawn_build_agent_process(prerequisites, prepared_worktree)?;
+        if let Err(error) = self.wait_for_build_agent_readiness(
+            &mut spawned_agent,
+            prerequisites.repo_path.as_str(),
+            task_id,
+            run_id,
+        ) {
+            terminate_child_process(&mut spawned_agent.child);
+            return Err(error);
+        }
+        Ok(spawned_agent)
+    }
+
+    fn spawn_build_agent_process(
+        &self,
+        prerequisites: &BuildPrerequisites,
+        prepared_worktree: &PreparedBuildWorktree,
     ) -> Result<SpawnedBuildAgent> {
         let port = pick_free_port()?;
         let metadata_namespace = self.config_store.task_metadata_namespace()?;
@@ -224,47 +257,119 @@ impl AppService {
                 return Err(error).context("Failed tracking spawned OpenCode build process");
             }
         };
+
+        Ok(SpawnedBuildAgent {
+            child,
+            opencode_process_guard,
+            port,
+        })
+    }
+
+    fn wait_for_build_agent_readiness(
+        &self,
+        spawned_agent: &mut SpawnedBuildAgent,
+        repo_path: &str,
+        task_id: &str,
+        run_id: &str,
+    ) -> Result<()> {
         let startup_policy = self.opencode_startup_readiness_policy();
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
-        self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
-            "build_runtime",
-            prerequisites.repo_path.as_str(),
-            Some(task_id),
-            "build",
-            port,
-            Some(StartupEventCorrelation::new("run_id", run_id)),
-            Some(startup_policy),
-        ));
+        self.emit_build_runtime_wait_begin(
+            repo_path,
+            task_id,
+            run_id,
+            spawned_agent.port,
+            startup_policy,
+        );
         let startup_report = match wait_for_local_server_with_process(
-            &mut child,
-            port,
+            &mut spawned_agent.child,
+            spawned_agent.port,
             startup_policy,
             &startup_cancel_epoch,
             startup_cancel_snapshot,
         ) {
             Ok(report) => report,
             Err(error) => {
-                self.emit_opencode_startup_event(StartupEventPayload::failed(
-                    "build_runtime",
-                    prerequisites.repo_path.as_str(),
-                    Some(task_id),
-                    "build",
-                    port,
-                    Some(StartupEventCorrelation::new("run_id", run_id)),
-                    Some(startup_policy),
+                self.emit_build_runtime_failed(
+                    repo_path,
+                    task_id,
+                    run_id,
+                    spawned_agent.port,
+                    startup_policy,
                     error.report,
                     error.reason,
-                ));
-                terminate_child_process(&mut child);
+                );
                 return Err(anyhow!(error)).with_context(|| {
                     format!("OpenCode build runtime failed to start for task {task_id}")
                 });
             }
         };
+        self.emit_build_runtime_ready(
+            repo_path,
+            task_id,
+            run_id,
+            spawned_agent.port,
+            startup_policy,
+            startup_report,
+        );
+        Ok(())
+    }
+
+    fn emit_build_runtime_wait_begin(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+        run_id: &str,
+        port: u16,
+        startup_policy: super::OpencodeStartupReadinessPolicy,
+    ) {
+        self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
+            "build_runtime",
+            repo_path,
+            Some(task_id),
+            "build",
+            port,
+            Some(StartupEventCorrelation::new("run_id", run_id)),
+            Some(startup_policy),
+        ));
+    }
+
+    fn emit_build_runtime_failed(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+        run_id: &str,
+        port: u16,
+        startup_policy: super::OpencodeStartupReadinessPolicy,
+        startup_report: super::OpencodeStartupWaitReport,
+        reason: &'static str,
+    ) {
+        self.emit_opencode_startup_event(StartupEventPayload::failed(
+            "build_runtime",
+            repo_path,
+            Some(task_id),
+            "build",
+            port,
+            Some(StartupEventCorrelation::new("run_id", run_id)),
+            Some(startup_policy),
+            startup_report,
+            reason,
+        ));
+    }
+
+    fn emit_build_runtime_ready(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+        run_id: &str,
+        port: u16,
+        startup_policy: super::OpencodeStartupReadinessPolicy,
+        startup_report: super::OpencodeStartupWaitReport,
+    ) {
         self.emit_opencode_startup_event(StartupEventPayload::ready(
             "build_runtime",
-            prerequisites.repo_path.as_str(),
+            repo_path,
             Some(task_id),
             "build",
             port,
@@ -272,12 +377,87 @@ impl AppService {
             Some(startup_policy),
             startup_report,
         ));
+    }
 
-        Ok(SpawnedBuildAgent {
-            child,
+    fn abort_started_build<T>(
+        spawned_agent: &mut SpawnedBuildAgent,
+        error: anyhow::Error,
+    ) -> Result<T> {
+        terminate_child_process(&mut spawned_agent.child);
+        Err(error)
+    }
+
+    fn emit_build_started_and_forward_output(
+        run_id: &str,
+        task_id: &str,
+        branch: &str,
+        stdout: Option<ChildStdout>,
+        stderr: Option<ChildStderr>,
+        emitter: RunEmitter,
+    ) {
+        emit_event(
+            &emitter,
+            RunEvent::RunStarted {
+                run_id: run_id.to_string(),
+                message: format!("Delegated task {} on branch {}", task_id, branch),
+                timestamp: now_rfc3339(),
+            },
+        );
+
+        if let Some(stdout) = stdout {
+            spawn_output_forwarder(run_id.to_string(), "stdout", stdout, emitter.clone());
+        }
+        if let Some(stderr) = stderr {
+            spawn_output_forwarder(run_id.to_string(), "stderr", stderr, emitter.clone());
+        }
+    }
+
+    fn register_build_run(
+        &self,
+        run_id: &str,
+        summary: RunSummary,
+        prerequisites: BuildPrerequisites,
+        task_id: &str,
+        worktree_path: String,
+        spawned_agent: SpawnedBuildAgent,
+        emitter: RunEmitter,
+    ) -> Result<RunSummary> {
+        let SpawnedBuildAgent {
+            mut child,
             opencode_process_guard,
-            port,
-        })
+            ..
+        } = spawned_agent;
+        let mut runs = match self.runs.lock() {
+            Ok(runs) => runs,
+            Err(_) => {
+                terminate_child_process(&mut child);
+                return Err(anyhow!("Run state lock poisoned"));
+            }
+        };
+
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        let process = RunProcess {
+            summary: summary.clone(),
+            child,
+            _opencode_process_guard: Some(opencode_process_guard),
+            repo_path: prerequisites.repo_path,
+            task_id: task_id.to_string(),
+            worktree_path: worktree_path.clone(),
+            repo_config: prerequisites.repo_config,
+        };
+
+        runs.insert(run_id.to_string(), process);
+        drop(runs);
+        Self::emit_build_started_and_forward_output(
+            run_id,
+            task_id,
+            summary.branch.as_str(),
+            stdout,
+            stderr,
+            emitter,
+        );
+        Ok(summary)
     }
 
     fn initiate_build_mode(
@@ -294,19 +474,21 @@ impl AppService {
             task_id,
             TaskStatus::InProgress,
             Some("Builder delegated"),
-        )?;
+        )
+        .or_else(|error| Self::abort_started_build(&mut spawned_agent, error))?;
 
         let worktree_path = prepared_worktree
             .worktree_dir
             .to_str()
-            .ok_or_else(|| anyhow!("Invalid worktree path"))?
-            .to_string();
+            .ok_or_else(|| anyhow!("Invalid worktree path"))
+            .map(|path| path.to_string())
+            .or_else(|error| Self::abort_started_build(&mut spawned_agent, error))?;
 
         let summary = RunSummary {
             run_id: run_id.to_string(),
             repo_path: prerequisites.repo_path.clone(),
             task_id: task_id.to_string(),
-            branch: prerequisites.branch,
+            branch: prerequisites.branch.clone(),
             worktree_path: worktree_path.clone(),
             port: spawned_agent.port,
             state: RunState::Running,
@@ -314,41 +496,15 @@ impl AppService {
             started_at: now_rfc3339(),
         };
 
-        let stdout = spawned_agent.child.stdout.take();
-        let stderr = spawned_agent.child.stderr.take();
-
-        let process = RunProcess {
-            summary: summary.clone(),
-            child: spawned_agent.child,
-            _opencode_process_guard: Some(spawned_agent.opencode_process_guard),
-            repo_path: prerequisites.repo_path,
-            task_id: task_id.to_string(),
-            worktree_path: worktree_path.clone(),
-            repo_config: prerequisites.repo_config,
-        };
-
-        self.runs
-            .lock()
-            .map_err(|_| anyhow!("Run state lock poisoned"))?
-            .insert(run_id.to_string(), process);
-
-        emit_event(
-            &emitter,
-            RunEvent::RunStarted {
-                run_id: run_id.to_string(),
-                message: format!("Delegated task {} on branch {}", task_id, summary.branch),
-                timestamp: now_rfc3339(),
-            },
-        );
-
-        if let Some(stdout) = stdout {
-            spawn_output_forwarder(run_id.to_string(), "stdout", stdout, emitter.clone());
-        }
-        if let Some(stderr) = stderr {
-            spawn_output_forwarder(run_id.to_string(), "stderr", stderr, emitter.clone());
-        }
-
-        Ok(summary)
+        self.register_build_run(
+            run_id,
+            summary,
+            prerequisites,
+            task_id,
+            worktree_path,
+            spawned_agent,
+            emitter,
+        )
     }
 
     pub fn build_respond(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator.rs
@@ -6,10 +6,11 @@ use super::{
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, RunEvent, RunState, RunSummary, TaskStatus};
-use host_infra_system::{build_branch_name, pick_free_port, remove_worktree};
+use host_infra_system::{build_branch_name, pick_free_port, remove_worktree, RepoConfig};
 use serde::Deserialize;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Child;
 use uuid::Uuid;
 
 /// Action responded by user during build/run (for approve/deny/message flow).
@@ -61,6 +62,23 @@ enum CleanupEvent<'a> {
     RunCompleted { review_label: &'a str },
 }
 
+struct BuildPrerequisites {
+    repo_path: String,
+    repo_config: RepoConfig,
+    branch: String,
+    worktree_base: String,
+}
+
+struct PreparedBuildWorktree {
+    worktree_dir: PathBuf,
+}
+
+struct SpawnedBuildAgent {
+    child: Child,
+    opencode_process_guard: super::process_registry::TrackedOpencodeProcessGuard,
+    port: u16,
+}
+
 impl AppService {
     pub fn build_start(
         &self,
@@ -68,10 +86,33 @@ impl AppService {
         task_id: &str,
         emitter: RunEmitter,
     ) -> Result<RunSummary> {
-        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
-        let repo_path = repo_path.as_str();
+        let run_id = format!("run-{}", Uuid::new_v4().simple());
+        let prerequisites = self.validate_build_prerequisites(repo_path, task_id)?;
+        let prepared_worktree = self.prepare_build_worktree(&prerequisites, task_id)?;
+        let spawned_agent = self.spawn_and_wait_for_agent(
+            &prerequisites,
+            &prepared_worktree,
+            task_id,
+            run_id.as_str(),
+        )?;
+        self.initiate_build_mode(
+            prerequisites,
+            prepared_worktree,
+            spawned_agent,
+            task_id,
+            run_id.as_str(),
+            emitter,
+        )
+    }
 
-        let repo_config = self.config_store.repo_config(repo_path)?;
+    fn validate_build_prerequisites(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+    ) -> Result<BuildPrerequisites> {
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let repo_path = repo_path.as_str().to_string();
+        let repo_config = self.config_store.repo_config(repo_path.as_str())?;
 
         let worktree_base = repo_config.worktree_base_path.clone().ok_or_else(|| {
             anyhow!(
@@ -80,9 +121,9 @@ impl AppService {
             )
         })?;
 
-        validate_hook_trust(repo_path, &repo_config)?;
+        validate_hook_trust(repo_path.as_str(), &repo_config)?;
 
-        let tasks = self.task_store.list_tasks(Path::new(repo_path))?;
+        let tasks = self.task_store.list_tasks(Path::new(repo_path.as_str()))?;
         let task = tasks
             .iter()
             .find(|entry| entry.id == task_id)
@@ -92,11 +133,24 @@ impl AppService {
 
         let branch = build_branch_name(&repo_config.branch_prefix, task_id, &task.title);
 
-        let worktree_dir = Path::new(&worktree_base).join(task_id);
-        fs::create_dir_all(Path::new(&worktree_base)).with_context(|| {
+        Ok(BuildPrerequisites {
+            repo_path,
+            repo_config,
+            branch,
+            worktree_base,
+        })
+    }
+
+    fn prepare_build_worktree(
+        &self,
+        prerequisites: &BuildPrerequisites,
+        task_id: &str,
+    ) -> Result<PreparedBuildWorktree> {
+        let worktree_dir = Path::new(prerequisites.worktree_base.as_str()).join(task_id);
+        fs::create_dir_all(Path::new(prerequisites.worktree_base.as_str())).with_context(|| {
             format!(
                 "Failed creating worktree base directory {}",
-                Path::new(&worktree_base).display()
+                Path::new(prerequisites.worktree_base.as_str()).display()
             )
         })?;
 
@@ -108,7 +162,7 @@ impl AppService {
             ));
         }
 
-        let repo_path_ref = Path::new(repo_path);
+        let repo_path_ref = Path::new(prerequisites.repo_path.as_str());
         host_infra_system::run_command(
             "git",
             &[
@@ -118,17 +172,17 @@ impl AppService {
                     .to_str()
                     .ok_or_else(|| anyhow!("Invalid worktree path"))?,
                 "-b",
-                &branch,
+                prerequisites.branch.as_str(),
             ],
             Some(repo_path_ref),
         )?;
 
-        for hook in &repo_config.hooks.pre_start {
+        for hook in &prerequisites.repo_config.hooks.pre_start {
             let (ok, _stdout, stderr) =
                 run_parsed_hook_command_allow_failure(hook, worktree_dir.as_path());
             if !ok {
                 let _ = self.task_transition(
-                    repo_path,
+                    prerequisites.repo_path.as_str(),
                     task_id,
                     TaskStatus::Blocked,
                     Some("Pre-start hook failed"),
@@ -145,13 +199,21 @@ impl AppService {
             }
         }
 
-        let run_id = format!("run-{}", Uuid::new_v4().simple());
+        Ok(PreparedBuildWorktree { worktree_dir })
+    }
+
+    fn spawn_and_wait_for_agent(
+        &self,
+        prerequisites: &BuildPrerequisites,
+        prepared_worktree: &PreparedBuildWorktree,
+        task_id: &str,
+        run_id: &str,
+    ) -> Result<SpawnedBuildAgent> {
         let port = pick_free_port()?;
         let metadata_namespace = self.config_store.task_metadata_namespace()?;
-
         let mut child = spawn_opencode_server(
-            worktree_dir.as_path(),
-            Path::new(repo_path),
+            prepared_worktree.worktree_dir.as_path(),
+            Path::new(prerequisites.repo_path.as_str()),
             metadata_namespace.as_str(),
             port,
         )?;
@@ -167,11 +229,11 @@ impl AppService {
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
         self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
             "build_runtime",
-            repo_path,
+            prerequisites.repo_path.as_str(),
             Some(task_id),
             "build",
             port,
-            Some(StartupEventCorrelation::new("run_id", run_id.as_str())),
+            Some(StartupEventCorrelation::new("run_id", run_id)),
             Some(startup_policy),
         ));
         let startup_report = match wait_for_local_server_with_process(
@@ -185,11 +247,11 @@ impl AppService {
             Err(error) => {
                 self.emit_opencode_startup_event(StartupEventPayload::failed(
                     "build_runtime",
-                    repo_path,
+                    prerequisites.repo_path.as_str(),
                     Some(task_id),
                     "build",
                     port,
-                    Some(StartupEventCorrelation::new("run_id", run_id.as_str())),
+                    Some(StartupEventCorrelation::new("run_id", run_id)),
                     Some(startup_policy),
                     error.report,
                     error.reason,
@@ -202,72 +264,88 @@ impl AppService {
         };
         self.emit_opencode_startup_event(StartupEventPayload::ready(
             "build_runtime",
-            repo_path,
+            prerequisites.repo_path.as_str(),
             Some(task_id),
             "build",
             port,
-            Some(StartupEventCorrelation::new("run_id", run_id.as_str())),
+            Some(StartupEventCorrelation::new("run_id", run_id)),
             Some(startup_policy),
             startup_report,
         ));
 
+        Ok(SpawnedBuildAgent {
+            child,
+            opencode_process_guard,
+            port,
+        })
+    }
+
+    fn initiate_build_mode(
+        &self,
+        prerequisites: BuildPrerequisites,
+        prepared_worktree: PreparedBuildWorktree,
+        mut spawned_agent: SpawnedBuildAgent,
+        task_id: &str,
+        run_id: &str,
+        emitter: RunEmitter,
+    ) -> Result<RunSummary> {
         self.task_transition(
-            repo_path,
+            prerequisites.repo_path.as_str(),
             task_id,
             TaskStatus::InProgress,
             Some("Builder delegated"),
         )?;
 
+        let worktree_path = prepared_worktree
+            .worktree_dir
+            .to_str()
+            .ok_or_else(|| anyhow!("Invalid worktree path"))?
+            .to_string();
+
         let summary = RunSummary {
-            run_id: run_id.clone(),
-            repo_path: repo_path.to_string(),
+            run_id: run_id.to_string(),
+            repo_path: prerequisites.repo_path.clone(),
             task_id: task_id.to_string(),
-            branch,
-            worktree_path: worktree_dir
-                .to_str()
-                .ok_or_else(|| anyhow!("Invalid worktree path"))?
-                .to_string(),
-            port,
+            branch: prerequisites.branch,
+            worktree_path: worktree_path.clone(),
+            port: spawned_agent.port,
             state: RunState::Running,
             last_message: Some("Opencode server running".to_string()),
             started_at: now_rfc3339(),
         };
 
-        let stdout = child.stdout.take();
-        let stderr = child.stderr.take();
+        let stdout = spawned_agent.child.stdout.take();
+        let stderr = spawned_agent.child.stderr.take();
 
         let process = RunProcess {
             summary: summary.clone(),
-            child,
-            _opencode_process_guard: Some(opencode_process_guard),
-            repo_path: repo_path.to_string(),
+            child: spawned_agent.child,
+            _opencode_process_guard: Some(spawned_agent.opencode_process_guard),
+            repo_path: prerequisites.repo_path,
             task_id: task_id.to_string(),
-            worktree_path: worktree_dir
-                .to_str()
-                .ok_or_else(|| anyhow!("Invalid worktree path"))?
-                .to_string(),
-            repo_config,
+            worktree_path: worktree_path.clone(),
+            repo_config: prerequisites.repo_config,
         };
 
         self.runs
             .lock()
             .map_err(|_| anyhow!("Run state lock poisoned"))?
-            .insert(run_id.clone(), process);
+            .insert(run_id.to_string(), process);
 
         emit_event(
             &emitter,
             RunEvent::RunStarted {
-                run_id: run_id.clone(),
+                run_id: run_id.to_string(),
                 message: format!("Delegated task {} on branch {}", task_id, summary.branch),
                 timestamp: now_rfc3339(),
             },
         );
 
         if let Some(stdout) = stdout {
-            spawn_output_forwarder(run_id.clone(), "stdout", stdout, emitter.clone());
+            spawn_output_forwarder(run_id.to_string(), "stdout", stdout, emitter.clone());
         }
         if let Some(stderr) = stderr {
-            spawn_output_forwarder(run_id.clone(), "stderr", stderr, emitter.clone());
+            spawn_output_forwarder(run_id.to_string(), "stderr", stderr, emitter.clone());
         }
 
         Ok(summary)

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -527,3 +527,87 @@ fn build_start_reports_opencode_startup_failure() -> Result<()> {
     let _ = fs::remove_dir_all(root);
     Ok(())
 }
+
+#[test]
+fn build_start_stops_spawned_child_when_run_state_lock_is_poisoned() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("build-run-lock-poison");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    let fake_opencode = root.join("opencode");
+    create_fake_opencode(&fake_opencode)?;
+    let pid_file = root.join("spawned-build.pid");
+    let _opencode_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        fake_opencode.to_string_lossy().as_ref(),
+    );
+    let _delay_guard = set_env_var("OPENDUCKTOR_TEST_STARTUP_DELAY_MS", "800");
+    let _pid_guard = set_env_var(
+        "OPENDUCKTOR_TEST_PID_FILE",
+        pid_file.to_string_lossy().as_ref(),
+    );
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let repo_path = repo.to_string_lossy().to_string();
+    let worktree_base = root.join("worktrees");
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "bug", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    let build_error = std::thread::scope(|scope| -> Result<anyhow::Error> {
+        let build_handle = scope.spawn(|| {
+            service.build_start(
+                repo_path.as_str(),
+                "task-1",
+                make_emitter(Arc::new(Mutex::new(Vec::new()))),
+            )
+        });
+
+        assert!(wait_for_path_exists(
+            pid_file.as_path(),
+            Duration::from_secs(2)
+        ));
+        let spawned_pid = fs::read_to_string(pid_file.as_path())?
+            .trim()
+            .parse::<i32>()
+            .expect("spawned build pid should parse as i32");
+
+        let poison_handle = scope.spawn(|| {
+            let _lock = service
+                .runs
+                .lock()
+                .expect("run lock should be available for poisoning");
+            panic!("poison run lock");
+        });
+        assert!(poison_handle.join().is_err());
+
+        let build_error = build_handle
+            .join()
+            .expect("build thread should join")
+            .expect_err("build_start should fail when run lock is poisoned");
+        assert!(wait_for_process_exit(spawned_pid, Duration::from_secs(2)));
+        Ok(build_error)
+    })?;
+    assert!(build_error.to_string().contains("Run state lock poisoned"));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- refactor `build_start` orchestration into explicit phases for prerequisite validation, worktree preparation, runtime startup, and build initiation
- harden build startup failure paths to ensure spawned OpenCode processes are terminated when late errors occur (including poisoned run-state lock)
- extract smaller startup/pre-start helper methods to reduce method length and improve readability
- add integration regression coverage for `build_start` cleanup when run lock poisoning happens

## Validation
- `cd apps/desktop/src-tauri && cargo fmt --all`
- `cd apps/desktop/src-tauri && cargo test -p host-application`
