### PR TITLE
ci(security): add deterministic Rust CVE scanning in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: bun run build
 
   tauri-rust-quality:
-    name: Tauri Rust Quality (clippy, check, test)
+    name: Tauri Rust Quality (audit, clippy, check, test)
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -92,6 +92,12 @@ jobs:
 
       - name: Pre-fetch Rust dependencies
         run: cargo fetch --locked
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Audit Rust dependencies
+        run: cargo audit
 
       - name: Lint Rust
         run: cargo clippy --all-targets --locked -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ concurrency:
 env:
   BUN_VERSION: 1.3.5
   CARGO_TERM_COLOR: always
+  CARGO_AUDIT_VERSION: 0.22.1
 
 jobs:
   bun-quality:
@@ -60,7 +61,7 @@ jobs:
         run: bun run build
 
   tauri-rust-quality:
-    name: Tauri Rust Quality (audit, clippy, check, test)
+    name: Tauri Rust Quality & Security (audit, clippy, check, test)
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -78,26 +79,26 @@ jobs:
           toolchain: stable
           components: clippy
 
-      - name: Install Linux dependencies for Tauri
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev librsvg2-dev patchelf
-          sudo apt-get install -y libayatana-appindicator3-dev || sudo apt-get install -y libappindicator3-dev
-
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           workspaces: |
             apps/desktop/src-tauri
 
-      - name: Pre-fetch Rust dependencies
-        run: cargo fetch --locked
-
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
+        run: cargo install cargo-audit --version "$CARGO_AUDIT_VERSION" --locked
 
       - name: Audit Rust dependencies
         run: cargo audit
+
+      - name: Install Linux dependencies for Tauri
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev librsvg2-dev patchelf
+          sudo apt-get install -y libayatana-appindicator3-dev || sudo apt-get install -y libappindicator3-dev
+
+      - name: Pre-fetch Rust dependencies
+        run: cargo fetch --locked
 
       - name: Lint Rust
         run: cargo clippy --all-targets --locked -- -D warnings


### PR DESCRIPTION
## Summary
- add Rust dependency CVE scanning with `cargo audit` in the `tauri-rust-quality` CI job
- pin `cargo-audit` via `CARGO_AUDIT_VERSION` (`0.22.1`) for deterministic CI behavior
- run Rust security audit before heavy Linux/Tauri package installation to fail fast
- update job display name to reflect security coverage

## Why
The pipeline already audited JS dependencies, but Rust dependencies had no equivalent CVE gate. This adds a RustSec-based control in CI.

## Validation
- YAML parse check for `.github/workflows/ci.yml`
- confirmed workflow diff and step ordering
