### PR TITLE
perf(tauri): collapse git worktree status fan-out and harden regressions

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -399,6 +399,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +678,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embed-resource"
@@ -1280,6 +1305,7 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "host-domain",
+ "rayon",
  "serde",
  "serde_json",
  "sha2",
@@ -2672,6 +2698,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -358,6 +358,7 @@ pub(crate) struct GitState {
     pub(crate) calls: Vec<GitCall>,
     pub(crate) branches: Vec<GitBranch>,
     pub(crate) current_branch: GitCurrentBranch,
+    pub(crate) worktree_status_data: Option<GitWorktreeStatusData>,
     pub(crate) last_push_remote: Option<String>,
     pub(crate) pull_branch_result: GitPullResult,
     pub(crate) commit_all_result: GitCommitAllResult,
@@ -517,6 +518,10 @@ impl GitPort for FakeGitPort {
             target_branch: target_branch.to_string(),
             diff_scope,
         });
+        if let Some(configured) = state.worktree_status_data.clone() {
+            return Ok(configured);
+        }
+
         let current_branch = state.current_branch.clone();
         let upstream_ahead_behind = if current_branch.name.is_some() {
             GitUpstreamAheadBehind::Tracking {
@@ -600,6 +605,7 @@ pub(crate) fn build_service_with_git_state_enforced(
         calls: Vec::new(),
         branches,
         current_branch,
+        worktree_status_data: None,
         last_push_remote: None,
         pull_branch_result: GitPullResult::UpToDate {
             output: "Already up to date.".to_string(),
@@ -650,6 +656,7 @@ pub(crate) fn build_service_with_git_state(
         calls: Vec::new(),
         branches,
         current_branch,
+        worktree_status_data: None,
         last_push_remote: None,
         pull_branch_result: GitPullResult::UpToDate {
             output: "Already up to date.".to_string(),
@@ -1065,6 +1072,7 @@ pub(crate) fn build_service_with_store(
         calls: Vec::new(),
         branches,
         current_branch,
+        worktree_status_data: None,
         last_push_remote: None,
         pull_branch_result: GitPullResult::UpToDate {
             output: "Already up to date.".to_string(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -18,11 +18,12 @@ use super::{
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, AgentWorkflows, CreateTaskInput, GitAheadBehind,
-    GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitFileDiff,
-    GitFileStatus, GitPort, GitPullRequest, GitPullResult, GitPushSummary, GitRebaseBranchRequest,
-    GitRebaseBranchResult, IssueType, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent,
-    RunState, RunSummary, SpecDocument, TaskAction, TaskCard, TaskDocumentSummary, TaskMetadata,
-    TaskStatus, TaskStore, UpdateTaskPatch,
+    GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope,
+    GitFileDiff, GitFileStatus, GitPort, GitPullRequest, GitPullResult, GitPushSummary,
+    GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatusData,
+    IssueType, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    SpecDocument, TaskAction, TaskCard, TaskDocumentSummary, TaskMetadata, TaskStatus, TaskStore,
+    UpdateTaskPatch,
 };
 use host_infra_system::{
     AppConfigStore, GlobalConfig, HookSet, OpencodeStartupReadinessConfig, RepoConfig,
@@ -345,6 +346,11 @@ pub(crate) enum GitCall {
         working_dir: Option<String>,
         target_branch: String,
     },
+    GetWorktreeStatus {
+        repo_path: String,
+        target_branch: String,
+        diff_scope: GitDiffScope,
+    },
 }
 
 #[derive(Debug)]
@@ -497,6 +503,40 @@ impl GitPort for FakeGitPort {
         _target_branch: Option<&str>,
     ) -> Result<Vec<GitFileDiff>> {
         Ok(Vec::new())
+    }
+
+    fn get_worktree_status(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+        diff_scope: GitDiffScope,
+    ) -> Result<GitWorktreeStatusData> {
+        let mut state = self.state.lock().expect("git state lock poisoned");
+        state.calls.push(GitCall::GetWorktreeStatus {
+            repo_path: repo_path.to_string_lossy().to_string(),
+            target_branch: target_branch.to_string(),
+            diff_scope,
+        });
+        let current_branch = state.current_branch.clone();
+        let upstream_ahead_behind = if current_branch.name.is_some() {
+            GitUpstreamAheadBehind::Tracking {
+                ahead: 0,
+                behind: 0,
+            }
+        } else {
+            GitUpstreamAheadBehind::Untracked { ahead: 0 }
+        };
+
+        Ok(GitWorktreeStatusData {
+            current_branch,
+            file_statuses: Vec::new(),
+            file_diffs: Vec::new(),
+            target_ahead_behind: GitAheadBehind {
+                ahead: 0,
+                behind: 0,
+            },
+            upstream_ahead_behind,
+        })
     }
 
     fn resolve_upstream_target(&self, _repo_path: &Path) -> Result<Option<String>> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
@@ -2,10 +2,12 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCommitAllRequest,
-    GitCommitAllResult, GitCurrentBranch, GitPort, GitPullRequest, GitPullResult,
-    GitRebaseBranchRequest, GitRebaseBranchResult, PlanSubtaskInput, QaReportDocument, QaVerdict,
-    RunEvent, RunState, RunSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitAheadBehind, GitBranch,
+    GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitFileDiff,
+    GitFileStatus, GitPort, GitPullRequest, GitPullResult, GitRebaseBranchRequest,
+    GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatusData, PlanSubtaskInput,
+    QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, TaskAction, TaskStatus,
+    TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -466,6 +468,67 @@ fn git_rebase_branch_forwards_trimmed_target_branch_and_can_conflict() -> Result
             target_branch: "origin/main".to_string(),
         }
     );
+
+    Ok(())
+}
+
+#[test]
+fn git_port_get_worktree_status_returns_configured_payload_from_fake_port() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-worktree-status";
+    let (service, _task_state, git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+
+    let expected = GitWorktreeStatusData {
+        current_branch: GitCurrentBranch {
+            name: Some("feature/composite".to_string()),
+            detached: false,
+        },
+        file_statuses: vec![GitFileStatus {
+            path: "src/main.rs".to_string(),
+            status: "modified".to_string(),
+            staged: false,
+        }],
+        file_diffs: vec![GitFileDiff {
+            file: "src/main.rs".to_string(),
+            diff_type: "modified".to_string(),
+            additions: 2,
+            deletions: 1,
+            diff: "@@ -1 +1 @@\n-old\n+new\n".to_string(),
+        }],
+        target_ahead_behind: GitAheadBehind {
+            ahead: 3,
+            behind: 1,
+        },
+        upstream_ahead_behind: GitUpstreamAheadBehind::Tracking {
+            ahead: 4,
+            behind: 5,
+        },
+    };
+
+    {
+        let mut state = git_state.lock().expect("git state lock poisoned");
+        state.worktree_status_data = Some(expected.clone());
+    }
+
+    let actual = service.git_port().get_worktree_status(
+        Path::new(repo_path),
+        "origin/main",
+        GitDiffScope::Target,
+    )?;
+    assert_eq!(actual, expected);
+
+    let state = git_state.lock().expect("git state lock poisoned");
+    assert!(state.calls.contains(&GitCall::GetWorktreeStatus {
+        repo_path: repo_path.to_string(),
+        target_branch: "origin/main".to_string(),
+        diff_scope: GitDiffScope::Target,
+    }));
 
     Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -117,6 +117,16 @@ pub struct GitWorktreeStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct GitWorktreeStatusData {
+    pub current_branch: GitCurrentBranch,
+    pub file_statuses: Vec<GitFileStatus>,
+    pub file_diffs: Vec<GitFileDiff>,
+    pub target_ahead_behind: GitAheadBehind,
+    pub upstream_ahead_behind: GitUpstreamAheadBehind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct GitCommitAllRequest {
     pub working_dir: Option<String>,
     pub message: String,
@@ -186,6 +196,12 @@ pub trait GitPort: Send + Sync {
     fn pull_branch(&self, repo_path: &Path, request: GitPullRequest) -> Result<GitPullResult>;
     fn get_status(&self, repo_path: &Path) -> Result<Vec<GitFileStatus>>;
     fn get_diff(&self, repo_path: &Path, target_branch: Option<&str>) -> Result<Vec<GitFileDiff>>;
+    fn get_worktree_status(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+        diff_scope: GitDiffScope,
+    ) -> Result<GitWorktreeStatusData>;
     fn resolve_upstream_target(&self, repo_path: &Path) -> Result<Option<String>>;
     fn commits_ahead_behind(&self, repo_path: &Path, target_branch: &str)
         -> Result<GitAheadBehind>;

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -14,7 +14,7 @@ pub use git::{
     GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
     GitDiffScope, GitFileDiff, GitFileStatus, GitPort, GitPullRequest, GitPullResult,
     GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind,
-    GitWorktreeStatus, GitWorktreeStatusSnapshot, GitWorktreeSummary,
+    GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSnapshot, GitWorktreeSummary,
 };
 pub use runtime::{AgentRuntimeSummary, RunEvent, RunState, RunSummary};
 pub use store::TaskStore;
@@ -95,6 +95,7 @@ mod tests {
             GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitPort,
             GitPullRequest, GitPullResult, GitPushSummary, GitRebaseBranchRequest,
             GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatus,
+            GitWorktreeStatusData,
             GitWorktreeStatusSnapshot, GitWorktreeSummary, IssueType, PlanSubtaskInput,
             QaReportDocument, QaVerdict, QaWorkflowVerdict, RunEvent, RunState, RunSummary,
             RuntimeCheck, SpecDocument, SystemCheck, TaskAction, TaskCard, TaskDocumentPresence,
@@ -130,6 +131,7 @@ mod tests {
             GitRebaseBranchResult,
             GitUpstreamAheadBehind,
             GitWorktreeStatus,
+            GitWorktreeStatusData,
             GitWorktreeStatusSnapshot,
             GitWorktreeSummary,
             IssueType,

--- a/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
@@ -11,4 +11,5 @@ serde_json = "1"
 thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
+rayon = "1"
 host-domain = { path = "../host-domain" }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/branch.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/branch.rs
@@ -30,6 +30,10 @@ impl GitCliPort {
 
     pub(super) fn get_current_branch_impl(&self, repo_path: &Path) -> Result<GitCurrentBranch> {
         self.ensure_repository(repo_path)?;
+        self.get_current_branch_unchecked(repo_path)
+    }
+
+    pub(super) fn get_current_branch_unchecked(&self, repo_path: &Path) -> Result<GitCurrentBranch> {
         let output = self.run_git(repo_path, &["branch", "--show-current"])?;
         let name = output
             .lines()

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
@@ -10,8 +10,8 @@ mod worktree;
 use anyhow::{Context, Result};
 use host_domain::{
     GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
-    GitFileDiff, GitFileStatus, GitPort, GitPullRequest, GitPullResult, GitPushSummary,
-    GitRebaseBranchRequest, GitRebaseBranchResult,
+    GitDiffScope, GitFileDiff, GitFileStatus, GitPort, GitPullRequest, GitPullResult,
+    GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult, GitWorktreeStatusData,
 };
 use std::path::Path;
 
@@ -110,6 +110,15 @@ impl GitPort for GitCliPort {
 
     fn get_diff(&self, repo_path: &Path, target_branch: Option<&str>) -> Result<Vec<GitFileDiff>> {
         self.get_diff_impl(repo_path, target_branch)
+    }
+
+    fn get_worktree_status(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+        diff_scope: GitDiffScope,
+    ) -> Result<GitWorktreeStatusData> {
+        self.get_worktree_status_impl(repo_path, target_branch, diff_scope)
     }
 
     fn resolve_upstream_target(&self, repo_path: &Path) -> Result<Option<String>> {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/remote.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/remote.rs
@@ -126,7 +126,16 @@ impl GitCliPort {
 
     pub(super) fn resolve_upstream_target_impl(&self, repo_path: &Path) -> Result<Option<String>> {
         self.ensure_repository(repo_path)?;
-        let branch = match self.get_current_branch_impl(repo_path)?.name {
+        let current_branch = self.get_current_branch_unchecked(repo_path)?;
+        self.resolve_upstream_target_for_branch_impl(repo_path, current_branch.name.as_deref())
+    }
+
+    pub(super) fn resolve_upstream_target_for_branch_impl(
+        &self,
+        repo_path: &Path,
+        branch_name: Option<&str>,
+    ) -> Result<Option<String>> {
+        let branch = match branch_name {
             Some(name) => name,
             None => return Ok(None),
         };

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -69,7 +69,12 @@ impl GitCliPort {
                 },
             )
         }))
-        .map_err(|_| anyhow!("git worktree status worker join failure"))?;
+        .map_err(|payload| {
+            anyhow!(
+                "git worktree status worker panicked: {}",
+                panic_payload_message(&*payload)
+            )
+        })?;
 
         let ((file_statuses, file_diffs), (target_ahead_behind, upstream_target_result)) = joined;
         let file_statuses = file_statuses?;
@@ -174,6 +179,14 @@ impl GitCliPort {
 
         parse_ahead_behind(&stdout)
     }
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|message| (*message).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown panic payload".to_string())
 }
 
 fn parse_status_porcelain(output: &str) -> Vec<GitFileStatus> {
@@ -363,7 +376,8 @@ fn parse_ahead_behind(output: &str) -> Result<GitAheadBehind> {
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_ahead_behind, parse_diff_git_header_token, split_diff_by_file, GitAheadBehind,
+        panic_payload_message, parse_ahead_behind, parse_diff_git_header_token, split_diff_by_file,
+        GitAheadBehind,
     };
 
     #[test]
@@ -419,6 +433,25 @@ mod tests {
                 ahead: 2,
                 behind: 4
             }
+        );
+    }
+
+    #[test]
+    fn panic_payload_message_reads_str_and_string_payloads() {
+        let str_payload: Box<dyn std::any::Any + Send> = Box::new("panic from &str");
+        assert_eq!(panic_payload_message(&*str_payload), "panic from &str");
+
+        let string_payload: Box<dyn std::any::Any + Send> =
+            Box::new("panic from String".to_string());
+        assert_eq!(panic_payload_message(&*string_payload), "panic from String");
+    }
+
+    #[test]
+    fn panic_payload_message_falls_back_for_unknown_payload_types() {
+        let unknown_payload: Box<dyn std::any::Any + Send> = Box::new(42u32);
+        assert_eq!(
+            panic_payload_message(&*unknown_payload),
+            "unknown panic payload"
         );
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -1,5 +1,8 @@
 use anyhow::{anyhow, Context, Result};
-use host_domain::{GitAheadBehind, GitFileDiff, GitFileStatus};
+use host_domain::{
+    GitAheadBehind, GitDiffScope, GitFileDiff, GitFileStatus, GitUpstreamAheadBehind,
+    GitWorktreeStatusData,
+};
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -9,8 +12,7 @@ use super::GitCliPort;
 impl GitCliPort {
     pub(super) fn get_status_impl(&self, repo_path: &Path) -> Result<Vec<GitFileStatus>> {
         self.ensure_repository(repo_path)?;
-        let output = self.run_git(repo_path, &["status", "--porcelain=v1"])?;
-        Ok(parse_status_porcelain(&output))
+        self.get_status_unchecked(repo_path)
     }
 
     pub(super) fn get_diff_impl(
@@ -19,9 +21,114 @@ impl GitCliPort {
         target_branch: Option<&str>,
     ) -> Result<Vec<GitFileDiff>> {
         self.ensure_repository(repo_path)?;
+        self.get_diff_unchecked(repo_path, target_branch)
+    }
 
+    pub(super) fn commits_ahead_behind_impl(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+    ) -> Result<GitAheadBehind> {
+        self.ensure_repository(repo_path)?;
+        self.commits_ahead_behind_unchecked(repo_path, target_branch)
+    }
+
+    pub(super) fn get_worktree_status_impl(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+        diff_scope: GitDiffScope,
+    ) -> Result<GitWorktreeStatusData> {
+        self.ensure_repository(repo_path)?;
+        let target_branch = normalize_non_empty(target_branch, "target branch")?;
+        let current_branch = self.get_current_branch_unchecked(repo_path)?;
+        let current_branch_name = current_branch.name.clone();
+        let diff_target = match diff_scope {
+            GitDiffScope::Target => Some(target_branch.as_str()),
+            GitDiffScope::Uncommitted => None,
+        };
+
+        let (file_statuses, file_diffs, target_ahead_behind, upstream_target_result) =
+            std::thread::scope(|scope| -> Result<(
+                Vec<GitFileStatus>,
+                Vec<GitFileDiff>,
+                GitAheadBehind,
+                Result<Option<String>>,
+            )> {
+                let status_worker = scope.spawn(|| self.get_status_unchecked(repo_path));
+                let diff_worker = scope.spawn(|| self.get_diff_unchecked(repo_path, diff_target));
+                let target_counts_worker = scope.spawn(|| {
+                    self.commits_ahead_behind_unchecked(repo_path, target_branch.as_str())
+                });
+                let upstream_target_worker = scope.spawn(|| {
+                    self.resolve_upstream_target_for_branch_impl(
+                        repo_path,
+                        current_branch_name.as_deref(),
+                    )
+                });
+
+                let file_statuses = status_worker
+                    .join()
+                    .map_err(|_| anyhow!("git status worker panicked"))??;
+                let file_diffs = diff_worker
+                    .join()
+                    .map_err(|_| anyhow!("git diff worker panicked"))??;
+                let target_ahead_behind = target_counts_worker
+                    .join()
+                    .map_err(|_| anyhow!("git rev-list worker panicked"))??;
+                let upstream_target_result = upstream_target_worker
+                    .join()
+                    .map_err(|_| anyhow!("git upstream worker panicked"))?;
+
+                Ok((
+                    file_statuses,
+                    file_diffs,
+                    target_ahead_behind,
+                    upstream_target_result,
+                ))
+            })?;
+
+        let upstream_ahead_behind = match upstream_target_result {
+            Ok(Some(upstream_target)) => match self
+                .commits_ahead_behind_unchecked(repo_path, upstream_target.as_str())
+            {
+                Ok(counts) => GitUpstreamAheadBehind::Tracking {
+                    ahead: counts.ahead,
+                    behind: counts.behind,
+                },
+                Err(error) => GitUpstreamAheadBehind::Error {
+                    message: format!("{error:#}"),
+                },
+            },
+            Ok(None) => GitUpstreamAheadBehind::Untracked {
+                ahead: target_ahead_behind.ahead,
+            },
+            Err(error) => GitUpstreamAheadBehind::Error {
+                message: format!("{error:#}"),
+            },
+        };
+
+        Ok(GitWorktreeStatusData {
+            current_branch,
+            file_statuses,
+            file_diffs,
+            target_ahead_behind,
+            upstream_ahead_behind,
+        })
+    }
+
+    pub(super) fn get_status_unchecked(&self, repo_path: &Path) -> Result<Vec<GitFileStatus>> {
+        let output = self.run_git(repo_path, &["status", "--porcelain=v1"])?;
+        Ok(parse_status_porcelain(&output))
+    }
+
+    pub(super) fn get_diff_unchecked(
+        &self,
+        repo_path: &Path,
+        target_branch: Option<&str>,
+    ) -> Result<Vec<GitFileDiff>> {
         let diff_spec = target_branch
-            .map(|b| b.trim().to_string())
+            .map(|value| value.trim().to_string())
             .unwrap_or_default();
         let diff_target = if diff_spec.is_empty() {
             "HEAD"
@@ -52,12 +159,11 @@ impl GitCliPort {
         Ok(build_file_diffs(&numstat_stdout, &diff_stdout))
     }
 
-    pub(super) fn commits_ahead_behind_impl(
+    pub(super) fn commits_ahead_behind_unchecked(
         &self,
         repo_path: &Path,
         target_branch: &str,
     ) -> Result<GitAheadBehind> {
-        self.ensure_repository(repo_path)?;
         let target = normalize_non_empty(target_branch, "target branch")?;
         let range = format!("{target}...HEAD");
         let (ok, stdout, stderr) = self.run_git_allow_failure(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -48,45 +48,33 @@ impl GitCliPort {
             GitDiffScope::Uncommitted => None,
         };
 
-        let (file_statuses, file_diffs, target_ahead_behind, upstream_target_result) =
-            std::thread::scope(|scope| -> Result<(
-                Vec<GitFileStatus>,
-                Vec<GitFileDiff>,
-                GitAheadBehind,
-                Result<Option<String>>,
-            )> {
-                let status_worker = scope.spawn(|| self.get_status_unchecked(repo_path));
-                let diff_worker = scope.spawn(|| self.get_diff_unchecked(repo_path, diff_target));
-                let target_counts_worker = scope.spawn(|| {
-                    self.commits_ahead_behind_unchecked(repo_path, target_branch.as_str())
-                });
-                let upstream_target_worker = scope.spawn(|| {
-                    self.resolve_upstream_target_for_branch_impl(
-                        repo_path,
-                        current_branch_name.as_deref(),
+        let joined = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            rayon::join(
+                || {
+                    rayon::join(
+                        || self.get_status_unchecked(repo_path),
+                        || self.get_diff_unchecked(repo_path, diff_target),
                     )
-                });
+                },
+                || {
+                    rayon::join(
+                        || self.commits_ahead_behind_unchecked(repo_path, target_branch.as_str()),
+                        || {
+                            self.resolve_upstream_target_for_branch_impl(
+                                repo_path,
+                                current_branch_name.as_deref(),
+                            )
+                        },
+                    )
+                },
+            )
+        }))
+        .map_err(|_| anyhow!("git worktree status worker join failure"))?;
 
-                let file_statuses = status_worker
-                    .join()
-                    .map_err(|_| anyhow!("git status worker panicked"))??;
-                let file_diffs = diff_worker
-                    .join()
-                    .map_err(|_| anyhow!("git diff worker panicked"))??;
-                let target_ahead_behind = target_counts_worker
-                    .join()
-                    .map_err(|_| anyhow!("git rev-list worker panicked"))??;
-                let upstream_target_result = upstream_target_worker
-                    .join()
-                    .map_err(|_| anyhow!("git upstream worker panicked"))?;
-
-                Ok((
-                    file_statuses,
-                    file_diffs,
-                    target_ahead_behind,
-                    upstream_target_result,
-                ))
-            })?;
+        let ((file_statuses, file_diffs), (target_ahead_behind, upstream_target_result)) = joined;
+        let file_statuses = file_statuses?;
+        let file_diffs = file_diffs?;
+        let target_ahead_behind = target_ahead_behind?;
 
         let upstream_ahead_behind = match upstream_target_result {
             Ok(Some(upstream_target)) => match self

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
@@ -3,6 +3,7 @@ use host_domain::{GitDiffScope, GitPort, GitUpstreamAheadBehind};
 use super::super::GitCliPort;
 use super::support::{git_available, run_git_ok, setup_bare_remote, setup_repo};
 use std::fs;
+use std::path::Path;
 
 #[test]
 fn get_diff_returns_error_when_target_branch_is_invalid() {
@@ -175,4 +176,109 @@ fn get_worktree_status_requires_non_empty_target_branch() {
         message.contains("target branch"),
         "error should preserve target branch context, got: {message}"
     );
+}
+
+#[test]
+fn get_worktree_status_honors_diff_scope_uncommitted_vs_target() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-diff-scope");
+    run_git_ok(&repo.path, &["switch", "-c", "feature/diff-scope"]);
+
+    fs::write(repo.path.join("committed_only.txt"), "committed\n")
+        .expect("committed file should write");
+    run_git_ok(&repo.path, &["add", "committed_only.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "add committed-only file"]);
+
+    fs::write(
+        repo.path.join("README.md"),
+        "# OpenDucktor\ntracked-uncommitted-change\n",
+    )
+    .expect("tracked uncommitted file should write");
+
+    let git = GitCliPort::new();
+    let target_scope = git
+        .get_worktree_status(&repo.path, "main", GitDiffScope::Target)
+        .expect("target scope should resolve");
+    let uncommitted_scope = git
+        .get_worktree_status(&repo.path, "main", GitDiffScope::Uncommitted)
+        .expect("uncommitted scope should resolve");
+
+    assert!(
+        target_scope
+            .file_diffs
+            .iter()
+            .any(|diff| diff.file == "committed_only.txt"),
+        "target scope should include committed changes against main"
+    );
+    assert!(
+        target_scope
+            .file_diffs
+            .iter()
+            .any(|diff| diff.file == "README.md"),
+        "target scope should include tracked uncommitted working tree changes"
+    );
+    assert!(
+        uncommitted_scope
+            .file_diffs
+            .iter()
+            .any(|diff| diff.file == "README.md"),
+        "uncommitted scope should include tracked working tree changes"
+    );
+    assert!(
+        !uncommitted_scope
+            .file_diffs
+            .iter()
+            .any(|diff| diff.file == "committed_only.txt"),
+        "uncommitted scope should exclude already committed feature-only changes"
+    );
+}
+
+#[test]
+fn get_worktree_status_surfaces_non_fatal_upstream_count_error() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-upstream-error");
+    let remote = setup_bare_remote("worktree-status-upstream-error-remote");
+    let remote_path = remote.path.to_string_lossy().to_string();
+    run_git_ok(
+        &repo.path,
+        &["remote", "add", "origin", remote_path.as_str()],
+    );
+    run_git_ok(&repo.path, &["push", "-u", "origin", "main"]);
+
+    let git_dir = run_git_ok(&repo.path, &["rev-parse", "--git-dir"]);
+    let git_dir_path = Path::new(git_dir.as_str());
+    let git_dir_abs = if git_dir_path.is_absolute() {
+        git_dir_path.to_path_buf()
+    } else {
+        repo.path.join(git_dir_path)
+    };
+    let broken_upstream_ref = git_dir_abs.join("refs/remotes/origin/main");
+    if let Some(parent) = broken_upstream_ref.parent() {
+        fs::create_dir_all(parent).expect("upstream ref parent directory should exist");
+    }
+
+    let blob_oid = run_git_ok(&repo.path, &["hash-object", "-w", "README.md"]);
+    fs::write(&broken_upstream_ref, format!("{blob_oid}\n"))
+        .expect("upstream ref should be overwritten with blob oid");
+
+    let git = GitCliPort::new();
+    let status = git
+        .get_worktree_status(&repo.path, "main", GitDiffScope::Target)
+        .expect("worktree status should stay non-fatal when upstream count fails");
+
+    match status.upstream_ahead_behind {
+        GitUpstreamAheadBehind::Error { message } => {
+            assert!(
+                message.contains("git rev-list --count --left-right"),
+                "upstream count error should preserve actionable command context, got: {message}"
+            );
+        }
+        other => panic!("expected upstream error outcome, got: {other:?}"),
+    }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
@@ -1,4 +1,4 @@
-use host_domain::GitPort;
+use host_domain::{GitDiffScope, GitPort, GitUpstreamAheadBehind};
 
 use super::super::GitCliPort;
 use super::support::{git_available, run_git_ok, setup_bare_remote, setup_repo};
@@ -102,5 +102,77 @@ fn get_diff_rejects_option_like_target_and_does_not_write_output_file() {
     assert!(
         !output_path.exists(),
         "option-like target must not create an output file"
+    );
+}
+
+#[test]
+fn get_worktree_status_returns_tracking_counts_when_upstream_exists() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-tracking");
+    let remote = setup_bare_remote("worktree-status-tracking-remote");
+    let remote_path = remote.path.to_string_lossy().to_string();
+    run_git_ok(
+        &repo.path,
+        &["remote", "add", "origin", remote_path.as_str()],
+    );
+    run_git_ok(&repo.path, &["push", "-u", "origin", "main"]);
+
+    fs::write(repo.path.join("tracking.txt"), "ahead\n").expect("tracking file should write");
+    run_git_ok(&repo.path, &["add", "tracking.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "ahead of origin"]);
+
+    let git = GitCliPort::new();
+    let status = git
+        .get_worktree_status(&repo.path, "origin/main", GitDiffScope::Target)
+        .expect("composite worktree status should resolve");
+
+    assert_eq!(status.current_branch.name.as_deref(), Some("main"));
+    assert_eq!(status.target_ahead_behind.ahead, 1);
+    assert_eq!(status.target_ahead_behind.behind, 0);
+    assert_eq!(
+        status.upstream_ahead_behind,
+        GitUpstreamAheadBehind::Tracking {
+            ahead: 1,
+            behind: 0,
+        }
+    );
+}
+
+#[test]
+fn get_worktree_status_reports_untracked_when_upstream_is_missing() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-untracked");
+    let git = GitCliPort::new();
+    let status = git
+        .get_worktree_status(&repo.path, "main", GitDiffScope::Target)
+        .expect("composite worktree status should resolve");
+
+    assert_eq!(
+        status.upstream_ahead_behind,
+        GitUpstreamAheadBehind::Untracked { ahead: 0 }
+    );
+}
+
+#[test]
+fn get_worktree_status_requires_non_empty_target_branch() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-empty-target");
+    let git = GitCliPort::new();
+    let error = git
+        .get_worktree_status(&repo.path, "   ", GitDiffScope::Target)
+        .expect_err("empty target branch should return error");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("target branch"),
+        "error should preserve target branch context, got: {message}"
     );
 }

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -253,56 +253,22 @@ pub async fn git_get_worktree_status(
         .map_err(|e| e.to_string())?;
     let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
     let repo = Path::new(&effective);
-
-    let current_branch = as_error(state.service.git_port().get_current_branch(repo))?;
-    let file_statuses = as_error(state.service.git_port().get_status(repo))?;
-    let file_diffs = as_error(state.service.git_port().get_diff(
+    let worktree_status = as_error(state.service.git_port().get_worktree_status(
         repo,
-        match &scope {
-            host_domain::GitDiffScope::Target => Some(trimmed_target),
-            host_domain::GitDiffScope::Uncommitted => None,
-        },
+        trimmed_target,
+        scope.clone(),
     ))?;
-    let target_ahead_behind = as_error(
-        state
-            .service
-            .git_port()
-            .commits_ahead_behind(repo, trimmed_target),
-    )?;
-    let upstream_ahead_behind = match state.service.git_port().resolve_upstream_target(repo) {
-        Ok(Some(upstream_target)) => {
-            match state
-                .service
-                .git_port()
-                .commits_ahead_behind(repo, upstream_target.as_str())
-            {
-                Ok(counts) => host_domain::GitUpstreamAheadBehind::Tracking {
-                    ahead: counts.ahead,
-                    behind: counts.behind,
-                },
-                Err(error) => host_domain::GitUpstreamAheadBehind::Error {
-                    message: format!("{error:#}"),
-                },
-            }
-        }
-        Ok(None) => host_domain::GitUpstreamAheadBehind::Untracked {
-            ahead: target_ahead_behind.ahead,
-        },
-        Err(error) => host_domain::GitUpstreamAheadBehind::Error {
-            message: format!("{error:#}"),
-        },
-    };
     let observed_at_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64;
 
     Ok(host_domain::GitWorktreeStatus {
-        current_branch,
-        file_statuses,
-        file_diffs,
-        target_ahead_behind,
-        upstream_ahead_behind,
+        current_branch: worktree_status.current_branch,
+        file_statuses: worktree_status.file_statuses,
+        file_diffs: worktree_status.file_diffs,
+        target_ahead_behind: worktree_status.target_ahead_behind,
+        upstream_ahead_behind: worktree_status.upstream_ahead_behind,
         snapshot: host_domain::GitWorktreeStatusSnapshot {
             effective_working_dir: effective,
             target_branch: trimmed_target.to_string(),

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -80,6 +80,36 @@ fn parse_diff_scope(diff_scope: Option<&str>) -> Result<host_domain::GitDiffScop
     }
 }
 
+fn require_target_branch(target_branch: &str) -> Result<&str, String> {
+    let trimmed_target = target_branch.trim();
+    if trimmed_target.is_empty() {
+        return Err("targetBranch is required".to_string());
+    }
+    Ok(trimmed_target)
+}
+
+fn build_worktree_status_with_snapshot(
+    status_data: host_domain::GitWorktreeStatusData,
+    effective_working_dir: String,
+    target_branch: String,
+    diff_scope: host_domain::GitDiffScope,
+    observed_at_ms: u64,
+) -> host_domain::GitWorktreeStatus {
+    host_domain::GitWorktreeStatus {
+        current_branch: status_data.current_branch,
+        file_statuses: status_data.file_statuses,
+        file_diffs: status_data.file_diffs,
+        target_ahead_behind: status_data.target_ahead_behind,
+        upstream_ahead_behind: status_data.upstream_ahead_behind,
+        snapshot: host_domain::GitWorktreeStatusSnapshot {
+            effective_working_dir,
+            target_branch,
+            diff_scope,
+            observed_at_ms,
+        },
+    }
+}
+
 #[tauri::command]
 pub async fn git_get_branches(
     state: State<'_, AppState>,
@@ -241,10 +271,7 @@ pub async fn git_get_worktree_status(
     diff_scope: Option<String>,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitWorktreeStatus, String> {
-    let trimmed_target = target_branch.trim();
-    if trimmed_target.is_empty() {
-        return Err("targetBranch is required".to_string());
-    }
+    let trimmed_target = require_target_branch(&target_branch)?;
     let scope = parse_diff_scope(diff_scope.as_deref())?;
 
     let _ = state
@@ -263,19 +290,13 @@ pub async fn git_get_worktree_status(
         .unwrap_or_default()
         .as_millis() as u64;
 
-    Ok(host_domain::GitWorktreeStatus {
-        current_branch: worktree_status.current_branch,
-        file_statuses: worktree_status.file_statuses,
-        file_diffs: worktree_status.file_diffs,
-        target_ahead_behind: worktree_status.target_ahead_behind,
-        upstream_ahead_behind: worktree_status.upstream_ahead_behind,
-        snapshot: host_domain::GitWorktreeStatusSnapshot {
-            effective_working_dir: effective,
-            target_branch: trimmed_target.to_string(),
-            diff_scope: scope,
-            observed_at_ms,
-        },
-    })
+    Ok(build_worktree_status_with_snapshot(
+        worktree_status,
+        effective,
+        trimmed_target.to_string(),
+        scope,
+        observed_at_ms,
+    ))
 }
 
 #[tauri::command]
@@ -352,7 +373,14 @@ pub async fn git_rebase_branch(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_working_dir;
+    use super::{
+        build_worktree_status_with_snapshot, parse_diff_scope, require_target_branch,
+        resolve_working_dir,
+    };
+    use host_domain::{
+        GitAheadBehind, GitCurrentBranch, GitDiffScope, GitFileDiff, GitFileStatus,
+        GitUpstreamAheadBehind, GitWorktreeStatusData,
+    };
     use std::{
         env, fs,
         path::{Path, PathBuf},
@@ -470,5 +498,87 @@ mod tests {
         );
 
         fs::remove_dir_all(&root).expect("failed to remove test directory");
+    }
+
+    #[test]
+    fn require_target_branch_rejects_blank_values() {
+        let error = require_target_branch("   ")
+            .expect_err("blank target branch should be rejected at command boundary");
+        assert_eq!(error, "targetBranch is required");
+    }
+
+    #[test]
+    fn parse_diff_scope_accepts_uncommitted_and_rejects_unknown_values() {
+        assert_eq!(
+            parse_diff_scope(Some("uncommitted")).expect("uncommitted scope should parse"),
+            GitDiffScope::Uncommitted
+        );
+
+        let error = parse_diff_scope(Some("staged"))
+            .expect_err("unknown diff scope should be rejected at command boundary");
+        assert!(
+            error.contains("diffScope must be either 'target' or 'uncommitted'"),
+            "unexpected scope parse error: {error}"
+        );
+    }
+
+    #[test]
+    fn build_worktree_status_with_snapshot_preserves_payload_and_snapshot_fields() {
+        let status_data = GitWorktreeStatusData {
+            current_branch: GitCurrentBranch {
+                name: Some("feature/snapshot".to_string()),
+                detached: false,
+            },
+            file_statuses: vec![GitFileStatus {
+                path: "src/main.rs".to_string(),
+                status: "modified".to_string(),
+                staged: false,
+            }],
+            file_diffs: vec![GitFileDiff {
+                file: "src/main.rs".to_string(),
+                diff_type: "modified".to_string(),
+                additions: 3,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n".to_string(),
+            }],
+            target_ahead_behind: GitAheadBehind {
+                ahead: 2,
+                behind: 0,
+            },
+            upstream_ahead_behind: GitUpstreamAheadBehind::Tracking {
+                ahead: 1,
+                behind: 4,
+            },
+        };
+
+        let built = build_worktree_status_with_snapshot(
+            status_data,
+            "/tmp/openducktor-worktree".to_string(),
+            "origin/main".to_string(),
+            GitDiffScope::Target,
+            42,
+        );
+
+        assert_eq!(
+            built.current_branch.name.as_deref(),
+            Some("feature/snapshot")
+        );
+        assert_eq!(built.file_statuses.len(), 1);
+        assert_eq!(built.file_diffs.len(), 1);
+        assert_eq!(built.target_ahead_behind.ahead, 2);
+        assert_eq!(
+            built.upstream_ahead_behind,
+            GitUpstreamAheadBehind::Tracking {
+                ahead: 1,
+                behind: 4
+            }
+        );
+        assert_eq!(
+            built.snapshot.effective_working_dir,
+            "/tmp/openducktor-worktree"
+        );
+        assert_eq!(built.snapshot.target_branch, "origin/main");
+        assert_eq!(built.snapshot.diff_scope, GitDiffScope::Target);
+        assert_eq!(built.snapshot.observed_at_ms, 42);
     }
 }


### PR DESCRIPTION
## Summary
This PR reduces the runtime overhead of `git_get_worktree_status` and hardens regression coverage around the new composite path.

- Refactors `git_get_worktree_status` to call a single composite `GitPort::get_worktree_status(...)` API.
- Introduces `GitWorktreeStatusData` in `host-domain` to carry composite results without snapshot metadata.
- Moves orchestration into `host-infra-system` so repository validation happens once per request.
- Reuses already-resolved branch state for upstream target lookup to avoid redundant git work.
- Executes independent read operations in bounded parallelism (Rayon `join`) instead of per-request thread fan-out.
- Preserves explicit and actionable error propagation; upstream count failures remain non-fatal and are surfaced as `GitUpstreamAheadBehind::Error`.

## Problem
Before this refactor, each worktree status refresh orchestrated several separate `GitPort` calls. Each call re-validated the repository and spawned additional git subprocesses, causing avoidable latency and CPU overhead during frequent polling.

## Implementation Details
### Domain/API
- Added `GitWorktreeStatusData` and `GitPort::get_worktree_status(...)`:
  - `apps/desktop/src-tauri/crates/host-domain/src/git.rs`
  - `apps/desktop/src-tauri/crates/host-domain/src/lib.rs`

### Tauri command path
- `git_get_worktree_status` now delegates to the composite port call and assembles snapshot metadata once:
  - `apps/desktop/src-tauri/src/commands/git.rs`

### Infra git adapter
- Added composite implementation in `GitCliPort`:
  - single `ensure_repository` call per composite request
  - shared `*_unchecked` helpers for internal reuse
  - branch/upstream reuse via `resolve_upstream_target_for_branch_impl`
  - bounded parallel execution with Rayon joins
- Files:
  - `apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs`
  - `apps/desktop/src-tauri/crates/host-infra-system/src/git/branch.rs`
  - `apps/desktop/src-tauri/crates/host-infra-system/src/git/remote.rs`
  - `apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs`

### Test hardening
- Added composite status coverage for:
  - `Target` vs `Uncommitted` diff scope semantics
  - non-fatal upstream-count error mapping
  - empty target branch validation
- Added command-module tests for:
  - `targetBranch` boundary validation
  - `diffScope` parsing
  - snapshot assembly correctness
- Improved `FakeGitPort` to support configurable composite status payloads and added integration assertion.
- Files:
  - `apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs`
  - `apps/desktop/src-tauri/src/commands/git.rs`
  - `apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs`
  - `apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs`

### Dependency
- Added `rayon` in `host-infra-system`:
  - `apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml`
  - `apps/desktop/src-tauri/Cargo.lock`

## Validation
Executed:

```sh
cd apps/desktop/src-tauri && cargo test -p host-infra-system
cd apps/desktop/src-tauri && cargo test -p host-application
cd apps/desktop/src-tauri && cargo test -p openducktor-desktop
cd apps/desktop/src-tauri && cargo check
```

All passed.

## Commits
- `eab3b65` perf(tauri): collapse git worktree status subprocess fan-out
- `b65648d` test(tauri): harden git worktree status regressions
