### PR TITLE
perf(agent-studio): add lightweight worktree status polling and on-demand full diffs

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -19,11 +19,11 @@ use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentRuntimeSummary, AgentSessionDocument, AgentWorkflows, CreateTaskInput, GitAheadBehind,
     GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope,
-    GitFileDiff, GitFileStatus, GitPort, GitPullRequest, GitPullResult, GitPushSummary,
-    GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatusData,
-    IssueType, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
-    SpecDocument, TaskAction, TaskCard, TaskDocumentSummary, TaskMetadata, TaskStatus, TaskStore,
-    UpdateTaskPatch,
+    GitFileDiff, GitFileStatus, GitFileStatusCounts, GitPort, GitPullRequest, GitPullResult,
+    GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind,
+    GitWorktreeStatusData, GitWorktreeStatusSummaryData, IssueType, PlanSubtaskInput,
+    QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, SpecDocument, TaskAction,
+    TaskCard, TaskDocumentSummary, TaskMetadata, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{
     AppConfigStore, GlobalConfig, HookSet, OpencodeStartupReadinessConfig, RepoConfig,
@@ -351,6 +351,11 @@ pub(crate) enum GitCall {
         target_branch: String,
         diff_scope: GitDiffScope,
     },
+    GetWorktreeStatusSummary {
+        repo_path: String,
+        target_branch: String,
+        diff_scope: GitDiffScope,
+    },
 }
 
 #[derive(Debug)]
@@ -541,6 +546,75 @@ impl GitPort for FakeGitPort {
                 behind: 0,
             },
             upstream_ahead_behind,
+        })
+    }
+
+    fn get_worktree_status_summary(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+        diff_scope: GitDiffScope,
+    ) -> Result<GitWorktreeStatusSummaryData> {
+        let mut state = self.state.lock().expect("git state lock poisoned");
+        state.calls.push(GitCall::GetWorktreeStatusSummary {
+            repo_path: repo_path.to_string_lossy().to_string(),
+            target_branch: target_branch.to_string(),
+            diff_scope,
+        });
+
+        let status_data = if let Some(configured) = state.worktree_status_data.clone() {
+            configured
+        } else {
+            let current_branch = state.current_branch.clone();
+            let upstream_ahead_behind = if current_branch.name.is_some() {
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 0,
+                    behind: 0,
+                }
+            } else {
+                GitUpstreamAheadBehind::Untracked { ahead: 0 }
+            };
+
+            GitWorktreeStatusData {
+                current_branch,
+                file_statuses: Vec::new(),
+                file_diffs: Vec::new(),
+                target_ahead_behind: GitAheadBehind {
+                    ahead: 0,
+                    behind: 0,
+                },
+                upstream_ahead_behind,
+            }
+        };
+
+        let total = u32::try_from(status_data.file_statuses.len()).map_err(|_| {
+            anyhow!(
+                "too many file statuses to summarize in FakeGitPort: {}",
+                status_data.file_statuses.len()
+            )
+        })?;
+        let staged = u32::try_from(
+            status_data
+                .file_statuses
+                .iter()
+                .filter(|status| status.staged)
+                .count(),
+        )
+        .map_err(|_| anyhow!("staged file status count overflowed u32 in FakeGitPort"))?;
+        let unstaged = total.checked_sub(staged).ok_or_else(|| {
+            anyhow!("unstaged file status count underflowed in FakeGitPort")
+        })?;
+
+        Ok(GitWorktreeStatusSummaryData {
+            current_branch: status_data.current_branch,
+            file_statuses: status_data.file_statuses,
+            file_status_counts: GitFileStatusCounts {
+                total,
+                staged,
+                unstaged,
+            },
+            target_ahead_behind: status_data.target_ahead_behind,
+            upstream_ahead_behind: status_data.upstream_ahead_behind,
         })
     }
 

--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -148,6 +148,16 @@ pub struct GitWorktreeStatusData {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct GitWorktreeStatusSummaryData {
+    pub current_branch: GitCurrentBranch,
+    pub file_statuses: Vec<GitFileStatus>,
+    pub file_status_counts: GitFileStatusCounts,
+    pub target_ahead_behind: GitAheadBehind,
+    pub upstream_ahead_behind: GitUpstreamAheadBehind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct GitCommitAllRequest {
     pub working_dir: Option<String>,
     pub message: String,
@@ -223,6 +233,12 @@ pub trait GitPort: Send + Sync {
         target_branch: &str,
         diff_scope: GitDiffScope,
     ) -> Result<GitWorktreeStatusData>;
+    fn get_worktree_status_summary(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+        diff_scope: GitDiffScope,
+    ) -> Result<GitWorktreeStatusSummaryData>;
     fn resolve_upstream_target(&self, repo_path: &Path) -> Result<Option<String>>;
     fn commits_ahead_behind(&self, repo_path: &Path, target_branch: &str)
         -> Result<GitAheadBehind>;

--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -64,6 +64,14 @@ pub struct GitFileStatus {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub struct GitFileStatusCounts {
+    pub total: u32,
+    pub staged: u32,
+    pub unstaged: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct GitFileDiff {
     pub file: String,
     #[serde(rename = "type")]
@@ -113,6 +121,16 @@ pub struct GitWorktreeStatus {
     pub current_branch: GitCurrentBranch,
     pub file_statuses: Vec<GitFileStatus>,
     pub file_diffs: Vec<GitFileDiff>,
+    pub target_ahead_behind: GitAheadBehind,
+    pub upstream_ahead_behind: GitUpstreamAheadBehind,
+    pub snapshot: GitWorktreeStatusSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GitWorktreeStatusSummary {
+    pub current_branch: GitCurrentBranch,
+    pub file_status_counts: GitFileStatusCounts,
     pub target_ahead_behind: GitAheadBehind,
     pub upstream_ahead_behind: GitUpstreamAheadBehind,
     pub snapshot: GitWorktreeStatusSnapshot,

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -12,9 +12,10 @@ pub use document::{
 };
 pub use git::{
     GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
-    GitDiffScope, GitFileDiff, GitFileStatus, GitPort, GitPullRequest, GitPullResult,
-    GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind,
-    GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSnapshot, GitWorktreeSummary,
+    GitDiffScope, GitFileDiff, GitFileStatus, GitFileStatusCounts, GitPort, GitPullRequest,
+    GitPullResult, GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult,
+    GitUpstreamAheadBehind, GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSnapshot,
+    GitWorktreeStatusSummary, GitWorktreeSummary,
 };
 pub use runtime::{
     AgentRuntimeRole, AgentRuntimeSummary, RunEvent, RunState, RunSummary, RuntimeRole,
@@ -94,15 +95,17 @@ mod tests {
     #[test]
     fn public_api_exports_compile() {
         use super::{
-            AgentRuntimeRole, AgentRuntimeSummary, AgentSessionDocument, AgentSessionModelSelection,
-            AgentWorkflowState, AgentWorkflows, BeadsCheck, CreateTaskInput, GitBranch,
-            GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitPort,
-            GitPullRequest, GitPullResult, GitPushSummary, GitRebaseBranchRequest,
-            GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatus,
-            GitWorktreeStatusData,
-            GitWorktreeStatusSnapshot, GitWorktreeSummary, IssueType, PlanSubtaskInput,
+            AgentRuntimeRole, AgentRuntimeSummary, AgentSessionDocument,
+            AgentSessionModelSelection, AgentWorkflowState, AgentWorkflows, BeadsCheck,
+            CreateTaskInput, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
+            GitDiffScope, GitFileStatusCounts, GitPort, GitPullRequest, GitPullResult,
+            GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind,
+            GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSnapshot,
+            GitWorktreeStatusSummary, GitWorktreeSummary, IssueType, PlanSubtaskInput,
             QaReportDocument, QaVerdict, QaWorkflowVerdict, RunEvent, RunState, RunSummary,
-            RuntimeCheck, RuntimeRole, SpecDocument, SystemCheck, TaskAction, TaskCard, TaskDocumentPresence, TaskDocumentSummary, TaskMetadata, TaskQaDocumentPresence, TaskStatus, TaskStore, UpdateTaskPatch, WorkspaceRecord,
+            RuntimeCheck, RuntimeRole, SpecDocument, SystemCheck, TaskAction, TaskCard,
+            TaskDocumentPresence, TaskDocumentSummary, TaskMetadata, TaskQaDocumentPresence,
+            TaskStatus, TaskStore, UpdateTaskPatch, WorkspaceRecord,
         };
 
         macro_rules! check_types_exported {
@@ -127,6 +130,7 @@ mod tests {
             GitCommitAllResult,
             GitCurrentBranch,
             GitDiffScope,
+            GitFileStatusCounts,
             GitPullRequest,
             GitPullResult,
             GitPushSummary,
@@ -136,6 +140,7 @@ mod tests {
             GitWorktreeStatus,
             GitWorktreeStatusData,
             GitWorktreeStatusSnapshot,
+            GitWorktreeStatusSummary,
             GitWorktreeSummary,
             IssueType,
             PlanSubtaskInput,

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -15,7 +15,7 @@ pub use git::{
     GitDiffScope, GitFileDiff, GitFileStatus, GitFileStatusCounts, GitPort, GitPullRequest,
     GitPullResult, GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult,
     GitUpstreamAheadBehind, GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSnapshot,
-    GitWorktreeStatusSummary, GitWorktreeSummary,
+    GitWorktreeStatusSummary, GitWorktreeStatusSummaryData, GitWorktreeSummary,
 };
 pub use runtime::{
     AgentRuntimeRole, AgentRuntimeSummary, RunEvent, RunState, RunSummary, RuntimeRole,
@@ -101,9 +101,9 @@ mod tests {
             GitDiffScope, GitFileStatusCounts, GitPort, GitPullRequest, GitPullResult,
             GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind,
             GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSnapshot,
-            GitWorktreeStatusSummary, GitWorktreeSummary, IssueType, PlanSubtaskInput,
-            QaReportDocument, QaVerdict, QaWorkflowVerdict, RunEvent, RunState, RunSummary,
-            RuntimeCheck, RuntimeRole, SpecDocument, SystemCheck, TaskAction, TaskCard,
+            GitWorktreeStatusSummary, GitWorktreeStatusSummaryData, GitWorktreeSummary, IssueType,
+            PlanSubtaskInput, QaReportDocument, QaVerdict, QaWorkflowVerdict, RunEvent, RunState,
+            RunSummary, RuntimeCheck, RuntimeRole, SpecDocument, SystemCheck, TaskAction, TaskCard,
             TaskDocumentPresence, TaskDocumentSummary, TaskMetadata, TaskQaDocumentPresence,
             TaskStatus, TaskStore, UpdateTaskPatch, WorkspaceRecord,
         };
@@ -141,6 +141,7 @@ mod tests {
             GitWorktreeStatusData,
             GitWorktreeStatusSnapshot,
             GitWorktreeStatusSummary,
+            GitWorktreeStatusSummaryData,
             GitWorktreeSummary,
             IssueType,
             PlanSubtaskInput,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
@@ -12,6 +12,7 @@ use host_domain::{
     GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
     GitDiffScope, GitFileDiff, GitFileStatus, GitPort, GitPullRequest, GitPullResult,
     GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult, GitWorktreeStatusData,
+    GitWorktreeStatusSummaryData,
 };
 use std::path::Path;
 
@@ -119,6 +120,15 @@ impl GitPort for GitCliPort {
         diff_scope: GitDiffScope,
     ) -> Result<GitWorktreeStatusData> {
         self.get_worktree_status_impl(repo_path, target_branch, diff_scope)
+    }
+
+    fn get_worktree_status_summary(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+        diff_scope: GitDiffScope,
+    ) -> Result<GitWorktreeStatusSummaryData> {
+        self.get_worktree_status_summary_impl(repo_path, target_branch, diff_scope)
     }
 
     fn resolve_upstream_target(&self, repo_path: &Path) -> Result<Option<String>> {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    GitAheadBehind, GitDiffScope, GitFileDiff, GitFileStatus, GitUpstreamAheadBehind,
-    GitWorktreeStatusData,
+    GitAheadBehind, GitDiffScope, GitFileDiff, GitFileStatus, GitFileStatusCounts,
+    GitUpstreamAheadBehind, GitWorktreeStatusData, GitWorktreeStatusSummaryData,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -105,6 +105,74 @@ impl GitCliPort {
             current_branch,
             file_statuses,
             file_diffs,
+            target_ahead_behind,
+            upstream_ahead_behind,
+        })
+    }
+
+    pub(super) fn get_worktree_status_summary_impl(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+        _diff_scope: GitDiffScope,
+    ) -> Result<GitWorktreeStatusSummaryData> {
+        self.ensure_repository(repo_path)?;
+        let target_branch = normalize_non_empty(target_branch, "target branch")?;
+        let current_branch = self.get_current_branch_unchecked(repo_path)?;
+        let current_branch_name = current_branch.name.clone();
+
+        let joined = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            rayon::join(
+                || {
+                    rayon::join(
+                        || self.get_status_unchecked(repo_path),
+                        || self.commits_ahead_behind_unchecked(repo_path, target_branch.as_str()),
+                    )
+                },
+                || {
+                    self.resolve_upstream_target_for_branch_impl(
+                        repo_path,
+                        current_branch_name.as_deref(),
+                    )
+                },
+            )
+        }))
+        .map_err(|payload| {
+            anyhow!(
+                "git worktree status summary worker panicked: {}",
+                panic_payload_message(&*payload)
+            )
+        })?;
+
+        let ((file_statuses, target_ahead_behind), upstream_target_result) = joined;
+        let file_statuses = file_statuses?;
+        let file_status_counts = build_file_status_counts(file_statuses.as_slice())?;
+        let target_ahead_behind = target_ahead_behind?;
+
+        let upstream_ahead_behind = match upstream_target_result {
+            Ok(Some(upstream_target)) => match self
+                .commits_ahead_behind_unchecked(repo_path, upstream_target.as_str())
+            {
+                Ok(counts) => GitUpstreamAheadBehind::Tracking {
+                    ahead: counts.ahead,
+                    behind: counts.behind,
+                },
+                Err(error) => GitUpstreamAheadBehind::Error {
+                    message: format!("{error:#}"),
+                },
+            },
+            Ok(None) => GitUpstreamAheadBehind::Untracked {
+                ahead: target_ahead_behind.ahead,
+            },
+            Err(error) => GitUpstreamAheadBehind::Error {
+                message: format!("{error:#}"),
+            },
+        };
+
+        Ok(GitWorktreeStatusSummaryData {
+            current_branch,
+            file_statuses,
+            file_status_counts,
             target_ahead_behind,
             upstream_ahead_behind,
         })
@@ -354,6 +422,26 @@ fn infer_diff_type(diff: &str) -> String {
         }
     }
     "modified".to_string()
+}
+
+fn build_file_status_counts(file_statuses: &[GitFileStatus]) -> Result<GitFileStatusCounts> {
+    let total = u32::try_from(file_statuses.len()).map_err(|_| {
+        anyhow!(
+            "too many file statuses to summarize: {}",
+            file_statuses.len()
+        )
+    })?;
+    let staged = u32::try_from(file_statuses.iter().filter(|status| status.staged).count())
+        .map_err(|_| anyhow!("staged file status count overflowed u32"))?;
+    let unstaged = total
+        .checked_sub(staged)
+        .ok_or_else(|| anyhow!("unstaged file status count underflowed"))?;
+
+    Ok(GitFileStatusCounts {
+        total,
+        staged,
+        unstaged,
+    })
 }
 
 fn parse_ahead_behind(output: &str) -> Result<GitAheadBehind> {

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -209,6 +209,75 @@ fn hash_worktree_diff_payload(file_diffs: &[host_domain::GitFileDiff]) -> String
     hasher.finish_hex()
 }
 
+fn hash_worktree_diff_summary_payload(
+    diff_scope: &host_domain::GitDiffScope,
+    target_ahead_behind: &host_domain::GitAheadBehind,
+    file_status_counts: &host_domain::GitFileStatusCounts,
+) -> String {
+    let mut hasher = Fnv1a64Hasher::new();
+
+    match diff_scope {
+        host_domain::GitDiffScope::Target => hasher.update_str("target"),
+        host_domain::GitDiffScope::Uncommitted => hasher.update_str("uncommitted"),
+    }
+
+    hasher.update_u32(target_ahead_behind.ahead);
+    hasher.update_u32(target_ahead_behind.behind);
+    hasher.update_u32(file_status_counts.total);
+    hasher.update_u32(file_status_counts.staged);
+    hasher.update_u32(file_status_counts.unstaged);
+
+    hasher.finish_hex()
+}
+
+fn build_file_status_counts(
+    file_statuses: &[host_domain::GitFileStatus],
+) -> Result<host_domain::GitFileStatusCounts, String> {
+    let total = u32::try_from(file_statuses.len()).map_err(|_| {
+        format!(
+            "too many file statuses to summarize: {}",
+            file_statuses.len()
+        )
+    })?;
+    let staged = u32::try_from(file_statuses.iter().filter(|status| status.staged).count())
+        .map_err(|_| "staged file status count overflowed u32".to_string())?;
+    let unstaged = total
+        .checked_sub(staged)
+        .ok_or_else(|| "unstaged file status count underflowed".to_string())?;
+
+    Ok(host_domain::GitFileStatusCounts {
+        total,
+        staged,
+        unstaged,
+    })
+}
+
+fn resolve_upstream_ahead_behind(
+    git_port: &dyn host_domain::GitPort,
+    repo: &Path,
+    target_ahead_behind: &host_domain::GitAheadBehind,
+) -> host_domain::GitUpstreamAheadBehind {
+    match git_port.resolve_upstream_target(repo) {
+        Ok(Some(upstream_target)) => {
+            match git_port.commits_ahead_behind(repo, upstream_target.as_str()) {
+                Ok(counts) => host_domain::GitUpstreamAheadBehind::Tracking {
+                    ahead: counts.ahead,
+                    behind: counts.behind,
+                },
+                Err(error) => host_domain::GitUpstreamAheadBehind::Error {
+                    message: format!("{error:#}"),
+                },
+            }
+        }
+        Ok(None) => host_domain::GitUpstreamAheadBehind::Untracked {
+            ahead: target_ahead_behind.ahead,
+        },
+        Err(error) => host_domain::GitUpstreamAheadBehind::Error {
+            message: format!("{error:#}"),
+        },
+    }
+}
+
 struct WorktreeSnapshotMetadata {
     effective_working_dir: String,
     target_branch: String,
@@ -229,6 +298,30 @@ fn build_worktree_status_with_snapshot(
         file_diffs: status_data.file_diffs,
         target_ahead_behind: status_data.target_ahead_behind,
         upstream_ahead_behind: status_data.upstream_ahead_behind,
+        snapshot: host_domain::GitWorktreeStatusSnapshot {
+            effective_working_dir: snapshot_metadata.effective_working_dir,
+            target_branch: snapshot_metadata.target_branch,
+            diff_scope: snapshot_metadata.diff_scope,
+            observed_at_ms: snapshot_metadata.observed_at_ms,
+            hash_version: snapshot_metadata.hash_version,
+            status_hash: snapshot_metadata.status_hash,
+            diff_hash: snapshot_metadata.diff_hash,
+        },
+    }
+}
+
+fn build_worktree_status_summary_with_snapshot(
+    current_branch: host_domain::GitCurrentBranch,
+    file_status_counts: host_domain::GitFileStatusCounts,
+    target_ahead_behind: host_domain::GitAheadBehind,
+    upstream_ahead_behind: host_domain::GitUpstreamAheadBehind,
+    snapshot_metadata: WorktreeSnapshotMetadata,
+) -> host_domain::GitWorktreeStatusSummary {
+    host_domain::GitWorktreeStatusSummary {
+        current_branch,
+        file_status_counts,
+        target_ahead_behind,
+        upstream_ahead_behind,
         snapshot: host_domain::GitWorktreeStatusSnapshot {
             effective_working_dir: snapshot_metadata.effective_working_dir,
             target_branch: snapshot_metadata.target_branch,
@@ -443,6 +536,61 @@ pub async fn git_get_worktree_status(
 }
 
 #[tauri::command]
+pub async fn git_get_worktree_status_summary(
+    state: State<'_, AppState>,
+    repo_path: String,
+    target_branch: String,
+    diff_scope: Option<String>,
+    working_dir: Option<String>,
+) -> Result<host_domain::GitWorktreeStatusSummary, String> {
+    let trimmed_target = require_target_branch(&target_branch)?;
+    let scope = parse_diff_scope(diff_scope.as_deref())?;
+
+    let _ = state
+        .service
+        .ensure_repo_authorized(&repo_path)
+        .map_err(|e| e.to_string())?;
+    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+    let repo = Path::new(&effective);
+    let git_port = state.service.git_port();
+
+    let current_branch = as_error(git_port.get_current_branch(repo))?;
+    let file_statuses = as_error(git_port.get_status(repo))?;
+    let file_status_counts = build_file_status_counts(file_statuses.as_slice())?;
+    let target_ahead_behind = as_error(git_port.commits_ahead_behind(repo, trimmed_target))?;
+    let upstream_ahead_behind = resolve_upstream_ahead_behind(git_port, repo, &target_ahead_behind);
+
+    let observed_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let status_hash = hash_worktree_status_payload(
+        &current_branch,
+        file_statuses.as_slice(),
+        &target_ahead_behind,
+        &upstream_ahead_behind,
+    );
+    let diff_hash =
+        hash_worktree_diff_summary_payload(&scope, &target_ahead_behind, &file_status_counts);
+
+    Ok(build_worktree_status_summary_with_snapshot(
+        current_branch,
+        file_status_counts,
+        target_ahead_behind,
+        upstream_ahead_behind,
+        WorktreeSnapshotMetadata {
+            effective_working_dir: effective,
+            target_branch: trimmed_target.to_string(),
+            diff_scope: scope,
+            observed_at_ms,
+            hash_version: GIT_WORKTREE_HASH_VERSION,
+            status_hash,
+            diff_hash,
+        },
+    ))
+}
+
+#[tauri::command]
 pub async fn git_commit_all(
     state: State<'_, AppState>,
     repo_path: String,
@@ -517,9 +665,11 @@ pub async fn git_rebase_branch(
 #[cfg(test)]
 mod tests {
     use super::{
+        build_file_status_counts, build_worktree_status_summary_with_snapshot,
         build_worktree_status_with_snapshot, git_get_worktree_status, hash_worktree_diff_payload,
-        hash_worktree_status_payload, parse_diff_scope, require_target_branch, resolve_working_dir,
-        WorktreeSnapshotMetadata, GIT_WORKTREE_HASH_VERSION,
+        hash_worktree_diff_summary_payload, hash_worktree_status_payload, parse_diff_scope,
+        require_target_branch, resolve_working_dir, WorktreeSnapshotMetadata,
+        GIT_WORKTREE_HASH_VERSION,
     };
     use crate::AppState;
     use anyhow::anyhow;
@@ -527,9 +677,10 @@ mod tests {
     use host_domain::GitPort;
     use host_domain::{
         GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
-        GitDiffScope, GitFileDiff, GitFileStatus, GitPullRequest, GitPullResult, GitPushSummary,
-        GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatus,
-        GitWorktreeStatusData, TaskStore, TASK_METADATA_NAMESPACE,
+        GitDiffScope, GitFileDiff, GitFileStatus, GitFileStatusCounts, GitPullRequest,
+        GitPullResult, GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult,
+        GitUpstreamAheadBehind, GitWorktreeStatus, GitWorktreeStatusData, TaskStore,
+        TASK_METADATA_NAMESPACE,
     };
     use host_infra_beads::BeadsTaskStore;
     use host_infra_system::AppConfigStore;
@@ -1334,5 +1485,117 @@ mod tests {
         let changed_hash = hash_worktree_diff_payload(changed_diff.as_slice());
 
         assert_ne!(baseline_hash, changed_hash);
+    }
+
+    #[test]
+    fn diff_summary_hash_changes_when_scope_or_counts_change() {
+        let target_ahead_behind = GitAheadBehind {
+            ahead: 1,
+            behind: 0,
+        };
+        let baseline_counts = GitFileStatusCounts {
+            total: 2,
+            staged: 1,
+            unstaged: 1,
+        };
+        let changed_counts = GitFileStatusCounts {
+            total: 3,
+            staged: 1,
+            unstaged: 2,
+        };
+
+        let baseline_hash = hash_worktree_diff_summary_payload(
+            &GitDiffScope::Target,
+            &target_ahead_behind,
+            &baseline_counts,
+        );
+        let changed_counts_hash = hash_worktree_diff_summary_payload(
+            &GitDiffScope::Target,
+            &target_ahead_behind,
+            &changed_counts,
+        );
+        let changed_scope_hash = hash_worktree_diff_summary_payload(
+            &GitDiffScope::Uncommitted,
+            &target_ahead_behind,
+            &baseline_counts,
+        );
+
+        assert_ne!(baseline_hash, changed_counts_hash);
+        assert_ne!(baseline_hash, changed_scope_hash);
+    }
+
+    #[test]
+    fn build_file_status_counts_splits_staged_and_unstaged_entries() {
+        let statuses = vec![
+            GitFileStatus {
+                path: "src/staged.ts".to_string(),
+                status: "M".to_string(),
+                staged: true,
+            },
+            GitFileStatus {
+                path: "src/unstaged.ts".to_string(),
+                status: "M".to_string(),
+                staged: false,
+            },
+        ];
+
+        let counts = build_file_status_counts(statuses.as_slice())
+            .expect("file status counts should be derived");
+        assert_eq!(counts.total, 2);
+        assert_eq!(counts.staged, 1);
+        assert_eq!(counts.unstaged, 1);
+    }
+
+    #[test]
+    fn build_worktree_status_summary_with_snapshot_preserves_payload_and_snapshot_fields() {
+        let built = build_worktree_status_summary_with_snapshot(
+            GitCurrentBranch {
+                name: Some("feature/snapshot".to_string()),
+                detached: false,
+            },
+            GitFileStatusCounts {
+                total: 4,
+                staged: 2,
+                unstaged: 2,
+            },
+            GitAheadBehind {
+                ahead: 3,
+                behind: 1,
+            },
+            GitUpstreamAheadBehind::Tracking {
+                ahead: 5,
+                behind: 0,
+            },
+            WorktreeSnapshotMetadata {
+                effective_working_dir: "/tmp/openducktor-worktree".to_string(),
+                target_branch: "origin/main".to_string(),
+                diff_scope: GitDiffScope::Uncommitted,
+                observed_at_ms: 99,
+                hash_version: GIT_WORKTREE_HASH_VERSION,
+                status_hash: "0123456789abcdef".to_string(),
+                diff_hash: "fedcba9876543210".to_string(),
+            },
+        );
+
+        assert_eq!(
+            built.current_branch.name.as_deref(),
+            Some("feature/snapshot")
+        );
+        assert_eq!(built.file_status_counts.total, 4);
+        assert_eq!(built.file_status_counts.staged, 2);
+        assert_eq!(built.file_status_counts.unstaged, 2);
+        assert_eq!(built.target_ahead_behind.ahead, 3);
+        assert_eq!(
+            built.upstream_ahead_behind,
+            GitUpstreamAheadBehind::Tracking {
+                ahead: 5,
+                behind: 0
+            }
+        );
+        assert_eq!(built.snapshot.diff_scope, GitDiffScope::Uncommitted);
+        assert_eq!(built.snapshot.observed_at_ms, 99);
+        assert_eq!(built.snapshot.hash_version, GIT_WORKTREE_HASH_VERSION);
+        assert_eq!(built.snapshot.status_hash, "0123456789abcdef");
+        assert_eq!(built.snapshot.diff_hash, "fedcba9876543210");
     }
 }

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -230,54 +230,6 @@ fn hash_worktree_diff_summary_payload(
     hasher.finish_hex()
 }
 
-fn build_file_status_counts(
-    file_statuses: &[host_domain::GitFileStatus],
-) -> Result<host_domain::GitFileStatusCounts, String> {
-    let total = u32::try_from(file_statuses.len()).map_err(|_| {
-        format!(
-            "too many file statuses to summarize: {}",
-            file_statuses.len()
-        )
-    })?;
-    let staged = u32::try_from(file_statuses.iter().filter(|status| status.staged).count())
-        .map_err(|_| "staged file status count overflowed u32".to_string())?;
-    let unstaged = total
-        .checked_sub(staged)
-        .ok_or_else(|| "unstaged file status count underflowed".to_string())?;
-
-    Ok(host_domain::GitFileStatusCounts {
-        total,
-        staged,
-        unstaged,
-    })
-}
-
-fn resolve_upstream_ahead_behind(
-    git_port: &dyn host_domain::GitPort,
-    repo: &Path,
-    target_ahead_behind: &host_domain::GitAheadBehind,
-) -> host_domain::GitUpstreamAheadBehind {
-    match git_port.resolve_upstream_target(repo) {
-        Ok(Some(upstream_target)) => {
-            match git_port.commits_ahead_behind(repo, upstream_target.as_str()) {
-                Ok(counts) => host_domain::GitUpstreamAheadBehind::Tracking {
-                    ahead: counts.ahead,
-                    behind: counts.behind,
-                },
-                Err(error) => host_domain::GitUpstreamAheadBehind::Error {
-                    message: format!("{error:#}"),
-                },
-            }
-        }
-        Ok(None) => host_domain::GitUpstreamAheadBehind::Untracked {
-            ahead: target_ahead_behind.ahead,
-        },
-        Err(error) => host_domain::GitUpstreamAheadBehind::Error {
-            message: format!("{error:#}"),
-        },
-    }
-}
-
 struct WorktreeSnapshotMetadata {
     effective_working_dir: String,
     target_branch: String,
@@ -552,32 +504,33 @@ pub async fn git_get_worktree_status_summary(
         .map_err(|e| e.to_string())?;
     let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
     let repo = Path::new(&effective);
-    let git_port = state.service.git_port();
-
-    let current_branch = as_error(git_port.get_current_branch(repo))?;
-    let file_statuses = as_error(git_port.get_status(repo))?;
-    let file_status_counts = build_file_status_counts(file_statuses.as_slice())?;
-    let target_ahead_behind = as_error(git_port.commits_ahead_behind(repo, trimmed_target))?;
-    let upstream_ahead_behind = resolve_upstream_ahead_behind(git_port, repo, &target_ahead_behind);
+    let worktree_status = as_error(state.service.git_port().get_worktree_status_summary(
+        repo,
+        trimmed_target,
+        scope.clone(),
+    ))?;
 
     let observed_at_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64;
     let status_hash = hash_worktree_status_payload(
-        &current_branch,
-        file_statuses.as_slice(),
-        &target_ahead_behind,
-        &upstream_ahead_behind,
+        &worktree_status.current_branch,
+        worktree_status.file_statuses.as_slice(),
+        &worktree_status.target_ahead_behind,
+        &worktree_status.upstream_ahead_behind,
     );
-    let diff_hash =
-        hash_worktree_diff_summary_payload(&scope, &target_ahead_behind, &file_status_counts);
+    let diff_hash = hash_worktree_diff_summary_payload(
+        &scope,
+        &worktree_status.target_ahead_behind,
+        &worktree_status.file_status_counts,
+    );
 
     Ok(build_worktree_status_summary_with_snapshot(
-        current_branch,
-        file_status_counts,
-        target_ahead_behind,
-        upstream_ahead_behind,
+        worktree_status.current_branch,
+        worktree_status.file_status_counts,
+        worktree_status.target_ahead_behind,
+        worktree_status.upstream_ahead_behind,
         WorktreeSnapshotMetadata {
             effective_working_dir: effective,
             target_branch: trimmed_target.to_string(),
@@ -665,8 +618,8 @@ pub async fn git_rebase_branch(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_file_status_counts, build_worktree_status_summary_with_snapshot,
-        build_worktree_status_with_snapshot, git_get_worktree_status, hash_worktree_diff_payload,
+        build_worktree_status_summary_with_snapshot, build_worktree_status_with_snapshot,
+        git_get_worktree_status, git_get_worktree_status_summary, hash_worktree_diff_payload,
         hash_worktree_diff_summary_payload, hash_worktree_status_payload, parse_diff_scope,
         require_target_branch, resolve_working_dir, WorktreeSnapshotMetadata,
         GIT_WORKTREE_HASH_VERSION,
@@ -679,8 +632,8 @@ mod tests {
         GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
         GitDiffScope, GitFileDiff, GitFileStatus, GitFileStatusCounts, GitPullRequest,
         GitPullResult, GitPushSummary, GitRebaseBranchRequest, GitRebaseBranchResult,
-        GitUpstreamAheadBehind, GitWorktreeStatus, GitWorktreeStatusData, TaskStore,
-        TASK_METADATA_NAMESPACE,
+        GitUpstreamAheadBehind, GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSummary,
+        GitWorktreeStatusSummaryData, TaskStore, TASK_METADATA_NAMESPACE,
     };
     use host_infra_beads::BeadsTaskStore;
     use host_infra_system::AppConfigStore;
@@ -706,8 +659,21 @@ mod tests {
         Err(String),
     }
 
+    #[derive(Clone)]
+    enum WorktreeStatusSummaryResult {
+        Ok(GitWorktreeStatusSummaryData),
+        Err(String),
+    }
+
     #[derive(Debug, Clone, PartialEq, Eq)]
     struct WorktreeStatusCall {
+        repo_path: String,
+        target_branch: String,
+        diff_scope: GitDiffScope,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct WorktreeStatusSummaryCall {
         repo_path: String,
         target_branch: String,
         diff_scope: GitDiffScope,
@@ -716,6 +682,8 @@ mod tests {
     struct CommandGitPortState {
         worktree_status_result: WorktreeStatusResult,
         worktree_status_calls: Vec<WorktreeStatusCall>,
+        worktree_status_summary_result: WorktreeStatusSummaryResult,
+        worktree_status_summary_calls: Vec<WorktreeStatusSummaryCall>,
     }
 
     struct CommandGitPort {
@@ -723,11 +691,16 @@ mod tests {
     }
 
     impl CommandGitPort {
-        fn new(result: WorktreeStatusResult) -> Self {
+        fn new_with_summary_result(
+            result: WorktreeStatusResult,
+            summary_result: WorktreeStatusSummaryResult,
+        ) -> Self {
             Self {
                 state: Arc::new(Mutex::new(CommandGitPortState {
                     worktree_status_result: result,
                     worktree_status_calls: Vec::new(),
+                    worktree_status_summary_result: summary_result,
+                    worktree_status_summary_calls: Vec::new(),
                 })),
             }
         }
@@ -822,6 +795,29 @@ mod tests {
             }
         }
 
+        fn get_worktree_status_summary(
+            &self,
+            repo_path: &Path,
+            target_branch: &str,
+            diff_scope: GitDiffScope,
+        ) -> anyhow::Result<GitWorktreeStatusSummaryData> {
+            let mut state = self
+                .state
+                .lock()
+                .expect("command git port state lock should not be poisoned");
+            state
+                .worktree_status_summary_calls
+                .push(WorktreeStatusSummaryCall {
+                    repo_path: repo_path.to_string_lossy().to_string(),
+                    target_branch: target_branch.to_string(),
+                    diff_scope,
+                });
+            match state.worktree_status_summary_result.clone() {
+                WorktreeStatusSummaryResult::Ok(payload) => Ok(payload),
+                WorktreeStatusSummaryResult::Err(message) => Err(anyhow!(message)),
+            }
+        }
+
         fn resolve_upstream_target(&self, _repo_path: &Path) -> anyhow::Result<Option<String>> {
             panic!("unexpected call: resolve_upstream_target");
         }
@@ -908,6 +904,25 @@ mod tests {
         result: WorktreeStatusResult,
         authorize_repo: bool,
     ) -> CommandGitFixture {
+        setup_command_git_fixture_with_summary(
+            prefix,
+            result,
+            WorktreeStatusSummaryResult::Ok(sample_worktree_status_summary_data(
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 0,
+                    behind: 0,
+                },
+            )),
+            authorize_repo,
+        )
+    }
+
+    fn setup_command_git_fixture_with_summary(
+        prefix: &str,
+        result: WorktreeStatusResult,
+        summary_result: WorktreeStatusSummaryResult,
+        authorize_repo: bool,
+    ) -> CommandGitFixture {
         let root = unique_test_dir(prefix);
         let repo = root.join("repo");
         init_repo(&repo);
@@ -919,7 +934,7 @@ mod tests {
                 .expect("workspace should be allowlisted");
         }
 
-        let git_port = CommandGitPort::new(result);
+        let git_port = CommandGitPort::new_with_summary_result(result, summary_result);
         let git_state = git_port.state.clone();
         let task_store: Arc<dyn TaskStore> = Arc::new(BeadsTaskStore::with_metadata_namespace(
             TASK_METADATA_NAMESPACE,
@@ -935,7 +950,10 @@ mod tests {
                 hook_trust_challenges: Mutex::new(HashMap::new()),
                 hook_trust_dialog_test_response: Mutex::new(None),
             })
-            .invoke_handler(tauri::generate_handler![git_get_worktree_status])
+            .invoke_handler(tauri::generate_handler![
+                git_get_worktree_status,
+                git_get_worktree_status_summary
+            ])
             .build(mock_context(noop_assets()))
             .expect("test app should build");
         let webview = WebviewWindowBuilder::new(&app, "main", Default::default())
@@ -995,6 +1013,32 @@ mod tests {
                 deletions: 0,
                 diff: "@@ -1 +1 @@\n-old\n+new\n".to_string(),
             }],
+            target_ahead_behind: GitAheadBehind {
+                ahead: 1,
+                behind: 0,
+            },
+            upstream_ahead_behind: upstream,
+        }
+    }
+
+    fn sample_worktree_status_summary_data(
+        upstream: GitUpstreamAheadBehind,
+    ) -> GitWorktreeStatusSummaryData {
+        GitWorktreeStatusSummaryData {
+            current_branch: GitCurrentBranch {
+                name: Some("feature/command".to_string()),
+                detached: false,
+            },
+            file_statuses: vec![GitFileStatus {
+                path: "src/main.rs".to_string(),
+                status: "M".to_string(),
+                staged: false,
+            }],
+            file_status_counts: GitFileStatusCounts {
+                total: 1,
+                staged: 0,
+                unstaged: 1,
+            },
             target_ahead_behind: GitAheadBehind {
                 ahead: 1,
                 behind: 0,
@@ -1222,6 +1266,228 @@ mod tests {
             .expect("command git state lock should not be poisoned");
         assert_eq!(state.worktree_status_calls.len(), 1);
         assert_eq!(state.worktree_status_calls[0].repo_path, expected_worktree);
+    }
+
+    #[test]
+    fn git_get_worktree_status_summary_rejects_unauthorized_repo() {
+        let fixture = setup_command_git_fixture(
+            "git-command-summary-unauthorized",
+            WorktreeStatusResult::Ok(sample_worktree_status_data(
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 0,
+                    behind: 0,
+                },
+            )),
+            false,
+        );
+
+        let error = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status_summary",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "origin/main",
+            }),
+        )
+        .expect_err("unauthorized repo should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Repository path is not in the configured workspace allowlist"),
+            "unexpected error: {error}"
+        );
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert!(
+            state.worktree_status_summary_calls.is_empty(),
+            "git port summary path should not run when authorization fails"
+        );
+    }
+
+    #[test]
+    fn git_get_worktree_status_summary_keeps_upstream_error_variant_and_snapshot_metadata() {
+        let fixture = setup_command_git_fixture_with_summary(
+            "git-command-summary-upstream-error",
+            WorktreeStatusResult::Ok(sample_worktree_status_data(
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 0,
+                    behind: 0,
+                },
+            )),
+            WorktreeStatusSummaryResult::Ok(sample_worktree_status_summary_data(
+                GitUpstreamAheadBehind::Error {
+                    message: "upstream not configured".to_string(),
+                },
+            )),
+            true,
+        );
+
+        let response = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status_summary",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "  origin/main  ",
+                "diffScope": "uncommitted",
+            }),
+        )
+        .expect("summary command should succeed");
+        let status: GitWorktreeStatusSummary = serde_json::from_value(response)
+            .expect("response should decode as GitWorktreeStatusSummary");
+
+        assert_eq!(
+            status.upstream_ahead_behind,
+            GitUpstreamAheadBehind::Error {
+                message: "upstream not configured".to_string()
+            }
+        );
+        assert_eq!(status.snapshot.target_branch, "origin/main");
+        assert_eq!(status.snapshot.diff_scope, GitDiffScope::Uncommitted);
+        assert_eq!(status.snapshot.hash_version, GIT_WORKTREE_HASH_VERSION);
+        assert_eq!(status.snapshot.status_hash.len(), 16);
+        assert_eq!(status.snapshot.diff_hash.len(), 16);
+
+        let expected_effective = fs::canonicalize(Path::new(&fixture.repo_path))
+            .expect("repo should canonicalize")
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(status.snapshot.effective_working_dir, expected_effective);
+
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert_eq!(state.worktree_status_summary_calls.len(), 1);
+        assert_eq!(
+            state.worktree_status_summary_calls[0],
+            WorktreeStatusSummaryCall {
+                repo_path: expected_effective,
+                target_branch: "origin/main".to_string(),
+                diff_scope: GitDiffScope::Uncommitted,
+            }
+        );
+    }
+
+    #[test]
+    fn git_get_worktree_status_summary_propagates_git_port_failures() {
+        let fixture = setup_command_git_fixture_with_summary(
+            "git-command-summary-status-failure",
+            WorktreeStatusResult::Ok(sample_worktree_status_data(
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 0,
+                    behind: 0,
+                },
+            )),
+            WorktreeStatusSummaryResult::Err("failed collecting summary status".to_string()),
+            true,
+        );
+
+        let error = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status_summary",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "origin/main",
+            }),
+        )
+        .expect_err("git port summary failure should be returned");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed collecting summary status"),
+            "unexpected error: {error}"
+        );
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert_eq!(state.worktree_status_summary_calls.len(), 1);
+    }
+
+    #[test]
+    fn git_get_worktree_status_summary_rejects_invalid_diff_scope_before_git_port_call() {
+        let fixture = setup_command_git_fixture(
+            "git-command-summary-invalid-scope",
+            WorktreeStatusResult::Ok(sample_worktree_status_data(
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 0,
+                    behind: 0,
+                },
+            )),
+            true,
+        );
+
+        let error = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status_summary",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "origin/main",
+                "diffScope": "staged",
+            }),
+        )
+        .expect_err("invalid diff scope should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("diffScope must be either 'target' or 'uncommitted'"),
+            "unexpected error: {error}"
+        );
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert!(
+            state.worktree_status_summary_calls.is_empty(),
+            "git port summary path should not run when diffScope is invalid"
+        );
+    }
+
+    #[test]
+    fn git_get_worktree_status_summary_rejects_unrelated_working_dir() {
+        let fixture = setup_command_git_fixture(
+            "git-command-summary-working-dir-reject",
+            WorktreeStatusResult::Ok(sample_worktree_status_data(
+                GitUpstreamAheadBehind::Tracking {
+                    ahead: 0,
+                    behind: 0,
+                },
+            )),
+            true,
+        );
+        let external = fixture.root.join("external-summary");
+        init_repo(&external);
+
+        let error = invoke_json(
+            &fixture.webview,
+            "git_get_worktree_status_summary",
+            json!({
+                "repoPath": fixture.repo_path.as_str(),
+                "targetBranch": "origin/main",
+                "workingDir": external.to_string_lossy().to_string(),
+            }),
+        )
+        .expect_err("unrelated working_dir should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("working_dir is not within authorized repository or linked worktrees"),
+            "unexpected error: {error}"
+        );
+        let state = fixture
+            .git_state
+            .lock()
+            .expect("command git state lock should not be poisoned");
+        assert!(
+            state.worktree_status_summary_calls.is_empty(),
+            "git port summary path should not run for unauthorized working_dir"
+        );
     }
 
     #[test]
@@ -1522,28 +1788,6 @@ mod tests {
 
         assert_ne!(baseline_hash, changed_counts_hash);
         assert_ne!(baseline_hash, changed_scope_hash);
-    }
-
-    #[test]
-    fn build_file_status_counts_splits_staged_and_unstaged_entries() {
-        let statuses = vec![
-            GitFileStatus {
-                path: "src/staged.ts".to_string(),
-                status: "M".to_string(),
-                staged: true,
-            },
-            GitFileStatus {
-                path: "src/unstaged.ts".to_string(),
-                status: "M".to_string(),
-                staged: false,
-            },
-        ];
-
-        let counts = build_file_status_counts(statuses.as_slice())
-            .expect("file status counts should be derived");
-        assert_eq!(counts.total, 2);
-        assert_eq!(counts.staged, 1);
-        assert_eq!(counts.unstaged, 1);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -226,6 +226,7 @@ fn startup_phase_command_registration(
         git_get_diff,
         git_commits_ahead_behind,
         git_get_worktree_status,
+        git_get_worktree_status_summary,
         git_commit_all,
         git_pull_branch,
         git_rebase_branch,

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -32,9 +32,7 @@ type AgentStudioGitPanelModel = import("./agent-studio-git-panel").AgentStudioGi
 
 let AgentStudioGitPanel: AgentStudioGitPanelComponent;
 
-const baseModel = (
-  overrides: Partial<AgentStudioGitPanelModel> = {},
-): AgentStudioGitPanelModel => {
+const baseModel = (overrides: Partial<AgentStudioGitPanelModel> = {}): AgentStudioGitPanelModel => {
   const model: AgentStudioGitPanelModel = {
     branch: "feature/task-11",
     worktreePath: "/tmp/worktree",
@@ -442,6 +440,49 @@ describe("AgentStudioGitPanel", () => {
       await flush();
     });
     expect(setSelectedFile).toHaveBeenNthCalledWith(2, null);
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+
+  test("handles rapid consecutive file toggles without stale expansion state", async () => {
+    const setSelectedFile = mock((_path: string | null) => {});
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(AgentStudioGitPanel, {
+          model: baseModel({
+            fileDiffs: [
+              {
+                file: "src/a.ts",
+                type: "modified",
+                additions: 2,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n",
+              },
+            ],
+            setSelectedFile,
+          }),
+        }),
+      );
+      await flush();
+    });
+
+    const root = getRoot(renderer);
+    const diffButton = findButtonByText(root, "a.ts");
+
+    await act(async () => {
+      diffButton.props.onClick();
+      diffButton.props.onClick();
+      await flush();
+    });
+
+    expect(setSelectedFile).toHaveBeenNthCalledWith(1, "src/a.ts");
+    expect(setSelectedFile).toHaveBeenNthCalledWith(2, null);
+    expect(countByTestId(root, "mock-pierre-diff-viewer")).toBe(0);
 
     await act(async () => {
       ensureRenderer(renderer).unmount();

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -34,32 +34,41 @@ let AgentStudioGitPanel: AgentStudioGitPanelComponent;
 
 const baseModel = (
   overrides: Partial<AgentStudioGitPanelModel> = {},
-): AgentStudioGitPanelModel => ({
-  branch: "feature/task-11",
-  worktreePath: "/tmp/worktree",
-  targetBranch: "origin/main",
-  diffScope: "target",
-  commitsAheadBehind: { ahead: 2, behind: 1 },
-  fileDiffs: [],
-  fileStatuses: [{ path: "src/a.ts", staged: false, status: "M" }],
-  isLoading: false,
-  error: null,
-  refresh: () => {},
-  selectedFile: null,
-  setSelectedFile: () => {},
-  setDiffScope: () => {},
-  isCommitting: false,
-  isPushing: false,
-  isRebasing: false,
-  commitError: null,
-  pushError: null,
-  rebaseError: null,
-  commitAll: async () => {},
-  pushBranch: async () => {},
-  rebaseOntoTarget: async () => {},
-  pullFromUpstream: async () => {},
-  ...overrides,
-});
+): AgentStudioGitPanelModel => {
+  const model: AgentStudioGitPanelModel = {
+    branch: "feature/task-11",
+    worktreePath: "/tmp/worktree",
+    targetBranch: "origin/main",
+    diffScope: "target",
+    commitsAheadBehind: { ahead: 2, behind: 1 },
+    fileDiffs: [],
+    fileStatuses: [{ path: "src/a.ts", staged: false, status: "M" }],
+    uncommittedFileCount: 1,
+    isLoading: false,
+    error: null,
+    refresh: () => {},
+    selectedFile: null,
+    setSelectedFile: () => {},
+    setDiffScope: () => {},
+    isCommitting: false,
+    isPushing: false,
+    isRebasing: false,
+    commitError: null,
+    pushError: null,
+    rebaseError: null,
+    commitAll: async () => {},
+    pushBranch: async () => {},
+    rebaseOntoTarget: async () => {},
+    pullFromUpstream: async () => {},
+    ...overrides,
+  };
+
+  if (overrides.uncommittedFileCount === undefined) {
+    model.uncommittedFileCount = model.fileStatuses.length;
+  }
+
+  return model;
+};
 
 const flush = async (): Promise<void> => {
   await Promise.resolve();
@@ -388,6 +397,51 @@ describe("AgentStudioGitPanel", () => {
     expect(
       Boolean(findByTestId(root, "agent-studio-git-commit-submit-button").props.disabled),
     ).toBe(true);
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+
+  test("notifies selected-file changes when a diff entry is expanded or collapsed", async () => {
+    const setSelectedFile = mock((_path: string | null) => {});
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(AgentStudioGitPanel, {
+          model: baseModel({
+            fileDiffs: [
+              {
+                file: "src/a.ts",
+                type: "modified",
+                additions: 2,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n",
+              },
+            ],
+            setSelectedFile,
+          }),
+        }),
+      );
+      await flush();
+    });
+
+    const root = getRoot(renderer);
+    const diffButton = findButtonByText(root, "a.ts");
+
+    await act(async () => {
+      diffButton.props.onClick();
+      await flush();
+    });
+    expect(setSelectedFile).toHaveBeenNthCalledWith(1, "src/a.ts");
+
+    await act(async () => {
+      diffButton.props.onClick();
+      await flush();
+    });
+    expect(setSelectedFile).toHaveBeenNthCalledWith(2, null);
 
     await act(async () => {
       ensureRenderer(renderer).unmount();

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
@@ -17,21 +17,24 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
 }): ReactElement {
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
   const [diffStyle, setDiffStyle] = useState<PierreDiffStyle>("unified");
-  const uncommittedFileCount = model.uncommittedFileCount ?? model.fileStatuses.length;
+  const uncommittedFileCount = model.uncommittedFileCount;
   const hasUncommittedFiles = uncommittedFileCount > 0;
   const hasFiles = model.fileDiffs.length > 0;
 
-  const toggleFile = useCallback((filePath: string): void => {
-    setExpandedFiles((previous) => {
-      const next = new Set(previous);
+  const toggleFile = useCallback(
+    (filePath: string): void => {
+      const next = new Set(expandedFiles);
       if (next.has(filePath)) {
         next.delete(filePath);
+        model.setSelectedFile(null);
       } else {
         next.add(filePath);
+        model.setSelectedFile(filePath);
       }
-      return next;
-    });
-  }, []);
+      setExpandedFiles(next);
+    },
+    [expandedFiles, model.setSelectedFile],
+  );
 
   const handleDiffScopeChange = useCallback(
     (scope: DiffScope): void => {
@@ -41,9 +44,10 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
         }
         return new Set<string>();
       });
+      model.setSelectedFile(null);
       model.setDiffScope(scope);
     },
-    [model.setDiffScope],
+    [model.setDiffScope, model.setSelectedFile],
   );
 
   useEffect(() => {
@@ -65,7 +69,14 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
 
       return changed ? next : previous;
     });
-  }, [model.fileDiffs]);
+
+    if (
+      model.selectedFile != null &&
+      !model.fileDiffs.some((fileDiff) => fileDiff.file === model.selectedFile)
+    ) {
+      model.setSelectedFile(null);
+    }
+  }, [model.fileDiffs, model.selectedFile, model.setSelectedFile]);
 
   return (
     <TooltipProvider>

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
@@ -17,7 +17,7 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
 }): ReactElement {
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
   const [diffStyle, setDiffStyle] = useState<PierreDiffStyle>("unified");
-  const uncommittedFileCount = model.fileStatuses.length;
+  const uncommittedFileCount = model.uncommittedFileCount ?? model.fileStatuses.length;
   const hasUncommittedFiles = uncommittedFileCount > 0;
   const hasFiles = model.fileDiffs.length > 0;
 

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
@@ -23,17 +23,19 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
 
   const toggleFile = useCallback(
     (filePath: string): void => {
-      const next = new Set(expandedFiles);
-      if (next.has(filePath)) {
-        next.delete(filePath);
-        model.setSelectedFile(null);
-      } else {
-        next.add(filePath);
-        model.setSelectedFile(filePath);
-      }
-      setExpandedFiles(next);
+      setExpandedFiles((previous) => {
+        const next = new Set(previous);
+        if (next.has(filePath)) {
+          next.delete(filePath);
+          model.setSelectedFile(null);
+        } else {
+          next.add(filePath);
+          model.setSelectedFile(filePath);
+        }
+        return next;
+      });
     },
-    [expandedFiles, model.setSelectedFile],
+    [model.setSelectedFile],
   );
 
   const handleDiffScopeChange = useCallback(

--- a/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -23,6 +23,7 @@ const diffModel: AgentStudioGitPanelModel = {
   commitsAheadBehind: null,
   fileDiffs: [],
   fileStatuses: [],
+  uncommittedFileCount: 0,
   isLoading: false,
   error: null,
   refresh: () => {},

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -317,6 +317,35 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("selected file triggers on-demand full reload for the active scope", async () => {
+    const harness = createHookHarness(createBaseArgs());
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      await harness.run((state) => {
+        state.setDiffScope("uncommitted");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+
+      await harness.run((state) => {
+        state.setSelectedFile("src/main.ts");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 3);
+
+      expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
+        3,
+        "/repo",
+        "origin/main",
+        "uncommitted",
+        undefined,
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("refresh syncs shared branch/upstream fields for cached inactive scope", async () => {
     const harness = createHookHarness(createBaseArgs());
 
@@ -464,6 +493,163 @@ describe("useAgentStudioDiffData", () => {
     } finally {
       await harness.unmount();
       expect(clearIntervalMock).toHaveBeenCalledTimes(1);
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    }
+  });
+
+  test("polling summary requests do not invalidate an in-flight full reload", async () => {
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearInterval = globalThis.clearInterval;
+    let intervalCallback: (() => void) | null = null;
+
+    const setIntervalMock = mock((callback: TimerHandler, _delay?: number) => {
+      if (typeof callback !== "function") {
+        throw new Error("Expected polling callback function");
+      }
+      intervalCallback = () => {
+        callback();
+      };
+      return 1;
+    });
+    const clearIntervalMock = mock((_intervalId: number) => {});
+    globalThis.setInterval = setIntervalMock as unknown as typeof globalThis.setInterval;
+    globalThis.clearInterval = clearIntervalMock as unknown as typeof globalThis.clearInterval;
+
+    const pendingFullReload = createDeferred<GitWorktreeStatus>();
+    let fullRequestCount = 0;
+    gitGetWorktreeStatusMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatus> => {
+        fullRequestCount += 1;
+
+        if (fullRequestCount === 2) {
+          return pendingFullReload.promise.then((snapshot) => ({
+            ...snapshot,
+            snapshot: {
+              ...snapshot.snapshot,
+              targetBranch,
+              diffScope: diffScope ?? snapshot.snapshot.diffScope,
+              effectiveWorkingDir: workingDir ?? snapshot.snapshot.effectiveWorkingDir,
+            },
+          }));
+        }
+
+        return withSnapshotHashes({
+          currentBranch: { name: "feature/base", detached: false },
+          fileStatuses: [{ path: "src/base.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/base.ts",
+              type: "modified",
+              additions: 1,
+              deletions: 0,
+              diff: "@@ -1 +1 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: workingDir ?? "/repo",
+            targetBranch,
+            diffScope: diffScope ?? "target",
+            observedAtMs: 1731000000000,
+          },
+        });
+      },
+    );
+    gitGetWorktreeStatusSummaryMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatusSummary> =>
+        toWorktreeStatusSummary(
+          withSnapshotHashes({
+            currentBranch: { name: "feature/summary", detached: false },
+            fileStatuses: [{ path: "src/summary.ts", status: "M", staged: false }],
+            fileDiffs: [],
+            targetAheadBehind: { ahead: 1, behind: 0 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000100,
+            },
+          }),
+        ),
+    );
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      enablePolling: true,
+    });
+
+    const runTick = (): void => {
+      if (intervalCallback == null) {
+        throw new Error("Polling callback was not registered");
+      }
+      intervalCallback();
+    };
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      await harness.run((state) => {
+        state.setSelectedFile("src/full.ts");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+
+      await harness.run(() => {
+        runTick();
+      });
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+      expect(gitGetWorktreeStatusSummaryMock.mock.calls.length).toBe(0);
+      expect(harness.getLatest().branch).toBe("feature/base");
+
+      pendingFullReload.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/full", detached: false },
+          fileStatuses: [{ path: "src/full.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/full.ts",
+              type: "modified",
+              additions: 5,
+              deletions: 1,
+              diff: "@@ -1 +1 @@\n-old\n+new\n",
+            },
+          ],
+          targetAheadBehind: { ahead: 2, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 2, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000000200,
+          },
+        }),
+      );
+
+      await harness.waitFor((state) => state.branch === "feature/full");
+      expect(harness.getLatest().fileDiffs[0]?.file).toBe("src/full.ts");
+
+      await harness.run(() => {
+        runTick();
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
+      expect(harness.getLatest().branch).toBe("feature/summary");
+    } finally {
+      await harness.unmount();
       globalThis.setInterval = originalSetInterval;
       globalThis.clearInterval = originalClearInterval;
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { GitWorktreeStatus } from "@openducktor/contracts";
+import type { GitWorktreeStatus, GitWorktreeStatusSummary } from "@openducktor/contracts";
 import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
@@ -40,11 +40,47 @@ const gitGetWorktreeStatusMock = mock(
       },
     }),
 );
+const gitGetWorktreeStatusSummaryMock = mock(
+  async (
+    _repoPath: string,
+    targetBranch: string,
+    diffScope?: "target" | "uncommitted",
+    workingDir?: string,
+  ): Promise<GitWorktreeStatusSummary> => {
+    const fullStatus = withSnapshotHashes({
+      currentBranch: { name: "feature/task-10", detached: false },
+      fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+      fileDiffs:
+        (diffScope ?? "target") === "target"
+          ? [
+              {
+                file: "src/main.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 0,
+                diff: "@@ -1 +1 @@",
+              },
+            ]
+          : [],
+      targetAheadBehind: { ahead: 0, behind: 0 },
+      upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+      snapshot: {
+        effectiveWorkingDir: workingDir ?? "/repo",
+        targetBranch,
+        diffScope: diffScope ?? "target",
+        observedAtMs: 1731000000000,
+      },
+    });
+
+    return toWorktreeStatusSummary(fullStatus);
+  },
+);
 
 mock.module("@/state/operations/host", () => ({
   host: {
     runsList: runsListMock,
     gitGetWorktreeStatus: gitGetWorktreeStatusMock,
+    gitGetWorktreeStatusSummary: gitGetWorktreeStatusSummaryMock,
   },
 }));
 
@@ -106,6 +142,22 @@ const withSnapshotHashes = (
   };
 };
 
+const toWorktreeStatusSummary = (status: GitWorktreeStatus): GitWorktreeStatusSummary => {
+  const staged = status.fileStatuses.filter((fileStatus) => fileStatus.staged).length;
+  const total = status.fileStatuses.length;
+  return {
+    currentBranch: status.currentBranch,
+    fileStatusCounts: {
+      total,
+      staged,
+      unstaged: total - staged,
+    },
+    targetAheadBehind: status.targetAheadBehind,
+    upstreamAheadBehind: status.upstreamAheadBehind,
+    snapshot: status.snapshot,
+  };
+};
+
 const createBaseArgs = (): HookArgs => ({
   repoPath: "/repo",
   sessionWorkingDirectory: null,
@@ -121,6 +173,7 @@ beforeAll(async () => {
 beforeEach(() => {
   runsListMock.mockClear();
   gitGetWorktreeStatusMock.mockClear();
+  gitGetWorktreeStatusSummaryMock.mockClear();
   gitGetWorktreeStatusMock.mockImplementation(
     async (
       _repoPath: string,
@@ -152,6 +205,41 @@ beforeEach(() => {
           observedAtMs: 1731000000000,
         },
       }),
+  );
+  gitGetWorktreeStatusSummaryMock.mockImplementation(
+    async (
+      _repoPath: string,
+      targetBranch: string,
+      diffScope?: "target" | "uncommitted",
+      workingDir?: string,
+    ): Promise<GitWorktreeStatusSummary> => {
+      const fullStatus = withSnapshotHashes({
+        currentBranch: { name: "feature/task-10", detached: false },
+        fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+        fileDiffs:
+          (diffScope ?? "target") === "target"
+            ? [
+                {
+                  file: "src/main.ts",
+                  type: "modified",
+                  additions: 1,
+                  deletions: 0,
+                  diff: "@@ -1 +1 @@",
+                },
+              ]
+            : [],
+        targetAheadBehind: { ahead: 0, behind: 0 },
+        upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+        snapshot: {
+          effectiveWorkingDir: workingDir ?? "/repo",
+          targetBranch,
+          diffScope: diffScope ?? "target",
+          observedAtMs: 1731000000000,
+        },
+      });
+
+      return toWorktreeStatusSummary(fullStatus);
+    },
   );
 });
 
@@ -339,21 +427,22 @@ describe("useAgentStudioDiffData", () => {
       await harness.run(() => {
         runTick();
       });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
-      expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
-        2,
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
+      expect(gitGetWorktreeStatusSummaryMock).toHaveBeenNthCalledWith(
+        1,
         "/repo",
         "origin/main",
         "target",
         undefined,
       );
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(1);
 
       await harness.run((state) => {
         state.setDiffScope("uncommitted");
       });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 3);
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
       expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
-        3,
+        2,
         "/repo",
         "origin/main",
         "uncommitted",
@@ -363,14 +452,15 @@ describe("useAgentStudioDiffData", () => {
       await harness.run(() => {
         runTick();
       });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 4);
-      expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
-        4,
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 2);
+      expect(gitGetWorktreeStatusSummaryMock).toHaveBeenNthCalledWith(
+        2,
         "/repo",
         "origin/main",
         "uncommitted",
         undefined,
       );
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
     } finally {
       await harness.unmount();
       expect(clearIntervalMock).toHaveBeenCalledTimes(1);
@@ -383,7 +473,6 @@ describe("useAgentStudioDiffData", () => {
     const originalSetInterval = globalThis.setInterval;
     const originalClearInterval = globalThis.clearInterval;
     let intervalCallback: (() => void) | null = null;
-    let callCount = 0;
 
     const setIntervalMock = mock((callback: TimerHandler, _delay?: number) => {
       if (typeof callback !== "function") {
@@ -396,20 +485,14 @@ describe("useAgentStudioDiffData", () => {
     });
     const clearIntervalMock = mock((_intervalId: number) => {});
 
-    gitGetWorktreeStatusMock.mockImplementation(
+    gitGetWorktreeStatusSummaryMock.mockImplementation(
       async (
         _repoPath: string,
         targetBranch: string,
         diffScope?: "target" | "uncommitted",
         workingDir?: string,
-      ): Promise<GitWorktreeStatus> => {
-        callCount += 1;
-        const upstream: GitWorktreeStatus["upstreamAheadBehind"] =
-          callCount === 1
-            ? { outcome: "untracked", ahead: 1 }
-            : { outcome: "tracking", ahead: 1, behind: 0 };
-
-        return withSnapshotHashes({
+      ): Promise<GitWorktreeStatusSummary> => {
+        const status = withSnapshotHashes({
           currentBranch: { name: "feature/task-10", detached: false },
           fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
           fileDiffs:
@@ -425,14 +508,16 @@ describe("useAgentStudioDiffData", () => {
                 ]
               : [],
           targetAheadBehind: { ahead: 1, behind: 0 },
-          upstreamAheadBehind: upstream,
+          upstreamAheadBehind: { outcome: "untracked", ahead: 1 },
           snapshot: {
             effectiveWorkingDir: workingDir ?? "/repo",
             targetBranch,
             diffScope: diffScope ?? "target",
-            observedAtMs: 1731000000000 + callCount,
+            observedAtMs: 1731000000000,
           },
         });
+
+        return toWorktreeStatusSummary(status);
       },
     );
 
@@ -460,7 +545,7 @@ describe("useAgentStudioDiffData", () => {
       await harness.run(() => {
         runTick();
       });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
       const secondState = harness.getLatest();
       expect(secondState.upstreamAheadBehind).toEqual({ ahead: 1, behind: 0 });
       expect(secondState).not.toBe(firstState);
@@ -468,9 +553,99 @@ describe("useAgentStudioDiffData", () => {
       await harness.run(() => {
         runTick();
       });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 3);
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 2);
       const thirdState = harness.getLatest();
       expect(thirdState).toBe(secondState);
+    } finally {
+      await harness.unmount();
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    }
+  });
+
+  test("polling updates uncommitted file count from summary payloads", async () => {
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearInterval = globalThis.clearInterval;
+    let intervalCallback: (() => void) | null = null;
+
+    const setIntervalMock = mock((callback: TimerHandler, _delay?: number) => {
+      if (typeof callback !== "function") {
+        throw new Error("Expected polling callback function");
+      }
+      intervalCallback = () => {
+        callback();
+      };
+      return 1;
+    });
+    const clearIntervalMock = mock((_intervalId: number) => {});
+
+    gitGetWorktreeStatusSummaryMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatusSummary> => {
+        const status = withSnapshotHashes({
+          currentBranch: { name: "feature/task-10", detached: false },
+          fileStatuses: [
+            { path: "src/a.ts", status: "M", staged: false },
+            { path: "src/b.ts", status: "A", staged: true },
+            { path: "src/c.ts", status: "D", staged: false },
+            { path: "src/d.ts", status: "M", staged: false },
+          ],
+          fileDiffs:
+            (diffScope ?? "target") === "target"
+              ? [
+                  {
+                    file: "src/main.ts",
+                    type: "modified",
+                    additions: 1,
+                    deletions: 0,
+                    diff: "@@ -1 +1 @@",
+                  },
+                ]
+              : [],
+          targetAheadBehind: { ahead: 1, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: workingDir ?? "/repo",
+            targetBranch,
+            diffScope: diffScope ?? "target",
+            observedAtMs: 1731000000000,
+          },
+        });
+
+        return toWorktreeStatusSummary(status);
+      },
+    );
+
+    globalThis.setInterval = setIntervalMock as unknown as typeof globalThis.setInterval;
+    globalThis.clearInterval = clearIntervalMock as unknown as typeof globalThis.clearInterval;
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      enablePolling: true,
+    });
+
+    const runTick = (): void => {
+      if (intervalCallback == null) {
+        throw new Error("Polling callback was not registered");
+      }
+      intervalCallback();
+    };
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      expect(harness.getLatest().uncommittedFileCount).toBe(1);
+
+      await harness.run(() => {
+        runTick();
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(1);
+      expect(harness.getLatest().uncommittedFileCount).toBe(4);
     } finally {
       await harness.unmount();
       globalThis.setInterval = originalSetInterval;
@@ -1040,6 +1215,7 @@ describe("useAgentStudioDiffData", () => {
 
       expect(setIntervalMock).not.toHaveBeenCalled();
       expect(gitGetWorktreeStatusMock).not.toHaveBeenCalled();
+      expect(gitGetWorktreeStatusSummaryMock).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
       globalThis.setInterval = originalSetInterval;

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
@@ -558,10 +558,7 @@ export function useAgentStudioDiffData({
       return;
     }
 
-    if (
-      mode === "summary" &&
-      inFlightScopeRequestRef.current[scope].full === requestKey
-    ) {
+    if (mode === "summary" && inFlightScopeRequestRef.current[scope].full === requestKey) {
       return;
     }
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
@@ -3,6 +3,7 @@ import type {
   FileDiff,
   FileStatus,
   GitWorktreeStatus,
+  GitWorktreeStatusSummary,
 } from "@openducktor/contracts";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { errorMessage } from "@/lib/errors";
@@ -29,6 +30,8 @@ export type DiffDataState = {
   fileDiffs: FileDiff[];
   /** File status from `git status`. */
   fileStatuses: FileStatus[];
+  /** Total changed files from lightweight worktree polling summaries. */
+  uncommittedFileCount?: number;
   /** Whether data is currently loading. */
   isLoading: boolean;
   /** Last error message, if any. */
@@ -69,6 +72,7 @@ type ScopeSnapshot = {
   branch: string | null;
   fileDiffs: FileDiff[];
   fileStatuses: FileStatus[];
+  uncommittedFileCount: number;
   commitsAheadBehind: CommitsAheadBehind | null;
   upstreamAheadBehind: CommitsAheadBehind | null;
   error: string | null;
@@ -102,6 +106,7 @@ type LoadDataContext = {
   targetBranch: string;
   workingDir: string | null;
   scope: DiffScope;
+  mode?: "full" | "summary";
 };
 
 /** Stable empty arrays hoisted outside the component (rerender-memo-with-default-value). */
@@ -112,6 +117,7 @@ const EMPTY_SCOPE_SNAPSHOT: ScopeSnapshot = {
   branch: null,
   fileDiffs: EMPTY_DIFFS,
   fileStatuses: EMPTY_STATUSES,
+  uncommittedFileCount: 0,
   commitsAheadBehind: null,
   upstreamAheadBehind: null,
   error: null,
@@ -231,6 +237,7 @@ const scopeSnapshotEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean 
       left.branch === right.branch &&
       arraysEqual(left.fileDiffs, right.fileDiffs, fileDiffEqual) &&
       arraysEqual(left.fileStatuses, right.fileStatuses, fileStatusEqual) &&
+      left.uncommittedFileCount === right.uncommittedFileCount &&
       aheadBehindEqual(left.commitsAheadBehind, right.commitsAheadBehind) &&
       aheadBehindEqual(left.upstreamAheadBehind, right.upstreamAheadBehind) &&
       left.error === right.error &&
@@ -276,6 +283,7 @@ const toScopeSnapshot = (snapshot: GitWorktreeStatus): ScopeSnapshot => {
     branch: snapshot.currentBranch.name ?? null,
     fileDiffs: snapshot.fileDiffs,
     fileStatuses: snapshot.fileStatuses,
+    uncommittedFileCount: snapshot.fileStatuses.length,
     commitsAheadBehind: snapshot.targetAheadBehind,
     upstreamAheadBehind,
     error,
@@ -285,10 +293,51 @@ const toScopeSnapshot = (snapshot: GitWorktreeStatus): ScopeSnapshot => {
   };
 };
 
+type ScopeSummaryFields = Pick<
+  ScopeSnapshot,
+  | "branch"
+  | "uncommittedFileCount"
+  | "commitsAheadBehind"
+  | "upstreamAheadBehind"
+  | "error"
+  | "hashVersion"
+  | "statusHash"
+  | "diffHash"
+>;
+
+const toScopeSummaryFields = (summary: GitWorktreeStatusSummary): ScopeSummaryFields => {
+  const { upstreamAheadBehind, error } = toUpstreamAndError(summary.upstreamAheadBehind);
+  return {
+    branch: summary.currentBranch.name ?? null,
+    uncommittedFileCount: summary.fileStatusCounts.total,
+    commitsAheadBehind: summary.targetAheadBehind,
+    upstreamAheadBehind,
+    error,
+    hashVersion: summary.snapshot.hashVersion,
+    statusHash: summary.snapshot.statusHash,
+    diffHash: summary.snapshot.diffHash,
+  };
+};
+
 const mergeSharedSnapshotFields = (base: ScopeSnapshot, source: ScopeSnapshot): ScopeSnapshot => ({
   ...base,
   branch: source.branch,
   fileStatuses: source.fileStatuses,
+  uncommittedFileCount: source.uncommittedFileCount,
+  commitsAheadBehind: source.commitsAheadBehind,
+  upstreamAheadBehind: source.upstreamAheadBehind,
+  error: source.error,
+  hashVersion: source.hashVersion,
+  statusHash: source.statusHash,
+});
+
+const mergeSharedSummaryFields = (
+  base: ScopeSnapshot,
+  source: ScopeSummaryFields,
+): ScopeSnapshot => ({
+  ...base,
+  branch: source.branch,
+  uncommittedFileCount: source.uncommittedFileCount,
   commitsAheadBehind: source.commitsAheadBehind,
   upstreamAheadBehind: source.upstreamAheadBehind,
   error: source.error,
@@ -499,7 +548,8 @@ export function useAgentStudioDiffData({
     const scope = context?.scope ?? diffScopeRef.current;
     const target = context?.targetBranch ?? targetBranchRef.current;
     const workingDir = context?.workingDir ?? workingDirRef.current;
-    const requestKey = `${path}::${target}::${workingDir ?? ""}`;
+    const mode = context?.mode ?? "full";
+    const requestKey = `${path}::${target}::${workingDir ?? ""}::${mode}`;
 
     if (inFlightScopeRequestRef.current[scope] === requestKey) {
       return;
@@ -516,6 +566,73 @@ export function useAgentStudioDiffData({
 
     try {
       const wd = workingDir ?? undefined;
+
+      if (mode === "summary") {
+        const summary = await host.gitGetWorktreeStatusSummary(path, target, scope, wd);
+
+        const hasContextChanged =
+          repoPathRef.current !== path ||
+          targetBranchRef.current !== target ||
+          (workingDirRef.current ?? null) !== workingDir;
+        if (hasContextChanged) {
+          return;
+        }
+
+        // Stale response guard
+        if (versionByScopeRef.current[scope] !== version) {
+          return;
+        }
+
+        setState((prev) => {
+          const summaryFields = toScopeSummaryFields(summary);
+          const previousFetchedScopeSnapshot = prev.byScope[scope];
+          const nextFetchedScopeSnapshot: ScopeSnapshot = {
+            ...previousFetchedScopeSnapshot,
+            ...summaryFields,
+          };
+          let didChange = false;
+          const nextByScope: Record<DiffScope, ScopeSnapshot> = {
+            ...prev.byScope,
+          };
+
+          if (!scopeSnapshotEqual(previousFetchedScopeSnapshot, nextFetchedScopeSnapshot)) {
+            nextByScope[scope] = nextFetchedScopeSnapshot;
+            didChange = true;
+          }
+
+          if (requestSequence >= latestSharedSequenceRef.current) {
+            latestSharedSequenceRef.current = requestSequence;
+            for (const otherScope of ALL_SCOPES) {
+              if (otherScope === scope) {
+                continue;
+              }
+
+              const previousOtherScopeSnapshot = nextByScope[otherScope];
+              const nextOtherScopeSnapshot = mergeSharedSummaryFields(
+                previousOtherScopeSnapshot,
+                summaryFields,
+              );
+
+              if (!scopeSnapshotEqual(previousOtherScopeSnapshot, nextOtherScopeSnapshot)) {
+                nextByScope[otherScope] = nextOtherScopeSnapshot;
+                didChange = true;
+              }
+            }
+          }
+
+          if (!didChange && !prev.isLoading) {
+            return prev;
+          }
+
+          return {
+            byScope: nextByScope,
+            loadedByScope: prev.loadedByScope,
+            isLoading: false,
+          };
+        });
+        return;
+      }
+
       const snapshot = await host.gitGetWorktreeStatus(path, target, scope, wd);
 
       const hasContextChanged =
@@ -604,7 +721,7 @@ export function useAgentStudioDiffData({
           };
 
           let nextLoadedByScope = prev.loadedByScope;
-          if (!prev.loadedByScope[scope]) {
+          if (mode === "full" && !prev.loadedByScope[scope]) {
             nextLoadedByScope = {
               ...prev.loadedByScope,
               [scope]: true,
@@ -728,6 +845,7 @@ export function useAgentStudioDiffData({
         targetBranch: targetBranchRef.current,
         workingDir: workingDirRef.current,
         scope: polledScope,
+        mode: "summary",
       });
     }, POLL_INTERVAL_MS);
 
@@ -763,6 +881,7 @@ export function useAgentStudioDiffData({
       upstreamAheadBehind: activeScopeState.upstreamAheadBehind,
       fileDiffs: activeScopeState.fileDiffs,
       fileStatuses: activeScopeState.fileStatuses,
+      uncommittedFileCount: activeScopeState.uncommittedFileCount,
       isLoading,
       error: displayError,
       refresh,

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
@@ -31,7 +31,7 @@ export type DiffDataState = {
   /** File status from `git status`. */
   fileStatuses: FileStatus[];
   /** Total changed files from lightweight worktree polling summaries. */
-  uncommittedFileCount?: number;
+  uncommittedFileCount: number;
   /** Whether data is currently loading. */
   isLoading: boolean;
   /** Last error message, if any. */
@@ -106,8 +106,10 @@ type LoadDataContext = {
   targetBranch: string;
   workingDir: string | null;
   scope: DiffScope;
-  mode?: "full" | "summary";
+  mode?: LoadDataMode;
 };
+
+type LoadDataMode = "full" | "summary";
 
 /** Stable empty arrays hoisted outside the component (rerender-memo-with-default-value). */
 const EMPTY_DIFFS: FileDiff[] = [];
@@ -139,6 +141,7 @@ const createInitialState = (): DiffBatchState => ({
 });
 
 const ALL_SCOPES: DiffScope[] = ["target", "uncommitted"];
+const ALL_LOAD_DATA_MODES: LoadDataMode[] = ["full", "summary"];
 const IDLE_WORKTREE_RESOLUTION_STATE: WorktreeResolutionState = { status: "idle" };
 
 const buildWorktreeResolutionError = (runId: string, reason?: string): string => {
@@ -355,22 +358,22 @@ export function useAgentStudioDiffData({
   enablePolling,
 }: UseAgentStudioDiffDataInput): DiffDataState {
   const [state, setState] = useState<DiffBatchState>(createInitialState);
-  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [selectedFile, setSelectedFileState] = useState<string | null>(null);
   const [diffScope, setDiffScope] = useState<DiffScope>("target");
   const [worktreeResolutionState, setWorktreeResolutionState] = useState<WorktreeResolutionState>(
     IDLE_WORKTREE_RESOLUTION_STATE,
   );
   const [worktreeResolutionRetryToken, setWorktreeResolutionRetryToken] = useState(0);
 
-  const versionByScopeRef = useRef<Record<DiffScope, number>>({
-    target: 0,
-    uncommitted: 0,
+  const versionByScopeAndModeRef = useRef<Record<DiffScope, Record<LoadDataMode, number>>>({
+    target: { full: 0, summary: 0 },
+    uncommitted: { full: 0, summary: 0 },
   });
   const requestSequenceRef = useRef(0);
   const latestSharedSequenceRef = useRef(0);
-  const inFlightScopeRequestRef = useRef<Record<DiffScope, string | null>>({
-    target: null,
-    uncommitted: null,
+  const inFlightScopeRequestRef = useRef<Record<DiffScope, Record<LoadDataMode, string | null>>>({
+    target: { full: null, summary: null },
+    uncommitted: { full: null, summary: null },
   });
   const requestContextKeyRef = useRef<string | null>(null);
 
@@ -549,14 +552,21 @@ export function useAgentStudioDiffData({
     const target = context?.targetBranch ?? targetBranchRef.current;
     const workingDir = context?.workingDir ?? workingDirRef.current;
     const mode = context?.mode ?? "full";
-    const requestKey = `${path}::${target}::${workingDir ?? ""}::${mode}`;
+    const requestKey = `${path}::${target}::${workingDir ?? ""}`;
 
-    if (inFlightScopeRequestRef.current[scope] === requestKey) {
+    if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
       return;
     }
 
-    inFlightScopeRequestRef.current[scope] = requestKey;
-    const version = ++versionByScopeRef.current[scope];
+    if (
+      mode === "summary" &&
+      inFlightScopeRequestRef.current[scope].full === requestKey
+    ) {
+      return;
+    }
+
+    inFlightScopeRequestRef.current[scope][mode] = requestKey;
+    const version = ++versionByScopeAndModeRef.current[scope][mode];
     const requestSequence = ++requestSequenceRef.current;
 
     // Only show loading indicator on initial load / manual refresh — NOT on polling
@@ -579,7 +589,7 @@ export function useAgentStudioDiffData({
         }
 
         // Stale response guard
-        if (versionByScopeRef.current[scope] !== version) {
+        if (versionByScopeAndModeRef.current[scope][mode] !== version) {
           return;
         }
 
@@ -644,7 +654,7 @@ export function useAgentStudioDiffData({
       }
 
       // Stale response guard
-      if (versionByScopeRef.current[scope] !== version) {
+      if (versionByScopeAndModeRef.current[scope][mode] !== version) {
         return;
       }
 
@@ -709,7 +719,7 @@ export function useAgentStudioDiffData({
         return;
       }
 
-      if (versionByScopeRef.current[scope] === version) {
+      if (versionByScopeAndModeRef.current[scope][mode] === version) {
         setState((prev) => {
           const previousScopeSnapshot = prev.byScope[scope];
           const nextScopeSnapshot: ScopeSnapshot = {
@@ -745,8 +755,8 @@ export function useAgentStudioDiffData({
         });
       }
     } finally {
-      if (inFlightScopeRequestRef.current[scope] === requestKey) {
-        inFlightScopeRequestRef.current[scope] = null;
+      if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
+        inFlightScopeRequestRef.current[scope][mode] = null;
       }
     }
   }, []);
@@ -761,14 +771,16 @@ export function useAgentStudioDiffData({
 
     if (repoPath && !shouldBlockDiffLoading) {
       if (hasContextChanged) {
-        versionByScopeRef.current.target += 1;
-        versionByScopeRef.current.uncommitted += 1;
-        inFlightScopeRequestRef.current.target = null;
-        inFlightScopeRequestRef.current.uncommitted = null;
+        for (const scope of ALL_SCOPES) {
+          for (const mode of ALL_LOAD_DATA_MODES) {
+            versionByScopeAndModeRef.current[scope][mode] += 1;
+            inFlightScopeRequestRef.current[scope][mode] = null;
+          }
+        }
         requestSequenceRef.current = 0;
         latestSharedSequenceRef.current = 0;
         setState(createInitialState());
-        setSelectedFile(null);
+        setSelectedFileState(null);
       }
 
       void loadData(true, {
@@ -782,27 +794,31 @@ export function useAgentStudioDiffData({
 
     if (repoPath) {
       if (hasContextChanged) {
-        versionByScopeRef.current.target += 1;
-        versionByScopeRef.current.uncommitted += 1;
-        inFlightScopeRequestRef.current.target = null;
-        inFlightScopeRequestRef.current.uncommitted = null;
+        for (const scope of ALL_SCOPES) {
+          for (const mode of ALL_LOAD_DATA_MODES) {
+            versionByScopeAndModeRef.current[scope][mode] += 1;
+            inFlightScopeRequestRef.current[scope][mode] = null;
+          }
+        }
         requestSequenceRef.current = 0;
         latestSharedSequenceRef.current = 0;
         setState(createInitialState());
-        setSelectedFile(null);
+        setSelectedFileState(null);
       }
       return;
     }
 
-    versionByScopeRef.current.target += 1;
-    versionByScopeRef.current.uncommitted += 1;
-    inFlightScopeRequestRef.current.target = null;
-    inFlightScopeRequestRef.current.uncommitted = null;
+    for (const scope of ALL_SCOPES) {
+      for (const mode of ALL_LOAD_DATA_MODES) {
+        versionByScopeAndModeRef.current[scope][mode] += 1;
+        inFlightScopeRequestRef.current[scope][mode] = null;
+      }
+    }
     requestSequenceRef.current = 0;
     latestSharedSequenceRef.current = 0;
     requestContextKeyRef.current = null;
     setState(createInitialState());
-    setSelectedFile(null);
+    setSelectedFileState(null);
   }, [
     repoPath,
     worktreePath,
@@ -870,6 +886,30 @@ export function useAgentStudioDiffData({
     void loadData(true);
   }, [loadData, shouldBlockDiffLoading, worktreeResolutionError]);
 
+  const setSelectedFile = useCallback(
+    (path: string | null): void => {
+      setSelectedFileState(path);
+
+      if (path === null || shouldBlockDiffLoading) {
+        return;
+      }
+
+      const selectedRepoPath = repoPathRef.current;
+      if (!selectedRepoPath) {
+        return;
+      }
+
+      void loadData(false, {
+        repoPath: selectedRepoPath,
+        targetBranch: targetBranchRef.current,
+        workingDir: workingDirRef.current,
+        scope: diffScopeRef.current,
+        mode: "full",
+      });
+    },
+    [loadData, shouldBlockDiffLoading],
+  );
+
   // Memoize return value to prevent parent re-renders (rerender-memo-with-default-value)
   return useMemo<DiffDataState>(
     () => ({
@@ -898,6 +938,7 @@ export function useAgentStudioDiffData({
       activeScopeState,
       refresh,
       selectedFile,
+      setSelectedFile,
     ],
   );
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
@@ -69,6 +69,7 @@ const diffModel: AgentStudioGitPanelModel = {
   commitsAheadBehind: null,
   fileDiffs: [],
   fileStatuses: [],
+  uncommittedFileCount: 0,
   isLoading: false,
   error: null,
   refresh: () => {},

--- a/packages/adapters-tauri-host/src/git-client.ts
+++ b/packages/adapters-tauri-host/src/git-client.ts
@@ -15,6 +15,7 @@ import {
   type GitRebaseBranchRequest,
   type GitRebaseBranchResult,
   type GitWorktreeStatus,
+  type GitWorktreeStatusSummary,
   type GitWorktreeSummary,
   gitBranchSchema,
   gitCommitAllResultSchema,
@@ -24,6 +25,7 @@ import {
   gitPushSummarySchema,
   gitRebaseBranchResultSchema,
   gitWorktreeStatusSchema,
+  gitWorktreeStatusSummarySchema,
   gitWorktreeSummarySchema,
 } from "@openducktor/contracts";
 import type { InvokeFn } from "./invoke-utils";
@@ -186,6 +188,22 @@ export const gitGetWorktreeStatus = async (
   return gitWorktreeStatusSchema.parse(payload);
 };
 
+export const gitGetWorktreeStatusSummary = async (
+  invokeFn: InvokeFn,
+  repoPath: string,
+  targetBranch: string,
+  diffScope?: "target" | "uncommitted",
+  workingDir?: string,
+): Promise<GitWorktreeStatusSummary> => {
+  const payload = await invokeFn<unknown>("git_get_worktree_status_summary", {
+    repoPath,
+    targetBranch,
+    diffScope: gitDiffScopeSchema.parse(diffScope ?? "target"),
+    workingDir: workingDir ?? null,
+  });
+  return gitWorktreeStatusSummarySchema.parse(payload);
+};
+
 export const gitCommitAll = async (
   invokeFn: InvokeFn,
   repoPath: string,
@@ -304,6 +322,21 @@ export class TauriGitClient {
     workingDir?: string,
   ): Promise<GitWorktreeStatus> {
     return gitGetWorktreeStatus(this.invokeFn, repoPath, targetBranch, diffScope, workingDir);
+  }
+
+  async gitGetWorktreeStatusSummary(
+    repoPath: string,
+    targetBranch: string,
+    diffScope?: "target" | "uncommitted",
+    workingDir?: string,
+  ): Promise<GitWorktreeStatusSummary> {
+    return gitGetWorktreeStatusSummary(
+      this.invokeFn,
+      repoPath,
+      targetBranch,
+      diffScope,
+      workingDir,
+    );
   }
 
   async gitCommitAll(

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -185,6 +185,7 @@ describe("TauriHostClient", () => {
       "gitGetDiff",
       "gitCommitsAheadBehind",
       "gitGetWorktreeStatus",
+      "gitGetWorktreeStatusSummary",
       "gitCommitAll",
       "gitRebaseBranch",
     ] as const;
@@ -454,6 +455,23 @@ describe("TauriHostClient", () => {
           },
         };
       }
+      if (command === "git_get_worktree_status_summary") {
+        return {
+          currentBranch: { name: "feature/task-1", detached: false },
+          fileStatusCounts: { total: 1, staged: 0, unstaged: 1 },
+          targetAheadBehind: { ahead: 1, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/tmp/wt/task-1",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000000000,
+            hashVersion: 1,
+            statusHash: "0123456789abcdef",
+            diffHash: "fedcba9876543210",
+          },
+        };
+      }
       throw new Error(`Unexpected command: ${command}`);
     });
 
@@ -479,6 +497,12 @@ describe("TauriHostClient", () => {
       "target",
       "/tmp/wt/task-1",
     );
+    const worktreeStatusSummary = await client.gitGetWorktreeStatusSummary(
+      "/repo",
+      "origin/main",
+      "target",
+      "/tmp/wt/task-1",
+    );
 
     expect(branches).toHaveLength(1);
     expect(current.detached).toBe(false);
@@ -491,6 +515,7 @@ describe("TauriHostClient", () => {
     expect(pushed.remote).toBe("origin");
     expect(worktreeStatus.currentBranch.name).toBe("feature/task-1");
     expect(worktreeStatus.targetAheadBehind.ahead).toBe(1);
+    expect(worktreeStatusSummary.fileStatusCounts.total).toBe(1);
 
     expect(calls.map((entry) => entry.command)).toEqual([
       "git_get_branches",
@@ -503,6 +528,7 @@ describe("TauriHostClient", () => {
       "git_pull_branch",
       "git_push_branch",
       "git_get_worktree_status",
+      "git_get_worktree_status_summary",
     ]);
     expect(calls[2].args).toEqual({
       repoPath: "/repo",
@@ -543,6 +569,12 @@ describe("TauriHostClient", () => {
       workingDir: "/tmp/wt/task-1",
     });
     expect(calls[9].args).toEqual({
+      repoPath: "/repo",
+      targetBranch: "origin/main",
+      diffScope: "target",
+      workingDir: "/tmp/wt/task-1",
+    });
+    expect(calls[10].args).toEqual({
       repoPath: "/repo",
       targetBranch: "origin/main",
       diffScope: "target",
@@ -602,6 +634,33 @@ describe("TauriHostClient", () => {
 
     await expect(
       client.gitGetWorktreeStatus("/repo", "origin/main", "target", "/tmp/wt/task-1"),
+    ).rejects.toThrow();
+  });
+
+  test("git worktree status summary rejects malformed payloads", async () => {
+    const { client } = createClient((command) => {
+      if (command === "git_get_worktree_status_summary") {
+        return {
+          currentBranch: { name: "feature/task-1", detached: false },
+          fileStatusCounts: { total: -1, staged: 0, unstaged: 0 },
+          targetAheadBehind: { ahead: 1, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/tmp/wt/task-1",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000000000,
+            hashVersion: 1,
+            statusHash: "0123456789abcdef",
+            diffHash: "fedcba9876543210",
+          },
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(
+      client.gitGetWorktreeStatusSummary("/repo", "origin/main", "target", "/tmp/wt/task-1"),
     ).rejects.toThrow();
   });
 

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -81,6 +81,7 @@ const GIT_METHODS = [
   "gitGetDiff",
   "gitCommitsAheadBehind",
   "gitGetWorktreeStatus",
+  "gitGetWorktreeStatusSummary",
 ] as const satisfies readonly MethodName<TauriGitClient>[];
 
 type WorkspaceMethodName = (typeof WORKSPACE_METHODS)[number];

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -24,6 +24,7 @@ import type {
   GitCommitAllResult,
   GitCurrentBranch,
   GitDiffScope,
+  GitFileStatusCounts,
   GitPullBranchRequest,
   GitPullBranchResult,
   GitPushSummary,
@@ -32,6 +33,7 @@ import type {
   GitUpstreamAheadBehind,
   GitWorktreeStatus,
   GitWorktreeStatusSnapshot,
+  GitWorktreeStatusSummary,
   GitWorktreeSummary,
   GlobalConfig,
   IssueType,
@@ -89,11 +91,13 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "defaultSpecTemplateMarkdown",
   "fileDiffSchema",
   "fileStatusSchema",
+  "gitFileStatusCountsSchema",
   "gitBranchSchema",
   "gitCurrentBranchSchema",
   "gitPushSummarySchema",
   "gitUpstreamAheadBehindSchema",
   "gitWorktreeStatusSchema",
+  "gitWorktreeStatusSummarySchema",
   "gitWorktreeStatusSnapshotSchema",
   "gitWorktreeSummarySchema",
   "globalConfigSchema",
@@ -147,6 +151,7 @@ type ExportedTypeContract = {
   GitCommitAllResult: GitCommitAllResult;
   FileDiff: FileDiff;
   FileStatus: FileStatus;
+  GitFileStatusCounts: GitFileStatusCounts;
   GitBranch: GitBranch;
   GitCurrentBranch: GitCurrentBranch;
   GitDiffScope: GitDiffScope;
@@ -157,6 +162,7 @@ type ExportedTypeContract = {
   GitRebaseBranchResult: GitRebaseBranchResult;
   GitUpstreamAheadBehind: GitUpstreamAheadBehind;
   GitWorktreeStatus: GitWorktreeStatus;
+  GitWorktreeStatusSummary: GitWorktreeStatusSummary;
   GitWorktreeStatusSnapshot: GitWorktreeStatusSnapshot;
   GitWorktreeSummary: GitWorktreeSummary;
   GlobalConfig: GlobalConfig;

--- a/packages/contracts/src/git-schemas.ts
+++ b/packages/contracts/src/git-schemas.ts
@@ -76,6 +76,13 @@ export const fileStatusSchema = z.object({
 });
 export type FileStatus = z.infer<typeof fileStatusSchema>;
 
+export const gitFileStatusCountsSchema = z.object({
+  total: z.number().int().nonnegative(),
+  staged: z.number().int().nonnegative(),
+  unstaged: z.number().int().nonnegative(),
+});
+export type GitFileStatusCounts = z.infer<typeof gitFileStatusCountsSchema>;
+
 /** Commits ahead/behind a reference branch (from `git rev-list --left-right`). */
 export const commitsAheadBehindSchema = z.object({
   ahead: z.number(),
@@ -123,6 +130,15 @@ export const gitWorktreeStatusSchema = z.object({
   snapshot: gitWorktreeStatusSnapshotSchema,
 });
 export type GitWorktreeStatus = z.infer<typeof gitWorktreeStatusSchema>;
+
+export const gitWorktreeStatusSummarySchema = z.object({
+  currentBranch: gitCurrentBranchSchema,
+  fileStatusCounts: gitFileStatusCountsSchema,
+  targetAheadBehind: commitsAheadBehindSchema,
+  upstreamAheadBehind: gitUpstreamAheadBehindSchema,
+  snapshot: gitWorktreeStatusSnapshotSchema,
+});
+export type GitWorktreeStatusSummary = z.infer<typeof gitWorktreeStatusSummarySchema>;
 
 export const gitCommitAllRequestSchema = z.object({
   repoPath: z.string(),

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -18,6 +18,7 @@ import {
   gitUpstreamAheadBehindSchema,
   gitWorktreeStatusSchema,
   gitWorktreeStatusSnapshotSchema,
+  gitWorktreeStatusSummarySchema,
   gitWorktreeSummarySchema,
   repoConfigSchema,
   runEventSchema,
@@ -387,6 +388,29 @@ describe("runtime schemas", () => {
     expect(status.snapshot.diffScope).toBe("target");
     expect(status.upstreamAheadBehind.outcome).toBe("tracking");
     expect(status.targetAheadBehind.behind).toBe(3);
+  });
+
+  test("git worktree status summary schema parses lightweight polling payload", () => {
+    const summary = gitWorktreeStatusSummarySchema.parse({
+      currentBranch: { name: "feature/task-1", detached: false },
+      fileStatusCounts: { total: 3, staged: 1, unstaged: 2 },
+      targetAheadBehind: { ahead: 1, behind: 3 },
+      upstreamAheadBehind: { outcome: "tracking", ahead: 2, behind: 0 },
+      snapshot: {
+        effectiveWorkingDir: "/repo",
+        targetBranch: "origin/main",
+        diffScope: "target",
+        observedAtMs: 1731000000000,
+        hashVersion: 1,
+        statusHash: "0123456789abcdef",
+        diffHash: "fedcba9876543210",
+      },
+    });
+
+    expect(summary.fileStatusCounts.total).toBe(3);
+    expect(summary.fileStatusCounts.staged).toBe(1);
+    expect(summary.fileStatusCounts.unstaged).toBe(2);
+    expect(summary.snapshot.diffScope).toBe("target");
   });
 
   test("git worktree status snapshot schema rejects malformed hash metadata", () => {


### PR DESCRIPTION
## Summary
This PR implements a lightweight worktree-status polling path for Agent Studio and keeps full diff retrieval on-demand.

The goal is to reduce IPC payload size and polling overhead by avoiding unified patch payloads during periodic polling, while preserving full-detail behavior for explicit/detail workflows.

## Problem
Polling in `use-agent-studio-diff-data` ran every 30 seconds and requested full `GitWorktreeStatus` payloads on each cycle, including `fileDiffs` patch content. This created avoidable serialization and IPC overhead when the polling UI only needed summary state.

## What Changed
### 1) New lightweight summary path (contracts + adapters + Tauri command)
- Added/used `GitWorktreeStatusSummary` schema/contract path for polling-safe payloads.
- Added `git_get_worktree_status_summary` usage in desktop hook polling.
- Added host adapter/client surface for summary fetch.

### 2) Source-layer orchestration for summary status
- Extended Rust `GitPort` with `get_worktree_status_summary(...)`.
- Implemented summary orchestration in infra (`host-infra-system`) so command layer delegates through the port.
- Kept full-detail `get_worktree_status(...)` behavior for explicit full payload retrieval.

### 3) Hook race hardening: full vs summary request coordination
- Split in-flight/versioning logic by request mode (`full` vs `summary`) to avoid summary polls invalidating full reloads.
- Prevented summary polling requests from preempting an active full request for the same scope/context.

### 4) On-demand full refresh for detail workflows
- Wired selected/expanded file interactions to trigger full worktree-status refresh on demand.
- Polling remains summary-only; detail flows still retrieve full diffs when needed.

### 5) Typing cleanup
- Made `uncommittedFileCount` required in the diff model.
- Removed fallback logic in panel rendering (`?? fileStatuses.length`).

## Testing
### Frontend / TS
- `bun test apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx`
- `bun run --filter @openducktor/desktop typecheck`

### Rust
- `cd apps/desktop/src-tauri && cargo test -p host-domain`
- `cd apps/desktop/src-tauri && cargo test -p host-infra-system`
- `cd apps/desktop/src-tauri && cargo test -p host-application`
- `cd apps/desktop/src-tauri && cargo test -p openducktor-desktop commands::git::tests::`

## Expected Impact
- Significant reduction in periodic polling payloads by omitting patch text in the steady-state poll loop.
- Lower IPC serialization/deserialization pressure for long-running Agent Studio sessions.
- Faster polling response and reduced UI thread work during active build sessions.

## Notes
- No fallback paths were added to mask failures.
- Full-diff API remains available and is used explicitly for detail interactions.
