### PR TITLE
refactor(adapters-opencode-sdk): route and harden session todo loading via client

### DIFF
--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -11,6 +11,7 @@ type MockSession = {
   abortCalls: unknown[];
   getCalls: unknown[];
   messagesCalls: unknown[];
+  todoCalls: unknown[];
   promptQueue: Array<{ info: { id: string; [key: string]: unknown }; parts: Part[] }>;
   messagesResponse: Array<{
     info: {
@@ -21,6 +22,9 @@ type MockSession = {
     };
     parts: Part[];
   }>;
+  todoResponse: unknown;
+  todoError?: unknown;
+  todoThrows?: Error;
 };
 
 type MockTool = {
@@ -44,11 +48,36 @@ type MockEventStream = {
   events: Event[];
 };
 
+type MakeMockClientInput = {
+  sessionId?: string;
+  streamEvents?: Event[];
+  promptQueue?: Array<{ info: { id: string; [key: string]: unknown }; parts: Part[] }>;
+  messagesResponse?: Array<{
+    info: {
+      id: string;
+      role: "user" | "assistant";
+      time: { created: number };
+      [key: string]: unknown;
+    };
+    parts: Part[];
+  }>;
+  todoResponse?: unknown;
+  todoError?: unknown;
+  todoThrows?: Error;
+  providerResponse?: unknown;
+  agentsResponse?: unknown;
+  toolIdsResponse?: unknown;
+  mcpStatusResponse?: unknown;
+};
+
 const makeMockClient = ({
   sessionId = "session-opencode-1",
   streamEvents = [],
   promptQueue = [],
   messagesResponse = [],
+  todoResponse,
+  todoError,
+  todoThrows,
   providerResponse = {
     providers: [
       {
@@ -76,24 +105,7 @@ const makeMockClient = ({
   agentsResponse = [],
   toolIdsResponse = [],
   mcpStatusResponse = {},
-}: {
-  sessionId?: string;
-  streamEvents?: Event[];
-  promptQueue?: Array<{ info: { id: string; [key: string]: unknown }; parts: Part[] }>;
-  messagesResponse?: Array<{
-    info: {
-      id: string;
-      role: "user" | "assistant";
-      time: { created: number };
-      [key: string]: unknown;
-    };
-    parts: Part[];
-  }>;
-  providerResponse?: unknown;
-  agentsResponse?: unknown;
-  toolIdsResponse?: unknown;
-  mcpStatusResponse?: unknown;
-}): {
+}: MakeMockClientInput): {
   client: OpencodeClient;
   session: MockSession;
   tool: MockTool;
@@ -108,8 +120,12 @@ const makeMockClient = ({
     abortCalls: [],
     getCalls: [],
     messagesCalls: [],
+    todoCalls: [],
     promptQueue: [...promptQueue],
     messagesResponse: [...messagesResponse],
+    todoResponse,
+    todoError,
+    todoThrows,
   };
   const permission: MockPermission = {
     replyCalls: [],
@@ -176,6 +192,16 @@ const makeMockClient = ({
         return {
           data: session.messagesResponse,
           error: undefined,
+        };
+      },
+      todo: async (input: unknown) => {
+        session.todoCalls.push(input);
+        if (session.todoThrows) {
+          throw session.todoThrows;
+        }
+        return {
+          data: session.todoResponse,
+          error: session.todoError,
         };
       },
     },
@@ -279,27 +305,24 @@ const defaultLoadSessionTodosInput = {
 };
 
 const runLoadSessionTodosWithWarningCapture = async (
-  fetchImpl: typeof fetch,
-): Promise<{ todos: AgentSessionTodoItem[]; warnCalls: unknown[][] }> => {
-  const originalFetch = globalThis.fetch;
+  mockInput: MakeMockClientInput,
+): Promise<{ todos: AgentSessionTodoItem[]; warnCalls: unknown[][]; session: MockSession }> => {
   const originalWarn = console.warn;
   const warnCalls: unknown[][] = [];
   console.warn = ((...args: unknown[]) => {
     warnCalls.push(args);
   }) as typeof console.warn;
-  globalThis.fetch = fetchImpl;
 
   try {
-    const mock = makeMockClient({});
+    const mock = makeMockClient(mockInput);
     const adapter = new OpencodeSdkAdapter({
       createClient: () => mock.client,
       now: () => "2026-02-17T12:00:00Z",
     });
 
     const todos = await adapter.loadSessionTodos(defaultLoadSessionTodosInput);
-    return { todos, warnCalls };
+    return { todos, warnCalls, session: mock.session };
   } finally {
-    globalThis.fetch = originalFetch;
     console.warn = originalWarn;
   }
 };
@@ -825,51 +848,8 @@ describe("OpencodeSdkAdapter", () => {
   });
 
   test("loadSessionTodos reads /session/:id/todo and normalizes entries", async () => {
-    const originalFetch = globalThis.fetch;
-    const fetchCalls: string[] = [];
-    globalThis.fetch = (async (input: string | URL | Request) => {
-      fetchCalls.push(typeof input === "string" ? input : input.toString());
-      return new Response(
-        JSON.stringify([
-          {
-            id: "todo-1",
-            content: "Inspect auth flow",
-            status: "in_progress",
-            priority: "high",
-          },
-          {
-            id: "todo-2",
-            content: "Write spec",
-            status: "unexpected_status",
-            priority: "unexpected_priority",
-          },
-        ]),
-        {
-          status: 200,
-          headers: {
-            "content-type": "application/json",
-          },
-        },
-      );
-    }) as typeof fetch;
-
-    try {
-      const mock = makeMockClient({});
-      const adapter = new OpencodeSdkAdapter({
-        createClient: () => mock.client,
-        now: () => "2026-02-17T12:00:00Z",
-      });
-
-      const todos = await adapter.loadSessionTodos({
-        baseUrl: "http://127.0.0.1:12345",
-        workingDirectory: "/repo",
-        externalSessionId: "session-opencode-1",
-      });
-
-      expect(fetchCalls).toEqual([
-        "http://127.0.0.1:12345/session/session-opencode-1/todo?directory=%2Frepo",
-      ]);
-      expect(todos).toEqual([
+    const mock = makeMockClient({
+      todoResponse: [
         {
           id: "todo-1",
           content: "Inspect auth flow",
@@ -879,41 +859,79 @@ describe("OpencodeSdkAdapter", () => {
         {
           id: "todo-2",
           content: "Write spec",
-          status: "pending",
-          priority: "medium",
+          status: "unexpected_status",
+          priority: "unexpected_priority",
         },
-      ]);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const todos = await adapter.loadSessionTodos({
+      baseUrl: "http://127.0.0.1:12345",
+      workingDirectory: "/repo",
+      externalSessionId: "session-opencode-1",
+    });
+
+    expect(mock.session.todoCalls).toEqual([
+      {
+        sessionID: "session-opencode-1",
+        directory: "/repo",
+      },
+    ]);
+    expect(todos).toEqual([
+      {
+        id: "todo-1",
+        content: "Inspect auth flow",
+        status: "in_progress",
+        priority: "high",
+      },
+      {
+        id: "todo-2",
+        content: "Write spec",
+        status: "pending",
+        priority: "medium",
+      },
+    ]);
   });
 
-  test("loadSessionTodos logs non-ok responses and returns empty todos", async () => {
-    const { todos, warnCalls } = await runLoadSessionTodosWithWarningCapture(async () => {
-      return new Response("upstream unavailable", {
-        status: 503,
-        statusText: "Service Unavailable",
-      });
+  test("loadSessionTodos logs client errors and returns empty todos", async () => {
+    const { todos, warnCalls, session } = await runLoadSessionTodosWithWarningCapture({
+      todoError: {
+        message: "Service Unavailable",
+      },
     });
 
     expect(todos).toEqual([]);
     expect(warnCalls).toHaveLength(1);
-    expect(warnCalls[0][0]).toBe("loadSessionTodos: HTTP 503");
-    expect(warnCalls[0][1]).toEqual({
-      statusText: "Service Unavailable",
-    });
+    expect(warnCalls[0][0]).toBe("loadSessionTodos: request failed");
+    expect((warnCalls[0][1] as Error).message).toBe("Service Unavailable");
+    expect(session.todoCalls).toEqual([
+      {
+        sessionID: "session-opencode-1",
+        directory: "/repo",
+      },
+    ]);
   });
 
-  test("loadSessionTodos logs fetch errors and returns empty todos", async () => {
-    const fetchError = new Error("network down");
-    const { todos, warnCalls } = await runLoadSessionTodosWithWarningCapture(async () => {
-      throw fetchError;
+  test("loadSessionTodos logs thrown request errors and returns empty todos", async () => {
+    const requestError = new Error("network down");
+    const { todos, warnCalls, session } = await runLoadSessionTodosWithWarningCapture({
+      todoThrows: requestError,
     });
 
     expect(todos).toEqual([]);
     expect(warnCalls).toHaveLength(1);
-    expect(warnCalls[0][0]).toBe("loadSessionTodos: fetch failed");
-    expect(warnCalls[0][1]).toBe(fetchError);
+    expect(warnCalls[0][0]).toBe("loadSessionTodos: request failed");
+    expect(warnCalls[0][1]).toBe(requestError);
+    expect(session.todoCalls).toEqual([
+      {
+        sessionID: "session-opencode-1",
+        directory: "/repo",
+      },
+    ]);
   });
 
   test("listAvailableModels returns provider models and primary agents", async () => {

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1016,8 +1016,12 @@ describe("OpencodeSdkAdapter", () => {
         data: [],
       },
     });
+    const createClientCalls: unknown[] = [];
     const adapter = new OpencodeSdkAdapter({
-      createClient: () => mock.client,
+      createClient: (input) => {
+        createClientCalls.push(input);
+        return mock.client;
+      },
       now: () => "2026-02-17T12:00:00Z",
     });
 
@@ -1031,6 +1035,39 @@ describe("OpencodeSdkAdapter", () => {
     expect(mock.session.todoCalls).toEqual([
       {
         sessionID: "session-opencode-1",
+      },
+    ]);
+    expect(createClientCalls).toEqual([
+      {
+        baseUrl: "http://127.0.0.1:12345",
+        workingDirectory: "   ",
+      },
+    ]);
+  });
+
+  test("loadSessionTodos trims workingDirectory before forwarding directory", async () => {
+    const mock = makeMockClient({
+      todoResult: {
+        mode: "success",
+        data: [],
+      },
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const todos = await adapter.loadSessionTodos({
+      baseUrl: "http://127.0.0.1:12345",
+      workingDirectory: "  /repo  ",
+      externalSessionId: "session-opencode-1",
+    });
+
+    expect(todos).toEqual([]);
+    expect(mock.session.todoCalls).toEqual([
+      {
+        sessionID: "session-opencode-1",
+        directory: "/repo",
       },
     ]);
   });

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -22,9 +22,7 @@ type MockSession = {
     };
     parts: Part[];
   }>;
-  todoResponse: unknown;
-  todoError?: unknown;
-  todoThrows?: Error;
+  todoResult: TodoMockResult;
 };
 
 type MockTool = {
@@ -48,6 +46,22 @@ type MockEventStream = {
   events: Event[];
 };
 
+type TodoMockResult =
+  | {
+      mode: "success";
+      data: unknown;
+    }
+  | {
+      mode: "api_error";
+      error: unknown;
+      status?: number;
+      statusText?: string;
+    }
+  | {
+      mode: "throw";
+      error: Error;
+    };
+
 type MakeMockClientInput = {
   sessionId?: string;
   streamEvents?: Event[];
@@ -61,9 +75,7 @@ type MakeMockClientInput = {
     };
     parts: Part[];
   }>;
-  todoResponse?: unknown;
-  todoError?: unknown;
-  todoThrows?: Error;
+  todoResult?: TodoMockResult;
   providerResponse?: unknown;
   agentsResponse?: unknown;
   toolIdsResponse?: unknown;
@@ -75,9 +87,10 @@ const makeMockClient = ({
   streamEvents = [],
   promptQueue = [],
   messagesResponse = [],
-  todoResponse,
-  todoError,
-  todoThrows,
+  todoResult = {
+    mode: "success",
+    data: [],
+  },
   providerResponse = {
     providers: [
       {
@@ -123,9 +136,7 @@ const makeMockClient = ({
     todoCalls: [],
     promptQueue: [...promptQueue],
     messagesResponse: [...messagesResponse],
-    todoResponse,
-    todoError,
-    todoThrows,
+    todoResult,
   };
   const permission: MockPermission = {
     replyCalls: [],
@@ -196,12 +207,26 @@ const makeMockClient = ({
       },
       todo: async (input: unknown) => {
         session.todoCalls.push(input);
-        if (session.todoThrows) {
-          throw session.todoThrows;
+        if (session.todoResult.mode === "throw") {
+          throw session.todoResult.error;
+        }
+        if (session.todoResult.mode === "api_error") {
+          return {
+            data: undefined,
+            error: session.todoResult.error,
+            response: {
+              status: session.todoResult.status ?? 500,
+              statusText: session.todoResult.statusText ?? "",
+            },
+          };
         }
         return {
-          data: session.todoResponse,
-          error: session.todoError,
+          data: session.todoResult.data,
+          error: undefined,
+          response: {
+            status: 200,
+            statusText: "OK",
+          },
         };
       },
     },
@@ -306,9 +331,15 @@ const defaultLoadSessionTodosInput = {
 
 const runLoadSessionTodosWithWarningCapture = async (
   mockInput: MakeMockClientInput,
-): Promise<{ todos: AgentSessionTodoItem[]; warnCalls: unknown[][]; session: MockSession }> => {
+): Promise<{
+  todos: AgentSessionTodoItem[];
+  warnCalls: unknown[][];
+  session: MockSession;
+  createClientCalls: unknown[];
+}> => {
   const originalWarn = console.warn;
   const warnCalls: unknown[][] = [];
+  const createClientCalls: unknown[] = [];
   console.warn = ((...args: unknown[]) => {
     warnCalls.push(args);
   }) as typeof console.warn;
@@ -316,12 +347,15 @@ const runLoadSessionTodosWithWarningCapture = async (
   try {
     const mock = makeMockClient(mockInput);
     const adapter = new OpencodeSdkAdapter({
-      createClient: () => mock.client,
+      createClient: (input) => {
+        createClientCalls.push(input);
+        return mock.client;
+      },
       now: () => "2026-02-17T12:00:00Z",
     });
 
     const todos = await adapter.loadSessionTodos(defaultLoadSessionTodosInput);
-    return { todos, warnCalls, session: mock.session };
+    return { todos, warnCalls, session: mock.session, createClientCalls };
   } finally {
     console.warn = originalWarn;
   }
@@ -849,23 +883,30 @@ describe("OpencodeSdkAdapter", () => {
 
   test("loadSessionTodos reads /session/:id/todo and normalizes entries", async () => {
     const mock = makeMockClient({
-      todoResponse: [
-        {
-          id: "todo-1",
-          content: "Inspect auth flow",
-          status: "in_progress",
-          priority: "high",
-        },
-        {
-          id: "todo-2",
-          content: "Write spec",
-          status: "unexpected_status",
-          priority: "unexpected_priority",
-        },
-      ],
+      todoResult: {
+        mode: "success",
+        data: [
+          {
+            id: "todo-1",
+            content: "Inspect auth flow",
+            status: "in_progress",
+            priority: "high",
+          },
+          {
+            id: "todo-2",
+            content: "Write spec",
+            status: "unexpected_status",
+            priority: "unexpected_priority",
+          },
+        ],
+      },
     });
+    const createClientCalls: unknown[] = [];
     const adapter = new OpencodeSdkAdapter({
-      createClient: () => mock.client,
+      createClient: (input) => {
+        createClientCalls.push(input);
+        return mock.client;
+      },
       now: () => "2026-02-17T12:00:00Z",
     });
 
@@ -879,6 +920,12 @@ describe("OpencodeSdkAdapter", () => {
       {
         sessionID: "session-opencode-1",
         directory: "/repo",
+      },
+    ]);
+    expect(createClientCalls).toEqual([
+      {
+        baseUrl: "http://127.0.0.1:12345",
+        workingDirectory: "/repo",
       },
     ]);
     expect(todos).toEqual([
@@ -898,38 +945,92 @@ describe("OpencodeSdkAdapter", () => {
   });
 
   test("loadSessionTodos logs client errors and returns empty todos", async () => {
-    const { todos, warnCalls, session } = await runLoadSessionTodosWithWarningCapture({
-      todoError: {
-        message: "Service Unavailable",
-      },
-    });
+    const { todos, warnCalls, session, createClientCalls } =
+      await runLoadSessionTodosWithWarningCapture({
+        todoResult: {
+          mode: "api_error",
+          error: {
+            message: "Service Unavailable",
+          },
+          status: 503,
+          statusText: "Service Unavailable",
+        },
+      });
 
     expect(todos).toEqual([]);
     expect(warnCalls).toHaveLength(1);
     expect(warnCalls[0][0]).toBe("loadSessionTodos: request failed");
-    expect((warnCalls[0][1] as Error).message).toBe("Service Unavailable");
+    expect(warnCalls[0][1]).toEqual({
+      message: "Service Unavailable",
+      status: 503,
+      statusText: "Service Unavailable",
+    });
     expect(session.todoCalls).toEqual([
       {
         sessionID: "session-opencode-1",
         directory: "/repo",
       },
     ]);
+    expect(createClientCalls).toEqual([
+      {
+        baseUrl: "http://127.0.0.1:12345",
+        workingDirectory: "/repo",
+      },
+    ]);
   });
 
   test("loadSessionTodos logs thrown request errors and returns empty todos", async () => {
     const requestError = new Error("network down");
-    const { todos, warnCalls, session } = await runLoadSessionTodosWithWarningCapture({
-      todoThrows: requestError,
-    });
+    const { todos, warnCalls, session, createClientCalls } =
+      await runLoadSessionTodosWithWarningCapture({
+        todoResult: {
+          mode: "throw",
+          error: requestError,
+        },
+      });
 
     expect(todos).toEqual([]);
     expect(warnCalls).toHaveLength(1);
     expect(warnCalls[0][0]).toBe("loadSessionTodos: request failed");
-    expect(warnCalls[0][1]).toBe(requestError);
+    expect(warnCalls[0][1]).toEqual({
+      message: "network down",
+    });
     expect(session.todoCalls).toEqual([
       {
         sessionID: "session-opencode-1",
         directory: "/repo",
+      },
+    ]);
+    expect(createClientCalls).toEqual([
+      {
+        baseUrl: "http://127.0.0.1:12345",
+        workingDirectory: "/repo",
+      },
+    ]);
+  });
+
+  test("loadSessionTodos omits directory when workingDirectory is blank", async () => {
+    const mock = makeMockClient({
+      todoResult: {
+        mode: "success",
+        data: [],
+      },
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const todos = await adapter.loadSessionTodos({
+      baseUrl: "http://127.0.0.1:12345",
+      workingDirectory: "   ",
+      externalSessionId: "session-opencode-1",
+    });
+
+    expect(todos).toEqual([]);
+    expect(mock.session.todoCalls).toEqual([
+      {
+        sessionID: "session-opencode-1",
       },
     ]);
   });

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -74,35 +74,27 @@ export const loadSessionHistory = async (
   return mapped;
 };
 
-export const loadSessionTodos = async (input: {
-  baseUrl: string;
-  workingDirectory: string;
-  externalSessionId: string;
-}): Promise<AgentSessionTodoItem[]> => {
+export const loadSessionTodos = async (
+  createClient: ClientFactory,
+  input: {
+    baseUrl: string;
+    workingDirectory: string;
+    externalSessionId: string;
+  },
+): Promise<AgentSessionTodoItem[]> => {
   try {
-    const baseUrl = input.baseUrl.replace(/\/+$/, "");
-    const url = new URL(`${baseUrl}/session/${encodeURIComponent(input.externalSessionId)}/todo`);
-    if (input.workingDirectory.trim().length > 0) {
-      url.searchParams.set("directory", input.workingDirectory);
-    }
-
-    const response = await fetch(url.toString(), {
-      method: "GET",
-      headers: {
-        Accept: "application/json",
-      },
+    const client = createClient({
+      baseUrl: input.baseUrl,
+      workingDirectory: input.workingDirectory,
     });
-    if (!response.ok) {
-      console.warn(`loadSessionTodos: HTTP ${response.status}`, {
-        statusText: response.statusText,
-      });
-      return [];
-    }
-
-    const payload = (await response.json().catch(() => null)) as unknown;
+    const response = await client.session.todo({
+      sessionID: input.externalSessionId,
+      directory: input.workingDirectory,
+    });
+    const payload = unwrapData(response, "load session todos");
     return normalizeTodoList(payload);
   } catch (error) {
-    console.warn("loadSessionTodos: fetch failed", error);
+    console.warn("loadSessionTodos: request failed", error);
     return [];
   }
 };

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -22,6 +22,63 @@ import type { ClientFactory, SessionRecord } from "./types";
 import { WORKFLOW_TOOL_CACHE_TTL_MS } from "./types";
 import { resolveWorkflowToolSelection } from "./workflow-tool-selection";
 
+type TodoRequestFailure = {
+  message: string;
+  status?: number;
+  statusText?: string;
+  code?: string;
+};
+
+const readUnknownProp = (value: unknown, key: string): unknown => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return (value as Record<string, unknown>)[key];
+};
+
+const readStringProp = (value: unknown, key: string): string | undefined => {
+  const candidate = readUnknownProp(value, key);
+  return typeof candidate === "string" && candidate.trim().length > 0 ? candidate : undefined;
+};
+
+const readNumberProp = (value: unknown, key: string): number | undefined => {
+  const candidate = readUnknownProp(value, key);
+  return typeof candidate === "number" ? candidate : undefined;
+};
+
+const normalizeTodoRequestFailure = (
+  error: unknown,
+  response?: { status?: unknown; statusText?: unknown },
+): TodoRequestFailure => {
+  const errorMessage =
+    (error instanceof Error && error.message.trim().length > 0 ? error.message : undefined) ??
+    readStringProp(error, "message") ??
+    readStringProp(readUnknownProp(error, "data"), "message") ??
+    "OpenCode request failed: load session todos";
+  const errorStatus = readNumberProp(error, "status");
+  const errorStatusText = readStringProp(error, "statusText");
+  const errorCodeRaw = readUnknownProp(error, "code");
+  const errorCode =
+    typeof errorCodeRaw === "string" || typeof errorCodeRaw === "number"
+      ? String(errorCodeRaw)
+      : undefined;
+
+  return {
+    message: errorMessage,
+    ...(typeof errorStatus === "number"
+      ? { status: errorStatus }
+      : typeof response?.status === "number"
+        ? { status: response.status }
+        : {}),
+    ...(errorStatusText
+      ? { statusText: errorStatusText }
+      : typeof response?.statusText === "string" && response.statusText.trim().length > 0
+        ? { statusText: response.statusText }
+        : {}),
+    ...(errorCode ? { code: errorCode } : {}),
+  };
+};
+
 export const loadSessionHistory = async (
   createClient: ClientFactory,
   now: () => string,
@@ -89,12 +146,21 @@ export const loadSessionTodos = async (
     });
     const response = await client.session.todo({
       sessionID: input.externalSessionId,
-      directory: input.workingDirectory,
+      ...(input.workingDirectory.trim().length > 0 ? { directory: input.workingDirectory } : {}),
     });
-    const payload = unwrapData(response, "load session todos");
+    if (response.data === undefined || response.data === null) {
+      const normalizedError = normalizeTodoRequestFailure(
+        response.error,
+        (response as { response?: { status?: unknown; statusText?: unknown } }).response,
+      );
+      console.warn("loadSessionTodos: request failed", normalizedError);
+      return [];
+    }
+    const payload = response.data;
     return normalizeTodoList(payload);
   } catch (error) {
-    console.warn("loadSessionTodos: request failed", error);
+    const normalizedError = normalizeTodoRequestFailure(error);
+    console.warn("loadSessionTodos: request failed", normalizedError);
     return [];
   }
 };

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -140,13 +140,14 @@ export const loadSessionTodos = async (
   },
 ): Promise<AgentSessionTodoItem[]> => {
   try {
+    const trimmedWorkingDirectory = input.workingDirectory.trim();
     const client = createClient({
       baseUrl: input.baseUrl,
       workingDirectory: input.workingDirectory,
     });
     const response = await client.session.todo({
       sessionID: input.externalSessionId,
-      ...(input.workingDirectory.trim().length > 0 ? { directory: input.workingDirectory } : {}),
+      ...(trimmedWorkingDirectory.length > 0 ? { directory: trimmedWorkingDirectory } : {}),
     });
     if (response.data === undefined || response.data === null) {
       const normalizedError = normalizeTodoRequestFailure(

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -144,7 +144,7 @@ export class OpencodeSdkAdapter implements AgentEnginePort {
   }
 
   async loadSessionTodos(input: LoadAgentSessionTodosInput): Promise<AgentSessionTodoItem[]> {
-    return loadSessionTodos(input);
+    return loadSessionTodos(this.createClient, input);
   }
 
   async listAvailableModels(input: {


### PR DESCRIPTION
## Summary
- route `loadSessionTodos` through `ClientFactory` / SDK `session.todo` to match other message ops
- harden todo request failure handling with normalized warning payloads (`message`, `status`, `statusText`, `code` when available)
- preserve prior behavior by omitting `directory` when `workingDirectory` is blank
- refactor adapter tests to use explicit todo response modes (`success` / `api_error` / `throw`) and assert `createClient` inputs

## Validation
- bun run --filter @openducktor/adapters-opencode-sdk test
- bun run --filter @openducktor/adapters-opencode-sdk typecheck
- bun run --filter @openducktor/adapters-opencode-sdk lint
