### PR TITLE
refactor(desktop): modularize and harden agent studio task tabs

### DIFF
--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
@@ -1,0 +1,108 @@
+import { type Dispatch, type SetStateAction, useCallback } from "react";
+import { closeTaskTab } from "./agents-page-session-tabs";
+
+type SetState<T> = Dispatch<SetStateAction<T>>;
+
+type NavigateToTask = (taskId: string) => void;
+
+const focusTaskTabTrigger = (taskId: string): void => {
+  globalThis.setTimeout(() => {
+    if (typeof globalThis.document === "undefined") {
+      return;
+    }
+
+    const nextTrigger = globalThis.document.getElementById(`agent-studio-tab-${taskId}`);
+    if (nextTrigger instanceof HTMLElement) {
+      nextTrigger.focus();
+    }
+  }, 0);
+};
+
+type UseTaskTabActionsArgs = {
+  tabTaskIds: string[];
+  activeTaskTabId: string;
+  clearComposerInput: () => void;
+  onContextSwitchIntent: (() => void) | undefined;
+  clearTaskSelection: () => void;
+  navigateToTask: NavigateToTask;
+  handleSelectTab: (nextTaskId: string) => void;
+  setOpenTaskTabs: SetState<string[]>;
+  setPersistedActiveTaskId: SetState<string | null>;
+  setIntentActiveTaskId: SetState<string | null>;
+};
+
+type UseTaskTabActionsResult = {
+  handleCreateTab: (nextTaskId: string) => void;
+  handleCloseTab: (taskIdToClose: string) => void;
+};
+
+export function useTaskTabActions(args: UseTaskTabActionsArgs): UseTaskTabActionsResult {
+  const {
+    tabTaskIds,
+    activeTaskTabId,
+    clearComposerInput,
+    onContextSwitchIntent,
+    clearTaskSelection,
+    navigateToTask,
+    handleSelectTab,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+  } = args;
+
+  const handleCreateTab = useCallback(
+    (nextTaskId: string): void => {
+      handleSelectTab(nextTaskId);
+    },
+    [handleSelectTab],
+  );
+
+  const handleCloseTab = useCallback(
+    (taskIdToClose: string): void => {
+      const { nextTabTaskIds, nextActiveTaskId } = closeTaskTab({
+        tabTaskIds,
+        taskIdToClose,
+        activeTaskId: activeTaskTabId,
+      });
+
+      if (nextTabTaskIds === tabTaskIds) {
+        return;
+      }
+
+      setOpenTaskTabs(nextTabTaskIds);
+      setPersistedActiveTaskId(nextActiveTaskId ?? null);
+
+      if (taskIdToClose !== activeTaskTabId) {
+        return;
+      }
+
+      clearComposerInput();
+      onContextSwitchIntent?.();
+      setIntentActiveTaskId(nextActiveTaskId ?? null);
+
+      if (!nextActiveTaskId) {
+        clearTaskSelection();
+        return;
+      }
+
+      focusTaskTabTrigger(nextActiveTaskId);
+      navigateToTask(nextActiveTaskId);
+    },
+    [
+      activeTaskTabId,
+      clearComposerInput,
+      clearTaskSelection,
+      navigateToTask,
+      onContextSwitchIntent,
+      setIntentActiveTaskId,
+      setOpenTaskTabs,
+      setPersistedActiveTaskId,
+      tabTaskIds,
+    ],
+  );
+
+  return {
+    handleCreateTab,
+    handleCloseTab,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-persistence.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-persistence.ts
@@ -1,0 +1,109 @@
+import type { TaskCard } from "@openducktor/contracts";
+import { type Dispatch, type SetStateAction, useEffect } from "react";
+import {
+  canPersistTaskTabs,
+  parsePersistedTaskTabs,
+  toPersistedTaskTabs,
+} from "./agents-page-session-tabs";
+import { toTabsStorageKey } from "./agents-page-utils";
+
+type SetState<T> = Dispatch<SetStateAction<T>>;
+
+type UseTaskTabPersistenceArgs = {
+  activeRepo: string | null;
+  taskId: string;
+  selectedTask: TaskCard | null;
+  tasks: TaskCard[];
+  isLoadingTasks: boolean;
+  openTaskTabs: string[];
+  tabsStorageHydratedRepo: string | null;
+  activeTaskTabId: string;
+  setOpenTaskTabs: SetState<string[]>;
+  setPersistedActiveTaskId: SetState<string | null>;
+  setIntentActiveTaskId: SetState<string | null>;
+  setTabsStorageHydratedRepo: SetState<string | null>;
+};
+
+export function useTaskTabPersistence(args: UseTaskTabPersistenceArgs): void {
+  const {
+    activeRepo,
+    taskId,
+    selectedTask,
+    tasks,
+    isLoadingTasks,
+    openTaskTabs,
+    tabsStorageHydratedRepo,
+    activeTaskTabId,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+    setTabsStorageHydratedRepo,
+  } = args;
+
+  useEffect(() => {
+    if (!activeRepo) {
+      setOpenTaskTabs([]);
+      setPersistedActiveTaskId(null);
+      setIntentActiveTaskId(null);
+      setTabsStorageHydratedRepo(null);
+      return;
+    }
+
+    const raw = globalThis.localStorage.getItem(toTabsStorageKey(activeRepo));
+    const persistedTabs = parsePersistedTaskTabs(raw);
+    setOpenTaskTabs(persistedTabs.tabs);
+    setPersistedActiveTaskId(persistedTabs.activeTaskId);
+    setTabsStorageHydratedRepo(activeRepo);
+  }, [
+    activeRepo,
+    setIntentActiveTaskId,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setTabsStorageHydratedRepo,
+  ]);
+
+  useEffect(() => {
+    if (isLoadingTasks) {
+      return;
+    }
+    const knownTaskIds = new Set(tasks.map((task) => task.id));
+    setOpenTaskTabs((current) => {
+      const filtered = current.filter((taskTabId) => knownTaskIds.has(taskTabId));
+      if (filtered.length === current.length) {
+        return current;
+      }
+      return filtered;
+    });
+  }, [isLoadingTasks, setOpenTaskTabs, tasks]);
+
+  useEffect(() => {
+    if (!taskId) {
+      return;
+    }
+    if (!selectedTask) {
+      return;
+    }
+    setOpenTaskTabs((current) => {
+      if (current.includes(taskId)) {
+        return current;
+      }
+      return [...current, taskId];
+    });
+  }, [selectedTask, setOpenTaskTabs, taskId]);
+
+  useEffect(() => {
+    if (!canPersistTaskTabs(activeRepo, tabsStorageHydratedRepo)) {
+      return;
+    }
+    if (!activeRepo) {
+      return;
+    }
+    globalThis.localStorage.setItem(
+      toTabsStorageKey(activeRepo),
+      toPersistedTaskTabs({
+        tabs: openTaskTabs,
+        activeTaskId: activeTaskTabId || null,
+      }),
+    );
+  }, [activeRepo, activeTaskTabId, openTaskTabs, tabsStorageHydratedRepo]);
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-persistence.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-persistence.ts
@@ -1,5 +1,6 @@
 import type { TaskCard } from "@openducktor/contracts";
 import { type Dispatch, type SetStateAction, useEffect } from "react";
+import { errorMessage } from "@/lib/errors";
 import {
   canPersistTaskTabs,
   parsePersistedTaskTabs,
@@ -8,6 +9,28 @@ import {
 import { toTabsStorageKey } from "./agents-page-utils";
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
+
+const readTaskTabsStorage = (storageKey: string): string | null => {
+  try {
+    return globalThis.localStorage.getItem(storageKey);
+  } catch (cause) {
+    throw new Error(
+      `Failed to read agent studio task tabs storage key "${storageKey}": ${errorMessage(cause)}`,
+      { cause },
+    );
+  }
+};
+
+const writeTaskTabsStorage = (storageKey: string, payload: string): void => {
+  try {
+    globalThis.localStorage.setItem(storageKey, payload);
+  } catch (cause) {
+    throw new Error(
+      `Failed to persist agent studio task tabs storage key "${storageKey}": ${errorMessage(cause)}`,
+      { cause },
+    );
+  }
+};
 
 type UseTaskTabPersistenceArgs = {
   activeRepo: string | null;
@@ -49,7 +72,8 @@ export function useTaskTabPersistence(args: UseTaskTabPersistenceArgs): void {
       return;
     }
 
-    const raw = globalThis.localStorage.getItem(toTabsStorageKey(activeRepo));
+    const tabsStorageKey = toTabsStorageKey(activeRepo);
+    const raw = readTaskTabsStorage(tabsStorageKey);
     const persistedTabs = parsePersistedTaskTabs(raw);
     setOpenTaskTabs(persistedTabs.tabs);
     setPersistedActiveTaskId(persistedTabs.activeTaskId);
@@ -98,8 +122,9 @@ export function useTaskTabPersistence(args: UseTaskTabPersistenceArgs): void {
     if (!activeRepo) {
       return;
     }
-    globalThis.localStorage.setItem(
-      toTabsStorageKey(activeRepo),
+    const tabsStorageKey = toTabsStorageKey(activeRepo);
+    writeTaskTabsStorage(
+      tabsStorageKey,
       toPersistedTaskTabs({
         tabs: openTaskTabs,
         activeTaskId: activeTaskTabId || null,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
@@ -1,0 +1,133 @@
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo } from "react";
+import { ensureActiveTaskTab, resolveFallbackTaskId } from "./agents-page-session-tabs";
+
+type SetState<T> = Dispatch<SetStateAction<T>>;
+
+type NavigateToTask = (taskId: string) => void;
+
+type UseTaskTabSelectionArgs = {
+  activeRepo: string | null;
+  taskId: string;
+  openTaskTabs: string[];
+  persistedActiveTaskId: string | null;
+  intentActiveTaskId: string | null;
+  tabsStorageHydratedRepo: string | null;
+  clearComposerInput: () => void;
+  onContextSwitchIntent: (() => void) | undefined;
+  navigateToTask: NavigateToTask;
+  setOpenTaskTabs: SetState<string[]>;
+  setPersistedActiveTaskId: SetState<string | null>;
+  setIntentActiveTaskId: SetState<string | null>;
+};
+
+type UseTaskTabSelectionResult = {
+  tabTaskIds: string[];
+  activeTaskTabId: string;
+  handleSelectTab: (nextTaskId: string) => void;
+};
+
+export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSelectionResult {
+  const {
+    activeRepo,
+    taskId,
+    openTaskTabs,
+    persistedActiveTaskId,
+    intentActiveTaskId,
+    tabsStorageHydratedRepo,
+    clearComposerInput,
+    onContextSwitchIntent,
+    navigateToTask,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+  } = args;
+
+  const tabTaskIds = useMemo(
+    () => ensureActiveTaskTab(openTaskTabs, taskId),
+    [openTaskTabs, taskId],
+  );
+
+  const activeTaskTabId = useMemo(() => {
+    if (intentActiveTaskId && tabTaskIds.includes(intentActiveTaskId)) {
+      return intentActiveTaskId;
+    }
+    if (taskId && tabTaskIds.includes(taskId)) {
+      return taskId;
+    }
+    if (persistedActiveTaskId && tabTaskIds.includes(persistedActiveTaskId)) {
+      return persistedActiveTaskId;
+    }
+    return tabTaskIds[0] ?? "";
+  }, [intentActiveTaskId, persistedActiveTaskId, tabTaskIds, taskId]);
+
+  useEffect(() => {
+    if (!intentActiveTaskId) {
+      return;
+    }
+    if (!tabTaskIds.includes(intentActiveTaskId) || taskId === intentActiveTaskId) {
+      setIntentActiveTaskId(null);
+    }
+  }, [intentActiveTaskId, setIntentActiveTaskId, tabTaskIds, taskId]);
+
+  useEffect(() => {
+    if (!activeRepo || tabsStorageHydratedRepo !== activeRepo) {
+      return;
+    }
+    if (taskId || tabTaskIds.length === 0) {
+      return;
+    }
+    const fallbackTaskId = resolveFallbackTaskId({
+      tabTaskIds,
+      persistedActiveTaskId,
+    });
+    if (!fallbackTaskId) {
+      return;
+    }
+    navigateToTask(fallbackTaskId);
+  }, [
+    activeRepo,
+    navigateToTask,
+    persistedActiveTaskId,
+    tabTaskIds,
+    tabsStorageHydratedRepo,
+    taskId,
+  ]);
+
+  const handleSelectTab = useCallback(
+    (nextTaskId: string): void => {
+      if (!nextTaskId) {
+        return;
+      }
+      if (nextTaskId === activeTaskTabId) {
+        return;
+      }
+
+      onContextSwitchIntent?.();
+      clearComposerInput();
+      setIntentActiveTaskId(nextTaskId);
+      setOpenTaskTabs((current) => {
+        if (current.includes(nextTaskId)) {
+          return current;
+        }
+        return [...current, nextTaskId];
+      });
+      setPersistedActiveTaskId(nextTaskId);
+      navigateToTask(nextTaskId);
+    },
+    [
+      activeTaskTabId,
+      clearComposerInput,
+      navigateToTask,
+      onContextSwitchIntent,
+      setIntentActiveTaskId,
+      setOpenTaskTabs,
+      setPersistedActiveTaskId,
+    ],
+  );
+
+  return {
+    tabTaskIds,
+    activeTaskTabId,
+    handleSelectTab,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
@@ -1,4 +1,4 @@
-import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
 import { ensureActiveTaskTab, resolveFallbackTaskId } from "./agents-page-session-tabs";
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
@@ -46,6 +46,7 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
     () => ensureActiveTaskTab(openTaskTabs, taskId),
     [openTaskTabs, taskId],
   );
+  const appliedFallbackKeyRef = useRef<string | null>(null);
 
   const activeTaskTabId = useMemo(() => {
     if (intentActiveTaskId && tabTaskIds.includes(intentActiveTaskId)) {
@@ -83,6 +84,11 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
     if (!fallbackTaskId) {
       return;
     }
+    const fallbackKey = `${activeRepo}:${fallbackTaskId}`;
+    if (appliedFallbackKeyRef.current === fallbackKey) {
+      return;
+    }
+    appliedFallbackKeyRef.current = fallbackKey;
     navigateToTask(fallbackTaskId);
   }, [
     activeRepo,
@@ -92,6 +98,12 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
     tabsStorageHydratedRepo,
     taskId,
   ]);
+
+  useEffect(() => {
+    if (!activeRepo || taskId) {
+      appliedFallbackKeyRef.current = null;
+    }
+  }, [activeRepo, taskId]);
 
   const handleSelectTab = useCallback(
     (nextTaskId: string): void => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -37,6 +37,39 @@ const createMemoryStorage = (): StorageLike => {
   };
 };
 
+const createThrowingStorage = (args: {
+  throwOnGetItem?: boolean;
+  throwOnSetItem?: boolean;
+  message?: string;
+}): StorageLike => {
+  const store = new Map<string, string>();
+  const message = args.message ?? "storage unavailable";
+  return {
+    getItem: (key) => {
+      if (args.throwOnGetItem) {
+        throw new Error(message);
+      }
+      return store.get(key) ?? null;
+    },
+    setItem: (key, value) => {
+      if (args.throwOnSetItem) {
+        throw new Error(message);
+      }
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+};
+
 const createTask = (id: string) => createTaskCardFixture({ id, title: id });
 
 const createSession = (taskId: string, sessionId: string) =>
@@ -310,6 +343,78 @@ describe("useAgentStudioTaskTabs", () => {
     }
   });
 
+  test("applies fallback routing only once for an unchanged fallback target", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toTabsStorageKey("/repo"),
+        toPersistedTaskTabs({
+          tabs: ["task-2"],
+          activeTaskId: "task-2",
+        }),
+      );
+
+      const updateCalls: Array<Record<string, string | undefined>> = [];
+      const latestSession = createSession("task-2", "session-2");
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-2")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-2", latestSession]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      await harness.mount();
+      await harness.waitFor(() => updateCalls.length === 1);
+
+      await harness.update({
+        activeRepo: "/repo",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-2")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-2", latestSession]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      await harness.update({
+        activeRepo: "/repo",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-2")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-2", latestSession]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      expect(updateCalls).toHaveLength(1);
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
   test("does not route stale fallback tab while switching repos", async () => {
     const memoryStorage = createMemoryStorage();
     const originalStorage = globalThis.localStorage;
@@ -431,6 +536,74 @@ describe("useAgentStudioTaskTabs", () => {
       expect(harness.getLatest().tabTaskIds).toEqual([]);
 
       await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("throws actionable error when task tabs storage read fails", async () => {
+    const throwingStorage = createThrowingStorage({
+      throwOnGetItem: true,
+      message: "read blocked",
+    });
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: throwingStorage,
+    });
+
+    try {
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-1")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map(),
+        updateQuery: () => {},
+        clearComposerInput: () => {},
+      });
+
+      await expect(harness.mount()).rejects.toThrow(
+        `Failed to read agent studio task tabs storage key "${toTabsStorageKey("/repo")}": read blocked`,
+      );
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("throws actionable error when task tabs storage persistence fails", async () => {
+    const throwingStorage = createThrowingStorage({
+      throwOnSetItem: true,
+      message: "write blocked",
+    });
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: throwingStorage,
+    });
+
+    try {
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "task-1",
+        selectedTask: createTask("task-1"),
+        tasks: [createTask("task-1")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map(),
+        updateQuery: () => {},
+        clearComposerInput: () => {},
+      });
+
+      await expect(harness.mount()).rejects.toThrow(
+        `Failed to persist agent studio task tabs storage key "${toTabsStorageKey("/repo")}": write blocked`,
+      );
     } finally {
       Object.defineProperty(globalThis, "localStorage", {
         configurable: true,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -254,4 +254,188 @@ describe("useAgentStudioTaskTabs", () => {
       });
     }
   });
+
+  test("routes fallback tab after hydration when URL task is empty", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toTabsStorageKey("/repo"),
+        toPersistedTaskTabs({
+          tabs: ["task-2"],
+          activeTaskId: "task-2",
+        }),
+      );
+
+      const latestSession = createSession("task-2", "session-2");
+      const updateCalls: Array<Record<string, string | undefined>> = [];
+
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-1"), createTask("task-2")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-2", latestSession]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      await harness.mount();
+      await harness.waitFor(() => updateCalls.length > 0);
+
+      expect(updateCalls).toHaveLength(1);
+      expect(updateCalls[0]).toEqual({
+        task: "task-2",
+        session: "session-2",
+        agent: "spec",
+        scenario: "spec_initial",
+        autostart: undefined,
+        start: undefined,
+      });
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("does not route stale fallback tab while switching repos", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toTabsStorageKey("/repo-b"),
+        toPersistedTaskTabs({
+          tabs: ["task-b"],
+          activeTaskId: "task-b",
+        }),
+      );
+
+      const updateCalls: Array<Record<string, string | undefined>> = [];
+      const harness = createHookHarness({
+        activeRepo: "/repo-a",
+        taskId: "task-a",
+        selectedTask: createTask("task-a"),
+        tasks: [createTask("task-a")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map(),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      await harness.mount();
+      expect(updateCalls).toHaveLength(0);
+
+      const repoBSession = createSession("task-b", "session-b");
+      await harness.update({
+        activeRepo: "/repo-b",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-b")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-b", repoBSession]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      await harness.waitFor(() => updateCalls.length > 0);
+
+      expect(updateCalls[0]).toEqual({
+        task: "task-b",
+        session: "session-b",
+        agent: "spec",
+        scenario: "spec_initial",
+        autostart: undefined,
+        start: undefined,
+      });
+      expect(updateCalls.some((call) => call.task === "task-a")).toBeFalse();
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("clearing active repo skips fallback routing and resets tabs", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toTabsStorageKey("/repo"),
+        toPersistedTaskTabs({
+          tabs: ["task-1"],
+          activeTaskId: "task-1",
+        }),
+      );
+
+      const updateCalls: Array<Record<string, string | undefined>> = [];
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-1")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map(),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      await harness.mount();
+      await harness.waitFor(() => updateCalls.length > 0);
+      updateCalls.length = 0;
+
+      await harness.update({
+        activeRepo: null,
+        taskId: "",
+        selectedTask: null,
+        tasks: [],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map(),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      expect(updateCalls).toHaveLength(0);
+      expect(harness.getLatest().tabTaskIds).toEqual([]);
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
@@ -1,6 +1,14 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentRole } from "@openducktor/core";
-import { startTransition, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type Dispatch,
+  type SetStateAction,
+  startTransition,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { firstScenario } from "./agents-page-constants";
@@ -19,6 +27,12 @@ import { toTabsStorageKey } from "./agents-page-utils";
 
 type QueryUpdate = Record<string, string | undefined>;
 
+type SetState<T> = Dispatch<SetStateAction<T>>;
+
+type TaskByIdMap = ReadonlyMap<string, TaskCard>;
+
+type NavigateToTask = (taskId: string) => void;
+
 const resolveDefaultRoleForTask = (task: TaskCard | null): AgentRole => {
   const roleEnabledByTask = buildRoleEnabledMapForTask(task);
   if (roleEnabledByTask.spec) {
@@ -35,6 +49,372 @@ const resolveDefaultRoleForTask = (task: TaskCard | null): AgentRole => {
   }
   return "spec";
 };
+
+const toTaskQueryUpdate = (params: {
+  taskId: string;
+  latestSessionByTaskId: ReadonlyMap<string, AgentSessionState>;
+  taskById: TaskByIdMap;
+}): QueryUpdate => {
+  const sessionForTask = params.latestSessionByTaskId.get(params.taskId);
+  if (sessionForTask) {
+    return {
+      task: sessionForTask.taskId,
+      session: sessionForTask.sessionId,
+      agent: sessionForTask.role,
+      scenario: sessionForTask.scenario,
+      autostart: undefined,
+      start: undefined,
+    };
+  }
+
+  const nextTask = params.taskById.get(params.taskId) ?? null;
+  const nextRole = resolveDefaultRoleForTask(nextTask);
+  return {
+    task: params.taskId,
+    session: undefined,
+    agent: nextRole,
+    scenario: firstScenario(nextRole),
+    autostart: undefined,
+    start: undefined,
+  };
+};
+
+const toClearTaskQueryUpdate = (): QueryUpdate => ({
+  task: undefined,
+  session: undefined,
+  agent: undefined,
+  scenario: undefined,
+  autostart: undefined,
+  start: undefined,
+});
+
+const focusTaskTabTrigger = (taskId: string): void => {
+  globalThis.setTimeout(() => {
+    if (typeof globalThis.document === "undefined") {
+      return;
+    }
+
+    const nextTrigger = globalThis.document.getElementById(`agent-studio-tab-${taskId}`);
+    if (nextTrigger instanceof HTMLElement) {
+      nextTrigger.focus();
+    }
+  }, 0);
+};
+
+type UseTaskTabPersistenceArgs = {
+  activeRepo: string | null;
+  taskId: string;
+  selectedTask: TaskCard | null;
+  tasks: TaskCard[];
+  isLoadingTasks: boolean;
+  openTaskTabs: string[];
+  tabsStorageHydratedRepo: string | null;
+  activeTaskTabId: string;
+  setOpenTaskTabs: SetState<string[]>;
+  setPersistedActiveTaskId: SetState<string | null>;
+  setIntentActiveTaskId: SetState<string | null>;
+  setTabsStorageHydratedRepo: SetState<string | null>;
+};
+
+export function useTaskTabPersistence(args: UseTaskTabPersistenceArgs): void {
+  const {
+    activeRepo,
+    taskId,
+    selectedTask,
+    tasks,
+    isLoadingTasks,
+    openTaskTabs,
+    tabsStorageHydratedRepo,
+    activeTaskTabId,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+    setTabsStorageHydratedRepo,
+  } = args;
+
+  useEffect(() => {
+    if (!activeRepo) {
+      setOpenTaskTabs([]);
+      setPersistedActiveTaskId(null);
+      setIntentActiveTaskId(null);
+      setTabsStorageHydratedRepo(null);
+      return;
+    }
+
+    const raw = globalThis.localStorage.getItem(toTabsStorageKey(activeRepo));
+    const persistedTabs = parsePersistedTaskTabs(raw);
+    setOpenTaskTabs(persistedTabs.tabs);
+    setPersistedActiveTaskId(persistedTabs.activeTaskId);
+    setTabsStorageHydratedRepo(activeRepo);
+  }, [
+    activeRepo,
+    setIntentActiveTaskId,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setTabsStorageHydratedRepo,
+  ]);
+
+  useEffect(() => {
+    if (isLoadingTasks) {
+      return;
+    }
+    const knownTaskIds = new Set(tasks.map((task) => task.id));
+    setOpenTaskTabs((current) => {
+      const filtered = current.filter((taskTabId) => knownTaskIds.has(taskTabId));
+      if (filtered.length === current.length) {
+        return current;
+      }
+      return filtered;
+    });
+  }, [isLoadingTasks, setOpenTaskTabs, tasks]);
+
+  useEffect(() => {
+    if (!taskId) {
+      return;
+    }
+    if (!selectedTask) {
+      return;
+    }
+    setOpenTaskTabs((current) => {
+      if (current.includes(taskId)) {
+        return current;
+      }
+      return [...current, taskId];
+    });
+  }, [selectedTask, setOpenTaskTabs, taskId]);
+
+  useEffect(() => {
+    if (!canPersistTaskTabs(activeRepo, tabsStorageHydratedRepo)) {
+      return;
+    }
+    if (!activeRepo) {
+      return;
+    }
+    globalThis.localStorage.setItem(
+      toTabsStorageKey(activeRepo),
+      toPersistedTaskTabs({
+        tabs: openTaskTabs,
+        activeTaskId: activeTaskTabId || null,
+      }),
+    );
+  }, [activeRepo, activeTaskTabId, openTaskTabs, tabsStorageHydratedRepo]);
+}
+
+type UseTaskTabSelectionArgs = {
+  activeRepo: string | null;
+  taskId: string;
+  openTaskTabs: string[];
+  persistedActiveTaskId: string | null;
+  intentActiveTaskId: string | null;
+  tabsStorageHydratedRepo: string | null;
+  clearComposerInput: () => void;
+  onContextSwitchIntent: (() => void) | undefined;
+  navigateToTask: NavigateToTask;
+  setOpenTaskTabs: SetState<string[]>;
+  setPersistedActiveTaskId: SetState<string | null>;
+  setIntentActiveTaskId: SetState<string | null>;
+};
+
+type UseTaskTabSelectionResult = {
+  tabTaskIds: string[];
+  activeTaskTabId: string;
+  handleSelectTab: (nextTaskId: string) => void;
+};
+
+export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSelectionResult {
+  const {
+    activeRepo,
+    taskId,
+    openTaskTabs,
+    persistedActiveTaskId,
+    intentActiveTaskId,
+    tabsStorageHydratedRepo,
+    clearComposerInput,
+    onContextSwitchIntent,
+    navigateToTask,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+  } = args;
+
+  const tabTaskIds = useMemo(
+    () => ensureActiveTaskTab(openTaskTabs, taskId),
+    [openTaskTabs, taskId],
+  );
+
+  const activeTaskTabId = useMemo(() => {
+    if (intentActiveTaskId && tabTaskIds.includes(intentActiveTaskId)) {
+      return intentActiveTaskId;
+    }
+    if (taskId && tabTaskIds.includes(taskId)) {
+      return taskId;
+    }
+    if (persistedActiveTaskId && tabTaskIds.includes(persistedActiveTaskId)) {
+      return persistedActiveTaskId;
+    }
+    return tabTaskIds[0] ?? "";
+  }, [intentActiveTaskId, persistedActiveTaskId, tabTaskIds, taskId]);
+
+  useEffect(() => {
+    if (!intentActiveTaskId) {
+      return;
+    }
+    if (!tabTaskIds.includes(intentActiveTaskId) || taskId === intentActiveTaskId) {
+      setIntentActiveTaskId(null);
+    }
+  }, [intentActiveTaskId, setIntentActiveTaskId, tabTaskIds, taskId]);
+
+  useEffect(() => {
+    if (!activeRepo || tabsStorageHydratedRepo !== activeRepo) {
+      return;
+    }
+    if (taskId || tabTaskIds.length === 0) {
+      return;
+    }
+    const fallbackTaskId = resolveFallbackTaskId({
+      tabTaskIds,
+      persistedActiveTaskId,
+    });
+    if (!fallbackTaskId) {
+      return;
+    }
+    navigateToTask(fallbackTaskId);
+  }, [
+    activeRepo,
+    navigateToTask,
+    persistedActiveTaskId,
+    tabTaskIds,
+    tabsStorageHydratedRepo,
+    taskId,
+  ]);
+
+  const handleSelectTab = useCallback(
+    (nextTaskId: string): void => {
+      if (!nextTaskId) {
+        return;
+      }
+      if (nextTaskId === activeTaskTabId) {
+        return;
+      }
+
+      onContextSwitchIntent?.();
+      clearComposerInput();
+      setIntentActiveTaskId(nextTaskId);
+      setOpenTaskTabs((current) => {
+        if (current.includes(nextTaskId)) {
+          return current;
+        }
+        return [...current, nextTaskId];
+      });
+      setPersistedActiveTaskId(nextTaskId);
+      navigateToTask(nextTaskId);
+    },
+    [
+      activeTaskTabId,
+      clearComposerInput,
+      navigateToTask,
+      onContextSwitchIntent,
+      setIntentActiveTaskId,
+      setOpenTaskTabs,
+      setPersistedActiveTaskId,
+    ],
+  );
+
+  return {
+    tabTaskIds,
+    activeTaskTabId,
+    handleSelectTab,
+  };
+}
+
+type UseTaskTabActionsArgs = {
+  tabTaskIds: string[];
+  activeTaskTabId: string;
+  clearComposerInput: () => void;
+  onContextSwitchIntent: (() => void) | undefined;
+  deferQueryUpdate: (updates: QueryUpdate) => void;
+  navigateToTask: NavigateToTask;
+  handleSelectTab: (nextTaskId: string) => void;
+  setOpenTaskTabs: SetState<string[]>;
+  setPersistedActiveTaskId: SetState<string | null>;
+  setIntentActiveTaskId: SetState<string | null>;
+};
+
+type UseTaskTabActionsResult = {
+  handleCreateTab: (nextTaskId: string) => void;
+  handleCloseTab: (taskIdToClose: string) => void;
+};
+
+export function useTaskTabActions(args: UseTaskTabActionsArgs): UseTaskTabActionsResult {
+  const {
+    tabTaskIds,
+    activeTaskTabId,
+    clearComposerInput,
+    onContextSwitchIntent,
+    deferQueryUpdate,
+    navigateToTask,
+    handleSelectTab,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+  } = args;
+
+  const handleCreateTab = useCallback(
+    (nextTaskId: string): void => {
+      handleSelectTab(nextTaskId);
+    },
+    [handleSelectTab],
+  );
+
+  const handleCloseTab = useCallback(
+    (taskIdToClose: string): void => {
+      const { nextTabTaskIds, nextActiveTaskId } = closeTaskTab({
+        tabTaskIds,
+        taskIdToClose,
+        activeTaskId: activeTaskTabId,
+      });
+
+      if (nextTabTaskIds === tabTaskIds) {
+        return;
+      }
+
+      setOpenTaskTabs(nextTabTaskIds);
+      setPersistedActiveTaskId(nextActiveTaskId ?? null);
+
+      if (taskIdToClose !== activeTaskTabId) {
+        return;
+      }
+
+      clearComposerInput();
+      onContextSwitchIntent?.();
+      setIntentActiveTaskId(nextActiveTaskId ?? null);
+
+      if (!nextActiveTaskId) {
+        deferQueryUpdate(toClearTaskQueryUpdate());
+        return;
+      }
+
+      focusTaskTabTrigger(nextActiveTaskId);
+      navigateToTask(nextActiveTaskId);
+    },
+    [
+      activeTaskTabId,
+      clearComposerInput,
+      deferQueryUpdate,
+      navigateToTask,
+      onContextSwitchIntent,
+      setIntentActiveTaskId,
+      setOpenTaskTabs,
+      setPersistedActiveTaskId,
+      tabTaskIds,
+    ],
+  );
+
+  return {
+    handleCreateTab,
+    handleCloseTab,
+  };
+}
 
 export function useAgentStudioTaskTabs(args: {
   activeRepo: string | null;
@@ -72,32 +452,62 @@ export function useAgentStudioTaskTabs(args: {
   const [intentActiveTaskId, setIntentActiveTaskId] = useState<string | null>(null);
   const [tabsStorageHydratedRepo, setTabsStorageHydratedRepo] = useState<string | null>(null);
 
-  const tabTaskIds = useMemo(
-    () => ensureActiveTaskTab(openTaskTabs, taskId),
-    [openTaskTabs, taskId],
+  const deferQueryUpdate = useCallback(
+    (updates: QueryUpdate): void => {
+      startTransition(() => {
+        updateQuery(updates);
+      });
+    },
+    [updateQuery],
   );
 
-  const activeTaskTabId = useMemo(() => {
-    if (intentActiveTaskId && tabTaskIds.includes(intentActiveTaskId)) {
-      return intentActiveTaskId;
-    }
-    if (taskId && tabTaskIds.includes(taskId)) {
-      return taskId;
-    }
-    if (persistedActiveTaskId && tabTaskIds.includes(persistedActiveTaskId)) {
-      return persistedActiveTaskId;
-    }
-    return tabTaskIds[0] ?? "";
-  }, [intentActiveTaskId, persistedActiveTaskId, tabTaskIds, taskId]);
+  const taskById = useMemo<TaskByIdMap>(
+    () => new Map(tasks.map((task): [string, TaskCard] => [task.id, task])),
+    [tasks],
+  );
 
-  useEffect(() => {
-    if (!intentActiveTaskId) {
-      return;
-    }
-    if (!tabTaskIds.includes(intentActiveTaskId) || taskId === intentActiveTaskId) {
-      setIntentActiveTaskId(null);
-    }
-  }, [intentActiveTaskId, tabTaskIds, taskId]);
+  const navigateToTask = useCallback<NavigateToTask>(
+    (nextTaskId) => {
+      deferQueryUpdate(
+        toTaskQueryUpdate({
+          taskId: nextTaskId,
+          latestSessionByTaskId,
+          taskById,
+        }),
+      );
+    },
+    [deferQueryUpdate, latestSessionByTaskId, taskById],
+  );
+
+  const { tabTaskIds, activeTaskTabId, handleSelectTab } = useTaskTabSelection({
+    activeRepo,
+    taskId,
+    openTaskTabs,
+    persistedActiveTaskId,
+    intentActiveTaskId,
+    tabsStorageHydratedRepo,
+    clearComposerInput,
+    onContextSwitchIntent,
+    navigateToTask,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+  });
+
+  useTaskTabPersistence({
+    activeRepo,
+    taskId,
+    selectedTask,
+    tasks,
+    isLoadingTasks,
+    openTaskTabs,
+    tabsStorageHydratedRepo,
+    activeTaskTabId,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+    setTabsStorageHydratedRepo,
+  });
 
   const availableTabTasks = useMemo(
     () => getAvailableTabTasks(tasks, tabTaskIds),
@@ -115,255 +525,18 @@ export function useAgentStudioTaskTabs(args: {
     [activeTaskTabId, latestSessionByTaskId, tabTaskIds, tasks],
   );
 
-  const deferQueryUpdate = useCallback(
-    (updates: QueryUpdate): void => {
-      startTransition(() => {
-        updateQuery(updates);
-      });
-    },
-    [updateQuery],
-  );
-
-  useEffect(() => {
-    if (!activeRepo) {
-      setOpenTaskTabs([]);
-      setPersistedActiveTaskId(null);
-      setIntentActiveTaskId(null);
-      setTabsStorageHydratedRepo(null);
-      return;
-    }
-
-    const raw = globalThis.localStorage.getItem(toTabsStorageKey(activeRepo));
-    const persistedTabs = parsePersistedTaskTabs(raw);
-    setOpenTaskTabs(persistedTabs.tabs);
-    setPersistedActiveTaskId(persistedTabs.activeTaskId);
-    setTabsStorageHydratedRepo(activeRepo);
-  }, [activeRepo]);
-
-  useEffect(() => {
-    if (isLoadingTasks) {
-      return;
-    }
-    const knownTaskIds = new Set(tasks.map((task) => task.id));
-    setOpenTaskTabs((current) => {
-      const filtered = current.filter((taskTabId) => knownTaskIds.has(taskTabId));
-      if (filtered.length === current.length) {
-        return current;
-      }
-      return filtered;
-    });
-  }, [isLoadingTasks, tasks]);
-
-  useEffect(() => {
-    if (!taskId) {
-      return;
-    }
-    if (!selectedTask) {
-      return;
-    }
-    setOpenTaskTabs((current) => {
-      if (current.includes(taskId)) {
-        return current;
-      }
-      return [...current, taskId];
-    });
-  }, [selectedTask, taskId]);
-
-  useEffect(() => {
-    if (!canPersistTaskTabs(activeRepo, tabsStorageHydratedRepo)) {
-      return;
-    }
-    if (!activeRepo) {
-      return;
-    }
-    globalThis.localStorage.setItem(
-      toTabsStorageKey(activeRepo),
-      toPersistedTaskTabs({
-        tabs: openTaskTabs,
-        activeTaskId: activeTaskTabId || null,
-      }),
-    );
-  }, [activeRepo, activeTaskTabId, openTaskTabs, tabsStorageHydratedRepo]);
-
-  useEffect(() => {
-    if (taskId || openTaskTabs.length === 0) {
-      return;
-    }
-    const fallbackTaskId = resolveFallbackTaskId({
-      tabTaskIds: openTaskTabs,
-      persistedActiveTaskId,
-    });
-    if (!fallbackTaskId) {
-      return;
-    }
-    const fallbackSession = latestSessionByTaskId.get(fallbackTaskId);
-    if (fallbackSession) {
-      deferQueryUpdate({
-        task: fallbackSession.taskId,
-        session: fallbackSession.sessionId,
-        agent: fallbackSession.role,
-        scenario: fallbackSession.scenario,
-        autostart: undefined,
-        start: undefined,
-      });
-      return;
-    }
-    const fallbackTask = tasks.find((entry) => entry.id === fallbackTaskId) ?? null;
-    const fallbackRole = resolveDefaultRoleForTask(fallbackTask);
-    deferQueryUpdate({
-      task: fallbackTaskId,
-      session: undefined,
-      agent: fallbackRole,
-      scenario: firstScenario(fallbackRole),
-      autostart: undefined,
-      start: undefined,
-    });
-  }, [deferQueryUpdate, latestSessionByTaskId, openTaskTabs, persistedActiveTaskId, taskId, tasks]);
-
-  const handleSelectTab = useCallback(
-    (nextTaskId: string): void => {
-      if (!nextTaskId) {
-        return;
-      }
-      if (nextTaskId === activeTaskTabId) {
-        return;
-      }
-
-      onContextSwitchIntent?.();
-
-      clearComposerInput();
-      setIntentActiveTaskId(nextTaskId);
-      setOpenTaskTabs((current) => {
-        if (current.includes(nextTaskId)) {
-          return current;
-        }
-        return [...current, nextTaskId];
-      });
-      setPersistedActiveTaskId(nextTaskId);
-
-      const sessionForTask = latestSessionByTaskId.get(nextTaskId);
-      if (sessionForTask) {
-        deferQueryUpdate({
-          task: sessionForTask.taskId,
-          session: sessionForTask.sessionId,
-          agent: sessionForTask.role,
-          scenario: sessionForTask.scenario,
-          autostart: undefined,
-          start: undefined,
-        });
-        return;
-      }
-
-      const nextTask = tasks.find((entry) => entry.id === nextTaskId) ?? null;
-      const nextRole = resolveDefaultRoleForTask(nextTask);
-      deferQueryUpdate({
-        task: nextTaskId,
-        session: undefined,
-        agent: nextRole,
-        scenario: firstScenario(nextRole),
-        autostart: undefined,
-        start: undefined,
-      });
-    },
-    [
-      activeTaskTabId,
-      clearComposerInput,
-      deferQueryUpdate,
-      latestSessionByTaskId,
-      onContextSwitchIntent,
-      tasks,
-    ],
-  );
-
-  const handleCreateTab = useCallback(
-    (nextTaskId: string): void => {
-      handleSelectTab(nextTaskId);
-    },
-    [handleSelectTab],
-  );
-
-  const handleCloseTab = useCallback(
-    (taskIdToClose: string): void => {
-      const { nextTabTaskIds, nextActiveTaskId } = closeTaskTab({
-        tabTaskIds,
-        taskIdToClose,
-        activeTaskId: activeTaskTabId,
-      });
-
-      if (nextTabTaskIds === tabTaskIds) {
-        return;
-      }
-
-      setOpenTaskTabs(nextTabTaskIds);
-      setPersistedActiveTaskId(nextActiveTaskId ?? null);
-
-      if (taskIdToClose !== activeTaskTabId) {
-        return;
-      }
-
-      clearComposerInput();
-      onContextSwitchIntent?.();
-      setIntentActiveTaskId(nextActiveTaskId ?? null);
-
-      if (!nextActiveTaskId) {
-        deferQueryUpdate({
-          task: undefined,
-          session: undefined,
-          agent: undefined,
-          scenario: undefined,
-          autostart: undefined,
-          start: undefined,
-        });
-        return;
-      }
-
-      globalThis.setTimeout(() => {
-        if (typeof globalThis.document === "undefined") {
-          return;
-        }
-
-        const nextTrigger = globalThis.document.getElementById(
-          `agent-studio-tab-${nextActiveTaskId}`,
-        );
-        if (nextTrigger instanceof HTMLElement) {
-          nextTrigger.focus();
-        }
-      }, 0);
-
-      const fallbackSession = latestSessionByTaskId.get(nextActiveTaskId);
-      if (fallbackSession) {
-        deferQueryUpdate({
-          task: fallbackSession.taskId,
-          session: fallbackSession.sessionId,
-          agent: fallbackSession.role,
-          scenario: fallbackSession.scenario,
-          autostart: undefined,
-          start: undefined,
-        });
-        return;
-      }
-
-      const fallbackTask = tasks.find((entry) => entry.id === nextActiveTaskId) ?? null;
-      const fallbackRole = resolveDefaultRoleForTask(fallbackTask);
-      deferQueryUpdate({
-        task: nextActiveTaskId,
-        session: undefined,
-        agent: fallbackRole,
-        scenario: firstScenario(fallbackRole),
-        autostart: undefined,
-        start: undefined,
-      });
-    },
-    [
-      clearComposerInput,
-      deferQueryUpdate,
-      latestSessionByTaskId,
-      onContextSwitchIntent,
-      activeTaskTabId,
-      tabTaskIds,
-      tasks,
-    ],
-  );
+  const { handleCreateTab, handleCloseTab } = useTaskTabActions({
+    tabTaskIds,
+    activeTaskTabId,
+    clearComposerInput,
+    onContextSwitchIntent,
+    deferQueryUpdate,
+    navigateToTask,
+    handleSelectTab,
+    setOpenTaskTabs,
+    setPersistedActiveTaskId,
+    setIntentActiveTaskId,
+  });
 
   return {
     tabTaskIds,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
@@ -1,37 +1,21 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentRole } from "@openducktor/core";
-import {
-  type Dispatch,
-  type SetStateAction,
-  startTransition,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { startTransition, useCallback, useMemo, useState } from "react";
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { firstScenario } from "./agents-page-constants";
 import {
   buildRoleEnabledMapForTask,
   buildTaskTabs,
-  canPersistTaskTabs,
-  closeTaskTab,
-  ensureActiveTaskTab,
   getAvailableTabTasks,
-  parsePersistedTaskTabs,
-  resolveFallbackTaskId,
-  toPersistedTaskTabs,
 } from "./agents-page-session-tabs";
-import { toTabsStorageKey } from "./agents-page-utils";
+import { useTaskTabActions } from "./use-agent-studio-task-tabs-actions";
+import { useTaskTabPersistence } from "./use-agent-studio-task-tabs-persistence";
+import { useTaskTabSelection } from "./use-agent-studio-task-tabs-selection";
 
 type QueryUpdate = Record<string, string | undefined>;
 
-type SetState<T> = Dispatch<SetStateAction<T>>;
-
 type TaskByIdMap = ReadonlyMap<string, TaskCard>;
-
-type NavigateToTask = (taskId: string) => void;
 
 const resolveDefaultRoleForTask = (task: TaskCard | null): AgentRole => {
   const roleEnabledByTask = buildRoleEnabledMapForTask(task);
@@ -88,334 +72,6 @@ const toClearTaskQueryUpdate = (): QueryUpdate => ({
   start: undefined,
 });
 
-const focusTaskTabTrigger = (taskId: string): void => {
-  globalThis.setTimeout(() => {
-    if (typeof globalThis.document === "undefined") {
-      return;
-    }
-
-    const nextTrigger = globalThis.document.getElementById(`agent-studio-tab-${taskId}`);
-    if (nextTrigger instanceof HTMLElement) {
-      nextTrigger.focus();
-    }
-  }, 0);
-};
-
-type UseTaskTabPersistenceArgs = {
-  activeRepo: string | null;
-  taskId: string;
-  selectedTask: TaskCard | null;
-  tasks: TaskCard[];
-  isLoadingTasks: boolean;
-  openTaskTabs: string[];
-  tabsStorageHydratedRepo: string | null;
-  activeTaskTabId: string;
-  setOpenTaskTabs: SetState<string[]>;
-  setPersistedActiveTaskId: SetState<string | null>;
-  setIntentActiveTaskId: SetState<string | null>;
-  setTabsStorageHydratedRepo: SetState<string | null>;
-};
-
-export function useTaskTabPersistence(args: UseTaskTabPersistenceArgs): void {
-  const {
-    activeRepo,
-    taskId,
-    selectedTask,
-    tasks,
-    isLoadingTasks,
-    openTaskTabs,
-    tabsStorageHydratedRepo,
-    activeTaskTabId,
-    setOpenTaskTabs,
-    setPersistedActiveTaskId,
-    setIntentActiveTaskId,
-    setTabsStorageHydratedRepo,
-  } = args;
-
-  useEffect(() => {
-    if (!activeRepo) {
-      setOpenTaskTabs([]);
-      setPersistedActiveTaskId(null);
-      setIntentActiveTaskId(null);
-      setTabsStorageHydratedRepo(null);
-      return;
-    }
-
-    const raw = globalThis.localStorage.getItem(toTabsStorageKey(activeRepo));
-    const persistedTabs = parsePersistedTaskTabs(raw);
-    setOpenTaskTabs(persistedTabs.tabs);
-    setPersistedActiveTaskId(persistedTabs.activeTaskId);
-    setTabsStorageHydratedRepo(activeRepo);
-  }, [
-    activeRepo,
-    setIntentActiveTaskId,
-    setOpenTaskTabs,
-    setPersistedActiveTaskId,
-    setTabsStorageHydratedRepo,
-  ]);
-
-  useEffect(() => {
-    if (isLoadingTasks) {
-      return;
-    }
-    const knownTaskIds = new Set(tasks.map((task) => task.id));
-    setOpenTaskTabs((current) => {
-      const filtered = current.filter((taskTabId) => knownTaskIds.has(taskTabId));
-      if (filtered.length === current.length) {
-        return current;
-      }
-      return filtered;
-    });
-  }, [isLoadingTasks, setOpenTaskTabs, tasks]);
-
-  useEffect(() => {
-    if (!taskId) {
-      return;
-    }
-    if (!selectedTask) {
-      return;
-    }
-    setOpenTaskTabs((current) => {
-      if (current.includes(taskId)) {
-        return current;
-      }
-      return [...current, taskId];
-    });
-  }, [selectedTask, setOpenTaskTabs, taskId]);
-
-  useEffect(() => {
-    if (!canPersistTaskTabs(activeRepo, tabsStorageHydratedRepo)) {
-      return;
-    }
-    if (!activeRepo) {
-      return;
-    }
-    globalThis.localStorage.setItem(
-      toTabsStorageKey(activeRepo),
-      toPersistedTaskTabs({
-        tabs: openTaskTabs,
-        activeTaskId: activeTaskTabId || null,
-      }),
-    );
-  }, [activeRepo, activeTaskTabId, openTaskTabs, tabsStorageHydratedRepo]);
-}
-
-type UseTaskTabSelectionArgs = {
-  activeRepo: string | null;
-  taskId: string;
-  openTaskTabs: string[];
-  persistedActiveTaskId: string | null;
-  intentActiveTaskId: string | null;
-  tabsStorageHydratedRepo: string | null;
-  clearComposerInput: () => void;
-  onContextSwitchIntent: (() => void) | undefined;
-  navigateToTask: NavigateToTask;
-  setOpenTaskTabs: SetState<string[]>;
-  setPersistedActiveTaskId: SetState<string | null>;
-  setIntentActiveTaskId: SetState<string | null>;
-};
-
-type UseTaskTabSelectionResult = {
-  tabTaskIds: string[];
-  activeTaskTabId: string;
-  handleSelectTab: (nextTaskId: string) => void;
-};
-
-export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSelectionResult {
-  const {
-    activeRepo,
-    taskId,
-    openTaskTabs,
-    persistedActiveTaskId,
-    intentActiveTaskId,
-    tabsStorageHydratedRepo,
-    clearComposerInput,
-    onContextSwitchIntent,
-    navigateToTask,
-    setOpenTaskTabs,
-    setPersistedActiveTaskId,
-    setIntentActiveTaskId,
-  } = args;
-
-  const tabTaskIds = useMemo(
-    () => ensureActiveTaskTab(openTaskTabs, taskId),
-    [openTaskTabs, taskId],
-  );
-
-  const activeTaskTabId = useMemo(() => {
-    if (intentActiveTaskId && tabTaskIds.includes(intentActiveTaskId)) {
-      return intentActiveTaskId;
-    }
-    if (taskId && tabTaskIds.includes(taskId)) {
-      return taskId;
-    }
-    if (persistedActiveTaskId && tabTaskIds.includes(persistedActiveTaskId)) {
-      return persistedActiveTaskId;
-    }
-    return tabTaskIds[0] ?? "";
-  }, [intentActiveTaskId, persistedActiveTaskId, tabTaskIds, taskId]);
-
-  useEffect(() => {
-    if (!intentActiveTaskId) {
-      return;
-    }
-    if (!tabTaskIds.includes(intentActiveTaskId) || taskId === intentActiveTaskId) {
-      setIntentActiveTaskId(null);
-    }
-  }, [intentActiveTaskId, setIntentActiveTaskId, tabTaskIds, taskId]);
-
-  useEffect(() => {
-    if (!activeRepo || tabsStorageHydratedRepo !== activeRepo) {
-      return;
-    }
-    if (taskId || tabTaskIds.length === 0) {
-      return;
-    }
-    const fallbackTaskId = resolveFallbackTaskId({
-      tabTaskIds,
-      persistedActiveTaskId,
-    });
-    if (!fallbackTaskId) {
-      return;
-    }
-    navigateToTask(fallbackTaskId);
-  }, [
-    activeRepo,
-    navigateToTask,
-    persistedActiveTaskId,
-    tabTaskIds,
-    tabsStorageHydratedRepo,
-    taskId,
-  ]);
-
-  const handleSelectTab = useCallback(
-    (nextTaskId: string): void => {
-      if (!nextTaskId) {
-        return;
-      }
-      if (nextTaskId === activeTaskTabId) {
-        return;
-      }
-
-      onContextSwitchIntent?.();
-      clearComposerInput();
-      setIntentActiveTaskId(nextTaskId);
-      setOpenTaskTabs((current) => {
-        if (current.includes(nextTaskId)) {
-          return current;
-        }
-        return [...current, nextTaskId];
-      });
-      setPersistedActiveTaskId(nextTaskId);
-      navigateToTask(nextTaskId);
-    },
-    [
-      activeTaskTabId,
-      clearComposerInput,
-      navigateToTask,
-      onContextSwitchIntent,
-      setIntentActiveTaskId,
-      setOpenTaskTabs,
-      setPersistedActiveTaskId,
-    ],
-  );
-
-  return {
-    tabTaskIds,
-    activeTaskTabId,
-    handleSelectTab,
-  };
-}
-
-type UseTaskTabActionsArgs = {
-  tabTaskIds: string[];
-  activeTaskTabId: string;
-  clearComposerInput: () => void;
-  onContextSwitchIntent: (() => void) | undefined;
-  deferQueryUpdate: (updates: QueryUpdate) => void;
-  navigateToTask: NavigateToTask;
-  handleSelectTab: (nextTaskId: string) => void;
-  setOpenTaskTabs: SetState<string[]>;
-  setPersistedActiveTaskId: SetState<string | null>;
-  setIntentActiveTaskId: SetState<string | null>;
-};
-
-type UseTaskTabActionsResult = {
-  handleCreateTab: (nextTaskId: string) => void;
-  handleCloseTab: (taskIdToClose: string) => void;
-};
-
-export function useTaskTabActions(args: UseTaskTabActionsArgs): UseTaskTabActionsResult {
-  const {
-    tabTaskIds,
-    activeTaskTabId,
-    clearComposerInput,
-    onContextSwitchIntent,
-    deferQueryUpdate,
-    navigateToTask,
-    handleSelectTab,
-    setOpenTaskTabs,
-    setPersistedActiveTaskId,
-    setIntentActiveTaskId,
-  } = args;
-
-  const handleCreateTab = useCallback(
-    (nextTaskId: string): void => {
-      handleSelectTab(nextTaskId);
-    },
-    [handleSelectTab],
-  );
-
-  const handleCloseTab = useCallback(
-    (taskIdToClose: string): void => {
-      const { nextTabTaskIds, nextActiveTaskId } = closeTaskTab({
-        tabTaskIds,
-        taskIdToClose,
-        activeTaskId: activeTaskTabId,
-      });
-
-      if (nextTabTaskIds === tabTaskIds) {
-        return;
-      }
-
-      setOpenTaskTabs(nextTabTaskIds);
-      setPersistedActiveTaskId(nextActiveTaskId ?? null);
-
-      if (taskIdToClose !== activeTaskTabId) {
-        return;
-      }
-
-      clearComposerInput();
-      onContextSwitchIntent?.();
-      setIntentActiveTaskId(nextActiveTaskId ?? null);
-
-      if (!nextActiveTaskId) {
-        deferQueryUpdate(toClearTaskQueryUpdate());
-        return;
-      }
-
-      focusTaskTabTrigger(nextActiveTaskId);
-      navigateToTask(nextActiveTaskId);
-    },
-    [
-      activeTaskTabId,
-      clearComposerInput,
-      deferQueryUpdate,
-      navigateToTask,
-      onContextSwitchIntent,
-      setIntentActiveTaskId,
-      setOpenTaskTabs,
-      setPersistedActiveTaskId,
-      tabTaskIds,
-    ],
-  );
-
-  return {
-    handleCreateTab,
-    handleCloseTab,
-  };
-}
-
 export function useAgentStudioTaskTabs(args: {
   activeRepo: string | null;
   taskId: string;
@@ -466,8 +122,8 @@ export function useAgentStudioTaskTabs(args: {
     [tasks],
   );
 
-  const navigateToTask = useCallback<NavigateToTask>(
-    (nextTaskId) => {
+  const navigateToTask = useCallback(
+    (nextTaskId: string) => {
       deferQueryUpdate(
         toTaskQueryUpdate({
           taskId: nextTaskId,
@@ -478,6 +134,10 @@ export function useAgentStudioTaskTabs(args: {
     },
     [deferQueryUpdate, latestSessionByTaskId, taskById],
   );
+
+  const clearTaskSelection = useCallback((): void => {
+    deferQueryUpdate(toClearTaskQueryUpdate());
+  }, [deferQueryUpdate]);
 
   const { tabTaskIds, activeTaskTabId, handleSelectTab } = useTaskTabSelection({
     activeRepo,
@@ -530,7 +190,7 @@ export function useAgentStudioTaskTabs(args: {
     activeTaskTabId,
     clearComposerInput,
     onContextSwitchIntent,
-    deferQueryUpdate,
+    clearTaskSelection,
     navigateToTask,
     handleSelectTab,
     setOpenTaskTabs,


### PR DESCRIPTION
## Summary
This PR decomposes `useAgentStudioTaskTabs` into focused modules and hardens task-tab fallback/persistence behavior for long-term maintainability and predictable state transitions.

## Why
The original task-tabs hook had tightly interleaved responsibilities (hydration, selection, actions, fallback routing, persistence), making effect ordering and dependency reasoning difficult.

This change separates those concerns and adds regression coverage around the riskiest paths (repo switch, hydration fallback, and storage failures).

## Changes
### 1) Hook decomposition
- Kept `useAgentStudioTaskTabs` as composition root:
  - `apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts`
- Extracted focused sub-hooks:
  - `apps/desktop/src/pages/agents/use-agent-studio-task-tabs-persistence.ts`
  - `apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts`
  - `apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts`

### 2) Fallback selection hardening
- Added idempotency guard for fallback navigation in `useTaskTabSelection` so unchanged fallback targets are applied once.
- Guard resets when repo/task context changes.

### 3) Storage error handling hardening
- Wrapped task-tab localStorage reads/writes in dedicated functions in `useTaskTabPersistence`.
- On failure, throws actionable errors with operation + storage key context.
- No silent fallback path is introduced.

### 4) Test coverage expansion
- Extended `use-agent-studio-task-tabs.test.tsx` with regressions for:
  - fallback routing after hydration with empty URL task
  - stale fallback prevention while switching repos
  - clearing repo resets tabs and skips fallback routing
  - idempotent fallback routing across repeated renders
  - actionable error propagation on storage read/write failure

## Validation
Executed successfully:
- `bun run --filter @openducktor/desktop test src/pages/agents/use-agent-studio-task-tabs.test.tsx`
- `bun run --filter @openducktor/desktop test src/pages/agents`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`

## Scope
- 5 files changed
- 857 insertions, 280 deletions

## Notes for reviewers
- Primary review points:
  1. Effect ordering and dependency behavior in `useTaskTabSelection` + `useTaskTabPersistence`
  2. Storage error propagation behavior (intended to fail loudly with actionable context)
  3. Test completeness for fallback/navigation edge cases
