### PR TITLE
refactor(openducktor-mcp): decompose OdtTaskStore orchestration boundaries

### DIFF
--- a/packages/openducktor-mcp/src/bd-persistence.test.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.test.ts
@@ -92,6 +92,24 @@ describe("BdPersistence", () => {
     await expect(persistence.showRawIssue("missing")).rejects.toThrow("Task not found: missing");
   });
 
+  test("showRawIssue throws when payload entry is not an object", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => [null],
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+    await expect(persistence.showRawIssue("task-1")).rejects.toThrow(
+      "Invalid issue payload for task task-1",
+    );
+  });
+
   test("listTasks maps issues to task cards and respects metadata namespace", async () => {
     const state: FakeClientState = {
       calls: [],
@@ -130,6 +148,22 @@ describe("BdPersistence", () => {
       },
     ]);
     expect(state.calls).toEqual([["list", "--all", "-n", "500"]]);
+  });
+
+  test("listTasks throws when bd payload is not an array", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => ({ invalid: true }),
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+    await expect(persistence.listTasks()).rejects.toThrow("bd list did not return an array");
   });
 
   test("writeNamespace updates metadata under namespace key", async () => {

--- a/packages/openducktor-mcp/src/bd-persistence.test.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import { BdPersistence } from "./bd-persistence";
+import type { BdRuntimeClient } from "./bd-runtime-client";
+import type { RawIssue } from "./contracts";
+
+type FakeClientState = {
+  calls: string[][];
+  ensureInitializedCalls: number;
+};
+
+const createClient = (
+  handlers: {
+    runBdJson: (args: string[]) => Promise<unknown>;
+    ensureInitialized?: () => Promise<void>;
+  },
+  state: FakeClientState,
+): BdRuntimeClient => {
+  return {
+    runBdJson: async (args: string[]) => {
+      state.calls.push([...args]);
+      return handlers.runBdJson(args);
+    },
+    ensureInitialized: async () => {
+      state.ensureInitializedCalls += 1;
+      if (handlers.ensureInitialized) {
+        await handlers.ensureInitialized();
+      }
+    },
+  } as unknown as BdRuntimeClient;
+};
+
+describe("BdPersistence", () => {
+  test("ensureInitialized delegates to runtime client", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => ({}),
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+    await persistence.ensureInitialized();
+
+    expect(state.ensureInitializedCalls).toBe(1);
+  });
+
+  test("showRawIssue validates payload and returns first issue", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const issue: RawIssue = {
+      id: "task-1",
+      title: "Task 1",
+      status: "open",
+      issue_type: "feature",
+      metadata: {},
+    };
+
+    const client = createClient(
+      {
+        runBdJson: async () => [issue],
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+    const result = await persistence.showRawIssue("task-1");
+
+    expect(result).toEqual(issue);
+    expect(state.calls).toEqual([["show", "task-1"]]);
+  });
+
+  test("showRawIssue throws when issue is missing", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => [],
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+
+    await expect(persistence.showRawIssue("missing")).rejects.toThrow("Task not found: missing");
+  });
+
+  test("listTasks maps issues to task cards and respects metadata namespace", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => [
+          {
+            id: "task-1",
+            title: "Task 1",
+            status: "in_progress",
+            issue_type: "feature",
+            metadata: {
+              openducktor: {
+                qaRequired: false,
+              },
+            },
+          },
+          "ignored",
+        ],
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+    const tasks = await persistence.listTasks();
+
+    expect(tasks).toEqual([
+      {
+        id: "task-1",
+        title: "Task 1",
+        status: "in_progress",
+        issueType: "feature",
+        aiReviewEnabled: false,
+      },
+    ]);
+    expect(state.calls).toEqual([["list", "--all", "-n", "500"]]);
+  });
+
+  test("writeNamespace updates metadata under namespace key", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => ({}),
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+    await persistence.writeNamespace(
+      "task-1",
+      {
+        external: { keep: true },
+      },
+      {
+        documents: {
+          spec: [],
+        },
+      },
+    );
+
+    expect(state.calls).toHaveLength(1);
+    expect(state.calls[0]?.slice(0, 3)).toEqual(["update", "task-1", "--metadata"]);
+    const metadataJson = state.calls[0]?.[3] ?? "{}";
+    expect(JSON.parse(metadataJson)).toEqual({
+      external: { keep: true },
+      openducktor: {
+        documents: {
+          spec: [],
+        },
+      },
+    });
+  });
+});

--- a/packages/openducktor-mcp/src/bd-persistence.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.ts
@@ -1,0 +1,60 @@
+import type { BdRuntimeClient } from "./bd-runtime-client";
+import type { JsonObject, RawIssue, TaskCard } from "./contracts";
+import { getNamespaceData, type NamespaceData } from "./metadata-docs";
+import { issueToTaskCard } from "./task-mapping";
+
+export class BdPersistence {
+  readonly metadataNamespace: string;
+  private readonly bdClient: BdRuntimeClient;
+
+  constructor(bdClient: BdRuntimeClient, metadataNamespace: string) {
+    this.bdClient = bdClient;
+    this.metadataNamespace = metadataNamespace;
+  }
+
+  async runBdJson(args: string[]): Promise<unknown> {
+    return this.bdClient.runBdJson(args);
+  }
+
+  async ensureInitialized(): Promise<void> {
+    await this.bdClient.ensureInitialized();
+  }
+
+  async showRawIssue(taskId: string): Promise<RawIssue> {
+    const payload = await this.runBdJson(["show", taskId]);
+    if (!Array.isArray(payload) || payload.length === 0) {
+      throw new Error(`Task not found: ${taskId}`);
+    }
+
+    const issue = payload[0];
+    if (!issue || typeof issue !== "object") {
+      throw new Error(`Invalid issue payload for task ${taskId}`);
+    }
+
+    return issue as RawIssue;
+  }
+
+  async listTasks(): Promise<TaskCard[]> {
+    const payload = await this.runBdJson(["list", "--all", "-n", "500"]);
+    if (!Array.isArray(payload)) {
+      throw new Error("bd list did not return an array");
+    }
+
+    return payload
+      .filter((entry) => entry && typeof entry === "object")
+      .map((entry) => issueToTaskCard(entry as RawIssue, this.metadataNamespace));
+  }
+
+  getNamespaceData(issue: RawIssue): NamespaceData {
+    return getNamespaceData(issue, this.metadataNamespace);
+  }
+
+  async writeNamespace(taskId: string, root: JsonObject, namespace: JsonObject): Promise<void> {
+    const nextRoot = {
+      ...root,
+      [this.metadataNamespace]: namespace,
+    };
+
+    await this.runBdJson(["update", taskId, "--metadata", JSON.stringify(nextRoot)]);
+  }
+}

--- a/packages/openducktor-mcp/src/bd-persistence.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.ts
@@ -3,7 +3,17 @@ import type { JsonObject, RawIssue, TaskCard } from "./contracts";
 import { getNamespaceData, type NamespaceData } from "./metadata-docs";
 import { issueToTaskCard } from "./task-mapping";
 
-export class BdPersistence {
+export type TaskPersistencePort = {
+  metadataNamespace: string;
+  runBdJson(args: string[]): Promise<unknown>;
+  ensureInitialized(): Promise<void>;
+  showRawIssue(taskId: string): Promise<RawIssue>;
+  listTasks(): Promise<TaskCard[]>;
+  getNamespaceData(issue: RawIssue): NamespaceData;
+  writeNamespace(taskId: string, root: JsonObject, namespace: JsonObject): Promise<void>;
+};
+
+export class BdPersistence implements TaskPersistencePort {
   readonly metadataNamespace: string;
   private readonly bdClient: BdRuntimeClient;
 

--- a/packages/openducktor-mcp/src/epic-subtask-replacement.test.ts
+++ b/packages/openducktor-mcp/src/epic-subtask-replacement.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import type { PlanSubtaskInput, TaskCard } from "./contracts";
+import { EpicSubtaskReplacementService } from "./epic-subtask-replacement";
+
+const makeTask = (input: {
+  id: string;
+  title: string;
+  status: TaskCard["status"];
+  issueType?: TaskCard["issueType"];
+  parentId?: string;
+}): TaskCard => {
+  return {
+    id: input.id,
+    title: input.title,
+    status: input.status,
+    issueType: input.issueType ?? "task",
+    aiReviewEnabled: true,
+    ...(input.parentId ? { parentId: input.parentId } : {}),
+  };
+};
+
+describe("EpicSubtaskReplacementService", () => {
+  test("prepareReplacement rejects when refreshed subtasks contain active work", async () => {
+    const service = new EpicSubtaskReplacementService({
+      listTasks: async () => [
+        makeTask({ id: "epic-1", title: "Epic", status: "spec_ready", issueType: "epic" }),
+        makeTask({
+          id: "sub-1",
+          title: "In progress",
+          status: "in_progress",
+          parentId: "epic-1",
+        }),
+      ],
+      createSubtask: async () => "unused",
+      deleteTask: async () => {},
+    });
+
+    await expect(
+      service.prepareReplacement(
+        makeTask({ id: "epic-1", title: "Epic", status: "spec_ready", issueType: "epic" }),
+        [{ title: "New subtask" }],
+      ),
+    ).rejects.toThrow("Cannot replace epic subtasks while active work exists");
+  });
+
+  test("applyReplacement deletes existing subtasks first and deduplicates by title key", async () => {
+    const operations: string[] = [];
+    const createInputs: Array<{ parentTaskId: string; subtask: PlanSubtaskInput }> = [];
+
+    const service = new EpicSubtaskReplacementService({
+      listTasks: async () => [],
+      createSubtask: async (parentTaskId, subtask) => {
+        operations.push(`create:${subtask.title}`);
+        createInputs.push({ parentTaskId, subtask });
+        return `${parentTaskId}-${createInputs.length}`;
+      },
+      deleteTask: async (taskId) => {
+        operations.push(`delete:${taskId}`);
+      },
+    });
+
+    const epic = makeTask({ id: "epic-1", title: "Epic", status: "spec_ready", issueType: "epic" });
+    const createdIds = await service.applyReplacement(
+      epic,
+      [
+        makeTask({ id: "legacy-1", title: "Legacy 1", status: "open", parentId: "epic-1" }),
+        makeTask({ id: "legacy-2", title: "Legacy 2", status: "open", parentId: "epic-1" }),
+      ],
+      [{ title: "Build API" }, { title: "build api" }, { title: "Write tests" }],
+    );
+
+    expect(operations).toEqual([
+      "delete:legacy-1",
+      "delete:legacy-2",
+      "create:Build API",
+      "create:Write tests",
+    ]);
+    expect(createInputs).toEqual([
+      { parentTaskId: "epic-1", subtask: { title: "Build API" } },
+      { parentTaskId: "epic-1", subtask: { title: "Write tests" } },
+    ]);
+    expect(createdIds).toEqual(["epic-1-1", "epic-1-2"]);
+  });
+});

--- a/packages/openducktor-mcp/src/epic-subtask-replacement.ts
+++ b/packages/openducktor-mcp/src/epic-subtask-replacement.ts
@@ -1,0 +1,82 @@
+import type { PlanSubtaskInput, TaskCard } from "./contracts";
+import { normalizeTitleKey } from "./task-resolution";
+import {
+  assertNoValidationError,
+  canReplaceEpicSubtaskStatus,
+  getSetPlanError,
+  validatePlanSubtaskRules,
+} from "./workflow-policy";
+
+export type EpicSubtaskReplacement = {
+  latestTask: TaskCard;
+  existingDirectSubtasks: TaskCard[];
+};
+
+export type EpicSubtaskReplacementDeps = {
+  listTasks: () => Promise<TaskCard[]>;
+  createSubtask: (parentTaskId: string, subtask: PlanSubtaskInput) => Promise<string>;
+  deleteTask: (taskId: string) => Promise<void>;
+};
+
+export class EpicSubtaskReplacementService {
+  private readonly deps: EpicSubtaskReplacementDeps;
+
+  constructor(deps: EpicSubtaskReplacementDeps) {
+    this.deps = deps;
+  }
+
+  async prepareReplacement(
+    task: TaskCard,
+    normalizedSubtasks: PlanSubtaskInput[],
+  ): Promise<EpicSubtaskReplacement> {
+    const latestTasks = await this.deps.listTasks();
+    const latestTask = latestTasks.find((entry) => entry.id === task.id);
+    if (!latestTask) {
+      throw new Error(`Task not found: ${task.id}`);
+    }
+
+    assertNoValidationError(getSetPlanError(latestTask));
+    validatePlanSubtaskRules(latestTask, latestTasks, normalizedSubtasks);
+
+    const existingDirectSubtasks = latestTasks.filter((entry) => entry.parentId === task.id);
+    const blockedSubtasks = existingDirectSubtasks.filter(
+      (entry) => !canReplaceEpicSubtaskStatus(entry.status),
+    );
+    if (blockedSubtasks.length > 0) {
+      const blockedSummary = blockedSubtasks
+        .map((entry) => `${entry.id} (${entry.status})`)
+        .join(", ");
+      throw new Error(
+        "Cannot replace epic subtasks while active work exists. " +
+          `Move subtasks to open/spec_ready/ready_for_dev first: ${blockedSummary}`,
+      );
+    }
+
+    return { latestTask, existingDirectSubtasks };
+  }
+
+  async applyReplacement(
+    task: TaskCard,
+    existingDirectSubtasks: TaskCard[],
+    normalizedSubtasks: PlanSubtaskInput[],
+  ): Promise<string[]> {
+    for (const existingSubtask of existingDirectSubtasks) {
+      await this.deps.deleteTask(existingSubtask.id);
+    }
+
+    const createdSubtaskIds: string[] = [];
+    const createdTitleKeys = new Set<string>();
+    for (const subtask of normalizedSubtasks) {
+      const key = normalizeTitleKey(subtask.title);
+      if (createdTitleKeys.has(key)) {
+        continue;
+      }
+
+      const createdId = await this.deps.createSubtask(task.id, subtask);
+      createdSubtaskIds.push(createdId);
+      createdTitleKeys.add(key);
+    }
+
+    return createdSubtaskIds;
+  }
+}

--- a/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import type { TaskPersistencePort } from "./bd-persistence";
+import type { RawIssue, TaskCard } from "./contracts";
+import { OdtTaskStore } from "./odt-task-store";
+import type { TaskDocumentPort } from "./task-document-store";
+
+const makeTask = (): TaskCard => ({
+  id: "task-1",
+  title: "Task 1",
+  status: "open",
+  issueType: "feature",
+  aiReviewEnabled: true,
+});
+
+describe("OdtTaskStore composition", () => {
+  test("uses injected ports and persistence namespace for read mapping", async () => {
+    const issue: RawIssue = {
+      id: "task-1",
+      title: "Task 1",
+      status: "open",
+      issue_type: "feature",
+      metadata: {
+        custom_ns: {
+          qaRequired: false,
+        },
+      },
+    };
+
+    const persistence: TaskPersistencePort = {
+      metadataNamespace: "custom_ns",
+      ensureInitialized: async () => {},
+      runBdJson: async () => {
+        throw new Error("runBdJson should not be called by readTask");
+      },
+      listTasks: async () => [makeTask()],
+      showRawIssue: async () => issue,
+      getNamespaceData: () => {
+        throw new Error("getNamespaceData should not be called by readTask");
+      },
+      writeNamespace: async () => {
+        throw new Error("writeNamespace should not be called by readTask");
+      },
+    };
+
+    const documentStore: TaskDocumentPort = {
+      parseDocs: () => ({
+        spec: { markdown: "spec", updatedAt: null },
+        implementationPlan: { markdown: "plan", updatedAt: null },
+        latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+      }),
+      persistSpec: async () => ({ updatedAt: "", revision: 1 }),
+      persistImplementationPlan: async () => ({ updatedAt: "", revision: 1 }),
+      appendQaReport: async () => {},
+    };
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "wrong_namespace",
+        beadsDir: "/beads",
+      },
+      {
+        persistence,
+        documentStore,
+      },
+    );
+
+    const result = (await store.readTask({ taskId: "task-1" })) as {
+      task: TaskCard;
+      documents: { spec: { markdown: string } };
+    };
+
+    expect(result.task.aiReviewEnabled).toBe(false);
+    expect(result.documents.spec.markdown).toBe("spec");
+  });
+});

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -1,19 +1,12 @@
+import { BdPersistence } from "./bd-persistence";
 import { BdRuntimeClient, type BdRuntimeClientDeps } from "./bd-runtime-client";
 import { nowIso, type TimeProvider } from "./beads-runtime";
-import type {
-  JsonObject,
-  MarkdownEntry,
-  PlanSubtaskInput,
-  QaEntry,
-  RawIssue,
-  TaskCard,
-  TaskStatus,
-} from "./contracts";
+import type { PlanSubtaskInput, TaskCard, TaskStatus } from "./contracts";
 import { createSubtask, deleteTaskById } from "./epic-subtasks";
-import { getNamespaceData, parseTaskDocuments } from "./metadata-docs";
 import { normalizePlanSubtasks } from "./plan-subtasks";
 import type { OdtStoreOptions } from "./store-context";
-import { issueToTaskCard, parseMarkdownEntries, parseQaEntries } from "./task-mapping";
+import { TaskDocumentStore } from "./task-document-store";
+import { issueToTaskCard } from "./task-mapping";
 import {
   buildTaskIndex,
   normalizeTitleKey,
@@ -56,58 +49,26 @@ export type OdtTaskStoreDeps = {
 export class OdtTaskStore {
   readonly repoPath: string;
   readonly metadataNamespace: string;
-  private readonly bdClient: BdRuntimeClient;
-  private readonly now: TimeProvider;
+  private readonly persistence: BdPersistence;
+  private readonly documentStore: TaskDocumentStore;
   private taskIndex: TaskIndex | null;
   private taskIndexBuildPromise: Promise<TaskIndex> | null;
 
   constructor(options: OdtStoreOptions, deps: OdtTaskStoreDeps = {}) {
     this.repoPath = options.repoPath;
     this.metadataNamespace = options.metadataNamespace;
-    this.bdClient = new BdRuntimeClient(this.repoPath, options.beadsDir ?? null, {
+    const bdClient = new BdRuntimeClient(this.repoPath, options.beadsDir ?? null, {
       ...(deps.runProcess ? { runProcess: deps.runProcess } : {}),
       ...(deps.resolveBeadsDir ? { resolveBeadsDir: deps.resolveBeadsDir } : {}),
     });
-    this.now = deps.now ?? nowIso;
+    this.persistence = new BdPersistence(bdClient, this.metadataNamespace);
+    this.documentStore = new TaskDocumentStore(this.persistence, deps.now ?? nowIso);
     this.taskIndex = null;
     this.taskIndexBuildPromise = null;
   }
 
-  private async runBdJson(args: string[]): Promise<unknown> {
-    return this.bdClient.runBdJson(args);
-  }
-
-  private async ensureInitialized(): Promise<void> {
-    await this.bdClient.ensureInitialized();
-  }
-
-  private async showRawIssue(taskId: string): Promise<RawIssue> {
-    const payload = await this.runBdJson(["show", taskId]);
-    if (!Array.isArray(payload) || payload.length === 0) {
-      throw new Error(`Task not found: ${taskId}`);
-    }
-
-    const issue = payload[0];
-    if (!issue || typeof issue !== "object") {
-      throw new Error(`Invalid issue payload for task ${taskId}`);
-    }
-
-    return issue as RawIssue;
-  }
-
-  private async listTasks(): Promise<TaskCard[]> {
-    const payload = await this.runBdJson(["list", "--all", "-n", "500"]);
-    if (!Array.isArray(payload)) {
-      throw new Error("bd list did not return an array");
-    }
-
-    return payload
-      .filter((entry) => entry && typeof entry === "object")
-      .map((entry) => issueToTaskCard(entry as RawIssue, this.metadataNamespace));
-  }
-
   private async refreshTaskIndex(): Promise<TaskIndex> {
-    const tasks = await this.listTasks();
+    const tasks = await this.persistence.listTasks();
     const next = buildTaskIndex(tasks);
     this.taskIndex = next;
     return next;
@@ -141,14 +102,14 @@ export class OdtTaskStore {
   }
 
   private async resolveTaskContext(taskId: string): Promise<TaskContext> {
-    return resolveTaskContext(taskId, () => this.listTasks());
+    return resolveTaskContext(taskId, () => this.persistence.listTasks());
   }
 
   private async refreshTaskContext(taskId: string, context?: TaskContext): Promise<TaskContext> {
     return refreshTaskContext({
       taskId,
       ...(context ? { context } : {}),
-      showRawIssue: (id) => this.showRawIssue(id),
+      showRawIssue: (id) => this.persistence.showRawIssue(id),
       metadataNamespace: this.metadataNamespace,
     });
   }
@@ -166,52 +127,19 @@ export class OdtTaskStore {
       taskId,
       nextStatus,
       ...(context ? { context } : {}),
-      listTasks: () => this.listTasks(),
-      runBdJson: (args) => this.runBdJson(args),
-      showRawIssue: (id) => this.showRawIssue(id),
+      listTasks: () => this.persistence.listTasks(),
+      runBdJson: (args) => this.persistence.runBdJson(args),
+      showRawIssue: (id) => this.persistence.showRawIssue(id),
       invalidateTaskIndex: () => this.invalidateTaskIndex(),
       metadataNamespace: this.metadataNamespace,
     });
-  }
-
-  private getNamespaceData(issue: RawIssue): {
-    root: JsonObject;
-    namespace: JsonObject;
-    documents: JsonObject;
-  } {
-    return getNamespaceData(issue, this.metadataNamespace);
-  }
-
-  private async writeNamespace(
-    taskId: string,
-    root: JsonObject,
-    namespace: JsonObject,
-  ): Promise<void> {
-    const nextRoot = {
-      ...root,
-      [this.metadataNamespace]: namespace,
-    };
-
-    await this.runBdJson(["update", taskId, "--metadata", JSON.stringify(nextRoot)]);
-  }
-
-  private parseDocs(issue: RawIssue): {
-    spec: { markdown: string; updatedAt: string | null };
-    implementationPlan: { markdown: string; updatedAt: string | null };
-    latestQaReport: {
-      markdown: string;
-      updatedAt: string | null;
-      verdict: "approved" | "rejected" | null;
-    };
-  } {
-    return parseTaskDocuments(issue, this.metadataNamespace);
   }
 
   private async createSubtask(parentTaskId: string, subtask: PlanSubtaskInput): Promise<string> {
     return createSubtask(
       parentTaskId,
       subtask,
-      (args) => this.runBdJson(args),
+      (args) => this.persistence.runBdJson(args),
       () => this.invalidateTaskIndex(),
     );
   }
@@ -219,7 +147,7 @@ export class OdtTaskStore {
   private async deleteTask(taskId: string, deleteSubtasks = false): Promise<void> {
     await deleteTaskById(
       taskId,
-      (args) => this.runBdJson(args),
+      (args) => this.persistence.runBdJson(args),
       () => this.invalidateTaskIndex(),
       deleteSubtasks,
     );
@@ -229,7 +157,7 @@ export class OdtTaskStore {
     task: TaskCard,
     normalizedSubtasks: PlanSubtaskInput[],
   ): Promise<{ latestTask: TaskCard; existingDirectSubtasks: TaskCard[] }> {
-    const latestTasks = await this.listTasks();
+    const latestTasks = await this.persistence.listTasks();
     const latestTask = latestTasks.find((entry) => entry.id === task.id);
     if (!latestTask) {
       throw new Error(`Task not found: ${task.id}`);
@@ -280,43 +208,8 @@ export class OdtTaskStore {
     return createdSubtaskIds;
   }
 
-  private async persistImplementationPlan(
-    taskId: string,
-    markdown: string,
-  ): Promise<{ updatedAt: string; revision: number }> {
-    const issue = await this.showRawIssue(taskId);
-    const { root, namespace, documents } = this.getNamespaceData(issue);
-    const nextRevision =
-      (parseMarkdownEntries(documents.implementationPlan).at(-1)?.revision ?? 0) + 1;
-
-    const updatedAt = this.now();
-    const entry: MarkdownEntry = {
-      markdown,
-      updatedAt,
-      updatedBy: "planner-agent",
-      sourceTool: "odt_set_plan",
-      revision: nextRevision,
-    };
-
-    const nextDocuments = {
-      ...documents,
-      implementationPlan: [entry],
-    };
-
-    const nextNamespace = {
-      ...namespace,
-      documents: nextDocuments,
-    };
-
-    await this.writeNamespace(taskId, root, nextNamespace);
-    return {
-      updatedAt,
-      revision: nextRevision,
-    };
-  }
-
   async readTask(rawInput: unknown): Promise<unknown> {
-    await this.ensureInitialized();
+    await this.persistence.ensureInitialized();
     const input = ReadTaskInputSchema.parse(rawInput);
     const index = await this.getOrBuildTaskIndex();
 
@@ -335,9 +228,9 @@ export class OdtTaskStore {
       task = resolveTaskFromIndex(refreshedIndex, input.taskId);
     }
 
-    const issue = await this.showRawIssue(task.id);
+    const issue = await this.persistence.showRawIssue(task.id);
     const taskCard = issueToTaskCard(issue, this.metadataNamespace);
-    const docs = this.parseDocs(issue);
+    const docs = this.documentStore.parseDocs(issue);
 
     return {
       task: taskCard,
@@ -346,7 +239,7 @@ export class OdtTaskStore {
   }
 
   async setSpec(rawInput: unknown): Promise<unknown> {
-    await this.ensureInitialized();
+    await this.persistence.ensureInitialized();
     const input = SetSpecInputSchema.parse(rawInput);
     const markdown = input.markdown.trim();
 
@@ -354,30 +247,7 @@ export class OdtTaskStore {
     const { task } = context;
     assertNoValidationError(getSetSpecError(task.status));
 
-    const issue = await this.showRawIssue(task.id);
-    const { root, namespace, documents } = this.getNamespaceData(issue);
-    const nextRevision = (parseMarkdownEntries(documents.spec).at(-1)?.revision ?? 0) + 1;
-
-    const updatedAt = this.now();
-    const entry: MarkdownEntry = {
-      markdown,
-      updatedAt,
-      updatedBy: "spec-agent",
-      sourceTool: "odt_set_spec",
-      revision: nextRevision,
-    };
-
-    const nextDocuments = {
-      ...documents,
-      spec: [entry],
-    };
-
-    const nextNamespace = {
-      ...namespace,
-      documents: nextDocuments,
-    };
-
-    await this.writeNamespace(task.id, root, nextNamespace);
+    const persistedDocument = await this.documentStore.persistSpec(task.id, markdown);
 
     let nextTask: TaskCard = task;
     if (task.status === "open") {
@@ -389,14 +259,14 @@ export class OdtTaskStore {
       task: nextTask,
       document: {
         markdown,
-        updatedAt,
-        revision: nextRevision,
+        updatedAt: persistedDocument.updatedAt,
+        revision: persistedDocument.revision,
       },
     };
   }
 
   async setPlan(rawInput: unknown): Promise<unknown> {
-    await this.ensureInitialized();
+    await this.persistence.ensureInitialized();
     const input = SetPlanInputSchema.parse(rawInput);
     const markdown = input.markdown.trim();
 
@@ -409,7 +279,7 @@ export class OdtTaskStore {
     if (task.issueType === "epic") {
       // Epic subtask replacement must validate against a fresh snapshot, not the initial context.
       const epicReplacement = await this.prepareEpicSubtaskReplacement(task, normalizedSubtasks);
-      persistedDocument = await this.persistImplementationPlan(task.id, markdown);
+      persistedDocument = await this.documentStore.persistImplementationPlan(task.id, markdown);
       createdSubtaskIds = await this.applyEpicSubtaskReplacement(
         epicReplacement.latestTask,
         epicReplacement.existingDirectSubtasks,
@@ -418,7 +288,7 @@ export class OdtTaskStore {
     } else {
       assertNoValidationError(getSetPlanError(task));
       validatePlanSubtaskRules(task, tasks, normalizedSubtasks);
-      persistedDocument = await this.persistImplementationPlan(task.id, markdown);
+      persistedDocument = await this.documentStore.persistImplementationPlan(task.id, markdown);
     }
 
     const refreshedTransitionContext = await this.refreshTaskContext(task.id, context);
@@ -440,7 +310,7 @@ export class OdtTaskStore {
   }
 
   async buildBlocked(rawInput: unknown): Promise<unknown> {
-    await this.ensureInitialized();
+    await this.persistence.ensureInitialized();
     const input = BuildBlockedInputSchema.parse(rawInput);
     const task = await this.transitionTask(input.taskId, "blocked");
     return {
@@ -450,14 +320,14 @@ export class OdtTaskStore {
   }
 
   async buildResumed(rawInput: unknown): Promise<unknown> {
-    await this.ensureInitialized();
+    await this.persistence.ensureInitialized();
     const input = BuildResumedInputSchema.parse(rawInput);
     const task = await this.transitionTask(input.taskId, "in_progress");
     return { task };
   }
 
   async buildCompleted(rawInput: unknown): Promise<unknown> {
-    await this.ensureInitialized();
+    await this.persistence.ensureInitialized();
     const input = BuildCompletedInputSchema.parse(rawInput);
 
     const context = await this.resolveTaskContext(input.taskId);
@@ -472,57 +342,25 @@ export class OdtTaskStore {
     };
   }
 
-  private async appendQaReport(
-    taskId: string,
-    markdown: string,
-    verdict: "approved" | "rejected",
-  ): Promise<void> {
-    const issue = await this.showRawIssue(taskId);
-    const { root, namespace, documents } = this.getNamespaceData(issue);
-    const entries = parseQaEntries(documents.qaReports);
-    const nextRevision = (entries.at(-1)?.revision ?? 0) + 1;
-
-    const entry: QaEntry = {
-      markdown,
-      verdict,
-      updatedAt: this.now(),
-      updatedBy: "qa-agent",
-      sourceTool: verdict === "approved" ? "odt_qa_approved" : "odt_qa_rejected",
-      revision: nextRevision,
-    };
-
-    const nextDocuments = {
-      ...documents,
-      qaReports: [...entries, entry],
-    };
-
-    const nextNamespace = {
-      ...namespace,
-      documents: nextDocuments,
-    };
-
-    await this.writeNamespace(taskId, root, nextNamespace);
-  }
-
   async qaApproved(rawInput: unknown): Promise<unknown> {
-    await this.ensureInitialized();
+    await this.persistence.ensureInitialized();
     const input = QaApprovedInputSchema.parse(rawInput);
     const context = await this.resolveTaskContext(input.taskId);
     const { task, tasks } = context;
     this.assertTransitionAllowed(task, tasks, "human_review");
-    await this.appendQaReport(task.id, input.reportMarkdown.trim(), "approved");
+    await this.documentStore.appendQaReport(task.id, input.reportMarkdown.trim(), "approved");
     const refreshedContext = await this.refreshTaskContext(task.id, context);
     const updated = await this.transitionTask(task.id, "human_review", refreshedContext);
     return { task: updated };
   }
 
   async qaRejected(rawInput: unknown): Promise<unknown> {
-    await this.ensureInitialized();
+    await this.persistence.ensureInitialized();
     const input = QaRejectedInputSchema.parse(rawInput);
     const context = await this.resolveTaskContext(input.taskId);
     const { task, tasks } = context;
     this.assertTransitionAllowed(task, tasks, "in_progress");
-    await this.appendQaReport(task.id, input.reportMarkdown.trim(), "rejected");
+    await this.documentStore.appendQaReport(task.id, input.reportMarkdown.trim(), "rejected");
     const refreshedContext = await this.refreshTaskContext(task.id, context);
     const updated = await this.transitionTask(task.id, "in_progress", refreshedContext);
     return { task: updated };

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -1,7 +1,7 @@
 import { BdPersistence, type TaskPersistencePort } from "./bd-persistence";
 import { BdRuntimeClient, type BdRuntimeClientDeps } from "./bd-runtime-client";
 import { nowIso, type TimeProvider } from "./beads-runtime";
-import type { PlanSubtaskInput, TaskCard, TaskStatus } from "./contracts";
+import type { TaskCard, TaskStatus } from "./contracts";
 import { EpicSubtaskReplacementService } from "./epic-subtask-replacement";
 import { createSubtask, deleteTaskById } from "./epic-subtasks";
 import { normalizePlanSubtasks } from "./plan-subtasks";
@@ -63,8 +63,20 @@ export class OdtTaskStore {
       deps.epicSubtaskReplacementService ??
       new EpicSubtaskReplacementService({
         listTasks: () => this.persistence.listTasks(),
-        createSubtask: async (parentTaskId, subtask) => this.createSubtask(parentTaskId, subtask),
-        deleteTask: async (taskId) => this.deleteTask(taskId),
+        createSubtask: async (parentTaskId, subtask) =>
+          createSubtask(
+            parentTaskId,
+            subtask,
+            (args) => this.persistence.runBdJson(args),
+            () => this.taskIndexCache.invalidate(),
+          ),
+        deleteTask: async (taskId) =>
+          deleteTaskById(
+            taskId,
+            (args) => this.persistence.runBdJson(args),
+            () => this.taskIndexCache.invalidate(),
+            false,
+          ),
       });
   }
 
@@ -111,24 +123,6 @@ export class OdtTaskStore {
       invalidateTaskIndex: () => this.taskIndexCache.invalidate(),
       metadataNamespace: this.metadataNamespace,
     });
-  }
-
-  private async createSubtask(parentTaskId: string, subtask: PlanSubtaskInput): Promise<string> {
-    return createSubtask(
-      parentTaskId,
-      subtask,
-      (args) => this.persistence.runBdJson(args),
-      () => this.taskIndexCache.invalidate(),
-    );
-  }
-
-  private async deleteTask(taskId: string, deleteSubtasks = false): Promise<void> {
-    await deleteTaskById(
-      taskId,
-      (args) => this.persistence.runBdJson(args),
-      () => this.taskIndexCache.invalidate(),
-      deleteSubtasks,
-    );
   }
 
   async readTask(rawInput: unknown): Promise<unknown> {

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -1,20 +1,14 @@
-import { BdPersistence } from "./bd-persistence";
+import { BdPersistence, type TaskPersistencePort } from "./bd-persistence";
 import { BdRuntimeClient, type BdRuntimeClientDeps } from "./bd-runtime-client";
 import { nowIso, type TimeProvider } from "./beads-runtime";
 import type { PlanSubtaskInput, TaskCard, TaskStatus } from "./contracts";
+import { EpicSubtaskReplacementService } from "./epic-subtask-replacement";
 import { createSubtask, deleteTaskById } from "./epic-subtasks";
 import { normalizePlanSubtasks } from "./plan-subtasks";
 import type { OdtStoreOptions } from "./store-context";
-import { TaskDocumentStore } from "./task-document-store";
+import { type TaskDocumentPort, TaskDocumentStore } from "./task-document-store";
+import { TaskIndexCache } from "./task-index-cache";
 import { issueToTaskCard } from "./task-mapping";
-import {
-  buildTaskIndex,
-  normalizeTitleKey,
-  resolveTaskFromIndex,
-  type TaskIndex,
-  TaskResolutionAmbiguousError,
-  TaskResolutionNotFoundError,
-} from "./task-resolution";
 import {
   assertTransitionAllowed as assertTaskTransitionAllowed,
   refreshTaskContext,
@@ -34,7 +28,6 @@ import {
 } from "./tool-schemas";
 import {
   assertNoValidationError,
-  canReplaceEpicSubtaskStatus,
   getSetPlanError,
   getSetSpecError,
   validatePlanSubtaskRules,
@@ -44,61 +37,46 @@ export type OdtTaskStoreDeps = {
   runProcess?: BdRuntimeClientDeps["runProcess"];
   resolveBeadsDir?: BdRuntimeClientDeps["resolveBeadsDir"];
   now?: TimeProvider;
+  persistence?: TaskPersistencePort;
+  documentStore?: TaskDocumentPort;
+  taskIndexCache?: TaskIndexCache;
+  epicSubtaskReplacementService?: EpicSubtaskReplacementService;
 };
 
 export class OdtTaskStore {
   readonly repoPath: string;
   readonly metadataNamespace: string;
-  private readonly persistence: BdPersistence;
-  private readonly documentStore: TaskDocumentStore;
-  private taskIndex: TaskIndex | null;
-  private taskIndexBuildPromise: Promise<TaskIndex> | null;
+  private readonly persistence: TaskPersistencePort;
+  private readonly documentStore: TaskDocumentPort;
+  private readonly taskIndexCache: TaskIndexCache;
+  private readonly epicSubtaskReplacementService: EpicSubtaskReplacementService;
 
   constructor(options: OdtStoreOptions, deps: OdtTaskStoreDeps = {}) {
     this.repoPath = options.repoPath;
-    this.metadataNamespace = options.metadataNamespace;
+    this.persistence = deps.persistence ?? this.createDefaultPersistence(options, deps);
+    this.metadataNamespace = this.persistence.metadataNamespace;
+    this.documentStore =
+      deps.documentStore ?? new TaskDocumentStore(this.persistence, deps.now ?? nowIso);
+    this.taskIndexCache =
+      deps.taskIndexCache ?? new TaskIndexCache(() => this.persistence.listTasks());
+    this.epicSubtaskReplacementService =
+      deps.epicSubtaskReplacementService ??
+      new EpicSubtaskReplacementService({
+        listTasks: () => this.persistence.listTasks(),
+        createSubtask: async (parentTaskId, subtask) => this.createSubtask(parentTaskId, subtask),
+        deleteTask: async (taskId) => this.deleteTask(taskId),
+      });
+  }
+
+  private createDefaultPersistence(
+    options: OdtStoreOptions,
+    deps: OdtTaskStoreDeps,
+  ): BdPersistence {
     const bdClient = new BdRuntimeClient(this.repoPath, options.beadsDir ?? null, {
       ...(deps.runProcess ? { runProcess: deps.runProcess } : {}),
       ...(deps.resolveBeadsDir ? { resolveBeadsDir: deps.resolveBeadsDir } : {}),
     });
-    this.persistence = new BdPersistence(bdClient, this.metadataNamespace);
-    this.documentStore = new TaskDocumentStore(this.persistence, deps.now ?? nowIso);
-    this.taskIndex = null;
-    this.taskIndexBuildPromise = null;
-  }
-
-  private async refreshTaskIndex(): Promise<TaskIndex> {
-    const tasks = await this.persistence.listTasks();
-    const next = buildTaskIndex(tasks);
-    this.taskIndex = next;
-    return next;
-  }
-
-  /**
-   * Get or build cached task index for O(1) lookups.
-   * Rebuilds index when tasks change.
-   */
-  private async getOrBuildTaskIndex(): Promise<TaskIndex> {
-    if (this.taskIndex) {
-      return this.taskIndex;
-    }
-
-    if (this.taskIndexBuildPromise) {
-      return this.taskIndexBuildPromise;
-    }
-
-    this.taskIndexBuildPromise = this.refreshTaskIndex();
-    try {
-      return await this.taskIndexBuildPromise;
-    } finally {
-      this.taskIndexBuildPromise = null;
-    }
-  }
-
-  /** Invalidate task index after mutations */
-  private invalidateTaskIndex(): void {
-    this.taskIndex = null;
-    this.taskIndexBuildPromise = null;
+    return new BdPersistence(bdClient, options.metadataNamespace);
   }
 
   private async resolveTaskContext(taskId: string): Promise<TaskContext> {
@@ -130,7 +108,7 @@ export class OdtTaskStore {
       listTasks: () => this.persistence.listTasks(),
       runBdJson: (args) => this.persistence.runBdJson(args),
       showRawIssue: (id) => this.persistence.showRawIssue(id),
-      invalidateTaskIndex: () => this.invalidateTaskIndex(),
+      invalidateTaskIndex: () => this.taskIndexCache.invalidate(),
       metadataNamespace: this.metadataNamespace,
     });
   }
@@ -140,7 +118,7 @@ export class OdtTaskStore {
       parentTaskId,
       subtask,
       (args) => this.persistence.runBdJson(args),
-      () => this.invalidateTaskIndex(),
+      () => this.taskIndexCache.invalidate(),
     );
   }
 
@@ -148,85 +126,15 @@ export class OdtTaskStore {
     await deleteTaskById(
       taskId,
       (args) => this.persistence.runBdJson(args),
-      () => this.invalidateTaskIndex(),
+      () => this.taskIndexCache.invalidate(),
       deleteSubtasks,
     );
-  }
-
-  private async prepareEpicSubtaskReplacement(
-    task: TaskCard,
-    normalizedSubtasks: PlanSubtaskInput[],
-  ): Promise<{ latestTask: TaskCard; existingDirectSubtasks: TaskCard[] }> {
-    const latestTasks = await this.persistence.listTasks();
-    const latestTask = latestTasks.find((entry) => entry.id === task.id);
-    if (!latestTask) {
-      throw new Error(`Task not found: ${task.id}`);
-    }
-
-    assertNoValidationError(getSetPlanError(latestTask));
-    validatePlanSubtaskRules(latestTask, latestTasks, normalizedSubtasks);
-
-    const existingDirectSubtasks = latestTasks.filter((entry) => entry.parentId === task.id);
-    const blockedSubtasks = existingDirectSubtasks.filter(
-      (entry) => !canReplaceEpicSubtaskStatus(entry.status),
-    );
-    if (blockedSubtasks.length > 0) {
-      const blockedSummary = blockedSubtasks
-        .map((entry) => `${entry.id} (${entry.status})`)
-        .join(", ");
-      throw new Error(
-        "Cannot replace epic subtasks while active work exists. " +
-          `Move subtasks to open/spec_ready/ready_for_dev first: ${blockedSummary}`,
-      );
-    }
-
-    return { latestTask, existingDirectSubtasks };
-  }
-
-  private async applyEpicSubtaskReplacement(
-    task: TaskCard,
-    existingDirectSubtasks: TaskCard[],
-    normalizedSubtasks: PlanSubtaskInput[],
-  ): Promise<string[]> {
-    for (const existingSubtask of existingDirectSubtasks) {
-      await this.deleteTask(existingSubtask.id);
-    }
-
-    const createdSubtaskIds: string[] = [];
-    const createdTitleKeys = new Set<string>();
-    for (const subtask of normalizedSubtasks) {
-      const key = normalizeTitleKey(subtask.title);
-      if (createdTitleKeys.has(key)) {
-        continue;
-      }
-
-      const createdId = await this.createSubtask(task.id, subtask);
-      createdSubtaskIds.push(createdId);
-      createdTitleKeys.add(key);
-    }
-
-    return createdSubtaskIds;
   }
 
   async readTask(rawInput: unknown): Promise<unknown> {
     await this.persistence.ensureInitialized();
     const input = ReadTaskInputSchema.parse(rawInput);
-    const index = await this.getOrBuildTaskIndex();
-
-    let task: TaskCard;
-    try {
-      task = resolveTaskFromIndex(index, input.taskId);
-    } catch (error) {
-      const shouldRefreshIndex =
-        error instanceof TaskResolutionNotFoundError ||
-        error instanceof TaskResolutionAmbiguousError;
-      if (!shouldRefreshIndex) {
-        throw error;
-      }
-
-      const refreshedIndex = await this.refreshTaskIndex();
-      task = resolveTaskFromIndex(refreshedIndex, input.taskId);
-    }
+    const task = await this.taskIndexCache.resolveTask(input.taskId);
 
     const issue = await this.persistence.showRawIssue(task.id);
     const taskCard = issueToTaskCard(issue, this.metadataNamespace);
@@ -278,9 +186,12 @@ export class OdtTaskStore {
     let createdSubtaskIds: string[] = [];
     if (task.issueType === "epic") {
       // Epic subtask replacement must validate against a fresh snapshot, not the initial context.
-      const epicReplacement = await this.prepareEpicSubtaskReplacement(task, normalizedSubtasks);
+      const epicReplacement = await this.epicSubtaskReplacementService.prepareReplacement(
+        task,
+        normalizedSubtasks,
+      );
       persistedDocument = await this.documentStore.persistImplementationPlan(task.id, markdown);
-      createdSubtaskIds = await this.applyEpicSubtaskReplacement(
+      createdSubtaskIds = await this.epicSubtaskReplacementService.applyReplacement(
         epicReplacement.latestTask,
         epicReplacement.existingDirectSubtasks,
         normalizedSubtasks,

--- a/packages/openducktor-mcp/src/task-document-store.test.ts
+++ b/packages/openducktor-mcp/src/task-document-store.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test } from "bun:test";
+import type { JsonObject, RawIssue } from "./contracts";
+import { getNamespaceData } from "./metadata-docs";
+import { type TaskDocumentPersistence, TaskDocumentStore } from "./task-document-store";
+
+const FIXED_NOW = "2026-03-01T12:00:00.000Z";
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+type PersistenceHarness = {
+  persistence: TaskDocumentPersistence;
+  getIssue: () => RawIssue;
+};
+
+const createPersistenceHarness = (initialIssue: RawIssue): PersistenceHarness => {
+  let issue = clone(initialIssue);
+
+  const persistence: TaskDocumentPersistence = {
+    metadataNamespace: "openducktor",
+    showRawIssue: async (taskId: string) => {
+      if (taskId !== issue.id) {
+        throw new Error(`Task not found: ${taskId}`);
+      }
+      return clone(issue);
+    },
+    getNamespaceData: (rawIssue: RawIssue) => getNamespaceData(rawIssue, "openducktor"),
+    writeNamespace: async (taskId: string, root: JsonObject, namespace: JsonObject) => {
+      if (taskId !== issue.id) {
+        throw new Error(`Task not found: ${taskId}`);
+      }
+
+      issue = {
+        ...issue,
+        metadata: {
+          ...root,
+          openducktor: namespace,
+        },
+      };
+    },
+  };
+
+  return {
+    persistence,
+    getIssue: () => clone(issue),
+  };
+};
+
+describe("TaskDocumentStore", () => {
+  test("parseDocs returns latest spec, plan, and QA report snapshot", () => {
+    const harness = createPersistenceHarness({
+      id: "task-1",
+      title: "Task 1",
+      status: "open",
+      issue_type: "feature",
+      metadata: {
+        openducktor: {
+          documents: {
+            spec: [
+              {
+                markdown: "# older spec",
+                updatedAt: "2026-02-20T00:00:00.000Z",
+                updatedBy: "spec-agent",
+                sourceTool: "odt_set_spec",
+                revision: 1,
+              },
+              {
+                markdown: "# latest spec",
+                updatedAt: "2026-02-21T00:00:00.000Z",
+                updatedBy: "spec-agent",
+                sourceTool: "odt_set_spec",
+                revision: 2,
+              },
+            ],
+            implementationPlan: [
+              {
+                markdown: "# plan",
+                updatedAt: "2026-02-22T00:00:00.000Z",
+                updatedBy: "planner-agent",
+                sourceTool: "odt_set_plan",
+                revision: 1,
+              },
+            ],
+            qaReports: [
+              {
+                markdown: "LGTM",
+                verdict: "approved",
+                updatedAt: "2026-02-23T00:00:00.000Z",
+                updatedBy: "qa-agent",
+                sourceTool: "odt_qa_approved",
+                revision: 1,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const documents = new TaskDocumentStore(harness.persistence, () => FIXED_NOW);
+    const snapshot = documents.parseDocs(harness.getIssue());
+
+    expect(snapshot).toEqual({
+      spec: {
+        markdown: "# latest spec",
+        updatedAt: "2026-02-21T00:00:00.000Z",
+      },
+      implementationPlan: {
+        markdown: "# plan",
+        updatedAt: "2026-02-22T00:00:00.000Z",
+      },
+      latestQaReport: {
+        markdown: "LGTM",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+        verdict: "approved",
+      },
+    });
+  });
+
+  test("persistImplementationPlan stores latest-only entry and increments revision", async () => {
+    const harness = createPersistenceHarness({
+      id: "task-1",
+      title: "Task 1",
+      status: "spec_ready",
+      issue_type: "feature",
+      metadata: {
+        keep: "value",
+        openducktor: {
+          custom: { owner: "team-a" },
+          documents: {
+            implementationPlan: [
+              {
+                markdown: "# old plan",
+                updatedAt: "2026-02-20T00:00:00.000Z",
+                updatedBy: "planner-agent",
+                sourceTool: "odt_set_plan",
+                revision: 1,
+              },
+              {
+                markdown: "invalid",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const documents = new TaskDocumentStore(harness.persistence, () => FIXED_NOW);
+    const persisted = await documents.persistImplementationPlan("task-1", "# new plan");
+
+    expect(persisted).toEqual({
+      updatedAt: FIXED_NOW,
+      revision: 2,
+    });
+
+    const updatedIssue = harness.getIssue();
+    expect(updatedIssue.metadata).toEqual({
+      keep: "value",
+      openducktor: {
+        custom: { owner: "team-a" },
+        documents: {
+          implementationPlan: [
+            {
+              markdown: "# new plan",
+              updatedAt: FIXED_NOW,
+              updatedBy: "planner-agent",
+              sourceTool: "odt_set_plan",
+              revision: 2,
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  test("appendQaReport appends new report and increments revision from valid entries", async () => {
+    const harness = createPersistenceHarness({
+      id: "task-1",
+      title: "Task 1",
+      status: "human_review",
+      issue_type: "feature",
+      metadata: {
+        openducktor: {
+          documents: {
+            qaReports: [
+              {
+                markdown: "initial",
+                verdict: "approved",
+                updatedAt: "2026-02-20T00:00:00.000Z",
+                updatedBy: "qa-agent",
+                sourceTool: "odt_qa_approved",
+                revision: 1,
+              },
+              {
+                markdown: "invalid",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const documents = new TaskDocumentStore(harness.persistence, () => FIXED_NOW);
+    await documents.appendQaReport("task-1", "needs changes", "rejected");
+
+    const updatedIssue = harness.getIssue();
+    expect(updatedIssue.metadata).toEqual({
+      openducktor: {
+        documents: {
+          qaReports: [
+            {
+              markdown: "initial",
+              verdict: "approved",
+              updatedAt: "2026-02-20T00:00:00.000Z",
+              updatedBy: "qa-agent",
+              sourceTool: "odt_qa_approved",
+              revision: 1,
+            },
+            {
+              markdown: "needs changes",
+              verdict: "rejected",
+              updatedAt: FIXED_NOW,
+              updatedBy: "qa-agent",
+              sourceTool: "odt_qa_rejected",
+              revision: 2,
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  test("persistSpec stores latest-only spec entry", async () => {
+    const harness = createPersistenceHarness({
+      id: "task-1",
+      title: "Task 1",
+      status: "open",
+      issue_type: "feature",
+      metadata: {
+        openducktor: {
+          documents: {
+            spec: [
+              {
+                markdown: "# old spec",
+                updatedAt: "2026-02-20T00:00:00.000Z",
+                updatedBy: "spec-agent",
+                sourceTool: "odt_set_spec",
+                revision: 1,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const documents = new TaskDocumentStore(harness.persistence, () => FIXED_NOW);
+    const persisted = await documents.persistSpec("task-1", "# new spec");
+
+    expect(persisted).toEqual({
+      updatedAt: FIXED_NOW,
+      revision: 2,
+    });
+
+    const updatedIssue = harness.getIssue();
+    expect(updatedIssue.metadata).toEqual({
+      openducktor: {
+        documents: {
+          spec: [
+            {
+              markdown: "# new spec",
+              updatedAt: FIXED_NOW,
+              updatedBy: "spec-agent",
+              sourceTool: "odt_set_spec",
+              revision: 2,
+            },
+          ],
+        },
+      },
+    });
+  });
+});

--- a/packages/openducktor-mcp/src/task-document-store.test.ts
+++ b/packages/openducktor-mcp/src/task-document-store.test.ts
@@ -115,7 +115,36 @@ describe("TaskDocumentStore", () => {
     });
   });
 
-  test("persistImplementationPlan stores latest-only entry and increments revision", async () => {
+  test("parseDocs returns empty snapshot when namespace documents are missing", () => {
+    const harness = createPersistenceHarness({
+      id: "task-1",
+      title: "Task 1",
+      status: "open",
+      issue_type: "feature",
+      metadata: {},
+    });
+
+    const documents = new TaskDocumentStore(harness.persistence, () => FIXED_NOW);
+    const snapshot = documents.parseDocs(harness.getIssue());
+
+    expect(snapshot).toEqual({
+      spec: {
+        markdown: "",
+        updatedAt: null,
+      },
+      implementationPlan: {
+        markdown: "",
+        updatedAt: null,
+      },
+      latestQaReport: {
+        markdown: "",
+        updatedAt: null,
+        verdict: null,
+      },
+    });
+  });
+
+  test("persistImplementationPlan stores latest-only entry and uses max revision + 1", async () => {
     const harness = createPersistenceHarness({
       id: "task-1",
       title: "Task 1",
@@ -128,11 +157,18 @@ describe("TaskDocumentStore", () => {
           documents: {
             implementationPlan: [
               {
-                markdown: "# old plan",
+                markdown: "# plan r4",
+                updatedAt: "2026-02-22T00:00:00.000Z",
+                updatedBy: "planner-agent",
+                sourceTool: "odt_set_plan",
+                revision: 4,
+              },
+              {
+                markdown: "# plan r2",
                 updatedAt: "2026-02-20T00:00:00.000Z",
                 updatedBy: "planner-agent",
                 sourceTool: "odt_set_plan",
-                revision: 1,
+                revision: 2,
               },
               {
                 markdown: "invalid",
@@ -148,7 +184,7 @@ describe("TaskDocumentStore", () => {
 
     expect(persisted).toEqual({
       updatedAt: FIXED_NOW,
-      revision: 2,
+      revision: 5,
     });
 
     const updatedIssue = harness.getIssue();
@@ -163,7 +199,7 @@ describe("TaskDocumentStore", () => {
               updatedAt: FIXED_NOW,
               updatedBy: "planner-agent",
               sourceTool: "odt_set_plan",
-              revision: 2,
+              revision: 5,
             },
           ],
         },
@@ -171,7 +207,7 @@ describe("TaskDocumentStore", () => {
     });
   });
 
-  test("appendQaReport appends new report and increments revision from valid entries", async () => {
+  test("appendQaReport appends new report and uses max revision + 1", async () => {
     const harness = createPersistenceHarness({
       id: "task-1",
       title: "Task 1",
@@ -184,10 +220,18 @@ describe("TaskDocumentStore", () => {
               {
                 markdown: "initial",
                 verdict: "approved",
-                updatedAt: "2026-02-20T00:00:00.000Z",
+                updatedAt: "2026-02-22T00:00:00.000Z",
                 updatedBy: "qa-agent",
                 sourceTool: "odt_qa_approved",
-                revision: 1,
+                revision: 4,
+              },
+              {
+                markdown: "older",
+                verdict: "rejected",
+                updatedAt: "2026-02-20T00:00:00.000Z",
+                updatedBy: "qa-agent",
+                sourceTool: "odt_qa_rejected",
+                revision: 2,
               },
               {
                 markdown: "invalid",
@@ -209,10 +253,18 @@ describe("TaskDocumentStore", () => {
             {
               markdown: "initial",
               verdict: "approved",
-              updatedAt: "2026-02-20T00:00:00.000Z",
+              updatedAt: "2026-02-22T00:00:00.000Z",
               updatedBy: "qa-agent",
               sourceTool: "odt_qa_approved",
-              revision: 1,
+              revision: 4,
+            },
+            {
+              markdown: "older",
+              verdict: "rejected",
+              updatedAt: "2026-02-20T00:00:00.000Z",
+              updatedBy: "qa-agent",
+              sourceTool: "odt_qa_rejected",
+              revision: 2,
             },
             {
               markdown: "needs changes",
@@ -220,7 +272,7 @@ describe("TaskDocumentStore", () => {
               updatedAt: FIXED_NOW,
               updatedBy: "qa-agent",
               sourceTool: "odt_qa_rejected",
-              revision: 2,
+              revision: 5,
             },
           ],
         },
@@ -275,5 +327,27 @@ describe("TaskDocumentStore", () => {
         },
       },
     });
+  });
+
+  test("propagates persistence write errors", async () => {
+    const persistence: TaskDocumentPersistence = {
+      metadataNamespace: "openducktor",
+      showRawIssue: async () => ({
+        id: "task-1",
+        title: "Task 1",
+        status: "open",
+        issue_type: "feature",
+        metadata: {},
+      }),
+      getNamespaceData: (rawIssue) => getNamespaceData(rawIssue, "openducktor"),
+      writeNamespace: async () => {
+        throw new Error("metadata write failed");
+      },
+    };
+    const documents = new TaskDocumentStore(persistence, () => FIXED_NOW);
+
+    await expect(documents.persistSpec("task-1", "# spec")).rejects.toThrow(
+      "metadata write failed",
+    );
   });
 });

--- a/packages/openducktor-mcp/src/task-document-store.ts
+++ b/packages/openducktor-mcp/src/task-document-store.ts
@@ -1,0 +1,131 @@
+import type { TimeProvider } from "./beads-runtime";
+import type { JsonObject, MarkdownEntry, QaEntry, RawIssue } from "./contracts";
+import {
+  type NamespaceData,
+  parseTaskDocuments,
+  type TaskDocumentsSnapshot,
+} from "./metadata-docs";
+import { parseMarkdownEntries, parseQaEntries } from "./task-mapping";
+
+type MarkdownDocumentKey = "spec" | "implementationPlan";
+
+type PersistLatestMarkdownInput = {
+  taskId: string;
+  markdown: string;
+  documentKey: MarkdownDocumentKey;
+  updatedBy: string;
+  sourceTool: string;
+};
+
+export type TaskDocumentPersistence = {
+  metadataNamespace: string;
+  showRawIssue: (taskId: string) => Promise<RawIssue>;
+  getNamespaceData: (issue: RawIssue) => NamespaceData;
+  writeNamespace: (taskId: string, root: JsonObject, namespace: JsonObject) => Promise<void>;
+};
+
+export class TaskDocumentStore {
+  private readonly persistence: TaskDocumentPersistence;
+  private readonly now: TimeProvider;
+
+  constructor(persistence: TaskDocumentPersistence, now: TimeProvider) {
+    this.persistence = persistence;
+    this.now = now;
+  }
+
+  parseDocs(issue: RawIssue): TaskDocumentsSnapshot {
+    return parseTaskDocuments(issue, this.persistence.metadataNamespace);
+  }
+
+  async persistSpec(
+    taskId: string,
+    markdown: string,
+  ): Promise<{ updatedAt: string; revision: number }> {
+    return this.persistLatestMarkdown({
+      taskId,
+      markdown,
+      documentKey: "spec",
+      updatedBy: "spec-agent",
+      sourceTool: "odt_set_spec",
+    });
+  }
+
+  async persistImplementationPlan(
+    taskId: string,
+    markdown: string,
+  ): Promise<{ updatedAt: string; revision: number }> {
+    return this.persistLatestMarkdown({
+      taskId,
+      markdown,
+      documentKey: "implementationPlan",
+      updatedBy: "planner-agent",
+      sourceTool: "odt_set_plan",
+    });
+  }
+
+  async appendQaReport(
+    taskId: string,
+    markdown: string,
+    verdict: "approved" | "rejected",
+  ): Promise<void> {
+    const issue = await this.persistence.showRawIssue(taskId);
+    const { root, namespace, documents } = this.persistence.getNamespaceData(issue);
+    const entries = parseQaEntries(documents.qaReports);
+    const nextRevision = (entries.at(-1)?.revision ?? 0) + 1;
+
+    const entry: QaEntry = {
+      markdown,
+      verdict,
+      updatedAt: this.now(),
+      updatedBy: "qa-agent",
+      sourceTool: verdict === "approved" ? "odt_qa_approved" : "odt_qa_rejected",
+      revision: nextRevision,
+    };
+
+    const nextDocuments = {
+      ...documents,
+      qaReports: [...entries, entry],
+    };
+
+    const nextNamespace = {
+      ...namespace,
+      documents: nextDocuments,
+    };
+
+    await this.persistence.writeNamespace(taskId, root, nextNamespace);
+  }
+
+  private async persistLatestMarkdown(
+    input: PersistLatestMarkdownInput,
+  ): Promise<{ updatedAt: string; revision: number }> {
+    const issue = await this.persistence.showRawIssue(input.taskId);
+    const { root, namespace, documents } = this.persistence.getNamespaceData(issue);
+    const nextRevision =
+      (parseMarkdownEntries(documents[input.documentKey]).at(-1)?.revision ?? 0) + 1;
+
+    const updatedAt = this.now();
+    const entry: MarkdownEntry = {
+      markdown: input.markdown,
+      updatedAt,
+      updatedBy: input.updatedBy,
+      sourceTool: input.sourceTool,
+      revision: nextRevision,
+    };
+
+    const nextDocuments = {
+      ...documents,
+      [input.documentKey]: [entry],
+    };
+
+    const nextNamespace = {
+      ...namespace,
+      documents: nextDocuments,
+    };
+
+    await this.persistence.writeNamespace(input.taskId, root, nextNamespace);
+    return {
+      updatedAt,
+      revision: nextRevision,
+    };
+  }
+}

--- a/packages/openducktor-mcp/src/task-document-store.ts
+++ b/packages/openducktor-mcp/src/task-document-store.ts
@@ -1,30 +1,67 @@
+import type { AgentToolName } from "@openducktor/contracts";
+import type { TaskPersistencePort } from "./bd-persistence";
 import type { TimeProvider } from "./beads-runtime";
-import type { JsonObject, MarkdownEntry, QaEntry, RawIssue } from "./contracts";
-import {
-  type NamespaceData,
-  parseTaskDocuments,
-  type TaskDocumentsSnapshot,
-} from "./metadata-docs";
+import type { MarkdownEntry, QaEntry, RawIssue } from "./contracts";
+import { parseTaskDocuments, type TaskDocumentsSnapshot } from "./metadata-docs";
 import { parseMarkdownEntries, parseQaEntries } from "./task-mapping";
 
 type MarkdownDocumentKey = "spec" | "implementationPlan";
+type QaVerdict = "approved" | "rejected";
 
 type PersistLatestMarkdownInput = {
   taskId: string;
   markdown: string;
   documentKey: MarkdownDocumentKey;
+};
+
+type DocumentSource = {
   updatedBy: string;
-  sourceTool: string;
+  sourceTool: AgentToolName;
 };
 
-export type TaskDocumentPersistence = {
-  metadataNamespace: string;
-  showRawIssue: (taskId: string) => Promise<RawIssue>;
-  getNamespaceData: (issue: RawIssue) => NamespaceData;
-  writeNamespace: (taskId: string, root: JsonObject, namespace: JsonObject) => Promise<void>;
+const MARKDOWN_DOCUMENT_SOURCES = {
+  spec: {
+    updatedBy: "spec-agent",
+    sourceTool: "odt_set_spec",
+  },
+  implementationPlan: {
+    updatedBy: "planner-agent",
+    sourceTool: "odt_set_plan",
+  },
+} as const satisfies Record<MarkdownDocumentKey, DocumentSource>;
+
+const QA_REPORT_SOURCES = {
+  approved: {
+    updatedBy: "qa-agent",
+    sourceTool: "odt_qa_approved",
+  },
+  rejected: {
+    updatedBy: "qa-agent",
+    sourceTool: "odt_qa_rejected",
+  },
+} as const satisfies Record<QaVerdict, DocumentSource>;
+
+const getNextRevision = (entries: Array<{ revision: number }>): number => {
+  const maxRevision = entries.reduce((max, entry) => Math.max(max, entry.revision), 0);
+  return maxRevision + 1;
 };
 
-export class TaskDocumentStore {
+export type TaskDocumentPort = {
+  parseDocs(issue: RawIssue): TaskDocumentsSnapshot;
+  persistSpec(taskId: string, markdown: string): Promise<{ updatedAt: string; revision: number }>;
+  persistImplementationPlan(
+    taskId: string,
+    markdown: string,
+  ): Promise<{ updatedAt: string; revision: number }>;
+  appendQaReport(taskId: string, markdown: string, verdict: QaVerdict): Promise<void>;
+};
+
+export type TaskDocumentPersistence = Pick<
+  TaskPersistencePort,
+  "metadataNamespace" | "showRawIssue" | "getNamespaceData" | "writeNamespace"
+>;
+
+export class TaskDocumentStore implements TaskDocumentPort {
   private readonly persistence: TaskDocumentPersistence;
   private readonly now: TimeProvider;
 
@@ -45,8 +82,6 @@ export class TaskDocumentStore {
       taskId,
       markdown,
       documentKey: "spec",
-      updatedBy: "spec-agent",
-      sourceTool: "odt_set_spec",
     });
   }
 
@@ -58,27 +93,22 @@ export class TaskDocumentStore {
       taskId,
       markdown,
       documentKey: "implementationPlan",
-      updatedBy: "planner-agent",
-      sourceTool: "odt_set_plan",
     });
   }
 
-  async appendQaReport(
-    taskId: string,
-    markdown: string,
-    verdict: "approved" | "rejected",
-  ): Promise<void> {
+  async appendQaReport(taskId: string, markdown: string, verdict: QaVerdict): Promise<void> {
     const issue = await this.persistence.showRawIssue(taskId);
     const { root, namespace, documents } = this.persistence.getNamespaceData(issue);
     const entries = parseQaEntries(documents.qaReports);
-    const nextRevision = (entries.at(-1)?.revision ?? 0) + 1;
+    const source = QA_REPORT_SOURCES[verdict];
+    const nextRevision = getNextRevision(entries);
 
     const entry: QaEntry = {
       markdown,
       verdict,
       updatedAt: this.now(),
-      updatedBy: "qa-agent",
-      sourceTool: verdict === "approved" ? "odt_qa_approved" : "odt_qa_rejected",
+      updatedBy: source.updatedBy,
+      sourceTool: source.sourceTool,
       revision: nextRevision,
     };
 
@@ -100,15 +130,15 @@ export class TaskDocumentStore {
   ): Promise<{ updatedAt: string; revision: number }> {
     const issue = await this.persistence.showRawIssue(input.taskId);
     const { root, namespace, documents } = this.persistence.getNamespaceData(issue);
-    const nextRevision =
-      (parseMarkdownEntries(documents[input.documentKey]).at(-1)?.revision ?? 0) + 1;
+    const source = MARKDOWN_DOCUMENT_SOURCES[input.documentKey];
+    const nextRevision = getNextRevision(parseMarkdownEntries(documents[input.documentKey]));
 
     const updatedAt = this.now();
     const entry: MarkdownEntry = {
       markdown: input.markdown,
       updatedAt,
-      updatedBy: input.updatedBy,
-      sourceTool: input.sourceTool,
+      updatedBy: source.updatedBy,
+      sourceTool: source.sourceTool,
       revision: nextRevision,
     };
 

--- a/packages/openducktor-mcp/src/task-index-cache.test.ts
+++ b/packages/openducktor-mcp/src/task-index-cache.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import type { TaskCard } from "./contracts";
+import { TaskIndexCache } from "./task-index-cache";
+
+const makeTask = (input: {
+  id: string;
+  title: string;
+  status?: TaskCard["status"];
+  issueType?: TaskCard["issueType"];
+  aiReviewEnabled?: boolean;
+}): TaskCard => {
+  return {
+    id: input.id,
+    title: input.title,
+    status: input.status ?? "open",
+    issueType: input.issueType ?? "feature",
+    aiReviewEnabled: input.aiReviewEnabled ?? true,
+  };
+};
+
+describe("TaskIndexCache", () => {
+  test("getOrBuild caches list calls until invalidated", async () => {
+    const calls: TaskCard[][] = [];
+    const cache = new TaskIndexCache(async () => {
+      const tasks = [makeTask({ id: "task-1", title: "Task 1" })];
+      calls.push(tasks);
+      return tasks;
+    });
+
+    const first = await cache.getOrBuild();
+    const second = await cache.getOrBuild();
+
+    expect(first).toBe(second);
+    expect(calls).toHaveLength(1);
+
+    cache.invalidate();
+    const third = await cache.getOrBuild();
+    expect(third).not.toBe(first);
+    expect(calls).toHaveLength(2);
+  });
+
+  test("resolveTask refreshes index when first resolution is ambiguous", async () => {
+    let listCalls = 0;
+    const cache = new TaskIndexCache(async () => {
+      listCalls += 1;
+      if (listCalls === 1) {
+        return [
+          makeTask({ id: "alpha-wsp", title: "Alpha" }),
+          makeTask({ id: "beta-wsp", title: "Beta" }),
+        ];
+      }
+
+      return [makeTask({ id: "alpha-wsp", title: "Alpha" })];
+    });
+
+    const resolved = await cache.resolveTask("wsp");
+
+    expect(resolved.id).toBe("alpha-wsp");
+    expect(listCalls).toBe(2);
+  });
+
+  test("resolveTask preserves not-found error after refresh", async () => {
+    let listCalls = 0;
+    const cache = new TaskIndexCache(async () => {
+      listCalls += 1;
+      return [makeTask({ id: "task-1", title: "Task 1" })];
+    });
+
+    await expect(cache.resolveTask("does-not-exist")).rejects.toThrow(
+      "Task not found: does-not-exist",
+    );
+    expect(listCalls).toBe(2);
+  });
+});

--- a/packages/openducktor-mcp/src/task-index-cache.ts
+++ b/packages/openducktor-mcp/src/task-index-cache.ts
@@ -1,0 +1,69 @@
+import type { TaskCard } from "./contracts";
+import {
+  buildTaskIndex,
+  resolveTaskFromIndex,
+  type TaskIndex,
+  TaskResolutionAmbiguousError,
+  TaskResolutionNotFoundError,
+} from "./task-resolution";
+
+export type TaskListLoader = () => Promise<TaskCard[]>;
+
+export class TaskIndexCache {
+  private readonly listTasks: TaskListLoader;
+  private taskIndex: TaskIndex | null;
+  private taskIndexBuildPromise: Promise<TaskIndex> | null;
+
+  constructor(listTasks: TaskListLoader) {
+    this.listTasks = listTasks;
+    this.taskIndex = null;
+    this.taskIndexBuildPromise = null;
+  }
+
+  async refresh(): Promise<TaskIndex> {
+    const tasks = await this.listTasks();
+    const next = buildTaskIndex(tasks);
+    this.taskIndex = next;
+    return next;
+  }
+
+  async getOrBuild(): Promise<TaskIndex> {
+    if (this.taskIndex) {
+      return this.taskIndex;
+    }
+
+    if (this.taskIndexBuildPromise) {
+      return this.taskIndexBuildPromise;
+    }
+
+    this.taskIndexBuildPromise = this.refresh();
+    try {
+      return await this.taskIndexBuildPromise;
+    } finally {
+      this.taskIndexBuildPromise = null;
+    }
+  }
+
+  invalidate(): void {
+    this.taskIndex = null;
+    this.taskIndexBuildPromise = null;
+  }
+
+  async resolveTask(taskId: string): Promise<TaskCard> {
+    const index = await this.getOrBuild();
+
+    try {
+      return resolveTaskFromIndex(index, taskId);
+    } catch (error) {
+      const shouldRefreshIndex =
+        error instanceof TaskResolutionNotFoundError ||
+        error instanceof TaskResolutionAmbiguousError;
+      if (!shouldRefreshIndex) {
+        throw error;
+      }
+
+      const refreshedIndex = await this.refresh();
+      return resolveTaskFromIndex(refreshedIndex, taskId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- extract Beads persistence and task document concerns from `OdtTaskStore` into dedicated modules
- introduce explicit orchestration seams with injectable ports and services (`TaskPersistencePort`, `TaskDocumentPort`)
- split remaining orchestration complexity into `TaskIndexCache` and `EpicSubtaskReplacementService`
- harden document revision progression to use max valid revision + 1 and centralize `odt_*` source metadata constants
- add targeted module tests plus composition tests and negative-path coverage

## Validation
- `bun run --filter @openducktor/openducktor-mcp lint`
- `bun run --filter @openducktor/openducktor-mcp typecheck`
- `bun run --filter @openducktor/openducktor-mcp test`
