### PR TITLE
refactor(desktop): split start-session type logic into focused modules

### DIFF
--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-support.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-support.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import type { StartedSessionContext } from "./start-session.types";
+import {
+  compareBySessionRecency,
+  createSessionStartTags,
+  pickLatestSession,
+} from "./start-session-support";
+
+describe("agent-orchestrator/handlers/start-session-support", () => {
+  test("compareBySessionRecency sorts newer startedAt values first", () => {
+    const older = { startedAt: "2026-02-22T08:00:00.000Z", sessionId: "session-1" };
+    const newer = { startedAt: "2026-02-22T08:10:00.000Z", sessionId: "session-2" };
+
+    expect(compareBySessionRecency(newer, older)).toBeLessThan(0);
+    expect(compareBySessionRecency(older, newer)).toBeGreaterThan(0);
+  });
+
+  test("compareBySessionRecency uses sessionId descending as tie-breaker", () => {
+    const sameTimeA = { startedAt: "2026-02-22T08:00:00.000Z", sessionId: "session-a" };
+    const sameTimeB = { startedAt: "2026-02-22T08:00:00.000Z", sessionId: "session-b" };
+
+    expect(compareBySessionRecency(sameTimeB, sameTimeA)).toBeLessThan(0);
+    expect(compareBySessionRecency(sameTimeA, sameTimeB)).toBeGreaterThan(0);
+    expect(compareBySessionRecency(sameTimeA, sameTimeA)).toBe(0);
+  });
+
+  test("pickLatestSession returns undefined for empty input", () => {
+    expect(pickLatestSession([])).toBeUndefined();
+  });
+
+  test("pickLatestSession returns the most recent entry and keeps input order intact", () => {
+    const sessions = [
+      { startedAt: "2026-02-22T08:00:00.000Z", sessionId: "session-a", marker: "first" },
+      { startedAt: "2026-02-22T08:10:00.000Z", sessionId: "session-b", marker: "second" },
+      { startedAt: "2026-02-22T08:05:00.000Z", sessionId: "session-c", marker: "third" },
+    ];
+
+    const latest = pickLatestSession(sessions);
+
+    expect(latest?.sessionId).toBe("session-b");
+    expect(latest?.marker).toBe("second");
+    expect(sessions.map((entry) => entry.sessionId)).toEqual([
+      "session-a",
+      "session-b",
+      "session-c",
+    ]);
+  });
+
+  test("pickLatestSession applies tie-breaker when startedAt values are equal", () => {
+    const sessions = [
+      { startedAt: "2026-02-22T08:00:00.000Z", sessionId: "session-a" },
+      { startedAt: "2026-02-22T08:00:00.000Z", sessionId: "session-b" },
+    ];
+
+    const latest = pickLatestSession(sessions);
+
+    expect(latest?.sessionId).toBe("session-b");
+  });
+
+  test("createSessionStartTags maps context fields into workflow tag payload", () => {
+    const startedCtx: StartedSessionContext = {
+      repoPath: "/tmp/repo",
+      taskId: "task-1",
+      role: "build",
+      isStaleRepoOperation: () => false,
+      resolvedScenario: "build_implementation_start",
+      summary: {
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        role: "build",
+        scenario: "build_implementation_start",
+        startedAt: "2026-02-22T08:00:10.000Z",
+        status: "idle",
+      },
+    };
+
+    expect(createSessionStartTags(startedCtx)).toEqual({
+      repoPath: "/tmp/repo",
+      taskId: "task-1",
+      role: "build",
+      scenario: "build_implementation_start",
+      sessionId: "session-1",
+    });
+  });
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-support.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-support.ts
@@ -16,7 +16,19 @@ export const compareBySessionRecency = (
 export const pickLatestSession = <T extends { startedAt: string; sessionId: string }>(
   sessions: T[],
 ): T | undefined => {
-  return [...sessions].sort(compareBySessionRecency)[0];
+  if (!sessions.length) {
+    return undefined;
+  }
+
+  let latest = sessions[0];
+  for (let index = 1; index < sessions.length; index++) {
+    const current = sessions[index];
+    if (compareBySessionRecency(current, latest) < 0) {
+      latest = current;
+    }
+  }
+
+  return latest;
 };
 
 export const createSessionStartTags = ({

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-support.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-support.ts
@@ -1,0 +1,34 @@
+import type { SessionStartTags, StartedSessionContext } from "./start-session.types";
+
+export const compareBySessionRecency = (
+  a: { startedAt: string; sessionId: string },
+  b: { startedAt: string; sessionId: string },
+): number => {
+  if (a.startedAt !== b.startedAt) {
+    return a.startedAt > b.startedAt ? -1 : 1;
+  }
+  if (a.sessionId === b.sessionId) {
+    return 0;
+  }
+  return a.sessionId > b.sessionId ? -1 : 1;
+};
+
+export const pickLatestSession = <T extends { startedAt: string; sessionId: string }>(
+  sessions: T[],
+): T | undefined => {
+  return [...sessions].sort(compareBySessionRecency)[0];
+};
+
+export const createSessionStartTags = ({
+  repoPath,
+  taskId,
+  role,
+  resolvedScenario,
+  summary,
+}: StartedSessionContext): SessionStartTags => ({
+  repoPath,
+  taskId,
+  role,
+  scenario: resolvedScenario,
+  sessionId: summary.sessionId,
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-support.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-support.ts
@@ -16,14 +16,15 @@ export const compareBySessionRecency = (
 export const pickLatestSession = <T extends { startedAt: string; sessionId: string }>(
   sessions: T[],
 ): T | undefined => {
-  if (!sessions.length) {
+  const first = sessions[0];
+  if (!first) {
     return undefined;
   }
 
-  let latest = sessions[0];
+  let latest = first;
   for (let index = 1; index < sessions.length; index++) {
     const current = sessions[index];
-    if (compareBySessionRecency(current, latest) < 0) {
+    if (current && compareBySessionRecency(current, latest) < 0) {
       latest = current;
     }
   }

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -1,16 +1,11 @@
 import type { TaskCard } from "@openducktor/contracts";
-import type {
-  AgentEnginePort,
-  AgentModelSelection,
-  AgentRole,
-  AgentScenario,
-} from "@openducktor/core";
+import type { AgentModelSelection, AgentScenario } from "@openducktor/core";
 import { buildAgentSystemPrompt } from "@openducktor/core";
 import { isRoleAvailableForTask, unavailableRoleErrorMessage } from "@/lib/task-agent-workflows";
-import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
 import { requireActiveRepo } from "../../task-operations-model";
-import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
+import type { RuntimeInfo } from "../runtime/runtime";
 import {
   captureOrchestratorFallback,
   runOrchestratorSideEffect,
@@ -21,157 +16,26 @@ import {
   kickoffPrompt,
   throwIfRepoStale,
 } from "../support/utils";
+import type {
+  ModelDependencies,
+  ResolvedRuntimeAndModel,
+  RuntimeDependencies,
+  SessionDependencies,
+  SessionStartTags,
+  StartAgentSessionInput,
+  StartedSessionContext,
+  StartOrReuseResult,
+  StartSessionContext,
+  StartSessionCreationInput,
+  StartSessionDependencies,
+  StartSessionExecutionDependencies,
+  TaskDependencies,
+} from "./start-session.types";
+import { createSessionStartTags, pickLatestSession } from "./start-session-support";
 
-export type StartAgentSessionInput = {
-  taskId: string;
-  role: AgentRole;
-  scenario?: AgentScenario;
-  selectedModel?: AgentModelSelection | null;
-  sendKickoff?: boolean;
-  startMode?: "reuse_latest" | "fresh";
-  requireModelReady?: boolean;
-};
-
-type SessionStateById = Record<string, AgentSessionState>;
-type SessionStateUpdater = SessionStateById | ((current: SessionStateById) => SessionStateById);
-
-type SessionDependencies = {
-  setSessionsById: (updater: SessionStateUpdater) => void;
-  sessionsRef: { current: SessionStateById };
-  inFlightStartsByRepoTaskRef: { current: Map<string, Promise<string>> };
-  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
-  persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;
-  attachSessionListener: (repoPath: string, sessionId: string) => void;
-};
-
-type RuntimeDependencies = {
-  adapter: AgentEnginePort;
-  ensureRuntime: (repoPath: string, taskId: string, role: AgentRole) => Promise<RuntimeInfo>;
-};
-
-type TaskDependencies = {
-  taskRef: { current: TaskCard[] };
-  loadTaskDocuments: (repoPath: string, taskId: string) => Promise<TaskDocuments>;
-  refreshTaskData: (repoPath: string) => Promise<void>;
-  sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
-};
-
-type ModelDependencies = {
-  loadRepoDefaultModel: (repoPath: string, role: AgentRole) => Promise<AgentModelSelection | null>;
-  loadSessionTodos: (
-    sessionId: string,
-    baseUrl: string,
-    workingDirectory: string,
-    externalSessionId: string,
-  ) => Promise<void>;
-  loadSessionModelCatalog: (
-    sessionId: string,
-    baseUrl: string,
-    workingDirectory: string,
-  ) => Promise<void>;
-};
-
-type RepoDependencies = {
-  activeRepo: string | null;
-  repoEpochRef: { current: number };
-  previousRepoRef: { current: string | null };
-};
-
-export type StartSessionDependencies = {
-  repo: RepoDependencies;
-  session: SessionDependencies;
-  runtime: RuntimeDependencies;
-  task: TaskDependencies;
-  model: ModelDependencies;
-};
+export type { StartAgentSessionInput, StartSessionDependencies } from "./start-session.types";
 
 const STALE_START_ERROR = "Workspace changed while starting session.";
-type RepoStaleGuard = () => boolean;
-type SessionStartSummary = Awaited<ReturnType<AgentEnginePort["startSession"]>>;
-
-type SessionStartTags = {
-  repoPath: string;
-  taskId: string;
-  role: AgentRole;
-  scenario: AgentScenario;
-  sessionId: string;
-};
-
-type StartSessionContext = {
-  repoPath: string;
-  taskId: string;
-  role: AgentRole;
-  isStaleRepoOperation: RepoStaleGuard;
-};
-
-type StartedSessionContext = StartSessionContext & {
-  summary: SessionStartSummary;
-  resolvedScenario: AgentScenario;
-};
-
-type StartSessionExecutionDependencies = Pick<
-  StartSessionDependencies,
-  "session" | "runtime" | "task" | "model"
->;
-
-type StartSessionCreationInput = {
-  scenario: AgentScenario | undefined;
-  selectedModel: AgentModelSelection | null;
-  startMode: "reuse_latest" | "fresh";
-};
-
-type ResolvedRuntimeAndModel = {
-  taskCard: TaskCard;
-  runtime: RuntimeInfo;
-  resolvedScenario: AgentScenario;
-  systemPrompt: string;
-  defaultModelSelectionPromise: Promise<AgentModelSelection | null>;
-};
-
-type StartOrReuseResult =
-  | {
-      kind: "reused";
-      sessionId: string;
-    }
-  | {
-      kind: "started";
-      runtimeInfo: RuntimeInfo;
-      ctx: StartedSessionContext;
-      defaultModelSelectionPromise: Promise<AgentModelSelection | null>;
-    };
-
-const compareBySessionRecency = (
-  a: { startedAt: string; sessionId: string },
-  b: { startedAt: string; sessionId: string },
-): number => {
-  if (a.startedAt !== b.startedAt) {
-    return a.startedAt > b.startedAt ? -1 : 1;
-  }
-  if (a.sessionId === b.sessionId) {
-    return 0;
-  }
-  return a.sessionId > b.sessionId ? -1 : 1;
-};
-
-const pickLatestSession = <T extends { startedAt: string; sessionId: string }>(
-  sessions: T[],
-): T | undefined => {
-  return [...sessions].sort(compareBySessionRecency)[0];
-};
-
-const createSessionStartTags = ({
-  repoPath,
-  taskId,
-  role,
-  resolvedScenario,
-  summary,
-}: StartedSessionContext): SessionStartTags => ({
-  repoPath,
-  taskId,
-  role,
-  scenario: resolvedScenario,
-  sessionId: summary.sessionId,
-});
 
 const stopSessionOnStaleAndThrow = async ({
   reason,

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
@@ -1,0 +1,128 @@
+import type { TaskCard } from "@openducktor/contracts";
+import type {
+  AgentEnginePort,
+  AgentModelSelection,
+  AgentRole,
+  AgentScenario,
+} from "@openducktor/core";
+import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
+import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
+
+export type StartAgentSessionInput = {
+  taskId: string;
+  role: AgentRole;
+  scenario?: AgentScenario;
+  selectedModel?: AgentModelSelection | null;
+  sendKickoff?: boolean;
+  startMode?: "reuse_latest" | "fresh";
+  requireModelReady?: boolean;
+};
+
+export type SessionStateById = Record<string, AgentSessionState>;
+export type SessionStateUpdater =
+  | SessionStateById
+  | ((current: SessionStateById) => SessionStateById);
+
+export type SessionDependencies = {
+  setSessionsById: (updater: SessionStateUpdater) => void;
+  sessionsRef: { current: SessionStateById };
+  inFlightStartsByRepoTaskRef: { current: Map<string, Promise<string>> };
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
+  persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;
+  attachSessionListener: (repoPath: string, sessionId: string) => void;
+};
+
+export type RuntimeDependencies = {
+  adapter: AgentEnginePort;
+  ensureRuntime: (repoPath: string, taskId: string, role: AgentRole) => Promise<RuntimeInfo>;
+};
+
+export type TaskDependencies = {
+  taskRef: { current: TaskCard[] };
+  loadTaskDocuments: (repoPath: string, taskId: string) => Promise<TaskDocuments>;
+  refreshTaskData: (repoPath: string) => Promise<void>;
+  sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
+};
+
+export type ModelDependencies = {
+  loadRepoDefaultModel: (repoPath: string, role: AgentRole) => Promise<AgentModelSelection | null>;
+  loadSessionTodos: (
+    sessionId: string,
+    baseUrl: string,
+    workingDirectory: string,
+    externalSessionId: string,
+  ) => Promise<void>;
+  loadSessionModelCatalog: (
+    sessionId: string,
+    baseUrl: string,
+    workingDirectory: string,
+  ) => Promise<void>;
+};
+
+export type RepoDependencies = {
+  activeRepo: string | null;
+  repoEpochRef: { current: number };
+  previousRepoRef: { current: string | null };
+};
+
+export type StartSessionDependencies = {
+  repo: RepoDependencies;
+  session: SessionDependencies;
+  runtime: RuntimeDependencies;
+  task: TaskDependencies;
+  model: ModelDependencies;
+};
+
+export type RepoStaleGuard = () => boolean;
+export type SessionStartSummary = Awaited<ReturnType<AgentEnginePort["startSession"]>>;
+
+export type SessionStartTags = {
+  repoPath: string;
+  taskId: string;
+  role: AgentRole;
+  scenario: AgentScenario;
+  sessionId: string;
+};
+
+export type StartSessionContext = {
+  repoPath: string;
+  taskId: string;
+  role: AgentRole;
+  isStaleRepoOperation: RepoStaleGuard;
+};
+
+export type StartedSessionContext = StartSessionContext & {
+  summary: SessionStartSummary;
+  resolvedScenario: AgentScenario;
+};
+
+export type StartSessionExecutionDependencies = Pick<
+  StartSessionDependencies,
+  "session" | "runtime" | "task" | "model"
+>;
+
+export type StartSessionCreationInput = {
+  scenario: AgentScenario | undefined;
+  selectedModel: AgentModelSelection | null;
+  startMode: "reuse_latest" | "fresh";
+};
+
+export type ResolvedRuntimeAndModel = {
+  taskCard: TaskCard;
+  runtime: RuntimeInfo;
+  resolvedScenario: AgentScenario;
+  systemPrompt: string;
+  defaultModelSelectionPromise: Promise<AgentModelSelection | null>;
+};
+
+export type StartOrReuseResult =
+  | {
+      kind: "reused";
+      sessionId: string;
+    }
+  | {
+      kind: "started";
+      runtimeInfo: RuntimeInfo;
+      ctx: StartedSessionContext;
+      defaultModelSelectionPromise: Promise<AgentModelSelection | null>;
+    };


### PR DESCRIPTION
## Summary
- extract start-session type declarations into `start-session.types.ts`
- extract session recency/tag helper utilities into `start-session-support.ts`
- keep orchestration flow in `start-session.ts` and preserve public type exports
- add dedicated helper contract tests in `start-session-support.test.ts`

## Validation
- bun run --filter @openducktor/desktop test ./src/state/operations/agent-orchestrator/handlers/start-session-support.test.ts ./src/state/operations/agent-orchestrator/handlers/start-session.test.ts
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop typecheck