### PR TITLE
fix(host-infra-system): harden command lookup against shell injection

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -113,7 +113,7 @@ pub fn version_command(program: &str, args: &[&str]) -> Option<String> {
 }
 
 fn shell_escape(value: &str) -> String {
-    value.replace('"', "\\\"")
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 #[cfg(test)]
@@ -182,5 +182,23 @@ mod tests {
         assert_eq!(version.as_deref(), Some("v-test"));
         assert!(!command_exists("definitely_not_a_real_binary_name"));
         assert!(command_path("definitely_not_a_real_binary_name").is_none());
+    }
+
+    #[test]
+    fn shell_escape_round_trips_dangerous_characters() {
+        let input = "name;$(echo injected)`uname`";
+        let escaped = super::shell_escape(input);
+        let output = run_command("sh", &["-lc", &format!("printf '%s' {}", escaped)], None)
+            .expect("escaped value should be treated as a literal");
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn shell_escape_handles_single_quotes() {
+        let input = "a'b";
+        let escaped = super::shell_escape(input);
+        let output = run_command("sh", &["-lc", &format!("printf '%s' {}", escaped)], None)
+            .expect("escaped value should preserve single quote");
+        assert_eq!(output, input);
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -85,19 +85,32 @@ pub fn run_command_allow_failure_with_env(
     ))
 }
 
+/// Resolves a command name using the active shell's PATH lookup.
+///
+/// The lookup script is static and `program` is passed as a positional shell
+/// argument (`$1`) to avoid shell interpolation of untrusted input.
 pub fn command_path(program: &str) -> Option<String> {
-    let lookup = format!("command -v {} 2>/dev/null", shell_escape(program));
-    run_command("sh", &["-lc", &lookup], None)
-        .ok()
-        .and_then(|output| {
-            output
-                .lines()
-                .find(|line| !line.trim().is_empty())
-                .map(|line| line.trim().to_string())
-        })
-        .filter(|path| !path.is_empty())
+    run_command(
+        "sh",
+        &[
+            "-lc",
+            "command -v \"$1\" 2>/dev/null",
+            "odt-command-path",
+            program,
+        ],
+        None,
+    )
+    .ok()
+    .and_then(|output| {
+        output
+            .lines()
+            .find(|line| !line.trim().is_empty())
+            .map(|line| line.trim().to_string())
+    })
+    .filter(|path| !path.is_empty())
 }
 
+/// Returns whether `program` can be resolved on PATH by [`command_path`].
 pub fn command_exists(program: &str) -> bool {
     command_path(program).is_some()
 }
@@ -112,16 +125,13 @@ pub fn version_command(program: &str, args: &[&str]) -> Option<String> {
     })
 }
 
-fn shell_escape(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
         command_exists, command_path, run_command, run_command_allow_failure,
         run_command_allow_failure_with_env, run_command_with_env, version_command,
     };
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn run_command_returns_stdout() {
@@ -185,20 +195,24 @@ mod tests {
     }
 
     #[test]
-    fn shell_escape_round_trips_dangerous_characters() {
-        let input = "name;$(echo injected)`uname`";
-        let escaped = super::shell_escape(input);
-        let output = run_command("sh", &["-lc", &format!("printf '%s' {}", escaped)], None)
-            .expect("escaped value should be treated as a literal");
-        assert_eq!(output, input);
+    fn command_path_treats_metacharacters_as_literal_program_name() {
+        let payload = "definitely_not_real_$(echo injected)`uname`;touch /tmp/odt";
+        assert!(command_path(payload).is_none());
     }
 
     #[test]
-    fn shell_escape_handles_single_quotes() {
-        let input = "a'b";
-        let escaped = super::shell_escape(input);
-        let output = run_command("sh", &["-lc", &format!("printf '%s' {}", escaped)], None)
-            .expect("escaped value should preserve single quote");
-        assert_eq!(output, input);
+    fn command_path_does_not_execute_shell_substitution_payloads() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let marker = std::env::temp_dir().join(format!("odt-command-path-marker-{nonce}"));
+        let payload = format!("definitely_not_real_$(touch {})", marker.display());
+
+        assert!(command_path(payload.as_str()).is_none());
+        assert!(
+            !marker.exists(),
+            "payload should not be able to execute touch via shell expansion"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- replace dynamic shell interpolation in `command_path` with a static shell script plus positional parameter (`$1`)
- remove custom `shell_escape` helper from process utility
- add API-level injection-resistance tests for metacharacters and command-substitution payloads
- add Rustdoc clarifying the security contract for `command_path`/`command_exists`

## Validation
- `cargo test -p host-infra-system` (run from `apps/desktop/src-tauri`)
- `cargo test -p host-application` (run from `apps/desktop/src-tauri`)

## Context
This closes the command-injection hardening gap in runtime binary resolution while preserving existing behavior.
