### PR TITLE
refactor(tauri): decompose desktop bootstrap and hardcode metadata namespace

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -5,7 +5,7 @@ use super::super::{
     StartupEventPayload, TrackedOpencodeProcessGuard,
 };
 use anyhow::{anyhow, Context, Result};
-use host_domain::TaskStatus;
+use host_domain::{TaskStatus, TASK_METADATA_NAMESPACE};
 use host_infra_system::{build_branch_name, pick_free_port, remove_worktree, RepoConfig};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -177,11 +177,10 @@ impl AppService {
         prepared_worktree: &PreparedBuildWorktree,
     ) -> Result<SpawnedBuildAgent> {
         let port = pick_free_port()?;
-        let metadata_namespace = self.config_store.task_metadata_namespace()?;
         let mut child = spawn_opencode_server(
             prepared_worktree.worktree_dir.as_path(),
             Path::new(prerequisites.repo_path.as_str()),
-            metadata_namespace.as_str(),
+            TASK_METADATA_NAMESPACE,
             port,
         )?;
         let opencode_process_guard = match self.track_pending_opencode_process(child.id()) {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -5,7 +5,10 @@ use super::{
     TrackedOpencodeProcessGuard,
 };
 use anyhow::{anyhow, Result};
-use host_domain::{now_rfc3339, AgentRuntimeRole, AgentRuntimeSummary, RunSummary, RuntimeRole};
+use host_domain::{
+    now_rfc3339, AgentRuntimeRole, AgentRuntimeSummary, RunSummary, RuntimeRole,
+    TASK_METADATA_NAMESPACE,
+};
 use host_infra_system::pick_free_port;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -290,11 +293,10 @@ impl AppService {
     fn spawn_runtime_server(&self, input: &RuntimeStartInput<'_>) -> Result<SpawnedRuntimeServer> {
         let port = pick_free_port()?;
         let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
-        let metadata_namespace = self.config_store.task_metadata_namespace()?;
         let mut child = spawn_opencode_server(
             Path::new(input.working_directory.as_str()),
             Path::new(input.repo_path),
-            metadata_namespace.as_str(),
+            TASK_METADATA_NAMESPACE,
             port,
         )?;
         let opencode_process_guard = match self.track_pending_opencode_process(child.id()) {

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -25,6 +25,8 @@ pub use task::{
     CreateTaskInput, IssueType, PlanSubtaskInput, TaskAction, TaskCard, TaskStatus, UpdateTaskPatch,
 };
 
+pub const TASK_METADATA_NAMESPACE: &str = "openducktor";
+
 pub fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/constants.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/constants.rs
@@ -1,3 +1,3 @@
-pub(crate) const DEFAULT_METADATA_NAMESPACE: &str = "openducktor";
+pub(crate) const DEFAULT_METADATA_NAMESPACE: &str = host_domain::TASK_METADATA_NAMESPACE;
 pub(crate) const CUSTOM_STATUS_VALUES: &str = "spec_ready,ready_for_dev,ai_review,human_review";
 pub(crate) const TASK_LIST_CACHE_TTL_MS: u64 = 2_000;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -3,7 +3,7 @@ use host_domain::{
     now_rfc3339, AgentSessionDocument, CreateTaskInput, QaReportDocument, QaVerdict, SpecDocument,
     TaskCard, TaskMetadata, TaskStore, UpdateTaskPatch,
 };
-use host_infra_system::{compute_repo_slug, resolve_central_beads_dir, AppConfigStore};
+use host_infra_system::{compute_repo_slug, resolve_central_beads_dir};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -28,12 +28,9 @@ mod task_ops;
 
 use cache::TaskListCacheState;
 
-type MetadataNamespaceResolver = Arc<dyn Fn() -> Result<String> + Send + Sync>;
-
 pub struct BeadsTaskStore {
     pub(crate) command_runner: Arc<dyn CommandRunner>,
     pub(crate) metadata_namespace: Mutex<String>,
-    pub(crate) metadata_namespace_resolver: Option<MetadataNamespaceResolver>,
     pub(crate) init_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
     pub(crate) initialized_repos: Mutex<HashSet<String>>,
     task_list_cache: Mutex<HashMap<String, TaskListCacheState>>,
@@ -43,10 +40,6 @@ impl fmt::Debug for BeadsTaskStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BeadsTaskStore")
             .field("metadata_namespace", &self.metadata_namespace_snapshot())
-            .field(
-                "has_metadata_namespace_resolver",
-                &self.metadata_namespace_resolver.is_some(),
-            )
             .finish_non_exhaustive()
     }
 }
@@ -59,30 +52,20 @@ impl Default for BeadsTaskStore {
 
 impl BeadsTaskStore {
     pub fn new() -> Self {
-        Self::with_metadata_namespace_and_runner(
-            DEFAULT_METADATA_NAMESPACE,
-            Arc::new(ProcessCommandRunner),
-            Some(Self::default_metadata_namespace_resolver()),
-        )
+        Self::with_metadata_namespace_and_runner(DEFAULT_METADATA_NAMESPACE, Arc::new(ProcessCommandRunner))
     }
 
     pub fn with_metadata_namespace(namespace: &str) -> Self {
-        Self::with_metadata_namespace_and_runner(
-            namespace,
-            Arc::new(ProcessCommandRunner),
-            Some(Self::default_metadata_namespace_resolver()),
-        )
+        Self::with_metadata_namespace_and_runner(namespace, Arc::new(ProcessCommandRunner))
     }
 
     fn with_metadata_namespace_and_runner(
         namespace: &str,
         command_runner: Arc<dyn CommandRunner>,
-        metadata_namespace_resolver: Option<MetadataNamespaceResolver>,
     ) -> Self {
         Self {
             command_runner,
             metadata_namespace: Mutex::new(Self::normalize_metadata_namespace(namespace)),
-            metadata_namespace_resolver,
             init_locks: Mutex::new(HashMap::new()),
             initialized_repos: Mutex::new(HashSet::new()),
             task_list_cache: Mutex::new(HashMap::new()),
@@ -94,20 +77,7 @@ impl BeadsTaskStore {
         namespace: &str,
         command_runner: Arc<dyn CommandRunner>,
     ) -> Self {
-        Self::with_metadata_namespace_and_runner(namespace, command_runner, None)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn with_test_runner_and_namespace_resolver(
-        namespace: &str,
-        command_runner: Arc<dyn CommandRunner>,
-        metadata_namespace_resolver: Arc<dyn Fn() -> Result<String> + Send + Sync>,
-    ) -> Self {
-        Self::with_metadata_namespace_and_runner(
-            namespace,
-            command_runner,
-            Some(metadata_namespace_resolver),
-        )
+        Self::with_metadata_namespace_and_runner(namespace, command_runner)
     }
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/namespace.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/namespace.rs
@@ -1,13 +1,6 @@
 use super::*;
 
 impl BeadsTaskStore {
-    pub(super) fn default_metadata_namespace_resolver() -> MetadataNamespaceResolver {
-        Arc::new(|| {
-            let config_store = AppConfigStore::new()?;
-            config_store.task_metadata_namespace()
-        })
-    }
-
     pub(super) fn normalize_metadata_namespace(namespace: &str) -> String {
         let trimmed = namespace.trim();
         if trimmed.is_empty() {
@@ -24,31 +17,7 @@ impl BeadsTaskStore {
         }
     }
 
-    fn set_metadata_namespace(&self, namespace: &str) {
-        let normalized = Self::normalize_metadata_namespace(namespace);
-        match self.metadata_namespace.lock() {
-            Ok(mut guard) => *guard = normalized,
-            Err(poisoned) => {
-                let mut guard = poisoned.into_inner();
-                *guard = normalized;
-            }
-        }
-    }
-
-    fn refresh_metadata_namespace(&self) {
-        let Some(resolve_namespace) = &self.metadata_namespace_resolver else {
-            return;
-        };
-
-        let Ok(namespace) = resolve_namespace() else {
-            return;
-        };
-
-        self.set_metadata_namespace(&namespace);
-    }
-
     pub(crate) fn current_metadata_namespace(&self) -> String {
-        self.refresh_metadata_namespace();
         self.metadata_namespace_snapshot()
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1370,54 +1370,6 @@ fn set_spec_trims_markdown_and_increments_revision() -> Result<()> {
 }
 
 #[test]
-fn set_spec_switches_namespace_after_config_recovers() -> Result<()> {
-    let repo = RepoFixture::new("set-spec-namespace-resync");
-    let current = issue_value("task-1", "open", "task", None, json!([]), None);
-    let runner = MockCommandRunner::with_steps(vec![
-        MockStep::WithEnv(Ok(json!([current.clone()]).to_string())),
-        MockStep::WithEnv(Ok("{}".to_string())),
-        MockStep::WithEnv(Ok(json!([current]).to_string())),
-        MockStep::WithEnv(Ok("{}".to_string())),
-    ]);
-
-    let namespace_results = Arc::new(Mutex::new(VecDeque::from(vec![
-        Err(anyhow!("config temporarily unreadable")),
-        Ok("custom-ns".to_string()),
-    ])));
-    let namespace_results_for_resolver = Arc::clone(&namespace_results);
-    let resolver: Arc<dyn Fn() -> Result<String> + Send + Sync> = Arc::new(move || {
-        let mut guard = namespace_results_for_resolver
-            .lock()
-            .map_err(|_| anyhow!("namespace resolver lock poisoned"))?;
-        guard
-            .pop_front()
-            .unwrap_or_else(|| Ok("custom-ns".to_string()))
-    });
-
-    let store = BeadsTaskStore::with_test_runner_and_namespace_resolver(
-        "openducktor",
-        runner.clone(),
-        resolver,
-    );
-
-    store.set_spec(repo.path(), "task-1", "First write")?;
-    store.set_spec(repo.path(), "task-1", "Second write")?;
-
-    let calls = runner.take_calls();
-    assert_eq!(calls.len(), 4);
-
-    let first_metadata_root = metadata_from_call(&calls[1]);
-    assert!(first_metadata_root.get("openducktor").is_some());
-    assert!(first_metadata_root.get("custom-ns").is_none());
-
-    let second_metadata_root = metadata_from_call(&calls[3]);
-    assert!(second_metadata_root.get("custom-ns").is_some());
-    assert!(second_metadata_root.get("openducktor").is_none());
-
-    Ok(())
-}
-
-#[test]
 fn get_and_set_plan_use_implementation_plan_metadata() -> Result<()> {
     let repo = RepoFixture::new("plan-docs");
     let current_with_plan = issue_value(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -46,38 +46,9 @@ mod tests {
         let (store, root) = test_store("load-default");
         let config = store.load().expect("load default");
         assert_eq!(config.version, 1);
-        assert_eq!(config.task_metadata_namespace, "openducktor");
         assert_eq!(config.opencode_startup.timeout_ms, 8_000);
         assert_eq!(config.opencode_startup.connect_timeout_ms, 250);
         assert!(config.repos.is_empty());
-        let _ = fs::remove_dir_all(root);
-    }
-
-    #[test]
-    fn task_metadata_namespace_defaults_when_blank() {
-        let (store, root) = test_store("namespace-default");
-        let config = GlobalConfig {
-            task_metadata_namespace: "   ".to_string(),
-            ..GlobalConfig::default()
-        };
-        store.save(&config).expect("save config");
-
-        let namespace = store.task_metadata_namespace().expect("namespace");
-        assert_eq!(namespace, "openducktor");
-        let _ = fs::remove_dir_all(root);
-    }
-
-    #[test]
-    fn task_metadata_namespace_trims_non_empty_value() {
-        let (store, root) = test_store("namespace-trim");
-        let config = GlobalConfig {
-            task_metadata_namespace: "  custom-ns  ".to_string(),
-            ..GlobalConfig::default()
-        };
-        store.save(&config).expect("save config");
-
-        let namespace = store.task_metadata_namespace().expect("namespace");
-        assert_eq!(namespace, "custom-ns");
         let _ = fs::remove_dir_all(root);
     }
 
@@ -482,7 +453,6 @@ mod tests {
         let payload = json!({
             "version": 1,
             "activeRepo": repo_str,
-            "taskMetadataNamespace": "   ",
             "repos": repos,
             "recentRepos": [],
             "scheduler": {
@@ -521,9 +491,6 @@ mod tests {
         assert_eq!(spec.model_id, "gpt-5");
         assert!(spec.variant.is_none());
         assert!(spec.opencode_agent.is_none());
-
-        let namespace = store.task_metadata_namespace().expect("namespace");
-        assert_eq!(namespace, "openducktor");
 
         let _ = fs::remove_dir_all(root);
     }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
@@ -1,7 +1,6 @@
 use super::types::{
-    default_branch_prefix, default_target_branch, default_task_metadata_namespace,
-    hook_set_fingerprint, AgentModelDefault, GlobalConfig, OpencodeStartupReadinessConfig,
-    RepoConfig,
+    default_branch_prefix, default_target_branch, hook_set_fingerprint, AgentModelDefault,
+    GlobalConfig, OpencodeStartupReadinessConfig, RepoConfig,
 };
 
 fn normalize_optional_non_empty(value: Option<String>) -> Option<String> {
@@ -97,12 +96,6 @@ pub(super) fn normalize_opencode_startup_readiness_config(
 }
 
 pub(super) fn normalize_global_config(config: &mut GlobalConfig) {
-    let namespace = config.task_metadata_namespace.trim();
-    config.task_metadata_namespace = if namespace.is_empty() {
-        default_task_metadata_namespace()
-    } else {
-        namespace.to_string()
-    };
     normalize_opencode_startup_readiness_config(&mut config.opencode_startup);
     for repo in config.repos.values_mut() {
         normalize_repo_config(repo);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -1,8 +1,7 @@
 use super::migrate::{canonicalize_workspace_key, migrate_repos_to_canonical_keys};
 use super::normalize::{normalize_global_config, normalize_repo_config};
 use super::types::{
-    default_task_metadata_namespace, hook_set_fingerprint, GlobalConfig, HookSet,
-    OpencodeStartupReadinessConfig, RepoConfig,
+    hook_set_fingerprint, GlobalConfig, HookSet, OpencodeStartupReadinessConfig, RepoConfig,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::WorkspaceRecord;
@@ -87,16 +86,6 @@ impl AppConfigStore {
         parsed.recent_repos = canonical_recent;
 
         Ok(parsed)
-    }
-
-    pub fn task_metadata_namespace(&self) -> Result<String> {
-        let config = self.load()?;
-        let trimmed = config.task_metadata_namespace.trim();
-        if trimmed.is_empty() {
-            Ok(default_task_metadata_namespace())
-        } else {
-            Ok(trimmed.to_string())
-        }
     }
 
     pub fn opencode_startup_readiness(&self) -> Result<OpencodeStartupReadinessConfig> {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -89,10 +89,6 @@ pub(super) fn default_target_branch() -> String {
     "origin/main".to_string()
 }
 
-pub(super) fn default_task_metadata_namespace() -> String {
-    "openducktor".to_string()
-}
-
 impl Default for RepoConfig {
     fn default() -> Self {
         Self {
@@ -197,8 +193,6 @@ fn default_theme() -> String {
 pub struct GlobalConfig {
     pub version: u8,
     pub active_repo: Option<String>,
-    #[serde(default = "default_task_metadata_namespace")]
-    pub task_metadata_namespace: String,
     #[serde(default = "default_theme")]
     pub theme: String,
     #[serde(default)]
@@ -216,7 +210,6 @@ impl Default for GlobalConfig {
         Self {
             version: 1,
             active_repo: None,
-            task_metadata_namespace: default_task_metadata_namespace(),
             theme: default_theme(),
             opencode_startup: OpencodeStartupReadinessConfig::default(),
             repos: HashMap::new(),

--- a/apps/desktop/src-tauri/src/commands/runtime.rs
+++ b/apps/desktop/src-tauri/src/commands/runtime.rs
@@ -1,4 +1,4 @@
-use crate::{as_error, extend_runtime_errors_with_startup, run_service_blocking, AppState};
+use crate::{as_error, run_service_blocking, AppState};
 use host_domain::{AgentRuntimeRole, AgentRuntimeSummary, BeadsCheck, RuntimeCheck, SystemCheck};
 use tauri::State;
 
@@ -15,15 +15,11 @@ pub async fn runtime_check(
     state: State<'_, AppState>,
     force: Option<bool>,
 ) -> Result<RuntimeCheck, String> {
-    let check = as_error(
+    as_error(
         state
             .service
             .runtime_check_with_refresh(force.unwrap_or(false)),
-    )?;
-    Ok(extend_runtime_errors_with_startup(
-        check,
-        &state.startup_errors,
-    ))
+    )
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Context};
 use host_application::{AppService, RunEmitter};
-use host_domain::RunEvent;
 #[cfg(test)]
 use host_domain::TaskStatus;
+use host_domain::{RunEvent, TASK_METADATA_NAMESPACE};
 use host_infra_beads::BeadsTaskStore;
 use host_infra_system::AppConfigStore;
 use serde::Deserialize;
@@ -28,7 +28,6 @@ struct AppState {
     hook_trust_challenges: Mutex<HashMap<String, HookTrustChallenge>>,
 }
 
-const FALLBACK_TASK_METADATA_NAMESPACE: &str = "openducktor";
 const HOOK_TRUST_CHALLENGE_TTL: Duration = Duration::from_secs(120);
 static TRACING_INITIALIZED: OnceLock<()> = OnceLock::new();
 
@@ -160,21 +159,6 @@ fn extend_runtime_errors_with_startup(
     check
 }
 
-fn namespace_with_startup_warning(
-    namespace_result: anyhow::Result<String>,
-) -> (String, Option<String>) {
-    match namespace_result {
-        Ok(namespace) => (namespace, None),
-        Err(error) => (
-            FALLBACK_TASK_METADATA_NAMESPACE.to_string(),
-            Some(format!(
-                "Failed to read task metadata namespace from config; using fallback namespace '{}': {error:#}",
-                FALLBACK_TASK_METADATA_NAMESPACE
-            )),
-        ),
-    }
-}
-
 fn run_emitter(app: AppHandle) -> RunEmitter {
     Arc::new(move |event: RunEvent| {
         let _ = app.emit("openducktor://run-event", event);
@@ -187,24 +171,14 @@ fn startup_phase_tracing() {
 
 fn startup_phase_service_bootstrap() -> anyhow::Result<ServiceBootstrapPhase> {
     let config_store = AppConfigStore::new().context("failed to initialize config store")?;
-    let mut startup_errors = Vec::new();
-    let (metadata_namespace, startup_warning) =
-        namespace_with_startup_warning(config_store.task_metadata_namespace());
-    if let Some(message) = startup_warning {
-        tracing::warn!(
-            target: "openducktor.startup",
-            warning = %message,
-            "OpenDucktor startup warning"
-        );
-        startup_errors.push(message);
-    }
-
-    let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(&metadata_namespace));
+    let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(
+        TASK_METADATA_NAMESPACE,
+    ));
     let service = Arc::new(AppService::new(task_store, config_store));
 
     Ok(ServiceBootstrapPhase {
         service,
-        startup_errors,
+        startup_errors: Vec::new(),
     })
 }
 
@@ -344,35 +318,6 @@ mod tests {
     use anyhow::anyhow;
     use host_domain::RuntimeCheck;
     use serde_json::{json, Value};
-
-    #[test]
-    fn namespace_with_startup_warning_uses_configured_namespace() {
-        let (namespace, warning) =
-            namespace_with_startup_warning(Ok("custom-namespace".to_string()));
-
-        assert_eq!(namespace, "custom-namespace");
-        assert!(warning.is_none());
-    }
-
-    #[test]
-    fn namespace_with_startup_warning_falls_back_and_reports_error_context() -> Result<(), String> {
-        let (namespace, warning) =
-            namespace_with_startup_warning(Err(anyhow!("config parse failure")));
-
-        assert_eq!(namespace, FALLBACK_TASK_METADATA_NAMESPACE);
-
-        let warning =
-            warning.ok_or_else(|| "expected startup warning for fallback namespace".to_string())?;
-        assert!(
-            warning.contains("using fallback namespace 'openducktor'"),
-            "warning should mention fallback namespace: {warning}"
-        );
-        assert!(
-            warning.contains("config parse failure"),
-            "warning should include original error context: {warning}"
-        );
-        Ok(())
-    }
 
     #[test]
     fn extend_runtime_errors_with_startup_appends_startup_messages() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -39,6 +39,11 @@ struct HookTrustChallenge {
     expires_at: SystemTime,
 }
 
+struct ServiceBootstrapPhase {
+    service: Arc<AppService>,
+    startup_errors: Vec<String>,
+}
+
 fn init_tracing_subscriber() {
     TRACING_INITIALIZED.get_or_init(|| {
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
@@ -176,7 +181,11 @@ fn run_emitter(app: AppHandle) -> RunEmitter {
     })
 }
 
-fn bootstrap_service() -> anyhow::Result<(Arc<AppService>, Vec<String>)> {
+fn startup_phase_tracing() {
+    init_tracing_subscriber();
+}
+
+fn startup_phase_service_bootstrap() -> anyhow::Result<ServiceBootstrapPhase> {
     let config_store = AppConfigStore::new().context("failed to initialize config store")?;
     let mut startup_errors = Vec::new();
     let (metadata_namespace, startup_warning) =
@@ -193,7 +202,10 @@ fn bootstrap_service() -> anyhow::Result<(Arc<AppService>, Vec<String>)> {
     let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(&metadata_namespace));
     let service = Arc::new(AppService::new(task_store, config_store));
 
-    Ok((service, startup_errors))
+    Ok(ServiceBootstrapPhase {
+        service,
+        startup_errors,
+    })
 }
 
 fn install_shutdown_signal_handler(service: Arc<AppService>) {
@@ -215,91 +227,113 @@ fn install_shutdown_signal_handler(service: Arc<AppService>) {
     }
 }
 
-pub fn run() -> anyhow::Result<()> {
-    init_tracing_subscriber();
-    let (service, startup_errors) = bootstrap_service()?;
-    install_shutdown_signal_handler(service.clone());
+fn startup_phase_shutdown_hooks(service: Arc<AppService>) {
+    install_shutdown_signal_handler(service);
+}
 
-    let app_service = service.clone();
-    tauri::Builder::default()
+fn startup_phase_command_registration(
+    builder: tauri::Builder<tauri::Wry>,
+) -> tauri::Builder<tauri::Wry> {
+    builder.invoke_handler(tauri::generate_handler![
+        system_check,
+        runtime_check,
+        beads_check,
+        workspace_list,
+        workspace_add,
+        workspace_select,
+        workspace_update_repo_config,
+        workspace_save_repo_settings,
+        workspace_update_repo_hooks,
+        workspace_prepare_trusted_hooks_challenge,
+        workspace_get_repo_config,
+        workspace_set_trusted_hooks,
+        git_get_branches,
+        git_get_current_branch,
+        git_switch_branch,
+        git_create_worktree,
+        git_remove_worktree,
+        git_push_branch,
+        git_get_status,
+        git_get_diff,
+        git_commits_ahead_behind,
+        git_get_worktree_status,
+        git_commit_all,
+        git_pull_branch,
+        git_rebase_branch,
+        tasks_list,
+        task_create,
+        task_update,
+        task_delete,
+        task_transition,
+        task_defer,
+        task_resume_deferred,
+        spec_get,
+        task_metadata_get,
+        set_spec,
+        spec_save_document,
+        plan_get,
+        set_plan,
+        plan_save_document,
+        qa_get_report,
+        qa_approved,
+        qa_rejected,
+        build_start,
+        build_respond,
+        build_stop,
+        build_cleanup,
+        build_blocked,
+        build_resumed,
+        build_completed,
+        human_request_changes,
+        human_approve,
+        runs_list,
+        opencode_runtime_list,
+        opencode_runtime_start,
+        opencode_runtime_stop,
+        opencode_repo_runtime_ensure,
+        agent_sessions_list,
+        agent_session_upsert,
+        get_theme,
+        set_theme
+    ])
+}
+
+fn startup_phase_build_tauri_app(
+    bootstrap: ServiceBootstrapPhase,
+) -> anyhow::Result<tauri::App<tauri::Wry>> {
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .manage(AppState {
-            service,
-            startup_errors,
+            service: bootstrap.service,
+            startup_errors: bootstrap.startup_errors,
             hook_trust_challenges: Mutex::new(HashMap::new()),
-        })
-        .invoke_handler(tauri::generate_handler![
-            system_check,
-            runtime_check,
-            beads_check,
-            workspace_list,
-            workspace_add,
-            workspace_select,
-            workspace_update_repo_config,
-            workspace_save_repo_settings,
-            workspace_update_repo_hooks,
-            workspace_prepare_trusted_hooks_challenge,
-            workspace_get_repo_config,
-            workspace_set_trusted_hooks,
-            git_get_branches,
-            git_get_current_branch,
-            git_switch_branch,
-            git_create_worktree,
-            git_remove_worktree,
-            git_push_branch,
-            git_get_status,
-            git_get_diff,
-            git_commits_ahead_behind,
-            git_get_worktree_status,
-            git_commit_all,
-            git_pull_branch,
-            git_rebase_branch,
-            tasks_list,
-            task_create,
-            task_update,
-            task_delete,
-            task_transition,
-            task_defer,
-            task_resume_deferred,
-            spec_get,
-            task_metadata_get,
-            set_spec,
-            spec_save_document,
-            plan_get,
-            set_plan,
-            plan_save_document,
-            qa_get_report,
-            qa_approved,
-            qa_rejected,
-            build_start,
-            build_respond,
-            build_stop,
-            build_cleanup,
-            build_blocked,
-            build_resumed,
-            build_completed,
-            human_request_changes,
-            human_approve,
-            runs_list,
-            opencode_runtime_list,
-            opencode_runtime_start,
-            opencode_runtime_stop,
-            opencode_repo_runtime_ensure,
-            agent_sessions_list,
-            agent_session_upsert,
-            get_theme,
-            set_theme
-        ])
-        .build(tauri::generate_context!())
-        .context("error while building openducktor")?
-        .run(move |_handle, event| {
-            if matches!(
-                event,
-                TauriRunEvent::ExitRequested { .. } | TauriRunEvent::Exit
-            ) {
-                let _ = app_service.shutdown();
-            }
         });
+
+    startup_phase_command_registration(builder)
+        .build(tauri::generate_context!())
+        .context("error while building openducktor")
+}
+
+fn startup_phase_exit_shutdown_handler(
+    app_service: Arc<AppService>,
+) -> impl FnMut(&AppHandle, TauriRunEvent) {
+    move |_handle, event| {
+        if matches!(
+            event,
+            TauriRunEvent::ExitRequested { .. } | TauriRunEvent::Exit
+        ) {
+            let _ = app_service.shutdown();
+        }
+    }
+}
+
+pub fn run() -> anyhow::Result<()> {
+    startup_phase_tracing();
+    let bootstrap = startup_phase_service_bootstrap()?;
+    let app_service = bootstrap.service.clone();
+    startup_phase_shutdown_hooks(app_service.clone());
+
+    startup_phase_build_tauri_app(bootstrap)?.run(startup_phase_exit_shutdown_handler(app_service));
 
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -24,7 +24,6 @@ use commands::workspace::*;
 
 struct AppState {
     service: Arc<AppService>,
-    startup_errors: Vec<String>,
     hook_trust_challenges: Mutex<HashMap<String, HookTrustChallenge>>,
 }
 
@@ -36,11 +35,6 @@ struct HookTrustChallenge {
     repo_path: String,
     fingerprint: String,
     expires_at: SystemTime,
-}
-
-struct ServiceBootstrapPhase {
-    service: Arc<AppService>,
-    startup_errors: Vec<String>,
 }
 
 fn init_tracing_subscriber() {
@@ -151,14 +145,6 @@ where
         .map_err(|error| anyhow!("{operation_name} worker join failure: {error}"))?
 }
 
-fn extend_runtime_errors_with_startup(
-    mut check: host_domain::RuntimeCheck,
-    startup_errors: &[String],
-) -> host_domain::RuntimeCheck {
-    check.errors.extend(startup_errors.iter().cloned());
-    check
-}
-
 fn run_emitter(app: AppHandle) -> RunEmitter {
     Arc::new(move |event: RunEvent| {
         let _ = app.emit("openducktor://run-event", event);
@@ -169,17 +155,14 @@ fn startup_phase_tracing() {
     init_tracing_subscriber();
 }
 
-fn startup_phase_service_bootstrap() -> anyhow::Result<ServiceBootstrapPhase> {
+fn startup_phase_service_bootstrap() -> anyhow::Result<Arc<AppService>> {
     let config_store = AppConfigStore::new().context("failed to initialize config store")?;
     let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(
         TASK_METADATA_NAMESPACE,
     ));
     let service = Arc::new(AppService::new(task_store, config_store));
 
-    Ok(ServiceBootstrapPhase {
-        service,
-        startup_errors: Vec::new(),
-    })
+    Ok(service)
 }
 
 fn install_shutdown_signal_handler(service: Arc<AppService>) {
@@ -273,13 +256,12 @@ fn startup_phase_command_registration(
 }
 
 fn startup_phase_build_tauri_app(
-    bootstrap: ServiceBootstrapPhase,
+    service: Arc<AppService>,
 ) -> anyhow::Result<tauri::App<tauri::Wry>> {
     let builder = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .manage(AppState {
-            service: bootstrap.service,
-            startup_errors: bootstrap.startup_errors,
+            service,
             hook_trust_challenges: Mutex::new(HashMap::new()),
         });
 
@@ -303,11 +285,11 @@ fn startup_phase_exit_shutdown_handler(
 
 pub fn run() -> anyhow::Result<()> {
     startup_phase_tracing();
-    let bootstrap = startup_phase_service_bootstrap()?;
-    let app_service = bootstrap.service.clone();
+    let service = startup_phase_service_bootstrap()?;
+    let app_service = service.clone();
     startup_phase_shutdown_hooks(app_service.clone());
 
-    startup_phase_build_tauri_app(bootstrap)?.run(startup_phase_exit_shutdown_handler(app_service));
+    startup_phase_build_tauri_app(service)?.run(startup_phase_exit_shutdown_handler(app_service));
 
     Ok(())
 }
@@ -316,27 +298,7 @@ pub fn run() -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use anyhow::anyhow;
-    use host_domain::RuntimeCheck;
     use serde_json::{json, Value};
-
-    #[test]
-    fn extend_runtime_errors_with_startup_appends_startup_messages() {
-        let runtime = RuntimeCheck {
-            git_ok: true,
-            git_version: Some("git version 2.0.0".to_string()),
-            opencode_ok: true,
-            opencode_version: Some("1.0.0".to_string()),
-            errors: vec!["runtime issue".to_string()],
-        };
-
-        let startup_errors = vec!["startup warning".to_string()];
-        let updated = extend_runtime_errors_with_startup(runtime, &startup_errors);
-
-        assert_eq!(
-            updated.errors,
-            vec!["runtime issue".to_string(), "startup warning".to_string()]
-        );
-    }
 
     #[test]
     fn run_service_blocking_propagates_operation_error() {

--- a/docs/task-workflow-status-model.md
+++ b/docs/task-workflow-status-model.md
@@ -84,12 +84,11 @@ When `qaRequired=false`, transition from build completion skips `ai_review` and 
 ## Metadata Contract (Agent-Owned Documents)
 Agent-authored documents are stored under issue `metadata` only, never in user-authored fields.
 
-Root namespace key is configurable and defaults to `openducktor`.
+Root namespace key is fixed to `openducktor`.
 
 ### Namespace Key Requirement
-- Config key: `taskMetadataNamespace`
-- Default value: `openducktor`
-- All metadata reads/writes must use that key (no hard-coded namespace)
+- Value: `openducktor`
+- All metadata reads/writes must use that key
 
 ### JSON Shape
 ```json

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -66,7 +66,6 @@ export type RepoConfig = z.infer<typeof repoConfigSchema>;
 export const globalConfigSchema = z.object({
   version: z.literal(1),
   activeRepo: z.string().optional(),
-  taskMetadataNamespace: z.string().min(1).default("openducktor"),
   repos: z.record(z.string(), repoConfigSchema).default({}),
   recentRepos: z.array(z.string()).default([]),
   scheduler: z


### PR DESCRIPTION
## Summary
This PR delivers two related Tauri bootstrap/config refactors:

1. Decomposes desktop bootstrap in `apps/desktop/src-tauri/src/lib.rs` into explicit startup phases, keeping `run()` as an orchestration shell.
2. Removes configurable `taskMetadataNamespace` from settings/contracts and makes the task metadata namespace an application constant (`openducktor`).

## Why
- Reduce bootstrap change coupling and make startup responsibilities easier to reason about.
- Remove fallback/config-driven namespace behavior and enforce a single canonical metadata namespace at the source.
- Keep runtime/build MCP metadata wiring deterministic across host layers.

## What Changed
### Tauri bootstrap decomposition
- Introduced phase-oriented startup helpers in `src/lib.rs`:
  - tracing phase
  - service bootstrap phase
  - command registration phase
  - shutdown hook phases
- Preserved command registration in `tauri::generate_handler!` and shutdown behavior.

### Metadata namespace cleanup
- Added shared Rust constant:
  - `host_domain::TASK_METADATA_NAMESPACE = "openducktor"`
- Removed namespace reads from config in runtime/build OpenCode startup paths.
- Removed dynamic namespace refresh/resolver path from `host-infra-beads` store.
- Wired `host-infra-beads` default namespace to the domain constant.

### Settings/contracts cleanup
- Removed `taskMetadataNamespace` from:
  - Rust global config type/normalization/store accessors (`host-infra-system`)
  - TS contracts global config schema (`packages/contracts/src/config-schemas.ts`)
- Updated workflow docs to reflect fixed namespace.

## Validation
Executed and passing:

- `bun run --filter @openducktor/contracts test`
- `cargo test -p host-domain`
- `cargo test -p host-infra-system`
- `cargo test -p host-infra-beads`
- `cargo test -p host-application`
- `cargo test -p openducktor-desktop --lib`
- `cargo clippy -p openducktor-desktop --lib -- -D warnings`

## Notes
- `taskMetadataNamespace` is now removed from the typed config contract and host config model.
- Metadata writes/reads are now consistently scoped to `openducktor` via application constant.
