### PR TITLE
fix(deps): patch express-rate-limit and isolate hygiene checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Dependency vulnerability guards
-        run: bun run deps:audit:high && bun run deps:audit:hono
-
       - name: Lint workspaces
         run: bun run lint
 

--- a/.github/workflows/dependency-hygiene.yml
+++ b/.github/workflows/dependency-hygiene.yml
@@ -33,7 +33,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Cache Bun download cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/dependency-hygiene.yml
+++ b/.github/workflows/dependency-hygiene.yml
@@ -2,6 +2,9 @@ name: Dependency Hygiene
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -10,6 +13,9 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  BUN_VERSION: 1.3.5
 
 jobs:
   knip-dependency-check:
@@ -24,7 +30,15 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3
         with:
-          bun-version: 1.3.5
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun download cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-${{ env.BUN_VERSION }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ cd apps/desktop/src-tauri && cargo check
 
 ## Dependency Hygiene
 
-- Blocking unused dependency check: `bun run deps:check`
-- Blocking high/critical advisory gate: `bun run deps:audit:high`
-- Blocking targeted vulnerability check (Hono GHSA-`xh87-mx6m-69f3`): `bun run deps:audit:hono`
+- All-in-one blocking hygiene check: `bun run deps:check`
+- Included unused dependency check: `bun run deps:unused:deps`
+- Included high/critical advisory gate: `bun run deps:audit:high`
+- Included targeted vulnerability check (Hono GHSA-`xh87-mx6m-69f3`): `bun run deps:audit:hono`
 - Non-blocking unused export report: `bun run deps:unused`
 - Outdated dependency report: `bun run deps:outdated`
 - Automated update PRs: `.github/dependabot.yml`

--- a/README.md
+++ b/README.md
@@ -123,11 +123,12 @@ cd apps/desktop/src-tauri && cargo check
 ## Dependency Hygiene
 
 - Blocking unused dependency check: `bun run deps:check`
+- Blocking high/critical advisory gate: `bun run deps:audit:high`
 - Blocking targeted vulnerability check (Hono GHSA-`xh87-mx6m-69f3`): `bun run deps:audit:hono`
 - Non-blocking unused export report: `bun run deps:unused`
 - Outdated dependency report: `bun run deps:outdated`
 - Automated update PRs: `.github/dependabot.yml`
-- CI automation: `.github/workflows/dependency-hygiene.yml`
+- Dedicated CI automation: `.github/workflows/dependency-hygiene.yml`
 - Review and upgrade cadence: `docs/dependency-hygiene.md`
 - MCP runtime transport and threat assumptions: `docs/mcp-runtime-security.md`
 

--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,7 @@
   },
   "overrides": {
     "@hono/node-server": "^1.19.11",
+    "express-rate-limit": "^8.2.2",
     "hono": "^4.12.5",
     "rollup": "^4.59.0",
   },
@@ -717,7 +718,7 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
-    "express-rate-limit": ["express-rate-limit@8.2.1", "", { "dependencies": { "ip-address": "10.0.1" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g=="],
+    "express-rate-limit": ["express-rate-limit@8.3.0", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -797,7 +798,7 @@
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
-    "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/docs/dependency-hygiene.md
+++ b/docs/dependency-hygiene.md
@@ -17,12 +17,13 @@ Dependabot and `knip` solve different problems:
 - Dependabot proposes version upgrades and security fixes.
 - `knip` detects unused dependencies/exports that update bots do not remove.
 
-## 1) Unused Dependency Detection (Blocking)
+## 1) Blocking Dependency Hygiene Gate
 
 - Command: `bun run deps:check`
-- Backed by: `knip`
-- Scope: all workspaces matching `@openducktor/*`
-- Check type: `dependencies`
+- Includes:
+  - `bun run deps:audit:high`
+  - `bun run deps:audit:hono`
+  - `bun run deps:unused:deps`
 
 This check runs on pull requests and `main` pushes and must pass.
 
@@ -30,7 +31,16 @@ Implementation notes:
 
 - Workflow: `.github/workflows/dependency-hygiene.yml`
 
-## 2) Unused Export Detection (Advisory)
+## 2) Unused Dependency Detection (Blocking Component)
+
+- Command: `bun run deps:unused:deps`
+- Backed by: `knip`
+- Scope: all workspaces matching `@openducktor/*`
+- Check type: `dependencies`
+
+This check is included in `deps:check`.
+
+## 3) Unused Export Detection (Advisory)
 
 - Command: `bun run deps:unused`
 - Backed by: `knip`
@@ -39,7 +49,7 @@ Implementation notes:
 
 The export section runs with `--no-exit-code` so teams can review and clean progressively without blocking all PRs.
 
-## 3) Outdated Dependency Review
+## 4) Outdated Dependency Review
 
 - Command: `bun run deps:outdated`
 - Backed by: `bun outdated`
@@ -49,7 +59,7 @@ Implementation notes:
 
 - Dedicated report workflow: `.github/workflows/dependency-hygiene-report.yml`
 
-## 4) High/Critical Vulnerability Gate
+## 5) High/Critical Vulnerability Gate
 
 - Command: `bun run deps:audit:high`
 - Backed by: `bun audit --json`
@@ -59,7 +69,7 @@ Implementation notes:
 
 - Included in `deps:check`, which runs in `.github/workflows/dependency-hygiene.yml`.
 
-## 5) Targeted Vulnerability Gate (Hono)
+## 6) Targeted Vulnerability Gate (Hono)
 
 - Command: `bun run deps:audit:hono`
 - Backed by: `bun audit --json`

--- a/docs/dependency-hygiene.md
+++ b/docs/dependency-hygiene.md
@@ -24,7 +24,7 @@ Dependabot and `knip` solve different problems:
 - Scope: all workspaces matching `@openducktor/*`
 - Check type: `dependencies`
 
-This check runs on pull requests and must pass.
+This check runs on pull requests and `main` pushes and must pass.
 
 Implementation notes:
 
@@ -49,7 +49,17 @@ Implementation notes:
 
 - Dedicated report workflow: `.github/workflows/dependency-hygiene-report.yml`
 
-## 4) Targeted Vulnerability Gate (Hono)
+## 4) High/Critical Vulnerability Gate
+
+- Command: `bun run deps:audit:high`
+- Backed by: `bun audit --json`
+- Scope: blocks any dependency that resolves to a high or critical advisory
+
+Implementation notes:
+
+- Included in `deps:check`, which runs in `.github/workflows/dependency-hygiene.yml`.
+
+## 5) Targeted Vulnerability Gate (Hono)
 
 - Command: `bun run deps:audit:hono`
 - Backed by: `bun audit --json`
@@ -57,13 +67,12 @@ Implementation notes:
 
 Implementation notes:
 
-- Included in `.github/workflows/ci.yml` Bun quality job.
 - Included in `deps:check`, which runs in `.github/workflows/dependency-hygiene.yml`.
 
 ## Cadence
 
 - Weekly (automated): Dependabot creates update PRs, and report CI publishes `bun run deps:unused:exports` plus `bun run deps:outdated` outputs.
-- Per PR (automated): CI runs `bun run deps:check` to catch dependency drift and the targeted Hono regression.
+- Per PR and on `main` pushes (automated): dependency hygiene CI runs `bun run deps:check` to catch dependency drift and vulnerability regressions without blocking lint/typecheck/test/build.
 - Monthly (manual): open a dependency refresh PR for safe patch/minor updates.
 - Urgent security advisories: process outside cadence and patch immediately.
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "overrides": {
     "@hono/node-server": "^1.19.11",
+    "express-rate-limit": "^8.2.2",
     "hono": "^4.12.5",
     "rollup": "^4.59.0"
   },


### PR DESCRIPTION
## Summary
- patch the transitive `express-rate-limit` vulnerability via a root override and lockfile refresh
- remove duplicate dependency audits from the main CI workflow so lint, typecheck, test, and build are not blocked behind dependency hygiene
- run dependency hygiene in its dedicated workflow for pull requests and `main` pushes, with Bun cache enabled

## Validation
- `bun audit --json`
- `bun run deps:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- YAML parse for `.github/workflows/ci.yml` and `.github/workflows/dependency-hygiene.yml`
- `git diff --check`