### PR TITLE
test(desktop): cover and harden agent studio model selection

### DIFF
--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
@@ -214,13 +214,32 @@ describe("use-agent-studio-model-selection-model", () => {
     });
   });
 
-  test("returns null when latest tokenized assistant message has no usable context window", () => {
+  test("falls back to an older assistant message when the latest tokenized one has no usable context window", () => {
     const lookup = toModelDescriptorByKey(CATALOG);
     const messages: AgentChatMessage[] = [
       createAssistantMessage({
         totalTokens: 12,
         contextWindow: 10_000,
       }),
+      createAssistantMessage({
+        totalTokens: 34,
+      }),
+    ];
+
+    expect(
+      extractLatestContextUsage({
+        messages,
+        modelDescriptorByKey: lookup,
+      }),
+    ).toEqual({
+      totalTokens: 12,
+      contextWindow: 10_000,
+    });
+  });
+
+  test("returns null when no assistant message has a usable context window", () => {
+    const lookup = toModelDescriptorByKey(CATALOG);
+    const messages: AgentChatMessage[] = [
       createAssistantMessage({
         totalTokens: 34,
       }),

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentModelCatalog } from "@openducktor/core";
+import type { AgentChatMessage } from "@/types/agent-orchestrator";
+import {
+  extractLatestContextUsage,
+  resolveDraftSelection,
+  resolveSessionSelection,
+  toModelDescriptorByKey,
+  toRoleDefaultSelection,
+} from "./use-agent-studio-model-selection-model";
+
+const CATALOG: AgentModelCatalog = {
+  models: [
+    {
+      id: "openai/gpt-5",
+      providerId: "openai",
+      providerName: "OpenAI",
+      modelId: "gpt-5",
+      modelName: "GPT-5",
+      variants: ["default", "high"],
+      contextWindow: 200_000,
+      outputLimit: 8_192,
+    },
+    {
+      id: "anthropic/claude-sonnet",
+      providerId: "anthropic",
+      providerName: "Anthropic",
+      modelId: "claude-sonnet",
+      modelName: "Claude Sonnet",
+      variants: [],
+      contextWindow: 100_000,
+    },
+  ],
+  defaultModelsByProvider: {
+    openai: "gpt-5",
+  },
+  agents: [
+    {
+      name: "spec-agent",
+      mode: "primary",
+      hidden: false,
+      color: "#f59e0b",
+    },
+    {
+      name: "hidden-subagent",
+      mode: "subagent",
+      hidden: true,
+    },
+  ],
+};
+
+let messageCounter = 0;
+
+const createAssistantMessage = (
+  overrides: Partial<Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "assistant" }>> = {},
+): AgentChatMessage => {
+  messageCounter += 1;
+  return {
+    id: `message-${messageCounter}`,
+    role: "assistant",
+    content: "",
+    timestamp: "2026-02-20T10:00:00.000Z",
+    meta: {
+      kind: "assistant",
+      agentRole: "spec",
+      ...overrides,
+    },
+  };
+};
+
+describe("use-agent-studio-model-selection-model", () => {
+  test("maps repo role defaults to model selection shape", () => {
+    expect(toRoleDefaultSelection(null)).toBeNull();
+    expect(
+      toRoleDefaultSelection({
+        providerId: "",
+        modelId: "gpt-5",
+        variant: "high",
+        opencodeAgent: "spec-agent",
+      }),
+    ).toBeNull();
+
+    expect(
+      toRoleDefaultSelection({
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "high",
+        opencodeAgent: "spec-agent",
+      }),
+    ).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      opencodeAgent: "spec-agent",
+    });
+  });
+
+  test("resolves draft selection by normalizing existing selection then falling back", () => {
+    expect(
+      resolveDraftSelection({
+        catalog: CATALOG,
+        existingSelection: {
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "missing-variant",
+          opencodeAgent: "hidden-subagent",
+        },
+        roleDefaultSelection: null,
+      }),
+    ).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+    });
+
+    expect(
+      resolveDraftSelection({
+        catalog: CATALOG,
+        existingSelection: null,
+        roleDefaultSelection: {
+          providerId: "anthropic",
+          modelId: "claude-sonnet",
+        },
+      }),
+    ).toEqual({
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+    });
+
+    expect(
+      resolveDraftSelection({
+        catalog: CATALOG,
+        existingSelection: null,
+        roleDefaultSelection: null,
+      }),
+    ).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+      opencodeAgent: "spec-agent",
+    });
+  });
+
+  test("resolves preferred session selection using selected model before defaults", () => {
+    expect(
+      resolveSessionSelection({
+        catalog: CATALOG,
+        selectedModel: {
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "high",
+          opencodeAgent: "spec-agent",
+        },
+        roleDefaultSelection: {
+          providerId: "anthropic",
+          modelId: "claude-sonnet",
+        },
+      }),
+    ).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      opencodeAgent: "spec-agent",
+    });
+
+    expect(
+      resolveSessionSelection({
+        catalog: CATALOG,
+        selectedModel: {
+          providerId: "missing",
+          modelId: "model",
+        },
+        roleDefaultSelection: null,
+      }),
+    ).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+      opencodeAgent: "spec-agent",
+    });
+  });
+
+  test("indexes model descriptors by provider and model id", () => {
+    const lookup = toModelDescriptorByKey(CATALOG);
+    expect(lookup.get("openai::gpt-5")?.id).toBe("openai/gpt-5");
+    expect(lookup.get("anthropic::claude-sonnet")?.id).toBe("anthropic/claude-sonnet");
+    expect(toModelDescriptorByKey(null).size).toBe(0);
+  });
+
+  test("extracts latest assistant context usage with descriptor fallback", () => {
+    const lookup = toModelDescriptorByKey(CATALOG);
+    const messages: AgentChatMessage[] = [
+      createAssistantMessage({
+        totalTokens: 12,
+        contextWindow: 10_000,
+        outputLimit: 500,
+      }),
+      createAssistantMessage({
+        totalTokens: 34,
+        providerId: "openai",
+        modelId: "gpt-5",
+      }),
+    ];
+
+    expect(
+      extractLatestContextUsage({
+        messages,
+        modelDescriptorByKey: lookup,
+      }),
+    ).toEqual({
+      totalTokens: 34,
+      contextWindow: 200_000,
+      outputLimit: 8_192,
+    });
+  });
+
+  test("returns null when latest tokenized assistant message has no usable context window", () => {
+    const lookup = toModelDescriptorByKey(CATALOG);
+    const messages: AgentChatMessage[] = [
+      createAssistantMessage({
+        totalTokens: 12,
+        contextWindow: 10_000,
+      }),
+      createAssistantMessage({
+        totalTokens: 34,
+      }),
+    ];
+
+    expect(
+      extractLatestContextUsage({
+        messages,
+        modelDescriptorByKey: lookup,
+      }),
+    ).toBeNull();
+  });
+
+  test("uses selected model context window as final fallback", () => {
+    const lookup = toModelDescriptorByKey(CATALOG);
+    const messages: AgentChatMessage[] = [
+      createAssistantMessage({
+        totalTokens: 55,
+      }),
+    ];
+
+    expect(
+      extractLatestContextUsage({
+        messages,
+        modelDescriptorByKey: lookup,
+        fallbackContextWindow: 50_000,
+      }),
+    ).toEqual({
+      totalTokens: 55,
+      contextWindow: 50_000,
+    });
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -1,0 +1,122 @@
+import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
+import type { AgentChatMessage } from "@/types/agent-orchestrator";
+import type { RepoSettingsInput } from "@/types/state-slices";
+import { normalizeSelectionForCatalog, pickDefaultSelectionForCatalog } from "./agents-page-utils";
+
+export type AgentStudioContextUsage = {
+  totalTokens: number;
+  contextWindow: number;
+  outputLimit?: number;
+} | null;
+
+type CatalogModelDescriptor = AgentModelCatalog["models"][number];
+
+export const toRoleDefaultSelection = (
+  roleDefault: RepoSettingsInput["agentDefaults"][AgentRole] | null | undefined,
+): AgentModelSelection | null => {
+  if (!roleDefault || !roleDefault.providerId || !roleDefault.modelId) {
+    return null;
+  }
+  return {
+    providerId: roleDefault.providerId,
+    modelId: roleDefault.modelId,
+    ...(roleDefault.variant ? { variant: roleDefault.variant } : {}),
+    ...(roleDefault.opencodeAgent ? { opencodeAgent: roleDefault.opencodeAgent } : {}),
+  };
+};
+
+export const resolveDraftSelection = ({
+  catalog,
+  existingSelection,
+  roleDefaultSelection,
+}: {
+  catalog: AgentModelCatalog | null;
+  existingSelection: AgentModelSelection | null;
+  roleDefaultSelection: AgentModelSelection | null;
+}): AgentModelSelection | null => {
+  const preferredBase =
+    existingSelection ?? roleDefaultSelection ?? pickDefaultSelectionForCatalog(catalog);
+  return (
+    normalizeSelectionForCatalog(catalog, preferredBase) ?? pickDefaultSelectionForCatalog(catalog)
+  );
+};
+
+export const resolveSessionSelection = ({
+  catalog,
+  selectedModel,
+  roleDefaultSelection,
+}: {
+  catalog: AgentModelCatalog | null;
+  selectedModel: AgentModelSelection | null;
+  roleDefaultSelection: AgentModelSelection | null;
+}): AgentModelSelection | null => {
+  const preferredBase =
+    selectedModel ?? roleDefaultSelection ?? pickDefaultSelectionForCatalog(catalog);
+  return (
+    normalizeSelectionForCatalog(catalog, preferredBase) ?? pickDefaultSelectionForCatalog(catalog)
+  );
+};
+
+export const toModelDescriptorKey = (providerId: string, modelId: string): string => {
+  return `${providerId}::${modelId}`;
+};
+
+export const toModelDescriptorByKey = (
+  catalog: AgentModelCatalog | null,
+): Map<string, CatalogModelDescriptor> => {
+  const map = new Map<string, CatalogModelDescriptor>();
+  if (!catalog) {
+    return map;
+  }
+  for (const descriptor of catalog.models) {
+    map.set(toModelDescriptorKey(descriptor.providerId, descriptor.modelId), descriptor);
+  }
+  return map;
+};
+
+export const extractLatestContextUsage = ({
+  messages,
+  modelDescriptorByKey,
+  fallbackContextWindow,
+}: {
+  messages: AgentChatMessage[] | null | undefined;
+  modelDescriptorByKey: ReadonlyMap<string, CatalogModelDescriptor>;
+  fallbackContextWindow?: number;
+}): AgentStudioContextUsage => {
+  if (!messages) {
+    return null;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || message.role !== "assistant" || message.meta?.kind !== "assistant") {
+      continue;
+    }
+
+    const totalTokens = message.meta.totalTokens;
+    if (typeof totalTokens !== "number" || totalTokens <= 0) {
+      continue;
+    }
+
+    const metaProviderId = message.meta.providerId;
+    const metaModelId = message.meta.modelId;
+    const modelDescriptor =
+      typeof metaProviderId === "string" && typeof metaModelId === "string"
+        ? modelDescriptorByKey.get(toModelDescriptorKey(metaProviderId, metaModelId))
+        : undefined;
+    const contextWindow =
+      message.meta.contextWindow ?? modelDescriptor?.contextWindow ?? fallbackContextWindow;
+    if (typeof contextWindow !== "number" || contextWindow <= 0) {
+      return null;
+    }
+    const outputLimit = message.meta.outputLimit ?? modelDescriptor?.outputLimit;
+
+    return {
+      totalTokens,
+      contextWindow,
+      ...(typeof outputLimit === "number" ? { outputLimit } : {}),
+    };
+  }
+
+  return null;
+};

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -123,7 +123,7 @@ export const extractLatestContextUsage = ({
     const contextWindow =
       message.meta.contextWindow ?? modelDescriptor?.contextWindow ?? fallbackContextWindow;
     if (typeof contextWindow !== "number" || contextWindow <= 0) {
-      return null;
+      continue;
     }
     const outputLimit = message.meta.outputLimit ?? modelDescriptor?.outputLimit;
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -25,6 +25,22 @@ export const toRoleDefaultSelection = (
   };
 };
 
+const resolvePreferredSelectionForCatalog = ({
+  catalog,
+  primarySelection,
+  secondarySelection,
+}: {
+  catalog: AgentModelCatalog | null;
+  primarySelection: AgentModelSelection | null;
+  secondarySelection: AgentModelSelection | null;
+}): AgentModelSelection | null => {
+  const preferredBase =
+    primarySelection ?? secondarySelection ?? pickDefaultSelectionForCatalog(catalog);
+  return (
+    normalizeSelectionForCatalog(catalog, preferredBase) ?? pickDefaultSelectionForCatalog(catalog)
+  );
+};
+
 export const resolveDraftSelection = ({
   catalog,
   existingSelection,
@@ -34,11 +50,11 @@ export const resolveDraftSelection = ({
   existingSelection: AgentModelSelection | null;
   roleDefaultSelection: AgentModelSelection | null;
 }): AgentModelSelection | null => {
-  const preferredBase =
-    existingSelection ?? roleDefaultSelection ?? pickDefaultSelectionForCatalog(catalog);
-  return (
-    normalizeSelectionForCatalog(catalog, preferredBase) ?? pickDefaultSelectionForCatalog(catalog)
-  );
+  return resolvePreferredSelectionForCatalog({
+    catalog,
+    primarySelection: existingSelection,
+    secondarySelection: roleDefaultSelection,
+  });
 };
 
 export const resolveSessionSelection = ({
@@ -50,11 +66,11 @@ export const resolveSessionSelection = ({
   selectedModel: AgentModelSelection | null;
   roleDefaultSelection: AgentModelSelection | null;
 }): AgentModelSelection | null => {
-  const preferredBase =
-    selectedModel ?? roleDefaultSelection ?? pickDefaultSelectionForCatalog(catalog);
-  return (
-    normalizeSelectionForCatalog(catalog, preferredBase) ?? pickDefaultSelectionForCatalog(catalog)
-  );
+  return resolvePreferredSelectionForCatalog({
+    catalog,
+    primarySelection: selectedModel,
+    secondarySelection: roleDefaultSelection,
+  });
 };
 
 export const toModelDescriptorKey = (providerId: string, modelId: string): string => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -55,6 +55,31 @@ const CATALOG: AgentModelCatalog = {
   ],
 };
 
+const ALTERNATE_CATALOG: AgentModelCatalog = {
+  models: [
+    {
+      id: "anthropic/claude-opus",
+      providerId: "anthropic",
+      providerName: "Anthropic",
+      modelId: "claude-opus",
+      modelName: "Claude Opus",
+      variants: ["extended"],
+      contextWindow: 300_000,
+    },
+  ],
+  defaultModelsByProvider: {
+    anthropic: "claude-opus",
+  },
+  agents: [
+    {
+      name: "planner-agent",
+      mode: "primary",
+      hidden: false,
+      color: "#0ea5e9",
+    },
+  ],
+};
+
 const createRepoSettings = (
   specDefault: RepoSettingsInput["agentDefaults"]["spec"] | null,
 ): RepoSettingsInput => ({
@@ -263,5 +288,72 @@ describe("useAgentStudioModelSelection", () => {
     await harness.waitFor((state) => state.isSelectionCatalogLoading === false);
 
     await harness.unmount();
+  });
+
+  test("invalidates composer catalog and ignores stale repo loads when active repo changes", async () => {
+    const repoALoad = createDeferred<AgentModelCatalog>();
+    const repoBLoad = createDeferred<AgentModelCatalog>();
+    const loadCatalog = mock((repoPath: string): Promise<AgentModelCatalog> => {
+      if (repoPath === "/repo-a") {
+        return repoALoad.promise;
+      }
+      if (repoPath === "/repo-b") {
+        return repoBLoad.promise;
+      }
+      return Promise.reject(new Error(`Unexpected repo path: ${repoPath}`));
+    });
+
+    const harness = createHookHarness(
+      createBaseProps({
+        activeRepo: "/repo-a",
+        loadCatalog,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().isSelectionCatalogLoading).toBe(true);
+
+      await harness.update(
+        createBaseProps({
+          activeRepo: "/repo-b",
+          loadCatalog,
+        }),
+      );
+
+      expect(loadCatalog).toHaveBeenCalledTimes(2);
+      expect(loadCatalog.mock.calls[0]).toEqual(["/repo-a"]);
+      expect(loadCatalog.mock.calls[1]).toEqual(["/repo-b"]);
+
+      await harness.run(async () => {
+        repoALoad.resolve(CATALOG);
+        await repoALoad.promise;
+      });
+
+      expect(harness.getLatest().isSelectionCatalogLoading).toBe(true);
+      expect(harness.getLatest().selectedModelSelection).toBeNull();
+
+      await harness.run(async () => {
+        repoBLoad.resolve(ALTERNATE_CATALOG);
+        await repoBLoad.promise;
+      });
+      await harness.waitFor(
+        (state) =>
+          state.isSelectionCatalogLoading === false &&
+          state.selectedModelSelection?.modelId === "claude-opus",
+      );
+
+      const state = harness.getLatest();
+      expect(state.selectedModelSelection).toEqual({
+        providerId: "anthropic",
+        modelId: "claude-opus",
+        variant: "extended",
+        opencodeAgent: "planner-agent",
+      });
+    } finally {
+      repoALoad.resolve(CATALOG);
+      repoBLoad.resolve(ALTERNATE_CATALOG);
+      await harness.unmount();
+    }
   });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AgentModelCatalog } from "@openducktor/core";
+import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
   createAgentSessionFixture,
@@ -13,6 +14,7 @@ enableReactActEnvironment();
 
 const TEST_RENDERER_DEPRECATION_WARNING = "react-test-renderer is deprecated";
 const originalConsoleError = console.error;
+let messageCounter = 0;
 
 type HookArgs = Parameters<typeof useAgentStudioModelSelection>[0];
 
@@ -110,6 +112,23 @@ const createActiveSession = (overrides = {}) =>
 
 const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useAgentStudioModelSelection, initialProps);
+
+const createAssistantMessage = (
+  overrides: Partial<Extract<NonNullable<AgentChatMessage["meta"]>, { kind: "assistant" }>> = {},
+): AgentChatMessage => {
+  messageCounter += 1;
+  return {
+    id: `assistant-message-${messageCounter}`,
+    role: "assistant",
+    content: "",
+    timestamp: "2026-02-20T10:00:00.000Z",
+    meta: {
+      kind: "assistant",
+      agentRole: "spec",
+      ...overrides,
+    },
+  };
+};
 
 const createBaseProps = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   activeRepo: "/repo",
@@ -353,6 +372,157 @@ describe("useAgentStudioModelSelection", () => {
     } finally {
       repoALoad.resolve(CATALOG);
       repoBLoad.resolve(ALTERNATE_CATALOG);
+      await harness.unmount();
+    }
+  });
+
+  test("uses defaults from the newly selected repository after switching repos", async () => {
+    const loadCatalog = mock(async (repoPath: string): Promise<AgentModelCatalog> => {
+      if (repoPath === "/repo-a") {
+        return CATALOG;
+      }
+      if (repoPath === "/repo-b") {
+        return ALTERNATE_CATALOG;
+      }
+      throw new Error(`Unexpected repo path: ${repoPath}`);
+    });
+
+    const harness = createHookHarness(
+      createBaseProps({
+        activeRepo: "/repo-a",
+        repoSettings: createRepoSettings({
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "high",
+          opencodeAgent: "build-agent",
+        }),
+        loadCatalog,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (state) =>
+          state.selectedModelSelection?.modelId === "gpt-5" &&
+          state.selectedModelSelection.variant === "high",
+      );
+
+      await harness.run(() => {
+        harness.getLatest().handleSelectModel("anthropic/claude-sonnet");
+      });
+      await harness.waitFor((state) => state.selectedModelSelection?.modelId === "claude-sonnet");
+
+      await harness.update(
+        createBaseProps({
+          activeRepo: "/repo-b",
+          repoSettings: createRepoSettings({
+            providerId: "anthropic",
+            modelId: "claude-opus",
+            variant: "extended",
+            opencodeAgent: "planner-agent",
+          }),
+          loadCatalog,
+        }),
+      );
+
+      await harness.waitFor((state) => state.selectedModelSelection?.modelId === "claude-opus");
+
+      expect(harness.getLatest().selectedModelSelection).toEqual({
+        providerId: "anthropic",
+        modelId: "claude-opus",
+        variant: "extended",
+        opencodeAgent: "planner-agent",
+      });
+      expect(harness.getLatest().selectionForNewSession).toEqual({
+        providerId: "anthropic",
+        modelId: "claude-opus",
+        variant: "extended",
+        opencodeAgent: "planner-agent",
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("derives context usage from latest assistant message with descriptor fallback", async () => {
+    const activeSession = createActiveSession({
+      messages: [
+        createAssistantMessage({
+          totalTokens: 12,
+          contextWindow: 40_000,
+          outputLimit: 1000,
+        }),
+        createAssistantMessage({
+          totalTokens: 24,
+          providerId: "openai",
+          modelId: "gpt-5",
+        }),
+      ],
+    });
+
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().activeSessionContextUsage).toEqual({
+        totalTokens: 24,
+        contextWindow: 200_000,
+        outputLimit: 8_192,
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("falls back to the selected model context window when message + descriptor metadata are missing", async () => {
+    const primaryModel = CATALOG.models[0];
+    const secondaryModel = CATALOG.models[1];
+    if (!primaryModel || !secondaryModel) {
+      throw new Error("Expected catalog fixture models");
+    }
+    const catalogWithContextFallback: AgentModelCatalog = {
+      ...CATALOG,
+      models: [
+        {
+          ...primaryModel,
+        },
+        {
+          ...secondaryModel,
+          contextWindow: 100_000,
+        },
+      ],
+    };
+    const activeSession = createActiveSession({
+      modelCatalog: catalogWithContextFallback,
+      selectedModel: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet",
+      },
+      messages: [
+        createAssistantMessage({
+          totalTokens: 33,
+        }),
+      ],
+    });
+
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().activeSessionContextUsage).toEqual({
+        totalTokens: 33,
+        contextWindow: 100_000,
+      });
+    } finally {
       await harness.unmount();
     }
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -180,6 +180,42 @@ describe("useAgentStudioModelSelection", () => {
     await harness.unmount();
   });
 
+  test("keeps repo defaults selectable when composer catalog is unavailable", async () => {
+    const harness = createHookHarness(
+      createBaseProps({
+        repoSettings: createRepoSettings({
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "high",
+          opencodeAgent: "build-agent",
+        }),
+        loadCatalog: async () => {
+          throw new Error("catalog unavailable");
+        },
+      }),
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.isSelectionCatalogLoading === false);
+
+      expect(harness.getLatest().selectedModelSelection).toEqual({
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "high",
+        opencodeAgent: "build-agent",
+      });
+      expect(harness.getLatest().selectionForNewSession).toEqual({
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "high",
+        opencodeAgent: "build-agent",
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("publishes agent colors from composer catalog before a session is started", async () => {
     const harness = createHookHarness(createBaseProps());
 
@@ -445,6 +481,79 @@ describe("useAgentStudioModelSelection", () => {
     }
   });
 
+  test("does not reuse stale repo defaults while waiting for the next repo settings", async () => {
+    const harness = createHookHarness(
+      createBaseProps({
+        activeRepo: "/repo-a",
+        repoSettings: createRepoSettings({
+          providerId: "openai",
+          modelId: "gpt-5",
+          variant: "high",
+          opencodeAgent: "build-agent",
+        }),
+        loadCatalog: async () => {
+          throw new Error("catalog unavailable");
+        },
+      }),
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (state) =>
+          state.isSelectionCatalogLoading === false &&
+          state.selectedModelSelection?.modelId === "gpt-5",
+      );
+
+      await harness.update(
+        createBaseProps({
+          activeRepo: "/repo-b",
+          repoSettings: createRepoSettings({
+            providerId: "openai",
+            modelId: "gpt-5",
+            variant: "high",
+            opencodeAgent: "build-agent",
+          }),
+          loadCatalog: async () => {
+            throw new Error("catalog unavailable");
+          },
+        }),
+      );
+
+      await harness.waitFor(
+        (state) =>
+          state.isSelectionCatalogLoading === false &&
+          state.selectedModelSelection === null &&
+          state.selectionForNewSession === null,
+      );
+
+      await harness.update(
+        createBaseProps({
+          activeRepo: "/repo-b",
+          repoSettings: createRepoSettings({
+            providerId: "anthropic",
+            modelId: "claude-opus",
+            variant: "extended",
+            opencodeAgent: "planner-agent",
+          }),
+          loadCatalog: async () => {
+            throw new Error("catalog unavailable");
+          },
+        }),
+      );
+
+      await harness.waitFor((state) => state.selectedModelSelection?.modelId === "claude-opus");
+      expect(harness.getLatest().selectionForNewSession).toEqual({
+        providerId: "anthropic",
+        modelId: "claude-opus",
+        variant: "extended",
+        opencodeAgent: "planner-agent",
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("derives context usage from latest assistant message with descriptor fallback", async () => {
     const activeSession = createActiveSession({
       messages: [
@@ -521,6 +630,40 @@ describe("useAgentStudioModelSelection", () => {
       expect(harness.getLatest().activeSessionContextUsage).toEqual({
         totalTokens: 33,
         contextWindow: 100_000,
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("uses an older assistant message for context usage when the latest tokenized one is incomplete", async () => {
+    const activeSession = createActiveSession({
+      selectedModel: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet",
+      },
+      messages: [
+        createAssistantMessage({
+          totalTokens: 11,
+          contextWindow: 25_000,
+        }),
+        createAssistantMessage({
+          totalTokens: 22,
+        }),
+      ],
+    });
+
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().activeSessionContextUsage).toEqual({
+        totalTokens: 11,
+        contextWindow: 25_000,
       });
     } finally {
       await harness.unmount();

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -16,6 +16,14 @@ import {
   normalizeSelectionForCatalog,
   pickDefaultSelectionForCatalog,
 } from "./agents-page-utils";
+import {
+  type AgentStudioContextUsage,
+  extractLatestContextUsage,
+  resolveDraftSelection,
+  resolveSessionSelection,
+  toModelDescriptorByKey,
+  toRoleDefaultSelection,
+} from "./use-agent-studio-model-selection-model";
 
 type UseAgentStudioModelSelectionArgs = {
   activeRepo: string | null;
@@ -25,12 +33,6 @@ type UseAgentStudioModelSelectionArgs = {
   updateAgentSessionModel: (sessionId: string, selection: AgentModelSelection | null) => void;
   loadCatalog?: (repoPath: string) => Promise<AgentModelCatalog>;
 };
-
-type AgentStudioContextUsage = {
-  totalTokens: number;
-  contextWindow: number;
-  outputLimit?: number;
-} | null;
 
 export type AgentStudioModelSelectionState = {
   selectionForNewSession: AgentModelSelection | null;
@@ -45,10 +47,6 @@ export type AgentStudioModelSelectionState = {
   handleSelectAgent: (opencodeAgent: string) => void;
   handleSelectModel: (modelKey: string) => void;
   handleSelectVariant: (variant: string) => void;
-};
-
-const toModelDescriptorKey = (providerId: string, modelId: string): string => {
-  return `${providerId}::${modelId}`;
 };
 
 export function useAgentStudioModelSelection({
@@ -96,16 +94,7 @@ export function useAgentStudioModelSelection({
   }, [activeRepo, loadCatalog]);
 
   const roleDefaultSelection = useMemo<AgentModelSelection | null>(() => {
-    const roleDefault = repoSettings?.agentDefaults[role];
-    if (!roleDefault || !roleDefault.providerId || !roleDefault.modelId) {
-      return null;
-    }
-    return {
-      providerId: roleDefault.providerId,
-      modelId: roleDefault.modelId,
-      ...(roleDefault.variant ? { variant: roleDefault.variant } : {}),
-      ...(roleDefault.opencodeAgent ? { opencodeAgent: roleDefault.opencodeAgent } : {}),
-    };
+    return toRoleDefaultSelection(repoSettings?.agentDefaults[role]);
   }, [repoSettings?.agentDefaults, role]);
 
   useEffect(() => {
@@ -114,11 +103,11 @@ export function useAgentStudioModelSelection({
     }
     setDraftSelectionByRole((current) => {
       const existing = current[role];
-      const preferredBase =
-        existing ?? roleDefaultSelection ?? pickDefaultSelectionForCatalog(composerCatalog);
-      const normalized =
-        normalizeSelectionForCatalog(composerCatalog, preferredBase) ??
-        pickDefaultSelectionForCatalog(composerCatalog);
+      const normalized = resolveDraftSelection({
+        catalog: composerCatalog,
+        existingSelection: existing,
+        roleDefaultSelection,
+      });
       if (isSameSelection(existing, normalized)) {
         return current;
       }
@@ -133,13 +122,11 @@ export function useAgentStudioModelSelection({
     if (!activeSession) {
       return;
     }
-    const preferredSelection =
-      normalizeSelectionForCatalog(
-        activeSession.modelCatalog,
-        activeSession.selectedModel ??
-          roleDefaultSelection ??
-          pickDefaultSelectionForCatalog(activeSession.modelCatalog),
-      ) ?? pickDefaultSelectionForCatalog(activeSession.modelCatalog);
+    const preferredSelection = resolveSessionSelection({
+      catalog: activeSession.modelCatalog,
+      selectedModel: activeSession.selectedModel,
+      roleDefaultSelection,
+    });
     if (!preferredSelection || isSameSelection(activeSession.selectedModel, preferredSelection)) {
       return;
     }
@@ -281,56 +268,17 @@ export function useAgentStudioModelSelection({
   const activeSessionMessages = activeSession?.messages;
   const activeSessionModelCatalog = activeSession?.modelCatalog;
   const activeSessionModelDescriptorByKey = useMemo(() => {
-    const map = new Map<string, NonNullable<typeof activeSessionModelCatalog>["models"][number]>();
-    if (!activeSessionModelCatalog) {
-      return map;
-    }
-
-    for (const descriptor of activeSessionModelCatalog.models) {
-      map.set(toModelDescriptorKey(descriptor.providerId, descriptor.modelId), descriptor);
-    }
-
-    return map;
+    return toModelDescriptorByKey(activeSessionModelCatalog ?? null);
   }, [activeSessionModelCatalog]);
 
   const activeSessionContextUsage = useMemo<AgentStudioContextUsage>(() => {
-    if (!activeSessionMessages) {
-      return null;
-    }
-
-    for (let index = activeSessionMessages.length - 1; index >= 0; index -= 1) {
-      const message = activeSessionMessages[index];
-      if (!message || message.role !== "assistant" || message.meta?.kind !== "assistant") {
-        continue;
-      }
-      const totalTokens = message.meta.totalTokens;
-      if (typeof totalTokens !== "number" || totalTokens <= 0) {
-        continue;
-      }
-
-      const metaProviderId = message.meta.providerId;
-      const metaModelId = message.meta.modelId;
-      const modelDescriptor =
-        typeof metaProviderId === "string" && typeof metaModelId === "string"
-          ? activeSessionModelDescriptorByKey.get(toModelDescriptorKey(metaProviderId, metaModelId))
-          : undefined;
-      const contextWindow =
-        message.meta.contextWindow ??
-        modelDescriptor?.contextWindow ??
-        selectedModelEntry?.contextWindow;
-      if (typeof contextWindow !== "number" || contextWindow <= 0) {
-        return null;
-      }
-      const outputLimit = message.meta.outputLimit ?? modelDescriptor?.outputLimit;
-
-      return {
-        totalTokens,
-        contextWindow,
-        ...(typeof outputLimit === "number" ? { outputLimit } : {}),
-      };
-    }
-
-    return null;
+    return extractLatestContextUsage({
+      messages: activeSessionMessages,
+      modelDescriptorByKey: activeSessionModelDescriptorByKey,
+      ...(typeof selectedModelEntry?.contextWindow === "number"
+        ? { fallbackContextWindow: selectedModelEntry.contextWindow }
+        : {}),
+    });
   }, [activeSessionMessages, activeSessionModelDescriptorByKey, selectedModelEntry?.contextWindow]);
 
   const handleSelectAgent = useCallback(

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -1,5 +1,5 @@
 import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   resolveAgentAccentColor,
   toModelGroupsByProvider,
@@ -49,6 +49,13 @@ export type AgentStudioModelSelectionState = {
   handleSelectVariant: (variant: string) => void;
 };
 
+const emptyDraftSelectionTouchedByRole = (): Record<AgentRole, boolean> => ({
+  spec: false,
+  planner: false,
+  build: false,
+  qa: false,
+});
+
 export function useAgentStudioModelSelection({
   activeRepo,
   activeSession,
@@ -57,10 +64,23 @@ export function useAgentStudioModelSelection({
   updateAgentSessionModel,
   loadCatalog = loadRepoOpencodeCatalog,
 }: UseAgentStudioModelSelectionArgs): AgentStudioModelSelectionState {
+  const previousActiveRepoRef = useRef<string | null>(activeRepo);
   const [composerCatalog, setComposerCatalog] = useState<AgentModelCatalog | null>(null);
   const [isLoadingComposerCatalog, setIsLoadingComposerCatalog] = useState(false);
   const [draftSelectionByRole, setDraftSelectionByRole] =
     useState<Record<AgentRole, AgentModelSelection | null>>(emptyDraftSelections);
+  const [draftSelectionTouchedByRole, setDraftSelectionTouchedByRole] = useState<
+    Record<AgentRole, boolean>
+  >(emptyDraftSelectionTouchedByRole);
+
+  useEffect(() => {
+    if (previousActiveRepoRef.current === activeRepo) {
+      return;
+    }
+    previousActiveRepoRef.current = activeRepo;
+    setDraftSelectionByRole(emptyDraftSelections());
+    setDraftSelectionTouchedByRole(emptyDraftSelectionTouchedByRole());
+  }, [activeRepo]);
 
   useEffect(() => {
     if (!activeRepo) {
@@ -96,16 +116,38 @@ export function useAgentStudioModelSelection({
   const roleDefaultSelection = useMemo<AgentModelSelection | null>(() => {
     return toRoleDefaultSelection(repoSettings?.agentDefaults[role]);
   }, [repoSettings?.agentDefaults, role]);
+  const isDraftSelectionTouched = draftSelectionTouchedByRole[role];
 
   useEffect(() => {
     if (activeSession) {
+      return;
+    }
+    if (!composerCatalog) {
+      setDraftSelectionByRole((current) => {
+        if (current[role] === null) {
+          return current;
+        }
+        return {
+          ...current,
+          [role]: null,
+        };
+      });
+      setDraftSelectionTouchedByRole((current) => {
+        if (!current[role]) {
+          return current;
+        }
+        return {
+          ...current,
+          [role]: false,
+        };
+      });
       return;
     }
     setDraftSelectionByRole((current) => {
       const existing = current[role];
       const normalized = resolveDraftSelection({
         catalog: composerCatalog,
-        existingSelection: existing,
+        existingSelection: isDraftSelectionTouched ? existing : null,
         roleDefaultSelection,
       });
       if (isSameSelection(existing, normalized)) {
@@ -116,7 +158,7 @@ export function useAgentStudioModelSelection({
         [role]: normalized,
       };
     });
-  }, [activeSession, composerCatalog, role, roleDefaultSelection]);
+  }, [activeSession, composerCatalog, isDraftSelectionTouched, role, roleDefaultSelection]);
 
   useEffect(() => {
     if (!activeSession) {
@@ -134,6 +176,15 @@ export function useAgentStudioModelSelection({
   }, [activeSession, roleDefaultSelection, updateAgentSessionModel]);
 
   const draftSelection = draftSelectionByRole[role];
+  const roleDefaultSelectionForComposer = useMemo<AgentModelSelection | null>(() => {
+    if (activeSession) {
+      return roleDefaultSelection;
+    }
+    if (!composerCatalog) {
+      return null;
+    }
+    return normalizeSelectionForCatalog(composerCatalog, roleDefaultSelection);
+  }, [activeSession, composerCatalog, roleDefaultSelection]);
   const selectionCatalog = activeSession?.modelCatalog ?? composerCatalog;
   const isSelectionCatalogLoading = activeSession
     ? activeSession.isLoadingModelCatalog && !activeSession.modelCatalog && !composerCatalog
@@ -146,10 +197,15 @@ export function useAgentStudioModelSelection({
     () =>
       activeSession?.selectedModel ??
       draftSelection ??
-      roleDefaultSelection ??
+      roleDefaultSelectionForComposer ??
       fallbackCatalogSelection ??
       null,
-    [activeSession?.selectedModel, draftSelection, fallbackCatalogSelection, roleDefaultSelection],
+    [
+      activeSession?.selectedModel,
+      draftSelection,
+      fallbackCatalogSelection,
+      roleDefaultSelectionForComposer,
+    ],
   );
 
   const applySelection = useCallback(
@@ -162,6 +218,10 @@ export function useAgentStudioModelSelection({
         ...current,
         [role]: selection,
       }));
+      setDraftSelectionTouchedByRole((current) => ({
+        ...current,
+        [role]: true,
+      }));
     },
     [activeSession, role, updateAgentSessionModel],
   );
@@ -169,11 +229,11 @@ export function useAgentStudioModelSelection({
   const selectionForNewSession = useMemo(
     () =>
       draftSelection ??
-      roleDefaultSelection ??
+      roleDefaultSelectionForComposer ??
       normalizeSelectionForCatalog(selectionCatalog, fallbackCatalogSelection) ??
       fallbackCatalogSelection ??
       null,
-    [draftSelection, fallbackCatalogSelection, roleDefaultSelection, selectionCatalog],
+    [draftSelection, fallbackCatalogSelection, roleDefaultSelectionForComposer, selectionCatalog],
   );
 
   const agentOptions = useMemo<ComboboxOption[]>(() => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -65,8 +65,12 @@ export function useAgentStudioModelSelection({
   loadCatalog = loadRepoOpencodeCatalog,
 }: UseAgentStudioModelSelectionArgs): AgentStudioModelSelectionState {
   const previousActiveRepoRef = useRef<string | null>(activeRepo);
+  const previousRepoForDefaultsRef = useRef<string | null>(activeRepo);
+  const previousRepoSettingsRef = useRef<RepoSettingsInput | null>(repoSettings);
   const [composerCatalog, setComposerCatalog] = useState<AgentModelCatalog | null>(null);
   const [isLoadingComposerCatalog, setIsLoadingComposerCatalog] = useState(false);
+  const [isAwaitingRepoSettingsForActiveRepo, setIsAwaitingRepoSettingsForActiveRepo] =
+    useState(false);
   const [draftSelectionByRole, setDraftSelectionByRole] =
     useState<Record<AgentRole, AgentModelSelection | null>>(emptyDraftSelections);
   const [draftSelectionTouchedByRole, setDraftSelectionTouchedByRole] = useState<
@@ -81,6 +85,25 @@ export function useAgentStudioModelSelection({
     setDraftSelectionByRole(emptyDraftSelections());
     setDraftSelectionTouchedByRole(emptyDraftSelectionTouchedByRole());
   }, [activeRepo]);
+
+  useEffect(() => {
+    if (previousRepoForDefaultsRef.current !== activeRepo) {
+      previousRepoForDefaultsRef.current = activeRepo;
+      previousRepoSettingsRef.current = repoSettings;
+      setIsAwaitingRepoSettingsForActiveRepo(Boolean(activeRepo));
+      return;
+    }
+
+    if (!isAwaitingRepoSettingsForActiveRepo) {
+      previousRepoSettingsRef.current = repoSettings;
+      return;
+    }
+
+    if (previousRepoSettingsRef.current !== repoSettings) {
+      previousRepoSettingsRef.current = repoSettings;
+      setIsAwaitingRepoSettingsForActiveRepo(false);
+    }
+  }, [activeRepo, isAwaitingRepoSettingsForActiveRepo, repoSettings]);
 
   useEffect(() => {
     if (!activeRepo) {
@@ -181,10 +204,10 @@ export function useAgentStudioModelSelection({
       return roleDefaultSelection;
     }
     if (!composerCatalog) {
-      return null;
+      return isAwaitingRepoSettingsForActiveRepo ? null : roleDefaultSelection;
     }
     return normalizeSelectionForCatalog(composerCatalog, roleDefaultSelection);
-  }, [activeSession, composerCatalog, roleDefaultSelection]);
+  }, [activeSession, composerCatalog, isAwaitingRepoSettingsForActiveRepo, roleDefaultSelection]);
   const selectionCatalog = activeSession?.modelCatalog ?? composerCatalog;
   const isSelectionCatalogLoading = activeSession
     ? activeSession.isLoadingModelCatalog && !activeSession.modelCatalog && !composerCatalog


### PR DESCRIPTION
## Summary
- extract pure model-selection/context-usage logic from `use-agent-studio-model-selection` into a companion model module
- add focused tests for extracted logic (selection normalization, descriptor lookup, context-usage extraction)
- add hook integration tests for catalog invalidation/stale-load handling and context usage paths
- fix repo-switch behavior so draft selection state is reset and defaults from the newly selected repository are applied
- dedupe internal selection resolution logic to reduce drift risk

## Validation
- `cd apps/desktop && bun test src/pages/agents/use-agent-studio-model-selection-model.test.ts src/pages/agents/use-agent-studio-model-selection.test.tsx`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop test`
