### PR TITLE
refactor(desktop): decompose AgentChatThread and add hook-level coverage

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
@@ -3,11 +3,11 @@ import type { ReactElement } from "react";
 import { cn } from "@/lib/utils";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { AgentChatMessageCard } from "./agent-chat-message-card";
-import type { AgentChatVirtualRow as AgentChatVirtualRowItem } from "./agent-chat-thread-virtualization";
+import type { AgentChatVirtualRow } from "./agent-chat-thread-virtualization";
 import { AgentTurnDurationSeparator } from "./agent-turn-duration-separator";
 
 type AgentChatVirtualRowProps = {
-  row: AgentChatVirtualRowItem;
+  row: AgentChatVirtualRow;
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionSelectedModel: AgentSessionState["selectedModel"] | null;
@@ -15,7 +15,7 @@ type AgentChatVirtualRowProps = {
   streamingRoleLabel: string;
 };
 
-export function AgentChatVirtualRow({
+export function AgentChatThreadRow({
   row,
   sessionAgentColors,
   sessionRole,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -3,7 +3,7 @@ import { Fragment, type ReactElement } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { AgentChatThreadModel } from "./agent-chat.types";
-import { AgentChatVirtualRow } from "./agent-chat-virtual-row";
+import { AgentChatThreadRow } from "./agent-chat-thread-row";
 import { AgentSessionPermissionCard } from "./agent-session-permission-card";
 import { AgentSessionQuestionCard } from "./agent-session-question-card";
 import { AgentSessionTodoPanel } from "./agent-session-todo-panel";
@@ -145,7 +145,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
                     width: "100%",
                   }}
                 >
-                  <AgentChatVirtualRow
+                  <AgentChatThreadRow
                     row={row}
                     sessionRole={sessionRole}
                     sessionSelectedModel={sessionSelectedModel}
@@ -163,7 +163,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
           hasRenderableSessionRows ? (
             virtualRows.map((row) => (
               <Fragment key={row.key}>
-                <AgentChatVirtualRow
+                <AgentChatThreadRow
                   row={row}
                   sessionRole={sessionRole}
                   sessionSelectedModel={sessionSelectedModel}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -1,31 +1,14 @@
-import { useVirtualizer } from "@tanstack/react-virtual";
-import { AlertTriangle, Bot, Brain, LoaderCircle, RefreshCcw, Sparkles } from "lucide-react";
-import {
-  Fragment,
-  type ReactElement,
-  type UIEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from "react";
+import { AlertTriangle, Bot, LoaderCircle, RefreshCcw, Sparkles } from "lucide-react";
+import { Fragment, type ReactElement } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import type { AgentChatThreadModel } from "./agent-chat.types";
-import { AgentChatMessageCard } from "./agent-chat-message-card";
-import {
-  AGENT_CHAT_VIRTUAL_OVERSCAN_ITEMS,
-  AGENT_CHAT_VIRTUAL_ROW_GAP_PX,
-  AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT,
-  type AgentChatVirtualRow,
-  buildAgentChatVirtualRows,
-  buildAgentChatVirtualRowsSignature,
-} from "./agent-chat-thread-virtualization";
+import { AgentChatVirtualRow } from "./agent-chat-virtual-row";
 import { AgentSessionPermissionCard } from "./agent-session-permission-card";
 import { AgentSessionQuestionCard } from "./agent-session-question-card";
 import { AgentSessionTodoPanel } from "./agent-session-todo-panel";
-import { AgentTurnDurationSeparator } from "./agent-turn-duration-separator";
+import { useAgentChatAutoScroll } from "./use-agent-chat-auto-scroll";
+import { useAgentChatVirtualization } from "./use-agent-chat-virtualization";
 
 export function AgentChatThread({ model }: { model: AgentChatThreadModel }): ReactElement {
   const {
@@ -61,217 +44,28 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const StreamingRoleIcon = streamingRoleDisplay?.icon ?? Bot;
   const streamingRoleLabel = streamingRoleDisplay?.label ?? "Assistant";
 
-  const messageIdentityTokenByMessageRef = useRef<WeakMap<AgentChatMessage, number>>(new WeakMap());
-  const nextMessageIdentityTokenRef = useRef(1);
-  const virtualRowsCacheRef = useRef<{ signature: string | null; rows: AgentChatVirtualRow[] }>({
-    signature: null,
-    rows: [],
+  const {
+    activeSessionId,
+    canRenderVirtualRows,
+    hasRenderableSessionRows,
+    shouldVirtualize,
+    virtualRows,
+    virtualRowsToRender,
+    virtualizer,
+  } = useAgentChatVirtualization({
+    session,
+    messagesContainerRef,
   });
-  const resolveMessageIdentityToken = useCallback((message: AgentChatMessage): number => {
-    const cached = messageIdentityTokenByMessageRef.current.get(message);
-    if (typeof cached === "number") {
-      return cached;
-    }
-
-    const nextToken = nextMessageIdentityTokenRef.current;
-    nextMessageIdentityTokenRef.current += 1;
-    messageIdentityTokenByMessageRef.current.set(message, nextToken);
-    return nextToken;
-  }, []);
-  const virtualRowsSignature = session
-    ? buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken)
-    : null;
-  const virtualRows = useMemo(() => {
-    const cached = virtualRowsCacheRef.current;
-    if (cached.signature === virtualRowsSignature) {
-      return cached.rows;
-    }
-
-    const nextRows = session ? buildAgentChatVirtualRows(session) : [];
-    virtualRowsCacheRef.current = {
-      signature: virtualRowsSignature,
-      rows: nextRows,
-    };
-    return nextRows;
-  }, [session, virtualRowsSignature]);
-  const virtualRowsRef = useRef(virtualRows);
-  virtualRowsRef.current = virtualRows;
-  const shouldVirtualize = virtualRows.length >= AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT;
-  const activeSessionId = session?.sessionId ?? null;
-  const measuredSessionIdRef = useRef<string | null>(null);
-  const measuredRowHeightByKeyRef = useRef<Record<string, number>>({});
-  const previousVirtualizedSessionIdRef = useRef<string | null>(null);
-
-  if (measuredSessionIdRef.current !== activeSessionId) {
-    measuredSessionIdRef.current = activeSessionId;
-    measuredRowHeightByKeyRef.current = {};
-  }
-
-  const estimateRowSize = useCallback((index: number): number => {
-    const rows = virtualRowsRef.current;
-    const row = rows[index];
-    if (!row) {
-      return 0;
-    }
-    const trailingGap = index < rows.length - 1 ? AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 0;
-    const measuredHeight = measuredRowHeightByKeyRef.current[row.key];
-    if (typeof measuredHeight === "number" && measuredHeight > 0) {
-      return measuredHeight + trailingGap;
-    }
-
-    return 1 + trailingGap;
-  }, []);
-
-  const measureVirtualRowElement = useCallback((element: Element): number => {
-    const measuredHeight = element.getBoundingClientRect().height;
-    const rowKey = element.getAttribute("data-row-key");
-    if (rowKey && measuredHeight > 0) {
-      const previousHeight = measuredRowHeightByKeyRef.current[rowKey];
-      if (typeof previousHeight !== "number") {
-        measuredRowHeightByKeyRef.current[rowKey] = measuredHeight;
-      } else if (Math.abs(previousHeight - measuredHeight) > 0.5) {
-        measuredRowHeightByKeyRef.current[rowKey] = measuredHeight;
-      }
-    }
-    return measuredHeight;
-  }, []);
-
-  const resolveRowKey = useCallback((index: number): string | number => {
-    return virtualRowsRef.current[index]?.key ?? index;
-  }, []);
-  const resolveScrollElement = useCallback((): HTMLDivElement | null => {
-    return messagesContainerRef.current;
-  }, [messagesContainerRef]);
-
-  const virtualizer = useVirtualizer({
-    count: shouldVirtualize ? virtualRows.length : 0,
-    getScrollElement: resolveScrollElement,
-    estimateSize: estimateRowSize,
-    measureElement: measureVirtualRowElement,
-    getItemKey: resolveRowKey,
-    overscan: AGENT_CHAT_VIRTUAL_OVERSCAN_ITEMS,
-  });
-
-  useEffect(() => {
-    if (!activeSessionId || !shouldVirtualize || virtualRows.length === 0) {
-      previousVirtualizedSessionIdRef.current = activeSessionId;
-      return;
-    }
-
-    const sessionChanged = previousVirtualizedSessionIdRef.current !== activeSessionId;
-    previousVirtualizedSessionIdRef.current = activeSessionId;
-
-    if (!sessionChanged && !isPinnedToBottom) {
-      return;
-    }
-
-    const lastRowIndex = virtualRows.length - 1;
-    const scrollToBottom = (): void => {
-      if (sessionChanged) {
-        virtualizer.measure();
-      }
-      virtualizer.scrollToIndex(lastRowIndex, { align: "end" });
-
-      const container = messagesContainerRef.current;
-      if (!container) {
-        return;
-      }
-
-      container.scrollTo({ top: container.scrollHeight, behavior: "auto" });
-    };
-
-    if (typeof window === "undefined") {
-      scrollToBottom();
-      return;
-    }
-
-    const rafId = window.requestAnimationFrame(() => {
-      scrollToBottom();
-    });
-
-    return () => {
-      window.cancelAnimationFrame(rafId);
-    };
-  }, [
+  useAgentChatAutoScroll({
     activeSessionId,
     isPinnedToBottom,
     messagesContainerRef,
     shouldVirtualize,
-    virtualRows.length,
+    virtualRowsCount: virtualRows.length,
     virtualizer,
-  ]);
-
-  const handleMessagesContainerScroll = useCallback(
-    (event: UIEvent<HTMLDivElement>): void => {
-      onMessagesScroll(event);
-    },
-    [onMessagesScroll],
-  );
-  const virtualItems = virtualizer.getVirtualItems();
-  const virtualRowsToRender = useMemo(
-    () =>
-      virtualItems
-        .map((virtualItem) => {
-          const row = virtualRows[virtualItem.index];
-          if (!row) {
-            return null;
-          }
-          return { row, virtualItem };
-        })
-        .filter(
-          (
-            entry,
-          ): entry is { row: AgentChatVirtualRow; virtualItem: (typeof virtualItems)[number] } =>
-            entry !== null,
-        ),
-    [virtualItems, virtualRows],
-  );
-  const canRenderVirtualRows = shouldVirtualize && virtualRowsToRender.length > 0;
-  const hasRenderableSessionRows = virtualRows.length > 0;
-
-  const renderVirtualRow = useCallback(
-    (row: AgentChatVirtualRow): ReactElement => {
-      if (row.kind === "turn_duration") {
-        return <AgentTurnDurationSeparator durationMs={row.durationMs} />;
-      }
-
-      if (row.kind === "message") {
-        const isUserMessage = row.message.role === "user";
-        return (
-          <div className={cn("flow-root", isUserMessage ? "pt-4" : undefined)}>
-            <AgentChatMessageCard
-              message={row.message}
-              sessionRole={session?.role ?? null}
-              sessionSelectedModel={session?.selectedModel ?? null}
-              sessionAgentColors={sessionAgentColors}
-            />
-          </div>
-        );
-      }
-
-      if (row.kind === "draft") {
-        return (
-          <article className="px-1 py-1 text-sm text-foreground">
-            <header className="mb-1 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-              <StreamingRoleIcon className="size-3" />
-              {streamingRoleLabel} (streaming)
-              <LoaderCircle className="size-3 animate-spin" />
-            </header>
-            <p className="whitespace-pre-wrap leading-6 text-foreground">{row.draftText}</p>
-          </article>
-        );
-      }
-
-      return (
-        <div className="flex items-center gap-2 rounded-md border border-dashed border-input bg-card px-3 py-2 text-xs text-muted-foreground">
-          <LoaderCircle className="size-3.5 animate-spin text-muted-foreground" />
-          <Brain className="size-3.5 text-pending-accent" />
-          Agent is thinking...
-        </div>
-      );
-    },
-    [session, sessionAgentColors, StreamingRoleIcon, streamingRoleLabel],
-  );
+  });
+  const sessionRole = session?.role ?? null;
+  const sessionSelectedModel = session?.selectedModel ?? null;
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
@@ -298,7 +92,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
       <div
         ref={messagesContainerRef}
         className="min-h-0 flex-1 space-y-1 overflow-y-auto p-4 pb-6"
-        onScroll={handleMessagesContainerScroll}
+        onScroll={onMessagesScroll}
       >
         {!session ? (
           <div className="space-y-3 rounded-lg border border-dashed border-input bg-card p-4 text-sm text-muted-foreground">
@@ -351,7 +145,14 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
                     width: "100%",
                   }}
                 >
-                  {renderVirtualRow(row)}
+                  <AgentChatVirtualRow
+                    row={row}
+                    sessionRole={sessionRole}
+                    sessionSelectedModel={sessionSelectedModel}
+                    sessionAgentColors={sessionAgentColors}
+                    streamingRoleIcon={StreamingRoleIcon}
+                    streamingRoleLabel={streamingRoleLabel}
+                  />
                 </div>
               );
             })}
@@ -360,7 +161,18 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
 
         {session && !canRenderVirtualRows ? (
           hasRenderableSessionRows ? (
-            virtualRows.map((row) => <Fragment key={row.key}>{renderVirtualRow(row)}</Fragment>)
+            virtualRows.map((row) => (
+              <Fragment key={row.key}>
+                <AgentChatVirtualRow
+                  row={row}
+                  sessionRole={sessionRole}
+                  sessionSelectedModel={sessionSelectedModel}
+                  sessionAgentColors={sessionAgentColors}
+                  streamingRoleIcon={StreamingRoleIcon}
+                  streamingRoleLabel={streamingRoleLabel}
+                />
+              </Fragment>
+            ))
           ) : (
             <div className="rounded-lg border border-dashed border-input bg-card p-4 text-sm text-muted-foreground">
               Loading session history...

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.virtualizer-callbacks.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.virtualizer-callbacks.test.ts
@@ -156,4 +156,82 @@ describe("AgentChatThread virtualizer callbacks", () => {
       renderer.unmount();
     });
   });
+
+  test("clears measured row cache when active session changes", async () => {
+    const { AgentChatThread } = await import("./agent-chat-thread");
+
+    const firstSession = buildSession({
+      sessionId: "session-a",
+      messages: Array.from({ length: 45 }, (_, index) =>
+        buildMessage("assistant", `Session A Message ${index + 1}`, {
+          id: `message-${index + 1}`,
+        }),
+      ),
+    });
+    const secondSession = buildSession({
+      sessionId: "session-b",
+      messages: Array.from({ length: 45 }, (_, index) =>
+        buildMessage("assistant", `Session B Message ${index + 1}`, {
+          id: `message-${index + 1}`,
+        }),
+      ),
+    });
+    const secondSessionFirstRowKey = `${secondSession.sessionId}:message-1`;
+    let model = {
+      ...baseModel,
+      session: firstSession,
+    };
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        createElement(AgentChatThread, {
+          model,
+        }),
+      );
+    });
+
+    const firstOptions = useVirtualizerOptionsByRender.at(-1);
+    expect(firstOptions).toBeDefined();
+    const seededMeasurement = firstOptions?.measureElement({
+      getBoundingClientRect: () => ({ height: 77 }),
+      getAttribute: (attributeName: string) => {
+        if (attributeName === "data-row-key") {
+          return secondSessionFirstRowKey;
+        }
+        if (attributeName === "data-index") {
+          return "0";
+        }
+        return null;
+      },
+    } as unknown as Element);
+    expect(seededMeasurement).toBe(77);
+
+    model = {
+      ...baseModel,
+      session: secondSession,
+    };
+    await act(async () => {
+      renderer.update(
+        createElement(AgentChatThread, {
+          model,
+        }),
+      );
+    });
+
+    const secondOptions = useVirtualizerOptionsByRender.at(-1);
+    expect(secondOptions).toBeDefined();
+    const secondSessionRows = buildAgentChatVirtualRows(secondSession);
+    const secondSessionRowIndex = secondSessionRows.findIndex(
+      (row) => row.key === secondSessionFirstRowKey,
+    );
+    expect(secondSessionRowIndex).toBeGreaterThanOrEqual(0);
+    const expectedDefaultEstimate =
+      secondSessionRowIndex < secondSessionRows.length - 1 ? 1 + AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 1;
+    expect(secondOptions?.estimateSize(secondSessionRowIndex)).toBe(expectedDefaultEstimate);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-virtual-row.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-virtual-row.tsx
@@ -1,0 +1,66 @@
+import { Brain, LoaderCircle, type LucideIcon } from "lucide-react";
+import type { ReactElement } from "react";
+import { cn } from "@/lib/utils";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { AgentChatMessageCard } from "./agent-chat-message-card";
+import type { AgentChatVirtualRow as AgentChatVirtualRowItem } from "./agent-chat-thread-virtualization";
+import { AgentTurnDurationSeparator } from "./agent-turn-duration-separator";
+
+type AgentChatVirtualRowProps = {
+  row: AgentChatVirtualRowItem;
+  sessionAgentColors: Record<string, string>;
+  sessionRole: AgentSessionState["role"] | null;
+  sessionSelectedModel: AgentSessionState["selectedModel"] | null;
+  streamingRoleIcon: LucideIcon;
+  streamingRoleLabel: string;
+};
+
+export function AgentChatVirtualRow({
+  row,
+  sessionAgentColors,
+  sessionRole,
+  sessionSelectedModel,
+  streamingRoleIcon,
+  streamingRoleLabel,
+}: AgentChatVirtualRowProps): ReactElement {
+  switch (row.kind) {
+    case "turn_duration": {
+      return <AgentTurnDurationSeparator durationMs={row.durationMs} />;
+    }
+    case "message": {
+      const isUserMessage = row.message.role === "user";
+      return (
+        <div className={cn("flow-root", isUserMessage ? "pt-4" : undefined)}>
+          <AgentChatMessageCard
+            message={row.message}
+            sessionRole={sessionRole}
+            sessionSelectedModel={sessionSelectedModel}
+            sessionAgentColors={sessionAgentColors}
+          />
+        </div>
+      );
+    }
+    case "draft": {
+      const StreamingRoleIcon = streamingRoleIcon;
+      return (
+        <article className="px-1 py-1 text-sm text-foreground">
+          <header className="mb-1 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            <StreamingRoleIcon className="size-3" />
+            {streamingRoleLabel} (streaming)
+            <LoaderCircle className="size-3 animate-spin" />
+          </header>
+          <p className="whitespace-pre-wrap leading-6 text-foreground">{row.draftText}</p>
+        </article>
+      );
+    }
+    case "thinking": {
+      return (
+        <div className="flex items-center gap-2 rounded-md border border-dashed border-input bg-card px-3 py-2 text-xs text-muted-foreground">
+          <LoaderCircle className="size-3.5 animate-spin text-muted-foreground" />
+          <Brain className="size-3.5 text-pending-accent" />
+          Agent is thinking...
+        </div>
+      );
+    }
+  }
+}

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-auto-scroll.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-auto-scroll.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createElement, createRef } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { useAgentChatAutoScroll } from "./use-agent-chat-auto-scroll";
+import type { AgentChatVirtualizer } from "./use-agent-chat-virtualization";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type AutoScrollHarnessProps = {
+  activeSessionId: string | null;
+  isPinnedToBottom: boolean;
+  messagesContainerRef: ReturnType<typeof createRef<HTMLDivElement>>;
+  shouldVirtualize: boolean;
+  virtualRowsCount: number;
+  virtualizer: AgentChatVirtualizer;
+};
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const getGlobalWindow = (): unknown => {
+  const globalWithWindow = globalThis as { window?: unknown };
+  return globalWithWindow.window;
+};
+
+const setGlobalWindow = (value: unknown): void => {
+  const globalWithWindow = globalThis as { window?: unknown };
+  if (typeof value === "undefined") {
+    delete globalWithWindow.window;
+    return;
+  }
+  globalWithWindow.window = value;
+};
+
+const createVirtualizerMock = () => {
+  const measure = mock(() => {});
+  const scrollToIndex = mock((_index: number, _options: { align: "end" }) => {});
+  return {
+    measure,
+    scrollToIndex,
+    virtualizer: {
+      measure,
+      scrollToIndex,
+    } as unknown as AgentChatVirtualizer,
+  };
+};
+
+const createContainerMock = () => {
+  const scrollTo = mock((_options: ScrollToOptions) => {});
+  return {
+    container: {
+      scrollHeight: 960,
+      scrollTo,
+    } as unknown as HTMLDivElement,
+    scrollTo,
+  };
+};
+
+const AutoScrollHarness = ({
+  activeSessionId,
+  isPinnedToBottom,
+  messagesContainerRef,
+  shouldVirtualize,
+  virtualRowsCount,
+  virtualizer,
+}: AutoScrollHarnessProps): null => {
+  useAgentChatAutoScroll({
+    activeSessionId,
+    isPinnedToBottom,
+    messagesContainerRef,
+    shouldVirtualize,
+    virtualRowsCount,
+    virtualizer,
+  });
+  return null;
+};
+
+describe("useAgentChatAutoScroll", () => {
+  const originalWindow = getGlobalWindow();
+
+  afterEach(() => {
+    setGlobalWindow(originalWindow);
+  });
+
+  test("scrolls and measures when session changes", async () => {
+    const rafCallbacks: FrameRequestCallback[] = [];
+    const requestAnimationFrame = mock((callback: FrameRequestCallback) => {
+      rafCallbacks.push(callback);
+      return 17;
+    });
+    const cancelAnimationFrame = mock((_id: number) => {});
+    setGlobalWindow({
+      cancelAnimationFrame,
+      requestAnimationFrame,
+    });
+
+    const { measure, scrollToIndex, virtualizer } = createVirtualizerMock();
+    const { container, scrollTo } = createContainerMock();
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    messagesContainerRef.current = container;
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(AutoScrollHarness, {
+          activeSessionId: "session-1",
+          isPinnedToBottom: true,
+          messagesContainerRef,
+          shouldVirtualize: true,
+          virtualRowsCount: 4,
+          virtualizer,
+        }),
+      );
+      await flush();
+    });
+
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(rafCallbacks.length).toBe(1);
+    expect(measure).toHaveBeenCalledTimes(0);
+    expect(scrollToIndex).toHaveBeenCalledTimes(0);
+
+    const rafCallback = rafCallbacks[0];
+    if (!rafCallback) {
+      throw new Error("Missing requestAnimationFrame callback");
+    }
+    rafCallback(0);
+
+    expect(measure).toHaveBeenCalledTimes(1);
+    expect(scrollToIndex).toHaveBeenCalledWith(3, { align: "end" });
+    expect(scrollTo).toHaveBeenCalledWith({ top: 960, behavior: "auto" });
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(17);
+  });
+
+  test("does not auto-scroll when staying on same session while unpinned", async () => {
+    const rafCallbacks: FrameRequestCallback[] = [];
+    const requestAnimationFrame = mock((callback: FrameRequestCallback) => {
+      rafCallbacks.push(callback);
+      return rafCallbacks.length;
+    });
+    const cancelAnimationFrame = mock((_id: number) => {});
+    setGlobalWindow({
+      cancelAnimationFrame,
+      requestAnimationFrame,
+    });
+
+    const { measure, scrollToIndex, virtualizer } = createVirtualizerMock();
+    const { container, scrollTo } = createContainerMock();
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    messagesContainerRef.current = container;
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(AutoScrollHarness, {
+          activeSessionId: "session-1",
+          isPinnedToBottom: true,
+          messagesContainerRef,
+          shouldVirtualize: true,
+          virtualRowsCount: 3,
+          virtualizer,
+        }),
+      );
+      await flush();
+    });
+
+    const initialCallback = rafCallbacks[0];
+    if (!initialCallback) {
+      throw new Error("Missing initial requestAnimationFrame callback");
+    }
+    initialCallback(0);
+    measure.mockClear();
+    scrollToIndex.mockClear();
+    scrollTo.mockClear();
+
+    await act(async () => {
+      renderer?.update(
+        createElement(AutoScrollHarness, {
+          activeSessionId: "session-1",
+          isPinnedToBottom: false,
+          messagesContainerRef,
+          shouldVirtualize: true,
+          virtualRowsCount: 4,
+          virtualizer,
+        }),
+      );
+      await flush();
+    });
+
+    expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(measure).toHaveBeenCalledTimes(0);
+    expect(scrollToIndex).toHaveBeenCalledTimes(0);
+    expect(scrollTo).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+
+  test("scrolls without measuring when pinned on same session", async () => {
+    const rafCallbacks: FrameRequestCallback[] = [];
+    setGlobalWindow({
+      cancelAnimationFrame: mock((_id: number) => {}),
+      requestAnimationFrame: mock((callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback);
+        return rafCallbacks.length;
+      }),
+    });
+
+    const { measure, scrollToIndex, virtualizer } = createVirtualizerMock();
+    const { container, scrollTo } = createContainerMock();
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    messagesContainerRef.current = container;
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(AutoScrollHarness, {
+          activeSessionId: "session-1",
+          isPinnedToBottom: true,
+          messagesContainerRef,
+          shouldVirtualize: true,
+          virtualRowsCount: 2,
+          virtualizer,
+        }),
+      );
+      await flush();
+    });
+
+    const initialCallback = rafCallbacks[0];
+    if (!initialCallback) {
+      throw new Error("Missing initial requestAnimationFrame callback");
+    }
+    initialCallback(0);
+    measure.mockClear();
+    scrollToIndex.mockClear();
+    scrollTo.mockClear();
+
+    await act(async () => {
+      renderer?.update(
+        createElement(AutoScrollHarness, {
+          activeSessionId: "session-1",
+          isPinnedToBottom: true,
+          messagesContainerRef,
+          shouldVirtualize: true,
+          virtualRowsCount: 5,
+          virtualizer,
+        }),
+      );
+      await flush();
+    });
+
+    const followupCallback = rafCallbacks[1];
+    if (!followupCallback) {
+      throw new Error("Missing follow-up requestAnimationFrame callback");
+    }
+    followupCallback(0);
+
+    expect(measure).toHaveBeenCalledTimes(0);
+    expect(scrollToIndex).toHaveBeenCalledWith(4, { align: "end" });
+    expect(scrollTo).toHaveBeenCalledWith({ top: 960, behavior: "auto" });
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-auto-scroll.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-auto-scroll.ts
@@ -1,0 +1,72 @@
+import type { RefObject } from "react";
+import { useEffect, useRef } from "react";
+import type { AgentChatVirtualizer } from "./use-agent-chat-virtualization";
+
+type UseAgentChatAutoScrollInput = {
+  activeSessionId: string | null;
+  isPinnedToBottom: boolean;
+  messagesContainerRef: RefObject<HTMLDivElement | null>;
+  shouldVirtualize: boolean;
+  virtualRowsCount: number;
+  virtualizer: AgentChatVirtualizer;
+};
+
+export function useAgentChatAutoScroll({
+  activeSessionId,
+  isPinnedToBottom,
+  messagesContainerRef,
+  shouldVirtualize,
+  virtualRowsCount,
+  virtualizer,
+}: UseAgentChatAutoScrollInput): void {
+  const previousVirtualizedSessionIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!activeSessionId || !shouldVirtualize || virtualRowsCount === 0) {
+      previousVirtualizedSessionIdRef.current = activeSessionId;
+      return;
+    }
+
+    const sessionChanged = previousVirtualizedSessionIdRef.current !== activeSessionId;
+    previousVirtualizedSessionIdRef.current = activeSessionId;
+
+    if (!sessionChanged && !isPinnedToBottom) {
+      return;
+    }
+
+    const lastRowIndex = virtualRowsCount - 1;
+    const scrollToBottom = (): void => {
+      if (sessionChanged) {
+        virtualizer.measure();
+      }
+      virtualizer.scrollToIndex(lastRowIndex, { align: "end" });
+
+      const container = messagesContainerRef.current;
+      if (!container) {
+        return;
+      }
+
+      container.scrollTo({ top: container.scrollHeight, behavior: "auto" });
+    };
+
+    if (typeof window === "undefined") {
+      scrollToBottom();
+      return;
+    }
+
+    const rafId = window.requestAnimationFrame(() => {
+      scrollToBottom();
+    });
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+    };
+  }, [
+    activeSessionId,
+    isPinnedToBottom,
+    messagesContainerRef,
+    shouldVirtualize,
+    virtualRowsCount,
+    virtualizer,
+  ]);
+}

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+import { createElement, createRef } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { buildMessage, buildSession } from "./agent-chat-test-fixtures";
+import {
+  AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT,
+  type AgentChatVirtualRow,
+} from "./agent-chat-thread-virtualization";
+import { useAgentChatVirtualization } from "./use-agent-chat-virtualization";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+type AgentChatVirtualizationState = {
+  activeSessionId: string | null;
+  canRenderVirtualRows: boolean;
+  hasRenderableSessionRows: boolean;
+  shouldVirtualize: boolean;
+  virtualRows: AgentChatVirtualRow[];
+  virtualRowsToRender: Array<{
+    row: AgentChatVirtualRow;
+    virtualItem: {
+      index: number;
+      key: string | number;
+      start: number;
+    };
+  }>;
+};
+
+const getLatestState = (stateRef: { current: AgentChatVirtualizationState | null }) => {
+  const state = stateRef.current;
+  if (!state) {
+    throw new Error("Missing hook state");
+  }
+  return state;
+};
+
+describe("useAgentChatVirtualization", () => {
+  test("returns empty state when no session is active", async () => {
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    const latestStateRef: { current: AgentChatVirtualizationState | null } = { current: null };
+
+    const Harness = (): null => {
+      latestStateRef.current = useAgentChatVirtualization({
+        session: null,
+        messagesContainerRef,
+      }) as AgentChatVirtualizationState;
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness));
+      await flush();
+    });
+
+    const latest = getLatestState(latestStateRef);
+    expect(latest.activeSessionId).toBeNull();
+    expect(latest.shouldVirtualize).toBe(false);
+    expect(latest.hasRenderableSessionRows).toBe(false);
+    expect(latest.virtualRows).toHaveLength(0);
+    expect(latest.virtualRowsToRender).toHaveLength(0);
+    expect(latest.canRenderVirtualRows).toBe(false);
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+
+  test("enables virtualization for sessions at threshold and exposes mapped rows", async () => {
+    const messages = Array.from(
+      { length: AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT + 2 },
+      (_, index) =>
+        buildMessage("assistant", `Message ${index + 1}`, { id: `message-${index + 1}` }),
+    );
+    const session = buildSession({ messages });
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    const latestStateRef: { current: AgentChatVirtualizationState | null } = { current: null };
+
+    const Harness = (): null => {
+      latestStateRef.current = useAgentChatVirtualization({
+        session,
+        messagesContainerRef,
+      }) as AgentChatVirtualizationState;
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness));
+      await flush();
+    });
+
+    const latest = getLatestState(latestStateRef);
+    expect(latest.activeSessionId).toBe(session.sessionId);
+    expect(latest.shouldVirtualize).toBe(true);
+    expect(latest.hasRenderableSessionRows).toBe(true);
+    expect(latest.virtualRows.length).toBeGreaterThanOrEqual(
+      AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT,
+    );
+    expect(latest.virtualRows.some((row) => row.kind === "message")).toBe(true);
+    expect(latest.virtualRowsToRender.every((entry) => entry.row.key.length > 0)).toBe(true);
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+
+  test("refreshes row model when message array mutates in place", async () => {
+    const messages = Array.from(
+      { length: AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT + 1 },
+      (_, index) =>
+        buildMessage("assistant", `Message ${index + 1}`, { id: `message-${index + 1}` }),
+    );
+    const session = buildSession({ messages });
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    const latestStateRef: { current: AgentChatVirtualizationState | null } = { current: null };
+
+    const Harness = (): null => {
+      latestStateRef.current = useAgentChatVirtualization({
+        session,
+        messagesContainerRef,
+      }) as AgentChatVirtualizationState;
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness));
+      await flush();
+    });
+
+    session.messages.push(
+      buildMessage("assistant", "Message added later", {
+        id: "message-late",
+      }),
+    );
+
+    await act(async () => {
+      renderer?.update(createElement(Harness));
+      await flush();
+    });
+
+    const latest = getLatestState(latestStateRef);
+    const messageRows = latest.virtualRows.filter((row) => row.kind === "message");
+    const lastMessageRow = messageRows.at(-1);
+    if (!lastMessageRow || lastMessageRow.kind !== "message") {
+      throw new Error("Missing latest message row");
+    }
+    expect(lastMessageRow.message.id).toBe("message-late");
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+
+  test("maps virtual items only to valid row entries", async () => {
+    const messages = Array.from(
+      { length: AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT + 1 },
+      (_, index) =>
+        buildMessage("assistant", `Message ${index + 1}`, { id: `message-${index + 1}` }),
+    );
+    const session = buildSession({ messages });
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    const latestStateRef: { current: AgentChatVirtualizationState | null } = { current: null };
+
+    const Harness = (): null => {
+      latestStateRef.current = useAgentChatVirtualization({
+        session,
+        messagesContainerRef,
+      }) as AgentChatVirtualizationState;
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness));
+      await flush();
+    });
+
+    const latest = getLatestState(latestStateRef);
+    expect(
+      latest.virtualRowsToRender.every(({ row, virtualItem }) => {
+        return latest.virtualRows[virtualItem.index]?.key === row.key;
+      }),
+    ).toBe(true);
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
@@ -59,10 +59,13 @@ export function useAgentChatVirtualization({
     activeSessionId,
     virtualRows,
   });
+  const resolveScrollElement = useCallback((): HTMLDivElement | null => {
+    return messagesContainerRef.current;
+  }, [messagesContainerRef]);
 
   const virtualizer = useVirtualizer({
     count: shouldVirtualize ? virtualRows.length : 0,
-    getScrollElement: () => messagesContainerRef.current,
+    getScrollElement: resolveScrollElement,
     estimateSize: estimateRowSize,
     measureElement: measureVirtualRowElement,
     getItemKey: resolveRowKey,
@@ -132,6 +135,8 @@ function useVirtualRowMeasurements({
   activeSessionId,
   virtualRows,
 }: UseVirtualRowMeasurementsInput): UseVirtualRowMeasurementsResult {
+  const virtualRowsRef = useRef(virtualRows);
+  virtualRowsRef.current = virtualRows;
   const measuredSessionIdRef = useRef<string | null>(null);
   const measuredRowHeightByKeyRef = useRef<Record<string, number>>({});
 
@@ -140,48 +145,48 @@ function useVirtualRowMeasurements({
     measuredRowHeightByKeyRef.current = {};
   }
 
-  const estimateRowSize = useCallback(
-    (index: number): number => {
-      const row = virtualRows[index];
-      if (!row) {
-        return 0;
-      }
-      const trailingGap = index < virtualRows.length - 1 ? AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 0;
-      const measuredHeight = measuredRowHeightByKeyRef.current[row.key];
-      if (typeof measuredHeight === "number" && measuredHeight > 0) {
-        return measuredHeight + trailingGap;
-      }
+  const estimateRowSize = useCallback((index: number): number => {
+    const rows = virtualRowsRef.current;
+    const row = rows[index];
+    if (!row) {
+      return 0;
+    }
+    const trailingGap = index < rows.length - 1 ? AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 0;
+    const measuredHeight = measuredRowHeightByKeyRef.current[row.key];
+    if (typeof measuredHeight === "number" && measuredHeight > 0) {
+      return measuredHeight + trailingGap;
+    }
 
-      return 1 + trailingGap;
-    },
-    [virtualRows],
-  );
+    return 1 + trailingGap;
+  }, []);
 
-  const measureVirtualRowElement = useCallback(
-    (element: Element): number => {
-      const measuredHeight = element.getBoundingClientRect().height;
+  const measureVirtualRowElement = useCallback((element: Element): number => {
+    const measuredHeight = element.getBoundingClientRect().height;
+    let rowKey = element.getAttribute("data-row-key");
+
+    if (!rowKey) {
       const indexValue = Number.parseInt(element.getAttribute("data-index") ?? "", 10);
       const row =
-        Number.isFinite(indexValue) && indexValue >= 0 ? virtualRows[indexValue] : undefined;
-      if (row && measuredHeight > 0) {
-        const previousHeight = measuredRowHeightByKeyRef.current[row.key];
-        if (typeof previousHeight !== "number") {
-          measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
-        } else if (Math.abs(previousHeight - measuredHeight) > 0.5) {
-          measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
-        }
-      }
-      return measuredHeight;
-    },
-    [virtualRows],
-  );
+        Number.isFinite(indexValue) && indexValue >= 0
+          ? virtualRowsRef.current[indexValue]
+          : undefined;
+      rowKey = row?.key ?? null;
+    }
 
-  const resolveRowKey = useCallback(
-    (index: number): string | number => {
-      return virtualRows[index]?.key ?? index;
-    },
-    [virtualRows],
-  );
+    if (rowKey && measuredHeight > 0) {
+      const previousHeight = measuredRowHeightByKeyRef.current[rowKey];
+      if (typeof previousHeight !== "number") {
+        measuredRowHeightByKeyRef.current[rowKey] = measuredHeight;
+      } else if (Math.abs(previousHeight - measuredHeight) > 0.5) {
+        measuredRowHeightByKeyRef.current[rowKey] = measuredHeight;
+      }
+    }
+    return measuredHeight;
+  }, []);
+
+  const resolveRowKey = useCallback((index: number): string | number => {
+    return virtualRowsRef.current[index]?.key ?? index;
+  }, []);
 
   return { estimateRowSize, measureVirtualRowElement, resolveRowKey };
 }

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
@@ -1,0 +1,161 @@
+import { useVirtualizer, type VirtualItem, type Virtualizer } from "@tanstack/react-virtual";
+import type { RefObject } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
+import {
+  AGENT_CHAT_VIRTUAL_OVERSCAN_ITEMS,
+  AGENT_CHAT_VIRTUAL_ROW_GAP_PX,
+  AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT,
+  type AgentChatVirtualRow,
+  buildAgentChatVirtualRows,
+  buildAgentChatVirtualRowsSignature,
+} from "./agent-chat-thread-virtualization";
+
+type UseAgentChatVirtualizationInput = {
+  session: AgentSessionState | null;
+  messagesContainerRef: RefObject<HTMLDivElement | null>;
+};
+
+export type AgentChatVirtualizer = Virtualizer<HTMLDivElement, Element>;
+
+type AgentChatVirtualRowsToRenderEntry = {
+  row: AgentChatVirtualRow;
+  virtualItem: VirtualItem;
+};
+
+type UseAgentChatVirtualizationResult = {
+  activeSessionId: string | null;
+  canRenderVirtualRows: boolean;
+  hasRenderableSessionRows: boolean;
+  shouldVirtualize: boolean;
+  virtualRows: AgentChatVirtualRow[];
+  virtualRowsToRender: AgentChatVirtualRowsToRenderEntry[];
+  virtualizer: AgentChatVirtualizer;
+};
+
+export function useAgentChatVirtualization({
+  session,
+  messagesContainerRef,
+}: UseAgentChatVirtualizationInput): UseAgentChatVirtualizationResult {
+  const messageIdentityTokenByMessageRef = useRef<WeakMap<AgentChatMessage, number>>(new WeakMap());
+  const nextMessageIdentityTokenRef = useRef(1);
+  const virtualRowsCacheRef = useRef<{ signature: string | null; rows: AgentChatVirtualRow[] }>({
+    signature: null,
+    rows: [],
+  });
+  const resolveMessageIdentityToken = useCallback((message: AgentChatMessage): number => {
+    const cached = messageIdentityTokenByMessageRef.current.get(message);
+    if (typeof cached === "number") {
+      return cached;
+    }
+
+    const nextToken = nextMessageIdentityTokenRef.current;
+    nextMessageIdentityTokenRef.current += 1;
+    messageIdentityTokenByMessageRef.current.set(message, nextToken);
+    return nextToken;
+  }, []);
+  const virtualRowsSignature = session
+    ? buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken)
+    : null;
+  const virtualRows = useMemo(() => {
+    const cached = virtualRowsCacheRef.current;
+    if (cached.signature === virtualRowsSignature) {
+      return cached.rows;
+    }
+
+    const nextRows = session ? buildAgentChatVirtualRows(session) : [];
+    virtualRowsCacheRef.current = {
+      signature: virtualRowsSignature,
+      rows: nextRows,
+    };
+    return nextRows;
+  }, [session, virtualRowsSignature]);
+  const shouldVirtualize = virtualRows.length >= AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT;
+  const activeSessionId = session?.sessionId ?? null;
+  const measuredSessionIdRef = useRef<string | null>(null);
+  const measuredRowHeightByKeyRef = useRef<Record<string, number>>({});
+
+  if (measuredSessionIdRef.current !== activeSessionId) {
+    measuredSessionIdRef.current = activeSessionId;
+    measuredRowHeightByKeyRef.current = {};
+  }
+
+  const estimateRowSize = useCallback(
+    (index: number): number => {
+      const row = virtualRows[index];
+      if (!row) {
+        return 0;
+      }
+      const trailingGap = index < virtualRows.length - 1 ? AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 0;
+      const measuredHeight = measuredRowHeightByKeyRef.current[row.key];
+      if (typeof measuredHeight === "number" && measuredHeight > 0) {
+        return measuredHeight + trailingGap;
+      }
+
+      return 1 + trailingGap;
+    },
+    [virtualRows],
+  );
+
+  const measureVirtualRowElement = useCallback(
+    (element: Element): number => {
+      const measuredHeight = element.getBoundingClientRect().height;
+      const indexValue = Number.parseInt(element.getAttribute("data-index") ?? "", 10);
+      const row =
+        Number.isFinite(indexValue) && indexValue >= 0 ? virtualRows[indexValue] : undefined;
+      if (row && measuredHeight > 0) {
+        const previousHeight = measuredRowHeightByKeyRef.current[row.key];
+        if (typeof previousHeight !== "number") {
+          measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
+        } else if (Math.abs(previousHeight - measuredHeight) > 0.5) {
+          measuredRowHeightByKeyRef.current[row.key] = measuredHeight;
+        }
+      }
+      return measuredHeight;
+    },
+    [virtualRows],
+  );
+
+  const resolveRowKey = useCallback(
+    (index: number): string | number => {
+      return virtualRows[index]?.key ?? index;
+    },
+    [virtualRows],
+  );
+
+  const virtualizer = useVirtualizer({
+    count: shouldVirtualize ? virtualRows.length : 0,
+    getScrollElement: () => messagesContainerRef.current,
+    estimateSize: estimateRowSize,
+    measureElement: measureVirtualRowElement,
+    getItemKey: resolveRowKey,
+    overscan: AGENT_CHAT_VIRTUAL_OVERSCAN_ITEMS,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+  const virtualRowsToRender = useMemo(
+    () =>
+      virtualItems
+        .map((virtualItem) => {
+          const row = virtualRows[virtualItem.index];
+          if (!row) {
+            return null;
+          }
+          return { row, virtualItem };
+        })
+        .filter((entry): entry is AgentChatVirtualRowsToRenderEntry => entry !== null),
+    [virtualItems, virtualRows],
+  );
+  const canRenderVirtualRows = shouldVirtualize && virtualRowsToRender.length > 0;
+  const hasRenderableSessionRows = virtualRows.length > 0;
+
+  return {
+    activeSessionId,
+    canRenderVirtualRows,
+    hasRenderableSessionRows,
+    shouldVirtualize,
+    virtualRows,
+    virtualRowsToRender,
+    virtualizer,
+  };
+}

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
@@ -1,6 +1,6 @@
 import { useVirtualizer, type VirtualItem, type Virtualizer } from "@tanstack/react-virtual";
 import type { RefObject } from "react";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
 import {
   AGENT_CHAT_VIRTUAL_OVERSCAN_ITEMS,
@@ -137,13 +137,16 @@ function useVirtualRowMeasurements({
 }: UseVirtualRowMeasurementsInput): UseVirtualRowMeasurementsResult {
   const virtualRowsRef = useRef(virtualRows);
   virtualRowsRef.current = virtualRows;
-  const measuredSessionIdRef = useRef<string | null>(null);
+  const measuredSessionIdRef = useRef<string | null>(activeSessionId);
   const measuredRowHeightByKeyRef = useRef<Record<string, number>>({});
 
-  if (measuredSessionIdRef.current !== activeSessionId) {
+  useEffect(() => {
+    if (measuredSessionIdRef.current === activeSessionId) {
+      return;
+    }
     measuredSessionIdRef.current = activeSessionId;
     measuredRowHeightByKeyRef.current = {};
-  }
+  }, [activeSessionId]);
 
   const estimateRowSize = useCallback((index: number): number => {
     const rows = virtualRowsRef.current;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
@@ -33,10 +33,58 @@ type UseAgentChatVirtualizationResult = {
   virtualizer: AgentChatVirtualizer;
 };
 
+type UseAgentChatVirtualRowsResult = {
+  activeSessionId: string | null;
+  shouldVirtualize: boolean;
+  virtualRows: AgentChatVirtualRow[];
+};
+
+type UseVirtualRowMeasurementsInput = {
+  activeSessionId: string | null;
+  virtualRows: AgentChatVirtualRow[];
+};
+
+type UseVirtualRowMeasurementsResult = {
+  estimateRowSize: (index: number) => number;
+  measureVirtualRowElement: (element: Element) => number;
+  resolveRowKey: (index: number) => string | number;
+};
+
 export function useAgentChatVirtualization({
   session,
   messagesContainerRef,
 }: UseAgentChatVirtualizationInput): UseAgentChatVirtualizationResult {
+  const { activeSessionId, shouldVirtualize, virtualRows } = useAgentChatVirtualRows(session);
+  const { estimateRowSize, measureVirtualRowElement, resolveRowKey } = useVirtualRowMeasurements({
+    activeSessionId,
+    virtualRows,
+  });
+
+  const virtualizer = useVirtualizer({
+    count: shouldVirtualize ? virtualRows.length : 0,
+    getScrollElement: () => messagesContainerRef.current,
+    estimateSize: estimateRowSize,
+    measureElement: measureVirtualRowElement,
+    getItemKey: resolveRowKey,
+    overscan: AGENT_CHAT_VIRTUAL_OVERSCAN_ITEMS,
+  });
+
+  const virtualRowsToRender = useVirtualRowsToRender(virtualRows, virtualizer.getVirtualItems());
+  const canRenderVirtualRows = shouldVirtualize && virtualRowsToRender.length > 0;
+  const hasRenderableSessionRows = virtualRows.length > 0;
+
+  return {
+    activeSessionId,
+    canRenderVirtualRows,
+    hasRenderableSessionRows,
+    shouldVirtualize,
+    virtualRows,
+    virtualRowsToRender,
+    virtualizer,
+  };
+}
+
+function useAgentChatVirtualRows(session: AgentSessionState | null): UseAgentChatVirtualRowsResult {
   const messageIdentityTokenByMessageRef = useRef<WeakMap<AgentChatMessage, number>>(new WeakMap());
   const nextMessageIdentityTokenRef = useRef(1);
   const virtualRowsCacheRef = useRef<{ signature: string | null; rows: AgentChatVirtualRow[] }>({
@@ -72,6 +120,18 @@ export function useAgentChatVirtualization({
   }, [session, virtualRowsSignature]);
   const shouldVirtualize = virtualRows.length >= AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT;
   const activeSessionId = session?.sessionId ?? null;
+
+  return {
+    activeSessionId,
+    shouldVirtualize,
+    virtualRows,
+  };
+}
+
+function useVirtualRowMeasurements({
+  activeSessionId,
+  virtualRows,
+}: UseVirtualRowMeasurementsInput): UseVirtualRowMeasurementsResult {
   const measuredSessionIdRef = useRef<string | null>(null);
   const measuredRowHeightByKeyRef = useRef<Record<string, number>>({});
 
@@ -123,17 +183,14 @@ export function useAgentChatVirtualization({
     [virtualRows],
   );
 
-  const virtualizer = useVirtualizer({
-    count: shouldVirtualize ? virtualRows.length : 0,
-    getScrollElement: () => messagesContainerRef.current,
-    estimateSize: estimateRowSize,
-    measureElement: measureVirtualRowElement,
-    getItemKey: resolveRowKey,
-    overscan: AGENT_CHAT_VIRTUAL_OVERSCAN_ITEMS,
-  });
+  return { estimateRowSize, measureVirtualRowElement, resolveRowKey };
+}
 
-  const virtualItems = virtualizer.getVirtualItems();
-  const virtualRowsToRender = useMemo(
+function useVirtualRowsToRender(
+  virtualRows: AgentChatVirtualRow[],
+  virtualItems: VirtualItem[],
+): AgentChatVirtualRowsToRenderEntry[] {
+  return useMemo(
     () =>
       virtualItems
         .map((virtualItem) => {
@@ -146,16 +203,4 @@ export function useAgentChatVirtualization({
         .filter((entry): entry is AgentChatVirtualRowsToRenderEntry => entry !== null),
     [virtualItems, virtualRows],
   );
-  const canRenderVirtualRows = shouldVirtualize && virtualRowsToRender.length > 0;
-  const hasRenderableSessionRows = virtualRows.length > 0;
-
-  return {
-    activeSessionId,
-    canRenderVirtualRows,
-    hasRenderableSessionRows,
-    shouldVirtualize,
-    virtualRows,
-    virtualRowsToRender,
-    virtualizer,
-  };
 }


### PR DESCRIPTION
## Summary
Refactors the `AgentChatThread` monolith into focused units and adds dedicated tests for extracted hook behavior.

This PR keeps runtime behavior unchanged while improving separation of concerns, readability, and regression safety around virtualization and auto-scroll logic.

## Problem
`AgentChatThread` had grown into a large component that mixed:
- virtual row construction and virtualization wiring
- scroll-to-bottom/session-change behavior
- row-kind rendering branches
- full thread template composition

This made changes riskier and harder to test in isolation.

## What Changed
- Extracted row rendering into `AgentChatThreadRow` (renamed from `AgentChatVirtualRow`).
- Kept `AgentChatThread` as a thin composition shell.
- Split virtualization internals in `use-agent-chat-virtualization.ts` into focused internal units:
  - `useAgentChatVirtualRows`
  - `useVirtualRowMeasurements`
  - `useVirtualRowsToRender`
- Added focused test coverage for extracted hooks:
  - `use-agent-chat-auto-scroll.test.ts`
  - `use-agent-chat-virtualization.test.ts`

## Behavior/Contract Notes
- No contract or data-shape changes.
- No `odt_*` workflow tool changes.
- No fallback paths introduced.
- Existing thread rendering behavior and virtualization thresholds are preserved.

## Validation
Ran the following checks:
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop test`
- `cd apps/desktop && bun test src/components/features/agents/agent-chat/agent-chat-thread.test.ts src/components/features/agents/agent-chat/use-agent-chat-auto-scroll.test.ts src/components/features/agents/agent-chat/use-agent-chat-virtualization.test.ts`

## Commits
- `229cbf8` refactor(desktop): decompose AgentChatThread into focused virtualization, scroll, and row-render modules
- `9efab11` refactor(desktop): split agent chat virtualization internals and add hook test coverage
