### PR TITLE
test(desktop-tauri): add comprehensive command coverage for git status and hook trust flows

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -30,3 +30,6 @@ host-domain = { path = "crates/host-domain" }
 host-application = { path = "crates/host-application" }
 host-infra-beads = { path = "crates/host-infra-beads" }
 host-infra-system = { path = "crates/host-infra-system" }
+
+[dev-dependencies]
+tauri = { version = "2", features = ["test"] }

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -517,20 +517,202 @@ pub async fn git_rebase_branch(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_worktree_status_with_snapshot, hash_worktree_diff_payload,
+        build_worktree_status_with_snapshot, git_get_worktree_status, hash_worktree_diff_payload,
         hash_worktree_status_payload, parse_diff_scope, require_target_branch, resolve_working_dir,
         WorktreeSnapshotMetadata, GIT_WORKTREE_HASH_VERSION,
     };
+    use crate::AppState;
+    use anyhow::anyhow;
+    use host_application::AppService;
+    use host_domain::GitPort;
     use host_domain::{
-        GitAheadBehind, GitCurrentBranch, GitDiffScope, GitFileDiff, GitFileStatus,
-        GitUpstreamAheadBehind, GitWorktreeStatusData,
+        GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
+        GitDiffScope, GitFileDiff, GitFileStatus, GitPullRequest, GitPullResult, GitPushSummary,
+        GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatus,
+        GitWorktreeStatusData, TaskStore, TASK_METADATA_NAMESPACE,
     };
+    use host_infra_beads::BeadsTaskStore;
+    use host_infra_system::AppConfigStore;
+    use serde_json::{json, Value};
     use std::{
+        collections::HashMap,
         env, fs,
         path::{Path, PathBuf},
         process::Command,
+        sync::{Arc, Mutex},
         time::{SystemTime, UNIX_EPOCH},
     };
+    use tauri::{
+        ipc::{CallbackFn, InvokeBody},
+        test::{mock_builder, mock_context, noop_assets, MockRuntime, INVOKE_KEY},
+        webview::InvokeRequest,
+        App, Webview, WebviewWindow, WebviewWindowBuilder,
+    };
+
+    #[derive(Clone)]
+    enum WorktreeStatusResult {
+        Ok(GitWorktreeStatusData),
+        Err(String),
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct WorktreeStatusCall {
+        repo_path: String,
+        target_branch: String,
+        diff_scope: GitDiffScope,
+    }
+
+    struct CommandGitPortState {
+        worktree_status_result: WorktreeStatusResult,
+        worktree_status_calls: Vec<WorktreeStatusCall>,
+    }
+
+    struct CommandGitPort {
+        state: Arc<Mutex<CommandGitPortState>>,
+    }
+
+    impl CommandGitPort {
+        fn new(result: WorktreeStatusResult) -> Self {
+            Self {
+                state: Arc::new(Mutex::new(CommandGitPortState {
+                    worktree_status_result: result,
+                    worktree_status_calls: Vec::new(),
+                })),
+            }
+        }
+    }
+
+    impl GitPort for CommandGitPort {
+        fn get_branches(&self, _repo_path: &Path) -> anyhow::Result<Vec<GitBranch>> {
+            panic!("unexpected call: get_branches");
+        }
+
+        fn get_current_branch(&self, _repo_path: &Path) -> anyhow::Result<GitCurrentBranch> {
+            panic!("unexpected call: get_current_branch");
+        }
+
+        fn switch_branch(
+            &self,
+            _repo_path: &Path,
+            _branch: &str,
+            _create: bool,
+        ) -> anyhow::Result<GitCurrentBranch> {
+            panic!("unexpected call: switch_branch");
+        }
+
+        fn create_worktree(
+            &self,
+            _repo_path: &Path,
+            _worktree_path: &Path,
+            _branch: &str,
+            _create_branch: bool,
+        ) -> anyhow::Result<()> {
+            panic!("unexpected call: create_worktree");
+        }
+
+        fn remove_worktree(
+            &self,
+            _repo_path: &Path,
+            _worktree_path: &Path,
+            _force: bool,
+        ) -> anyhow::Result<()> {
+            panic!("unexpected call: remove_worktree");
+        }
+
+        fn push_branch(
+            &self,
+            _repo_path: &Path,
+            _remote: &str,
+            _branch: &str,
+            _set_upstream: bool,
+            _force_with_lease: bool,
+        ) -> anyhow::Result<GitPushSummary> {
+            panic!("unexpected call: push_branch");
+        }
+
+        fn pull_branch(
+            &self,
+            _repo_path: &Path,
+            _request: GitPullRequest,
+        ) -> anyhow::Result<GitPullResult> {
+            panic!("unexpected call: pull_branch");
+        }
+
+        fn get_status(&self, _repo_path: &Path) -> anyhow::Result<Vec<GitFileStatus>> {
+            panic!("unexpected call: get_status");
+        }
+
+        fn get_diff(
+            &self,
+            _repo_path: &Path,
+            _target_branch: Option<&str>,
+        ) -> anyhow::Result<Vec<GitFileDiff>> {
+            panic!("unexpected call: get_diff");
+        }
+
+        fn get_worktree_status(
+            &self,
+            repo_path: &Path,
+            target_branch: &str,
+            diff_scope: GitDiffScope,
+        ) -> anyhow::Result<GitWorktreeStatusData> {
+            let mut state = self
+                .state
+                .lock()
+                .expect("command git port state lock should not be poisoned");
+            state.worktree_status_calls.push(WorktreeStatusCall {
+                repo_path: repo_path.to_string_lossy().to_string(),
+                target_branch: target_branch.to_string(),
+                diff_scope,
+            });
+            match state.worktree_status_result.clone() {
+                WorktreeStatusResult::Ok(payload) => Ok(payload),
+                WorktreeStatusResult::Err(message) => Err(anyhow!(message)),
+            }
+        }
+
+        fn resolve_upstream_target(&self, _repo_path: &Path) -> anyhow::Result<Option<String>> {
+            panic!("unexpected call: resolve_upstream_target");
+        }
+
+        fn commits_ahead_behind(
+            &self,
+            _repo_path: &Path,
+            _target_branch: &str,
+        ) -> anyhow::Result<GitAheadBehind> {
+            panic!("unexpected call: commits_ahead_behind");
+        }
+
+        fn commit_all(
+            &self,
+            _repo_path: &Path,
+            _request: GitCommitAllRequest,
+        ) -> anyhow::Result<GitCommitAllResult> {
+            panic!("unexpected call: commit_all");
+        }
+
+        fn rebase_branch(
+            &self,
+            _repo_path: &Path,
+            _request: GitRebaseBranchRequest,
+        ) -> anyhow::Result<GitRebaseBranchResult> {
+            panic!("unexpected call: rebase_branch");
+        }
+    }
+
+    struct CommandGitFixture {
+        _app: App<MockRuntime>,
+        webview: WebviewWindow<MockRuntime>,
+        repo_path: String,
+        git_state: Arc<Mutex<CommandGitPortState>>,
+        root: PathBuf,
+    }
+
+    impl Drop for CommandGitFixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
 
     fn unique_test_dir(prefix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -568,6 +750,231 @@ mod tests {
             ],
             path,
         );
+    }
+
+    fn setup_command_git_fixture(
+        prefix: &str,
+        result: WorktreeStatusResult,
+        authorize_repo: bool,
+    ) -> CommandGitFixture {
+        let root = unique_test_dir(prefix);
+        let repo = root.join("repo");
+        fs::create_dir_all(repo.join(".git")).expect("fake git workspace should exist");
+
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        if authorize_repo {
+            config_store
+                .add_workspace(repo.to_string_lossy().as_ref())
+                .expect("workspace should be allowlisted");
+        }
+
+        let git_port = CommandGitPort::new(result);
+        let git_state = git_port.state.clone();
+        let task_store: Arc<dyn TaskStore> = Arc::new(BeadsTaskStore::with_metadata_namespace(
+            TASK_METADATA_NAMESPACE,
+        ));
+        let service = Arc::new(AppService::with_git_port(
+            task_store,
+            config_store,
+            Arc::new(git_port),
+        ));
+        let app = mock_builder()
+            .manage(AppState {
+                service,
+                hook_trust_challenges: Mutex::new(HashMap::new()),
+            })
+            .invoke_handler(tauri::generate_handler![git_get_worktree_status])
+            .build(mock_context(noop_assets()))
+            .expect("test app should build");
+        let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .expect("test webview should build");
+
+        CommandGitFixture {
+            _app: app,
+            webview,
+            repo_path: repo.to_string_lossy().to_string(),
+            git_state,
+            root,
+        }
+    }
+
+    fn invoke_json<W: AsRef<Webview<MockRuntime>>>(
+        webview: &W,
+        cmd: &str,
+        body: Value,
+    ) -> Result<Value, Value> {
+        tauri::test::get_ipc_response(
+            webview,
+            InvokeRequest {
+                cmd: cmd.to_string(),
+                callback: CallbackFn(0),
+                error: CallbackFn(1),
+                url: "http://tauri.localhost"
+                    .parse()
+                    .expect("invoke URL should parse"),
+                body: InvokeBody::Json(body),
+                headers: Default::default(),
+                invoke_key: INVOKE_KEY.to_string(),
+            },
+        )
+        .map(|payload| {
+            payload
+                .deserialize::<Value>()
+                .expect("command response should deserialize")
+        })
+    }
+
+    fn sample_worktree_status_data(upstream: GitUpstreamAheadBehind) -> GitWorktreeStatusData {
+        GitWorktreeStatusData {
+            current_branch: GitCurrentBranch {
+                name: Some("feature/command".to_string()),
+                detached: false,
+            },
+            file_statuses: vec![GitFileStatus {
+                path: "src/main.rs".to_string(),
+                status: "M".to_string(),
+                staged: false,
+            }],
+            file_diffs: vec![GitFileDiff {
+                file: "src/main.rs".to_string(),
+                diff_type: "modified".to_string(),
+                additions: 1,
+                deletions: 0,
+                diff: "@@ -1 +1 @@\n-old\n+new\n".to_string(),
+            }],
+            target_ahead_behind: GitAheadBehind {
+                ahead: 1,
+                behind: 0,
+            },
+            upstream_ahead_behind: upstream,
+        }
+    }
+
+    #[test]
+    fn git_get_worktree_status_rejects_unauthorized_repo() {
+        let fixture = setup_command_git_fixture(
+            "git-command-unauthorized",
+            WorktreeStatusResult::Ok(sample_worktree_status_data(
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 0,
+                    behind: 0,
+                },
+            )),
+            false,
+        );
+
+        let error = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "origin/main",
+            }),
+        )
+        .expect_err("unauthorized repo should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Repository path is not in the configured workspace allowlist"),
+            "unexpected error: {error}"
+        );
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert!(
+            state.worktree_status_calls.is_empty(),
+            "git port should not run when authorization fails"
+        );
+    }
+
+    #[test]
+    fn git_get_worktree_status_keeps_upstream_error_variant_and_snapshot_metadata() {
+        let fixture = setup_command_git_fixture(
+            "git-command-upstream-error",
+            WorktreeStatusResult::Ok(sample_worktree_status_data(GitUpstreamAheadBehind::Error {
+                message: "upstream not configured".to_string(),
+            })),
+            true,
+        );
+
+        let response = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "  origin/main  ",
+                "diffScope": "uncommitted",
+            }),
+        )
+        .expect("command should succeed");
+        let status: GitWorktreeStatus =
+            serde_json::from_value(response).expect("response should decode as GitWorktreeStatus");
+
+        assert_eq!(
+            status.upstream_ahead_behind,
+            GitUpstreamAheadBehind::Error {
+                message: "upstream not configured".to_string()
+            }
+        );
+        assert_eq!(status.snapshot.target_branch, "origin/main");
+        assert_eq!(status.snapshot.diff_scope, GitDiffScope::Uncommitted);
+        assert_eq!(status.snapshot.hash_version, GIT_WORKTREE_HASH_VERSION);
+        assert_eq!(status.snapshot.status_hash.len(), 16);
+        assert_eq!(status.snapshot.diff_hash.len(), 16);
+
+        let expected_effective = fs::canonicalize(Path::new(&fixture.repo_path))
+            .expect("repo should canonicalize")
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(status.snapshot.effective_working_dir, expected_effective);
+
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert_eq!(state.worktree_status_calls.len(), 1);
+        assert_eq!(
+            state.worktree_status_calls[0],
+            WorktreeStatusCall {
+                repo_path: expected_effective,
+                target_branch: "origin/main".to_string(),
+                diff_scope: GitDiffScope::Uncommitted,
+            }
+        );
+    }
+
+    #[test]
+    fn git_get_worktree_status_propagates_upstream_status_collection_failures() {
+        let fixture = setup_command_git_fixture(
+            "git-command-status-failure",
+            WorktreeStatusResult::Err("failed collecting upstream status".to_string()),
+            true,
+        );
+
+        let error = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "origin/main",
+            }),
+        )
+        .expect_err("git port failure should be returned");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed collecting upstream status"),
+            "unexpected error: {error}"
+        );
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert_eq!(state.worktree_status_calls.len(), 1);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -782,6 +782,7 @@ mod tests {
             .manage(AppState {
                 service,
                 hook_trust_challenges: Mutex::new(HashMap::new()),
+                hook_trust_dialog_test_response: Mutex::new(None),
             })
             .invoke_handler(tauri::generate_handler![git_get_worktree_status])
             .build(mock_context(noop_assets()))

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -759,7 +759,7 @@ mod tests {
     ) -> CommandGitFixture {
         let root = unique_test_dir(prefix);
         let repo = root.join("repo");
-        fs::create_dir_all(repo.join(".git")).expect("fake git workspace should exist");
+        init_repo(&repo);
 
         let config_store = AppConfigStore::from_path(root.join("config.json"));
         if authorize_repo {
@@ -975,6 +975,101 @@ mod tests {
             .lock()
             .expect("command git state lock should not be poisoned");
         assert_eq!(state.worktree_status_calls.len(), 1);
+    }
+
+    #[test]
+    fn git_get_worktree_status_rejects_unrelated_working_dir() {
+        let fixture = setup_command_git_fixture(
+            "git-command-working-dir-reject",
+            WorktreeStatusResult::Ok(sample_worktree_status_data(
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 0,
+                    behind: 0,
+                },
+            )),
+            true,
+        );
+        let external = fixture.root.join("external");
+        init_repo(&external);
+
+        let error = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "origin/main",
+                "workingDir": external.to_string_lossy().to_string(),
+            }),
+        )
+        .expect_err("unrelated working_dir should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("working_dir is not within authorized repository or linked worktrees"),
+            "unexpected error: {error}"
+        );
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert!(
+            state.worktree_status_calls.is_empty(),
+            "git port should not run for unauthorized working_dir"
+        );
+    }
+
+    #[test]
+    fn git_get_worktree_status_accepts_registered_worktree_working_dir() {
+        let fixture = setup_command_git_fixture(
+            "git-command-working-dir-accept",
+            WorktreeStatusResult::Ok(sample_worktree_status_data(
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 1,
+                    behind: 0,
+                },
+            )),
+            true,
+        );
+        let worktree = fixture.root.join("repo-wt");
+        let worktree_str = worktree.to_string_lossy().to_string();
+        run_git(
+            &[
+                "-C",
+                fixture.repo_path.as_str(),
+                "worktree",
+                "add",
+                "-b",
+                "feature/command-working-dir",
+                worktree_str.as_str(),
+            ],
+            Path::new(&fixture.repo_path),
+        );
+
+        let response = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "origin/main",
+                "workingDir": worktree_str,
+            }),
+        )
+        .expect("registered worktree should be accepted");
+        let status: GitWorktreeStatus =
+            serde_json::from_value(response).expect("response should decode as GitWorktreeStatus");
+        let expected_worktree = fs::canonicalize(&worktree)
+            .expect("worktree should canonicalize")
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(status.snapshot.effective_working_dir, expected_worktree);
+
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert_eq!(state.worktree_status_calls.len(), 1);
+        assert_eq!(state.worktree_status_calls[0].repo_path, expected_worktree);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -5,6 +5,8 @@ use crate::{
 use host_infra_system::{hook_set_fingerprint, HookSet, RepoConfig};
 use std::path::Path;
 use std::time::SystemTime;
+#[cfg(test)]
+use tauri::Manager;
 use tauri::{AppHandle, State};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use uuid::Uuid;
@@ -330,6 +332,24 @@ async fn confirm_hook_trust_dialog<R: tauri::Runtime>(
     repo_path: &str,
     hooks: &HookSet,
 ) -> Result<(), String> {
+    #[cfg(test)]
+    {
+        let test_response = {
+            let state = app.state::<AppState>();
+            let response = state
+                .hook_trust_dialog_test_response
+                .lock()
+                .map_err(|_| "Hook trust dialog test response lock poisoned".to_string())?;
+            *response
+        };
+        if let Some(confirmed) = test_response {
+            if !confirmed {
+                return Err("Hook trust confirmation was cancelled by the user.".to_string());
+            }
+            return Ok(());
+        }
+    }
+
     let dialog_message = format!(
         "Approve trusted hooks for this workspace?\n\nRepository:\n{repo}\n\nPre-start hooks:\n{pre}\n\nPost-complete hooks:\n{post}\n\nTrusted hooks can execute shell commands on this machine.",
         repo = repo_path,
@@ -450,6 +470,14 @@ mod tests {
     }
 
     fn setup_workspace_command_fixture(prefix: &str, hooks: HookSet) -> WorkspaceCommandFixture {
+        setup_workspace_command_fixture_with_dialog_response(prefix, hooks, None)
+    }
+
+    fn setup_workspace_command_fixture_with_dialog_response(
+        prefix: &str,
+        hooks: HookSet,
+        dialog_response: Option<bool>,
+    ) -> WorkspaceCommandFixture {
         let root = unique_test_dir(prefix);
         let repo = root.join("repo");
         fs::create_dir_all(repo.join(".git")).expect("fake git workspace should exist");
@@ -476,6 +504,7 @@ mod tests {
             .manage(AppState {
                 service: service.clone(),
                 hook_trust_challenges: Mutex::new(HashMap::new()),
+                hook_trust_dialog_test_response: Mutex::new(dialog_response),
             })
             .invoke_handler(tauri::generate_handler![workspace_set_trusted_hooks])
             .build(mock_context(noop_assets()))
@@ -693,6 +722,49 @@ mod tests {
         assert!(
             replay_error.contains("missing or expired"),
             "unexpected replay error: {replay_error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_accepts_valid_challenge_and_persists_trust() -> Result<(), String>
+    {
+        let hooks = HookSet {
+            pre_start: vec!["echo pre".to_string()],
+            post_complete: vec!["echo post".to_string()],
+        };
+        let fixture = setup_workspace_command_fixture_with_dialog_response(
+            "trusted-hooks-happy-path",
+            hooks.clone(),
+            Some(true),
+        );
+        let nonce = "nonce-trust-success".to_string();
+        let fingerprint = hook_set_fingerprint(&hooks);
+        insert_challenge(
+            &fixture,
+            nonce.as_str(),
+            HookTrustChallenge {
+                repo_path: canonical_repo_key(fixture.repo_path.as_str()),
+                fingerprint: fingerprint.clone(),
+                expires_at: SystemTime::now()
+                    .checked_add(Duration::from_secs(60))
+                    .ok_or_else(|| "future time should be valid".to_string())?,
+            },
+        )?;
+
+        let updated =
+            run_workspace_set_trusted_hooks(&fixture, true, Some(nonce), Some(fingerprint.clone()))
+                .expect("valid challenge should trust hooks");
+        assert_eq!(updated.path, canonical_repo_key(fixture.repo_path.as_str()));
+
+        let repo_config = fixture
+            .service
+            .workspace_get_repo_config(fixture.repo_path.as_str())
+            .map_err(|error| error.to_string())?;
+        assert!(repo_config.trusted_hooks);
+        assert_eq!(
+            repo_config.trusted_hooks_fingerprint.as_deref(),
+            Some(fingerprint.as_str())
         );
         Ok(())
     }

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -94,9 +94,9 @@ pub async fn workspace_update_repo_config(
 }
 
 #[tauri::command]
-pub async fn workspace_save_repo_settings(
+pub async fn workspace_save_repo_settings<R: tauri::Runtime>(
     state: State<'_, AppState>,
-    app: AppHandle,
+    app: AppHandle<R>,
     repo_path: String,
     settings: RepoSettingsPayload,
 ) -> Result<host_domain::WorkspaceRecord, String> {
@@ -194,9 +194,9 @@ pub async fn workspace_get_repo_config(
 }
 
 #[tauri::command]
-pub async fn workspace_set_trusted_hooks(
+pub async fn workspace_set_trusted_hooks<R: tauri::Runtime>(
     state: State<'_, AppState>,
-    app: AppHandle,
+    app: AppHandle<R>,
     repo_path: String,
     trusted: bool,
     challenge_nonce: Option<String>,
@@ -319,8 +319,8 @@ fn sanitize_hook_preview(command: &str) -> String {
     escaped
 }
 
-async fn confirm_hook_trust_dialog(
-    app: &AppHandle,
+async fn confirm_hook_trust_dialog<R: tauri::Runtime>(
+    app: &AppHandle<R>,
     repo_path: &str,
     hooks: &HookSet,
 ) -> Result<(), String> {
@@ -397,9 +397,291 @@ fn normalize_hook_commands(commands: &mut Vec<String>) {
 mod tests {
     use super::{
         canonical_repo_key, format_hook_list, normalize_hook_set, sanitize_hook_preview,
-        validate_trust_challenge_entry, HookSet, HookTrustChallenge,
+        validate_trust_challenge_entry, workspace_set_trusted_hooks, HookSet, HookTrustChallenge,
     };
-    use std::time::{Duration, SystemTime};
+    use crate::AppState;
+    use host_application::AppService;
+    use host_domain::{TaskStore, WorkspaceRecord, TASK_METADATA_NAMESPACE};
+    use host_infra_beads::BeadsTaskStore;
+    use host_infra_system::{hook_set_fingerprint, AppConfigStore, GitCliPort};
+    use std::{
+        collections::HashMap,
+        fs,
+        path::PathBuf,
+        sync::{Arc, Mutex},
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+    use tauri::{
+        test::{mock_builder, mock_context, noop_assets, MockRuntime},
+        App, Manager,
+    };
+
+    struct WorkspaceCommandFixture {
+        app: App<MockRuntime>,
+        service: Arc<AppService>,
+        repo_path: String,
+        root: PathBuf,
+    }
+
+    impl Drop for WorkspaceCommandFixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn unique_test_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("openducktor-workspace-command-{prefix}-{nanos}"));
+        fs::create_dir_all(&root).expect("test root should be created");
+        root
+    }
+
+    fn setup_workspace_command_fixture(prefix: &str, hooks: HookSet) -> WorkspaceCommandFixture {
+        let root = unique_test_dir(prefix);
+        let repo = root.join("repo");
+        fs::create_dir_all(repo.join(".git")).expect("fake git workspace should exist");
+        let repo_path = repo.to_string_lossy().to_string();
+
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        config_store
+            .add_workspace(repo_path.as_str())
+            .expect("workspace should be allowlisted");
+        config_store
+            .update_repo_hooks(repo_path.as_str(), hooks)
+            .expect("hooks should be persisted");
+
+        let task_store: Arc<dyn TaskStore> = Arc::new(BeadsTaskStore::with_metadata_namespace(
+            TASK_METADATA_NAMESPACE,
+        ));
+        let service = Arc::new(AppService::with_git_port(
+            task_store,
+            config_store,
+            Arc::new(GitCliPort::new()),
+        ));
+
+        let app = mock_builder()
+            .manage(AppState {
+                service: service.clone(),
+                hook_trust_challenges: Mutex::new(HashMap::new()),
+            })
+            .build(mock_context(noop_assets()))
+            .expect("test app should build");
+
+        WorkspaceCommandFixture {
+            app,
+            service,
+            repo_path,
+            root,
+        }
+    }
+
+    fn run_workspace_set_trusted_hooks(
+        fixture: &WorkspaceCommandFixture,
+        trusted: bool,
+        challenge_nonce: Option<String>,
+        challenge_fingerprint: Option<String>,
+    ) -> Result<WorkspaceRecord, String> {
+        let state = fixture.app.state::<AppState>();
+        let app_handle = fixture.app.handle().clone();
+        tauri::async_runtime::block_on(workspace_set_trusted_hooks(
+            state,
+            app_handle,
+            fixture.repo_path.clone(),
+            trusted,
+            challenge_nonce,
+            challenge_fingerprint,
+        ))
+    }
+
+    fn insert_challenge(
+        fixture: &WorkspaceCommandFixture,
+        nonce: &str,
+        challenge: HookTrustChallenge,
+    ) -> Result<(), String> {
+        let state = fixture.app.state::<AppState>();
+        let mut map = state
+            .hook_trust_challenges
+            .lock()
+            .map_err(|_| "challenge lock poisoned".to_string())?;
+        map.insert(nonce.to_string(), challenge);
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_requires_nonce_and_fingerprint_when_enabling() {
+        let fixture =
+            setup_workspace_command_fixture("missing-challenge-fields", HookSet::default());
+
+        let missing_nonce =
+            run_workspace_set_trusted_hooks(&fixture, true, None, Some("abc".to_string()))
+                .expect_err("missing nonce should fail");
+        assert!(
+            missing_nonce.contains("requires challenge nonce"),
+            "unexpected nonce error: {missing_nonce}"
+        );
+
+        let missing_fingerprint =
+            run_workspace_set_trusted_hooks(&fixture, true, Some("nonce-1".to_string()), None)
+                .expect_err("missing fingerprint should fail");
+        assert!(
+            missing_fingerprint.contains("requires challenge fingerprint"),
+            "unexpected fingerprint error: {missing_fingerprint}"
+        );
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_rejects_expired_challenge_entries() -> Result<(), String> {
+        let fixture = setup_workspace_command_fixture("expired-challenge", HookSet::default());
+        let nonce = "expired-nonce".to_string();
+        let fingerprint = hook_set_fingerprint(&HookSet::default());
+        insert_challenge(
+            &fixture,
+            nonce.as_str(),
+            HookTrustChallenge {
+                repo_path: canonical_repo_key(fixture.repo_path.as_str()),
+                fingerprint: fingerprint.clone(),
+                expires_at: SystemTime::now()
+                    .checked_sub(Duration::from_secs(1))
+                    .ok_or_else(|| "expired time should be valid".to_string())?,
+            },
+        )?;
+
+        let error = run_workspace_set_trusted_hooks(&fixture, true, Some(nonce), Some(fingerprint))
+            .expect_err("expired challenge should fail");
+        assert!(
+            error.contains("missing or expired"),
+            "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_rejects_fingerprint_mismatch() -> Result<(), String> {
+        let hooks = HookSet {
+            pre_start: vec!["echo pre".to_string()],
+            post_complete: Vec::new(),
+        };
+        let fixture = setup_workspace_command_fixture("fingerprint-mismatch", hooks.clone());
+        let nonce = "nonce-fp-mismatch".to_string();
+        let expected_fingerprint = hook_set_fingerprint(&hooks);
+        insert_challenge(
+            &fixture,
+            nonce.as_str(),
+            HookTrustChallenge {
+                repo_path: canonical_repo_key(fixture.repo_path.as_str()),
+                fingerprint: expected_fingerprint,
+                expires_at: SystemTime::now()
+                    .checked_add(Duration::from_secs(60))
+                    .ok_or_else(|| "future time should be valid".to_string())?,
+            },
+        )?;
+
+        let error = run_workspace_set_trusted_hooks(
+            &fixture,
+            true,
+            Some(nonce),
+            Some("different-fingerprint".to_string()),
+        )
+        .expect_err("fingerprint mismatch should fail");
+        assert!(
+            error.contains("fingerprint mismatch"),
+            "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_consumes_nonce_and_rejects_replay_after_hook_changes(
+    ) -> Result<(), String> {
+        let original_hooks = HookSet {
+            pre_start: vec!["echo pre".to_string()],
+            post_complete: Vec::new(),
+        };
+        let fixture = setup_workspace_command_fixture("replay-and-stale", original_hooks.clone());
+        let nonce = "nonce-replay".to_string();
+        let challenge_fingerprint = hook_set_fingerprint(&original_hooks);
+        insert_challenge(
+            &fixture,
+            nonce.as_str(),
+            HookTrustChallenge {
+                repo_path: canonical_repo_key(fixture.repo_path.as_str()),
+                fingerprint: challenge_fingerprint.clone(),
+                expires_at: SystemTime::now()
+                    .checked_add(Duration::from_secs(60))
+                    .ok_or_else(|| "future time should be valid".to_string())?,
+            },
+        )?;
+
+        fixture
+            .service
+            .workspace_update_repo_hooks(
+                fixture.repo_path.as_str(),
+                HookSet {
+                    pre_start: vec!["echo changed".to_string()],
+                    post_complete: Vec::new(),
+                },
+            )
+            .map_err(|error| error.to_string())?;
+
+        let stale_error = run_workspace_set_trusted_hooks(
+            &fixture,
+            true,
+            Some(nonce.clone()),
+            Some(challenge_fingerprint),
+        )
+        .expect_err("stale hook challenge should fail");
+        assert!(
+            stale_error.contains("Hook commands changed after challenge generation"),
+            "unexpected stale challenge error: {stale_error}"
+        );
+
+        let replay_error = run_workspace_set_trusted_hooks(
+            &fixture,
+            true,
+            Some(nonce),
+            Some("ignored".to_string()),
+        )
+        .expect_err("replay should fail after nonce consumption");
+        assert!(
+            replay_error.contains("missing or expired"),
+            "unexpected replay error: {replay_error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_disables_without_challenge() -> Result<(), String> {
+        let hooks = HookSet {
+            pre_start: vec!["echo pre".to_string()],
+            post_complete: Vec::new(),
+        };
+        let fixture = setup_workspace_command_fixture("disable-without-challenge", hooks.clone());
+        let fingerprint = hook_set_fingerprint(&hooks);
+        fixture
+            .service
+            .workspace_set_trusted_hooks(
+                fixture.repo_path.as_str(),
+                true,
+                Some(fingerprint.as_str()),
+            )
+            .map_err(|error| error.to_string())?;
+
+        let updated = run_workspace_set_trusted_hooks(&fixture, false, None, None)
+            .expect("disabling trust should succeed");
+        assert_eq!(updated.path, canonical_repo_key(fixture.repo_path.as_str()));
+
+        let repo_config = fixture
+            .service
+            .workspace_get_repo_config(fixture.repo_path.as_str())
+            .map_err(|error| error.to_string())?;
+        assert!(!repo_config.trusted_hooks);
+        assert!(repo_config.trusted_hooks_fingerprint.is_none());
+        Ok(())
+    }
 
     #[test]
     fn sanitize_hook_preview_escapes_controls_and_truncates() {

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -93,6 +93,8 @@ pub async fn workspace_update_repo_config(
     )
 }
 
+// Generic runtime keeps this command testable under MockRuntime without changing
+// production behavior on the default Wry runtime.
 #[tauri::command]
 pub async fn workspace_save_repo_settings<R: tauri::Runtime>(
     state: State<'_, AppState>,
@@ -193,6 +195,8 @@ pub async fn workspace_get_repo_config(
     as_error(state.service.workspace_get_repo_config(&repo_path))
 }
 
+// Generic runtime keeps this command testable under MockRuntime without changing
+// production behavior on the default Wry runtime.
 #[tauri::command]
 pub async fn workspace_set_trusted_hooks<R: tauri::Runtime>(
     state: State<'_, AppState>,
@@ -319,6 +323,8 @@ fn sanitize_hook_preview(command: &str) -> String {
     escaped
 }
 
+// Generic runtime keeps dialog plumbing compatible with command tests that run
+// under MockRuntime.
 async fn confirm_hook_trust_dialog<R: tauri::Runtime>(
     app: &AppHandle<R>,
     repo_path: &str,
@@ -404,6 +410,7 @@ mod tests {
     use host_domain::{TaskStore, WorkspaceRecord, TASK_METADATA_NAMESPACE};
     use host_infra_beads::BeadsTaskStore;
     use host_infra_system::{hook_set_fingerprint, AppConfigStore, GitCliPort};
+    use serde_json::{json, Value};
     use std::{
         collections::HashMap,
         fs,
@@ -412,7 +419,9 @@ mod tests {
         time::{Duration, SystemTime, UNIX_EPOCH},
     };
     use tauri::{
+        ipc::{CallbackFn, InvokeBody},
         test::{mock_builder, mock_context, noop_assets, MockRuntime},
+        webview::InvokeRequest,
         App, Manager,
     };
 
@@ -468,6 +477,7 @@ mod tests {
                 service: service.clone(),
                 hook_trust_challenges: Mutex::new(HashMap::new()),
             })
+            .invoke_handler(tauri::generate_handler![workspace_set_trusted_hooks])
             .build(mock_context(noop_assets()))
             .expect("test app should build");
 
@@ -511,6 +521,41 @@ mod tests {
         Ok(())
     }
 
+    fn invoke_workspace_set_trusted_hooks_ipc(
+        fixture: &WorkspaceCommandFixture,
+        payload: Value,
+    ) -> Result<Value, Value> {
+        let label = format!(
+            "main-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos()
+        );
+        let webview = tauri::WebviewWindowBuilder::new(&fixture.app, label, Default::default())
+            .build()
+            .expect("test webview should build");
+
+        tauri::test::get_ipc_response(
+            &webview,
+            InvokeRequest {
+                cmd: "workspace_set_trusted_hooks".to_string(),
+                callback: CallbackFn(0),
+                error: CallbackFn(1),
+                url: "http://tauri.localhost"
+                    .parse()
+                    .expect("invoke URL should parse"),
+                body: InvokeBody::Json(payload),
+                headers: Default::default(),
+                invoke_key: tauri::test::INVOKE_KEY.to_string(),
+            },
+        )
+        .map(|body| {
+            body.deserialize::<Value>()
+                .expect("IPC response should deserialize")
+        })
+    }
+
     #[test]
     fn workspace_set_trusted_hooks_requires_nonce_and_fingerprint_when_enabling() {
         let fixture =
@@ -530,6 +575,24 @@ mod tests {
         assert!(
             missing_fingerprint.contains("requires challenge fingerprint"),
             "unexpected fingerprint error: {missing_fingerprint}"
+        );
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_ipc_rejects_missing_nonce() {
+        let fixture = setup_workspace_command_fixture("ipc-missing-nonce", HookSet::default());
+        let error = invoke_workspace_set_trusted_hooks_ipc(
+            &fixture,
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "trusted": true,
+                "challengeFingerprint": "abc",
+            }),
+        )
+        .expect_err("missing nonce should fail over IPC");
+        assert!(
+            error.to_string().contains("requires challenge nonce"),
+            "unexpected IPC error: {error}"
         );
     }
 
@@ -590,6 +653,46 @@ mod tests {
         assert!(
             error.contains("fingerprint mismatch"),
             "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_rejects_repository_mismatch_and_consumes_nonce(
+    ) -> Result<(), String> {
+        let fixture = setup_workspace_command_fixture("repo-mismatch", HookSet::default());
+        let nonce = "nonce-repo-mismatch".to_string();
+        let fingerprint = hook_set_fingerprint(&HookSet::default());
+        insert_challenge(
+            &fixture,
+            nonce.as_str(),
+            HookTrustChallenge {
+                repo_path: "/tmp/not-the-same-repo".to_string(),
+                fingerprint: fingerprint.clone(),
+                expires_at: SystemTime::now()
+                    .checked_add(Duration::from_secs(60))
+                    .ok_or_else(|| "future time should be valid".to_string())?,
+            },
+        )?;
+
+        let mismatch_error = run_workspace_set_trusted_hooks(
+            &fixture,
+            true,
+            Some(nonce.clone()),
+            Some(fingerprint.clone()),
+        )
+        .expect_err("repository mismatch should fail");
+        assert!(
+            mismatch_error.contains("repository mismatch"),
+            "unexpected mismatch error: {mismatch_error}"
+        );
+
+        let replay_error =
+            run_workspace_set_trusted_hooks(&fixture, true, Some(nonce), Some(fingerprint))
+                .expect_err("challenge nonce should be consumed after mismatch");
+        assert!(
+            replay_error.contains("missing or expired"),
+            "unexpected replay error: {replay_error}"
         );
         Ok(())
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -25,6 +25,8 @@ use commands::workspace::*;
 struct AppState {
     service: Arc<AppService>,
     hook_trust_challenges: Mutex<HashMap<String, HookTrustChallenge>>,
+    #[cfg(test)]
+    hook_trust_dialog_test_response: Mutex<Option<bool>>,
 }
 
 const HOOK_TRUST_CHALLENGE_TTL: Duration = Duration::from_secs(120);
@@ -167,7 +169,9 @@ fn startup_phase_tracing() {
 fn startup_phase_service_bootstrap() -> anyhow::Result<Arc<AppService>> {
     let config_store = AppConfigStore::new().context("failed to initialize config store")?;
     validate_startup_config(&config_store)?;
-    let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(TASK_METADATA_NAMESPACE));
+    let task_store = Arc::new(BeadsTaskStore::with_metadata_namespace(
+        TASK_METADATA_NAMESPACE,
+    ));
     let service = Arc::new(AppService::new(task_store, config_store));
 
     Ok(service)
@@ -271,6 +275,8 @@ fn startup_phase_build_tauri_app(
         .manage(AppState {
             service,
             hook_trust_challenges: Mutex::new(HashMap::new()),
+            #[cfg(test)]
+            hook_trust_dialog_test_response: Mutex::new(None),
         });
 
     startup_phase_command_registration(builder)


### PR DESCRIPTION
## Summary
Add deep command-level test coverage for the two high-risk Tauri command paths identified in the code quality audit:
- `git_get_worktree_status` in `apps/desktop/src-tauri/src/commands/git.rs`
- `workspace_set_trusted_hooks` in `apps/desktop/src-tauri/src/commands/workspace.rs`

This closes gaps where only helper-level tests existed and command-level behavior (authorization, worktree resolution, challenge validation/replay handling, and IPC invocation boundaries) was not directly protected.

## What Changed

### 1) `git_get_worktree_status` command-level coverage
File: `apps/desktop/src-tauri/src/commands/git.rs`

Added a command-focused test harness using `tauri::test` + managed `AppState` + a controllable fake `GitPort`, then added tests for:
- unauthorized repository rejection at command boundary
- upstream-status error propagation from port failures
- preservation of upstream error variant in aggregated payload + snapshot metadata assertions
- rejection of unrelated `working_dir` (authorization/linked-worktree checks)
- acceptance of registered worktree `working_dir` and verification of effective path forwarded to `GitPort`

Also adjusted the fixture setup to initialize a real git repo so command-level `working_dir` resolution paths are exercised end-to-end.

### 2) `workspace_set_trusted_hooks` command-level coverage
File: `apps/desktop/src-tauri/src/commands/workspace.rs`

Extended command-level tests to cover challenge and trust flow edge cases:
- missing nonce/fingerprint rejection
- expired challenge rejection
- fingerprint mismatch rejection
- repository mismatch rejection
- nonce replay rejection after first consumption
- stale challenge rejection when hooks mutate after challenge generation
- disable path (`trusted=false`) without challenge data

### 3) IPC invocation boundary test
File: `apps/desktop/src-tauri/src/commands/workspace.rs`

Added an explicit IPC-level test (using `tauri::test::get_ipc_response`) for `workspace_set_trusted_hooks` on a dialog-free error branch to validate command handler registration and invoke argument mapping, not only direct function invocation.

### 4) Runtime-generic command intent documentation
File: `apps/desktop/src-tauri/src/commands/workspace.rs`

Added concise comments clarifying why runtime-generic signatures are used for `workspace_save_repo_settings`, `workspace_set_trusted_hooks`, and `confirm_hook_trust_dialog` (MockRuntime testability without behavior changes under Wry).

### 5) Test dependency support
File: `apps/desktop/src-tauri/Cargo.toml`

Added dev dependency feature support for Tauri test utilities:
- `tauri = { version = "2", features = ["test"] }`

## Why
These command handlers contain multi-branch logic with high regression risk (authorization, canonicalization/worktree checks, challenge nonce/fingerprint/expiry semantics, replay behavior). This PR ensures those contracts are directly tested at command level instead of relying only on helper tests.

## Validation
Executed focused Rust test suites in `apps/desktop/src-tauri`:
- `cargo test --lib git_get_worktree_status_`
- `cargo test --lib workspace_set_trusted_hooks_`
- `cargo test --lib commands::git::tests::`
- `cargo test --lib commands::workspace::tests::`

All passed.

## Risk / Compatibility
- No production workflow logic change intended beyond testability-oriented signature generalization across Tauri runtimes.
- Existing command behavior and error messages are preserved; this PR primarily increases behavioral test coverage and lock-in of command contracts.
