### PR TITLE
fix: reject invalid Beads task data coercion

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -34,6 +34,10 @@ use std::ffi::OsString;
 use std::fs;
 use std::io::Write;
 use std::net::{TcpListener, TcpStream};
+#[cfg(unix)]
+use std::fs::Permissions;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -61,6 +65,13 @@ pub(crate) fn make_task(id: &str, issue_type: &str, status: TaskStatus) -> TaskC
         updated_at: "2026-01-01T00:00:00Z".to_string(),
         created_at: "2026-01-01T00:00:00Z".to_string(),
     }
+}
+
+pub(crate) fn write_private_file(path: &Path, contents: &str) -> Result<()> {
+    fs::write(path, contents)?;
+    #[cfg(unix)]
+    fs::set_permissions(path, Permissions::from_mode(0o600))?;
+    Ok(())
 }
 
 #[derive(Debug, Default)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -23,7 +23,8 @@ use crate::app_service::test_support::{
     create_orphanable_opencode, empty_patch, init_git_repo, lock_env, make_emitter, make_session,
     make_task, prepend_path, process_is_alive, remove_env_var, set_env_var, spawn_sleep_process,
     unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
-    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+    wait_for_process_exit, write_executable_script, write_private_file, FakeTaskStore, GitCall,
+    TaskStoreState,
 };
 use crate::app_service::{
     build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
@@ -588,7 +589,7 @@ fn build_start_fails_on_invalid_startup_config_before_worktree_creation() -> Res
         },
     )?;
 
-    fs::write(&config_path, "{ invalid json")?;
+    write_private_file(&config_path, "{ invalid json")?;
 
     let error = service
         .build_start(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -24,7 +24,8 @@ use crate::app_service::test_support::{
     create_orphanable_opencode, empty_patch, init_git_repo, lock_env, make_emitter, make_session,
     make_task, prepend_path, process_is_alive, remove_env_var, set_env_var, spawn_sleep_process,
     unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
-    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+    wait_for_process_exit, write_executable_script, write_private_file, FakeTaskStore, GitCall,
+    TaskStoreState,
 };
 use crate::app_service::{
     build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
@@ -512,7 +513,7 @@ fn opencode_runtime_start_fails_on_invalid_startup_config_before_qa_worktree_set
         },
     )?;
 
-    fs::write(&config_path, "{ invalid json")?;
+    write_private_file(&config_path, "{ invalid json")?;
 
     let error = service
         .opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Qa)
@@ -559,7 +560,7 @@ fn opencode_runtime_start_reuses_existing_runtime_for_same_task_and_role() -> Re
     let first =
         service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)?;
     let config_path = root.join("config.json");
-    fs::write(&config_path, "{ invalid json")?;
+    write_private_file(&config_path, "{ invalid json")?;
     let second =
         service.opencode_runtime_start(repo_path.as_str(), "task-1", AgentRuntimeRole::Spec)?;
     assert_eq!(first.runtime_id, second.runtime_id);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::app_service::test_support::{
-    make_task, unique_temp_path, FakeTaskStore, TaskStoreState,
+    make_task, unique_temp_path, write_private_file, FakeTaskStore, TaskStoreState,
 };
 use crate::app_service::{
     allows_transition, build_opencode_startup_event_payload, can_set_plan,
@@ -442,7 +442,7 @@ fn opencode_startup_readiness_policy_returns_actionable_error_on_invalid_config(
     let root = unique_temp_path("startup-policy-invalid-config");
     let config_path = root.join("runtime-config.json");
     fs::create_dir_all(&root)?;
-    fs::write(&config_path, "{ invalid json")?;
+    write_private_file(&config_path, "{ invalid json")?;
 
     let config_store = AppConfigStore::from_path(root.join("config.json"));
     let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore {
@@ -480,7 +480,7 @@ fn resolve_build_startup_policy_emits_config_failure_metrics() -> Result<()> {
     let root = unique_temp_path("build-startup-policy-invalid-config");
     let config_path = root.join("runtime-config.json");
     fs::create_dir_all(&root)?;
-    fs::write(&config_path, "{ invalid json")?;
+    write_private_file(&config_path, "{ invalid json")?;
 
     let config_store = AppConfigStore::from_path(root.join("config.json"));
     let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore {
@@ -507,7 +507,7 @@ fn resolve_runtime_startup_policy_emits_config_failure_metrics() -> Result<()> {
     let root = unique_temp_path("runtime-startup-policy-invalid-config");
     let config_path = root.join("runtime-config.json");
     fs::create_dir_all(&root)?;
-    fs::write(&config_path, "{ invalid json")?;
+    write_private_file(&config_path, "{ invalid json")?;
 
     let config_store = AppConfigStore::from_path(root.join("config.json"));
     let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
@@ -22,7 +22,8 @@ use metadata::{
 };
 #[cfg(test)]
 use normalize::{
-    default_ai_review_enabled, normalize_issue_type, normalize_labels, normalize_text_option,
+    default_ai_review_enabled, parse_issue_type, parse_task_status, normalize_labels,
+    normalize_text_option,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/normalize.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/normalize.rs
@@ -1,4 +1,9 @@
-use host_domain::IssueType;
+use anyhow::{anyhow, Result};
+use host_domain::{IssueType, TaskStatus};
+
+const VALID_ISSUE_TYPES: &str = "task, feature, bug, epic";
+const VALID_TASK_STATUSES: &str =
+    "open, spec_ready, ready_for_dev, in_progress, blocked, ai_review, human_review, deferred, closed";
 
 pub(crate) fn normalize_labels(labels: Vec<String>) -> Vec<String> {
     let mut normalized: Vec<String> = labels
@@ -22,13 +27,31 @@ pub(crate) fn normalize_text_option(value: Option<String>) -> Option<String> {
     })
 }
 
-pub(crate) fn normalize_issue_type(issue_type: &str) -> IssueType {
-    IssueType::from_cli_value(issue_type).unwrap_or(IssueType::Task)
+pub(crate) fn parse_issue_type(task_id: &str, issue_type: &str) -> Result<IssueType> {
+    IssueType::from_cli_value(issue_type).ok_or_else(|| {
+        anyhow!(
+            "Invalid Beads issue type for task {}: received {:?}. Expected one of: {}.",
+            task_id,
+            issue_type,
+            VALID_ISSUE_TYPES
+        )
+    })
 }
 
-pub(crate) fn default_ai_review_enabled(issue_type: &str) -> bool {
+pub(crate) fn parse_task_status(task_id: &str, status: &str) -> Result<TaskStatus> {
+    TaskStatus::from_cli_value(status).ok_or_else(|| {
+        anyhow!(
+            "Invalid Beads status for task {}: received {:?}. Expected one of: {}.",
+            task_id,
+            status,
+            VALID_TASK_STATUSES
+        )
+    })
+}
+
+pub(crate) fn default_ai_review_enabled(issue_type: &IssueType) -> bool {
     matches!(
-        normalize_issue_type(issue_type),
+        issue_type,
         IssueType::Epic | IssueType::Feature | IssueType::Task | IssueType::Bug
     )
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/parsing.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/parsing.rs
@@ -1,11 +1,13 @@
-use anyhow::{anyhow, Result};
-use host_domain::{AgentWorkflows, TaskCard, TaskStatus};
+use anyhow::Result;
+use host_domain::{AgentWorkflows, TaskCard};
 
 use crate::metadata::{
     metadata_bool_qa_required, metadata_document_summary, metadata_namespace, parse_metadata_root,
 };
 use crate::model::RawIssue;
-use crate::normalize::{default_ai_review_enabled, normalize_issue_type, normalize_labels};
+use crate::normalize::{
+    default_ai_review_enabled, parse_issue_type, parse_task_status, normalize_labels,
+};
 use crate::store::BeadsTaskStore;
 
 impl BeadsTaskStore {
@@ -14,17 +16,15 @@ impl BeadsTaskStore {
         issue: RawIssue,
         metadata_namespace_key: &str,
     ) -> Result<TaskCard> {
-        let status = TaskStatus::from_cli_value(&issue.status)
-            .ok_or_else(|| anyhow!("Unknown task status from bd: {}", issue.status))?;
+        let issue_type = parse_issue_type(&issue.id, &issue.issue_type)?;
+        let status = parse_task_status(&issue.id, &issue.status)?;
 
         let metadata_root = parse_metadata_root(issue.metadata);
         let namespace = metadata_namespace(&metadata_root, metadata_namespace_key);
         let ai_review_enabled = namespace
             .and_then(metadata_bool_qa_required)
-            .unwrap_or_else(|| default_ai_review_enabled(&issue.issue_type));
+            .unwrap_or_else(|| default_ai_review_enabled(&issue_type));
         let document_summary = metadata_document_summary(namespace);
-
-        let normalized_issue_type = normalize_issue_type(&issue.issue_type);
 
         let parent_id = issue.parent.or_else(|| {
             issue.dependencies.iter().find_map(|dependency| {
@@ -46,7 +46,7 @@ impl BeadsTaskStore {
             notes: issue.notes,
             status,
             priority: issue.priority,
-            issue_type: normalized_issue_type,
+            issue_type,
             ai_review_enabled,
             available_actions: Vec::new(),
             labels: normalize_labels(issue.labels),

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1,8 +1,8 @@
 use super::{
-    default_ai_review_enabled, metadata_bool_qa_required, metadata_namespace, normalize_issue_type,
-    normalize_labels, normalize_text_option, parse_agent_sessions, parse_markdown_entries,
-    parse_metadata_root, parse_qa_entries, BeadsTaskStore, CommandRunner, ProcessCommandRunner,
-    CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS,
+    default_ai_review_enabled, metadata_bool_qa_required, metadata_namespace, normalize_labels,
+    normalize_text_option, parse_agent_sessions, parse_issue_type, parse_markdown_entries,
+    parse_metadata_root, parse_qa_entries, parse_task_status, BeadsTaskStore, CommandRunner,
+    ProcessCommandRunner, CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS,
 };
 use anyhow::{anyhow, Result};
 use host_domain::{
@@ -377,11 +377,71 @@ fn show_task_uses_id_flag_when_loading_issue() -> Result<()> {
 }
 
 #[test]
-fn issue_type_and_ai_review_defaults_are_normalized() {
-    assert_eq!(normalize_issue_type("feature"), IssueType::Feature);
-    assert_eq!(normalize_issue_type("unknown-type"), IssueType::Task);
-    assert!(default_ai_review_enabled("epic"));
-    assert!(default_ai_review_enabled("unknown-type"));
+fn strict_issue_type_and_status_parsers_return_actionable_errors() {
+    assert_eq!(
+        parse_issue_type("task-1", "feature").expect("feature should parse"),
+        IssueType::Feature
+    );
+    assert_eq!(
+        parse_task_status("task-1", "blocked").expect("blocked should parse"),
+        TaskStatus::Blocked
+    );
+    assert!(default_ai_review_enabled(&IssueType::Epic));
+    assert!(default_ai_review_enabled(&IssueType::Bug));
+
+    let issue_type_error = parse_issue_type("task-1", "unknown-type")
+        .expect_err("unknown issue type should fail")
+        .to_string();
+    assert!(issue_type_error.contains("task-1"));
+    assert!(issue_type_error.contains("issue type"));
+    assert!(issue_type_error.contains("unknown-type"));
+
+    let status_error = parse_task_status("task-1", "backlog")
+        .expect_err("unknown status should fail")
+        .to_string();
+    assert!(status_error.contains("task-1"));
+    assert!(status_error.contains("status"));
+    assert!(status_error.contains("backlog"));
+}
+
+#[test]
+fn show_task_rejects_invalid_issue_type_with_task_context() {
+    let repo = RepoFixture::new("show-invalid-issue-type");
+    let issue = issue_value("task-bad-type", "open", "decision", None, json!([]), None);
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([issue]).to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let error = store
+        .show_task(repo.path(), "task-bad-type")
+        .expect_err("invalid issue type should fail");
+    let message = error.to_string();
+    assert!(message.contains("task-bad-type"));
+    assert!(message.contains("issue type"));
+    assert!(message.contains("decision"));
+}
+
+#[test]
+fn list_tasks_rejects_invalid_status_with_task_context() {
+    let repo = RepoFixture::new("list-invalid-status");
+    let payload = json!([issue_value(
+        "task-bad-status",
+        "backlog",
+        "task",
+        None,
+        json!([]),
+        None
+    )]);
+    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(payload.to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let error = store
+        .list_tasks(repo.path())
+        .expect_err("invalid status should fail");
+    let message = error.to_string();
+    assert!(message.contains("task-bad-status"));
+    assert!(message.contains("status"));
+    assert!(message.contains("backlog"));
 }
 
 #[test]

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -54,20 +54,20 @@ describe("runtime schemas", () => {
     });
   });
 
-  test("task card coerces unsupported issue types to task", () => {
-    const parsed = taskCardSchema.parse({
-      id: "task-2",
-      title: "Legacy type",
-      description: "",
-      status: "open",
-      priority: 2,
-      issueType: "decision",
-      labels: [],
-      updatedAt: "2026-01-01T00:00:00.000Z",
-      createdAt: "2026-01-01T00:00:00.000Z",
-    });
-
-    expect(parsed.issueType).toBe("task");
+  test("task card rejects unsupported issue types", () => {
+    expect(() =>
+      taskCardSchema.parse({
+        id: "task-2",
+        title: "Legacy type",
+        description: "",
+        status: "open",
+        priority: 2,
+        issueType: "decision",
+        labels: [],
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ).toThrow();
   });
 
   test("task card parses document summary flags and updated timestamps", () => {

--- a/packages/contracts/src/task-schemas.ts
+++ b/packages/contracts/src/task-schemas.ts
@@ -29,12 +29,6 @@ export const taskActionSchema = z.enum([
 ]);
 export type TaskAction = z.infer<typeof taskActionSchema>;
 
-const issueTypeFallbackSchema = z.preprocess(
-  (value) =>
-    value === "task" || value === "feature" || value === "bug" || value === "epic" ? value : "task",
-  issueTypeSchema,
-);
-
 export const taskPrioritySchema = z.number().int().min(0).max(4);
 export type TaskPriority = z.infer<typeof taskPrioritySchema>;
 
@@ -146,7 +140,7 @@ export const taskCardSchema = z.object({
   notes: z.string().optional().default(""),
   status: taskStatusSchema,
   priority: taskPrioritySchema.default(2),
-  issueType: issueTypeFallbackSchema.default("task"),
+  issueType: issueTypeSchema,
   aiReviewEnabled: z.boolean().optional().default(true),
   availableActions: z.array(taskActionSchema).default([]),
   labels: z.array(z.string()).default([]),

--- a/packages/openducktor-mcp/src/bd-persistence.test.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.test.ts
@@ -220,6 +220,53 @@ describe("BdPersistence", () => {
     );
   });
 
+  test("listTasks ignores non-task Beads issue types before strict parsing", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => [
+          {
+            id: "task-4",
+            title: "Task 4",
+            status: "open",
+            issue_type: "task",
+            metadata: {},
+          },
+          {
+            id: "event-1",
+            title: "Calendar event",
+            status: "open",
+            issue_type: "event",
+            metadata: {},
+          },
+          {
+            id: "gate-1",
+            title: "Review gate",
+            status: "open",
+            issue_type: "gate",
+            metadata: {},
+          },
+        ],
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+
+    await expect(persistence.listTasks()).resolves.toEqual([
+      {
+        id: "task-4",
+        title: "Task 4",
+        status: "open",
+        issueType: "task",
+        aiReviewEnabled: true,
+      },
+    ]);
+  });
+
   test("writeNamespace updates metadata under namespace key", async () => {
     const state: FakeClientState = {
       calls: [],

--- a/packages/openducktor-mcp/src/bd-persistence.test.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.test.ts
@@ -193,6 +193,33 @@ describe("BdPersistence", () => {
     );
   });
 
+  test("listTasks surfaces invalid Beads issue types instead of coercing them", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => [
+          {
+            id: "task-3",
+            title: "Broken issue type",
+            status: "open",
+            issue_type: "decision",
+            metadata: {},
+          },
+        ],
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+
+    await expect(persistence.listTasks()).rejects.toThrow(
+      'Invalid Beads issue type for task task-3: received "decision".',
+    );
+  });
+
   test("writeNamespace updates metadata under namespace key", async () => {
     const state: FakeClientState = {
       calls: [],

--- a/packages/openducktor-mcp/src/bd-persistence.test.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.test.ts
@@ -166,6 +166,33 @@ describe("BdPersistence", () => {
     await expect(persistence.listTasks()).rejects.toThrow("bd list did not return an array");
   });
 
+  test("listTasks surfaces invalid Beads task status instead of coercing it", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => [
+          {
+            id: "task-2",
+            title: "Broken status",
+            status: { raw: "open" },
+            issue_type: "task",
+            metadata: {},
+          },
+        ],
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+
+    await expect(persistence.listTasks()).rejects.toThrow(
+      'Invalid Beads status for task task-2: received {"raw":"open"}.',
+    );
+  });
+
   test("writeNamespace updates metadata under namespace key", async () => {
     const state: FakeClientState = {
       calls: [],

--- a/packages/openducktor-mcp/src/bd-persistence.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.ts
@@ -1,4 +1,5 @@
 import type { BdRuntimeClient } from "./bd-runtime-client";
+import { isNonTaskBeadsIssueType } from "./beads-task-parsing";
 import type { JsonObject, RawIssue, TaskCard } from "./contracts";
 import { getNamespaceData, type NamespaceData } from "./metadata-docs";
 import { issueToTaskCard } from "./task-mapping";
@@ -52,6 +53,7 @@ export class BdPersistence implements TaskPersistencePort {
 
     return payload
       .filter((entry) => entry && typeof entry === "object")
+      .filter((entry) => !isNonTaskBeadsIssueType((entry as RawIssue).issue_type))
       .map((entry) => issueToTaskCard(entry as RawIssue, this.metadataNamespace));
   }
 

--- a/packages/openducktor-mcp/src/beads-task-parsing.ts
+++ b/packages/openducktor-mcp/src/beads-task-parsing.ts
@@ -1,0 +1,48 @@
+import { issueTypeSchema, taskStatusSchema } from "@openducktor/contracts";
+import type { IssueType, TaskStatus } from "./contracts";
+
+const TASK_STATUS_SET = new Set<string>(taskStatusSchema.options);
+const TASK_STATUS_VALUES = taskStatusSchema.options.join(", ");
+const ISSUE_TYPE_VALUES = issueTypeSchema.options.join(", ");
+const NON_TASK_BEADS_ISSUE_TYPES = new Set(["event", "gate"]);
+
+const describeInvalidValue = (value: unknown): string => {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+
+  const serialized = JSON.stringify(value);
+  if (typeof serialized === "string") {
+    return serialized;
+  }
+
+  return String(value);
+};
+
+export const isNonTaskBeadsIssueType = (value: unknown): boolean => {
+  return typeof value === "string" && NON_TASK_BEADS_ISSUE_TYPES.has(value);
+};
+
+export const parseBeadsIssueType = (taskId: string, value: unknown): IssueType => {
+  const parsed = issueTypeSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid Beads issue type for task ${taskId}: received ${describeInvalidValue(value)}. ` +
+        `Expected one of: ${ISSUE_TYPE_VALUES}.`,
+    );
+  }
+
+  return parsed.data;
+};
+
+export const parseBeadsTaskStatus = (taskId: string, value: unknown): TaskStatus => {
+  const parsed = taskStatusSchema.safeParse(value);
+  if (!parsed.success || !TASK_STATUS_SET.has(parsed.data)) {
+    throw new Error(
+      `Invalid Beads status for task ${taskId}: received ${describeInvalidValue(value)}. ` +
+        `Expected one of: ${TASK_STATUS_VALUES}.`,
+    );
+  }
+
+  return parsed.data;
+};

--- a/packages/openducktor-mcp/src/contracts.ts
+++ b/packages/openducktor-mcp/src/contracts.ts
@@ -19,8 +19,8 @@ export type TaskCard = Pick<
 export type RawIssue = {
   id: string;
   title: string;
-  status: string;
-  issue_type?: string;
+  status: unknown;
+  issue_type?: unknown;
   parent?: string | null;
   dependencies?: Array<{
     type?: string;

--- a/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
@@ -73,4 +73,110 @@ describe("OdtTaskStore composition", () => {
     expect(result.task.aiReviewEnabled).toBe(false);
     expect(result.documents.spec.markdown).toBe("spec");
   });
+
+  test("readTask surfaces invalid Beads issue types from showRawIssue", async () => {
+    const issue: RawIssue = {
+      id: "task-1",
+      title: "Task 1",
+      status: "open",
+      issue_type: "decision",
+      metadata: {},
+    };
+
+    const persistence: TaskPersistencePort = {
+      metadataNamespace: "openducktor",
+      ensureInitialized: async () => {},
+      runBdJson: async () => {
+        throw new Error("runBdJson should not be called by readTask");
+      },
+      listTasks: async () => [makeTask()],
+      showRawIssue: async () => issue,
+      getNamespaceData: () => {
+        throw new Error("getNamespaceData should not be called by readTask");
+      },
+      writeNamespace: async () => {
+        throw new Error("writeNamespace should not be called by readTask");
+      },
+    };
+
+    const documentStore: TaskDocumentPort = {
+      parseDocs: () => ({
+        spec: { markdown: "", updatedAt: null },
+        implementationPlan: { markdown: "", updatedAt: null },
+        latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+      }),
+      persistSpec: async () => ({ updatedAt: "", revision: 1 }),
+      persistImplementationPlan: async () => ({ updatedAt: "", revision: 1 }),
+      appendQaReport: async () => {},
+    };
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      {
+        persistence,
+        documentStore,
+      },
+    );
+
+    await expect(store.readTask({ taskId: "task-1" })).rejects.toThrow(
+      'Invalid Beads issue type for task task-1: received "decision".',
+    );
+  });
+
+  test("readTask surfaces invalid Beads statuses from showRawIssue", async () => {
+    const issue: RawIssue = {
+      id: "task-1",
+      title: "Task 1",
+      status: null,
+      issue_type: "feature",
+      metadata: {},
+    };
+
+    const persistence: TaskPersistencePort = {
+      metadataNamespace: "openducktor",
+      ensureInitialized: async () => {},
+      runBdJson: async () => {
+        throw new Error("runBdJson should not be called by readTask");
+      },
+      listTasks: async () => [makeTask()],
+      showRawIssue: async () => issue,
+      getNamespaceData: () => {
+        throw new Error("getNamespaceData should not be called by readTask");
+      },
+      writeNamespace: async () => {
+        throw new Error("writeNamespace should not be called by readTask");
+      },
+    };
+
+    const documentStore: TaskDocumentPort = {
+      parseDocs: () => ({
+        spec: { markdown: "", updatedAt: null },
+        implementationPlan: { markdown: "", updatedAt: null },
+        latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+      }),
+      persistSpec: async () => ({ updatedAt: "", revision: 1 }),
+      persistImplementationPlan: async () => ({ updatedAt: "", revision: 1 }),
+      appendQaReport: async () => {},
+    };
+
+    const store = new OdtTaskStore(
+      {
+        repoPath: "/repo",
+        metadataNamespace: "openducktor",
+        beadsDir: "/beads",
+      },
+      {
+        persistence,
+        documentStore,
+      },
+    );
+
+    await expect(store.readTask({ taskId: "task-1" })).rejects.toThrow(
+      "Invalid Beads status for task task-1: received null.",
+    );
+  });
 });

--- a/packages/openducktor-mcp/src/plan-subtasks.ts
+++ b/packages/openducktor-mcp/src/plan-subtasks.ts
@@ -1,5 +1,5 @@
+import { issueTypeSchema } from "@openducktor/contracts";
 import type { PlanSubtaskInput } from "./contracts";
-import { normalizeIssueType } from "./task-mapping";
 
 export const normalizePlanSubtasks = (inputs: PlanSubtaskInput[]): PlanSubtaskInput[] => {
   const normalized: PlanSubtaskInput[] = [];
@@ -10,7 +10,7 @@ export const normalizePlanSubtasks = (inputs: PlanSubtaskInput[]): PlanSubtaskIn
       throw new Error("Subtask proposals require a non-empty title.");
     }
 
-    const issueType = normalizeIssueType(input.issueType);
+    const issueType = issueTypeSchema.parse(input.issueType ?? "task");
     if (issueType === "epic") {
       throw new Error("Epic subtasks are not allowed.");
     }

--- a/packages/openducktor-mcp/src/task-mapping.test.ts
+++ b/packages/openducktor-mcp/src/task-mapping.test.ts
@@ -1,7 +1,34 @@
 import { describe, expect, test } from "bun:test";
-import { parseMarkdownEntries, parseQaEntries } from "./task-mapping";
+import type { RawIssue } from "./contracts";
+import { issueToTaskCard, parseMarkdownEntries, parseQaEntries } from "./task-mapping";
 
 describe("task mapping entry parsers", () => {
+  test("issueToTaskCard rejects invalid Beads issue types with task context", () => {
+    const issue: RawIssue = {
+      id: "task-42",
+      title: "Broken issue type",
+      status: "open",
+      issue_type: "decision",
+    };
+
+    expect(() => issueToTaskCard(issue, "openducktor")).toThrow(
+      'Invalid Beads issue type for task task-42: received "decision".',
+    );
+  });
+
+  test("issueToTaskCard rejects invalid Beads statuses with task context", () => {
+    const issue: RawIssue = {
+      id: "task-99",
+      title: "Broken status",
+      status: 42,
+      issue_type: "task",
+    };
+
+    expect(() => issueToTaskCard(issue, "openducktor")).toThrow(
+      "Invalid Beads status for task task-99: received 42.",
+    );
+  });
+
   test("parseMarkdownEntries returns only valid markdown metadata entries", () => {
     const parsed = parseMarkdownEntries([
       {

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -8,7 +8,7 @@ import type {
   RawIssue,
   TaskCard,
 } from "./contracts";
-import { toTaskStatus } from "./workflow-policy";
+import { parseBeadsTaskStatus } from "./workflow-policy";
 
 const ISSUE_TYPE_VALUES = issueTypeSchema.options.join(", ");
 
@@ -25,7 +25,7 @@ const describeInvalidValue = (value: unknown): string => {
   return String(value);
 };
 
-export const normalizeIssueType = (taskId: string, value: unknown): IssueType => {
+const parseBeadsIssueType = (taskId: string, value: unknown): IssueType => {
   const parsed = issueTypeSchema.safeParse(value);
   if (!parsed.success) {
     throw new Error(
@@ -125,7 +125,7 @@ const normalizeParentId = (issue: RawIssue): string | undefined => {
 };
 
 export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): TaskCard => {
-  const issueType = normalizeIssueType(issue.id, issue.issue_type);
+  const issueType = parseBeadsIssueType(issue.id, issue.issue_type);
   const root = parseMetadataRoot(issue.metadata);
   const namespace = ensureObject(root[metadataNamespace]);
   const qaRequired =
@@ -138,7 +138,7 @@ export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): Tas
   return {
     id: issue.id,
     title: issue.title,
-    status: toTaskStatus(issue.id, issue.status),
+    status: parseBeadsTaskStatus(issue.id, issue.status),
     issueType,
     aiReviewEnabled: qaRequired,
     ...(parentId ? { parentId } : {}),

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -1,43 +1,8 @@
-import { issueTypeSchema } from "@openducktor/contracts";
 import { z } from "zod";
-import type {
-  IssueType,
-  JsonObject,
-  MarkdownEntry,
-  QaEntry,
-  RawIssue,
-  TaskCard,
-} from "./contracts";
-import { parseBeadsTaskStatus } from "./workflow-policy";
+import { parseBeadsIssueType, parseBeadsTaskStatus } from "./beads-task-parsing";
+import type { JsonObject, MarkdownEntry, QaEntry, RawIssue, TaskCard } from "./contracts";
 
-const ISSUE_TYPE_VALUES = issueTypeSchema.options.join(", ");
-
-const describeInvalidValue = (value: unknown): string => {
-  if (typeof value === "string") {
-    return JSON.stringify(value);
-  }
-
-  const serialized = JSON.stringify(value);
-  if (typeof serialized === "string") {
-    return serialized;
-  }
-
-  return String(value);
-};
-
-const parseBeadsIssueType = (taskId: string, value: unknown): IssueType => {
-  const parsed = issueTypeSchema.safeParse(value);
-  if (!parsed.success) {
-    throw new Error(
-      `Invalid Beads issue type for task ${taskId}: received ${describeInvalidValue(value)}. ` +
-        `Expected one of: ${ISSUE_TYPE_VALUES}.`,
-    );
-  }
-
-  return parsed.data;
-};
-
-const defaultQaRequiredForIssueType = (_issueType: IssueType): boolean => true;
+const defaultQaRequiredForIssueType = (): boolean => true;
 
 export const parseMetadataRoot = (metadata: unknown): JsonObject => {
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
@@ -131,7 +96,7 @@ export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): Tas
   const qaRequired =
     typeof namespace.qaRequired === "boolean"
       ? namespace.qaRequired
-      : defaultQaRequiredForIssueType(issueType);
+      : defaultQaRequiredForIssueType();
 
   const parentId = normalizeParentId(issue);
 

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -1,3 +1,4 @@
+import { issueTypeSchema } from "@openducktor/contracts";
 import { z } from "zod";
 import type {
   IssueType,
@@ -9,11 +10,31 @@ import type {
 } from "./contracts";
 import { toTaskStatus } from "./workflow-policy";
 
-export const normalizeIssueType = (value: unknown): IssueType => {
-  if (value === "epic" || value === "feature" || value === "bug") {
-    return value;
+const ISSUE_TYPE_VALUES = issueTypeSchema.options.join(", ");
+
+const describeInvalidValue = (value: unknown): string => {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
   }
-  return "task";
+
+  const serialized = JSON.stringify(value);
+  if (typeof serialized === "string") {
+    return serialized;
+  }
+
+  return String(value);
+};
+
+export const normalizeIssueType = (taskId: string, value: unknown): IssueType => {
+  const parsed = issueTypeSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid Beads issue type for task ${taskId}: received ${describeInvalidValue(value)}. ` +
+        `Expected one of: ${ISSUE_TYPE_VALUES}.`,
+    );
+  }
+
+  return parsed.data;
 };
 
 const defaultQaRequiredForIssueType = (_issueType: IssueType): boolean => true;
@@ -104,20 +125,21 @@ const normalizeParentId = (issue: RawIssue): string | undefined => {
 };
 
 export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): TaskCard => {
+  const issueType = normalizeIssueType(issue.id, issue.issue_type);
   const root = parseMetadataRoot(issue.metadata);
   const namespace = ensureObject(root[metadataNamespace]);
   const qaRequired =
     typeof namespace.qaRequired === "boolean"
       ? namespace.qaRequired
-      : defaultQaRequiredForIssueType(normalizeIssueType(issue.issue_type));
+      : defaultQaRequiredForIssueType(issueType);
 
   const parentId = normalizeParentId(issue);
 
   return {
     id: issue.id,
     title: issue.title,
-    status: toTaskStatus(issue.status),
-    issueType: normalizeIssueType(issue.issue_type),
+    status: toTaskStatus(issue.id, issue.status),
+    issueType,
     aiReviewEnabled: qaRequired,
     ...(parentId ? { parentId } : {}),
   };

--- a/packages/openducktor-mcp/src/workflow-policy.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.ts
@@ -19,7 +19,7 @@ const describeInvalidValue = (value: unknown): string => {
   return String(value);
 };
 
-export const toTaskStatus = (taskId: string, value: unknown): TaskStatus => {
+export const parseBeadsTaskStatus = (taskId: string, value: unknown): TaskStatus => {
   if (typeof value !== "string" || !isTaskStatus(value)) {
     throw new Error(
       `Invalid Beads status for task ${taskId}: received ${describeInvalidValue(value)}. ` +

--- a/packages/openducktor-mcp/src/workflow-policy.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.ts
@@ -2,14 +2,32 @@ import { taskStatusSchema } from "@openducktor/contracts";
 import type { IssueType, PlanSubtaskInput, TaskCard, TaskStatus } from "./contracts";
 
 const TASK_STATUS_SET = new Set<string>(taskStatusSchema.options);
+const TASK_STATUS_VALUES = taskStatusSchema.options.join(", ");
 
 const isTaskStatus = (value: string): value is TaskStatus => TASK_STATUS_SET.has(value);
 
-export const toTaskStatus = (value: unknown): TaskStatus => {
-  if (typeof value !== "string") {
-    return "open";
+const describeInvalidValue = (value: unknown): string => {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
   }
-  return isTaskStatus(value) ? value : "open";
+
+  const serialized = JSON.stringify(value);
+  if (typeof serialized === "string") {
+    return serialized;
+  }
+
+  return String(value);
+};
+
+export const toTaskStatus = (taskId: string, value: unknown): TaskStatus => {
+  if (typeof value !== "string" || !isTaskStatus(value)) {
+    throw new Error(
+      `Invalid Beads status for task ${taskId}: received ${describeInvalidValue(value)}. ` +
+        `Expected one of: ${TASK_STATUS_VALUES}.`,
+    );
+  }
+
+  return value;
 };
 
 const canSkipSpecAndPlanning = (task: TaskCard): boolean => {

--- a/packages/openducktor-mcp/src/workflow-policy.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.ts
@@ -1,34 +1,4 @@
-import { taskStatusSchema } from "@openducktor/contracts";
 import type { IssueType, PlanSubtaskInput, TaskCard, TaskStatus } from "./contracts";
-
-const TASK_STATUS_SET = new Set<string>(taskStatusSchema.options);
-const TASK_STATUS_VALUES = taskStatusSchema.options.join(", ");
-
-const isTaskStatus = (value: string): value is TaskStatus => TASK_STATUS_SET.has(value);
-
-const describeInvalidValue = (value: unknown): string => {
-  if (typeof value === "string") {
-    return JSON.stringify(value);
-  }
-
-  const serialized = JSON.stringify(value);
-  if (typeof serialized === "string") {
-    return serialized;
-  }
-
-  return String(value);
-};
-
-export const parseBeadsTaskStatus = (taskId: string, value: unknown): TaskStatus => {
-  if (typeof value !== "string" || !isTaskStatus(value)) {
-    throw new Error(
-      `Invalid Beads status for task ${taskId}: received ${describeInvalidValue(value)}. ` +
-        `Expected one of: ${TASK_STATUS_VALUES}.`,
-    );
-  }
-
-  return value;
-};
 
 const canSkipSpecAndPlanning = (task: TaskCard): boolean => {
   return task.issueType === "task" || task.issueType === "bug";


### PR DESCRIPTION
## Summary
- remove silent Beads issue type/status coercion from the shared task contracts and MCP ingestion path
- make the Rust host-infra-beads adapter reject invalid `issue_type` and `status` with task-scoped actionable errors instead of normalizing them
- add regression coverage for MCP persistence/read paths and the Rust Beads adapter list/show paths

## Testing
- bun run --filter @openducktor/contracts test
- bun run --filter @openducktor/contracts typecheck
- bun run --filter @openducktor/openducktor-mcp test
- bun run --filter @openducktor/openducktor-mcp typecheck
- cargo test -p host-infra-beads
- cargo test -p host-application *(currently fails in `app_service::tests::unit::opencode_startup_readiness_policy_returns_actionable_error_on_invalid_config` due an unrelated temp-file permission-mode assertion, 0644 vs expected 0600)*