### PR TITLE
refactor(agent-studio): reduce submodel arg bloat and harden memo contracts

### DIFF
--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -458,6 +458,89 @@ describe("useAgentStudioPageModels", () => {
     await harness.unmount();
   });
 
+  test("keeps composer model stable for thread-only updates", async () => {
+    const session = createSession("session-1", "external-1");
+    const baseProps = createHookArgs({
+      core: {
+        activeSession: session,
+        sessionsForTask: [session],
+      },
+      composer: {
+        input: "draft",
+      },
+    });
+    const harness = createHookHarness(baseProps);
+
+    await harness.mount();
+    const initialState = harness.getLatest();
+    const initialThreadModel = initialState.agentChatModel.thread;
+    const initialComposerModel = initialState.agentChatModel.composer;
+
+    await harness.run((state) => {
+      state.agentChatModel.thread.onToggleTodoPanel();
+    });
+
+    const nextState = harness.getLatest();
+    expect(nextState.agentChatModel.thread).not.toBe(initialThreadModel);
+    expect(nextState.agentChatModel.composer).toBe(initialComposerModel);
+    expect(nextState.agentChatModel.thread.todoPanelCollapsed).toBe(true);
+
+    await harness.unmount();
+  });
+
+  test("updates thread model for pending request maps without rebuilding composer", async () => {
+    const session = createSession("session-1", "external-1");
+    const baseProps = createHookArgs({
+      core: {
+        activeSession: session,
+        sessionsForTask: [session],
+      },
+      composer: {
+        input: "draft",
+      },
+    });
+    const harness = createHookHarness(baseProps);
+
+    await harness.mount();
+    const initialState = harness.getLatest();
+    const initialThreadModel = initialState.agentChatModel.thread;
+    const initialComposerModel = initialState.agentChatModel.composer;
+
+    const permissionUpdateProps = {
+      ...baseProps,
+      permissions: {
+        ...baseProps.permissions,
+        isSubmittingPermissionByRequestId: {
+          "perm-1": true,
+        },
+      },
+    };
+    await harness.update(permissionUpdateProps);
+
+    const permissionState = harness.getLatest();
+    const permissionThreadModel = permissionState.agentChatModel.thread;
+    expect(permissionThreadModel).not.toBe(initialThreadModel);
+    expect(permissionState.agentChatModel.composer).toBe(initialComposerModel);
+    expect(permissionThreadModel.isSubmittingPermissionByRequestId["perm-1"]).toBe(true);
+
+    await harness.update({
+      ...permissionUpdateProps,
+      sessionActions: {
+        ...permissionUpdateProps.sessionActions,
+        isSubmittingQuestionByRequestId: {
+          "q-1": true,
+        },
+      },
+    });
+
+    const questionState = harness.getLatest();
+    expect(questionState.agentChatModel.thread).not.toBe(permissionThreadModel);
+    expect(questionState.agentChatModel.composer).toBe(initialComposerModel);
+    expect(questionState.agentChatModel.thread.isSubmittingQuestionByRequestId["q-1"]).toBe(true);
+
+    await harness.unmount();
+  });
+
   test("treats unavailable selected role as read-only and hides kickoff action", async () => {
     const unavailablePlannerTask = createTaskCardFixture({
       status: "open",

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -541,6 +541,51 @@ describe("useAgentStudioPageModels", () => {
     await harness.unmount();
   });
 
+  test("keeps composer model stable when active session reference changes with same session id", async () => {
+    const initialSession = createSession("session-1", "external-1", {
+      role: "spec",
+      status: "running",
+      isLoadingModelCatalog: false,
+    });
+    const baseProps = createHookArgs({
+      core: {
+        activeSession: initialSession,
+        sessionsForTask: [initialSession],
+      },
+      composer: {
+        input: "draft",
+      },
+      sessionActions: {
+        isSessionWorking: true,
+      },
+    });
+    const harness = createHookHarness(baseProps);
+
+    await harness.mount();
+    const initialComposerModel = harness.getLatest().agentChatModel.composer;
+
+    const sameSessionIdNewRef = createSession("session-1", "external-1", {
+      role: "spec",
+      status: "running",
+      isLoadingModelCatalog: false,
+    });
+    await harness.update(
+      createHookArgs({
+        ...baseProps,
+        core: {
+          ...baseProps.core,
+          activeSession: sameSessionIdNewRef,
+          sessionsForTask: [sameSessionIdNewRef],
+        },
+      }),
+    );
+
+    const nextComposerModel = harness.getLatest().agentChatModel.composer;
+    expect(nextComposerModel).toBe(initialComposerModel);
+
+    await harness.unmount();
+  });
+
   test("treats unavailable selected role as read-only and hides kickoff action", async () => {
     const unavailablePlannerTask = createTaskCardFixture({
       status: "open",

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -23,6 +23,20 @@ import {
   buildWorkflowModelContext,
   toChatContextUsage,
 } from "./use-agent-studio-page-model-builders";
+import type {
+  AgentStudioComposerInteractionContext,
+  AgentStudioComposerLayoutContext,
+  AgentStudioComposerReadinessContext,
+  AgentStudioComposerSelectionContext,
+  AgentStudioComposerSessionContext,
+  AgentStudioThreadKickoffContext,
+  AgentStudioThreadPermissionsContext,
+  AgentStudioThreadQuestionsContext,
+  AgentStudioThreadReadinessContext,
+  AgentStudioThreadScrollContext,
+  AgentStudioThreadSessionContext,
+  AgentStudioThreadTodoPanelContext,
+} from "./use-agent-studio-page-submodel-contracts";
 import {
   useAgentStudioComposerModel,
   useAgentStudioHeaderModel,
@@ -67,12 +81,7 @@ type AgentStudioSessionActionsContext = {
   stopAgentSession: (sessionId: string) => Promise<void>;
 };
 
-type AgentStudioReadinessContext = {
-  agentStudioReady: boolean;
-  agentStudioBlockedReason: string;
-  isLoadingChecks: boolean;
-  refreshChecks: () => Promise<void>;
-};
+type AgentStudioReadinessContext = AgentStudioThreadReadinessContext;
 
 type AgentStudioModelSelectionContext = {
   selectedModelSelection: AgentModelSelection | null;
@@ -88,11 +97,7 @@ type AgentStudioModelSelectionContext = {
   activeSessionContextUsage: AgentStudioSessionContextUsage;
 };
 
-type AgentStudioPermissionContext = {
-  isSubmittingPermissionByRequestId: Record<string, boolean>;
-  permissionReplyErrorByRequestId: Record<string, string>;
-  onReplyPermission: (requestId: string, reply: "once" | "always" | "reject") => Promise<void>;
-};
+type AgentStudioPermissionContext = AgentStudioThreadPermissionsContext;
 
 type AgentStudioComposerContext = {
   input: string;
@@ -271,7 +276,7 @@ export function useAgentStudioPageModels({
     }));
   }, [activeSessionId]);
 
-  const threadSessionContext = useMemo(
+  const threadSessionContext = useMemo<AgentStudioThreadSessionContext>(
     () => ({
       threadSession,
       taskId: core.taskId,
@@ -280,7 +285,7 @@ export function useAgentStudioPageModels({
     [core.taskId, modelSelection.activeSessionAgentColors, threadSession],
   );
 
-  const threadReadinessContext = useMemo(
+  const threadReadinessContext = useMemo<AgentStudioThreadReadinessContext>(
     () => ({
       agentStudioReady: readiness.agentStudioReady,
       agentStudioBlockedReason: readiness.agentStudioBlockedReason,
@@ -295,7 +300,7 @@ export function useAgentStudioPageModels({
     ],
   );
 
-  const threadKickoffContext = useMemo(
+  const threadKickoffContext = useMemo<AgentStudioThreadKickoffContext>(
     () => ({
       canKickoffNewSession: sessionActions.canKickoffNewSession,
       selectedRoleAvailable,
@@ -314,7 +319,7 @@ export function useAgentStudioPageModels({
     ],
   );
 
-  const threadQuestionContext = useMemo(
+  const threadQuestionContext = useMemo<AgentStudioThreadQuestionsContext>(
     () => ({
       isSubmittingQuestionByRequestId: sessionActions.isSubmittingQuestionByRequestId,
       onSubmitQuestionAnswers: sessionActions.onSubmitQuestionAnswers,
@@ -322,7 +327,7 @@ export function useAgentStudioPageModels({
     [sessionActions.isSubmittingQuestionByRequestId, sessionActions.onSubmitQuestionAnswers],
   );
 
-  const threadPermissionContext = useMemo(
+  const threadPermissionContext = useMemo<AgentStudioThreadPermissionsContext>(
     () => ({
       isSubmittingPermissionByRequestId: permissions.isSubmittingPermissionByRequestId,
       permissionReplyErrorByRequestId: permissions.permissionReplyErrorByRequestId,
@@ -335,7 +340,7 @@ export function useAgentStudioPageModels({
     ],
   );
 
-  const threadTodoPanelContext = useMemo(
+  const threadTodoPanelContext = useMemo<AgentStudioThreadTodoPanelContext>(
     () => ({
       todoPanelCollapsed: activeTodoPanelCollapsed,
       onToggleTodoPanel: handleToggleTodoPanel,
@@ -344,7 +349,7 @@ export function useAgentStudioPageModels({
     [activeTodoPanelCollapsed, handleToggleTodoPanel, todoPanelBottomOffset],
   );
 
-  const threadScrollContext = useMemo(
+  const threadScrollContext = useMemo<AgentStudioThreadScrollContext>(
     () => ({
       isPinnedToBottom,
       messagesContainerRef,
@@ -363,7 +368,7 @@ export function useAgentStudioPageModels({
     scroll: threadScrollContext,
   });
 
-  const composerSessionContext = useMemo(
+  const composerSessionContext = useMemo<AgentStudioComposerSessionContext>(
     () => ({
       taskId: core.taskId,
       activeSession: core.activeSession,
@@ -380,7 +385,7 @@ export function useAgentStudioPageModels({
     ],
   );
 
-  const composerReadinessContext = useMemo(
+  const composerReadinessContext = useMemo<AgentStudioComposerReadinessContext>(
     () => ({
       agentStudioReady: readiness.agentStudioReady,
       workflow: {
@@ -391,7 +396,7 @@ export function useAgentStudioPageModels({
     [readiness.agentStudioReady, selectedRoleAvailable, selectedRoleReadOnlyReason],
   );
 
-  const composerInteractionContext = useMemo(
+  const composerInteractionContext = useMemo<AgentStudioComposerInteractionContext>(
     () => ({
       input: composer.input,
       setInput: composer.setInput,
@@ -410,7 +415,7 @@ export function useAgentStudioPageModels({
     ],
   );
 
-  const composerSelectionContext = useMemo(
+  const composerSelectionContext = useMemo<AgentStudioComposerSelectionContext>(
     () => ({
       selectedModelSelection: modelSelection.selectedModelSelection,
       isSelectionCatalogLoading: modelSelection.isSelectionCatalogLoading,
@@ -437,7 +442,7 @@ export function useAgentStudioPageModels({
     ],
   );
 
-  const composerLayoutContext = useMemo(
+  const composerLayoutContext = useMemo<AgentStudioComposerLayoutContext>(
     () => ({
       composerFormRef,
       composerTextareaRef,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -271,63 +271,187 @@ export function useAgentStudioPageModels({
     }));
   }, [activeSessionId]);
 
+  const threadSessionContext = useMemo(
+    () => ({
+      threadSession,
+      taskId: core.taskId,
+      activeSessionAgentColors: modelSelection.activeSessionAgentColors,
+    }),
+    [core.taskId, modelSelection.activeSessionAgentColors, threadSession],
+  );
+
+  const threadReadinessContext = useMemo(
+    () => ({
+      agentStudioReady: readiness.agentStudioReady,
+      agentStudioBlockedReason: readiness.agentStudioBlockedReason,
+      isLoadingChecks: readiness.isLoadingChecks,
+      refreshChecks: readiness.refreshChecks,
+    }),
+    [
+      readiness.agentStudioBlockedReason,
+      readiness.agentStudioReady,
+      readiness.isLoadingChecks,
+      readiness.refreshChecks,
+    ],
+  );
+
+  const threadKickoffContext = useMemo(
+    () => ({
+      canKickoffNewSession: sessionActions.canKickoffNewSession,
+      selectedRoleAvailable,
+      kickoffLabel: sessionActions.kickoffLabel,
+      startScenarioKickoff: sessionActions.startScenarioKickoff,
+      isStarting: sessionActions.isStarting,
+      isSending: sessionActions.isSending,
+    }),
+    [
+      selectedRoleAvailable,
+      sessionActions.canKickoffNewSession,
+      sessionActions.isSending,
+      sessionActions.isStarting,
+      sessionActions.kickoffLabel,
+      sessionActions.startScenarioKickoff,
+    ],
+  );
+
+  const threadQuestionContext = useMemo(
+    () => ({
+      isSubmittingQuestionByRequestId: sessionActions.isSubmittingQuestionByRequestId,
+      onSubmitQuestionAnswers: sessionActions.onSubmitQuestionAnswers,
+    }),
+    [sessionActions.isSubmittingQuestionByRequestId, sessionActions.onSubmitQuestionAnswers],
+  );
+
+  const threadPermissionContext = useMemo(
+    () => ({
+      isSubmittingPermissionByRequestId: permissions.isSubmittingPermissionByRequestId,
+      permissionReplyErrorByRequestId: permissions.permissionReplyErrorByRequestId,
+      onReplyPermission: permissions.onReplyPermission,
+    }),
+    [
+      permissions.isSubmittingPermissionByRequestId,
+      permissions.onReplyPermission,
+      permissions.permissionReplyErrorByRequestId,
+    ],
+  );
+
+  const threadTodoPanelContext = useMemo(
+    () => ({
+      todoPanelCollapsed: activeTodoPanelCollapsed,
+      onToggleTodoPanel: handleToggleTodoPanel,
+      todoPanelBottomOffset,
+    }),
+    [activeTodoPanelCollapsed, handleToggleTodoPanel, todoPanelBottomOffset],
+  );
+
+  const threadScrollContext = useMemo(
+    () => ({
+      isPinnedToBottom,
+      messagesContainerRef,
+      onMessagesScroll: handleMessagesScroll,
+    }),
+    [handleMessagesScroll, isPinnedToBottom, messagesContainerRef],
+  );
+
   const agentChatThreadModel = useAgentStudioThreadModel({
-    threadSession,
-    taskId: core.taskId,
-    agentStudioReady: readiness.agentStudioReady,
-    agentStudioBlockedReason: readiness.agentStudioBlockedReason,
-    isLoadingChecks: readiness.isLoadingChecks,
-    refreshChecks: readiness.refreshChecks,
-    canKickoffNewSession: sessionActions.canKickoffNewSession,
-    selectedRoleAvailable,
-    kickoffLabel: sessionActions.kickoffLabel,
-    startScenarioKickoff: sessionActions.startScenarioKickoff,
-    isStarting: sessionActions.isStarting,
-    isSending: sessionActions.isSending,
-    activeSessionAgentColors: modelSelection.activeSessionAgentColors,
-    isSubmittingQuestionByRequestId: sessionActions.isSubmittingQuestionByRequestId,
-    onSubmitQuestionAnswers: sessionActions.onSubmitQuestionAnswers,
-    isSubmittingPermissionByRequestId: permissions.isSubmittingPermissionByRequestId,
-    permissionReplyErrorByRequestId: permissions.permissionReplyErrorByRequestId,
-    onReplyPermission: permissions.onReplyPermission,
-    todoPanelCollapsed: activeTodoPanelCollapsed,
-    onToggleTodoPanel: handleToggleTodoPanel,
-    todoPanelBottomOffset,
-    isPinnedToBottom,
-    messagesContainerRef,
-    onMessagesScroll: handleMessagesScroll,
+    session: threadSessionContext,
+    readiness: threadReadinessContext,
+    kickoff: threadKickoffContext,
+    questions: threadQuestionContext,
+    permissions: threadPermissionContext,
+    todoPanel: threadTodoPanelContext,
+    scroll: threadScrollContext,
   });
 
+  const composerSessionContext = useMemo(
+    () => ({
+      taskId: core.taskId,
+      activeSession: core.activeSession,
+      isSessionWorking: sessionActions.isSessionWorking,
+      canStopSession: sessionActions.canStopSession,
+      stopAgentSession: sessionActions.stopAgentSession,
+    }),
+    [
+      core.activeSession,
+      core.taskId,
+      sessionActions.canStopSession,
+      sessionActions.isSessionWorking,
+      sessionActions.stopAgentSession,
+    ],
+  );
+
+  const composerReadinessContext = useMemo(
+    () => ({
+      agentStudioReady: readiness.agentStudioReady,
+      workflow: {
+        selectedRoleAvailable,
+        selectedRoleReadOnlyReason,
+      },
+    }),
+    [readiness.agentStudioReady, selectedRoleAvailable, selectedRoleReadOnlyReason],
+  );
+
+  const composerInteractionContext = useMemo(
+    () => ({
+      input: composer.input,
+      setInput: composer.setInput,
+      onSend: sessionActions.onSend,
+      isSending: sessionActions.isSending,
+      isStarting: sessionActions.isStarting,
+      chatContextUsage,
+    }),
+    [
+      chatContextUsage,
+      composer.input,
+      composer.setInput,
+      sessionActions.isSending,
+      sessionActions.isStarting,
+      sessionActions.onSend,
+    ],
+  );
+
+  const composerSelectionContext = useMemo(
+    () => ({
+      selectedModelSelection: modelSelection.selectedModelSelection,
+      isSelectionCatalogLoading: modelSelection.isSelectionCatalogLoading,
+      agentOptions: modelSelection.agentOptions,
+      modelOptions: modelSelection.modelOptions,
+      modelGroups: modelSelection.modelGroups,
+      variantOptions: modelSelection.variantOptions,
+      onSelectAgent: modelSelection.onSelectAgent,
+      onSelectModel: modelSelection.onSelectModel,
+      onSelectVariant: modelSelection.onSelectVariant,
+      activeSessionAgentColors: modelSelection.activeSessionAgentColors,
+    }),
+    [
+      modelSelection.activeSessionAgentColors,
+      modelSelection.agentOptions,
+      modelSelection.isSelectionCatalogLoading,
+      modelSelection.modelGroups,
+      modelSelection.modelOptions,
+      modelSelection.onSelectAgent,
+      modelSelection.onSelectModel,
+      modelSelection.onSelectVariant,
+      modelSelection.selectedModelSelection,
+      modelSelection.variantOptions,
+    ],
+  );
+
+  const composerLayoutContext = useMemo(
+    () => ({
+      composerFormRef,
+      composerTextareaRef,
+      resizeComposerTextarea,
+    }),
+    [composerFormRef, composerTextareaRef, resizeComposerTextarea],
+  );
+
   const agentChatComposerModel = useAgentStudioComposerModel({
-    taskId: core.taskId,
-    activeSession: core.activeSession,
-    agentStudioReady: readiness.agentStudioReady,
-    workflow: {
-      selectedRoleAvailable,
-      selectedRoleReadOnlyReason,
-    },
-    input: composer.input,
-    setInput: composer.setInput,
-    onSend: sessionActions.onSend,
-    isSending: sessionActions.isSending,
-    isStarting: sessionActions.isStarting,
-    isSessionWorking: sessionActions.isSessionWorking,
-    selectedModelSelection: modelSelection.selectedModelSelection,
-    isSelectionCatalogLoading: modelSelection.isSelectionCatalogLoading,
-    agentOptions: modelSelection.agentOptions,
-    modelOptions: modelSelection.modelOptions,
-    modelGroups: modelSelection.modelGroups,
-    variantOptions: modelSelection.variantOptions,
-    onSelectAgent: modelSelection.onSelectAgent,
-    onSelectModel: modelSelection.onSelectModel,
-    onSelectVariant: modelSelection.onSelectVariant,
-    activeSessionAgentColors: modelSelection.activeSessionAgentColors,
-    chatContextUsage,
-    canStopSession: sessionActions.canStopSession,
-    stopAgentSession: sessionActions.stopAgentSession,
-    composerFormRef,
-    composerTextareaRef,
-    resizeComposerTextarea,
+    session: composerSessionContext,
+    readiness: composerReadinessContext,
+    interaction: composerInteractionContext,
+    selection: composerSelectionContext,
+    layout: composerLayoutContext,
   });
 
   const agentChatModel = useMemo(

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodel-contracts.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodel-contracts.ts
@@ -1,0 +1,110 @@
+import type { AgentModelSelection, AgentRole } from "@openducktor/core";
+import type { RefObject, UIEvent } from "react";
+import type { AgentChatModel } from "@/components/features/agents";
+import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { WorkflowModelContext } from "./use-agent-studio-page-model-builders";
+
+export type WorkflowHeaderContext = Pick<
+  WorkflowModelContext,
+  | "workflowStateByRole"
+  | "selectedInteractionRole"
+  | "latestSessionByRole"
+  | "sessionSelectorValue"
+  | "sessionSelectorGroups"
+  | "sessionCreateOptions"
+  | "createSessionDisabled"
+>;
+
+export type WorkflowComposerContext = Pick<
+  WorkflowModelContext,
+  "selectedRoleAvailable" | "selectedRoleReadOnlyReason"
+>;
+
+export type AgentStudioThreadSessionContext = {
+  threadSession: AgentSessionState | null;
+  taskId: string;
+  activeSessionAgentColors: Record<string, string>;
+};
+
+export type AgentStudioThreadReadinessContext = {
+  agentStudioReady: boolean;
+  agentStudioBlockedReason: string;
+  isLoadingChecks: boolean;
+  refreshChecks: () => Promise<void>;
+};
+
+export type AgentStudioThreadKickoffContext = {
+  canKickoffNewSession: boolean;
+  selectedRoleAvailable: boolean;
+  kickoffLabel: string;
+  startScenarioKickoff: () => Promise<void>;
+  isStarting: boolean;
+  isSending: boolean;
+};
+
+export type AgentStudioThreadQuestionsContext = {
+  isSubmittingQuestionByRequestId: Record<string, boolean>;
+  onSubmitQuestionAnswers: (requestId: string, answers: string[][]) => Promise<void>;
+};
+
+export type AgentStudioThreadPermissionsContext = {
+  isSubmittingPermissionByRequestId: Record<string, boolean>;
+  permissionReplyErrorByRequestId: Record<string, string>;
+  onReplyPermission: (requestId: string, reply: "once" | "always" | "reject") => Promise<void>;
+};
+
+export type AgentStudioThreadTodoPanelContext = {
+  todoPanelCollapsed: boolean;
+  onToggleTodoPanel: () => void;
+  todoPanelBottomOffset: number;
+};
+
+export type AgentStudioThreadScrollContext = {
+  isPinnedToBottom: boolean;
+  messagesContainerRef: RefObject<HTMLDivElement | null>;
+  onMessagesScroll: (event: UIEvent<HTMLDivElement>) => void;
+};
+
+export type AgentStudioComposerSessionContext = {
+  taskId: string;
+  activeSession: AgentSessionState | null;
+  isSessionWorking: boolean;
+  canStopSession: boolean;
+  stopAgentSession: (sessionId: string) => Promise<void>;
+};
+
+export type AgentStudioComposerReadinessContext = {
+  agentStudioReady: boolean;
+  workflow: WorkflowComposerContext;
+};
+
+export type AgentStudioComposerInteractionContext = {
+  input: string;
+  setInput: (value: string) => void;
+  onSend: () => Promise<void>;
+  isSending: boolean;
+  isStarting: boolean;
+  chatContextUsage: AgentChatModel["composer"]["contextUsage"];
+};
+
+export type AgentStudioComposerSelectionContext = {
+  selectedModelSelection: AgentModelSelection | null;
+  isSelectionCatalogLoading: boolean;
+  agentOptions: ComboboxOption[];
+  modelOptions: ComboboxOption[];
+  modelGroups: ComboboxGroup[];
+  variantOptions: ComboboxOption[];
+  onSelectAgent: (agent: string) => void;
+  onSelectModel: (model: string) => void;
+  onSelectVariant: (variant: string) => void;
+  activeSessionAgentColors: Record<string, string>;
+};
+
+export type AgentStudioComposerLayoutContext = {
+  composerFormRef: RefObject<HTMLFormElement | null>;
+  composerTextareaRef: RefObject<HTMLTextAreaElement | null>;
+  resizeComposerTextarea: () => void;
+};
+
+export type AgentStudioWorkflowStepSelect = (role: AgentRole, sessionId: string | null) => void;

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -1,8 +1,5 @@
 import type { TaskCard } from "@openducktor/contracts";
-import type { AgentModelSelection, AgentRole } from "@openducktor/core";
-import { type RefObject, type UIEvent, useCallback, useMemo } from "react";
-import type { AgentChatModel } from "@/components/features/agents";
-import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
+import { useCallback, useMemo } from "react";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { ROLE_OPTIONS } from "./agents-page-constants";
 import type { SessionCreateOption } from "./agents-page-session-tabs";
@@ -11,23 +8,22 @@ import {
   buildAgentChatThreadModel,
   buildAgentStudioHeaderModel,
 } from "./agents-page-view-model";
-import type { WorkflowModelContext } from "./use-agent-studio-page-model-builders";
-
-type WorkflowHeaderContext = Pick<
-  WorkflowModelContext,
-  | "workflowStateByRole"
-  | "selectedInteractionRole"
-  | "latestSessionByRole"
-  | "sessionSelectorValue"
-  | "sessionSelectorGroups"
-  | "sessionCreateOptions"
-  | "createSessionDisabled"
->;
-
-type WorkflowComposerContext = Pick<
-  WorkflowModelContext,
-  "selectedRoleAvailable" | "selectedRoleReadOnlyReason"
->;
+import type {
+  AgentStudioComposerInteractionContext,
+  AgentStudioComposerLayoutContext,
+  AgentStudioComposerReadinessContext,
+  AgentStudioComposerSelectionContext,
+  AgentStudioComposerSessionContext,
+  AgentStudioThreadKickoffContext,
+  AgentStudioThreadPermissionsContext,
+  AgentStudioThreadQuestionsContext,
+  AgentStudioThreadReadinessContext,
+  AgentStudioThreadScrollContext,
+  AgentStudioThreadSessionContext,
+  AgentStudioThreadTodoPanelContext,
+  AgentStudioWorkflowStepSelect,
+  WorkflowHeaderContext,
+} from "./use-agent-studio-page-submodel-contracts";
 
 export type UseAgentStudioHeaderModelArgs = {
   selectedTask: TaskCard | null;
@@ -36,7 +32,7 @@ export type UseAgentStudioHeaderModelArgs = {
   contextSessionsLength: number;
   agentStudioReady: boolean;
   isStarting: boolean;
-  onWorkflowStepSelect: (role: AgentRole, sessionId: string | null) => void;
+  onWorkflowStepSelect: AgentStudioWorkflowStepSelect;
   onSessionSelectionChange: (nextValue: string) => void;
   onCreateSession: (option: SessionCreateOption) => void;
   workflow: WorkflowHeaderContext;
@@ -97,44 +93,13 @@ export const useAgentStudioHeaderModel = ({
 };
 
 export type UseAgentStudioThreadModelArgs = {
-  session: {
-    threadSession: AgentSessionState | null;
-    taskId: string;
-    activeSessionAgentColors: Record<string, string>;
-  };
-  readiness: {
-    agentStudioReady: boolean;
-    agentStudioBlockedReason: string;
-    isLoadingChecks: boolean;
-    refreshChecks: () => Promise<void>;
-  };
-  kickoff: {
-    canKickoffNewSession: boolean;
-    selectedRoleAvailable: boolean;
-    kickoffLabel: string;
-    startScenarioKickoff: () => Promise<void>;
-    isStarting: boolean;
-    isSending: boolean;
-  };
-  questions: {
-    isSubmittingQuestionByRequestId: Record<string, boolean>;
-    onSubmitQuestionAnswers: (requestId: string, answers: string[][]) => Promise<void>;
-  };
-  permissions: {
-    isSubmittingPermissionByRequestId: Record<string, boolean>;
-    permissionReplyErrorByRequestId: Record<string, string>;
-    onReplyPermission: (requestId: string, reply: "once" | "always" | "reject") => Promise<void>;
-  };
-  todoPanel: {
-    todoPanelCollapsed: boolean;
-    onToggleTodoPanel: () => void;
-    todoPanelBottomOffset: number;
-  };
-  scroll: {
-    isPinnedToBottom: boolean;
-    messagesContainerRef: RefObject<HTMLDivElement | null>;
-    onMessagesScroll: (event: UIEvent<HTMLDivElement>) => void;
-  };
+  session: AgentStudioThreadSessionContext;
+  readiness: AgentStudioThreadReadinessContext;
+  kickoff: AgentStudioThreadKickoffContext;
+  questions: AgentStudioThreadQuestionsContext;
+  permissions: AgentStudioThreadPermissionsContext;
+  todoPanel: AgentStudioThreadTodoPanelContext;
+  scroll: AgentStudioThreadScrollContext;
 };
 
 export const useAgentStudioThreadModel = ({
@@ -193,54 +158,37 @@ export const useAgentStudioThreadModel = ({
       handleKickoff,
       handlePermissionReply,
       handleRefreshChecks,
-      kickoff,
-      permissions,
-      questions,
-      readiness,
-      scroll,
-      session,
-      todoPanel,
+      kickoff.canKickoffNewSession,
+      kickoff.isSending,
+      kickoff.isStarting,
+      kickoff.kickoffLabel,
+      kickoff.selectedRoleAvailable,
+      permissions.isSubmittingPermissionByRequestId,
+      permissions.permissionReplyErrorByRequestId,
+      questions.isSubmittingQuestionByRequestId,
+      questions.onSubmitQuestionAnswers,
+      readiness.agentStudioBlockedReason,
+      readiness.agentStudioReady,
+      readiness.isLoadingChecks,
+      scroll.isPinnedToBottom,
+      scroll.messagesContainerRef,
+      scroll.onMessagesScroll,
+      session.activeSessionAgentColors,
+      session.taskId,
+      session.threadSession,
+      todoPanel.onToggleTodoPanel,
+      todoPanel.todoPanelBottomOffset,
+      todoPanel.todoPanelCollapsed,
     ],
   );
 };
 
 export type UseAgentStudioComposerModelArgs = {
-  session: {
-    taskId: string;
-    activeSession: AgentSessionState | null;
-    isSessionWorking: boolean;
-    canStopSession: boolean;
-    stopAgentSession: (sessionId: string) => Promise<void>;
-  };
-  readiness: {
-    agentStudioReady: boolean;
-    workflow: WorkflowComposerContext;
-  };
-  interaction: {
-    input: string;
-    setInput: (value: string) => void;
-    onSend: () => Promise<void>;
-    isSending: boolean;
-    isStarting: boolean;
-    chatContextUsage: AgentChatModel["composer"]["contextUsage"];
-  };
-  selection: {
-    selectedModelSelection: AgentModelSelection | null;
-    isSelectionCatalogLoading: boolean;
-    agentOptions: ComboboxOption[];
-    modelOptions: ComboboxOption[];
-    modelGroups: ComboboxGroup[];
-    variantOptions: ComboboxOption[];
-    onSelectAgent: (agent: string) => void;
-    onSelectModel: (model: string) => void;
-    onSelectVariant: (variant: string) => void;
-    activeSessionAgentColors: Record<string, string>;
-  };
-  layout: {
-    composerFormRef: RefObject<HTMLFormElement | null>;
-    composerTextareaRef: RefObject<HTMLTextAreaElement | null>;
-    resizeComposerTextarea: () => void;
-  };
+  session: AgentStudioComposerSessionContext;
+  readiness: AgentStudioComposerReadinessContext;
+  interaction: AgentStudioComposerInteractionContext;
+  selection: AgentStudioComposerSelectionContext;
+  layout: AgentStudioComposerLayoutContext;
 };
 
 export const useAgentStudioComposerModel = ({
@@ -300,11 +248,30 @@ export const useAgentStudioComposerModel = ({
       handleSend,
       handleStopSession,
       isModelSelectionPending,
-      interaction,
-      layout,
-      readiness,
-      selection,
-      session,
+      interaction.chatContextUsage,
+      interaction.input,
+      interaction.isSending,
+      interaction.isStarting,
+      interaction.setInput,
+      layout.composerFormRef,
+      layout.composerTextareaRef,
+      layout.resizeComposerTextarea,
+      readiness.agentStudioReady,
+      readiness.workflow.selectedRoleAvailable,
+      readiness.workflow.selectedRoleReadOnlyReason,
+      selection.activeSessionAgentColors,
+      selection.agentOptions,
+      selection.isSelectionCatalogLoading,
+      selection.modelGroups,
+      selection.modelOptions,
+      selection.onSelectAgent,
+      selection.onSelectModel,
+      selection.onSelectVariant,
+      selection.selectedModelSelection,
+      selection.variantOptions,
+      session.canStopSession,
+      session.isSessionWorking,
+      session.taskId,
     ],
   );
 };

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -201,17 +201,18 @@ export const useAgentStudioComposerModel = ({
   const isModelSelectionPending = Boolean(
     session.activeSession?.isLoadingModelCatalog && !session.activeSession?.selectedModel,
   );
+  const activeSessionId = session.activeSession?.sessionId;
 
   const handleSend = useCallback((): void => {
     void interaction.onSend();
   }, [interaction.onSend]);
 
   const handleStopSession = useCallback((): void => {
-    if (!session.activeSession) {
+    if (!activeSessionId) {
       return;
     }
-    void session.stopAgentSession(session.activeSession.sessionId);
-  }, [session.activeSession, session.stopAgentSession]);
+    void session.stopAgentSession(activeSessionId);
+  }, [activeSessionId, session.stopAgentSession]);
 
   return useMemo(
     () =>

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -97,261 +97,214 @@ export const useAgentStudioHeaderModel = ({
 };
 
 export type UseAgentStudioThreadModelArgs = {
-  threadSession: AgentSessionState | null;
-  taskId: string;
-  agentStudioReady: boolean;
-  agentStudioBlockedReason: string;
-  isLoadingChecks: boolean;
-  refreshChecks: () => Promise<void>;
-  canKickoffNewSession: boolean;
-  selectedRoleAvailable: boolean;
-  kickoffLabel: string;
-  startScenarioKickoff: () => Promise<void>;
-  isStarting: boolean;
-  isSending: boolean;
-  activeSessionAgentColors: Record<string, string>;
-  isSubmittingQuestionByRequestId: Record<string, boolean>;
-  onSubmitQuestionAnswers: (requestId: string, answers: string[][]) => Promise<void>;
-  isSubmittingPermissionByRequestId: Record<string, boolean>;
-  permissionReplyErrorByRequestId: Record<string, string>;
-  onReplyPermission: (requestId: string, reply: "once" | "always" | "reject") => Promise<void>;
-  todoPanelCollapsed: boolean;
-  onToggleTodoPanel: () => void;
-  todoPanelBottomOffset: number;
-  isPinnedToBottom: boolean;
-  messagesContainerRef: RefObject<HTMLDivElement | null>;
-  onMessagesScroll: (event: UIEvent<HTMLDivElement>) => void;
+  session: {
+    threadSession: AgentSessionState | null;
+    taskId: string;
+    activeSessionAgentColors: Record<string, string>;
+  };
+  readiness: {
+    agentStudioReady: boolean;
+    agentStudioBlockedReason: string;
+    isLoadingChecks: boolean;
+    refreshChecks: () => Promise<void>;
+  };
+  kickoff: {
+    canKickoffNewSession: boolean;
+    selectedRoleAvailable: boolean;
+    kickoffLabel: string;
+    startScenarioKickoff: () => Promise<void>;
+    isStarting: boolean;
+    isSending: boolean;
+  };
+  questions: {
+    isSubmittingQuestionByRequestId: Record<string, boolean>;
+    onSubmitQuestionAnswers: (requestId: string, answers: string[][]) => Promise<void>;
+  };
+  permissions: {
+    isSubmittingPermissionByRequestId: Record<string, boolean>;
+    permissionReplyErrorByRequestId: Record<string, string>;
+    onReplyPermission: (requestId: string, reply: "once" | "always" | "reject") => Promise<void>;
+  };
+  todoPanel: {
+    todoPanelCollapsed: boolean;
+    onToggleTodoPanel: () => void;
+    todoPanelBottomOffset: number;
+  };
+  scroll: {
+    isPinnedToBottom: boolean;
+    messagesContainerRef: RefObject<HTMLDivElement | null>;
+    onMessagesScroll: (event: UIEvent<HTMLDivElement>) => void;
+  };
 };
 
 export const useAgentStudioThreadModel = ({
-  threadSession,
-  taskId,
-  agentStudioReady,
-  agentStudioBlockedReason,
-  isLoadingChecks,
-  refreshChecks,
-  canKickoffNewSession,
-  selectedRoleAvailable,
-  kickoffLabel,
-  startScenarioKickoff,
-  isStarting,
-  isSending,
-  activeSessionAgentColors,
-  isSubmittingQuestionByRequestId,
-  onSubmitQuestionAnswers,
-  isSubmittingPermissionByRequestId,
-  permissionReplyErrorByRequestId,
-  onReplyPermission,
-  todoPanelCollapsed,
-  onToggleTodoPanel,
-  todoPanelBottomOffset,
-  isPinnedToBottom,
-  messagesContainerRef,
-  onMessagesScroll,
+  session,
+  readiness,
+  kickoff,
+  questions,
+  permissions,
+  todoPanel,
+  scroll,
 }: UseAgentStudioThreadModelArgs): ReturnType<typeof buildAgentChatThreadModel> => {
   const handleRefreshChecks = useCallback((): void => {
-    void refreshChecks();
-  }, [refreshChecks]);
+    void readiness.refreshChecks();
+  }, [readiness.refreshChecks]);
 
   const handleKickoff = useCallback((): void => {
-    void startScenarioKickoff();
-  }, [startScenarioKickoff]);
+    void kickoff.startScenarioKickoff();
+  }, [kickoff.startScenarioKickoff]);
 
   const handlePermissionReply = useCallback(
     (requestId: string, reply: "once" | "always" | "reject"): Promise<void> => {
-      return onReplyPermission(requestId, reply);
+      return permissions.onReplyPermission(requestId, reply);
     },
-    [onReplyPermission],
+    [permissions.onReplyPermission],
   );
 
   return useMemo(
     () =>
       buildAgentChatThreadModel({
-        activeSession: threadSession,
+        activeSession: session.threadSession,
         roleOptions: ROLE_OPTIONS,
-        agentStudioReady,
-        agentStudioBlockedReason,
-        isLoadingChecks,
+        agentStudioReady: readiness.agentStudioReady,
+        agentStudioBlockedReason: readiness.agentStudioBlockedReason,
+        isLoadingChecks: readiness.isLoadingChecks,
         onRefreshChecks: handleRefreshChecks,
-        taskId,
-        canKickoffNewSession: canKickoffNewSession && selectedRoleAvailable,
-        kickoffLabel,
+        taskId: session.taskId,
+        canKickoffNewSession: kickoff.canKickoffNewSession && kickoff.selectedRoleAvailable,
+        kickoffLabel: kickoff.kickoffLabel,
         onKickoff: handleKickoff,
-        isStarting,
-        isSending,
-        activeSessionAgentColors,
-        isSubmittingQuestionByRequestId,
-        onSubmitQuestionAnswers,
-        isSubmittingPermissionByRequestId,
-        permissionReplyErrorByRequestId,
+        isStarting: kickoff.isStarting,
+        isSending: kickoff.isSending,
+        activeSessionAgentColors: session.activeSessionAgentColors,
+        isSubmittingQuestionByRequestId: questions.isSubmittingQuestionByRequestId,
+        onSubmitQuestionAnswers: questions.onSubmitQuestionAnswers,
+        isSubmittingPermissionByRequestId: permissions.isSubmittingPermissionByRequestId,
+        permissionReplyErrorByRequestId: permissions.permissionReplyErrorByRequestId,
         onReplyPermission: handlePermissionReply,
-        todoPanelCollapsed,
-        onToggleTodoPanel,
-        todoPanelBottomOffset,
-        isPinnedToBottom,
-        messagesContainerRef,
-        onMessagesScroll,
+        todoPanelCollapsed: todoPanel.todoPanelCollapsed,
+        onToggleTodoPanel: todoPanel.onToggleTodoPanel,
+        todoPanelBottomOffset: todoPanel.todoPanelBottomOffset,
+        isPinnedToBottom: scroll.isPinnedToBottom,
+        messagesContainerRef: scroll.messagesContainerRef,
+        onMessagesScroll: scroll.onMessagesScroll,
       }),
     [
-      activeSessionAgentColors,
-      agentStudioBlockedReason,
-      agentStudioReady,
-      canKickoffNewSession,
       handleKickoff,
       handlePermissionReply,
       handleRefreshChecks,
-      isLoadingChecks,
-      isPinnedToBottom,
-      isSending,
-      isStarting,
-      isSubmittingPermissionByRequestId,
-      isSubmittingQuestionByRequestId,
-      kickoffLabel,
-      messagesContainerRef,
-      onMessagesScroll,
-      onSubmitQuestionAnswers,
-      permissionReplyErrorByRequestId,
-      selectedRoleAvailable,
-      taskId,
-      threadSession,
-      todoPanelBottomOffset,
-      todoPanelCollapsed,
-      onToggleTodoPanel,
+      kickoff,
+      permissions,
+      questions,
+      readiness,
+      scroll,
+      session,
+      todoPanel,
     ],
   );
 };
 
 export type UseAgentStudioComposerModelArgs = {
-  taskId: string;
-  activeSession: AgentSessionState | null;
-  agentStudioReady: boolean;
-  workflow: WorkflowComposerContext;
-  input: string;
-  setInput: (value: string) => void;
-  onSend: () => Promise<void>;
-  isSending: boolean;
-  isStarting: boolean;
-  isSessionWorking: boolean;
-  selectedModelSelection: AgentModelSelection | null;
-  isSelectionCatalogLoading: boolean;
-  agentOptions: ComboboxOption[];
-  modelOptions: ComboboxOption[];
-  modelGroups: ComboboxGroup[];
-  variantOptions: ComboboxOption[];
-  onSelectAgent: (agent: string) => void;
-  onSelectModel: (model: string) => void;
-  onSelectVariant: (variant: string) => void;
-  activeSessionAgentColors: Record<string, string>;
-  chatContextUsage: AgentChatModel["composer"]["contextUsage"];
-  canStopSession: boolean;
-  stopAgentSession: (sessionId: string) => Promise<void>;
-  composerFormRef: RefObject<HTMLFormElement | null>;
-  composerTextareaRef: RefObject<HTMLTextAreaElement | null>;
-  resizeComposerTextarea: () => void;
+  session: {
+    taskId: string;
+    activeSession: AgentSessionState | null;
+    isSessionWorking: boolean;
+    canStopSession: boolean;
+    stopAgentSession: (sessionId: string) => Promise<void>;
+  };
+  readiness: {
+    agentStudioReady: boolean;
+    workflow: WorkflowComposerContext;
+  };
+  interaction: {
+    input: string;
+    setInput: (value: string) => void;
+    onSend: () => Promise<void>;
+    isSending: boolean;
+    isStarting: boolean;
+    chatContextUsage: AgentChatModel["composer"]["contextUsage"];
+  };
+  selection: {
+    selectedModelSelection: AgentModelSelection | null;
+    isSelectionCatalogLoading: boolean;
+    agentOptions: ComboboxOption[];
+    modelOptions: ComboboxOption[];
+    modelGroups: ComboboxGroup[];
+    variantOptions: ComboboxOption[];
+    onSelectAgent: (agent: string) => void;
+    onSelectModel: (model: string) => void;
+    onSelectVariant: (variant: string) => void;
+    activeSessionAgentColors: Record<string, string>;
+  };
+  layout: {
+    composerFormRef: RefObject<HTMLFormElement | null>;
+    composerTextareaRef: RefObject<HTMLTextAreaElement | null>;
+    resizeComposerTextarea: () => void;
+  };
 };
 
 export const useAgentStudioComposerModel = ({
-  taskId,
-  activeSession,
-  agentStudioReady,
-  workflow,
-  input,
-  setInput,
-  onSend,
-  isSending,
-  isStarting,
-  isSessionWorking,
-  selectedModelSelection,
-  isSelectionCatalogLoading,
-  agentOptions,
-  modelOptions,
-  modelGroups,
-  variantOptions,
-  onSelectAgent,
-  onSelectModel,
-  onSelectVariant,
-  activeSessionAgentColors,
-  chatContextUsage,
-  canStopSession,
-  stopAgentSession,
-  composerFormRef,
-  composerTextareaRef,
-  resizeComposerTextarea,
+  session,
+  readiness,
+  interaction,
+  selection,
+  layout,
 }: UseAgentStudioComposerModelArgs): ReturnType<typeof buildAgentChatComposerModel> => {
   const isModelSelectionPending = Boolean(
-    activeSession?.isLoadingModelCatalog && !activeSession?.selectedModel,
+    session.activeSession?.isLoadingModelCatalog && !session.activeSession?.selectedModel,
   );
 
   const handleSend = useCallback((): void => {
-    void onSend();
-  }, [onSend]);
+    void interaction.onSend();
+  }, [interaction.onSend]);
 
   const handleStopSession = useCallback((): void => {
-    if (!activeSession) {
+    if (!session.activeSession) {
       return;
     }
-    void stopAgentSession(activeSession.sessionId);
-  }, [activeSession, stopAgentSession]);
+    void session.stopAgentSession(session.activeSession.sessionId);
+  }, [session.activeSession, session.stopAgentSession]);
 
   return useMemo(
     () =>
       buildAgentChatComposerModel({
-        taskId,
-        agentStudioReady,
-        isReadOnly: !workflow.selectedRoleAvailable,
-        readOnlyReason: workflow.selectedRoleReadOnlyReason,
-        input,
-        onInputChange: setInput,
+        taskId: session.taskId,
+        agentStudioReady: readiness.agentStudioReady,
+        isReadOnly: !readiness.workflow.selectedRoleAvailable,
+        readOnlyReason: readiness.workflow.selectedRoleReadOnlyReason,
+        input: interaction.input,
+        onInputChange: interaction.setInput,
         onSend: handleSend,
-        isSending,
-        isStarting,
-        isSessionWorking,
+        isSending: interaction.isSending,
+        isStarting: interaction.isStarting,
+        isSessionWorking: session.isSessionWorking,
         isModelSelectionPending,
-        selectedModelSelection,
-        isSelectionCatalogLoading,
-        agentOptions,
-        modelOptions,
-        modelGroups,
-        variantOptions,
-        onSelectAgent,
-        onSelectModel,
-        onSelectVariant,
-        activeSessionAgentColors,
-        contextUsage: chatContextUsage,
-        canStopSession,
+        selectedModelSelection: selection.selectedModelSelection,
+        isSelectionCatalogLoading: selection.isSelectionCatalogLoading,
+        agentOptions: selection.agentOptions,
+        modelOptions: selection.modelOptions,
+        modelGroups: selection.modelGroups,
+        variantOptions: selection.variantOptions,
+        onSelectAgent: selection.onSelectAgent,
+        onSelectModel: selection.onSelectModel,
+        onSelectVariant: selection.onSelectVariant,
+        activeSessionAgentColors: selection.activeSessionAgentColors,
+        contextUsage: interaction.chatContextUsage,
+        canStopSession: session.canStopSession,
         onStopSession: handleStopSession,
-        composerFormRef,
-        composerTextareaRef,
-        onComposerTextareaInput: resizeComposerTextarea,
+        composerFormRef: layout.composerFormRef,
+        composerTextareaRef: layout.composerTextareaRef,
+        onComposerTextareaInput: layout.resizeComposerTextarea,
       }),
     [
-      activeSessionAgentColors,
-      agentOptions,
-      agentStudioReady,
-      canStopSession,
-      chatContextUsage,
-      composerFormRef,
-      composerTextareaRef,
       handleSend,
       handleStopSession,
-      input,
       isModelSelectionPending,
-      isSelectionCatalogLoading,
-      isSending,
-      isSessionWorking,
-      isStarting,
-      modelGroups,
-      modelOptions,
-      onSelectAgent,
-      onSelectModel,
-      onSelectVariant,
-      resizeComposerTextarea,
-      selectedModelSelection,
-      setInput,
-      taskId,
-      variantOptions,
-      workflow.selectedRoleAvailable,
-      workflow.selectedRoleReadOnlyReason,
+      interaction,
+      layout,
+      readiness,
+      selection,
+      session,
     ],
   );
 };


### PR DESCRIPTION
## Summary
This PR completes the Agent Studio submodel quality refactor by reducing parameter proliferation and hardening memoization behavior.

### Included changes
1. Refactored `useAgentStudioThreadModel` and `useAgentStudioComposerModel` to consume grouped concern-based contexts instead of large flat argument lists.
2. Added a shared contracts module for submodel context shapes to remove duplicated local type definitions and reduce drift risk:
   - `use-agent-studio-page-submodel-contracts.ts`
3. Hardened `useMemo` dependencies in submodel hooks to depend on concrete fields rather than context object identity.
4. Added regression coverage for reciprocal model stability:
   - composer remains stable on thread-only updates
   - thread updates on permission/question map changes without rebuilding composer

## Why
- Reduce API complexity and primitive obsession in Agent Studio page submodels.
- Keep the grouping pattern aligned with existing orchestration context conventions.
- Prevent future perf regressions caused by accidental inline object recreation at call sites.
- Improve confidence with targeted memoization regression tests.

## Files changed
- `apps/desktop/src/pages/agents/use-agent-studio-page-models.ts`
- `apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts`
- `apps/desktop/src/pages/agents/use-agent-studio-page-submodel-contracts.ts` (new)
- `apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx`

## Validation
- `bun run --filter @openducktor/desktop test ./src/pages/agents/use-agent-studio-page-models.test.tsx`
- `bun run --filter @openducktor/desktop test`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`

All commands passed.
