### PR TITLE
refactor(desktop): reduce Agent Studio page-model bridge parameter bloat

### DIFF
--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { createAgentSessionFixture, createTaskCardFixture } from "./agent-studio-test-utils";
 import { buildAgentStudioPageModelsArgs } from "./use-agent-studio-orchestration-controller";
 
+type BuildArgs = Parameters<typeof buildAgentStudioPageModelsArgs>[0];
+
 const taskDocument = {
   markdown: "# doc",
   updatedAt: "2026-02-22T10:00:00.000Z",
@@ -10,92 +12,93 @@ const taskDocument = {
   loaded: true,
 };
 
+const task = createTaskCardFixture({ id: "task-1", title: "Task 1" });
+const session = createAgentSessionFixture({
+  sessionId: "session-1",
+  taskId: "task-1",
+  role: "planner",
+  scenario: "planner_initial",
+});
+const onCreateTab = () => {};
+const onCloseTab = () => {};
+const handleSelectAgent = () => {};
+const handleSelectModel = () => {};
+const handleSelectVariant = () => {};
+
+const baseArgs: BuildArgs = {
+  view: {
+    viewTaskId: "task-1",
+    viewRole: "planner",
+    viewSelectedTask: task,
+    contextSwitchVersion: 4,
+    isActiveTaskHydrated: true,
+  },
+  sessions: {
+    viewSessionsForTask: [session],
+    viewActiveSession: session,
+  },
+  tabs: {
+    activeTaskTabId: "task-1",
+    taskTabs: [],
+    availableTabTasks: [task],
+    isLoadingTasks: false,
+    onCreateTab,
+    onCloseTab,
+  },
+  documents: {
+    specDoc: taskDocument,
+    planDoc: taskDocument,
+    qaDoc: taskDocument,
+  },
+  readiness: {
+    agentStudioReady: true,
+    agentStudioBlockedReason: "",
+    isLoadingChecks: false,
+    refreshChecks: async () => {},
+  },
+  sessionActions: {
+    handleWorkflowStepSelect: () => {},
+    handleSessionSelectionChange: () => {},
+    handleCreateSession: () => {},
+    isStarting: false,
+    isSending: false,
+    isSessionWorking: false,
+    canKickoffNewSession: false,
+    kickoffLabel: "Kickoff",
+    canStopSession: false,
+    startScenarioKickoff: async () => {},
+    onSend: async () => {},
+    onSubmitQuestionAnswers: async () => {},
+    isSubmittingQuestionByRequestId: {},
+    stopAgentSession: async () => {},
+  },
+  modelSelection: {
+    selectedModelSelection: null,
+    isSelectionCatalogLoading: false,
+    agentOptions: [],
+    modelOptions: [],
+    modelGroups: [],
+    variantOptions: [],
+    handleSelectAgent,
+    handleSelectModel,
+    handleSelectVariant,
+    activeSessionAgentColors: {},
+    activeSessionContextUsage: null,
+  },
+  permissions: {
+    isSubmittingPermissionByRequestId: {},
+    permissionReplyErrorByRequestId: {},
+    onReplyPermission: async () => {},
+  },
+  composer: {
+    input: "hello",
+    setInput: () => {},
+  },
+};
+
 describe("buildAgentStudioPageModelsArgs", () => {
   test("maps grouped orchestration context into page-model contracts", () => {
-    const task = createTaskCardFixture({ id: "task-1", title: "Task 1" });
-    const session = createAgentSessionFixture({
-      sessionId: "session-1",
-      taskId: "task-1",
-      role: "planner",
-      scenario: "planner_initial",
-    });
-
-    const onCreateTab = () => {};
-    const onCloseTab = () => {};
-    const handleSelectAgent = () => {};
-    const handleSelectModel = () => {};
-    const handleSelectVariant = () => {};
-
-    const mapped = buildAgentStudioPageModelsArgs({
-      view: {
-        viewTaskId: "task-1",
-        viewRole: "planner",
-        viewSelectedTask: task,
-        contextSwitchVersion: 4,
-        isActiveTaskHydrated: true,
-      },
-      sessions: {
-        viewSessionsForTask: [session],
-        viewActiveSession: session,
-      },
-      tabs: {
-        activeTaskTabId: "task-1",
-        taskTabs: [],
-        availableTabTasks: [task],
-        isLoadingTasks: false,
-        onCreateTab,
-        onCloseTab,
-      },
-      documents: {
-        specDoc: taskDocument,
-        planDoc: taskDocument,
-        qaDoc: taskDocument,
-      },
-      readiness: {
-        agentStudioReady: true,
-        agentStudioBlockedReason: "",
-        isLoadingChecks: false,
-        refreshChecks: async () => {},
-      },
-      sessionActions: {
-        handleWorkflowStepSelect: () => {},
-        handleSessionSelectionChange: () => {},
-        handleCreateSession: () => {},
-        isStarting: false,
-        isSending: false,
-        isSessionWorking: false,
-        canKickoffNewSession: false,
-        kickoffLabel: "Kickoff",
-        canStopSession: false,
-        startScenarioKickoff: async () => {},
-        onSend: async () => {},
-        onSubmitQuestionAnswers: async () => {},
-        isSubmittingQuestionByRequestId: {},
-        stopAgentSession: async () => {},
-      },
-      modelSelection: {
-        selectedModelSelection: null,
-        isSelectionCatalogLoading: false,
-        agentOptions: [],
-        modelOptions: [],
-        modelGroups: [],
-        variantOptions: [],
-        handleSelectAgent,
-        handleSelectModel,
-        handleSelectVariant,
-        activeSessionAgentColors: {},
-        activeSessionContextUsage: null,
-      },
-      permissions: {
-        isSubmittingPermissionByRequestId: {},
-        permissionReplyErrorByRequestId: {},
-        onReplyPermission: async () => {},
-      },
-      composer: {
-        input: "hello",
-        setInput: () => {},
-      },
-    });
+    const mapped = buildAgentStudioPageModelsArgs(baseArgs);
 
     expect(mapped.core.role).toBe("planner");
     expect(mapped.core.contextSwitchVersion).toBe(4);
@@ -106,5 +109,78 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(mapped.modelSelection.onSelectModel).toBe(handleSelectModel);
     expect(mapped.modelSelection.onSelectVariant).toBe(handleSelectVariant);
     expect(mapped.composer.input).toBe("hello");
+  });
+
+  test("derives activeTabValue from tab id, task id, then empty sentinel", () => {
+    const withActiveTab = buildAgentStudioPageModelsArgs({
+      ...baseArgs,
+      tabs: {
+        ...baseArgs.tabs,
+        activeTaskTabId: "task-tab-2",
+      },
+    });
+    const withTaskFallback = buildAgentStudioPageModelsArgs({
+      ...baseArgs,
+      tabs: {
+        ...baseArgs.tabs,
+        activeTaskTabId: "",
+      },
+    });
+    const withEmptyFallback = buildAgentStudioPageModelsArgs({
+      ...baseArgs,
+      view: {
+        ...baseArgs.view,
+        viewTaskId: "",
+      },
+      tabs: {
+        ...baseArgs.tabs,
+        activeTaskTabId: "",
+      },
+    });
+
+    expect(withActiveTab.core.activeTabValue).toBe("task-tab-2");
+    expect(withTaskFallback.core.activeTabValue).toBe("task-1");
+    expect(withEmptyFallback.core.activeTabValue).toBe("__agent_studio_empty__");
+  });
+
+  test("derives isTaskHydrating only when a task exists and hydration is incomplete", () => {
+    const hydrating = buildAgentStudioPageModelsArgs({
+      ...baseArgs,
+      view: {
+        ...baseArgs.view,
+        isActiveTaskHydrated: false,
+      },
+    });
+    const hydrated = buildAgentStudioPageModelsArgs(baseArgs);
+    const noTaskSelected = buildAgentStudioPageModelsArgs({
+      ...baseArgs,
+      view: {
+        ...baseArgs.view,
+        viewTaskId: "",
+        isActiveTaskHydrated: false,
+      },
+    });
+
+    expect(hydrating.core.isTaskHydrating).toBe(true);
+    expect(hydrated.core.isTaskHydrating).toBe(false);
+    expect(noTaskSelected.core.isTaskHydrating).toBe(false);
+  });
+
+  test("derives contextSessionsLength from the sessions context size", () => {
+    const secondSession = createAgentSessionFixture({
+      sessionId: "session-2",
+      taskId: "task-1",
+      role: "planner",
+      scenario: "planner_initial",
+    });
+    const mapped = buildAgentStudioPageModelsArgs({
+      ...baseArgs,
+      sessions: {
+        ...baseArgs.sessions,
+        viewSessionsForTask: [session, secondSession],
+      },
+    });
+
+    expect(mapped.core.contextSessionsLength).toBe(2);
   });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -22,27 +22,35 @@ describe("buildAgentStudioPageModelsArgs", () => {
 
     const onCreateTab = () => {};
     const onCloseTab = () => {};
-    const onSelectAgent = () => {};
-    const onSelectModel = () => {};
-    const onSelectVariant = () => {};
+    const handleSelectAgent = () => {};
+    const handleSelectModel = () => {};
+    const handleSelectVariant = () => {};
 
     const mapped = buildAgentStudioPageModelsArgs({
-      viewTaskId: "task-1",
-      viewRole: "planner",
-      viewSelectedTask: task,
-      viewSessionsForTask: [session],
-      viewActiveSession: session,
-      activeTaskTabId: "task-1",
-      taskTabs: [],
-      availableTabTasks: [task],
-      onCreateTab,
-      onCloseTab,
-      contextSwitchVersion: 4,
-      isLoadingTasks: false,
-      isActiveTaskHydrated: true,
-      specDoc: taskDocument,
-      planDoc: taskDocument,
-      qaDoc: taskDocument,
+      view: {
+        viewTaskId: "task-1",
+        viewRole: "planner",
+        viewSelectedTask: task,
+        contextSwitchVersion: 4,
+        isActiveTaskHydrated: true,
+      },
+      sessions: {
+        viewSessionsForTask: [session],
+        viewActiveSession: session,
+      },
+      tabs: {
+        activeTaskTabId: "task-1",
+        taskTabs: [],
+        availableTabTasks: [task],
+        isLoadingTasks: false,
+        onCreateTab,
+        onCloseTab,
+      },
+      documents: {
+        specDoc: taskDocument,
+        planDoc: taskDocument,
+        qaDoc: taskDocument,
+      },
       readiness: {
         agentStudioReady: true,
         agentStudioBlockedReason: "",
@@ -72,9 +80,9 @@ describe("buildAgentStudioPageModelsArgs", () => {
         modelOptions: [],
         modelGroups: [],
         variantOptions: [],
-        onSelectAgent,
-        onSelectModel,
-        onSelectVariant,
+        handleSelectAgent,
+        handleSelectModel,
+        handleSelectVariant,
         activeSessionAgentColors: {},
         activeSessionContextUsage: null,
       },
@@ -94,9 +102,9 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(mapped.taskTabs.onCreateTab).toBe(onCreateTab);
     expect(mapped.taskTabs.onCloseTab).toBe(onCloseTab);
     expect(mapped.documents.planDoc.markdown).toBe("# doc");
-    expect(mapped.modelSelection.onSelectAgent).toBe(onSelectAgent);
-    expect(mapped.modelSelection.onSelectModel).toBe(onSelectModel);
-    expect(mapped.modelSelection.onSelectVariant).toBe(onSelectVariant);
+    expect(mapped.modelSelection.onSelectAgent).toBe(handleSelectAgent);
+    expect(mapped.modelSelection.onSelectModel).toBe(handleSelectModel);
+    expect(mapped.modelSelection.onSelectVariant).toBe(handleSelectVariant);
     expect(mapped.composer.input).toBe("hello");
   });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -146,44 +146,37 @@ export const buildAgentStudioPageModelsArgs = ({
   modelSelection,
   permissions,
   composer,
-}: BuildAgentStudioPageModelsArgsInput): Parameters<typeof useAgentStudioPageModels>[0] => ({
-  core: {
-    activeTabValue: tabs.activeTaskTabId || view.viewTaskId || "__agent_studio_empty__",
-    taskId: view.viewTaskId,
-    role: view.viewRole,
-    selectedTask: view.viewSelectedTask,
-    sessionsForTask: sessions.viewSessionsForTask,
-    contextSessionsLength: sessions.viewSessionsForTask.length,
-    activeSession: sessions.viewActiveSession,
-    isTaskHydrating: Boolean(view.viewTaskId && !view.isActiveTaskHydrated),
-    contextSwitchVersion: view.contextSwitchVersion,
-  },
-  taskTabs: {
-    taskTabs: tabs.taskTabs,
-    availableTabTasks: tabs.availableTabTasks,
-    isLoadingTasks: tabs.isLoadingTasks,
-    onCreateTab: tabs.onCreateTab,
-    onCloseTab: tabs.onCloseTab,
-  },
-  documents,
-  readiness,
-  sessionActions,
-  modelSelection: {
-    selectedModelSelection: modelSelection.selectedModelSelection,
-    isSelectionCatalogLoading: modelSelection.isSelectionCatalogLoading,
-    agentOptions: modelSelection.agentOptions,
-    modelOptions: modelSelection.modelOptions,
-    modelGroups: modelSelection.modelGroups,
-    variantOptions: modelSelection.variantOptions,
-    onSelectAgent: modelSelection.handleSelectAgent,
-    onSelectModel: modelSelection.handleSelectModel,
-    onSelectVariant: modelSelection.handleSelectVariant,
-    activeSessionAgentColors: modelSelection.activeSessionAgentColors,
-    activeSessionContextUsage: modelSelection.activeSessionContextUsage,
-  },
-  permissions,
-  composer,
-});
+}: BuildAgentStudioPageModelsArgsInput): Parameters<typeof useAgentStudioPageModels>[0] => {
+  const { activeTaskTabId, ...taskTabs } = tabs;
+  const { handleSelectAgent, handleSelectModel, handleSelectVariant, ...restOfModelSelection } =
+    modelSelection;
+
+  return {
+    core: {
+      activeTabValue: activeTaskTabId || view.viewTaskId || "__agent_studio_empty__",
+      taskId: view.viewTaskId,
+      role: view.viewRole,
+      selectedTask: view.viewSelectedTask,
+      sessionsForTask: sessions.viewSessionsForTask,
+      contextSessionsLength: sessions.viewSessionsForTask.length,
+      activeSession: sessions.viewActiveSession,
+      isTaskHydrating: Boolean(view.viewTaskId && !view.isActiveTaskHydrated),
+      contextSwitchVersion: view.contextSwitchVersion,
+    },
+    taskTabs,
+    documents,
+    readiness,
+    sessionActions,
+    modelSelection: {
+      ...restOfModelSelection,
+      onSelectAgent: handleSelectAgent,
+      onSelectModel: handleSelectModel,
+      onSelectVariant: handleSelectVariant,
+    },
+    permissions,
+    composer,
+  };
+};
 
 export function useAgentStudioOrchestrationController({
   workspace,

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -80,69 +80,69 @@ type UseAgentStudioOrchestrationControllerResult = {
   rightPanel: ReturnType<typeof useAgentStudioRightPanel>;
 };
 
+type AgentStudioPageModelsViewContext = Pick<
+  AgentStudioOrchestrationSelectionContext,
+  "viewTaskId" | "viewRole" | "viewSelectedTask" | "contextSwitchVersion" | "isActiveTaskHydrated"
+>;
+
+type AgentStudioPageModelsSessionsContext = Pick<
+  AgentStudioOrchestrationSelectionContext,
+  "viewSessionsForTask" | "viewActiveSession"
+>;
+
+type AgentStudioPageModelsTabsContext = Pick<
+  AgentStudioOrchestrationSelectionContext,
+  | "activeTaskTabId"
+  | "taskTabs"
+  | "availableTabTasks"
+  | "isLoadingTasks"
+  | "onCreateTab"
+  | "onCloseTab"
+>;
+
+type AgentStudioPageModelsDocumentsContext = Pick<
+  ReturnType<typeof useAgentStudioDocuments>,
+  "specDoc" | "planDoc" | "qaDoc"
+>;
+
+type AgentStudioPageModelsSessionActionsContext = ReturnType<
+  typeof useAgentStudioSessionActions
+> & {
+  stopAgentSession: AgentStateContextValue["stopAgentSession"];
+};
+
+type AgentStudioPageModelsModelSelectionContext = Pick<
+  ReturnType<typeof useAgentStudioModelSelection>,
+  | "selectedModelSelection"
+  | "isSelectionCatalogLoading"
+  | "agentOptions"
+  | "modelOptions"
+  | "modelGroups"
+  | "variantOptions"
+  | "activeSessionAgentColors"
+  | "activeSessionContextUsage"
+  | "handleSelectAgent"
+  | "handleSelectModel"
+  | "handleSelectVariant"
+>;
+
 type BuildAgentStudioPageModelsArgsInput = {
-  viewTaskId: string;
-  viewRole: AgentRole;
-  viewSelectedTask: TaskCard | null;
-  viewSessionsForTask: AgentSessionState[];
-  viewActiveSession: AgentSessionState | null;
-  activeTaskTabId: string;
-  taskTabs: AgentStudioTaskTabsModel["tabs"];
-  availableTabTasks: TaskCard[];
-  onCreateTab: (taskId: string) => void;
-  onCloseTab: (taskId: string) => void;
-  contextSwitchVersion: number;
-  isLoadingTasks: boolean;
-  isActiveTaskHydrated: boolean;
-  specDoc: ReturnType<typeof useAgentStudioDocuments>["specDoc"];
-  planDoc: ReturnType<typeof useAgentStudioDocuments>["planDoc"];
-  qaDoc: ReturnType<typeof useAgentStudioDocuments>["qaDoc"];
+  view: AgentStudioPageModelsViewContext;
+  sessions: AgentStudioPageModelsSessionsContext;
+  tabs: AgentStudioPageModelsTabsContext;
+  documents: AgentStudioPageModelsDocumentsContext;
   readiness: AgentStudioOrchestrationReadinessContext;
-  sessionActions: ReturnType<typeof useAgentStudioSessionActions> & {
-    stopAgentSession: AgentStateContextValue["stopAgentSession"];
-  };
-  modelSelection: {
-    selectedModelSelection: ReturnType<
-      typeof useAgentStudioModelSelection
-    >["selectedModelSelection"];
-    isSelectionCatalogLoading: ReturnType<
-      typeof useAgentStudioModelSelection
-    >["isSelectionCatalogLoading"];
-    agentOptions: ReturnType<typeof useAgentStudioModelSelection>["agentOptions"];
-    modelOptions: ReturnType<typeof useAgentStudioModelSelection>["modelOptions"];
-    modelGroups: ReturnType<typeof useAgentStudioModelSelection>["modelGroups"];
-    variantOptions: ReturnType<typeof useAgentStudioModelSelection>["variantOptions"];
-    onSelectAgent: ReturnType<typeof useAgentStudioModelSelection>["handleSelectAgent"];
-    onSelectModel: ReturnType<typeof useAgentStudioModelSelection>["handleSelectModel"];
-    onSelectVariant: ReturnType<typeof useAgentStudioModelSelection>["handleSelectVariant"];
-    activeSessionAgentColors: ReturnType<
-      typeof useAgentStudioModelSelection
-    >["activeSessionAgentColors"];
-    activeSessionContextUsage: ReturnType<
-      typeof useAgentStudioModelSelection
-    >["activeSessionContextUsage"];
-  };
+  sessionActions: AgentStudioPageModelsSessionActionsContext;
+  modelSelection: AgentStudioPageModelsModelSelectionContext;
   permissions: ReturnType<typeof useAgentSessionPermissionActions>;
   composer: AgentStudioOrchestrationComposerContext;
 };
 
 export const buildAgentStudioPageModelsArgs = ({
-  viewTaskId,
-  viewRole,
-  viewSelectedTask,
-  viewSessionsForTask,
-  viewActiveSession,
-  activeTaskTabId,
-  taskTabs,
-  availableTabTasks,
-  onCreateTab,
-  onCloseTab,
-  contextSwitchVersion,
-  isLoadingTasks,
-  isActiveTaskHydrated,
-  specDoc,
-  planDoc,
-  qaDoc,
+  view,
+  sessions,
+  tabs,
+  documents,
   readiness,
   sessionActions,
   modelSelection,
@@ -150,31 +150,39 @@ export const buildAgentStudioPageModelsArgs = ({
   composer,
 }: BuildAgentStudioPageModelsArgsInput): Parameters<typeof useAgentStudioPageModels>[0] => ({
   core: {
-    activeTabValue: activeTaskTabId || viewTaskId || "__agent_studio_empty__",
-    taskId: viewTaskId,
-    role: viewRole,
-    selectedTask: viewSelectedTask,
-    sessionsForTask: viewSessionsForTask,
-    contextSessionsLength: viewSessionsForTask.length,
-    activeSession: viewActiveSession,
-    isTaskHydrating: Boolean(viewTaskId && !isActiveTaskHydrated),
-    contextSwitchVersion,
+    activeTabValue: tabs.activeTaskTabId || view.viewTaskId || "__agent_studio_empty__",
+    taskId: view.viewTaskId,
+    role: view.viewRole,
+    selectedTask: view.viewSelectedTask,
+    sessionsForTask: sessions.viewSessionsForTask,
+    contextSessionsLength: sessions.viewSessionsForTask.length,
+    activeSession: sessions.viewActiveSession,
+    isTaskHydrating: Boolean(view.viewTaskId && !view.isActiveTaskHydrated),
+    contextSwitchVersion: view.contextSwitchVersion,
   },
   taskTabs: {
-    taskTabs,
-    availableTabTasks,
-    isLoadingTasks,
-    onCreateTab,
-    onCloseTab,
+    taskTabs: tabs.taskTabs,
+    availableTabTasks: tabs.availableTabTasks,
+    isLoadingTasks: tabs.isLoadingTasks,
+    onCreateTab: tabs.onCreateTab,
+    onCloseTab: tabs.onCloseTab,
   },
-  documents: {
-    specDoc,
-    planDoc,
-    qaDoc,
-  },
+  documents,
   readiness,
   sessionActions,
-  modelSelection,
+  modelSelection: {
+    selectedModelSelection: modelSelection.selectedModelSelection,
+    isSelectionCatalogLoading: modelSelection.isSelectionCatalogLoading,
+    agentOptions: modelSelection.agentOptions,
+    modelOptions: modelSelection.modelOptions,
+    modelGroups: modelSelection.modelGroups,
+    variantOptions: modelSelection.variantOptions,
+    onSelectAgent: modelSelection.handleSelectAgent,
+    onSelectModel: modelSelection.handleSelectModel,
+    onSelectVariant: modelSelection.handleSelectVariant,
+    activeSessionAgentColors: modelSelection.activeSessionAgentColors,
+    activeSessionContextUsage: modelSelection.activeSessionContextUsage,
+  },
   permissions,
   composer,
 });
@@ -295,22 +303,30 @@ export function useAgentStudioOrchestrationController({
     });
 
   const pageModelsArgs = buildAgentStudioPageModelsArgs({
-    viewTaskId,
-    viewRole,
-    viewSelectedTask,
-    viewSessionsForTask,
-    viewActiveSession,
-    activeTaskTabId,
-    taskTabs,
-    availableTabTasks,
-    onCreateTab,
-    onCloseTab,
-    contextSwitchVersion,
-    isLoadingTasks,
-    isActiveTaskHydrated,
-    specDoc,
-    planDoc,
-    qaDoc,
+    view: {
+      viewTaskId,
+      viewRole,
+      viewSelectedTask,
+      contextSwitchVersion,
+      isActiveTaskHydrated,
+    },
+    sessions: {
+      viewSessionsForTask,
+      viewActiveSession,
+    },
+    tabs: {
+      activeTaskTabId,
+      taskTabs,
+      availableTabTasks,
+      isLoadingTasks,
+      onCreateTab,
+      onCloseTab,
+    },
+    documents: {
+      specDoc,
+      planDoc,
+      qaDoc,
+    },
     readiness,
     sessionActions: {
       isStarting,
@@ -337,9 +353,9 @@ export function useAgentStudioOrchestrationController({
       variantOptions,
       activeSessionAgentColors,
       activeSessionContextUsage,
-      onSelectAgent: handleSelectAgent,
-      onSelectModel: handleSelectModel,
-      onSelectVariant: handleSelectVariant,
+      handleSelectAgent,
+      handleSelectModel,
+      handleSelectVariant,
     },
     permissions: {
       isSubmittingPermissionByRequestId,

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -105,11 +105,9 @@ type AgentStudioPageModelsDocumentsContext = Pick<
   "specDoc" | "planDoc" | "qaDoc"
 >;
 
-type AgentStudioPageModelsSessionActionsContext = ReturnType<
-  typeof useAgentStudioSessionActions
-> & {
-  stopAgentSession: AgentStateContextValue["stopAgentSession"];
-};
+type AgentStudioPageModelsSessionActionsContext = Parameters<
+  typeof useAgentStudioPageModels
+>[0]["sessionActions"];
 
 type AgentStudioPageModelsModelSelectionContext = Pick<
   ReturnType<typeof useAgentStudioModelSelection>,


### PR DESCRIPTION
## Summary
- Refactors `buildAgentStudioPageModelsArgs` to accept grouped contexts (`view`, `sessions`, `tabs`, `documents`, `readiness`, `sessionActions`, `modelSelection`, `permissions`, `composer`) instead of 22 flat fields.
- Preserves the page-model contract while keeping normalization in one boundary (`handleSelect*` to `onSelect*`).
- Tightens `sessionActions` bridge typing to the `useAgentStudioPageModels` contract instead of coupling to the full `useAgentStudioSessionActions` return shape.

## Why
- Addresses parameter bloat / primitive obsession in the orchestration-to-page-model bridge.
- Reduces call-site fragility when upstream hook return shapes evolve.
- Improves maintainability and testability for derived mapping behavior.

## What Changed
- Updated grouped bridge input types in:
  - `apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts`
- Updated orchestration call site to pass grouped context objects.
- Added/expanded tests for:
  - core mapping contract integrity
  - `activeTabValue` fallback chain
  - `isTaskHydrating` derivation
  - `contextSessionsLength` derivation
  in `apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts`.

## Validation
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop typecheck`
- `bun test apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts`
- `bun run --filter @openducktor/desktop test`

## Notes
- No functional behavior changes are intended; this PR focuses on contract shape, coupling reduction, and coverage hardening.
