### PR TITLE
Refactor MCP task store into internal workflow use cases

### DIFF
--- a/packages/openducktor-mcp/src/bd-persistence.test.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.test.ts
@@ -304,4 +304,34 @@ describe("BdPersistence", () => {
       },
     });
   });
+
+  test("updateTask writes status and metadata in a single bd update call", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async () => ({}),
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+    await persistence.updateTask("task-1", {
+      metadataRoot: { openducktor: { documents: { qaReports: [] } } },
+      status: "human_review",
+    });
+
+    expect(state.calls).toEqual([
+      [
+        "update",
+        "task-1",
+        "--status",
+        "human_review",
+        "--metadata",
+        JSON.stringify({ openducktor: { documents: { qaReports: [] } } }),
+      ],
+    ]);
+  });
 });

--- a/packages/openducktor-mcp/src/bd-persistence.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.ts
@@ -1,8 +1,13 @@
 import type { BdRuntimeClient } from "./bd-runtime-client";
 import { isNonTaskBeadsIssueType } from "./beads-task-parsing";
-import type { JsonObject, RawIssue, TaskCard } from "./contracts";
+import type { JsonObject, RawIssue, TaskCard, TaskStatus } from "./contracts";
 import { getNamespaceData, type NamespaceData } from "./metadata-docs";
 import { issueToTaskCard } from "./task-mapping";
+
+export type TaskUpdateInput = {
+  status?: TaskStatus;
+  metadataRoot?: JsonObject;
+};
 
 export type TaskPersistencePort = {
   metadataNamespace: string;
@@ -10,6 +15,7 @@ export type TaskPersistencePort = {
   ensureInitialized(): Promise<void>;
   showRawIssue(taskId: string): Promise<RawIssue>;
   listTasks(): Promise<TaskCard[]>;
+  updateTask(taskId: string, input: TaskUpdateInput): Promise<void>;
   getNamespaceData(issue: RawIssue): NamespaceData;
   writeNamespace(taskId: string, root: JsonObject, namespace: JsonObject): Promise<void>;
 };
@@ -61,12 +67,30 @@ export class BdPersistence implements TaskPersistencePort {
     return getNamespaceData(issue, this.metadataNamespace);
   }
 
+  async updateTask(taskId: string, input: TaskUpdateInput): Promise<void> {
+    const args = ["update", taskId];
+
+    if (input.status) {
+      args.push("--status", input.status);
+    }
+
+    if (input.metadataRoot) {
+      args.push("--metadata", JSON.stringify(input.metadataRoot));
+    }
+
+    if (args.length === 2) {
+      return;
+    }
+
+    await this.runBdJson(args);
+  }
+
   async writeNamespace(taskId: string, root: JsonObject, namespace: JsonObject): Promise<void> {
     const nextRoot = {
       ...root,
       [this.metadataNamespace]: namespace,
     };
 
-    await this.runBdJson(["update", taskId, "--metadata", JSON.stringify(nextRoot)]);
+    await this.updateTask(taskId, { metadataRoot: nextRoot });
   }
 }

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -820,6 +820,20 @@ describe("openducktor-mcp lib", () => {
           ]),
         };
       }
+      if (command === "show") {
+        return {
+          ok: true,
+          stdout: JSON.stringify([
+            {
+              id: "task-1",
+              title: "Task 1",
+              status: "open",
+              issue_type: "feature",
+              metadata: {},
+            },
+          ]),
+        };
+      }
       if (command === "update" && args.includes("--metadata")) {
         metadataUpdateCalls += 1;
         return { ok: true, stdout: "{}" };
@@ -849,6 +863,7 @@ describe("openducktor-mcp lib", () => {
   test("qaApproved appends qa report metadata and transitions to human_review", async () => {
     let metadataPayload: Record<string, unknown> | null = null;
     let statusTransition: string | null = null;
+    let updateCalls = 0;
 
     const { runProcess } = buildProcessRunner((args) => {
       const command = args[1];
@@ -886,13 +901,15 @@ describe("openducktor-mcp lib", () => {
           ]),
         };
       }
-      if (command === "update" && args.includes("--metadata")) {
-        const metadataArg = args[args.indexOf("--metadata") + 1];
-        metadataPayload = JSON.parse(metadataArg ?? "{}") as Record<string, unknown>;
-        return { ok: true, stdout: "{}" };
-      }
-      if (command === "update" && args.includes("--status")) {
-        statusTransition = args[args.indexOf("--status") + 1] ?? null;
+      if (command === "update") {
+        updateCalls += 1;
+        if (args.includes("--metadata")) {
+          const metadataArg = args[args.indexOf("--metadata") + 1];
+          metadataPayload = JSON.parse(metadataArg ?? "{}") as Record<string, unknown>;
+        }
+        if (args.includes("--status")) {
+          statusTransition = args[args.indexOf("--status") + 1] ?? null;
+        }
         return { ok: true, stdout: "{}" };
       }
       throw new Error(`Unexpected bd command: ${args.join(" ")}`);
@@ -917,6 +934,7 @@ describe("openducktor-mcp lib", () => {
 
     expect(result.task.status).toBe("human_review");
     expect(statusTransition).toBe("human_review");
+    expect(updateCalls).toBe(1);
 
     const metadataRoot = (metadataPayload ?? {}) as Record<string, unknown>;
     const namespaceValue = metadataRoot.openducktor;
@@ -1602,11 +1620,12 @@ describe("openducktor-mcp lib", () => {
     expect(statusUpdateCalls).toBe(0);
   });
 
-  test("qaApproved revalidates transition after report append and avoids stale status updates", async () => {
+  test("qaApproved applies metadata and status in a single update call", async () => {
     let status = "ai_review";
     let listCalls = 0;
     let metadataUpdateCalls = 0;
     let statusUpdateCalls = 0;
+    let updateCalls = 0;
 
     const { runProcess } = buildProcessRunner((args) => {
       const command = args[1];
@@ -1645,13 +1664,15 @@ describe("openducktor-mcp lib", () => {
           ]),
         };
       }
-      if (command === "update" && args.includes("--metadata")) {
-        metadataUpdateCalls += 1;
-        status = "closed";
-        return { ok: true, stdout: "{}" };
-      }
-      if (command === "update" && args.includes("--status")) {
-        statusUpdateCalls += 1;
+      if (command === "update") {
+        updateCalls += 1;
+        if (args.includes("--metadata")) {
+          metadataUpdateCalls += 1;
+        }
+        if (args.includes("--status")) {
+          statusUpdateCalls += 1;
+          status = args[args.indexOf("--status") + 1] ?? status;
+        }
         return { ok: true, stdout: "{}" };
       }
       throw new Error(`Unexpected bd command: ${args.join(" ")}`);
@@ -1666,23 +1687,24 @@ describe("openducktor-mcp lib", () => {
       { runProcess },
     );
 
-    await expect(
-      store.qaApproved({
-        taskId: "task-1",
-        reportMarkdown: "## QA",
-      }),
-    ).rejects.toThrow("Transition not allowed");
+    const result = (await store.qaApproved({
+      taskId: "task-1",
+      reportMarkdown: "## QA",
+    })) as { task: { status: string } };
 
     expect(listCalls).toBe(1);
+    expect(result.task.status).toBe("human_review");
+    expect(updateCalls).toBe(1);
     expect(metadataUpdateCalls).toBe(1);
-    expect(statusUpdateCalls).toBe(0);
+    expect(statusUpdateCalls).toBe(1);
   });
 
-  test("qaRejected revalidates transition after report append and avoids stale status updates", async () => {
-    let status = "human_review";
+  test("qaRejected applies metadata and status in a single update call", async () => {
+    let status = "ai_review";
     let listCalls = 0;
     let metadataUpdateCalls = 0;
     let statusUpdateCalls = 0;
+    let updateCalls = 0;
 
     const { runProcess } = buildProcessRunner((args) => {
       const command = args[1];
@@ -1721,13 +1743,15 @@ describe("openducktor-mcp lib", () => {
           ]),
         };
       }
-      if (command === "update" && args.includes("--metadata")) {
-        metadataUpdateCalls += 1;
-        status = "closed";
-        return { ok: true, stdout: "{}" };
-      }
-      if (command === "update" && args.includes("--status")) {
-        statusUpdateCalls += 1;
+      if (command === "update") {
+        updateCalls += 1;
+        if (args.includes("--metadata")) {
+          metadataUpdateCalls += 1;
+        }
+        if (args.includes("--status")) {
+          statusUpdateCalls += 1;
+          status = args[args.indexOf("--status") + 1] ?? status;
+        }
         return { ok: true, stdout: "{}" };
       }
       throw new Error(`Unexpected bd command: ${args.join(" ")}`);
@@ -1742,15 +1766,15 @@ describe("openducktor-mcp lib", () => {
       { runProcess },
     );
 
-    await expect(
-      store.qaRejected({
-        taskId: "task-1",
-        reportMarkdown: "## QA",
-      }),
-    ).rejects.toThrow("Transition not allowed");
+    const result = (await store.qaRejected({
+      taskId: "task-1",
+      reportMarkdown: "## QA",
+    })) as { task: { status: string } };
 
     expect(listCalls).toBe(1);
+    expect(result.task.status).toBe("in_progress");
+    expect(updateCalls).toBe(1);
     expect(metadataUpdateCalls).toBe(1);
-    expect(statusUpdateCalls).toBe(0);
+    expect(statusUpdateCalls).toBe(1);
   });
 });

--- a/packages/openducktor-mcp/src/lib.ts
+++ b/packages/openducktor-mcp/src/lib.ts
@@ -6,27 +6,8 @@ export type {
   TaskStatus,
 } from "./contracts";
 export { OdtTaskStore, type OdtTaskStoreDeps } from "./odt-task-store";
-export {
-  BuildBlockedUseCase,
-  BuildCompletedUseCase,
-  BuildResumedUseCase,
-  type CreateOdtTaskStoreUseCasesDeps,
-  createOdtTaskStoreUseCases,
-  type OdtTaskStoreUseCase,
-  type OdtTaskStoreUseCases,
-  QaApprovedUseCase,
-  QaRejectedUseCase,
-  ReadTaskUseCase,
-  SetPlanUseCase,
-  SetSpecUseCase,
-} from "./odt-task-store-use-cases";
 export { normalizePlanSubtasks } from "./plan-subtasks";
 export { type OdtStoreContext, resolveStoreContext } from "./store-context";
-export {
-  createOdtTaskWorkflowRuntime,
-  type OdtTaskWorkflowRuntimeDeps,
-  type OdtTaskWorkflowRuntimePort,
-} from "./task-workflow-runtime";
 export {
   type BuildBlockedInput,
   type BuildCompletedInput,

--- a/packages/openducktor-mcp/src/lib.ts
+++ b/packages/openducktor-mcp/src/lib.ts
@@ -6,8 +6,27 @@ export type {
   TaskStatus,
 } from "./contracts";
 export { OdtTaskStore, type OdtTaskStoreDeps } from "./odt-task-store";
+export {
+  BuildBlockedUseCase,
+  BuildCompletedUseCase,
+  BuildResumedUseCase,
+  type CreateOdtTaskStoreUseCasesDeps,
+  createOdtTaskStoreUseCases,
+  type OdtTaskStoreUseCase,
+  type OdtTaskStoreUseCases,
+  QaApprovedUseCase,
+  QaRejectedUseCase,
+  ReadTaskUseCase,
+  SetPlanUseCase,
+  SetSpecUseCase,
+} from "./odt-task-store-use-cases";
 export { normalizePlanSubtasks } from "./plan-subtasks";
 export { type OdtStoreContext, resolveStoreContext } from "./store-context";
+export {
+  createOdtTaskWorkflowRuntime,
+  type OdtTaskWorkflowRuntimeDeps,
+  type OdtTaskWorkflowRuntimePort,
+} from "./task-workflow-runtime";
 export {
   type BuildBlockedInput,
   type BuildCompletedInput,

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, test } from "bun:test";
+import type { RawIssue, TaskCard } from "./contracts";
+import {
+  BuildCompletedUseCase,
+  QaApprovedUseCase,
+  ReadTaskUseCase,
+  SetPlanUseCase,
+  SetSpecUseCase,
+} from "./odt-task-store-use-cases";
+
+const makeTask = (overrides: Partial<TaskCard> = {}): TaskCard => ({
+  id: "task-1",
+  title: "Task 1",
+  status: "open",
+  issueType: "feature",
+  aiReviewEnabled: true,
+  ...overrides,
+});
+
+const makeIssue = (overrides: Partial<RawIssue> = {}): RawIssue => ({
+  id: "task-1",
+  title: "Task 1",
+  status: "open",
+  issue_type: "feature",
+  metadata: {},
+  ...overrides,
+});
+
+describe("odt task workflow use cases", () => {
+  test("ReadTaskUseCase returns the latest task snapshot and parsed documents", async () => {
+    const issue = makeIssue();
+    const task = makeTask({ status: "spec_ready" });
+    const calls: string[] = [];
+
+    const useCase = new ReadTaskUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        readTaskSnapshot: async (taskId) => {
+          calls.push(`read:${taskId}`);
+          return { issue, task };
+        },
+      },
+      documentStore: {
+        parseDocs: (rawIssue) => {
+          calls.push(`docs:${rawIssue.id}`);
+          return {
+            spec: { markdown: "# Spec", updatedAt: null },
+            implementationPlan: { markdown: "# Plan", updatedAt: null },
+            latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+          };
+        },
+      },
+    });
+
+    await expect(useCase.execute({ taskId: "task-1" })).resolves.toEqual({
+      task,
+      documents: {
+        spec: { markdown: "# Spec", updatedAt: null },
+        implementationPlan: { markdown: "# Plan", updatedAt: null },
+        latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+      },
+    });
+    expect(calls).toEqual(["init", "read:task-1", "docs:task-1"]);
+  });
+
+  test("SetSpecUseCase persists the document before transitioning open tasks", async () => {
+    const initialTask = makeTask({ status: "open" });
+    const transitionedTask = makeTask({ status: "spec_ready" });
+    const calls: string[] = [];
+
+    const useCase = new SetSpecUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        resolveTaskContext: async (taskId) => {
+          calls.push(`resolve:${taskId}`);
+          return { task: initialTask, tasks: [initialTask] };
+        },
+        refreshTaskContext: async (taskId, context) => {
+          calls.push(`refresh:${taskId}:${context?.task.status ?? "none"}`);
+          return { task: initialTask, tasks: [initialTask] };
+        },
+        transitionTask: async (taskId, nextStatus) => {
+          calls.push(`transition:${taskId}:${nextStatus}`);
+          return transitionedTask;
+        },
+      },
+      documentStore: {
+        persistSpec: async (taskId, markdown) => {
+          calls.push(`persist:${taskId}:${markdown}`);
+          return { updatedAt: "2026-03-01T00:00:00.000Z", revision: 2 };
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({ taskId: "task-1", markdown: "  # Refined spec  " }),
+    ).resolves.toEqual({
+      task: transitionedTask,
+      document: {
+        markdown: "# Refined spec",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+        revision: 2,
+      },
+    });
+    expect(calls).toEqual([
+      "init",
+      "resolve:task-1",
+      "persist:task-1:# Refined spec",
+      "refresh:task-1:open",
+      "transition:task-1:spec_ready",
+    ]);
+  });
+
+  test("SetPlanUseCase coordinates epic replacement through injected ports", async () => {
+    const epicTask = makeTask({
+      id: "epic-1",
+      title: "Epic",
+      status: "spec_ready",
+      issueType: "epic",
+    });
+    const readyTask = makeTask({
+      id: "epic-1",
+      title: "Epic",
+      status: "ready_for_dev",
+      issueType: "epic",
+    });
+    const calls: string[] = [];
+
+    const useCase = new SetPlanUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        resolveTaskContext: async (taskId) => {
+          calls.push(`resolve:${taskId}`);
+          return { task: epicTask, tasks: [epicTask] };
+        },
+        refreshTaskContext: async (taskId, context) => {
+          calls.push(`refresh:${taskId}:${context?.task.status ?? "none"}`);
+          return { task: epicTask, tasks: [epicTask] };
+        },
+        transitionTask: async (taskId, nextStatus) => {
+          calls.push(`transition:${taskId}:${nextStatus}`);
+          return readyTask;
+        },
+      },
+      documentStore: {
+        persistImplementationPlan: async (taskId, markdown) => {
+          calls.push(`persist:${taskId}:${markdown}`);
+          return { updatedAt: "2026-03-02T00:00:00.000Z", revision: 4 };
+        },
+      },
+      epicSubtaskReplacementService: {
+        prepareReplacement: async (task, subtasks) => {
+          calls.push(`prepare:${task.id}:${subtasks.length}`);
+          return {
+            latestTask: task,
+            existingDirectSubtasks: [makeTask({ id: "sub-legacy", parentId: task.id })],
+          };
+        },
+        applyReplacement: async (task, currentSubtasks, subtasks) => {
+          calls.push(`apply:${task.id}:${currentSubtasks.length}:${subtasks.length}`);
+          return ["epic-1-sub-1"];
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({
+        taskId: "epic-1",
+        markdown: "  # Execution plan  ",
+        subtasks: [{ title: "Build API" }],
+      }),
+    ).resolves.toEqual({
+      task: readyTask,
+      document: {
+        markdown: "# Execution plan",
+        updatedAt: "2026-03-02T00:00:00.000Z",
+        revision: 4,
+      },
+      createdSubtaskIds: ["epic-1-sub-1"],
+    });
+    expect(calls).toEqual([
+      "init",
+      "resolve:epic-1",
+      "prepare:epic-1:1",
+      "persist:epic-1:# Execution plan",
+      "apply:epic-1:1:1",
+      "refresh:epic-1:spec_ready",
+      "transition:epic-1:ready_for_dev",
+    ]);
+  });
+
+  test("BuildCompletedUseCase routes to ai_review when AI review is enabled", async () => {
+    const inProgressTask = makeTask({ status: "in_progress", aiReviewEnabled: true });
+    const aiReviewTask = makeTask({ status: "ai_review", aiReviewEnabled: true });
+    const calls: string[] = [];
+
+    const useCase = new BuildCompletedUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        resolveTaskContext: async (taskId) => {
+          calls.push(`resolve:${taskId}`);
+          return { task: inProgressTask, tasks: [inProgressTask] };
+        },
+        refreshTaskContext: async (taskId, context) => {
+          calls.push(`refresh:${taskId}:${context?.task.status ?? "none"}`);
+          return { task: inProgressTask, tasks: [inProgressTask] };
+        },
+        transitionTask: async (taskId, nextStatus) => {
+          calls.push(`transition:${taskId}:${nextStatus}`);
+          return aiReviewTask;
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({ taskId: "task-1", summary: "Implementation complete" }),
+    ).resolves.toEqual({
+      task: aiReviewTask,
+      summary: "Implementation complete",
+    });
+    expect(calls).toEqual([
+      "init",
+      "resolve:task-1",
+      "refresh:task-1:in_progress",
+      "transition:task-1:ai_review",
+    ]);
+  });
+
+  test("QaApprovedUseCase rejects invalid transitions before writing qa metadata", async () => {
+    let appendCalled = false;
+    let refreshCalled = false;
+    let transitionCalled = false;
+    const currentTask = makeTask({ status: "open" });
+
+    const useCase = new QaApprovedUseCase({
+      workflow: {
+        ensureInitialized: async () => {},
+        resolveTaskContext: async () => ({ task: currentTask, tasks: [currentTask] }),
+        assertTransitionAllowed: () => {
+          throw new Error("Transition not allowed");
+        },
+        refreshTaskContext: async () => {
+          refreshCalled = true;
+          return { task: currentTask, tasks: [currentTask] };
+        },
+        transitionTask: async () => {
+          transitionCalled = true;
+          return currentTask;
+        },
+      },
+      documentStore: {
+        appendQaReport: async () => {
+          appendCalled = true;
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
+    ).rejects.toThrow("Transition not allowed");
+    expect(appendCalled).toBe(false);
+    expect(refreshCalled).toBe(false);
+    expect(transitionCalled).toBe(false);
+  });
+});

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { RawIssue, TaskCard } from "./contracts";
 import {
+  BuildBlockedUseCase,
   BuildCompletedUseCase,
+  BuildResumedUseCase,
   QaApprovedUseCase,
+  QaRejectedUseCase,
   ReadTaskUseCase,
   SetPlanUseCase,
   SetSpecUseCase,
@@ -234,31 +237,135 @@ describe("odt task workflow use cases", () => {
     ]);
   });
 
-  test("QaApprovedUseCase rejects invalid transitions before writing qa metadata", async () => {
-    let appendCalled = false;
-    let refreshCalled = false;
-    let transitionCalled = false;
+  test("BuildBlockedUseCase returns the blocker reason and transitions to blocked", async () => {
+    const blockedTask = makeTask({ status: "blocked" });
+    const calls: string[] = [];
+
+    const useCase = new BuildBlockedUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        transitionTask: async (taskId, nextStatus) => {
+          calls.push(`transition:${taskId}:${nextStatus}`);
+          return blockedTask;
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({ taskId: "task-1", reason: "Waiting on upstream change" }),
+    ).resolves.toEqual({
+      task: blockedTask,
+      reason: "Waiting on upstream change",
+    });
+    expect(calls).toEqual(["init", "transition:task-1:blocked"]);
+  });
+
+  test("BuildResumedUseCase transitions back to in_progress", async () => {
+    const resumedTask = makeTask({ status: "in_progress" });
+    const calls: string[] = [];
+
+    const useCase = new BuildResumedUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        transitionTask: async (taskId, nextStatus) => {
+          calls.push(`transition:${taskId}:${nextStatus}`);
+          return resumedTask;
+        },
+      },
+    });
+
+    await expect(useCase.execute({ taskId: "task-1" })).resolves.toEqual({
+      task: resumedTask,
+    });
+    expect(calls).toEqual(["init", "transition:task-1:in_progress"]);
+  });
+
+  test("QaApprovedUseCase writes the qa report and status in a single task update", async () => {
+    const qaTask = makeTask({ status: "ai_review" });
+    const issue = makeIssue({ status: "ai_review" });
+    const approvedTask = makeTask({ status: "human_review" });
+    const calls: string[] = [];
+    let appliedUpdate: { metadataRoot?: unknown; status?: string } | null = null;
+
+    const useCase = new QaApprovedUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        readTaskSnapshot: async (taskId) => {
+          calls.push(`read:${taskId}`);
+          return { issue, task: qaTask };
+        },
+        assertTransitionAllowed: () => {
+          calls.push("assert");
+        },
+        applyTaskUpdate: async (taskId, input) => {
+          calls.push(`apply:${taskId}:${input.status ?? "none"}`);
+          appliedUpdate = input;
+          return approvedTask;
+        },
+      },
+      documentStore: {
+        prepareQaReportWrite: (rawIssue, markdown, verdict) => {
+          calls.push(`prepare:${rawIssue.id}:${verdict}:${markdown}`);
+          return {
+            metadataRoot: { openducktor: { documents: { qaReports: [{ verdict, markdown }] } } },
+            namespace: {},
+            root: {},
+          };
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
+    ).resolves.toEqual({ task: approvedTask });
+    expect(calls).toEqual([
+      "init",
+      "read:task-1",
+      "assert",
+      "prepare:task-1:approved:## QA review",
+      "apply:task-1:human_review",
+    ]);
+    expect(appliedUpdate).toEqual({
+      metadataRoot: {
+        openducktor: {
+          documents: { qaReports: [{ verdict: "approved", markdown: "## QA review" }] },
+        },
+      },
+      status: "human_review",
+    });
+  });
+
+  test("QaApprovedUseCase rejects invalid transitions before preparing qa metadata", async () => {
+    let prepareCalled = false;
+    let updateCalled = false;
     const currentTask = makeTask({ status: "open" });
 
     const useCase = new QaApprovedUseCase({
       workflow: {
         ensureInitialized: async () => {},
-        resolveTaskContext: async () => ({ task: currentTask, tasks: [currentTask] }),
+        readTaskSnapshot: async () => ({ issue: makeIssue(), task: currentTask }),
         assertTransitionAllowed: () => {
           throw new Error("Transition not allowed");
         },
-        refreshTaskContext: async () => {
-          refreshCalled = true;
-          return { task: currentTask, tasks: [currentTask] };
-        },
-        transitionTask: async () => {
-          transitionCalled = true;
+        applyTaskUpdate: async () => {
+          updateCalled = true;
           return currentTask;
         },
       },
       documentStore: {
-        appendQaReport: async () => {
-          appendCalled = true;
+        prepareQaReportWrite: () => {
+          prepareCalled = true;
+          return {
+            metadataRoot: {},
+            namespace: {},
+            root: {},
+          };
         },
       },
     });
@@ -266,8 +373,43 @@ describe("odt task workflow use cases", () => {
     await expect(
       useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
     ).rejects.toThrow("Transition not allowed");
-    expect(appendCalled).toBe(false);
-    expect(refreshCalled).toBe(false);
-    expect(transitionCalled).toBe(false);
+    expect(prepareCalled).toBe(false);
+    expect(updateCalled).toBe(false);
+  });
+
+  test("QaRejectedUseCase rejects invalid transitions before preparing qa metadata", async () => {
+    let prepareCalled = false;
+    let updateCalled = false;
+    const currentTask = makeTask({ status: "open" });
+
+    const useCase = new QaRejectedUseCase({
+      workflow: {
+        ensureInitialized: async () => {},
+        readTaskSnapshot: async () => ({ issue: makeIssue(), task: currentTask }),
+        assertTransitionAllowed: () => {
+          throw new Error("Transition not allowed");
+        },
+        applyTaskUpdate: async () => {
+          updateCalled = true;
+          return currentTask;
+        },
+      },
+      documentStore: {
+        prepareQaReportWrite: () => {
+          prepareCalled = true;
+          return {
+            metadataRoot: {},
+            namespace: {},
+            root: {},
+          };
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
+    ).rejects.toThrow("Transition not allowed");
+    expect(prepareCalled).toBe(false);
+    expect(updateCalled).toBe(false);
   });
 });

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
@@ -1,17 +1,18 @@
 import type { TaskCard } from "./contracts";
 import type { EpicSubtaskReplacementService } from "./epic-subtask-replacement";
+import type { TaskDocumentsSnapshot } from "./metadata-docs";
 import { normalizePlanSubtasks } from "./plan-subtasks";
 import type { TaskDocumentPort } from "./task-document-store";
 import type { OdtTaskWorkflowRuntimePort } from "./task-workflow-runtime";
-import {
-  BuildBlockedInputSchema,
-  BuildCompletedInputSchema,
-  BuildResumedInputSchema,
-  QaApprovedInputSchema,
-  QaRejectedInputSchema,
-  ReadTaskInputSchema,
-  SetPlanInputSchema,
-  SetSpecInputSchema,
+import type {
+  BuildBlockedInput,
+  BuildCompletedInput,
+  BuildResumedInput,
+  QaApprovedInput,
+  QaRejectedInput,
+  ReadTaskInput,
+  SetPlanInput,
+  SetSpecInput,
 } from "./tool-schemas";
 import {
   assertNoValidationError,
@@ -20,19 +21,63 @@ import {
   validatePlanSubtaskRules,
 } from "./workflow-policy";
 
-export type OdtTaskStoreUseCase = {
-  execute(rawInput: unknown): Promise<unknown>;
+type PersistedDocumentResult = {
+  markdown: string;
+  updatedAt: string;
+  revision: number;
 };
 
 export type OdtTaskStoreUseCases = {
-  readTask: OdtTaskStoreUseCase;
-  setSpec: OdtTaskStoreUseCase;
-  setPlan: OdtTaskStoreUseCase;
-  buildBlocked: OdtTaskStoreUseCase;
-  buildResumed: OdtTaskStoreUseCase;
-  buildCompleted: OdtTaskStoreUseCase;
-  qaApproved: OdtTaskStoreUseCase;
-  qaRejected: OdtTaskStoreUseCase;
+  readTask: OdtTaskStoreUseCase<ReadTaskInput, ReadTaskResult>;
+  setSpec: OdtTaskStoreUseCase<SetSpecInput, SetSpecResult>;
+  setPlan: OdtTaskStoreUseCase<SetPlanInput, SetPlanResult>;
+  buildBlocked: OdtTaskStoreUseCase<BuildBlockedInput, BuildBlockedResult>;
+  buildResumed: OdtTaskStoreUseCase<BuildResumedInput, BuildResumedResult>;
+  buildCompleted: OdtTaskStoreUseCase<BuildCompletedInput, BuildCompletedResult>;
+  qaApproved: OdtTaskStoreUseCase<QaApprovedInput, QaApprovedResult>;
+  qaRejected: OdtTaskStoreUseCase<QaRejectedInput, QaRejectedResult>;
+};
+
+export type OdtTaskStoreUseCase<Input, Output> = {
+  execute(input: Input): Promise<Output>;
+};
+
+export type ReadTaskResult = {
+  task: TaskCard;
+  documents: TaskDocumentsSnapshot;
+};
+
+export type SetSpecResult = {
+  task: TaskCard;
+  document: PersistedDocumentResult;
+};
+
+export type SetPlanResult = {
+  task: TaskCard;
+  document: PersistedDocumentResult;
+  createdSubtaskIds: string[];
+};
+
+export type BuildBlockedResult = {
+  task: TaskCard;
+  reason: string;
+};
+
+export type BuildResumedResult = {
+  task: TaskCard;
+};
+
+export type BuildCompletedResult = {
+  task: TaskCard;
+  summary?: string;
+};
+
+export type QaApprovedResult = {
+  task: TaskCard;
+};
+
+export type QaRejectedResult = {
+  task: TaskCard;
 };
 
 type EpicSubtaskReplacementPort = Pick<
@@ -45,7 +90,7 @@ type ReadTaskUseCaseDeps = {
   documentStore: Pick<TaskDocumentPort, "parseDocs">;
 };
 
-export class ReadTaskUseCase implements OdtTaskStoreUseCase {
+export class ReadTaskUseCase implements OdtTaskStoreUseCase<ReadTaskInput, ReadTaskResult> {
   private readonly workflow: ReadTaskUseCaseDeps["workflow"];
   private readonly documentStore: ReadTaskUseCaseDeps["documentStore"];
 
@@ -54,9 +99,8 @@ export class ReadTaskUseCase implements OdtTaskStoreUseCase {
     this.documentStore = deps.documentStore;
   }
 
-  async execute(rawInput: unknown): Promise<unknown> {
+  async execute(input: ReadTaskInput): Promise<ReadTaskResult> {
     await this.workflow.ensureInitialized();
-    const input = ReadTaskInputSchema.parse(rawInput);
     const { issue, task } = await this.workflow.readTaskSnapshot(input.taskId);
 
     return {
@@ -74,7 +118,7 @@ type SetSpecUseCaseDeps = {
   documentStore: Pick<TaskDocumentPort, "persistSpec">;
 };
 
-export class SetSpecUseCase implements OdtTaskStoreUseCase {
+export class SetSpecUseCase implements OdtTaskStoreUseCase<SetSpecInput, SetSpecResult> {
   private readonly workflow: SetSpecUseCaseDeps["workflow"];
   private readonly documentStore: SetSpecUseCaseDeps["documentStore"];
 
@@ -83,9 +127,8 @@ export class SetSpecUseCase implements OdtTaskStoreUseCase {
     this.documentStore = deps.documentStore;
   }
 
-  async execute(rawInput: unknown): Promise<unknown> {
+  async execute(input: SetSpecInput): Promise<SetSpecResult> {
     await this.workflow.ensureInitialized();
-    const input = SetSpecInputSchema.parse(rawInput);
     const markdown = input.markdown.trim();
 
     const context = await this.workflow.resolveTaskContext(input.taskId);
@@ -120,7 +163,7 @@ type SetPlanUseCaseDeps = {
   epicSubtaskReplacementService: EpicSubtaskReplacementPort;
 };
 
-export class SetPlanUseCase implements OdtTaskStoreUseCase {
+export class SetPlanUseCase implements OdtTaskStoreUseCase<SetPlanInput, SetPlanResult> {
   private readonly workflow: SetPlanUseCaseDeps["workflow"];
   private readonly documentStore: SetPlanUseCaseDeps["documentStore"];
   private readonly epicSubtaskReplacementService: SetPlanUseCaseDeps["epicSubtaskReplacementService"];
@@ -131,9 +174,8 @@ export class SetPlanUseCase implements OdtTaskStoreUseCase {
     this.epicSubtaskReplacementService = deps.epicSubtaskReplacementService;
   }
 
-  async execute(rawInput: unknown): Promise<unknown> {
+  async execute(input: SetPlanInput): Promise<SetPlanResult> {
     await this.workflow.ensureInitialized();
-    const input = SetPlanInputSchema.parse(rawInput);
     const markdown = input.markdown.trim();
 
     const context = await this.workflow.resolveTaskContext(input.taskId);
@@ -179,16 +221,17 @@ type TransitionTaskUseCaseDeps = {
   workflow: Pick<OdtTaskWorkflowRuntimePort, "ensureInitialized" | "transitionTask">;
 };
 
-export class BuildBlockedUseCase implements OdtTaskStoreUseCase {
+export class BuildBlockedUseCase
+  implements OdtTaskStoreUseCase<BuildBlockedInput, BuildBlockedResult>
+{
   private readonly workflow: TransitionTaskUseCaseDeps["workflow"];
 
   constructor(deps: TransitionTaskUseCaseDeps) {
     this.workflow = deps.workflow;
   }
 
-  async execute(rawInput: unknown): Promise<unknown> {
+  async execute(input: BuildBlockedInput): Promise<BuildBlockedResult> {
     await this.workflow.ensureInitialized();
-    const input = BuildBlockedInputSchema.parse(rawInput);
     const task = await this.workflow.transitionTask(input.taskId, "blocked");
     return {
       task,
@@ -197,16 +240,17 @@ export class BuildBlockedUseCase implements OdtTaskStoreUseCase {
   }
 }
 
-export class BuildResumedUseCase implements OdtTaskStoreUseCase {
+export class BuildResumedUseCase
+  implements OdtTaskStoreUseCase<BuildResumedInput, BuildResumedResult>
+{
   private readonly workflow: TransitionTaskUseCaseDeps["workflow"];
 
   constructor(deps: TransitionTaskUseCaseDeps) {
     this.workflow = deps.workflow;
   }
 
-  async execute(rawInput: unknown): Promise<unknown> {
+  async execute(input: BuildResumedInput): Promise<BuildResumedResult> {
     await this.workflow.ensureInitialized();
-    const input = BuildResumedInputSchema.parse(rawInput);
     const task = await this.workflow.transitionTask(input.taskId, "in_progress");
     return { task };
   }
@@ -219,16 +263,17 @@ type BuildCompletedUseCaseDeps = {
   >;
 };
 
-export class BuildCompletedUseCase implements OdtTaskStoreUseCase {
+export class BuildCompletedUseCase
+  implements OdtTaskStoreUseCase<BuildCompletedInput, BuildCompletedResult>
+{
   private readonly workflow: BuildCompletedUseCaseDeps["workflow"];
 
   constructor(deps: BuildCompletedUseCaseDeps) {
     this.workflow = deps.workflow;
   }
 
-  async execute(rawInput: unknown): Promise<unknown> {
+  async execute(input: BuildCompletedInput): Promise<BuildCompletedResult> {
     await this.workflow.ensureInitialized();
-    const input = BuildCompletedInputSchema.parse(rawInput);
 
     const context = await this.workflow.resolveTaskContext(input.taskId);
     const refreshedContext = await this.workflow.refreshTaskContext(context.task.id, context);
@@ -255,7 +300,7 @@ type QaUseCaseDeps = {
   documentStore: Pick<TaskDocumentPort, "appendQaReport">;
 };
 
-export class QaApprovedUseCase implements OdtTaskStoreUseCase {
+export class QaApprovedUseCase implements OdtTaskStoreUseCase<QaApprovedInput, QaApprovedResult> {
   private readonly workflow: QaUseCaseDeps["workflow"];
   private readonly documentStore: QaUseCaseDeps["documentStore"];
 
@@ -264,9 +309,8 @@ export class QaApprovedUseCase implements OdtTaskStoreUseCase {
     this.documentStore = deps.documentStore;
   }
 
-  async execute(rawInput: unknown): Promise<unknown> {
+  async execute(input: QaApprovedInput): Promise<QaApprovedResult> {
     await this.workflow.ensureInitialized();
-    const input = QaApprovedInputSchema.parse(rawInput);
     const context = await this.workflow.resolveTaskContext(input.taskId);
     const { task, tasks } = context;
     this.workflow.assertTransitionAllowed(task, tasks, "human_review");
@@ -281,7 +325,7 @@ export class QaApprovedUseCase implements OdtTaskStoreUseCase {
   }
 }
 
-export class QaRejectedUseCase implements OdtTaskStoreUseCase {
+export class QaRejectedUseCase implements OdtTaskStoreUseCase<QaRejectedInput, QaRejectedResult> {
   private readonly workflow: QaUseCaseDeps["workflow"];
   private readonly documentStore: QaUseCaseDeps["documentStore"];
 
@@ -290,9 +334,8 @@ export class QaRejectedUseCase implements OdtTaskStoreUseCase {
     this.documentStore = deps.documentStore;
   }
 
-  async execute(rawInput: unknown): Promise<unknown> {
+  async execute(input: QaRejectedInput): Promise<QaRejectedResult> {
     await this.workflow.ensureInitialized();
-    const input = QaRejectedInputSchema.parse(rawInput);
     const context = await this.workflow.resolveTaskContext(input.taskId);
     const { task, tasks } = context;
     this.workflow.assertTransitionAllowed(task, tasks, "in_progress");

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
@@ -1,0 +1,349 @@
+import type { TaskCard } from "./contracts";
+import type { EpicSubtaskReplacementService } from "./epic-subtask-replacement";
+import { normalizePlanSubtasks } from "./plan-subtasks";
+import type { TaskDocumentPort } from "./task-document-store";
+import type { OdtTaskWorkflowRuntimePort } from "./task-workflow-runtime";
+import {
+  BuildBlockedInputSchema,
+  BuildCompletedInputSchema,
+  BuildResumedInputSchema,
+  QaApprovedInputSchema,
+  QaRejectedInputSchema,
+  ReadTaskInputSchema,
+  SetPlanInputSchema,
+  SetSpecInputSchema,
+} from "./tool-schemas";
+import {
+  assertNoValidationError,
+  getSetPlanError,
+  getSetSpecError,
+  validatePlanSubtaskRules,
+} from "./workflow-policy";
+
+export type OdtTaskStoreUseCase = {
+  execute(rawInput: unknown): Promise<unknown>;
+};
+
+export type OdtTaskStoreUseCases = {
+  readTask: OdtTaskStoreUseCase;
+  setSpec: OdtTaskStoreUseCase;
+  setPlan: OdtTaskStoreUseCase;
+  buildBlocked: OdtTaskStoreUseCase;
+  buildResumed: OdtTaskStoreUseCase;
+  buildCompleted: OdtTaskStoreUseCase;
+  qaApproved: OdtTaskStoreUseCase;
+  qaRejected: OdtTaskStoreUseCase;
+};
+
+type EpicSubtaskReplacementPort = Pick<
+  EpicSubtaskReplacementService,
+  "prepareReplacement" | "applyReplacement"
+>;
+
+type ReadTaskUseCaseDeps = {
+  workflow: Pick<OdtTaskWorkflowRuntimePort, "ensureInitialized" | "readTaskSnapshot">;
+  documentStore: Pick<TaskDocumentPort, "parseDocs">;
+};
+
+export class ReadTaskUseCase implements OdtTaskStoreUseCase {
+  private readonly workflow: ReadTaskUseCaseDeps["workflow"];
+  private readonly documentStore: ReadTaskUseCaseDeps["documentStore"];
+
+  constructor(deps: ReadTaskUseCaseDeps) {
+    this.workflow = deps.workflow;
+    this.documentStore = deps.documentStore;
+  }
+
+  async execute(rawInput: unknown): Promise<unknown> {
+    await this.workflow.ensureInitialized();
+    const input = ReadTaskInputSchema.parse(rawInput);
+    const { issue, task } = await this.workflow.readTaskSnapshot(input.taskId);
+
+    return {
+      task,
+      documents: this.documentStore.parseDocs(issue),
+    };
+  }
+}
+
+type SetSpecUseCaseDeps = {
+  workflow: Pick<
+    OdtTaskWorkflowRuntimePort,
+    "ensureInitialized" | "resolveTaskContext" | "refreshTaskContext" | "transitionTask"
+  >;
+  documentStore: Pick<TaskDocumentPort, "persistSpec">;
+};
+
+export class SetSpecUseCase implements OdtTaskStoreUseCase {
+  private readonly workflow: SetSpecUseCaseDeps["workflow"];
+  private readonly documentStore: SetSpecUseCaseDeps["documentStore"];
+
+  constructor(deps: SetSpecUseCaseDeps) {
+    this.workflow = deps.workflow;
+    this.documentStore = deps.documentStore;
+  }
+
+  async execute(rawInput: unknown): Promise<unknown> {
+    await this.workflow.ensureInitialized();
+    const input = SetSpecInputSchema.parse(rawInput);
+    const markdown = input.markdown.trim();
+
+    const context = await this.workflow.resolveTaskContext(input.taskId);
+    const { task } = context;
+    assertNoValidationError(getSetSpecError(task.status));
+
+    const persistedDocument = await this.documentStore.persistSpec(task.id, markdown);
+
+    let nextTask: TaskCard = task;
+    if (task.status === "open") {
+      const refreshedContext = await this.workflow.refreshTaskContext(task.id, context);
+      nextTask = await this.workflow.transitionTask(task.id, "spec_ready", refreshedContext);
+    }
+
+    return {
+      task: nextTask,
+      document: {
+        markdown,
+        updatedAt: persistedDocument.updatedAt,
+        revision: persistedDocument.revision,
+      },
+    };
+  }
+}
+
+type SetPlanUseCaseDeps = {
+  workflow: Pick<
+    OdtTaskWorkflowRuntimePort,
+    "ensureInitialized" | "resolveTaskContext" | "refreshTaskContext" | "transitionTask"
+  >;
+  documentStore: Pick<TaskDocumentPort, "persistImplementationPlan">;
+  epicSubtaskReplacementService: EpicSubtaskReplacementPort;
+};
+
+export class SetPlanUseCase implements OdtTaskStoreUseCase {
+  private readonly workflow: SetPlanUseCaseDeps["workflow"];
+  private readonly documentStore: SetPlanUseCaseDeps["documentStore"];
+  private readonly epicSubtaskReplacementService: SetPlanUseCaseDeps["epicSubtaskReplacementService"];
+
+  constructor(deps: SetPlanUseCaseDeps) {
+    this.workflow = deps.workflow;
+    this.documentStore = deps.documentStore;
+    this.epicSubtaskReplacementService = deps.epicSubtaskReplacementService;
+  }
+
+  async execute(rawInput: unknown): Promise<unknown> {
+    await this.workflow.ensureInitialized();
+    const input = SetPlanInputSchema.parse(rawInput);
+    const markdown = input.markdown.trim();
+
+    const context = await this.workflow.resolveTaskContext(input.taskId);
+    const { task, tasks } = context;
+
+    const normalizedSubtasks = normalizePlanSubtasks(input.subtasks ?? []);
+    let persistedDocument: { updatedAt: string; revision: number };
+    let createdSubtaskIds: string[] = [];
+    if (task.issueType === "epic") {
+      // Epic subtask replacement must validate against a fresh snapshot, not the initial context.
+      const epicReplacement = await this.epicSubtaskReplacementService.prepareReplacement(
+        task,
+        normalizedSubtasks,
+      );
+      persistedDocument = await this.documentStore.persistImplementationPlan(task.id, markdown);
+      createdSubtaskIds = await this.epicSubtaskReplacementService.applyReplacement(
+        epicReplacement.latestTask,
+        epicReplacement.existingDirectSubtasks,
+        normalizedSubtasks,
+      );
+    } else {
+      assertNoValidationError(getSetPlanError(task));
+      validatePlanSubtaskRules(task, tasks, normalizedSubtasks);
+      persistedDocument = await this.documentStore.persistImplementationPlan(task.id, markdown);
+    }
+
+    const refreshedContext = await this.workflow.refreshTaskContext(task.id, context);
+    const nextTask = await this.workflow.transitionTask(task.id, "ready_for_dev", refreshedContext);
+
+    return {
+      task: nextTask,
+      document: {
+        markdown,
+        updatedAt: persistedDocument.updatedAt,
+        revision: persistedDocument.revision,
+      },
+      createdSubtaskIds,
+    };
+  }
+}
+
+type TransitionTaskUseCaseDeps = {
+  workflow: Pick<OdtTaskWorkflowRuntimePort, "ensureInitialized" | "transitionTask">;
+};
+
+export class BuildBlockedUseCase implements OdtTaskStoreUseCase {
+  private readonly workflow: TransitionTaskUseCaseDeps["workflow"];
+
+  constructor(deps: TransitionTaskUseCaseDeps) {
+    this.workflow = deps.workflow;
+  }
+
+  async execute(rawInput: unknown): Promise<unknown> {
+    await this.workflow.ensureInitialized();
+    const input = BuildBlockedInputSchema.parse(rawInput);
+    const task = await this.workflow.transitionTask(input.taskId, "blocked");
+    return {
+      task,
+      reason: input.reason,
+    };
+  }
+}
+
+export class BuildResumedUseCase implements OdtTaskStoreUseCase {
+  private readonly workflow: TransitionTaskUseCaseDeps["workflow"];
+
+  constructor(deps: TransitionTaskUseCaseDeps) {
+    this.workflow = deps.workflow;
+  }
+
+  async execute(rawInput: unknown): Promise<unknown> {
+    await this.workflow.ensureInitialized();
+    const input = BuildResumedInputSchema.parse(rawInput);
+    const task = await this.workflow.transitionTask(input.taskId, "in_progress");
+    return { task };
+  }
+}
+
+type BuildCompletedUseCaseDeps = {
+  workflow: Pick<
+    OdtTaskWorkflowRuntimePort,
+    "ensureInitialized" | "resolveTaskContext" | "refreshTaskContext" | "transitionTask"
+  >;
+};
+
+export class BuildCompletedUseCase implements OdtTaskStoreUseCase {
+  private readonly workflow: BuildCompletedUseCaseDeps["workflow"];
+
+  constructor(deps: BuildCompletedUseCaseDeps) {
+    this.workflow = deps.workflow;
+  }
+
+  async execute(rawInput: unknown): Promise<unknown> {
+    await this.workflow.ensureInitialized();
+    const input = BuildCompletedInputSchema.parse(rawInput);
+
+    const context = await this.workflow.resolveTaskContext(input.taskId);
+    const refreshedContext = await this.workflow.refreshTaskContext(context.task.id, context);
+    const { task } = refreshedContext;
+
+    const nextStatus = task.aiReviewEnabled ? "ai_review" : "human_review";
+    const updatedTask = await this.workflow.transitionTask(task.id, nextStatus, refreshedContext);
+    return {
+      task: updatedTask,
+      ...(input.summary ? { summary: input.summary } : {}),
+    };
+  }
+}
+
+type QaUseCaseDeps = {
+  workflow: Pick<
+    OdtTaskWorkflowRuntimePort,
+    | "ensureInitialized"
+    | "resolveTaskContext"
+    | "assertTransitionAllowed"
+    | "refreshTaskContext"
+    | "transitionTask"
+  >;
+  documentStore: Pick<TaskDocumentPort, "appendQaReport">;
+};
+
+export class QaApprovedUseCase implements OdtTaskStoreUseCase {
+  private readonly workflow: QaUseCaseDeps["workflow"];
+  private readonly documentStore: QaUseCaseDeps["documentStore"];
+
+  constructor(deps: QaUseCaseDeps) {
+    this.workflow = deps.workflow;
+    this.documentStore = deps.documentStore;
+  }
+
+  async execute(rawInput: unknown): Promise<unknown> {
+    await this.workflow.ensureInitialized();
+    const input = QaApprovedInputSchema.parse(rawInput);
+    const context = await this.workflow.resolveTaskContext(input.taskId);
+    const { task, tasks } = context;
+    this.workflow.assertTransitionAllowed(task, tasks, "human_review");
+    await this.documentStore.appendQaReport(task.id, input.reportMarkdown.trim(), "approved");
+    const refreshedContext = await this.workflow.refreshTaskContext(task.id, context);
+    const updatedTask = await this.workflow.transitionTask(
+      task.id,
+      "human_review",
+      refreshedContext,
+    );
+    return { task: updatedTask };
+  }
+}
+
+export class QaRejectedUseCase implements OdtTaskStoreUseCase {
+  private readonly workflow: QaUseCaseDeps["workflow"];
+  private readonly documentStore: QaUseCaseDeps["documentStore"];
+
+  constructor(deps: QaUseCaseDeps) {
+    this.workflow = deps.workflow;
+    this.documentStore = deps.documentStore;
+  }
+
+  async execute(rawInput: unknown): Promise<unknown> {
+    await this.workflow.ensureInitialized();
+    const input = QaRejectedInputSchema.parse(rawInput);
+    const context = await this.workflow.resolveTaskContext(input.taskId);
+    const { task, tasks } = context;
+    this.workflow.assertTransitionAllowed(task, tasks, "in_progress");
+    await this.documentStore.appendQaReport(task.id, input.reportMarkdown.trim(), "rejected");
+    const refreshedContext = await this.workflow.refreshTaskContext(task.id, context);
+    const updatedTask = await this.workflow.transitionTask(
+      task.id,
+      "in_progress",
+      refreshedContext,
+    );
+    return { task: updatedTask };
+  }
+}
+
+export type CreateOdtTaskStoreUseCasesDeps = {
+  workflow: OdtTaskWorkflowRuntimePort;
+  documentStore: TaskDocumentPort;
+  epicSubtaskReplacementService: EpicSubtaskReplacementPort;
+};
+
+export const createOdtTaskStoreUseCases = (
+  deps: CreateOdtTaskStoreUseCasesDeps,
+): OdtTaskStoreUseCases => ({
+  readTask: new ReadTaskUseCase({
+    workflow: deps.workflow,
+    documentStore: deps.documentStore,
+  }),
+  setSpec: new SetSpecUseCase({
+    workflow: deps.workflow,
+    documentStore: deps.documentStore,
+  }),
+  setPlan: new SetPlanUseCase({
+    workflow: deps.workflow,
+    documentStore: deps.documentStore,
+    epicSubtaskReplacementService: deps.epicSubtaskReplacementService,
+  }),
+  buildBlocked: new BuildBlockedUseCase({
+    workflow: deps.workflow,
+  }),
+  buildResumed: new BuildResumedUseCase({
+    workflow: deps.workflow,
+  }),
+  buildCompleted: new BuildCompletedUseCase({
+    workflow: deps.workflow,
+  }),
+  qaApproved: new QaApprovedUseCase({
+    workflow: deps.workflow,
+    documentStore: deps.documentStore,
+  }),
+  qaRejected: new QaRejectedUseCase({
+    workflow: deps.workflow,
+    documentStore: deps.documentStore,
+  }),
+});

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
@@ -291,13 +291,9 @@ export class BuildCompletedUseCase
 type QaUseCaseDeps = {
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
-    | "ensureInitialized"
-    | "resolveTaskContext"
-    | "assertTransitionAllowed"
-    | "refreshTaskContext"
-    | "transitionTask"
+    "applyTaskUpdate" | "assertTransitionAllowed" | "ensureInitialized" | "readTaskSnapshot"
   >;
-  documentStore: Pick<TaskDocumentPort, "appendQaReport">;
+  documentStore: Pick<TaskDocumentPort, "prepareQaReportWrite">;
 };
 
 export class QaApprovedUseCase implements OdtTaskStoreUseCase<QaApprovedInput, QaApprovedResult> {
@@ -311,16 +307,17 @@ export class QaApprovedUseCase implements OdtTaskStoreUseCase<QaApprovedInput, Q
 
   async execute(input: QaApprovedInput): Promise<QaApprovedResult> {
     await this.workflow.ensureInitialized();
-    const context = await this.workflow.resolveTaskContext(input.taskId);
-    const { task, tasks } = context;
-    this.workflow.assertTransitionAllowed(task, tasks, "human_review");
-    await this.documentStore.appendQaReport(task.id, input.reportMarkdown.trim(), "approved");
-    const refreshedContext = await this.workflow.refreshTaskContext(task.id, context);
-    const updatedTask = await this.workflow.transitionTask(
-      task.id,
-      "human_review",
-      refreshedContext,
+    const { issue, task } = await this.workflow.readTaskSnapshot(input.taskId);
+    this.workflow.assertTransitionAllowed(task, [task], "human_review");
+    const preparedWrite = this.documentStore.prepareQaReportWrite(
+      issue,
+      input.reportMarkdown.trim(),
+      "approved",
     );
+    const updatedTask = await this.workflow.applyTaskUpdate(task.id, {
+      metadataRoot: preparedWrite.metadataRoot,
+      status: "human_review",
+    });
     return { task: updatedTask };
   }
 }
@@ -336,16 +333,17 @@ export class QaRejectedUseCase implements OdtTaskStoreUseCase<QaRejectedInput, Q
 
   async execute(input: QaRejectedInput): Promise<QaRejectedResult> {
     await this.workflow.ensureInitialized();
-    const context = await this.workflow.resolveTaskContext(input.taskId);
-    const { task, tasks } = context;
-    this.workflow.assertTransitionAllowed(task, tasks, "in_progress");
-    await this.documentStore.appendQaReport(task.id, input.reportMarkdown.trim(), "rejected");
-    const refreshedContext = await this.workflow.refreshTaskContext(task.id, context);
-    const updatedTask = await this.workflow.transitionTask(
-      task.id,
-      "in_progress",
-      refreshedContext,
+    const { issue, task } = await this.workflow.readTaskSnapshot(input.taskId);
+    this.workflow.assertTransitionAllowed(task, [task], "in_progress");
+    const preparedWrite = this.documentStore.prepareQaReportWrite(
+      issue,
+      input.reportMarkdown.trim(),
+      "rejected",
     );
+    const updatedTask = await this.workflow.applyTaskUpdate(task.id, {
+      metadataRoot: preparedWrite.metadataRoot,
+      status: "in_progress",
+    });
     return { task: updatedTask };
   }
 }

--- a/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
@@ -37,6 +37,9 @@ describe("OdtTaskStore composition", () => {
       getNamespaceData: () => {
         throw new Error("getNamespaceData should not be called by readTask");
       },
+      updateTask: async () => {
+        throw new Error("updateTask should not be called by readTask");
+      },
       writeNamespace: async () => {
         throw new Error("writeNamespace should not be called by readTask");
       },
@@ -47,6 +50,11 @@ describe("OdtTaskStore composition", () => {
         spec: { markdown: "spec", updatedAt: null },
         implementationPlan: { markdown: "plan", updatedAt: null },
         latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+      }),
+      prepareQaReportWrite: () => ({
+        metadataRoot: {},
+        namespace: {},
+        root: {},
       }),
       persistSpec: async () => ({ updatedAt: "", revision: 1 }),
       persistImplementationPlan: async () => ({ updatedAt: "", revision: 1 }),
@@ -94,6 +102,9 @@ describe("OdtTaskStore composition", () => {
       getNamespaceData: () => {
         throw new Error("getNamespaceData should not be called by readTask");
       },
+      updateTask: async () => {
+        throw new Error("updateTask should not be called by readTask");
+      },
       writeNamespace: async () => {
         throw new Error("writeNamespace should not be called by readTask");
       },
@@ -104,6 +115,11 @@ describe("OdtTaskStore composition", () => {
         spec: { markdown: "", updatedAt: null },
         implementationPlan: { markdown: "", updatedAt: null },
         latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+      }),
+      prepareQaReportWrite: () => ({
+        metadataRoot: {},
+        namespace: {},
+        root: {},
       }),
       persistSpec: async () => ({ updatedAt: "", revision: 1 }),
       persistImplementationPlan: async () => ({ updatedAt: "", revision: 1 }),
@@ -147,6 +163,9 @@ describe("OdtTaskStore composition", () => {
       getNamespaceData: () => {
         throw new Error("getNamespaceData should not be called by readTask");
       },
+      updateTask: async () => {
+        throw new Error("updateTask should not be called by readTask");
+      },
       writeNamespace: async () => {
         throw new Error("writeNamespace should not be called by readTask");
       },
@@ -157,6 +176,11 @@ describe("OdtTaskStore composition", () => {
         spec: { markdown: "", updatedAt: null },
         implementationPlan: { markdown: "", updatedAt: null },
         latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+      }),
+      prepareQaReportWrite: () => ({
+        metadataRoot: {},
+        namespace: {},
+        root: {},
       }),
       persistSpec: async () => ({ updatedAt: "", revision: 1 }),
       persistImplementationPlan: async () => ({ updatedAt: "", revision: 1 }),

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -8,6 +8,16 @@ import type { OdtStoreOptions } from "./store-context";
 import { type TaskDocumentPort, TaskDocumentStore } from "./task-document-store";
 import { TaskIndexCache } from "./task-index-cache";
 import { createOdtTaskWorkflowRuntime } from "./task-workflow-runtime";
+import {
+  BuildBlockedInputSchema,
+  BuildCompletedInputSchema,
+  BuildResumedInputSchema,
+  QaApprovedInputSchema,
+  QaRejectedInputSchema,
+  ReadTaskInputSchema,
+  SetPlanInputSchema,
+  SetSpecInputSchema,
+} from "./tool-schemas";
 
 export type OdtTaskStoreDeps = {
   runProcess?: BdRuntimeClientDeps["runProcess"];
@@ -52,7 +62,7 @@ export class OdtTaskStore {
     this.metadataNamespace = persistence.metadataNamespace;
     const workflow = createOdtTaskWorkflowRuntime({
       persistence,
-      taskIndexCache,
+      taskLookup: taskIndexCache,
     });
     this.useCases = createOdtTaskStoreUseCases({
       workflow,
@@ -72,35 +82,51 @@ export class OdtTaskStore {
     return new BdPersistence(bdClient, options.metadataNamespace);
   }
 
-  async readTask(rawInput: unknown): Promise<unknown> {
-    return this.useCases.readTask.execute(rawInput);
+  async readTask(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["readTask"]["execute"]>>> {
+    return this.useCases.readTask.execute(ReadTaskInputSchema.parse(rawInput));
   }
 
-  async setSpec(rawInput: unknown): Promise<unknown> {
-    return this.useCases.setSpec.execute(rawInput);
+  async setSpec(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["setSpec"]["execute"]>>> {
+    return this.useCases.setSpec.execute(SetSpecInputSchema.parse(rawInput));
   }
 
-  async setPlan(rawInput: unknown): Promise<unknown> {
-    return this.useCases.setPlan.execute(rawInput);
+  async setPlan(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["setPlan"]["execute"]>>> {
+    return this.useCases.setPlan.execute(SetPlanInputSchema.parse(rawInput));
   }
 
-  async buildBlocked(rawInput: unknown): Promise<unknown> {
-    return this.useCases.buildBlocked.execute(rawInput);
+  async buildBlocked(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["buildBlocked"]["execute"]>>> {
+    return this.useCases.buildBlocked.execute(BuildBlockedInputSchema.parse(rawInput));
   }
 
-  async buildResumed(rawInput: unknown): Promise<unknown> {
-    return this.useCases.buildResumed.execute(rawInput);
+  async buildResumed(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["buildResumed"]["execute"]>>> {
+    return this.useCases.buildResumed.execute(BuildResumedInputSchema.parse(rawInput));
   }
 
-  async buildCompleted(rawInput: unknown): Promise<unknown> {
-    return this.useCases.buildCompleted.execute(rawInput);
+  async buildCompleted(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["buildCompleted"]["execute"]>>> {
+    return this.useCases.buildCompleted.execute(BuildCompletedInputSchema.parse(rawInput));
   }
 
-  async qaApproved(rawInput: unknown): Promise<unknown> {
-    return this.useCases.qaApproved.execute(rawInput);
+  async qaApproved(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["qaApproved"]["execute"]>>> {
+    return this.useCases.qaApproved.execute(QaApprovedInputSchema.parse(rawInput));
   }
 
-  async qaRejected(rawInput: unknown): Promise<unknown> {
-    return this.useCases.qaRejected.execute(rawInput);
+  async qaRejected(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["qaRejected"]["execute"]>>> {
+    return this.useCases.qaRejected.execute(QaRejectedInputSchema.parse(rawInput));
   }
 }

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -1,37 +1,13 @@
 import { BdPersistence, type TaskPersistencePort } from "./bd-persistence";
 import { BdRuntimeClient, type BdRuntimeClientDeps } from "./bd-runtime-client";
 import { nowIso, type TimeProvider } from "./beads-runtime";
-import type { TaskCard, TaskStatus } from "./contracts";
 import { EpicSubtaskReplacementService } from "./epic-subtask-replacement";
 import { createSubtask, deleteTaskById } from "./epic-subtasks";
-import { normalizePlanSubtasks } from "./plan-subtasks";
+import { createOdtTaskStoreUseCases, type OdtTaskStoreUseCases } from "./odt-task-store-use-cases";
 import type { OdtStoreOptions } from "./store-context";
 import { type TaskDocumentPort, TaskDocumentStore } from "./task-document-store";
 import { TaskIndexCache } from "./task-index-cache";
-import { issueToTaskCard } from "./task-mapping";
-import {
-  assertTransitionAllowed as assertTaskTransitionAllowed,
-  refreshTaskContext,
-  resolveTaskContext,
-  type TaskContext,
-  transitionTask,
-} from "./task-transitions";
-import {
-  BuildBlockedInputSchema,
-  BuildCompletedInputSchema,
-  BuildResumedInputSchema,
-  QaApprovedInputSchema,
-  QaRejectedInputSchema,
-  ReadTaskInputSchema,
-  SetPlanInputSchema,
-  SetSpecInputSchema,
-} from "./tool-schemas";
-import {
-  assertNoValidationError,
-  getSetPlanError,
-  getSetSpecError,
-  validatePlanSubtaskRules,
-} from "./workflow-policy";
+import { createOdtTaskWorkflowRuntime } from "./task-workflow-runtime";
 
 export type OdtTaskStoreDeps = {
   runProcess?: BdRuntimeClientDeps["runProcess"];
@@ -46,38 +22,43 @@ export type OdtTaskStoreDeps = {
 export class OdtTaskStore {
   readonly repoPath: string;
   readonly metadataNamespace: string;
-  private readonly persistence: TaskPersistencePort;
-  private readonly documentStore: TaskDocumentPort;
-  private readonly taskIndexCache: TaskIndexCache;
-  private readonly epicSubtaskReplacementService: EpicSubtaskReplacementService;
+  private readonly useCases: OdtTaskStoreUseCases;
 
   constructor(options: OdtStoreOptions, deps: OdtTaskStoreDeps = {}) {
     this.repoPath = options.repoPath;
-    this.persistence = deps.persistence ?? this.createDefaultPersistence(options, deps);
-    this.metadataNamespace = this.persistence.metadataNamespace;
-    this.documentStore =
-      deps.documentStore ?? new TaskDocumentStore(this.persistence, deps.now ?? nowIso);
-    this.taskIndexCache =
-      deps.taskIndexCache ?? new TaskIndexCache(() => this.persistence.listTasks());
-    this.epicSubtaskReplacementService =
+    const persistence = deps.persistence ?? this.createDefaultPersistence(options, deps);
+    const documentStore =
+      deps.documentStore ?? new TaskDocumentStore(persistence, deps.now ?? nowIso);
+    const taskIndexCache = deps.taskIndexCache ?? new TaskIndexCache(() => persistence.listTasks());
+    const epicSubtaskReplacementService =
       deps.epicSubtaskReplacementService ??
       new EpicSubtaskReplacementService({
-        listTasks: () => this.persistence.listTasks(),
+        listTasks: () => persistence.listTasks(),
         createSubtask: async (parentTaskId, subtask) =>
           createSubtask(
             parentTaskId,
             subtask,
-            (args) => this.persistence.runBdJson(args),
-            () => this.taskIndexCache.invalidate(),
+            (args) => persistence.runBdJson(args),
+            () => taskIndexCache.invalidate(),
           ),
         deleteTask: async (taskId) =>
           deleteTaskById(
             taskId,
-            (args) => this.persistence.runBdJson(args),
-            () => this.taskIndexCache.invalidate(),
+            (args) => persistence.runBdJson(args),
+            () => taskIndexCache.invalidate(),
             false,
           ),
       });
+    this.metadataNamespace = persistence.metadataNamespace;
+    const workflow = createOdtTaskWorkflowRuntime({
+      persistence,
+      taskIndexCache,
+    });
+    this.useCases = createOdtTaskStoreUseCases({
+      workflow,
+      documentStore,
+      epicSubtaskReplacementService,
+    });
   }
 
   private createDefaultPersistence(
@@ -91,183 +72,35 @@ export class OdtTaskStore {
     return new BdPersistence(bdClient, options.metadataNamespace);
   }
 
-  private async resolveTaskContext(taskId: string): Promise<TaskContext> {
-    return resolveTaskContext(taskId, () => this.persistence.listTasks());
-  }
-
-  private async refreshTaskContext(taskId: string, context?: TaskContext): Promise<TaskContext> {
-    return refreshTaskContext({
-      taskId,
-      ...(context ? { context } : {}),
-      showRawIssue: (id) => this.persistence.showRawIssue(id),
-      metadataNamespace: this.metadataNamespace,
-    });
-  }
-
-  private assertTransitionAllowed(task: TaskCard, tasks: TaskCard[], nextStatus: TaskStatus): void {
-    assertTaskTransitionAllowed(task, tasks, nextStatus);
-  }
-
-  private async transitionTask(
-    taskId: string,
-    nextStatus: TaskStatus,
-    context?: TaskContext,
-  ): Promise<TaskCard> {
-    return transitionTask({
-      taskId,
-      nextStatus,
-      ...(context ? { context } : {}),
-      listTasks: () => this.persistence.listTasks(),
-      runBdJson: (args) => this.persistence.runBdJson(args),
-      showRawIssue: (id) => this.persistence.showRawIssue(id),
-      invalidateTaskIndex: () => this.taskIndexCache.invalidate(),
-      metadataNamespace: this.metadataNamespace,
-    });
-  }
-
   async readTask(rawInput: unknown): Promise<unknown> {
-    await this.persistence.ensureInitialized();
-    const input = ReadTaskInputSchema.parse(rawInput);
-    const task = await this.taskIndexCache.resolveTask(input.taskId);
-
-    const issue = await this.persistence.showRawIssue(task.id);
-    const taskCard = issueToTaskCard(issue, this.metadataNamespace);
-    const docs = this.documentStore.parseDocs(issue);
-
-    return {
-      task: taskCard,
-      documents: docs,
-    };
+    return this.useCases.readTask.execute(rawInput);
   }
 
   async setSpec(rawInput: unknown): Promise<unknown> {
-    await this.persistence.ensureInitialized();
-    const input = SetSpecInputSchema.parse(rawInput);
-    const markdown = input.markdown.trim();
-
-    const context = await this.resolveTaskContext(input.taskId);
-    const { task } = context;
-    assertNoValidationError(getSetSpecError(task.status));
-
-    const persistedDocument = await this.documentStore.persistSpec(task.id, markdown);
-
-    let nextTask: TaskCard = task;
-    if (task.status === "open") {
-      const refreshedContext = await this.refreshTaskContext(task.id, context);
-      nextTask = await this.transitionTask(task.id, "spec_ready", refreshedContext);
-    }
-
-    return {
-      task: nextTask,
-      document: {
-        markdown,
-        updatedAt: persistedDocument.updatedAt,
-        revision: persistedDocument.revision,
-      },
-    };
+    return this.useCases.setSpec.execute(rawInput);
   }
 
   async setPlan(rawInput: unknown): Promise<unknown> {
-    await this.persistence.ensureInitialized();
-    const input = SetPlanInputSchema.parse(rawInput);
-    const markdown = input.markdown.trim();
-
-    const context = await this.resolveTaskContext(input.taskId);
-    const { task, tasks } = context;
-
-    const normalizedSubtasks = normalizePlanSubtasks(input.subtasks ?? []);
-    let persistedDocument: { updatedAt: string; revision: number };
-    let createdSubtaskIds: string[] = [];
-    if (task.issueType === "epic") {
-      // Epic subtask replacement must validate against a fresh snapshot, not the initial context.
-      const epicReplacement = await this.epicSubtaskReplacementService.prepareReplacement(
-        task,
-        normalizedSubtasks,
-      );
-      persistedDocument = await this.documentStore.persistImplementationPlan(task.id, markdown);
-      createdSubtaskIds = await this.epicSubtaskReplacementService.applyReplacement(
-        epicReplacement.latestTask,
-        epicReplacement.existingDirectSubtasks,
-        normalizedSubtasks,
-      );
-    } else {
-      assertNoValidationError(getSetPlanError(task));
-      validatePlanSubtaskRules(task, tasks, normalizedSubtasks);
-      persistedDocument = await this.documentStore.persistImplementationPlan(task.id, markdown);
-    }
-
-    const refreshedTransitionContext = await this.refreshTaskContext(task.id, context);
-    const nextTask = await this.transitionTask(
-      task.id,
-      "ready_for_dev",
-      refreshedTransitionContext,
-    );
-
-    return {
-      task: nextTask,
-      document: {
-        markdown,
-        updatedAt: persistedDocument.updatedAt,
-        revision: persistedDocument.revision,
-      },
-      createdSubtaskIds,
-    };
+    return this.useCases.setPlan.execute(rawInput);
   }
 
   async buildBlocked(rawInput: unknown): Promise<unknown> {
-    await this.persistence.ensureInitialized();
-    const input = BuildBlockedInputSchema.parse(rawInput);
-    const task = await this.transitionTask(input.taskId, "blocked");
-    return {
-      task,
-      reason: input.reason,
-    };
+    return this.useCases.buildBlocked.execute(rawInput);
   }
 
   async buildResumed(rawInput: unknown): Promise<unknown> {
-    await this.persistence.ensureInitialized();
-    const input = BuildResumedInputSchema.parse(rawInput);
-    const task = await this.transitionTask(input.taskId, "in_progress");
-    return { task };
+    return this.useCases.buildResumed.execute(rawInput);
   }
 
   async buildCompleted(rawInput: unknown): Promise<unknown> {
-    await this.persistence.ensureInitialized();
-    const input = BuildCompletedInputSchema.parse(rawInput);
-
-    const context = await this.resolveTaskContext(input.taskId);
-    const refreshedContext = await this.refreshTaskContext(context.task.id, context);
-    const { task } = refreshedContext;
-
-    const nextStatus: TaskStatus = task.aiReviewEnabled ? "ai_review" : "human_review";
-    const updated = await this.transitionTask(task.id, nextStatus, refreshedContext);
-    return {
-      task: updated,
-      ...(input.summary ? { summary: input.summary } : {}),
-    };
+    return this.useCases.buildCompleted.execute(rawInput);
   }
 
   async qaApproved(rawInput: unknown): Promise<unknown> {
-    await this.persistence.ensureInitialized();
-    const input = QaApprovedInputSchema.parse(rawInput);
-    const context = await this.resolveTaskContext(input.taskId);
-    const { task, tasks } = context;
-    this.assertTransitionAllowed(task, tasks, "human_review");
-    await this.documentStore.appendQaReport(task.id, input.reportMarkdown.trim(), "approved");
-    const refreshedContext = await this.refreshTaskContext(task.id, context);
-    const updated = await this.transitionTask(task.id, "human_review", refreshedContext);
-    return { task: updated };
+    return this.useCases.qaApproved.execute(rawInput);
   }
 
   async qaRejected(rawInput: unknown): Promise<unknown> {
-    await this.persistence.ensureInitialized();
-    const input = QaRejectedInputSchema.parse(rawInput);
-    const context = await this.resolveTaskContext(input.taskId);
-    const { task, tasks } = context;
-    this.assertTransitionAllowed(task, tasks, "in_progress");
-    await this.documentStore.appendQaReport(task.id, input.reportMarkdown.trim(), "rejected");
-    const refreshedContext = await this.refreshTaskContext(task.id, context);
-    const updated = await this.transitionTask(task.id, "in_progress", refreshedContext);
-    return { task: updated };
+    return this.useCases.qaRejected.execute(rawInput);
   }
 }

--- a/packages/openducktor-mcp/src/task-document-store.ts
+++ b/packages/openducktor-mcp/src/task-document-store.ts
@@ -9,7 +9,7 @@ type MarkdownDocumentKey = "spec" | "implementationPlan";
 type QaVerdict = "approved" | "rejected";
 
 type PersistLatestMarkdownInput = {
-  taskId: string;
+  issue: RawIssue;
   markdown: string;
   documentKey: MarkdownDocumentKey;
 };
@@ -46,6 +46,14 @@ const getNextRevision = (entries: Array<{ revision: number }>): number => {
   return maxRevision + 1;
 };
 
+type PreparedNamespaceWrite = {
+  metadataRoot: Record<string, unknown>;
+  namespace: Record<string, unknown>;
+  root: Record<string, unknown>;
+};
+
+export type PreparedQaReportWrite = PreparedNamespaceWrite;
+
 export type TaskDocumentPort = {
   parseDocs(issue: RawIssue): TaskDocumentsSnapshot;
   persistSpec(taskId: string, markdown: string): Promise<{ updatedAt: string; revision: number }>;
@@ -54,6 +62,11 @@ export type TaskDocumentPort = {
     markdown: string,
   ): Promise<{ updatedAt: string; revision: number }>;
   appendQaReport(taskId: string, markdown: string, verdict: QaVerdict): Promise<void>;
+  prepareQaReportWrite(
+    issue: RawIssue,
+    markdown: string,
+    verdict: QaVerdict,
+  ): PreparedQaReportWrite;
 };
 
 export type TaskDocumentPersistence = Pick<
@@ -78,8 +91,9 @@ export class TaskDocumentStore implements TaskDocumentPort {
     taskId: string,
     markdown: string,
   ): Promise<{ updatedAt: string; revision: number }> {
+    const issue = await this.persistence.showRawIssue(taskId);
     return this.persistLatestMarkdown({
-      taskId,
+      issue,
       markdown,
       documentKey: "spec",
     });
@@ -89,8 +103,9 @@ export class TaskDocumentStore implements TaskDocumentPort {
     taskId: string,
     markdown: string,
   ): Promise<{ updatedAt: string; revision: number }> {
+    const issue = await this.persistence.showRawIssue(taskId);
     return this.persistLatestMarkdown({
-      taskId,
+      issue,
       markdown,
       documentKey: "implementationPlan",
     });
@@ -98,6 +113,15 @@ export class TaskDocumentStore implements TaskDocumentPort {
 
   async appendQaReport(taskId: string, markdown: string, verdict: QaVerdict): Promise<void> {
     const issue = await this.persistence.showRawIssue(taskId);
+    const preparedWrite = this.prepareQaReportWrite(issue, markdown, verdict);
+    await this.persistence.writeNamespace(taskId, preparedWrite.root, preparedWrite.namespace);
+  }
+
+  prepareQaReportWrite(
+    issue: RawIssue,
+    markdown: string,
+    verdict: QaVerdict,
+  ): PreparedQaReportWrite {
     const { root, namespace, documents } = this.persistence.getNamespaceData(issue);
     const entries = parseQaEntries(documents.qaReports);
     const source = QA_REPORT_SOURCES[verdict];
@@ -112,24 +136,28 @@ export class TaskDocumentStore implements TaskDocumentPort {
       revision: nextRevision,
     };
 
-    const nextDocuments = {
-      ...documents,
-      qaReports: [...entries, entry],
-    };
-
     const nextNamespace = {
       ...namespace,
-      documents: nextDocuments,
+      documents: {
+        ...documents,
+        qaReports: [...entries, entry],
+      },
     };
 
-    await this.persistence.writeNamespace(taskId, root, nextNamespace);
+    return {
+      metadataRoot: {
+        ...root,
+        [this.persistence.metadataNamespace]: nextNamespace,
+      },
+      namespace: nextNamespace,
+      root,
+    };
   }
 
   private async persistLatestMarkdown(
     input: PersistLatestMarkdownInput,
   ): Promise<{ updatedAt: string; revision: number }> {
-    const issue = await this.persistence.showRawIssue(input.taskId);
-    const { root, namespace, documents } = this.persistence.getNamespaceData(issue);
+    const { root, namespace, documents } = this.persistence.getNamespaceData(input.issue);
     const source = MARKDOWN_DOCUMENT_SOURCES[input.documentKey];
     const nextRevision = getNextRevision(parseMarkdownEntries(documents[input.documentKey]));
 
@@ -152,7 +180,7 @@ export class TaskDocumentStore implements TaskDocumentPort {
       documents: nextDocuments,
     };
 
-    await this.persistence.writeNamespace(input.taskId, root, nextNamespace);
+    await this.persistence.writeNamespace(input.issue.id, root, nextNamespace);
     return {
       updatedAt,
       revision: nextRevision,

--- a/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { createOdtTaskWorkflowRuntime } from "./task-workflow-runtime";
+
+type TaskCardFixtureInput = {
+  id: string;
+  title: string;
+  status: "open" | "spec_ready" | "ready_for_dev";
+  issueType: "feature" | "task";
+  aiReviewEnabled: boolean;
+};
+
+const makeTask = (overrides: Partial<TaskCardFixtureInput> = {}) =>
+  createTaskCard({
+    id: "task-1",
+    title: "Task 1",
+    status: "open",
+    issueType: "feature",
+    aiReviewEnabled: true,
+    ...overrides,
+  });
+
+const createTaskCard = (input: TaskCardFixtureInput) => ({
+  id: input.id,
+  title: input.title,
+  status: input.status,
+  issueType: input.issueType,
+  aiReviewEnabled: input.aiReviewEnabled,
+});
+
+const makeIssue = (input: { id?: string; status?: string; metadata?: unknown }) => ({
+  id: input.id ?? "task-1",
+  title: "Task 1",
+  status: input.status ?? "open",
+  issue_type: "feature",
+  metadata: input.metadata ?? {},
+});
+
+describe("task workflow runtime", () => {
+  test("readTaskSnapshot resolves the canonical task id through the lookup port", async () => {
+    const taskLookupCalls: string[] = [];
+    const runtime = createOdtTaskWorkflowRuntime({
+      persistence: {
+        metadataNamespace: "openducktor",
+        ensureInitialized: async () => {},
+        runBdJson: async () => {
+          throw new Error("runBdJson should not be called");
+        },
+        listTasks: async () => [],
+        showRawIssue: async (taskId) =>
+          makeIssue({
+            id: taskId,
+            status: "spec_ready",
+            metadata: { openducktor: { qaRequired: false } },
+          }),
+        getNamespaceData: () => {
+          throw new Error("getNamespaceData should not be called");
+        },
+        writeNamespace: async () => {
+          throw new Error("writeNamespace should not be called");
+        },
+      },
+      taskLookup: {
+        resolveTask: async (taskId) => {
+          taskLookupCalls.push(taskId);
+          return makeTask({ id: "canonical-task-1", status: "open" });
+        },
+        invalidate: () => {},
+      },
+    });
+
+    await expect(runtime.readTaskSnapshot("task-1")).resolves.toEqual({
+      issue: makeIssue({
+        id: "canonical-task-1",
+        status: "spec_ready",
+        metadata: { openducktor: { qaRequired: false } },
+      }),
+      task: makeTask({
+        id: "canonical-task-1",
+        status: "spec_ready",
+        aiReviewEnabled: false,
+      }),
+    });
+    expect(taskLookupCalls).toEqual(["task-1"]);
+  });
+
+  test("refreshTaskContext replaces the task entry inside an existing context", async () => {
+    const currentTask = makeTask({ status: "open" });
+    const runtime = createOdtTaskWorkflowRuntime({
+      persistence: {
+        metadataNamespace: "openducktor",
+        ensureInitialized: async () => {},
+        runBdJson: async () => {
+          throw new Error("runBdJson should not be called");
+        },
+        listTasks: async () => [],
+        showRawIssue: async () => makeIssue({ status: "spec_ready" }),
+        getNamespaceData: () => {
+          throw new Error("getNamespaceData should not be called");
+        },
+        writeNamespace: async () => {
+          throw new Error("writeNamespace should not be called");
+        },
+      },
+      taskLookup: {
+        resolveTask: async () => currentTask,
+        invalidate: () => {},
+      },
+    });
+
+    await expect(
+      runtime.refreshTaskContext("task-1", {
+        task: currentTask,
+        tasks: [currentTask],
+      }),
+    ).resolves.toEqual({
+      task: makeTask({ status: "spec_ready" }),
+      tasks: [makeTask({ status: "spec_ready" })],
+    });
+  });
+
+  test("transitionTask invalidates lookup state after a successful status update", async () => {
+    const runCalls: string[][] = [];
+    let invalidateCalls = 0;
+    const currentTask = makeTask({ status: "spec_ready" });
+    const runtime = createOdtTaskWorkflowRuntime({
+      persistence: {
+        metadataNamespace: "openducktor",
+        ensureInitialized: async () => {},
+        runBdJson: async (args) => {
+          runCalls.push(args);
+          return {};
+        },
+        listTasks: async () => [currentTask],
+        showRawIssue: async () => makeIssue({ status: "ready_for_dev" }),
+        getNamespaceData: () => {
+          throw new Error("getNamespaceData should not be called");
+        },
+        writeNamespace: async () => {
+          throw new Error("writeNamespace should not be called");
+        },
+      },
+      taskLookup: {
+        resolveTask: async () => currentTask,
+        invalidate: () => {
+          invalidateCalls += 1;
+        },
+      },
+    });
+
+    await expect(runtime.transitionTask("task-1", "ready_for_dev")).resolves.toEqual(
+      makeTask({ status: "ready_for_dev" }),
+    );
+    expect(runCalls).toEqual([["update", "task-1", "--status", "ready_for_dev"]]);
+    expect(invalidateCalls).toBe(1);
+  });
+});

--- a/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import type { TaskStatus } from "./contracts";
 import { createOdtTaskWorkflowRuntime } from "./task-workflow-runtime";
 
 type TaskCardFixtureInput = {
   id: string;
   title: string;
-  status: "open" | "spec_ready" | "ready_for_dev";
+  status: TaskStatus;
   issueType: "feature" | "task";
   aiReviewEnabled: boolean;
 };
@@ -52,6 +53,9 @@ describe("task workflow runtime", () => {
             status: "spec_ready",
             metadata: { openducktor: { qaRequired: false } },
           }),
+        updateTask: async () => {
+          throw new Error("updateTask should not be called");
+        },
         getNamespaceData: () => {
           throw new Error("getNamespaceData should not be called");
         },
@@ -94,6 +98,9 @@ describe("task workflow runtime", () => {
         },
         listTasks: async () => [],
         showRawIssue: async () => makeIssue({ status: "spec_ready" }),
+        updateTask: async () => {
+          throw new Error("updateTask should not be called");
+        },
         getNamespaceData: () => {
           throw new Error("getNamespaceData should not be called");
         },
@@ -132,6 +139,9 @@ describe("task workflow runtime", () => {
         },
         listTasks: async () => [currentTask],
         showRawIssue: async () => makeIssue({ status: "ready_for_dev" }),
+        updateTask: async () => {
+          throw new Error("updateTask should not be called");
+        },
         getNamespaceData: () => {
           throw new Error("getNamespaceData should not be called");
         },
@@ -151,6 +161,60 @@ describe("task workflow runtime", () => {
       makeTask({ status: "ready_for_dev" }),
     );
     expect(runCalls).toEqual([["update", "task-1", "--status", "ready_for_dev"]]);
+    expect(invalidateCalls).toBe(1);
+  });
+
+  test("applyTaskUpdate writes metadata and status together and invalidates lookup state", async () => {
+    const updateCalls: Array<{ metadataRoot?: unknown; status?: string }> = [];
+    let invalidateCalls = 0;
+
+    const runtime = createOdtTaskWorkflowRuntime({
+      persistence: {
+        metadataNamespace: "openducktor",
+        ensureInitialized: async () => {},
+        runBdJson: async () => {
+          throw new Error("runBdJson should not be called");
+        },
+        listTasks: async () => [],
+        showRawIssue: async () =>
+          makeIssue({
+            status: "human_review",
+            metadata: { openducktor: { documents: { qaReports: [{ verdict: "approved" }] } } },
+          }),
+        updateTask: async (taskId, input) => {
+          expect(taskId).toBe("task-1");
+          updateCalls.push({
+            metadataRoot: input.metadataRoot,
+            status: input.status,
+          });
+        },
+        getNamespaceData: () => {
+          throw new Error("getNamespaceData should not be called");
+        },
+        writeNamespace: async () => {
+          throw new Error("writeNamespace should not be called");
+        },
+      },
+      taskLookup: {
+        resolveTask: async () => makeTask(),
+        invalidate: () => {
+          invalidateCalls += 1;
+        },
+      },
+    });
+
+    await expect(
+      runtime.applyTaskUpdate("task-1", {
+        metadataRoot: { openducktor: { documents: { qaReports: [{ verdict: "approved" }] } } },
+        status: "human_review",
+      }),
+    ).resolves.toEqual(makeTask({ status: "human_review" }));
+    expect(updateCalls).toEqual([
+      {
+        metadataRoot: { openducktor: { documents: { qaReports: [{ verdict: "approved" }] } } },
+        status: "human_review",
+      },
+    ]);
     expect(invalidateCalls).toBe(1);
   });
 });

--- a/packages/openducktor-mcp/src/task-workflow-runtime.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.ts
@@ -20,19 +20,21 @@ export type OdtTaskWorkflowRuntimePort = {
   transitionTask(taskId: string, nextStatus: TaskStatus, context?: TaskContext): Promise<TaskCard>;
 };
 
+type TaskLookupPort = Pick<TaskIndexCache, "invalidate" | "resolveTask">;
+
 export type OdtTaskWorkflowRuntimeDeps = {
   persistence: TaskPersistencePort;
-  taskIndexCache: TaskIndexCache;
+  taskLookup: TaskLookupPort;
 };
 
 class DefaultOdtTaskWorkflowRuntime implements OdtTaskWorkflowRuntimePort {
   readonly metadataNamespace: string;
   private readonly persistence: TaskPersistencePort;
-  private readonly taskIndexCache: TaskIndexCache;
+  private readonly taskLookup: TaskLookupPort;
 
   constructor(deps: OdtTaskWorkflowRuntimeDeps) {
     this.persistence = deps.persistence;
-    this.taskIndexCache = deps.taskIndexCache;
+    this.taskLookup = deps.taskLookup;
     this.metadataNamespace = deps.persistence.metadataNamespace;
   }
 
@@ -41,7 +43,7 @@ class DefaultOdtTaskWorkflowRuntime implements OdtTaskWorkflowRuntimePort {
   }
 
   async readTaskSnapshot(taskId: string): Promise<{ issue: RawIssue; task: TaskCard }> {
-    const resolvedTask = await this.taskIndexCache.resolveTask(taskId);
+    const resolvedTask = await this.taskLookup.resolveTask(taskId);
     const issue = await this.persistence.showRawIssue(resolvedTask.id);
     const task = issueToTaskCard(issue, this.metadataNamespace);
     return { issue, task };
@@ -76,7 +78,7 @@ class DefaultOdtTaskWorkflowRuntime implements OdtTaskWorkflowRuntimePort {
       listTasks: () => this.persistence.listTasks(),
       runBdJson: (args) => this.persistence.runBdJson(args),
       showRawIssue: (id) => this.persistence.showRawIssue(id),
-      invalidateTaskIndex: () => this.taskIndexCache.invalidate(),
+      invalidateTaskIndex: () => this.taskLookup.invalidate(),
       metadataNamespace: this.metadataNamespace,
     });
   }

--- a/packages/openducktor-mcp/src/task-workflow-runtime.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.ts
@@ -1,0 +1,87 @@
+import type { TaskPersistencePort } from "./bd-persistence";
+import type { RawIssue, TaskCard, TaskStatus } from "./contracts";
+import type { TaskIndexCache } from "./task-index-cache";
+import { issueToTaskCard } from "./task-mapping";
+import {
+  assertTransitionAllowed as assertTaskTransitionAllowed,
+  refreshTaskContext,
+  resolveTaskContext,
+  type TaskContext,
+  transitionTask,
+} from "./task-transitions";
+
+export type OdtTaskWorkflowRuntimePort = {
+  metadataNamespace: string;
+  ensureInitialized(): Promise<void>;
+  readTaskSnapshot(taskId: string): Promise<{ issue: RawIssue; task: TaskCard }>;
+  resolveTaskContext(taskId: string): Promise<TaskContext>;
+  refreshTaskContext(taskId: string, context?: TaskContext): Promise<TaskContext>;
+  assertTransitionAllowed(task: TaskCard, tasks: TaskCard[], nextStatus: TaskStatus): void;
+  transitionTask(taskId: string, nextStatus: TaskStatus, context?: TaskContext): Promise<TaskCard>;
+};
+
+export type OdtTaskWorkflowRuntimeDeps = {
+  persistence: TaskPersistencePort;
+  taskIndexCache: TaskIndexCache;
+};
+
+class DefaultOdtTaskWorkflowRuntime implements OdtTaskWorkflowRuntimePort {
+  readonly metadataNamespace: string;
+  private readonly persistence: TaskPersistencePort;
+  private readonly taskIndexCache: TaskIndexCache;
+
+  constructor(deps: OdtTaskWorkflowRuntimeDeps) {
+    this.persistence = deps.persistence;
+    this.taskIndexCache = deps.taskIndexCache;
+    this.metadataNamespace = deps.persistence.metadataNamespace;
+  }
+
+  async ensureInitialized(): Promise<void> {
+    await this.persistence.ensureInitialized();
+  }
+
+  async readTaskSnapshot(taskId: string): Promise<{ issue: RawIssue; task: TaskCard }> {
+    const resolvedTask = await this.taskIndexCache.resolveTask(taskId);
+    const issue = await this.persistence.showRawIssue(resolvedTask.id);
+    const task = issueToTaskCard(issue, this.metadataNamespace);
+    return { issue, task };
+  }
+
+  async resolveTaskContext(taskId: string): Promise<TaskContext> {
+    return resolveTaskContext(taskId, () => this.persistence.listTasks());
+  }
+
+  async refreshTaskContext(taskId: string, context?: TaskContext): Promise<TaskContext> {
+    return refreshTaskContext({
+      taskId,
+      ...(context ? { context } : {}),
+      showRawIssue: (id) => this.persistence.showRawIssue(id),
+      metadataNamespace: this.metadataNamespace,
+    });
+  }
+
+  assertTransitionAllowed(task: TaskCard, tasks: TaskCard[], nextStatus: TaskStatus): void {
+    assertTaskTransitionAllowed(task, tasks, nextStatus);
+  }
+
+  async transitionTask(
+    taskId: string,
+    nextStatus: TaskStatus,
+    context?: TaskContext,
+  ): Promise<TaskCard> {
+    return transitionTask({
+      taskId,
+      nextStatus,
+      ...(context ? { context } : {}),
+      listTasks: () => this.persistence.listTasks(),
+      runBdJson: (args) => this.persistence.runBdJson(args),
+      showRawIssue: (id) => this.persistence.showRawIssue(id),
+      invalidateTaskIndex: () => this.taskIndexCache.invalidate(),
+      metadataNamespace: this.metadataNamespace,
+    });
+  }
+}
+
+export const createOdtTaskWorkflowRuntime = (
+  deps: OdtTaskWorkflowRuntimeDeps,
+): OdtTaskWorkflowRuntimePort => new DefaultOdtTaskWorkflowRuntime(deps);

--- a/packages/openducktor-mcp/src/task-workflow-runtime.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.ts
@@ -1,4 +1,4 @@
-import type { TaskPersistencePort } from "./bd-persistence";
+import type { TaskPersistencePort, TaskUpdateInput } from "./bd-persistence";
 import type { RawIssue, TaskCard, TaskStatus } from "./contracts";
 import type { TaskIndexCache } from "./task-index-cache";
 import { issueToTaskCard } from "./task-mapping";
@@ -13,6 +13,7 @@ import {
 export type OdtTaskWorkflowRuntimePort = {
   metadataNamespace: string;
   ensureInitialized(): Promise<void>;
+  applyTaskUpdate(taskId: string, input: TaskUpdateInput): Promise<TaskCard>;
   readTaskSnapshot(taskId: string): Promise<{ issue: RawIssue; task: TaskCard }>;
   resolveTaskContext(taskId: string): Promise<TaskContext>;
   refreshTaskContext(taskId: string, context?: TaskContext): Promise<TaskContext>;
@@ -40,6 +41,14 @@ class DefaultOdtTaskWorkflowRuntime implements OdtTaskWorkflowRuntimePort {
 
   async ensureInitialized(): Promise<void> {
     await this.persistence.ensureInitialized();
+  }
+
+  async applyTaskUpdate(taskId: string, input: TaskUpdateInput): Promise<TaskCard> {
+    await this.persistence.updateTask(taskId, input);
+
+    const refreshed = await this.persistence.showRawIssue(taskId);
+    this.taskLookup.invalidate();
+    return issueToTaskCard(refreshed, this.metadataNamespace);
   }
 
   async readTaskSnapshot(taskId: string): Promise<{ issue: RawIssue; task: TaskCard }> {


### PR DESCRIPTION
## Summary
- split `OdtTaskStore` into a thin MCP-facing composition root plus dedicated workflow use cases for each `odt_*` path
- introduce an internal workflow runtime adapter for task lookup, context refresh, and transitions so workflow orchestration is easier to test in isolation
- keep the new runtime/use-case layer internal to `packages/openducktor-mcp` and move schema parsing back to `OdtTaskStore` so the public package surface stays MCP-focused
- add direct unit coverage for the extracted workflow runtime and preserve the existing store-level integration coverage

## Testing
- `bun run --filter @openducktor/openducktor-mcp test`
- `bun run --filter @openducktor/openducktor-mcp typecheck`
- `bun run --filter @openducktor/openducktor-mcp lint`
