### PR TITLE
fix(security): ensure tauri Cargo.lock is kept in VCS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ apps/desktop/src-tauri/gen
 apps/desktop/src-tauri/.cargo
 apps/desktop/src-tauri/binaries
 apps/desktop/src-tauri/crates/*/target
+# Keep the Tauri app workspace lockfile in VCS for reproducible builds.
+!apps/desktop/src-tauri/Cargo.lock
 apps/desktop/src-tauri/crates/*/Cargo.lock


### PR DESCRIPTION
## Summary
- ensure the Tauri workspace lockfile remains version-controlled for reproducible Rust builds
- add an explicit allow rule for `apps/desktop/src-tauri/Cargo.lock` in root `.gitignore`
- keep crate-level `crates/*/Cargo.lock` ignored as intended for workspace member libraries

## Validation
- `git check-ignore apps/desktop/src-tauri/Cargo.lock` returns not ignored
- `cd apps/desktop/src-tauri && cargo fetch --locked`
- `cd apps/desktop/src-tauri && cargo test --locked -q`
