### PR TITLE
refactor(core): centralize record guards and reuse across desktop and adapter

### DIFF
--- a/apps/desktop/src/lib/guards.ts
+++ b/apps/desktop/src/lib/guards.ts
@@ -1,0 +1,2 @@
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/apps/desktop/src/lib/guards.ts
+++ b/apps/desktop/src/lib/guards.ts
@@ -1,2 +1,0 @@
-export const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -2,6 +2,7 @@ import type { AgentWorkflowState, TaskCard } from "@openducktor/contracts";
 import type { AgentRole, AgentScenario } from "@openducktor/core";
 import type { AgentStudioTaskTab } from "@/components/features/agents";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
+import { isRecord } from "@/lib/guards";
 import { buildRoleWorkflowMapForTask as resolveRoleWorkflowMapForTask } from "@/lib/task-agent-workflows";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentWorkflowStepState } from "@/types/agent-workflow";
@@ -46,9 +47,6 @@ const normalizeTaskTabs = (entries: unknown): string[] => {
     ),
   );
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 export const buildLatestSessionByTaskMap = (
   sessions: AgentSessionState[],

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -1,8 +1,7 @@
 import type { AgentWorkflowState, TaskCard } from "@openducktor/contracts";
-import type { AgentRole, AgentScenario } from "@openducktor/core";
+import { type AgentRole, type AgentScenario, isRecord } from "@openducktor/core";
 import type { AgentStudioTaskTab } from "@/components/features/agents";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
-import { isRecord } from "@/lib/guards";
 import { buildRoleWorkflowMapForTask as resolveRoleWorkflowMapForTask } from "@/lib/task-agent-workflows";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentWorkflowStepState } from "@/types/agent-workflow";

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-sync.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-sync.ts
@@ -1,7 +1,6 @@
-import type { AgentRole } from "@openducktor/core";
+import { type AgentRole, isRecord } from "@openducktor/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
-import { isRecord } from "@/lib/guards";
 import { isRole } from "./agents-page-constants";
 import { toContextStorageKey } from "./agents-page-utils";
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-sync.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-sync.ts
@@ -1,6 +1,7 @@
 import type { AgentRole } from "@openducktor/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
+import { isRecord } from "@/lib/guards";
 import { isRole } from "./agents-page-constants";
 import { toContextStorageKey } from "./agents-page-utils";
 
@@ -11,9 +12,6 @@ type PersistedAgentStudioContext = {
   role?: AgentRole;
   sessionId?: string;
 };
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 const readOptionalString = (value: unknown): string | undefined => {
   if (typeof value !== "string") {

--- a/packages/adapters-opencode-sdk/src/guards.ts
+++ b/packages/adapters-opencode-sdk/src/guards.ts
@@ -1,8 +1,8 @@
-export type UnknownRecord = Record<string, unknown>;
+import { isUnknownRecord as isCoreUnknownRecord, type UnknownRecord } from "@openducktor/core";
 
-export const isUnknownRecord = (value: unknown): value is UnknownRecord => {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-};
+export type { UnknownRecord };
+
+export const isUnknownRecord = isCoreUnknownRecord;
 
 export const asUnknownRecord = (value: unknown): UnknownRecord | undefined => {
   return isUnknownRecord(value) ? value : undefined;

--- a/packages/core/src/exports.contract.test.ts
+++ b/packages/core/src/exports.contract.test.ts
@@ -4,6 +4,7 @@ import type {
   AgentSessionTodoPriority,
   AgentSessionTodoStatus,
   NormalizeAgentSessionTodoInput,
+  UnknownRecord,
 } from "./index";
 import * as core from "./index";
 
@@ -12,6 +13,7 @@ type TodoNormalizerTypeContract = {
   AgentSessionTodoPriority: AgentSessionTodoPriority;
   AgentSessionTodoStatus: AgentSessionTodoStatus;
   NormalizeAgentSessionTodoInput: NormalizeAgentSessionTodoInput;
+  UnknownRecord: UnknownRecord;
 };
 
 describe("core exports contract", () => {
@@ -20,6 +22,11 @@ describe("core exports contract", () => {
     expect(typeof core.normalizeAgentSessionTodoList).toBe("function");
     expect(typeof core.normalizeAgentSessionTodoPriority).toBe("function");
     expect(typeof core.normalizeAgentSessionTodoStatus).toBe("function");
+  });
+
+  test("re-exports shared record guards from the barrel", () => {
+    expect(typeof core.isRecord).toBe("function");
+    expect(typeof core.isUnknownRecord).toBe("function");
   });
 
   test("keeps todo normalizer type exports importable from the barrel", () => {

--- a/packages/core/src/guards.test.ts
+++ b/packages/core/src/guards.test.ts
@@ -2,13 +2,18 @@ import { describe, expect, test } from "bun:test";
 import { isRecord, isUnknownRecord } from "./guards";
 
 describe("guards", () => {
-  test("isUnknownRecord returns true for non-array objects", () => {
+  test("isUnknownRecord returns true for plain objects", () => {
     expect(isUnknownRecord({ key: "value" })).toBe(true);
     expect(isUnknownRecord(Object.create(null))).toBe(true);
-    expect(isUnknownRecord(new Date())).toBe(true);
   });
 
-  test("isUnknownRecord returns false for null, arrays, and primitives", () => {
+  test("isUnknownRecord returns false for non-plain objects and primitives", () => {
+    class ExampleClass {
+      readonly id = "example";
+    }
+
+    expect(isUnknownRecord(new Date())).toBe(false);
+    expect(isUnknownRecord(new ExampleClass())).toBe(false);
     expect(isUnknownRecord(null)).toBe(false);
     expect(isUnknownRecord([])).toBe(false);
     expect(isUnknownRecord("value")).toBe(false);

--- a/packages/core/src/guards.test.ts
+++ b/packages/core/src/guards.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { isRecord, isUnknownRecord } from "./guards";
+
+describe("guards", () => {
+  test("isUnknownRecord returns true for non-array objects", () => {
+    expect(isUnknownRecord({ key: "value" })).toBe(true);
+    expect(isUnknownRecord(Object.create(null))).toBe(true);
+    expect(isUnknownRecord(new Date())).toBe(true);
+  });
+
+  test("isUnknownRecord returns false for null, arrays, and primitives", () => {
+    expect(isUnknownRecord(null)).toBe(false);
+    expect(isUnknownRecord([])).toBe(false);
+    expect(isUnknownRecord("value")).toBe(false);
+    expect(isUnknownRecord(123)).toBe(false);
+    expect(isUnknownRecord(false)).toBe(false);
+    expect(isUnknownRecord(() => "value")).toBe(false);
+    expect(isUnknownRecord(undefined)).toBe(false);
+  });
+
+  test("isRecord is an alias of isUnknownRecord", () => {
+    expect(isRecord).toBe(isUnknownRecord);
+  });
+});

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -1,0 +1,6 @@
+export type UnknownRecord = Record<string, unknown>;
+
+export const isUnknownRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const isRecord = isUnknownRecord;

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -1,6 +1,11 @@
 export type UnknownRecord = Record<string, unknown>;
 
-export const isUnknownRecord = (value: unknown): value is UnknownRecord =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+export const isUnknownRecord = (value: unknown): value is UnknownRecord => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+};
 
 export const isRecord = isUnknownRecord;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./guards";
 export * from "./ports/agent-engine";
 export * from "./services/agent-session-todos";
 export * from "./services/agent-system-prompts";


### PR DESCRIPTION
## Summary
- extract duplicated `isRecord` usage from desktop agent page modules
- introduce canonical shared record guards in `@openducktor/core` (`UnknownRecord`, `isUnknownRecord`, `isRecord`)
- migrate desktop and `@openducktor/adapters-opencode-sdk` guard usage to core
- remove desktop-local guard utility and add core guard/unit export contract coverage

## Validation
- `bun run --filter @openducktor/core lint`
- `bun run --filter @openducktor/core typecheck`
- `bun run --filter @openducktor/core test`
- `bun run --filter @openducktor/adapters-opencode-sdk lint`
- `bun run --filter @openducktor/adapters-opencode-sdk typecheck`
- `bun run --filter @openducktor/adapters-opencode-sdk test`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop test`
