### PR TITLE
perf(desktop): stabilize AgentChatThread virtualizer callbacks and measurements

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -124,15 +124,13 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
 
   const measureVirtualRowElement = useCallback((element: Element): number => {
     const measuredHeight = element.getBoundingClientRect().height;
-    const indexValue = Number.parseInt(element.getAttribute("data-index") ?? "", 10);
-    const rows = virtualRowsRef.current;
-    const row = Number.isFinite(indexValue) && indexValue >= 0 ? rows[indexValue] : undefined;
-    if (row && measuredHeight > 0) {
-      const previousHeight = measuredRowHeightByKeyRef.current[row.key];
+    const rowKey = element.getAttribute("data-row-key");
+    if (rowKey && measuredHeight > 0) {
+      const previousHeight = measuredRowHeightByKeyRef.current[rowKey];
       if (typeof previousHeight !== "number") {
-        measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
+        measuredRowHeightByKeyRef.current[rowKey] = measuredHeight;
       } else if (Math.abs(previousHeight - measuredHeight) > 0.5) {
-        measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
+        measuredRowHeightByKeyRef.current[rowKey] = measuredHeight;
       }
     }
     return measuredHeight;
@@ -141,10 +139,13 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const resolveRowKey = useCallback((index: number): string | number => {
     return virtualRowsRef.current[index]?.key ?? index;
   }, []);
+  const resolveScrollElement = useCallback((): HTMLDivElement | null => {
+    return messagesContainerRef.current;
+  }, [messagesContainerRef]);
 
   const virtualizer = useVirtualizer({
     count: shouldVirtualize ? virtualRows.length : 0,
-    getScrollElement: () => messagesContainerRef.current,
+    getScrollElement: resolveScrollElement,
     estimateSize: estimateRowSize,
     measureElement: measureVirtualRowElement,
     getItemKey: resolveRowKey,
@@ -340,6 +341,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
                 <div
                   key={virtualItem.key}
                   data-index={virtualItem.index}
+                  data-row-key={row.key}
                   ref={virtualizer.measureElement}
                   style={{
                     left: 0,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -94,6 +94,8 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     };
     return nextRows;
   }, [session, virtualRowsSignature]);
+  const virtualRowsRef = useRef(virtualRows);
+  virtualRowsRef.current = virtualRows;
   const shouldVirtualize = virtualRows.length >= AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT;
   const activeSessionId = session?.sessionId ?? null;
   const measuredSessionIdRef = useRef<string | null>(null);
@@ -105,48 +107,40 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     measuredRowHeightByKeyRef.current = {};
   }
 
-  const estimateRowSize = useCallback(
-    (index: number): number => {
-      const row = virtualRows[index];
-      if (!row) {
-        return 0;
-      }
-      const trailingGap = index < virtualRows.length - 1 ? AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 0;
-      const measuredHeight = measuredRowHeightByKeyRef.current[row.key];
-      if (typeof measuredHeight === "number" && measuredHeight > 0) {
-        return measuredHeight + trailingGap;
-      }
+  const estimateRowSize = useCallback((index: number): number => {
+    const rows = virtualRowsRef.current;
+    const row = rows[index];
+    if (!row) {
+      return 0;
+    }
+    const trailingGap = index < rows.length - 1 ? AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 0;
+    const measuredHeight = measuredRowHeightByKeyRef.current[row.key];
+    if (typeof measuredHeight === "number" && measuredHeight > 0) {
+      return measuredHeight + trailingGap;
+    }
 
-      return 1 + trailingGap;
-    },
-    [virtualRows],
-  );
+    return 1 + trailingGap;
+  }, []);
 
-  const measureVirtualRowElement = useCallback(
-    (element: Element): number => {
-      const measuredHeight = element.getBoundingClientRect().height;
-      const indexValue = Number.parseInt(element.getAttribute("data-index") ?? "", 10);
-      const row =
-        Number.isFinite(indexValue) && indexValue >= 0 ? virtualRows[indexValue] : undefined;
-      if (row && measuredHeight > 0) {
-        const previousHeight = measuredRowHeightByKeyRef.current[row.key];
-        if (typeof previousHeight !== "number") {
-          measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
-        } else if (Math.abs(previousHeight - measuredHeight) > 0.5) {
-          measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
-        }
+  const measureVirtualRowElement = useCallback((element: Element): number => {
+    const measuredHeight = element.getBoundingClientRect().height;
+    const indexValue = Number.parseInt(element.getAttribute("data-index") ?? "", 10);
+    const rows = virtualRowsRef.current;
+    const row = Number.isFinite(indexValue) && indexValue >= 0 ? rows[indexValue] : undefined;
+    if (row && measuredHeight > 0) {
+      const previousHeight = measuredRowHeightByKeyRef.current[row.key];
+      if (typeof previousHeight !== "number") {
+        measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
+      } else if (Math.abs(previousHeight - measuredHeight) > 0.5) {
+        measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
       }
-      return measuredHeight;
-    },
-    [virtualRows],
-  );
+    }
+    return measuredHeight;
+  }, []);
 
-  const resolveRowKey = useCallback(
-    (index: number): string | number => {
-      return virtualRows[index]?.key ?? index;
-    },
-    [virtualRows],
-  );
+  const resolveRowKey = useCallback((index: number): string | number => {
+    return virtualRowsRef.current[index]?.key ?? index;
+  }, []);
 
   const virtualizer = useVirtualizer({
     count: shouldVirtualize ? virtualRows.length : 0,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.virtualizer-callbacks.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.virtualizer-callbacks.test.ts
@@ -2,11 +2,16 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createElement, createRef } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { buildMessage, buildSession, TEST_ROLE_OPTIONS } from "./agent-chat-test-fixtures";
+import {
+  AGENT_CHAT_VIRTUAL_ROW_GAP_PX,
+  buildAgentChatVirtualRows,
+} from "./agent-chat-thread-virtualization";
 
 type VirtualizerOptions = {
   estimateSize: (index: number) => number;
   measureElement: (element: Element) => number;
   getItemKey: (index: number) => string | number;
+  getScrollElement: () => Element | null;
 };
 
 const useVirtualizerOptionsByRender: VirtualizerOptions[] = [];
@@ -78,6 +83,12 @@ describe("AgentChatThread virtualizer callbacks", () => {
         }),
       ),
     });
+    const measuredRowKey = `${session.sessionId}:message-1`;
+    const initialRows = buildAgentChatVirtualRows(session);
+    const initialRowCount = initialRows.length;
+    const appendedRowIndex = initialRowCount;
+    const measuredRowIndex = initialRows.findIndex((row) => row.key === measuredRowKey);
+    expect(measuredRowIndex).toBeGreaterThanOrEqual(0);
     const model = {
       ...baseModel,
       session,
@@ -94,6 +105,27 @@ describe("AgentChatThread virtualizer callbacks", () => {
 
     const firstOptions = useVirtualizerOptionsByRender.at(-1);
     expect(firstOptions).toBeDefined();
+    expect(firstOptions?.estimateSize(appendedRowIndex)).toBe(0);
+    expect(firstOptions?.getItemKey(appendedRowIndex)).toBe(appendedRowIndex);
+
+    const firstMeasureElement = firstOptions?.measureElement;
+    expect(firstMeasureElement).toBeDefined();
+    const measuredHeight = firstMeasureElement?.({
+      getBoundingClientRect: () => ({ height: 32 }),
+      getAttribute: (attributeName: string) => {
+        if (attributeName === "data-row-key") {
+          return measuredRowKey;
+        }
+        if (attributeName === "data-index") {
+          return "999";
+        }
+        return null;
+      },
+    } as unknown as Element);
+    expect(measuredHeight).toBe(32);
+    const measuredRowTrailingGap =
+      measuredRowIndex < initialRowCount - 1 ? AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 0;
+    expect(firstOptions?.estimateSize(measuredRowIndex)).toBe(32 + measuredRowTrailingGap);
 
     session.messages.push(
       buildMessage("assistant", "Message 46", {
@@ -115,6 +147,10 @@ describe("AgentChatThread virtualizer callbacks", () => {
     expect(secondOptions?.estimateSize).toBe(firstOptions?.estimateSize);
     expect(secondOptions?.measureElement).toBe(firstOptions?.measureElement);
     expect(secondOptions?.getItemKey).toBe(firstOptions?.getItemKey);
+    expect(secondOptions?.getScrollElement).toBe(firstOptions?.getScrollElement);
+    const updatedRows = buildAgentChatVirtualRows(session);
+    expect(firstOptions?.estimateSize(appendedRowIndex)).toBeGreaterThan(0);
+    expect(firstOptions?.getItemKey(appendedRowIndex)).toBe(updatedRows[appendedRowIndex]?.key);
 
     await act(async () => {
       renderer.unmount();

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.virtualizer-callbacks.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.virtualizer-callbacks.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement, createRef } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { buildMessage, buildSession, TEST_ROLE_OPTIONS } from "./agent-chat-test-fixtures";
+
+type VirtualizerOptions = {
+  estimateSize: (index: number) => number;
+  measureElement: (element: Element) => number;
+  getItemKey: (index: number) => string | number;
+};
+
+const useVirtualizerOptionsByRender: VirtualizerOptions[] = [];
+
+const useVirtualizerMock = mock((options: VirtualizerOptions) => {
+  useVirtualizerOptionsByRender.push(options);
+  return {
+    getVirtualItems: () => [],
+    getTotalSize: () => 0,
+    measureElement: () => 0,
+    measure: () => {},
+    scrollToIndex: () => {},
+  };
+});
+
+mock.module("@tanstack/react-virtual", () => ({
+  useVirtualizer: (options: VirtualizerOptions) => useVirtualizerMock(options),
+}));
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const baseModel = {
+  roleOptions: TEST_ROLE_OPTIONS,
+  agentStudioReady: true,
+  blockedReason: "",
+  isLoadingChecks: false,
+  onRefreshChecks: () => {},
+  taskSelected: true,
+  canKickoffNewSession: false,
+  kickoffLabel: "Start Spec",
+  onKickoff: () => {},
+  isStarting: false,
+  isSending: false,
+  sessionAgentColors: {},
+  isSubmittingQuestionByRequestId: {},
+  isSubmittingPermissionByRequestId: {},
+  permissionReplyErrorByRequestId: {},
+  onSubmitQuestionAnswers: async () => {},
+  onReplyPermission: async () => {},
+  todoPanelCollapsed: false,
+  onToggleTodoPanel: () => {},
+  todoPanelBottomOffset: 120,
+  isPinnedToBottom: true,
+  messagesContainerRef: createRef<HTMLDivElement>(),
+  onMessagesScroll: () => {},
+} as const;
+
+describe("AgentChatThread virtualizer callbacks", () => {
+  beforeEach(() => {
+    useVirtualizerMock.mockClear();
+    useVirtualizerOptionsByRender.length = 0;
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("keeps virtualizer callback references stable when virtual rows change", async () => {
+    const { AgentChatThread } = await import("./agent-chat-thread");
+
+    const session = buildSession({
+      messages: Array.from({ length: 45 }, (_, index) =>
+        buildMessage("assistant", `Message ${index + 1}`, {
+          id: `message-${index + 1}`,
+        }),
+      ),
+    });
+    const model = {
+      ...baseModel,
+      session,
+    };
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        createElement(AgentChatThread, {
+          model,
+        }),
+      );
+    });
+
+    const firstOptions = useVirtualizerOptionsByRender.at(-1);
+    expect(firstOptions).toBeDefined();
+
+    session.messages.push(
+      buildMessage("assistant", "Message 46", {
+        id: "message-46",
+      }),
+    );
+
+    await act(async () => {
+      renderer.update(
+        createElement(AgentChatThread, {
+          model,
+        }),
+      );
+    });
+
+    const secondOptions = useVirtualizerOptionsByRender.at(-1);
+    expect(secondOptions).toBeDefined();
+
+    expect(secondOptions?.estimateSize).toBe(firstOptions?.estimateSize);
+    expect(secondOptions?.measureElement).toBe(firstOptions?.measureElement);
+    expect(secondOptions?.getItemKey).toBe(firstOptions?.getItemKey);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR stabilizes `AgentChatThread` virtualization behavior by removing callback identity churn and hardening row measurement keying.

## Problem
`useVirtualizer` in `agent-chat-thread.tsx` was receiving callback option references that changed more often than necessary:
- callbacks previously closed over `virtualRows`, which increased option churn when rows changed
- row measurement writes were index-based (`data-index`), which can misattribute cached heights during row index churn

This created avoidable virtualizer option resets and measurement fragility.

## What Changed
### 1) Stabilized virtualizer option callbacks
- kept `estimateRowSize`, `measureVirtualRowElement`, and `resolveRowKey` stable while reading current rows from refs
- stabilized `getScrollElement` via `useCallback`

### 2) Hardened measurement cache keying
- added `data-row-key` to each virtual row wrapper
- updated `measureVirtualRowElement` to cache heights by `data-row-key` instead of index lookup

### 3) Expanded regression coverage
- added/extended `agent-chat-thread.virtualizer-callbacks.test.ts` to verify:
  - callback identity stability across rerenders (`estimateSize`, `measureElement`, `getItemKey`, `getScrollElement`)
  - callback freshness after row growth (same function refs still read latest rows)
  - row-key-based measurement behavior even when `data-index` is stale

## Files Changed
- `apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx`
- `apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.virtualizer-callbacks.test.ts`

## Validation
Executed successfully:
- `bun test ./src/components/features/agents/agent-chat/agent-chat-thread.test.ts ./src/components/features/agents/agent-chat/agent-chat-thread.virtualizer-callbacks.test.ts` (11 pass)
- `bun run typecheck` (apps/desktop)
- `bun run lint` (apps/desktop)
- `bun run --filter @openducktor/desktop test` (592 pass, 0 fail)

## Impact
- reduces avoidable virtualizer option churn during rerenders
- improves measurement cache correctness under row index movement
- adds regression guards for both stability and correctness of virtualizer callbacks
