### PR TITLE
refactor: compact session metadata and fix Agent Studio/beads regressions

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow.rs
@@ -534,8 +534,8 @@ Move subtasks to open/spec_ready/ready_for_dev first: {}",
         mut session: AgentSessionDocument,
     ) -> Result<bool> {
         let repo_path = self.resolve_initialized_repo_path(repo_path)?;
-        if session.task_id != task_id {
-            session.task_id = task_id.to_string();
+        if session.task_id.as_deref() != Some(task_id) {
+            session.task_id = Some(task_id.to_string());
         }
         self.task_store
             .upsert_agent_session(Path::new(&repo_path), task_id, session)

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -683,17 +683,17 @@ pub(crate) fn build_service_with_git_state(
 pub(crate) fn make_session(task_id: &str, session_id: &str) -> AgentSessionDocument {
     AgentSessionDocument {
         session_id: session_id.to_string(),
-        external_session_id: format!("external-{session_id}"),
-        task_id: task_id.to_string(),
+        external_session_id: Some(format!("external-{session_id}")),
+        task_id: Some(task_id.to_string()),
         role: "build".to_string(),
-        scenario: "build_default".to_string(),
-        status: "running".to_string(),
+        scenario: Some("build_default".to_string()),
+        status: Some("running".to_string()),
         started_at: "2026-02-20T12:00:00Z".to_string(),
-        updated_at: "2026-02-20T12:00:10Z".to_string(),
+        updated_at: Some("2026-02-20T12:00:10Z".to_string()),
         ended_at: None,
         runtime_id: Some("runtime-1".to_string()),
         run_id: Some("run-1".to_string()),
-        base_url: "http://127.0.0.1:4173".to_string(),
+        base_url: Some("http://127.0.0.1:4173".to_string()),
         working_directory: "/tmp/repo".to_string(),
         selected_model: None,
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -909,6 +909,6 @@ fn agent_sessions_list_and_upsert_flow_through_store() -> Result<()> {
     let task_state = task_state.lock().expect("task lock poisoned");
     assert_eq!(task_state.upserted_sessions.len(), 1);
     assert_eq!(task_state.upserted_sessions[0].0, "task-1");
-    assert_eq!(task_state.upserted_sessions[0].1.task_id, "task-1");
+    assert_eq!(task_state.upserted_sessions[0].1.task_id.as_deref(), Some("task-1"));
     Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-domain/src/document.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/document.rs
@@ -115,7 +115,9 @@ pub struct QaReportDocument {
 pub struct AgentSessionModelSelection {
     pub provider_id: String,
     pub model_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub variant: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opencode_agent: Option<String>,
 }
 
@@ -123,18 +125,28 @@ pub struct AgentSessionModelSelection {
 #[serde(rename_all = "camelCase")]
 pub struct AgentSessionDocument {
     pub session_id: String,
-    pub external_session_id: String,
-    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
     pub role: String,
-    pub scenario: String,
-    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scenario: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
     pub started_at: String,
-    pub updated_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ended_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub run_id: Option<String>,
-    pub base_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
     pub working_directory: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selected_model: Option<AgentSessionModelSelection>,
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -15,6 +15,15 @@ impl BeadsTaskStore {
             return Err(anyhow!("Agent session role is required"));
         }
 
+        let scenario = session
+            .scenario
+            .as_mut()
+            .ok_or_else(|| anyhow!("Agent session scenario is required"))?;
+        *scenario = scenario.trim().to_string();
+        if scenario.is_empty() {
+            return Err(anyhow!("Agent session scenario is required"));
+        }
+
         session.started_at = session.started_at.trim().to_string();
         if session.started_at.is_empty() {
             return Err(anyhow!("Agent session startedAt is required"));
@@ -27,7 +36,6 @@ impl BeadsTaskStore {
 
         session.external_session_id = None;
         session.task_id = None;
-        session.scenario = None;
         session.status = None;
         session.updated_at = None;
         session.ended_at = None;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -1,6 +1,43 @@
 use super::*;
 
 impl BeadsTaskStore {
+    fn compact_agent_session_for_storage(
+        &self,
+        mut session: AgentSessionDocument,
+    ) -> Result<AgentSessionDocument> {
+        session.session_id = session.session_id.trim().to_string();
+        if session.session_id.is_empty() {
+            return Err(anyhow!("Agent session sessionId is required"));
+        }
+
+        session.role = session.role.trim().to_string();
+        if session.role.is_empty() {
+            return Err(anyhow!("Agent session role is required"));
+        }
+
+        session.started_at = session.started_at.trim().to_string();
+        if session.started_at.is_empty() {
+            return Err(anyhow!("Agent session startedAt is required"));
+        }
+
+        session.working_directory = session.working_directory.trim().to_string();
+        if session.working_directory.is_empty() {
+            return Err(anyhow!("Agent session workingDirectory is required"));
+        }
+
+        session.external_session_id = None;
+        session.task_id = None;
+        session.scenario = None;
+        session.status = None;
+        session.updated_at = None;
+        session.ended_at = None;
+        session.runtime_id = None;
+        session.run_id = None;
+        session.base_url = None;
+
+        Ok(session)
+    }
+
     pub(super) fn list_agent_sessions_impl(
         &self,
         repo_path: &Path,
@@ -24,6 +61,7 @@ impl BeadsTaskStore {
         task_id: &str,
         session: AgentSessionDocument,
     ) -> Result<()> {
+        let compact_session = self.compact_agent_session_for_storage(session)?;
         let (mut root, namespace_key, mut namespace_map) =
             self.load_namespace(repo_path, task_id)?;
         let mut sessions = namespace_map
@@ -33,11 +71,11 @@ impl BeadsTaskStore {
 
         if let Some(existing_index) = sessions
             .iter()
-            .position(|entry| entry.session_id == session.session_id)
+            .position(|entry| entry.session_id == compact_session.session_id)
         {
-            sessions[existing_index] = session;
+            sessions[existing_index] = compact_session;
         } else {
-            sessions.push(session);
+            sessions.push(compact_session);
         }
 
         sessions.sort_by(|a, b| b.started_at.cmp(&a.started_at));

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -229,17 +229,17 @@ fn assert_beads_env(call: &RecordedCall) {
 fn make_session(session_id: &str, started_at: &str, status: &str) -> AgentSessionDocument {
     AgentSessionDocument {
         session_id: session_id.to_string(),
-        external_session_id: format!("external-{session_id}"),
-        task_id: "task-1".to_string(),
+        external_session_id: Some(format!("external-{session_id}")),
+        task_id: Some("task-1".to_string()),
         role: "build".to_string(),
-        scenario: "build_default".to_string(),
-        status: status.to_string(),
+        scenario: Some("build_default".to_string()),
+        status: Some(status.to_string()),
         started_at: started_at.to_string(),
-        updated_at: started_at.to_string(),
+        updated_at: Some(started_at.to_string()),
         ended_at: None,
         runtime_id: Some("runtime-1".to_string()),
         run_id: None,
-        base_url: "http://127.0.0.1:4173".to_string(),
+        base_url: Some("http://127.0.0.1:4173".to_string()),
         working_directory: "/repo".to_string(),
         selected_model: None,
     }
@@ -448,7 +448,10 @@ fn markdown_and_qa_entry_parsers_filter_invalid_entries() {
     .expect("agent sessions");
     assert_eq!(sessions.len(), 1);
     assert_eq!(sessions[0].session_id, "obp-session-1");
-    assert_eq!(sessions[0].external_session_id, "session-opencode-1");
+    assert_eq!(
+        sessions[0].external_session_id.as_deref(),
+        Some("session-opencode-1")
+    );
 }
 
 #[test]
@@ -1581,7 +1584,7 @@ fn upsert_agent_session_updates_existing_session_without_duplication() -> Result
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     let mut updated = make_session("session-1", "2026-02-20T12:00:00Z", "running");
-    updated.updated_at = "2026-02-20T12:01:00Z".to_string();
+    updated.updated_at = Some("2026-02-20T12:01:00Z".to_string());
     store.upsert_agent_session(repo.path(), "task-1", updated)?;
 
     let calls = runner.take_calls();
@@ -1594,7 +1597,9 @@ fn upsert_agent_session_updates_existing_session_without_duplication() -> Result
         .iter()
         .find(|entry| entry["sessionId"] == Value::String("session-1".to_string()))
         .expect("session-1 missing");
-    assert_eq!(session_1["status"], Value::String("running".to_string()));
+    assert!(session_1.get("status").is_none());
+    assert!(session_1.get("scenario").is_none());
+    assert!(session_1.get("baseUrl").is_none());
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1598,7 +1598,10 @@ fn upsert_agent_session_updates_existing_session_without_duplication() -> Result
         .find(|entry| entry["sessionId"] == Value::String("session-1".to_string()))
         .expect("session-1 missing");
     assert!(session_1.get("status").is_none());
-    assert!(session_1.get("scenario").is_none());
+    assert_eq!(
+        session_1.get("scenario").and_then(Value::as_str),
+        Some("build_default")
+    );
     assert!(session_1.get("baseUrl").is_none());
     Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -28,14 +28,7 @@ pub fn compute_repo_id(repo_path: &Path) -> Result<String> {
 pub fn resolve_central_beads_dir(repo_path: &Path) -> Result<PathBuf> {
     let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
     let repo_id = compute_repo_id(repo_path)?;
-    let repo_root = home.join(".openducktor").join("beads").join(repo_id);
-    fs::create_dir_all(&repo_root).with_context(|| {
-        format!(
-            "Failed to create centralized Beads directory {}",
-            repo_root.display()
-        )
-    })?;
-    Ok(repo_root.join(".beads"))
+    Ok(home.join(".openducktor").join("beads").join(repo_id).join(".beads"))
 }
 
 fn canonical_or_absolute(repo_path: &Path) -> Result<PathBuf> {
@@ -85,7 +78,8 @@ fn sanitize_slug(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{compute_repo_id, compute_repo_slug, resolve_central_beads_dir};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn slug_sanitizes_to_ascii_and_collapses_separators() {
@@ -121,5 +115,36 @@ mod tests {
         let as_string = resolved.to_string_lossy();
         assert!(as_string.contains(".openducktor/beads/"));
         assert!(as_string.ends_with("/.beads"));
+    }
+
+    #[test]
+    fn central_beads_dir_resolution_does_not_create_directories() {
+        let home = dirs::home_dir().expect("home directory should resolve");
+
+        for attempt in 0..64 {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time should be after epoch")
+                .as_nanos();
+            let candidate =
+                PathBuf::from(format!("/tmp/odt-beads-no-side-effect-{nanos}-{attempt}/repo"));
+            let repo_id = compute_repo_id(&candidate).expect("repo id should resolve");
+            let repo_root = home.join(".openducktor").join("beads").join(repo_id);
+            if repo_root.exists() {
+                continue;
+            }
+
+            let resolved =
+                resolve_central_beads_dir(&candidate).expect("beads path should resolve");
+            assert_eq!(resolved, repo_root.join(".beads"));
+            assert!(
+                !repo_root.exists(),
+                "resolve_central_beads_dir should not create {}",
+                repo_root.display()
+            );
+            return;
+        }
+
+        panic!("failed to generate unique beads directory candidate path");
     }
 }

--- a/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.tsx
+++ b/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.tsx
@@ -45,7 +45,7 @@ export function TaskDeleteConfirmDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-2 rounded-lg border border-destructive-border bg-destructive-surface px-3 py-2 text-sm text-destructive-surface-foreground">
+        <div className="mt-4 space-y-2 rounded-lg border border-destructive-border bg-destructive-surface px-3 py-2 text-sm text-destructive-surface-foreground">
           <p className="font-medium">This action permanently removes the task from Beads.</p>
           {hasSubtasks ? (
             <p>Direct subtasks will also be deleted to avoid orphaned children in the workflow.</p>

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -286,6 +286,66 @@ describe("useAgentStudioDocuments", () => {
     }
   });
 
+  test("retries completed tool messages after loading clears for spec/plan/qa", async () => {
+    const scenarios = [
+      { tool: "odt_set_spec", section: "spec" as const, sessionId: "session-spec-loading" },
+      { tool: "odt_set_plan", section: "plan" as const, sessionId: "session-plan-loading" },
+      { tool: "odt_qa_rejected", section: "qa" as const, sessionId: "session-qa-loading" },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      reloadDocumentMock.mockClear();
+      applyDocumentUpdateMock.mockClear();
+
+      setTaskDocumentsState({
+        specDoc: createDocumentState({
+          markdown: "",
+          updatedAt: null,
+          isLoading: scenario.section === "spec",
+        }),
+        planDoc: createDocumentState({
+          markdown: "",
+          updatedAt: null,
+          isLoading: scenario.section === "plan",
+        }),
+        qaDoc: createDocumentState({
+          markdown: "",
+          updatedAt: null,
+          isLoading: scenario.section === "qa",
+        }),
+      });
+
+      const activeSession = createAgentSessionFixture({
+        sessionId: scenario.sessionId,
+        messages: [createCompletedToolMessage({ tool: scenario.tool, input: {}, output: "done" })],
+      });
+
+      const baseArgs = {
+        ...createBaseArgs(),
+        selectedTask: null,
+        activeSession,
+      };
+      const harness = createHookHarness(baseArgs);
+
+      try {
+        await harness.mount();
+        expect(reloadDocumentMock).not.toHaveBeenCalled();
+
+        setTaskDocumentsState({
+          specDoc: createDocumentState({ markdown: "", updatedAt: null, isLoading: false }),
+          planDoc: createDocumentState({ markdown: "", updatedAt: null, isLoading: false }),
+          qaDoc: createDocumentState({ markdown: "", updatedAt: null, isLoading: false }),
+        });
+        await harness.update(baseArgs);
+
+        expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
+        expect(reloadDocumentMock).toHaveBeenCalledWith(scenario.section);
+      } finally {
+        await harness.unmount();
+      }
+    }
+  });
+
   test("resets processed tool-event context when switching sessions", async () => {
     setTaskDocumentsState({
       specDoc: createDocumentState({

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
@@ -27,14 +27,12 @@ export function useAgentStudioDocuments({
 
   const documentContextKey = `${taskId}:${activeSession?.sessionId ?? ""}`;
   const processedDocumentToolEventsRef = useRef(new Set<string>());
-  const processedDocumentMessageCountBySessionRef = useRef<Record<string, number>>({});
   const documentReloadAttemptsRef = useRef(new Map<string, number>());
   const refreshedTaskVersionsRef = useRef(new Set<string>());
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Context key intentionally controls reset boundary.
   useEffect(() => {
     processedDocumentToolEventsRef.current.clear();
-    processedDocumentMessageCountBySessionRef.current = {};
     documentReloadAttemptsRef.current.clear();
   }, [documentContextKey]);
 
@@ -68,12 +66,7 @@ export function useAgentStudioDocuments({
       return;
     }
 
-    const previousMessageCount =
-      processedDocumentMessageCountBySessionRef.current[activeSession.sessionId] ?? 0;
-    const startIndex =
-      previousMessageCount > activeSession.messages.length ? 0 : previousMessageCount;
-
-    for (let index = startIndex; index < activeSession.messages.length; index += 1) {
+    for (let index = 0; index < activeSession.messages.length; index += 1) {
       const message = activeSession.messages[index];
       if (!message) {
         continue;
@@ -150,9 +143,6 @@ export function useAgentStudioDocuments({
         documentReloadAttemptsRef.current.set(eventKey, attempts + 1);
       }
     }
-
-    processedDocumentMessageCountBySessionRef.current[activeSession.sessionId] =
-      activeSession.messages.length;
   }, [activeSession, applyDocumentUpdate, planDoc, qaDoc, reloadDocument, specDoc, taskId]);
 
   return {

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-session-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-session-sync.test.tsx
@@ -121,7 +121,7 @@ describe("useAgentStudioQuerySessionSync", () => {
     }
   });
 
-  test("aligns query params with resolved active session", async () => {
+  test("aligns query params with resolved active session when session param is present", async () => {
     const scheduleQueryUpdate = mock((_updates: Record<string, string | undefined>) => {});
     const activeSession = createAgentSessionFixture({
       sessionId: "session-1",
@@ -133,7 +133,8 @@ describe("useAgentStudioQuerySessionSync", () => {
     const harness = createHookHarness(
       createBaseArgs({
         taskIdParam: "task-1",
-        sessionParam: null,
+        sessionParam: "stale-session-id",
+        selectedSessionById: activeSession,
         taskId: "task-1",
         activeSession,
         roleFromQuery: "spec",
@@ -151,6 +152,34 @@ describe("useAgentStudioQuerySessionSync", () => {
           agent: "planner",
         },
       ]);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("does not repin session when query intentionally omits session", async () => {
+    const scheduleQueryUpdate = mock((_updates: Record<string, string | undefined>) => {});
+    const activeSession = createAgentSessionFixture({
+      sessionId: "session-1",
+      externalSessionId: "ext-session-1",
+      taskId: "task-1",
+      role: "spec",
+      scenario: "spec_initial",
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        taskIdParam: "task-1",
+        sessionParam: null,
+        taskId: "task-1",
+        activeSession,
+        roleFromQuery: "spec",
+        scheduleQueryUpdate,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      expect(scheduleQueryUpdate).toHaveBeenCalledTimes(0);
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-session-sync.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-session-sync.ts
@@ -76,6 +76,9 @@ export function useAgentStudioQuerySessionSync({
     if (!activeSession) {
       return;
     }
+    if (!sessionParam) {
+      return;
+    }
 
     const updates: Record<string, string | undefined> = {};
     if (taskIdParam !== activeSession.taskId) {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -9,6 +9,7 @@ import {
 } from "../support/async-side-effects";
 import {
   createRepoStaleGuard,
+  defaultScenarioForRole,
   fromPersistedSessionRecord,
   historyToChatMessages,
   normalizePersistedSelection,
@@ -134,7 +135,7 @@ export const createLoadAgentSessions = ({
         if (next[record.sessionId]) {
           continue;
         }
-        next[record.sessionId] = fromPersistedSessionRecord(record);
+        next[record.sessionId] = fromPersistedSessionRecord(record, taskId);
       }
       return next;
     });
@@ -201,10 +202,17 @@ export const createLoadAgentSessions = ({
         return;
       }
 
-      const baseUrl = workspaceRuntime ? toBaseUrl(workspaceRuntime.port) : record.baseUrl;
+      const baseUrl = workspaceRuntime ? toBaseUrl(workspaceRuntime.port) : (record.baseUrl ?? "");
+      if (!workspaceRuntime && baseUrl.length === 0) {
+        throw new Error(
+          `Cannot hydrate session ${record.sessionId}: runtime baseUrl is missing from metadata.`,
+        );
+      }
       // Always use the persisted workingDirectory — it is the source of truth.
       // Build sessions store the worktree path; other roles store repoPath.
       const workingDirectory = record.workingDirectory;
+      const externalSessionId = record.externalSessionId ?? record.sessionId;
+      const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
       const existingSession = sessionsRef.current[record.sessionId];
       if (existingSession && existingSession.messages.length > 0) {
         if (isStaleRepoOperation()) {
@@ -219,7 +227,7 @@ export const createLoadAgentSessions = ({
           }),
           { persist: false },
         );
-        warmSessionData(record.sessionId, baseUrl, workingDirectory, record.externalSessionId);
+        warmSessionData(record.sessionId, baseUrl, workingDirectory, externalSessionId);
         return;
       }
 
@@ -229,7 +237,7 @@ export const createLoadAgentSessions = ({
           const history = await adapter.loadSessionHistory({
             baseUrl,
             workingDirectory,
-            externalSessionId: record.externalSessionId,
+            externalSessionId,
             limit: INITIAL_SESSION_HISTORY_LIMIT,
           });
           return { ok: true as const, history };
@@ -237,9 +245,9 @@ export const createLoadAgentSessions = ({
         {
           tags: {
             repoPath,
-            taskId: record.taskId,
+            taskId,
             sessionId: record.sessionId,
-            externalSessionId: record.externalSessionId,
+            externalSessionId,
           },
           logLevel: "warn",
           fallback: (failure): SessionHistoryLoadResult => ({
@@ -254,12 +262,12 @@ export const createLoadAgentSessions = ({
         {
           id: `history:session-start:${record.sessionId}`,
           role: "system",
-          content: `Session started (${record.role} - ${record.scenario})`,
+          content: `Session started (${record.role} - ${resolvedScenario})`,
           timestamp: record.startedAt,
         },
       ];
 
-      const task = taskRef.current.find((entry) => entry.id === record.taskId);
+      const task = taskRef.current.find((entry) => entry.id === taskId);
       const preludeMessages = task
         ? [
             ...basicPreludeMessages,
@@ -268,7 +276,7 @@ export const createLoadAgentSessions = ({
               role: "system" as const,
               content: `System prompt:\n\n${buildAgentSystemPrompt({
                 role: record.role,
-                scenario: record.scenario,
+                scenario: resolvedScenario,
                 task: {
                   taskId: task.id,
                   title: task.title,
@@ -312,7 +320,7 @@ export const createLoadAgentSessions = ({
           }),
           { persist: false },
         );
-        warmSessionData(record.sessionId, baseUrl, workingDirectory, record.externalSessionId);
+        warmSessionData(record.sessionId, baseUrl, workingDirectory, externalSessionId);
         return;
       }
 
@@ -332,7 +340,7 @@ export const createLoadAgentSessions = ({
         }),
         { persist: false },
       );
-      warmSessionData(record.sessionId, baseUrl, workingDirectory, record.externalSessionId);
+      warmSessionData(record.sessionId, baseUrl, workingDirectory, externalSessionId);
     };
 
     for (

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -28,18 +28,18 @@ const recordFixture: AgentSessionRecord = {
 
 describe("agent-orchestrator/support/persistence", () => {
   test("normalizes persisted running status to stopped", () => {
-    const hydrated = fromPersistedSessionRecord(recordFixture);
+    const hydrated = fromPersistedSessionRecord(recordFixture, "task-1");
     expect(hydrated.status).toBe("stopped");
     expect(hydrated.selectedModel?.modelId).toBe("gpt-5");
   });
 
   test("persists session with endedAt for terminal states", () => {
     const session: AgentSessionState = {
-      ...fromPersistedSessionRecord(recordFixture),
+      ...fromPersistedSessionRecord(recordFixture, "task-1"),
       status: "error",
     };
     const persisted = toPersistedSessionRecord(session, "2026-02-22T08:10:00.000Z");
-    expect(persisted.endedAt).toBe("2026-02-22T08:10:00.000Z");
+    expect(persisted.endedAt).toBeUndefined();
   });
 
   test("maps empty history to empty chat messages", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -33,12 +33,13 @@ describe("agent-orchestrator/support/persistence", () => {
     expect(hydrated.selectedModel?.modelId).toBe("gpt-5");
   });
 
-  test("persists session with endedAt for terminal states", () => {
+  test("persists compact session fields and keeps scenario", () => {
     const session: AgentSessionState = {
       ...fromPersistedSessionRecord(recordFixture, "task-1"),
       status: "error",
     };
-    const persisted = toPersistedSessionRecord(session, "2026-02-22T08:10:00.000Z");
+    const persisted = toPersistedSessionRecord(session);
+    expect(persisted.scenario).toBe("build_implementation_start");
     expect(persisted.endedAt).toBeUndefined();
   });
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -12,12 +12,10 @@ import { normalizeToolInput, normalizeToolText } from "./tool-messages";
 
 type HistoryPart = AgentSessionHistoryMessage["parts"][number];
 
-export const toPersistedSessionRecord = (
-  session: AgentSessionState,
-  _updatedAt: string,
-): AgentSessionRecord => ({
+export const toPersistedSessionRecord = (session: AgentSessionState): AgentSessionRecord => ({
   sessionId: session.sessionId,
   role: session.role,
+  scenario: session.scenario,
   startedAt: session.startedAt,
   workingDirectory: session.workingDirectory,
   selectedModel: session.selectedModel ?? undefined,

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -1,5 +1,10 @@
 import type { AgentSessionRecord } from "@openducktor/contracts";
-import type { AgentModelSelection, AgentRole, AgentSessionHistoryMessage } from "@openducktor/core";
+import type {
+  AgentModelSelection,
+  AgentRole,
+  AgentScenario,
+  AgentSessionHistoryMessage,
+} from "@openducktor/core";
 import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
 import { formatToolContent } from "../../agent-tool-messages";
 import { normalizePersistedSelection } from "./models";
@@ -9,38 +14,46 @@ type HistoryPart = AgentSessionHistoryMessage["parts"][number];
 
 export const toPersistedSessionRecord = (
   session: AgentSessionState,
-  updatedAt: string,
+  _updatedAt: string,
 ): AgentSessionRecord => ({
   sessionId: session.sessionId,
-  externalSessionId: session.externalSessionId,
-  taskId: session.taskId,
   role: session.role,
-  scenario: session.scenario,
-  status: session.status,
   startedAt: session.startedAt,
-  updatedAt,
-  ...(session.status === "stopped" || session.status === "error" ? { endedAt: updatedAt } : {}),
-  runtimeId: session.runtimeId ?? undefined,
-  runId: session.runId ?? undefined,
-  baseUrl: session.baseUrl,
   workingDirectory: session.workingDirectory,
   selectedModel: session.selectedModel ?? undefined,
 });
 
-export const fromPersistedSessionRecord = (session: AgentSessionRecord): AgentSessionState => {
+export const defaultScenarioForRole = (role: AgentRole): AgentScenario => {
+  if (role === "spec") {
+    return "spec_initial";
+  }
+  if (role === "planner") {
+    return "planner_initial";
+  }
+  if (role === "qa") {
+    return "qa_review";
+  }
+  return "build_implementation_start";
+};
+
+export const fromPersistedSessionRecord = (
+  session: AgentSessionRecord,
+  fallbackTaskId: string,
+): AgentSessionState => {
+  const persistedStatus = session.status ?? "stopped";
   const normalizedStatus =
-    session.status === "starting" || session.status === "running" ? "stopped" : session.status;
+    persistedStatus === "starting" || persistedStatus === "running" ? "stopped" : persistedStatus;
   return {
     sessionId: session.sessionId,
-    externalSessionId: session.externalSessionId,
-    taskId: session.taskId,
+    externalSessionId: session.externalSessionId ?? session.sessionId,
+    taskId: session.taskId ?? fallbackTaskId,
     role: session.role,
-    scenario: session.scenario,
+    scenario: session.scenario ?? defaultScenarioForRole(session.role),
     status: normalizedStatus,
     startedAt: session.startedAt,
     runtimeId: session.runtimeId ?? null,
     runId: session.runId ?? null,
-    baseUrl: session.baseUrl,
+    baseUrl: session.baseUrl ?? "",
     workingDirectory: session.workingDirectory,
     messages: [],
     draftAssistantText: "",

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/utils.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/utils.ts
@@ -17,6 +17,7 @@ export {
   pickDefaultModel,
 } from "./models";
 export {
+  defaultScenarioForRole,
   fromPersistedSessionRecord,
   historyToChatMessages,
   toPersistedSessionRecord,

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.ts
@@ -13,7 +13,6 @@ import {
   createLoadAgentSessions,
   loadRepoDefaultModel,
   loadTaskDocuments,
-  now,
   runOrchestratorSideEffect,
   toPersistedSessionRecord,
 } from "./agent-orchestrator";
@@ -69,12 +68,7 @@ export function useAgentOrchestratorOperations({
       if (!activeRepo) {
         return;
       }
-      const updatedAt = now();
-      await host.agentSessionUpsert(
-        activeRepo,
-        session.taskId,
-        toPersistedSessionRecord(session, updatedAt),
-      );
+      await host.agentSessionUpsert(activeRepo, session.taskId, toPersistedSessionRecord(session));
     },
     [activeRepo],
   );

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -768,7 +768,7 @@ describe("TauriHostClient", () => {
     });
   });
 
-  test("agentSessionsList normalizes legacy scenarios and skips invalid rows", async () => {
+  test("agentSessionsList normalizes legacy scenarios and strips invalid scenario values", async () => {
     const { client } = createClient((command) => {
       if (command === "task_metadata_get") {
         return {
@@ -832,9 +832,10 @@ describe("TauriHostClient", () => {
 
     const sessions = await client.agentSessionsList("/repo", "task-1");
 
-    expect(sessions).toHaveLength(2);
+    expect(sessions).toHaveLength(3);
     expect(sessions[0]?.scenario).toBe("spec_initial");
     expect(sessions[1]?.scenario).toBe("planner_initial");
+    expect(sessions[2]?.scenario).toBeUndefined();
   });
 
   test("spec, plan, qa, and session reads share one metadata IPC call per task", async () => {

--- a/packages/adapters-tauri-host/src/task-metadata-cache.ts
+++ b/packages/adapters-tauri-host/src/task-metadata-cache.ts
@@ -1,7 +1,7 @@
 import {
   type AgentSessionRecord,
-  agentSessionScenarioSchema,
   agentSessionRecordSchema,
+  agentSessionScenarioSchema,
   type TaskMetadataPayload,
   taskMetadataPayloadSchema,
 } from "@openducktor/contracts";

--- a/packages/adapters-tauri-host/src/task-metadata-cache.ts
+++ b/packages/adapters-tauri-host/src/task-metadata-cache.ts
@@ -1,5 +1,6 @@
 import {
   type AgentSessionRecord,
+  agentSessionScenarioSchema,
   agentSessionRecordSchema,
   type TaskMetadataPayload,
   taskMetadataPayloadSchema,
@@ -11,7 +12,7 @@ const LEGACY_AGENT_SESSION_SCENARIO_MAP: Record<string, AgentSessionRecord["scen
   planner_revision: "planner_initial",
 };
 
-const normalizeLegacyAgentSessionScenario = (entry: unknown): unknown => {
+const normalizeAgentSessionScenario = (entry: unknown): unknown => {
   if (!entry || typeof entry !== "object") {
     return entry;
   }
@@ -21,7 +22,11 @@ const normalizeLegacyAgentSessionScenario = (entry: unknown): unknown => {
   }
   const normalizedScenario = LEGACY_AGENT_SESSION_SCENARIO_MAP[candidate.scenario];
   if (!normalizedScenario) {
-    return entry;
+    if (agentSessionScenarioSchema.safeParse(candidate.scenario).success) {
+      return entry;
+    }
+    const { scenario: _ignoredScenario, ...rest } = entry as Record<string, unknown>;
+    return rest;
   }
   return {
     ...entry,
@@ -36,7 +41,7 @@ export type ParsedTaskMetadata = Omit<TaskMetadataPayload, "agentSessions"> & {
 const parseAgentSessions = (entries: unknown[]): AgentSessionRecord[] => {
   const sessions: AgentSessionRecord[] = [];
   for (const entry of entries) {
-    const parsed = agentSessionRecordSchema.safeParse(normalizeLegacyAgentSessionScenario(entry));
+    const parsed = agentSessionRecordSchema.safeParse(normalizeAgentSessionScenario(entry));
     if (parsed.success) {
       sessions.push(parsed.data);
     }

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -476,4 +476,18 @@ describe("runtime schemas", () => {
     expect(parsed.externalSessionId).toBe("session-opencode-1");
     expect(parsed.selectedModel?.modelId).toBe("gpt-5");
   });
+
+  test("agent session record parses compact persisted payload", () => {
+    const parsed = agentSessionRecordSchema.parse({
+      sessionId: "obp-session-2",
+      role: "planner",
+      startedAt: "2026-02-18T17:11:00.000Z",
+      workingDirectory: "/repo",
+    });
+
+    expect(parsed.role).toBe("planner");
+    expect(parsed.scenario).toBeUndefined();
+    expect(parsed.externalSessionId).toBeUndefined();
+    expect(parsed.status).toBeUndefined();
+  });
 });

--- a/packages/contracts/src/session-schemas.ts
+++ b/packages/contracts/src/session-schemas.ts
@@ -21,19 +21,30 @@ export const agentSessionModelSelectionSchema = z.object({
 });
 export type AgentSessionModelSelection = z.infer<typeof agentSessionModelSelectionSchema>;
 
+const optionalStringFromNullable = z.preprocess(
+  (value) => (value === null ? undefined : value),
+  z.string().optional(),
+);
+
 export const agentSessionRecordSchema = z.object({
   sessionId: z.string(),
-  externalSessionId: z.string(),
-  taskId: z.string(),
+  externalSessionId: optionalStringFromNullable,
+  taskId: optionalStringFromNullable,
   role: agentSessionRoleSchema,
-  scenario: agentSessionScenarioSchema,
-  status: agentSessionStatusSchema,
+  scenario: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    agentSessionScenarioSchema.optional(),
+  ),
+  status: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    agentSessionStatusSchema.optional(),
+  ),
   startedAt: z.string(),
-  updatedAt: z.string(),
-  endedAt: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
-  runtimeId: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
-  runId: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
-  baseUrl: z.string(),
+  updatedAt: optionalStringFromNullable,
+  endedAt: optionalStringFromNullable,
+  runtimeId: optionalStringFromNullable,
+  runId: optionalStringFromNullable,
+  baseUrl: optionalStringFromNullable,
   workingDirectory: z.string(),
   selectedModel: z.preprocess(
     (value) => (value === null ? undefined : value),

--- a/packages/contracts/src/session-schemas.ts
+++ b/packages/contracts/src/session-schemas.ts
@@ -10,35 +10,26 @@ export type AgentSessionRole = z.infer<typeof agentSessionRoleSchema>;
 export const agentSessionScenarioSchema = agentScenarioSchema;
 export type AgentSessionScenario = z.infer<typeof agentSessionScenarioSchema>;
 
+const optionalFromNullable = <T extends z.ZodTypeAny>(schema: T) =>
+  z.preprocess((value) => (value === null ? undefined : value), schema.optional());
+
 export const agentSessionModelSelectionSchema = z.object({
   providerId: z.string(),
   modelId: z.string(),
-  variant: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
-  opencodeAgent: z.preprocess(
-    (value) => (value === null ? undefined : value),
-    z.string().optional(),
-  ),
+  variant: optionalFromNullable(z.string()),
+  opencodeAgent: optionalFromNullable(z.string()),
 });
 export type AgentSessionModelSelection = z.infer<typeof agentSessionModelSelectionSchema>;
 
-const optionalStringFromNullable = z.preprocess(
-  (value) => (value === null ? undefined : value),
-  z.string().optional(),
-);
+const optionalStringFromNullable = optionalFromNullable(z.string());
 
 export const agentSessionRecordSchema = z.object({
   sessionId: z.string(),
   externalSessionId: optionalStringFromNullable,
   taskId: optionalStringFromNullable,
   role: agentSessionRoleSchema,
-  scenario: z.preprocess(
-    (value) => (value === null ? undefined : value),
-    agentSessionScenarioSchema.optional(),
-  ),
-  status: z.preprocess(
-    (value) => (value === null ? undefined : value),
-    agentSessionStatusSchema.optional(),
-  ),
+  scenario: optionalFromNullable(agentSessionScenarioSchema),
+  status: optionalFromNullable(agentSessionStatusSchema),
   startedAt: z.string(),
   updatedAt: optionalStringFromNullable,
   endedAt: optionalStringFromNullable,
@@ -46,9 +37,6 @@ export const agentSessionRecordSchema = z.object({
   runId: optionalStringFromNullable,
   baseUrl: optionalStringFromNullable,
   workingDirectory: z.string(),
-  selectedModel: z.preprocess(
-    (value) => (value === null ? undefined : value),
-    agentSessionModelSelectionSchema.optional(),
-  ),
+  selectedModel: optionalFromNullable(agentSessionModelSelectionSchema),
 });
 export type AgentSessionRecord = z.infer<typeof agentSessionRecordSchema>;

--- a/packages/openducktor-mcp/src/beads-runtime.ts
+++ b/packages/openducktor-mcp/src/beads-runtime.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, realpath } from "node:fs/promises";
+import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, resolve } from "node:path";
 
@@ -115,6 +115,5 @@ export const computeRepoId = async (repoPath: string): Promise<string> => {
 export const resolveCentralBeadsDir = async (repoPath: string): Promise<string> => {
   const repoId = await computeRepoId(repoPath);
   const root = resolve(homedir(), ".openducktor", "beads", repoId);
-  await mkdir(root, { recursive: true });
   return resolve(root, ".beads");
 };

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
 import {
   computeRepoId,
   normalizePlanSubtasks,
   ODT_TOOL_SCHEMAS,
   OdtTaskStore,
+  resolveCentralBeadsDir,
   resolveStoreContext,
 } from "./lib";
 
@@ -157,6 +161,19 @@ describe("openducktor-mcp lib", () => {
   test("computes stable repo id with slug and hash", async () => {
     const id = await computeRepoId("/tmp/OpenDucktor Repo");
     expect(id).toMatch(/^openducktor-repo-[a-f0-9]{8}$/);
+  });
+
+  test("resolveCentralBeadsDir does not create directory side effects", async () => {
+    const nonce = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const repoPath = `/tmp/odt-beads-no-side-effect-${nonce}/repo`;
+    const repoId = await computeRepoId(repoPath);
+    const repoRoot = resolve(homedir(), ".openducktor", "beads", repoId);
+
+    expect(existsSync(repoRoot)).toBe(false);
+
+    const resolved = await resolveCentralBeadsDir(repoPath);
+    expect(resolved).toBe(resolve(repoRoot, ".beads"));
+    expect(existsSync(repoRoot)).toBe(false);
   });
 
   test("schema validates odt_set_spec required fields", () => {


### PR DESCRIPTION
## Branch Overview
This PR includes the full `refactor/task-metadata` branch (5 commits), not only the latest UI fix.

### 1) Compact persisted agent session metadata (`848fbff`)
- Refactors persisted Agent Studio session records to store a minimal subset.
- Makes non-essential historical fields nullable/optional in contracts (`externalSessionId`, `taskId`, `scenario`, `status`, `updatedAt`, `endedAt`, `runtimeId`, `runId`, `baseUrl`).
- Rebuilds missing runtime context on hydration in desktop orchestrator persistence (role-based default scenario, normalized stopped status for stale running/starting records, fallback IDs/base URL).
- Updates related Tauri host/adapters/contracts tests and metadata cache behavior.

### 2) Fix beads path resolution side effects (`8d8d68d`)
- Fixes central beads directory resolution to be pure path computation (no implicit directory creation during resolution).
- Prevents accidental creation of many `~/.openducktor/beads/repo-*` directories from read-path operations.
- Adds regression coverage in Rust + MCP runtime tests.

### 3) Fix Agent Studio session flicker on fresh starts (`8715cdd`)
- Fixes query/session sync so the app does not re-pin an old `session` query param when the param is intentionally omitted.
- Removes the observed UI flicker between prior and freshly-started sessions.
- Adds focused tests for this URL sync behavior.

### 4) Fix Agent Studio document panel loading race (`4a349b9`)
- Fixes root cause where completed workflow tool events could be skipped if the target document section was loading.
- Removes index-based message cursor optimization and re-evaluates messages with deterministic event dedupe/retry behavior.
- Ensures planner/spec/qa document updates are retried once loading clears.
- Adds regression tests for `odt_set_spec`, `odt_set_plan`, `odt_qa_rejected` loading-to-ready transitions.

### 5) UI polish in delete modal (`315a479`)
- Adds spacing above the destructive warning card in the task delete confirmation modal.

## Included Commits
- `848fbff` refactor: compact persisted agent session metadata
- `8d8d68d` fix: avoid side-effect beads dir creation during path resolution
- `8715cdd` fix: prevent agent studio session selection flicker on fresh start
- `4a349b9` fix(desktop): retry workflow document updates after loading race
- `315a479` style(desktop): add spacing above delete warning card

## Validation
- `bun test packages/core/src/services/odt-workflow-tools.test.ts apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.test.ts`
- `bun run --filter @openducktor/core lint`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/core typecheck`
- `bun run --filter @openducktor/desktop typecheck`
