### PR TITLE
perf(desktop): stabilize premium markdown renderer memoization

### DIFF
--- a/apps/desktop/src/components/ui/markdown-renderer-premium.test.tsx
+++ b/apps/desktop/src/components/ui/markdown-renderer-premium.test.tsx
@@ -1,0 +1,114 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactElement, type ReactNode } from "react";
+import type { Components } from "react-markdown";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+const markdownRenderMock = mock((_props: Record<string, unknown>) => {});
+
+mock.module("react-markdown", () => {
+  const MockMarkdown = ({
+    children,
+    ...props
+  }: Record<string, unknown> & {
+    children?: unknown;
+  }): ReactElement => {
+    markdownRenderMock(props);
+    return createElement("mock-react-markdown", props, children as ReactNode);
+  };
+
+  return {
+    __esModule: true,
+    default: MockMarkdown,
+    defaultUrlTransform: (url: string) => url,
+  };
+});
+
+type PremiumMarkdownRendererComponent = typeof import("./markdown-renderer-premium").default;
+let PremiumMarkdownRenderer: PremiumMarkdownRendererComponent;
+
+const getLatestComponentsProp = (): Components => {
+  const latest = markdownRenderMock.mock.calls.at(-1)?.[0] as
+    | { components?: Components }
+    | undefined;
+  const components = latest?.components;
+  if (!components) {
+    throw new Error("Expected react-markdown to receive components");
+  }
+  return components;
+};
+
+beforeAll(async () => {
+  ({ default: PremiumMarkdownRenderer } = await import("./markdown-renderer-premium"));
+});
+
+beforeEach(() => {
+  markdownRenderMock.mockClear();
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+describe("PremiumMarkdownRenderer memoization", () => {
+  test("keeps enhanced components reference stable when markdown or fallback changes", async () => {
+    const components: Components = {};
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <PremiumMarkdownRenderer
+          markdown="alpha"
+          components={components}
+          fallback={<span>Loading alpha</span>}
+        />,
+      );
+    });
+
+    const firstReference = getLatestComponentsProp();
+
+    await act(async () => {
+      renderer.update(
+        <PremiumMarkdownRenderer
+          markdown="beta"
+          components={components}
+          fallback={<span>Loading beta</span>}
+        />,
+      );
+    });
+
+    const secondReference = getLatestComponentsProp();
+    expect(secondReference).toBe(firstReference);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("rebuilds enhanced components when base components prop changes", async () => {
+    const componentsA: Components = {};
+    const componentsB: Components = {
+      strong: ({ node: _node, ...props }) => <strong {...props} />,
+    };
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<PremiumMarkdownRenderer markdown="alpha" components={componentsA} />);
+    });
+
+    const firstReference = getLatestComponentsProp();
+
+    await act(async () => {
+      renderer.update(<PremiumMarkdownRenderer markdown="alpha" components={componentsB} />);
+    });
+
+    const secondReference = getLatestComponentsProp();
+    expect(secondReference).not.toBe(firstReference);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+});

--- a/apps/desktop/src/components/ui/markdown-renderer-premium.tsx
+++ b/apps/desktop/src/components/ui/markdown-renderer-premium.tsx
@@ -1,4 +1,4 @@
-import { lazy, memo, type ReactElement, Suspense, useDeferredValue } from "react";
+import { lazy, memo, type ReactElement, Suspense, useDeferredValue, useMemo } from "react";
 import Markdown, { type Components, defaultUrlTransform, type UrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -25,28 +25,31 @@ const PremiumMarkdownRenderer = memo(function PremiumMarkdownRenderer({
 }: MarkdownPremiumRendererProps): ReactElement {
   const deferredMarkdown = useDeferredValue(markdown);
 
-  const enhancedComponents: Components = {
-    ...components,
-    code: ({ node: _node, className, children, ...props }) => {
-      const languageMatch = LANGUAGE_CLASS_PATTERN.exec(className ?? "");
-      const rawCode = String(children);
-      const code = rawCode.endsWith("\n") ? rawCode.slice(0, -1) : rawCode;
+  const enhancedComponents = useMemo<Components>(
+    () => ({
+      ...components,
+      code: ({ node: _node, className, children, ...props }) => {
+        const languageMatch = LANGUAGE_CLASS_PATTERN.exec(className ?? "");
+        const rawCode = String(children);
+        const code = rawCode.endsWith("\n") ? rawCode.slice(0, -1) : rawCode;
 
-      if (!languageMatch?.[1]) {
+        if (!languageMatch?.[1]) {
+          return (
+            <code {...props} className={className}>
+              {children}
+            </code>
+          );
+        }
+
         return (
-          <code {...props} className={className}>
-            {children}
-          </code>
+          <Suspense fallback={fallback ?? createPlainCodeFallback(code)}>
+            <MarkdownSyntaxBlock language={languageMatch[1]} code={code} />
+          </Suspense>
         );
-      }
-
-      return (
-        <Suspense fallback={fallback ?? createPlainCodeFallback(code)}>
-          <MarkdownSyntaxBlock language={languageMatch[1]} code={code} />
-        </Suspense>
-      );
-    },
-  };
+      },
+    }),
+    [components, fallback],
+  );
 
   return (
     <Markdown

--- a/apps/desktop/src/components/ui/markdown-renderer-premium.tsx
+++ b/apps/desktop/src/components/ui/markdown-renderer-premium.tsx
@@ -1,5 +1,20 @@
-import { lazy, memo, type ReactElement, Suspense, useDeferredValue, useMemo } from "react";
-import Markdown, { type Components, defaultUrlTransform, type UrlTransform } from "react-markdown";
+import {
+  type ComponentProps,
+  lazy,
+  memo,
+  type ReactElement,
+  Suspense,
+  useCallback,
+  useDeferredValue,
+  useMemo,
+  useRef,
+} from "react";
+import Markdown, {
+  type Components,
+  defaultUrlTransform,
+  type ExtraProps,
+  type UrlTransform,
+} from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import type { MarkdownPremiumRendererProps } from "./markdown-renderer";
@@ -9,6 +24,7 @@ const MarkdownSyntaxBlock = lazy(() => import("./markdown-syntax-block"));
 const REMARK_PLUGINS = [remarkGfm];
 const MARKDOWN_URL_TRANSFORM: UrlTransform = (url) => defaultUrlTransform(url);
 const LANGUAGE_CLASS_PATTERN = /language-([a-z0-9-]+)/i;
+type CodeOverrideProps = ComponentProps<"code"> & ExtraProps;
 
 function createPlainCodeFallback(code: string): ReactElement {
   return (
@@ -24,31 +40,38 @@ const PremiumMarkdownRenderer = memo(function PremiumMarkdownRenderer({
   fallback,
 }: MarkdownPremiumRendererProps): ReactElement {
   const deferredMarkdown = useDeferredValue(markdown);
+  const fallbackRef = useRef(fallback);
+  fallbackRef.current = fallback;
+
+  const stableCodeOverride = useCallback(
+    ({ node: _node, className, children, ...props }: CodeOverrideProps): ReactElement => {
+      const languageMatch = LANGUAGE_CLASS_PATTERN.exec(className ?? "");
+      const rawCode = String(children);
+      const code = rawCode.endsWith("\n") ? rawCode.slice(0, -1) : rawCode;
+
+      if (!languageMatch?.[1]) {
+        return (
+          <code {...props} className={className}>
+            {children}
+          </code>
+        );
+      }
+
+      return (
+        <Suspense fallback={fallbackRef.current ?? createPlainCodeFallback(code)}>
+          <MarkdownSyntaxBlock language={languageMatch[1]} code={code} />
+        </Suspense>
+      );
+    },
+    [],
+  );
 
   const enhancedComponents = useMemo<Components>(
     () => ({
       ...components,
-      code: ({ node: _node, className, children, ...props }) => {
-        const languageMatch = LANGUAGE_CLASS_PATTERN.exec(className ?? "");
-        const rawCode = String(children);
-        const code = rawCode.endsWith("\n") ? rawCode.slice(0, -1) : rawCode;
-
-        if (!languageMatch?.[1]) {
-          return (
-            <code {...props} className={className}>
-              {children}
-            </code>
-          );
-        }
-
-        return (
-          <Suspense fallback={fallback ?? createPlainCodeFallback(code)}>
-            <MarkdownSyntaxBlock language={languageMatch[1]} code={code} />
-          </Suspense>
-        );
-      },
+      code: stableCodeOverride,
     }),
-    [components, fallback],
+    [components, stableCodeOverride],
   );
 
   return (


### PR DESCRIPTION
## Summary
Improve markdown rendering performance in premium mode by stabilizing the components prop passed to react-markdown, so streaming updates no longer trigger avoidable full markdown subtree rerenders.

## Changes
- Memoized enhancedComponents in PremiumMarkdownRenderer
- Introduced a stable code override callback and ref-backed fallback access to avoid identity churn from fallback node changes
- Added targeted regression tests for components reference stability and invalidation behavior when base components change

## Files
- apps/desktop/src/components/ui/markdown-renderer-premium.tsx
- apps/desktop/src/components/ui/markdown-renderer-premium.test.tsx

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test
