### PR TITLE
refactor(desktop): reduce orchestrator ref-shadow sync and centralize session commits

### DIFF
--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -399,21 +399,14 @@ const createOrReuseSession = async ({
     systemPrompt: resolved.systemPrompt,
   });
 
-  const optimisticSessions = {
-    ...deps.session.sessionsRef.current,
-    [summary.sessionId]: initialSession,
-  };
-  deps.session.sessionsRef.current = optimisticSessions;
   deps.session.setSessionsById((current) => {
     if (ctx.isStaleRepoOperation()) {
-      deps.session.sessionsRef.current = current;
       return current;
     }
     const nextSessions = {
       ...current,
       [summary.sessionId]: initialSession,
     };
-    deps.session.sessionsRef.current = nextSessions;
     return nextSessions;
   });
   throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
@@ -519,7 +512,6 @@ const applyResolvedModelSelection = ({
       ...current,
       [startedCtx.summary.sessionId]: nextSession,
     };
-    session.sessionsRef.current = nextSessions;
     return nextSessions;
   });
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -136,7 +136,6 @@ export const createLoadAgentSessions = ({
         }
         next[record.sessionId] = fromPersistedSessionRecord(record);
       }
-      sessionsRef.current = next;
       return next;
     });
 

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
@@ -1047,4 +1047,261 @@ describe("use-agent-orchestrator-operations", () => {
       }
     });
   });
+
+  test("uses latest runs after args update when starting build sessions", async () => {
+    await withSuppressedRendererWarning(async () => {
+      let buildStartCalls = 0;
+      let startWorkingDirectory = "";
+
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+      const originalBuildStart = host.buildStart;
+      const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
+
+      const originalStartSession = OpencodeSdkAdapter.prototype.startSession;
+      const originalSubscribeEvents = OpencodeSdkAdapter.prototype.subscribeEvents;
+      const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+      const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+
+      host.agentSessionsList = async () => [];
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+      host.buildStart = async () => {
+        buildStartCalls += 1;
+        return runningRunFixture;
+      };
+      host.workspaceGetRepoConfig = async () => ({
+        branchPrefix: "obp",
+        trustedHooks: false,
+        hooks: {
+          preStart: [],
+          postComplete: [],
+        },
+        agentDefaults: {},
+      });
+
+      OpencodeSdkAdapter.prototype.startSession = async (input) => {
+        startWorkingDirectory = input.workingDirectory;
+        return {
+          sessionId: "session-updated-runs",
+          externalSessionId: "external-updated-runs",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          role: "build",
+          scenario: "build_implementation_start",
+          status: "idle",
+        };
+      };
+      OpencodeSdkAdapter.prototype.subscribeEvents = (_sessionId, _listener) => () => {};
+      OpencodeSdkAdapter.prototype.listAvailableModels = async () => ({
+        models: [],
+        defaultModelsByProvider: {},
+        agents: [],
+      });
+      OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture],
+        runs: [],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+        await harness.updateArgs({ runs: [runningRunFixture] });
+
+        await harness.run(async () => {
+          await harness.getLatest().startAgentSession({ taskId: "task-1", role: "build" });
+        });
+
+        expect(buildStartCalls).toBe(0);
+        expect(startWorkingDirectory).toBe(runningRunFixture.worktreePath);
+      } finally {
+        await harness.unmount();
+
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+        host.buildStart = originalBuildStart;
+        host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
+
+        OpencodeSdkAdapter.prototype.startSession = originalStartSession;
+        OpencodeSdkAdapter.prototype.subscribeEvents = originalSubscribeEvents;
+        OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+        OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+      }
+    });
+  });
+
+  test("uses latest tasks after args update when validating send permissions", async () => {
+    await withSuppressedRendererWarning(async () => {
+      let sendCalls = 0;
+
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+
+      const originalHasSession = OpencodeSdkAdapter.prototype.hasSession;
+      const originalSubscribeEvents = OpencodeSdkAdapter.prototype.subscribeEvents;
+      const originalSendUserMessage = OpencodeSdkAdapter.prototype.sendUserMessage;
+      const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+      const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+      const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
+
+      host.agentSessionsList = async () => [persistedSessionFixture];
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+
+      OpencodeSdkAdapter.prototype.hasSession = () => true;
+      OpencodeSdkAdapter.prototype.subscribeEvents = () => () => {};
+      OpencodeSdkAdapter.prototype.sendUserMessage = async () => {
+        sendCalls += 1;
+      };
+      OpencodeSdkAdapter.prototype.listAvailableModels = async () => ({
+        models: [],
+        defaultModelsByProvider: {},
+        agents: [],
+      });
+      OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
+      OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture],
+        runs: [runningRunFixture],
+        refreshTaskData: async () => {},
+      });
+
+      const unavailableTask: TaskCard = {
+        ...taskFixture,
+        status: "open",
+        agentWorkflows: {
+          spec: { required: true, canSkip: false, available: true, completed: false },
+          planner: { required: true, canSkip: false, available: false, completed: false },
+          builder: { required: true, canSkip: false, available: false, completed: false },
+          qa: { required: true, canSkip: false, available: false, completed: false },
+        },
+      };
+
+      try {
+        await harness.mount();
+
+        await harness.run(async () => {
+          await harness.getLatest().loadAgentSessions("task-1");
+        });
+        await harness.updateArgs({ tasks: [unavailableTask] });
+
+        await harness.run(async () => {
+          await expect(harness.getLatest().sendAgentMessage("session-1", "hello")).rejects.toThrow(
+            "Role 'build' is unavailable for task 'task-1' in status 'open'.",
+          );
+        });
+
+        expect(sendCalls).toBe(0);
+      } finally {
+        await harness.unmount();
+
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+
+        OpencodeSdkAdapter.prototype.hasSession = originalHasSession;
+        OpencodeSdkAdapter.prototype.subscribeEvents = originalSubscribeEvents;
+        OpencodeSdkAdapter.prototype.sendUserMessage = originalSendUserMessage;
+        OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+        OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+        OpencodeSdkAdapter.prototype.loadSessionHistory = originalLoadSessionHistory;
+      }
+    });
+  });
+
+  test("reuses freshly loaded sessions without starting a new session", async () => {
+    await withSuppressedRendererWarning(async () => {
+      let startCalls = 0;
+
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+
+      const originalStartSession = OpencodeSdkAdapter.prototype.startSession;
+      const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
+      const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+      const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+
+      host.agentSessionsList = async () => [persistedSessionFixture];
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+
+      OpencodeSdkAdapter.prototype.startSession = async () => {
+        startCalls += 1;
+        return {
+          sessionId: "session-unexpected",
+          externalSessionId: "external-unexpected",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          role: "build",
+          scenario: "build_implementation_start",
+          status: "idle",
+        };
+      };
+      OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
+      OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
+      OpencodeSdkAdapter.prototype.listAvailableModels = async () => ({
+        models: [],
+        defaultModelsByProvider: {},
+        agents: [],
+      });
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture],
+        runs: [runningRunFixture],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+
+        let reusedSessionId = "";
+        await harness.run(async () => {
+          await harness.getLatest().loadAgentSessions("task-1");
+          reusedSessionId = await harness
+            .getLatest()
+            .startAgentSession({ taskId: "task-1", role: "build" });
+        });
+
+        expect(reusedSessionId).toBe("session-1");
+        expect(startCalls).toBe(0);
+      } finally {
+        await harness.unmount();
+
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+
+        OpencodeSdkAdapter.prototype.startSession = originalStartSession;
+        OpencodeSdkAdapter.prototype.loadSessionHistory = originalLoadSessionHistory;
+        OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+        OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+      }
+    });
+  });
 });

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
@@ -5,6 +5,7 @@ import type {
   AgentRole,
   AgentScenario,
 } from "@openducktor/core";
+import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
@@ -62,6 +63,23 @@ type UseAgentOrchestratorOperationsResult = {
   answerAgentQuestion: (sessionId: string, requestId: string, answers: string[][]) => Promise<void>;
 };
 
+type OrchestratorRefs = {
+  sessionsRef: MutableRefObject<Record<string, AgentSessionState>>;
+  taskRef: MutableRefObject<TaskCard[]>;
+  runsRef: MutableRefObject<RunSummary[]>;
+  previousRepoRef: MutableRefObject<string | null>;
+  repoEpochRef: MutableRefObject<number>;
+  inFlightStartsByRepoTaskRef: MutableRefObject<Map<string, Promise<string>>>;
+  unsubscribersRef: MutableRefObject<Map<string, () => void>>;
+  draftRawBySessionRef: MutableRefObject<Record<string, string>>;
+  draftSourceBySessionRef: MutableRefObject<Record<string, "delta" | "part">>;
+  turnStartedAtBySessionRef: MutableRefObject<Record<string, number>>;
+};
+
+const createMutableRef = <T>(value: T): MutableRefObject<T> => ({
+  current: value,
+});
+
 export function useAgentOrchestratorOperations({
   activeRepo,
   tasks,
@@ -70,46 +88,42 @@ export function useAgentOrchestratorOperations({
   agentEngine,
 }: UseAgentOrchestratorOperationsArgs): UseAgentOrchestratorOperationsResult {
   const [sessionsById, setSessionsById] = useState<Record<string, AgentSessionState>>({});
-  const sessionsRef = useRef<Record<string, AgentSessionState>>({});
-  const taskRef = useRef<TaskCard[]>(tasks);
-  const runsRef = useRef(runs);
-  const previousRepoRef = useRef<string | null>(null);
-  const repoEpochRef = useRef(0);
-  const inFlightStartsByRepoTaskRef = useRef<Map<string, Promise<string>>>(new Map());
-  const unsubscribersRef = useRef<Map<string, () => void>>(new Map());
-  const draftRawBySessionRef = useRef<Record<string, string>>({});
-  const draftSourceBySessionRef = useRef<Record<string, "delta" | "part">>({});
-  const turnStartedAtBySessionRef = useRef<Record<string, number>>({});
+  const orchestratorRefs = useRef<OrchestratorRefs>({
+    sessionsRef: createMutableRef<Record<string, AgentSessionState>>({}),
+    taskRef: createMutableRef<TaskCard[]>(tasks),
+    runsRef: createMutableRef<RunSummary[]>(runs),
+    previousRepoRef: createMutableRef<string | null>(null),
+    repoEpochRef: createMutableRef(0),
+    inFlightStartsByRepoTaskRef: createMutableRef(new Map<string, Promise<string>>()),
+    unsubscribersRef: createMutableRef(new Map<string, () => void>()),
+    draftRawBySessionRef: createMutableRef<Record<string, string>>({}),
+    draftSourceBySessionRef: createMutableRef<Record<string, "delta" | "part">>({}),
+    turnStartedAtBySessionRef: createMutableRef<Record<string, number>>({}),
+  });
 
   useEffect(() => {
-    sessionsRef.current = sessionsById;
-  }, [sessionsById]);
+    orchestratorRefs.current.sessionsRef.current = sessionsById;
+    orchestratorRefs.current.taskRef.current = tasks;
+    orchestratorRefs.current.runsRef.current = runs;
+  }, [runs, sessionsById, tasks]);
 
   useEffect(() => {
-    taskRef.current = tasks;
-  }, [tasks]);
-
-  useEffect(() => {
-    runsRef.current = runs;
-  }, [runs]);
-
-  useEffect(() => {
-    if (previousRepoRef.current === activeRepo) {
+    if (orchestratorRefs.current.previousRepoRef.current === activeRepo) {
       return;
     }
-    repoEpochRef.current += 1;
-    previousRepoRef.current = activeRepo;
+    orchestratorRefs.current.repoEpochRef.current += 1;
+    orchestratorRefs.current.previousRepoRef.current = activeRepo;
 
-    const unsubs = [...unsubscribersRef.current.values()];
+    const unsubs = [...orchestratorRefs.current.unsubscribersRef.current.values()];
     for (const unsubscribe of unsubs) {
       unsubscribe();
     }
-    unsubscribersRef.current.clear();
-    draftRawBySessionRef.current = {};
-    draftSourceBySessionRef.current = {};
-    turnStartedAtBySessionRef.current = {};
-    inFlightStartsByRepoTaskRef.current.clear();
-    sessionsRef.current = {};
+    orchestratorRefs.current.unsubscribersRef.current.clear();
+    orchestratorRefs.current.draftRawBySessionRef.current = {};
+    orchestratorRefs.current.draftSourceBySessionRef.current = {};
+    orchestratorRefs.current.turnStartedAtBySessionRef.current = {};
+    orchestratorRefs.current.inFlightStartsByRepoTaskRef.current.clear();
+    orchestratorRefs.current.sessionsRef.current = {};
     setSessionsById({});
   }, [activeRepo]);
 
@@ -134,7 +148,7 @@ export function useAgentOrchestratorOperations({
       updater: (current: AgentSessionState) => AgentSessionState,
       options?: { persist?: boolean },
     ): void => {
-      const currentSessions = sessionsRef.current;
+      const currentSessions = orchestratorRefs.current.sessionsRef.current;
       const current = currentSessions[sessionId];
       if (!current) {
         return;
@@ -160,7 +174,7 @@ export function useAgentOrchestratorOperations({
         ...currentSessions,
         [sessionId]: nextSession,
       };
-      sessionsRef.current = nextSessions;
+      orchestratorRefs.current.sessionsRef.current = nextSessions;
       setSessionsById(nextSessions);
 
       if (options?.persist !== false) {
@@ -190,7 +204,7 @@ export function useAgentOrchestratorOperations({
       const parsedTimestamp = Date.parse(timestamp);
       const endedAt = Number.isNaN(parsedTimestamp) ? Date.now() : parsedTimestamp;
 
-      const startedAt = turnStartedAtBySessionRef.current[sessionId];
+      const startedAt = orchestratorRefs.current.turnStartedAtBySessionRef.current[sessionId];
       if (typeof startedAt === "number" && endedAt >= startedAt) {
         return Math.max(0, endedAt - startedAt);
       }
@@ -209,7 +223,7 @@ export function useAgentOrchestratorOperations({
   );
 
   const clearTurnDuration = useCallback((sessionId: string): void => {
-    delete turnStartedAtBySessionRef.current[sessionId];
+    delete orchestratorRefs.current.turnStartedAtBySessionRef.current[sessionId];
   }, []);
 
   const loadSessionModelCatalog = useCallback(
@@ -289,11 +303,11 @@ export function useAgentOrchestratorOperations({
       createLoadAgentSessions({
         activeRepo,
         adapter: agentEngine,
-        repoEpochRef,
-        previousRepoRef,
-        sessionsRef,
+        repoEpochRef: orchestratorRefs.current.repoEpochRef,
+        previousRepoRef: orchestratorRefs.current.previousRepoRef,
+        sessionsRef: orchestratorRefs.current.sessionsRef,
         setSessionsById,
-        taskRef,
+        taskRef: orchestratorRefs.current.taskRef,
         updateSession,
         loadSessionTodos,
         loadSessionModelCatalog,
@@ -307,10 +321,10 @@ export function useAgentOrchestratorOperations({
         adapter: agentEngine,
         repoPath,
         sessionId,
-        sessionsRef,
-        draftRawBySessionRef,
-        draftSourceBySessionRef,
-        turnStartedAtBySessionRef,
+        sessionsRef: orchestratorRefs.current.sessionsRef,
+        draftRawBySessionRef: orchestratorRefs.current.draftRawBySessionRef,
+        draftSourceBySessionRef: orchestratorRefs.current.draftSourceBySessionRef,
+        turnStartedAtBySessionRef: orchestratorRefs.current.turnStartedAtBySessionRef,
         updateSession,
         resolveTurnDurationMs,
         clearTurnDuration,
@@ -318,7 +332,7 @@ export function useAgentOrchestratorOperations({
         loadSessionTodos,
       });
 
-      unsubscribersRef.current.set(sessionId, unsubscribe);
+      orchestratorRefs.current.unsubscribersRef.current.set(sessionId, unsubscribe);
     },
     [
       agentEngine,
@@ -333,7 +347,7 @@ export function useAgentOrchestratorOperations({
   const ensureRuntime = useMemo(
     () =>
       createEnsureRuntime({
-        runsRef,
+        runsRef: orchestratorRefs.current.runsRef,
         refreshTaskData,
       }),
     [refreshTaskData],
@@ -345,13 +359,13 @@ export function useAgentOrchestratorOperations({
         activeRepo,
         adapter: agentEngine,
         setSessionsById,
-        sessionsRef,
-        taskRef,
-        repoEpochRef,
-        previousRepoRef,
-        inFlightStartsByRepoTaskRef,
-        unsubscribersRef,
-        turnStartedAtBySessionRef,
+        sessionsRef: orchestratorRefs.current.sessionsRef,
+        taskRef: orchestratorRefs.current.taskRef,
+        repoEpochRef: orchestratorRefs.current.repoEpochRef,
+        previousRepoRef: orchestratorRefs.current.previousRepoRef,
+        inFlightStartsByRepoTaskRef: orchestratorRefs.current.inFlightStartsByRepoTaskRef,
+        unsubscribersRef: orchestratorRefs.current.unsubscribersRef,
+        turnStartedAtBySessionRef: orchestratorRefs.current.turnStartedAtBySessionRef,
         updateSession,
         attachSessionListener,
         ensureRuntime,
@@ -381,12 +395,12 @@ export function useAgentOrchestratorOperations({
 
   useEffect(() => {
     return () => {
-      const unsubs = [...unsubscribersRef.current.values()];
+      const unsubs = [...orchestratorRefs.current.unsubscribersRef.current.values()];
       for (const unsubscribe of unsubs) {
         unsubscribe();
       }
-      unsubscribersRef.current.clear();
-      inFlightStartsByRepoTaskRef.current.clear();
+      orchestratorRefs.current.unsubscribersRef.current.clear();
+      orchestratorRefs.current.inFlightStartsByRepoTaskRef.current.clear();
     };
   }, []);
 

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
@@ -63,7 +63,23 @@ type UseAgentOrchestratorOperationsResult = {
   answerAgentQuestion: (sessionId: string, requestId: string, answers: string[][]) => Promise<void>;
 };
 
-type OrchestratorRefs = {
+type SessionStateById = Record<string, AgentSessionState>;
+type SessionStateUpdater = SessionStateById | ((current: SessionStateById) => SessionStateById);
+
+type OrchestratorMutableState = {
+  sessionsById: SessionStateById;
+  tasks: TaskCard[];
+  runs: RunSummary[];
+  previousRepo: string | null;
+  repoEpoch: number;
+  inFlightStartsByRepoTask: Map<string, Promise<string>>;
+  unsubscribersBySession: Map<string, () => void>;
+  draftRawBySession: Record<string, string>;
+  draftSourceBySession: Record<string, "delta" | "part">;
+  turnStartedAtBySession: Record<string, number>;
+};
+
+type OrchestratorRefBridges = {
   sessionsRef: MutableRefObject<Record<string, AgentSessionState>>;
   taskRef: MutableRefObject<TaskCard[]>;
   runsRef: MutableRefObject<RunSummary[]>;
@@ -76,9 +92,18 @@ type OrchestratorRefs = {
   turnStartedAtBySessionRef: MutableRefObject<Record<string, number>>;
 };
 
-const createMutableRef = <T>(value: T): MutableRefObject<T> => ({
-  current: value,
-});
+const createMutableBridge = <K extends keyof OrchestratorMutableState>(
+  stateRef: MutableRefObject<OrchestratorMutableState>,
+  key: K,
+): MutableRefObject<OrchestratorMutableState[K]> =>
+  ({
+    get current() {
+      return stateRef.current[key];
+    },
+    set current(value: OrchestratorMutableState[K]) {
+      stateRef.current[key] = value;
+    },
+  }) as MutableRefObject<OrchestratorMutableState[K]>;
 
 export function useAgentOrchestratorOperations({
   activeRepo,
@@ -87,45 +112,65 @@ export function useAgentOrchestratorOperations({
   refreshTaskData,
   agentEngine,
 }: UseAgentOrchestratorOperationsArgs): UseAgentOrchestratorOperationsResult {
-  const [sessionsById, setSessionsById] = useState<Record<string, AgentSessionState>>({});
-  const orchestratorRefs = useRef<OrchestratorRefs>({
-    sessionsRef: createMutableRef<Record<string, AgentSessionState>>({}),
-    taskRef: createMutableRef<TaskCard[]>(tasks),
-    runsRef: createMutableRef<RunSummary[]>(runs),
-    previousRepoRef: createMutableRef<string | null>(null),
-    repoEpochRef: createMutableRef(0),
-    inFlightStartsByRepoTaskRef: createMutableRef(new Map<string, Promise<string>>()),
-    unsubscribersRef: createMutableRef(new Map<string, () => void>()),
-    draftRawBySessionRef: createMutableRef<Record<string, string>>({}),
-    draftSourceBySessionRef: createMutableRef<Record<string, "delta" | "part">>({}),
-    turnStartedAtBySessionRef: createMutableRef<Record<string, number>>({}),
+  const [sessionsById, setSessionsById] = useState<SessionStateById>({});
+  const mutableStateRef = useRef<OrchestratorMutableState>({
+    sessionsById: {},
+    tasks,
+    runs,
+    previousRepo: null,
+    repoEpoch: 0,
+    inFlightStartsByRepoTask: new Map<string, Promise<string>>(),
+    unsubscribersBySession: new Map<string, () => void>(),
+    draftRawBySession: {},
+    draftSourceBySession: {},
+    turnStartedAtBySession: {},
   });
+  const refBridges = useMemo<OrchestratorRefBridges>(
+    () => ({
+      sessionsRef: createMutableBridge(mutableStateRef, "sessionsById"),
+      taskRef: createMutableBridge(mutableStateRef, "tasks"),
+      runsRef: createMutableBridge(mutableStateRef, "runs"),
+      previousRepoRef: createMutableBridge(mutableStateRef, "previousRepo"),
+      repoEpochRef: createMutableBridge(mutableStateRef, "repoEpoch"),
+      inFlightStartsByRepoTaskRef: createMutableBridge(mutableStateRef, "inFlightStartsByRepoTask"),
+      unsubscribersRef: createMutableBridge(mutableStateRef, "unsubscribersBySession"),
+      draftRawBySessionRef: createMutableBridge(mutableStateRef, "draftRawBySession"),
+      draftSourceBySessionRef: createMutableBridge(mutableStateRef, "draftSourceBySession"),
+      turnStartedAtBySessionRef: createMutableBridge(mutableStateRef, "turnStartedAtBySession"),
+    }),
+    [],
+  );
+
+  const commitSessions = useCallback((updater: SessionStateUpdater): void => {
+    const current = mutableStateRef.current.sessionsById;
+    const next = typeof updater === "function" ? updater(current) : updater;
+    mutableStateRef.current.sessionsById = next;
+    setSessionsById(next);
+  }, []);
 
   useEffect(() => {
-    orchestratorRefs.current.sessionsRef.current = sessionsById;
-    orchestratorRefs.current.taskRef.current = tasks;
-    orchestratorRefs.current.runsRef.current = runs;
-  }, [runs, sessionsById, tasks]);
+    mutableStateRef.current.tasks = tasks;
+    mutableStateRef.current.runs = runs;
+  }, [runs, tasks]);
 
   useEffect(() => {
-    if (orchestratorRefs.current.previousRepoRef.current === activeRepo) {
+    if (mutableStateRef.current.previousRepo === activeRepo) {
       return;
     }
-    orchestratorRefs.current.repoEpochRef.current += 1;
-    orchestratorRefs.current.previousRepoRef.current = activeRepo;
+    mutableStateRef.current.repoEpoch += 1;
+    mutableStateRef.current.previousRepo = activeRepo;
 
-    const unsubs = [...orchestratorRefs.current.unsubscribersRef.current.values()];
+    const unsubs = [...mutableStateRef.current.unsubscribersBySession.values()];
     for (const unsubscribe of unsubs) {
       unsubscribe();
     }
-    orchestratorRefs.current.unsubscribersRef.current.clear();
-    orchestratorRefs.current.draftRawBySessionRef.current = {};
-    orchestratorRefs.current.draftSourceBySessionRef.current = {};
-    orchestratorRefs.current.turnStartedAtBySessionRef.current = {};
-    orchestratorRefs.current.inFlightStartsByRepoTaskRef.current.clear();
-    orchestratorRefs.current.sessionsRef.current = {};
-    setSessionsById({});
-  }, [activeRepo]);
+    mutableStateRef.current.unsubscribersBySession.clear();
+    mutableStateRef.current.draftRawBySession = {};
+    mutableStateRef.current.draftSourceBySession = {};
+    mutableStateRef.current.turnStartedAtBySession = {};
+    mutableStateRef.current.inFlightStartsByRepoTask.clear();
+    commitSessions({});
+  }, [activeRepo, commitSessions]);
 
   const persistSessionSnapshot = useCallback(
     async (session: AgentSessionState): Promise<void> => {
@@ -148,7 +193,7 @@ export function useAgentOrchestratorOperations({
       updater: (current: AgentSessionState) => AgentSessionState,
       options?: { persist?: boolean },
     ): void => {
-      const currentSessions = orchestratorRefs.current.sessionsRef.current;
+      const currentSessions = mutableStateRef.current.sessionsById;
       const current = currentSessions[sessionId];
       if (!current) {
         return;
@@ -174,8 +219,7 @@ export function useAgentOrchestratorOperations({
         ...currentSessions,
         [sessionId]: nextSession,
       };
-      orchestratorRefs.current.sessionsRef.current = nextSessions;
-      setSessionsById(nextSessions);
+      commitSessions(nextSessions);
 
       if (options?.persist !== false) {
         runOrchestratorSideEffect(
@@ -192,7 +236,7 @@ export function useAgentOrchestratorOperations({
         );
       }
     },
-    [activeRepo, persistSessionSnapshot],
+    [activeRepo, commitSessions, persistSessionSnapshot],
   );
 
   const resolveTurnDurationMs = useCallback(
@@ -204,7 +248,7 @@ export function useAgentOrchestratorOperations({
       const parsedTimestamp = Date.parse(timestamp);
       const endedAt = Number.isNaN(parsedTimestamp) ? Date.now() : parsedTimestamp;
 
-      const startedAt = orchestratorRefs.current.turnStartedAtBySessionRef.current[sessionId];
+      const startedAt = mutableStateRef.current.turnStartedAtBySession[sessionId];
       if (typeof startedAt === "number" && endedAt >= startedAt) {
         return Math.max(0, endedAt - startedAt);
       }
@@ -223,7 +267,7 @@ export function useAgentOrchestratorOperations({
   );
 
   const clearTurnDuration = useCallback((sessionId: string): void => {
-    delete orchestratorRefs.current.turnStartedAtBySessionRef.current[sessionId];
+    delete mutableStateRef.current.turnStartedAtBySession[sessionId];
   }, []);
 
   const loadSessionModelCatalog = useCallback(
@@ -303,16 +347,24 @@ export function useAgentOrchestratorOperations({
       createLoadAgentSessions({
         activeRepo,
         adapter: agentEngine,
-        repoEpochRef: orchestratorRefs.current.repoEpochRef,
-        previousRepoRef: orchestratorRefs.current.previousRepoRef,
-        sessionsRef: orchestratorRefs.current.sessionsRef,
-        setSessionsById,
-        taskRef: orchestratorRefs.current.taskRef,
+        repoEpochRef: refBridges.repoEpochRef,
+        previousRepoRef: refBridges.previousRepoRef,
+        sessionsRef: refBridges.sessionsRef,
+        setSessionsById: commitSessions,
+        taskRef: refBridges.taskRef,
         updateSession,
         loadSessionTodos,
         loadSessionModelCatalog,
       }),
-    [activeRepo, agentEngine, loadSessionModelCatalog, loadSessionTodos, updateSession],
+    [
+      activeRepo,
+      agentEngine,
+      commitSessions,
+      loadSessionModelCatalog,
+      loadSessionTodos,
+      refBridges,
+      updateSession,
+    ],
   );
 
   const attachSessionListener = useCallback(
@@ -321,10 +373,10 @@ export function useAgentOrchestratorOperations({
         adapter: agentEngine,
         repoPath,
         sessionId,
-        sessionsRef: orchestratorRefs.current.sessionsRef,
-        draftRawBySessionRef: orchestratorRefs.current.draftRawBySessionRef,
-        draftSourceBySessionRef: orchestratorRefs.current.draftSourceBySessionRef,
-        turnStartedAtBySessionRef: orchestratorRefs.current.turnStartedAtBySessionRef,
+        sessionsRef: refBridges.sessionsRef,
+        draftRawBySessionRef: refBridges.draftRawBySessionRef,
+        draftSourceBySessionRef: refBridges.draftSourceBySessionRef,
+        turnStartedAtBySessionRef: refBridges.turnStartedAtBySessionRef,
         updateSession,
         resolveTurnDurationMs,
         clearTurnDuration,
@@ -332,12 +384,13 @@ export function useAgentOrchestratorOperations({
         loadSessionTodos,
       });
 
-      orchestratorRefs.current.unsubscribersRef.current.set(sessionId, unsubscribe);
+      mutableStateRef.current.unsubscribersBySession.set(sessionId, unsubscribe);
     },
     [
       agentEngine,
       clearTurnDuration,
       loadSessionTodos,
+      refBridges,
       refreshTaskData,
       resolveTurnDurationMs,
       updateSession,
@@ -347,10 +400,10 @@ export function useAgentOrchestratorOperations({
   const ensureRuntime = useMemo(
     () =>
       createEnsureRuntime({
-        runsRef: orchestratorRefs.current.runsRef,
+        runsRef: refBridges.runsRef,
         refreshTaskData,
       }),
-    [refreshTaskData],
+    [refBridges, refreshTaskData],
   );
 
   const sessionActions = useMemo(
@@ -358,14 +411,14 @@ export function useAgentOrchestratorOperations({
       createAgentSessionActions({
         activeRepo,
         adapter: agentEngine,
-        setSessionsById,
-        sessionsRef: orchestratorRefs.current.sessionsRef,
-        taskRef: orchestratorRefs.current.taskRef,
-        repoEpochRef: orchestratorRefs.current.repoEpochRef,
-        previousRepoRef: orchestratorRefs.current.previousRepoRef,
-        inFlightStartsByRepoTaskRef: orchestratorRefs.current.inFlightStartsByRepoTaskRef,
-        unsubscribersRef: orchestratorRefs.current.unsubscribersRef,
-        turnStartedAtBySessionRef: orchestratorRefs.current.turnStartedAtBySessionRef,
+        setSessionsById: commitSessions,
+        sessionsRef: refBridges.sessionsRef,
+        taskRef: refBridges.taskRef,
+        repoEpochRef: refBridges.repoEpochRef,
+        previousRepoRef: refBridges.previousRepoRef,
+        inFlightStartsByRepoTaskRef: refBridges.inFlightStartsByRepoTaskRef,
+        unsubscribersRef: refBridges.unsubscribersRef,
+        turnStartedAtBySessionRef: refBridges.turnStartedAtBySessionRef,
         updateSession,
         attachSessionListener,
         ensureRuntime,
@@ -383,11 +436,13 @@ export function useAgentOrchestratorOperations({
       agentEngine,
       attachSessionListener,
       clearTurnDuration,
+      commitSessions,
       ensureRuntime,
       loadAgentSessions,
       loadSessionModelCatalog,
       loadSessionTodos,
       persistSessionSnapshot,
+      refBridges,
       refreshTaskData,
       updateSession,
     ],
@@ -395,12 +450,12 @@ export function useAgentOrchestratorOperations({
 
   useEffect(() => {
     return () => {
-      const unsubs = [...orchestratorRefs.current.unsubscribersRef.current.values()];
+      const unsubs = [...mutableStateRef.current.unsubscribersBySession.values()];
       for (const unsubscribe of unsubs) {
         unsubscribe();
       }
-      orchestratorRefs.current.unsubscribersRef.current.clear();
-      orchestratorRefs.current.inFlightStartsByRepoTaskRef.current.clear();
+      mutableStateRef.current.unsubscribersBySession.clear();
+      mutableStateRef.current.inFlightStartsByRepoTask.clear();
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- replace ad-hoc orchestrator `useRef` shadow state wiring with a single mutable orchestrator context in `use-agent-orchestrator-operations`
- introduce a single `commitSessions` mutation path so session map updates stay synchronized between React state and imperative consumers
- remove direct `sessionsRef.current` mutation in `start-session` and `load-sessions`, routing writes through the shared commit path
- add regression tests for prop-sync behavior (`runs`/`tasks`) and load-then-reuse session flow in `use-agent-orchestrator-operations`

## Why
This reduces stale-closure/sync fragility and removes multi-writer divergence risk between `sessionsRef` and React state.

## Validation
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop test src/state/operations/agent-orchestrator/handlers/start-session.test.ts`
- `bun run --filter @openducktor/desktop test src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts`
- `bun run --filter @openducktor/desktop test src/state/operations/use-agent-orchestrator-operations.test.tsx`
- `bun run --filter @openducktor/desktop test`
