### PR TITLE
refactor(adapters-tauri-host): decompose TauriHostClient by domain

### DIFF
--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -15,6 +15,10 @@ import {
 import type { InvokeFn } from "./invoke-utils";
 import { parseArray } from "./invoke-utils";
 
+export type RuntimeRole = "spec" | "planner" | "qa";
+export type BuildRespondAction = "approve" | "deny" | "message";
+export type BuildCleanupMode = "success" | "failure";
+
 export const systemCheck = async (invokeFn: InvokeFn, repoPath: string): Promise<SystemCheck> => {
   const payload = await invokeFn<unknown>("system_check", { repoPath });
   return systemCheckSchema.parse(payload);
@@ -47,7 +51,7 @@ export const opencodeRuntimeStart = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
-  role: "spec" | "planner" | "qa",
+  role: RuntimeRole,
 ): Promise<AgentRuntimeSummary> => {
   const payload = await invokeFn<unknown>("opencode_runtime_start", {
     repoPath,
@@ -154,7 +158,7 @@ export const humanApprove = async (
 export const buildRespond = async (
   invokeFn: InvokeFn,
   runId: string,
-  action: "approve" | "deny" | "message",
+  action: BuildRespondAction,
   payload?: string,
 ): Promise<{ ok: boolean }> => {
   return invokeFn<{ ok: boolean }>("build_respond", { runId, action, payload });
@@ -167,7 +171,87 @@ export const buildStop = async (invokeFn: InvokeFn, runId: string): Promise<{ ok
 export const buildCleanup = async (
   invokeFn: InvokeFn,
   runId: string,
-  mode: "success" | "failure",
+  mode: BuildCleanupMode,
 ): Promise<{ ok: boolean }> => {
   return invokeFn<{ ok: boolean }>("build_cleanup", { runId, mode });
 };
+
+export class TauriAgentClient {
+  constructor(private readonly invokeFn: InvokeFn) {}
+
+  async systemCheck(repoPath: string): Promise<SystemCheck> {
+    return systemCheck(this.invokeFn, repoPath);
+  }
+
+  async runtimeCheck(force = false): Promise<RuntimeCheck> {
+    return runtimeCheck(this.invokeFn, force);
+  }
+
+  async beadsCheck(repoPath: string): Promise<BeadsCheck> {
+    return beadsCheck(this.invokeFn, repoPath);
+  }
+
+  async runsList(repoPath?: string): Promise<RunSummary[]> {
+    return runsList(this.invokeFn, repoPath);
+  }
+
+  async opencodeRuntimeList(repoPath?: string): Promise<AgentRuntimeSummary[]> {
+    return opencodeRuntimeList(this.invokeFn, repoPath);
+  }
+
+  async opencodeRuntimeStart(
+    repoPath: string,
+    taskId: string,
+    role: RuntimeRole,
+  ): Promise<AgentRuntimeSummary> {
+    return opencodeRuntimeStart(this.invokeFn, repoPath, taskId, role);
+  }
+
+  async opencodeRuntimeStop(runtimeId: string): Promise<{ ok: boolean }> {
+    return opencodeRuntimeStop(this.invokeFn, runtimeId);
+  }
+
+  async opencodeRepoRuntimeEnsure(repoPath: string): Promise<AgentRuntimeSummary> {
+    return opencodeRepoRuntimeEnsure(this.invokeFn, repoPath);
+  }
+
+  async buildStart(repoPath: string, taskId: string): Promise<RunSummary> {
+    return buildStart(this.invokeFn, repoPath, taskId);
+  }
+
+  async buildBlocked(repoPath: string, taskId: string, reason: string): Promise<TaskCard> {
+    return buildBlocked(this.invokeFn, repoPath, taskId, reason);
+  }
+
+  async buildResumed(repoPath: string, taskId: string): Promise<TaskCard> {
+    return buildResumed(this.invokeFn, repoPath, taskId);
+  }
+
+  async buildCompleted(repoPath: string, taskId: string, summary?: string): Promise<TaskCard> {
+    return buildCompleted(this.invokeFn, repoPath, taskId, summary);
+  }
+
+  async humanRequestChanges(repoPath: string, taskId: string, note?: string): Promise<TaskCard> {
+    return humanRequestChanges(this.invokeFn, repoPath, taskId, note);
+  }
+
+  async humanApprove(repoPath: string, taskId: string): Promise<TaskCard> {
+    return humanApprove(this.invokeFn, repoPath, taskId);
+  }
+
+  async buildRespond(
+    runId: string,
+    action: BuildRespondAction,
+    payload?: string,
+  ): Promise<{ ok: boolean }> {
+    return buildRespond(this.invokeFn, runId, action, payload);
+  }
+
+  async buildStop(runId: string): Promise<{ ok: boolean }> {
+    return buildStop(this.invokeFn, runId);
+  }
+
+  async buildCleanup(runId: string, mode: BuildCleanupMode): Promise<{ ok: boolean }> {
+    return buildCleanup(this.invokeFn, runId, mode);
+  }
+}

--- a/packages/adapters-tauri-host/src/git-client.ts
+++ b/packages/adapters-tauri-host/src/git-client.ts
@@ -89,3 +89,52 @@ export const gitPushBranch = async (
   });
   return gitPushSummarySchema.parse(payload);
 };
+
+export class TauriGitClient {
+  constructor(private readonly invokeFn: InvokeFn) {}
+
+  async gitGetBranches(repoPath: string): Promise<GitBranch[]> {
+    return gitGetBranches(this.invokeFn, repoPath);
+  }
+
+  async gitGetCurrentBranch(repoPath: string): Promise<GitCurrentBranch> {
+    return gitGetCurrentBranch(this.invokeFn, repoPath);
+  }
+
+  async gitSwitchBranch(
+    repoPath: string,
+    branch: string,
+    options?: { create?: boolean },
+  ): Promise<GitCurrentBranch> {
+    return gitSwitchBranch(this.invokeFn, repoPath, branch, options);
+  }
+
+  async gitCreateWorktree(
+    repoPath: string,
+    worktreePath: string,
+    branch: string,
+    options?: { createBranch?: boolean },
+  ): Promise<GitWorktreeSummary> {
+    return gitCreateWorktree(this.invokeFn, repoPath, worktreePath, branch, options);
+  }
+
+  async gitRemoveWorktree(
+    repoPath: string,
+    worktreePath: string,
+    options?: { force?: boolean },
+  ): Promise<{ ok: boolean }> {
+    return gitRemoveWorktree(this.invokeFn, repoPath, worktreePath, options);
+  }
+
+  async gitPushBranch(
+    repoPath: string,
+    branch: string,
+    options?: {
+      remote?: string;
+      setUpstream?: boolean;
+      forceWithLease?: boolean;
+    },
+  ): Promise<GitPushSummary> {
+    return gitPushBranch(this.invokeFn, repoPath, branch, options);
+  }
+}

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1,4 +1,5 @@
 import type {} from "./bun-test";
+import type { TauriHostClient as TauriHostClientType } from "./index";
 import { TauriHostClient } from "./index";
 
 type InvokeCall = {
@@ -73,7 +74,114 @@ const createClient = (resolver: (command: string, args?: Record<string, unknown>
   return { client: new TauriHostClient(invoke), calls };
 };
 
+const assertClientType = (client: TauriHostClientType): TauriHostClientType => client;
+
 describe("TauriHostClient", () => {
+  test("exports a value and type-compatible host client", async () => {
+    const { client } = createClient((command) => {
+      if (command === "set_spec") {
+        return { updatedAt: "2026-02-20T10:00:00Z" };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const typedClient = assertClientType(client);
+    const output = await typedClient.setSpec({
+      repoPath: "/repo",
+      taskId: "task-1",
+      markdown: "# Spec",
+    });
+
+    expect(output.updatedAt).toBe("2026-02-20T10:00:00Z");
+  });
+
+  test("delegated methods are writable and configurable for test doubles", async () => {
+    const { client } = createClient((command) => {
+      if (command === "tasks_list") {
+        return [makeTaskCardPayload()];
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const descriptor = Object.getOwnPropertyDescriptor(client, "tasksList");
+    expect(descriptor?.writable).toBe(true);
+    expect(descriptor?.configurable).toBe(true);
+
+    const original = client.tasksList.bind(client);
+    const replacement = async (_repoPath: string) => [];
+    client.tasksList = replacement;
+
+    await expect(client.tasksList("/repo")).resolves.toEqual([]);
+
+    client.tasksList = original;
+    await expect(client.tasksList("/repo")).resolves.toHaveLength(1);
+  });
+
+  test("facade exposes every delegated API method", () => {
+    const { client } = createClient((command) => {
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const expectedMethods = [
+      "workspaceList",
+      "workspaceAdd",
+      "workspaceSelect",
+      "workspaceUpdateRepoConfig",
+      "workspaceSaveRepoSettings",
+      "workspaceUpdateRepoHooks",
+      "workspaceGetRepoConfig",
+      "workspacePrepareTrustedHooksChallenge",
+      "workspaceSetTrustedHooks",
+      "getTheme",
+      "setTheme",
+      "tasksList",
+      "taskCreate",
+      "taskUpdate",
+      "taskDelete",
+      "taskTransition",
+      "taskDefer",
+      "taskResumeDeferred",
+      "specGet",
+      "setSpec",
+      "saveSpecDocument",
+      "setPlan",
+      "savePlanDocument",
+      "planGet",
+      "qaGetReport",
+      "qaApproved",
+      "qaRejected",
+      "agentSessionsList",
+      "agentSessionUpsert",
+      "systemCheck",
+      "runtimeCheck",
+      "beadsCheck",
+      "runsList",
+      "opencodeRuntimeList",
+      "opencodeRuntimeStart",
+      "opencodeRuntimeStop",
+      "opencodeRepoRuntimeEnsure",
+      "buildStart",
+      "buildBlocked",
+      "buildResumed",
+      "buildCompleted",
+      "humanRequestChanges",
+      "humanApprove",
+      "buildRespond",
+      "buildStop",
+      "buildCleanup",
+      "gitGetBranches",
+      "gitGetCurrentBranch",
+      "gitSwitchBranch",
+      "gitCreateWorktree",
+      "gitRemoveWorktree",
+      "gitPushBranch",
+    ] as const;
+
+    for (const methodName of expectedMethods) {
+      expect(typeof client[methodName]).toBe("function");
+    }
+  });
+
   test("saveSpecDocument uses dedicated non-transition IPC route", async () => {
     const { client, calls } = createClient((command) => {
       if (command === "spec_save_document") {

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -122,6 +122,8 @@ describe("TauriHostClient", () => {
       throw new Error(`Unexpected command: ${command}`);
     });
 
+    // Keep this explicit: importing internal method-group constants from index.ts
+    // would make this facade-surface assertion tautological.
     const expectedMethods = [
       "workspaceList",
       "workspaceAdd",

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -107,9 +107,9 @@ const bindDelegates = <
     }
 
     Object.defineProperty(host, methodName, {
-      configurable: false,
+      configurable: true,
       enumerable: false,
-      writable: false,
+      writable: true,
       value: candidate.bind(client),
     });
   }
@@ -152,6 +152,8 @@ class TauriHostClientImpl implements PlannerTools {
   }
 }
 
+export type TauriHostClient = TauriHostClientApi & PlannerTools;
+
 export const TauriHostClient = TauriHostClientImpl as unknown as new (
   invokeFn: InvokeFn,
-) => TauriHostClientApi & PlannerTools;
+) => TauriHostClient;

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -1,408 +1,157 @@
-import type {
-  AgentRuntimeSummary,
-  AgentSessionRecord,
-  BeadsCheck,
-  GitBranch,
-  GitCurrentBranch,
-  GitPushSummary,
-  GitWorktreeSummary,
-  RepoConfig,
-  RunSummary,
-  RuntimeCheck,
-  SystemCheck,
-  TaskCard,
-  TaskCreateInput,
-  TaskStatus,
-  TaskUpdatePatch,
-  WorkspaceRecord,
-} from "@openducktor/contracts";
-import type { PlannerTools, SetPlanOutput, SetSpecOutput } from "@openducktor/core";
+import type { PlannerTools } from "@openducktor/core";
 import {
-  beadsCheck,
-  buildBlocked,
-  buildCleanup,
-  buildCompleted,
-  buildRespond,
-  buildResumed,
-  buildStart,
-  buildStop,
-  humanApprove,
-  humanRequestChanges,
-  opencodeRepoRuntimeEnsure,
-  opencodeRuntimeList,
-  opencodeRuntimeStart,
-  opencodeRuntimeStop,
-  runsList,
-  runtimeCheck,
-  systemCheck,
+  type BuildCleanupMode,
+  type BuildRespondAction,
+  type RuntimeRole,
+  TauriAgentClient,
 } from "./build-runtime-client";
-import {
-  gitCreateWorktree,
-  gitGetBranches,
-  gitGetCurrentBranch,
-  gitPushBranch,
-  gitRemoveWorktree,
-  gitSwitchBranch,
-} from "./git-client";
+import { TauriGitClient } from "./git-client";
 import type { InvokeFn } from "./invoke-utils";
-import {
-  agentSessionsList,
-  agentSessionUpsert,
-  planGet,
-  qaApproved,
-  qaGetReport,
-  qaRejected,
-  savePlanDocument,
-  saveSpecDocument,
-  setPlan,
-  setSpec,
-  specGet,
-  taskCreate,
-  taskDefer,
-  taskDelete,
-  taskResumeDeferred,
-  tasksList,
-  taskTransition,
-  taskUpdate,
-} from "./task-client";
+import { type SetPlanInput, type SetSpecInput, TauriTaskClient } from "./task-client";
 import { TaskMetadataCache } from "./task-metadata-cache";
-import {
-  getTheme,
-  setTheme,
-  workspaceAdd,
-  workspaceGetRepoConfig,
-  workspaceList,
-  workspacePrepareTrustedHooksChallenge,
-  workspaceSaveRepoSettings,
-  workspaceSelect,
-  workspaceSetTrustedHooks,
-  workspaceUpdateRepoConfig,
-  workspaceUpdateRepoHooks,
-} from "./workspace-client";
+import { TauriWorkspaceClient } from "./workspace-client";
 
-export class TauriHostClient implements PlannerTools {
-  private readonly taskMetadataCache = new TaskMetadataCache();
+type MethodName<TClient extends object> = {
+  [TKey in keyof TClient]: TClient[TKey] extends (...args: infer _TArgs) => infer _TReturn
+    ? TKey
+    : never;
+}[keyof TClient];
 
-  constructor(private readonly invokeFn: InvokeFn) {}
+const WORKSPACE_METHODS = [
+  "workspaceList",
+  "workspaceAdd",
+  "workspaceSelect",
+  "workspaceUpdateRepoConfig",
+  "workspaceSaveRepoSettings",
+  "workspaceUpdateRepoHooks",
+  "workspaceGetRepoConfig",
+  "workspacePrepareTrustedHooksChallenge",
+  "workspaceSetTrustedHooks",
+  "getTheme",
+  "setTheme",
+] as const satisfies readonly MethodName<TauriWorkspaceClient>[];
 
-  async workspaceList(): Promise<WorkspaceRecord[]> {
-    return workspaceList(this.invokeFn);
+const TASK_METHODS = [
+  "tasksList",
+  "taskCreate",
+  "taskUpdate",
+  "taskDelete",
+  "taskTransition",
+  "taskDefer",
+  "taskResumeDeferred",
+  "specGet",
+  "setSpec",
+  "saveSpecDocument",
+  "setPlan",
+  "savePlanDocument",
+  "planGet",
+  "qaGetReport",
+  "qaApproved",
+  "qaRejected",
+  "agentSessionsList",
+  "agentSessionUpsert",
+] as const satisfies readonly MethodName<TauriTaskClient>[];
+
+const AGENT_METHODS = [
+  "systemCheck",
+  "runtimeCheck",
+  "beadsCheck",
+  "runsList",
+  "opencodeRuntimeList",
+  "opencodeRuntimeStart",
+  "opencodeRuntimeStop",
+  "opencodeRepoRuntimeEnsure",
+  "buildStart",
+  "buildBlocked",
+  "buildResumed",
+  "buildCompleted",
+  "humanRequestChanges",
+  "humanApprove",
+  "buildRespond",
+  "buildStop",
+  "buildCleanup",
+] as const satisfies readonly MethodName<TauriAgentClient>[];
+
+const GIT_METHODS = [
+  "gitGetBranches",
+  "gitGetCurrentBranch",
+  "gitSwitchBranch",
+  "gitCreateWorktree",
+  "gitRemoveWorktree",
+  "gitPushBranch",
+] as const satisfies readonly MethodName<TauriGitClient>[];
+
+type WorkspaceMethodName = (typeof WORKSPACE_METHODS)[number];
+type TaskMethodName = (typeof TASK_METHODS)[number];
+type AgentMethodName = (typeof AGENT_METHODS)[number];
+type GitMethodName = (typeof GIT_METHODS)[number];
+
+type TauriHostClientApi = Pick<TauriWorkspaceClient, WorkspaceMethodName> &
+  Pick<TauriTaskClient, TaskMethodName> &
+  Pick<TauriAgentClient, AgentMethodName> &
+  Pick<TauriGitClient, GitMethodName>;
+
+const bindDelegates = <
+  THost extends object,
+  TClient extends object,
+  TMethodName extends MethodName<TClient>,
+>(
+  host: THost,
+  client: TClient,
+  methods: readonly TMethodName[],
+): void => {
+  for (const methodName of methods) {
+    const candidate = client[methodName];
+    if (typeof candidate !== "function") {
+      throw new Error(`Cannot delegate non-function member: ${String(methodName)}`);
+    }
+
+    Object.defineProperty(host, methodName, {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+      value: candidate.bind(client),
+    });
   }
+};
 
-  async workspaceAdd(repoPath: string): Promise<WorkspaceRecord> {
-    return workspaceAdd(this.invokeFn, repoPath);
-  }
+class TauriHostClientImpl implements PlannerTools {
+  private readonly workspaceClient: TauriWorkspaceClient;
+  private readonly taskClient: TauriTaskClient;
+  private readonly agentClient: TauriAgentClient;
+  private readonly gitClient: TauriGitClient;
 
-  async workspaceSelect(repoPath: string): Promise<WorkspaceRecord> {
-    return workspaceSelect(this.invokeFn, repoPath);
-  }
-
-  async systemCheck(repoPath: string): Promise<SystemCheck> {
-    return systemCheck(this.invokeFn, repoPath);
-  }
-
-  async runtimeCheck(force = false): Promise<RuntimeCheck> {
-    return runtimeCheck(this.invokeFn, force);
-  }
-
-  async beadsCheck(repoPath: string): Promise<BeadsCheck> {
-    return beadsCheck(this.invokeFn, repoPath);
-  }
-
-  async tasksList(repoPath: string): Promise<TaskCard[]> {
-    return tasksList(this.invokeFn, repoPath);
-  }
-
-  async taskCreate(repoPath: string, input: TaskCreateInput): Promise<TaskCard> {
-    return taskCreate(this.invokeFn, repoPath, input);
-  }
-
-  async taskUpdate(repoPath: string, taskId: string, patch: TaskUpdatePatch): Promise<TaskCard> {
-    return taskUpdate(this.invokeFn, repoPath, taskId, patch);
-  }
-
-  async taskDelete(
+  declare setSpec: (input: SetSpecInput) => ReturnType<TauriTaskClient["setSpec"]>;
+  declare setPlan: (input: SetPlanInput) => ReturnType<TauriTaskClient["setPlan"]>;
+  declare opencodeRuntimeStart: (
     repoPath: string,
     taskId: string,
-    deleteSubtasks = false,
-  ): Promise<{ ok: boolean }> {
-    return taskDelete(this.invokeFn, this.taskMetadataCache, repoPath, taskId, deleteSubtasks);
-  }
-
-  async taskTransition(
-    repoPath: string,
-    taskId: string,
-    status: TaskStatus,
-    reason?: string,
-  ): Promise<TaskCard> {
-    return taskTransition(this.invokeFn, repoPath, taskId, status, reason);
-  }
-
-  async taskDefer(repoPath: string, taskId: string, reason?: string): Promise<TaskCard> {
-    return taskDefer(this.invokeFn, repoPath, taskId, reason);
-  }
-
-  async taskResumeDeferred(repoPath: string, taskId: string): Promise<TaskCard> {
-    return taskResumeDeferred(this.invokeFn, repoPath, taskId);
-  }
-
-  async specGet(
-    repoPath: string,
-    taskId: string,
-  ): Promise<{ markdown: string; updatedAt: string | null }> {
-    return specGet(this.taskMetadataCache, this.invokeFn, repoPath, taskId);
-  }
-
-  async setSpec(input: {
-    taskId: string;
-    markdown: string;
-    repoPath?: string;
-  }): Promise<SetSpecOutput> {
-    return setSpec(this.invokeFn, this.taskMetadataCache, input);
-  }
-
-  async saveSpecDocument(
-    repoPath: string,
-    taskId: string,
-    markdown: string,
-  ): Promise<SetSpecOutput> {
-    return saveSpecDocument(this.invokeFn, this.taskMetadataCache, repoPath, taskId, markdown);
-  }
-
-  async setPlan(input: {
-    taskId: string;
-    markdown: string;
-    subtasks?: Array<{
-      title: string;
-      issueType?: "task" | "feature" | "bug";
-      priority?: number;
-      description?: string;
-    }>;
-    repoPath?: string;
-  }): Promise<SetPlanOutput> {
-    return setPlan(this.invokeFn, this.taskMetadataCache, input);
-  }
-
-  async savePlanDocument(
-    repoPath: string,
-    taskId: string,
-    markdown: string,
-  ): Promise<SetPlanOutput> {
-    return savePlanDocument(this.invokeFn, this.taskMetadataCache, repoPath, taskId, markdown);
-  }
-
-  async planGet(
-    repoPath: string,
-    taskId: string,
-  ): Promise<{ markdown: string; updatedAt: string | null }> {
-    return planGet(this.taskMetadataCache, this.invokeFn, repoPath, taskId);
-  }
-
-  async qaGetReport(
-    repoPath: string,
-    taskId: string,
-  ): Promise<{ markdown: string; updatedAt: string | null }> {
-    return qaGetReport(this.taskMetadataCache, this.invokeFn, repoPath, taskId);
-  }
-
-  async qaApproved(repoPath: string, taskId: string, markdown: string): Promise<TaskCard> {
-    return qaApproved(this.invokeFn, this.taskMetadataCache, repoPath, taskId, markdown);
-  }
-
-  async qaRejected(repoPath: string, taskId: string, markdown: string): Promise<TaskCard> {
-    return qaRejected(this.invokeFn, this.taskMetadataCache, repoPath, taskId, markdown);
-  }
-
-  async runsList(repoPath?: string): Promise<RunSummary[]> {
-    return runsList(this.invokeFn, repoPath);
-  }
-
-  async opencodeRuntimeList(repoPath?: string): Promise<AgentRuntimeSummary[]> {
-    return opencodeRuntimeList(this.invokeFn, repoPath);
-  }
-
-  async opencodeRuntimeStart(
-    repoPath: string,
-    taskId: string,
-    role: "spec" | "planner" | "qa",
-  ): Promise<AgentRuntimeSummary> {
-    return opencodeRuntimeStart(this.invokeFn, repoPath, taskId, role);
-  }
-
-  async opencodeRuntimeStop(runtimeId: string): Promise<{ ok: boolean }> {
-    return opencodeRuntimeStop(this.invokeFn, runtimeId);
-  }
-
-  async opencodeRepoRuntimeEnsure(repoPath: string): Promise<AgentRuntimeSummary> {
-    return opencodeRepoRuntimeEnsure(this.invokeFn, repoPath);
-  }
-
-  async agentSessionsList(repoPath: string, taskId: string): Promise<AgentSessionRecord[]> {
-    return agentSessionsList(this.taskMetadataCache, this.invokeFn, repoPath, taskId);
-  }
-
-  async agentSessionUpsert(
-    repoPath: string,
-    taskId: string,
-    session: AgentSessionRecord,
-  ): Promise<void> {
-    return agentSessionUpsert(this.invokeFn, this.taskMetadataCache, repoPath, taskId, session);
-  }
-
-  async workspaceUpdateRepoConfig(
-    repoPath: string,
-    config: {
-      worktreeBasePath?: string;
-      branchPrefix?: string;
-      agentDefaults?: {
-        spec?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-        planner?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-        build?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-        qa?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-      };
-    },
-  ): Promise<WorkspaceRecord> {
-    return workspaceUpdateRepoConfig(this.invokeFn, repoPath, config);
-  }
-
-  async workspaceSaveRepoSettings(
-    repoPath: string,
-    settings: {
-      worktreeBasePath?: string;
-      branchPrefix?: string;
-      trustedHooks: boolean;
-      hooks?: { preStart?: string[]; postComplete?: string[] };
-      agentDefaults?: {
-        spec?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-        planner?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-        build?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-        qa?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-      };
-    },
-  ): Promise<WorkspaceRecord> {
-    return workspaceSaveRepoSettings(this.invokeFn, repoPath, settings);
-  }
-
-  async workspaceUpdateRepoHooks(
-    repoPath: string,
-    hooks: { preStart?: string[]; postComplete?: string[] },
-  ): Promise<WorkspaceRecord> {
-    return workspaceUpdateRepoHooks(this.invokeFn, repoPath, hooks);
-  }
-
-  async workspaceGetRepoConfig(repoPath: string): Promise<RepoConfig> {
-    return workspaceGetRepoConfig(this.invokeFn, repoPath);
-  }
-
-  async workspacePrepareTrustedHooksChallenge(repoPath: string): Promise<{
-    nonce: string;
-    repoPath: string;
-    fingerprint: string;
-    expiresAt: string;
-    preStartCount: number;
-    postCompleteCount: number;
-  }> {
-    return workspacePrepareTrustedHooksChallenge(this.invokeFn, repoPath);
-  }
-
-  async workspaceSetTrustedHooks(
-    repoPath: string,
-    trusted: boolean,
-    challenge?: { nonce: string; fingerprint: string },
-  ): Promise<WorkspaceRecord> {
-    return workspaceSetTrustedHooks(this.invokeFn, repoPath, trusted, challenge);
-  }
-
-  async getTheme(): Promise<string> {
-    return getTheme(this.invokeFn);
-  }
-
-  async setTheme(theme: string): Promise<void> {
-    return setTheme(this.invokeFn, theme);
-  }
-
-  async gitGetBranches(repoPath: string): Promise<GitBranch[]> {
-    return gitGetBranches(this.invokeFn, repoPath);
-  }
-
-  async gitGetCurrentBranch(repoPath: string): Promise<GitCurrentBranch> {
-    return gitGetCurrentBranch(this.invokeFn, repoPath);
-  }
-
-  async gitSwitchBranch(
-    repoPath: string,
-    branch: string,
-    options?: { create?: boolean },
-  ): Promise<GitCurrentBranch> {
-    return gitSwitchBranch(this.invokeFn, repoPath, branch, options);
-  }
-
-  async gitCreateWorktree(
-    repoPath: string,
-    worktreePath: string,
-    branch: string,
-    options?: { createBranch?: boolean },
-  ): Promise<GitWorktreeSummary> {
-    return gitCreateWorktree(this.invokeFn, repoPath, worktreePath, branch, options);
-  }
-
-  async gitRemoveWorktree(
-    repoPath: string,
-    worktreePath: string,
-    options?: { force?: boolean },
-  ): Promise<{ ok: boolean }> {
-    return gitRemoveWorktree(this.invokeFn, repoPath, worktreePath, options);
-  }
-
-  async gitPushBranch(
-    repoPath: string,
-    branch: string,
-    options?: {
-      remote?: string;
-      setUpstream?: boolean;
-      forceWithLease?: boolean;
-    },
-  ): Promise<GitPushSummary> {
-    return gitPushBranch(this.invokeFn, repoPath, branch, options);
-  }
-
-  async buildStart(repoPath: string, taskId: string): Promise<RunSummary> {
-    return buildStart(this.invokeFn, repoPath, taskId);
-  }
-
-  async buildBlocked(repoPath: string, taskId: string, reason: string): Promise<TaskCard> {
-    return buildBlocked(this.invokeFn, repoPath, taskId, reason);
-  }
-
-  async buildResumed(repoPath: string, taskId: string): Promise<TaskCard> {
-    return buildResumed(this.invokeFn, repoPath, taskId);
-  }
-
-  async buildCompleted(repoPath: string, taskId: string, summary?: string): Promise<TaskCard> {
-    return buildCompleted(this.invokeFn, repoPath, taskId, summary);
-  }
-
-  async humanRequestChanges(repoPath: string, taskId: string, note?: string): Promise<TaskCard> {
-    return humanRequestChanges(this.invokeFn, repoPath, taskId, note);
-  }
-
-  async humanApprove(repoPath: string, taskId: string): Promise<TaskCard> {
-    return humanApprove(this.invokeFn, repoPath, taskId);
-  }
-
-  async buildRespond(
+    role: RuntimeRole,
+  ) => ReturnType<TauriAgentClient["opencodeRuntimeStart"]>;
+  declare buildRespond: (
     runId: string,
-    action: "approve" | "deny" | "message",
+    action: BuildRespondAction,
     payload?: string,
-  ): Promise<{ ok: boolean }> {
-    return buildRespond(this.invokeFn, runId, action, payload);
-  }
+  ) => ReturnType<TauriAgentClient["buildRespond"]>;
+  declare buildCleanup: (
+    runId: string,
+    mode: BuildCleanupMode,
+  ) => ReturnType<TauriAgentClient["buildCleanup"]>;
 
-  async buildStop(runId: string): Promise<{ ok: boolean }> {
-    return buildStop(this.invokeFn, runId);
-  }
+  constructor(invokeFn: InvokeFn) {
+    const metadataCache = new TaskMetadataCache();
+    this.workspaceClient = new TauriWorkspaceClient(invokeFn);
+    this.taskClient = new TauriTaskClient(invokeFn, metadataCache);
+    this.agentClient = new TauriAgentClient(invokeFn);
+    this.gitClient = new TauriGitClient(invokeFn);
 
-  async buildCleanup(runId: string, mode: "success" | "failure"): Promise<{ ok: boolean }> {
-    return buildCleanup(this.invokeFn, runId, mode);
+    bindDelegates(this, this.workspaceClient, WORKSPACE_METHODS);
+    bindDelegates(this, this.taskClient, TASK_METHODS);
+    bindDelegates(this, this.agentClient, AGENT_METHODS);
+    bindDelegates(this, this.gitClient, GIT_METHODS);
   }
 }
+
+export const TauriHostClient = TauriHostClientImpl as unknown as new (
+  invokeFn: InvokeFn,
+) => TauriHostClientApi & PlannerTools;

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -14,6 +14,26 @@ import type { InvokeFn } from "./invoke-utils";
 import { parseArray } from "./invoke-utils";
 import type { TaskMetadataCache } from "./task-metadata-cache";
 
+export type SetSpecInput = {
+  taskId: string;
+  markdown: string;
+  repoPath?: string;
+};
+
+export type PlanSubtaskInput = {
+  title: string;
+  issueType?: "task" | "feature" | "bug";
+  priority?: number;
+  description?: string;
+};
+
+export type SetPlanInput = {
+  taskId: string;
+  markdown: string;
+  subtasks?: PlanSubtaskInput[];
+  repoPath?: string;
+};
+
 export const tasksList = async (invokeFn: InvokeFn, repoPath: string): Promise<TaskCard[]> => {
   const payload = await invokeFn<unknown>("tasks_list", { repoPath });
   return parseArray(taskCardSchema, payload);
@@ -122,11 +142,7 @@ export const specGet = async (
 export const setSpec = async (
   invokeFn: InvokeFn,
   metadataCache: TaskMetadataCache,
-  input: {
-    taskId: string;
-    markdown: string;
-    repoPath?: string;
-  },
+  input: SetSpecInput,
 ): Promise<SetSpecOutput> => {
   if (!input.repoPath) {
     throw new Error("repoPath is required to set spec");
@@ -161,17 +177,7 @@ export const saveSpecDocument = async (
 export const setPlan = async (
   invokeFn: InvokeFn,
   metadataCache: TaskMetadataCache,
-  input: {
-    taskId: string;
-    markdown: string;
-    subtasks?: Array<{
-      title: string;
-      issueType?: "task" | "feature" | "bug";
-      priority?: number;
-      description?: string;
-    }>;
-    repoPath?: string;
-  },
+  input: SetPlanInput,
 ): Promise<SetPlanOutput> => {
   if (!input.repoPath) {
     throw new Error("repoPath is required to set plan");
@@ -288,3 +294,112 @@ export const agentSessionUpsert = async (
   });
   metadataCache.invalidate(repoPath, taskId);
 };
+
+export class TauriTaskClient {
+  constructor(
+    private readonly invokeFn: InvokeFn,
+    private readonly metadataCache: TaskMetadataCache,
+  ) {}
+
+  async tasksList(repoPath: string): Promise<TaskCard[]> {
+    return tasksList(this.invokeFn, repoPath);
+  }
+
+  async taskCreate(repoPath: string, input: TaskCreateInput): Promise<TaskCard> {
+    return taskCreate(this.invokeFn, repoPath, input);
+  }
+
+  async taskUpdate(repoPath: string, taskId: string, patch: TaskUpdatePatch): Promise<TaskCard> {
+    return taskUpdate(this.invokeFn, repoPath, taskId, patch);
+  }
+
+  async taskDelete(
+    repoPath: string,
+    taskId: string,
+    deleteSubtasks = false,
+  ): Promise<{ ok: boolean }> {
+    return taskDelete(this.invokeFn, this.metadataCache, repoPath, taskId, deleteSubtasks);
+  }
+
+  async taskTransition(
+    repoPath: string,
+    taskId: string,
+    status: TaskStatus,
+    reason?: string,
+  ): Promise<TaskCard> {
+    return taskTransition(this.invokeFn, repoPath, taskId, status, reason);
+  }
+
+  async taskDefer(repoPath: string, taskId: string, reason?: string): Promise<TaskCard> {
+    return taskDefer(this.invokeFn, repoPath, taskId, reason);
+  }
+
+  async taskResumeDeferred(repoPath: string, taskId: string): Promise<TaskCard> {
+    return taskResumeDeferred(this.invokeFn, repoPath, taskId);
+  }
+
+  async specGet(
+    repoPath: string,
+    taskId: string,
+  ): Promise<{ markdown: string; updatedAt: string | null }> {
+    return specGet(this.metadataCache, this.invokeFn, repoPath, taskId);
+  }
+
+  async setSpec(input: SetSpecInput): Promise<SetSpecOutput> {
+    return setSpec(this.invokeFn, this.metadataCache, input);
+  }
+
+  async saveSpecDocument(
+    repoPath: string,
+    taskId: string,
+    markdown: string,
+  ): Promise<SetSpecOutput> {
+    return saveSpecDocument(this.invokeFn, this.metadataCache, repoPath, taskId, markdown);
+  }
+
+  async setPlan(input: SetPlanInput): Promise<SetPlanOutput> {
+    return setPlan(this.invokeFn, this.metadataCache, input);
+  }
+
+  async savePlanDocument(
+    repoPath: string,
+    taskId: string,
+    markdown: string,
+  ): Promise<SetPlanOutput> {
+    return savePlanDocument(this.invokeFn, this.metadataCache, repoPath, taskId, markdown);
+  }
+
+  async planGet(
+    repoPath: string,
+    taskId: string,
+  ): Promise<{ markdown: string; updatedAt: string | null }> {
+    return planGet(this.metadataCache, this.invokeFn, repoPath, taskId);
+  }
+
+  async qaGetReport(
+    repoPath: string,
+    taskId: string,
+  ): Promise<{ markdown: string; updatedAt: string | null }> {
+    return qaGetReport(this.metadataCache, this.invokeFn, repoPath, taskId);
+  }
+
+  async qaApproved(repoPath: string, taskId: string, markdown: string): Promise<TaskCard> {
+    return qaApproved(this.invokeFn, this.metadataCache, repoPath, taskId, markdown);
+  }
+
+  async qaRejected(repoPath: string, taskId: string, markdown: string): Promise<TaskCard> {
+    return qaRejected(this.invokeFn, this.metadataCache, repoPath, taskId, markdown);
+  }
+
+  async agentSessionsList(repoPath: string, taskId: string): Promise<AgentSessionRecord[]> {
+    return agentSessionsList(this.metadataCache, this.invokeFn, repoPath, taskId);
+  }
+
+  async agentSessionUpsert(
+    repoPath: string,
+    taskId: string,
+    session: AgentSessionRecord,
+  ): Promise<void> {
+    return agentSessionUpsert(this.invokeFn, this.metadataCache, repoPath, taskId, session);
+  }
+}

--- a/packages/adapters-tauri-host/src/workspace-client.ts
+++ b/packages/adapters-tauri-host/src/workspace-client.ts
@@ -7,6 +7,50 @@ import {
 import type { InvokeFn } from "./invoke-utils";
 import { parseArray } from "./invoke-utils";
 
+export type AgentDefaultConfig = {
+  providerId: string;
+  modelId: string;
+  variant?: string;
+  opencodeAgent?: string;
+};
+
+export type WorkspaceAgentDefaults = {
+  spec?: AgentDefaultConfig;
+  planner?: AgentDefaultConfig;
+  build?: AgentDefaultConfig;
+  qa?: AgentDefaultConfig;
+};
+
+export type WorkspaceRepoConfigInput = {
+  worktreeBasePath?: string;
+  branchPrefix?: string;
+  agentDefaults?: WorkspaceAgentDefaults;
+};
+
+export type WorkspaceRepoSettingsInput = WorkspaceRepoConfigInput & {
+  trustedHooks: boolean;
+  hooks?: WorkspaceRepoHooksInput;
+};
+
+export type WorkspaceRepoHooksInput = {
+  preStart?: string[];
+  postComplete?: string[];
+};
+
+export type TrustedHooksChallenge = {
+  nonce: string;
+  repoPath: string;
+  fingerprint: string;
+  expiresAt: string;
+  preStartCount: number;
+  postCompleteCount: number;
+};
+
+export type TrustedHooksProof = {
+  nonce: string;
+  fingerprint: string;
+};
+
 export const workspaceList = async (invokeFn: InvokeFn): Promise<WorkspaceRecord[]> => {
   const payload = await invokeFn<unknown>("workspace_list");
   return parseArray(workspaceRecordSchema, payload);
@@ -31,16 +75,7 @@ export const workspaceSelect = async (
 export const workspaceUpdateRepoConfig = async (
   invokeFn: InvokeFn,
   repoPath: string,
-  config: {
-    worktreeBasePath?: string;
-    branchPrefix?: string;
-    agentDefaults?: {
-      spec?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-      planner?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-      build?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-      qa?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-    };
-  },
+  config: WorkspaceRepoConfigInput,
 ): Promise<WorkspaceRecord> => {
   const payload = await invokeFn<unknown>("workspace_update_repo_config", {
     repoPath,
@@ -52,18 +87,7 @@ export const workspaceUpdateRepoConfig = async (
 export const workspaceSaveRepoSettings = async (
   invokeFn: InvokeFn,
   repoPath: string,
-  settings: {
-    worktreeBasePath?: string;
-    branchPrefix?: string;
-    trustedHooks: boolean;
-    hooks?: { preStart?: string[]; postComplete?: string[] };
-    agentDefaults?: {
-      spec?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-      planner?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-      build?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-      qa?: { providerId: string; modelId: string; variant?: string; opencodeAgent?: string };
-    };
-  },
+  settings: WorkspaceRepoSettingsInput,
 ): Promise<WorkspaceRecord> => {
   const payload = await invokeFn<unknown>("workspace_save_repo_settings", {
     repoPath,
@@ -75,7 +99,7 @@ export const workspaceSaveRepoSettings = async (
 export const workspaceUpdateRepoHooks = async (
   invokeFn: InvokeFn,
   repoPath: string,
-  hooks: { preStart?: string[]; postComplete?: string[] },
+  hooks: WorkspaceRepoHooksInput,
 ): Promise<WorkspaceRecord> => {
   const payload = await invokeFn<unknown>("workspace_update_repo_hooks", {
     repoPath,
@@ -96,7 +120,7 @@ export const workspaceSetTrustedHooks = async (
   invokeFn: InvokeFn,
   repoPath: string,
   trusted: boolean,
-  challenge?: { nonce: string; fingerprint: string },
+  challenge?: TrustedHooksProof,
 ): Promise<WorkspaceRecord> => {
   const payload = await invokeFn<unknown>("workspace_set_trusted_hooks", {
     repoPath,
@@ -114,14 +138,7 @@ export const workspaceSetTrustedHooks = async (
 export const workspacePrepareTrustedHooksChallenge = async (
   invokeFn: InvokeFn,
   repoPath: string,
-): Promise<{
-  nonce: string;
-  repoPath: string;
-  fingerprint: string;
-  expiresAt: string;
-  preStartCount: number;
-  postCompleteCount: number;
-}> => {
+): Promise<TrustedHooksChallenge> => {
   return invokeFn("workspace_prepare_trusted_hooks_challenge", { repoPath });
 };
 
@@ -132,3 +149,64 @@ export const getTheme = async (invokeFn: InvokeFn): Promise<string> => {
 export const setTheme = async (invokeFn: InvokeFn, theme: string): Promise<void> => {
   await invokeFn<void>("set_theme", { theme });
 };
+
+export class TauriWorkspaceClient {
+  constructor(private readonly invokeFn: InvokeFn) {}
+
+  async workspaceList(): Promise<WorkspaceRecord[]> {
+    return workspaceList(this.invokeFn);
+  }
+
+  async workspaceAdd(repoPath: string): Promise<WorkspaceRecord> {
+    return workspaceAdd(this.invokeFn, repoPath);
+  }
+
+  async workspaceSelect(repoPath: string): Promise<WorkspaceRecord> {
+    return workspaceSelect(this.invokeFn, repoPath);
+  }
+
+  async workspaceUpdateRepoConfig(
+    repoPath: string,
+    config: WorkspaceRepoConfigInput,
+  ): Promise<WorkspaceRecord> {
+    return workspaceUpdateRepoConfig(this.invokeFn, repoPath, config);
+  }
+
+  async workspaceSaveRepoSettings(
+    repoPath: string,
+    settings: WorkspaceRepoSettingsInput,
+  ): Promise<WorkspaceRecord> {
+    return workspaceSaveRepoSettings(this.invokeFn, repoPath, settings);
+  }
+
+  async workspaceUpdateRepoHooks(
+    repoPath: string,
+    hooks: WorkspaceRepoHooksInput,
+  ): Promise<WorkspaceRecord> {
+    return workspaceUpdateRepoHooks(this.invokeFn, repoPath, hooks);
+  }
+
+  async workspaceGetRepoConfig(repoPath: string): Promise<RepoConfig> {
+    return workspaceGetRepoConfig(this.invokeFn, repoPath);
+  }
+
+  async workspacePrepareTrustedHooksChallenge(repoPath: string): Promise<TrustedHooksChallenge> {
+    return workspacePrepareTrustedHooksChallenge(this.invokeFn, repoPath);
+  }
+
+  async workspaceSetTrustedHooks(
+    repoPath: string,
+    trusted: boolean,
+    challenge?: TrustedHooksProof,
+  ): Promise<WorkspaceRecord> {
+    return workspaceSetTrustedHooks(this.invokeFn, repoPath, trusted, challenge);
+  }
+
+  async getTheme(): Promise<string> {
+    return getTheme(this.invokeFn);
+  }
+
+  async setTheme(theme: string): Promise<void> {
+    return setTheme(this.invokeFn, theme);
+  }
+}


### PR DESCRIPTION
## Summary
- Split the monolithic `TauriHostClient` implementation into domain-focused sub-clients:
  - `TauriWorkspaceClient`
  - `TauriTaskClient`
  - `TauriAgentClient`
  - `TauriGitClient`
- Keep `TauriHostClient` as a facade so the public API remains stable.
- Add shared domain input/action/role types to reduce duplicated inline signatures.
- Restore downstream typing compatibility by exporting `TauriHostClient` as both a constructor value and usable type.
- Make delegated facade methods writable/configurable for test doubles and runtime overrides.
- Add regression tests for type compatibility, method mutability, and facade API surface completeness.

## Commits
- `18711a6` refactor(adapters-tauri-host): decompose TauriHostClient into domain sub-clients
- `8be70bf` fix(adapters-tauri-host): restore host client type export and delegation safety

## Validation
- `bun run --filter @openducktor/adapters-tauri-host typecheck`
- `bun run --filter @openducktor/adapters-tauri-host lint`
- `bun run --filter @openducktor/adapters-tauri-host test`
- `bun run --filter @openducktor/desktop typecheck`
