### PR TITLE
fix(host-infra-system): harden ~/.openducktor config permissions

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1305,6 +1305,7 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "host-domain",
+ "libc",
  "rayon",
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
@@ -12,4 +12,5 @@ thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
 rayon = "1"
+libc = "0.2"
 host-domain = { path = "../host-domain" }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
-use std::{fs::OpenOptions, io::Write};
+use std::{ffi::OsString, fs::OpenOptions, io::ErrorKind, io::Write, time::SystemTime};
 
 #[cfg(unix)]
 const CONFIG_DIR_MODE: u32 = 0o700;
@@ -28,6 +28,7 @@ pub struct AppConfigStore {
 #[derive(Debug, Clone)]
 pub struct RuntimeConfigStore {
     pub(super) path: PathBuf,
+    pub(super) enforce_private_parent_permissions: bool,
 }
 
 const USER_SETTINGS_FILENAME: &str = "config.json";
@@ -359,11 +360,18 @@ impl RuntimeConfigStore {
     pub fn new() -> Result<Self> {
         Ok(Self {
             path: resolve_default_path(RUNTIME_SETTINGS_FILENAME)?,
+            enforce_private_parent_permissions: true,
         })
     }
 
     pub fn from_path(path: PathBuf) -> Self {
-        Self { path }
+        let enforce_private_parent_permissions = resolve_default_path(RUNTIME_SETTINGS_FILENAME)
+            .map(|default_path| default_path == path)
+            .unwrap_or(false);
+        Self {
+            path,
+            enforce_private_parent_permissions,
+        }
     }
 
     pub fn from_user_settings_store(config_store: &AppConfigStore) -> Self {
@@ -372,7 +380,10 @@ impl RuntimeConfigStore {
             .parent()
             .map_or_else(PathBuf::new, Path::to_path_buf)
             .join(RUNTIME_SETTINGS_FILENAME);
-        Self { path: runtime_path }
+        Self {
+            path: runtime_path,
+            enforce_private_parent_permissions: config_store.enforce_private_parent_permissions,
+        }
     }
 
     pub fn path(&self) -> &Path {
@@ -383,6 +394,8 @@ impl RuntimeConfigStore {
         if !self.path.exists() {
             return Ok(RuntimeConfig::default());
         }
+
+        validate_config_access(&self.path, self.enforce_private_parent_permissions)?;
 
         let data = fs::read_to_string(&self.path)
             .with_context(|| format!("Failed reading config file {}", self.path.display()))?;
@@ -397,12 +410,13 @@ impl RuntimeConfigStore {
             fs::create_dir_all(parent).with_context(|| {
                 format!("Failed creating config directory {}", parent.display())
             })?;
+            enforce_directory_permissions(parent, self.enforce_private_parent_permissions)?;
         }
         let mut normalized = config.clone();
         normalize_runtime_config(&mut normalized);
         let payload = serde_json::to_string_pretty(&normalized)?;
-        fs::write(&self.path, payload)
-            .with_context(|| format!("Failed writing config file {}", self.path.display()))?;
+        write_config_file(&self.path, payload.as_bytes())?;
+        validate_config_access(&self.path, self.enforce_private_parent_permissions)?;
         Ok(())
     }
 }
@@ -416,26 +430,7 @@ pub(crate) fn touch_recent(recent: &mut Vec<String>, repo_path: &str) {
 fn write_config_file(path: &Path, contents: &[u8]) -> Result<()> {
     #[cfg(unix)]
     {
-        let mut file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .mode(CONFIG_FILE_MODE)
-            .open(path)
-            .with_context(|| format!("Failed opening config file {}", path.display()))?;
-        file.write_all(contents)
-            .with_context(|| format!("Failed writing config file {}", path.display()))?;
-        file.sync_all()
-            .with_context(|| format!("Failed syncing config file {}", path.display()))?;
-        fs::set_permissions(path, fs::Permissions::from_mode(CONFIG_FILE_MODE)).with_context(
-            || {
-                format!(
-                    "Failed setting secure permissions on config file {}",
-                    path.display()
-                )
-            },
-        )?;
-        return Ok(());
+        return write_config_file_atomic(path, contents);
     }
 
     #[cfg(not(unix))]
@@ -444,6 +439,88 @@ fn write_config_file(path: &Path, contents: &[u8]) -> Result<()> {
             .with_context(|| format!("Failed writing config file {}", path.display()))?;
         Ok(())
     }
+}
+
+#[cfg(unix)]
+fn write_config_file_atomic(path: &Path, contents: &[u8]) -> Result<()> {
+    for attempt in 0..8_u8 {
+        let temp_path = create_temporary_config_path(path, attempt)?;
+        match OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(CONFIG_FILE_MODE)
+            .open(&temp_path)
+        {
+            Ok(mut file) => {
+                let write_result = (|| -> Result<()> {
+                    file.write_all(contents).with_context(|| {
+                        format!("Failed writing config temp file {}", temp_path.display())
+                    })?;
+                    file.sync_all().with_context(|| {
+                        format!("Failed syncing config temp file {}", temp_path.display())
+                    })?;
+                    drop(file);
+                    fs::rename(&temp_path, path).with_context(|| {
+                        format!(
+                            "Failed atomically replacing config file {} with {}",
+                            path.display(),
+                            temp_path.display()
+                        )
+                    })?;
+                    Ok(())
+                })();
+
+                if let Err(error) = write_result {
+                    if temp_path.exists() {
+                        fs::remove_file(&temp_path).with_context(|| {
+                            format!(
+                                "Failed cleaning up config temp file {} after write failure",
+                                temp_path.display()
+                            )
+                        })?;
+                    }
+                    return Err(error);
+                }
+
+                return Ok(());
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Failed opening config temp file {}", temp_path.display())
+                });
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "Failed creating unique temp file for config write at {} after 8 attempts",
+        path.display()
+    ))
+}
+
+#[cfg(unix)]
+fn create_temporary_config_path(path: &Path, attempt: u8) -> Result<PathBuf> {
+    let parent = path.parent().ok_or_else(|| {
+        anyhow!(
+            "Config file path {} is invalid: missing parent directory",
+            path.display()
+        )
+    })?;
+    let file_name = path.file_name().ok_or_else(|| {
+        anyhow!(
+            "Config file path {} is invalid: missing file name",
+            path.display()
+        )
+    })?;
+    let nanos = SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| anyhow!("System clock error while building temp config path: {error}"))?
+        .as_nanos();
+    let mut temp_name = OsString::from(".");
+    temp_name.push(file_name);
+    temp_name.push(format!(".tmp-{}-{nanos}-{attempt}", std::process::id()));
+    Ok(parent.join(temp_name))
 }
 
 fn validate_config_access(path: &Path, enforce_private_parent_permissions: bool) -> Result<()> {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -14,6 +14,8 @@ use std::{ffi::OsString, fs::OpenOptions, io::ErrorKind, io::Write, time::System
 const CONFIG_DIR_MODE: u32 = 0o700;
 #[cfg(unix)]
 const CONFIG_FILE_MODE: u32 = 0o600;
+#[cfg(unix)]
+const MAX_TEMP_FILE_ATTEMPTS: u8 = 8;
 
 fn has_configured_worktree(repo: &RepoConfig) -> bool {
     repo.worktree_base_path.is_some()
@@ -39,6 +41,12 @@ fn resolve_default_path(file_name: &str) -> Result<PathBuf> {
     Ok(home.join(".openducktor").join(file_name))
 }
 
+fn should_enforce_private_parent_permissions(path: &Path, file_name: &str) -> bool {
+    resolve_default_path(file_name)
+        .map(|default_path| default_path == path)
+        .unwrap_or(false)
+}
+
 impl Default for AppConfigStore {
     fn default() -> Self {
         Self::new().expect("failed to initialize config store")
@@ -54,9 +62,8 @@ impl AppConfigStore {
     }
 
     pub fn from_path(path: PathBuf) -> Self {
-        let enforce_private_parent_permissions = resolve_default_path(USER_SETTINGS_FILENAME)
-            .map(|default_path| default_path == path)
-            .unwrap_or(false);
+        let enforce_private_parent_permissions =
+            should_enforce_private_parent_permissions(&path, USER_SETTINGS_FILENAME);
         Self {
             path,
             enforce_private_parent_permissions,
@@ -365,9 +372,8 @@ impl RuntimeConfigStore {
     }
 
     pub fn from_path(path: PathBuf) -> Self {
-        let enforce_private_parent_permissions = resolve_default_path(RUNTIME_SETTINGS_FILENAME)
-            .map(|default_path| default_path == path)
-            .unwrap_or(false);
+        let enforce_private_parent_permissions =
+            should_enforce_private_parent_permissions(&path, RUNTIME_SETTINGS_FILENAME);
         Self {
             path,
             enforce_private_parent_permissions,
@@ -443,7 +449,7 @@ fn write_config_file(path: &Path, contents: &[u8]) -> Result<()> {
 
 #[cfg(unix)]
 fn write_config_file_atomic(path: &Path, contents: &[u8]) -> Result<()> {
-    for attempt in 0..8_u8 {
+    for attempt in 0..MAX_TEMP_FILE_ATTEMPTS {
         let temp_path = create_temporary_config_path(path, attempt)?;
         match OpenOptions::new()
             .create_new(true)
@@ -504,8 +510,9 @@ fn write_config_file_atomic(path: &Path, contents: &[u8]) -> Result<()> {
     }
 
     Err(anyhow!(
-        "Failed creating unique temp file for config write at {} after 8 attempts",
-        path.display()
+        "Failed creating unique temp file for config write at {} after {} attempts",
+        path.display(),
+        MAX_TEMP_FILE_ATTEMPTS
     ))
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -4,7 +4,16 @@ use super::types::{hook_set_fingerprint, GlobalConfig, HookSet, RepoConfig, Runt
 use anyhow::{anyhow, Context, Result};
 use host_domain::WorkspaceRecord;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::{fs::OpenOptions, io::Write};
+
+#[cfg(unix)]
+const CONFIG_DIR_MODE: u32 = 0o700;
+#[cfg(unix)]
+const CONFIG_FILE_MODE: u32 = 0o600;
 
 fn has_configured_worktree(repo: &RepoConfig) -> bool {
     repo.worktree_base_path.is_some()
@@ -53,6 +62,8 @@ impl AppConfigStore {
         if !self.path.exists() {
             return Ok(GlobalConfig::default());
         }
+
+        validate_config_access(&self.path)?;
 
         let data = fs::read_to_string(&self.path)
             .with_context(|| format!("Failed reading config file {}", self.path.display()))?;
@@ -103,12 +114,13 @@ impl AppConfigStore {
             fs::create_dir_all(parent).with_context(|| {
                 format!("Failed creating config directory {}", parent.display())
             })?;
+            enforce_directory_permissions(parent)?;
         }
         let mut normalized = config.clone();
         normalize_global_config(&mut normalized);
         let payload = serde_json::to_string_pretty(&normalized)?;
-        fs::write(&self.path, payload)
-            .with_context(|| format!("Failed writing config file {}", self.path.display()))?;
+        write_config_file(&self.path, payload.as_bytes())?;
+        validate_config_access(&self.path)?;
         Ok(())
     }
 
@@ -391,4 +403,136 @@ pub(crate) fn touch_recent(recent: &mut Vec<String>, repo_path: &str) {
     recent.retain(|entry| entry != repo_path);
     recent.insert(0, repo_path.to_string());
     recent.truncate(20);
+}
+
+fn write_config_file(path: &Path, contents: &[u8]) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(CONFIG_FILE_MODE)
+            .open(path)
+            .with_context(|| format!("Failed opening config file {}", path.display()))?;
+        file.write_all(contents)
+            .with_context(|| format!("Failed writing config file {}", path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("Failed syncing config file {}", path.display()))?;
+        fs::set_permissions(path, fs::Permissions::from_mode(CONFIG_FILE_MODE)).with_context(
+            || {
+                format!(
+                    "Failed setting secure permissions on config file {}",
+                    path.display()
+                )
+            },
+        )?;
+        return Ok(());
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(path, contents)
+            .with_context(|| format!("Failed writing config file {}", path.display()))?;
+        Ok(())
+    }
+}
+
+fn validate_config_access(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let parent = path.parent().ok_or_else(|| {
+            anyhow!(
+                "Config file path {} is invalid: missing parent directory",
+                path.display()
+            )
+        })?;
+        let expected_uid = current_user_uid()?;
+        validate_private_directory(parent, expected_uid)?;
+        validate_private_file(path, expected_uid)?;
+    }
+    Ok(())
+}
+
+fn enforce_directory_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        fs::set_permissions(path, fs::Permissions::from_mode(CONFIG_DIR_MODE)).with_context(
+            || {
+                format!(
+                    "Failed setting secure permissions on config directory {}",
+                    path.display()
+                )
+            },
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn current_user_uid() -> Result<u32> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
+    let metadata = fs::metadata(&home).with_context(|| {
+        format!(
+            "Failed reading metadata for home directory {}",
+            home.display()
+        )
+    })?;
+    Ok(metadata.uid())
+}
+
+#[cfg(unix)]
+fn validate_private_directory(path: &Path, expected_uid: u32) -> Result<()> {
+    let metadata = fs::metadata(path).with_context(|| {
+        format!(
+            "Failed reading config directory metadata {}",
+            path.display()
+        )
+    })?;
+    let mode = metadata.mode() & 0o777;
+    let owner_uid = metadata.uid();
+    if owner_uid != expected_uid {
+        return Err(anyhow!(
+            "Config directory {} must be owned by the current user (uid {}). Found uid {}. Run `chown -R $(whoami) {}`.",
+            path.display(),
+            expected_uid,
+            owner_uid,
+            path.display()
+        ));
+    }
+    if mode & 0o077 != 0 {
+        return Err(anyhow!(
+            "Config directory {} is too permissive (mode {:04o}). Expected 0700 or stricter. Run `chmod 700 {}`.",
+            path.display(),
+            mode,
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_private_file(path: &Path, expected_uid: u32) -> Result<()> {
+    let metadata = fs::metadata(path)
+        .with_context(|| format!("Failed reading config file metadata {}", path.display()))?;
+    let mode = metadata.mode() & 0o777;
+    let owner_uid = metadata.uid();
+    if owner_uid != expected_uid {
+        return Err(anyhow!(
+            "Config file {} must be owned by the current user (uid {}). Found uid {}. Run `chown $(whoami) {}`.",
+            path.display(),
+            expected_uid,
+            owner_uid,
+            path.display()
+        ));
+    }
+    if mode & 0o077 != 0 {
+        return Err(anyhow!(
+            "Config file {} is too permissive (mode {:04o}). Expected 0600 or stricter. Run `chmod 600 {}`.",
+            path.display(),
+            mode,
+            path.display()
+        ));
+    }
+    Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -22,6 +22,7 @@ fn has_configured_worktree(repo: &RepoConfig) -> bool {
 #[derive(Debug, Clone)]
 pub struct AppConfigStore {
     pub(super) path: PathBuf,
+    pub(super) enforce_private_parent_permissions: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -47,11 +48,18 @@ impl AppConfigStore {
     pub fn new() -> Result<Self> {
         Ok(Self {
             path: resolve_default_path(USER_SETTINGS_FILENAME)?,
+            enforce_private_parent_permissions: true,
         })
     }
 
     pub fn from_path(path: PathBuf) -> Self {
-        Self { path }
+        let enforce_private_parent_permissions = resolve_default_path(USER_SETTINGS_FILENAME)
+            .map(|default_path| default_path == path)
+            .unwrap_or(false);
+        Self {
+            path,
+            enforce_private_parent_permissions,
+        }
     }
 
     pub fn path(&self) -> &Path {
@@ -63,7 +71,7 @@ impl AppConfigStore {
             return Ok(GlobalConfig::default());
         }
 
-        validate_config_access(&self.path)?;
+        validate_config_access(&self.path, self.enforce_private_parent_permissions)?;
 
         let data = fs::read_to_string(&self.path)
             .with_context(|| format!("Failed reading config file {}", self.path.display()))?;
@@ -114,13 +122,13 @@ impl AppConfigStore {
             fs::create_dir_all(parent).with_context(|| {
                 format!("Failed creating config directory {}", parent.display())
             })?;
-            enforce_directory_permissions(parent)?;
+            enforce_directory_permissions(parent, self.enforce_private_parent_permissions)?;
         }
         let mut normalized = config.clone();
         normalize_global_config(&mut normalized);
         let payload = serde_json::to_string_pretty(&normalized)?;
         write_config_file(&self.path, payload.as_bytes())?;
-        validate_config_access(&self.path)?;
+        validate_config_access(&self.path, self.enforce_private_parent_permissions)?;
         Ok(())
     }
 
@@ -438,7 +446,7 @@ fn write_config_file(path: &Path, contents: &[u8]) -> Result<()> {
     }
 }
 
-fn validate_config_access(path: &Path) -> Result<()> {
+fn validate_config_access(path: &Path, enforce_private_parent_permissions: bool) -> Result<()> {
     #[cfg(unix)]
     {
         let parent = path.parent().ok_or_else(|| {
@@ -447,38 +455,39 @@ fn validate_config_access(path: &Path) -> Result<()> {
                 path.display()
             )
         })?;
-        let expected_uid = current_user_uid()?;
-        validate_private_directory(parent, expected_uid)?;
+        let expected_uid = current_effective_uid();
+        if enforce_private_parent_permissions {
+            validate_private_directory(parent, expected_uid)?;
+        }
         validate_private_file(path, expected_uid)?;
     }
     Ok(())
 }
 
-fn enforce_directory_permissions(path: &Path) -> Result<()> {
+fn enforce_directory_permissions(
+    path: &Path,
+    enforce_private_parent_permissions: bool,
+) -> Result<()> {
     #[cfg(unix)]
     {
-        fs::set_permissions(path, fs::Permissions::from_mode(CONFIG_DIR_MODE)).with_context(
-            || {
-                format!(
-                    "Failed setting secure permissions on config directory {}",
-                    path.display()
-                )
-            },
-        )?;
+        if enforce_private_parent_permissions {
+            fs::set_permissions(path, fs::Permissions::from_mode(CONFIG_DIR_MODE)).with_context(
+                || {
+                    format!(
+                        "Failed setting secure permissions on config directory {}",
+                        path.display()
+                    )
+                },
+            )?;
+        }
     }
     Ok(())
 }
 
 #[cfg(unix)]
-fn current_user_uid() -> Result<u32> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
-    let metadata = fs::metadata(&home).with_context(|| {
-        format!(
-            "Failed reading metadata for home directory {}",
-            home.display()
-        )
-    })?;
-    Ok(metadata.uid())
+fn current_effective_uid() -> u32 {
+    // SAFETY: geteuid has no preconditions and does not dereference pointers.
+    unsafe { libc::geteuid() as u32 }
 }
 
 #[cfg(unix)]
@@ -500,9 +509,9 @@ fn validate_private_directory(path: &Path, expected_uid: u32) -> Result<()> {
             path.display()
         ));
     }
-    if mode & 0o077 != 0 {
+    if mode != CONFIG_DIR_MODE {
         return Err(anyhow!(
-            "Config directory {} is too permissive (mode {:04o}). Expected 0700 or stricter. Run `chmod 700 {}`.",
+            "Config directory {} has unsupported mode {:04o}. Expected 0700 exactly. Run `chmod 700 {}`.",
             path.display(),
             mode,
             path.display()
@@ -526,9 +535,9 @@ fn validate_private_file(path: &Path, expected_uid: u32) -> Result<()> {
             path.display()
         ));
     }
-    if mode & 0o077 != 0 {
+    if mode != CONFIG_FILE_MODE {
         return Err(anyhow!(
-            "Config file {} is too permissive (mode {:04o}). Expected 0600 or stricter. Run `chmod 600 {}`.",
+            "Config file {} has unsupported mode {:04o}. Expected 0600 exactly. Run `chmod 600 {}`.",
             path.display(),
             mode,
             path.display()

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -453,6 +453,13 @@ fn write_config_file_atomic(path: &Path, contents: &[u8]) -> Result<()> {
         {
             Ok(mut file) => {
                 let write_result = (|| -> Result<()> {
+                    file.set_permissions(fs::Permissions::from_mode(CONFIG_FILE_MODE))
+                        .with_context(|| {
+                            format!(
+                                "Failed setting secure permissions on config temp file {}",
+                                temp_path.display()
+                            )
+                        })?;
                     file.write_all(contents).with_context(|| {
                         format!("Failed writing config temp file {}", temp_path.display())
                     })?;
@@ -471,13 +478,16 @@ fn write_config_file_atomic(path: &Path, contents: &[u8]) -> Result<()> {
                 })();
 
                 if let Err(error) = write_result {
-                    if temp_path.exists() {
-                        fs::remove_file(&temp_path).with_context(|| {
-                            format!(
-                                "Failed cleaning up config temp file {} after write failure",
-                                temp_path.display()
-                            )
-                        })?;
+                    if let Err(cleanup_error) = fs::remove_file(&temp_path) {
+                        if cleanup_error.kind() != ErrorKind::NotFound {
+                            return Err(error).with_context(|| {
+                                format!(
+                                    "Failed cleaning up config temp file {} after write failure: {}",
+                                    temp_path.display(),
+                                    cleanup_error
+                                )
+                            });
+                        }
                     }
                     return Err(error);
                 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/constructors_and_io.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/constructors_and_io.rs
@@ -3,6 +3,8 @@ use super::{
     TestStoreHarness,
 };
 use std::fs;
+#[cfg(unix)]
+use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
 #[test]
 fn save_and_load_report_io_and_parse_errors() {
@@ -11,7 +13,13 @@ fn save_and_load_report_io_and_parse_errors() {
     let root = harness.root();
 
     fs::create_dir_all(root).expect("temp root should exist");
+    #[cfg(unix)]
+    fs::set_permissions(root, Permissions::from_mode(0o700))
+        .expect("config root should be private");
     fs::write(store.path(), "{ invalid json").expect("invalid config should write");
+    #[cfg(unix)]
+    fs::set_permissions(store.path(), Permissions::from_mode(0o600))
+        .expect("config file should be private");
     let parse_error = store.load().expect_err("invalid json should fail parsing");
     assert!(parse_error
         .to_string()

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/mod.rs
@@ -8,6 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 mod constructors_and_io;
 mod normalization;
+mod permissions;
 mod runtime_config;
 mod trust_fingerprint;
 mod workspace_config;

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
@@ -1,6 +1,8 @@
 use super::{RepoConfig, TestStoreHarness};
 use serde_json::json;
 use std::fs;
+#[cfg(unix)]
+use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
 #[test]
 fn load_missing_returns_default_config() {
@@ -130,6 +132,14 @@ fn load_normalizes_legacy_blank_repo_config_values() {
         serde_json::to_string_pretty(&payload).expect("serialize payload"),
     )
     .expect("write config");
+    #[cfg(unix)]
+    {
+        let parent = store.path().parent().expect("config parent");
+        fs::set_permissions(parent, Permissions::from_mode(0o700))
+            .expect("config directory should be private");
+        fs::set_permissions(store.path(), Permissions::from_mode(0o600))
+            .expect("config file should be private");
+    }
 
     let workspaces = store.list_workspaces().expect("list workspaces");
     assert_eq!(workspaces.len(), 1);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/permissions.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/permissions.rs
@@ -1,0 +1,214 @@
+use super::{unique_temp_path, AppConfigStore, GlobalConfig, RuntimeConfig, RuntimeConfigStore};
+use std::fs;
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+
+#[cfg(unix)]
+fn strict_app_store(name: &str) -> (AppConfigStore, PathBuf) {
+    let root = unique_temp_path(name);
+    let path = root.join("config.json");
+    (
+        AppConfigStore {
+            path,
+            enforce_private_parent_permissions: true,
+        },
+        root,
+    )
+}
+
+#[cfg(unix)]
+fn strict_runtime_store(name: &str) -> (RuntimeConfigStore, PathBuf) {
+    let root = unique_temp_path(name);
+    let path = root.join("runtime-config.json");
+    (
+        RuntimeConfigStore {
+            path,
+            enforce_private_parent_permissions: true,
+        },
+        root,
+    )
+}
+
+#[cfg(unix)]
+#[test]
+fn app_save_enforces_private_permissions_for_config_directory_and_file() {
+    let (store, root) = strict_app_store("app-config-permissions-save");
+    store.save(&GlobalConfig::default()).expect("save config");
+
+    let parent = store.path().parent().expect("config parent should exist");
+    let dir_mode = fs::metadata(parent)
+        .expect("directory metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    let file_mode = fs::metadata(store.path())
+        .expect("file metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(dir_mode, 0o700);
+    assert_eq!(file_mode, 0o600);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn app_load_rejects_config_file_mode_that_is_not_0600() {
+    let (store, root) = strict_app_store("app-config-permissions-file-load");
+    store.save(&GlobalConfig::default()).expect("save config");
+
+    fs::set_permissions(store.path(), Permissions::from_mode(0o400))
+        .expect("config file permission should change");
+
+    let error = store
+        .load()
+        .expect_err("load should reject unsupported config file mode");
+    assert!(error.to_string().contains("Expected 0600 exactly"));
+    assert!(error.to_string().contains("chmod 600"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn app_load_rejects_config_directory_mode_that_is_not_0700() {
+    let (store, root) = strict_app_store("app-config-permissions-dir-load");
+    store.save(&GlobalConfig::default()).expect("save config");
+
+    let parent = store.path().parent().expect("config parent should exist");
+    fs::set_permissions(parent, Permissions::from_mode(0o500))
+        .expect("config directory permission should change");
+
+    let error = store
+        .load()
+        .expect_err("load should reject unsupported config directory mode");
+    assert!(error.to_string().contains("Expected 0700 exactly"));
+    assert!(error.to_string().contains("chmod 700"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn app_from_path_does_not_enforce_private_parent_directory_permissions() {
+    let root = unique_temp_path("app-custom-config-parent-permissions");
+    let custom_parent = root.join("shared-config-dir");
+    fs::create_dir_all(&custom_parent).expect("custom parent should be created");
+    fs::set_permissions(&custom_parent, Permissions::from_mode(0o755))
+        .expect("custom parent should be non-private");
+
+    let store = AppConfigStore::from_path(custom_parent.join("config.json"));
+    store
+        .save(&GlobalConfig::default())
+        .expect("save should succeed");
+    store.load().expect("load should succeed");
+
+    let parent_mode = fs::metadata(&custom_parent)
+        .expect("parent metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    let file_mode = fs::metadata(store.path())
+        .expect("file metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(parent_mode, 0o755);
+    assert_eq!(file_mode, 0o600);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_save_enforces_private_permissions_for_config_directory_and_file() {
+    let (store, root) = strict_runtime_store("runtime-config-permissions-save");
+    store.save(&RuntimeConfig::default()).expect("save config");
+
+    let parent = store.path().parent().expect("config parent should exist");
+    let dir_mode = fs::metadata(parent)
+        .expect("directory metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    let file_mode = fs::metadata(store.path())
+        .expect("file metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(dir_mode, 0o700);
+    assert_eq!(file_mode, 0o600);
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_load_rejects_config_file_mode_that_is_not_0600() {
+    let (store, root) = strict_runtime_store("runtime-config-permissions-file-load");
+    store.save(&RuntimeConfig::default()).expect("save config");
+
+    fs::set_permissions(store.path(), Permissions::from_mode(0o400))
+        .expect("config file permission should change");
+
+    let error = store
+        .load()
+        .expect_err("load should reject unsupported config file mode");
+    assert!(error.to_string().contains("Expected 0600 exactly"));
+    assert!(error.to_string().contains("chmod 600"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_load_rejects_config_directory_mode_that_is_not_0700() {
+    let (store, root) = strict_runtime_store("runtime-config-permissions-dir-load");
+    store.save(&RuntimeConfig::default()).expect("save config");
+
+    let parent = store.path().parent().expect("config parent should exist");
+    fs::set_permissions(parent, Permissions::from_mode(0o500))
+        .expect("config directory permission should change");
+
+    let error = store
+        .load()
+        .expect_err("load should reject unsupported config directory mode");
+    assert!(error.to_string().contains("Expected 0700 exactly"));
+    assert!(error.to_string().contains("chmod 700"));
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn runtime_from_path_does_not_enforce_private_parent_directory_permissions() {
+    let root = unique_temp_path("runtime-custom-config-parent-permissions");
+    let custom_parent = root.join("shared-runtime-config-dir");
+    fs::create_dir_all(&custom_parent).expect("custom parent should be created");
+    fs::set_permissions(&custom_parent, Permissions::from_mode(0o755))
+        .expect("custom parent should be non-private");
+
+    let store = RuntimeConfigStore::from_path(custom_parent.join("runtime-config.json"));
+    store
+        .save(&RuntimeConfig::default())
+        .expect("save should succeed");
+    store.load().expect("load should succeed");
+
+    let parent_mode = fs::metadata(&custom_parent)
+        .expect("parent metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    let file_mode = fs::metadata(store.path())
+        .expect("file metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(parent_mode, 0o755);
+    assert_eq!(file_mode, 0o600);
+
+    let _ = fs::remove_dir_all(root);
+}

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/permissions.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/permissions.rs
@@ -1,14 +1,46 @@
 use super::{unique_temp_path, AppConfigStore, GlobalConfig, RuntimeConfig, RuntimeConfigStore};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
 use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
 #[cfg(unix)]
-fn strict_app_store(name: &str) -> (AppConfigStore, PathBuf) {
-    let root = unique_temp_path(name);
-    let path = root.join("config.json");
+struct TempRootGuard {
+    root: PathBuf,
+}
+
+#[cfg(unix)]
+impl TempRootGuard {
+    fn new(name: &str) -> Self {
+        Self {
+            root: unique_temp_path(name),
+        }
+    }
+
+    fn root(&self) -> &Path {
+        self.root.as_path()
+    }
+}
+
+#[cfg(unix)]
+impl Drop for TempRootGuard {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_dir_all(&self.root) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                panic!(
+                    "failed removing test temp directory {}: {error}",
+                    self.root.display()
+                );
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn strict_app_store(name: &str) -> (AppConfigStore, TempRootGuard) {
+    let root = TempRootGuard::new(name);
+    let path = root.root().join("config.json");
     (
         AppConfigStore {
             path,
@@ -19,9 +51,9 @@ fn strict_app_store(name: &str) -> (AppConfigStore, PathBuf) {
 }
 
 #[cfg(unix)]
-fn strict_runtime_store(name: &str) -> (RuntimeConfigStore, PathBuf) {
-    let root = unique_temp_path(name);
-    let path = root.join("runtime-config.json");
+fn strict_runtime_store(name: &str) -> (RuntimeConfigStore, TempRootGuard) {
+    let root = TempRootGuard::new(name);
+    let path = root.root().join("runtime-config.json");
     (
         RuntimeConfigStore {
             path,
@@ -34,7 +66,7 @@ fn strict_runtime_store(name: &str) -> (RuntimeConfigStore, PathBuf) {
 #[cfg(unix)]
 #[test]
 fn app_save_enforces_private_permissions_for_config_directory_and_file() {
-    let (store, root) = strict_app_store("app-config-permissions-save");
+    let (store, _root) = strict_app_store("app-config-permissions-save");
     store.save(&GlobalConfig::default()).expect("save config");
 
     let parent = store.path().parent().expect("config parent should exist");
@@ -50,14 +82,12 @@ fn app_save_enforces_private_permissions_for_config_directory_and_file() {
         & 0o777;
     assert_eq!(dir_mode, 0o700);
     assert_eq!(file_mode, 0o600);
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(unix)]
 #[test]
 fn app_load_rejects_config_file_mode_that_is_not_0600() {
-    let (store, root) = strict_app_store("app-config-permissions-file-load");
+    let (store, _root) = strict_app_store("app-config-permissions-file-load");
     store.save(&GlobalConfig::default()).expect("save config");
 
     fs::set_permissions(store.path(), Permissions::from_mode(0o400))
@@ -68,14 +98,12 @@ fn app_load_rejects_config_file_mode_that_is_not_0600() {
         .expect_err("load should reject unsupported config file mode");
     assert!(error.to_string().contains("Expected 0600 exactly"));
     assert!(error.to_string().contains("chmod 600"));
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(unix)]
 #[test]
 fn app_load_rejects_config_directory_mode_that_is_not_0700() {
-    let (store, root) = strict_app_store("app-config-permissions-dir-load");
+    let (store, _root) = strict_app_store("app-config-permissions-dir-load");
     store.save(&GlobalConfig::default()).expect("save config");
 
     let parent = store.path().parent().expect("config parent should exist");
@@ -88,14 +116,15 @@ fn app_load_rejects_config_directory_mode_that_is_not_0700() {
     assert!(error.to_string().contains("Expected 0700 exactly"));
     assert!(error.to_string().contains("chmod 700"));
 
-    let _ = fs::remove_dir_all(root);
+    fs::set_permissions(parent, Permissions::from_mode(0o700))
+        .expect("config directory permission should be restorable");
 }
 
 #[cfg(unix)]
 #[test]
 fn app_from_path_does_not_enforce_private_parent_directory_permissions() {
-    let root = unique_temp_path("app-custom-config-parent-permissions");
-    let custom_parent = root.join("shared-config-dir");
+    let root = TempRootGuard::new("app-custom-config-parent-permissions");
+    let custom_parent = root.root().join("shared-config-dir");
     fs::create_dir_all(&custom_parent).expect("custom parent should be created");
     fs::set_permissions(&custom_parent, Permissions::from_mode(0o755))
         .expect("custom parent should be non-private");
@@ -118,14 +147,12 @@ fn app_from_path_does_not_enforce_private_parent_directory_permissions() {
         & 0o777;
     assert_eq!(parent_mode, 0o755);
     assert_eq!(file_mode, 0o600);
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(unix)]
 #[test]
 fn runtime_save_enforces_private_permissions_for_config_directory_and_file() {
-    let (store, root) = strict_runtime_store("runtime-config-permissions-save");
+    let (store, _root) = strict_runtime_store("runtime-config-permissions-save");
     store.save(&RuntimeConfig::default()).expect("save config");
 
     let parent = store.path().parent().expect("config parent should exist");
@@ -141,14 +168,12 @@ fn runtime_save_enforces_private_permissions_for_config_directory_and_file() {
         & 0o777;
     assert_eq!(dir_mode, 0o700);
     assert_eq!(file_mode, 0o600);
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(unix)]
 #[test]
 fn runtime_load_rejects_config_file_mode_that_is_not_0600() {
-    let (store, root) = strict_runtime_store("runtime-config-permissions-file-load");
+    let (store, _root) = strict_runtime_store("runtime-config-permissions-file-load");
     store.save(&RuntimeConfig::default()).expect("save config");
 
     fs::set_permissions(store.path(), Permissions::from_mode(0o400))
@@ -159,14 +184,12 @@ fn runtime_load_rejects_config_file_mode_that_is_not_0600() {
         .expect_err("load should reject unsupported config file mode");
     assert!(error.to_string().contains("Expected 0600 exactly"));
     assert!(error.to_string().contains("chmod 600"));
-
-    let _ = fs::remove_dir_all(root);
 }
 
 #[cfg(unix)]
 #[test]
 fn runtime_load_rejects_config_directory_mode_that_is_not_0700() {
-    let (store, root) = strict_runtime_store("runtime-config-permissions-dir-load");
+    let (store, _root) = strict_runtime_store("runtime-config-permissions-dir-load");
     store.save(&RuntimeConfig::default()).expect("save config");
 
     let parent = store.path().parent().expect("config parent should exist");
@@ -179,14 +202,15 @@ fn runtime_load_rejects_config_directory_mode_that_is_not_0700() {
     assert!(error.to_string().contains("Expected 0700 exactly"));
     assert!(error.to_string().contains("chmod 700"));
 
-    let _ = fs::remove_dir_all(root);
+    fs::set_permissions(parent, Permissions::from_mode(0o700))
+        .expect("config directory permission should be restorable");
 }
 
 #[cfg(unix)]
 #[test]
 fn runtime_from_path_does_not_enforce_private_parent_directory_permissions() {
-    let root = unique_temp_path("runtime-custom-config-parent-permissions");
-    let custom_parent = root.join("shared-runtime-config-dir");
+    let root = TempRootGuard::new("runtime-custom-config-parent-permissions");
+    let custom_parent = root.root().join("shared-runtime-config-dir");
     fs::create_dir_all(&custom_parent).expect("custom parent should be created");
     fs::set_permissions(&custom_parent, Permissions::from_mode(0o755))
         .expect("custom parent should be non-private");
@@ -209,6 +233,4 @@ fn runtime_from_path_does_not_enforce_private_parent_directory_permissions() {
         & 0o777;
     assert_eq!(parent_mode, 0o755);
     assert_eq!(file_mode, 0o600);
-
-    let _ = fs::remove_dir_all(root);
 }


### PR DESCRIPTION
## Summary
This PR hardens local config security for OpenDucktor by enforcing strict Unix permissions and ownership checks for the user config store under `~/.openducktor`, while preserving safe behavior for custom config paths.

## Problem
`~/.openducktor/config.json` was previously written with default OS permissions and loaded without validating ownership/mode safety. On permissive `umask` or shared-user systems, this could allow unintended read/write access.

## Changes
- Enforced secure write permissions for the user config store:
- config directory `~/.openducktor` -> `0700`
- config file `config.json` -> `0600`
- Added load-time ownership and mode validation with actionable remediation errors (`chmod`/`chown`).
- Scoped strict parent-directory enforcement to the default user config path only.
- Preserved `from_path(...)` behavior for custom paths so shared/non-private parents are not force-chmod’d.
- Switched ownership check source to effective UID (`geteuid`) via `libc`.
- Tightened mode validation to exact expected modes:
- directory must be `0700`
- file must be `0600`
- Added/updated tests for:
- strict mode enforcement and rejections
- custom-path behavior
- regression coverage in config store tests

## Files changed
- `apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs`
- `apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs`
- `apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml`
- `apps/desktop/src-tauri/Cargo.lock`

## Validation
Executed from repo root:
- `bun run lint` ✅
- `bun run typecheck` ✅
- `bun run test` ✅

Additional focused Rust validation:
- `cd apps/desktop/src-tauri && cargo test -p host-infra-system config::tests` ✅
- `cd apps/desktop/src-tauri && cargo clippy -p host-infra-system --tests -- -D warnings` ✅

## Security impact
- Addresses local config permission hardening concerns (CWE-732 / OWASP A05 Security Misconfiguration).
- Fails fast with actionable errors when ownership/mode is unsafe.

## Commits
- `f051770d` fix(host-infra-system): harden openducktor config file permissions
- `c16aacb6` fix(host-infra-system): refine config permission enforcement and validation
