### PR TITLE
refactor(host-infra-system): extract config store primitives and restore Windows build compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+          targets: x86_64-pc-windows-gnu
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -104,6 +105,9 @@ jobs:
 
       - name: Lint Tauri app
         run: cargo rust-lint-tauri
+
+      - name: Cross-platform config build check
+        run: cargo check --locked --target x86_64-pc-windows-gnu -p host-infra-system
 
       - name: Run Tauri app tests
         run: cargo rust-test-tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         run: cargo rust-lint-tauri
 
       - name: Cross-platform config build check
-        run: cargo check --locked --target x86_64-pc-windows-gnu -p host-infra-system
+        run: cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --locked --target x86_64-pc-windows-gnu -p host-infra-system
 
       - name: Run Tauri app tests
         run: cargo rust-test-tauri

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -1,5 +1,7 @@
 mod migrate;
 mod normalize;
+mod persistence;
+mod security;
 mod store;
 mod types;
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
@@ -7,11 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
 use std::{
-    ffi::OsString,
-    fs::OpenOptions,
-    io::ErrorKind,
-    io::Write,
-    os::unix::fs::{OpenOptionsExt, PermissionsExt},
+    ffi::OsString, fs::OpenOptions, io::ErrorKind, io::Write, os::unix::fs::OpenOptionsExt,
     time::SystemTime,
 };
 
@@ -105,13 +101,6 @@ fn write_config_file_atomic(path: &Path, contents: &[u8]) -> Result<()> {
         {
             Ok(mut file) => {
                 let write_result = (|| -> Result<()> {
-                    file.set_permissions(fs::Permissions::from_mode(CONFIG_FILE_MODE))
-                        .with_context(|| {
-                            format!(
-                                "Failed setting secure permissions on config temp file {}",
-                                temp_path.display()
-                            )
-                        })?;
                     file.write_all(contents).with_context(|| {
                         format!("Failed writing config temp file {}", temp_path.display())
                     })?;

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
@@ -1,0 +1,185 @@
+use super::security::{enforce_directory_permissions, validate_config_access, CONFIG_FILE_MODE};
+use anyhow::{anyhow, Context, Result};
+use serde::{de::DeserializeOwned, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::{
+    ffi::OsString,
+    fs::OpenOptions,
+    io::ErrorKind,
+    io::Write,
+    os::unix::fs::{OpenOptionsExt, PermissionsExt},
+    time::SystemTime,
+};
+
+#[cfg(unix)]
+const MAX_TEMP_FILE_ATTEMPTS: u8 = 8;
+
+pub(super) fn resolve_default_path(file_name: &str) -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
+    Ok(home.join(".openducktor").join(file_name))
+}
+
+pub(super) fn should_enforce_private_parent_permissions(path: &Path, file_name: &str) -> bool {
+    resolve_default_path(file_name)
+        .map(|default_path| default_path == path)
+        .unwrap_or(false)
+}
+
+pub(super) fn load_config_or_default<T, Normalize, PostLoad>(
+    path: &Path,
+    enforce_private_parent_permissions: bool,
+    normalize: Normalize,
+    post_load: PostLoad,
+) -> Result<T>
+where
+    T: DeserializeOwned + Default,
+    Normalize: FnOnce(&mut T),
+    PostLoad: FnOnce(&mut T),
+{
+    if !path.exists() {
+        return Ok(T::default());
+    }
+
+    validate_config_access(path, enforce_private_parent_permissions)?;
+
+    let data = fs::read_to_string(path)
+        .with_context(|| format!("Failed reading config file {}", path.display()))?;
+    let mut parsed: T = serde_json::from_str(&data)
+        .with_context(|| format!("Failed parsing config file {}", path.display()))?;
+    normalize(&mut parsed);
+    post_load(&mut parsed);
+    Ok(parsed)
+}
+
+pub(super) fn save_config<T, Normalize>(
+    path: &Path,
+    enforce_private_parent_permissions: bool,
+    config: &T,
+    normalize: Normalize,
+) -> Result<()>
+where
+    T: Serialize + Clone,
+    Normalize: FnOnce(&mut T),
+{
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed creating config directory {}", parent.display()))?;
+        enforce_directory_permissions(parent, enforce_private_parent_permissions)?;
+    }
+
+    let mut normalized = config.clone();
+    normalize(&mut normalized);
+    let payload = serde_json::to_string_pretty(&normalized)?;
+    write_config_file(path, payload.as_bytes())?;
+    validate_config_access(path, enforce_private_parent_permissions)?;
+    Ok(())
+}
+
+fn write_config_file(path: &Path, contents: &[u8]) -> Result<()> {
+    #[cfg(unix)]
+    {
+        return write_config_file_atomic(path, contents);
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(path, contents)
+            .with_context(|| format!("Failed writing config file {}", path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn write_config_file_atomic(path: &Path, contents: &[u8]) -> Result<()> {
+    for attempt in 0..MAX_TEMP_FILE_ATTEMPTS {
+        let temp_path = create_temporary_config_path(path, attempt)?;
+        match OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .mode(CONFIG_FILE_MODE)
+            .open(&temp_path)
+        {
+            Ok(mut file) => {
+                let write_result = (|| -> Result<()> {
+                    file.set_permissions(fs::Permissions::from_mode(CONFIG_FILE_MODE))
+                        .with_context(|| {
+                            format!(
+                                "Failed setting secure permissions on config temp file {}",
+                                temp_path.display()
+                            )
+                        })?;
+                    file.write_all(contents).with_context(|| {
+                        format!("Failed writing config temp file {}", temp_path.display())
+                    })?;
+                    file.sync_all().with_context(|| {
+                        format!("Failed syncing config temp file {}", temp_path.display())
+                    })?;
+                    drop(file);
+                    fs::rename(&temp_path, path).with_context(|| {
+                        format!(
+                            "Failed atomically replacing config file {} with {}",
+                            path.display(),
+                            temp_path.display()
+                        )
+                    })?;
+                    Ok(())
+                })();
+
+                if let Err(error) = write_result {
+                    if let Err(cleanup_error) = fs::remove_file(&temp_path) {
+                        if cleanup_error.kind() != ErrorKind::NotFound {
+                            return Err(error).with_context(|| {
+                                format!(
+                                    "Failed cleaning up config temp file {} after write failure: {}",
+                                    temp_path.display(),
+                                    cleanup_error
+                                )
+                            });
+                        }
+                    }
+                    return Err(error);
+                }
+
+                return Ok(());
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Failed opening config temp file {}", temp_path.display())
+                });
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "Failed creating unique temp file for config write at {} after {} attempts",
+        path.display(),
+        MAX_TEMP_FILE_ATTEMPTS
+    ))
+}
+
+#[cfg(unix)]
+fn create_temporary_config_path(path: &Path, attempt: u8) -> Result<PathBuf> {
+    let parent = path.parent().ok_or_else(|| {
+        anyhow!(
+            "Config file path {} is invalid: missing parent directory",
+            path.display()
+        )
+    })?;
+    let file_name = path.file_name().ok_or_else(|| {
+        anyhow!(
+            "Config file path {} is invalid: missing file name",
+            path.display()
+        )
+    })?;
+    let nanos = SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| anyhow!("System clock error while building temp config path: {error}"))?
+        .as_nanos();
+    let mut temp_name = OsString::from(".");
+    temp_name.push(file_name);
+    temp_name.push(format!(".tmp-{}-{nanos}-{attempt}", std::process::id()));
+    Ok(parent.join(temp_name))
+}

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
@@ -78,7 +78,7 @@ where
 fn write_config_file(path: &Path, contents: &[u8]) -> Result<()> {
     #[cfg(unix)]
     {
-        return write_config_file_atomic(path, contents);
+        write_config_file_atomic(path, contents)
     }
 
     #[cfg(not(unix))]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
@@ -1,4 +1,6 @@
-use super::security::{enforce_directory_permissions, validate_config_access, CONFIG_FILE_MODE};
+#[cfg(unix)]
+use super::security::CONFIG_FILE_MODE;
+use super::security::{enforce_directory_permissions, validate_config_access};
 use anyhow::{anyhow, Context, Result};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fs;

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/security.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/security.rs
@@ -1,0 +1,113 @@
+use anyhow::{anyhow, Context, Result};
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::Path;
+
+#[cfg(unix)]
+pub(super) const CONFIG_DIR_MODE: u32 = 0o700;
+#[cfg(unix)]
+pub(super) const CONFIG_FILE_MODE: u32 = 0o600;
+
+pub(super) fn validate_config_access(
+    path: &Path,
+    enforce_private_parent_permissions: bool,
+) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let parent = path.parent().ok_or_else(|| {
+            anyhow!(
+                "Config file path {} is invalid: missing parent directory",
+                path.display()
+            )
+        })?;
+        let expected_uid = current_effective_uid();
+        if enforce_private_parent_permissions {
+            validate_private_directory(parent, expected_uid)?;
+        }
+        validate_private_file(path, expected_uid)?;
+    }
+    Ok(())
+}
+
+pub(super) fn enforce_directory_permissions(
+    path: &Path,
+    enforce_private_parent_permissions: bool,
+) -> Result<()> {
+    #[cfg(unix)]
+    {
+        if enforce_private_parent_permissions {
+            fs::set_permissions(path, fs::Permissions::from_mode(CONFIG_DIR_MODE)).with_context(
+                || {
+                    format!(
+                        "Failed setting secure permissions on config directory {}",
+                        path.display()
+                    )
+                },
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn current_effective_uid() -> u32 {
+    // SAFETY: geteuid has no preconditions and does not dereference pointers.
+    unsafe { libc::geteuid() as u32 }
+}
+
+#[cfg(unix)]
+fn validate_private_directory(path: &Path, expected_uid: u32) -> Result<()> {
+    let metadata = fs::metadata(path).with_context(|| {
+        format!(
+            "Failed reading config directory metadata {}",
+            path.display()
+        )
+    })?;
+    let mode = metadata.mode() & 0o777;
+    let owner_uid = metadata.uid();
+    if owner_uid != expected_uid {
+        return Err(anyhow!(
+            "Config directory {} must be owned by the current user (uid {}). Found uid {}. Run `chown -R $(whoami) {}`.",
+            path.display(),
+            expected_uid,
+            owner_uid,
+            path.display()
+        ));
+    }
+    if mode != CONFIG_DIR_MODE {
+        return Err(anyhow!(
+            "Config directory {} has unsupported mode {:04o}. Expected 0700 exactly. Run `chmod 700 {}`.",
+            path.display(),
+            mode,
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_private_file(path: &Path, expected_uid: u32) -> Result<()> {
+    let metadata = fs::metadata(path)
+        .with_context(|| format!("Failed reading config file metadata {}", path.display()))?;
+    let mode = metadata.mode() & 0o777;
+    let owner_uid = metadata.uid();
+    if owner_uid != expected_uid {
+        return Err(anyhow!(
+            "Config file {} must be owned by the current user (uid {}). Found uid {}. Run `chown $(whoami) {}`.",
+            path.display(),
+            expected_uid,
+            owner_uid,
+            path.display()
+        ));
+    }
+    if mode != CONFIG_FILE_MODE {
+        return Err(anyhow!(
+            "Config file {} has unsupported mode {:04o}. Expected 0600 exactly. Run `chmod 600 {}`.",
+            path.display(),
+            mode,
+            path.display()
+        ));
+    }
+    Ok(())
+}

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -1,21 +1,13 @@
 use super::migrate::{canonicalize_workspace_key, migrate_repos_to_canonical_keys};
 use super::normalize::{normalize_global_config, normalize_repo_config, normalize_runtime_config};
+use super::persistence::{
+    load_config_or_default, resolve_default_path, save_config,
+    should_enforce_private_parent_permissions,
+};
 use super::types::{hook_set_fingerprint, GlobalConfig, HookSet, RepoConfig, RuntimeConfig};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use host_domain::WorkspaceRecord;
-use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
-#[cfg(unix)]
-use std::{ffi::OsString, fs::OpenOptions, io::ErrorKind, io::Write, time::SystemTime};
-
-#[cfg(unix)]
-const CONFIG_DIR_MODE: u32 = 0o700;
-#[cfg(unix)]
-const CONFIG_FILE_MODE: u32 = 0o600;
-#[cfg(unix)]
-const MAX_TEMP_FILE_ATTEMPTS: u8 = 8;
 
 fn has_configured_worktree(repo: &RepoConfig) -> bool {
     repo.worktree_base_path.is_some()
@@ -35,17 +27,6 @@ pub struct RuntimeConfigStore {
 
 const USER_SETTINGS_FILENAME: &str = "config.json";
 const RUNTIME_SETTINGS_FILENAME: &str = "runtime-config.json";
-
-fn resolve_default_path(file_name: &str) -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
-    Ok(home.join(".openducktor").join(file_name))
-}
-
-fn should_enforce_private_parent_permissions(path: &Path, file_name: &str) -> bool {
-    resolve_default_path(file_name)
-        .map(|default_path| default_path == path)
-        .unwrap_or(false)
-}
 
 impl Default for AppConfigStore {
     fn default() -> Self {
@@ -75,69 +56,21 @@ impl AppConfigStore {
     }
 
     pub fn load(&self) -> Result<GlobalConfig> {
-        if !self.path.exists() {
-            return Ok(GlobalConfig::default());
-        }
-
-        validate_config_access(&self.path, self.enforce_private_parent_permissions)?;
-
-        let data = fs::read_to_string(&self.path)
-            .with_context(|| format!("Failed reading config file {}", self.path.display()))?;
-        let mut parsed: GlobalConfig = serde_json::from_str(&data)
-            .with_context(|| format!("Failed parsing config file {}", self.path.display()))?;
-        normalize_global_config(&mut parsed);
-
-        // Migrate repo keys to canonical form.
-        // Pass active_repo to prefer the user's current configuration on collision.
-        let canonical_repos =
-            migrate_repos_to_canonical_keys(&mut parsed.repos, parsed.active_repo.as_ref());
-        parsed.repos = canonical_repos;
-
-        // Also migrate active_repo to canonical key if it exists.
-        if let Some(active) = &parsed.active_repo {
-            if let Ok(canonical_active) = canonicalize_workspace_key(active) {
-                if parsed.repos.contains_key(&canonical_active) {
-                    parsed.active_repo = Some(canonical_active);
-                }
-            }
-        }
-
-        // Migrate recent_repos to canonical keys.
-        let mut canonical_recent: Vec<String> = Vec::new();
-        for recent in &parsed.recent_repos {
-            match canonicalize_workspace_key(recent) {
-                Ok(canonical_recent_key) => {
-                    if parsed.repos.contains_key(&canonical_recent_key)
-                        && !canonical_recent.contains(&canonical_recent_key)
-                    {
-                        canonical_recent.push(canonical_recent_key);
-                    }
-                }
-                Err(_) => {
-                    if !canonical_recent.contains(recent) {
-                        canonical_recent.push(recent.clone());
-                    }
-                }
-            }
-        }
-        parsed.recent_repos = canonical_recent;
-
-        Ok(parsed)
+        load_config_or_default(
+            &self.path,
+            self.enforce_private_parent_permissions,
+            normalize_global_config,
+            migrate_loaded_global_config,
+        )
     }
 
     pub fn save(&self, config: &GlobalConfig) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("Failed creating config directory {}", parent.display())
-            })?;
-            enforce_directory_permissions(parent, self.enforce_private_parent_permissions)?;
-        }
-        let mut normalized = config.clone();
-        normalize_global_config(&mut normalized);
-        let payload = serde_json::to_string_pretty(&normalized)?;
-        write_config_file(&self.path, payload.as_bytes())?;
-        validate_config_access(&self.path, self.enforce_private_parent_permissions)?;
-        Ok(())
+        save_config(
+            &self.path,
+            self.enforce_private_parent_permissions,
+            config,
+            normalize_global_config,
+        )
     }
 
     pub fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>> {
@@ -166,53 +99,25 @@ impl AppConfigStore {
             return Err(anyhow!("Workspace is not a git repository: {repo_path}"));
         }
 
-        let canonical_path = canonicalize_workspace_key(repo_path)?;
-
-        let mut config = self.load()?;
-        config
-            .repos
-            .entry(canonical_path.clone())
-            .or_insert_with(RepoConfig::default);
-        config.active_repo = Some(canonical_path.clone());
-        touch_recent(&mut config.recent_repos, &canonical_path);
-        self.save(&config)?;
-
-        Ok(WorkspaceRecord {
-            path: canonical_path.clone(),
-            is_active: true,
-            has_config: config
+        let workspace_key = canonicalize_workspace_key(repo_path)?;
+        self.update_workspace(workspace_key, |config, workspace_key| {
+            config
                 .repos
-                .get(&canonical_path)
-                .map(has_configured_worktree)
-                .unwrap_or(false),
-            configured_worktree_base_path: config
-                .repos
-                .get(&canonical_path)
-                .and_then(|repo| repo.worktree_base_path.clone()),
+                .entry(workspace_key.to_string())
+                .or_insert_with(RepoConfig::default);
+            config.active_repo = Some(workspace_key.to_string());
+            Ok(())
         })
     }
 
     pub fn select_workspace(&self, repo_path: &str) -> Result<WorkspaceRecord> {
-        let canonical_path =
-            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
-
-        let mut config = self.load()?;
-        if !config.repos.contains_key(&canonical_path) {
-            return Err(anyhow!("Workspace not found in config: {repo_path}"));
-        }
-        config.active_repo = Some(canonical_path.clone());
-        touch_recent(&mut config.recent_repos, &canonical_path);
-        self.save(&config)?;
-
-        let repo = config
-            .repos
-            .get(&canonical_path)
-            .ok_or_else(|| anyhow!("Workspace disappeared from config"))?;
-        Ok(WorkspaceRecord {
-            path: canonical_path,
-            is_active: true,
-            has_config: has_configured_worktree(repo),
-            configured_worktree_base_path: repo.worktree_base_path.clone(),
+        let workspace_key = workspace_lookup_key(repo_path);
+        self.update_workspace(workspace_key, |config, workspace_key| {
+            if !config.repos.contains_key(workspace_key) {
+                return Err(anyhow!("Workspace not found in config: {repo_path}"));
+            }
+            config.active_repo = Some(workspace_key.to_string());
+            Ok(())
         })
     }
 
@@ -223,29 +128,18 @@ impl AppConfigStore {
     ) -> Result<WorkspaceRecord> {
         normalize_repo_config(&mut repo_config);
 
-        let canonical_path =
-            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
-
-        let mut config = self.load()?;
-        if !config.repos.contains_key(&canonical_path) {
-            return Err(anyhow!(
-                "Workspace not found in config: {repo_path}. Add/select the workspace before updating configuration."
-            ));
-        }
-        config
-            .repos
-            .insert(canonical_path.clone(), repo_config.clone());
-        if config.active_repo.is_none() {
-            config.active_repo = Some(canonical_path.clone());
-        }
-        touch_recent(&mut config.recent_repos, &canonical_path);
-        self.save(&config)?;
-
-        Ok(WorkspaceRecord {
-            path: canonical_path.clone(),
-            is_active: config.active_repo.as_deref() == Some(&canonical_path),
-            has_config: has_configured_worktree(&repo_config),
-            configured_worktree_base_path: repo_config.worktree_base_path,
+        let workspace_key = workspace_lookup_key(repo_path);
+        self.update_workspace(workspace_key, move |config, workspace_key| {
+            if !config.repos.contains_key(workspace_key) {
+                return Err(anyhow!(
+                    "Workspace not found in config: {repo_path}. Add/select the workspace before updating configuration."
+                ));
+            }
+            config.repos.insert(workspace_key.to_string(), repo_config);
+            if config.active_repo.is_none() {
+                config.active_repo = Some(workspace_key.to_string());
+            }
+            Ok(())
         })
     }
 
@@ -254,8 +148,7 @@ impl AppConfigStore {
         repo_path: &str,
         mut hooks: HookSet,
     ) -> Result<WorkspaceRecord> {
-        let canonical_path =
-            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
+        let workspace_key = workspace_lookup_key(repo_path);
         let mut normalized_repo = RepoConfig {
             hooks,
             ..RepoConfig::default()
@@ -263,11 +156,10 @@ impl AppConfigStore {
         normalize_repo_config(&mut normalized_repo);
         hooks = normalized_repo.hooks;
 
-        let mut config = self.load()?;
-        let (has_config, configured_worktree_base_path) = {
+        self.update_workspace(workspace_key, move |config, workspace_key| {
             let repo = config
                 .repos
-                .get_mut(&canonical_path)
+                .get_mut(workspace_key)
                 .ok_or_else(|| anyhow!("Repository is not configured"))?;
             let previous_hooks = repo.hooks.clone();
             repo.hooks = hooks;
@@ -277,40 +169,26 @@ impl AppConfigStore {
             } else if repo.trusted_hooks {
                 repo.trusted_hooks_fingerprint = Some(hook_set_fingerprint(&repo.hooks));
             }
-            (
-                has_configured_worktree(repo),
-                repo.worktree_base_path.clone(),
-            )
-        };
-        touch_recent(&mut config.recent_repos, &canonical_path);
-        self.save(&config)?;
-
-        Ok(WorkspaceRecord {
-            path: canonical_path.clone(),
-            is_active: config.active_repo.as_deref() == Some(&canonical_path),
-            has_config,
-            configured_worktree_base_path,
+            Ok(())
         })
     }
 
     pub fn repo_config(&self, repo_path: &str) -> Result<RepoConfig> {
-        let canonical_path =
-            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
+        let workspace_key = workspace_lookup_key(repo_path);
 
         let config = self.load()?;
         config
             .repos
-            .get(&canonical_path)
+            .get(&workspace_key)
             .cloned()
             .ok_or_else(|| anyhow!("Repository is not configured in {}", self.path.display()))
     }
 
     pub fn repo_config_optional(&self, repo_path: &str) -> Result<Option<RepoConfig>> {
-        let canonical_path =
-            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
+        let workspace_key = workspace_lookup_key(repo_path);
 
         let config = self.load()?;
-        Ok(config.repos.get(&canonical_path).cloned())
+        Ok(config.repos.get(&workspace_key).cloned())
     }
 
     pub fn set_repo_trust_hooks(
@@ -319,30 +197,15 @@ impl AppConfigStore {
         trusted: bool,
         trusted_fingerprint: Option<String>,
     ) -> Result<WorkspaceRecord> {
-        let canonical_path =
-            canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string());
-
-        let mut config = self.load()?;
-        let (has_config, configured_worktree_base_path) = {
+        let workspace_key = workspace_lookup_key(repo_path);
+        self.update_workspace(workspace_key, move |config, workspace_key| {
             let repo = config
                 .repos
-                .get_mut(&canonical_path)
+                .get_mut(workspace_key)
                 .ok_or_else(|| anyhow!("Repository is not configured"))?;
             repo.trusted_hooks = trusted;
             repo.trusted_hooks_fingerprint = if trusted { trusted_fingerprint } else { None };
-            (
-                has_configured_worktree(repo),
-                repo.worktree_base_path.clone(),
-            )
-        };
-        touch_recent(&mut config.recent_repos, &canonical_path);
-        self.save(&config)?;
-
-        Ok(WorkspaceRecord {
-            path: canonical_path.clone(),
-            is_active: config.active_repo.as_deref() == Some(&canonical_path),
-            has_config,
-            configured_worktree_base_path,
+            Ok(())
         })
     }
 
@@ -351,9 +214,29 @@ impl AppConfigStore {
     }
 
     pub fn set_theme(&self, theme: &str) -> Result<()> {
+        self.update_config(|config| {
+            config.theme = theme.to_string();
+            Ok(())
+        })
+    }
+
+    fn update_config<T>(&self, update: impl FnOnce(&mut GlobalConfig) -> Result<T>) -> Result<T> {
         let mut config = self.load()?;
-        config.theme = theme.to_string();
-        self.save(&config)
+        let output = update(&mut config)?;
+        self.save(&config)?;
+        Ok(output)
+    }
+
+    fn update_workspace(
+        &self,
+        workspace_key: String,
+        update: impl FnOnce(&mut GlobalConfig, &str) -> Result<()>,
+    ) -> Result<WorkspaceRecord> {
+        self.update_config(|config| {
+            update(config, &workspace_key)?;
+            touch_recent(&mut config.recent_repos, &workspace_key);
+            workspace_record(config, &workspace_key)
+        })
     }
 }
 
@@ -397,33 +280,21 @@ impl RuntimeConfigStore {
     }
 
     pub fn load(&self) -> Result<RuntimeConfig> {
-        if !self.path.exists() {
-            return Ok(RuntimeConfig::default());
-        }
-
-        validate_config_access(&self.path, self.enforce_private_parent_permissions)?;
-
-        let data = fs::read_to_string(&self.path)
-            .with_context(|| format!("Failed reading config file {}", self.path.display()))?;
-        let mut parsed: RuntimeConfig = serde_json::from_str(&data)
-            .with_context(|| format!("Failed parsing config file {}", self.path.display()))?;
-        normalize_runtime_config(&mut parsed);
-        Ok(parsed)
+        load_config_or_default(
+            &self.path,
+            self.enforce_private_parent_permissions,
+            normalize_runtime_config,
+            |_| {},
+        )
     }
 
     pub fn save(&self, config: &RuntimeConfig) -> Result<()> {
-        if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("Failed creating config directory {}", parent.display())
-            })?;
-            enforce_directory_permissions(parent, self.enforce_private_parent_permissions)?;
-        }
-        let mut normalized = config.clone();
-        normalize_runtime_config(&mut normalized);
-        let payload = serde_json::to_string_pretty(&normalized)?;
-        write_config_file(&self.path, payload.as_bytes())?;
-        validate_config_access(&self.path, self.enforce_private_parent_permissions)?;
-        Ok(())
+        save_config(
+            &self.path,
+            self.enforce_private_parent_permissions,
+            config,
+            normalize_runtime_config,
+        )
     }
 }
 
@@ -433,209 +304,53 @@ pub(crate) fn touch_recent(recent: &mut Vec<String>, repo_path: &str) {
     recent.truncate(20);
 }
 
-fn write_config_file(path: &Path, contents: &[u8]) -> Result<()> {
-    #[cfg(unix)]
-    {
-        write_config_file_atomic(path, contents)
+fn migrate_loaded_global_config(config: &mut GlobalConfig) {
+    // Pass active_repo to prefer the user's current configuration on collision.
+    let canonical_repos =
+        migrate_repos_to_canonical_keys(&mut config.repos, config.active_repo.as_ref());
+    config.repos = canonical_repos;
+
+    if let Some(active) = &config.active_repo {
+        if let Ok(canonical_active) = canonicalize_workspace_key(active) {
+            if config.repos.contains_key(&canonical_active) {
+                config.active_repo = Some(canonical_active);
+            }
+        }
     }
 
-    #[cfg(not(unix))]
-    {
-        fs::write(path, contents)
-            .with_context(|| format!("Failed writing config file {}", path.display()))?;
-        Ok(())
-    }
-}
-
-#[cfg(unix)]
-fn write_config_file_atomic(path: &Path, contents: &[u8]) -> Result<()> {
-    for attempt in 0..MAX_TEMP_FILE_ATTEMPTS {
-        let temp_path = create_temporary_config_path(path, attempt)?;
-        match OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .mode(CONFIG_FILE_MODE)
-            .open(&temp_path)
-        {
-            Ok(mut file) => {
-                let write_result = (|| -> Result<()> {
-                    file.set_permissions(fs::Permissions::from_mode(CONFIG_FILE_MODE))
-                        .with_context(|| {
-                            format!(
-                                "Failed setting secure permissions on config temp file {}",
-                                temp_path.display()
-                            )
-                        })?;
-                    file.write_all(contents).with_context(|| {
-                        format!("Failed writing config temp file {}", temp_path.display())
-                    })?;
-                    file.sync_all().with_context(|| {
-                        format!("Failed syncing config temp file {}", temp_path.display())
-                    })?;
-                    drop(file);
-                    fs::rename(&temp_path, path).with_context(|| {
-                        format!(
-                            "Failed atomically replacing config file {} with {}",
-                            path.display(),
-                            temp_path.display()
-                        )
-                    })?;
-                    Ok(())
-                })();
-
-                if let Err(error) = write_result {
-                    if let Err(cleanup_error) = fs::remove_file(&temp_path) {
-                        if cleanup_error.kind() != ErrorKind::NotFound {
-                            return Err(error).with_context(|| {
-                                format!(
-                                    "Failed cleaning up config temp file {} after write failure: {}",
-                                    temp_path.display(),
-                                    cleanup_error
-                                )
-                            });
-                        }
-                    }
-                    return Err(error);
+    let mut canonical_recent: Vec<String> = Vec::new();
+    for recent in &config.recent_repos {
+        match canonicalize_workspace_key(recent) {
+            Ok(canonical_recent_key) => {
+                if config.repos.contains_key(&canonical_recent_key)
+                    && !canonical_recent.contains(&canonical_recent_key)
+                {
+                    canonical_recent.push(canonical_recent_key);
                 }
-
-                return Ok(());
             }
-            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
-            Err(error) => {
-                return Err(error).with_context(|| {
-                    format!("Failed opening config temp file {}", temp_path.display())
-                });
+            Err(_) => {
+                if !canonical_recent.contains(recent) {
+                    canonical_recent.push(recent.clone());
+                }
             }
         }
     }
-
-    Err(anyhow!(
-        "Failed creating unique temp file for config write at {} after {} attempts",
-        path.display(),
-        MAX_TEMP_FILE_ATTEMPTS
-    ))
+    config.recent_repos = canonical_recent;
 }
 
-#[cfg(unix)]
-fn create_temporary_config_path(path: &Path, attempt: u8) -> Result<PathBuf> {
-    let parent = path.parent().ok_or_else(|| {
-        anyhow!(
-            "Config file path {} is invalid: missing parent directory",
-            path.display()
-        )
-    })?;
-    let file_name = path.file_name().ok_or_else(|| {
-        anyhow!(
-            "Config file path {} is invalid: missing file name",
-            path.display()
-        )
-    })?;
-    let nanos = SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_err(|error| anyhow!("System clock error while building temp config path: {error}"))?
-        .as_nanos();
-    let mut temp_name = OsString::from(".");
-    temp_name.push(file_name);
-    temp_name.push(format!(".tmp-{}-{nanos}-{attempt}", std::process::id()));
-    Ok(parent.join(temp_name))
+fn workspace_lookup_key(repo_path: &str) -> String {
+    canonicalize_workspace_key(repo_path).unwrap_or_else(|_| repo_path.to_string())
 }
 
-fn validate_config_access(path: &Path, enforce_private_parent_permissions: bool) -> Result<()> {
-    #[cfg(unix)]
-    {
-        let parent = path.parent().ok_or_else(|| {
-            anyhow!(
-                "Config file path {} is invalid: missing parent directory",
-                path.display()
-            )
-        })?;
-        let expected_uid = current_effective_uid();
-        if enforce_private_parent_permissions {
-            validate_private_directory(parent, expected_uid)?;
-        }
-        validate_private_file(path, expected_uid)?;
-    }
-    Ok(())
-}
-
-fn enforce_directory_permissions(
-    path: &Path,
-    enforce_private_parent_permissions: bool,
-) -> Result<()> {
-    #[cfg(unix)]
-    {
-        if enforce_private_parent_permissions {
-            fs::set_permissions(path, fs::Permissions::from_mode(CONFIG_DIR_MODE)).with_context(
-                || {
-                    format!(
-                        "Failed setting secure permissions on config directory {}",
-                        path.display()
-                    )
-                },
-            )?;
-        }
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn current_effective_uid() -> u32 {
-    // SAFETY: geteuid has no preconditions and does not dereference pointers.
-    unsafe { libc::geteuid() as u32 }
-}
-
-#[cfg(unix)]
-fn validate_private_directory(path: &Path, expected_uid: u32) -> Result<()> {
-    let metadata = fs::metadata(path).with_context(|| {
-        format!(
-            "Failed reading config directory metadata {}",
-            path.display()
-        )
-    })?;
-    let mode = metadata.mode() & 0o777;
-    let owner_uid = metadata.uid();
-    if owner_uid != expected_uid {
-        return Err(anyhow!(
-            "Config directory {} must be owned by the current user (uid {}). Found uid {}. Run `chown -R $(whoami) {}`.",
-            path.display(),
-            expected_uid,
-            owner_uid,
-            path.display()
-        ));
-    }
-    if mode != CONFIG_DIR_MODE {
-        return Err(anyhow!(
-            "Config directory {} has unsupported mode {:04o}. Expected 0700 exactly. Run `chmod 700 {}`.",
-            path.display(),
-            mode,
-            path.display()
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn validate_private_file(path: &Path, expected_uid: u32) -> Result<()> {
-    let metadata = fs::metadata(path)
-        .with_context(|| format!("Failed reading config file metadata {}", path.display()))?;
-    let mode = metadata.mode() & 0o777;
-    let owner_uid = metadata.uid();
-    if owner_uid != expected_uid {
-        return Err(anyhow!(
-            "Config file {} must be owned by the current user (uid {}). Found uid {}. Run `chown $(whoami) {}`.",
-            path.display(),
-            expected_uid,
-            owner_uid,
-            path.display()
-        ));
-    }
-    if mode != CONFIG_FILE_MODE {
-        return Err(anyhow!(
-            "Config file {} has unsupported mode {:04o}. Expected 0600 exactly. Run `chmod 600 {}`.",
-            path.display(),
-            mode,
-            path.display()
-        ));
-    }
-    Ok(())
+fn workspace_record(config: &GlobalConfig, workspace_key: &str) -> Result<WorkspaceRecord> {
+    let repo = config
+        .repos
+        .get(workspace_key)
+        .ok_or_else(|| anyhow!("Workspace disappeared from config"))?;
+    Ok(WorkspaceRecord {
+        path: workspace_key.to_string(),
+        is_active: config.active_repo.as_deref() == Some(workspace_key),
+        has_config: has_configured_worktree(repo),
+        configured_worktree_base_path: repo.worktree_base_path.clone(),
+    })
 }


### PR DESCRIPTION
## Summary
- extract shared config persistence and permission enforcement out of `host-infra-system`'s `config/store.rs` into dedicated `persistence.rs` and `security.rs` modules
- reduce duplicated app/runtime store load-save-update flow by routing `AppConfigStore` and `RuntimeConfigStore` through shared primitives and workspace mutation helpers
- add a Windows-target CI check for `host-infra-system` so non-Unix cfg regressions are caught automatically while preserving the newer Rust workflow layout from `main`

## Testing
- cargo test -p host-infra-system