### PR TITLE
refactor(adapters-tauri-host): consolidate task-client and harden API surface

### DIFF
--- a/packages/adapters-tauri-host/package.json
+++ b/packages/adapters-tauri-host/package.json
@@ -2,6 +2,9 @@
   "name": "@openducktor/adapters-tauri-host",
   "version": "0.1.0",
   "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/adapters-tauri-host/src/task-client.contract.test.ts
+++ b/packages/adapters-tauri-host/src/task-client.contract.test.ts
@@ -1,0 +1,31 @@
+import type {} from "./bun-test";
+import type { SetPlanInput, SetSpecInput } from "./task-client";
+import * as taskClientModule from "./task-client";
+import { TauriTaskClient } from "./task-client";
+
+const acceptSetSpecInput = (_input: SetSpecInput): void => {};
+const acceptSetPlanInput = (_input: SetPlanInput): void => {};
+
+describe("task-client exports contract", () => {
+  test("keeps class export as the runtime surface", () => {
+    expect(Object.keys(taskClientModule)).toEqual(["TauriTaskClient"]);
+    expect(taskClientModule.TauriTaskClient).toBe(TauriTaskClient);
+  });
+
+  test("keeps planner input types importable", () => {
+    acceptSetSpecInput({
+      taskId: "task-1",
+      markdown: "# Spec",
+      repoPath: "/repo",
+    });
+
+    acceptSetPlanInput({
+      taskId: "task-1",
+      markdown: "# Plan",
+      repoPath: "/repo",
+      subtasks: [{ title: "Subtask" }],
+    });
+
+    expect(typeof TauriTaskClient).toBe("function");
+  });
+});

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -12,7 +12,7 @@ import {
 import type { SetPlanOutput, SetSpecOutput } from "@openducktor/core";
 import type { InvokeFn } from "./invoke-utils";
 import { parseArray } from "./invoke-utils";
-import type { TaskMetadataCache } from "./task-metadata-cache";
+import type { ParsedTaskMetadata, TaskMetadataCache } from "./task-metadata-cache";
 
 export type SetSpecInput = {
   taskId: string;
@@ -40,7 +40,7 @@ export class TauriTaskClient {
     private readonly metadataCache: TaskMetadataCache,
   ) {}
 
-  private readTaskMetadata(repoPath: string, taskId: string) {
+  private readTaskMetadata(repoPath: string, taskId: string): Promise<ParsedTaskMetadata> {
     return this.metadataCache.get(this.invokeFn, repoPath, taskId);
   }
 

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -34,267 +34,6 @@ export type SetPlanInput = {
   repoPath?: string;
 };
 
-export const tasksList = async (invokeFn: InvokeFn, repoPath: string): Promise<TaskCard[]> => {
-  const payload = await invokeFn<unknown>("tasks_list", { repoPath });
-  return parseArray(taskCardSchema, payload);
-};
-
-export const taskCreate = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-  input: TaskCreateInput,
-): Promise<TaskCard> => {
-  const createInput = taskCreateInputSchema.parse(input);
-  const payload = await invokeFn<unknown>("task_create", {
-    repoPath,
-    input: createInput,
-  });
-  return taskCardSchema.parse(payload);
-};
-
-export const taskUpdate = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-  patch: TaskUpdatePatch,
-): Promise<TaskCard> => {
-  const updatePatch = taskUpdatePatchSchema.parse(patch);
-  const payload = await invokeFn<unknown>("task_update", {
-    repoPath,
-    taskId,
-    patch: updatePatch,
-  });
-  return taskCardSchema.parse(payload);
-};
-
-export const taskDelete = async (
-  invokeFn: InvokeFn,
-  metadataCache: TaskMetadataCache,
-  repoPath: string,
-  taskId: string,
-  deleteSubtasks = false,
-): Promise<{ ok: boolean }> => {
-  const payload = await invokeFn<{ ok: boolean }>("task_delete", {
-    repoPath,
-    taskId,
-    deleteSubtasks,
-  });
-  metadataCache.invalidate(repoPath, taskId);
-  return payload;
-};
-
-export const taskTransition = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-  status: TaskStatus,
-  reason?: string,
-): Promise<TaskCard> => {
-  taskStatusSchema.parse(status);
-  const payload = await invokeFn<unknown>("task_transition", {
-    repoPath,
-    taskId,
-    status,
-    reason,
-  });
-  return taskCardSchema.parse(payload);
-};
-
-export const taskDefer = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-  reason?: string,
-): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("task_defer", {
-    repoPath,
-    taskId,
-    reason,
-  });
-  return taskCardSchema.parse(payload);
-};
-
-export const taskResumeDeferred = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("task_resume_deferred", {
-    repoPath,
-    taskId,
-  });
-  return taskCardSchema.parse(payload);
-};
-
-export const specGet = async (
-  metadataCache: TaskMetadataCache,
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-): Promise<{ markdown: string; updatedAt: string | null }> => {
-  const payload = await metadataCache.get(invokeFn, repoPath, taskId);
-  return {
-    markdown: payload.spec.markdown,
-    updatedAt: payload.spec.updatedAt ?? null,
-  };
-};
-
-export const setSpec = async (
-  invokeFn: InvokeFn,
-  metadataCache: TaskMetadataCache,
-  input: SetSpecInput,
-): Promise<SetSpecOutput> => {
-  if (!input.repoPath) {
-    throw new Error("repoPath is required to set spec");
-  }
-
-  const payload = await invokeFn<{ updatedAt: string }>("set_spec", {
-    repoPath: input.repoPath,
-    taskId: input.taskId,
-    markdown: input.markdown,
-  });
-
-  metadataCache.invalidate(input.repoPath, input.taskId);
-  return { updatedAt: payload.updatedAt };
-};
-
-export const saveSpecDocument = async (
-  invokeFn: InvokeFn,
-  metadataCache: TaskMetadataCache,
-  repoPath: string,
-  taskId: string,
-  markdown: string,
-): Promise<SetSpecOutput> => {
-  const payload = await invokeFn<{ updatedAt: string }>("spec_save_document", {
-    repoPath,
-    taskId,
-    markdown,
-  });
-  metadataCache.invalidate(repoPath, taskId);
-  return { updatedAt: payload.updatedAt };
-};
-
-export const setPlan = async (
-  invokeFn: InvokeFn,
-  metadataCache: TaskMetadataCache,
-  input: SetPlanInput,
-): Promise<SetPlanOutput> => {
-  if (!input.repoPath) {
-    throw new Error("repoPath is required to set plan");
-  }
-
-  const payload = await invokeFn<{ updatedAt: string }>("set_plan", {
-    repoPath: input.repoPath,
-    taskId: input.taskId,
-    input: {
-      markdown: input.markdown,
-      subtasks: input.subtasks,
-    },
-  });
-
-  metadataCache.invalidate(input.repoPath, input.taskId);
-  return { updatedAt: payload.updatedAt };
-};
-
-export const savePlanDocument = async (
-  invokeFn: InvokeFn,
-  metadataCache: TaskMetadataCache,
-  repoPath: string,
-  taskId: string,
-  markdown: string,
-): Promise<SetPlanOutput> => {
-  const payload = await invokeFn<{ updatedAt: string }>("plan_save_document", {
-    repoPath,
-    taskId,
-    markdown,
-  });
-  metadataCache.invalidate(repoPath, taskId);
-  return { updatedAt: payload.updatedAt };
-};
-
-export const planGet = async (
-  metadataCache: TaskMetadataCache,
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-): Promise<{ markdown: string; updatedAt: string | null }> => {
-  const payload = await metadataCache.get(invokeFn, repoPath, taskId);
-  return {
-    markdown: payload.plan.markdown,
-    updatedAt: payload.plan.updatedAt ?? null,
-  };
-};
-
-export const qaGetReport = async (
-  metadataCache: TaskMetadataCache,
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-): Promise<{ markdown: string; updatedAt: string | null }> => {
-  const payload = await metadataCache.get(invokeFn, repoPath, taskId);
-  return {
-    markdown: payload.qaReport?.markdown ?? "",
-    updatedAt: payload.qaReport?.updatedAt ?? null,
-  };
-};
-
-export const qaApproved = async (
-  invokeFn: InvokeFn,
-  metadataCache: TaskMetadataCache,
-  repoPath: string,
-  taskId: string,
-  markdown: string,
-): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("qa_approved", {
-    repoPath,
-    taskId,
-    input: { markdown },
-  });
-  metadataCache.invalidate(repoPath, taskId);
-  return taskCardSchema.parse(payload);
-};
-
-export const qaRejected = async (
-  invokeFn: InvokeFn,
-  metadataCache: TaskMetadataCache,
-  repoPath: string,
-  taskId: string,
-  markdown: string,
-): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("qa_rejected", {
-    repoPath,
-    taskId,
-    input: { markdown },
-  });
-  metadataCache.invalidate(repoPath, taskId);
-  return taskCardSchema.parse(payload);
-};
-
-export const agentSessionsList = async (
-  metadataCache: TaskMetadataCache,
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-): Promise<AgentSessionRecord[]> => {
-  const payload = await metadataCache.get(invokeFn, repoPath, taskId);
-  return payload.agentSessions;
-};
-
-export const agentSessionUpsert = async (
-  invokeFn: InvokeFn,
-  metadataCache: TaskMetadataCache,
-  repoPath: string,
-  taskId: string,
-  session: AgentSessionRecord,
-): Promise<void> => {
-  await invokeFn<unknown>("agent_session_upsert", {
-    repoPath,
-    taskId,
-    session,
-  });
-  metadataCache.invalidate(repoPath, taskId);
-};
-
 export class TauriTaskClient {
   constructor(
     private readonly invokeFn: InvokeFn,
@@ -302,15 +41,27 @@ export class TauriTaskClient {
   ) {}
 
   async tasksList(repoPath: string): Promise<TaskCard[]> {
-    return tasksList(this.invokeFn, repoPath);
+    const payload = await this.invokeFn<unknown>("tasks_list", { repoPath });
+    return parseArray(taskCardSchema, payload);
   }
 
   async taskCreate(repoPath: string, input: TaskCreateInput): Promise<TaskCard> {
-    return taskCreate(this.invokeFn, repoPath, input);
+    const createInput = taskCreateInputSchema.parse(input);
+    const payload = await this.invokeFn<unknown>("task_create", {
+      repoPath,
+      input: createInput,
+    });
+    return taskCardSchema.parse(payload);
   }
 
   async taskUpdate(repoPath: string, taskId: string, patch: TaskUpdatePatch): Promise<TaskCard> {
-    return taskUpdate(this.invokeFn, repoPath, taskId, patch);
+    const updatePatch = taskUpdatePatchSchema.parse(patch);
+    const payload = await this.invokeFn<unknown>("task_update", {
+      repoPath,
+      taskId,
+      patch: updatePatch,
+    });
+    return taskCardSchema.parse(payload);
   }
 
   async taskDelete(
@@ -318,7 +69,13 @@ export class TauriTaskClient {
     taskId: string,
     deleteSubtasks = false,
   ): Promise<{ ok: boolean }> {
-    return taskDelete(this.invokeFn, this.metadataCache, repoPath, taskId, deleteSubtasks);
+    const payload = await this.invokeFn<{ ok: boolean }>("task_delete", {
+      repoPath,
+      taskId,
+      deleteSubtasks,
+    });
+    this.metadataCache.invalidate(repoPath, taskId);
+    return payload;
   }
 
   async taskTransition(
@@ -327,26 +84,57 @@ export class TauriTaskClient {
     status: TaskStatus,
     reason?: string,
   ): Promise<TaskCard> {
-    return taskTransition(this.invokeFn, repoPath, taskId, status, reason);
+    taskStatusSchema.parse(status);
+    const payload = await this.invokeFn<unknown>("task_transition", {
+      repoPath,
+      taskId,
+      status,
+      reason,
+    });
+    return taskCardSchema.parse(payload);
   }
 
   async taskDefer(repoPath: string, taskId: string, reason?: string): Promise<TaskCard> {
-    return taskDefer(this.invokeFn, repoPath, taskId, reason);
+    const payload = await this.invokeFn<unknown>("task_defer", {
+      repoPath,
+      taskId,
+      reason,
+    });
+    return taskCardSchema.parse(payload);
   }
 
   async taskResumeDeferred(repoPath: string, taskId: string): Promise<TaskCard> {
-    return taskResumeDeferred(this.invokeFn, repoPath, taskId);
+    const payload = await this.invokeFn<unknown>("task_resume_deferred", {
+      repoPath,
+      taskId,
+    });
+    return taskCardSchema.parse(payload);
   }
 
   async specGet(
     repoPath: string,
     taskId: string,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    return specGet(this.metadataCache, this.invokeFn, repoPath, taskId);
+    const payload = await this.metadataCache.get(this.invokeFn, repoPath, taskId);
+    return {
+      markdown: payload.spec.markdown,
+      updatedAt: payload.spec.updatedAt ?? null,
+    };
   }
 
   async setSpec(input: SetSpecInput): Promise<SetSpecOutput> {
-    return setSpec(this.invokeFn, this.metadataCache, input);
+    if (!input.repoPath) {
+      throw new Error("repoPath is required to set spec");
+    }
+
+    const payload = await this.invokeFn<{ updatedAt: string }>("set_spec", {
+      repoPath: input.repoPath,
+      taskId: input.taskId,
+      markdown: input.markdown,
+    });
+
+    this.metadataCache.invalidate(input.repoPath, input.taskId);
+    return { updatedAt: payload.updatedAt };
   }
 
   async saveSpecDocument(
@@ -354,11 +142,31 @@ export class TauriTaskClient {
     taskId: string,
     markdown: string,
   ): Promise<SetSpecOutput> {
-    return saveSpecDocument(this.invokeFn, this.metadataCache, repoPath, taskId, markdown);
+    const payload = await this.invokeFn<{ updatedAt: string }>("spec_save_document", {
+      repoPath,
+      taskId,
+      markdown,
+    });
+    this.metadataCache.invalidate(repoPath, taskId);
+    return { updatedAt: payload.updatedAt };
   }
 
   async setPlan(input: SetPlanInput): Promise<SetPlanOutput> {
-    return setPlan(this.invokeFn, this.metadataCache, input);
+    if (!input.repoPath) {
+      throw new Error("repoPath is required to set plan");
+    }
+
+    const payload = await this.invokeFn<{ updatedAt: string }>("set_plan", {
+      repoPath: input.repoPath,
+      taskId: input.taskId,
+      input: {
+        markdown: input.markdown,
+        subtasks: input.subtasks,
+      },
+    });
+
+    this.metadataCache.invalidate(input.repoPath, input.taskId);
+    return { updatedAt: payload.updatedAt };
   }
 
   async savePlanDocument(
@@ -366,33 +174,60 @@ export class TauriTaskClient {
     taskId: string,
     markdown: string,
   ): Promise<SetPlanOutput> {
-    return savePlanDocument(this.invokeFn, this.metadataCache, repoPath, taskId, markdown);
+    const payload = await this.invokeFn<{ updatedAt: string }>("plan_save_document", {
+      repoPath,
+      taskId,
+      markdown,
+    });
+    this.metadataCache.invalidate(repoPath, taskId);
+    return { updatedAt: payload.updatedAt };
   }
 
   async planGet(
     repoPath: string,
     taskId: string,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    return planGet(this.metadataCache, this.invokeFn, repoPath, taskId);
+    const payload = await this.metadataCache.get(this.invokeFn, repoPath, taskId);
+    return {
+      markdown: payload.plan.markdown,
+      updatedAt: payload.plan.updatedAt ?? null,
+    };
   }
 
   async qaGetReport(
     repoPath: string,
     taskId: string,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    return qaGetReport(this.metadataCache, this.invokeFn, repoPath, taskId);
+    const payload = await this.metadataCache.get(this.invokeFn, repoPath, taskId);
+    return {
+      markdown: payload.qaReport?.markdown ?? "",
+      updatedAt: payload.qaReport?.updatedAt ?? null,
+    };
   }
 
   async qaApproved(repoPath: string, taskId: string, markdown: string): Promise<TaskCard> {
-    return qaApproved(this.invokeFn, this.metadataCache, repoPath, taskId, markdown);
+    const payload = await this.invokeFn<unknown>("qa_approved", {
+      repoPath,
+      taskId,
+      input: { markdown },
+    });
+    this.metadataCache.invalidate(repoPath, taskId);
+    return taskCardSchema.parse(payload);
   }
 
   async qaRejected(repoPath: string, taskId: string, markdown: string): Promise<TaskCard> {
-    return qaRejected(this.invokeFn, this.metadataCache, repoPath, taskId, markdown);
+    const payload = await this.invokeFn<unknown>("qa_rejected", {
+      repoPath,
+      taskId,
+      input: { markdown },
+    });
+    this.metadataCache.invalidate(repoPath, taskId);
+    return taskCardSchema.parse(payload);
   }
 
   async agentSessionsList(repoPath: string, taskId: string): Promise<AgentSessionRecord[]> {
-    return agentSessionsList(this.metadataCache, this.invokeFn, repoPath, taskId);
+    const payload = await this.metadataCache.get(this.invokeFn, repoPath, taskId);
+    return payload.agentSessions;
   }
 
   async agentSessionUpsert(
@@ -400,6 +235,11 @@ export class TauriTaskClient {
     taskId: string,
     session: AgentSessionRecord,
   ): Promise<void> {
-    return agentSessionUpsert(this.invokeFn, this.metadataCache, repoPath, taskId, session);
+    await this.invokeFn<unknown>("agent_session_upsert", {
+      repoPath,
+      taskId,
+      session,
+    });
+    this.metadataCache.invalidate(repoPath, taskId);
   }
 }

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -40,6 +40,21 @@ export class TauriTaskClient {
     private readonly metadataCache: TaskMetadataCache,
   ) {}
 
+  private readTaskMetadata(repoPath: string, taskId: string) {
+    return this.metadataCache.get(this.invokeFn, repoPath, taskId);
+  }
+
+  private invalidateTaskMetadata(repoPath: string, taskId: string): void {
+    this.metadataCache.invalidate(repoPath, taskId);
+  }
+
+  private requireRepoPath(repoPath: string | undefined, documentType: "spec" | "plan"): string {
+    if (!repoPath) {
+      throw new Error(`repoPath is required to set ${documentType}`);
+    }
+    return repoPath;
+  }
+
   async tasksList(repoPath: string): Promise<TaskCard[]> {
     const payload = await this.invokeFn<unknown>("tasks_list", { repoPath });
     return parseArray(taskCardSchema, payload);
@@ -74,7 +89,7 @@ export class TauriTaskClient {
       taskId,
       deleteSubtasks,
     });
-    this.metadataCache.invalidate(repoPath, taskId);
+    this.invalidateTaskMetadata(repoPath, taskId);
     return payload;
   }
 
@@ -115,7 +130,7 @@ export class TauriTaskClient {
     repoPath: string,
     taskId: string,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.metadataCache.get(this.invokeFn, repoPath, taskId);
+    const payload = await this.readTaskMetadata(repoPath, taskId);
     return {
       markdown: payload.spec.markdown,
       updatedAt: payload.spec.updatedAt ?? null,
@@ -123,17 +138,15 @@ export class TauriTaskClient {
   }
 
   async setSpec(input: SetSpecInput): Promise<SetSpecOutput> {
-    if (!input.repoPath) {
-      throw new Error("repoPath is required to set spec");
-    }
+    const repoPath = this.requireRepoPath(input.repoPath, "spec");
 
     const payload = await this.invokeFn<{ updatedAt: string }>("set_spec", {
-      repoPath: input.repoPath,
+      repoPath,
       taskId: input.taskId,
       markdown: input.markdown,
     });
 
-    this.metadataCache.invalidate(input.repoPath, input.taskId);
+    this.invalidateTaskMetadata(repoPath, input.taskId);
     return { updatedAt: payload.updatedAt };
   }
 
@@ -147,17 +160,15 @@ export class TauriTaskClient {
       taskId,
       markdown,
     });
-    this.metadataCache.invalidate(repoPath, taskId);
+    this.invalidateTaskMetadata(repoPath, taskId);
     return { updatedAt: payload.updatedAt };
   }
 
   async setPlan(input: SetPlanInput): Promise<SetPlanOutput> {
-    if (!input.repoPath) {
-      throw new Error("repoPath is required to set plan");
-    }
+    const repoPath = this.requireRepoPath(input.repoPath, "plan");
 
     const payload = await this.invokeFn<{ updatedAt: string }>("set_plan", {
-      repoPath: input.repoPath,
+      repoPath,
       taskId: input.taskId,
       input: {
         markdown: input.markdown,
@@ -165,7 +176,7 @@ export class TauriTaskClient {
       },
     });
 
-    this.metadataCache.invalidate(input.repoPath, input.taskId);
+    this.invalidateTaskMetadata(repoPath, input.taskId);
     return { updatedAt: payload.updatedAt };
   }
 
@@ -179,7 +190,7 @@ export class TauriTaskClient {
       taskId,
       markdown,
     });
-    this.metadataCache.invalidate(repoPath, taskId);
+    this.invalidateTaskMetadata(repoPath, taskId);
     return { updatedAt: payload.updatedAt };
   }
 
@@ -187,7 +198,7 @@ export class TauriTaskClient {
     repoPath: string,
     taskId: string,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.metadataCache.get(this.invokeFn, repoPath, taskId);
+    const payload = await this.readTaskMetadata(repoPath, taskId);
     return {
       markdown: payload.plan.markdown,
       updatedAt: payload.plan.updatedAt ?? null,
@@ -198,7 +209,7 @@ export class TauriTaskClient {
     repoPath: string,
     taskId: string,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.metadataCache.get(this.invokeFn, repoPath, taskId);
+    const payload = await this.readTaskMetadata(repoPath, taskId);
     return {
       markdown: payload.qaReport?.markdown ?? "",
       updatedAt: payload.qaReport?.updatedAt ?? null,
@@ -211,7 +222,7 @@ export class TauriTaskClient {
       taskId,
       input: { markdown },
     });
-    this.metadataCache.invalidate(repoPath, taskId);
+    this.invalidateTaskMetadata(repoPath, taskId);
     return taskCardSchema.parse(payload);
   }
 
@@ -221,12 +232,12 @@ export class TauriTaskClient {
       taskId,
       input: { markdown },
     });
-    this.metadataCache.invalidate(repoPath, taskId);
+    this.invalidateTaskMetadata(repoPath, taskId);
     return taskCardSchema.parse(payload);
   }
 
   async agentSessionsList(repoPath: string, taskId: string): Promise<AgentSessionRecord[]> {
-    const payload = await this.metadataCache.get(this.invokeFn, repoPath, taskId);
+    const payload = await this.readTaskMetadata(repoPath, taskId);
     return payload.agentSessions;
   }
 
@@ -240,6 +251,6 @@ export class TauriTaskClient {
       taskId,
       session,
     });
-    this.metadataCache.invalidate(repoPath, taskId);
+    this.invalidateTaskMetadata(repoPath, taskId);
   }
 }


### PR DESCRIPTION
## Summary
- remove duplicated `task-client` free-function/class-delegate layering by keeping class-only implementations
- deduplicate repeated metadata read/invalidation and repoPath guard logic via private helpers in `TauriTaskClient`
- lock adapter package public surface with an explicit `exports` map and add a `task-client` exports contract test

## Validation
- bun run --filter @openducktor/adapters-tauri-host typecheck
- bun run --filter @openducktor/adapters-tauri-host test
- bun run --filter @openducktor/adapters-tauri-host lint
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop test
