### PR TITLE
refactor(runtime): enforce typed runtime roles across host and contracts

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -1,7 +1,8 @@
 use anyhow::{anyhow, Context, Result};
 use fs2::FileExt;
 use host_domain::{
-    AgentRuntimeSummary, GitPort, RunEvent, RunSummary, RuntimeCheck, TaskCard, TaskStore,
+    AgentRuntimeSummary, GitPort, RunEvent, RunSummary, RuntimeCheck, RuntimeRole, TaskCard,
+    TaskStore,
 };
 use host_infra_system::{AppConfigStore, GitCliPort, RepoConfig};
 use serde::{Deserialize, Serialize};

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -5,7 +5,7 @@ use super::{
     TrackedOpencodeProcessGuard,
 };
 use anyhow::{anyhow, Result};
-use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary, RuntimeRole};
+use host_domain::{now_rfc3339, AgentRuntimeRole, AgentRuntimeSummary, RunSummary, RuntimeRole};
 use host_infra_system::pick_free_port;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -190,10 +190,11 @@ impl AppService {
         &self,
         repo_path: &str,
         task_id: &str,
-        role: RuntimeRole,
+        role: AgentRuntimeRole,
     ) -> Result<AgentRuntimeSummary> {
         let repo_key = self.resolve_initialized_repo_path(repo_path)?;
         let repo_path = repo_key.as_str();
+        let runtime_role = RuntimeRole::from(role);
         let prerequisites = match self.resolve_runtime_prerequisites(repo_path, task_id, role)? {
             RuntimePrerequisiteResolution::Existing(existing) => return Ok(existing),
             RuntimePrerequisiteResolution::Ready(prerequisites) => prerequisites,
@@ -204,7 +205,7 @@ impl AppService {
             repo_path,
             repo_key: repo_key.clone(),
             task_id,
-            role,
+            role: runtime_role,
             working_directory: prerequisites.working_directory,
             cleanup_repo_path: prerequisites.cleanup_repo_path,
             cleanup_worktree_path: prerequisites.cleanup_worktree_path,
@@ -213,7 +214,7 @@ impl AppService {
             post_start_policy: Some(RuntimePostStartPolicy {
                 existing_lookup: RuntimeExistingLookup {
                     repo_key: repo_key.as_str(),
-                    role,
+                    role: runtime_role,
                     task_id: Some(task_id),
                 },
                 prune_error_context: format!(
@@ -227,18 +228,8 @@ impl AppService {
         &self,
         repo_key: &str,
         task_id: &str,
-        role: RuntimeRole,
+        role: AgentRuntimeRole,
     ) -> Result<RuntimePrerequisiteResolution> {
-        match role {
-            RuntimeRole::Workspace => {
-                return Err(anyhow!(
-                    "Unsupported agent runtime role: {}. Supported: spec, planner, qa",
-                    role
-                ));
-            }
-            RuntimeRole::Spec | RuntimeRole::Planner | RuntimeRole::Qa => {}
-        }
-
         let tasks = self.task_store.list_tasks(Path::new(repo_key))?;
         let task = tasks
             .iter()
@@ -256,7 +247,7 @@ impl AppService {
                 &runtimes,
                 RuntimeExistingLookup {
                     repo_key,
-                    role,
+                    role: role.into(),
                     task_id: Some(task_id),
                 },
             ) {
@@ -265,7 +256,7 @@ impl AppService {
         }
 
         let prerequisites = match role {
-            RuntimeRole::Qa => {
+            AgentRuntimeRole::Qa => {
                 let setup = prepare_qa_worktree(
                     repo_key,
                     task_id,
@@ -278,12 +269,11 @@ impl AppService {
                     cleanup_worktree_path: Some(setup.worktree_path),
                 }
             }
-            RuntimeRole::Spec | RuntimeRole::Planner => RuntimePrerequisites {
+            AgentRuntimeRole::Spec | AgentRuntimeRole::Planner => RuntimePrerequisites {
                 working_directory: repo_key.to_string(),
                 cleanup_repo_path: None,
                 cleanup_worktree_path: None,
             },
-            RuntimeRole::Workspace => unreachable!("workspace role is rejected above"),
         };
 
         Ok(RuntimePrerequisiteResolution::Ready(prerequisites))

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -5,7 +5,7 @@ use super::{
     TrackedOpencodeProcessGuard,
 };
 use anyhow::{anyhow, Result};
-use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary};
+use host_domain::{now_rfc3339, AgentRuntimeSummary, RunSummary, RuntimeRole};
 use host_infra_system::pick_free_port;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -15,7 +15,7 @@ use uuid::Uuid;
 #[derive(Clone, Copy)]
 struct RuntimeExistingLookup<'a> {
     repo_key: &'a str,
-    role: &'a str,
+    role: RuntimeRole,
     task_id: Option<&'a str>,
 }
 
@@ -29,7 +29,7 @@ struct RuntimeStartInput<'a> {
     repo_path: &'a str,
     repo_key: String,
     task_id: &'a str,
-    role: &'a str,
+    role: RuntimeRole,
     working_directory: String,
     cleanup_repo_path: Option<String>,
     cleanup_worktree_path: Option<String>,
@@ -190,7 +190,7 @@ impl AppService {
         &self,
         repo_path: &str,
         task_id: &str,
-        role: &str,
+        role: RuntimeRole,
     ) -> Result<AgentRuntimeSummary> {
         let repo_key = self.resolve_initialized_repo_path(repo_path)?;
         let repo_path = repo_key.as_str();
@@ -227,12 +227,16 @@ impl AppService {
         &self,
         repo_key: &str,
         task_id: &str,
-        role: &str,
+        role: RuntimeRole,
     ) -> Result<RuntimePrerequisiteResolution> {
-        if !matches!(role, "spec" | "planner" | "qa") {
-            return Err(anyhow!(
-                "Unsupported agent runtime role: {role}. Supported: spec, planner, qa"
-            ));
+        match role {
+            RuntimeRole::Workspace => {
+                return Err(anyhow!(
+                    "Unsupported agent runtime role: {}. Supported: spec, planner, qa",
+                    role
+                ));
+            }
+            RuntimeRole::Spec | RuntimeRole::Planner | RuntimeRole::Qa => {}
         }
 
         let tasks = self.task_store.list_tasks(Path::new(repo_key))?;
@@ -260,20 +264,26 @@ impl AppService {
             }
         }
 
-        let prerequisites = if role == "qa" {
-            let setup =
-                prepare_qa_worktree(repo_key, task_id, task.title.as_str(), &self.config_store)?;
-            RuntimePrerequisites {
-                working_directory: setup.worktree_path.clone(),
-                cleanup_repo_path: Some(setup.repo_path),
-                cleanup_worktree_path: Some(setup.worktree_path),
+        let prerequisites = match role {
+            RuntimeRole::Qa => {
+                let setup = prepare_qa_worktree(
+                    repo_key,
+                    task_id,
+                    task.title.as_str(),
+                    &self.config_store,
+                )?;
+                RuntimePrerequisites {
+                    working_directory: setup.worktree_path.clone(),
+                    cleanup_repo_path: Some(setup.repo_path),
+                    cleanup_worktree_path: Some(setup.worktree_path),
+                }
             }
-        } else {
-            RuntimePrerequisites {
+            RuntimeRole::Spec | RuntimeRole::Planner => RuntimePrerequisites {
                 working_directory: repo_key.to_string(),
                 cleanup_repo_path: None,
                 cleanup_worktree_path: None,
-            }
+            },
+            RuntimeRole::Workspace => unreachable!("workspace role is rejected above"),
         };
 
         Ok(RuntimePrerequisiteResolution::Ready(prerequisites))
@@ -319,7 +329,7 @@ impl AppService {
             input.startup_scope,
             input.repo_path,
             Some(input.task_id),
-            input.role,
+            input.role.as_str(),
             port,
             Some(StartupEventCorrelation::new(
                 "runtime_id",
@@ -340,7 +350,7 @@ impl AppService {
                     input.startup_scope,
                     input.repo_path,
                     Some(input.task_id),
-                    input.role,
+                    input.role.as_str(),
                     port,
                     Some(StartupEventCorrelation::new(
                         "runtime_id",
@@ -365,7 +375,7 @@ impl AppService {
             input.startup_scope,
             input.repo_path,
             Some(input.task_id),
-            input.role,
+            input.role.as_str(),
             port,
             Some(StartupEventCorrelation::new(
                 "runtime_id",
@@ -404,7 +414,7 @@ impl AppService {
             runtime_id: spawned_server.runtime_id.clone(),
             repo_path: repo_key,
             task_id: task_id.to_string(),
-            role: role.to_string(),
+            role,
             working_directory,
             port: spawned_server.port,
             started_at: now_rfc3339(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
@@ -51,7 +51,7 @@ impl Drop for AppService {
 }
 
 impl AppService {
-    pub(super) const WORKSPACE_RUNTIME_ROLE: &'static str = "workspace";
+    pub(super) const WORKSPACE_RUNTIME_ROLE: RuntimeRole = RuntimeRole::Workspace;
     pub(super) const WORKSPACE_RUNTIME_TASK_ID: &'static str = "__workspace__";
 
     pub fn new(task_store: Arc<dyn TaskStore>, config_store: AppConfigStore) -> Self {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
     GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
-    TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    RuntimeRole, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{hook_set_fingerprint, AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -124,7 +124,7 @@ fn opencode_workspace_runtime_ensure_stops_spawned_child_when_post_start_prune_f
                     runtime_id: "runtime-stale-prune-failure-window".to_string(),
                     repo_path: "/tmp/other-repo-for-prune".to_string(),
                     task_id: "task-1".to_string(),
-                    role: "spec".to_string(),
+                    role: RuntimeRole::Spec,
                     working_directory: "/tmp/other-repo-for-prune".to_string(),
                     port: 1,
                     started_at: "2026-02-20T12:00:00Z".to_string(),
@@ -204,19 +204,20 @@ fn opencode_runtime_start_supports_spec_and_qa_roles() -> Result<()> {
         },
     )?;
 
-    let spec_runtime = service.opencode_runtime_start(repo_path.as_str(), "task-1", "spec")?;
-    assert_eq!(spec_runtime.role, "spec");
+    let spec_runtime =
+        service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec)?;
+    assert_eq!(spec_runtime.role, RuntimeRole::Spec);
     assert!(service.opencode_runtime_stop(spec_runtime.runtime_id.as_str())?);
 
-    let qa_runtime = service.opencode_runtime_start(repo_path.as_str(), "task-1", "qa")?;
-    assert_eq!(qa_runtime.role, "qa");
+    let qa_runtime = service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)?;
+    assert_eq!(qa_runtime.role, RuntimeRole::Qa);
     let qa_worktree = PathBuf::from(qa_runtime.working_directory.clone());
     assert!(qa_worktree.exists());
     assert!(service.opencode_runtime_stop(qa_runtime.runtime_id.as_str())?);
     assert!(!qa_worktree.exists());
 
     let bad_role = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", "build")
+        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Workspace)
         .expect_err("unsupported role should fail");
     assert!(bad_role
         .to_string()
@@ -251,7 +252,7 @@ fn opencode_runtime_start_persists_canonical_repo_path_in_summary() -> Result<()
     );
     let repo_path_with_suffix = format!("{}/.", repo.to_string_lossy());
     let runtime =
-        service.opencode_runtime_start(repo_path_with_suffix.as_str(), "task-1", "spec")?;
+        service.opencode_runtime_start(repo_path_with_suffix.as_str(), "task-1", RuntimeRole::Spec)?;
 
     let expected_repo_key = fs::canonicalize(&repo)?.to_string_lossy().to_string();
     assert_eq!(runtime.repo_path, expected_repo_key);
@@ -279,7 +280,7 @@ fn opencode_runtime_start_reports_missing_task() -> Result<()> {
 
     let repo_path = repo.to_string_lossy().to_string();
     let error = service
-        .opencode_runtime_start(repo_path.as_str(), "missing-task", "spec")
+        .opencode_runtime_start(repo_path.as_str(), "missing-task", RuntimeRole::Spec)
         .expect_err("missing task should fail");
     assert!(error.to_string().contains("Task not found: missing-task"));
     let _ = fs::remove_dir_all(root);
@@ -318,7 +319,7 @@ fn opencode_runtime_start_qa_validates_config_and_existing_worktree_path() -> Re
         },
     )?;
     let missing_base_error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", "qa")
+        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
         .expect_err("qa runtime should require worktree base path");
     assert!(missing_base_error
         .to_string()
@@ -340,7 +341,7 @@ fn opencode_runtime_start_qa_validates_config_and_existing_worktree_path() -> Re
         },
     )?;
     let trust_error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", "qa")
+        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
         .expect_err("qa runtime should reject untrusted hooks");
     assert!(trust_error
         .to_string()
@@ -360,7 +361,7 @@ fn opencode_runtime_start_qa_validates_config_and_existing_worktree_path() -> Re
     )?;
     fs::create_dir_all(worktree_base.join("qa-task-1"))?;
     let existing_path_error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", "qa")
+        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
         .expect_err("existing qa worktree should fail");
     assert!(existing_path_error
         .to_string()
@@ -407,7 +408,7 @@ fn opencode_runtime_start_surfaces_qa_pre_start_cleanup_failure() -> Result<()> 
     )?;
 
     let error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", "qa")
+        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
         .expect_err("cleanup failure should be surfaced when pre-start hook fails");
     let message = error.to_string();
     assert!(message.contains("QA pre-start hook failed"));
@@ -456,7 +457,7 @@ fn opencode_runtime_start_surfaces_cleanup_failure_after_startup_error() -> Resu
     )?;
 
     let error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", "qa")
+        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
         .expect_err("startup cleanup failure should be surfaced");
     let message = error.to_string();
     assert!(message.contains("OpenCode runtime failed to start for task task-1"));
@@ -490,8 +491,8 @@ fn opencode_runtime_start_reuses_existing_runtime_for_same_task_and_role() -> Re
     );
     let repo_path = repo.to_string_lossy().to_string();
 
-    let first = service.opencode_runtime_start(repo_path.as_str(), "task-1", "spec")?;
-    let second = service.opencode_runtime_start(repo_path.as_str(), "task-1", "spec")?;
+    let first = service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec)?;
+    let second = service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec)?;
     assert_eq!(first.runtime_id, second.runtime_id);
     assert!(service.opencode_runtime_stop(first.runtime_id.as_str())?);
     let _ = fs::remove_dir_all(root);
@@ -525,9 +526,9 @@ fn opencode_runtime_start_deduplicates_concurrent_same_task_and_role() -> Result
 
     let (first, second) = thread::scope(|scope| {
         let first_start =
-            scope.spawn(|| service.opencode_runtime_start(repo_path.as_str(), "task-1", "spec"));
+            scope.spawn(|| service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec));
         let second_start =
-            scope.spawn(|| service.opencode_runtime_start(repo_path.as_str(), "task-1", "spec"));
+            scope.spawn(|| service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec));
         (
             first_start
                 .join()
@@ -679,7 +680,7 @@ fn opencode_runtime_start_cleans_up_qa_worktree_when_tracking_fails() -> Result<
     assert!(poison_handle.join().is_err());
 
     let error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", "qa")
+        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
         .expect_err("qa runtime start should fail when tracked process lock is poisoned");
     assert!(error
         .to_string()
@@ -729,7 +730,7 @@ fn opencode_runtime_stop_reports_cleanup_failure() -> Result<()> {
                     runtime_id: runtime_id.clone(),
                     repo_path: "/tmp/repo".to_string(),
                     task_id: "task-1".to_string(),
-                    role: "qa".to_string(),
+                    role: RuntimeRole::Qa,
                     working_directory: "/tmp/repo".to_string(),
                     port: 1,
                     started_at: "2026-02-20T12:00:00Z".to_string(),
@@ -784,7 +785,7 @@ fn opencode_runtime_list_prunes_stale_entries() -> Result<()> {
         runtime_id: "runtime-stale".to_string(),
         repo_path: repo.to_string_lossy().to_string(),
         task_id: "task-1".to_string(),
-        role: "spec".to_string(),
+        role: RuntimeRole::Spec,
         working_directory: repo.to_string_lossy().to_string(),
         port: 1,
         started_at: "2026-02-20T12:00:00Z".to_string(),
@@ -840,7 +841,7 @@ fn opencode_runtime_list_surfaces_stale_cleanup_failure() -> Result<()> {
         runtime_id: "runtime-stale-cleanup-error".to_string(),
         repo_path: repo.to_string_lossy().to_string(),
         task_id: "task-1".to_string(),
-        role: "qa".to_string(),
+        role: RuntimeRole::Qa,
         working_directory: repo.to_string_lossy().to_string(),
         port: 1,
         started_at: "2026-02-20T12:00:00Z".to_string(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -2,9 +2,9 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
-    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
-    RuntimeRole, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    AgentRuntimeRole, AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch,
+    GitCurrentBranch, GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState,
+    RunSummary, RuntimeRole, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{hook_set_fingerprint, AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -205,23 +205,17 @@ fn opencode_runtime_start_supports_spec_and_qa_roles() -> Result<()> {
     )?;
 
     let spec_runtime =
-        service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec)?;
+        service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)?;
     assert_eq!(spec_runtime.role, RuntimeRole::Spec);
     assert!(service.opencode_runtime_stop(spec_runtime.runtime_id.as_str())?);
 
-    let qa_runtime = service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)?;
+    let qa_runtime =
+        service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Qa)?;
     assert_eq!(qa_runtime.role, RuntimeRole::Qa);
     let qa_worktree = PathBuf::from(qa_runtime.working_directory.clone());
     assert!(qa_worktree.exists());
     assert!(service.opencode_runtime_stop(qa_runtime.runtime_id.as_str())?);
     assert!(!qa_worktree.exists());
-
-    let bad_role = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Workspace)
-        .expect_err("unsupported role should fail");
-    assert!(bad_role
-        .to_string()
-        .contains("Unsupported agent runtime role"));
 
     let _ = fs::remove_dir_all(root);
     Ok(())
@@ -251,8 +245,11 @@ fn opencode_runtime_start_persists_canonical_repo_path_in_summary() -> Result<()
         config_store,
     );
     let repo_path_with_suffix = format!("{}/.", repo.to_string_lossy());
-    let runtime =
-        service.opencode_runtime_start(repo_path_with_suffix.as_str(), "task-1", RuntimeRole::Spec)?;
+    let runtime = service.opencode_runtime_start(
+        repo_path_with_suffix.as_str(),
+        "task-1",
+        AgentRuntimeRole::Spec,
+    )?;
 
     let expected_repo_key = fs::canonicalize(&repo)?.to_string_lossy().to_string();
     assert_eq!(runtime.repo_path, expected_repo_key);
@@ -280,7 +277,7 @@ fn opencode_runtime_start_reports_missing_task() -> Result<()> {
 
     let repo_path = repo.to_string_lossy().to_string();
     let error = service
-        .opencode_runtime_start(repo_path.as_str(), "missing-task", RuntimeRole::Spec)
+        .opencode_runtime_start(repo_path.as_str(), "missing-task", AgentRuntimeRole::Spec)
         .expect_err("missing task should fail");
     assert!(error.to_string().contains("Task not found: missing-task"));
     let _ = fs::remove_dir_all(root);
@@ -319,7 +316,7 @@ fn opencode_runtime_start_qa_validates_config_and_existing_worktree_path() -> Re
         },
     )?;
     let missing_base_error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
+        .opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Qa)
         .expect_err("qa runtime should require worktree base path");
     assert!(missing_base_error
         .to_string()
@@ -341,7 +338,7 @@ fn opencode_runtime_start_qa_validates_config_and_existing_worktree_path() -> Re
         },
     )?;
     let trust_error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
+        .opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Qa)
         .expect_err("qa runtime should reject untrusted hooks");
     assert!(trust_error
         .to_string()
@@ -361,7 +358,7 @@ fn opencode_runtime_start_qa_validates_config_and_existing_worktree_path() -> Re
     )?;
     fs::create_dir_all(worktree_base.join("qa-task-1"))?;
     let existing_path_error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
+        .opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Qa)
         .expect_err("existing qa worktree should fail");
     assert!(existing_path_error
         .to_string()
@@ -408,7 +405,7 @@ fn opencode_runtime_start_surfaces_qa_pre_start_cleanup_failure() -> Result<()> 
     )?;
 
     let error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
+        .opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Qa)
         .expect_err("cleanup failure should be surfaced when pre-start hook fails");
     let message = error.to_string();
     assert!(message.contains("QA pre-start hook failed"));
@@ -457,7 +454,7 @@ fn opencode_runtime_start_surfaces_cleanup_failure_after_startup_error() -> Resu
     )?;
 
     let error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
+        .opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Qa)
         .expect_err("startup cleanup failure should be surfaced");
     let message = error.to_string();
     assert!(message.contains("OpenCode runtime failed to start for task task-1"));
@@ -491,8 +488,10 @@ fn opencode_runtime_start_reuses_existing_runtime_for_same_task_and_role() -> Re
     );
     let repo_path = repo.to_string_lossy().to_string();
 
-    let first = service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec)?;
-    let second = service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec)?;
+    let first =
+        service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)?;
+    let second =
+        service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)?;
     assert_eq!(first.runtime_id, second.runtime_id);
     assert!(service.opencode_runtime_stop(first.runtime_id.as_str())?);
     let _ = fs::remove_dir_all(root);
@@ -526,9 +525,13 @@ fn opencode_runtime_start_deduplicates_concurrent_same_task_and_role() -> Result
 
     let (first, second) = thread::scope(|scope| {
         let first_start =
-            scope.spawn(|| service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec));
+            scope.spawn(|| {
+                service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)
+            });
         let second_start =
-            scope.spawn(|| service.opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Spec));
+            scope.spawn(|| {
+                service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)
+            });
         (
             first_start
                 .join()
@@ -680,7 +683,7 @@ fn opencode_runtime_start_cleans_up_qa_worktree_when_tracking_fails() -> Result<
     assert!(poison_handle.join().is_err());
 
     let error = service
-        .opencode_runtime_start(repo_path.as_str(), "task-1", RuntimeRole::Qa)
+        .opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Qa)
         .expect_err("qa runtime start should fail when tracked process lock is poisoned");
     assert!(error
         .to_string()

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
     GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
-    TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    RuntimeRole, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -89,7 +89,7 @@ fn shutdown_reports_runtime_cleanup_errors_and_drains_state() -> Result<()> {
                     runtime_id,
                     repo_path: "/tmp/repo".to_string(),
                     task_id: "task-1".to_string(),
-                    role: "qa".to_string(),
+                    role: RuntimeRole::Qa,
                     working_directory: "/tmp/worktree".to_string(),
                     port: 1,
                     started_at: "2026-02-20T12:00:00Z".to_string(),
@@ -226,7 +226,7 @@ fn shutdown_drains_runs_and_runtimes_when_pending_opencode_cleanup_fails() -> Re
                     runtime_id: "runtime-shutdown-registry-error".to_string(),
                     repo_path: "/tmp/repo".to_string(),
                     task_id: "task-1".to_string(),
-                    role: "spec".to_string(),
+                    role: RuntimeRole::Spec,
                     working_directory: "/tmp/repo".to_string(),
                     port: 1,
                     started_at: "2026-02-20T12:00:00Z".to_string(),

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -16,7 +16,7 @@ pub use git::{
     GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind,
     GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSnapshot, GitWorktreeSummary,
 };
-pub use runtime::{AgentRuntimeSummary, RunEvent, RunState, RunSummary};
+pub use runtime::{AgentRuntimeSummary, RunEvent, RunState, RunSummary, RuntimeRole};
 pub use store::TaskStore;
 pub use system::{BeadsCheck, RuntimeCheck, SystemCheck, WorkspaceRecord};
 pub use task::{
@@ -98,9 +98,9 @@ mod tests {
             GitWorktreeStatusData,
             GitWorktreeStatusSnapshot, GitWorktreeSummary, IssueType, PlanSubtaskInput,
             QaReportDocument, QaVerdict, QaWorkflowVerdict, RunEvent, RunState, RunSummary,
-            RuntimeCheck, SpecDocument, SystemCheck, TaskAction, TaskCard, TaskDocumentPresence,
-            TaskDocumentSummary, TaskMetadata, TaskQaDocumentPresence, TaskStatus, TaskStore,
-            UpdateTaskPatch, WorkspaceRecord,
+            RuntimeCheck, RuntimeRole, SpecDocument, SystemCheck, TaskAction, TaskCard,
+            TaskDocumentPresence, TaskDocumentSummary, TaskMetadata, TaskQaDocumentPresence,
+            TaskStatus, TaskStore, UpdateTaskPatch, WorkspaceRecord,
         };
 
         macro_rules! check_types_exported {
@@ -143,6 +143,7 @@ mod tests {
             RunState,
             RunSummary,
             RuntimeCheck,
+            RuntimeRole,
             SpecDocument,
             SystemCheck,
             TaskAction,

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -16,7 +16,9 @@ pub use git::{
     GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind,
     GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSnapshot, GitWorktreeSummary,
 };
-pub use runtime::{AgentRuntimeSummary, RunEvent, RunState, RunSummary, RuntimeRole};
+pub use runtime::{
+    AgentRuntimeRole, AgentRuntimeSummary, RunEvent, RunState, RunSummary, RuntimeRole,
+};
 pub use store::TaskStore;
 pub use system::{BeadsCheck, RuntimeCheck, SystemCheck, WorkspaceRecord};
 pub use task::{
@@ -90,7 +92,7 @@ mod tests {
     #[test]
     fn public_api_exports_compile() {
         use super::{
-            AgentRuntimeSummary, AgentSessionDocument, AgentSessionModelSelection,
+            AgentRuntimeRole, AgentRuntimeSummary, AgentSessionDocument, AgentSessionModelSelection,
             AgentWorkflowState, AgentWorkflows, BeadsCheck, CreateTaskInput, GitBranch,
             GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitPort,
             GitPullRequest, GitPullResult, GitPushSummary, GitRebaseBranchRequest,
@@ -98,9 +100,7 @@ mod tests {
             GitWorktreeStatusData,
             GitWorktreeStatusSnapshot, GitWorktreeSummary, IssueType, PlanSubtaskInput,
             QaReportDocument, QaVerdict, QaWorkflowVerdict, RunEvent, RunState, RunSummary,
-            RuntimeCheck, RuntimeRole, SpecDocument, SystemCheck, TaskAction, TaskCard,
-            TaskDocumentPresence, TaskDocumentSummary, TaskMetadata, TaskQaDocumentPresence,
-            TaskStatus, TaskStore, UpdateTaskPatch, WorkspaceRecord,
+            RuntimeCheck, RuntimeRole, SpecDocument, SystemCheck, TaskAction, TaskCard, TaskDocumentPresence, TaskDocumentSummary, TaskMetadata, TaskQaDocumentPresence, TaskStatus, TaskStore, UpdateTaskPatch, WorkspaceRecord,
         };
 
         macro_rules! check_types_exported {
@@ -118,6 +118,7 @@ mod tests {
             AgentWorkflowState,
             AgentWorkflows,
             BeadsCheck,
+            AgentRuntimeRole,
             CreateTaskInput,
             GitBranch,
             GitCommitAllRequest,

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -10,6 +11,32 @@ pub enum RunState {
     Completed,
     Failed,
     Stopped,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeRole {
+    Workspace,
+    Spec,
+    Planner,
+    Qa,
+}
+
+impl RuntimeRole {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Workspace => "workspace",
+            Self::Spec => "spec",
+            Self::Planner => "planner",
+            Self::Qa => "qa",
+        }
+    }
+}
+
+impl fmt::Display for RuntimeRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -32,7 +59,7 @@ pub struct AgentRuntimeSummary {
     pub runtime_id: String,
     pub repo_path: String,
     pub task_id: String,
-    pub role: String,
+    pub role: RuntimeRole,
     pub working_directory: String,
     pub port: u16,
     pub started_at: String,

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
@@ -39,6 +39,40 @@ impl fmt::Display for RuntimeRole {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRuntimeRole {
+    Spec,
+    Planner,
+    Qa,
+}
+
+impl AgentRuntimeRole {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Spec => "spec",
+            Self::Planner => "planner",
+            Self::Qa => "qa",
+        }
+    }
+}
+
+impl fmt::Display for AgentRuntimeRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<AgentRuntimeRole> for RuntimeRole {
+    fn from(value: AgentRuntimeRole) -> Self {
+        match value {
+            AgentRuntimeRole::Spec => Self::Spec,
+            AgentRuntimeRole::Planner => Self::Planner,
+            AgentRuntimeRole::Qa => Self::Qa,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunSummary {

--- a/apps/desktop/src-tauri/src/commands/runtime.rs
+++ b/apps/desktop/src-tauri/src/commands/runtime.rs
@@ -1,5 +1,5 @@
 use crate::{as_error, extend_runtime_errors_with_startup, run_service_blocking, AppState};
-use host_domain::{AgentRuntimeSummary, BeadsCheck, RuntimeCheck, SystemCheck};
+use host_domain::{AgentRuntimeSummary, BeadsCheck, RuntimeCheck, RuntimeRole, SystemCheck};
 use tauri::State;
 
 #[tauri::command]
@@ -47,11 +47,11 @@ pub async fn opencode_runtime_start(
     state: State<'_, AppState>,
     repo_path: String,
     task_id: String,
-    role: String,
+    role: RuntimeRole,
 ) -> Result<AgentRuntimeSummary, String> {
     let service = state.service.clone();
     let result = run_service_blocking("opencode_runtime_start", move || {
-        service.opencode_runtime_start(&repo_path, &task_id, &role)
+        service.opencode_runtime_start(&repo_path, &task_id, role)
     })
     .await;
     as_error(result)

--- a/apps/desktop/src-tauri/src/commands/runtime.rs
+++ b/apps/desktop/src-tauri/src/commands/runtime.rs
@@ -1,5 +1,5 @@
 use crate::{as_error, extend_runtime_errors_with_startup, run_service_blocking, AppState};
-use host_domain::{AgentRuntimeSummary, BeadsCheck, RuntimeCheck, RuntimeRole, SystemCheck};
+use host_domain::{AgentRuntimeRole, AgentRuntimeSummary, BeadsCheck, RuntimeCheck, SystemCheck};
 use tauri::State;
 
 #[tauri::command]
@@ -47,7 +47,7 @@ pub async fn opencode_runtime_start(
     state: State<'_, AppState>,
     repo_path: String,
     task_id: String,
-    role: RuntimeRole,
+    role: AgentRuntimeRole,
 ) -> Result<AgentRuntimeSummary, String> {
     let service = state.service.clone();
     let result = run_service_blocking("opencode_runtime_start", move || {
@@ -81,4 +81,49 @@ pub async fn opencode_repo_runtime_ensure(
     })
     .await;
     as_error(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AgentRuntimeRole;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct OpencodeRuntimeStartPayload {
+        repo_path: String,
+        task_id: String,
+        role: AgentRuntimeRole,
+    }
+
+    #[test]
+    fn opencode_runtime_start_payload_accepts_spec_role() {
+        let payload = json!({
+            "repoPath": "/repo",
+            "taskId": "task-1",
+            "role": "spec",
+        });
+        let parsed: OpencodeRuntimeStartPayload =
+            serde_json::from_value(payload).expect("payload should deserialize");
+        assert_eq!(parsed.repo_path, "/repo");
+        assert_eq!(parsed.task_id, "task-1");
+        assert_eq!(parsed.role, AgentRuntimeRole::Spec);
+    }
+
+    #[test]
+    fn opencode_runtime_start_payload_rejects_workspace_role() {
+        let payload = json!({
+            "repoPath": "/repo",
+            "taskId": "task-1",
+            "role": "workspace",
+        });
+        let error = serde_json::from_value::<OpencodeRuntimeStartPayload>(payload)
+            .expect_err("workspace role should be rejected at command boundary");
+        let message = error.to_string();
+        assert!(message.contains("unknown variant `workspace`"));
+        assert!(message.contains("spec"));
+        assert!(message.contains("planner"));
+        assert!(message.contains("qa"));
+    }
 }

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import type { AgentRuntimeSummary } from "@openducktor/contracts";
 import { buildDiagnosticsPanelModel } from "./diagnostics-panel-model";
 
-const runtimeSummary = {
+const runtimeSummary: AgentRuntimeSummary = {
   runtimeId: "runtime-1",
   repoPath: "/repo",
   taskId: "repo-main",

--- a/apps/desktop/src/state/operations/opencode-catalog.test.ts
+++ b/apps/desktop/src/state/operations/opencode-catalog.test.ts
@@ -9,7 +9,7 @@ const runtimeFixture: RuntimeSummary = {
   runtimeId: "runtime-1",
   repoPath: "/tmp/repo",
   taskId: "task-1",
-  role: "build",
+  role: "workspace",
   workingDirectory: "/tmp/repo/worktree",
   port: 4444,
   startedAt: "2026-02-22T08:00:00.000Z",

--- a/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
@@ -214,7 +214,7 @@ describe("use-workspace-operations", () => {
       runtimeId: string;
       repoPath: string;
       taskId: string;
-      role: "build";
+      role: "workspace";
       workingDirectory: string;
       port: number;
       startedAt: string;
@@ -224,7 +224,7 @@ describe("use-workspace-operations", () => {
       runtimeId: "runtime-1",
       repoPath: "/repo-a",
       taskId: "task-1",
-      role: "build",
+      role: "workspace",
       workingDirectory: "/tmp/repo-a",
       port: 3030,
       startedAt: "2026-02-22T08:00:00.000Z",

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -1,4 +1,5 @@
 import {
+  type AgentRuntimeStartRole,
   type AgentRuntimeSummary,
   agentRuntimeSummarySchema,
   type BeadsCheck,
@@ -15,7 +16,7 @@ import {
 import type { InvokeFn } from "./invoke-utils";
 import { parseArray } from "./invoke-utils";
 
-export type RuntimeRole = "spec" | "planner" | "qa";
+export type RuntimeRole = AgentRuntimeStartRole;
 export type BuildRespondAction = "approve" | "deny" | "message";
 export type BuildCleanupMode = "success" | "failure";
 

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import type {
   AgentModelDefault,
   AgentRole,
+  AgentRuntimeStartRole,
   AgentRuntimeSummary,
+  AgentRuntimeSummaryRole,
   AgentScenario,
   AgentSessionModelSelection,
   AgentSessionRecord,
@@ -67,7 +69,9 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "agentModelDefaultSchema",
   "agentToolNameSchema",
   "agentToolNameValues",
+  "agentRuntimeStartRoleSchema",
   "agentRuntimeSummarySchema",
+  "agentRuntimeSummaryRoleSchema",
   "agentSessionModelSelectionSchema",
   "agentSessionRecordSchema",
   "agentSessionRoleSchema",
@@ -125,7 +129,9 @@ type ExportedTypeContract = {
   AgentRole: AgentRole;
   AgentModelDefault: AgentModelDefault;
   AgentScenario: AgentScenario;
+  AgentRuntimeStartRole: AgentRuntimeStartRole;
   AgentRuntimeSummary: AgentRuntimeSummary;
+  AgentRuntimeSummaryRole: AgentRuntimeSummaryRole;
   AgentSessionModelSelection: AgentSessionModelSelection;
   AgentSessionTodoPayloadRecord: AgentSessionTodoPayloadRecord;
   AgentSessionRecord: AgentSessionRecord;

--- a/packages/contracts/src/run-schemas.ts
+++ b/packages/contracts/src/run-schemas.ts
@@ -52,13 +52,17 @@ export const runSummarySchema = z.object({
 });
 export type RunSummary = z.infer<typeof runSummarySchema>;
 
-const agentRuntimeRoleSchema = z.enum(["workspace", "spec", "planner", "qa"]);
+export const agentRuntimeSummaryRoleSchema = z.enum(["workspace", "spec", "planner", "qa"]);
+export type AgentRuntimeSummaryRole = z.infer<typeof agentRuntimeSummaryRoleSchema>;
+
+export const agentRuntimeStartRoleSchema = z.enum(["spec", "planner", "qa"]);
+export type AgentRuntimeStartRole = z.infer<typeof agentRuntimeStartRoleSchema>;
 
 export const agentRuntimeSummarySchema = z.object({
   runtimeId: z.string(),
   repoPath: z.string(),
   taskId: z.string(),
-  role: agentRuntimeRoleSchema,
+  role: agentRuntimeSummaryRoleSchema,
   workingDirectory: z.string(),
   port: z.number().int().positive(),
   startedAt: z.string(),

--- a/packages/contracts/src/run-schemas.ts
+++ b/packages/contracts/src/run-schemas.ts
@@ -52,11 +52,13 @@ export const runSummarySchema = z.object({
 });
 export type RunSummary = z.infer<typeof runSummarySchema>;
 
+const agentRuntimeRoleSchema = z.enum(["workspace", "spec", "planner", "qa"]);
+
 export const agentRuntimeSummarySchema = z.object({
   runtimeId: z.string(),
   repoPath: z.string(),
   taskId: z.string(),
-  role: z.string(),
+  role: agentRuntimeRoleSchema,
   workingDirectory: z.string(),
   port: z.number().int().positive(),
   startedAt: z.string(),

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -1,6 +1,8 @@
 // @ts-expect-error
 import { describe, expect, test } from "bun:test";
 import {
+  agentRuntimeStartRoleSchema,
+  agentRuntimeSummaryRoleSchema,
   agentRuntimeSummarySchema,
   agentSessionRecordSchema,
   gitBranchSchema,
@@ -409,6 +411,12 @@ describe("runtime schemas", () => {
 
     expect(parsed.runtimeId).toBe("runtime-1");
     expect(parsed.port).toBe(4100);
+  });
+
+  test("agent runtime role schemas enforce summary vs start boundaries", () => {
+    expect(agentRuntimeSummaryRoleSchema.parse("workspace")).toBe("workspace");
+    expect(agentRuntimeStartRoleSchema.parse("spec")).toBe("spec");
+    expect(() => agentRuntimeStartRoleSchema.parse("workspace")).toThrow();
   });
 
   test("agent session record parses persisted history payload", () => {


### PR DESCRIPTION
## Summary
This PR hardens runtime role typing across host-domain, Tauri command boundaries, and TypeScript contracts by replacing stringly role handling with explicit enums/schemas.

## Problem
Runtime orchestration previously carried role values as strings and validated them at runtime. This made workflow-critical behavior easier to drift and allowed invalid values to survive too long in the call path.

## What Changed
### Rust (host-domain / host-application / Tauri)
- Added `RuntimeRole` and new task-scoped `AgentRuntimeRole` domain enums.
- Updated `AgentRuntimeSummary.role` to use typed `RuntimeRole`.
- Refactored `opencode_runtime_start` and prerequisite resolution to accept `AgentRuntimeRole` end-to-end.
- Removed string comparisons for runtime-start role branching in favor of exhaustive enum matches.
- Kept workspace runtime behavior typed via `RuntimeRole::Workspace` (summary/listing path).
- Updated Tauri `opencode_runtime_start` command to deserialize `AgentRuntimeRole` directly at the IPC boundary.
- Added command-boundary tests proving:
  - valid role payloads deserialize,
  - invalid workspace role is rejected before orchestration.

### TypeScript contracts + adapter alignment
- Introduced explicit contract schemas/types:
  - `agentRuntimeSummaryRoleSchema` (`workspace | spec | planner | qa`)
  - `agentRuntimeStartRoleSchema` (`spec | planner | qa`)
- Updated `agentRuntimeSummarySchema.role` to use the explicit summary role schema.
- Aligned `@openducktor/adapters-tauri-host` runtime-start role typing to consume the contract start-role type (removed local union drift).
- Expanded contract tests to enforce role schema boundaries and export surface.

### Tests updated
- Integration tests in runtime orchestrator suite updated to call start APIs with `AgentRuntimeRole`.
- Removed obsolete runtime test that depended on passing unsupported "workspace" through service start signature.

## Why This Is Better
- Compile-time safety for runtime-start role-gated logic.
- Eliminates stringly branching in workflow-critical orchestration.
- Makes command boundary validation explicit and early.
- Removes duplicated role unions across layers and reduces contract drift risk.

## Validation
All relevant checks passed:
- `cd apps/desktop/src-tauri && cargo test -p host-domain`
- `cd apps/desktop/src-tauri && cargo test -p host-application`
- `bun run --filter @openducktor/contracts test`
- `bun run --filter @openducktor/adapters-tauri-host test`

## Notes
- No fallback behavior was added.
- Errors remain actionable and are surfaced from the proper source layer.
