### PR TITLE
ci: optimize rust audit and workspace checks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -41,7 +41,8 @@ rust-lint-tauri = [
   "apps/desktop/src-tauri/Cargo.toml",
   "-p",
   "openducktor-desktop",
-  "--all-targets",
+  "--lib",
+  "--tests",
   "--locked",
   "--",
   "-D",
@@ -53,5 +54,6 @@ rust-test-tauri = [
   "apps/desktop/src-tauri/Cargo.toml",
   "-p",
   "openducktor-desktop",
+  "--lib",
   "--locked",
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,57 @@
+[alias]
+rust-fetch = ["fetch", "--manifest-path", "apps/desktop/src-tauri/Cargo.toml", "--locked"]
+rust-lint-host = [
+  "clippy",
+  "--manifest-path",
+  "apps/desktop/src-tauri/Cargo.toml",
+  "--workspace",
+  "--exclude",
+  "openducktor-desktop",
+  "--all-targets",
+  "--locked",
+  "--",
+  "-D",
+  "warnings",
+]
+rust-test-host-unit = [
+  "test",
+  "--manifest-path",
+  "apps/desktop/src-tauri/Cargo.toml",
+  "--workspace",
+  "--exclude",
+  "openducktor-desktop",
+  "--lib",
+  "--locked",
+  "--",
+  "--skip",
+  "app_service::tests::integration::",
+]
+rust-test-host-integration = [
+  "test",
+  "--manifest-path",
+  "apps/desktop/src-tauri/Cargo.toml",
+  "-p",
+  "host-application",
+  "--locked",
+  "app_service::tests::integration::",
+]
+rust-lint-tauri = [
+  "clippy",
+  "--manifest-path",
+  "apps/desktop/src-tauri/Cargo.toml",
+  "-p",
+  "openducktor-desktop",
+  "--all-targets",
+  "--locked",
+  "--",
+  "-D",
+  "warnings",
+]
+rust-test-tauri = [
+  "test",
+  "--manifest-path",
+  "apps/desktop/src-tauri/Cargo.toml",
+  "-p",
+  "openducktor-desktop",
+  "--locked",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
         run: bun run build
 
   tauri-rust-quality:
-    name: Tauri Rust Quality (clippy, check, test)
-    runs-on: ubuntu-latest
+    name: Rust Workspace Quality
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     defaults:
@@ -84,20 +84,22 @@ jobs:
           workspaces: |
             apps/desktop/src-tauri
 
-      - name: Install Linux dependencies for Tauri
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev librsvg2-dev patchelf
-          sudo apt-get install -y libayatana-appindicator3-dev || sudo apt-get install -y libappindicator3-dev
-
       - name: Pre-fetch Rust dependencies
         run: cargo fetch --locked
 
-      - name: Lint Rust
-        run: cargo clippy --all-targets --locked -- -D warnings
+      - name: Lint host crates
+        run: cargo clippy --workspace --exclude openducktor-desktop --all-targets --locked -- -D warnings
 
-      - name: Build check
-        run: cargo check --locked
+      - name: Run host crate tests
+        run: cargo test --workspace --exclude openducktor-desktop --locked
 
-      - name: Run Rust tests
-        run: cargo test --locked
+      - name: Install Linux dependencies for Tauri
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev librsvg2-dev patchelf libayatana-appindicator3-dev
+
+      - name: Lint Tauri app
+        run: cargo clippy -p openducktor-desktop --all-targets --locked -- -D warnings
+
+      - name: Run Tauri app tests
+        run: cargo test -p openducktor-desktop --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,16 @@ jobs:
       - name: Lint host crates
         run: cargo clippy --workspace --exclude openducktor-desktop --all-targets --locked -- -D warnings
 
-      - name: Run host crate tests
-        run: cargo test --workspace --exclude openducktor-desktop --locked
+      - name: Run host crate unit tests
+        run: "cargo test --workspace --exclude openducktor-desktop --lib --locked -- --skip app_service::tests::integration::"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Run host-application integration tests
+        run: "cargo test -p host-application --locked app_service::tests::integration::"
 
       - name: Install Linux dependencies for Tauri
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,6 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 
-    defaults:
-      run:
-        working-directory: apps/desktop/src-tauri
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -85,13 +81,13 @@ jobs:
             apps/desktop/src-tauri
 
       - name: Pre-fetch Rust dependencies
-        run: cargo fetch --locked
+        run: cargo rust-fetch
 
       - name: Lint host crates
-        run: cargo clippy --workspace --exclude openducktor-desktop --all-targets --locked -- -D warnings
+        run: cargo rust-lint-host
 
       - name: Run host crate unit tests
-        run: "cargo test --workspace --exclude openducktor-desktop --lib --locked -- --skip app_service::tests::integration::"
+        run: cargo rust-test-host-unit
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
@@ -99,7 +95,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Run host-application integration tests
-        run: "cargo test -p host-application --locked app_service::tests::integration::"
+        run: cargo rust-test-host-integration
 
       - name: Install Linux dependencies for Tauri
         run: |
@@ -107,7 +103,7 @@ jobs:
           sudo apt-get install --no-install-recommends -y pkg-config libgtk-3-dev libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-dev libsoup-3.0-dev librsvg2-dev patchelf libayatana-appindicator3-dev
 
       - name: Lint Tauri app
-        run: cargo clippy -p openducktor-desktop --all-targets --locked -- -D warnings
+        run: cargo rust-lint-tauri
 
       - name: Run Tauri app tests
-        run: cargo test -p openducktor-desktop --locked
+        run: cargo rust-test-tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
     name: Rust Workspace Quality
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ concurrency:
 env:
   BUN_VERSION: 1.3.5
   CARGO_TERM_COLOR: always
-  CARGO_AUDIT_VERSION: 0.22.1
 
 jobs:
   bun-quality:
@@ -61,7 +60,7 @@ jobs:
         run: bun run build
 
   tauri-rust-quality:
-    name: Tauri Rust Quality & Security (audit, clippy, check, test)
+    name: Tauri Rust Quality (clippy, check, test)
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -84,12 +83,6 @@ jobs:
         with:
           workspaces: |
             apps/desktop/src-tauri
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --version "$CARGO_AUDIT_VERSION" --locked
-
-      - name: Audit Rust dependencies
-        run: cargo audit
 
       - name: Install Linux dependencies for Tauri
         run: |

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -30,7 +30,7 @@ jobs:
   rust-audit:
     name: Rust Security Audit
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -24,7 +24,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   rust-audit:

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -1,0 +1,43 @@
+name: Rust Security Audit
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/rust-audit.yml
+      - apps/desktop/src-tauri/Cargo.lock
+      - apps/desktop/src-tauri/**/Cargo.toml
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/rust-audit.yml
+      - apps/desktop/src-tauri/Cargo.lock
+      - apps/desktop/src-tauri/**/Cargo.toml
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust-audit:
+    name: Rust Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Audit Rust dependencies
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: apps/desktop/src-tauri

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -19,25 +19,42 @@ on:
 
 permissions:
   contents: read
-  checks: write
-  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
+env:
+  CARGO_AUDIT_VERSION: 0.22.1
+
 jobs:
   rust-audit:
     name: Rust Security Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Audit Rust dependencies
-        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          working-directory: apps/desktop/src-tauri
+          toolchain: stable
+
+      - name: Cache cargo-audit binary
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        id: cargo-audit-cache
+        with:
+          path: |
+            ~/.cargo/bin/cargo-audit
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+          key: cargo-audit-${{ runner.os }}-${{ runner.arch }}-${{ env.CARGO_AUDIT_VERSION }}
+
+      - name: Install cargo-audit
+        if: steps.cargo-audit-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-audit --version $CARGO_AUDIT_VERSION --locked --no-default-features
+
+      - name: Audit Rust dependencies
+        run: cargo audit --file apps/desktop/src-tauri/Cargo.lock

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -5,6 +5,15 @@ description = "OpenDucktor Desktop"
 authors = ["OpenDucktor"]
 edition = "2021"
 
+[workspace]
+members = [
+  "crates/host-application",
+  "crates/host-domain",
+  "crates/host-infra-beads",
+  "crates/host-infra-system",
+]
+resolver = "2"
+
 [lib]
 name = "openducktor_desktop_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -1,7 +1,8 @@
 use super::super::{
     emit_event, spawn_output_forwarder, terminate_child_process, AppService,
     OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, RunEmitter, RunProcess,
-    StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
+    StartupEventContext, StartupEventCorrelation, StartupEventPayload,
+    STARTUP_CONFIG_INVALID_REASON,
 };
 use super::build_runtime_setup::{BuildPrerequisites, PreparedBuildWorktree, SpawnedBuildAgent};
 use super::BuildResponseAction;
@@ -145,19 +146,20 @@ impl AppService {
         run_id: &str,
     ) -> Result<OpencodeStartupReadinessPolicy> {
         self.opencode_startup_readiness_policy()
-            .map_err(|error| {
+            .inspect_err(|_| {
                 self.emit_opencode_startup_event(StartupEventPayload::failed(
-                    "build_runtime",
-                    repo_path,
-                    Some(task_id),
-                    "build",
-                    0,
-                    Some(StartupEventCorrelation::new("run_id", run_id)),
-                    None,
+                    StartupEventContext::new(
+                        "build_runtime",
+                        repo_path,
+                        Some(task_id),
+                        "build",
+                        0,
+                        Some(StartupEventCorrelation::new("run_id", run_id)),
+                        None,
+                    ),
                     OpencodeStartupWaitReport::zero(),
                     STARTUP_CONFIG_INVALID_REASON,
                 ));
-                error
             })
             .with_context(|| {
                 format!(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -1,8 +1,8 @@
 use super::super::{
     run_parsed_hook_command_allow_failure, spawn_opencode_server, terminate_child_process,
     validate_hook_trust, validate_transition, wait_for_local_server_with_process, AppService,
-    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupEventCorrelation,
-    StartupEventPayload, TrackedOpencodeProcessGuard,
+    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupEventContext,
+    StartupEventCorrelation, StartupEventPayload, TrackedOpencodeProcessGuard,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{TaskStatus, TASK_METADATA_NAMESPACE};
@@ -262,25 +262,29 @@ impl AppService {
         startup_policy: OpencodeStartupReadinessPolicy,
     ) {
         self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
-            "build_runtime",
-            repo_path,
-            Some(task_id),
-            "build",
-            port,
-            Some(StartupEventCorrelation::new("run_id", run_id)),
-            Some(startup_policy),
+            StartupEventContext::new(
+                "build_runtime",
+                repo_path,
+                Some(task_id),
+                "build",
+                port,
+                Some(StartupEventCorrelation::new("run_id", run_id)),
+                Some(startup_policy),
+            ),
         ));
     }
 
     fn emit_build_runtime_failed(&self, failure: BuildRuntimeFailureEvent<'_>) {
         self.emit_opencode_startup_event(StartupEventPayload::failed(
-            "build_runtime",
-            failure.repo_path,
-            Some(failure.task_id),
-            "build",
-            failure.port,
-            Some(StartupEventCorrelation::new("run_id", failure.run_id)),
-            Some(failure.startup_policy),
+            StartupEventContext::new(
+                "build_runtime",
+                failure.repo_path,
+                Some(failure.task_id),
+                "build",
+                failure.port,
+                Some(StartupEventCorrelation::new("run_id", failure.run_id)),
+                Some(failure.startup_policy),
+            ),
             failure.startup_report,
             failure.reason,
         ));
@@ -296,13 +300,15 @@ impl AppService {
         startup_report: OpencodeStartupWaitReport,
     ) {
         self.emit_opencode_startup_event(StartupEventPayload::ready(
-            "build_runtime",
-            repo_path,
-            Some(task_id),
-            "build",
-            port,
-            Some(StartupEventCorrelation::new("run_id", run_id)),
-            Some(startup_policy),
+            StartupEventContext::new(
+                "build_runtime",
+                repo_path,
+                Some(task_id),
+                "build",
+                port,
+                Some(StartupEventCorrelation::new("run_id", run_id)),
+                Some(startup_policy),
+            ),
             startup_report,
         ));
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -59,7 +59,8 @@ pub(crate) use startup_metrics::{
     build_opencode_startup_event_payload, OpencodeStartupMetricsSnapshot,
 };
 pub(crate) use startup_metrics::{
-    StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
+    StartupEventContext, StartupEventCorrelation, StartupEventPayload,
+    STARTUP_CONFIG_INVALID_REASON,
 };
 pub(crate) use workflow_rules::{
     can_replace_epic_subtask_status, can_set_plan, can_set_spec_from_status,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
@@ -212,7 +212,7 @@ fn spawn_opencode_server_with_binary(
     config_content: &str,
     port: u16,
 ) -> Result<Child> {
-    let mut command = Command::new(&opencode_binary);
+    let mut command = Command::new(opencode_binary);
     command
         .arg("serve")
         .arg("--hostname")

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/process_registry.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/process_registry.rs
@@ -113,6 +113,7 @@ pub(crate) fn with_locked_opencode_process_registry<T>(
 
     let mut file = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(path)

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/query.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/query.rs
@@ -59,7 +59,7 @@ impl AppService {
                     && runtime.summary.role == lookup.role
                     && lookup
                         .task_id
-                        .map_or(true, |task_id| runtime.summary.task_id == task_id)
+                        .is_none_or(|task_id| runtime.summary.task_id == task_id)
             })
             .map(|runtime| runtime.summary.clone())
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
@@ -1,7 +1,7 @@
 use super::super::{
     spawn_opencode_server, wait_for_local_server_with_process, AppService,
-    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupEventCorrelation,
-    StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
+    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupEventContext,
+    StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
 };
 use super::{RuntimeStartInput, SpawnedRuntimeServer};
 use anyhow::{anyhow, Context, Result};
@@ -20,19 +20,20 @@ impl AppService {
         startup_error_context: &str,
     ) -> Result<OpencodeStartupReadinessPolicy> {
         self.opencode_startup_readiness_policy()
-            .map_err(|error| {
+            .inspect_err(|_| {
                 self.emit_opencode_startup_event(StartupEventPayload::failed(
-                    startup_scope,
-                    repo_path,
-                    Some(task_id),
-                    role.as_str(),
-                    0,
-                    None,
-                    None,
+                    StartupEventContext::new(
+                        startup_scope,
+                        repo_path,
+                        Some(task_id),
+                        role.as_str(),
+                        0,
+                        None,
+                        None,
+                    ),
                     OpencodeStartupWaitReport::zero(),
                     STARTUP_CONFIG_INVALID_REASON,
                 ));
-                error
             })
             .with_context(|| startup_error_context.to_string())
     }
@@ -65,16 +66,18 @@ impl AppService {
         let startup_cancel_epoch = self.startup_cancel_epoch();
         let startup_cancel_snapshot = self.startup_cancel_snapshot();
         self.emit_opencode_startup_event(StartupEventPayload::wait_begin(
-            input.startup_scope,
-            input.repo_path,
-            Some(input.task_id),
-            input.role.as_str(),
-            port,
-            Some(StartupEventCorrelation::new(
-                "runtime_id",
-                runtime_id.as_str(),
-            )),
-            Some(startup_policy),
+            StartupEventContext::new(
+                input.startup_scope,
+                input.repo_path,
+                Some(input.task_id),
+                input.role.as_str(),
+                port,
+                Some(StartupEventCorrelation::new(
+                    "runtime_id",
+                    runtime_id.as_str(),
+                )),
+                Some(startup_policy),
+            ),
         ));
         let startup_report = match wait_for_local_server_with_process(
             &mut child,
@@ -86,16 +89,18 @@ impl AppService {
             Ok(report) => report,
             Err(error) => {
                 self.emit_opencode_startup_event(StartupEventPayload::failed(
-                    input.startup_scope,
-                    input.repo_path,
-                    Some(input.task_id),
-                    input.role.as_str(),
-                    port,
-                    Some(StartupEventCorrelation::new(
-                        "runtime_id",
-                        runtime_id.as_str(),
-                    )),
-                    Some(startup_policy),
+                    StartupEventContext::new(
+                        input.startup_scope,
+                        input.repo_path,
+                        Some(input.task_id),
+                        input.role.as_str(),
+                        port,
+                        Some(StartupEventCorrelation::new(
+                            "runtime_id",
+                            runtime_id.as_str(),
+                        )),
+                        Some(startup_policy),
+                    ),
                     error.report,
                     error.reason,
                 ));
@@ -109,16 +114,18 @@ impl AppService {
             }
         };
         self.emit_opencode_startup_event(StartupEventPayload::ready(
-            input.startup_scope,
-            input.repo_path,
-            Some(input.task_id),
-            input.role.as_str(),
-            port,
-            Some(StartupEventCorrelation::new(
-                "runtime_id",
-                runtime_id.as_str(),
-            )),
-            Some(startup_policy),
+            StartupEventContext::new(
+                input.startup_scope,
+                input.repo_path,
+                Some(input.task_id),
+                input.role.as_str(),
+                port,
+                Some(StartupEventCorrelation::new(
+                    "runtime_id",
+                    runtime_id.as_str(),
+                )),
+                Some(startup_policy),
+            ),
             startup_report,
         ));
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/startup_metrics.rs
@@ -73,6 +73,39 @@ impl<'a> StartupEventCorrelation<'a> {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub(crate) struct StartupEventContext<'a> {
+    runtime_type: &'a str,
+    repo_path: &'a str,
+    task_id: Option<&'a str>,
+    role: &'a str,
+    port: u16,
+    correlation: Option<StartupEventCorrelation<'a>>,
+    policy: Option<OpencodeStartupReadinessPolicy>,
+}
+
+impl<'a> StartupEventContext<'a> {
+    pub(crate) const fn new(
+        runtime_type: &'a str,
+        repo_path: &'a str,
+        task_id: Option<&'a str>,
+        role: &'a str,
+        port: u16,
+        correlation: Option<StartupEventCorrelation<'a>>,
+        policy: Option<OpencodeStartupReadinessPolicy>,
+    ) -> Self {
+        Self {
+            runtime_type,
+            repo_path,
+            task_id,
+            role,
+            port,
+            correlation,
+            policy,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 enum StartupEventKind {
     WaitBegin,
     Ready(OpencodeStartupWaitReport),
@@ -84,79 +117,35 @@ enum StartupEventKind {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct StartupEventPayload<'a> {
-    runtime_type: &'a str,
-    repo_path: &'a str,
-    task_id: Option<&'a str>,
-    role: &'a str,
-    port: u16,
-    correlation: Option<StartupEventCorrelation<'a>>,
-    policy: Option<OpencodeStartupReadinessPolicy>,
+    context: StartupEventContext<'a>,
     kind: StartupEventKind,
 }
 
 impl<'a> StartupEventPayload<'a> {
-    pub(crate) fn wait_begin(
-        runtime_type: &'a str,
-        repo_path: &'a str,
-        task_id: Option<&'a str>,
-        role: &'a str,
-        port: u16,
-        correlation: Option<StartupEventCorrelation<'a>>,
-        policy: Option<OpencodeStartupReadinessPolicy>,
-    ) -> Self {
+    pub(crate) fn wait_begin(context: StartupEventContext<'a>) -> Self {
         Self {
-            runtime_type,
-            repo_path,
-            task_id,
-            role,
-            port,
-            correlation,
-            policy,
+            context,
             kind: StartupEventKind::WaitBegin,
         }
     }
 
     pub(crate) fn ready(
-        runtime_type: &'a str,
-        repo_path: &'a str,
-        task_id: Option<&'a str>,
-        role: &'a str,
-        port: u16,
-        correlation: Option<StartupEventCorrelation<'a>>,
-        policy: Option<OpencodeStartupReadinessPolicy>,
+        context: StartupEventContext<'a>,
         report: OpencodeStartupWaitReport,
     ) -> Self {
         Self {
-            runtime_type,
-            repo_path,
-            task_id,
-            role,
-            port,
-            correlation,
-            policy,
+            context,
             kind: StartupEventKind::Ready(report),
         }
     }
 
     pub(crate) fn failed(
-        runtime_type: &'a str,
-        repo_path: &'a str,
-        task_id: Option<&'a str>,
-        role: &'a str,
-        port: u16,
-        correlation: Option<StartupEventCorrelation<'a>>,
-        policy: Option<OpencodeStartupReadinessPolicy>,
+        context: StartupEventContext<'a>,
         report: OpencodeStartupWaitReport,
         failure_reason: &'static str,
     ) -> Self {
         Self {
-            runtime_type,
-            repo_path,
-            task_id,
-            role,
-            port,
-            correlation,
-            policy,
+            context,
             kind: StartupEventKind::Failed {
                 report,
                 failure_reason,
@@ -188,12 +177,14 @@ impl<'a> StartupEventPayload<'a> {
     }
 
     fn correlation_parts(&self) -> (Option<&'a str>, Option<&'a str>) {
-        self.correlation.map_or((None, None), |correlation| {
-            (
-                Some(correlation.correlation_type),
-                Some(correlation.correlation_id),
-            )
-        })
+        self.context
+            .correlation
+            .map_or((None, None), |correlation| {
+                (
+                    Some(correlation.correlation_type),
+                    Some(correlation.correlation_id),
+                )
+            })
     }
 }
 
@@ -350,39 +341,36 @@ impl Default for OpencodeStartupMetrics {
 }
 
 pub(crate) fn build_opencode_startup_event_payload(
-    event: &str,
-    scope: &str,
-    repo_path: &str,
-    task_id: Option<&str>,
-    role: &str,
-    port: u16,
-    correlation_type: Option<&str>,
-    correlation_id: Option<&str>,
-    policy: Option<OpencodeStartupReadinessPolicy>,
-    report: Option<OpencodeStartupWaitReport>,
-    reason: Option<&str>,
+    event: &StartupEventPayload<'_>,
     metrics: Option<OpencodeStartupMetricsSnapshot>,
     alerts: Vec<String>,
 ) -> OpencodeStartupEventPayload {
-    let policy_payload = policy.map(|entry| OpencodeStartupPolicyPayload {
-        timeout_ms: entry.timeout_ms(),
-        connect_timeout_ms: entry.connect_timeout_ms(),
-        initial_retry_delay_ms: entry.initial_retry_delay_ms(),
-        max_retry_delay_ms: entry.max_retry_delay_ms(),
-        child_check_interval_ms: entry.child_state_check_interval_ms(),
-    });
+    let event_name = event.event_name();
+    let report = event.report();
+    let reason = event.failure_reason();
+    let (correlation_type, correlation_id) = event.correlation_parts();
+    let policy_payload = event
+        .context
+        .policy
+        .map(|entry| OpencodeStartupPolicyPayload {
+            timeout_ms: entry.timeout_ms(),
+            connect_timeout_ms: entry.connect_timeout_ms(),
+            initial_retry_delay_ms: entry.initial_retry_delay_ms(),
+            max_retry_delay_ms: entry.max_retry_delay_ms(),
+            child_check_interval_ms: entry.child_state_check_interval_ms(),
+        });
     let report_payload = report.map(|entry| OpencodeStartupReportPayload {
         startup_ms: entry.startup_ms(),
         attempts: entry.attempts(),
     });
 
     OpencodeStartupEventPayload {
-        event: event.to_string(),
-        scope: scope.to_string(),
-        repo_path: repo_path.to_string(),
-        task_id: task_id.map(str::to_string),
-        role: role.to_string(),
-        port,
+        event: event_name.to_string(),
+        scope: event.context.runtime_type.to_string(),
+        repo_path: event.context.repo_path.to_string(),
+        task_id: event.context.task_id.map(str::to_string),
+        role: event.context.role.to_string(),
+        port: event.context.port,
         correlation_type: correlation_type.map(str::to_string),
         correlation_id: correlation_id.map(str::to_string),
         policy: policy_payload,
@@ -427,12 +415,11 @@ impl AppService {
 
     pub(crate) fn emit_opencode_startup_event(&self, event: StartupEventPayload<'_>) {
         let event_name = event.event_name();
-        let runtime_type = event.runtime_type;
-        let repo_path = event.repo_path;
-        let task_id = event.task_id;
-        let role = event.role;
-        let port = event.port;
-        let policy = event.policy;
+        let runtime_type = event.context.runtime_type;
+        let repo_path = event.context.repo_path;
+        let task_id = event.context.task_id;
+        let role = event.context.role;
+        let port = event.context.port;
         let report = event.report();
         let failure_reason = event.failure_reason();
         let (correlation_type, correlation_id) = event.correlation_parts();
@@ -457,17 +444,7 @@ impl AppService {
         };
         let include_metrics = matches!(event_name, "startup_ready" | "startup_failed");
         let payload = build_opencode_startup_event_payload(
-            event_name,
-            runtime_type,
-            repo_path,
-            task_id,
-            role,
-            port,
-            correlation_type,
-            correlation_id,
-            policy,
-            report,
-            failure_reason,
+            &event,
             include_metrics.then_some(metrics),
             alerts.clone(),
         );
@@ -532,7 +509,7 @@ mod tests {
 
     #[test]
     fn startup_event_payload_wait_begin_has_no_terminal_fields() {
-        let event = StartupEventPayload::wait_begin(
+        let event = StartupEventPayload::wait_begin(StartupEventContext::new(
             "agent_runtime",
             "/tmp/repo",
             Some("task-42"),
@@ -540,7 +517,7 @@ mod tests {
             4242,
             Some(StartupEventCorrelation::new("runtime_id", "runtime-abc")),
             Some(test_startup_policy()),
-        );
+        ));
 
         assert_eq!(event.event_name(), "startup_wait_begin");
         assert!(event.report().is_none());
@@ -555,13 +532,15 @@ mod tests {
     fn startup_event_payload_failed_requires_reason_with_report() {
         let report = test_startup_report();
         let event = StartupEventPayload::failed(
-            "agent_runtime",
-            "/tmp/repo",
-            Some("task-42"),
-            "qa",
-            4242,
-            Some(StartupEventCorrelation::new("runtime_id", "runtime-abc")),
-            Some(test_startup_policy()),
+            StartupEventContext::new(
+                "agent_runtime",
+                "/tmp/repo",
+                Some("task-42"),
+                "qa",
+                4242,
+                Some(StartupEventCorrelation::new("runtime_id", "runtime-abc")),
+                Some(test_startup_policy()),
+            ),
             report,
             "timeout",
         );

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -32,10 +32,10 @@ use host_infra_system::{
 use serde_json::Value;
 use std::ffi::OsString;
 use std::fs;
-use std::io::Write;
-use std::net::{TcpListener, TcpStream};
 #[cfg(unix)]
 use std::fs::Permissions;
+use std::io::Write;
+use std::net::{TcpListener, TcpStream};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -307,7 +307,7 @@ fn tracked_guard_drop_refcounts_prevent_pid_reuse_untracking() -> Result<()> {
     );
     let remaining_after_first = read_opencode_process_registry(registry_path.as_path())?;
     assert!(remaining_after_first.iter().any(|instance| {
-        instance.parent_pid == parent_pid && instance.child_pids.iter().any(|pid| *pid == child_pid)
+        instance.parent_pid == parent_pid && instance.child_pids.contains(&child_pid)
     }));
 
     {
@@ -444,8 +444,7 @@ fn startup_reconcile_keeps_non_orphan_registered_opencode_processes() -> Result<
     assert!(process_is_alive(live_pid as i32));
     let remaining = read_opencode_process_registry(registry_path.as_path())?;
     assert!(remaining.iter().any(|instance| {
-        instance.parent_pid == live_parent_pid
-            && instance.child_pids.iter().any(|entry| *entry == live_pid)
+        instance.parent_pid == live_parent_pid && instance.child_pids.contains(&live_pid)
     }));
 
     terminate_child_process(&mut live_parent_process);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -23,7 +23,8 @@ use crate::app_service::{
     validate_parent_relationships_for_create, validate_parent_relationships_for_update,
     validate_plan_subtask_rules, validate_transition, wait_for_local_server,
     wait_for_local_server_with_process, AppService, OpencodeStartupMetricsSnapshot,
-    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
+    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupEventContext,
+    StartupEventCorrelation, StartupEventPayload,
 };
 
 #[test]
@@ -359,10 +360,12 @@ fn test_startup_policy(timeout: Duration) -> OpencodeStartupReadinessPolicy {
 fn opencode_startup_event_payload_contract_includes_correlation_and_metrics() {
     let policy = test_startup_policy(Duration::from_millis(8_000));
     let report = OpencodeStartupWaitReport::from_parts(7, Duration::from_millis(321));
-    let mut metrics = OpencodeStartupMetricsSnapshot::default();
-    metrics.total = 4;
-    metrics.ready = 3;
-    metrics.failed = 1;
+    let mut metrics = OpencodeStartupMetricsSnapshot {
+        total: 4,
+        ready: 3,
+        failed: 1,
+        ..OpencodeStartupMetricsSnapshot::default()
+    };
     metrics.failed_by_reason.insert("timeout".to_string(), 1);
     if let Some(bucket) = metrics.startup_ms_histogram.get_mut("<=500") {
         *bucket = 4;
@@ -371,18 +374,20 @@ fn opencode_startup_event_payload_contract_includes_correlation_and_metrics() {
         *bucket = 4;
     }
 
+    let event = StartupEventPayload::ready(
+        StartupEventContext::new(
+            "agent_runtime",
+            "/tmp/repo",
+            Some("task-42"),
+            "qa",
+            4242,
+            Some(StartupEventCorrelation::new("runtime_id", "runtime-abc")),
+            Some(policy),
+        ),
+        report,
+    );
     let payload = build_opencode_startup_event_payload(
-        "startup_ready",
-        "agent_runtime",
-        "/tmp/repo",
-        Some("task-42"),
-        "qa",
-        4242,
-        Some("runtime_id"),
-        Some("runtime-abc"),
-        Some(policy),
-        Some(report),
-        None,
+        &event,
         Some(metrics),
         vec!["startup_duration_high:321".to_string()],
     );

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
@@ -40,7 +40,7 @@ fn module_normalize_title_key_is_case_insensitive_and_trimmed() {
 fn module_derive_available_actions_exposes_resume_for_deferred_task() {
     let deferred = make_task("task-1", "task", TaskStatus::Deferred);
 
-    let actions = derive_available_actions(&deferred, &[deferred.clone()]);
+    let actions = derive_available_actions(&deferred, std::slice::from_ref(&deferred));
 
     assert!(actions.contains(&TaskAction::ResumeDeferred));
 }

--- a/apps/desktop/src-tauri/crates/host-domain/src/task.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/task.rs
@@ -1,5 +1,6 @@
 use crate::document::{AgentWorkflows, TaskDocumentSummary};
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -34,22 +35,26 @@ impl IssueType {
         }
     }
 
-    pub fn from_str(value: &str) -> Option<Self> {
-        match value {
-            "task" => Some(IssueType::Task),
-            "feature" => Some(IssueType::Feature),
-            "bug" => Some(IssueType::Bug),
-            "epic" => Some(IssueType::Epic),
-            _ => None,
-        }
-    }
-
     pub fn as_cli_value(&self) -> &'static str {
         self.as_str()
     }
 
     pub fn from_cli_value(value: &str) -> Option<Self> {
-        Self::from_str(value)
+        value.parse().ok()
+    }
+}
+
+impl FromStr for IssueType {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "task" => Ok(IssueType::Task),
+            "feature" => Ok(IssueType::Feature),
+            "bug" => Ok(IssueType::Bug),
+            "epic" => Ok(IssueType::Epic),
+            _ => Err(format!("Unsupported issue type: {value}")),
+        }
     }
 }
 
@@ -157,4 +162,25 @@ pub struct UpdateTaskPatch {
     pub labels: Option<Vec<String>>,
     pub assignee: Option<String>,
     pub parent_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IssueType;
+    use std::str::FromStr;
+
+    #[test]
+    fn issue_type_accepts_known_cli_values() {
+        assert_eq!(IssueType::from_cli_value("task"), Some(IssueType::Task));
+        assert_eq!(IssueType::from_str("feature"), Ok(IssueType::Feature));
+    }
+
+    #[test]
+    fn issue_type_rejects_unknown_values() {
+        assert_eq!(IssueType::from_cli_value("unknown"), None);
+        assert_eq!(
+            IssueType::from_str("unknown"),
+            Err("Unsupported issue type: unknown".to_string())
+        );
+    }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs
@@ -22,8 +22,8 @@ use metadata::{
 };
 #[cfg(test)]
 use normalize::{
-    default_ai_review_enabled, parse_issue_type, parse_task_status, normalize_labels,
-    normalize_text_option,
+    default_ai_review_enabled, normalize_labels, normalize_text_option, parse_issue_type,
+    parse_task_status,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata_ops.rs
@@ -5,6 +5,8 @@ use std::path::Path;
 use crate::metadata::parse_metadata_root;
 use crate::store::BeadsTaskStore;
 
+type NamespaceLoadResult = (Map<String, Value>, String, Map<String, Value>);
+
 impl BeadsTaskStore {
     pub(crate) fn write_metadata(
         &self,
@@ -25,7 +27,7 @@ impl BeadsTaskStore {
         &self,
         repo_path: &Path,
         task_id: &str,
-    ) -> Result<(Map<String, Value>, String, Map<String, Value>)> {
+    ) -> Result<NamespaceLoadResult> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
         let mut root = parse_metadata_root(issue.metadata);
         let namespace_key = self.current_metadata_namespace();

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/parsing.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/parsing.rs
@@ -6,7 +6,7 @@ use crate::metadata::{
 };
 use crate::model::RawIssue;
 use crate::normalize::{
-    default_ai_review_enabled, parse_issue_type, parse_task_status, normalize_labels,
+    default_ai_review_enabled, normalize_labels, parse_issue_type, parse_task_status,
 };
 use crate::store::BeadsTaskStore;
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -436,7 +436,7 @@ pub(crate) fn touch_recent(recent: &mut Vec<String>, repo_path: &str) {
 fn write_config_file(path: &Path, contents: &[u8]) -> Result<()> {
     #[cfg(unix)]
     {
-        return write_config_file_atomic(path, contents);
+        write_config_file_atomic(path, contents)
     }
 
     #[cfg(not(unix))]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -2,22 +2,13 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct HookSet {
     #[serde(default)]
     pub pre_start: Vec<String>,
     #[serde(default)]
     pub post_complete: Vec<String>,
-}
-
-impl Default for HookSet {
-    fn default() -> Self {
-        Self {
-            pre_start: Vec::new(),
-            post_complete: Vec::new(),
-        }
-    }
 }
 
 pub fn hook_set_fingerprint(hooks: &HookSet) -> String {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -264,8 +264,9 @@ fn parse_status_porcelain(output: &str) -> Vec<GitFileStatus> {
             if line.len() < 4 {
                 return None;
             }
-            let index = line.chars().nth(0)?;
-            let worktree = line.chars().nth(1)?;
+            let mut status_chars = line.chars();
+            let index = status_chars.next()?;
+            let worktree = status_chars.next()?;
             let path = line[3..].to_string();
 
             let (status, staged) = match (index, worktree) {
@@ -396,11 +397,7 @@ fn parse_diff_git_header_token(input: &str) -> Option<(String, &str)> {
                 return Some((token, remaining));
             }
 
-            if ch == '\\' && !escaped {
-                escaped = true;
-            } else {
-                escaped = false;
-            }
+            escaped = ch == '\\' && !escaped;
         }
         return None;
     }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/support.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/support.rs
@@ -60,7 +60,7 @@ pub(super) fn run_git_ok(cwd: &Path, args: &[&str]) -> String {
 
 pub(super) fn setup_repo(prefix: &str) -> TempPath {
     let repo = TempPath::new(prefix);
-    run_git_ok(&repo.path, &["init"]);
+    run_git_ok(&repo.path, &["init", "--initial-branch=main"]);
     run_git_ok(
         &repo.path,
         &["config", "user.email", "tests@openducktor.local"],
@@ -69,12 +69,11 @@ pub(super) fn setup_repo(prefix: &str) -> TempPath {
     fs::write(repo.path.join("README.md"), "# OpenDucktor\n").expect("seed file should write");
     run_git_ok(&repo.path, &["add", "README.md"]);
     run_git_ok(&repo.path, &["commit", "-m", "initial"]);
-    run_git_ok(&repo.path, &["branch", "-M", "main"]);
     repo
 }
 
 pub(super) fn setup_bare_remote(prefix: &str) -> TempPath {
     let remote = TempPath::new(prefix);
-    run_git_ok(&remote.path, &["init", "--bare"]);
+    run_git_ok(&remote.path, &["init", "--bare", "--initial-branch=main"]);
     remote
 }

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -1121,14 +1121,14 @@ mod tests {
     use host_application::AppService;
     use host_domain::GitPort;
     use host_domain::{
-        GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
-        GitDiffScope, GitFileDiff, GitFileStatus, GitFileStatusCounts, GitPullRequest,
-        GitPullResult, GitPushResult, GitRebaseAbortRequest, GitRebaseAbortResult,
-        GitRebaseBranchRequest, GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatus,
-        GitWorktreeStatusData, GitWorktreeStatusSummary, GitWorktreeStatusSummaryData, TaskStore,
-        TASK_METADATA_NAMESPACE,
+        AgentSessionDocument, CreateTaskInput, GitAheadBehind, GitBranch, GitCommitAllRequest,
+        GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitFileDiff, GitFileStatus,
+        GitFileStatusCounts, GitPullRequest, GitPullResult, GitPushResult, GitRebaseAbortRequest,
+        GitRebaseAbortResult, GitRebaseBranchRequest, GitRebaseBranchResult,
+        GitUpstreamAheadBehind, GitWorktreeStatus, GitWorktreeStatusData, GitWorktreeStatusSummary,
+        GitWorktreeStatusSummaryData, QaReportDocument, QaVerdict, SpecDocument, TaskCard,
+        TaskMetadata, TaskStore, UpdateTaskPatch,
     };
-    use host_infra_beads::BeadsTaskStore;
     use host_infra_system::AppConfigStore;
     use serde_json::{json, Value};
     use std::{
@@ -1199,6 +1199,142 @@ mod tests {
 
     struct CommandGitPort {
         state: Arc<Mutex<CommandGitPortState>>,
+    }
+
+    struct CommandTaskStore;
+
+    fn empty_spec_document() -> SpecDocument {
+        SpecDocument {
+            markdown: String::new(),
+            updated_at: None,
+        }
+    }
+
+    impl TaskStore for CommandTaskStore {
+        fn ensure_repo_initialized(&self, _repo_path: &Path) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn list_tasks(&self, _repo_path: &Path) -> anyhow::Result<Vec<TaskCard>> {
+            Ok(Vec::new())
+        }
+
+        fn create_task(
+            &self,
+            _repo_path: &Path,
+            _input: CreateTaskInput,
+        ) -> anyhow::Result<TaskCard> {
+            Err(anyhow!(
+                "unexpected task store create_task call in git command tests"
+            ))
+        }
+
+        fn update_task(
+            &self,
+            _repo_path: &Path,
+            _task_id: &str,
+            _patch: UpdateTaskPatch,
+        ) -> anyhow::Result<TaskCard> {
+            Err(anyhow!(
+                "unexpected task store update_task call in git command tests"
+            ))
+        }
+
+        fn delete_task(
+            &self,
+            _repo_path: &Path,
+            _task_id: &str,
+            _delete_subtasks: bool,
+        ) -> anyhow::Result<bool> {
+            Err(anyhow!(
+                "unexpected task store delete_task call in git command tests"
+            ))
+        }
+
+        fn get_spec(&self, _repo_path: &Path, _task_id: &str) -> anyhow::Result<SpecDocument> {
+            Ok(empty_spec_document())
+        }
+
+        fn set_spec(
+            &self,
+            _repo_path: &Path,
+            _task_id: &str,
+            markdown: &str,
+        ) -> anyhow::Result<SpecDocument> {
+            Ok(SpecDocument {
+                markdown: markdown.to_string(),
+                updated_at: None,
+            })
+        }
+
+        fn get_plan(&self, _repo_path: &Path, _task_id: &str) -> anyhow::Result<SpecDocument> {
+            Ok(empty_spec_document())
+        }
+
+        fn set_plan(
+            &self,
+            _repo_path: &Path,
+            _task_id: &str,
+            markdown: &str,
+        ) -> anyhow::Result<SpecDocument> {
+            Ok(SpecDocument {
+                markdown: markdown.to_string(),
+                updated_at: None,
+            })
+        }
+
+        fn get_latest_qa_report(
+            &self,
+            _repo_path: &Path,
+            _task_id: &str,
+        ) -> anyhow::Result<Option<QaReportDocument>> {
+            Ok(None)
+        }
+
+        fn append_qa_report(
+            &self,
+            _repo_path: &Path,
+            _task_id: &str,
+            markdown: &str,
+            verdict: QaVerdict,
+        ) -> anyhow::Result<QaReportDocument> {
+            Ok(QaReportDocument {
+                markdown: markdown.to_string(),
+                verdict,
+                updated_at: String::new(),
+                revision: 0,
+            })
+        }
+
+        fn list_agent_sessions(
+            &self,
+            _repo_path: &Path,
+            _task_id: &str,
+        ) -> anyhow::Result<Vec<AgentSessionDocument>> {
+            Ok(Vec::new())
+        }
+
+        fn upsert_agent_session(
+            &self,
+            _repo_path: &Path,
+            _task_id: &str,
+            _session: AgentSessionDocument,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn get_task_metadata(
+            &self,
+            _repo_path: &Path,
+            _task_id: &str,
+        ) -> anyhow::Result<TaskMetadata> {
+            Ok(TaskMetadata {
+                spec: empty_spec_document(),
+                plan: empty_spec_document(),
+                qa_report: None,
+                agent_sessions: Vec::new(),
+            })
+        }
     }
 
     impl CommandGitPort {
@@ -1430,7 +1566,7 @@ mod tests {
 
     fn init_repo(path: &Path) {
         fs::create_dir_all(path).expect("failed to create repo directory");
-        run_git(&["init"], path);
+        run_git(&["init", "--initial-branch=main"], path);
         fs::write(path.join("README.md"), "init\n").expect("failed to write seed file");
         run_git(&["add", "."], path);
         run_git(
@@ -1509,9 +1645,7 @@ mod tests {
             worktree_mutation_allowed,
         );
         let git_state = git_port.state.clone();
-        let task_store: Arc<dyn TaskStore> = Arc::new(BeadsTaskStore::with_metadata_namespace(
-            TASK_METADATA_NAMESPACE,
-        ));
+        let task_store: Arc<dyn TaskStore> = Arc::new(CommandTaskStore);
         let service = Arc::new(AppService::with_git_port(
             task_store,
             config_store,


### PR DESCRIPTION
## Summary
- move Rust security auditing to the official RustSec action in a dedicated workflow
- turn `apps/desktop/src-tauri` into a Cargo workspace and split host-crate checks from Tauri app checks in CI
- fix the newly exposed Rust clippy findings so the stricter workspace lint passes

## Verification
- cargo clippy --workspace --exclude openducktor-desktop --all-targets --locked -- -D warnings
- cargo clippy -p openducktor-desktop --all-targets --locked -- -D warnings
- cargo test --workspace --exclude openducktor-desktop --locked --no-run
- cargo test -p openducktor-desktop --locked --no-run