### PR TITLE
refactor(desktop): extract and stabilize kanban virtualization hook

### DIFF
--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -1,34 +1,14 @@
 import type { RunSummary } from "@openducktor/contracts";
 import type { KanbanColumn as KanbanColumnData, KanbanColumnId } from "@openducktor/core";
 import { Inbox } from "lucide-react";
-import {
-  type ComponentProps,
-  memo,
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import {
-  buildVirtualColumnLayout,
-  findVirtualWindowRange,
-  getVirtualWindowEdgeOffsets,
-  resolveVirtualViewportWindow,
-  type VirtualWindowRange,
-} from "@/components/features/kanban/kanban-column-virtualization";
+import { type ComponentProps, memo, type ReactElement, useEffect, useRef } from "react";
 import { KanbanTaskCard } from "@/components/features/kanban/kanban-task-card";
 import { laneTheme } from "@/components/features/kanban/kanban-theme";
+import { useKanbanVirtualization } from "@/components/features/kanban/use-kanban-virtualization";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 
-const VIRTUALIZATION_MIN_TASK_COUNT = 30;
-const VIRTUAL_CARD_ESTIMATED_HEIGHT_PX = 180;
-const VIRTUAL_CARD_GAP_PX = 12;
-const VIRTUAL_OVERSCAN_PX = 360;
-const INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX = 900;
 type RunningTaskSessions = NonNullable<ComponentProps<typeof KanbanTaskCard>["activeSessions"]>;
 const EMPTY_ACTIVE_SESSIONS: RunningTaskSessions = [];
 
@@ -171,166 +151,17 @@ export function KanbanColumn({
   onHumanRequestChanges,
 }: KanbanColumnProps): ReactElement {
   const theme = laneTheme(column.id);
-  const cardsViewportRef = useRef<HTMLDivElement | null>(null);
-  const shouldVirtualize = column.tasks.length >= VIRTUALIZATION_MIN_TASK_COUNT;
-  const [measuredCardHeightsById, setMeasuredCardHeightsById] = useState<Record<string, number>>(
-    {},
-  );
-
-  const taskHeights = useMemo(
-    () =>
-      column.tasks.map(
-        (task) => measuredCardHeightsById[task.id] ?? VIRTUAL_CARD_ESTIMATED_HEIGHT_PX,
-      ),
-    [column.tasks, measuredCardHeightsById],
-  );
-
-  const virtualLayout = useMemo(
-    () => buildVirtualColumnLayout(taskHeights, VIRTUAL_CARD_GAP_PX),
-    [taskHeights],
-  );
-
-  const [visibleRange, setVisibleRange] = useState<VirtualWindowRange>(() =>
-    findVirtualWindowRange({
-      itemOffsets: virtualLayout.itemOffsets,
-      itemHeights: taskHeights,
-      totalHeight: virtualLayout.totalHeight,
-      viewportStart: -VIRTUAL_OVERSCAN_PX,
-      viewportEnd:
-        (typeof window === "undefined" ? INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX : window.innerHeight) +
-        VIRTUAL_OVERSCAN_PX,
-    }),
-  );
-
-  const syncViewport = useCallback((): void => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const viewportElement = cardsViewportRef.current;
-    if (!viewportElement) {
-      return;
-    }
-
-    const rect = viewportElement.getBoundingClientRect();
-    const scrollContainer = viewportElement.closest(
-      "[data-main-scroll-container='true']",
-    ) as HTMLElement | null;
-    const containerRect = scrollContainer?.getBoundingClientRect();
-    const viewportHeight = scrollContainer?.clientHeight ?? window.innerHeight;
-    const { viewportStart, viewportEnd } = resolveVirtualViewportWindow({
-      laneTop: rect.top,
-      viewportTop: containerRect?.top ?? 0,
-      viewportHeight,
-    });
-    const nextRange = findVirtualWindowRange({
-      itemOffsets: virtualLayout.itemOffsets,
-      itemHeights: taskHeights,
-      totalHeight: virtualLayout.totalHeight,
-      viewportStart: viewportStart - VIRTUAL_OVERSCAN_PX,
-      viewportEnd: viewportEnd + VIRTUAL_OVERSCAN_PX,
-    });
-
-    setVisibleRange((current) => {
-      if (current.startIndex === nextRange.startIndex && current.endIndex === nextRange.endIndex) {
-        return current;
-      }
-      return nextRange;
-    });
-  }, [taskHeights, virtualLayout.itemOffsets, virtualLayout.totalHeight]);
-
-  const { topSpacerHeight, bottomSpacerHeight } = useMemo(
-    () =>
-      getVirtualWindowEdgeOffsets({
-        range: visibleRange,
-        itemOffsets: virtualLayout.itemOffsets,
-        itemHeights: taskHeights,
-        totalHeight: virtualLayout.totalHeight,
-      }),
-    [taskHeights, virtualLayout.itemOffsets, virtualLayout.totalHeight, visibleRange],
-  );
-
-  useEffect(() => {
-    if (!shouldVirtualize || typeof window === "undefined") {
-      return;
-    }
-
-    const rafRef: { current: number | null } = { current: null };
-
-    const scheduleViewportSync = (): void => {
-      if (rafRef.current !== null) {
-        return;
-      }
-      rafRef.current = window.requestAnimationFrame(() => {
-        rafRef.current = null;
-        syncViewport();
-      });
-    };
-
-    const scrollContainer = cardsViewportRef.current?.closest(
-      "[data-main-scroll-container='true']",
-    ) as HTMLElement | null;
-
-    scheduleViewportSync();
-    window.addEventListener("scroll", scheduleViewportSync, { passive: true });
-    window.addEventListener("resize", scheduleViewportSync);
-    scrollContainer?.addEventListener("scroll", scheduleViewportSync, { passive: true });
-
-    const viewportElement = cardsViewportRef.current;
-    const resizeObserver =
-      typeof ResizeObserver === "undefined"
-        ? null
-        : new ResizeObserver(() => {
-            scheduleViewportSync();
-          });
-
-    if (resizeObserver && viewportElement) {
-      resizeObserver.observe(viewportElement);
-    }
-
-    return () => {
-      window.removeEventListener("scroll", scheduleViewportSync);
-      window.removeEventListener("resize", scheduleViewportSync);
-      scrollContainer?.removeEventListener("scroll", scheduleViewportSync);
-      if (rafRef.current !== null) {
-        window.cancelAnimationFrame(rafRef.current);
-      }
-      resizeObserver?.disconnect();
-    };
-  }, [shouldVirtualize, syncViewport]);
-
-  useEffect(() => {
-    if (!shouldVirtualize) {
-      return;
-    }
-    const taskIds = new Set(column.tasks.map((task) => task.id));
-    setMeasuredCardHeightsById((current) => {
-      let changed = false;
-      const next: Record<string, number> = {};
-      for (const [taskId, measuredHeight] of Object.entries(current)) {
-        if (taskIds.has(taskId)) {
-          next[taskId] = measuredHeight;
-          continue;
-        }
-        changed = true;
-      }
-      return changed ? next : current;
-    });
-  }, [column.tasks, shouldVirtualize]);
-
-  const handleMeasuredHeight = useCallback((taskId: string, nextHeight: number): void => {
-    setMeasuredCardHeightsById((current) => {
-      if (current[taskId] === nextHeight) {
-        return current;
-      }
-      return { ...current, [taskId]: nextHeight };
-    });
-  }, []);
-
-  const visibleTasks = !shouldVirtualize
-    ? column.tasks
-    : visibleRange.endIndex >= visibleRange.startIndex
-      ? column.tasks.slice(visibleRange.startIndex, visibleRange.endIndex + 1)
-      : [];
+  const {
+    containerRef: cardsViewportRef,
+    shouldVirtualize,
+    totalHeight,
+    topSpacerHeight,
+    bottomSpacerHeight,
+    visibleTasks,
+    onMeasuredHeight: handleMeasuredHeight,
+  } = useKanbanVirtualization({
+    tasks: column.tasks,
+  });
 
   return (
     <section
@@ -344,7 +175,7 @@ export function KanbanColumn({
         {column.tasks.length === 0 ? <LaneEmptyState id={column.id} /> : null}
 
         {column.tasks.length > 0 && shouldVirtualize ? (
-          <>
+          <div style={{ minHeight: totalHeight }}>
             {topSpacerHeight > 0 ? <div style={{ height: topSpacerHeight }} /> : null}
             <div className="space-y-3">
               {visibleTasks.map((task) => (
@@ -364,7 +195,7 @@ export function KanbanColumn({
               ))}
             </div>
             {bottomSpacerHeight > 0 ? <div style={{ height: bottomSpacerHeight }} /> : null}
-          </>
+          </div>
         ) : null}
 
         {column.tasks.length > 0 && !shouldVirtualize ? (

--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -153,15 +153,12 @@ export function KanbanColumn({
   const theme = laneTheme(column.id);
   const {
     containerRef: cardsViewportRef,
-    shouldVirtualize,
-    totalHeight,
-    topSpacerHeight,
-    bottomSpacerHeight,
-    visibleTasks,
+    renderModel,
     onMeasuredHeight: handleMeasuredHeight,
   } = useKanbanVirtualization({
     tasks: column.tasks,
   });
+  const isVirtualized = renderModel.kind === "virtualized";
 
   return (
     <section
@@ -174,11 +171,13 @@ export function KanbanColumn({
       <div ref={cardsViewportRef} className="flex-1 p-3">
         {column.tasks.length === 0 ? <LaneEmptyState id={column.id} /> : null}
 
-        {column.tasks.length > 0 && shouldVirtualize ? (
-          <div style={{ minHeight: totalHeight }}>
-            {topSpacerHeight > 0 ? <div style={{ height: topSpacerHeight }} /> : null}
+        {column.tasks.length > 0 && isVirtualized ? (
+          <div style={{ minHeight: renderModel.totalHeight }}>
+            {renderModel.topSpacerHeight > 0 ? (
+              <div style={{ height: renderModel.topSpacerHeight }} />
+            ) : null}
             <div className="space-y-3">
-              {visibleTasks.map((task) => (
+              {renderModel.visibleTasks.map((task) => (
                 <MeasuredTaskCard
                   key={task.id}
                   task={task}
@@ -194,13 +193,15 @@ export function KanbanColumn({
                 />
               ))}
             </div>
-            {bottomSpacerHeight > 0 ? <div style={{ height: bottomSpacerHeight }} /> : null}
+            {renderModel.bottomSpacerHeight > 0 ? (
+              <div style={{ height: renderModel.bottomSpacerHeight }} />
+            ) : null}
           </div>
         ) : null}
 
-        {column.tasks.length > 0 && !shouldVirtualize ? (
+        {column.tasks.length > 0 && !isVirtualized ? (
           <div className="space-y-3">
-            {column.tasks.map((task) => (
+            {renderModel.visibleTasks.map((task) => (
               <KanbanTaskCard
                 key={task.id}
                 task={task}

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { KanbanColumn as KanbanColumnData } from "@openducktor/core";
 import { createElement, type ReactElement } from "react";
 import TestRenderer, { act } from "react-test-renderer";
@@ -23,6 +23,16 @@ const flush = async (): Promise<void> => {
   await Promise.resolve();
 };
 
+const getVirtualizedRenderModel = (
+  state: HookState,
+): Extract<HookState["renderModel"], { kind: "virtualized" }> => {
+  if (state.renderModel.kind !== "virtualized") {
+    throw new Error("Expected virtualized render model");
+  }
+
+  return state.renderModel;
+};
+
 const createHarness = (initialProps: HookArgs) => {
   let latest: HookState | null = null;
 
@@ -36,6 +46,17 @@ const createHarness = (initialProps: HookArgs) => {
   const mount = async (): Promise<void> => {
     await act(async () => {
       renderer = TestRenderer.create(createElement(Harness, initialProps));
+      await flush();
+    });
+  };
+
+  const update = async (nextProps: HookArgs): Promise<void> => {
+    if (!renderer) {
+      throw new Error("Renderer not mounted");
+    }
+
+    await act(async () => {
+      renderer?.update(createElement(Harness, nextProps));
       await flush();
     });
   };
@@ -66,18 +87,58 @@ const createHarness = (initialProps: HookArgs) => {
     });
   };
 
-  return { mount, run, getLatest, unmount };
+  return { mount, update, run, getLatest, unmount };
+};
+
+const installMockWindow = () => {
+  const globalWithWindow = globalThis as typeof globalThis & {
+    window?: Window & typeof globalThis;
+  };
+  const previousWindow = globalWithWindow.window;
+
+  const addEventListener = mock(
+    (_type: string, _listener: EventListenerOrEventListenerObject, _options?: unknown) => {},
+  );
+  const removeEventListener = mock(
+    (_type: string, _listener: EventListenerOrEventListenerObject, _options?: unknown) => {},
+  );
+  const requestAnimationFrame = mock((_callback: FrameRequestCallback): number => 1);
+  const cancelAnimationFrame = mock((_handle: number) => {});
+
+  globalWithWindow.window = {
+    innerHeight: 900,
+    addEventListener: addEventListener as unknown as Window["addEventListener"],
+    removeEventListener: removeEventListener as unknown as Window["removeEventListener"],
+    requestAnimationFrame: requestAnimationFrame as unknown as Window["requestAnimationFrame"],
+    cancelAnimationFrame: cancelAnimationFrame as unknown as Window["cancelAnimationFrame"],
+  } as Window & typeof globalThis;
+
+  const restore = (): void => {
+    if (typeof previousWindow === "undefined") {
+      delete globalWithWindow.window;
+      return;
+    }
+
+    globalWithWindow.window = previousWindow;
+  };
+
+  return {
+    addEventListener,
+    removeEventListener,
+    requestAnimationFrame,
+    cancelAnimationFrame,
+    restore,
+  };
 };
 
 describe("useKanbanVirtualization", () => {
-  test("returns all tasks when virtualization threshold is not met", async () => {
+  test("returns a simple render model when virtualization threshold is not met", async () => {
     const harness = createHarness({ tasks: createTasks(5) });
     await harness.mount();
 
     const state = harness.getLatest();
-    expect(state.shouldVirtualize).toBe(false);
-    expect(state.visibleTasks).toHaveLength(5);
-    expect(state.totalHeight).toBe(0);
+    expect(state.renderModel.kind).toBe("simple");
+    expect(state.renderModel.visibleTasks).toHaveLength(5);
 
     await harness.unmount();
   });
@@ -87,10 +148,10 @@ describe("useKanbanVirtualization", () => {
     await harness.mount();
 
     const state = harness.getLatest();
-    expect(state.shouldVirtualize).toBe(true);
-    expect(state.totalHeight).toBe(5748);
-    expect(state.visibleTasks.length).toBeGreaterThan(0);
-    expect(state.visibleTasks[0]?.id).toBe("task-0");
+    const renderModel = getVirtualizedRenderModel(state);
+    expect(renderModel.totalHeight).toBe(5748);
+    expect(renderModel.visibleTasks.length).toBeGreaterThan(0);
+    expect(renderModel.visibleTasks[0]?.id).toBe("task-0");
 
     await harness.unmount();
   });
@@ -99,20 +160,81 @@ describe("useKanbanVirtualization", () => {
     const harness = createHarness({ tasks: createTasks(30) });
     await harness.mount();
 
-    const initialTotalHeight = harness.getLatest().totalHeight;
+    const initialTotalHeight = getVirtualizedRenderModel(harness.getLatest()).totalHeight;
 
     await harness.run(() => {
       harness.getLatest().onMeasuredHeight("task-0", 300);
     });
 
-    const resizedTotalHeight = harness.getLatest().totalHeight;
+    const resizedTotalHeight = getVirtualizedRenderModel(harness.getLatest()).totalHeight;
     expect(resizedTotalHeight - initialTotalHeight).toBe(120);
 
     await harness.run(() => {
       harness.getLatest().onMeasuredHeight("task-0", 300);
     });
 
-    expect(harness.getLatest().totalHeight).toBe(resizedTotalHeight);
+    expect(getVirtualizedRenderModel(harness.getLatest()).totalHeight).toBe(resizedTotalHeight);
     await harness.unmount();
+  });
+
+  test("switches render mode when task count crosses virtualization threshold", async () => {
+    const harness = createHarness({ tasks: createTasks(29) });
+    await harness.mount();
+
+    expect(harness.getLatest().renderModel.kind).toBe("simple");
+
+    await harness.update({ tasks: createTasks(30) });
+    expect(harness.getLatest().renderModel.kind).toBe("virtualized");
+
+    await harness.update({ tasks: createTasks(29) });
+    const latest = harness.getLatest();
+    expect(latest.renderModel.kind).toBe("simple");
+    expect(latest.renderModel.visibleTasks).toHaveLength(29);
+
+    await harness.unmount();
+  });
+
+  test("prunes removed task measurements before re-entering virtualization", async () => {
+    const harness = createHarness({ tasks: createTasks(30) });
+    await harness.mount();
+
+    const initialTotalHeight = getVirtualizedRenderModel(harness.getLatest()).totalHeight;
+
+    await harness.run(() => {
+      harness.getLatest().onMeasuredHeight("task-29", 300);
+    });
+    expect(getVirtualizedRenderModel(harness.getLatest()).totalHeight - initialTotalHeight).toBe(
+      120,
+    );
+
+    await harness.update({ tasks: createTasks(29) });
+    expect(harness.getLatest().renderModel.kind).toBe("simple");
+
+    await harness.update({ tasks: createTasks(30) });
+    expect(getVirtualizedRenderModel(harness.getLatest()).totalHeight).toBe(initialTotalHeight);
+
+    await harness.unmount();
+  });
+
+  test("keeps global listeners stable while measured heights change", async () => {
+    const mockWindow = installMockWindow();
+    const harness = createHarness({ tasks: createTasks(30) });
+
+    try {
+      await harness.mount();
+      expect(mockWindow.addEventListener).toHaveBeenCalledTimes(2);
+      expect(mockWindow.requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+      await harness.run(() => {
+        harness.getLatest().onMeasuredHeight("task-0", 320);
+      });
+      expect(mockWindow.addEventListener).toHaveBeenCalledTimes(2);
+
+      await harness.unmount();
+      expect(mockWindow.removeEventListener).toHaveBeenCalledTimes(2);
+    } finally {
+      await harness.unmount();
+      mockWindow.restore();
+    }
   });
 });

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import type { KanbanColumn as KanbanColumnData } from "@openducktor/core";
+import { createElement, type ReactElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { useKanbanVirtualization } from "./use-kanban-virtualization";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type HookArgs = Parameters<typeof useKanbanVirtualization>[0];
+type HookState = ReturnType<typeof useKanbanVirtualization>;
+
+const createTasks = (count: number): KanbanColumnData["tasks"] =>
+  Array.from({ length: count }, (_unused, index) => ({
+    id: `task-${index}`,
+  })) as KanbanColumnData["tasks"];
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createHarness = (initialProps: HookArgs) => {
+  let latest: HookState | null = null;
+
+  const Harness = (props: HookArgs): ReactElement | null => {
+    latest = useKanbanVirtualization(props);
+    return null;
+  };
+
+  let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+  const mount = async (): Promise<void> => {
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness, initialProps));
+      await flush();
+    });
+  };
+
+  const run = async (fn: () => void): Promise<void> => {
+    await act(async () => {
+      fn();
+      await flush();
+    });
+  };
+
+  const getLatest = (): HookState => {
+    if (!latest) {
+      throw new Error("Hook state unavailable");
+    }
+
+    return latest;
+  };
+
+  const unmount = async (): Promise<void> => {
+    if (!renderer) {
+      return;
+    }
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  };
+
+  return { mount, run, getLatest, unmount };
+};
+
+describe("useKanbanVirtualization", () => {
+  test("returns all tasks when virtualization threshold is not met", async () => {
+    const harness = createHarness({ tasks: createTasks(5) });
+    await harness.mount();
+
+    const state = harness.getLatest();
+    expect(state.shouldVirtualize).toBe(false);
+    expect(state.visibleTasks).toHaveLength(5);
+    expect(state.totalHeight).toBe(0);
+
+    await harness.unmount();
+  });
+
+  test("computes virtualized totals and visible task window for large columns", async () => {
+    const harness = createHarness({ tasks: createTasks(30) });
+    await harness.mount();
+
+    const state = harness.getLatest();
+    expect(state.shouldVirtualize).toBe(true);
+    expect(state.totalHeight).toBe(5748);
+    expect(state.visibleTasks.length).toBeGreaterThan(0);
+    expect(state.visibleTasks[0]?.id).toBe("task-0");
+
+    await harness.unmount();
+  });
+
+  test("updates total height only when a measured height changes", async () => {
+    const harness = createHarness({ tasks: createTasks(30) });
+    await harness.mount();
+
+    const initialTotalHeight = harness.getLatest().totalHeight;
+
+    await harness.run(() => {
+      harness.getLatest().onMeasuredHeight("task-0", 300);
+    });
+
+    const resizedTotalHeight = harness.getLatest().totalHeight;
+    expect(resizedTotalHeight - initialTotalHeight).toBe(120);
+
+    await harness.run(() => {
+      harness.getLatest().onMeasuredHeight("task-0", 300);
+    });
+
+    expect(harness.getLatest().totalHeight).toBe(resizedTotalHeight);
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
@@ -237,4 +237,33 @@ describe("useKanbanVirtualization", () => {
       mockWindow.restore();
     }
   });
+
+  test("recomputes viewport when measured heights change without scroll events", async () => {
+    const mockWindow = installMockWindow();
+    const harness = createHarness({ tasks: createTasks(30) });
+    const getBoundingClientRect = mock(() => ({ top: 120 }));
+
+    try {
+      await harness.mount();
+
+      await harness.run(() => {
+        harness.getLatest().containerRef.current = {
+          getBoundingClientRect,
+          closest: () => null,
+        } as unknown as HTMLDivElement;
+      });
+
+      const callsBeforeMeasure = getBoundingClientRect.mock.calls.length;
+
+      await harness.run(() => {
+        harness.getLatest().onMeasuredHeight("task-0", 320);
+      });
+
+      expect(getBoundingClientRect.mock.calls.length).toBeGreaterThan(callsBeforeMeasure);
+      expect(mockWindow.addEventListener).toHaveBeenCalledTimes(2);
+    } finally {
+      await harness.unmount();
+      mockWindow.restore();
+    }
+  });
 });

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
@@ -71,6 +71,10 @@ export function useKanbanVirtualization({
     () => buildVirtualColumnLayout(itemHeights, VIRTUAL_CARD_GAP_PX),
     [itemHeights],
   );
+  const virtualLayoutSyncToken = useMemo(
+    () => `${tasks.length}:${virtualLayout.totalHeight}:${itemHeights.join(",")}`,
+    [itemHeights, tasks.length, virtualLayout.totalHeight],
+  );
 
   const layoutRef = useRef<VirtualLayoutSnapshot>({
     itemOffsets: virtualLayout.itemOffsets,
@@ -204,6 +208,18 @@ export function useKanbanVirtualization({
         : EMPTY_RANGE,
     );
   }, [shouldVirtualize]);
+
+  useEffect(() => {
+    if (!shouldVirtualize) {
+      return;
+    }
+
+    if (virtualLayoutSyncToken.length === 0) {
+      return;
+    }
+
+    syncViewportRef.current();
+  }, [shouldVirtualize, virtualLayoutSyncToken]);
 
   useEffect(() => {
     const taskIds = new Set(tasks.map((task) => task.id));

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
@@ -13,26 +13,45 @@ const VIRTUAL_CARD_ESTIMATED_HEIGHT_PX = 180;
 const VIRTUAL_CARD_GAP_PX = 12;
 const VIRTUAL_OVERSCAN_PX = 360;
 const INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX = 900;
+const EMPTY_RANGE: VirtualWindowRange = { startIndex: 0, endIndex: -1 };
 
 type UseKanbanVirtualizationArgs = {
   tasks: KanbanColumnData["tasks"];
 };
 
-type UseKanbanVirtualizationResult = {
-  containerRef: { current: HTMLDivElement | null };
-  shouldVirtualize: boolean;
+type KanbanVirtualizedRenderModel = {
+  kind: "virtualized";
   totalHeight: number;
   topSpacerHeight: number;
   bottomSpacerHeight: number;
   visibleTasks: KanbanColumnData["tasks"];
+};
+
+type KanbanSimpleRenderModel = {
+  kind: "simple";
+  visibleTasks: KanbanColumnData["tasks"];
+};
+
+export type KanbanVirtualizationRenderModel =
+  | KanbanSimpleRenderModel
+  | KanbanVirtualizedRenderModel;
+
+type UseKanbanVirtualizationResult = {
+  containerRef: { current: HTMLDivElement | null };
+  renderModel: KanbanVirtualizationRenderModel;
   onMeasuredHeight: (taskId: string, height: number) => void;
+};
+
+type VirtualLayoutSnapshot = {
+  itemOffsets: number[];
+  itemHeights: number[];
+  totalHeight: number;
 };
 
 export function useKanbanVirtualization({
   tasks,
 }: UseKanbanVirtualizationArgs): UseKanbanVirtualizationResult {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const itemHeightsRef = useRef<Record<string, number>>({});
   const [measuredHeightsByTaskId, setMeasuredHeightsByTaskId] = useState<Record<string, number>>(
     {},
   );
@@ -53,6 +72,19 @@ export function useKanbanVirtualization({
     [itemHeights],
   );
 
+  const layoutRef = useRef<VirtualLayoutSnapshot>({
+    itemOffsets: virtualLayout.itemOffsets,
+    itemHeights,
+    totalHeight: virtualLayout.totalHeight,
+  });
+  useEffect(() => {
+    layoutRef.current = {
+      itemOffsets: virtualLayout.itemOffsets,
+      itemHeights,
+      totalHeight: virtualLayout.totalHeight,
+    };
+  }, [itemHeights, virtualLayout.itemOffsets, virtualLayout.totalHeight]);
+
   const [visibleRange, setVisibleRange] = useState<VirtualWindowRange>(() =>
     findVirtualWindowRange({
       itemOffsets: virtualLayout.itemOffsets,
@@ -65,54 +97,51 @@ export function useKanbanVirtualization({
     }),
   );
 
-  const syncViewport = useCallback((): void => {
-    if (!shouldVirtualize || typeof window === "undefined") {
-      return;
-    }
-
-    const viewportElement = containerRef.current;
-    if (!viewportElement) {
-      return;
-    }
-
-    const rect = viewportElement.getBoundingClientRect();
-    const scrollContainer = viewportElement.closest(
-      "[data-main-scroll-container='true']",
-    ) as HTMLElement | null;
-    const containerRect = scrollContainer?.getBoundingClientRect();
-    const viewportHeight = scrollContainer?.clientHeight ?? window.innerHeight;
-    const { viewportStart, viewportEnd } = resolveVirtualViewportWindow({
-      laneTop: rect.top,
-      viewportTop: containerRect?.top ?? 0,
-      viewportHeight,
-    });
-
-    const nextRange = findVirtualWindowRange({
-      itemOffsets: virtualLayout.itemOffsets,
-      itemHeights,
-      totalHeight: virtualLayout.totalHeight,
-      viewportStart: viewportStart - VIRTUAL_OVERSCAN_PX,
-      viewportEnd: viewportEnd + VIRTUAL_OVERSCAN_PX,
-    });
-
-    setVisibleRange((current) => {
-      if (current.startIndex === nextRange.startIndex && current.endIndex === nextRange.endIndex) {
-        return current;
+  const syncViewportRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    syncViewportRef.current = () => {
+      if (!shouldVirtualize || typeof window === "undefined") {
+        return;
       }
-      return nextRange;
-    });
-  }, [itemHeights, shouldVirtualize, virtualLayout.itemOffsets, virtualLayout.totalHeight]);
 
-  const { topSpacerHeight, bottomSpacerHeight } = useMemo(
-    () =>
-      getVirtualWindowEdgeOffsets({
-        range: visibleRange,
-        itemOffsets: virtualLayout.itemOffsets,
-        itemHeights,
-        totalHeight: virtualLayout.totalHeight,
-      }),
-    [itemHeights, virtualLayout.itemOffsets, virtualLayout.totalHeight, visibleRange],
-  );
+      const viewportElement = containerRef.current;
+      if (!viewportElement) {
+        return;
+      }
+
+      const { itemOffsets, itemHeights: latestItemHeights, totalHeight } = layoutRef.current;
+      const rect = viewportElement.getBoundingClientRect();
+      const scrollContainer = viewportElement.closest(
+        "[data-main-scroll-container='true']",
+      ) as HTMLElement | null;
+      const containerRect = scrollContainer?.getBoundingClientRect();
+      const viewportHeight = scrollContainer?.clientHeight ?? window.innerHeight;
+      const { viewportStart, viewportEnd } = resolveVirtualViewportWindow({
+        laneTop: rect.top,
+        viewportTop: containerRect?.top ?? 0,
+        viewportHeight,
+      });
+
+      const nextRange = findVirtualWindowRange({
+        itemOffsets,
+        itemHeights: latestItemHeights,
+        totalHeight,
+        viewportStart: viewportStart - VIRTUAL_OVERSCAN_PX,
+        viewportEnd: viewportEnd + VIRTUAL_OVERSCAN_PX,
+      });
+
+      setVisibleRange((current) => {
+        if (
+          current.startIndex === nextRange.startIndex &&
+          current.endIndex === nextRange.endIndex
+        ) {
+          return current;
+        }
+
+        return nextRange;
+      });
+    };
+  }, [shouldVirtualize]);
 
   useEffect(() => {
     if (!shouldVirtualize || typeof window === "undefined") {
@@ -128,7 +157,7 @@ export function useKanbanVirtualization({
 
       rafRef.current = window.requestAnimationFrame(() => {
         rafRef.current = null;
-        syncViewport();
+        syncViewportRef.current();
       });
     };
 
@@ -162,11 +191,19 @@ export function useKanbanVirtualization({
       }
       resizeObserver?.disconnect();
     };
-  }, [shouldVirtualize, syncViewport]);
+  }, [shouldVirtualize]);
 
   useEffect(() => {
-    itemHeightsRef.current = measuredHeightsByTaskId;
-  }, [measuredHeightsByTaskId]);
+    if (shouldVirtualize) {
+      return;
+    }
+
+    setVisibleRange((current) =>
+      current.startIndex === EMPTY_RANGE.startIndex && current.endIndex === EMPTY_RANGE.endIndex
+        ? current
+        : EMPTY_RANGE,
+    );
+  }, [shouldVirtualize]);
 
   useEffect(() => {
     const taskIds = new Set(tasks.map((task) => task.id));
@@ -182,12 +219,7 @@ export function useKanbanVirtualization({
         next[taskId] = measuredHeight;
       }
 
-      if (!changed) {
-        return current;
-      }
-
-      itemHeightsRef.current = next;
-      return next;
+      return changed ? next : current;
     });
   }, [tasks]);
 
@@ -201,9 +233,7 @@ export function useKanbanVirtualization({
         return current;
       }
 
-      const next = { ...current, [taskId]: nextHeight };
-      itemHeightsRef.current = next;
-      return next;
+      return { ...current, [taskId]: nextHeight };
     });
   }, []);
 
@@ -219,13 +249,45 @@ export function useKanbanVirtualization({
     return tasks.slice(visibleRange.startIndex, visibleRange.endIndex + 1);
   }, [shouldVirtualize, tasks, visibleRange]);
 
+  const virtualSpacerOffsets = useMemo(() => {
+    if (!shouldVirtualize) {
+      return { topSpacerHeight: 0, bottomSpacerHeight: 0 };
+    }
+
+    return getVirtualWindowEdgeOffsets({
+      range: visibleRange,
+      itemOffsets: virtualLayout.itemOffsets,
+      itemHeights,
+      totalHeight: virtualLayout.totalHeight,
+    });
+  }, [
+    shouldVirtualize,
+    itemHeights,
+    virtualLayout.itemOffsets,
+    virtualLayout.totalHeight,
+    visibleRange,
+  ]);
+
+  const renderModel = useMemo<KanbanVirtualizationRenderModel>(() => {
+    if (!shouldVirtualize) {
+      return {
+        kind: "simple",
+        visibleTasks: tasks,
+      };
+    }
+
+    return {
+      kind: "virtualized",
+      totalHeight: virtualLayout.totalHeight,
+      topSpacerHeight: virtualSpacerOffsets.topSpacerHeight,
+      bottomSpacerHeight: virtualSpacerOffsets.bottomSpacerHeight,
+      visibleTasks,
+    };
+  }, [shouldVirtualize, tasks, virtualLayout.totalHeight, virtualSpacerOffsets, visibleTasks]);
+
   return {
     containerRef,
-    shouldVirtualize,
-    totalHeight: virtualLayout.totalHeight,
-    topSpacerHeight,
-    bottomSpacerHeight,
-    visibleTasks,
+    renderModel,
     onMeasuredHeight,
   };
 }

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
@@ -1,0 +1,231 @@
+import type { KanbanColumn as KanbanColumnData } from "@openducktor/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  buildVirtualColumnLayout,
+  findVirtualWindowRange,
+  getVirtualWindowEdgeOffsets,
+  resolveVirtualViewportWindow,
+  type VirtualWindowRange,
+} from "@/components/features/kanban/kanban-column-virtualization";
+
+const VIRTUALIZATION_MIN_TASK_COUNT = 30;
+const VIRTUAL_CARD_ESTIMATED_HEIGHT_PX = 180;
+const VIRTUAL_CARD_GAP_PX = 12;
+const VIRTUAL_OVERSCAN_PX = 360;
+const INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX = 900;
+
+type UseKanbanVirtualizationArgs = {
+  tasks: KanbanColumnData["tasks"];
+};
+
+type UseKanbanVirtualizationResult = {
+  containerRef: { current: HTMLDivElement | null };
+  shouldVirtualize: boolean;
+  totalHeight: number;
+  topSpacerHeight: number;
+  bottomSpacerHeight: number;
+  visibleTasks: KanbanColumnData["tasks"];
+  onMeasuredHeight: (taskId: string, height: number) => void;
+};
+
+export function useKanbanVirtualization({
+  tasks,
+}: UseKanbanVirtualizationArgs): UseKanbanVirtualizationResult {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const itemHeightsRef = useRef<Record<string, number>>({});
+  const [measuredHeightsByTaskId, setMeasuredHeightsByTaskId] = useState<Record<string, number>>(
+    {},
+  );
+  const shouldVirtualize = tasks.length >= VIRTUALIZATION_MIN_TASK_COUNT;
+
+  const itemHeights = useMemo(() => {
+    if (!shouldVirtualize) {
+      return [];
+    }
+
+    return tasks.map(
+      (task) => measuredHeightsByTaskId[task.id] ?? VIRTUAL_CARD_ESTIMATED_HEIGHT_PX,
+    );
+  }, [measuredHeightsByTaskId, shouldVirtualize, tasks]);
+
+  const virtualLayout = useMemo(
+    () => buildVirtualColumnLayout(itemHeights, VIRTUAL_CARD_GAP_PX),
+    [itemHeights],
+  );
+
+  const [visibleRange, setVisibleRange] = useState<VirtualWindowRange>(() =>
+    findVirtualWindowRange({
+      itemOffsets: virtualLayout.itemOffsets,
+      itemHeights,
+      totalHeight: virtualLayout.totalHeight,
+      viewportStart: -VIRTUAL_OVERSCAN_PX,
+      viewportEnd:
+        (typeof window === "undefined" ? INITIAL_VIEWPORT_HEIGHT_FALLBACK_PX : window.innerHeight) +
+        VIRTUAL_OVERSCAN_PX,
+    }),
+  );
+
+  const syncViewport = useCallback((): void => {
+    if (!shouldVirtualize || typeof window === "undefined") {
+      return;
+    }
+
+    const viewportElement = containerRef.current;
+    if (!viewportElement) {
+      return;
+    }
+
+    const rect = viewportElement.getBoundingClientRect();
+    const scrollContainer = viewportElement.closest(
+      "[data-main-scroll-container='true']",
+    ) as HTMLElement | null;
+    const containerRect = scrollContainer?.getBoundingClientRect();
+    const viewportHeight = scrollContainer?.clientHeight ?? window.innerHeight;
+    const { viewportStart, viewportEnd } = resolveVirtualViewportWindow({
+      laneTop: rect.top,
+      viewportTop: containerRect?.top ?? 0,
+      viewportHeight,
+    });
+
+    const nextRange = findVirtualWindowRange({
+      itemOffsets: virtualLayout.itemOffsets,
+      itemHeights,
+      totalHeight: virtualLayout.totalHeight,
+      viewportStart: viewportStart - VIRTUAL_OVERSCAN_PX,
+      viewportEnd: viewportEnd + VIRTUAL_OVERSCAN_PX,
+    });
+
+    setVisibleRange((current) => {
+      if (current.startIndex === nextRange.startIndex && current.endIndex === nextRange.endIndex) {
+        return current;
+      }
+      return nextRange;
+    });
+  }, [itemHeights, shouldVirtualize, virtualLayout.itemOffsets, virtualLayout.totalHeight]);
+
+  const { topSpacerHeight, bottomSpacerHeight } = useMemo(
+    () =>
+      getVirtualWindowEdgeOffsets({
+        range: visibleRange,
+        itemOffsets: virtualLayout.itemOffsets,
+        itemHeights,
+        totalHeight: virtualLayout.totalHeight,
+      }),
+    [itemHeights, virtualLayout.itemOffsets, virtualLayout.totalHeight, visibleRange],
+  );
+
+  useEffect(() => {
+    if (!shouldVirtualize || typeof window === "undefined") {
+      return;
+    }
+
+    const rafRef: { current: number | null } = { current: null };
+
+    const scheduleViewportSync = (): void => {
+      if (rafRef.current !== null) {
+        return;
+      }
+
+      rafRef.current = window.requestAnimationFrame(() => {
+        rafRef.current = null;
+        syncViewport();
+      });
+    };
+
+    const scrollContainer = containerRef.current?.closest(
+      "[data-main-scroll-container='true']",
+    ) as HTMLElement | null;
+
+    scheduleViewportSync();
+    window.addEventListener("scroll", scheduleViewportSync, { passive: true });
+    window.addEventListener("resize", scheduleViewportSync);
+    scrollContainer?.addEventListener("scroll", scheduleViewportSync, { passive: true });
+
+    const viewportElement = containerRef.current;
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            scheduleViewportSync();
+          });
+
+    if (resizeObserver && viewportElement) {
+      resizeObserver.observe(viewportElement);
+    }
+
+    return () => {
+      window.removeEventListener("scroll", scheduleViewportSync);
+      window.removeEventListener("resize", scheduleViewportSync);
+      scrollContainer?.removeEventListener("scroll", scheduleViewportSync);
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current);
+      }
+      resizeObserver?.disconnect();
+    };
+  }, [shouldVirtualize, syncViewport]);
+
+  useEffect(() => {
+    itemHeightsRef.current = measuredHeightsByTaskId;
+  }, [measuredHeightsByTaskId]);
+
+  useEffect(() => {
+    const taskIds = new Set(tasks.map((task) => task.id));
+    setMeasuredHeightsByTaskId((current) => {
+      let changed = false;
+      const next: Record<string, number> = {};
+
+      for (const [taskId, measuredHeight] of Object.entries(current)) {
+        if (!taskIds.has(taskId)) {
+          changed = true;
+          continue;
+        }
+        next[taskId] = measuredHeight;
+      }
+
+      if (!changed) {
+        return current;
+      }
+
+      itemHeightsRef.current = next;
+      return next;
+    });
+  }, [tasks]);
+
+  const onMeasuredHeight = useCallback((taskId: string, nextHeight: number): void => {
+    if (nextHeight <= 0) {
+      return;
+    }
+
+    setMeasuredHeightsByTaskId((current) => {
+      if (current[taskId] === nextHeight) {
+        return current;
+      }
+
+      const next = { ...current, [taskId]: nextHeight };
+      itemHeightsRef.current = next;
+      return next;
+    });
+  }, []);
+
+  const visibleTasks = useMemo<KanbanColumnData["tasks"]>(() => {
+    if (!shouldVirtualize) {
+      return tasks;
+    }
+
+    if (visibleRange.endIndex < visibleRange.startIndex) {
+      return [];
+    }
+
+    return tasks.slice(visibleRange.startIndex, visibleRange.endIndex + 1);
+  }, [shouldVirtualize, tasks, visibleRange]);
+
+  return {
+    containerRef,
+    shouldVirtualize,
+    totalHeight: virtualLayout.totalHeight,
+    topSpacerHeight,
+    bottomSpacerHeight,
+    visibleTasks,
+    onMeasuredHeight,
+  };
+}


### PR DESCRIPTION
## Summary
- extract Kanban column virtualization state and viewport synchronization into a dedicated hook
- tighten the hook API to return a discriminated render model so `KanbanColumn` stays focused on rendering
- stabilize virtual scroll listeners by decoupling listener lifecycle from measurement-driven layout updates
- expand hook tests for threshold transitions, measurement pruning, and listener stability

## Validation
- `bun run --filter @openducktor/desktop lint`
- `cd apps/desktop && bun test ./src/components/features/kanban/use-kanban-virtualization.test.tsx ./src/components/features/kanban/kanban-column-virtualization.test.ts`
- `bun run --filter @openducktor/desktop test`
