### PR TITLE
refactor(desktop-state): split AppStateProvider and harden provider-test isolation

### DIFF
--- a/apps/desktop/src/state/app-state-contexts.ts
+++ b/apps/desktop/src/state/app-state-contexts.ts
@@ -1,4 +1,10 @@
-import type { BeadsCheck, RunEvent, RunSummary, TaskCard } from "@openducktor/contracts";
+import type {
+  BeadsCheck,
+  RunEvent,
+  RunSummary,
+  RuntimeCheck,
+  TaskCard,
+} from "@openducktor/contracts";
 import { type Context, createContext, type Dispatch, type SetStateAction, useContext } from "react";
 import type { RepoOpencodeHealthCheck } from "@/types/diagnostics";
 import type {
@@ -23,7 +29,7 @@ export type ActiveRepoContextValue = {
 };
 
 export type ChecksOperationsContextValue = {
-  refreshRuntimeCheck: (force?: boolean) => Promise<unknown>;
+  refreshRuntimeCheck: (force?: boolean) => Promise<RuntimeCheck>;
   refreshBeadsCheckForRepo: (repoPath: string, force?: boolean) => Promise<BeadsCheck>;
   refreshRepoOpencodeHealthForRepo: (
     repoPath: string,
@@ -37,9 +43,12 @@ export type ChecksOperationsContextValue = {
   hasCachedRepoOpencodeHealth: (repoPath: string) => boolean;
 };
 
-export type TaskOperationsContextValue = {
+export type TaskDataContextValue = {
   tasks: TaskCard[];
   runs: RunSummary[];
+};
+
+export type TaskControlContextValue = {
   refreshTaskData: (repoPath: string) => Promise<void>;
   clearTaskData: () => void;
   setIsLoadingTasks: (value: boolean) => void;
@@ -57,7 +66,8 @@ export type DelegationEventsContextValue = {
 
 export const ActiveRepoContext = createContext<ActiveRepoContextValue | null>(null);
 export const ChecksOperationsContext = createContext<ChecksOperationsContextValue | null>(null);
-export const TaskOperationsContext = createContext<TaskOperationsContextValue | null>(null);
+export const TaskDataContext = createContext<TaskDataContextValue | null>(null);
+export const TaskControlContext = createContext<TaskControlContextValue | null>(null);
 export const WorkspaceOperationsContext = createContext<WorkspaceOperationsContextValue | null>(
   null,
 );
@@ -77,8 +87,11 @@ export const useActiveRepoContext = (): ActiveRepoContextValue =>
 export const useChecksOperationsContext = (): ChecksOperationsContextValue =>
   useRequiredContext(ChecksOperationsContext, "useChecksOperationsContext");
 
-export const useTaskOperationsContext = (): TaskOperationsContextValue =>
-  useRequiredContext(TaskOperationsContext, "useTaskOperationsContext");
+export const useTaskDataContext = (): TaskDataContextValue =>
+  useRequiredContext(TaskDataContext, "useTaskDataContext");
+
+export const useTaskControlContext = (): TaskControlContextValue =>
+  useRequiredContext(TaskControlContext, "useTaskControlContext");
 
 export const useWorkspaceOperationsContext = (): WorkspaceOperationsContextValue =>
   useRequiredContext(WorkspaceOperationsContext, "useWorkspaceOperationsContext");

--- a/apps/desktop/src/state/app-state-contexts.ts
+++ b/apps/desktop/src/state/app-state-contexts.ts
@@ -1,0 +1,87 @@
+import type { BeadsCheck, RunEvent, RunSummary, TaskCard } from "@openducktor/contracts";
+import { type Context, createContext, type Dispatch, type SetStateAction, useContext } from "react";
+import type { RepoOpencodeHealthCheck } from "@/types/diagnostics";
+import type {
+  AgentStateContextValue,
+  ChecksStateContextValue,
+  DelegationStateContextValue,
+  SpecStateContextValue,
+  TasksStateContextValue,
+  WorkspaceStateContextValue,
+} from "@/types/state-slices";
+
+export const WorkspaceStateContext = createContext<WorkspaceStateContextValue | null>(null);
+export const ChecksStateContext = createContext<ChecksStateContextValue | null>(null);
+export const TasksStateContext = createContext<TasksStateContextValue | null>(null);
+export const DelegationStateContext = createContext<DelegationStateContextValue | null>(null);
+export const SpecStateContext = createContext<SpecStateContextValue | null>(null);
+export const AgentStateContext = createContext<AgentStateContextValue | null>(null);
+
+export type ActiveRepoContextValue = {
+  activeRepo: string | null;
+  setActiveRepo: Dispatch<SetStateAction<string | null>>;
+};
+
+export type ChecksOperationsContextValue = {
+  refreshRuntimeCheck: (force?: boolean) => Promise<unknown>;
+  refreshBeadsCheckForRepo: (repoPath: string, force?: boolean) => Promise<BeadsCheck>;
+  refreshRepoOpencodeHealthForRepo: (
+    repoPath: string,
+    force?: boolean,
+  ) => Promise<RepoOpencodeHealthCheck>;
+  clearActiveBeadsCheck: () => void;
+  clearActiveRepoOpencodeHealth: () => void;
+  setIsLoadingChecks: (value: boolean) => void;
+  hasRuntimeCheck: () => boolean;
+  hasCachedBeadsCheck: (repoPath: string) => boolean;
+  hasCachedRepoOpencodeHealth: (repoPath: string) => boolean;
+};
+
+export type TaskOperationsContextValue = {
+  tasks: TaskCard[];
+  runs: RunSummary[];
+  refreshTaskData: (repoPath: string) => Promise<void>;
+  clearTaskData: () => void;
+  setIsLoadingTasks: (value: boolean) => void;
+};
+
+export type WorkspaceOperationsContextValue = {
+  refreshWorkspaces: () => Promise<void>;
+  refreshBranches: (force?: boolean) => Promise<void>;
+  clearBranchData: () => void;
+};
+
+export type DelegationEventsContextValue = {
+  setEvents: Dispatch<SetStateAction<RunEvent[]>>;
+};
+
+export const ActiveRepoContext = createContext<ActiveRepoContextValue | null>(null);
+export const ChecksOperationsContext = createContext<ChecksOperationsContextValue | null>(null);
+export const TaskOperationsContext = createContext<TaskOperationsContextValue | null>(null);
+export const WorkspaceOperationsContext = createContext<WorkspaceOperationsContextValue | null>(
+  null,
+);
+export const DelegationEventsContext = createContext<DelegationEventsContextValue | null>(null);
+
+export const useRequiredContext = <T>(context: Context<T | null>, name: string): T => {
+  const value = useContext(context);
+  if (!value) {
+    throw new Error(`${name} must be used inside AppStateProvider`);
+  }
+  return value;
+};
+
+export const useActiveRepoContext = (): ActiveRepoContextValue =>
+  useRequiredContext(ActiveRepoContext, "useActiveRepoContext");
+
+export const useChecksOperationsContext = (): ChecksOperationsContextValue =>
+  useRequiredContext(ChecksOperationsContext, "useChecksOperationsContext");
+
+export const useTaskOperationsContext = (): TaskOperationsContextValue =>
+  useRequiredContext(TaskOperationsContext, "useTaskOperationsContext");
+
+export const useWorkspaceOperationsContext = (): WorkspaceOperationsContextValue =>
+  useRequiredContext(WorkspaceOperationsContext, "useWorkspaceOperationsContext");
+
+export const useDelegationEventsContext = (): DelegationEventsContextValue =>
+  useRequiredContext(DelegationEventsContext, "useDelegationEventsContext");

--- a/apps/desktop/src/state/app-state-provider.test.tsx
+++ b/apps/desktop/src/state/app-state-provider.test.tsx
@@ -1,418 +1,97 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import type {
-  AgentRuntimeSummary,
-  BeadsCheck,
-  GitBranch,
-  RunSummary,
-  TaskCard,
-  WorkspaceRecord,
-} from "@openducktor/contracts";
-import { createElement, type ReactElement } from "react";
+import { describe, expect, test } from "bun:test";
+import { Component, createElement, type ReactElement, type ReactNode } from "react";
 import TestRenderer, { act } from "react-test-renderer";
-import type { RepoOpencodeHealthCheck } from "@/types/diagnostics";
-import type {
-  AgentStateContextValue,
-  ChecksStateContextValue,
-  DelegationStateContextValue,
-  SpecStateContextValue,
-  TasksStateContextValue,
-  WorkspaceStateContextValue,
-} from "@/types/state-slices";
+import {
+  useAgentState,
+  useChecksState,
+  useDelegationState,
+  useSpecState,
+  useTasksState,
+  useWorkspaceState,
+} from "./app-state-provider";
 
 const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
 reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
 
-const flush = async (): Promise<void> => {
-  await Promise.resolve();
-  await new Promise((resolve) => setTimeout(resolve, 0));
+type ErrorBoundaryProps = {
+  children: ReactNode;
 };
 
-const runtimeInfo: AgentRuntimeSummary = {
-  runtimeId: "runtime-1",
-  repoPath: "/repo-a",
-  taskId: "task-1",
-  role: "build",
-  workingDirectory: "/tmp/repo-a",
-  port: 8080,
-  startedAt: "2026-02-28T10:00:00.000Z",
+type ErrorBoundaryState = {
+  error: Error | null;
 };
 
-const workspaceRecord: WorkspaceRecord = {
-  path: "/repo-a",
-  isActive: true,
-  hasConfig: true,
-  configuredWorktreeBasePath: null,
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  public static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  public render(): ReactNode {
+    if (this.state.error) {
+      return null;
+    }
+    return this.props.children;
+  }
+}
+
+const HookProbe = ({ hook }: { hook: () => unknown }): ReactElement => {
+  hook();
+  return createElement("div");
 };
 
-const branchRecord: GitBranch = {
-  name: "main",
-  isCurrent: true,
-  isRemote: false,
+const captureHookErrorMessage = (hook: () => unknown): string | null => {
+  let renderer!: TestRenderer.ReactTestRenderer;
+
+  act(() => {
+    renderer = TestRenderer.create(
+      createElement(ErrorBoundary, null, createElement(HookProbe, { hook })),
+    );
+  });
+
+  const boundary = renderer.root.findByType(ErrorBoundary).instance as ErrorBoundary;
+  const message = boundary.state.error?.message ?? null;
+  renderer.unmount();
+  return message;
 };
 
-const tasksList: TaskCard[] = [
-  {
-    id: "task-1",
-    title: "Task One",
-    status: "open",
-    createdAt: "2026-02-28T10:00:00.000Z",
-    updatedAt: "2026-02-28T10:00:00.000Z",
-  } as TaskCard,
-];
+describe("AppStateProvider hooks", () => {
+  test("throw clear errors when used outside AppStateProvider", () => {
+    const expectations: Array<{ hook: () => unknown; expected: string }> = [
+      {
+        hook: useWorkspaceState,
+        expected: "useWorkspaceState must be used inside AppStateProvider",
+      },
+      {
+        hook: useChecksState,
+        expected: "useChecksState must be used inside AppStateProvider",
+      },
+      {
+        hook: useTasksState,
+        expected: "useTasksState must be used inside AppStateProvider",
+      },
+      {
+        hook: useDelegationState,
+        expected: "useDelegationState must be used inside AppStateProvider",
+      },
+      {
+        hook: useSpecState,
+        expected: "useSpecState must be used inside AppStateProvider",
+      },
+      {
+        hook: useAgentState,
+        expected: "useAgentState must be used inside AppStateProvider",
+      },
+    ];
 
-const runsList: RunSummary[] = [
-  {
-    runId: "run-1",
-    repoPath: "/repo-a",
-    taskId: "task-1",
-    branch: "main",
-    worktreePath: "/tmp/repo-a",
-    port: 8080,
-    state: "running",
-    lastMessage: null,
-    startedAt: "2026-02-28T10:00:00.000Z",
-  },
-];
-
-const beadsCheck: BeadsCheck = {
-  beadsOk: true,
-  beadsPath: "/repo-a/.beads",
-  beadsError: null,
-};
-
-const opencodeHealth: RepoOpencodeHealthCheck = {
-  runtimeOk: true,
-  runtimeError: null,
-  runtime: runtimeInfo,
-  mcpOk: true,
-  mcpError: null,
-  mcpServerName: "openducktor",
-  mcpServerStatus: "connected",
-  mcpServerError: null,
-  availableToolIds: ["odt_read_task"],
-  checkedAt: "2026-02-28T10:00:00.000Z",
-  errors: [],
-};
-
-const checkRepoOpencodeHealth = mock(async (_repoPath: string) => opencodeHealth);
-const createHostCatalogOps = mock((_agentEngine: unknown) => ({
-  checkRepoOpencodeHealth,
-}));
-const configureCatalogOps = mock((_ops: unknown) => {});
-
-const refreshRuntimeCheck = mock(async (_force?: boolean) => ({
-  gitOk: true,
-  gitVersion: "2.45.0",
-  opencodeOk: true,
-  opencodeVersion: "0.12.0",
-  errors: [],
-}));
-const refreshBeadsCheckForRepo = mock(async (_repoPath: string, _force?: boolean) => beadsCheck);
-const refreshRepoOpencodeHealthForRepo = mock(
-  async (_repoPath: string, _force?: boolean) => opencodeHealth,
-);
-const refreshChecks = mock(async () => {});
-const hasRuntimeCheck = mock(() => true);
-const hasCachedBeadsCheck = mock((_repoPath: string) => false);
-const hasCachedRepoOpencodeHealth = mock((_repoPath: string) => false);
-const clearActiveBeadsCheck = mock(() => {});
-const clearActiveRepoOpencodeHealth = mock(() => {});
-const setIsLoadingChecks = mock((_value: boolean) => {});
-const useChecksHook = mock((_args: { activeRepo: string | null }) => ({
-  runtimeCheck: null,
-  activeBeadsCheck: null,
-  activeRepoOpencodeHealth: null,
-  isLoadingChecks: false,
-  setIsLoadingChecks,
-  refreshRuntimeCheck,
-  refreshBeadsCheckForRepo,
-  refreshRepoOpencodeHealthForRepo,
-  refreshChecks,
-  hasRuntimeCheck,
-  hasCachedBeadsCheck,
-  hasCachedRepoOpencodeHealth,
-  clearActiveBeadsCheck,
-  clearActiveRepoOpencodeHealth,
-}));
-
-const refreshTaskData = mock(async (_repoPath: string) => {});
-const refreshTasks = mock(async () => {});
-const createTask = mock(async (_input: unknown) => {});
-const updateTask = mock(async (_taskId: string, _patch: unknown) => {});
-const deleteTask = mock(async (_taskId: string, _deleteSubtasks?: boolean) => {});
-const transitionTask = mock(async (_taskId: string, _status: unknown, _reason?: string) => {});
-const deferTask = mock(async (_taskId: string) => {});
-const resumeDeferredTask = mock(async (_taskId: string) => {});
-const humanApproveTask = mock(async (_taskId: string) => {});
-const humanRequestChangesTask = mock(async (_taskId: string, _note?: string) => {});
-const clearTaskData = mock(() => {});
-const setIsLoadingTasks = mock((_value: boolean) => {});
-const useTaskOperationsHook = mock((_args: { activeRepo: string | null }) => ({
-  tasks: tasksList,
-  runs: runsList,
-  isLoadingTasks: false,
-  setIsLoadingTasks,
-  clearTaskData,
-  refreshTaskData,
-  refreshTasks,
-  createTask,
-  updateTask,
-  deleteTask,
-  transitionTask,
-  deferTask,
-  resumeDeferredTask,
-  humanApproveTask,
-  humanRequestChangesTask,
-}));
-
-const refreshWorkspaces = mock(async () => {});
-const addWorkspace = mock(async (_repoPath: string) => {});
-const selectWorkspace = mock(async (_repoPath: string) => {});
-const refreshBranches = mock(async (_force?: boolean) => {});
-const switchBranch = mock(async (_branchName: string) => {});
-const clearBranchData = mock(() => {});
-const useWorkspaceOperationsHook = mock(
-  (_args: { activeRepo: string | null; setActiveRepo: (value: string | null) => void }) => ({
-    workspaces: [workspaceRecord],
-    branches: [branchRecord],
-    activeBranch: { name: "main", detached: false },
-    isSwitchingWorkspace: false,
-    isLoadingBranches: false,
-    isSwitchingBranch: false,
-    refreshWorkspaces,
-    addWorkspace,
-    selectWorkspace,
-    refreshBranches,
-    switchBranch,
-    clearBranchData,
-  }),
-);
-
-const loadRepoSettings = mock(async () => ({
-  worktreeBasePath: "/tmp/worktree",
-  branchPrefix: "codex/",
-  trustedHooks: false,
-  preStartHooks: [],
-  postCompleteHooks: [],
-  agentDefaults: {
-    spec: null,
-    planner: null,
-    build: null,
-    qa: null,
-  },
-}));
-const saveRepoSettings = mock(async (_input: unknown) => {});
-const useRepoSettingsOperationsHook = mock((_args: { activeRepo: string | null }) => ({
-  loadRepoSettings,
-  saveRepoSettings,
-}));
-
-const delegateTask = mock(async (_taskId: string) => {});
-const delegateRespond = mock(async (_runId: string, _action: unknown, _payload?: string) => {});
-const delegateStop = mock(async (_runId: string) => {});
-const delegateCleanup = mock(async (_runId: string, _mode: unknown) => {});
-const useDelegationOperationsHook = mock((_args: { activeRepo: string | null }) => ({
-  delegateTask,
-  delegateRespond,
-  delegateStop,
-  delegateCleanup,
-}));
-
-const loadSpec = mock(async (_taskId: string) => "spec");
-const loadSpecDocument = mock(async (_taskId: string) => ({
-  markdown: "spec",
-  updatedAt: "2026-02-28T10:00:00.000Z",
-}));
-const loadPlanDocument = mock(async (_taskId: string) => ({
-  markdown: "plan",
-  updatedAt: "2026-02-28T10:00:00.000Z",
-}));
-const loadQaReportDocument = mock(async (_taskId: string) => ({
-  markdown: "qa",
-  updatedAt: "2026-02-28T10:00:00.000Z",
-}));
-const saveSpec = mock(async (_taskId: string, _markdown: string) => ({
-  updatedAt: "2026-02-28T10:00:00.000Z",
-}));
-const saveSpecDocument = mock(async (_taskId: string, _markdown: string) => ({
-  updatedAt: "2026-02-28T10:00:00.000Z",
-}));
-const savePlanDocument = mock(async (_taskId: string, _markdown: string) => ({
-  updatedAt: "2026-02-28T10:00:00.000Z",
-}));
-const useSpecOperationsHook = mock((_args: { activeRepo: string | null }) => ({
-  loadSpec,
-  loadSpecDocument,
-  loadPlanDocument,
-  loadQaReportDocument,
-  saveSpec,
-  saveSpecDocument,
-  savePlanDocument,
-}));
-
-const loadAgentSessions = mock(async (_taskId: string) => {});
-const startAgentSession = mock(async (_input: unknown) => "session-1");
-const sendAgentMessage = mock(async (_sessionId: string, _content: string) => {});
-const stopAgentSession = mock(async (_sessionId: string) => {});
-const updateAgentSessionModel = mock((_sessionId: string, _selection: unknown) => {});
-const replyAgentPermission = mock(
-  async (_sessionId: string, _requestId: string, _reply: unknown, _message?: string) => {},
-);
-const answerAgentQuestion = mock(
-  async (_sessionId: string, _requestId: string, _answers: string[][]) => {},
-);
-const useAgentOrchestratorOperationsHook = mock((_args: { activeRepo: string | null }) => ({
-  sessions: [],
-  loadAgentSessions,
-  startAgentSession,
-  sendAgentMessage,
-  stopAgentSession,
-  updateAgentSessionModel,
-  replyAgentPermission,
-  answerAgentQuestion,
-}));
-
-const useAppLifecycleHook = mock((_args: unknown) => {});
-
-mock.module("@openducktor/adapters-opencode-sdk", () => ({
-  OpencodeSdkAdapter: class OpencodeSdkAdapter {},
-}));
-
-mock.module("./operations", () => ({
-  configureOpencodeCatalogOperations: (ops: unknown) => configureCatalogOps(ops),
-  createHostOpencodeCatalogOperations: (agentEngine: unknown) => createHostCatalogOps(agentEngine),
-  useAgentOrchestratorOperations: (args: unknown) =>
-    useAgentOrchestratorOperationsHook(args as { activeRepo: string | null }),
-  useChecks: (args: unknown) => useChecksHook(args as { activeRepo: string | null }),
-  useDelegationOperations: (args: unknown) =>
-    useDelegationOperationsHook(args as { activeRepo: string | null }),
-  useRepoSettingsOperations: (args: unknown) =>
-    useRepoSettingsOperationsHook(args as { activeRepo: string | null }),
-  useSpecOperations: (args: unknown) =>
-    useSpecOperationsHook(args as { activeRepo: string | null }),
-  useTaskOperations: (args: unknown) =>
-    useTaskOperationsHook(args as { activeRepo: string | null }),
-  useWorkspaceOperations: (args: unknown) =>
-    useWorkspaceOperationsHook(
-      args as { activeRepo: string | null; setActiveRepo: (value: string | null) => void },
-    ),
-}));
-
-mock.module("./lifecycle/use-app-lifecycle", () => ({
-  useAppLifecycle: (args: unknown) => useAppLifecycleHook(args),
-}));
-
-type StateModule = typeof import("./app-state-provider");
-
-let AppStateProvider: StateModule["AppStateProvider"];
-let useWorkspaceState: StateModule["useWorkspaceState"];
-let useChecksState: StateModule["useChecksState"];
-let useTasksState: StateModule["useTasksState"];
-let useDelegationState: StateModule["useDelegationState"];
-let useSpecState: StateModule["useSpecState"];
-let useAgentState: StateModule["useAgentState"];
-
-beforeAll(async () => {
-  ({
-    AppStateProvider,
-    useWorkspaceState,
-    useChecksState,
-    useTasksState,
-    useDelegationState,
-    useSpecState,
-    useAgentState,
-  } = await import("./app-state-provider"));
-});
-
-beforeEach(() => {
-  createHostCatalogOps.mockClear();
-  configureCatalogOps.mockClear();
-  useChecksHook.mockClear();
-  useTaskOperationsHook.mockClear();
-  useWorkspaceOperationsHook.mockClear();
-  useRepoSettingsOperationsHook.mockClear();
-  useDelegationOperationsHook.mockClear();
-  useSpecOperationsHook.mockClear();
-  useAgentOrchestratorOperationsHook.mockClear();
-  useAppLifecycleHook.mockClear();
-});
-
-describe("AppStateProvider", () => {
-  test("composes all state slices and preserves hook access", async () => {
-    type Snapshot = {
-      workspace: WorkspaceStateContextValue;
-      checks: ChecksStateContextValue;
-      tasks: TasksStateContextValue;
-      delegation: DelegationStateContextValue;
-      spec: SpecStateContextValue;
-      agent: AgentStateContextValue;
-    };
-
-    let snapshot = {} as Snapshot;
-
-    const Probe = (): ReactElement => {
-      snapshot = {
-        workspace: useWorkspaceState(),
-        checks: useChecksState(),
-        tasks: useTasksState(),
-        delegation: useDelegationState(),
-        spec: useSpecState(),
-        agent: useAgentState(),
-      };
-      return createElement("div");
-    };
-
-    let renderer: TestRenderer.ReactTestRenderer | null = null;
-
-    try {
-      await act(async () => {
-        renderer = TestRenderer.create(createElement(AppStateProvider, null, createElement(Probe)));
-      });
-      await flush();
-
-      expect(snapshot.workspace.activeRepo).toBeNull();
-      expect(snapshot.workspace.workspaces).toEqual([workspaceRecord]);
-      expect(snapshot.checks.isLoadingChecks).toBe(false);
-      expect(snapshot.tasks.tasks).toEqual(tasksList);
-      expect(snapshot.tasks.runs).toEqual(runsList);
-      expect(snapshot.delegation.events).toEqual([]);
-      expect(snapshot.spec.loadSpec).toBe(loadSpec);
-      expect(snapshot.agent.sessions).toEqual([]);
-
-      expect(useChecksHook).toHaveBeenCalledWith({
-        activeRepo: null,
-        checkRepoOpencodeHealth,
-      });
-
-      expect(useTaskOperationsHook).toHaveBeenCalledWith({
-        activeRepo: null,
-        refreshBeadsCheckForRepo,
-      });
-
-      expect(useWorkspaceOperationsHook).toHaveBeenCalledWith({
-        activeRepo: null,
-        setActiveRepo: expect.any(Function),
-        clearTaskData,
-        clearActiveBeadsCheck,
-      });
-
-      expect(useAgentOrchestratorOperationsHook).toHaveBeenCalledWith({
-        activeRepo: null,
-        tasks: tasksList,
-        runs: runsList,
-        refreshTaskData,
-        agentEngine: expect.anything(),
-      });
-
-      expect(useAppLifecycleHook).toHaveBeenCalledTimes(1);
-      expect(createHostCatalogOps).toHaveBeenCalledTimes(1);
-      expect(configureCatalogOps).toHaveBeenCalledTimes(1);
-    } finally {
-      await act(async () => {
-        renderer?.unmount();
-      });
+    for (const { hook, expected } of expectations) {
+      expect(captureHookErrorMessage(hook)).toBe(expected);
     }
   });
 });

--- a/apps/desktop/src/state/app-state-provider.test.tsx
+++ b/apps/desktop/src/state/app-state-provider.test.tsx
@@ -1,0 +1,418 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  AgentRuntimeSummary,
+  BeadsCheck,
+  GitBranch,
+  RunSummary,
+  TaskCard,
+  WorkspaceRecord,
+} from "@openducktor/contracts";
+import { createElement, type ReactElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import type { RepoOpencodeHealthCheck } from "@/types/diagnostics";
+import type {
+  AgentStateContextValue,
+  ChecksStateContextValue,
+  DelegationStateContextValue,
+  SpecStateContextValue,
+  TasksStateContextValue,
+  WorkspaceStateContextValue,
+} from "@/types/state-slices";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const runtimeInfo: AgentRuntimeSummary = {
+  runtimeId: "runtime-1",
+  repoPath: "/repo-a",
+  taskId: "task-1",
+  role: "build",
+  workingDirectory: "/tmp/repo-a",
+  port: 8080,
+  startedAt: "2026-02-28T10:00:00.000Z",
+};
+
+const workspaceRecord: WorkspaceRecord = {
+  path: "/repo-a",
+  isActive: true,
+  hasConfig: true,
+  configuredWorktreeBasePath: null,
+};
+
+const branchRecord: GitBranch = {
+  name: "main",
+  isCurrent: true,
+  isRemote: false,
+};
+
+const tasksList: TaskCard[] = [
+  {
+    id: "task-1",
+    title: "Task One",
+    status: "open",
+    createdAt: "2026-02-28T10:00:00.000Z",
+    updatedAt: "2026-02-28T10:00:00.000Z",
+  } as TaskCard,
+];
+
+const runsList: RunSummary[] = [
+  {
+    runId: "run-1",
+    repoPath: "/repo-a",
+    taskId: "task-1",
+    branch: "main",
+    worktreePath: "/tmp/repo-a",
+    port: 8080,
+    state: "running",
+    lastMessage: null,
+    startedAt: "2026-02-28T10:00:00.000Z",
+  },
+];
+
+const beadsCheck: BeadsCheck = {
+  beadsOk: true,
+  beadsPath: "/repo-a/.beads",
+  beadsError: null,
+};
+
+const opencodeHealth: RepoOpencodeHealthCheck = {
+  runtimeOk: true,
+  runtimeError: null,
+  runtime: runtimeInfo,
+  mcpOk: true,
+  mcpError: null,
+  mcpServerName: "openducktor",
+  mcpServerStatus: "connected",
+  mcpServerError: null,
+  availableToolIds: ["odt_read_task"],
+  checkedAt: "2026-02-28T10:00:00.000Z",
+  errors: [],
+};
+
+const checkRepoOpencodeHealth = mock(async (_repoPath: string) => opencodeHealth);
+const createHostCatalogOps = mock((_agentEngine: unknown) => ({
+  checkRepoOpencodeHealth,
+}));
+const configureCatalogOps = mock((_ops: unknown) => {});
+
+const refreshRuntimeCheck = mock(async (_force?: boolean) => ({
+  gitOk: true,
+  gitVersion: "2.45.0",
+  opencodeOk: true,
+  opencodeVersion: "0.12.0",
+  errors: [],
+}));
+const refreshBeadsCheckForRepo = mock(async (_repoPath: string, _force?: boolean) => beadsCheck);
+const refreshRepoOpencodeHealthForRepo = mock(
+  async (_repoPath: string, _force?: boolean) => opencodeHealth,
+);
+const refreshChecks = mock(async () => {});
+const hasRuntimeCheck = mock(() => true);
+const hasCachedBeadsCheck = mock((_repoPath: string) => false);
+const hasCachedRepoOpencodeHealth = mock((_repoPath: string) => false);
+const clearActiveBeadsCheck = mock(() => {});
+const clearActiveRepoOpencodeHealth = mock(() => {});
+const setIsLoadingChecks = mock((_value: boolean) => {});
+const useChecksHook = mock((_args: { activeRepo: string | null }) => ({
+  runtimeCheck: null,
+  activeBeadsCheck: null,
+  activeRepoOpencodeHealth: null,
+  isLoadingChecks: false,
+  setIsLoadingChecks,
+  refreshRuntimeCheck,
+  refreshBeadsCheckForRepo,
+  refreshRepoOpencodeHealthForRepo,
+  refreshChecks,
+  hasRuntimeCheck,
+  hasCachedBeadsCheck,
+  hasCachedRepoOpencodeHealth,
+  clearActiveBeadsCheck,
+  clearActiveRepoOpencodeHealth,
+}));
+
+const refreshTaskData = mock(async (_repoPath: string) => {});
+const refreshTasks = mock(async () => {});
+const createTask = mock(async (_input: unknown) => {});
+const updateTask = mock(async (_taskId: string, _patch: unknown) => {});
+const deleteTask = mock(async (_taskId: string, _deleteSubtasks?: boolean) => {});
+const transitionTask = mock(async (_taskId: string, _status: unknown, _reason?: string) => {});
+const deferTask = mock(async (_taskId: string) => {});
+const resumeDeferredTask = mock(async (_taskId: string) => {});
+const humanApproveTask = mock(async (_taskId: string) => {});
+const humanRequestChangesTask = mock(async (_taskId: string, _note?: string) => {});
+const clearTaskData = mock(() => {});
+const setIsLoadingTasks = mock((_value: boolean) => {});
+const useTaskOperationsHook = mock((_args: { activeRepo: string | null }) => ({
+  tasks: tasksList,
+  runs: runsList,
+  isLoadingTasks: false,
+  setIsLoadingTasks,
+  clearTaskData,
+  refreshTaskData,
+  refreshTasks,
+  createTask,
+  updateTask,
+  deleteTask,
+  transitionTask,
+  deferTask,
+  resumeDeferredTask,
+  humanApproveTask,
+  humanRequestChangesTask,
+}));
+
+const refreshWorkspaces = mock(async () => {});
+const addWorkspace = mock(async (_repoPath: string) => {});
+const selectWorkspace = mock(async (_repoPath: string) => {});
+const refreshBranches = mock(async (_force?: boolean) => {});
+const switchBranch = mock(async (_branchName: string) => {});
+const clearBranchData = mock(() => {});
+const useWorkspaceOperationsHook = mock(
+  (_args: { activeRepo: string | null; setActiveRepo: (value: string | null) => void }) => ({
+    workspaces: [workspaceRecord],
+    branches: [branchRecord],
+    activeBranch: { name: "main", detached: false },
+    isSwitchingWorkspace: false,
+    isLoadingBranches: false,
+    isSwitchingBranch: false,
+    refreshWorkspaces,
+    addWorkspace,
+    selectWorkspace,
+    refreshBranches,
+    switchBranch,
+    clearBranchData,
+  }),
+);
+
+const loadRepoSettings = mock(async () => ({
+  worktreeBasePath: "/tmp/worktree",
+  branchPrefix: "codex/",
+  trustedHooks: false,
+  preStartHooks: [],
+  postCompleteHooks: [],
+  agentDefaults: {
+    spec: null,
+    planner: null,
+    build: null,
+    qa: null,
+  },
+}));
+const saveRepoSettings = mock(async (_input: unknown) => {});
+const useRepoSettingsOperationsHook = mock((_args: { activeRepo: string | null }) => ({
+  loadRepoSettings,
+  saveRepoSettings,
+}));
+
+const delegateTask = mock(async (_taskId: string) => {});
+const delegateRespond = mock(async (_runId: string, _action: unknown, _payload?: string) => {});
+const delegateStop = mock(async (_runId: string) => {});
+const delegateCleanup = mock(async (_runId: string, _mode: unknown) => {});
+const useDelegationOperationsHook = mock((_args: { activeRepo: string | null }) => ({
+  delegateTask,
+  delegateRespond,
+  delegateStop,
+  delegateCleanup,
+}));
+
+const loadSpec = mock(async (_taskId: string) => "spec");
+const loadSpecDocument = mock(async (_taskId: string) => ({
+  markdown: "spec",
+  updatedAt: "2026-02-28T10:00:00.000Z",
+}));
+const loadPlanDocument = mock(async (_taskId: string) => ({
+  markdown: "plan",
+  updatedAt: "2026-02-28T10:00:00.000Z",
+}));
+const loadQaReportDocument = mock(async (_taskId: string) => ({
+  markdown: "qa",
+  updatedAt: "2026-02-28T10:00:00.000Z",
+}));
+const saveSpec = mock(async (_taskId: string, _markdown: string) => ({
+  updatedAt: "2026-02-28T10:00:00.000Z",
+}));
+const saveSpecDocument = mock(async (_taskId: string, _markdown: string) => ({
+  updatedAt: "2026-02-28T10:00:00.000Z",
+}));
+const savePlanDocument = mock(async (_taskId: string, _markdown: string) => ({
+  updatedAt: "2026-02-28T10:00:00.000Z",
+}));
+const useSpecOperationsHook = mock((_args: { activeRepo: string | null }) => ({
+  loadSpec,
+  loadSpecDocument,
+  loadPlanDocument,
+  loadQaReportDocument,
+  saveSpec,
+  saveSpecDocument,
+  savePlanDocument,
+}));
+
+const loadAgentSessions = mock(async (_taskId: string) => {});
+const startAgentSession = mock(async (_input: unknown) => "session-1");
+const sendAgentMessage = mock(async (_sessionId: string, _content: string) => {});
+const stopAgentSession = mock(async (_sessionId: string) => {});
+const updateAgentSessionModel = mock((_sessionId: string, _selection: unknown) => {});
+const replyAgentPermission = mock(
+  async (_sessionId: string, _requestId: string, _reply: unknown, _message?: string) => {},
+);
+const answerAgentQuestion = mock(
+  async (_sessionId: string, _requestId: string, _answers: string[][]) => {},
+);
+const useAgentOrchestratorOperationsHook = mock((_args: { activeRepo: string | null }) => ({
+  sessions: [],
+  loadAgentSessions,
+  startAgentSession,
+  sendAgentMessage,
+  stopAgentSession,
+  updateAgentSessionModel,
+  replyAgentPermission,
+  answerAgentQuestion,
+}));
+
+const useAppLifecycleHook = mock((_args: unknown) => {});
+
+mock.module("@openducktor/adapters-opencode-sdk", () => ({
+  OpencodeSdkAdapter: class OpencodeSdkAdapter {},
+}));
+
+mock.module("./operations", () => ({
+  configureOpencodeCatalogOperations: (ops: unknown) => configureCatalogOps(ops),
+  createHostOpencodeCatalogOperations: (agentEngine: unknown) => createHostCatalogOps(agentEngine),
+  useAgentOrchestratorOperations: (args: unknown) =>
+    useAgentOrchestratorOperationsHook(args as { activeRepo: string | null }),
+  useChecks: (args: unknown) => useChecksHook(args as { activeRepo: string | null }),
+  useDelegationOperations: (args: unknown) =>
+    useDelegationOperationsHook(args as { activeRepo: string | null }),
+  useRepoSettingsOperations: (args: unknown) =>
+    useRepoSettingsOperationsHook(args as { activeRepo: string | null }),
+  useSpecOperations: (args: unknown) =>
+    useSpecOperationsHook(args as { activeRepo: string | null }),
+  useTaskOperations: (args: unknown) =>
+    useTaskOperationsHook(args as { activeRepo: string | null }),
+  useWorkspaceOperations: (args: unknown) =>
+    useWorkspaceOperationsHook(
+      args as { activeRepo: string | null; setActiveRepo: (value: string | null) => void },
+    ),
+}));
+
+mock.module("./lifecycle/use-app-lifecycle", () => ({
+  useAppLifecycle: (args: unknown) => useAppLifecycleHook(args),
+}));
+
+type StateModule = typeof import("./app-state-provider");
+
+let AppStateProvider: StateModule["AppStateProvider"];
+let useWorkspaceState: StateModule["useWorkspaceState"];
+let useChecksState: StateModule["useChecksState"];
+let useTasksState: StateModule["useTasksState"];
+let useDelegationState: StateModule["useDelegationState"];
+let useSpecState: StateModule["useSpecState"];
+let useAgentState: StateModule["useAgentState"];
+
+beforeAll(async () => {
+  ({
+    AppStateProvider,
+    useWorkspaceState,
+    useChecksState,
+    useTasksState,
+    useDelegationState,
+    useSpecState,
+    useAgentState,
+  } = await import("./app-state-provider"));
+});
+
+beforeEach(() => {
+  createHostCatalogOps.mockClear();
+  configureCatalogOps.mockClear();
+  useChecksHook.mockClear();
+  useTaskOperationsHook.mockClear();
+  useWorkspaceOperationsHook.mockClear();
+  useRepoSettingsOperationsHook.mockClear();
+  useDelegationOperationsHook.mockClear();
+  useSpecOperationsHook.mockClear();
+  useAgentOrchestratorOperationsHook.mockClear();
+  useAppLifecycleHook.mockClear();
+});
+
+describe("AppStateProvider", () => {
+  test("composes all state slices and preserves hook access", async () => {
+    type Snapshot = {
+      workspace: WorkspaceStateContextValue;
+      checks: ChecksStateContextValue;
+      tasks: TasksStateContextValue;
+      delegation: DelegationStateContextValue;
+      spec: SpecStateContextValue;
+      agent: AgentStateContextValue;
+    };
+
+    let snapshot = {} as Snapshot;
+
+    const Probe = (): ReactElement => {
+      snapshot = {
+        workspace: useWorkspaceState(),
+        checks: useChecksState(),
+        tasks: useTasksState(),
+        delegation: useDelegationState(),
+        spec: useSpecState(),
+        agent: useAgentState(),
+      };
+      return createElement("div");
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    try {
+      await act(async () => {
+        renderer = TestRenderer.create(createElement(AppStateProvider, null, createElement(Probe)));
+      });
+      await flush();
+
+      expect(snapshot.workspace.activeRepo).toBeNull();
+      expect(snapshot.workspace.workspaces).toEqual([workspaceRecord]);
+      expect(snapshot.checks.isLoadingChecks).toBe(false);
+      expect(snapshot.tasks.tasks).toEqual(tasksList);
+      expect(snapshot.tasks.runs).toEqual(runsList);
+      expect(snapshot.delegation.events).toEqual([]);
+      expect(snapshot.spec.loadSpec).toBe(loadSpec);
+      expect(snapshot.agent.sessions).toEqual([]);
+
+      expect(useChecksHook).toHaveBeenCalledWith({
+        activeRepo: null,
+        checkRepoOpencodeHealth,
+      });
+
+      expect(useTaskOperationsHook).toHaveBeenCalledWith({
+        activeRepo: null,
+        refreshBeadsCheckForRepo,
+      });
+
+      expect(useWorkspaceOperationsHook).toHaveBeenCalledWith({
+        activeRepo: null,
+        setActiveRepo: expect.any(Function),
+        clearTaskData,
+        clearActiveBeadsCheck,
+      });
+
+      expect(useAgentOrchestratorOperationsHook).toHaveBeenCalledWith({
+        activeRepo: null,
+        tasks: tasksList,
+        runs: runsList,
+        refreshTaskData,
+        agentEngine: expect.anything(),
+      });
+
+      expect(useAppLifecycleHook).toHaveBeenCalledTimes(1);
+      expect(createHostCatalogOps).toHaveBeenCalledTimes(1);
+      expect(configureCatalogOps).toHaveBeenCalledTimes(1);
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+      });
+    }
+  });
+});

--- a/apps/desktop/src/state/app-state-provider.tsx
+++ b/apps/desktop/src/state/app-state-provider.tsx
@@ -1,14 +1,5 @@
 import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
-import type { RunEvent } from "@openducktor/contracts";
-import {
-  type Context,
-  createContext,
-  type PropsWithChildren,
-  type ReactElement,
-  useContext,
-  useMemo,
-  useState,
-} from "react";
+import { type PropsWithChildren, type ReactElement, useMemo } from "react";
 import type {
   AgentStateContextValue,
   ChecksStateContextValue,
@@ -19,45 +10,30 @@ import type {
   WorkspaceStateContextValue,
 } from "@/types/state-slices";
 import {
-  buildAgentStateValue,
-  buildChecksStateValue,
-  buildDelegationStateValue,
-  buildSpecStateValue,
-  buildTasksStateValue,
-  buildWorkspaceStateValue,
-  findActiveWorkspace,
-} from "./app-state-context-values";
-import { useAppLifecycle } from "./lifecycle/use-app-lifecycle";
+  AgentStateContext,
+  ChecksStateContext,
+  DelegationStateContext,
+  SpecStateContext,
+  TasksStateContext,
+  useRequiredContext,
+  WorkspaceStateContext,
+} from "./app-state-contexts";
 import {
   configureOpencodeCatalogOperations,
   createHostOpencodeCatalogOperations,
-  useAgentOrchestratorOperations,
-  useChecks,
-  useDelegationOperations,
-  useRepoSettingsOperations,
-  useSpecOperations,
-  useTaskOperations,
-  useWorkspaceOperations,
 } from "./operations";
-
-const WorkspaceStateContext = createContext<WorkspaceStateContextValue | null>(null);
-const ChecksStateContext = createContext<ChecksStateContextValue | null>(null);
-const TasksStateContext = createContext<TasksStateContextValue | null>(null);
-const DelegationStateContext = createContext<DelegationStateContextValue | null>(null);
-const SpecStateContext = createContext<SpecStateContextValue | null>(null);
-const AgentStateContext = createContext<AgentStateContextValue | null>(null);
-
-const useRequiredContext = <T,>(context: Context<T | null>, name: string): T => {
-  const value = useContext(context);
-  if (!value) {
-    throw new Error(`${name} must be used inside AppStateProvider`);
-  }
-  return value;
-};
+import {
+  AgentStudioStateProvider,
+  AppLifecycleStateProvider,
+  AppRuntimeProvider,
+  ChecksStateProvider,
+  DelegationStateProvider,
+  SpecStateProvider,
+  TasksStateProvider,
+  WorkspaceStateProvider,
+} from "./providers";
 
 export function AppStateProvider({ children }: PropsWithChildren): ReactElement {
-  const [activeRepo, setActiveRepo] = useState<string | null>(null);
-  const [events, setEvents] = useState<RunEvent[]>([]);
   const agentEngine = useMemo(() => new OpencodeSdkAdapter(), []);
   const opencodeCatalogOperations = useMemo(() => {
     const ops = createHostOpencodeCatalogOperations(agentEngine);
@@ -65,283 +41,24 @@ export function AppStateProvider({ children }: PropsWithChildren): ReactElement 
     return ops;
   }, [agentEngine]);
 
-  const {
-    runtimeCheck,
-    activeBeadsCheck,
-    activeRepoOpencodeHealth,
-    isLoadingChecks,
-    setIsLoadingChecks,
-    refreshRuntimeCheck,
-    refreshBeadsCheckForRepo,
-    refreshRepoOpencodeHealthForRepo,
-    refreshChecks,
-    hasRuntimeCheck,
-    hasCachedBeadsCheck,
-    hasCachedRepoOpencodeHealth,
-    clearActiveBeadsCheck,
-    clearActiveRepoOpencodeHealth,
-  } = useChecks({
-    activeRepo,
-    checkRepoOpencodeHealth: opencodeCatalogOperations.checkRepoOpencodeHealth,
-  });
-
-  const {
-    tasks,
-    runs,
-    isLoadingTasks,
-    setIsLoadingTasks,
-    clearTaskData,
-    refreshTaskData,
-    refreshTasks,
-    createTask,
-    updateTask,
-    deleteTask,
-    transitionTask,
-    deferTask,
-    resumeDeferredTask,
-    humanApproveTask,
-    humanRequestChangesTask,
-  } = useTaskOperations({
-    activeRepo,
-    refreshBeadsCheckForRepo,
-  });
-
-  const { delegateTask, delegateRespond, delegateStop, delegateCleanup } = useDelegationOperations({
-    activeRepo,
-    refreshTaskData,
-  });
-
-  const {
-    loadSpec,
-    loadSpecDocument,
-    loadPlanDocument,
-    loadQaReportDocument,
-    saveSpec,
-    saveSpecDocument,
-    savePlanDocument,
-  } = useSpecOperations({
-    activeRepo,
-  });
-
-  const {
-    sessions,
-    loadAgentSessions,
-    startAgentSession,
-    sendAgentMessage,
-    stopAgentSession,
-    updateAgentSessionModel,
-    replyAgentPermission,
-    answerAgentQuestion,
-  } = useAgentOrchestratorOperations({
-    activeRepo,
-    tasks,
-    runs,
-    refreshTaskData,
-    agentEngine,
-  });
-
-  const {
-    workspaces,
-    branches,
-    activeBranch,
-    isSwitchingWorkspace,
-    isLoadingBranches,
-    isSwitchingBranch,
-    refreshWorkspaces,
-    addWorkspace,
-    selectWorkspace,
-    refreshBranches,
-    switchBranch,
-    clearBranchData,
-  } = useWorkspaceOperations({
-    activeRepo,
-    setActiveRepo,
-    clearTaskData,
-    clearActiveBeadsCheck,
-  });
-
-  const { loadRepoSettings, saveRepoSettings } = useRepoSettingsOperations({
-    activeRepo,
-    refreshWorkspaces,
-  });
-
-  useAppLifecycle({
-    activeRepo,
-    setEvents,
-    refreshWorkspaces,
-    refreshBranches,
-    refreshRuntimeCheck,
-    refreshBeadsCheckForRepo,
-    refreshRepoOpencodeHealthForRepo,
-    refreshTaskData,
-    clearTaskData,
-    clearBranchData,
-    clearActiveBeadsCheck,
-    clearActiveRepoOpencodeHealth,
-    setIsLoadingChecks,
-    setIsLoadingTasks,
-    hasRuntimeCheck,
-    hasCachedBeadsCheck,
-    hasCachedRepoOpencodeHealth,
-  });
-
-  const activeWorkspace = useMemo(
-    () => findActiveWorkspace(workspaces, activeRepo),
-    [activeRepo, workspaces],
-  );
-
-  const workspaceStateValue = useMemo<WorkspaceStateContextValue>(
-    () =>
-      buildWorkspaceStateValue({
-        isSwitchingWorkspace,
-        isLoadingBranches,
-        isSwitchingBranch,
-        workspaces,
-        activeRepo,
-        activeWorkspace,
-        branches,
-        activeBranch,
-        addWorkspace,
-        selectWorkspace,
-        refreshBranches,
-        switchBranch,
-        loadRepoSettings,
-        saveRepoSettings,
-      }),
-    [
-      activeRepo,
-      activeBranch,
-      activeWorkspace,
-      addWorkspace,
-      branches,
-      isLoadingBranches,
-      isSwitchingBranch,
-      isSwitchingWorkspace,
-      loadRepoSettings,
-      refreshBranches,
-      saveRepoSettings,
-      selectWorkspace,
-      switchBranch,
-      workspaces,
-    ],
-  );
-
-  const checksStateValue = useMemo<ChecksStateContextValue>(
-    () =>
-      buildChecksStateValue({
-        runtimeCheck,
-        beadsCheck: activeBeadsCheck,
-        opencodeHealth: activeRepoOpencodeHealth,
-        isLoadingChecks,
-        refreshChecks,
-      }),
-    [activeBeadsCheck, activeRepoOpencodeHealth, isLoadingChecks, refreshChecks, runtimeCheck],
-  );
-
-  const tasksStateValue = useMemo<TasksStateContextValue>(
-    () =>
-      buildTasksStateValue({
-        isLoadingTasks,
-        tasks,
-        runs,
-        refreshTasks,
-        createTask,
-        updateTask,
-        deleteTask,
-        transitionTask,
-        deferTask,
-        resumeDeferredTask,
-        humanApproveTask,
-        humanRequestChangesTask,
-      }),
-    [
-      createTask,
-      deleteTask,
-      deferTask,
-      humanApproveTask,
-      humanRequestChangesTask,
-      isLoadingTasks,
-      refreshTasks,
-      resumeDeferredTask,
-      runs,
-      tasks,
-      transitionTask,
-      updateTask,
-    ],
-  );
-
-  const delegationStateValue = useMemo<DelegationStateContextValue>(
-    () =>
-      buildDelegationStateValue({
-        events,
-        delegateTask,
-        delegateRespond,
-        delegateStop,
-        delegateCleanup,
-      }),
-    [delegateCleanup, delegateRespond, delegateStop, delegateTask, events],
-  );
-
-  const specStateValue = useMemo<SpecStateContextValue>(
-    () =>
-      buildSpecStateValue({
-        loadSpec,
-        loadSpecDocument,
-        loadPlanDocument,
-        loadQaReportDocument,
-        saveSpec,
-        saveSpecDocument,
-        savePlanDocument,
-      }),
-    [
-      loadPlanDocument,
-      loadQaReportDocument,
-      loadSpec,
-      loadSpecDocument,
-      saveSpec,
-      saveSpecDocument,
-      savePlanDocument,
-    ],
-  );
-
-  const agentStateValue = useMemo<AgentStateContextValue>(
-    () =>
-      buildAgentStateValue({
-        sessions,
-        loadAgentSessions,
-        startAgentSession,
-        sendAgentMessage,
-        stopAgentSession,
-        updateAgentSessionModel,
-        replyAgentPermission,
-        answerAgentQuestion,
-      }),
-    [
-      answerAgentQuestion,
-      loadAgentSessions,
-      replyAgentPermission,
-      sendAgentMessage,
-      sessions,
-      startAgentSession,
-      stopAgentSession,
-      updateAgentSessionModel,
-    ],
-  );
-
   return (
-    <WorkspaceStateContext.Provider value={workspaceStateValue}>
-      <ChecksStateContext.Provider value={checksStateValue}>
-        <TasksStateContext.Provider value={tasksStateValue}>
-          <DelegationStateContext.Provider value={delegationStateValue}>
-            <SpecStateContext.Provider value={specStateValue}>
-              <AgentStateContext.Provider value={agentStateValue}>
-                {children}
-              </AgentStateContext.Provider>
-            </SpecStateContext.Provider>
-          </DelegationStateContext.Provider>
-        </TasksStateContext.Provider>
-      </ChecksStateContext.Provider>
-    </WorkspaceStateContext.Provider>
+    <AppRuntimeProvider>
+      <ChecksStateProvider
+        checkRepoOpencodeHealth={opencodeCatalogOperations.checkRepoOpencodeHealth}
+      >
+        <TasksStateProvider>
+          <WorkspaceStateProvider>
+            <DelegationStateProvider>
+              <SpecStateProvider>
+                <AgentStudioStateProvider agentEngine={agentEngine}>
+                  <AppLifecycleStateProvider>{children}</AppLifecycleStateProvider>
+                </AgentStudioStateProvider>
+              </SpecStateProvider>
+            </DelegationStateProvider>
+          </WorkspaceStateProvider>
+        </TasksStateProvider>
+      </ChecksStateProvider>
+    </AppRuntimeProvider>
   );
 }
 

--- a/apps/desktop/src/state/app-state-provider.tsx
+++ b/apps/desktop/src/state/app-state-provider.tsx
@@ -43,21 +43,21 @@ export function AppStateProvider({ children }: PropsWithChildren): ReactElement 
 
   return (
     <AppRuntimeProvider>
-      <ChecksStateProvider
-        checkRepoOpencodeHealth={opencodeCatalogOperations.checkRepoOpencodeHealth}
-      >
-        <TasksStateProvider>
-          <WorkspaceStateProvider>
-            <DelegationStateProvider>
-              <SpecStateProvider>
-                <AgentStudioStateProvider agentEngine={agentEngine}>
+      <SpecStateProvider>
+        <ChecksStateProvider
+          checkRepoOpencodeHealth={opencodeCatalogOperations.checkRepoOpencodeHealth}
+        >
+          <TasksStateProvider>
+            <AgentStudioStateProvider agentEngine={agentEngine}>
+              <DelegationStateProvider>
+                <WorkspaceStateProvider>
                   <AppLifecycleStateProvider>{children}</AppLifecycleStateProvider>
-                </AgentStudioStateProvider>
-              </SpecStateProvider>
-            </DelegationStateProvider>
-          </WorkspaceStateProvider>
-        </TasksStateProvider>
-      </ChecksStateProvider>
+                </WorkspaceStateProvider>
+              </DelegationStateProvider>
+            </AgentStudioStateProvider>
+          </TasksStateProvider>
+        </ChecksStateProvider>
+      </SpecStateProvider>
     </AppRuntimeProvider>
   );
 }

--- a/apps/desktop/src/state/providers/agent-studio-state-provider.tsx
+++ b/apps/desktop/src/state/providers/agent-studio-state-provider.tsx
@@ -4,7 +4,8 @@ import { buildAgentStateValue } from "../app-state-context-values";
 import {
   AgentStateContext,
   useActiveRepoContext,
-  useTaskOperationsContext,
+  useTaskControlContext,
+  useTaskDataContext,
 } from "../app-state-contexts";
 import { useAgentOrchestratorOperations } from "../operations";
 
@@ -17,7 +18,8 @@ export function AgentStudioStateProvider({
   children,
 }: AgentStudioStateProviderProps): ReactElement {
   const { activeRepo } = useActiveRepoContext();
-  const { tasks, runs, refreshTaskData } = useTaskOperationsContext();
+  const { tasks, runs } = useTaskDataContext();
+  const { refreshTaskData } = useTaskControlContext();
   const {
     sessions,
     loadAgentSessions,

--- a/apps/desktop/src/state/providers/agent-studio-state-provider.tsx
+++ b/apps/desktop/src/state/providers/agent-studio-state-provider.tsx
@@ -1,0 +1,65 @@
+import type { AgentEnginePort } from "@openducktor/core";
+import { type PropsWithChildren, type ReactElement, useMemo } from "react";
+import { buildAgentStateValue } from "../app-state-context-values";
+import {
+  AgentStateContext,
+  useActiveRepoContext,
+  useTaskOperationsContext,
+} from "../app-state-contexts";
+import { useAgentOrchestratorOperations } from "../operations";
+
+type AgentStudioStateProviderProps = PropsWithChildren<{
+  agentEngine: AgentEnginePort;
+}>;
+
+export function AgentStudioStateProvider({
+  agentEngine,
+  children,
+}: AgentStudioStateProviderProps): ReactElement {
+  const { activeRepo } = useActiveRepoContext();
+  const { tasks, runs, refreshTaskData } = useTaskOperationsContext();
+  const {
+    sessions,
+    loadAgentSessions,
+    startAgentSession,
+    sendAgentMessage,
+    stopAgentSession,
+    updateAgentSessionModel,
+    replyAgentPermission,
+    answerAgentQuestion,
+  } = useAgentOrchestratorOperations({
+    activeRepo,
+    tasks,
+    runs,
+    refreshTaskData,
+    agentEngine,
+  });
+
+  const agentStateValue = useMemo(
+    () =>
+      buildAgentStateValue({
+        sessions,
+        loadAgentSessions,
+        startAgentSession,
+        sendAgentMessage,
+        stopAgentSession,
+        updateAgentSessionModel,
+        replyAgentPermission,
+        answerAgentQuestion,
+      }),
+    [
+      answerAgentQuestion,
+      loadAgentSessions,
+      replyAgentPermission,
+      sendAgentMessage,
+      sessions,
+      startAgentSession,
+      stopAgentSession,
+      updateAgentSessionModel,
+    ],
+  );
+
+  return (
+    <AgentStateContext.Provider value={agentStateValue}>{children}</AgentStateContext.Provider>
+  );
+}

--- a/apps/desktop/src/state/providers/app-lifecycle-state-provider.tsx
+++ b/apps/desktop/src/state/providers/app-lifecycle-state-provider.tsx
@@ -1,0 +1,49 @@
+import type { PropsWithChildren, ReactElement } from "react";
+import {
+  useActiveRepoContext,
+  useChecksOperationsContext,
+  useDelegationEventsContext,
+  useTaskOperationsContext,
+  useWorkspaceOperationsContext,
+} from "../app-state-contexts";
+import { useAppLifecycle } from "../lifecycle/use-app-lifecycle";
+
+export function AppLifecycleStateProvider({ children }: PropsWithChildren): ReactElement {
+  const { activeRepo } = useActiveRepoContext();
+  const { refreshWorkspaces, refreshBranches, clearBranchData } = useWorkspaceOperationsContext();
+  const {
+    refreshRuntimeCheck,
+    refreshBeadsCheckForRepo,
+    refreshRepoOpencodeHealthForRepo,
+    clearActiveBeadsCheck,
+    clearActiveRepoOpencodeHealth,
+    setIsLoadingChecks,
+    hasRuntimeCheck,
+    hasCachedBeadsCheck,
+    hasCachedRepoOpencodeHealth,
+  } = useChecksOperationsContext();
+  const { refreshTaskData, clearTaskData, setIsLoadingTasks } = useTaskOperationsContext();
+  const { setEvents } = useDelegationEventsContext();
+
+  useAppLifecycle({
+    activeRepo,
+    setEvents,
+    refreshWorkspaces,
+    refreshBranches,
+    refreshRuntimeCheck,
+    refreshBeadsCheckForRepo,
+    refreshRepoOpencodeHealthForRepo,
+    refreshTaskData,
+    clearTaskData,
+    clearBranchData,
+    clearActiveBeadsCheck,
+    clearActiveRepoOpencodeHealth,
+    setIsLoadingChecks,
+    setIsLoadingTasks,
+    hasRuntimeCheck,
+    hasCachedBeadsCheck,
+    hasCachedRepoOpencodeHealth,
+  });
+
+  return <>{children}</>;
+}

--- a/apps/desktop/src/state/providers/app-lifecycle-state-provider.tsx
+++ b/apps/desktop/src/state/providers/app-lifecycle-state-provider.tsx
@@ -3,7 +3,7 @@ import {
   useActiveRepoContext,
   useChecksOperationsContext,
   useDelegationEventsContext,
-  useTaskOperationsContext,
+  useTaskControlContext,
   useWorkspaceOperationsContext,
 } from "../app-state-contexts";
 import { useAppLifecycle } from "../lifecycle/use-app-lifecycle";
@@ -22,7 +22,7 @@ export function AppLifecycleStateProvider({ children }: PropsWithChildren): Reac
     hasCachedBeadsCheck,
     hasCachedRepoOpencodeHealth,
   } = useChecksOperationsContext();
-  const { refreshTaskData, clearTaskData, setIsLoadingTasks } = useTaskOperationsContext();
+  const { refreshTaskData, clearTaskData, setIsLoadingTasks } = useTaskControlContext();
   const { setEvents } = useDelegationEventsContext();
 
   useAppLifecycle({

--- a/apps/desktop/src/state/providers/app-runtime-provider.tsx
+++ b/apps/desktop/src/state/providers/app-runtime-provider.tsx
@@ -1,0 +1,17 @@
+import { type PropsWithChildren, type ReactElement, useMemo, useState } from "react";
+import { ActiveRepoContext, type ActiveRepoContextValue } from "../app-state-contexts";
+
+export function AppRuntimeProvider({ children }: PropsWithChildren): ReactElement {
+  const [activeRepo, setActiveRepo] = useState<string | null>(null);
+  const activeRepoValue = useMemo<ActiveRepoContextValue>(
+    () => ({
+      activeRepo,
+      setActiveRepo,
+    }),
+    [activeRepo],
+  );
+
+  return (
+    <ActiveRepoContext.Provider value={activeRepoValue}>{children}</ActiveRepoContext.Provider>
+  );
+}

--- a/apps/desktop/src/state/providers/checks-state-provider.tsx
+++ b/apps/desktop/src/state/providers/checks-state-provider.tsx
@@ -1,0 +1,83 @@
+import { type PropsWithChildren, type ReactElement, useMemo } from "react";
+import type { RepoOpencodeHealthCheck } from "@/types/diagnostics";
+import { buildChecksStateValue } from "../app-state-context-values";
+import {
+  ChecksOperationsContext,
+  type ChecksOperationsContextValue,
+  ChecksStateContext,
+  useActiveRepoContext,
+} from "../app-state-contexts";
+import { useChecks } from "../operations";
+
+type ChecksStateProviderProps = PropsWithChildren<{
+  checkRepoOpencodeHealth: (repoPath: string) => Promise<RepoOpencodeHealthCheck>;
+}>;
+
+export function ChecksStateProvider({
+  checkRepoOpencodeHealth,
+  children,
+}: ChecksStateProviderProps): ReactElement {
+  const { activeRepo } = useActiveRepoContext();
+  const {
+    runtimeCheck,
+    activeBeadsCheck,
+    activeRepoOpencodeHealth,
+    isLoadingChecks,
+    setIsLoadingChecks,
+    refreshRuntimeCheck,
+    refreshBeadsCheckForRepo,
+    refreshRepoOpencodeHealthForRepo,
+    refreshChecks,
+    hasRuntimeCheck,
+    hasCachedBeadsCheck,
+    hasCachedRepoOpencodeHealth,
+    clearActiveBeadsCheck,
+    clearActiveRepoOpencodeHealth,
+  } = useChecks({
+    activeRepo,
+    checkRepoOpencodeHealth,
+  });
+
+  const checksStateValue = useMemo(
+    () =>
+      buildChecksStateValue({
+        runtimeCheck,
+        beadsCheck: activeBeadsCheck,
+        opencodeHealth: activeRepoOpencodeHealth,
+        isLoadingChecks,
+        refreshChecks,
+      }),
+    [activeBeadsCheck, activeRepoOpencodeHealth, isLoadingChecks, refreshChecks, runtimeCheck],
+  );
+
+  const checksOperationsValue = useMemo<ChecksOperationsContextValue>(
+    () => ({
+      refreshRuntimeCheck,
+      refreshBeadsCheckForRepo,
+      refreshRepoOpencodeHealthForRepo,
+      clearActiveBeadsCheck,
+      clearActiveRepoOpencodeHealth,
+      setIsLoadingChecks,
+      hasRuntimeCheck,
+      hasCachedBeadsCheck,
+      hasCachedRepoOpencodeHealth,
+    }),
+    [
+      clearActiveBeadsCheck,
+      clearActiveRepoOpencodeHealth,
+      hasCachedBeadsCheck,
+      hasCachedRepoOpencodeHealth,
+      hasRuntimeCheck,
+      refreshBeadsCheckForRepo,
+      refreshRepoOpencodeHealthForRepo,
+      refreshRuntimeCheck,
+      setIsLoadingChecks,
+    ],
+  );
+
+  return (
+    <ChecksOperationsContext.Provider value={checksOperationsValue}>
+      <ChecksStateContext.Provider value={checksStateValue}>{children}</ChecksStateContext.Provider>
+    </ChecksOperationsContext.Provider>
+  );
+}

--- a/apps/desktop/src/state/providers/delegation-state-provider.tsx
+++ b/apps/desktop/src/state/providers/delegation-state-provider.tsx
@@ -1,0 +1,48 @@
+import type { RunEvent } from "@openducktor/contracts";
+import { type PropsWithChildren, type ReactElement, useMemo, useState } from "react";
+import { buildDelegationStateValue } from "../app-state-context-values";
+import {
+  DelegationEventsContext,
+  type DelegationEventsContextValue,
+  DelegationStateContext,
+  useActiveRepoContext,
+  useTaskOperationsContext,
+} from "../app-state-contexts";
+import { useDelegationOperations } from "../operations";
+
+export function DelegationStateProvider({ children }: PropsWithChildren): ReactElement {
+  const { activeRepo } = useActiveRepoContext();
+  const { refreshTaskData } = useTaskOperationsContext();
+  const [events, setEvents] = useState<RunEvent[]>([]);
+  const { delegateTask, delegateRespond, delegateStop, delegateCleanup } = useDelegationOperations({
+    activeRepo,
+    refreshTaskData,
+  });
+
+  const delegationStateValue = useMemo(
+    () =>
+      buildDelegationStateValue({
+        events,
+        delegateTask,
+        delegateRespond,
+        delegateStop,
+        delegateCleanup,
+      }),
+    [delegateCleanup, delegateRespond, delegateStop, delegateTask, events],
+  );
+
+  const delegationEventsValue = useMemo<DelegationEventsContextValue>(
+    () => ({
+      setEvents,
+    }),
+    [],
+  );
+
+  return (
+    <DelegationEventsContext.Provider value={delegationEventsValue}>
+      <DelegationStateContext.Provider value={delegationStateValue}>
+        {children}
+      </DelegationStateContext.Provider>
+    </DelegationEventsContext.Provider>
+  );
+}

--- a/apps/desktop/src/state/providers/delegation-state-provider.tsx
+++ b/apps/desktop/src/state/providers/delegation-state-provider.tsx
@@ -6,13 +6,13 @@ import {
   type DelegationEventsContextValue,
   DelegationStateContext,
   useActiveRepoContext,
-  useTaskOperationsContext,
+  useTaskControlContext,
 } from "../app-state-contexts";
 import { useDelegationOperations } from "../operations";
 
 export function DelegationStateProvider({ children }: PropsWithChildren): ReactElement {
   const { activeRepo } = useActiveRepoContext();
-  const { refreshTaskData } = useTaskOperationsContext();
+  const { refreshTaskData } = useTaskControlContext();
   const [events, setEvents] = useState<RunEvent[]>([]);
   const { delegateTask, delegateRespond, delegateStop, delegateCleanup } = useDelegationOperations({
     activeRepo,

--- a/apps/desktop/src/state/providers/index.ts
+++ b/apps/desktop/src/state/providers/index.ts
@@ -1,0 +1,8 @@
+export { AgentStudioStateProvider } from "./agent-studio-state-provider";
+export { AppLifecycleStateProvider } from "./app-lifecycle-state-provider";
+export { AppRuntimeProvider } from "./app-runtime-provider";
+export { ChecksStateProvider } from "./checks-state-provider";
+export { DelegationStateProvider } from "./delegation-state-provider";
+export { SpecStateProvider } from "./spec-state-provider";
+export { TasksStateProvider } from "./tasks-state-provider";
+export { WorkspaceStateProvider } from "./workspace-state-provider";

--- a/apps/desktop/src/state/providers/spec-state-provider.tsx
+++ b/apps/desktop/src/state/providers/spec-state-provider.tsx
@@ -1,0 +1,43 @@
+import { type PropsWithChildren, type ReactElement, useMemo } from "react";
+import { buildSpecStateValue } from "../app-state-context-values";
+import { SpecStateContext, useActiveRepoContext } from "../app-state-contexts";
+import { useSpecOperations } from "../operations";
+
+export function SpecStateProvider({ children }: PropsWithChildren): ReactElement {
+  const { activeRepo } = useActiveRepoContext();
+  const {
+    loadSpec,
+    loadSpecDocument,
+    loadPlanDocument,
+    loadQaReportDocument,
+    saveSpec,
+    saveSpecDocument,
+    savePlanDocument,
+  } = useSpecOperations({
+    activeRepo,
+  });
+
+  const specStateValue = useMemo(
+    () =>
+      buildSpecStateValue({
+        loadSpec,
+        loadSpecDocument,
+        loadPlanDocument,
+        loadQaReportDocument,
+        saveSpec,
+        saveSpecDocument,
+        savePlanDocument,
+      }),
+    [
+      loadPlanDocument,
+      loadQaReportDocument,
+      loadSpec,
+      loadSpecDocument,
+      saveSpec,
+      saveSpecDocument,
+      savePlanDocument,
+    ],
+  );
+
+  return <SpecStateContext.Provider value={specStateValue}>{children}</SpecStateContext.Provider>;
+}

--- a/apps/desktop/src/state/providers/tasks-state-provider.tsx
+++ b/apps/desktop/src/state/providers/tasks-state-provider.tsx
@@ -1,8 +1,10 @@
 import { type PropsWithChildren, type ReactElement, useMemo } from "react";
 import { buildTasksStateValue } from "../app-state-context-values";
 import {
-  TaskOperationsContext,
-  type TaskOperationsContextValue,
+  TaskControlContext,
+  type TaskControlContextValue,
+  TaskDataContext,
+  type TaskDataContextValue,
   TasksStateContext,
   useActiveRepoContext,
   useChecksOperationsContext,
@@ -65,20 +67,28 @@ export function TasksStateProvider({ children }: PropsWithChildren): ReactElemen
     ],
   );
 
-  const taskOperationsValue = useMemo<TaskOperationsContextValue>(
+  const taskDataValue = useMemo<TaskDataContextValue>(
     () => ({
       tasks,
       runs,
+    }),
+    [runs, tasks],
+  );
+
+  const taskControlValue = useMemo<TaskControlContextValue>(
+    () => ({
       refreshTaskData,
       clearTaskData,
       setIsLoadingTasks,
     }),
-    [clearTaskData, refreshTaskData, runs, setIsLoadingTasks, tasks],
+    [clearTaskData, refreshTaskData, setIsLoadingTasks],
   );
 
   return (
-    <TaskOperationsContext.Provider value={taskOperationsValue}>
-      <TasksStateContext.Provider value={tasksStateValue}>{children}</TasksStateContext.Provider>
-    </TaskOperationsContext.Provider>
+    <TaskDataContext.Provider value={taskDataValue}>
+      <TaskControlContext.Provider value={taskControlValue}>
+        <TasksStateContext.Provider value={tasksStateValue}>{children}</TasksStateContext.Provider>
+      </TaskControlContext.Provider>
+    </TaskDataContext.Provider>
   );
 }

--- a/apps/desktop/src/state/providers/tasks-state-provider.tsx
+++ b/apps/desktop/src/state/providers/tasks-state-provider.tsx
@@ -1,0 +1,84 @@
+import { type PropsWithChildren, type ReactElement, useMemo } from "react";
+import { buildTasksStateValue } from "../app-state-context-values";
+import {
+  TaskOperationsContext,
+  type TaskOperationsContextValue,
+  TasksStateContext,
+  useActiveRepoContext,
+  useChecksOperationsContext,
+} from "../app-state-contexts";
+import { useTaskOperations } from "../operations";
+
+export function TasksStateProvider({ children }: PropsWithChildren): ReactElement {
+  const { activeRepo } = useActiveRepoContext();
+  const { refreshBeadsCheckForRepo } = useChecksOperationsContext();
+  const {
+    tasks,
+    runs,
+    isLoadingTasks,
+    setIsLoadingTasks,
+    clearTaskData,
+    refreshTaskData,
+    refreshTasks,
+    createTask,
+    updateTask,
+    deleteTask,
+    transitionTask,
+    deferTask,
+    resumeDeferredTask,
+    humanApproveTask,
+    humanRequestChangesTask,
+  } = useTaskOperations({
+    activeRepo,
+    refreshBeadsCheckForRepo,
+  });
+
+  const tasksStateValue = useMemo(
+    () =>
+      buildTasksStateValue({
+        isLoadingTasks,
+        tasks,
+        runs,
+        refreshTasks,
+        createTask,
+        updateTask,
+        deleteTask,
+        transitionTask,
+        deferTask,
+        resumeDeferredTask,
+        humanApproveTask,
+        humanRequestChangesTask,
+      }),
+    [
+      createTask,
+      deleteTask,
+      deferTask,
+      humanApproveTask,
+      humanRequestChangesTask,
+      isLoadingTasks,
+      refreshTasks,
+      resumeDeferredTask,
+      runs,
+      tasks,
+      transitionTask,
+      updateTask,
+    ],
+  );
+
+  const taskOperationsValue = useMemo<TaskOperationsContextValue>(
+    () => ({
+      tasks,
+      runs,
+      refreshTaskData,
+      clearTaskData,
+      setIsLoadingTasks,
+    }),
+    [clearTaskData, refreshTaskData, runs, setIsLoadingTasks, tasks],
+  );
+
+  return (
+    <TaskOperationsContext.Provider value={taskOperationsValue}>
+      <TasksStateContext.Provider value={tasksStateValue}>{children}</TasksStateContext.Provider>
+    </TaskOperationsContext.Provider>
+  );
+}

--- a/apps/desktop/src/state/providers/workspace-state-provider.tsx
+++ b/apps/desktop/src/state/providers/workspace-state-provider.tsx
@@ -1,0 +1,100 @@
+import { type PropsWithChildren, type ReactElement, useMemo } from "react";
+import { buildWorkspaceStateValue, findActiveWorkspace } from "../app-state-context-values";
+import {
+  useActiveRepoContext,
+  useChecksOperationsContext,
+  useTaskOperationsContext,
+  WorkspaceOperationsContext,
+  type WorkspaceOperationsContextValue,
+  WorkspaceStateContext,
+} from "../app-state-contexts";
+import { useRepoSettingsOperations, useWorkspaceOperations } from "../operations";
+
+export function WorkspaceStateProvider({ children }: PropsWithChildren): ReactElement {
+  const { activeRepo, setActiveRepo } = useActiveRepoContext();
+  const { clearTaskData } = useTaskOperationsContext();
+  const { clearActiveBeadsCheck } = useChecksOperationsContext();
+
+  const {
+    workspaces,
+    branches,
+    activeBranch,
+    isSwitchingWorkspace,
+    isLoadingBranches,
+    isSwitchingBranch,
+    refreshWorkspaces,
+    addWorkspace,
+    selectWorkspace,
+    refreshBranches,
+    switchBranch,
+    clearBranchData,
+  } = useWorkspaceOperations({
+    activeRepo,
+    setActiveRepo,
+    clearTaskData,
+    clearActiveBeadsCheck,
+  });
+
+  const { loadRepoSettings, saveRepoSettings } = useRepoSettingsOperations({
+    activeRepo,
+    refreshWorkspaces,
+  });
+
+  const activeWorkspace = useMemo(
+    () => findActiveWorkspace(workspaces, activeRepo),
+    [activeRepo, workspaces],
+  );
+
+  const workspaceStateValue = useMemo(
+    () =>
+      buildWorkspaceStateValue({
+        isSwitchingWorkspace,
+        isLoadingBranches,
+        isSwitchingBranch,
+        workspaces,
+        activeRepo,
+        activeWorkspace,
+        branches,
+        activeBranch,
+        addWorkspace,
+        selectWorkspace,
+        refreshBranches,
+        switchBranch,
+        loadRepoSettings,
+        saveRepoSettings,
+      }),
+    [
+      activeRepo,
+      activeBranch,
+      activeWorkspace,
+      addWorkspace,
+      branches,
+      isLoadingBranches,
+      isSwitchingBranch,
+      isSwitchingWorkspace,
+      loadRepoSettings,
+      refreshBranches,
+      saveRepoSettings,
+      selectWorkspace,
+      switchBranch,
+      workspaces,
+    ],
+  );
+
+  const workspaceOperationsValue = useMemo<WorkspaceOperationsContextValue>(
+    () => ({
+      refreshWorkspaces,
+      refreshBranches,
+      clearBranchData,
+    }),
+    [clearBranchData, refreshBranches, refreshWorkspaces],
+  );
+
+  return (
+    <WorkspaceOperationsContext.Provider value={workspaceOperationsValue}>
+      <WorkspaceStateContext.Provider value={workspaceStateValue}>
+        {children}
+      </WorkspaceStateContext.Provider>
+    </WorkspaceOperationsContext.Provider>
+  );
+}

--- a/apps/desktop/src/state/providers/workspace-state-provider.tsx
+++ b/apps/desktop/src/state/providers/workspace-state-provider.tsx
@@ -3,7 +3,7 @@ import { buildWorkspaceStateValue, findActiveWorkspace } from "../app-state-cont
 import {
   useActiveRepoContext,
   useChecksOperationsContext,
-  useTaskOperationsContext,
+  useTaskControlContext,
   WorkspaceOperationsContext,
   type WorkspaceOperationsContextValue,
   WorkspaceStateContext,
@@ -12,7 +12,7 @@ import { useRepoSettingsOperations, useWorkspaceOperations } from "../operations
 
 export function WorkspaceStateProvider({ children }: PropsWithChildren): ReactElement {
   const { activeRepo, setActiveRepo } = useActiveRepoContext();
-  const { clearTaskData } = useTaskOperationsContext();
+  const { clearTaskData } = useTaskControlContext();
   const { clearActiveBeadsCheck } = useChecksOperationsContext();
 
   const {


### PR DESCRIPTION
## Summary
- Decompose `AppStateProvider` into focused provider components (workspace, checks, tasks, delegation, spec, agent studio, lifecycle bridge).
- Extract shared state and internal wiring contexts into a dedicated module to keep the composition root thin.
- Split internal task wiring into `TaskDataContext` and `TaskControlContext` to reduce provider coupling and rerender fan-out.
- Replace the brittle AppStateProvider module-mocking test with an isolation-safe hook guard test to prevent cross-suite mock leakage.
- Tighten `ChecksOperationsContext` typing: `refreshRuntimeCheck` now returns `RuntimeCheck`.

## Validation
- `bun run --filter @openducktor/desktop lint` ✅
- `bun run --filter @openducktor/desktop test` ✅
- `bun run --filter @openducktor/desktop typecheck` ⚠️ still fails in pre-existing `agent-studio-header.test.ts` fixture typing (`hasRunningSession` missing), unrelated to this branch.

## Notes
- Public state hooks remain unchanged for consumers.
