### PR TITLE
fix(desktop): harden agent studio git handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
   tauri-rust-quality:
     name: Tauri Rust Quality & Security (audit, clippy, check, test)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     defaults:
       run:

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -506,6 +506,7 @@ fn parse_authorized_worktree_entries(stdout: &str) -> Vec<AuthorizedWorktreeList
 
         if line.starts_with("prunable") {
             current_prunable = true;
+            continue;
         }
     }
 

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -25,6 +25,11 @@ struct AuthorizedWorktreeCacheEntry {
     worktrees: HashSet<PathBuf>,
 }
 
+struct AuthorizedWorktreeListEntry {
+    path: String,
+    prunable: bool,
+}
+
 static AUTHORIZED_WORKTREE_CACHE: OnceLock<Mutex<HashMap<String, AuthorizedWorktreeCacheEntry>>> =
     OnceLock::new();
 static AUTHORIZED_WORKTREE_MISS_LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
@@ -452,16 +457,60 @@ fn list_authorized_worktrees(repo_path: &Path) -> Result<Vec<PathBuf>, String> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed_entries = parse_authorized_worktree_entries(stdout.as_ref());
     let mut worktrees = Vec::new();
-    for path in stdout
-        .lines()
-        .filter_map(|line| line.strip_prefix("worktree "))
-    {
-        let canonicalized = fs::canonicalize(path)
-            .map_err(|e| format!("failed to canonicalize authorized worktree path {path}: {e}"))?;
+    for entry in parsed_entries {
+        if entry.prunable {
+            continue;
+        }
+
+        let canonicalized = fs::canonicalize(entry.path.as_str()).map_err(|e| {
+            format!(
+                "failed to canonicalize authorized worktree path {}: {e}",
+                entry.path
+            )
+        })?;
         worktrees.push(canonicalized);
     }
     Ok(worktrees)
+}
+
+fn parse_authorized_worktree_entries(stdout: &str) -> Vec<AuthorizedWorktreeListEntry> {
+    let mut entries = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current_prunable = false;
+
+    let flush_current = |entries: &mut Vec<AuthorizedWorktreeListEntry>,
+                         current_path: &mut Option<String>,
+                         current_prunable: &mut bool| {
+        if let Some(path) = current_path.take() {
+            entries.push(AuthorizedWorktreeListEntry {
+                path,
+                prunable: *current_prunable,
+            });
+        }
+        *current_prunable = false;
+    };
+
+    for line in stdout.lines() {
+        if line.is_empty() {
+            flush_current(&mut entries, &mut current_path, &mut current_prunable);
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("worktree ") {
+            flush_current(&mut entries, &mut current_path, &mut current_prunable);
+            current_path = Some(path.to_string());
+            continue;
+        }
+
+        if line.starts_with("prunable") {
+            current_prunable = true;
+        }
+    }
+
+    flush_current(&mut entries, &mut current_path, &mut current_prunable);
+    entries
 }
 
 /// Resolve the effective path for a git operation. If `working_dir` is
@@ -2217,6 +2266,60 @@ mod tests {
             .to_string_lossy()
             .to_string();
         assert_eq!(resolved_two, expected_two);
+
+        clear_authorized_worktree_cache_for_repo(&repo);
+        fs::remove_dir_all(&root).expect("failed to remove test directory");
+    }
+
+    #[test]
+    fn resolve_working_dir_ignores_prunable_worktree_entries() {
+        let root = unique_test_dir("git-worktree-prunable");
+        let repo = root.join("repo");
+        let removed_worktree = root.join("repo-wt-removed");
+        let active_worktree = root.join("repo-wt-active");
+        init_repo(&repo);
+        clear_authorized_worktree_cache_for_repo(&repo);
+
+        let repo_str = repo.to_string_lossy().to_string();
+        let removed_worktree_str = removed_worktree.to_string_lossy().to_string();
+        let active_worktree_str = active_worktree.to_string_lossy().to_string();
+
+        run_git(
+            &[
+                "-C",
+                repo_str.as_str(),
+                "worktree",
+                "add",
+                "-b",
+                "feature/prunable-removed",
+                removed_worktree_str.as_str(),
+            ],
+            &repo,
+        );
+        run_git(
+            &[
+                "-C",
+                repo_str.as_str(),
+                "worktree",
+                "add",
+                "-b",
+                "feature/prunable-active",
+                active_worktree_str.as_str(),
+            ],
+            &repo,
+        );
+
+        fs::remove_dir_all(&removed_worktree)
+            .expect("removed worktree directory should be deleted for prunable test");
+
+        let resolved_active =
+            resolve_working_dir(repo_str.as_str(), Some(active_worktree_str.as_str()))
+                .expect("active worktree should resolve even when another entry is prunable");
+        let expected_active = fs::canonicalize(&active_worktree)
+            .expect("active worktree should canonicalize")
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(resolved_active, expected_active);
 
         clear_authorized_worktree_cache_for_repo(&repo);
         fs::remove_dir_all(&root).expect("failed to remove test directory");

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -748,13 +748,14 @@ describe("AgentStudioGitPanel", () => {
     });
   });
 
-  test("renders the generic lock banner when git actions are locked without a conflict strip", async () => {
+  test("hides the generic lock banner when builder locking is tooltip-only", async () => {
     let renderer: TestRenderer.ReactTestRenderer | null = null;
     await act(async () => {
       renderer = TestRenderer.create(
         createElement(AgentStudioGitPanel, {
           model: baseModel({
             isGitActionsLocked: true,
+            showLockReasonBanner: false,
             gitActionsLockReason: "Git actions are disabled while the Builder session is working.",
           }),
         }),
@@ -763,8 +764,33 @@ describe("AgentStudioGitPanel", () => {
     });
 
     const root = getRoot(renderer);
+    expect(countByTestId(root, "agent-studio-git-lock-reason")).toBe(0);
+    expect(hasVisibleText(root, "Builder session is working")).toBe(true);
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+
+  test("renders the generic lock banner when explicitly requested", async () => {
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(AgentStudioGitPanel, {
+          model: baseModel({
+            isGitActionsLocked: true,
+            showLockReasonBanner: true,
+            gitActionsLockReason: "Git actions are temporarily disabled.",
+          }),
+        }),
+      );
+      await flush();
+    });
+
+    const root = getRoot(renderer);
     expect(getNodeText(findByTestId(root, "agent-studio-git-lock-reason"))).toContain(
-      "Builder session is working",
+      "temporarily disabled",
     );
 
     await act(async () => {

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
@@ -304,7 +304,7 @@ describe("agents-page-session-tabs", () => {
     expect(groups[0]?.options[0]?.label).toBe("Spec #2");
     expect(groups[0]?.options[1]?.value).toBe("spec-2");
     expect(groups[0]?.options[1]?.label).toBe("Spec #1");
-    expect(groups[0]?.options[0]?.secondaryLabel).toBe("SPEC");
+    expect(groups[0]?.options[0]?.secondaryLabel).toBeUndefined();
     expect(groups[1]?.label).toBe("Planner");
     expect(groups[1]?.options[0]?.value).toBe("planner-1");
     expect(groups[1]?.options[0]?.label).toBe("Planner #1");

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -244,7 +244,6 @@ export const buildSessionSelectorGroups = (params: {
         return `${baseLabel} #${sessionNumber}`;
       })(),
       description: describeSessionOption(session),
-      secondaryLabel: role.toUpperCase(),
       searchKeywords: [role, session.scenario, session.sessionId],
     }));
     groups.push({

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
@@ -445,6 +445,26 @@ describe("useAgentStudioGitActions", () => {
     }
   });
 
+  test("suppresses the lock banner when git actions are locked only because Builder is working", async () => {
+    const harness = createHookHarness(
+      createBaseArgs({
+        isBuilderSessionWorking: true,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(harness.getLatest().isGitActionsLocked).toBe(true);
+      expect(harness.getLatest().gitActionsLockReason).toBe(
+        "Git actions are disabled while the Builder session is working.",
+      );
+      expect(harness.getLatest().showLockReasonBanner).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("reports clear pull error when branch is unavailable", async () => {
     const harness = createHookHarness(createBaseArgs({ branch: null }));
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
@@ -465,6 +465,19 @@ describe("useAgentStudioGitActions", () => {
     }
   });
 
+  test("does not request a lock banner when git actions are unlocked", async () => {
+    const harness = createHookHarness(createBaseArgs());
+
+    try {
+      await harness.mount();
+
+      expect(harness.getLatest().isGitActionsLocked).toBe(false);
+      expect(harness.getLatest().showLockReasonBanner).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("reports clear pull error when branch is unavailable", async () => {
     const harness = createHookHarness(createBaseArgs({ branch: null }));
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
@@ -627,7 +627,7 @@ export function useAgentStudioGitActions({
     rebaseConflictAction,
     rebaseConflictAutoOpenNonce,
     rebaseConflictCloseNonce,
-    showLockReasonBanner: !isBuilderSessionWorking,
+    showLockReasonBanner: isGitActionsLocked && !isBuilderSessionWorking,
     isGitActionsLocked,
     gitActionsLockReason,
     rebaseConflict: activeRebaseConflict,

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
@@ -36,6 +36,7 @@ export type AgentStudioGitActionState = {
   rebaseConflictAction: AgentStudioRebaseConflictAction;
   rebaseConflictAutoOpenNonce: number;
   rebaseConflictCloseNonce: number;
+  showLockReasonBanner: boolean;
   isGitActionsLocked: boolean;
   gitActionsLockReason: string | null;
   rebaseConflict: AgentStudioRebaseConflict | null;
@@ -626,6 +627,7 @@ export function useAgentStudioGitActions({
     rebaseConflictAction,
     rebaseConflictAutoOpenNonce,
     rebaseConflictCloseNonce,
+    showLockReasonBanner: !isBuilderSessionWorking,
     isGitActionsLocked,
     gitActionsLockReason,
     rebaseConflict: activeRebaseConflict,


### PR DESCRIPTION
## Summary
- ignore prunable git worktree entries when authorizing Builder worktrees so stale sibling worktrees do not break the git panel
- hide the redundant Builder-working git lock banner while keeping the existing disabled actions and tooltips
- remove redundant role labels from grouped session selector rows to avoid overflow in long session titles

## Testing
- cargo fmt --check --manifest-path apps/desktop/src-tauri/Cargo.toml
- cargo test -p openducktor-desktop --manifest-path apps/desktop/src-tauri/Cargo.toml resolve_working_dir_ -- --nocapture
- bun test src/pages/agents/use-agent-studio-git-actions.test.tsx src/components/features/agents/agent-studio-git-panel.test.tsx
- bun test src/pages/agents/agents-page-session-tabs.test.ts
- bun run typecheck