### PR TITLE
refactor(openducktor-mcp): remove unsafe MCP registration casts

### DIFF
--- a/packages/openducktor-mcp/src/index.test.js
+++ b/packages/openducktor-mcp/src/index.test.js
@@ -40,6 +40,114 @@ describe("registerOdtTool", () => {
     expect(fakeServer._registeredTools).toEqual(["odt_read_task"]);
   });
 
+  test("registers MCP input schema using tool shape entries", () => {
+    let capturedConfig = null;
+
+    const fakeServer = {
+      registerTool(_name, config, _handler) {
+        capturedConfig = config;
+      },
+    };
+
+    registerOdtTool(
+      fakeServer,
+      {},
+      {
+        name: "odt_read_task",
+        description: "Read task",
+        execute: async () => ({ ok: true }),
+      },
+    );
+
+    expect(capturedConfig).not.toBeNull();
+    expect(Object.keys(capturedConfig.inputSchema)).toEqual(
+      Object.keys(ODT_TOOL_SCHEMAS.odt_read_task.shape),
+    );
+    expect(typeof capturedConfig.inputSchema.taskId.parse).toBe("function");
+  });
+
+  test("rejects invalid input schema shape before registering tool", () => {
+    const originalSchema = ODT_TOOL_SCHEMAS.odt_read_task;
+
+    ODT_TOOL_SCHEMAS.odt_read_task = {
+      shape: { taskId: {} },
+      parse: (input) => input,
+    };
+
+    try {
+      const fakeServer = {
+        registerTool() {},
+      };
+
+      expect(() =>
+        registerOdtTool(
+          fakeServer,
+          {},
+          {
+            name: "odt_read_task",
+            description: "Read task",
+            execute: async () => ({ ok: true }),
+          },
+        ),
+      ).toThrow("Invalid MCP input schema for tool 'odt_read_task'.");
+    } finally {
+      ODT_TOOL_SCHEMAS.odt_read_task = originalSchema;
+    }
+  });
+
+  test("returns tool error envelope when execution throws", async () => {
+    let capturedHandler = null;
+
+    const fakeServer = {
+      registerTool(_name, _config, handler) {
+        capturedHandler = handler;
+      },
+    };
+
+    registerOdtTool(
+      fakeServer,
+      {},
+      {
+        name: "odt_read_task",
+        description: "Read task",
+        execute: async () => {
+          throw new Error("Task exploded");
+        },
+      },
+    );
+
+    const result = await capturedHandler({ taskId: "task-1" });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Task exploded" }],
+      isError: true,
+    });
+  });
+
+  test("returns tool error envelope when input fails schema parsing", async () => {
+    let capturedHandler = null;
+
+    const fakeServer = {
+      registerTool(_name, _config, handler) {
+        capturedHandler = handler;
+      },
+    };
+
+    registerOdtTool(
+      fakeServer,
+      {},
+      {
+        name: "odt_read_task",
+        description: "Read task",
+        execute: async () => ({ ok: true }),
+      },
+    );
+
+    const result = await capturedHandler({});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toContain("taskId");
+  });
+
   test("keeps registered tools in sync with MCP schema keys", () => {
     const schemaToolNames = Object.keys(ODT_TOOL_SCHEMAS);
     expect(ODT_REGISTERED_TOOL_NAMES).toEqual(schemaToolNames);

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -189,14 +189,18 @@ export const ODT_REGISTERED_TOOL_NAMES = Object.keys(
 ) as RegisteredToolName[];
 
 const registerTools = (server: McpServer, store: OdtTaskStore): void => {
-  for (const toolName of ODT_REGISTERED_TOOL_NAMES) {
+  const registerOneTool = <Name extends RegisteredToolName>(toolName: Name): void => {
     const spec = ODT_REGISTERED_TOOL_SPECS[toolName];
-    const tool: RegisteredTool<typeof toolName> = {
+    const tool: RegisteredTool<Name> = {
       name: toolName,
       description: spec.description,
-      execute: spec.execute as RegisteredTool<typeof toolName>["execute"],
+      execute: spec.execute,
     };
     registerOdtTool(server, store, tool);
+  };
+
+  for (const toolName of ODT_REGISTERED_TOOL_NAMES) {
+    registerOneTool(toolName);
   }
 };
 

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -73,24 +73,34 @@ const parseCliArgs = (argv: string[]): OdtStoreContext => {
   return next;
 };
 
-type RegisteredTool = {
-  name: keyof typeof ODT_TOOL_SCHEMAS;
+type RegisteredToolName = keyof typeof ODT_TOOL_SCHEMAS;
+type ToolInputByName<Name extends RegisteredToolName> = ReturnType<
+  (typeof ODT_TOOL_SCHEMAS)[Name]["parse"]
+>;
+
+type RegisteredTool<Name extends RegisteredToolName = RegisteredToolName> = {
+  name: Name;
   description: string;
-  execute: (store: OdtTaskStore, input: unknown) => Promise<unknown>;
+  execute(store: OdtTaskStore, input: ToolInputByName<Name>): Promise<unknown>;
 };
 
-type RegisteredToolName = keyof typeof ODT_TOOL_SCHEMAS;
-
-type RegisteredToolSpec = {
-  description: string;
-  execute: (store: OdtTaskStore, input: unknown) => Promise<unknown>;
+type RegisteredToolSpecs = {
+  [Name in RegisteredToolName]: {
+    description: string;
+    execute(store: OdtTaskStore, input: ToolInputByName<Name>): Promise<unknown>;
+  };
 };
 
 const isSchemaLike = (value: unknown): value is ZodRawShapeCompat[string] => {
   if (!value || typeof value !== "object") {
     return false;
   }
-  return typeof (value as { parse?: unknown }).parse === "function";
+  const candidate = value as { parse?: unknown; _def?: unknown; _zod?: unknown };
+  return (
+    typeof candidate.parse === "function" ||
+    candidate._def !== undefined ||
+    candidate._zod !== undefined
+  );
 };
 
 const isRegisterToolInputSchema = (value: unknown): value is ZodRawShapeCompat => {
@@ -109,10 +119,10 @@ const assertRegisterToolInputSchema: (
   }
 };
 
-export const registerOdtTool = (
+export const registerOdtTool = <Name extends RegisteredToolName>(
   server: McpServer,
   store: OdtTaskStore,
-  tool: RegisteredTool,
+  tool: RegisteredTool<Name>,
 ): void => {
   const schema = ODT_TOOL_SCHEMAS[tool.name];
   const inputSchema: unknown = schema.shape;
@@ -126,7 +136,8 @@ export const registerOdtTool = (
     },
     async (input: unknown) => {
       try {
-        const result = await tool.execute(store, input);
+        const parsedInput = schema.parse(input) as ToolInputByName<Name>;
+        const result = await tool.execute(store, parsedInput);
         return toToolResult(result);
       } catch (error) {
         return toToolError(error);
@@ -135,7 +146,7 @@ export const registerOdtTool = (
   );
 };
 
-export const ODT_REGISTERED_TOOL_SPECS: Readonly<Record<RegisteredToolName, RegisteredToolSpec>> = {
+export const ODT_REGISTERED_TOOL_SPECS: Readonly<RegisteredToolSpecs> = {
   odt_read_task: {
     description:
       "Read one OpenDucktor task with its current status and agent documents (spec/plan/latest QA).",
@@ -180,10 +191,10 @@ export const ODT_REGISTERED_TOOL_NAMES = Object.keys(
 const registerTools = (server: McpServer, store: OdtTaskStore): void => {
   for (const toolName of ODT_REGISTERED_TOOL_NAMES) {
     const spec = ODT_REGISTERED_TOOL_SPECS[toolName];
-    const tool: RegisteredTool = {
+    const tool: RegisteredTool<typeof toolName> = {
       name: toolName,
       description: spec.description,
-      execute: spec.execute,
+      execute: spec.execute as RegisteredTool<typeof toolName>["execute"],
     };
     registerOdtTool(server, store, tool);
   }

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
 import { ODT_TOOL_SCHEMAS, type OdtStoreContext, OdtTaskStore, resolveStoreContext } from "./lib";
 
 type ToolResult = {
@@ -85,40 +86,47 @@ type RegisteredToolSpec = {
   execute: (store: OdtTaskStore, input: unknown) => Promise<unknown>;
 };
 
-type ToolInputSchema = {
-  shape: Record<string, unknown>;
-  parse: (input: unknown) => unknown;
+const isSchemaLike = (value: unknown): value is ZodRawShapeCompat[string] => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return typeof (value as { parse?: unknown }).parse === "function";
 };
 
-type RegisterToolCall = (
-  this: McpServer,
-  name: string,
-  config: {
-    description: string;
-    inputSchema: unknown;
-  },
-  handler: (input: unknown) => Promise<ToolResult>,
-) => void;
+const isRegisterToolInputSchema = (value: unknown): value is ZodRawShapeCompat => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  return Object.values(value as Record<string, unknown>).every((entry) => isSchemaLike(entry));
+};
+
+const assertRegisterToolInputSchema: (
+  toolName: RegisteredToolName,
+  value: unknown,
+) => asserts value is ZodRawShapeCompat = (toolName, value) => {
+  if (!isRegisterToolInputSchema(value)) {
+    throw new TypeError(`Invalid MCP input schema for tool '${toolName}'.`);
+  }
+};
 
 export const registerOdtTool = (
   server: McpServer,
   store: OdtTaskStore,
   tool: RegisteredTool,
 ): void => {
-  const schema = ODT_TOOL_SCHEMAS[tool.name] as unknown as ToolInputSchema;
-  const registerTool = server.registerTool as unknown as RegisterToolCall;
+  const schema = ODT_TOOL_SCHEMAS[tool.name];
+  const inputSchema: unknown = schema.shape;
+  assertRegisterToolInputSchema(tool.name, inputSchema);
 
-  registerTool.call(
-    server,
+  server.registerTool(
     tool.name,
     {
       description: tool.description,
-      inputSchema: schema.shape,
+      inputSchema,
     },
     async (input: unknown) => {
       try {
-        const parsed = schema.parse(input);
-        const result = await tool.execute(store, parsed);
+        const result = await tool.execute(store, input);
         return toToolResult(result);
       } catch (error) {
         return toToolError(error);


### PR DESCRIPTION
## Summary
- remove unsafe `as unknown as` double-casts in MCP tool registration
- replace shadow registration typing with direct `server.registerTool(...)` usage and runtime schema-shape guard
- tighten registration typings to bind tool names to schema-derived input shapes
- add regression tests for schema wiring, invalid shape rejection, execution error envelope, and parse-failure envelope

## Validation
- `bun run --filter @openducktor/openducktor-mcp typecheck`
- `bun run --filter @openducktor/openducktor-mcp test`
- `bun run --filter @openducktor/openducktor-mcp lint`

## Files
- `packages/openducktor-mcp/src/index.ts`
- `packages/openducktor-mcp/src/index.test.js`
