### PR TITLE
refactor(desktop): extract and harden Kanban session-start toast action

### DIFF
--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -228,19 +228,28 @@ describe("KanbanPage session start modal flow", () => {
       | undefined;
     const toastDescription = toastCall?.[1]?.description;
     expect(isValidElement(toastDescription)).toBe(true);
-    if (isValidElement(toastDescription)) {
-      let toastDescriptionRenderer!: ReactTestRenderer;
-      await act(async () => {
-        toastDescriptionRenderer = create(toastDescription);
-      });
-
-      const actionButton = toastDescriptionRenderer.root.findByType("button");
-      expect(actionButton.props.className).toContain("cursor-pointer");
-
-      await act(async () => {
-        toastDescriptionRenderer.unmount();
-      });
+    if (!isValidElement(toastDescription)) {
+      throw new Error("Expected background toast description to render an action element.");
     }
+    let toastDescriptionRenderer!: ReactTestRenderer;
+    await act(async () => {
+      toastDescriptionRenderer = create(toastDescription);
+    });
+
+    const actionButton = toastDescriptionRenderer.root.findByType("button");
+    expect(typeof actionButton.props.onClick).toBe("function");
+    await act(async () => {
+      actionButton.props.onClick();
+      await Promise.resolve();
+    });
+    expect(latestLocation).toContain("/agents?task=TASK-123");
+    expect(latestLocation).toContain("session=session-1");
+    expect(latestLocation).toContain("agent=build");
+    expect(latestLocation).toContain("scenario=build_implementation_start");
+
+    await act(async () => {
+      toastDescriptionRenderer.unmount();
+    });
 
     await act(async () => {
       renderer.unmount();

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -228,8 +228,18 @@ describe("KanbanPage session start modal flow", () => {
       | undefined;
     const toastDescription = toastCall?.[1]?.description;
     expect(isValidElement(toastDescription)).toBe(true);
-    if (isValidElement<{ className?: string }>(toastDescription)) {
-      expect(toastDescription.props.className).toContain("cursor-pointer");
+    if (isValidElement(toastDescription)) {
+      let toastDescriptionRenderer!: ReactTestRenderer;
+      await act(async () => {
+        toastDescriptionRenderer = create(toastDescription);
+      });
+
+      const actionButton = toastDescriptionRenderer.root.findByType("button");
+      expect(actionButton.props.className).toContain("cursor-pointer");
+
+      await act(async () => {
+        toastDescriptionRenderer.unmount();
+      });
     }
 
     await act(async () => {

--- a/apps/desktop/src/pages/kanban/session-started-toast-action.tsx
+++ b/apps/desktop/src/pages/kanban/session-started-toast-action.tsx
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+import type { KanbanSessionStartIntent } from "./kanban-page-model-types";
+
+type SessionStartedToastActionProps = {
+  intent: KanbanSessionStartIntent;
+  sessionId: string;
+  onOpen: (intent: KanbanSessionStartIntent, sessionId: string) => void;
+};
+
+function SessionStartedToastAction({ intent, sessionId, onOpen }: SessionStartedToastActionProps) {
+  const handleOpen = useCallback(() => {
+    onOpen(intent, sessionId);
+  }, [intent, onOpen, sessionId]);
+
+  return (
+    <button
+      type="button"
+      className="w-fit cursor-pointer p-0 text-sm font-medium text-foreground underline underline-offset-2"
+      onClick={handleOpen}
+    >
+      Open in Agent Studio
+    </button>
+  );
+}
+
+export const buildSessionStartedToastDescription = (
+  intent: KanbanSessionStartIntent,
+  sessionId: string,
+  onOpen: (intent: KanbanSessionStartIntent, sessionId: string) => void,
+) => {
+  return <SessionStartedToastAction intent={intent} sessionId={sessionId} onOpen={onOpen} />;
+};

--- a/apps/desktop/src/pages/kanban/session-started-toast-action.tsx
+++ b/apps/desktop/src/pages/kanban/session-started-toast-action.tsx
@@ -1,32 +1,19 @@
-import { useCallback } from "react";
+import { Button } from "@/components/ui/button";
 import type { KanbanSessionStartIntent } from "./kanban-page-model-types";
 
-type SessionStartedToastActionProps = {
-  intent: KanbanSessionStartIntent;
-  sessionId: string;
-  onOpen: (intent: KanbanSessionStartIntent, sessionId: string) => void;
-};
-
-function SessionStartedToastAction({ intent, sessionId, onOpen }: SessionStartedToastActionProps) {
-  const handleOpen = useCallback(() => {
-    onOpen(intent, sessionId);
-  }, [intent, onOpen, sessionId]);
-
-  return (
-    <button
-      type="button"
-      className="w-fit cursor-pointer p-0 text-sm font-medium text-foreground underline underline-offset-2"
-      onClick={handleOpen}
-    >
-      Open in Agent Studio
-    </button>
-  );
-}
-
-export const buildSessionStartedToastDescription = (
+export const renderSessionStartedToastAction = (
   intent: KanbanSessionStartIntent,
   sessionId: string,
   onOpen: (intent: KanbanSessionStartIntent, sessionId: string) => void,
 ) => {
-  return <SessionStartedToastAction intent={intent} sessionId={sessionId} onOpen={onOpen} />;
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      className="h-auto w-fit p-0 text-sm font-medium text-foreground underline underline-offset-2 hover:bg-transparent"
+      onClick={() => onOpen(intent, sessionId)}
+    >
+      Open in Agent Studio
+    </Button>
+  );
 };

--- a/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
@@ -10,6 +10,7 @@ import type { AgentStateContextValue, RepoSettingsInput } from "@/types/state-sl
 import { firstScenario, kickoffPromptForScenario } from "../agents/agents-page-constants";
 import { useSessionStartModalCoordinator } from "../shared/use-session-start-modal-coordinator";
 import type { KanbanSessionStartIntent } from "./kanban-page-model-types";
+import { buildSessionStartedToastDescription } from "./session-started-toast-action";
 
 type UseKanbanSessionStartFlowArgs = {
   activeRepo: string | null;
@@ -171,14 +172,10 @@ export function useKanbanSessionStartFlow({
             const roleLabel = AGENT_ROLE_LABELS[intent.role] ?? intent.role.toUpperCase();
             toast.success(`Started ${roleLabel} session in background for ${intent.taskId}.`, {
               duration: 10000,
-              description: (
-                <button
-                  type="button"
-                  className="w-fit cursor-pointer p-0 text-sm font-medium text-foreground underline underline-offset-2"
-                  onClick={() => openSessionInAgentStudio(intent, sessionId)}
-                >
-                  Open in Agent Studio
-                </button>
+              description: buildSessionStartedToastDescription(
+                intent,
+                sessionId,
+                openSessionInAgentStudio,
               ),
             });
           } else {

--- a/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
@@ -10,7 +10,7 @@ import type { AgentStateContextValue, RepoSettingsInput } from "@/types/state-sl
 import { firstScenario, kickoffPromptForScenario } from "../agents/agents-page-constants";
 import { useSessionStartModalCoordinator } from "../shared/use-session-start-modal-coordinator";
 import type { KanbanSessionStartIntent } from "./kanban-page-model-types";
-import { buildSessionStartedToastDescription } from "./session-started-toast-action";
+import { renderSessionStartedToastAction } from "./session-started-toast-action";
 
 type UseKanbanSessionStartFlowArgs = {
   activeRepo: string | null;
@@ -172,7 +172,7 @@ export function useKanbanSessionStartFlow({
             const roleLabel = AGENT_ROLE_LABELS[intent.role] ?? intent.role.toUpperCase();
             toast.success(`Started ${roleLabel} session in background for ${intent.taskId}.`, {
               duration: 10000,
-              description: buildSessionStartedToastDescription(
+              description: renderSessionStartedToastAction(
                 intent,
                 sessionId,
                 openSessionInAgentStudio,


### PR DESCRIPTION
## Summary
- extract the Kanban background session toast action out of `use-kanban-session-start-flow` into a dedicated toast action renderer
- keep the flow hook as a `.ts` file and keep orchestration concerns separate from JSX rendering
- strengthen Kanban tests to validate actionable behavior (clicking toast action navigates to Agent Studio with expected params)
- use shared shadcn `Button` for the toast action and simplify helper/component indirection

## Validation
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test
