### PR TITLE
fix(task-delete): clean up managed worktrees on delete

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -11,7 +11,8 @@ use host_infra_system::{
     PromptOverrides, RepoConfig,
 };
 use std::collections::HashMap;
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 const RUNTIME_CHECK_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
@@ -22,6 +23,10 @@ fn resolve_execution_path(repo_path: &str, working_dir: Option<&str>) -> String 
         .filter(|value| !value.is_empty())
         .unwrap_or(repo_path)
         .to_string()
+}
+
+fn normalize_path_for_comparison(path: &str) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| Path::new(path).to_path_buf())
 }
 
 impl AppService {
@@ -317,8 +322,32 @@ impl AppService {
         if worktree.is_empty() {
             return Err(anyhow!("worktree path cannot be empty"));
         }
+
+        let normalized_repo = normalize_path_for_comparison(&repo_path);
+        let normalized_worktree = normalize_path_for_comparison(worktree);
+        if normalized_repo == normalized_worktree {
+            return Err(anyhow!("worktree path cannot be the repository root"));
+        }
+
         self.git_port
             .remove_worktree(Path::new(&repo_path), Path::new(worktree), force)?;
+        Ok(true)
+    }
+
+    pub fn git_delete_local_branch(
+        &self,
+        repo_path: &str,
+        branch: &str,
+        force: bool,
+    ) -> Result<bool> {
+        let repo_path = self.resolve_initialized_repo_path(repo_path)?;
+        let branch = branch.trim();
+        if branch.is_empty() {
+            return Err(anyhow!("branch cannot be empty"));
+        }
+
+        self.git_port
+            .delete_local_branch(Path::new(&repo_path), branch, force)?;
         Ok(true)
     }
 
@@ -461,6 +490,25 @@ mod tests {
             .expect_err("empty worktree path should fail");
 
         assert!(error.to_string().contains("worktree path cannot be empty"));
+    }
+
+    #[test]
+    fn module_git_remove_worktree_rejects_repository_root() {
+        let (service, _task_state, git_state) = build_service_with_state(vec![]);
+
+        let error = service
+            .git_remove_worktree("/tmp/odt-repo-module", "/tmp/odt-repo-module", true)
+            .expect_err("repository root should be rejected for worktree removal");
+
+        assert!(error
+            .to_string()
+            .contains("worktree path cannot be the repository root"));
+
+        let git_state = git_state.lock().expect("git state lock poisoned");
+        assert!(
+            git_state.calls.is_empty(),
+            "git port should not run when path is repository root"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -4,7 +4,12 @@ use crate::app_service::workflow_rules::{
     validate_parent_relationships_for_update, validate_transition,
 };
 use anyhow::{anyhow, Context, Result};
-use host_domain::{CreateTaskInput, TaskCard, TaskMetadata, TaskStatus, UpdateTaskPatch};
+use host_domain::{
+    AgentSessionDocument, CreateTaskInput, TaskCard, TaskMetadata, TaskStatus, UpdateTaskPatch,
+};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 impl AppService {
     pub fn tasks_list(&self, repo_path: &str) -> Result<Vec<TaskCard>> {
@@ -66,6 +71,66 @@ impl AppService {
                 "Task {task_id} has {} subtasks. Confirm subtask deletion to continue.",
                 direct_subtask_ids.len()
             ));
+        }
+
+        let target_tasks =
+            collect_task_delete_targets(&context.repo.tasks, task_id, delete_subtasks);
+        let normalized_repo = normalize_path_for_comparison(context.repo.repo_path.as_str());
+        let branch_prefix = self
+            .config_store
+            .repo_config(&context.repo.repo_path)?
+            .branch_prefix;
+        let mut removable_worktrees = Vec::new();
+        let mut seen_worktrees = HashSet::new();
+        let mut related_local_branches = HashSet::new();
+
+        for target_task in target_tasks {
+            let sessions =
+                self.agent_sessions_list(context.repo.repo_path.as_str(), target_task.id.as_str())?;
+            for session in sessions {
+                let worktree_path = session.working_directory.trim();
+                if !is_managed_worktree_session(&session, &normalized_repo, worktree_path) {
+                    continue;
+                }
+                if !seen_worktrees.insert(worktree_path.to_string()) {
+                    continue;
+                }
+
+                let current_branch = self
+                    .git_port
+                    .get_current_branch(Path::new(worktree_path))
+                    .with_context(|| {
+                        format!(
+                            "Failed to inspect current branch for task worktree {}",
+                            worktree_path
+                        )
+                    })?;
+                if let Some(branch_name) = current_branch.name {
+                    if is_related_task_branch(
+                        branch_name.as_str(),
+                        branch_prefix.as_str(),
+                        target_task.id.as_str(),
+                    ) {
+                        related_local_branches.insert(branch_name);
+                    }
+                }
+
+                removable_worktrees.push(worktree_path.to_string());
+            }
+        }
+
+        for worktree_path in &removable_worktrees {
+            self.git_remove_worktree(context.repo.repo_path.as_str(), worktree_path, true)
+                .with_context(|| format!("Failed to remove task worktree {worktree_path}"))?;
+        }
+
+        for branch_name in related_local_branches {
+            self.git_delete_local_branch(
+                context.repo.repo_path.as_str(),
+                branch_name.as_str(),
+                true,
+            )
+            .with_context(|| format!("Failed to delete related local branch {branch_name}"))?;
         }
 
         self.task_store
@@ -233,4 +298,58 @@ impl AppService {
             .get_task_metadata(std::path::Path::new(&repo_path), task_id)
             .with_context(|| format!("Failed to load task metadata for {task_id}"))
     }
+}
+
+fn collect_task_delete_targets<'a>(
+    tasks: &'a [TaskCard],
+    task_id: &str,
+    delete_subtasks: bool,
+) -> Vec<&'a TaskCard> {
+    let mut target_ids = HashSet::from([task_id.to_string()]);
+    if delete_subtasks {
+        loop {
+            let previous_len = target_ids.len();
+            for task in tasks {
+                if task
+                    .parent_id
+                    .as_deref()
+                    .is_some_and(|parent_id| target_ids.contains(parent_id))
+                {
+                    target_ids.insert(task.id.clone());
+                }
+            }
+            if target_ids.len() == previous_len {
+                break;
+            }
+        }
+    }
+
+    tasks
+        .iter()
+        .filter(|task| target_ids.contains(task.id.as_str()))
+        .collect()
+}
+
+fn normalize_path_for_comparison(path: &str) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path))
+}
+
+fn is_managed_worktree_session(
+    session: &AgentSessionDocument,
+    normalized_repo: &Path,
+    working_directory: &str,
+) -> bool {
+    matches!(session.role.as_str(), "build" | "qa")
+        && !working_directory.is_empty()
+        && normalize_path_for_comparison(working_directory) != normalized_repo
+}
+
+fn is_related_task_branch(branch_name: &str, branch_prefix: &str, task_id: &str) -> bool {
+    let clean_prefix = if branch_prefix.trim().is_empty() {
+        "obp"
+    } else {
+        branch_prefix.trim()
+    };
+    let task_prefix = format!("{clean_prefix}/{task_id}");
+    branch_name == task_prefix || branch_name.starts_with(&format!("{task_prefix}-"))
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -75,14 +75,17 @@ impl AppService {
 
         let target_tasks =
             collect_task_delete_targets(&context.repo.tasks, task_id, delete_subtasks);
+        let target_task_ids = target_tasks
+            .iter()
+            .map(|task| task.id.as_str())
+            .collect::<Vec<_>>();
         let normalized_repo = normalize_path_for_comparison(context.repo.repo_path.as_str());
         let branch_prefix = self
             .config_store
             .repo_config(&context.repo.repo_path)?
             .branch_prefix;
         let mut removable_worktrees = Vec::new();
-        let mut seen_worktrees = HashSet::new();
-        let mut related_local_branches = HashSet::new();
+        let mut seen_worktree_keys = HashSet::new();
 
         for target_task in target_tasks {
             let sessions =
@@ -92,32 +95,29 @@ impl AppService {
                 if !is_managed_worktree_session(&session, &normalized_repo, worktree_path) {
                     continue;
                 }
-                if !seen_worktrees.insert(worktree_path.to_string()) {
+                let worktree_key = normalize_path_key(worktree_path);
+                if !seen_worktree_keys.insert(worktree_key) {
                     continue;
                 }
 
-                let current_branch = self
-                    .git_port
-                    .get_current_branch(Path::new(worktree_path))
-                    .with_context(|| {
-                        format!(
-                            "Failed to inspect current branch for task worktree {}",
-                            worktree_path
-                        )
-                    })?;
-                if let Some(branch_name) = current_branch.name {
-                    if is_related_task_branch(
-                        branch_name.as_str(),
-                        branch_prefix.as_str(),
-                        target_task.id.as_str(),
-                    ) {
-                        related_local_branches.insert(branch_name);
-                    }
+                if Path::new(worktree_path).exists() {
+                    removable_worktrees.push(worktree_path.to_string());
                 }
-
-                removable_worktrees.push(worktree_path.to_string());
             }
         }
+
+        let related_local_branches = self
+            .git_port
+            .get_branches(context.repo_dir())?
+            .into_iter()
+            .filter(|branch| !branch.is_remote)
+            .filter(|branch| {
+                target_task_ids.iter().any(|task_id| {
+                    is_related_task_branch(branch.name.as_str(), branch_prefix.as_str(), task_id)
+                })
+            })
+            .map(|branch| branch.name)
+            .collect::<HashSet<_>>();
 
         for worktree_path in &removable_worktrees {
             self.git_remove_worktree(context.repo.repo_path.as_str(), worktree_path, true)
@@ -331,7 +331,25 @@ fn collect_task_delete_targets<'a>(
 }
 
 fn normalize_path_for_comparison(path: &str) -> PathBuf {
-    fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path))
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return PathBuf::new();
+    }
+
+    fs::canonicalize(trimmed).unwrap_or_else(|_| {
+        let without_trailing_separators = trimmed.trim_end_matches(['/', '\\']);
+        if without_trailing_separators.is_empty() {
+            PathBuf::from(trimmed)
+        } else {
+            PathBuf::from(without_trailing_separators)
+        }
+    })
+}
+
+fn normalize_path_key(path: &str) -> String {
+    normalize_path_for_comparison(path)
+        .to_string_lossy()
+        .to_string()
 }
 
 fn is_managed_worktree_session(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -30,6 +30,7 @@ use host_infra_system::{
     AppConfigStore, GlobalConfig, HookSet, OpencodeStartupReadinessConfig, RepoConfig,
 };
 use serde_json::Value;
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
 #[cfg(unix)]
@@ -308,7 +309,12 @@ impl TaskStore for FakeTaskStore {
         _task_id: &str,
     ) -> Result<Vec<AgentSessionDocument>> {
         let state = self.state.lock().expect("task store lock poisoned");
-        Ok(state.agent_sessions.clone())
+        Ok(state
+            .agent_sessions
+            .iter()
+            .filter(|session| session.task_id.as_deref() == Some(_task_id))
+            .cloned()
+            .collect())
     }
 
     fn upsert_agent_session(
@@ -337,7 +343,12 @@ impl TaskStore for FakeTaskStore {
         let mut state = self.state.lock().expect("task store lock poisoned");
         state.metadata_get_calls.push(_task_id.to_string());
         let qa_report = state.latest_qa_report.clone();
-        let agent_sessions = state.agent_sessions.clone();
+        let agent_sessions = state
+            .agent_sessions
+            .iter()
+            .filter(|session| session.task_id.as_deref() == Some(_task_id))
+            .cloned()
+            .collect();
         Ok(TaskMetadata {
             spec: SpecDocument {
                 markdown: String::new(),
@@ -375,6 +386,11 @@ pub(crate) enum GitCall {
     RemoveWorktree {
         repo_path: String,
         worktree_path: String,
+        force: bool,
+    },
+    DeleteLocalBranch {
+        repo_path: String,
+        branch: String,
         force: bool,
     },
     PushBranch {
@@ -419,6 +435,9 @@ pub(crate) struct GitState {
     pub(crate) calls: Vec<GitCall>,
     pub(crate) branches: Vec<GitBranch>,
     pub(crate) current_branch: GitCurrentBranch,
+    pub(crate) current_branches_by_path: HashMap<String, GitCurrentBranch>,
+    pub(crate) remove_worktree_error: Option<String>,
+    pub(crate) delete_local_branch_error: Option<String>,
     pub(crate) worktree_status_data: Option<GitWorktreeStatusData>,
     pub(crate) last_push_remote: Option<String>,
     pub(crate) push_branch_result: GitPushResult,
@@ -444,10 +463,15 @@ impl GitPort for FakeGitPort {
 
     fn get_current_branch(&self, repo_path: &Path) -> Result<GitCurrentBranch> {
         let mut state = self.state.lock().expect("git state lock poisoned");
+        let repo_path = repo_path.to_string_lossy().to_string();
         state.calls.push(GitCall::GetCurrentBranch {
-            repo_path: repo_path.to_string_lossy().to_string(),
+            repo_path: repo_path.clone(),
         });
-        Ok(state.current_branch.clone())
+        Ok(state
+            .current_branches_by_path
+            .get(repo_path.as_str())
+            .cloned()
+            .unwrap_or_else(|| state.current_branch.clone()))
     }
 
     fn switch_branch(
@@ -493,6 +517,22 @@ impl GitPort for FakeGitPort {
             worktree_path: worktree_path.to_string_lossy().to_string(),
             force,
         });
+        if let Some(message) = state.remove_worktree_error.clone() {
+            return Err(anyhow!(message));
+        }
+        Ok(())
+    }
+
+    fn delete_local_branch(&self, repo_path: &Path, branch: &str, force: bool) -> Result<()> {
+        let mut state = self.state.lock().expect("git state lock poisoned");
+        state.calls.push(GitCall::DeleteLocalBranch {
+            repo_path: repo_path.to_string_lossy().to_string(),
+            branch: branch.to_string(),
+            force,
+        });
+        if let Some(message) = state.delete_local_branch_error.clone() {
+            return Err(anyhow!(message));
+        }
         Ok(())
     }
 
@@ -747,6 +787,9 @@ pub(crate) fn build_service_with_git_state_enforced(
         calls: Vec::new(),
         branches,
         current_branch,
+        current_branches_by_path: HashMap::new(),
+        remove_worktree_error: None,
+        delete_local_branch_error: None,
         worktree_status_data: None,
         last_push_remote: None,
         push_branch_result: GitPushResult::Pushed {
@@ -807,6 +850,9 @@ pub(crate) fn build_service_with_git_state(
         calls: Vec::new(),
         branches,
         current_branch,
+        current_branches_by_path: HashMap::new(),
+        remove_worktree_error: None,
+        delete_local_branch_error: None,
         worktree_status_data: None,
         last_push_remote: None,
         push_branch_result: GitPushResult::Pushed {
@@ -1232,6 +1278,9 @@ pub(crate) fn build_service_with_store(
         calls: Vec::new(),
         branches,
         current_branch,
+        current_branches_by_path: HashMap::new(),
+        remove_worktree_error: None,
+        delete_local_branch_error: None,
         worktree_status_data: None,
         last_push_remote: None,
         push_branch_result: GitPushResult::Pushed {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
@@ -191,6 +191,53 @@ fn git_remove_worktree_forwards_force_flag() -> Result<()> {
 }
 
 #[test]
+fn git_remove_worktree_rejects_repository_root() {
+    let repo_path = "/tmp/odt-repo-remove-worktree-root";
+    let (service, _task_state, git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+
+    let error = service
+        .git_remove_worktree(repo_path, repo_path, true)
+        .expect_err("repo root removal should be rejected");
+
+    assert!(error.to_string().contains("repository root"));
+    let git_state = git_state.lock().expect("git lock poisoned");
+    assert!(!git_state
+        .calls
+        .iter()
+        .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
+}
+
+#[test]
+fn git_delete_local_branch_forwards_force_flag() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-delete-local-branch";
+    let (service, _task_state, git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+
+    assert!(service.git_delete_local_branch(repo_path, "obp/task-123-cleanup", true)?);
+
+    let git_state = git_state.lock().expect("git lock poisoned");
+    assert!(git_state.calls.contains(&GitCall::DeleteLocalBranch {
+        repo_path: repo_path.to_string(),
+        branch: "obp/task-123-cleanup".to_string(),
+        force: true,
+    }));
+    Ok(())
+}
+
+#[test]
 fn git_push_branch_defaults_remote_to_origin() -> Result<()> {
     let repo_path = "/tmp/odt-repo-push";
     let working_dir = "/tmp/odt-repo-push-worktree";

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -228,6 +228,7 @@ fn task_delete_removes_managed_worktrees_and_related_branches() -> Result<()> {
     let repo_path = "/tmp/odt-repo-task-delete-cleanup";
     let worktree_path = "/tmp/odt-repo-task-delete-cleanup-worktree";
     fs::create_dir_all(repo_path)?;
+    fs::create_dir_all(worktree_path)?;
     init_git_repo(Path::new(repo_path))?;
     let parent = make_task("parent-1", "epic", TaskStatus::Open);
     let mut build_session = make_session("parent-1", "build-session");
@@ -235,14 +236,18 @@ fn task_delete_removes_managed_worktrees_and_related_branches() -> Result<()> {
     let mut qa_session = make_session("parent-1", "qa-session");
     qa_session.role = "qa".to_string();
     qa_session.scenario = Some("qa_review".to_string());
-    qa_session.working_directory = worktree_path.to_string();
+    qa_session.working_directory = format!("{worktree_path}/");
     let mut planner_session = make_session("parent-1", "planner-session");
     planner_session.role = "planner".to_string();
     planner_session.scenario = Some("planner_initial".to_string());
     planner_session.working_directory = repo_path.to_string();
     let (service, task_state, git_state) = build_service_with_git_state(
         vec![parent],
-        vec![],
+        vec![GitBranch {
+            name: "obp/parent-1-cleanup".to_string(),
+            is_current: false,
+            is_remote: false,
+        }],
         GitCurrentBranch {
             name: Some("main".to_string()),
             detached: false,
@@ -268,34 +273,16 @@ fn task_delete_removes_managed_worktrees_and_related_branches() -> Result<()> {
         .lock()
         .expect("task lock poisoned")
         .agent_sessions = vec![build_session, qa_session, planner_session];
-    git_state
-        .lock()
-        .expect("git lock poisoned")
-        .current_branches_by_path
-        .insert(
-            worktree_path.to_string(),
-            GitCurrentBranch {
-                name: Some("obp/parent-1-cleanup".to_string()),
-                detached: false,
-            },
-        );
 
     service.task_delete(repo_path, "parent-1", false)?;
 
     let git_calls = git_state.lock().expect("git lock poisoned").calls.clone();
-    assert_eq!(
-        git_calls
-            .iter()
-            .filter(|call| {
-                matches!(
-                    call,
-                    GitCall::GetCurrentBranch { repo_path: call_repo_path }
-                        if call_repo_path == worktree_path
-                )
-            })
-            .count(),
-        1
-    );
+    assert!(git_calls
+        .iter()
+        .any(|call| matches!(call, GitCall::GetBranches { .. })));
+    assert!(!git_calls
+        .iter()
+        .any(|call| matches!(call, GitCall::GetCurrentBranch { .. })));
     assert_eq!(
         git_calls
             .iter()
@@ -342,6 +329,7 @@ fn task_delete_cascade_cleans_descendant_worktrees() -> Result<()> {
     let repo_path = "/tmp/odt-repo-task-delete-descendants";
     let child_worktree_path = "/tmp/odt-repo-task-delete-descendants-child";
     fs::create_dir_all(repo_path)?;
+    fs::create_dir_all(child_worktree_path)?;
     init_git_repo(Path::new(repo_path))?;
     let parent = make_task("parent-1", "epic", TaskStatus::Open);
     let mut child = make_task("child-1", "task", TaskStatus::Open);
@@ -350,7 +338,11 @@ fn task_delete_cascade_cleans_descendant_worktrees() -> Result<()> {
     child_session.working_directory = child_worktree_path.to_string();
     let (service, task_state, git_state) = build_service_with_git_state(
         vec![parent, child],
-        vec![],
+        vec![GitBranch {
+            name: "obp/child-1-cleanup".to_string(),
+            is_current: false,
+            is_remote: false,
+        }],
         GitCurrentBranch {
             name: Some("main".to_string()),
             detached: false,
@@ -376,17 +368,6 @@ fn task_delete_cascade_cleans_descendant_worktrees() -> Result<()> {
         .lock()
         .expect("task lock poisoned")
         .agent_sessions = vec![child_session];
-    git_state
-        .lock()
-        .expect("git lock poisoned")
-        .current_branches_by_path
-        .insert(
-            child_worktree_path.to_string(),
-            GitCurrentBranch {
-                name: Some("obp/child-1-cleanup".to_string()),
-                detached: false,
-            },
-        );
 
     service.task_delete(repo_path, "parent-1", true)?;
 
@@ -419,13 +400,18 @@ fn task_delete_stops_before_store_delete_when_worktree_cleanup_fails() {
     let repo_path = "/tmp/odt-repo-task-delete-worktree-failure";
     let worktree_path = "/tmp/odt-repo-task-delete-worktree-failure-worktree";
     fs::create_dir_all(repo_path).expect("repo directory should be created");
+    fs::create_dir_all(worktree_path).expect("worktree directory should be created");
     init_git_repo(Path::new(repo_path)).expect("repo should be initialized");
     let parent = make_task("parent-1", "epic", TaskStatus::Open);
     let mut build_session = make_session("parent-1", "build-session");
     build_session.working_directory = worktree_path.to_string();
     let (service, task_state, git_state) = build_service_with_git_state(
         vec![parent],
-        vec![],
+        vec![GitBranch {
+            name: "obp/parent-1-cleanup".to_string(),
+            is_current: false,
+            is_remote: false,
+        }],
         GitCurrentBranch {
             name: Some("main".to_string()),
             detached: false,
@@ -456,13 +442,6 @@ fn task_delete_stops_before_store_delete_when_worktree_cleanup_fails() {
         .expect("task lock poisoned")
         .agent_sessions = vec![build_session];
     let mut git_state = git_state.lock().expect("git lock poisoned");
-    git_state.current_branches_by_path.insert(
-        worktree_path.to_string(),
-        GitCurrentBranch {
-            name: Some("obp/parent-1-cleanup".to_string()),
-            detached: false,
-        },
-    );
     git_state.remove_worktree_error = Some("remove failed".to_string());
     drop(git_state);
 
@@ -473,6 +452,90 @@ fn task_delete_stops_before_store_delete_when_worktree_cleanup_fails() {
     assert!(format!("{error:#}").contains("remove failed"));
     let task_state = task_state.lock().expect("task lock poisoned");
     assert!(task_state.delete_calls.is_empty());
+}
+
+#[test]
+fn task_delete_retries_branch_cleanup_after_worktree_was_removed() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-task-delete-branch-retry";
+    let worktree_path = "/tmp/odt-repo-task-delete-branch-retry-worktree";
+    fs::create_dir_all(repo_path)?;
+    fs::create_dir_all(worktree_path)?;
+    init_git_repo(Path::new(repo_path))?;
+    let parent = make_task("parent-1", "epic", TaskStatus::Open);
+    let mut build_session = make_session("parent-1", "build-session");
+    build_session.working_directory = worktree_path.to_string();
+    let (service, task_state, git_state) = build_service_with_git_state(
+        vec![parent],
+        vec![GitBranch {
+            name: "obp/parent-1-cleanup".to_string(),
+            is_current: false,
+            is_remote: false,
+        }],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+    service.workspace_add(repo_path)?;
+    service.workspace_update_repo_config(
+        repo_path,
+        RepoConfig {
+            worktree_base_path: Some("/tmp/odt-test-worktrees".to_string()),
+            branch_prefix: "obp".to_string(),
+            default_target_branch: "origin/main".to_string(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            worktree_file_copies: Vec::new(),
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    task_state
+        .lock()
+        .expect("task lock poisoned")
+        .agent_sessions = vec![build_session];
+    git_state
+        .lock()
+        .expect("git lock poisoned")
+        .delete_local_branch_error = Some("branch blocked".to_string());
+
+    let first_error = service
+        .task_delete(repo_path, "parent-1", false)
+        .expect_err("first delete should fail on branch cleanup");
+    assert!(format!("{first_error:#}").contains("branch blocked"));
+    fs::remove_dir_all(worktree_path)?;
+
+    git_state
+        .lock()
+        .expect("git lock poisoned")
+        .delete_local_branch_error = None;
+
+    service.task_delete(repo_path, "parent-1", false)?;
+
+    let git_calls = git_state.lock().expect("git lock poisoned").calls.clone();
+    assert_eq!(
+        git_calls
+            .iter()
+            .filter(|call| matches!(call, GitCall::RemoveWorktree { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(
+        git_calls
+            .iter()
+            .filter(|call| matches!(call, GitCall::DeleteLocalBranch { .. }))
+            .count(),
+        2
+    );
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert_eq!(
+        task_state.delete_calls,
+        vec![("parent-1".to_string(), false)]
+    );
+    Ok(())
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -184,6 +184,8 @@ fn task_delete_blocks_when_subtasks_exist_without_confirmation() {
 #[test]
 fn task_delete_allows_cascade_and_forwards_delete_flag() -> Result<()> {
     let repo_path = "/tmp/odt-repo-task-delete-cascade";
+    fs::create_dir_all(repo_path)?;
+    init_git_repo(Path::new(repo_path))?;
     let parent = make_task("parent-1", "epic", TaskStatus::Open);
     let mut child = make_task("child-1", "task", TaskStatus::Open);
     child.parent_id = Some("parent-1".to_string());
@@ -195,6 +197,21 @@ fn task_delete_allows_cascade_and_forwards_delete_flag() -> Result<()> {
             detached: false,
         },
     );
+    service.workspace_add(repo_path)?;
+    service.workspace_update_repo_config(
+        repo_path,
+        RepoConfig {
+            worktree_base_path: Some("/tmp/odt-test-worktrees".to_string()),
+            branch_prefix: "obp".to_string(),
+            default_target_branch: "origin/main".to_string(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            worktree_file_copies: Vec::new(),
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
 
     service.task_delete(repo_path, "parent-1", true)?;
 
@@ -204,6 +221,258 @@ fn task_delete_allows_cascade_and_forwards_delete_flag() -> Result<()> {
         vec![("parent-1".to_string(), true)]
     );
     Ok(())
+}
+
+#[test]
+fn task_delete_removes_managed_worktrees_and_related_branches() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-task-delete-cleanup";
+    let worktree_path = "/tmp/odt-repo-task-delete-cleanup-worktree";
+    fs::create_dir_all(repo_path)?;
+    init_git_repo(Path::new(repo_path))?;
+    let parent = make_task("parent-1", "epic", TaskStatus::Open);
+    let mut build_session = make_session("parent-1", "build-session");
+    build_session.working_directory = worktree_path.to_string();
+    let mut qa_session = make_session("parent-1", "qa-session");
+    qa_session.role = "qa".to_string();
+    qa_session.scenario = Some("qa_review".to_string());
+    qa_session.working_directory = worktree_path.to_string();
+    let mut planner_session = make_session("parent-1", "planner-session");
+    planner_session.role = "planner".to_string();
+    planner_session.scenario = Some("planner_initial".to_string());
+    planner_session.working_directory = repo_path.to_string();
+    let (service, task_state, git_state) = build_service_with_git_state(
+        vec![parent],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+    service.workspace_add(repo_path)?;
+    service.workspace_update_repo_config(
+        repo_path,
+        RepoConfig {
+            worktree_base_path: Some("/tmp/odt-test-worktrees".to_string()),
+            branch_prefix: "obp".to_string(),
+            default_target_branch: "origin/main".to_string(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            worktree_file_copies: Vec::new(),
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    task_state
+        .lock()
+        .expect("task lock poisoned")
+        .agent_sessions = vec![build_session, qa_session, planner_session];
+    git_state
+        .lock()
+        .expect("git lock poisoned")
+        .current_branches_by_path
+        .insert(
+            worktree_path.to_string(),
+            GitCurrentBranch {
+                name: Some("obp/parent-1-cleanup".to_string()),
+                detached: false,
+            },
+        );
+
+    service.task_delete(repo_path, "parent-1", false)?;
+
+    let git_calls = git_state.lock().expect("git lock poisoned").calls.clone();
+    assert_eq!(
+        git_calls
+            .iter()
+            .filter(|call| {
+                matches!(
+                    call,
+                    GitCall::GetCurrentBranch { repo_path: call_repo_path }
+                        if call_repo_path == worktree_path
+                )
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        git_calls
+            .iter()
+            .filter(|call| {
+                matches!(
+                    call,
+                    GitCall::RemoveWorktree {
+                        repo_path: _,
+                        worktree_path: call_worktree_path,
+                        force,
+                    } if call_worktree_path == worktree_path && *force
+                )
+            })
+            .count(),
+        1
+    );
+    assert_eq!(
+        git_calls
+            .iter()
+            .filter(|call| {
+                matches!(
+                    call,
+                    GitCall::DeleteLocalBranch {
+                        repo_path: _,
+                        branch,
+                        force,
+                    } if branch == "obp/parent-1-cleanup" && *force
+                )
+            })
+            .count(),
+        1
+    );
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert_eq!(
+        task_state.delete_calls,
+        vec![("parent-1".to_string(), false)]
+    );
+    Ok(())
+}
+
+#[test]
+fn task_delete_cascade_cleans_descendant_worktrees() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-task-delete-descendants";
+    let child_worktree_path = "/tmp/odt-repo-task-delete-descendants-child";
+    fs::create_dir_all(repo_path)?;
+    init_git_repo(Path::new(repo_path))?;
+    let parent = make_task("parent-1", "epic", TaskStatus::Open);
+    let mut child = make_task("child-1", "task", TaskStatus::Open);
+    child.parent_id = Some("parent-1".to_string());
+    let mut child_session = make_session("child-1", "child-build-session");
+    child_session.working_directory = child_worktree_path.to_string();
+    let (service, task_state, git_state) = build_service_with_git_state(
+        vec![parent, child],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+    service.workspace_add(repo_path)?;
+    service.workspace_update_repo_config(
+        repo_path,
+        RepoConfig {
+            worktree_base_path: Some("/tmp/odt-test-worktrees".to_string()),
+            branch_prefix: "obp".to_string(),
+            default_target_branch: "origin/main".to_string(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            worktree_file_copies: Vec::new(),
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    task_state
+        .lock()
+        .expect("task lock poisoned")
+        .agent_sessions = vec![child_session];
+    git_state
+        .lock()
+        .expect("git lock poisoned")
+        .current_branches_by_path
+        .insert(
+            child_worktree_path.to_string(),
+            GitCurrentBranch {
+                name: Some("obp/child-1-cleanup".to_string()),
+                detached: false,
+            },
+        );
+
+    service.task_delete(repo_path, "parent-1", true)?;
+
+    let git_calls = git_state.lock().expect("git lock poisoned").calls.clone();
+    assert!(git_calls.iter().any(|call| {
+        matches!(
+            call,
+            GitCall::RemoveWorktree {
+                repo_path: _,
+                worktree_path,
+                force,
+            } if worktree_path == child_worktree_path && *force
+        )
+    }));
+    assert!(git_calls.iter().any(|call| {
+        matches!(
+            call,
+            GitCall::DeleteLocalBranch {
+                repo_path: _,
+                branch,
+                force,
+            } if branch == "obp/child-1-cleanup" && *force
+        )
+    }));
+    Ok(())
+}
+
+#[test]
+fn task_delete_stops_before_store_delete_when_worktree_cleanup_fails() {
+    let repo_path = "/tmp/odt-repo-task-delete-worktree-failure";
+    let worktree_path = "/tmp/odt-repo-task-delete-worktree-failure-worktree";
+    fs::create_dir_all(repo_path).expect("repo directory should be created");
+    init_git_repo(Path::new(repo_path)).expect("repo should be initialized");
+    let parent = make_task("parent-1", "epic", TaskStatus::Open);
+    let mut build_session = make_session("parent-1", "build-session");
+    build_session.working_directory = worktree_path.to_string();
+    let (service, task_state, git_state) = build_service_with_git_state(
+        vec![parent],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+        },
+    );
+    service
+        .workspace_add(repo_path)
+        .expect("workspace add should succeed");
+    service
+        .workspace_update_repo_config(
+            repo_path,
+            RepoConfig {
+                worktree_base_path: Some("/tmp/odt-test-worktrees".to_string()),
+                branch_prefix: "obp".to_string(),
+                default_target_branch: "origin/main".to_string(),
+                trusted_hooks: true,
+                trusted_hooks_fingerprint: None,
+                hooks: HookSet::default(),
+                worktree_file_copies: Vec::new(),
+                prompt_overrides: Default::default(),
+                agent_defaults: Default::default(),
+            },
+        )
+        .expect("repo config update should succeed");
+
+    task_state
+        .lock()
+        .expect("task lock poisoned")
+        .agent_sessions = vec![build_session];
+    let mut git_state = git_state.lock().expect("git lock poisoned");
+    git_state.current_branches_by_path.insert(
+        worktree_path.to_string(),
+        GitCurrentBranch {
+            name: Some("obp/parent-1-cleanup".to_string()),
+            detached: false,
+        },
+    );
+    git_state.remove_worktree_error = Some("remove failed".to_string());
+    drop(git_state);
+
+    let error = service
+        .task_delete(repo_path, "parent-1", false)
+        .expect_err("task delete should fail when worktree cleanup fails");
+
+    assert!(format!("{error:#}").contains("remove failed"));
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert!(task_state.delete_calls.is_empty());
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -235,6 +235,7 @@ pub trait GitPort: Send + Sync {
         create_branch: bool,
     ) -> Result<()>;
     fn remove_worktree(&self, repo_path: &Path, worktree_path: &Path, force: bool) -> Result<()>;
+    fn delete_local_branch(&self, repo_path: &Path, branch: &str, force: bool) -> Result<()>;
     fn push_branch(
         &self,
         repo_path: &Path,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/branch.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/branch.rs
@@ -66,6 +66,24 @@ impl GitCliPort {
 
         self.get_current_branch_impl(repo_path)
     }
+
+    pub(super) fn delete_local_branch_impl(
+        &self,
+        repo_path: &Path,
+        branch: &str,
+        force: bool,
+    ) -> Result<()> {
+        self.ensure_repository(repo_path)?;
+        let branch = normalize_non_empty(branch, "branch")?;
+
+        let delete_flag = if force { "-D" } else { "-d" };
+        self.run_git(
+            repo_path,
+            &["branch", delete_flag, "--end-of-options", branch.as_str()],
+        )?;
+
+        Ok(())
+    }
 }
 
 fn parse_branch_rows(output: &str) -> Vec<GitBranch> {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
@@ -90,6 +90,10 @@ impl GitPort for GitCliPort {
         self.remove_worktree_impl(repo_path, worktree_path, force)
     }
 
+    fn delete_local_branch(&self, repo_path: &Path, branch: &str, force: bool) -> Result<()> {
+        self.delete_local_branch_impl(repo_path, branch, force)
+    }
+
     fn push_branch(
         &self,
         repo_path: &Path,

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -1432,6 +1432,15 @@ mod tests {
             Ok(())
         }
 
+        fn delete_local_branch(
+            &self,
+            _repo_path: &Path,
+            _branch: &str,
+            _force: bool,
+        ) -> anyhow::Result<()> {
+            panic!("unexpected call: delete_local_branch");
+        }
+
         fn push_branch(
             &self,
             _repo_path: &Path,

--- a/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.test.tsx
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { formatManagedSessionCleanupMessage } from "./task-delete-confirm-dialog";
+import {
+  formatManagedSessionCleanupMessage,
+  formatUnknownManagedSessionCleanupMessage,
+} from "./task-delete-confirm-dialog";
 
 describe("TaskDeleteConfirmDialog", () => {
   test("mentions worktree and related branch cleanup when managed sessions exist", () => {
@@ -10,16 +13,16 @@ describe("TaskDeleteConfirmDialog", () => {
     expect(message).toContain("uncommitted changes");
   });
 
-  test("omits worktree cleanup copy when no managed worktrees exist", () => {
+  test("uses exact-count wording when managed worktree count is known", () => {
     const message = formatManagedSessionCleanupMessage(1);
 
     expect(message).not.toContain("if they exist");
   });
 
-  test("falls back to a conservative warning when cleanup impact is unknown", () => {
-    const message = formatManagedSessionCleanupMessage(0);
+  test("uses explicit unknown-impact wording when cleanup impact cannot be loaded", () => {
+    const message = formatUnknownManagedSessionCleanupMessage();
 
-    expect(message).toContain("will also be deleted if they exist");
+    expect(message).toContain("may also be deleted");
     expect(message).toContain("related local branches");
     expect(message).toContain("uncommitted changes");
   });

--- a/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { formatManagedSessionCleanupMessage } from "./task-delete-confirm-dialog";
+
+describe("TaskDeleteConfirmDialog", () => {
+  test("mentions worktree and related branch cleanup when managed sessions exist", () => {
+    const message = formatManagedSessionCleanupMessage(2);
+
+    expect(message).toContain("2 linked task worktrees");
+    expect(message).toContain("related local branches");
+    expect(message).toContain("uncommitted changes");
+  });
+
+  test("omits worktree cleanup copy when no managed worktrees exist", () => {
+    const message = formatManagedSessionCleanupMessage(1);
+
+    expect(message).not.toContain("if they exist");
+  });
+
+  test("falls back to a conservative warning when cleanup impact is unknown", () => {
+    const message = formatManagedSessionCleanupMessage(0);
+
+    expect(message).toContain("will also be deleted if they exist");
+    expect(message).toContain("related local branches");
+    expect(message).toContain("uncommitted changes");
+  });
+});

--- a/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.tsx
+++ b/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.tsx
@@ -20,6 +20,7 @@ type TaskDeleteConfirmDialogProps = {
   hasSubtasks: boolean;
   hasManagedSessionCleanup: boolean;
   managedWorktreeCount: number;
+  impactError: string | null;
   isDeletePending: boolean;
   deleteError: string | null;
 };
@@ -32,6 +33,9 @@ export const formatManagedSessionCleanupMessage = (managedWorktreeCount: number)
   return "Linked task worktrees and their related local branches will also be deleted if they exist. Any uncommitted changes in those worktrees will be lost.";
 };
 
+export const formatUnknownManagedSessionCleanupMessage = (): string =>
+  "Linked task worktrees and their related local branches may also be deleted. Any uncommitted changes in those worktrees will be lost.";
+
 export function TaskDeleteConfirmDialog({
   open,
   onOpenChange,
@@ -42,6 +46,7 @@ export function TaskDeleteConfirmDialog({
   hasSubtasks,
   hasManagedSessionCleanup,
   managedWorktreeCount,
+  impactError,
   isDeletePending,
   deleteError,
 }: TaskDeleteConfirmDialogProps): ReactElement {
@@ -62,9 +67,12 @@ export function TaskDeleteConfirmDialog({
           {hasSubtasks ? (
             <p>Direct subtasks will also be deleted to avoid orphaned children in the workflow.</p>
           ) : null}
-          {hasManagedSessionCleanup ? (
+          {impactError ? (
+            <p>{formatUnknownManagedSessionCleanupMessage()}</p>
+          ) : hasManagedSessionCleanup ? (
             <p>{formatManagedSessionCleanupMessage(managedWorktreeCount)}</p>
           ) : null}
+          {impactError ? <p className="text-destructive-muted">{impactError}</p> : null}
           {deleteError ? <p className="text-destructive-muted">{deleteError}</p> : null}
         </div>
 

--- a/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.tsx
+++ b/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.tsx
@@ -18,8 +18,18 @@ type TaskDeleteConfirmDialogProps = {
   taskId: string;
   subtasksCount: number;
   hasSubtasks: boolean;
+  hasManagedSessionCleanup: boolean;
+  managedWorktreeCount: number;
   isDeletePending: boolean;
   deleteError: string | null;
+};
+
+export const formatManagedSessionCleanupMessage = (managedWorktreeCount: number): string => {
+  if (managedWorktreeCount > 0) {
+    return `${managedWorktreeCount} linked task worktree${managedWorktreeCount === 1 ? "" : "s"} and their related local branches will also be deleted. Any uncommitted changes in those worktrees will be lost.`;
+  }
+
+  return "Linked task worktrees and their related local branches will also be deleted if they exist. Any uncommitted changes in those worktrees will be lost.";
 };
 
 export function TaskDeleteConfirmDialog({
@@ -30,6 +40,8 @@ export function TaskDeleteConfirmDialog({
   taskId,
   subtasksCount,
   hasSubtasks,
+  hasManagedSessionCleanup,
+  managedWorktreeCount,
   isDeletePending,
   deleteError,
 }: TaskDeleteConfirmDialogProps): ReactElement {
@@ -49,6 +61,9 @@ export function TaskDeleteConfirmDialog({
           <p className="font-medium">This action permanently removes the task from Beads.</p>
           {hasSubtasks ? (
             <p>Direct subtasks will also be deleted to avoid orphaned children in the workflow.</p>
+          ) : null}
+          {hasManagedSessionCleanup ? (
+            <p>{formatManagedSessionCleanupMessage(managedWorktreeCount)}</p>
           ) : null}
           {deleteError ? <p className="text-destructive-muted">{deleteError}</p> : null}
         </div>

--- a/apps/desktop/src/components/features/task-details/task-details-sheet-model.test.ts
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { TaskCard } from "@openducktor/contracts";
 import {
+  collectDeleteImpactTaskIds,
   runTaskWorkflowAction,
   shouldLoadDocumentSection,
   toSubtasks,
@@ -50,6 +51,20 @@ describe("task-details-sheet-model", () => {
 
     expect(toSubtasks(parent, byId)).toEqual([subtask]);
     expect(toSubtasks(null, byId)).toEqual([]);
+  });
+
+  test("collects delete impact ids across descendant subtasks", () => {
+    const leaf = makeTask("T-3");
+    const child = makeTask("T-2", { subtaskIds: ["T-3"] });
+    const parent = makeTask("T-1", { subtaskIds: ["T-2", "T-999"] });
+    const byId = new Map<string, TaskCard>([
+      [parent.id, parent],
+      [child.id, child],
+      [leaf.id, leaf],
+    ]);
+
+    expect(collectDeleteImpactTaskIds(parent, byId)).toEqual(["T-1", "T-2", "T-999", "T-3"]);
+    expect(collectDeleteImpactTaskIds(null, byId)).toEqual([]);
   });
 
   test("routes workflow actions to matching callbacks", () => {

--- a/apps/desktop/src/components/features/task-details/task-details-sheet-model.ts
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-model.ts
@@ -24,6 +24,42 @@ export const toSubtasks = (task: TaskCard | null, taskById: Map<string, TaskCard
     .filter((entry): entry is TaskCard => Boolean(entry));
 };
 
+export const collectDeleteImpactTaskIds = (
+  task: TaskCard | null,
+  taskById: Map<string, TaskCard>,
+): string[] => {
+  if (!task) {
+    return [];
+  }
+
+  const collectedIds: string[] = [];
+  const pendingIds = [task.id];
+  const seenIds = new Set<string>();
+
+  while (pendingIds.length > 0) {
+    const currentId = pendingIds.shift();
+    if (!currentId || seenIds.has(currentId)) {
+      continue;
+    }
+
+    seenIds.add(currentId);
+    collectedIds.push(currentId);
+
+    const currentTask = taskById.get(currentId);
+    if (!currentTask) {
+      continue;
+    }
+
+    for (const subtaskId of currentTask.subtaskIds) {
+      if (!seenIds.has(subtaskId)) {
+        pendingIds.push(subtaskId);
+      }
+    }
+  }
+
+  return collectedIds;
+};
+
 export const runTaskWorkflowAction = (
   action: TaskWorkflowAction,
   taskId: string | null,

--- a/apps/desktop/src/components/features/task-details/task-details-sheet.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet.tsx
@@ -120,6 +120,7 @@ export function TaskDetailsSheet({
           hasSubtasks={viewModel.subtasks.length > 0}
           hasManagedSessionCleanup={viewModel.hasManagedSessionCleanup}
           managedWorktreeCount={viewModel.managedWorktreeCount}
+          impactError={viewModel.impactError}
           isDeletePending={viewModel.isDeletePending}
           deleteError={viewModel.deleteError}
         />

--- a/apps/desktop/src/components/features/task-details/task-details-sheet.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet.tsx
@@ -118,6 +118,8 @@ export function TaskDetailsSheet({
           taskId={viewModel.taskId}
           subtasksCount={viewModel.subtasks.length}
           hasSubtasks={viewModel.subtasks.length > 0}
+          hasManagedSessionCleanup={viewModel.hasManagedSessionCleanup}
+          managedWorktreeCount={viewModel.managedWorktreeCount}
           isDeletePending={viewModel.isDeletePending}
           deleteError={viewModel.deleteError}
         />

--- a/apps/desktop/src/components/features/task-details/use-task-delete-impact.test.tsx
+++ b/apps/desktop/src/components/features/task-details/use-task-delete-impact.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import {
+  getConservativeTaskDeleteImpact,
+  getManagedTaskDeleteImpact,
+  getManagedTaskDeleteImpactFromTasks,
+} from "./use-task-delete-impact";
+
+const makeSession = (overrides: Partial<AgentSessionRecord> = {}): AgentSessionRecord => ({
+  sessionId: overrides.sessionId ?? "session-1",
+  role: overrides.role ?? "build",
+  scenario: overrides.scenario ?? "build_implementation_start",
+  startedAt: overrides.startedAt ?? "2026-03-06T10:00:00.000Z",
+  workingDirectory: overrides.workingDirectory ?? "/repo",
+  ...overrides,
+});
+
+describe("getManagedTaskDeleteImpact", () => {
+  test("counts unique build and qa worktrees outside the repo root", () => {
+    const impact = getManagedTaskDeleteImpact("/repo", [
+      makeSession({
+        sessionId: "build-1",
+        role: "build",
+        workingDirectory: "/repo/worktrees/task-1",
+      }),
+      makeSession({
+        sessionId: "qa-1",
+        role: "qa",
+        scenario: "qa_review",
+        workingDirectory: "/repo/worktrees/task-1",
+      }),
+      makeSession({
+        sessionId: "build-2",
+        role: "build",
+        workingDirectory: "/repo/worktrees/task-2",
+      }),
+      makeSession({
+        sessionId: "planner-1",
+        role: "planner",
+        scenario: "planner_initial",
+        workingDirectory: "/repo/worktrees/task-3",
+      }),
+      makeSession({ sessionId: "build-root", role: "build", workingDirectory: "/repo" }),
+    ]);
+
+    expect(impact).toEqual({
+      hasManagedSessionCleanup: true,
+      managedWorktreeCount: 2,
+    });
+  });
+
+  test("normalizes trailing separators when comparing against the repo root", () => {
+    const impact = getManagedTaskDeleteImpact("/repo/", [
+      makeSession({ sessionId: "build-root", workingDirectory: "/repo" }),
+      makeSession({
+        sessionId: "qa-root",
+        role: "qa",
+        scenario: "qa_review",
+        workingDirectory: "/repo///",
+      }),
+    ]);
+
+    expect(impact).toEqual({
+      hasManagedSessionCleanup: false,
+      managedWorktreeCount: 0,
+    });
+  });
+
+  test("aggregates managed worktrees across multiple task session lists", () => {
+    const impact = getManagedTaskDeleteImpactFromTasks("/repo", [
+      [makeSession({ sessionId: "parent", workingDirectory: "/repo" })],
+      [makeSession({ sessionId: "child", workingDirectory: "/repo/worktrees/task-2" })],
+    ]);
+
+    expect(impact).toEqual({
+      hasManagedSessionCleanup: true,
+      managedWorktreeCount: 1,
+    });
+  });
+
+  test("falls back to a conservative cleanup warning when impact lookup fails", () => {
+    expect(getConservativeTaskDeleteImpact()).toEqual({
+      hasManagedSessionCleanup: true,
+      managedWorktreeCount: 0,
+    });
+  });
+});

--- a/apps/desktop/src/components/features/task-details/use-task-delete-impact.test.tsx
+++ b/apps/desktop/src/components/features/task-details/use-task-delete-impact.test.tsx
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import {
-  getConservativeTaskDeleteImpact,
   getManagedTaskDeleteImpact,
   getManagedTaskDeleteImpactFromTasks,
+  TASK_DELETE_IMPACT_ERROR_MESSAGE,
 } from "./use-task-delete-impact";
 
 const makeSession = (overrides: Partial<AgentSessionRecord> = {}): AgentSessionRecord => ({
@@ -46,6 +46,7 @@ describe("getManagedTaskDeleteImpact", () => {
     expect(impact).toEqual({
       hasManagedSessionCleanup: true,
       managedWorktreeCount: 2,
+      impactError: null,
     });
   });
 
@@ -63,6 +64,7 @@ describe("getManagedTaskDeleteImpact", () => {
     expect(impact).toEqual({
       hasManagedSessionCleanup: false,
       managedWorktreeCount: 0,
+      impactError: null,
     });
   });
 
@@ -75,13 +77,11 @@ describe("getManagedTaskDeleteImpact", () => {
     expect(impact).toEqual({
       hasManagedSessionCleanup: true,
       managedWorktreeCount: 1,
+      impactError: null,
     });
   });
 
-  test("falls back to a conservative cleanup warning when impact lookup fails", () => {
-    expect(getConservativeTaskDeleteImpact()).toEqual({
-      hasManagedSessionCleanup: true,
-      managedWorktreeCount: 0,
-    });
+  test("includes a stable explicit error message for impact lookup failures", () => {
+    expect(TASK_DELETE_IMPACT_ERROR_MESSAGE).toBe("Unable to load linked worktree cleanup impact.");
   });
 });

--- a/apps/desktop/src/components/features/task-details/use-task-delete-impact.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-delete-impact.ts
@@ -1,0 +1,95 @@
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import { useEffect, useState } from "react";
+import { useWorkspaceState } from "@/state";
+import { host } from "@/state/operations/host";
+
+export type TaskDeleteImpact = {
+  hasManagedSessionCleanup: boolean;
+  managedWorktreeCount: number;
+};
+
+const EMPTY_DELETE_IMPACT: TaskDeleteImpact = {
+  hasManagedSessionCleanup: false,
+  managedWorktreeCount: 0,
+};
+
+const normalizePathForComparison = (path: string): string => {
+  const trimmed = path.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+  const withoutTrailingSeparators = trimmed.replace(/[\\/]+$/u, "");
+  return withoutTrailingSeparators.length > 0 ? withoutTrailingSeparators : trimmed;
+};
+
+export const getManagedTaskDeleteImpact = (
+  repoPath: string,
+  sessions: AgentSessionRecord[],
+): TaskDeleteImpact => {
+  const normalizedRepoPath = normalizePathForComparison(repoPath);
+  const managedWorktrees = new Set<string>();
+
+  for (const session of sessions) {
+    if (session.role !== "build" && session.role !== "qa") {
+      continue;
+    }
+
+    const normalizedWorkingDirectory = normalizePathForComparison(session.workingDirectory);
+    if (
+      normalizedWorkingDirectory.length === 0 ||
+      normalizedWorkingDirectory === normalizedRepoPath
+    ) {
+      continue;
+    }
+
+    managedWorktrees.add(normalizedWorkingDirectory);
+  }
+
+  return {
+    hasManagedSessionCleanup: managedWorktrees.size > 0,
+    managedWorktreeCount: managedWorktrees.size,
+  };
+};
+
+export const getManagedTaskDeleteImpactFromTasks = (
+  repoPath: string,
+  taskSessions: AgentSessionRecord[][],
+): TaskDeleteImpact => getManagedTaskDeleteImpact(repoPath, taskSessions.flat());
+
+export const getConservativeTaskDeleteImpact = (): TaskDeleteImpact => ({
+  hasManagedSessionCleanup: true,
+  managedWorktreeCount: 0,
+});
+
+export function useTaskDeleteImpact(taskIds: string[], open: boolean): TaskDeleteImpact {
+  const { activeRepo } = useWorkspaceState();
+  const [impact, setImpact] = useState<TaskDeleteImpact>(EMPTY_DELETE_IMPACT);
+
+  useEffect(() => {
+    if (taskIds.length === 0 || !open || !activeRepo) {
+      setImpact(EMPTY_DELETE_IMPACT);
+      return;
+    }
+
+    let cancelled = false;
+    void Promise.all(taskIds.map((taskId) => host.agentSessionsList(activeRepo, taskId)))
+      .then((taskSessions: AgentSessionRecord[][]) => {
+        if (cancelled) {
+          return;
+        }
+        setImpact(getManagedTaskDeleteImpactFromTasks(activeRepo, taskSessions));
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        setImpact(getConservativeTaskDeleteImpact());
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeRepo, open, taskIds]);
+
+  return impact;
+}

--- a/apps/desktop/src/components/features/task-details/use-task-delete-impact.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-delete-impact.ts
@@ -6,11 +6,13 @@ import { host } from "@/state/operations/host";
 export type TaskDeleteImpact = {
   hasManagedSessionCleanup: boolean;
   managedWorktreeCount: number;
+  impactError: string | null;
 };
 
 const EMPTY_DELETE_IMPACT: TaskDeleteImpact = {
   hasManagedSessionCleanup: false,
   managedWorktreeCount: 0,
+  impactError: null,
 };
 
 const normalizePathForComparison = (path: string): string => {
@@ -48,6 +50,7 @@ export const getManagedTaskDeleteImpact = (
   return {
     hasManagedSessionCleanup: managedWorktrees.size > 0,
     managedWorktreeCount: managedWorktrees.size,
+    impactError: null,
   };
 };
 
@@ -56,10 +59,7 @@ export const getManagedTaskDeleteImpactFromTasks = (
   taskSessions: AgentSessionRecord[][],
 ): TaskDeleteImpact => getManagedTaskDeleteImpact(repoPath, taskSessions.flat());
 
-export const getConservativeTaskDeleteImpact = (): TaskDeleteImpact => ({
-  hasManagedSessionCleanup: true,
-  managedWorktreeCount: 0,
-});
+export const TASK_DELETE_IMPACT_ERROR_MESSAGE = "Unable to load linked worktree cleanup impact.";
 
 export function useTaskDeleteImpact(taskIds: string[], open: boolean): TaskDeleteImpact {
   const { activeRepo } = useWorkspaceState();
@@ -83,7 +83,11 @@ export function useTaskDeleteImpact(taskIds: string[], open: boolean): TaskDelet
         if (cancelled) {
           return;
         }
-        setImpact(getConservativeTaskDeleteImpact());
+        setImpact({
+          hasManagedSessionCleanup: false,
+          managedWorktreeCount: 0,
+          impactError: TASK_DELETE_IMPACT_ERROR_MESSAGE,
+        });
       });
 
     return () => {

--- a/apps/desktop/src/components/features/task-details/use-task-details-sheet-view-model.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-details-sheet-view-model.ts
@@ -40,6 +40,7 @@ type TaskDetailsSheetViewModel = {
   deleteError: string | null;
   hasManagedSessionCleanup: boolean;
   managedWorktreeCount: number;
+  impactError: string | null;
   openDeleteDialog: () => void;
   closeDeleteDialog: () => void;
   handleDeleteDialogOpenChange: (nextOpen: boolean) => void;
@@ -83,7 +84,7 @@ export function useTaskDetailsSheetViewModel({
     () => collectDeleteImpactTaskIds(task, taskById),
     [task, taskById],
   );
-  const { hasManagedSessionCleanup, managedWorktreeCount } = useTaskDeleteImpact(
+  const { hasManagedSessionCleanup, managedWorktreeCount, impactError } = useTaskDeleteImpact(
     deleteImpactTaskIds,
     open,
   );
@@ -181,6 +182,7 @@ export function useTaskDetailsSheetViewModel({
     deleteError,
     hasManagedSessionCleanup,
     managedWorktreeCount,
+    impactError,
     openDeleteDialog,
     closeDeleteDialog,
     handleDeleteDialogOpenChange,

--- a/apps/desktop/src/components/features/task-details/use-task-details-sheet-view-model.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-details-sheet-view-model.ts
@@ -2,6 +2,7 @@ import type { TaskCard } from "@openducktor/contracts";
 import { useCallback, useMemo } from "react";
 import type { TaskWorkflowAction } from "@/components/features/kanban/kanban-task-workflow";
 import {
+  collectDeleteImpactTaskIds,
   runTaskWorkflowAction,
   shouldLoadDocumentSection,
   toSubtasks,
@@ -9,6 +10,7 @@ import {
 } from "@/components/features/task-details/task-details-sheet-model";
 import type { TaskDetailsSheetProps } from "@/components/features/task-details/task-details-sheet-types";
 import { useTaskDeleteDialog } from "@/components/features/task-details/use-task-delete-dialog";
+import { useTaskDeleteImpact } from "@/components/features/task-details/use-task-delete-impact";
 import {
   type DocumentSectionKey,
   type TaskDocumentState,
@@ -36,6 +38,8 @@ type TaskDetailsSheetViewModel = {
   isDeleteDialogOpen: boolean;
   isDeletePending: boolean;
   deleteError: string | null;
+  hasManagedSessionCleanup: boolean;
+  managedWorktreeCount: number;
   openDeleteDialog: () => void;
   closeDeleteDialog: () => void;
   handleDeleteDialogOpenChange: (nextOpen: boolean) => void;
@@ -75,6 +79,14 @@ export function useTaskDetailsSheetViewModel({
   const { specDoc, planDoc, qaDoc, ensureDocumentLoaded } = useTaskDocuments(taskId, open);
 
   const taskById = useMemo(() => new Map(allTasks.map((entry) => [entry.id, entry])), [allTasks]);
+  const deleteImpactTaskIds = useMemo(
+    () => collectDeleteImpactTaskIds(task, taskById),
+    [task, taskById],
+  );
+  const { hasManagedSessionCleanup, managedWorktreeCount } = useTaskDeleteImpact(
+    deleteImpactTaskIds,
+    open,
+  );
   const subtasks = useMemo(() => toSubtasks(task, taskById), [task, taskById]);
   const hasSubtasks = subtasks.length > 0;
   const shouldRenderSubtasks = task?.issueType === "epic";
@@ -167,6 +179,8 @@ export function useTaskDetailsSheetViewModel({
     isDeleteDialogOpen,
     isDeletePending,
     deleteError,
+    hasManagedSessionCleanup,
+    managedWorktreeCount,
     openDeleteDialog,
     closeDeleteDialog,
     handleDeleteDialogOpenChange,


### PR DESCRIPTION
## Summary
- delete managed build and QA worktrees plus their related managed local branches before Beads task deletion, including descendant-task cleanup during cascade deletes
- guard against removing the main repository workdir and add backend coverage for cleanup ordering, descendant cleanup, and failure short-circuit behavior
- warn in the task delete dialog when linked worktrees and related branches will be removed, with conservative fallback messaging if impact lookup cannot complete

## Testing
- cargo check
- cargo test -p host-application
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop build