### PR TITLE
perf(desktop): stabilize AgentChatThread virtual row memoization

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts
@@ -1,12 +1,31 @@
 import { describe, expect, test } from "bun:test";
-import { buildMessage, buildSession } from "./agent-chat-test-fixtures";
+import type { AgentChatMessage } from "@/types/agent-orchestrator";
+import { buildMessage, buildModelSelection, buildSession } from "./agent-chat-test-fixtures";
 import {
   buildAgentChatVirtualRows,
+  buildAgentChatVirtualRowsSignature,
   buildVirtualRowLayout,
   findVirtualWindowRange,
   getVirtualWindowEdgeOffsets,
   normalizeVirtualWindowRange,
 } from "./agent-chat-thread-virtualization";
+
+const createMessageIdentityResolver = (): ((message: AgentChatMessage) => number) => {
+  const tokenByMessage = new WeakMap<AgentChatMessage, number>();
+  let nextToken = 1;
+
+  return (message: AgentChatMessage): number => {
+    const cached = tokenByMessage.get(message);
+    if (typeof cached === "number") {
+      return cached;
+    }
+
+    const assignedToken = nextToken;
+    nextToken += 1;
+    tokenByMessage.set(message, assignedToken);
+    return assignedToken;
+  };
+};
 
 describe("agent-chat-thread virtualization helpers", () => {
   test("buildAgentChatVirtualRows keeps message order and stable synthetic row keys", () => {
@@ -56,6 +75,86 @@ describe("agent-chat-thread virtualization helpers", () => {
     expect(firstKeys).toContain("session-a:message-1");
     expect(secondKeys).toContain("session-b:message-1");
     expect(firstKeys).not.toContain("session-b:message-1");
+  });
+
+  test("buildAgentChatVirtualRowsSignature stays stable for non-row session updates", () => {
+    const messages = [buildMessage("assistant", "Message 1", { id: "message-1" })];
+    const baseSession = buildSession({
+      messages,
+      selectedModel: buildModelSelection({ variant: "high" }),
+      isLoadingModelCatalog: false,
+    });
+    const updatedSession = {
+      ...baseSession,
+      selectedModel: buildModelSelection({ variant: "low" }),
+      isLoadingModelCatalog: true,
+    };
+    const resolveMessageIdentityToken = createMessageIdentityResolver();
+
+    const baselineSignature = buildAgentChatVirtualRowsSignature(
+      baseSession,
+      resolveMessageIdentityToken,
+    );
+    const updatedSignature = buildAgentChatVirtualRowsSignature(
+      updatedSession,
+      resolveMessageIdentityToken,
+    );
+
+    expect(updatedSignature).toBe(baselineSignature);
+  });
+
+  test("buildAgentChatVirtualRowsSignature changes when messages are appended in place", () => {
+    const messages = [buildMessage("assistant", "Message 1", { id: "message-1" })];
+    const session = buildSession({ messages });
+    const resolveMessageIdentityToken = createMessageIdentityResolver();
+
+    const previousSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+    messages.push(buildMessage("assistant", "Message 2", { id: "message-2" }));
+    const nextSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+
+    expect(nextSignature).not.toBe(previousSignature);
+  });
+
+  test("buildAgentChatVirtualRowsSignature changes when a message object is replaced in place", () => {
+    const messages = [buildMessage("assistant", "Message 1", { id: "message-1" })];
+    const session = buildSession({ messages });
+    const resolveMessageIdentityToken = createMessageIdentityResolver();
+
+    const previousSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+    messages[0] = buildMessage("assistant", "Message 1 updated", { id: "message-1" });
+    const nextSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+
+    expect(nextSignature).not.toBe(previousSignature);
+  });
+
+  test("buildAgentChatVirtualRowsSignature changes when assistant duration mutates in place", () => {
+    const messages = [
+      buildMessage("assistant", "Message 1", {
+        id: "message-1",
+        meta: {
+          kind: "assistant",
+          agentRole: "spec",
+          opencodeAgent: "Hephaestus (Deep Agent)",
+          durationMs: 1_500,
+        },
+      }),
+    ];
+    const session = buildSession({ messages });
+    const resolveMessageIdentityToken = createMessageIdentityResolver();
+    const previousSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+
+    const assistantMessage = messages[0];
+    if (!assistantMessage) {
+      throw new Error("Expected assistant message");
+    }
+    expect(assistantMessage.meta?.kind).toBe("assistant");
+    if (assistantMessage.meta?.kind !== "assistant") {
+      throw new Error("Expected assistant message metadata");
+    }
+    assistantMessage.meta.durationMs = 2_400;
+
+    const nextSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+    expect(nextSignature).not.toBe(previousSignature);
   });
 
   test("buildAgentChatVirtualRows appends thinking row when session is running without draft", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts
@@ -108,7 +108,10 @@ describe("agent-chat-thread virtualization helpers", () => {
     const session = buildSession({ messages });
     const resolveMessageIdentityToken = createMessageIdentityResolver();
 
-    const previousSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+    const previousSignature = buildAgentChatVirtualRowsSignature(
+      session,
+      resolveMessageIdentityToken,
+    );
     messages.push(buildMessage("assistant", "Message 2", { id: "message-2" }));
     const nextSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
 
@@ -120,7 +123,10 @@ describe("agent-chat-thread virtualization helpers", () => {
     const session = buildSession({ messages });
     const resolveMessageIdentityToken = createMessageIdentityResolver();
 
-    const previousSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+    const previousSignature = buildAgentChatVirtualRowsSignature(
+      session,
+      resolveMessageIdentityToken,
+    );
     messages[0] = buildMessage("assistant", "Message 1 updated", { id: "message-1" });
     const nextSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
 
@@ -141,7 +147,10 @@ describe("agent-chat-thread virtualization helpers", () => {
     ];
     const session = buildSession({ messages });
     const resolveMessageIdentityToken = createMessageIdentityResolver();
-    const previousSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+    const previousSignature = buildAgentChatVirtualRowsSignature(
+      session,
+      resolveMessageIdentityToken,
+    );
 
     const assistantMessage = messages[0];
     if (!assistantMessage) {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.ts
@@ -101,6 +101,33 @@ export function buildAgentChatVirtualRows(session: AgentSessionState): AgentChat
   return rows;
 }
 
+export function buildAgentChatVirtualRowsSignature(
+  session: AgentSessionState,
+  resolveMessageIdentityToken: (message: AgentChatMessage) => number,
+): string {
+  const signatureParts: string[] = [
+    session.sessionId,
+    session.status,
+    session.draftAssistantText,
+    String(session.pendingQuestions.length),
+  ];
+
+  for (const message of session.messages) {
+    const assistantDurationToken =
+      message.meta?.kind === "assistant" && typeof message.meta.durationMs === "number"
+        ? String(message.meta.durationMs)
+        : "";
+    signatureParts.push(
+      String(resolveMessageIdentityToken(message)),
+      message.id,
+      message.role,
+      assistantDurationToken,
+    );
+  }
+
+  return signatureParts.join("\u001f");
+}
+
 export function buildVirtualRowLayout({ itemHeights, gapPx }: BuildVirtualRowLayoutArgs): {
   itemOffsets: number[];
   totalHeight: number;

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -59,7 +59,16 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const StreamingRoleIcon = streamingRoleDisplay?.icon ?? Bot;
   const streamingRoleLabel = streamingRoleDisplay?.label ?? "Assistant";
 
-  const virtualRows = session ? buildAgentChatVirtualRows(session) : [];
+  const virtualRows = useMemo(
+    () => (session ? buildAgentChatVirtualRows(session) : []),
+    [
+      session,
+      session?.messages.length,
+      session?.draftAssistantText,
+      session?.status,
+      session?.pendingQuestions.length,
+    ],
+  );
   const shouldVirtualize = virtualRows.length >= AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT;
   const activeSessionId = session?.sessionId ?? null;
   const measuredSessionIdRef = useRef<string | null>(null);

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import type { AgentChatThreadModel } from "./agent-chat.types";
 import { AgentChatMessageCard } from "./agent-chat-message-card";
 import {
@@ -19,6 +20,7 @@ import {
   AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT,
   type AgentChatVirtualRow,
   buildAgentChatVirtualRows,
+  buildAgentChatVirtualRowsSignature,
 } from "./agent-chat-thread-virtualization";
 import { AgentSessionPermissionCard } from "./agent-session-permission-card";
 import { AgentSessionQuestionCard } from "./agent-session-question-card";
@@ -59,16 +61,39 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const StreamingRoleIcon = streamingRoleDisplay?.icon ?? Bot;
   const streamingRoleLabel = streamingRoleDisplay?.label ?? "Assistant";
 
-  const virtualRows = useMemo(
-    () => (session ? buildAgentChatVirtualRows(session) : []),
-    [
-      session,
-      session?.messages.length,
-      session?.draftAssistantText,
-      session?.status,
-      session?.pendingQuestions.length,
-    ],
-  );
+  const messageIdentityTokenByMessageRef = useRef<WeakMap<AgentChatMessage, number>>(new WeakMap());
+  const nextMessageIdentityTokenRef = useRef(1);
+  const virtualRowsCacheRef = useRef<{ signature: string | null; rows: AgentChatVirtualRow[] }>({
+    signature: null,
+    rows: [],
+  });
+  const resolveMessageIdentityToken = useCallback((message: AgentChatMessage): number => {
+    const cached = messageIdentityTokenByMessageRef.current.get(message);
+    if (typeof cached === "number") {
+      return cached;
+    }
+
+    const nextToken = nextMessageIdentityTokenRef.current;
+    nextMessageIdentityTokenRef.current += 1;
+    messageIdentityTokenByMessageRef.current.set(message, nextToken);
+    return nextToken;
+  }, []);
+  const virtualRowsSignature = session
+    ? buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken)
+    : null;
+  const virtualRows = useMemo(() => {
+    const cached = virtualRowsCacheRef.current;
+    if (cached.signature === virtualRowsSignature) {
+      return cached.rows;
+    }
+
+    const nextRows = session ? buildAgentChatVirtualRows(session) : [];
+    virtualRowsCacheRef.current = {
+      signature: virtualRowsSignature,
+      rows: nextRows,
+    };
+    return nextRows;
+  }, [session, virtualRowsSignature]);
   const shouldVirtualize = virtualRows.length >= AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT;
   const activeSessionId = session?.sessionId ?? null;
   const measuredSessionIdRef = useRef<string | null>(null);


### PR DESCRIPTION
## Summary
This PR improves `AgentChatThread` runtime performance by stabilizing virtualization inputs and callback dependencies.

The original hotspot was `buildAgentChatVirtualRows(session)` being recomputed during render churn, which caused callback identity churn (`estimateSize`, `measureElement`, `getItemKey`) and extra work in `useVirtualizer`.

## Problem
`AgentChatThread` was producing a fresh `virtualRows` array too often, including renders triggered by non-row session updates. That propagated unstable references into virtualizer callbacks and could force unnecessary virtualizer recomputation.

## What Changed
1. Added row-signature helper in `agent-chat-thread-virtualization.ts`:
   - `buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken)`
   - Signature includes row-driving fields and per-message identity markers.

2. Updated `AgentChatThread` row memoization strategy:
   - Added message identity token resolver backed by `WeakMap<AgentChatMessage, number>`.
   - Added signature-keyed `virtualRows` cache.
   - Recompute rows only when signature changes; return cached rows otherwise.

3. Expanded test coverage in `agent-chat-thread-virtualization.test.ts`:
   - Signature is stable for non-row session updates.
   - Signature changes for in-place message append.
   - Signature changes for same-length message object replacement.
   - Signature changes for in-place assistant-duration mutation.

4. Kept and validated existing thread behavior in `agent-chat-thread.test.ts`:
   - Existing mutation regression case remains green.

## Why This Approach
Using a row signature plus message identity tokens gives precise invalidation:
- Avoids broad `session`-identity invalidations on unrelated state updates.
- Still captures row-relevant mutations, including in-place updates where array length may not change.

## Validation
Executed successfully:

```sh
bun run --filter @openducktor/desktop typecheck
bun run --filter @openducktor/desktop test src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts src/components/features/agents/agent-chat/agent-chat-thread.test.ts
bun run --filter @openducktor/desktop test
```

Results:
- Full desktop suite: `570 pass, 0 fail`.
- Typecheck: pass.

## Scope
Files changed:
- `apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx`
- `apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.ts`
- `apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts`
