### PR TITLE
fix(security): harden ODT tool authorization with exact allowlists

### DIFF
--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -467,7 +467,7 @@ describe("OpencodeSdkAdapter", () => {
 
   test("sendUserMessage applies runtime workflow aliases when available", async () => {
     const mock = makeMockClient({
-      toolIdsResponse: ["customprefix_odt_set_spec", "customprefix_odt_set_plan"],
+      toolIdsResponse: ["openducktor_odt_set_spec", "openducktor_odt_set_plan"],
     });
     const adapter = new OpencodeSdkAdapter({
       createClient: () => mock.client,
@@ -484,8 +484,8 @@ describe("OpencodeSdkAdapter", () => {
     expect(mock.session.promptCalls).toHaveLength(1);
     const tools = (mock.session.promptCalls[0] as { tools?: Record<string, boolean> }).tools;
     expect(tools).toMatchObject({
-      customprefix_odt_set_spec: true,
-      customprefix_odt_set_plan: false,
+      openducktor_odt_set_spec: true,
+      openducktor_odt_set_plan: false,
     });
   });
 

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -4,6 +4,24 @@ import type { AgentEvent, AgentSessionTodoItem } from "@openducktor/core";
 import { OpencodeSdkAdapter } from "./index";
 
 const flushAsync = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+const DEFAULT_ODT_RUNTIME_TOOL_IDS = [
+  "odt_read_task",
+  "odt_set_spec",
+  "odt_set_plan",
+  "odt_build_blocked",
+  "odt_build_resumed",
+  "odt_build_completed",
+  "odt_qa_approved",
+  "odt_qa_rejected",
+  "openducktor_odt_read_task",
+  "openducktor_odt_set_spec",
+  "openducktor_odt_set_plan",
+  "openducktor_odt_build_blocked",
+  "openducktor_odt_build_resumed",
+  "openducktor_odt_build_completed",
+  "openducktor_odt_qa_approved",
+  "openducktor_odt_qa_rejected",
+] as const;
 
 type MockSession = {
   createCalls: unknown[];
@@ -116,8 +134,8 @@ const makeMockClient = ({
     },
   },
   agentsResponse = [],
-  toolIdsResponse = [],
-  mcpStatusResponse = {},
+  toolIdsResponse = [...DEFAULT_ODT_RUNTIME_TOOL_IDS],
+  mcpStatusResponse = { openducktor: { status: "connected" } },
 }: MakeMockClientInput): {
   client: OpencodeClient;
   session: MockSession;
@@ -467,7 +485,11 @@ describe("OpencodeSdkAdapter", () => {
 
   test("sendUserMessage applies runtime workflow aliases when available", async () => {
     const mock = makeMockClient({
-      toolIdsResponse: ["openducktor_odt_set_spec", "openducktor_odt_set_plan"],
+      toolIdsResponse: [
+        "openducktor_odt_read_task",
+        "openducktor_odt_set_spec",
+        "openducktor_odt_set_plan",
+      ],
     });
     const adapter = new OpencodeSdkAdapter({
       createClient: () => mock.client,
@@ -484,9 +506,51 @@ describe("OpencodeSdkAdapter", () => {
     expect(mock.session.promptCalls).toHaveLength(1);
     const tools = (mock.session.promptCalls[0] as { tools?: Record<string, boolean> }).tools;
     expect(tools).toMatchObject({
+      openducktor_odt_read_task: true,
       openducktor_odt_set_spec: true,
       openducktor_odt_set_plan: false,
     });
+  });
+
+  test("sendUserMessage fails closed when trusted MCP server is disconnected", async () => {
+    const mock = makeMockClient({
+      toolIdsResponse: ["odt_read_task", "odt_set_spec"],
+      mcpStatusResponse: { openducktor: { status: "failed", error: "connection closed" } },
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+    await startDefaultSession(adapter, "session-1", "spec");
+
+    await expect(
+      adapter.sendUserMessage({
+        sessionId: "session-1",
+        content: "Write and persist spec",
+      }),
+    ).rejects.toThrow('MCP server "openducktor" is "failed"');
+
+    expect(mock.session.promptCalls).toHaveLength(0);
+  });
+
+  test("sendUserMessage fails closed when required trusted role tools are missing", async () => {
+    const mock = makeMockClient({
+      toolIdsResponse: ["odt_read_task", "odt_set_plan"],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+    await startDefaultSession(adapter, "session-1", "spec");
+
+    await expect(
+      adapter.sendUserMessage({
+        sessionId: "session-1",
+        content: "Write and persist spec",
+      }),
+    ).rejects.toThrow("missing trusted runtime tool IDs");
+
+    expect(mock.session.promptCalls).toHaveLength(0);
   });
 
   test("loadSessionHistory preserves assistant text and maps streamed parts", async () => {

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { resolveWorkflowToolSelection } from "./workflow-tool-selection";
 
-const makeClient = (input: { toolIds?: unknown; throwOnIds?: boolean }): OpencodeClient => {
+const makeClient = (input: {
+  toolIds?: unknown;
+  throwOnIds?: boolean;
+  mcpStatusResponse?: unknown;
+  throwOnMcpStatus?: boolean;
+}): OpencodeClient => {
   return {
     tool: {
       ids: async () => {
@@ -15,6 +20,17 @@ const makeClient = (input: { toolIds?: unknown; throwOnIds?: boolean }): Opencod
         };
       },
     },
+    mcp: {
+      status: async () => {
+        if (input.throwOnMcpStatus) {
+          throw new Error("mcp-down");
+        }
+        return {
+          data: input.mcpStatusResponse ?? { openducktor: { status: "connected" } },
+          error: undefined,
+        };
+      },
+    },
   } as unknown as OpencodeClient;
 };
 
@@ -22,36 +38,99 @@ describe("workflow-tool-selection", () => {
   test("uses runtime tool aliases when available", async () => {
     const selection = await resolveWorkflowToolSelection({
       client: makeClient({
-        toolIds: ["openducktor_odt_set_spec", "openducktor_odt_set_plan"],
+        toolIds: [
+          "openducktor_odt_read_task",
+          "openducktor_odt_set_spec",
+          "openducktor_odt_set_plan",
+        ],
       }),
       role: "spec",
       workingDirectory: "/repo",
     });
 
+    expect(selection.openducktor_odt_read_task).toBe(true);
     expect(selection.openducktor_odt_set_spec).toBe(true);
     expect(selection.openducktor_odt_set_plan).toBe(false);
+    expect(selection.odt_read_task).toBeUndefined();
   });
 
-  test("falls back to known alias policy when tool discovery fails", async () => {
+  test("accepts exact canonical runtime tool ids", async () => {
     const selection = await resolveWorkflowToolSelection({
-      client: makeClient({ throwOnIds: true }),
-      role: "qa",
+      client: makeClient({
+        toolIds: ["odt_read_task", "odt_set_spec", "odt_set_plan"],
+      }),
+      role: "spec",
       workingDirectory: "/repo",
     });
 
     expect(selection.odt_read_task).toBe(true);
-    expect(selection.odt_qa_approved).toBe(true);
-    expect(selection.odt_set_spec).toBe(false);
+    expect(selection.odt_set_spec).toBe(true);
+    expect(selection.odt_set_plan).toBe(false);
   });
 
-  test("ignores malformed runtime aliases and keeps canonical role policy", async () => {
+  test("propagates tool discovery errors", async () => {
+    const selection = await resolveWorkflowToolSelection({
+      client: makeClient({ throwOnIds: true }),
+      role: "spec",
+      workingDirectory: "/repo",
+    }).catch((error: unknown) => error);
+
+    expect(selection).toBeInstanceOf(Error);
+    expect((selection as Error).message).toBe("boom");
+  });
+
+  test("throws actionable error when trusted MCP server is disconnected", async () => {
+    const selectionError = await resolveWorkflowToolSelection({
+      client: makeClient({
+        toolIds: ["odt_read_task", "odt_set_spec"],
+        mcpStatusResponse: { openducktor: { status: "failed", error: "connection closed" } },
+      }),
+      role: "spec",
+      workingDirectory: "/repo",
+    }).catch((error: unknown) => error);
+
+    expect(selectionError).toBeInstanceOf(Error);
+    expect((selectionError as Error).message).toContain('MCP server "openducktor" is "failed"');
+    expect((selectionError as Error).message).toContain("connection closed");
+  });
+
+  test("propagates trusted MCP status lookup failures", async () => {
+    const selectionError = await resolveWorkflowToolSelection({
+      client: makeClient({
+        toolIds: ["odt_read_task", "odt_set_spec"],
+        throwOnMcpStatus: true,
+      }),
+      role: "spec",
+      workingDirectory: "/repo",
+    }).catch((error: unknown) => error);
+
+    expect(selectionError).toBeInstanceOf(Error);
+    expect((selectionError as Error).message).toBe("mcp-down");
+  });
+
+  test("throws actionable error when trusted runtime ids are missing for role tools", async () => {
+    const selectionError = await resolveWorkflowToolSelection({
+      client: makeClient({
+        toolIds: ["odt_read_task", "odt_set_plan"],
+      }),
+      role: "spec",
+      workingDirectory: "/repo",
+    }).catch((error: unknown) => error);
+
+    expect(selectionError).toBeInstanceOf(Error);
+    expect((selectionError as Error).message).toContain("missing trusted runtime tool IDs");
+    expect((selectionError as Error).message).toContain("odt_set_spec");
+  });
+
+  test("ignores malformed or untrusted runtime aliases", async () => {
     const selection = await resolveWorkflowToolSelection({
       client: makeClient({
         toolIds: [
+          "odt_read_task",
+          "odt_set_spec",
           "openducktor_odt_set_spec_extra",
-          "customprefix_odt_",
           "customprefix_odt_set_plan",
-          "openducktor_odt_set_plan",
+          "OpenDucktor_ODT_SET_SPEC",
         ],
       }),
       role: "spec",
@@ -62,6 +141,6 @@ describe("workflow-tool-selection", () => {
     expect(selection.odt_set_spec).toBe(true);
     expect(selection.openducktor_odt_set_spec_extra).toBeUndefined();
     expect(selection.customprefix_odt_set_plan).toBeUndefined();
-    expect(selection.openducktor_odt_set_plan).toBe(false);
+    expect(selection.OpenDucktor_ODT_SET_SPEC).toBeUndefined();
   });
 });

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
@@ -22,14 +22,14 @@ describe("workflow-tool-selection", () => {
   test("uses runtime tool aliases when available", async () => {
     const selection = await resolveWorkflowToolSelection({
       client: makeClient({
-        toolIds: ["customprefix_odt_set_spec", "customprefix_odt_set_plan"],
+        toolIds: ["openducktor_odt_set_spec", "openducktor_odt_set_plan"],
       }),
       role: "spec",
       workingDirectory: "/repo",
     });
 
-    expect(selection.customprefix_odt_set_spec).toBe(true);
-    expect(selection.customprefix_odt_set_plan).toBe(false);
+    expect(selection.openducktor_odt_set_spec).toBe(true);
+    expect(selection.openducktor_odt_set_plan).toBe(false);
   });
 
   test("falls back to known alias policy when tool discovery fails", async () => {
@@ -48,9 +48,10 @@ describe("workflow-tool-selection", () => {
     const selection = await resolveWorkflowToolSelection({
       client: makeClient({
         toolIds: [
-          "customprefix_odt_set_spec_extra",
+          "openducktor_odt_set_spec_extra",
           "customprefix_odt_",
           "customprefix_odt_set_plan",
+          "openducktor_odt_set_plan",
         ],
       }),
       role: "spec",
@@ -59,7 +60,8 @@ describe("workflow-tool-selection", () => {
 
     expect(selection.odt_read_task).toBe(true);
     expect(selection.odt_set_spec).toBe(true);
-    expect(selection.customprefix_odt_set_spec_extra).toBeUndefined();
-    expect(selection.customprefix_odt_set_plan).toBe(false);
+    expect(selection.openducktor_odt_set_spec_extra).toBeUndefined();
+    expect(selection.customprefix_odt_set_plan).toBeUndefined();
+    expect(selection.openducktor_odt_set_plan).toBe(false);
   });
 });

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
@@ -1,26 +1,101 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
-import { type AgentRole, buildRoleScopedOdtToolSelection } from "@openducktor/core";
+import {
+  AGENT_ROLE_TOOL_POLICY,
+  type AgentRole,
+  type AgentToolName,
+  buildRoleScopedOdtToolSelection,
+  resolveOdtWorkflowToolNameForAuthorization,
+} from "@openducktor/core";
 import { unwrapData } from "./data-utils";
+import { asUnknownRecord, readStringProp } from "./guards";
 import { toToolIdList } from "./payload-mappers";
+
+const TRUSTED_ODT_MCP_SERVER_NAME = "openducktor";
+const CONNECTED_MCP_SERVER_STATUSES = new Set(["connected"]);
+
+const assertTrustedOdtMcpServerConnected = async (input: {
+  client: OpencodeClient;
+  workingDirectory: string;
+}): Promise<void> => {
+  const mcp = (input.client as { mcp?: { status?: unknown } }).mcp;
+  if (!mcp || typeof mcp.status !== "function") {
+    throw new Error(
+      `ODT workflow tools unavailable: OpenCode MCP status API is unavailable for "${TRUSTED_ODT_MCP_SERVER_NAME}".`,
+    );
+  }
+
+  const response = await (mcp.status as (args: { directory: string }) => Promise<unknown>)({
+    directory: input.workingDirectory,
+  });
+  const statusPayload = unwrapData(
+    response as { data?: unknown; error?: { message?: string } | unknown },
+    "get mcp status for role policy",
+  );
+  const statusRecord = asUnknownRecord(statusPayload);
+  if (!statusRecord) {
+    throw new Error(
+      `ODT workflow tools unavailable: invalid MCP status payload while checking "${TRUSTED_ODT_MCP_SERVER_NAME}".`,
+    );
+  }
+
+  const serverStatus = statusRecord[TRUSTED_ODT_MCP_SERVER_NAME];
+  const status = readStringProp(serverStatus, ["status"]);
+  if (!status) {
+    throw new Error(
+      `ODT workflow tools unavailable: MCP server "${TRUSTED_ODT_MCP_SERVER_NAME}" status is missing.`,
+    );
+  }
+  const normalizedStatus = status.trim().toLowerCase();
+  if (CONNECTED_MCP_SERVER_STATUSES.has(normalizedStatus)) {
+    return;
+  }
+
+  const errorDetails = readStringProp(serverStatus, ["error"]);
+  throw new Error(
+    `ODT workflow tools unavailable: MCP server "${TRUSTED_ODT_MCP_SERVER_NAME}" is "${status.trim()}"${
+      errorDetails ? ` (${errorDetails})` : ""
+    }.`,
+  );
+};
 
 export const resolveWorkflowToolSelection = async (input: {
   client: OpencodeClient;
   role: AgentRole;
   workingDirectory: string;
 }): Promise<Record<string, boolean>> => {
-  const selectionFromKnownAliases = buildRoleScopedOdtToolSelection(input.role);
-  try {
-    const response = await input.client.tool.ids({
-      directory: input.workingDirectory,
-    });
-    const runtimeToolIds = toToolIdList(unwrapData(response, "list tool ids for role policy"));
-    if (runtimeToolIds.length === 0) {
-      return selectionFromKnownAliases;
-    }
-    return buildRoleScopedOdtToolSelection(input.role, {
-      runtimeToolIds,
-    });
-  } catch {
-    return selectionFromKnownAliases;
+  const response = await input.client.tool.ids({
+    directory: input.workingDirectory,
+  });
+  const runtimeToolIds = toToolIdList(unwrapData(response, "list tool ids for role policy"));
+  if (runtimeToolIds.length === 0) {
+    throw new Error("ODT workflow tools unavailable: runtime tool ID list is empty.");
   }
+
+  await assertTrustedOdtMcpServerConnected({
+    client: input.client,
+    workingDirectory: input.workingDirectory,
+  });
+
+  const discoveredTrustedTools = new Set<AgentToolName>();
+  for (const runtimeToolId of runtimeToolIds) {
+    const normalizedTool = resolveOdtWorkflowToolNameForAuthorization(runtimeToolId);
+    if (normalizedTool) {
+      discoveredTrustedTools.add(normalizedTool);
+    }
+  }
+  const missingRequiredTools = AGENT_ROLE_TOOL_POLICY[input.role].filter(
+    (tool) => !discoveredTrustedTools.has(tool),
+  );
+  if (missingRequiredTools.length > 0) {
+    throw new Error(
+      `ODT workflow tools unavailable: missing trusted runtime tool IDs for role "${input.role}": ${missingRequiredTools.join(
+        ", ",
+      )}.`,
+    );
+  }
+
+  return buildRoleScopedOdtToolSelection(input.role, {
+    includeCanonicalDefaults: false,
+    runtimeToolIds,
+  });
 };

--- a/packages/core/src/services/odt-workflow-tools.test.ts
+++ b/packages/core/src/services/odt-workflow-tools.test.ts
@@ -35,6 +35,7 @@ describe("odt workflow tools", () => {
     expect(resolveOdtWorkflowToolNameForAuthorization("openducktor_odt_set_spec")).toBe(
       "odt_set_spec",
     );
+    expect(resolveOdtWorkflowToolNameForAuthorization("openducktor_odt_set_spec_extra")).toBeNull();
     expect(resolveOdtWorkflowToolNameForAuthorization("OpenDucktor_ODT_SET_SPEC")).toBeNull();
     expect(resolveOdtWorkflowToolNameForAuthorization("odt_SET_SPEC")).toBeNull();
     expect(resolveOdtWorkflowToolNameForAuthorization("customprefix_odt_set_spec")).toBeNull();

--- a/packages/core/src/services/odt-workflow-tools.test.ts
+++ b/packages/core/src/services/odt-workflow-tools.test.ts
@@ -4,6 +4,7 @@ import {
   isOdtWorkflowMutationToolName,
   isOdtWorkflowToolName,
   normalizeOdtWorkflowToolName,
+  resolveOdtWorkflowToolNameForAuthorization,
   toOdtWorkflowToolDisplayName,
 } from "./odt-workflow-tools";
 
@@ -29,19 +30,31 @@ describe("odt workflow tools", () => {
     expect(isOdtWorkflowMutationToolName("odt_read_task")).toBe(false);
   });
 
-  test("builds role-scoped selection with plain and namespaced aliases", () => {
+  test("resolves trusted workflow tool ids for authorization with exact case-sensitive matching", () => {
+    expect(resolveOdtWorkflowToolNameForAuthorization("odt_set_spec")).toBe("odt_set_spec");
+    expect(resolveOdtWorkflowToolNameForAuthorization("openducktor_odt_set_spec")).toBe(
+      "odt_set_spec",
+    );
+    expect(resolveOdtWorkflowToolNameForAuthorization("OpenDucktor_ODT_SET_SPEC")).toBeNull();
+    expect(resolveOdtWorkflowToolNameForAuthorization("odt_SET_SPEC")).toBeNull();
+    expect(resolveOdtWorkflowToolNameForAuthorization("customprefix_odt_set_spec")).toBeNull();
+  });
+
+  test("builds role-scoped selection with canonical defaults", () => {
     const selection = buildRoleScopedOdtToolSelection("spec");
     expect(selection.odt_read_task).toBe(true);
     expect(selection.odt_set_spec).toBe(true);
     expect(selection.odt_set_plan).toBe(false);
-    expect(selection.openducktor_odt_set_spec).toBe(true);
-    expect(selection.openducktor_odt_build_completed).toBe(false);
+    expect(selection.openducktor_odt_set_spec).toBeUndefined();
+    expect(selection.openducktor_odt_build_completed).toBeUndefined();
   });
 
   test("applies only trusted runtime aliases to role-scoped selection", () => {
     const selection = buildRoleScopedOdtToolSelection("qa", {
+      includeCanonicalDefaults: false,
       runtimeToolIds: [
         "openducktor_odt_qa_approved",
+        "OpenDucktor_ODT_QA_REJECTED",
         " customprefix_odt_set_spec ",
         " odt_read_task ",
         "glob",
@@ -49,6 +62,7 @@ describe("odt workflow tools", () => {
     });
     expect(selection.openducktor_odt_qa_approved).toBe(true);
     expect(selection.odt_read_task).toBe(true);
+    expect(selection.OpenDucktor_ODT_QA_REJECTED).toBeUndefined();
     expect(selection.customprefix_odt_set_spec).toBeUndefined();
     expect(selection.glob).toBeUndefined();
   });

--- a/packages/core/src/services/odt-workflow-tools.test.ts
+++ b/packages/core/src/services/odt-workflow-tools.test.ts
@@ -12,7 +12,7 @@ describe("odt workflow tools", () => {
     expect(normalizeOdtWorkflowToolName("odt_set_spec")).toBe("odt_set_spec");
     expect(normalizeOdtWorkflowToolName("OpenDucktor_ODT_SET_SPEC")).toBe("odt_set_spec");
     expect(normalizeOdtWorkflowToolName("  openducktor_odt_qa_rejected  ")).toBe("odt_qa_rejected");
-    expect(normalizeOdtWorkflowToolName("customprefix_odt_set_plan")).toBe("odt_set_plan");
+    expect(normalizeOdtWorkflowToolName("customprefix_odt_set_plan")).toBeNull();
     expect(normalizeOdtWorkflowToolName("customprefix_odt_")).toBeNull();
     expect(normalizeOdtWorkflowToolName("customprefix_odt_set_plan_extra")).toBeNull();
     expect(normalizeOdtWorkflowToolName("ODT_")).toBeNull();
@@ -23,6 +23,7 @@ describe("odt workflow tools", () => {
   test("detects workflow tool ids", () => {
     expect(isOdtWorkflowToolName("odt_set_plan")).toBe(true);
     expect(isOdtWorkflowToolName("openducktor_odt_set_plan")).toBe(true);
+    expect(isOdtWorkflowToolName("customprefix_odt_set_plan")).toBe(false);
     expect(isOdtWorkflowToolName("glob")).toBe(false);
     expect(isOdtWorkflowMutationToolName("odt_set_plan")).toBe(true);
     expect(isOdtWorkflowMutationToolName("odt_read_task")).toBe(false);
@@ -37,12 +38,18 @@ describe("odt workflow tools", () => {
     expect(selection.openducktor_odt_build_completed).toBe(false);
   });
 
-  test("applies runtime aliases to role-scoped selection", () => {
+  test("applies only trusted runtime aliases to role-scoped selection", () => {
     const selection = buildRoleScopedOdtToolSelection("qa", {
-      runtimeToolIds: ["customprefix_odt_qa_approved", " customprefix_odt_set_spec ", "glob"],
+      runtimeToolIds: [
+        "openducktor_odt_qa_approved",
+        " customprefix_odt_set_spec ",
+        " odt_read_task ",
+        "glob",
+      ],
     });
-    expect(selection.customprefix_odt_qa_approved).toBe(true);
-    expect(selection.customprefix_odt_set_spec).toBe(false);
+    expect(selection.openducktor_odt_qa_approved).toBe(true);
+    expect(selection.odt_read_task).toBe(true);
+    expect(selection.customprefix_odt_set_spec).toBeUndefined();
     expect(selection.glob).toBeUndefined();
   });
 

--- a/packages/core/src/services/odt-workflow-tools.ts
+++ b/packages/core/src/services/odt-workflow-tools.ts
@@ -7,12 +7,31 @@ import {
 
 export const ODT_WORKFLOW_TOOL_NAMES = agentToolNameValues satisfies readonly AgentToolName[];
 
-const ODT_WORKFLOW_TOOL_SET = new Set<AgentToolName>(ODT_WORKFLOW_TOOL_NAMES);
 export const ODT_WORKFLOW_MUTATION_TOOL_NAMES = ODT_WORKFLOW_TOOL_NAMES.filter(
   (tool) => tool !== "odt_read_task",
 );
 const ODT_WORKFLOW_MUTATION_TOOL_SET = new Set<AgentToolName>(ODT_WORKFLOW_MUTATION_TOOL_NAMES);
 const ODT_MCP_TOOL_PREFIXES = ["openducktor_"] as const;
+
+const createOdtWorkflowRuntimeToolIdMap = (
+  mapToolId: (toolId: string) => string,
+): ReadonlyMap<string, AgentToolName> => {
+  const runtimeToolIdMap = new Map<string, AgentToolName>();
+  for (const workflowTool of ODT_WORKFLOW_TOOL_NAMES) {
+    runtimeToolIdMap.set(mapToolId(workflowTool), workflowTool);
+    for (const prefix of ODT_MCP_TOOL_PREFIXES) {
+      runtimeToolIdMap.set(mapToolId(`${prefix}${workflowTool}`), workflowTool);
+    }
+  }
+  return runtimeToolIdMap;
+};
+
+const ODT_WORKFLOW_AUTHORIZATION_TOOL_ID_MAP = createOdtWorkflowRuntimeToolIdMap(
+  (toolId) => toolId,
+);
+const ODT_WORKFLOW_NORMALIZED_TOOL_ID_MAP = createOdtWorkflowRuntimeToolIdMap((toolId) =>
+  toolId.toLowerCase(),
+);
 
 export const normalizeOdtWorkflowToolName = (toolName: string): AgentToolName | null => {
   const normalized = toolName.trim().toLowerCase();
@@ -20,48 +39,18 @@ export const normalizeOdtWorkflowToolName = (toolName: string): AgentToolName | 
     return null;
   }
 
-  if (ODT_WORKFLOW_TOOL_SET.has(normalized as AgentToolName)) {
-    return normalized as AgentToolName;
-  }
-
-  for (const prefix of ODT_MCP_TOOL_PREFIXES) {
-    if (!normalized.startsWith(prefix)) {
-      continue;
-    }
-    const candidate = normalized.slice(prefix.length);
-    return ODT_WORKFLOW_TOOL_SET.has(candidate as AgentToolName)
-      ? (candidate as AgentToolName)
-      : null;
-  }
-
-  return null;
+  return ODT_WORKFLOW_NORMALIZED_TOOL_ID_MAP.get(normalized) ?? null;
 };
 
 export const resolveOdtWorkflowToolNameForAuthorization = (
   toolId: string,
-  options?: { trustedMcpToolPrefixes?: readonly string[] },
 ): AgentToolName | null => {
   const trimmedToolId = toolId.trim();
   if (trimmedToolId.length === 0) {
     return null;
   }
 
-  if (ODT_WORKFLOW_TOOL_SET.has(trimmedToolId as AgentToolName)) {
-    return trimmedToolId as AgentToolName;
-  }
-
-  const trustedMcpToolPrefixes = options?.trustedMcpToolPrefixes ?? ODT_MCP_TOOL_PREFIXES;
-  for (const prefix of trustedMcpToolPrefixes) {
-    if (!trimmedToolId.startsWith(prefix)) {
-      continue;
-    }
-    const candidate = trimmedToolId.slice(prefix.length);
-    return ODT_WORKFLOW_TOOL_SET.has(candidate as AgentToolName)
-      ? (candidate as AgentToolName)
-      : null;
-  }
-
-  return null;
+  return ODT_WORKFLOW_AUTHORIZATION_TOOL_ID_MAP.get(trimmedToolId) ?? null;
 };
 
 export const isOdtWorkflowToolName = (toolName: string): boolean => {
@@ -83,7 +72,6 @@ export const buildRoleScopedOdtToolSelection = (
   options?: {
     runtimeToolIds?: readonly string[];
     includeCanonicalDefaults?: boolean;
-    trustedMcpToolPrefixes?: readonly string[];
   },
 ): Record<string, boolean> => {
   const allowed = new Set(AGENT_ROLE_TOOL_POLICY[role]);
@@ -97,12 +85,7 @@ export const buildRoleScopedOdtToolSelection = (
   }
 
   for (const toolId of options?.runtimeToolIds ?? []) {
-    const normalizedTool = resolveOdtWorkflowToolNameForAuthorization(
-      toolId,
-      options?.trustedMcpToolPrefixes
-        ? { trustedMcpToolPrefixes: options.trustedMcpToolPrefixes }
-        : undefined,
-    );
+    const normalizedTool = resolveOdtWorkflowToolNameForAuthorization(toolId);
     if (!normalizedTool) {
       continue;
     }

--- a/packages/core/src/services/odt-workflow-tools.ts
+++ b/packages/core/src/services/odt-workflow-tools.ts
@@ -24,15 +24,17 @@ export const normalizeOdtWorkflowToolName = (toolName: string): AgentToolName | 
     return normalized as AgentToolName;
   }
 
-  const odtMarkerIndex = normalized.lastIndexOf("odt_");
-  if (odtMarkerIndex <= 0) {
-    return null;
+  for (const prefix of ODT_MCP_TOOL_PREFIXES) {
+    if (!normalized.startsWith(prefix)) {
+      continue;
+    }
+    const candidate = normalized.slice(prefix.length);
+    return ODT_WORKFLOW_TOOL_SET.has(candidate as AgentToolName)
+      ? (candidate as AgentToolName)
+      : null;
   }
 
-  const candidate = normalized.slice(odtMarkerIndex);
-  return ODT_WORKFLOW_TOOL_SET.has(candidate as AgentToolName)
-    ? (candidate as AgentToolName)
-    : null;
+  return null;
 };
 
 export const isOdtWorkflowToolName = (toolName: string): boolean => {

--- a/packages/core/src/services/odt-workflow-tools.ts
+++ b/packages/core/src/services/odt-workflow-tools.ts
@@ -37,6 +37,33 @@ export const normalizeOdtWorkflowToolName = (toolName: string): AgentToolName | 
   return null;
 };
 
+export const resolveOdtWorkflowToolNameForAuthorization = (
+  toolId: string,
+  options?: { trustedMcpToolPrefixes?: readonly string[] },
+): AgentToolName | null => {
+  const trimmedToolId = toolId.trim();
+  if (trimmedToolId.length === 0) {
+    return null;
+  }
+
+  if (ODT_WORKFLOW_TOOL_SET.has(trimmedToolId as AgentToolName)) {
+    return trimmedToolId as AgentToolName;
+  }
+
+  const trustedMcpToolPrefixes = options?.trustedMcpToolPrefixes ?? ODT_MCP_TOOL_PREFIXES;
+  for (const prefix of trustedMcpToolPrefixes) {
+    if (!trimmedToolId.startsWith(prefix)) {
+      continue;
+    }
+    const candidate = trimmedToolId.slice(prefix.length);
+    return ODT_WORKFLOW_TOOL_SET.has(candidate as AgentToolName)
+      ? (candidate as AgentToolName)
+      : null;
+  }
+
+  return null;
+};
+
 export const isOdtWorkflowToolName = (toolName: string): boolean => {
   return normalizeOdtWorkflowToolName(toolName) !== null;
 };
@@ -53,21 +80,29 @@ export const toOdtWorkflowToolDisplayName = (toolName: string): string => {
 
 export const buildRoleScopedOdtToolSelection = (
   role: AgentRole,
-  options?: { runtimeToolIds?: readonly string[] },
+  options?: {
+    runtimeToolIds?: readonly string[];
+    includeCanonicalDefaults?: boolean;
+    trustedMcpToolPrefixes?: readonly string[];
+  },
 ): Record<string, boolean> => {
   const allowed = new Set(AGENT_ROLE_TOOL_POLICY[role]);
   const selection: Record<string, boolean> = {};
+  const includeCanonicalDefaults = options?.includeCanonicalDefaults ?? true;
 
-  for (const workflowTool of ODT_WORKFLOW_TOOL_NAMES) {
-    const enabled = allowed.has(workflowTool);
-    selection[workflowTool] = enabled;
-    for (const prefix of ODT_MCP_TOOL_PREFIXES) {
-      selection[`${prefix}${workflowTool}`] = enabled;
+  if (includeCanonicalDefaults) {
+    for (const workflowTool of ODT_WORKFLOW_TOOL_NAMES) {
+      selection[workflowTool] = allowed.has(workflowTool);
     }
   }
 
   for (const toolId of options?.runtimeToolIds ?? []) {
-    const normalizedTool = normalizeOdtWorkflowToolName(toolId);
+    const normalizedTool = resolveOdtWorkflowToolNameForAuthorization(
+      toolId,
+      options?.trustedMcpToolPrefixes
+        ? { trustedMcpToolPrefixes: options.trustedMcpToolPrefixes }
+        : undefined,
+    );
     if (!normalizedTool) {
       continue;
     }


### PR DESCRIPTION
## Summary
This PR hardens ODT workflow tool authorization to prevent tool-name confusion and role-allowlist bypass via spoofed MCP tool IDs.

It replaces pattern-oriented trust decisions with exact known tool-ID validation and enforces fail-closed runtime selection when trust prerequisites are missing.

## Problem
The previous flow could infer trust from tool-name shape (`odt_*` and prefixed variants), which leaves room for confusion attacks when runtime tool IDs are not strictly validated against trusted, known IDs and MCP server state.

## What Changed
### 1) Core: exact known-ID authorization map
- Added deterministic runtime tool-ID maps generated from canonical workflow tools and trusted `openducktor_` aliases.
- `resolveOdtWorkflowToolNameForAuthorization` now performs exact, case-sensitive lookup only.
- Removed pattern/prefix slicing for authorization decisions.

Files:
- `packages/core/src/services/odt-workflow-tools.ts`
- `packages/core/src/services/odt-workflow-tools.test.ts`

### 2) Adapter: trust-bound runtime gating + fail-closed behavior
- Runtime tool selection now requires:
  - successful runtime tool ID discovery,
  - verified `openducktor` MCP server connectivity,
  - presence of required role tools in discovered trusted IDs.
- If any prerequisite fails, selection now returns actionable errors and no prompt is sent.
- Removed permissive fallback behavior for this security-critical path.

Files:
- `packages/adapters-opencode-sdk/src/workflow-tool-selection.ts`
- `packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts`
- `packages/adapters-opencode-sdk/src/index.test.ts`

## Security Impact
- Prevents arbitrary tool-name/prefix confusion from inheriting ODT role permissions.
- Enforces least privilege by binding enablement to exact known IDs and trusted server state.
- Aligns behavior with fail-safe defaults for authorization-sensitive logic.

## Testing
Executed and passing:
- `bun run --filter @openducktor/core test`
- `bun run --filter @openducktor/adapters-opencode-sdk test`
- `bun run --filter @openducktor/core typecheck`
- `bun run --filter @openducktor/adapters-opencode-sdk typecheck`
- `bun run --filter @openducktor/core lint`
- `bun run --filter @openducktor/adapters-opencode-sdk lint`

## Notes for Review
- This change is intentionally strict: authorization accepts only exact known runtime IDs.
- Erroring on missing trust prerequisites is intentional to avoid silent policy degradation.
