### PR TITLE
perf(agent-studio): short-circuit diff polling equality with snapshot hashes

### DIFF
--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -94,6 +94,9 @@ pub struct GitWorktreeStatusSnapshot {
     pub target_branch: String,
     pub diff_scope: GitDiffScope,
     pub observed_at_ms: u64,
+    pub hash_version: u32,
+    pub status_hash: String,
+    pub diff_hash: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -148,7 +148,6 @@ fn hash_optional_str(hasher: &mut Fnv1a64Hasher, value: Option<&str>) {
         }
     }
 }
-
 fn hash_upstream_ahead_behind(
     hasher: &mut Fnv1a64Hasher,
     upstream_ahead_behind: &host_domain::GitUpstreamAheadBehind,

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -210,8 +210,7 @@ fn hash_worktree_diff_payload(file_diffs: &[host_domain::GitFileDiff]) -> String
     hasher.finish_hex()
 }
 
-fn build_worktree_status_with_snapshot(
-    status_data: host_domain::GitWorktreeStatusData,
+struct WorktreeSnapshotMetadata {
     effective_working_dir: String,
     target_branch: String,
     diff_scope: host_domain::GitDiffScope,
@@ -219,6 +218,11 @@ fn build_worktree_status_with_snapshot(
     hash_version: u32,
     status_hash: String,
     diff_hash: String,
+}
+
+fn build_worktree_status_with_snapshot(
+    status_data: host_domain::GitWorktreeStatusData,
+    snapshot_metadata: WorktreeSnapshotMetadata,
 ) -> host_domain::GitWorktreeStatus {
     host_domain::GitWorktreeStatus {
         current_branch: status_data.current_branch,
@@ -227,13 +231,13 @@ fn build_worktree_status_with_snapshot(
         target_ahead_behind: status_data.target_ahead_behind,
         upstream_ahead_behind: status_data.upstream_ahead_behind,
         snapshot: host_domain::GitWorktreeStatusSnapshot {
-            effective_working_dir,
-            target_branch,
-            diff_scope,
-            observed_at_ms,
-            hash_version,
-            status_hash,
-            diff_hash,
+            effective_working_dir: snapshot_metadata.effective_working_dir,
+            target_branch: snapshot_metadata.target_branch,
+            diff_scope: snapshot_metadata.diff_scope,
+            observed_at_ms: snapshot_metadata.observed_at_ms,
+            hash_version: snapshot_metadata.hash_version,
+            status_hash: snapshot_metadata.status_hash,
+            diff_hash: snapshot_metadata.diff_hash,
         },
     }
 }
@@ -427,13 +431,15 @@ pub async fn git_get_worktree_status(
 
     Ok(build_worktree_status_with_snapshot(
         worktree_status,
-        effective,
-        trimmed_target.to_string(),
-        scope,
-        observed_at_ms,
-        GIT_WORKTREE_HASH_VERSION,
-        status_hash,
-        diff_hash,
+        WorktreeSnapshotMetadata {
+            effective_working_dir: effective,
+            target_branch: trimmed_target.to_string(),
+            diff_scope: scope,
+            observed_at_ms,
+            hash_version: GIT_WORKTREE_HASH_VERSION,
+            status_hash,
+            diff_hash,
+        },
     ))
 }
 
@@ -514,7 +520,7 @@ mod tests {
     use super::{
         build_worktree_status_with_snapshot, parse_diff_scope, require_target_branch,
         hash_worktree_diff_payload, hash_worktree_status_payload, resolve_working_dir,
-        GIT_WORKTREE_HASH_VERSION,
+        WorktreeSnapshotMetadata, GIT_WORKTREE_HASH_VERSION,
     };
     use host_domain::{
         GitAheadBehind, GitCurrentBranch, GitDiffScope, GitFileDiff, GitFileStatus,
@@ -692,13 +698,15 @@ mod tests {
 
         let built = build_worktree_status_with_snapshot(
             status_data,
-            "/tmp/openducktor-worktree".to_string(),
-            "origin/main".to_string(),
-            GitDiffScope::Target,
-            42,
-            GIT_WORKTREE_HASH_VERSION,
-            "0123456789abcdef".to_string(),
-            "fedcba9876543210".to_string(),
+            WorktreeSnapshotMetadata {
+                effective_working_dir: "/tmp/openducktor-worktree".to_string(),
+                target_branch: "origin/main".to_string(),
+                diff_scope: GitDiffScope::Target,
+                observed_at_ms: 42,
+                hash_version: GIT_WORKTREE_HASH_VERSION,
+                status_hash: "0123456789abcdef".to_string(),
+                diff_hash: "fedcba9876543210".to_string(),
+            },
         );
 
         assert_eq!(built.current_branch.name.as_deref(), Some("feature/snapshot"));

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -7,6 +7,11 @@ use std::{
 };
 use tauri::State;
 
+const GIT_WORKTREE_HASH_VERSION: u32 = 1;
+const FNV1A_64_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV1A_64_PRIME: u64 = 0x100000001b3;
+const FNV1A_64_MASK: u64 = u64::MAX;
+
 fn canonicalize_for_validation(path: &str, field: &str) -> Result<PathBuf, String> {
     fs::canonicalize(path)
         .map_err(|_| format!("{field} does not exist or is not accessible: {path}"))
@@ -88,12 +93,133 @@ fn require_target_branch(target_branch: &str) -> Result<&str, String> {
     Ok(trimmed_target)
 }
 
+struct Fnv1a64Hasher {
+    state: u64,
+}
+
+impl Fnv1a64Hasher {
+    fn new() -> Self {
+        Self {
+            state: FNV1A_64_OFFSET_BASIS,
+        }
+    }
+
+    fn update_byte(&mut self, byte: u8) {
+        self.state ^= u64::from(byte);
+        self.state = self.state.wrapping_mul(FNV1A_64_PRIME) & FNV1A_64_MASK;
+    }
+
+    fn update_bytes(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.update_byte(*byte);
+        }
+    }
+
+    fn update_bool(&mut self, value: bool) {
+        self.update_byte(u8::from(value));
+    }
+
+    fn update_u32(&mut self, value: u32) {
+        self.update_bytes(&value.to_le_bytes());
+    }
+
+    fn update_u64(&mut self, value: u64) {
+        self.update_bytes(&value.to_le_bytes());
+    }
+
+    fn update_str(&mut self, value: &str) {
+        self.update_u64(value.len() as u64);
+        self.update_bytes(value.as_bytes());
+    }
+
+    fn finish_hex(self) -> String {
+        format!("{:016x}", self.state)
+    }
+}
+
+fn hash_optional_str(hasher: &mut Fnv1a64Hasher, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            hasher.update_byte(1);
+            hasher.update_str(value);
+        }
+        None => {
+            hasher.update_byte(0);
+        }
+    }
+}
+
+fn hash_upstream_ahead_behind(
+    hasher: &mut Fnv1a64Hasher,
+    upstream_ahead_behind: &host_domain::GitUpstreamAheadBehind,
+) {
+    match upstream_ahead_behind {
+        host_domain::GitUpstreamAheadBehind::Tracking { ahead, behind } => {
+            hasher.update_str("tracking");
+            hasher.update_u32(*ahead);
+            hasher.update_u32(*behind);
+        }
+        host_domain::GitUpstreamAheadBehind::Untracked { ahead } => {
+            hasher.update_str("untracked");
+            hasher.update_u32(*ahead);
+        }
+        host_domain::GitUpstreamAheadBehind::Error { message } => {
+            hasher.update_str("error");
+            hasher.update_str(message);
+        }
+    }
+}
+
+fn hash_worktree_status_payload(
+    current_branch: &host_domain::GitCurrentBranch,
+    file_statuses: &[host_domain::GitFileStatus],
+    target_ahead_behind: &host_domain::GitAheadBehind,
+    upstream_ahead_behind: &host_domain::GitUpstreamAheadBehind,
+) -> String {
+    let mut hasher = Fnv1a64Hasher::new();
+
+    hash_optional_str(&mut hasher, current_branch.name.as_deref());
+    hasher.update_bool(current_branch.detached);
+
+    hasher.update_u64(file_statuses.len() as u64);
+    for status in file_statuses {
+        hasher.update_str(&status.path);
+        hasher.update_str(&status.status);
+        hasher.update_bool(status.staged);
+    }
+
+    hasher.update_u32(target_ahead_behind.ahead);
+    hasher.update_u32(target_ahead_behind.behind);
+
+    hash_upstream_ahead_behind(&mut hasher, upstream_ahead_behind);
+
+    hasher.finish_hex()
+}
+
+fn hash_worktree_diff_payload(file_diffs: &[host_domain::GitFileDiff]) -> String {
+    let mut hasher = Fnv1a64Hasher::new();
+    hasher.update_u64(file_diffs.len() as u64);
+
+    for diff in file_diffs {
+        hasher.update_str(&diff.file);
+        hasher.update_str(&diff.diff_type);
+        hasher.update_u32(diff.additions);
+        hasher.update_u32(diff.deletions);
+        hasher.update_str(&diff.diff);
+    }
+
+    hasher.finish_hex()
+}
+
 fn build_worktree_status_with_snapshot(
     status_data: host_domain::GitWorktreeStatusData,
     effective_working_dir: String,
     target_branch: String,
     diff_scope: host_domain::GitDiffScope,
     observed_at_ms: u64,
+    hash_version: u32,
+    status_hash: String,
+    diff_hash: String,
 ) -> host_domain::GitWorktreeStatus {
     host_domain::GitWorktreeStatus {
         current_branch: status_data.current_branch,
@@ -106,6 +232,9 @@ fn build_worktree_status_with_snapshot(
             target_branch,
             diff_scope,
             observed_at_ms,
+            hash_version,
+            status_hash,
+            diff_hash,
         },
     }
 }
@@ -289,6 +418,13 @@ pub async fn git_get_worktree_status(
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64;
+    let status_hash = hash_worktree_status_payload(
+        &worktree_status.current_branch,
+        worktree_status.file_statuses.as_slice(),
+        &worktree_status.target_ahead_behind,
+        &worktree_status.upstream_ahead_behind,
+    );
+    let diff_hash = hash_worktree_diff_payload(worktree_status.file_diffs.as_slice());
 
     Ok(build_worktree_status_with_snapshot(
         worktree_status,
@@ -296,6 +432,9 @@ pub async fn git_get_worktree_status(
         trimmed_target.to_string(),
         scope,
         observed_at_ms,
+        GIT_WORKTREE_HASH_VERSION,
+        status_hash,
+        diff_hash,
     ))
 }
 
@@ -375,7 +514,8 @@ pub async fn git_rebase_branch(
 mod tests {
     use super::{
         build_worktree_status_with_snapshot, parse_diff_scope, require_target_branch,
-        resolve_working_dir,
+        hash_worktree_diff_payload, hash_worktree_status_payload, resolve_working_dir,
+        GIT_WORKTREE_HASH_VERSION,
     };
     use host_domain::{
         GitAheadBehind, GitCurrentBranch, GitDiffScope, GitFileDiff, GitFileStatus,
@@ -557,12 +697,12 @@ mod tests {
             "origin/main".to_string(),
             GitDiffScope::Target,
             42,
+            GIT_WORKTREE_HASH_VERSION,
+            "0123456789abcdef".to_string(),
+            "fedcba9876543210".to_string(),
         );
 
-        assert_eq!(
-            built.current_branch.name.as_deref(),
-            Some("feature/snapshot")
-        );
+        assert_eq!(built.current_branch.name.as_deref(), Some("feature/snapshot"));
         assert_eq!(built.file_statuses.len(), 1);
         assert_eq!(built.file_diffs.len(), 1);
         assert_eq!(built.target_ahead_behind.ahead, 2);
@@ -580,5 +720,107 @@ mod tests {
         assert_eq!(built.snapshot.target_branch, "origin/main");
         assert_eq!(built.snapshot.diff_scope, GitDiffScope::Target);
         assert_eq!(built.snapshot.observed_at_ms, 42);
+        assert_eq!(built.snapshot.hash_version, GIT_WORKTREE_HASH_VERSION);
+        assert_eq!(built.snapshot.status_hash, "0123456789abcdef");
+        assert_eq!(built.snapshot.diff_hash, "fedcba9876543210");
+    }
+
+    #[test]
+    fn status_hash_changes_when_status_payload_changes() {
+        let current_branch = GitCurrentBranch {
+            name: Some("feature/task-1".to_string()),
+            detached: false,
+        };
+        let file_statuses = vec![GitFileStatus {
+            path: "src/main.rs".to_string(),
+            status: "M".to_string(),
+            staged: false,
+        }];
+        let target_ahead_behind = GitAheadBehind {
+            ahead: 1,
+            behind: 0,
+        };
+        let baseline_upstream = GitUpstreamAheadBehind::Tracking {
+            ahead: 1,
+            behind: 0,
+        };
+        let changed_upstream = GitUpstreamAheadBehind::Tracking {
+            ahead: 2,
+            behind: 0,
+        };
+
+        let baseline_hash = hash_worktree_status_payload(
+            &current_branch,
+            file_statuses.as_slice(),
+            &target_ahead_behind,
+            &baseline_upstream,
+        );
+        let changed_hash = hash_worktree_status_payload(
+            &current_branch,
+            file_statuses.as_slice(),
+            &target_ahead_behind,
+            &changed_upstream,
+        );
+
+        assert_ne!(baseline_hash, changed_hash);
+    }
+
+    #[test]
+    fn status_hash_is_stable_for_identical_payload() {
+        let current_branch = GitCurrentBranch {
+            name: Some("feature/task-1".to_string()),
+            detached: false,
+        };
+        let file_statuses = vec![GitFileStatus {
+            path: "src/main.rs".to_string(),
+            status: "M".to_string(),
+            staged: false,
+        }];
+        let target_ahead_behind = GitAheadBehind {
+            ahead: 1,
+            behind: 0,
+        };
+        let upstream = GitUpstreamAheadBehind::Tracking {
+            ahead: 1,
+            behind: 0,
+        };
+
+        let first_hash = hash_worktree_status_payload(
+            &current_branch,
+            file_statuses.as_slice(),
+            &target_ahead_behind,
+            &upstream,
+        );
+        let second_hash = hash_worktree_status_payload(
+            &current_branch,
+            file_statuses.as_slice(),
+            &target_ahead_behind,
+            &upstream,
+        );
+
+        assert_eq!(first_hash, second_hash);
+    }
+
+    #[test]
+    fn diff_hash_changes_when_diff_payload_changes() {
+        let baseline_diff = vec![GitFileDiff {
+            file: "src/main.rs".to_string(),
+            diff_type: "modified".to_string(),
+            additions: 1,
+            deletions: 0,
+            diff: "@@ -1 +1 @@".to_string(),
+        }];
+        let changed_diff = vec![GitFileDiff {
+            file: "src/main.rs".to_string(),
+            diff_type: "modified".to_string(),
+            additions: 2,
+            deletions: 1,
+            diff: "@@ -1 +1,2 @@".to_string(),
+        }];
+
+        let baseline_hash = hash_worktree_diff_payload(baseline_diff.as_slice());
+        let changed_hash = hash_worktree_diff_payload(changed_diff.as_slice());
+
+        assert_ne!(baseline_hash, changed_hash);
     }
 }

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -10,7 +10,6 @@ use tauri::State;
 const GIT_WORKTREE_HASH_VERSION: u32 = 1;
 const FNV1A_64_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV1A_64_PRIME: u64 = 0x100000001b3;
-const FNV1A_64_MASK: u64 = u64::MAX;
 
 fn canonicalize_for_validation(path: &str, field: &str) -> Result<PathBuf, String> {
     fs::canonicalize(path)
@@ -106,7 +105,7 @@ impl Fnv1a64Hasher {
 
     fn update_byte(&mut self, byte: u8) {
         self.state ^= u64::from(byte);
-        self.state = self.state.wrapping_mul(FNV1A_64_PRIME) & FNV1A_64_MASK;
+        self.state = self.state.wrapping_mul(FNV1A_64_PRIME);
     }
 
     fn update_bytes(&mut self, bytes: &[u8]) {

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -70,14 +70,14 @@ const createDeferred = <T,>() => {
 };
 
 const hashTestPayload = (value: unknown): string => {
-  const json = JSON.stringify(value);
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < json.length; index += 1) {
-    hash ^= json.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
+  const payload = new TextEncoder().encode(JSON.stringify(value));
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of payload) {
+    hash ^= BigInt(byte);
+    hash = (hash * 0x100000001b3n) & 0xffffffffffffffffn;
   }
 
-  return (hash >>> 0).toString(16).padStart(8, "0");
+  return hash.toString(16).padStart(16, "0");
 };
 
 const withSnapshotHashes = (
@@ -374,6 +374,105 @@ describe("useAgentStudioDiffData", () => {
     } finally {
       await harness.unmount();
       expect(clearIntervalMock).toHaveBeenCalledTimes(1);
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    }
+  });
+
+  test("polling persists hash metadata changes even when derived shared fields stay equal", async () => {
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearInterval = globalThis.clearInterval;
+    let intervalCallback: (() => void) | null = null;
+    let callCount = 0;
+
+    const setIntervalMock = mock((callback: TimerHandler, _delay?: number) => {
+      if (typeof callback !== "function") {
+        throw new Error("Expected polling callback function");
+      }
+      intervalCallback = () => {
+        callback();
+      };
+      return 1;
+    });
+    const clearIntervalMock = mock((_intervalId: number) => {});
+
+    gitGetWorktreeStatusMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatus> => {
+        callCount += 1;
+        const upstream: GitWorktreeStatus["upstreamAheadBehind"] =
+          callCount === 1
+            ? { outcome: "untracked", ahead: 1 }
+            : { outcome: "tracking", ahead: 1, behind: 0 };
+
+        return withSnapshotHashes({
+          currentBranch: { name: "feature/task-10", detached: false },
+          fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+          fileDiffs:
+            (diffScope ?? "target") === "target"
+              ? [
+                  {
+                    file: "src/main.ts",
+                    type: "modified",
+                    additions: 1,
+                    deletions: 0,
+                    diff: "@@ -1 +1 @@",
+                  },
+                ]
+              : [],
+          targetAheadBehind: { ahead: 1, behind: 0 },
+          upstreamAheadBehind: upstream,
+          snapshot: {
+            effectiveWorkingDir: workingDir ?? "/repo",
+            targetBranch,
+            diffScope: diffScope ?? "target",
+            observedAtMs: 1731000000000 + callCount,
+          },
+        });
+      },
+    );
+
+    globalThis.setInterval = setIntervalMock as unknown as typeof globalThis.setInterval;
+    globalThis.clearInterval = clearIntervalMock as unknown as typeof globalThis.clearInterval;
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      enablePolling: true,
+    });
+
+    const runTick = (): void => {
+      if (intervalCallback == null) {
+        throw new Error("Polling callback was not registered");
+      }
+      intervalCallback();
+    };
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      const firstState = harness.getLatest();
+      expect(firstState.upstreamAheadBehind).toEqual({ ahead: 1, behind: 0 });
+
+      await harness.run(() => {
+        runTick();
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+      const secondState = harness.getLatest();
+      expect(secondState.upstreamAheadBehind).toEqual({ ahead: 1, behind: 0 });
+      expect(secondState).not.toBe(firstState);
+
+      await harness.run(() => {
+        runTick();
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 3);
+      const thirdState = harness.getLatest();
+      expect(thirdState).toBe(secondState);
+    } finally {
+      await harness.unmount();
       globalThis.setInterval = originalSetInterval;
       globalThis.clearInterval = originalClearInterval;
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -14,30 +14,31 @@ const gitGetWorktreeStatusMock = mock(
     targetBranch: string,
     diffScope?: "target" | "uncommitted",
     workingDir?: string,
-  ): Promise<GitWorktreeStatus> => ({
-    currentBranch: { name: "feature/task-10", detached: false },
-    fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
-    fileDiffs:
-      (diffScope ?? "target") === "target"
-        ? [
-            {
-              file: "src/main.ts",
-              type: "modified",
-              additions: 1,
-              deletions: 0,
-              diff: "@@ -1 +1 @@",
-            },
-          ]
-        : [],
-    targetAheadBehind: { ahead: 0, behind: 0 },
-    upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
-    snapshot: {
-      effectiveWorkingDir: workingDir ?? "/repo",
-      targetBranch,
-      diffScope: diffScope ?? "target",
-      observedAtMs: 1731000000000,
-    },
-  }),
+  ): Promise<GitWorktreeStatus> =>
+    withSnapshotHashes({
+      currentBranch: { name: "feature/task-10", detached: false },
+      fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+      fileDiffs:
+        (diffScope ?? "target") === "target"
+          ? [
+              {
+                file: "src/main.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 0,
+                diff: "@@ -1 +1 @@",
+              },
+            ]
+          : [],
+      targetAheadBehind: { ahead: 0, behind: 0 },
+      upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+      snapshot: {
+        effectiveWorkingDir: workingDir ?? "/repo",
+        targetBranch,
+        diffScope: diffScope ?? "target",
+        observedAtMs: 1731000000000,
+      },
+    }),
 );
 
 mock.module("@/state/operations/host", () => ({
@@ -68,6 +69,43 @@ const createDeferred = <T,>() => {
   return { promise, resolve, reject };
 };
 
+const hashTestPayload = (value: unknown): string => {
+  const json = JSON.stringify(value);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < json.length; index += 1) {
+    hash ^= json.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, "0");
+};
+
+const withSnapshotHashes = (
+  status: Omit<GitWorktreeStatus, "snapshot"> & {
+    snapshot: Omit<GitWorktreeStatus["snapshot"], "hashVersion" | "statusHash" | "diffHash">;
+  },
+): GitWorktreeStatus => {
+  const statusHash = hashTestPayload({
+    currentBranch: status.currentBranch,
+    fileStatuses: status.fileStatuses,
+    targetAheadBehind: status.targetAheadBehind,
+    upstreamAheadBehind: status.upstreamAheadBehind,
+  });
+  const diffHash = hashTestPayload({
+    fileDiffs: status.fileDiffs,
+  });
+
+  return {
+    ...status,
+    snapshot: {
+      ...status.snapshot,
+      hashVersion: 1,
+      statusHash,
+      diffHash,
+    },
+  };
+};
+
 const createBaseArgs = (): HookArgs => ({
   repoPath: "/repo",
   sessionWorkingDirectory: null,
@@ -89,30 +127,31 @@ beforeEach(() => {
       targetBranch: string,
       diffScope?: "target" | "uncommitted",
       workingDir?: string,
-    ): Promise<GitWorktreeStatus> => ({
-      currentBranch: { name: "feature/task-10", detached: false },
-      fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
-      fileDiffs:
-        (diffScope ?? "target") === "target"
-          ? [
-              {
-                file: "src/main.ts",
-                type: "modified",
-                additions: 1,
-                deletions: 0,
-                diff: "@@ -1 +1 @@",
-              },
-            ]
-          : [],
-      targetAheadBehind: { ahead: 0, behind: 0 },
-      upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
-      snapshot: {
-        effectiveWorkingDir: workingDir ?? "/repo",
-        targetBranch,
-        diffScope: diffScope ?? "target",
-        observedAtMs: 1731000000000,
-      },
-    }),
+    ): Promise<GitWorktreeStatus> =>
+      withSnapshotHashes({
+        currentBranch: { name: "feature/task-10", detached: false },
+        fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+        fileDiffs:
+          (diffScope ?? "target") === "target"
+            ? [
+                {
+                  file: "src/main.ts",
+                  type: "modified",
+                  additions: 1,
+                  deletions: 0,
+                  diff: "@@ -1 +1 @@",
+                },
+              ]
+            : [],
+        targetAheadBehind: { ahead: 0, behind: 0 },
+        upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+        snapshot: {
+          effectiveWorkingDir: workingDir ?? "/repo",
+          targetBranch,
+          diffScope: diffScope ?? "target",
+          observedAtMs: 1731000000000,
+        },
+      }),
   );
 });
 
@@ -213,30 +252,31 @@ describe("useAgentStudioDiffData", () => {
           targetBranch: string,
           diffScope?: "target" | "uncommitted",
           workingDir?: string,
-        ): Promise<GitWorktreeStatus> => ({
-          currentBranch: { name: "feature/task-11", detached: false },
-          fileStatuses: [{ path: "src/updated.ts", status: "M", staged: false }],
-          fileDiffs:
-            (diffScope ?? "target") === "target"
-              ? [
-                  {
-                    file: "src/updated.ts",
-                    type: "modified",
-                    additions: 4,
-                    deletions: 1,
-                    diff: "@@ -1 +1 @@",
-                  },
-                ]
-              : [],
-          targetAheadBehind: { ahead: 2, behind: 1 },
-          upstreamAheadBehind: { outcome: "tracking", ahead: 5, behind: 2 },
-          snapshot: {
-            effectiveWorkingDir: workingDir ?? "/repo",
-            targetBranch,
-            diffScope: diffScope ?? "target",
-            observedAtMs: 1731000000001,
-          },
-        }),
+        ): Promise<GitWorktreeStatus> =>
+          withSnapshotHashes({
+            currentBranch: { name: "feature/task-11", detached: false },
+            fileStatuses: [{ path: "src/updated.ts", status: "M", staged: false }],
+            fileDiffs:
+              (diffScope ?? "target") === "target"
+                ? [
+                    {
+                      file: "src/updated.ts",
+                      type: "modified",
+                      additions: 4,
+                      deletions: 1,
+                      diff: "@@ -1 +1 @@",
+                    },
+                  ]
+                : [],
+            targetAheadBehind: { ahead: 2, behind: 1 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 5, behind: 2 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000001,
+            },
+          }),
       );
 
       await harness.run((state) => {
@@ -441,51 +481,55 @@ describe("useAgentStudioDiffData", () => {
         undefined,
       );
 
-      secondRequest.resolve({
-        currentBranch: { name: "feature/repo-b", detached: false },
-        fileStatuses: [{ path: "src/repo-b.ts", status: "M", staged: false }],
-        fileDiffs: [
-          {
-            file: "src/repo-b.ts",
-            type: "modified",
-            additions: 3,
-            deletions: 1,
-            diff: "@@ -1 +1 @@",
+      secondRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/repo-b", detached: false },
+          fileStatuses: [{ path: "src/repo-b.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/repo-b.ts",
+              type: "modified",
+              additions: 3,
+              deletions: 1,
+              diff: "@@ -1 +1 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo-b",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000002000,
           },
-        ],
-        targetAheadBehind: { ahead: 0, behind: 0 },
-        upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
-        snapshot: {
-          effectiveWorkingDir: "/repo-b",
-          targetBranch: "origin/main",
-          diffScope: "target",
-          observedAtMs: 1731000002000,
-        },
-      });
+        }),
+      );
 
       await harness.waitFor((state) => state.branch === "feature/repo-b");
 
-      firstRequest.resolve({
-        currentBranch: { name: "feature/repo-a", detached: false },
-        fileStatuses: [{ path: "src/repo-a.ts", status: "M", staged: false }],
-        fileDiffs: [
-          {
-            file: "src/repo-a.ts",
-            type: "modified",
-            additions: 1,
-            deletions: 0,
-            diff: "@@ -1 +1 @@",
+      firstRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/repo-a", detached: false },
+          fileStatuses: [{ path: "src/repo-a.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/repo-a.ts",
+              type: "modified",
+              additions: 1,
+              deletions: 0,
+              diff: "@@ -1 +1 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo-a",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000001000,
           },
-        ],
-        targetAheadBehind: { ahead: 0, behind: 0 },
-        upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
-        snapshot: {
-          effectiveWorkingDir: "/repo-a",
-          targetBranch: "origin/main",
-          diffScope: "target",
-          observedAtMs: 1731000001000,
-        },
-      });
+        }),
+      );
 
       await harness.run(async () => {
         await Promise.resolve();
@@ -535,27 +579,29 @@ describe("useAgentStudioDiffData", () => {
       });
       await harness.waitFor((state) => state.branch === null && state.fileDiffs.length === 0);
 
-      pendingRequest.resolve({
-        currentBranch: { name: "feature/stale", detached: false },
-        fileStatuses: [{ path: "src/stale.ts", status: "M", staged: false }],
-        fileDiffs: [
-          {
-            file: "src/stale.ts",
-            type: "modified",
-            additions: 1,
-            deletions: 0,
-            diff: "@@ -1 +1 @@",
+      pendingRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/stale", detached: false },
+          fileStatuses: [{ path: "src/stale.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/stale.ts",
+              type: "modified",
+              additions: 1,
+              deletions: 0,
+              diff: "@@ -1 +1 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo-a",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000003000,
           },
-        ],
-        targetAheadBehind: { ahead: 0, behind: 0 },
-        upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
-        snapshot: {
-          effectiveWorkingDir: "/repo-a",
-          targetBranch: "origin/main",
-          diffScope: "target",
-          observedAtMs: 1731000003000,
-        },
-      });
+        }),
+      );
 
       await harness.run(async () => {
         await Promise.resolve();
@@ -609,42 +655,46 @@ describe("useAgentStudioDiffData", () => {
       });
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
 
-      uncommittedRequest.resolve({
-        currentBranch: { name: "feature/newer", detached: false },
-        fileStatuses: [{ path: "src/newer.ts", status: "M", staged: false }],
-        fileDiffs: [],
-        targetAheadBehind: { ahead: 2, behind: 1 },
-        upstreamAheadBehind: { outcome: "tracking", ahead: 4, behind: 1 },
-        snapshot: {
-          effectiveWorkingDir: "/repo",
-          targetBranch: "origin/main",
-          diffScope: "uncommitted",
-          observedAtMs: 1731000004000,
-        },
-      });
+      uncommittedRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/newer", detached: false },
+          fileStatuses: [{ path: "src/newer.ts", status: "M", staged: false }],
+          fileDiffs: [],
+          targetAheadBehind: { ahead: 2, behind: 1 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 4, behind: 1 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch: "origin/main",
+            diffScope: "uncommitted",
+            observedAtMs: 1731000004000,
+          },
+        }),
+      );
       await harness.waitFor((state) => state.branch === "feature/newer");
 
-      targetRequest.resolve({
-        currentBranch: { name: "feature/older", detached: false },
-        fileStatuses: [{ path: "src/older.ts", status: "M", staged: false }],
-        fileDiffs: [
-          {
-            file: "src/older.ts",
-            type: "modified",
-            additions: 1,
-            deletions: 0,
-            diff: "@@ -1 +1 @@",
+      targetRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/older", detached: false },
+          fileStatuses: [{ path: "src/older.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/older.ts",
+              type: "modified",
+              additions: 1,
+              deletions: 0,
+              diff: "@@ -1 +1 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000003000,
           },
-        ],
-        targetAheadBehind: { ahead: 0, behind: 0 },
-        upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
-        snapshot: {
-          effectiveWorkingDir: "/repo",
-          targetBranch: "origin/main",
-          diffScope: "target",
-          observedAtMs: 1731000003000,
-        },
-      });
+        }),
+      );
 
       await harness.run(async () => {
         await Promise.resolve();
@@ -717,19 +767,20 @@ describe("useAgentStudioDiffData", () => {
         targetBranch: string,
         _diffScope?: "target" | "uncommitted",
         _workingDir?: string,
-      ): Promise<GitWorktreeStatus> => ({
-        currentBranch: { name: "feature/task-10", detached: false },
-        fileStatuses: [],
-        fileDiffs: [],
-        targetAheadBehind: { ahead: 3, behind: 1 },
-        upstreamAheadBehind: { outcome: "untracked", ahead: 3 },
-        snapshot: {
-          effectiveWorkingDir: "/repo",
-          targetBranch,
-          diffScope: "target",
-          observedAtMs: 1731000000000,
-        },
-      }),
+      ): Promise<GitWorktreeStatus> =>
+        withSnapshotHashes({
+          currentBranch: { name: "feature/task-10", detached: false },
+          fileStatuses: [],
+          fileDiffs: [],
+          targetAheadBehind: { ahead: 3, behind: 1 },
+          upstreamAheadBehind: { outcome: "untracked", ahead: 3 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch,
+            diffScope: "target",
+            observedAtMs: 1731000000000,
+          },
+        }),
     );
 
     const harness = createHookHarness(createBaseArgs());
@@ -752,19 +803,20 @@ describe("useAgentStudioDiffData", () => {
         targetBranch: string,
         _diffScope?: "target" | "uncommitted",
         _workingDir?: string,
-      ): Promise<GitWorktreeStatus> => ({
-        currentBranch: { name: "feature/task-10", detached: false },
-        fileStatuses: [],
-        fileDiffs: [],
-        targetAheadBehind: { ahead: 1, behind: 0 },
-        upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 1 },
-        snapshot: {
-          effectiveWorkingDir: "/repo",
-          targetBranch,
-          diffScope: "target",
-          observedAtMs: 1731000000000,
-        },
-      }),
+      ): Promise<GitWorktreeStatus> =>
+        withSnapshotHashes({
+          currentBranch: { name: "feature/task-10", detached: false },
+          fileStatuses: [],
+          fileDiffs: [],
+          targetAheadBehind: { ahead: 1, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 1 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch,
+            diffScope: "target",
+            observedAtMs: 1731000000000,
+          },
+        }),
     );
 
     const harness = createHookHarness(createBaseArgs());
@@ -788,7 +840,7 @@ describe("useAgentStudioDiffData", () => {
         _diffScope?: "target" | "uncommitted",
         _workingDir?: string,
       ): Promise<GitWorktreeStatus> => {
-        return {
+        return withSnapshotHashes({
           currentBranch: { name: "feature/task-10", detached: false },
           fileStatuses: [],
           fileDiffs: [],
@@ -800,7 +852,7 @@ describe("useAgentStudioDiffData", () => {
             diffScope: "target",
             observedAtMs: 1731000000000,
           },
-        };
+        });
       },
     );
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
@@ -154,6 +154,11 @@ const aheadBehindEqual = (a: CommitsAheadBehind | null, b: CommitsAheadBehind | 
   return a.ahead === b.ahead && a.behind === b.behind;
 };
 
+const hashMetadataEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean =>
+  left.hashVersion === right.hashVersion &&
+  left.statusHash === right.statusHash &&
+  left.diffHash === right.diffHash;
+
 const scopeSnapshotEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean =>
   (() => {
     const canUseHashShortCircuit =
@@ -178,7 +183,8 @@ const scopeSnapshotEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean 
       arraysEqual(left.fileStatuses, right.fileStatuses, fileStatusEqual) &&
       aheadBehindEqual(left.commitsAheadBehind, right.commitsAheadBehind) &&
       aheadBehindEqual(left.upstreamAheadBehind, right.upstreamAheadBehind) &&
-      left.error === right.error
+      left.error === right.error &&
+      hashMetadataEqual(left, right)
     );
   })();
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
@@ -70,6 +70,9 @@ type ScopeSnapshot = {
   commitsAheadBehind: CommitsAheadBehind | null;
   upstreamAheadBehind: CommitsAheadBehind | null;
   error: string | null;
+  hashVersion: number | null;
+  statusHash: string | null;
+  diffHash: string | null;
 };
 
 type ResolvedWorktreeState = {
@@ -96,6 +99,9 @@ const EMPTY_SCOPE_SNAPSHOT: ScopeSnapshot = {
   commitsAheadBehind: null,
   upstreamAheadBehind: null,
   error: null,
+  hashVersion: null,
+  statusHash: null,
+  diffHash: null,
 };
 
 const createInitialState = (): DiffBatchState => ({
@@ -149,12 +155,32 @@ const aheadBehindEqual = (a: CommitsAheadBehind | null, b: CommitsAheadBehind | 
 };
 
 const scopeSnapshotEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean =>
-  left.branch === right.branch &&
-  arraysEqual(left.fileDiffs, right.fileDiffs, fileDiffEqual) &&
-  arraysEqual(left.fileStatuses, right.fileStatuses, fileStatusEqual) &&
-  aheadBehindEqual(left.commitsAheadBehind, right.commitsAheadBehind) &&
-  aheadBehindEqual(left.upstreamAheadBehind, right.upstreamAheadBehind) &&
-  left.error === right.error;
+  (() => {
+    const canUseHashShortCircuit =
+      left.hashVersion !== null &&
+      right.hashVersion !== null &&
+      left.hashVersion === right.hashVersion &&
+      left.statusHash !== null &&
+      right.statusHash !== null &&
+      left.diffHash !== null &&
+      right.diffHash !== null;
+
+    if (canUseHashShortCircuit) {
+      const hashesMatch = left.statusHash === right.statusHash && left.diffHash === right.diffHash;
+      if (hashesMatch && left.error === right.error) {
+        return true;
+      }
+    }
+
+    return (
+      left.branch === right.branch &&
+      arraysEqual(left.fileDiffs, right.fileDiffs, fileDiffEqual) &&
+      arraysEqual(left.fileStatuses, right.fileStatuses, fileStatusEqual) &&
+      aheadBehindEqual(left.commitsAheadBehind, right.commitsAheadBehind) &&
+      aheadBehindEqual(left.upstreamAheadBehind, right.upstreamAheadBehind) &&
+      left.error === right.error
+    );
+  })();
 
 const toUpstreamAndError = (
   upstreamAheadBehind: GitWorktreeStatus["upstreamAheadBehind"],
@@ -197,6 +223,9 @@ const toScopeSnapshot = (snapshot: GitWorktreeStatus): ScopeSnapshot => {
     commitsAheadBehind: snapshot.targetAheadBehind,
     upstreamAheadBehind,
     error,
+    hashVersion: snapshot.snapshot.hashVersion,
+    statusHash: snapshot.snapshot.statusHash,
+    diffHash: snapshot.snapshot.diffHash,
   };
 };
 
@@ -207,6 +236,8 @@ const mergeSharedSnapshotFields = (base: ScopeSnapshot, source: ScopeSnapshot): 
   commitsAheadBehind: source.commitsAheadBehind,
   upstreamAheadBehind: source.upstreamAheadBehind,
   error: source.error,
+  hashVersion: source.hashVersion,
+  statusHash: source.statusHash,
 });
 
 // ─── Hook ──────────────────────────────────────────────────────────────────────
@@ -428,6 +459,9 @@ export function useAgentStudioDiffData({
           const nextScopeSnapshot: ScopeSnapshot = {
             ...previousScopeSnapshot,
             error: String(err),
+            hashVersion: null,
+            statusHash: null,
+            diffHash: null,
           };
 
           let nextLoadedByScope = prev.loadedByScope;

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -447,6 +447,9 @@ describe("TauriHostClient", () => {
             targetBranch: "origin/main",
             diffScope: "target",
             observedAtMs: 1731000000000,
+            hashVersion: 1,
+            statusHash: "status-hash",
+            diffHash: "diff-hash",
           },
         };
       }

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -448,8 +448,8 @@ describe("TauriHostClient", () => {
             diffScope: "target",
             observedAtMs: 1731000000000,
             hashVersion: 1,
-            statusHash: "status-hash",
-            diffHash: "diff-hash",
+            statusHash: "0123456789abcdef",
+            diffHash: "fedcba9876543210",
           },
         };
       }
@@ -566,6 +566,42 @@ describe("TauriHostClient", () => {
     await expect(client.gitCommitAll("/repo", "Build all changes")).rejects.toThrow();
     await expect(client.gitPullBranch("/repo")).rejects.toThrow();
     await expect(client.gitRebaseBranch("/repo", "origin/main")).rejects.toThrow();
+  });
+
+  test("git worktree status rejects malformed hash metadata payloads", async () => {
+    const { client } = createClient((command) => {
+      if (command === "git_get_worktree_status") {
+        return {
+          currentBranch: { name: "feature/task-1", detached: false },
+          fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/main.ts",
+              type: "modified",
+              additions: 2,
+              deletions: 1,
+              diff: "@@ -1 +1 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 1, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/tmp/wt/task-1",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000000000,
+            hashVersion: 1,
+            statusHash: "status-hash",
+            diffHash: "fedcba9876543210",
+          },
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(
+      client.gitGetWorktreeStatus("/repo", "origin/main", "target", "/tmp/wt/task-1"),
+    ).rejects.toThrow();
   });
 
   test("git pull parses typed conflicts outcome", async () => {

--- a/packages/contracts/src/git-schemas.ts
+++ b/packages/contracts/src/git-schemas.ts
@@ -109,8 +109,8 @@ export const gitWorktreeStatusSnapshotSchema = z.object({
   diffScope: gitDiffScopeSchema,
   observedAtMs: z.number(),
   hashVersion: z.number().int().positive(),
-  statusHash: z.string().min(1),
-  diffHash: z.string().min(1),
+  statusHash: z.string().regex(/^[0-9a-f]{16}$/),
+  diffHash: z.string().regex(/^[0-9a-f]{16}$/),
 });
 export type GitWorktreeStatusSnapshot = z.infer<typeof gitWorktreeStatusSnapshotSchema>;
 

--- a/packages/contracts/src/git-schemas.ts
+++ b/packages/contracts/src/git-schemas.ts
@@ -108,6 +108,9 @@ export const gitWorktreeStatusSnapshotSchema = z.object({
   targetBranch: z.string(),
   diffScope: gitDiffScopeSchema,
   observedAtMs: z.number(),
+  hashVersion: z.number().int().positive(),
+  statusHash: z.string().min(1),
+  diffHash: z.string().min(1),
 });
 export type GitWorktreeStatusSnapshot = z.infer<typeof gitWorktreeStatusSnapshotSchema>;
 

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -363,6 +363,9 @@ describe("runtime schemas", () => {
       targetBranch: "origin/main",
       diffScope: scope,
       observedAtMs: 1731000000000,
+      hashVersion: 1,
+      statusHash: "status-hash",
+      diffHash: "diff-hash",
     });
     const status = gitWorktreeStatusSchema.parse({
       currentBranch: { name: "feature/task-1", detached: false },

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -364,8 +364,8 @@ describe("runtime schemas", () => {
       diffScope: scope,
       observedAtMs: 1731000000000,
       hashVersion: 1,
-      statusHash: "status-hash",
-      diffHash: "diff-hash",
+      statusHash: "0123456789abcdef",
+      diffHash: "fedcba9876543210",
     });
     const status = gitWorktreeStatusSchema.parse({
       currentBranch: { name: "feature/task-1", detached: false },
@@ -387,6 +387,32 @@ describe("runtime schemas", () => {
     expect(status.snapshot.diffScope).toBe("target");
     expect(status.upstreamAheadBehind.outcome).toBe("tracking");
     expect(status.targetAheadBehind.behind).toBe(3);
+  });
+
+  test("git worktree status snapshot schema rejects malformed hash metadata", () => {
+    expect(() =>
+      gitWorktreeStatusSnapshotSchema.parse({
+        effectiveWorkingDir: "/repo",
+        targetBranch: "origin/main",
+        diffScope: "target",
+        observedAtMs: 1731000000000,
+        hashVersion: 1,
+        statusHash: "status-hash",
+        diffHash: "fedcba9876543210",
+      }),
+    ).toThrow();
+
+    expect(() =>
+      gitWorktreeStatusSnapshotSchema.parse({
+        effectiveWorkingDir: "/repo",
+        targetBranch: "origin/main",
+        diffScope: "target",
+        observedAtMs: 1731000000000,
+        hashVersion: 1,
+        statusHash: "0123456789abcdef",
+        diffHash: "xyz",
+      }),
+    ).toThrow();
   });
 
   test("git upstream schema parses untracked outcome", () => {


### PR DESCRIPTION
## Summary
- replace per-poll deep diff-string equality as the first-line unchanged check with snapshot hash metadata checks in Agent Studio diff polling
- extend the git worktree snapshot contract with `hashVersion`, `statusHash`, and `diffHash`
- compute deterministic 64-bit FNV-1a hashes in the Tauri git command layer for both status payloads and diff payloads
- keep deep structural comparison as a guarded fallback when hash metadata is absent/mismatched to preserve correctness during mixed payload versions
- add/expand tests across desktop hook, Tauri host command, adapter, and runtime schemas

## Problem
`use-agent-studio-diff-data` previously compared `fileDiffs[].diff` strings on each poll cycle. For large patch payloads this makes unchanged checks O(total diff text size), increasing main-thread work and rerender decision cost.

## Solution Details
- Contracts (`packages/contracts`): add snapshot hash fields and schema validation for stable hex hash format.
- Host command (`apps/desktop/src-tauri/src/commands/git.rs`):
  - split payload collection from snapshot construction (`GitWorktreeStatusData`)
  - compute `statusHash` from branch/status/ahead-behind payload
  - compute `diffHash` from file diff payload including patch text
  - attach `hashVersion` for forward-compatible hash algorithm changes
- Frontend hook (`use-agent-studio-diff-data.ts`):
  - short-circuit equality when both snapshots provide matching hash metadata under the same version
  - include `error` in fast-path guard to avoid hiding upstream error transitions
  - retain deep comparison fallback for safety and backward compatibility

## Expected Impact
- O(1) unchanged-state checks on most polling cycles when hashes match
- reduced main-thread CPU spent in polling equality checks under large diffs
- smoother Agent Studio updates during continuous polling

## Validation
- `cd apps/desktop/src-tauri && cargo test -p openducktor-desktop commands::git::tests`
- `bun run --filter @openducktor/desktop test -- use-agent-studio-diff-data.test.tsx`
