### PR TITLE
fix(tauri-host): fail fast when startup config is invalid

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -1,12 +1,16 @@
 use super::super::{
-    emit_event, spawn_output_forwarder, terminate_child_process, AppService, RunEmitter, RunProcess,
+    emit_event, spawn_output_forwarder, terminate_child_process, AppService,
+    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, RunEmitter, RunProcess,
+    StartupEventCorrelation, StartupEventPayload,
 };
 use super::build_runtime_setup::{BuildPrerequisites, PreparedBuildWorktree, SpawnedBuildAgent};
 use super::BuildResponseAction;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, RunEvent, RunState, RunSummary, TaskStatus};
 use std::process::{ChildStderr, ChildStdout};
 use uuid::Uuid;
+
+const STARTUP_CONFIG_INVALID_REASON: &str = "startup_config_invalid";
 
 struct BuildRunRegistration {
     run_id: String,
@@ -27,12 +31,18 @@ impl AppService {
     ) -> Result<RunSummary> {
         let run_id = format!("run-{}", Uuid::new_v4().simple());
         let prerequisites = self.validate_build_prerequisites(repo_path, task_id)?;
+        let startup_policy = self.resolve_build_startup_policy(
+            prerequisites.repo_path.as_str(),
+            task_id,
+            run_id.as_str(),
+        )?;
         let prepared_worktree = self.prepare_build_worktree(&prerequisites, task_id)?;
         let spawned_agent = self.spawn_and_wait_for_agent(
             &prerequisites,
             &prepared_worktree,
             task_id,
             run_id.as_str(),
+            startup_policy,
         )?;
 
         self.initiate_build_mode(
@@ -128,6 +138,34 @@ impl AppService {
         );
 
         Ok(true)
+    }
+
+    pub(crate) fn resolve_build_startup_policy(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+        run_id: &str,
+    ) -> Result<OpencodeStartupReadinessPolicy> {
+        self.opencode_startup_readiness_policy()
+            .map_err(|error| {
+                self.emit_opencode_startup_event(StartupEventPayload::failed(
+                    "build_runtime",
+                    repo_path,
+                    Some(task_id),
+                    "build",
+                    0,
+                    Some(StartupEventCorrelation::new("run_id", run_id)),
+                    None,
+                    OpencodeStartupWaitReport::zero(),
+                    STARTUP_CONFIG_INVALID_REASON,
+                ));
+                error
+            })
+            .with_context(|| {
+                format!(
+                    "OpenCode build runtime failed before worktree preparation for task {task_id}"
+                )
+            })
     }
 
     fn abort_started_build<T>(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -1,7 +1,7 @@
 use super::super::{
     emit_event, spawn_output_forwarder, terminate_child_process, AppService,
     OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, RunEmitter, RunProcess,
-    StartupEventCorrelation, StartupEventPayload,
+    StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
 };
 use super::build_runtime_setup::{BuildPrerequisites, PreparedBuildWorktree, SpawnedBuildAgent};
 use super::BuildResponseAction;
@@ -9,8 +9,6 @@ use anyhow::{anyhow, Context, Result};
 use host_domain::{now_rfc3339, RunEvent, RunState, RunSummary, TaskStatus};
 use std::process::{ChildStderr, ChildStdout};
 use uuid::Uuid;
-
-const STARTUP_CONFIG_INVALID_REASON: &str = "startup_config_invalid";
 
 struct BuildRunRegistration {
     run_id: String,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -157,6 +157,7 @@ impl AppService {
         prepared_worktree: &PreparedBuildWorktree,
         task_id: &str,
         run_id: &str,
+        startup_policy: OpencodeStartupReadinessPolicy,
     ) -> Result<SpawnedBuildAgent> {
         let mut spawned_agent = self.spawn_build_agent_process(prerequisites, prepared_worktree)?;
         if let Err(error) = self.wait_for_build_agent_readiness(
@@ -164,6 +165,7 @@ impl AppService {
             prerequisites.repo_path.as_str(),
             task_id,
             run_id,
+            startup_policy,
         ) {
             terminate_child_process(&mut spawned_agent.child);
             return Err(error);
@@ -204,12 +206,8 @@ impl AppService {
         repo_path: &str,
         task_id: &str,
         run_id: &str,
+        startup_policy: OpencodeStartupReadinessPolicy,
     ) -> Result<()> {
-        let startup_policy = self
-            .opencode_startup_readiness_policy()
-            .with_context(|| {
-                format!("OpenCode build runtime failed before readiness wait for task {task_id}")
-            })?;
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
         self.emit_build_runtime_wait_begin(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -205,7 +205,11 @@ impl AppService {
         task_id: &str,
         run_id: &str,
     ) -> Result<()> {
-        let startup_policy = self.opencode_startup_readiness_policy();
+        let startup_policy = self
+            .opencode_startup_readiness_policy()
+            .with_context(|| {
+                format!("OpenCode build runtime failed before readiness wait for task {task_id}")
+            })?;
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
         self.emit_build_runtime_wait_begin(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -50,13 +50,17 @@ pub(crate) use process_registry::{
     with_locked_opencode_process_registry, OpencodeProcessRegistryInstance,
     OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
-pub(crate) use service_core::{AgentRuntimeProcess, CachedRuntimeCheck, RunProcess, RuntimeCleanupTarget};
+pub(crate) use service_core::{
+    AgentRuntimeProcess, CachedRuntimeCheck, RunProcess, RuntimeCleanupTarget,
+};
 pub use service_core::{AppService, RunEmitter};
 #[cfg(test)]
 pub(crate) use startup_metrics::{
     build_opencode_startup_event_payload, OpencodeStartupMetricsSnapshot,
 };
-pub(crate) use startup_metrics::{StartupEventCorrelation, StartupEventPayload};
+pub(crate) use startup_metrics::{
+    StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
+};
 pub(crate) use workflow_rules::{
     can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,
     default_qa_required_for_issue_type, derive_agent_workflows, derive_available_actions,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/startup_readiness/policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/startup_readiness/policy.rs
@@ -71,6 +71,13 @@ impl OpencodeStartupWaitReport {
         self.elapsed.as_millis().min(u64::MAX as u128) as u64
     }
 
+    pub(crate) fn zero() -> Self {
+        Self {
+            attempts: 0,
+            elapsed: Duration::ZERO,
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn from_parts(attempts: u32, elapsed: Duration) -> Self {
         Self { attempts, elapsed }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -51,8 +51,6 @@ pub(super) struct SpawnedRuntimeServer {
     opencode_process_guard: super::TrackedOpencodeProcessGuard,
 }
 
-pub(super) const STARTUP_CONFIG_INVALID_REASON: &str = "startup_config_invalid";
-
 impl AppService {
     pub fn runs_list(&self, repo_path: Option<&str>) -> Result<Vec<RunSummary>> {
         let repo_key_filter = repo_path
@@ -159,6 +157,11 @@ impl AppService {
         let repo_key = self.resolve_initialized_repo_path(repo_path)?;
         let repo_path = repo_key.as_str();
         let runtime_role = RuntimeRole::from(role);
+        if let Some(existing) =
+            self.resolve_existing_runtime_for_start(repo_path, runtime_role, task_id)?
+        {
+            return Ok(existing);
+        }
         let startup_error_context = format!("OpenCode runtime failed to start for task {task_id}");
         let startup_policy = self.resolve_runtime_startup_policy(
             "agent_runtime",

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -26,6 +26,7 @@ pub(super) struct RuntimeStartInput<'a> {
     repo_key: String,
     task_id: &'a str,
     role: RuntimeRole,
+    startup_policy: super::OpencodeStartupReadinessPolicy,
     working_directory: String,
     cleanup_target: Option<super::RuntimeCleanupTarget>,
     tracking_error_context: &'static str,
@@ -49,6 +50,8 @@ pub(super) struct SpawnedRuntimeServer {
     child: Child,
     opencode_process_guard: super::TrackedOpencodeProcessGuard,
 }
+
+pub(super) const STARTUP_CONFIG_INVALID_REASON: &str = "startup_config_invalid";
 
 impl AppService {
     pub fn runs_list(&self, repo_path: Option<&str>) -> Result<Vec<RunSummary>> {
@@ -113,16 +116,27 @@ impl AppService {
             }
         }
 
+        let startup_error_context =
+            format!("OpenCode workspace runtime failed to start for {repo_path}");
+        let startup_policy = self.resolve_runtime_startup_policy(
+            "workspace_runtime",
+            repo_path,
+            Self::WORKSPACE_RUNTIME_TASK_ID,
+            Self::WORKSPACE_RUNTIME_ROLE,
+            startup_error_context.as_str(),
+        )?;
+
         self.spawn_and_register_runtime(RuntimeStartInput {
             startup_scope: "workspace_runtime",
             repo_path,
             repo_key: repo_key.clone(),
             task_id: Self::WORKSPACE_RUNTIME_TASK_ID,
             role: Self::WORKSPACE_RUNTIME_ROLE,
+            startup_policy,
             working_directory: repo_key.clone(),
             cleanup_target: None,
             tracking_error_context: "Failed tracking spawned OpenCode workspace runtime",
-            startup_error_context: format!("OpenCode workspace runtime failed to start for {repo_path}"),
+            startup_error_context,
             post_start_policy: Some(RuntimePostStartPolicy {
                 existing_lookup: RuntimeExistingLookup {
                     repo_key: repo_key.as_str(),
@@ -145,6 +159,14 @@ impl AppService {
         let repo_key = self.resolve_initialized_repo_path(repo_path)?;
         let repo_path = repo_key.as_str();
         let runtime_role = RuntimeRole::from(role);
+        let startup_error_context = format!("OpenCode runtime failed to start for task {task_id}");
+        let startup_policy = self.resolve_runtime_startup_policy(
+            "agent_runtime",
+            repo_path,
+            task_id,
+            runtime_role,
+            startup_error_context.as_str(),
+        )?;
         let prerequisites = match self.resolve_runtime_prerequisites(repo_path, task_id, role)? {
             RuntimePrerequisiteResolution::Existing(existing) => return Ok(existing),
             RuntimePrerequisiteResolution::Ready(prerequisites) => prerequisites,
@@ -156,10 +178,11 @@ impl AppService {
             repo_key: repo_key.clone(),
             task_id,
             role: runtime_role,
+            startup_policy,
             working_directory: prerequisites.working_directory,
             cleanup_target: prerequisites.cleanup_target,
             tracking_error_context: "Failed tracking spawned OpenCode agent runtime",
-            startup_error_context: format!("OpenCode runtime failed to start for task {task_id}"),
+            startup_error_context,
             post_start_policy: Some(RuntimePostStartPolicy {
                 existing_lookup: RuntimeExistingLookup {
                     repo_key: repo_key.as_str(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/prerequisites.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/prerequisites.rs
@@ -1,10 +1,32 @@
 use super::super::{qa_worktree::prepare_qa_worktree, AppService, RuntimeCleanupTarget};
 use super::{RuntimeExistingLookup, RuntimePrerequisiteResolution, RuntimePrerequisites};
 use anyhow::{anyhow, Result};
-use host_domain::AgentRuntimeRole;
+use host_domain::{AgentRuntimeRole, AgentRuntimeSummary, RuntimeRole};
 use std::path::Path;
 
 impl AppService {
+    pub(super) fn resolve_existing_runtime_for_start(
+        &self,
+        repo_key: &str,
+        role: RuntimeRole,
+        task_id: &str,
+    ) -> Result<Option<AgentRuntimeSummary>> {
+        let mut runtimes = self
+            .agent_runtimes
+            .lock()
+            .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
+        Self::prune_stale_runtimes(&mut runtimes)?;
+
+        Ok(Self::find_existing_runtime(
+            &runtimes,
+            RuntimeExistingLookup {
+                repo_key,
+                role,
+                task_id: Some(task_id),
+            },
+        ))
+    }
+
     pub(super) fn resolve_runtime_prerequisites(
         &self,
         repo_key: &str,
@@ -38,8 +60,12 @@ impl AppService {
 
         let prerequisites = match role {
             AgentRuntimeRole::Qa => {
-                let setup =
-                    prepare_qa_worktree(repo_key, task_id, task.title.as_str(), &self.config_store)?;
+                let setup = prepare_qa_worktree(
+                    repo_key,
+                    task_id,
+                    task.title.as_str(),
+                    &self.config_store,
+                )?;
                 RuntimePrerequisites {
                     working_directory: setup.worktree_path.clone(),
                     cleanup_target: Some(RuntimeCleanupTarget {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
@@ -36,7 +36,22 @@ impl AppService {
             }
         };
 
-        let startup_policy = self.opencode_startup_readiness_policy();
+        let startup_policy = match self.opencode_startup_readiness_policy() {
+            Ok(policy) => policy,
+            Err(error) => {
+                let startup_policy_error = error.context(input.startup_error_context.clone());
+                if let Err(cleanup_error) = Self::cleanup_started_runtime(
+                    &mut child,
+                    input.cleanup_target.as_ref(),
+                ) {
+                    return Err(Self::append_cleanup_error(
+                        startup_policy_error,
+                        cleanup_error,
+                    ));
+                }
+                return Err(startup_policy_error);
+            }
+        };
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
         self.emit_opencode_startup_event(StartupEventPayload::wait_begin(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
@@ -1,9 +1,9 @@
 use super::super::{
     spawn_opencode_server, wait_for_local_server_with_process, AppService,
     OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupEventCorrelation,
-    StartupEventPayload,
+    StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
 };
-use super::{RuntimeStartInput, SpawnedRuntimeServer, STARTUP_CONFIG_INVALID_REASON};
+use super::{RuntimeStartInput, SpawnedRuntimeServer};
 use anyhow::{anyhow, Context, Result};
 use host_domain::{RuntimeRole, TASK_METADATA_NAMESPACE};
 use host_infra_system::pick_free_port;
@@ -54,10 +54,9 @@ impl AppService {
             Ok(guard) => guard,
             Err(error) => {
                 let tracking_error = anyhow!(error).context(input.tracking_error_context);
-                if let Err(cleanup_error) = Self::cleanup_started_runtime(
-                    &mut child,
-                    input.cleanup_target.as_ref(),
-                ) {
+                if let Err(cleanup_error) =
+                    Self::cleanup_started_runtime(&mut child, input.cleanup_target.as_ref())
+                {
                     return Err(Self::append_cleanup_error(tracking_error, cleanup_error));
                 }
                 return Err(tracking_error);
@@ -101,10 +100,9 @@ impl AppService {
                     error.reason,
                 ));
                 let startup_error = anyhow!(error).context(input.startup_error_context.clone());
-                if let Err(cleanup_error) = Self::cleanup_started_runtime(
-                    &mut child,
-                    input.cleanup_target.as_ref(),
-                ) {
+                if let Err(cleanup_error) =
+                    Self::cleanup_started_runtime(&mut child, input.cleanup_target.as_ref())
+                {
                     return Err(Self::append_cleanup_error(startup_error, cleanup_error));
                 }
                 return Err(startup_error);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
@@ -1,21 +1,49 @@
 use super::super::{
     spawn_opencode_server, wait_for_local_server_with_process, AppService,
-    StartupEventCorrelation, StartupEventPayload,
+    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupEventCorrelation,
+    StartupEventPayload,
 };
-use super::{RuntimeStartInput, SpawnedRuntimeServer};
-use anyhow::{anyhow, Result};
-use host_domain::TASK_METADATA_NAMESPACE;
+use super::{RuntimeStartInput, SpawnedRuntimeServer, STARTUP_CONFIG_INVALID_REASON};
+use anyhow::{anyhow, Context, Result};
+use host_domain::{RuntimeRole, TASK_METADATA_NAMESPACE};
 use host_infra_system::pick_free_port;
 use std::path::Path;
 use uuid::Uuid;
 
 impl AppService {
+    pub(crate) fn resolve_runtime_startup_policy(
+        &self,
+        startup_scope: &str,
+        repo_path: &str,
+        task_id: &str,
+        role: RuntimeRole,
+        startup_error_context: &str,
+    ) -> Result<OpencodeStartupReadinessPolicy> {
+        self.opencode_startup_readiness_policy()
+            .map_err(|error| {
+                self.emit_opencode_startup_event(StartupEventPayload::failed(
+                    startup_scope,
+                    repo_path,
+                    Some(task_id),
+                    role.as_str(),
+                    0,
+                    None,
+                    None,
+                    OpencodeStartupWaitReport::zero(),
+                    STARTUP_CONFIG_INVALID_REASON,
+                ));
+                error
+            })
+            .with_context(|| startup_error_context.to_string())
+    }
+
     pub(super) fn spawn_runtime_server(
         &self,
         input: &RuntimeStartInput<'_>,
     ) -> Result<SpawnedRuntimeServer> {
         let port = pick_free_port()?;
         let runtime_id = format!("runtime-{}", Uuid::new_v4().simple());
+        let startup_policy = input.startup_policy;
         let mut child = spawn_opencode_server(
             Path::new(input.working_directory.as_str()),
             Path::new(input.repo_path),
@@ -33,23 +61,6 @@ impl AppService {
                     return Err(Self::append_cleanup_error(tracking_error, cleanup_error));
                 }
                 return Err(tracking_error);
-            }
-        };
-
-        let startup_policy = match self.opencode_startup_readiness_policy() {
-            Ok(policy) => policy,
-            Err(error) => {
-                let startup_policy_error = error.context(input.startup_error_context.clone());
-                if let Err(cleanup_error) = Self::cleanup_started_runtime(
-                    &mut child,
-                    input.cleanup_target.as_ref(),
-                ) {
-                    return Err(Self::append_cleanup_error(
-                        startup_policy_error,
-                        cleanup_error,
-                    ));
-                }
-                return Err(startup_policy_error);
             }
         };
         let startup_cancel_epoch = self.startup_cancel_epoch();

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
@@ -393,18 +393,16 @@ pub(crate) fn build_opencode_startup_event_payload(
 }
 
 impl AppService {
-    pub(crate) fn opencode_startup_readiness_policy(&self) -> OpencodeStartupReadinessPolicy {
-        match self.config_store.opencode_startup_readiness() {
-            Ok(config) => OpencodeStartupReadinessPolicy::from_config(config),
-            Err(error) => {
-                tracing::warn!(
-                    target: "openducktor.opencode.startup",
-                    error = %format!("{error:#}"),
-                    "Failed loading OpenCode startup readiness config; using defaults"
-                );
-                OpencodeStartupReadinessPolicy::default()
-            }
-        }
+    pub(crate) fn opencode_startup_readiness_policy(
+        &self,
+    ) -> Result<OpencodeStartupReadinessPolicy> {
+        let config = self.config_store.opencode_startup_readiness().with_context(|| {
+            format!(
+                "Failed loading OpenCode startup readiness config from {}. Fix invalid JSON in this file or delete it so OpenDucktor can recreate defaults.",
+                self.config_store.path().display()
+            )
+        })?;
+        Ok(OpencodeStartupReadinessPolicy::from_config(config))
     }
 
     pub(crate) fn startup_cancel_epoch(&self) -> StartupCancelEpoch {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
@@ -413,6 +413,15 @@ impl AppService {
         self.startup_cancel_epoch.load(Ordering::SeqCst)
     }
 
+    #[cfg(test)]
+    pub(crate) fn startup_metrics_snapshot(&self) -> Result<OpencodeStartupMetricsSnapshot> {
+        let metrics = self
+            .startup_metrics
+            .lock()
+            .map_err(|_| anyhow!("OpenCode startup metrics lock poisoned"))?;
+        Ok(metrics.snapshot())
+    }
+
     pub(crate) fn emit_opencode_startup_event(&self, event: StartupEventPayload<'_>) {
         let event_name = event.event_name();
         let runtime_type = event.runtime_type;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
@@ -8,6 +8,7 @@ const STARTUP_MS_BUCKETS: [&str; 7] = [
     "<=100", "<=250", "<=500", "<=1000", "<=2000", "<=5000", ">5000",
 ];
 const STARTUP_ATTEMPTS_BUCKETS: [&str; 6] = ["<=1", "<=3", "<=5", "<=10", "<=20", ">20"];
+pub(crate) const STARTUP_CONFIG_INVALID_REASON: &str = "startup_config_invalid";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -537,6 +537,60 @@ fn build_start_reports_opencode_startup_failure() -> Result<()> {
 }
 
 #[test]
+fn build_start_fails_on_invalid_startup_config_before_worktree_creation() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("build-invalid-startup-config");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+
+    let config_path = root.join("config.json");
+    let config_store = AppConfigStore::from_path(config_path.clone());
+    let repo_path = repo.to_string_lossy().to_string();
+    let worktree_base = root.join("worktrees");
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "bug", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: "origin/main".to_string(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    fs::write(&config_path, "{ invalid json")?;
+
+    let error = service
+        .build_start(
+            repo_path.as_str(),
+            "task-1",
+            make_emitter(Arc::new(Mutex::new(Vec::new()))),
+        )
+        .expect_err("invalid config should fail build start before worktree preparation");
+    let message = error.to_string();
+    assert!(message.contains("Failed parsing config file"));
+    assert!(
+        !worktree_base.join("task-1").exists(),
+        "worktree should not be created when startup config is invalid"
+    );
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn build_start_stops_spawned_child_when_run_state_lock_is_poisoned() -> Result<()> {
     let _env_lock = lock_env();
     let root = unique_temp_path("build-run-lock-poison");

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -465,6 +465,61 @@ fn opencode_runtime_start_surfaces_cleanup_failure_after_startup_error() -> Resu
 }
 
 #[test]
+fn opencode_runtime_start_fails_on_invalid_startup_config_before_qa_worktree_setup() -> Result<()>
+{
+    let _env_lock = lock_env();
+    let root = unique_temp_path("runtime-invalid-startup-config");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+
+    let config_path = root.join("config.json");
+    let config_store = AppConfigStore::from_path(config_path.clone());
+    let repo_path = repo.to_string_lossy().to_string();
+    let worktree_base = root.join("qa-worktrees");
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: "origin/main".to_string(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    fs::write(&config_path, "{ invalid json")?;
+
+    let error = service
+        .opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Qa)
+        .expect_err("invalid config should fail runtime start before QA worktree setup");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("Failed parsing config file")
+            || message.contains("Failed loading OpenCode startup readiness config"),
+        "runtime startup error should preserve actionable config context: {message}"
+    );
+    assert!(
+        !worktree_base.exists(),
+        "QA worktree base should not be created when startup config is invalid"
+    );
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn opencode_runtime_start_reuses_existing_runtime_for_same_task_and_role() -> Result<()> {
     let _env_lock = lock_env();
     let root = unique_temp_path("runtime-reuse");

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -134,8 +134,8 @@ fn opencode_workspace_runtime_ensure_stops_spawned_child_when_post_start_prune_f
                 _opencode_process_guard: None,
                 cleanup_target: Some(RuntimeCleanupTarget {
                     repo_path: "/tmp/non-existent-repo-for-ensure-post-start-prune".to_string(),
-                    worktree_path:
-                        "/tmp/non-existent-worktree-for-ensure-post-start-prune".to_string(),
+                    worktree_path: "/tmp/non-existent-worktree-for-ensure-post-start-prune"
+                        .to_string(),
                 }),
             },
         );
@@ -465,8 +465,7 @@ fn opencode_runtime_start_surfaces_cleanup_failure_after_startup_error() -> Resu
 }
 
 #[test]
-fn opencode_runtime_start_fails_on_invalid_startup_config_before_qa_worktree_setup() -> Result<()>
-{
+fn opencode_runtime_start_fails_on_invalid_startup_config_before_qa_worktree_setup() -> Result<()> {
     let _env_lock = lock_env();
     let root = unique_temp_path("runtime-invalid-startup-config");
     let repo = root.join("repo");
@@ -545,6 +544,8 @@ fn opencode_runtime_start_reuses_existing_runtime_for_same_task_and_role() -> Re
 
     let first =
         service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)?;
+    let config_path = root.join("config.json");
+    fs::write(&config_path, "{ invalid json")?;
     let second =
         service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)?;
     assert_eq!(first.runtime_id, second.runtime_id);
@@ -579,14 +580,12 @@ fn opencode_runtime_start_deduplicates_concurrent_same_task_and_role() -> Result
     let repo_path = repo.to_string_lossy().to_string();
 
     let (first, second) = thread::scope(|scope| {
-        let first_start =
-            scope.spawn(|| {
-                service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)
-            });
-        let second_start =
-            scope.spawn(|| {
-                service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)
-            });
+        let first_start = scope.spawn(|| {
+            service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)
+        });
+        let second_start = scope.spawn(|| {
+            service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)
+        });
         (
             first_start
                 .join()

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -423,12 +423,50 @@ fn opencode_startup_readiness_policy_uses_config_overrides() -> Result<()> {
         state: Arc::new(Mutex::new(TaskStoreState::default())),
     });
     let service = AppService::new(task_store, config_store);
-    let policy = service.opencode_startup_readiness_policy();
+    let policy = service.opencode_startup_readiness_policy()?;
     assert_eq!(policy.timeout, Duration::from_millis(12_345));
     assert_eq!(policy.connect_timeout, Duration::from_millis(456));
     assert_eq!(policy.initial_retry_delay, Duration::from_millis(33));
     assert_eq!(policy.max_retry_delay, Duration::from_millis(99));
     assert_eq!(policy.child_state_check_interval, Duration::from_millis(77));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn opencode_startup_readiness_policy_returns_actionable_error_on_invalid_config() -> Result<()> {
+    let root = unique_temp_path("startup-policy-invalid-config");
+    let config_path = root.join("config.json");
+    fs::create_dir_all(&root)?;
+    fs::write(&config_path, "{ invalid json")?;
+
+    let config_store = AppConfigStore::from_path(config_path.clone());
+    let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore {
+        state: Arc::new(Mutex::new(TaskStoreState::default())),
+    });
+    let service = AppService::new(task_store, config_store);
+    let error = service
+        .opencode_startup_readiness_policy()
+        .expect_err("invalid config should fail startup readiness policy load");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains(&format!(
+            "Failed loading OpenCode startup readiness config from {}",
+            config_path.display()
+        )),
+        "error should include startup context and config path: {message}"
+    );
+    assert!(
+        message.contains(
+            "Fix invalid JSON in this file or delete it so OpenDucktor can recreate defaults"
+        ),
+        "error should include recovery instruction: {message}"
+    );
+    assert!(
+        message.contains("Failed parsing config file"),
+        "error should preserve parse failure context: {message}"
+    );
 
     let _ = fs::remove_dir_all(root);
     Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use host_domain::{
-    CreateTaskInput, IssueType, PlanSubtaskInput, TaskAction, TaskStatus, TaskStore,
+    CreateTaskInput, IssueType, PlanSubtaskInput, RuntimeRole, TaskAction, TaskStatus, TaskStore,
     UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, OpencodeStartupReadinessConfig};
@@ -469,6 +469,60 @@ fn opencode_startup_readiness_policy_returns_actionable_error_on_invalid_config(
     );
 
     let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn resolve_build_startup_policy_emits_config_failure_metrics() -> Result<()> {
+    let root = unique_temp_path("build-startup-policy-invalid-config");
+    let config_path = root.join("config.json");
+    fs::create_dir_all(&root)?;
+    fs::write(&config_path, "{ invalid json")?;
+
+    let config_store = AppConfigStore::from_path(config_path);
+    let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore {
+        state: Arc::new(Mutex::new(TaskStoreState::default())),
+    });
+    let service = AppService::new(task_store, config_store);
+    let error = service
+        .resolve_build_startup_policy("/tmp/repo", "task-42", "run-abc")
+        .expect_err("invalid config should fail build startup policy resolution");
+    let message = format!("{error:#}");
+    assert!(message.contains("OpenCode build runtime failed before worktree preparation"));
+    assert!(message.contains("Failed loading OpenCode startup readiness config"));
+
+    let metrics = service.startup_metrics_snapshot()?;
+    assert_eq!(metrics.failed_by_reason.get("startup_config_invalid"), Some(&1));
+    Ok(())
+}
+
+#[test]
+fn resolve_runtime_startup_policy_emits_config_failure_metrics() -> Result<()> {
+    let root = unique_temp_path("runtime-startup-policy-invalid-config");
+    let config_path = root.join("config.json");
+    fs::create_dir_all(&root)?;
+    fs::write(&config_path, "{ invalid json")?;
+
+    let config_store = AppConfigStore::from_path(config_path);
+    let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore {
+        state: Arc::new(Mutex::new(TaskStoreState::default())),
+    });
+    let service = AppService::new(task_store, config_store);
+    let error = service
+        .resolve_runtime_startup_policy(
+            "agent_runtime",
+            "/tmp/repo",
+            "task-42",
+            RuntimeRole::Qa,
+            "OpenCode runtime failed to start for task task-42",
+        )
+        .expect_err("invalid config should fail runtime startup policy resolution");
+    let message = format!("{error:#}");
+    assert!(message.contains("OpenCode runtime failed to start for task task-42"));
+    assert!(message.contains("Failed loading OpenCode startup readiness config"));
+
+    let metrics = service.startup_metrics_snapshot()?;
+    assert_eq!(metrics.failed_by_reason.get("startup_config_invalid"), Some(&1));
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -145,6 +145,15 @@ where
         .map_err(|error| anyhow!("{operation_name} worker join failure: {error}"))?
 }
 
+fn validate_startup_config(config_store: &AppConfigStore) -> anyhow::Result<()> {
+    config_store.load().with_context(|| {
+        format!(
+            "Failed loading startup config from {}. Fix invalid JSON in this file or delete it so OpenDucktor can recreate defaults.",
+            config_store.path().display()
+        )
+    })?;
+    Ok(())
+}
 fn run_emitter(app: AppHandle) -> RunEmitter {
     Arc::new(move |event: RunEvent| {
         let _ = app.emit("openducktor://run-event", event);
@@ -157,9 +166,8 @@ fn startup_phase_tracing() {
 
 fn startup_phase_service_bootstrap() -> anyhow::Result<Arc<AppService>> {
     let config_store = AppConfigStore::new().context("failed to initialize config store")?;
-    let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(
-        TASK_METADATA_NAMESPACE,
-    ));
+    validate_startup_config(&config_store)?;
+    let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(TASK_METADATA_NAMESPACE));
     let service = Arc::new(AppService::new(task_store, config_store));
 
     Ok(service)
@@ -299,7 +307,62 @@ mod tests {
     use super::*;
     use anyhow::anyhow;
     use serde_json::{json, Value};
+    use std::fs;
+    use std::path::PathBuf;
 
+    fn unique_temp_path(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system clock should be after UNIX_EPOCH")
+            .as_nanos();
+        std::env::temp_dir().join(format!("openducktor-lib-tests-{prefix}-{nanos}"))
+    }
+
+    #[test]
+    fn validate_startup_config_succeeds_with_valid_config() -> anyhow::Result<()> {
+        let root = unique_temp_path("startup-config-valid");
+        let config_path = root.join("config.json");
+        let config_store = AppConfigStore::from_path(config_path);
+        let config = host_infra_system::GlobalConfig::default();
+        config_store.save(&config)?;
+
+        validate_startup_config(&config_store)?;
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn validate_startup_config_returns_actionable_error_on_config_failure() -> anyhow::Result<()> {
+        let root = unique_temp_path("startup-config-invalid");
+        let config_path = root.join("config.json");
+        fs::create_dir_all(&root)?;
+        fs::write(&config_path, "{ invalid json")?;
+
+        let config_store = AppConfigStore::from_path(config_path.clone());
+        let error = validate_startup_config(&config_store)
+            .expect_err("invalid config should fail startup config validation");
+        let message = format!("{error:#}");
+
+        assert!(
+            message.contains(&format!(
+                "Failed loading startup config from {}",
+                config_path.display()
+            )),
+            "error should include config path and startup context: {message}"
+        );
+        assert!(
+            message.contains(
+                "Fix invalid JSON in this file or delete it so OpenDucktor can recreate defaults"
+            ),
+            "error should include recovery instruction: {message}"
+        );
+        assert!(
+            message.contains("Failed parsing config file"),
+            "error should preserve parse failure context: {message}"
+        );
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
     #[test]
     fn run_service_blocking_propagates_operation_error() {
         let result = tauri::async_runtime::block_on(run_service_blocking(


### PR DESCRIPTION
## Summary
This PR removes startup-config fallbacks that allowed host startup to continue with degraded/default behavior when configuration loading failed.

The host now treats startup config read/parse failures as actionable startup errors and fails fast instead of substituting operational defaults.

## Problem
Two startup paths previously masked configuration corruption:
- host bootstrap could continue using fallback metadata namespace when config loading failed
- startup readiness policy paths could fall back to default policy values on config errors

This created ambiguous runtime behavior and violated the source-of-truth/no-fallback rule.

## Changes
- **Bootstrap validation (`apps/desktop/src-tauri/src/lib.rs`)**
  - Removed startup fallback behavior during config validation.
  - Startup config load failures now surface explicit actionable errors.

- **Startup policy resolution (`host-application`)**
  - Preload startup readiness policy before build/runtime side effects.
  - On startup policy config failure, emit explicit startup failure telemetry (`startup_config_invalid`) and return error.
  - Removed default-policy substitution on config failures.

- **Build/runtime orchestration**
  - Thread resolved startup policy through build and runtime startup flows.
  - Prevent worktree/setup side effects when critical startup config is invalid.

- **Diagnostics/metrics**
  - Added zeroed startup wait report helper for failure payload consistency.
  - Added startup metrics snapshot helper for verification in tests.

- **Tests**
  - Added/updated unit and integration coverage for fail-fast behavior:
    - config failure metrics emission during build/runtime startup policy resolution
    - build startup aborts before worktree creation on invalid startup config
    - runtime startup aborts before QA worktree setup on invalid startup config

## Validation
Executed on this branch:
- `cd apps/desktop/src-tauri && cargo test -p host-application` (153 passed)
- `cd apps/desktop/src-tauri && cargo test -p openducktor-desktop` (30 passed)
- `cd apps/desktop/src-tauri && cargo test -p host-infra-beads` (35 passed, 1 ignored)

## Impact
Startup behavior is now deterministic and strict:
- critical config corruption is surfaced immediately
- no hidden fallback operational values
- side effects are blocked when startup policy/config is invalid
