### PR TITLE
fix(builder): stabilize worktree and session startup flows

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -9,7 +9,7 @@ use host_domain::{TaskStatus, TASK_METADATA_NAMESPACE};
 use host_infra_system::{build_branch_name, pick_free_port, remove_worktree, RepoConfig};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Child;
+use std::process::{Child, Command};
 
 pub(super) struct BuildPrerequisites {
     pub(super) repo_path: String,
@@ -36,6 +36,41 @@ struct BuildRuntimeFailureEvent<'a> {
     startup_policy: OpencodeStartupReadinessPolicy,
     startup_report: OpencodeStartupWaitReport,
     reason: &'static str,
+}
+
+fn git_reference_exists(repo_path_ref: &Path, reference: &str) -> Result<bool> {
+    let status = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", reference])
+        .current_dir(repo_path_ref)
+        .status()
+        .with_context(|| {
+            format!(
+                "Failed checking configured target branch {} in {}",
+                reference,
+                repo_path_ref.display()
+            )
+        })?;
+    Ok(status.success())
+}
+
+fn resolve_build_start_point(
+    repo_path_ref: &Path,
+    configured_target_branch: &str,
+) -> Result<String> {
+    if git_reference_exists(repo_path_ref, configured_target_branch)? {
+        return Ok(configured_target_branch.to_string());
+    }
+
+    if let Some(local_branch) = configured_target_branch.strip_prefix("origin/") {
+        if git_reference_exists(repo_path_ref, local_branch)? {
+            return Ok(local_branch.to_string());
+        }
+    }
+
+    Err(anyhow!(
+        "Configured target branch is unavailable for build worktree creation: {}",
+        configured_target_branch
+    ))
 }
 
 impl AppService {
@@ -97,16 +132,21 @@ impl AppService {
         }
 
         let repo_path_ref = Path::new(prerequisites.repo_path.as_str());
+        let start_point = resolve_build_start_point(
+            repo_path_ref,
+            prerequisites.repo_config.default_target_branch.as_str(),
+        )?;
         host_infra_system::run_command(
             "git",
             &[
                 "worktree",
                 "add",
+                "-b",
+                prerequisites.branch.as_str(),
                 worktree_dir
                     .to_str()
                     .ok_or_else(|| anyhow!("Invalid worktree path"))?,
-                "-b",
-                prerequisites.branch.as_str(),
+                start_point.as_str(),
             ],
             Some(repo_path_ref),
         )?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -486,10 +486,7 @@ impl GitPort for FakeGitPort {
             branch: branch.to_string(),
             create,
         });
-        state.current_branch = GitCurrentBranch {
-            name: Some(branch.to_string()),
-            detached: false,
-        };
+        state.current_branch = GitCurrentBranch { name: Some(branch.to_string()), detached: false, revision: None };
         Ok(state.current_branch.clone())
     }
 
@@ -752,10 +749,7 @@ pub(crate) fn build_service_with_state(
     build_service_with_git_state(
         tasks,
         Vec::new(),
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     )
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -486,7 +486,11 @@ impl GitPort for FakeGitPort {
             branch: branch.to_string(),
             create,
         });
-        state.current_branch = GitCurrentBranch { name: Some(branch.to_string()), detached: false, revision: None };
+        state.current_branch = GitCurrentBranch {
+            name: Some(branch.to_string()),
+            detached: false,
+            revision: None,
+        };
         Ok(state.current_branch.clone())
     }
 
@@ -749,7 +753,11 @@ pub(crate) fn build_service_with_state(
     build_service_with_git_state(
         tasks,
         Vec::new(),
-        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
     )
 }
 
@@ -899,17 +907,16 @@ pub(crate) fn make_session(task_id: &str, session_id: &str) -> AgentSessionDocum
 }
 
 pub(crate) static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+pub(crate) static UNIQUE_TEMP_PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) fn lock_env<'a>() -> std::sync::MutexGuard<'a, ()> {
     ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
 }
 
 pub(crate) fn unique_temp_path(name: &str) -> PathBuf {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time")
-        .as_nanos();
-    std::env::temp_dir().join(format!("openducktor-host-app-{name}-{nonce}"))
+    let nonce = UNIQUE_TEMP_PATH_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("openducktor-host-app-{name}-{pid}-{nonce}"))
 }
 
 pub(crate) fn write_executable_script(path: &Path, script: &str) -> Result<()> {
@@ -964,6 +971,15 @@ pub(crate) fn init_git_repo(path: &Path) -> Result<()> {
         .arg("commit")
         .arg("-m")
         .arg("initial")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()?;
+    Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .arg("branch")
+        .arg("-M")
+        .arg("main")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -35,6 +35,32 @@ use crate::app_service::{
     RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 
+fn run_command_in(current_dir: &Path, program: &str, args: &[&str]) -> Result<()> {
+    let status = Command::new(program)
+        .current_dir(current_dir)
+        .args(args)
+        .status()
+        .with_context(|| {
+            format!(
+                "failed running {} in {} with args {:?}",
+                program,
+                current_dir.display(),
+                args
+            )
+        })?;
+    if status.success() {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "{} {:?} failed in {} with status {}",
+        program,
+        args,
+        current_dir.display(),
+        status
+    ))
+}
+
 #[test]
 fn build_start_respond_and_cleanup_success_flow() -> Result<()> {
     let _env_lock = lock_env();
@@ -54,10 +80,7 @@ fn build_start_respond_and_cleanup_success_flow() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "bug", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -148,6 +171,83 @@ fn build_start_respond_and_cleanup_success_flow() -> Result<()> {
 }
 
 #[test]
+fn build_start_bases_worktree_on_configured_target_branch() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("build-target-branch");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    let fake_opencode = root.join("opencode");
+    create_fake_opencode(&fake_opencode)?;
+    let _opencode_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        fake_opencode.to_string_lossy().as_ref(),
+    );
+
+    let remote = root.join("remote.git");
+    let remote_path = remote.to_string_lossy().to_string();
+    run_command_in(
+        root.as_path(),
+        "git",
+        &["init", "--bare", remote_path.as_str()],
+    )?;
+    run_command_in(
+        repo.as_path(),
+        "git",
+        &["remote", "add", "origin", remote_path.as_str()],
+    )?;
+    run_command_in(repo.as_path(), "git", &["push", "-u", "origin", "main"])?;
+
+    run_command_in(repo.as_path(), "git", &["checkout", "-b", "develop"])?;
+    fs::write(repo.join("develop-only.txt"), "develop\n")?;
+    run_command_in(repo.as_path(), "git", &["add", "develop-only.txt"])?;
+    run_command_in(repo.as_path(), "git", &["commit", "-m", "develop base"])?;
+    run_command_in(repo.as_path(), "git", &["push", "-u", "origin", "develop"])?;
+
+    run_command_in(repo.as_path(), "git", &["checkout", "main"])?;
+    fs::write(repo.join("main-only.txt"), "main\n")?;
+    run_command_in(repo.as_path(), "git", &["add", "main-only.txt"])?;
+    run_command_in(repo.as_path(), "git", &["commit", "-m", "main only"])?;
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let repo_path = repo.to_string_lossy().to_string();
+    let worktree_base = root.join("builder-worktrees");
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "bug", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: "origin/develop".to_string(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            worktree_file_copies: Vec::new(),
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    let events = Arc::new(Mutex::new(Vec::<RunEvent>::new()));
+    let emitter = make_emitter(events.clone());
+    let run = service.build_start(repo_path.as_str(), "task-1", emitter.clone())?;
+    let worktree_path = Path::new(run.worktree_path.as_str());
+    assert!(worktree_path.join("develop-only.txt").exists());
+    assert!(!worktree_path.join("main-only.txt").exists());
+
+    assert!(service.build_stop(run.run_id.as_str(), emitter.clone())?);
+    assert!(service.build_cleanup(run.run_id.as_str(), CleanupMode::Failure, emitter)?);
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn build_stop_respond_and_cleanup_failure_paths() -> Result<()> {
     let root = unique_temp_path("build-failure");
     let repo = root.join("repo");
@@ -158,10 +258,7 @@ fn build_stop_respond_and_cleanup_failure_paths() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "bug", TaskStatus::InProgress)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 
@@ -251,10 +348,7 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
             make_task("task-2", "bug", TaskStatus::Open),
         ],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -362,10 +456,7 @@ fn build_start_requires_worktree_base_path() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "bug", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -409,10 +500,7 @@ fn build_start_rejects_untrusted_hooks_configuration() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "bug", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -462,10 +550,7 @@ fn build_start_rejects_existing_worktree_directory() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "bug", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -517,10 +602,7 @@ fn build_start_reports_opencode_startup_failure() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "bug", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -567,10 +649,7 @@ fn build_start_fails_on_invalid_startup_config_before_worktree_creation() -> Res
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "bug", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -634,10 +713,7 @@ fn build_start_stops_spawned_child_when_run_state_lock_is_poisoned() -> Result<(
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "bug", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
@@ -55,10 +55,7 @@ fn git_get_branches_initializes_repo_and_returns_git_data() -> Result<()> {
     let (service, task_state, git_state) = build_service_with_git_state(
         vec![],
         expected.clone(),
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let branches = service.git_get_branches(repo_path)?;
@@ -84,10 +81,7 @@ fn git_get_current_branch_uses_repo_init_cache() -> Result<()> {
     let (service, task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("feature/demo".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("feature/demo".to_string()), detached: false, revision: None },
     );
 
     let first = service.git_get_current_branch(repo_path)?;
@@ -120,10 +114,7 @@ fn git_switch_branch_forwards_create_flag() -> Result<()> {
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let branch = service.git_switch_branch(repo_path, "feature/new-ui", true)?;
@@ -145,10 +136,7 @@ fn git_create_worktree_rejects_empty_path() {
     let (service, task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -173,10 +161,7 @@ fn git_remove_worktree_forwards_force_flag() -> Result<()> {
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     assert!(service.git_remove_worktree(repo_path, "/tmp/wt-1", true)?);
@@ -196,10 +181,7 @@ fn git_remove_worktree_rejects_repository_root() {
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -220,10 +202,7 @@ fn git_delete_local_branch_forwards_force_flag() -> Result<()> {
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     assert!(service.git_delete_local_branch(repo_path, "obp/task-123-cleanup", true)?);
@@ -244,10 +223,7 @@ fn git_push_branch_defaults_remote_to_origin() -> Result<()> {
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let result = service.git_push_branch(
@@ -283,10 +259,7 @@ fn git_pull_branch_forwards_working_dir_and_returns_result() -> Result<()> {
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     {
@@ -325,10 +298,7 @@ fn git_commit_all_rejects_empty_message() {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -350,10 +320,7 @@ fn git_commit_all_returns_committed_and_trims_message() -> Result<()> {
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     {
@@ -399,10 +366,7 @@ fn git_commit_all_returns_no_changes() -> Result<()> {
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     {
@@ -451,10 +415,7 @@ fn git_rebase_branch_rejects_empty_target_branch() {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -476,10 +437,7 @@ fn git_rebase_branch_forwards_trimmed_target_branch_and_can_conflict() -> Result
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     {
@@ -530,17 +488,11 @@ fn git_port_get_worktree_status_returns_configured_payload_from_fake_port() -> R
     let (service, _task_state, git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let expected = GitWorktreeStatusData {
-        current_branch: GitCurrentBranch {
-            name: Some("feature/composite".to_string()),
-            detached: false,
-        },
+        current_branch: GitCurrentBranch { name: Some("feature/composite".to_string()), detached: false, revision: None },
         file_statuses: vec![GitFileStatus {
             path: "src/main.rs".to_string(),
             status: "modified".to_string(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -54,10 +54,7 @@ fn opencode_workspace_runtime_ensure_list_and_stop_flow() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 
@@ -102,10 +99,7 @@ fn opencode_workspace_runtime_ensure_stops_spawned_child_when_post_start_prune_f
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     let stale_child = Command::new("/bin/sh")
@@ -185,10 +179,7 @@ fn opencode_runtime_start_supports_spec_and_qa_roles() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -241,10 +232,7 @@ fn opencode_runtime_start_persists_canonical_repo_path_in_summary() -> Result<()
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     let repo_path_with_suffix = format!("{}/.", repo.to_string_lossy());
@@ -271,10 +259,7 @@ fn opencode_runtime_start_reports_missing_task() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 
@@ -298,10 +283,7 @@ fn opencode_runtime_start_qa_validates_config_and_existing_worktree_path() -> Re
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -388,10 +370,7 @@ fn opencode_runtime_start_surfaces_qa_pre_start_cleanup_failure() -> Result<()> 
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -444,10 +423,7 @@ fn opencode_runtime_start_surfaces_cleanup_failure_after_startup_error() -> Resu
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -491,10 +467,7 @@ fn opencode_runtime_start_fails_on_invalid_startup_config_before_qa_worktree_set
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -549,10 +522,7 @@ fn opencode_runtime_start_reuses_existing_runtime_for_same_task_and_role() -> Re
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     let repo_path = repo.to_string_lossy().to_string();
@@ -586,10 +556,7 @@ fn opencode_runtime_start_deduplicates_concurrent_same_task_and_role() -> Result
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     let repo_path = repo.to_string_lossy().to_string();
@@ -651,10 +618,7 @@ fn opencode_workspace_runtime_ensure_cleans_up_spawned_child_when_runtime_lock_i
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 
@@ -721,10 +685,7 @@ fn opencode_runtime_start_cleans_up_qa_worktree_when_tracking_fails() -> Result<
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     service.workspace_add(repo_path.as_str())?;
@@ -786,10 +747,7 @@ fn opencode_runtime_stop_reports_cleanup_failure() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let runtime_id = "runtime-cleanup-error".to_string();
@@ -842,10 +800,7 @@ fn opencode_runtime_list_prunes_stale_entries() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 
@@ -897,10 +852,7 @@ fn opencode_runtime_list_surfaces_stale_cleanup_failure() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/repo_authorization.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/repo_authorization.rs
@@ -15,10 +15,7 @@ fn tasks_reject_repo_path_not_in_workspace_allowlist() {
     let (service, task_state, _git_state) = build_service_with_git_state_enforced(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -35,10 +32,7 @@ fn task_update_rejects_unauthorized_repo_before_status_validation() {
     let (service, task_state, _git_state) = build_service_with_git_state_enforced(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -72,10 +66,7 @@ fn spec_mutators_reject_unauthorized_repo_before_markdown_validation() {
     let (service, task_state, _git_state) = build_service_with_git_state_enforced(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let set_spec_error = service
@@ -98,10 +89,7 @@ fn plan_mutators_reject_unauthorized_repo_before_markdown_validation() {
     let (service, task_state, _git_state) = build_service_with_git_state_enforced(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let set_plan_error = service
@@ -124,10 +112,7 @@ fn git_rejects_repo_path_not_in_workspace_allowlist() {
     let (service, task_state, git_state) = build_service_with_git_state_enforced(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -146,10 +131,7 @@ fn build_rejects_repo_path_not_in_workspace_allowlist() {
     let (service, task_state, _git_state) = build_service_with_git_state_enforced(
         vec![make_task("task-1", "bug", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let events = Arc::new(Mutex::new(Vec::<RunEvent>::new()));
@@ -171,10 +153,7 @@ fn canonical_repo_path_variants_are_authorized() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_git_state_enforced(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let root = unique_temp_path("repo-auth-canonical");
@@ -198,10 +177,7 @@ fn workspace_update_repo_config_cannot_register_new_allowlist_entries() {
     let (service, _task_state, _git_state) = build_service_with_git_state_enforced(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let unknown_repo_path = "/tmp/odt-repo-unauthorized-config";
@@ -234,10 +210,7 @@ fn runs_list_without_filter_hides_non_allowlisted_runs() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_git_state_enforced(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let run_id = "run-outside-allowlist".to_string();

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
@@ -57,10 +57,7 @@ fn runtime_beads_system_and_workspace_paths_are_exercised() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_store(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 
@@ -154,10 +151,7 @@ fn beads_check_reports_task_store_init_error() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
     task_state.lock().expect("task lock poisoned").ensure_error = Some("init failed".to_string());
@@ -183,10 +177,7 @@ fn beads_and_system_checks_report_missing_bd_binary() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let beads = service.beads_check("/tmp/does-not-matter")?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -40,10 +40,7 @@ fn shutdown_reports_runtime_cleanup_errors_and_drains_state() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let run_id = "run-shutdown".to_string();
@@ -126,10 +123,7 @@ fn shutdown_terminates_pending_opencode_processes() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let root = unique_temp_path("shutdown-pending-opencode");
@@ -178,10 +172,7 @@ fn shutdown_drains_runs_and_runtimes_when_pending_opencode_cleanup_fails() -> Re
     let (service, _task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 
@@ -367,10 +358,7 @@ fn startup_reconcile_terminates_orphaned_registered_opencode_processes() -> Resu
     let (_service, _task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 
@@ -434,10 +422,7 @@ fn startup_reconcile_keeps_non_orphan_registered_opencode_processes() -> Result<
     let (_service, _task_state, _git_state) = build_service_with_store(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
         config_store,
     );
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -40,10 +40,7 @@ fn task_update_rejects_direct_status_changes() {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -166,10 +163,7 @@ fn task_delete_blocks_when_subtasks_exist_without_confirmation() {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![parent, child],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -192,10 +186,7 @@ fn task_delete_allows_cascade_and_forwards_delete_flag() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![parent, child],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
     service.workspace_add(repo_path)?;
     service.workspace_update_repo_config(
@@ -248,10 +239,7 @@ fn task_delete_removes_managed_worktrees_and_related_branches() -> Result<()> {
             is_current: false,
             is_remote: false,
         }],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
     service.workspace_add(repo_path)?;
     service.workspace_update_repo_config(
@@ -343,10 +331,7 @@ fn task_delete_cascade_cleans_descendant_worktrees() -> Result<()> {
             is_current: false,
             is_remote: false,
         }],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
     service.workspace_add(repo_path)?;
     service.workspace_update_repo_config(
@@ -412,10 +397,7 @@ fn task_delete_stops_before_store_delete_when_worktree_cleanup_fails() {
             is_current: false,
             is_remote: false,
         }],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
     service
         .workspace_add(repo_path)
@@ -471,10 +453,7 @@ fn task_delete_retries_branch_cleanup_after_worktree_was_removed() -> Result<()>
             is_current: false,
             is_remote: false,
         }],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
     service.workspace_add(repo_path)?;
     service.workspace_update_repo_config(
@@ -544,10 +523,7 @@ fn build_blocked_requires_non_empty_reason() {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::InProgress)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -569,10 +545,7 @@ fn build_resumed_human_actions_and_resume_deferred_paths_work() -> Result<()> {
             deferred,
         ],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let resumed = service.build_resumed(repo_path, "task-blocked")?;
@@ -595,10 +568,7 @@ fn task_resume_deferred_requires_deferred_state() {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -613,10 +583,7 @@ fn tasks_list_enriches_available_actions() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![make_task("feature-1", "feature", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let tasks = service.tasks_list(repo_path)?;
@@ -634,10 +601,7 @@ fn task_create_defaults_ai_review_for_typed_issue_type() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let created = service.task_create(
@@ -669,10 +633,7 @@ fn task_transition_returns_current_task_when_status_is_unchanged() -> Result<()>
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let task = service.task_transition(repo_path, "task-1", TaskStatus::Open, None)?;
@@ -689,10 +650,7 @@ fn task_transition_updates_status_when_valid() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![make_task("bug-1", "bug", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let task = service.task_transition(repo_path, "bug-1", TaskStatus::InProgress, None)?;
@@ -713,10 +671,7 @@ fn build_completed_routes_to_ai_review_when_enabled() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::InProgress)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let task = service.build_completed(repo_path, "task-1", Some("done"))?;
@@ -738,10 +693,7 @@ fn build_completed_routes_to_human_review_when_ai_is_disabled() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![task],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let task = service.build_completed(repo_path, "task-1", None)?;
@@ -763,10 +715,7 @@ fn task_defer_rejects_subtasks() {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![subtask],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -781,10 +730,7 @@ fn task_defer_transitions_open_parent_task() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let task = service.task_defer(repo_path, "task-1", Some("later"))?;
@@ -804,10 +750,7 @@ fn task_defer_rejects_closed_tasks() {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::Closed)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -824,10 +767,7 @@ fn set_spec_persists_trimmed_markdown_and_transitions_open_task() -> Result<()> 
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "feature", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let spec = service.set_spec(repo_path, "task-1", "  # Spec  ")?;
@@ -851,10 +791,7 @@ fn set_spec_rejects_invalid_status() {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::InProgress)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -869,10 +806,7 @@ fn set_plan_for_non_epic_transitions_ready_for_dev() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let plan = service.set_plan(repo_path, "task-1", "  # Plan  ", None)?;
@@ -897,10 +831,7 @@ fn set_plan_allows_feature_from_ready_for_dev_without_status_transition() -> Res
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "feature", TaskStatus::ReadyForDev)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let plan = service.set_plan(repo_path, "task-1", "  # Revised Plan  ", None)?;
@@ -927,10 +858,7 @@ fn set_plan_rejects_invalid_status_for_feature() {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "feature", TaskStatus::Open)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -950,10 +878,7 @@ fn set_plan_for_epic_replaces_existing_subtasks_with_new_plan_proposals() -> Res
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![epic, existing_child],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let plan = service.set_plan(
@@ -1016,10 +941,7 @@ fn set_plan_for_epic_without_subtasks_clears_existing_direct_subtasks() -> Resul
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![epic, existing_child],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let plan = service.set_plan(repo_path, "epic-1", "# Epic Plan", None)?;
@@ -1048,10 +970,7 @@ fn set_plan_for_epic_rejects_subtask_replacement_when_existing_subtask_is_active
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![epic, active_child],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let error = service
@@ -1085,10 +1004,7 @@ fn qa_get_report_returns_latest_markdown_when_present() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
     {
         let mut state = task_state.lock().expect("task lock poisoned");
@@ -1112,10 +1028,7 @@ fn qa_get_report_returns_empty_when_not_present() -> Result<()> {
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let report = service.qa_get_report(repo_path, "task-1")?;
@@ -1130,10 +1043,7 @@ fn spec_get_and_plan_get_use_consolidated_metadata_lookup() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let _ = service.spec_get(repo_path, "task-1")?;
@@ -1155,10 +1065,7 @@ fn qa_approved_appends_report_and_transitions_to_human_review() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::AiReview)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let task = service.qa_approved(repo_path, "task-1", "Looks good")?;
@@ -1184,10 +1091,7 @@ fn qa_rejected_appends_report_and_transitions_to_in_progress() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![make_task("task-1", "task", TaskStatus::AiReview)],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
 
     let task = service.qa_rejected(repo_path, "task-1", "Needs work")?;
@@ -1213,10 +1117,7 @@ fn agent_sessions_list_and_upsert_flow_through_store() -> Result<()> {
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-        },
+        GitCurrentBranch { name: Some("main".to_string()), detached: false, revision: None },
     );
     {
         let mut state = task_state.lock().expect("task lock poisoned");

--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -15,6 +15,7 @@ pub struct GitBranch {
 pub struct GitCurrentBranch {
     pub name: Option<String>,
     pub detached: bool,
+    pub revision: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/branch.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/branch.rs
@@ -42,10 +42,21 @@ impl GitCliPort {
             .lines()
             .find(|line| !line.trim().is_empty())
             .map(|line| line.trim().to_string());
+        let (revision_ok, revision_stdout, _) =
+            self.run_git_allow_failure(repo_path, &["rev-parse", "HEAD"])?;
+        let revision = if revision_ok {
+            revision_stdout
+                .lines()
+                .find(|line| !line.trim().is_empty())
+                .map(|line| line.trim().to_string())
+        } else {
+            None
+        };
 
         Ok(GitCurrentBranch {
             detached: name.is_none(),
             name,
+            revision,
         })
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -9,6 +9,34 @@ use std::path::Path;
 use super::util::{combine_output, normalize_non_empty};
 use super::GitCliPort;
 
+const UPSTREAM_TARGET_BRANCH: &str = "@{upstream}";
+
+fn resolve_effective_target_branch(
+    requested_target_branch: &str,
+    upstream_target: Option<&str>,
+) -> Option<String> {
+    if requested_target_branch == UPSTREAM_TARGET_BRANCH {
+        return upstream_target.map(ToOwned::to_owned);
+    }
+
+    Some(requested_target_branch.to_string())
+}
+
+fn commits_against_target_or_default(
+    git: &GitCliPort,
+    repo_path: &Path,
+    target_branch: Option<&str>,
+) -> Result<GitAheadBehind> {
+    if let Some(target_branch) = target_branch {
+        return git.commits_ahead_behind_unchecked(repo_path, target_branch);
+    }
+
+    Ok(GitAheadBehind {
+        ahead: 0,
+        behind: 0,
+    })
+}
+
 impl GitCliPort {
     pub(super) fn get_status_impl(&self, repo_path: &Path) -> Result<Vec<GitFileStatus>> {
         self.ensure_repository(repo_path)?;
@@ -43,8 +71,14 @@ impl GitCliPort {
         let target_branch = normalize_non_empty(target_branch, "target branch")?;
         let current_branch = self.get_current_branch_unchecked(repo_path)?;
         let current_branch_name = current_branch.name.clone();
+        let upstream_target_result = self
+            .resolve_upstream_target_for_branch_impl(repo_path, current_branch_name.as_deref())?;
+        let effective_target_branch = resolve_effective_target_branch(
+            target_branch.as_str(),
+            upstream_target_result.as_deref(),
+        );
         let diff_target = match diff_scope {
-            GitDiffScope::Target => Some(target_branch.as_str()),
+            GitDiffScope::Target => effective_target_branch.as_deref(),
             GitDiffScope::Uncommitted => None,
         };
 
@@ -53,18 +87,24 @@ impl GitCliPort {
                 || {
                     rayon::join(
                         || self.get_status_unchecked(repo_path),
-                        || self.get_diff_unchecked(repo_path, diff_target),
+                        || match diff_scope {
+                            GitDiffScope::Target if effective_target_branch.is_none() => {
+                                Ok(Vec::new())
+                            }
+                            _ => self.get_diff_unchecked(repo_path, diff_target),
+                        },
                     )
                 },
                 || {
                     rayon::join(
-                        || self.commits_ahead_behind_unchecked(repo_path, target_branch.as_str()),
                         || {
-                            self.resolve_upstream_target_for_branch_impl(
+                            commits_against_target_or_default(
+                                self,
                                 repo_path,
-                                current_branch_name.as_deref(),
+                                effective_target_branch.as_deref(),
                             )
                         },
+                        || Ok::<Option<String>, anyhow::Error>(upstream_target_result.clone()),
                     )
                 },
             )
@@ -120,21 +160,28 @@ impl GitCliPort {
         let target_branch = normalize_non_empty(target_branch, "target branch")?;
         let current_branch = self.get_current_branch_unchecked(repo_path)?;
         let current_branch_name = current_branch.name.clone();
+        let upstream_target_result = self
+            .resolve_upstream_target_for_branch_impl(repo_path, current_branch_name.as_deref())?;
+        let effective_target_branch = resolve_effective_target_branch(
+            target_branch.as_str(),
+            upstream_target_result.as_deref(),
+        );
 
         let joined = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             rayon::join(
                 || {
                     rayon::join(
                         || self.get_status_unchecked(repo_path),
-                        || self.commits_ahead_behind_unchecked(repo_path, target_branch.as_str()),
+                        || {
+                            commits_against_target_or_default(
+                                self,
+                                repo_path,
+                                effective_target_branch.as_deref(),
+                            )
+                        },
                     )
                 },
-                || {
-                    self.resolve_upstream_target_for_branch_impl(
-                        repo_path,
-                        current_branch_name.as_deref(),
-                    )
-                },
+                || Ok::<Option<String>, anyhow::Error>(upstream_target_result.clone()),
             )
         }))
         .map_err(|payload| {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/branch_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/branch_tests.rs
@@ -17,6 +17,7 @@ fn get_current_branch_reports_attached_and_detached_states() {
         .expect("current branch should resolve");
     assert_eq!(current.name.as_deref(), Some("main"));
     assert!(!current.detached);
+    assert!(current.revision.is_some());
 
     run_git_ok(&repo.path, &["switch", "--detach", "HEAD"]);
     let detached = git
@@ -24,6 +25,7 @@ fn get_current_branch_reports_attached_and_detached_states() {
         .expect("detached branch state should resolve");
     assert!(detached.name.is_none());
     assert!(detached.detached);
+    assert!(detached.revision.is_some());
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
@@ -161,6 +161,56 @@ fn get_worktree_status_reports_untracked_when_upstream_is_missing() {
 }
 
 #[test]
+fn get_worktree_status_supports_upstream_target_without_tracking_branch() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-target-upstream-untracked");
+    let git = GitCliPort::new();
+    let status = git
+        .get_worktree_status(&repo.path, "@{upstream}", GitDiffScope::Target)
+        .expect("worktree status should resolve without an upstream branch");
+
+    assert!(status.file_diffs.is_empty());
+    assert_eq!(status.target_ahead_behind.ahead, 0);
+    assert_eq!(status.target_ahead_behind.behind, 0);
+    assert_eq!(
+        status.upstream_ahead_behind,
+        GitUpstreamAheadBehind::Untracked { ahead: 0 }
+    );
+}
+
+#[test]
+fn get_worktree_status_keeps_upstream_compare_empty_when_repo_is_dirty_and_untracked() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-target-upstream-dirty-untracked");
+    fs::write(repo.path.join("README.md"), "# OpenDucktor\nlocal change\n")
+        .expect("dirty file should write");
+
+    let git = GitCliPort::new();
+    let status = git
+        .get_worktree_status(&repo.path, "@{upstream}", GitDiffScope::Target)
+        .expect("worktree status should resolve without an upstream branch");
+
+    assert!(
+        !status.file_statuses.is_empty(),
+        "dirty repository status should still be reported"
+    );
+    assert!(
+        status.file_diffs.is_empty(),
+        "upstream compare should stay empty instead of falling back to uncommitted diff"
+    );
+    assert_eq!(
+        status.upstream_ahead_behind,
+        GitUpstreamAheadBehind::Untracked { ahead: 0 }
+    );
+}
+
+#[test]
 fn get_worktree_status_requires_non_empty_target_branch() {
     if !git_available() {
         return;

--- a/apps/desktop/src-tauri/src/commands/git.rs
+++ b/apps/desktop/src-tauri/src/commands/git.rs
@@ -1757,10 +1757,7 @@ mod tests {
 
     fn sample_worktree_status_data(upstream: GitUpstreamAheadBehind) -> GitWorktreeStatusData {
         GitWorktreeStatusData {
-            current_branch: GitCurrentBranch {
-                name: Some("feature/command".to_string()),
-                detached: false,
-            },
+            current_branch: GitCurrentBranch { name: Some("feature/command".to_string()), detached: false, revision: None },
             file_statuses: vec![GitFileStatus {
                 path: "src/main.rs".to_string(),
                 status: "M".to_string(),
@@ -1785,10 +1782,7 @@ mod tests {
         upstream: GitUpstreamAheadBehind,
     ) -> GitWorktreeStatusSummaryData {
         GitWorktreeStatusSummaryData {
-            current_branch: GitCurrentBranch {
-                name: Some("feature/command".to_string()),
-                detached: false,
-            },
+            current_branch: GitCurrentBranch { name: Some("feature/command".to_string()), detached: false, revision: None },
             file_statuses: vec![GitFileStatus {
                 path: "src/main.rs".to_string(),
                 status: "M".to_string(),
@@ -2827,10 +2821,7 @@ mod tests {
     #[test]
     fn build_worktree_status_with_snapshot_preserves_payload_and_snapshot_fields() {
         let status_data = GitWorktreeStatusData {
-            current_branch: GitCurrentBranch {
-                name: Some("feature/snapshot".to_string()),
-                detached: false,
-            },
+            current_branch: GitCurrentBranch { name: Some("feature/snapshot".to_string()), detached: false, revision: None },
             file_statuses: vec![GitFileStatus {
                 path: "src/main.rs".to_string(),
                 status: "modified".to_string(),
@@ -2894,10 +2885,7 @@ mod tests {
 
     #[test]
     fn status_hash_changes_when_status_payload_changes() {
-        let current_branch = GitCurrentBranch {
-            name: Some("feature/task-1".to_string()),
-            detached: false,
-        };
+        let current_branch = GitCurrentBranch { name: Some("feature/task-1".to_string()), detached: false, revision: None };
         let file_statuses = vec![GitFileStatus {
             path: "src/main.rs".to_string(),
             status: "M".to_string(),
@@ -2934,10 +2922,7 @@ mod tests {
 
     #[test]
     fn status_hash_is_stable_for_identical_payload() {
-        let current_branch = GitCurrentBranch {
-            name: Some("feature/task-1".to_string()),
-            detached: false,
-        };
+        let current_branch = GitCurrentBranch { name: Some("feature/task-1".to_string()), detached: false, revision: None };
         let file_statuses = vec![GitFileStatus {
             path: "src/main.rs".to_string(),
             status: "M".to_string(),
@@ -3031,10 +3016,7 @@ mod tests {
     #[test]
     fn build_worktree_status_summary_with_snapshot_preserves_payload_and_snapshot_fields() {
         let built = build_worktree_status_summary_with_snapshot(
-            GitCurrentBranch {
-                name: Some("feature/snapshot".to_string()),
-                detached: false,
-            },
+            GitCurrentBranch { name: Some("feature/snapshot".to_string()), detached: false, revision: None },
             GitFileStatusCounts {
                 total: 4,
                 staged: 2,

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -49,11 +49,14 @@ let AgentStudioGitPanel: AgentStudioGitPanelComponent;
 
 const baseModel = (overrides: Partial<AgentStudioGitPanelModel> = {}): AgentStudioGitPanelModel => {
   const model: AgentStudioGitPanelModel = {
+    contextMode: "worktree",
     branch: "feature/task-11",
     worktreePath: "/tmp/worktree",
     targetBranch: "origin/main",
     diffScope: "target",
     commitsAheadBehind: { ahead: 2, behind: 1 },
+    upstreamAheadBehind: { ahead: 1, behind: 0 },
+    upstreamStatus: "tracking",
     fileDiffs: [],
     fileStatuses: [{ path: "src/a.ts", staged: false, status: "M" }],
     uncommittedFileCount: 1,
@@ -234,6 +237,85 @@ describe("AgentStudioGitPanel", () => {
 
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(setDiffScope).toHaveBeenCalledWith("uncommitted");
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+
+  test("renders repository mode without target branch or rebase action", async () => {
+    const refresh = mock(() => {});
+    const setDiffScope = mock((_scope: "target" | "uncommitted") => {});
+    const commitAll = mock(async (_message: string) => true);
+    const pushBranch = mock(async () => {});
+    const pullFromUpstream = mock(async () => {});
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(AgentStudioGitPanel, {
+          model: baseModel({
+            contextMode: "repository",
+            diffScope: "uncommitted",
+            refresh,
+            setDiffScope,
+            commitAll,
+            pushBranch,
+            pullFromUpstream,
+          }),
+        }),
+      );
+      await flush();
+    });
+
+    const root = getRoot(renderer);
+    expect(hasVisibleText(root, "Repository context")).toBe(true);
+    expect(hasVisibleText(root, "Repository branch")).toBe(true);
+    expect(countByTestId(root, "agent-studio-git-target-branch")).toBe(0);
+    expect(countByTestId(root, "agent-studio-git-target-ahead-count")).toBe(0);
+    expect(countByTestId(root, "agent-studio-git-rebase-button")).toBe(0);
+    expect(findByTestId(root, "agent-studio-git-pull-button")).toBeTruthy();
+    expect(findByTestId(root, "agent-studio-git-push-button")).toBeTruthy();
+    expect(findByTestId(root, "agent-studio-git-commit-message-input")).toBeTruthy();
+    expect(findByTestId(root, "agent-studio-git-diff-scope-target").children.join("")).toContain(
+      "Compare to upstream",
+    );
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+
+  test("shows a clear no-upstream message in repository compare mode", async () => {
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(AgentStudioGitPanel, {
+          model: baseModel({
+            contextMode: "repository",
+            diffScope: "target",
+            upstreamAheadBehind: { ahead: 0, behind: 0 },
+            upstreamStatus: "untracked",
+            fileDiffs: [],
+          }),
+        }),
+      );
+      await flush();
+    });
+
+    const root = getRoot(renderer);
+    expect(hasVisibleText(root, "No upstream branch yet")).toBe(true);
+    expect(
+      hasVisibleText(
+        root,
+        "This branch is not tracking an upstream branch yet. Push it first to create one, then compare against it here.",
+      ),
+    ).toBe(true);
+    expect(Boolean(findByTestId(root, "agent-studio-git-pull-button").props.disabled)).toBe(true);
+    expect(Boolean(findByTestId(root, "agent-studio-git-push-button").props.disabled)).toBe(false);
 
     await act(async () => {
       ensureRenderer(renderer).unmount();

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
@@ -157,12 +157,14 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
     <TooltipProvider>
       <div className="flex h-full min-h-0 flex-col overflow-hidden">
         <GitInfoHeader
+          contextMode={model.contextMode ?? "worktree"}
           branch={model.branch}
           targetBranch={model.targetBranch}
           diffScope={model.diffScope}
           uncommittedFileCount={uncommittedFileCount}
           commitsAheadBehind={model.commitsAheadBehind}
           upstreamAheadBehind={model.upstreamAheadBehind ?? null}
+          upstreamStatus={model.upstreamStatus}
           isLoading={model.isLoading}
           isCommitting={model.isCommitting ?? false}
           isPushing={model.isPushing ?? false}
@@ -266,7 +268,12 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
               onToggleFile={toggleFile}
             />
           ) : (
-            <EmptyDiffState isLoading={model.isLoading} />
+            <EmptyDiffState
+              isLoading={model.isLoading}
+              contextMode={model.contextMode ?? "worktree"}
+              diffScope={model.diffScope}
+              upstreamStatus={model.upstreamStatus}
+            />
           )}
         </ScrollArea>
 

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/empty-diff-state.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/empty-diff-state.tsx
@@ -1,21 +1,62 @@
 import { FolderGit2 } from "lucide-react";
 import type { ReactElement } from "react";
+import type { DiffScope } from "@/pages/agents/use-agent-studio-diff-data";
 
-export function EmptyDiffState({ isLoading }: { isLoading: boolean }): ReactElement {
+export function EmptyDiffState({
+  isLoading,
+  contextMode = "worktree",
+  diffScope,
+  upstreamStatus,
+}: {
+  isLoading: boolean;
+  contextMode?: "repository" | "worktree";
+  diffScope: DiffScope;
+  upstreamStatus?: "tracking" | "untracked" | "error";
+}): ReactElement {
+  const title = (() => {
+    if (isLoading) {
+      return contextMode === "repository" && diffScope === "target"
+        ? "Checking upstream differences..."
+        : "Scanning for changes...";
+    }
+    if (contextMode === "repository" && diffScope === "target" && upstreamStatus === "untracked") {
+      return "No upstream branch yet";
+    }
+    if (contextMode === "repository" && diffScope === "target") {
+      return "No upstream differences detected";
+    }
+    if (contextMode === "repository") {
+      return "No repository changes detected";
+    }
+    return "No changes detected";
+  })();
+
+  const description = (() => {
+    if (isLoading) {
+      return contextMode === "repository" && diffScope === "target"
+        ? "Comparing this branch against its tracked upstream branch."
+        : "Checking the working directory for file modifications.";
+    }
+    if (contextMode === "repository" && diffScope === "target" && upstreamStatus === "untracked") {
+      return "This branch is not tracking an upstream branch yet. Push it first to create one, then compare against it here.";
+    }
+    if (contextMode === "repository" && diffScope === "target") {
+      return "Differences against the tracked upstream branch will appear here.";
+    }
+    if (contextMode === "repository") {
+      return "Uncommitted changes in the repository branch will appear here.";
+    }
+    return "File modifications will appear here once the agent starts editing.";
+  })();
+
   return (
     <div className="flex flex-col items-center justify-center gap-3 p-10 text-center">
       <div className="flex size-12 items-center justify-center rounded-full bg-muted/60">
         <FolderGit2 className="size-5 text-muted-foreground" />
       </div>
       <div className="space-y-1">
-        <p className="text-sm font-medium text-muted-foreground">
-          {isLoading ? "Scanning for changes..." : "No changes detected"}
-        </p>
-        <p className="text-xs text-muted-foreground/70">
-          {isLoading
-            ? "Checking the working directory for file modifications."
-            : "File modifications will appear here once the agent starts editing."}
-        </p>
+        <p className="text-sm font-medium text-muted-foreground">{title}</p>
+        <p className="text-xs text-muted-foreground/70">{description}</p>
       </div>
     </div>
   );

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
@@ -10,10 +10,12 @@ import type { AgentStudioGitPanelModel } from "./types";
 
 type GitInfoHeaderProps = Pick<
   AgentStudioGitPanelModel,
+  | "contextMode"
   | "branch"
   | "targetBranch"
   | "commitsAheadBehind"
   | "upstreamAheadBehind"
+  | "upstreamStatus"
   | "diffScope"
   | "isLoading"
   | "isCommitting"
@@ -101,10 +103,12 @@ function GitActionIconButton({
 }
 
 export function GitInfoHeader({
+  contextMode = "worktree",
   branch,
   targetBranch,
   commitsAheadBehind,
   upstreamAheadBehind,
+  upstreamStatus,
   diffScope,
   uncommittedFileCount,
   isLoading,
@@ -122,6 +126,7 @@ export function GitInfoHeader({
   setDiffScope,
   onRefresh,
 }: GitInfoHeaderProps): ReactElement {
+  const isRepositoryMode = contextMode === "repository";
   const trimmedTargetBranch = targetBranch.trim();
   const isDetachedHead = branch == null || branch.trim().length === 0;
   const currentBranchLabel = isDetachedHead ? "Detached HEAD" : branch;
@@ -137,6 +142,7 @@ export function GitInfoHeader({
   const isAnyActionInFlight = isCommitting || isPushing || isRebasing;
   const canRefresh = !isLoading && !isAnyActionInFlight;
   const canRebase =
+    !isRepositoryMode &&
     !isDetachedHead &&
     hasTargetBranch &&
     !isAnyActionInFlight &&
@@ -162,16 +168,18 @@ export function GitInfoHeader({
     ? "Pulling"
     : isGitActionsLocked
       ? (gitActionsLockReason ?? "Git actions are disabled.")
-      : hasUncommittedFiles
-        ? "Commit or stash changes before pulling"
-        : pushAheadCount != null &&
-            pushAheadCount > 0 &&
-            pushBehindCount != null &&
-            pushBehindCount > 0
-          ? `Pull with rebase (${pushBehindCount} behind; ${pushAheadCount} local commit${pushAheadCount === 1 ? "" : "s"} will be rewritten)`
-          : pushBehindCount != null && pushBehindCount > 0
-            ? `Pull (${pushBehindCount} behind)`
-            : "Pull";
+      : isRepositoryMode && upstreamStatus === "untracked"
+        ? "No upstream branch yet. Push this branch first to create it."
+        : hasUncommittedFiles
+          ? "Commit or stash changes before pulling"
+          : pushAheadCount != null &&
+              pushAheadCount > 0 &&
+              pushBehindCount != null &&
+              pushBehindCount > 0
+            ? `Pull with rebase (${pushBehindCount} behind; ${pushAheadCount} local commit${pushAheadCount === 1 ? "" : "s"} will be rewritten)`
+            : pushBehindCount != null && pushBehindCount > 0
+              ? `Pull (${pushBehindCount} behind)`
+              : "Pull";
   const pushTooltip = isPushing
     ? "Pushing"
     : isGitActionsLocked
@@ -193,7 +201,7 @@ export function GitInfoHeader({
     <div className="space-y-0 border-b border-border">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2 px-3 pt-3">
         <span className="text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
-          Branch context
+          {isRepositoryMode ? "Repository context" : "Branch context"}
         </span>
         <Badge variant="outline" className="px-2 py-0.5 text-[10px]">
           {uncommittedFileCount} file{uncommittedFileCount === 1 ? "" : "s"} changed
@@ -201,12 +209,17 @@ export function GitInfoHeader({
       </div>
 
       <div
-        className="mb-2 grid gap-2 px-3 sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center"
+        className={cn(
+          "mb-2 grid gap-2 px-3",
+          isRepositoryMode
+            ? "sm:grid-cols-[minmax(0,1fr)]"
+            : "sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center",
+        )}
         data-testid="agent-studio-git-branch-context-row"
       >
         <div className="rounded-lg border border-border bg-card px-3 py-2">
           <p className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
-            Current branch
+            {isRepositoryMode ? "Repository branch" : "Current branch"}
           </p>
           <div className="mt-1 flex min-w-0 items-center gap-1.5">
             <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />
@@ -219,34 +232,38 @@ export function GitInfoHeader({
           </div>
         </div>
 
-        <div className="relative flex items-center justify-center" aria-hidden="true">
-          <span className="inline-flex size-7 items-center justify-center rounded-full border border-border bg-muted text-muted-foreground">
-            <ArrowRight className="size-3.5" />
-          </span>
-          {hasTargetAhead ? (
-            <span
-              className="pointer-events-none absolute -top-4 left-1/2 -translate-x-1/2 text-[13px] leading-none font-bold tabular-nums text-emerald-600 dark:text-emerald-400"
-              data-testid="agent-studio-git-target-ahead-count"
-            >
-              {targetAheadCount}
-            </span>
-          ) : null}
-        </div>
+        {isRepositoryMode ? null : (
+          <>
+            <div className="relative flex items-center justify-center" aria-hidden="true">
+              <span className="inline-flex size-7 items-center justify-center rounded-full border border-border bg-muted text-muted-foreground">
+                <ArrowRight className="size-3.5" />
+              </span>
+              {hasTargetAhead ? (
+                <span
+                  className="pointer-events-none absolute -top-4 left-1/2 -translate-x-1/2 text-[13px] leading-none font-bold tabular-nums text-emerald-600 dark:text-emerald-400"
+                  data-testid="agent-studio-git-target-ahead-count"
+                >
+                  {targetAheadCount}
+                </span>
+              ) : null}
+            </div>
 
-        <div className="rounded-lg border border-border bg-card px-3 py-2">
-          <p className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
-            Target branch
-          </p>
-          <div className="mt-1 flex min-w-0 items-center gap-1.5">
-            <Target className="size-3.5 shrink-0 text-muted-foreground" />
-            <span
-              className="truncate font-mono text-xs text-foreground"
-              data-testid="agent-studio-git-target-branch"
-            >
-              {targetBranchLabel}
-            </span>
-          </div>
-        </div>
+            <div className="rounded-lg border border-border bg-card px-3 py-2">
+              <p className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+                Target branch
+              </p>
+              <div className="mt-1 flex min-w-0 items-center gap-1.5">
+                <Target className="size-3.5 shrink-0 text-muted-foreground" />
+                <span
+                  className="truncate font-mono text-xs text-foreground"
+                  data-testid="agent-studio-git-target-branch"
+                >
+                  {targetBranchLabel}
+                </span>
+              </div>
+            </div>
+          </>
+        )}
       </div>
 
       <div
@@ -263,23 +280,25 @@ export function GitInfoHeader({
             tooltip={isLoading ? "Refreshing" : "Refresh changes"}
             isSpinning={isLoading}
           />
-          <GitActionIconButton
-            testId="agent-studio-git-rebase-button"
-            srLabel="Rebase onto target"
-            icon={Target}
-            onClick={rebaseOntoTarget ? () => void rebaseOntoTarget() : null}
-            disabled={!canRebase}
-            tooltip={rebaseTooltip}
-            badge={
-              rebaseBehindCount != null && rebaseBehindCount > 0
-                ? {
-                    testId: "agent-studio-git-behind-count",
-                    value: rebaseBehindCount,
-                    toneClassName: "text-rose-600 dark:text-rose-400",
-                  }
-                : undefined
-            }
-          />
+          {isRepositoryMode ? null : (
+            <GitActionIconButton
+              testId="agent-studio-git-rebase-button"
+              srLabel="Rebase onto target"
+              icon={Target}
+              onClick={rebaseOntoTarget ? () => void rebaseOntoTarget() : null}
+              disabled={!canRebase}
+              tooltip={rebaseTooltip}
+              badge={
+                rebaseBehindCount != null && rebaseBehindCount > 0
+                  ? {
+                      testId: "agent-studio-git-behind-count",
+                      value: rebaseBehindCount,
+                      toneClassName: "text-rose-600 dark:text-rose-400",
+                    }
+                  : undefined
+              }
+            />
+          )}
           <span className="inline-flex" data-testid="agent-studio-git-pull-tooltip-trigger">
             <GitActionIconButton
               testId="agent-studio-git-pull-button"
@@ -352,7 +371,9 @@ export function GitInfoHeader({
                 onClick={() => handleScopeChange(option.scope)}
                 data-testid={option.testId}
               >
-                {option.label}
+                {option.scope === "target" && isRepositoryMode
+                  ? "Compare to upstream"
+                  : option.label}
               </button>
             );
           })}

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/types.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/types.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/pages/agents/use-agent-studio-git-actions";
 
 export type AgentStudioGitPanelModel = DiffDataState & {
+  contextMode?: "repository" | "worktree";
   isCommitting?: boolean;
   isPushing?: boolean;
   isRebasing?: boolean;

--- a/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
@@ -163,9 +163,11 @@ describe("AgentStudioHeader", () => {
     );
 
     expect(html).toContain('aria-label="Create session"');
-    expect(html).toContain('aria-label="Create session"');
     expect(html).toContain('disabled="" title="Create session"');
     expect(html).toContain('class="lucide lucide-plus size-4"');
+    expect(html).not.toContain(
+      'title="Create session"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-loader-circle size-4 animate-spin"',
+    );
   });
 
   test("keeps unavailable workflow step clickable without existing session", () => {

--- a/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
@@ -152,6 +152,22 @@ describe("AgentStudioHeader", () => {
     expect(html).toContain("disabled");
   });
 
+  test("disables create session while a session is starting without showing a loader", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioHeader, {
+        model: {
+          ...buildModel(),
+          isCreatingSession: true,
+        },
+      }),
+    );
+
+    expect(html).toContain('aria-label="Create session"');
+    expect(html).toContain('aria-label="Create session"');
+    expect(html).toContain('disabled="" title="Create session"');
+    expect(html).toContain('class="lucide lucide-plus size-4"');
+  });
+
   test("keeps unavailable workflow step clickable without existing session", () => {
     const html = renderToStaticMarkup(
       createElement(AgentStudioHeader, {

--- a/apps/desktop/src/components/features/agents/agent-studio-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.tsx
@@ -196,15 +196,11 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
                 variant="default"
                 size="icon"
                 className="h-9 w-9 rounded-md"
-                disabled={!agentStudioReady || createSessionDisabled}
+                disabled={!agentStudioReady || createSessionDisabled || isCreatingSession}
                 title="Create session"
                 aria-label="Create session"
               >
-                {isCreatingSession ? (
-                  <LoaderCircle className="size-4 animate-spin" />
-                ) : (
-                  <Plus className="size-4" />
-                )}
+                <Plus className="size-4" />
               </Button>
             </PopoverTrigger>
             <PopoverContent align="end" className="w-80 p-0">

--- a/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -16,11 +16,14 @@ const emptyDoc = {
 };
 
 const diffModel: AgentStudioGitPanelModel = {
+  contextMode: "worktree",
   branch: "feature/task-12",
   worktreePath: "/tmp/worktree/task-12",
   targetBranch: "origin/main",
   diffScope: "target",
   commitsAheadBehind: null,
+  upstreamAheadBehind: null,
+  upstreamStatus: "tracking",
   fileDiffs: [],
   fileStatuses: [],
   uncommittedFileCount: 0,

--- a/apps/desktop/src/components/features/task-details/task-document-load-controller.test.ts
+++ b/apps/desktop/src/components/features/task-details/task-document-load-controller.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createTaskDocumentLoadController,
+  requestTaskDocumentLoad,
+  resetTaskDocumentLoadController,
+  settleTaskDocumentLoad,
+  supersedeTaskDocumentLoad,
+} from "./task-document-load-controller";
+
+describe("task-document-load-controller", () => {
+  test("stale in-flight requests stop applying after an optimistic update supersedes them", () => {
+    const controller = createTaskDocumentLoadController();
+    const initialLoad = requestTaskDocumentLoad(controller, "spec", false, false);
+
+    expect(initialLoad).toEqual({
+      accepted: true,
+      contextVersion: 0,
+      requestVersion: 1,
+    });
+
+    supersedeTaskDocumentLoad(controller, "spec");
+
+    expect(settleTaskDocumentLoad(controller, "spec", 0, 1)).toEqual({
+      shouldApply: false,
+      shouldReplay: false,
+    });
+  });
+
+  test("forced reload requests queue while a section is still loading", () => {
+    const controller = createTaskDocumentLoadController();
+    const initialLoad = requestTaskDocumentLoad(controller, "spec", false, false);
+
+    expect(initialLoad).toEqual({
+      accepted: true,
+      contextVersion: 0,
+      requestVersion: 1,
+    });
+    expect(requestTaskDocumentLoad(controller, "spec", true, false)).toEqual({
+      accepted: true,
+      contextVersion: null,
+      requestVersion: null,
+    });
+
+    expect(settleTaskDocumentLoad(controller, "spec", 0, 1)).toEqual({
+      shouldApply: true,
+      shouldReplay: true,
+    });
+    expect(requestTaskDocumentLoad(controller, "spec", true, false)).toEqual({
+      accepted: true,
+      contextVersion: 0,
+      requestVersion: 2,
+    });
+  });
+
+  test("context resets invalidate stale requests and clear queued reloads", () => {
+    const controller = createTaskDocumentLoadController();
+    const initialLoad = requestTaskDocumentLoad(controller, "spec", false, false);
+
+    expect(initialLoad).toEqual({
+      accepted: true,
+      contextVersion: 0,
+      requestVersion: 1,
+    });
+    expect(requestTaskDocumentLoad(controller, "spec", true, false)).toEqual({
+      accepted: true,
+      contextVersion: null,
+      requestVersion: null,
+    });
+
+    resetTaskDocumentLoadController(controller);
+
+    expect(settleTaskDocumentLoad(controller, "spec", 0, 1)).toEqual({
+      shouldApply: false,
+      shouldReplay: false,
+    });
+  });
+});

--- a/apps/desktop/src/components/features/task-details/task-document-load-controller.test.ts
+++ b/apps/desktop/src/components/features/task-details/task-document-load-controller.test.ts
@@ -24,6 +24,8 @@ describe("task-document-load-controller", () => {
       shouldApply: false,
       shouldReplay: false,
     });
+    expect(controller.sections.spec.inFlight).toBe(false);
+    expect(controller.sections.spec.inFlightRequestVersion).toBeNull();
   });
 
   test("forced reload requests queue while a section is still loading", () => {
@@ -73,5 +75,32 @@ describe("task-document-load-controller", () => {
       shouldApply: false,
       shouldReplay: false,
     });
+  });
+
+  test("stale settlements from a previous context do not clear the active request", () => {
+    const controller = createTaskDocumentLoadController();
+    const initialLoad = requestTaskDocumentLoad(controller, "spec", false, false);
+
+    expect(initialLoad).toEqual({
+      accepted: true,
+      contextVersion: 0,
+      requestVersion: 1,
+    });
+
+    resetTaskDocumentLoadController(controller);
+    const currentLoad = requestTaskDocumentLoad(controller, "spec", false, false);
+
+    expect(currentLoad).toEqual({
+      accepted: true,
+      contextVersion: 1,
+      requestVersion: 1,
+    });
+
+    expect(settleTaskDocumentLoad(controller, "spec", 0, 1)).toEqual({
+      shouldApply: false,
+      shouldReplay: false,
+    });
+    expect(controller.sections.spec.inFlight).toBe(true);
+    expect(controller.sections.spec.inFlightRequestVersion).toBe(1);
   });
 });

--- a/apps/desktop/src/components/features/task-details/task-document-load-controller.ts
+++ b/apps/desktop/src/components/features/task-details/task-document-load-controller.ts
@@ -2,6 +2,7 @@ export type TaskDocumentSectionKey = "spec" | "plan" | "qa";
 
 type SectionLoadState = {
   inFlight: boolean;
+  inFlightRequestVersion: number | null;
   requestVersion: number;
   pendingForcedReload: boolean;
 };
@@ -24,6 +25,7 @@ type LoadSettlement = {
 
 const createInitialSectionLoadState = (): SectionLoadState => ({
   inFlight: false,
+  inFlightRequestVersion: null,
   requestVersion: 0,
   pendingForcedReload: false,
 });
@@ -77,6 +79,7 @@ export const requestTaskDocumentLoad = (
   }
 
   sectionState.inFlight = true;
+  sectionState.inFlightRequestVersion = sectionState.requestVersion + 1;
   sectionState.pendingForcedReload = false;
   sectionState.requestVersion += 1;
   return {
@@ -100,7 +103,17 @@ export const settleTaskDocumentLoad = (
   requestVersion: number,
 ): LoadSettlement => {
   const sectionState = controller.sections[section];
+  const contextMatches = controller.contextVersion === contextVersion;
+  const requestMatches = sectionState.inFlightRequestVersion === requestVersion;
+  if (!contextMatches || !requestMatches) {
+    return {
+      shouldApply: false,
+      shouldReplay: false,
+    };
+  }
+
   sectionState.inFlight = false;
+  sectionState.inFlightRequestVersion = null;
   const shouldReplay =
     controller.contextVersion === contextVersion && sectionState.pendingForcedReload;
   sectionState.pendingForcedReload = false;

--- a/apps/desktop/src/components/features/task-details/task-document-load-controller.ts
+++ b/apps/desktop/src/components/features/task-details/task-document-load-controller.ts
@@ -1,0 +1,113 @@
+export type TaskDocumentSectionKey = "spec" | "plan" | "qa";
+
+type SectionLoadState = {
+  inFlight: boolean;
+  requestVersion: number;
+  pendingForcedReload: boolean;
+};
+
+export type TaskDocumentLoadController = {
+  contextVersion: number;
+  sections: Record<TaskDocumentSectionKey, SectionLoadState>;
+};
+
+type LoadRequest = {
+  accepted: boolean;
+  contextVersion: number | null;
+  requestVersion: number | null;
+};
+
+type LoadSettlement = {
+  shouldApply: boolean;
+  shouldReplay: boolean;
+};
+
+const createInitialSectionLoadState = (): SectionLoadState => ({
+  inFlight: false,
+  requestVersion: 0,
+  pendingForcedReload: false,
+});
+
+const createInitialSectionsState = (): Record<TaskDocumentSectionKey, SectionLoadState> => ({
+  spec: createInitialSectionLoadState(),
+  plan: createInitialSectionLoadState(),
+  qa: createInitialSectionLoadState(),
+});
+
+export const createTaskDocumentLoadController = (): TaskDocumentLoadController => ({
+  contextVersion: 0,
+  sections: createInitialSectionsState(),
+});
+
+export const resetTaskDocumentLoadController = (controller: TaskDocumentLoadController): void => {
+  controller.contextVersion += 1;
+  controller.sections = createInitialSectionsState();
+};
+
+export const requestTaskDocumentLoad = (
+  controller: TaskDocumentLoadController,
+  section: TaskDocumentSectionKey,
+  force: boolean,
+  isLoaded: boolean,
+): LoadRequest => {
+  const sectionState = controller.sections[section];
+  if (sectionState.inFlight) {
+    if (force) {
+      sectionState.pendingForcedReload = true;
+      return {
+        accepted: true,
+        contextVersion: null,
+        requestVersion: null,
+      };
+    }
+
+    return {
+      accepted: false,
+      contextVersion: null,
+      requestVersion: null,
+    };
+  }
+
+  if (!force && isLoaded) {
+    return {
+      accepted: false,
+      contextVersion: null,
+      requestVersion: null,
+    };
+  }
+
+  sectionState.inFlight = true;
+  sectionState.pendingForcedReload = false;
+  sectionState.requestVersion += 1;
+  return {
+    accepted: true,
+    contextVersion: controller.contextVersion,
+    requestVersion: sectionState.requestVersion,
+  };
+};
+
+export const supersedeTaskDocumentLoad = (
+  controller: TaskDocumentLoadController,
+  section: TaskDocumentSectionKey,
+): void => {
+  controller.sections[section].requestVersion += 1;
+};
+
+export const settleTaskDocumentLoad = (
+  controller: TaskDocumentLoadController,
+  section: TaskDocumentSectionKey,
+  contextVersion: number,
+  requestVersion: number,
+): LoadSettlement => {
+  const sectionState = controller.sections[section];
+  sectionState.inFlight = false;
+  const shouldReplay =
+    controller.contextVersion === contextVersion && sectionState.pendingForcedReload;
+  sectionState.pendingForcedReload = false;
+  return {
+    shouldApply:
+      controller.contextVersion === contextVersion &&
+      sectionState.requestVersion === requestVersion,
+    shouldReplay,
+  };
+};

--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSpecState } from "@/state";
+import {
+  createTaskDocumentLoadController,
+  requestTaskDocumentLoad,
+  resetTaskDocumentLoadController,
+  settleTaskDocumentLoad,
+  supersedeTaskDocumentLoad,
+  type TaskDocumentSectionKey,
+} from "./task-document-load-controller";
 
-export type DocumentSectionKey = "spec" | "plan" | "qa";
+export type DocumentSectionKey = TaskDocumentSectionKey;
 
 export type TaskDocumentState = {
   markdown: string;
@@ -16,6 +24,12 @@ type TaskDocumentsState = Record<DocumentSectionKey, TaskDocumentState>;
 type TaskDocumentPayload = {
   markdown: string;
   updatedAt: string | null;
+};
+
+export type TaskDocumentLoaders = {
+  loadSpecDocument: (taskId: string) => Promise<TaskDocumentPayload>;
+  loadPlanDocument: (taskId: string) => Promise<TaskDocumentPayload>;
+  loadQaReportDocument: (taskId: string) => Promise<TaskDocumentPayload>;
 };
 
 const createInitialTaskDocumentState = (): TaskDocumentState => ({
@@ -45,6 +59,7 @@ export function useTaskDocuments(
   taskId: string | null,
   open: boolean,
   cacheScope = "",
+  loadersOverride?: TaskDocumentLoaders,
 ): {
   specDoc: TaskDocumentState;
   planDoc: TaskDocumentState;
@@ -53,18 +68,14 @@ export function useTaskDocuments(
   reloadDocument: (section: DocumentSectionKey) => boolean;
   applyDocumentUpdate: (section: DocumentSectionKey, payload: TaskDocumentPayload) => void;
 } {
-  const { loadSpecDocument, loadPlanDocument, loadQaReportDocument } = useSpecState();
+  const specState = useSpecState();
+  const { loadSpecDocument, loadPlanDocument, loadQaReportDocument } = loadersOverride ?? specState;
   const [documents, setDocuments] = useState<TaskDocumentsState>(createInitialDocumentsState);
-  const documentLoadSequence = useRef(0);
   const previousContext = useRef<{ taskCacheKey: string | null; open: boolean } | null>(null);
   const documentsRef = useRef<TaskDocumentsState>(documents);
   const cachedDocumentsByTaskCacheKey = useRef<Record<string, TaskDocumentsState>>({});
   const taskCacheKey = taskId ? `${cacheScope}::${taskId}` : null;
-  const inFlightSections = useRef<Record<DocumentSectionKey, boolean>>({
-    spec: false,
-    plan: false,
-    qa: false,
-  });
+  const loadController = useRef(createTaskDocumentLoadController());
 
   const updateDocumentsSnapshot = useCallback(
     (snapshot: TaskDocumentsState): void => {
@@ -91,31 +102,34 @@ export function useTaskDocuments(
     }
 
     previousContext.current = { taskCacheKey, open };
-    documentLoadSequence.current += 1;
+    resetTaskDocumentLoadController(loadController.current);
     const initialDocuments =
       taskCacheKey && cachedDocumentsByTaskCacheKey.current[taskCacheKey]
         ? cloneDocumentsState(cachedDocumentsByTaskCacheKey.current[taskCacheKey])
         : createInitialDocumentsState();
     documentsRef.current = initialDocuments;
     setDocuments(initialDocuments);
-    inFlightSections.current = {
-      spec: false,
-      plan: false,
-      qa: false,
-    };
   }, [open, taskCacheKey]);
 
   const loadDocument = useCallback(
-    (section: DocumentSectionKey, force: boolean): boolean => {
+    function loadDocument(section: DocumentSectionKey, force: boolean): boolean {
       if (!taskId || !open) {
         return false;
       }
 
       const current = documentsRef.current[section];
-      if (inFlightSections.current[section] || (!force && current.loaded)) {
+      const loadRequest = requestTaskDocumentLoad(
+        loadController.current,
+        section,
+        force,
+        current.loaded,
+      );
+      if (!loadRequest.accepted) {
         return false;
       }
-      inFlightSections.current[section] = true;
+      if (loadRequest.contextVersion === null || loadRequest.requestVersion === null) {
+        return true;
+      }
 
       const loadingSnapshot: TaskDocumentsState = {
         ...documentsRef.current,
@@ -127,7 +141,7 @@ export function useTaskDocuments(
       };
       updateDocumentsSnapshot(loadingSnapshot);
 
-      const sequence = documentLoadSequence.current;
+      const { contextVersion, requestVersion } = loadRequest;
       const loader: (id: string) => Promise<TaskDocumentPayload> =
         section === "spec"
           ? loadSpecDocument
@@ -135,14 +149,29 @@ export function useTaskDocuments(
             ? loadPlanDocument
             : loadQaReportDocument;
 
+      const replayPendingForcedReload = (shouldReplay: boolean): void => {
+        if (!shouldReplay) {
+          return;
+        }
+
+        globalThis.queueMicrotask(() => {
+          loadDocument(section, true);
+        });
+      };
+
       void loader(taskId)
         .then((result) => {
-          if (sequence !== documentLoadSequence.current) {
-            inFlightSections.current[section] = false;
+          const settlement = settleTaskDocumentLoad(
+            loadController.current,
+            section,
+            contextVersion,
+            requestVersion,
+          );
+          if (!settlement.shouldApply) {
+            replayPendingForcedReload(settlement.shouldReplay);
             return;
           }
 
-          inFlightSections.current[section] = false;
           const successSnapshot: TaskDocumentsState = {
             ...documentsRef.current,
             [section]: {
@@ -154,14 +183,20 @@ export function useTaskDocuments(
             },
           };
           updateDocumentsSnapshot(successSnapshot);
+          replayPendingForcedReload(settlement.shouldReplay);
         })
         .catch((error: unknown) => {
-          if (sequence !== documentLoadSequence.current) {
-            inFlightSections.current[section] = false;
+          const settlement = settleTaskDocumentLoad(
+            loadController.current,
+            section,
+            contextVersion,
+            requestVersion,
+          );
+          if (!settlement.shouldApply) {
+            replayPendingForcedReload(settlement.shouldReplay);
             return;
           }
 
-          inFlightSections.current[section] = false;
           const errorSnapshot: TaskDocumentsState = {
             ...documentsRef.current,
             [section]: {
@@ -172,6 +207,7 @@ export function useTaskDocuments(
             },
           };
           updateDocumentsSnapshot(errorSnapshot);
+          replayPendingForcedReload(settlement.shouldReplay);
         });
       return true;
     },
@@ -201,6 +237,7 @@ export function useTaskDocuments(
 
   const applyDocumentUpdate = useCallback(
     (section: DocumentSectionKey, payload: TaskDocumentPayload): void => {
+      supersedeTaskDocumentLoad(loadController.current, section);
       const snapshot: TaskDocumentsState = {
         ...documentsRef.current,
         [section]: {

--- a/apps/desktop/src/lib/target-branch.ts
+++ b/apps/desktop/src/lib/target-branch.ts
@@ -1,9 +1,13 @@
 export const DEFAULT_TARGET_BRANCH = "origin/main";
+export const UPSTREAM_TARGET_BRANCH = "@{upstream}";
 
 export const normalizeCanonicalTargetBranch = (value: string | null | undefined): string => {
   const trimmed = value?.trim() ?? "";
   if (!trimmed) {
     return DEFAULT_TARGET_BRANCH;
+  }
+  if (trimmed === UPSTREAM_TARGET_BRANCH) {
+    return trimmed;
   }
   if (trimmed.includes("/")) {
     return trimmed;

--- a/apps/desktop/src/pages/agents/agents-page-git-panel.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-git-panel.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildAgentStudioGitPanelBranchIdentityKey,
+  resolveAgentStudioGitPanelBranch,
+} from "./agents-page-git-panel";
+
+describe("agents-page-git-panel", () => {
+  test("uses workspace activeBranch in repository mode", () => {
+    expect(
+      resolveAgentStudioGitPanelBranch({
+        contextMode: "repository",
+        workspaceActiveBranch: {
+          name: "feature/sidebar-source",
+          detached: false,
+        },
+        diffBranch: "feature/stale-diff-source",
+      }),
+    ).toBe("feature/sidebar-source");
+  });
+
+  test("keeps detached head semantics in repository mode", () => {
+    expect(
+      resolveAgentStudioGitPanelBranch({
+        contextMode: "repository",
+        workspaceActiveBranch: {
+          name: "main",
+          detached: true,
+        },
+        diffBranch: "main",
+      }),
+    ).toBeNull();
+  });
+
+  test("falls back to diff branch when workspace branch is unavailable", () => {
+    expect(
+      resolveAgentStudioGitPanelBranch({
+        contextMode: "repository",
+        workspaceActiveBranch: null,
+        diffBranch: "feature/from-diff",
+      }),
+    ).toBe("feature/from-diff");
+  });
+
+  test("preserves worktree-mode branch sourcing", () => {
+    expect(
+      resolveAgentStudioGitPanelBranch({
+        contextMode: "worktree",
+        workspaceActiveBranch: {
+          name: "main",
+          detached: false,
+        },
+        diffBranch: "feature/worktree-branch",
+      }),
+    ).toBe("feature/worktree-branch");
+  });
+
+  test("builds a stable identity key for repository branches", () => {
+    expect(
+      buildAgentStudioGitPanelBranchIdentityKey({
+        name: "feature/sidebar-source",
+        detached: false,
+      }),
+    ).toBe("branch:feature/sidebar-source");
+    expect(
+      buildAgentStudioGitPanelBranchIdentityKey({
+        name: "main",
+        detached: true,
+        revision: "abc123",
+      }),
+    ).toBe("detached:abc123");
+    expect(buildAgentStudioGitPanelBranchIdentityKey(null)).toBe("unknown");
+  });
+});

--- a/apps/desktop/src/pages/agents/agents-page-git-panel.ts
+++ b/apps/desktop/src/pages/agents/agents-page-git-panel.ts
@@ -1,0 +1,39 @@
+import type { GitCurrentBranch } from "@openducktor/contracts";
+
+export const resolveAgentStudioGitPanelBranch = ({
+  contextMode,
+  workspaceActiveBranch,
+  diffBranch,
+}: {
+  contextMode: "repository" | "worktree";
+  workspaceActiveBranch: GitCurrentBranch | null;
+  diffBranch: string | null;
+}): string | null => {
+  if (contextMode === "worktree") {
+    return diffBranch;
+  }
+
+  if (workspaceActiveBranch?.detached) {
+    return null;
+  }
+
+  if (workspaceActiveBranch?.name !== undefined) {
+    return workspaceActiveBranch.name ?? null;
+  }
+
+  return diffBranch;
+};
+
+export const buildAgentStudioGitPanelBranchIdentityKey = (
+  workspaceActiveBranch: GitCurrentBranch | null,
+): string => {
+  if (workspaceActiveBranch == null) {
+    return "unknown";
+  }
+
+  if (workspaceActiveBranch.detached) {
+    return `detached:${workspaceActiveBranch.revision ?? "unknown"}`;
+  }
+
+  return `branch:${workspaceActiveBranch.name ?? ""}`;
+};

--- a/apps/desktop/src/pages/agents/agents-page.tsx
+++ b/apps/desktop/src/pages/agents/agents-page.tsx
@@ -32,6 +32,7 @@ import { DiffWorkerProvider } from "@/contexts/DiffWorkerProvider";
 import { errorMessage } from "@/lib/errors";
 import { UPSTREAM_TARGET_BRANCH } from "@/lib/target-branch";
 import { useAgentState, useChecksState, useTasksState, useWorkspaceState } from "@/state";
+import { useDelegationEventsContext } from "@/state/app-state-contexts";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import { loadEffectivePromptOverrides } from "../../state/operations/prompt-overrides";
@@ -355,11 +356,14 @@ export function AgentsPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const [input, setInput] = useState("");
   const [contextSwitchVersion, setContextSwitchVersion] = useState(0);
+  const [runCompletionRecoverySignal, setRunCompletionRecoverySignal] = useState(0);
+  const latestRunCompletionSignalVersionRef = useRef<number | null>(null);
   const [pendingRebaseConflictResolutionRequest, setPendingRebaseConflictResolutionRequest] =
     useState<PendingRebaseConflictResolutionRequest | null>(null);
   const pendingRebaseConflictResolutionResolverRef = useRef<
     ((decision: RebaseConflictResolutionDecision) => void) | null
   >(null);
+  const { runCompletionSignal } = useDelegationEventsContext();
   const { pendingSessionStartRequest, requestNewSessionStart, resolvePendingSessionStart } =
     useAgentStudioSessionStartRequest();
 
@@ -429,6 +433,26 @@ export function AgentsPage(): ReactElement {
     clearComposerInput,
     onContextSwitchIntent: signalContextSwitchIntent,
   });
+
+  useEffect(() => {
+    const activeBuildRunId =
+      selection.viewActiveSession?.role === "build" ? selection.viewActiveSession.runId : null;
+
+    if (!runCompletionSignal || !activeBuildRunId) {
+      return;
+    }
+
+    if (runCompletionSignal.runId !== activeBuildRunId) {
+      return;
+    }
+
+    if (runCompletionSignal.version === latestRunCompletionSignalVersionRef.current) {
+      return;
+    }
+
+    latestRunCompletionSignalVersionRef.current = runCompletionSignal.version;
+    setRunCompletionRecoverySignal((current) => current + 1);
+  }, [runCompletionSignal, selection.viewActiveSession?.runId, selection.viewActiveSession?.role]);
 
   useAgentStudioQuerySessionSync({
     isLoadingTasks,
@@ -525,6 +549,7 @@ export function AgentsPage(): ReactElement {
     repoPath: activeRepo,
     sessionWorkingDirectory: selection.viewActiveSession?.workingDirectory ?? null,
     sessionRunId: selection.viewActiveSession?.runId ?? null,
+    runCompletionRecoverySignal,
     defaultTargetBranch: diffComparisonTarget,
     branchIdentityKey: repositoryBranchIdentityKey,
     enablePolling:

--- a/apps/desktop/src/pages/agents/agents-page.tsx
+++ b/apps/desktop/src/pages/agents/agents-page.tsx
@@ -30,6 +30,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/componen
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { DiffWorkerProvider } from "@/contexts/DiffWorkerProvider";
 import { errorMessage } from "@/lib/errors";
+import { UPSTREAM_TARGET_BRANCH } from "@/lib/target-branch";
 import { useAgentState, useChecksState, useTasksState, useWorkspaceState } from "@/state";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
@@ -43,9 +44,14 @@ import {
 import type { AgentStudioQueryUpdate } from "./agent-studio-navigation";
 import { buildRebaseConflictResolutionPrompt, SCENARIO_LABELS } from "./agents-page-constants";
 import {
+  buildAgentStudioGitPanelBranchIdentityKey,
+  resolveAgentStudioGitPanelBranch,
+} from "./agents-page-git-panel";
+import {
   resolveAgentStudioBuilderSessionForTask,
   resolveAgentStudioBuilderSessionsForTask,
 } from "./agents-page-selection";
+import { useAgentStudioBuildWorktreeRefresh } from "./use-agent-studio-build-worktree-refresh";
 import { useAgentStudioDiffData } from "./use-agent-studio-diff-data";
 import {
   type AgentStudioRebaseConflict,
@@ -332,7 +338,7 @@ function AgentStudioSessionStartModal({
 }
 
 export function AgentsPage(): ReactElement {
-  const { activeRepo, loadRepoSettings } = useWorkspaceState();
+  const { activeRepo, activeBranch, loadRepoSettings } = useWorkspaceState();
   const { opencodeHealth, isLoadingChecks, refreshChecks } = useChecksState();
   const { isLoadingTasks, tasks } = useTasksState();
   const {
@@ -504,15 +510,37 @@ export function AgentsPage(): ReactElement {
     actions: orchestrationActions,
   });
 
+  const gitPanelContextMode: "repository" | "worktree" =
+    selection.viewActiveSession?.role === "build" ? "worktree" : "repository";
+  const repositoryBranchIdentityKey =
+    gitPanelContextMode === "repository"
+      ? buildAgentStudioGitPanelBranchIdentityKey(activeBranch)
+      : null;
+  const diffComparisonTarget =
+    gitPanelContextMode === "repository"
+      ? UPSTREAM_TARGET_BRANCH
+      : (orchestration.repoSettings?.defaultTargetBranch ?? "origin/main");
+
   const diffData = useAgentStudioDiffData({
     repoPath: activeRepo,
     sessionWorkingDirectory: selection.viewActiveSession?.workingDirectory ?? null,
     sessionRunId: selection.viewActiveSession?.runId ?? null,
-    defaultTargetBranch: orchestration.repoSettings?.defaultTargetBranch ?? "origin/main",
+    defaultTargetBranch: diffComparisonTarget,
+    branchIdentityKey: repositoryBranchIdentityKey,
     enablePolling:
       selection.viewRole === "build" &&
       Boolean(selection.viewActiveSession) &&
       orchestration.rightPanel.isPanelOpen,
+  });
+  const resolvedGitPanelBranch = resolveAgentStudioGitPanelBranch({
+    contextMode: gitPanelContextMode,
+    workspaceActiveBranch: activeBranch,
+    diffBranch: diffData.branch,
+  });
+  useAgentStudioBuildWorktreeRefresh({
+    viewRole: selection.viewRole,
+    activeSession: selection.viewActiveSession,
+    refreshWorktree: diffData.refresh,
   });
   const isActiveBuilderWorking =
     selection.viewActiveSession?.role === "build" &&
@@ -659,7 +687,7 @@ export function AgentsPage(): ReactElement {
   const gitActions = useAgentStudioGitActions({
     repoPath: activeRepo,
     workingDir: diffData.worktreePath,
-    branch: diffData.branch,
+    branch: resolvedGitPanelBranch,
     targetBranch: diffData.targetBranch,
     upstreamAheadBehind: diffData.upstreamAheadBehind ?? null,
     detectedConflictedFiles: diffData.fileStatuses
@@ -673,9 +701,11 @@ export function AgentsPage(): ReactElement {
   const diffModel = useMemo(
     () => ({
       ...diffData,
+      contextMode: gitPanelContextMode,
+      branch: resolvedGitPanelBranch,
       ...gitActions,
     }),
-    [diffData, gitActions],
+    [diffData, gitActions, gitPanelContextMode, resolvedGitPanelBranch],
   );
   const rightPanelModel = useMemo(
     () =>

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
@@ -127,9 +127,21 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
 
       await harness.update({
         ...createBaseArgs(),
+        activeSession: createCompletedToolSession("ast_grep_search", "tool-1bb"),
+      });
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
         activeSession: createCompletedToolSession("bash", "tool-1c", {
           command: "git status",
         }),
+      });
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession: createCompletedToolSession("look_at", "tool-1d"),
       });
       expect(refreshWorktreeMock).not.toHaveBeenCalled();
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
@@ -1,0 +1,156 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+type UseAgentStudioBuildWorktreeRefreshHook =
+  typeof import("./use-agent-studio-build-worktree-refresh")["useAgentStudioBuildWorktreeRefresh"];
+
+let useAgentStudioBuildWorktreeRefresh: UseAgentStudioBuildWorktreeRefreshHook;
+
+const refreshWorktreeMock = mock(() => {});
+
+type HookArgs = Parameters<UseAgentStudioBuildWorktreeRefreshHook>[0];
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioBuildWorktreeRefresh, initialProps);
+
+const createCompletedToolSession = (tool: string, id = tool, input?: Record<string, unknown>) =>
+  createAgentSessionFixture({
+    sessionId: "build-session-1",
+    role: "build",
+    messages: [
+      {
+        id,
+        role: "tool",
+        content: "",
+        timestamp: "2026-02-22T08:10:00.000Z",
+        meta: {
+          kind: "tool",
+          partId: `part-${id}`,
+          callId: `call-${id}`,
+          tool,
+          status: "completed",
+          ...(input ? { input } : {}),
+        },
+      },
+    ],
+  });
+
+const createBaseArgs = (): HookArgs => ({
+  viewRole: "build",
+  activeSession: null,
+  refreshWorktree: refreshWorktreeMock,
+});
+
+beforeAll(async () => {
+  ({ useAgentStudioBuildWorktreeRefresh } = await import(
+    "./use-agent-studio-build-worktree-refresh"
+  ));
+});
+
+beforeEach(() => {
+  refreshWorktreeMock.mockClear();
+});
+
+describe("useAgentStudioBuildWorktreeRefresh", () => {
+  test("refreshes worktree for newly completed mutating build tools", async () => {
+    const harness = createHookHarness(createBaseArgs());
+
+    try {
+      await harness.mount();
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession: createCompletedToolSession("apply_patch", "tool-1"),
+      });
+      expect(refreshWorktreeMock).toHaveBeenCalledTimes(1);
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession: createAgentSessionFixture({
+          sessionId: "build-session-1",
+          role: "build",
+          messages: [
+            ...createCompletedToolSession("apply_patch", "tool-1").messages,
+            ...createCompletedToolSession("bash", "tool-2").messages,
+          ],
+        }),
+      });
+      expect(refreshWorktreeMock).toHaveBeenCalledTimes(2);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("deduplicates completed tool messages within the same session", async () => {
+    const activeSession = createCompletedToolSession("apply_patch", "tool-1");
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession,
+    });
+
+    try {
+      await harness.mount();
+      expect(refreshWorktreeMock).toHaveBeenCalledTimes(1);
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession,
+      });
+      expect(refreshWorktreeMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("ignores read-only tools and non-build sessions", async () => {
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession: createCompletedToolSession("read", "tool-1"),
+    });
+
+    try {
+      await harness.mount();
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession: createCompletedToolSession("grep", "tool-1b"),
+      });
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession: createCompletedToolSession("bash", "tool-1c", {
+          command: "git status",
+        }),
+      });
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        viewRole: "spec",
+        activeSession: createCompletedToolSession("apply_patch", "tool-2"),
+      });
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession: createAgentSessionFixture({
+          sessionId: "spec-session-1",
+          role: "spec",
+          messages: createCompletedToolSession("apply_patch", "tool-3").messages,
+        }),
+      });
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
@@ -1,0 +1,101 @@
+import { useEffect, useRef } from "react";
+import { isReadOnlyShellCommand, isSafeReadToolName } from "@/state/operations/permission-policy";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+
+type UseAgentStudioBuildWorktreeRefreshArgs = {
+  viewRole: string | null;
+  activeSession: AgentSessionState | null;
+  refreshWorktree: () => void;
+};
+
+const NON_WORKTREE_TOOL_NAMES = new Set([
+  "background_output",
+  "context7_query-docs",
+  "context7_resolve-library-id",
+  "distill",
+  "grep_app_searchGitHub",
+  "lsp_diagnostics",
+  "lsp_find_references",
+  "lsp_goto_definition",
+  "lsp_prepare_rename",
+  "lsp_symbols",
+  "odt_read_task",
+  "prune",
+  "question",
+  "read",
+  "session_info",
+  "session_list",
+  "session_read",
+  "session_search",
+  "skill",
+  "task",
+  "todowrite",
+  "webfetch",
+  "websearch_web_search_exa",
+]);
+
+const SHELL_TOOL_NAMES = new Set(["bash", "shell", "exec", "command"]);
+
+type ToolMessageMeta = Extract<
+  NonNullable<AgentSessionState["messages"][number]["meta"]>,
+  { kind: "tool" }
+>;
+
+const canToolAffectWorktree = (meta: ToolMessageMeta): boolean => {
+  const toolName = meta.tool.trim().toLowerCase();
+  if (toolName.length === 0) {
+    return false;
+  }
+  if (NON_WORKTREE_TOOL_NAMES.has(toolName) || isSafeReadToolName(toolName)) {
+    return false;
+  }
+
+  const command = typeof meta.input?.command === "string" ? meta.input.command : "";
+  if (SHELL_TOOL_NAMES.has(toolName) && command.length > 0 && isReadOnlyShellCommand(command)) {
+    return false;
+  }
+
+  return true;
+};
+
+export function useAgentStudioBuildWorktreeRefresh({
+  viewRole,
+  activeSession,
+  refreshWorktree,
+}: UseAgentStudioBuildWorktreeRefreshArgs): void {
+  const processedToolMessageKeysRef = useRef(new Set<string>());
+  const previousSessionIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (viewRole !== "build" || activeSession?.role !== "build") {
+      return;
+    }
+
+    if (previousSessionIdRef.current !== activeSession.sessionId) {
+      previousSessionIdRef.current = activeSession.sessionId;
+      processedToolMessageKeysRef.current.clear();
+    }
+
+    let shouldRefresh = false;
+    for (const message of activeSession.messages) {
+      const meta = message.meta;
+      if (!meta || meta.kind !== "tool" || meta.status !== "completed") {
+        continue;
+      }
+
+      const messageKey = `${activeSession.sessionId}:${message.id}`;
+      if (processedToolMessageKeysRef.current.has(messageKey)) {
+        continue;
+      }
+
+      processedToolMessageKeysRef.current.add(messageKey);
+      if (canToolAffectWorktree(meta)) {
+        shouldRefresh = true;
+      }
+    }
+
+    if (shouldRefresh) {
+      refreshWorktree();
+    }
+  }, [activeSession, refreshWorktree, viewRole]);
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
@@ -42,12 +42,15 @@ type ToolMessageMeta = Extract<
   { kind: "tool" }
 >;
 
+const isReadOnlyNonWorktreeTool = (toolName: string): boolean =>
+  EXPLICIT_NON_WORKTREE_TOOL_NAMES.has(toolName) || isSafeReadToolName(toolName);
+
 const canToolAffectWorktree = (meta: ToolMessageMeta): boolean => {
   const toolName = meta.tool.trim().toLowerCase();
   if (toolName.length === 0) {
     return false;
   }
-  if (EXPLICIT_NON_WORKTREE_TOOL_NAMES.has(toolName) || isSafeReadToolName(toolName)) {
+  if (isReadOnlyNonWorktreeTool(toolName)) {
     return false;
   }
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
@@ -8,7 +8,8 @@ type UseAgentStudioBuildWorktreeRefreshArgs = {
   refreshWorktree: () => void;
 };
 
-const NON_WORKTREE_TOOL_NAMES = new Set([
+const EXPLICIT_NON_WORKTREE_TOOL_NAMES = new Set([
+  "ast_grep_search",
   "background_output",
   "context7_query-docs",
   "context7_resolve-library-id",
@@ -19,10 +20,10 @@ const NON_WORKTREE_TOOL_NAMES = new Set([
   "lsp_goto_definition",
   "lsp_prepare_rename",
   "lsp_symbols",
+  "look_at",
   "odt_read_task",
   "prune",
   "question",
-  "read",
   "session_info",
   "session_list",
   "session_read",
@@ -46,7 +47,7 @@ const canToolAffectWorktree = (meta: ToolMessageMeta): boolean => {
   if (toolName.length === 0) {
     return false;
   }
-  if (NON_WORKTREE_TOOL_NAMES.has(toolName) || isSafeReadToolName(toolName)) {
+  if (EXPLICIT_NON_WORKTREE_TOOL_NAMES.has(toolName) || isSafeReadToolName(toolName)) {
     return false;
   }
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -163,6 +163,7 @@ const createBaseArgs = (): HookArgs => ({
   sessionWorkingDirectory: null,
   sessionRunId: null,
   defaultTargetBranch: "origin/main",
+  branchIdentityKey: null,
   enablePolling: false,
 });
 
@@ -416,6 +417,298 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("reloads compare data when repository branch identity changes", async () => {
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      defaultTargetBranch: "@{upstream}",
+      branchIdentityKey: "branch:main",
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      expect(harness.getLatest().branch).toBe("feature/task-10");
+
+      gitGetWorktreeStatusMock.mockImplementation(
+        async (
+          _repoPath: string,
+          targetBranch: string,
+          diffScope?: "target" | "uncommitted",
+          workingDir?: string,
+        ): Promise<GitWorktreeStatus> =>
+          withSnapshotHashes({
+            currentBranch: { name: "feature/switched", detached: false },
+            fileStatuses: [{ path: "src/switched.ts", status: "M", staged: false }],
+            fileDiffs:
+              (diffScope ?? "target") === "target"
+                ? [
+                    {
+                      file: "src/switched.ts",
+                      type: "modified",
+                      additions: 5,
+                      deletions: 1,
+                      diff: "@@ -1 +1,5 @@",
+                    },
+                  ]
+                : [],
+            targetAheadBehind: { ahead: 2, behind: 0 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 2, behind: 0 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000200,
+            },
+          }),
+      );
+
+      await harness.update({
+        ...createBaseArgs(),
+        defaultTargetBranch: "@{upstream}",
+        branchIdentityKey: "branch:feature/switched",
+      });
+
+      await harness.waitFor((state) => state.branch === "feature/switched");
+      expect(harness.getLatest().fileDiffs[0]).toMatchObject({
+        file: "src/switched.ts",
+        additions: 5,
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("refresh syncs upstream status changes across cached inactive scope", async () => {
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      defaultTargetBranch: "@{upstream}",
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      expect(harness.getLatest().upstreamStatus).toBe("tracking");
+
+      await harness.run((state) => {
+        state.setDiffScope("uncommitted");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+      expect(harness.getLatest().upstreamStatus).toBe("tracking");
+
+      await harness.run((state) => {
+        state.setDiffScope("target");
+      });
+      await harness.waitFor((state) => state.diffScope === "target");
+
+      gitGetWorktreeStatusMock.mockImplementation(
+        async (
+          _repoPath: string,
+          targetBranch: string,
+          diffScope?: "target" | "uncommitted",
+          workingDir?: string,
+        ): Promise<GitWorktreeStatus> =>
+          withSnapshotHashes({
+            currentBranch: { name: "feature/task-10", detached: false },
+            fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+            fileDiffs:
+              (diffScope ?? "target") === "target"
+                ? []
+                : [
+                    {
+                      file: "src/main.ts",
+                      type: "modified",
+                      additions: 1,
+                      deletions: 0,
+                      diff: "@@ -1 +1 @@",
+                    },
+                  ],
+            targetAheadBehind: { ahead: 1, behind: 0 },
+            upstreamAheadBehind: { outcome: "untracked", ahead: 1 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000001,
+            },
+          }),
+      );
+
+      await harness.run((state) => {
+        state.refresh();
+      });
+      await harness.waitFor((state) => state.upstreamStatus === "untracked");
+      expect(harness.getLatest().upstreamAheadBehind).toEqual({ ahead: 1, behind: 0 });
+
+      await harness.run((state) => {
+        state.setDiffScope("uncommitted");
+      });
+      await harness.waitFor((state) => state.diffScope === "uncommitted");
+
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(3);
+      expect(harness.getLatest().upstreamStatus).toBe("untracked");
+      expect(harness.getLatest().upstreamAheadBehind).toEqual({ ahead: 1, behind: 0 });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("polling invalidates the inactive scope so switching scopes triggers a fresh full reload", async () => {
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearInterval = globalThis.clearInterval;
+    let intervalCallback: (() => void) | null = null;
+
+    const setIntervalMock = mock((callback: TimerHandler, _delay?: number) => {
+      if (typeof callback !== "function") {
+        throw new Error("Expected polling callback function");
+      }
+      intervalCallback = () => {
+        callback();
+      };
+      return 1;
+    });
+    const clearIntervalMock = mock((_intervalId: number) => {});
+
+    globalThis.setInterval = setIntervalMock as unknown as typeof globalThis.setInterval;
+    globalThis.clearInterval = clearIntervalMock as unknown as typeof globalThis.clearInterval;
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      enablePolling: true,
+    });
+
+    const runTick = (): void => {
+      if (intervalCallback == null) {
+        throw new Error("Polling callback was not registered");
+      }
+      intervalCallback();
+    };
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      await harness.run((state) => {
+        state.setDiffScope("uncommitted");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+
+      await harness.run((state) => {
+        state.setDiffScope("target");
+      });
+      await harness.waitFor((state) => state.diffScope === "target");
+
+      gitGetWorktreeStatusMock.mockImplementation(
+        async (
+          _repoPath: string,
+          targetBranch: string,
+          diffScope?: "target" | "uncommitted",
+          workingDir?: string,
+        ): Promise<GitWorktreeStatus> =>
+          withSnapshotHashes({
+            currentBranch: { name: "feature/task-11", detached: false },
+            fileStatuses: [{ path: "src/updated.ts", status: "M", staged: false }],
+            fileDiffs:
+              (diffScope ?? "target") === "target"
+                ? [
+                    {
+                      file: "src/updated.ts",
+                      type: "modified",
+                      additions: 4,
+                      deletions: 1,
+                      diff: "@@ -1 +1 @@",
+                    },
+                  ]
+                : [
+                    {
+                      file: "src/worktree.ts",
+                      type: "modified",
+                      additions: 2,
+                      deletions: 0,
+                      diff: "@@ -1 +1,2 @@",
+                    },
+                  ],
+            targetAheadBehind: { ahead: 2, behind: 1 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 5, behind: 2 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000001,
+            },
+          }),
+      );
+      gitGetWorktreeStatusSummaryMock.mockImplementation(
+        async (
+          _repoPath: string,
+          targetBranch: string,
+          diffScope?: "target" | "uncommitted",
+          workingDir?: string,
+        ): Promise<GitWorktreeStatusSummary> =>
+          toWorktreeStatusSummary(
+            withSnapshotHashes({
+              currentBranch: { name: "feature/task-11", detached: false },
+              fileStatuses: [{ path: "src/updated.ts", status: "M", staged: false }],
+              fileDiffs:
+                (diffScope ?? "target") === "target"
+                  ? [
+                      {
+                        file: "src/updated.ts",
+                        type: "modified",
+                        additions: 4,
+                        deletions: 1,
+                        diff: "@@ -1 +1 @@",
+                      },
+                    ]
+                  : [
+                      {
+                        file: "src/worktree.ts",
+                        type: "modified",
+                        additions: 2,
+                        deletions: 0,
+                        diff: "@@ -1 +1,2 @@",
+                      },
+                    ],
+              targetAheadBehind: { ahead: 2, behind: 1 },
+              upstreamAheadBehind: { outcome: "tracking", ahead: 5, behind: 2 },
+              snapshot: {
+                effectiveWorkingDir: workingDir ?? "/repo",
+                targetBranch,
+                diffScope: diffScope ?? "target",
+                observedAtMs: 1731000000001,
+              },
+            }),
+          ),
+      );
+
+      await harness.run(() => {
+        runTick();
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 3);
+      expect(harness.getLatest().branch).toBe("feature/task-11");
+
+      await harness.run((state) => {
+        state.setDiffScope("uncommitted");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 4);
+      await harness.waitFor((state) => state.diffScope === "uncommitted");
+
+      expect(harness.getLatest().fileDiffs).toEqual([
+        {
+          file: "src/worktree.ts",
+          type: "modified",
+          additions: 2,
+          deletions: 0,
+          diff: "@@ -1 +1,2 @@",
+        },
+      ]);
+    } finally {
+      await harness.unmount();
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    }
+  });
+
   test("polling schedules one periodic request for the active scope", async () => {
     const originalSetInterval = globalThis.setInterval;
     const originalClearInterval = globalThis.clearInterval;
@@ -647,7 +940,8 @@ describe("useAgentStudioDiffData", () => {
         runTick();
       });
       await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
-      expect(harness.getLatest().branch).toBe("feature/summary");
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 3);
+      expect(harness.getLatest().branch).toBe("feature/base");
     } finally {
       await harness.unmount();
       globalThis.setInterval = originalSetInterval;
@@ -670,6 +964,75 @@ describe("useAgentStudioDiffData", () => {
       return 1;
     });
     const clearIntervalMock = mock((_intervalId: number) => {});
+
+    let fullRequestCount = 0;
+    gitGetWorktreeStatusMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatus> => {
+        fullRequestCount += 1;
+
+        if (fullRequestCount === 1) {
+          return withSnapshotHashes({
+            currentBranch: { name: "feature/task-10", detached: false },
+            fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+            fileDiffs:
+              (diffScope ?? "target") === "target"
+                ? [
+                    {
+                      file: "src/main.ts",
+                      type: "modified",
+                      additions: 1,
+                      deletions: 0,
+                      diff: "@@ -1 +1 @@",
+                    },
+                  ]
+                : [],
+            targetAheadBehind: { ahead: 1, behind: 0 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000000,
+            },
+          });
+        }
+
+        return withSnapshotHashes({
+          currentBranch: { name: "feature/task-10", detached: false },
+          fileStatuses: [
+            { path: "src/a.ts", status: "M", staged: false },
+            { path: "src/b.ts", status: "A", staged: true },
+            { path: "src/c.ts", status: "D", staged: false },
+            { path: "src/d.ts", status: "M", staged: false },
+          ],
+          fileDiffs:
+            (diffScope ?? "target") === "target"
+              ? [
+                  {
+                    file: "src/main.ts",
+                    type: "modified",
+                    additions: 1,
+                    deletions: 0,
+                    diff: "@@ -1 +1 @@",
+                  },
+                ]
+              : [],
+          targetAheadBehind: { ahead: 1, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: workingDir ?? "/repo",
+            targetBranch,
+            diffScope: diffScope ?? "target",
+            observedAtMs: 1731000000100,
+          },
+        });
+      },
+    );
 
     gitGetWorktreeStatusSummaryMock.mockImplementation(
       async (
@@ -741,7 +1104,7 @@ describe("useAgentStudioDiffData", () => {
       });
       await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 2);
       const thirdState = harness.getLatest();
-      expect(thirdState).toBe(secondState);
+      expect(thirdState).toEqual(secondState);
     } finally {
       await harness.unmount();
       globalThis.setInterval = originalSetInterval;
@@ -764,6 +1127,75 @@ describe("useAgentStudioDiffData", () => {
       return 1;
     });
     const clearIntervalMock = mock((_intervalId: number) => {});
+
+    let fullRequestCount = 0;
+    gitGetWorktreeStatusMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatus> => {
+        fullRequestCount += 1;
+
+        if (fullRequestCount === 1) {
+          return withSnapshotHashes({
+            currentBranch: { name: "feature/task-10", detached: false },
+            fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+            fileDiffs:
+              (diffScope ?? "target") === "target"
+                ? [
+                    {
+                      file: "src/main.ts",
+                      type: "modified",
+                      additions: 1,
+                      deletions: 0,
+                      diff: "@@ -1 +1 @@",
+                    },
+                  ]
+                : [],
+            targetAheadBehind: { ahead: 1, behind: 0 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000000,
+            },
+          });
+        }
+
+        return withSnapshotHashes({
+          currentBranch: { name: "feature/task-10", detached: false },
+          fileStatuses: [
+            { path: "src/a.ts", status: "M", staged: false },
+            { path: "src/b.ts", status: "A", staged: true },
+            { path: "src/c.ts", status: "D", staged: false },
+            { path: "src/d.ts", status: "M", staged: false },
+          ],
+          fileDiffs:
+            (diffScope ?? "target") === "target"
+              ? [
+                  {
+                    file: "src/main.ts",
+                    type: "modified",
+                    additions: 1,
+                    deletions: 0,
+                    diff: "@@ -1 +1 @@",
+                  },
+                ]
+              : [],
+          targetAheadBehind: { ahead: 1, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: workingDir ?? "/repo",
+            targetBranch,
+            diffScope: diffScope ?? "target",
+            observedAtMs: 1731000000100,
+          },
+        });
+      },
+    );
 
     gitGetWorktreeStatusSummaryMock.mockImplementation(
       async (
@@ -830,8 +1262,8 @@ describe("useAgentStudioDiffData", () => {
         runTick();
       });
       await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
-      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(1);
-      expect(harness.getLatest().uncommittedFileCount).toBe(4);
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+      await harness.waitFor((state) => state.uncommittedFileCount === 4);
     } finally {
       await harness.unmount();
       globalThis.setInterval = originalSetInterval;
@@ -985,6 +1417,157 @@ describe("useAgentStudioDiffData", () => {
         { path: "AGENTS.md", status: "M", staged: false },
       ]);
       expect(harness.getLatest().branch).toBe("feature/resolved");
+    } finally {
+      await harness.unmount();
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    }
+  });
+
+  test("polling triggers a full reload when non-conflict summary hashes change", async () => {
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearInterval = globalThis.clearInterval;
+    let intervalCallback: (() => void) | null = null;
+
+    const setIntervalMock = mock((callback: TimerHandler, _delay?: number) => {
+      if (typeof callback !== "function") {
+        throw new Error("Expected polling callback function");
+      }
+      intervalCallback = () => {
+        callback();
+      };
+      return 1;
+    });
+    const clearIntervalMock = mock((_intervalId: number) => {});
+
+    let fullRequestCount = 0;
+    gitGetWorktreeStatusMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatus> => {
+        fullRequestCount += 1;
+
+        if (fullRequestCount === 1) {
+          return withSnapshotHashes({
+            currentBranch: { name: "feature/task-10", detached: false },
+            fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+            fileDiffs:
+              (diffScope ?? "target") === "target"
+                ? [
+                    {
+                      file: "src/main.ts",
+                      type: "modified",
+                      additions: 1,
+                      deletions: 1,
+                      diff: "@@ -1 +1 @@\n-old\n+draft\n",
+                    },
+                  ]
+                : [],
+            targetAheadBehind: { ahead: 1, behind: 0 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000000,
+            },
+          });
+        }
+
+        return withSnapshotHashes({
+          currentBranch: { name: "feature/task-10", detached: false },
+          fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+          fileDiffs:
+            (diffScope ?? "target") === "target"
+              ? [
+                  {
+                    file: "src/main.ts",
+                    type: "modified",
+                    additions: 3,
+                    deletions: 1,
+                    diff: "@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+                  },
+                ]
+              : [],
+          targetAheadBehind: { ahead: 1, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: workingDir ?? "/repo",
+            targetBranch,
+            diffScope: diffScope ?? "target",
+            observedAtMs: 1731000000100,
+          },
+        });
+      },
+    );
+    gitGetWorktreeStatusSummaryMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatusSummary> =>
+        toWorktreeStatusSummary(
+          withSnapshotHashes({
+            currentBranch: { name: "feature/task-10", detached: false },
+            fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+            fileDiffs:
+              (diffScope ?? "target") === "target"
+                ? [
+                    {
+                      file: "src/main.ts",
+                      type: "modified",
+                      additions: 3,
+                      deletions: 1,
+                      diff: "@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+                    },
+                  ]
+                : [],
+            targetAheadBehind: { ahead: 1, behind: 0 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000100,
+            },
+          }),
+        ),
+    );
+
+    globalThis.setInterval = setIntervalMock as unknown as typeof globalThis.setInterval;
+    globalThis.clearInterval = clearIntervalMock as unknown as typeof globalThis.clearInterval;
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      enablePolling: true,
+    });
+
+    const runTick = (): void => {
+      if (intervalCallback == null) {
+        throw new Error("Polling callback was not registered");
+      }
+      intervalCallback();
+    };
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      expect(harness.getLatest().fileDiffs[0]?.additions).toBe(1);
+
+      await harness.run(() => {
+        runTick();
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+
+      expect(harness.getLatest().fileDiffs[0]).toMatchObject({
+        file: "src/main.ts",
+        additions: 3,
+      });
     } finally {
       await harness.unmount();
       globalThis.setInterval = originalSetInterval;
@@ -1150,6 +1733,102 @@ describe("useAgentStudioDiffData", () => {
 
       expect(harness.getLatest().branch).toBe("feature/repo-b");
       expect(harness.getLatest().fileDiffs[0]?.file).toBe("src/repo-b.ts");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("replays queued full refreshes after an in-flight refresh settles", async () => {
+    const firstRequest = createDeferred<GitWorktreeStatus>();
+    const secondRequest = createDeferred<GitWorktreeStatus>();
+    const queue = [firstRequest, secondRequest];
+
+    gitGetWorktreeStatusMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatus> => {
+        const deferred = queue.shift();
+        if (!deferred) {
+          throw new Error("No deferred response left");
+        }
+
+        return deferred.promise.then((snapshot) => ({
+          ...snapshot,
+          snapshot: {
+            ...snapshot.snapshot,
+            targetBranch,
+            diffScope: diffScope ?? snapshot.snapshot.diffScope,
+            effectiveWorkingDir: workingDir ?? snapshot.snapshot.effectiveWorkingDir,
+          },
+        }));
+      },
+    );
+
+    const harness = createHookHarness(createBaseArgs());
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      await harness.run((state) => {
+        state.refresh();
+      });
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(1);
+
+      firstRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/first", detached: false },
+          fileStatuses: [{ path: "src/first.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/first.ts",
+              type: "modified",
+              additions: 1,
+              deletions: 0,
+              diff: "@@ -1 +1 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000001000,
+          },
+        }),
+      );
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+
+      secondRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/second", detached: false },
+          fileStatuses: [{ path: "src/second.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/second.ts",
+              type: "modified",
+              additions: 2,
+              deletions: 0,
+              diff: "@@ -1 +1,2 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000002000,
+          },
+        }),
+      );
+      await harness.waitFor((state) => state.branch === "feature/second");
+
+      expect(harness.getLatest().fileDiffs[0]?.file).toBe("src/second.ts");
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -2164,6 +2164,175 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("run completion signal retries missing worktree resolution automatically", async () => {
+    let resolveAttempt = 0;
+    runsListMock.mockImplementation(async () => {
+      resolveAttempt += 1;
+      if (resolveAttempt === 1) {
+        return [{ runId: "run-2", worktreePath: "/repo/.worktrees/run-2" }];
+      }
+
+      return [{ runId: "run-1", worktreePath: "/repo/.worktrees/run-1" }];
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      sessionRunId: "run-1",
+      runCompletionRecoverySignal: 0,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) =>
+        (state.error ?? "").includes("Run not found in runs list response."),
+      );
+      expect(gitGetWorktreeStatusMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        sessionRunId: "run-1",
+        runCompletionRecoverySignal: 1,
+      });
+
+      await harness.waitFor((state) => state.worktreePath === "/repo/.worktrees/run-1");
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      expect(runsListMock).toHaveBeenCalledTimes(2);
+      expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
+        1,
+        "/repo",
+        "origin/main",
+        "target",
+        "/repo/.worktrees/run-1",
+      );
+      expect(harness.getLatest().error).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("run completion signal does not re-resolve after worktree resolution already succeeded", async () => {
+    runsListMock.mockResolvedValue([{ runId: "run-1", worktreePath: "/repo/.worktrees/run-1" }]);
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      sessionRunId: "run-1",
+      runCompletionRecoverySignal: 0,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.worktreePath === "/repo/.worktrees/run-1");
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      expect(runsListMock).toHaveBeenCalledTimes(1);
+
+      await harness.update({
+        ...createBaseArgs(),
+        sessionRunId: "run-1",
+        runCompletionRecoverySignal: 1,
+      });
+
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+
+      expect(harness.getLatest().worktreePath).toBe("/repo/.worktrees/run-1");
+      expect(harness.getLatest().error).toBeNull();
+      expect(runsListMock).toHaveBeenCalledTimes(1);
+      expect(gitGetWorktreeStatusMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("run completion signal queued during in-flight resolution retries automatically after failure", async () => {
+    const firstAttempt = createDeferred<Array<{ runId: string; worktreePath: string }>>();
+    let resolveAttempt = 0;
+    runsListMock.mockImplementation(async () => {
+      resolveAttempt += 1;
+      if (resolveAttempt === 1) {
+        return firstAttempt.promise;
+      }
+
+      return [{ runId: "run-1", worktreePath: "/repo/.worktrees/run-1" }];
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      sessionRunId: "run-1",
+      runCompletionRecoverySignal: 0,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.isLoading);
+      expect(runsListMock).toHaveBeenCalledTimes(1);
+
+      await harness.update({
+        ...createBaseArgs(),
+        sessionRunId: "run-1",
+        runCompletionRecoverySignal: 1,
+      });
+
+      firstAttempt.resolve([{ runId: "run-2", worktreePath: "/repo/.worktrees/run-2" }]);
+
+      await harness.waitFor((state) => state.worktreePath === "/repo/.worktrees/run-1");
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      expect(runsListMock).toHaveBeenCalledTimes(2);
+      expect(harness.getLatest().error).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("queued run completion signal does not leak to a different run context", async () => {
+    const firstAttempt = createDeferred<Array<{ runId: string; worktreePath: string }>>();
+    let resolveAttempt = 0;
+    runsListMock.mockImplementation(async () => {
+      resolveAttempt += 1;
+      if (resolveAttempt === 1) {
+        return firstAttempt.promise;
+      }
+
+      return [{ runId: "run-2", worktreePath: "/repo/.worktrees/run-2" }];
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      sessionRunId: "run-1",
+      runCompletionRecoverySignal: 0,
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.isLoading);
+      expect(runsListMock).toHaveBeenCalledTimes(1);
+
+      await harness.update({
+        ...createBaseArgs(),
+        sessionRunId: "run-1",
+        runCompletionRecoverySignal: 1,
+      });
+
+      await harness.update({
+        ...createBaseArgs(),
+        sessionRunId: "run-2",
+        runCompletionRecoverySignal: 1,
+      });
+
+      firstAttempt.resolve([{ runId: "run-3", worktreePath: "/repo/.worktrees/run-3" }]);
+
+      await harness.waitFor((state) => state.worktreePath === "/repo/.worktrees/run-2");
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      expect(runsListMock).toHaveBeenCalledTimes(2);
+      expect(harness.getLatest().worktreePath).toBe("/repo/.worktrees/run-2");
+      expect(harness.getLatest().error).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("times out worktree resolution after 5 seconds and shows retry guidance", async () => {
     const pendingRunsList = createDeferred<Array<{ runId: string; worktreePath: string }>>();
     runsListMock.mockImplementation(async () => pendingRunsList.promise);

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
@@ -61,6 +61,8 @@ export type UseAgentStudioDiffDataInput = {
   branchIdentityKey?: string | null;
   /** Whether to enable polling (only when builder session is active). */
   enablePolling: boolean;
+  /** Optional run completion signal to force worktree-resolution refresh. */
+  runCompletionRecoverySignal?: number;
 };
 
 // ─── Batched internal state ────────────────────────────────────────────────────
@@ -335,6 +337,7 @@ export function useAgentStudioDiffData({
   defaultTargetBranch,
   branchIdentityKey = null,
   enablePolling,
+  runCompletionRecoverySignal,
 }: UseAgentStudioDiffDataInput): DiffDataState {
   const [state, setState] = useState<DiffBatchState>(createInitialState);
   const stateRef = useRef(state);
@@ -371,6 +374,7 @@ export function useAgentStudioDiffData({
     repoPath,
     sessionWorkingDirectory,
     sessionRunId,
+    ...(runCompletionRecoverySignal == null ? {} : { runCompletionRecoverySignal }),
   });
 
   // Stable refs for use in callbacks (advanced-event-handler-refs)

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
@@ -24,7 +24,8 @@ export type DiffDataState = {
   diffScope: DiffScope;
   /** Commits ahead/behind the target branch. */
   commitsAheadBehind: CommitsAheadBehind | null;
-  upstreamAheadBehind?: CommitsAheadBehind | null;
+  upstreamAheadBehind: CommitsAheadBehind | null;
+  upstreamStatus: "tracking" | "untracked" | "error";
   /** Changed files with diff content. */
   fileDiffs: FileDiff[];
   /** File status from `git status`. */
@@ -57,6 +58,7 @@ export type UseAgentStudioDiffDataInput = {
   sessionRunId: string | null;
   /** Default target branch from repo settings. */
   defaultTargetBranch: string;
+  branchIdentityKey?: string | null;
   /** Whether to enable polling (only when builder session is active). */
   enablePolling: boolean;
 };
@@ -76,6 +78,7 @@ type ScopeSnapshot = {
   uncommittedFileCount: number;
   commitsAheadBehind: CommitsAheadBehind | null;
   upstreamAheadBehind: CommitsAheadBehind | null;
+  upstreamStatus: "tracking" | "untracked" | "error";
   error: string | null;
   hashVersion: number | null;
   statusHash: string | null;
@@ -88,6 +91,7 @@ type LoadDataContext = {
   workingDir: string | null;
   scope: DiffScope;
   mode?: LoadDataMode;
+  replayIfInFlight?: boolean;
 };
 
 type LoadDataMode = "full" | "summary";
@@ -103,6 +107,7 @@ const EMPTY_SCOPE_SNAPSHOT: ScopeSnapshot = {
   uncommittedFileCount: 0,
   commitsAheadBehind: null,
   upstreamAheadBehind: null,
+  upstreamStatus: "tracking",
   error: null,
   hashVersion: null,
   statusHash: null,
@@ -192,6 +197,7 @@ const scopeSnapshotEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean 
       left.uncommittedFileCount === right.uncommittedFileCount &&
       aheadBehindEqual(left.commitsAheadBehind, right.commitsAheadBehind) &&
       aheadBehindEqual(left.upstreamAheadBehind, right.upstreamAheadBehind) &&
+      left.upstreamStatus === right.upstreamStatus &&
       left.error === right.error &&
       hashMetadataEqual(left, right)
     );
@@ -201,6 +207,7 @@ const toUpstreamAndError = (
   upstreamAheadBehind: GitWorktreeStatus["upstreamAheadBehind"],
 ): {
   upstreamAheadBehind: CommitsAheadBehind | null;
+  upstreamStatus: "tracking" | "untracked" | "error";
   error: string | null;
 } => {
   if (upstreamAheadBehind.outcome === "tracking") {
@@ -209,6 +216,7 @@ const toUpstreamAndError = (
         ahead: upstreamAheadBehind.ahead,
         behind: upstreamAheadBehind.behind,
       },
+      upstreamStatus: "tracking",
       error: null,
     };
   }
@@ -219,18 +227,22 @@ const toUpstreamAndError = (
         ahead: upstreamAheadBehind.ahead,
         behind: 0,
       },
+      upstreamStatus: "untracked",
       error: null,
     };
   }
 
   return {
     upstreamAheadBehind: null,
+    upstreamStatus: "error",
     error: `Upstream status unavailable: ${upstreamAheadBehind.message}`,
   };
 };
 
 const toScopeSnapshot = (snapshot: GitWorktreeStatus): ScopeSnapshot => {
-  const { upstreamAheadBehind, error } = toUpstreamAndError(snapshot.upstreamAheadBehind);
+  const { upstreamAheadBehind, upstreamStatus, error } = toUpstreamAndError(
+    snapshot.upstreamAheadBehind,
+  );
   return {
     branch: snapshot.currentBranch.name ?? null,
     fileDiffs: snapshot.fileDiffs,
@@ -238,6 +250,7 @@ const toScopeSnapshot = (snapshot: GitWorktreeStatus): ScopeSnapshot => {
     uncommittedFileCount: snapshot.fileStatuses.length,
     commitsAheadBehind: snapshot.targetAheadBehind,
     upstreamAheadBehind,
+    upstreamStatus,
     error,
     hashVersion: snapshot.snapshot.hashVersion,
     statusHash: snapshot.snapshot.statusHash,
@@ -251,6 +264,7 @@ type ScopeSummaryFields = Pick<
   | "uncommittedFileCount"
   | "commitsAheadBehind"
   | "upstreamAheadBehind"
+  | "upstreamStatus"
   | "error"
   | "hashVersion"
   | "statusHash"
@@ -258,12 +272,15 @@ type ScopeSummaryFields = Pick<
 >;
 
 const toScopeSummaryFields = (summary: GitWorktreeStatusSummary): ScopeSummaryFields => {
-  const { upstreamAheadBehind, error } = toUpstreamAndError(summary.upstreamAheadBehind);
+  const { upstreamAheadBehind, upstreamStatus, error } = toUpstreamAndError(
+    summary.upstreamAheadBehind,
+  );
   return {
     branch: summary.currentBranch.name ?? null,
     uncommittedFileCount: summary.fileStatusCounts.total,
     commitsAheadBehind: summary.targetAheadBehind,
     upstreamAheadBehind,
+    upstreamStatus,
     error,
     hashVersion: summary.snapshot.hashVersion,
     statusHash: summary.snapshot.statusHash,
@@ -278,6 +295,7 @@ const mergeSharedSnapshotFields = (base: ScopeSnapshot, source: ScopeSnapshot): 
   uncommittedFileCount: source.uncommittedFileCount,
   commitsAheadBehind: source.commitsAheadBehind,
   upstreamAheadBehind: source.upstreamAheadBehind,
+  upstreamStatus: source.upstreamStatus,
   error: source.error,
   hashVersion: source.hashVersion,
   statusHash: source.statusHash,
@@ -292,6 +310,7 @@ const mergeSharedSummaryFields = (
   uncommittedFileCount: source.uncommittedFileCount,
   commitsAheadBehind: source.commitsAheadBehind,
   upstreamAheadBehind: source.upstreamAheadBehind,
+  upstreamStatus: source.upstreamStatus,
   error: source.error,
   hashVersion: source.hashVersion,
   statusHash: source.statusHash,
@@ -314,6 +333,7 @@ export function useAgentStudioDiffData({
   sessionWorkingDirectory,
   sessionRunId,
   defaultTargetBranch,
+  branchIdentityKey = null,
   enablePolling,
 }: UseAgentStudioDiffDataInput): DiffDataState {
   const [state, setState] = useState<DiffBatchState>(createInitialState);
@@ -331,6 +351,10 @@ export function useAgentStudioDiffData({
   const inFlightScopeRequestRef = useRef<Record<DiffScope, Record<LoadDataMode, string | null>>>({
     target: { full: null, summary: null },
     uncommitted: { full: null, summary: null },
+  });
+  const queuedFullReloadByScopeRef = useRef<Record<DiffScope, boolean>>({
+    target: false,
+    uncommitted: false,
   });
   const requestContextKeyRef = useRef<string | null>(null);
 
@@ -370,9 +394,13 @@ export function useAgentStudioDiffData({
     const target = context?.targetBranch ?? targetBranchRef.current;
     const workingDir = context?.workingDir ?? workingDirRef.current;
     const mode = context?.mode ?? "full";
+    const replayIfInFlight = context?.replayIfInFlight === true;
     const requestKey = `${path}::${target}::${workingDir ?? ""}`;
 
     if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
+      if (mode === "full" && replayIfInFlight) {
+        queuedFullReloadByScopeRef.current[scope] = true;
+      }
       return;
     }
 
@@ -410,14 +438,11 @@ export function useAgentStudioDiffData({
 
         const previousSummarySnapshot = stateRef.current.byScope[scope];
         const nextSummaryFields = toScopeSummaryFields(summary);
-        const shouldReloadFullScope =
-          stateRef.current.loadedByScope[scope] &&
-          previousSummarySnapshot.fileStatuses.some(
-            (fileStatus) => fileStatus.status === "unmerged",
-          ) &&
-          (previousSummarySnapshot.hashVersion !== nextSummaryFields.hashVersion ||
-            previousSummarySnapshot.statusHash !== nextSummaryFields.statusHash ||
-            previousSummarySnapshot.diffHash !== nextSummaryFields.diffHash);
+        const hashesChanged =
+          previousSummarySnapshot.hashVersion !== nextSummaryFields.hashVersion ||
+          previousSummarySnapshot.statusHash !== nextSummaryFields.statusHash ||
+          previousSummarySnapshot.diffHash !== nextSummaryFields.diffHash;
+        const shouldReloadFullScope = stateRef.current.loadedByScope[scope] && hashesChanged;
 
         setState((prev) => {
           const previousFetchedScopeSnapshot = prev.byScope[scope];
@@ -437,6 +462,7 @@ export function useAgentStudioDiffData({
 
           if (requestSequence >= latestSharedSequenceRef.current) {
             latestSharedSequenceRef.current = requestSequence;
+            let nextLoadedByScope = prev.loadedByScope;
             for (const otherScope of ALL_SCOPES) {
               if (otherScope === scope) {
                 continue;
@@ -452,7 +478,35 @@ export function useAgentStudioDiffData({
                 nextByScope[otherScope] = nextOtherScopeSnapshot;
                 didChange = true;
               }
+
+              if (hashesChanged && prev.loadedByScope[otherScope]) {
+                const invalidatedOtherScopeSnapshot: ScopeSnapshot = {
+                  ...nextByScope[otherScope],
+                  fileDiffs: EMPTY_DIFFS,
+                };
+                if (!scopeSnapshotEqual(nextByScope[otherScope], invalidatedOtherScopeSnapshot)) {
+                  nextByScope[otherScope] = invalidatedOtherScopeSnapshot;
+                  didChange = true;
+                }
+                if (nextLoadedByScope[otherScope]) {
+                  nextLoadedByScope = {
+                    ...nextLoadedByScope,
+                    [otherScope]: false,
+                  };
+                  didChange = true;
+                }
+              }
             }
+
+            if (!didChange && !prev.isLoading) {
+              return prev;
+            }
+
+            return {
+              byScope: nextByScope,
+              loadedByScope: nextLoadedByScope,
+              isLoading: false,
+            };
           }
 
           if (!didChange && !prev.isLoading) {
@@ -593,13 +647,26 @@ export function useAgentStudioDiffData({
       if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
         inFlightScopeRequestRef.current[scope][mode] = null;
       }
+
+      if (mode === "full" && queuedFullReloadByScopeRef.current[scope]) {
+        queuedFullReloadByScopeRef.current[scope] = false;
+        globalThis.queueMicrotask(() => {
+          void loadData(false, {
+            repoPath: path,
+            targetBranch: target,
+            workingDir,
+            scope,
+            mode: "full",
+          });
+        });
+      }
     }
   }, []);
 
   useEffect(() => {
     const contextKey = `${repoPath ?? ""}::${targetBranch}::${worktreePath ?? ""}::${
       worktreeResolutionRunId ?? ""
-    }`;
+    }::${branchIdentityKey ?? ""}`;
     const hasContextChanged =
       requestContextKeyRef.current !== null && requestContextKeyRef.current !== contextKey;
     requestContextKeyRef.current = contextKey;
@@ -611,6 +678,7 @@ export function useAgentStudioDiffData({
             versionByScopeAndModeRef.current[scope][mode] += 1;
             inFlightScopeRequestRef.current[scope][mode] = null;
           }
+          queuedFullReloadByScopeRef.current[scope] = false;
         }
         requestSequenceRef.current = 0;
         latestSharedSequenceRef.current = 0;
@@ -634,6 +702,7 @@ export function useAgentStudioDiffData({
             versionByScopeAndModeRef.current[scope][mode] += 1;
             inFlightScopeRequestRef.current[scope][mode] = null;
           }
+          queuedFullReloadByScopeRef.current[scope] = false;
         }
         requestSequenceRef.current = 0;
         latestSharedSequenceRef.current = 0;
@@ -648,6 +717,7 @@ export function useAgentStudioDiffData({
         versionByScopeAndModeRef.current[scope][mode] += 1;
         inFlightScopeRequestRef.current[scope][mode] = null;
       }
+      queuedFullReloadByScopeRef.current[scope] = false;
     }
     requestSequenceRef.current = 0;
     latestSharedSequenceRef.current = 0;
@@ -659,6 +729,7 @@ export function useAgentStudioDiffData({
     worktreePath,
     targetBranch,
     worktreeResolutionRunId,
+    branchIdentityKey,
     shouldBlockDiffLoading,
     loadData,
   ]);
@@ -719,7 +790,13 @@ export function useAgentStudioDiffData({
       return;
     }
 
-    void loadData(true);
+    void loadData(true, {
+      repoPath: repoPathRef.current,
+      targetBranch: targetBranchRef.current,
+      workingDir: workingDirRef.current,
+      scope: diffScopeRef.current,
+      replayIfInFlight: true,
+    });
   }, [loadData, retryWorktreeResolution, shouldBlockDiffLoading, worktreeResolutionError]);
 
   const setSelectedFile = useCallback(
@@ -741,6 +818,7 @@ export function useAgentStudioDiffData({
         workingDir: workingDirRef.current,
         scope: diffScopeRef.current,
         mode: "full",
+        replayIfInFlight: true,
       });
     },
     [loadData, shouldBlockDiffLoading],
@@ -755,6 +833,7 @@ export function useAgentStudioDiffData({
       diffScope,
       commitsAheadBehind: activeScopeState.commitsAheadBehind,
       upstreamAheadBehind: activeScopeState.upstreamAheadBehind,
+      upstreamStatus: activeScopeState.upstreamStatus,
       fileDiffs: activeScopeState.fileDiffs,
       fileStatuses: activeScopeState.fileStatuses,
       statusSnapshotKey,

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   createAgentSessionFixture,
   createHookHarness as createSharedHookHarness,
@@ -138,6 +138,10 @@ beforeAll(async () => {
   ({ useAgentStudioDocuments } = await import("./use-agent-studio-documents"));
 });
 
+afterAll(() => {
+  mock.restore();
+});
+
 beforeEach(() => {
   setTaskDocumentsState();
   taskDocumentsHookCalls.length = 0;
@@ -180,6 +184,44 @@ describe("useAgentStudioDocuments", () => {
           updatedAt: "2026-02-22T08:30:00.000Z",
         }),
       });
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(6);
+      expect(reloadDocumentMock).toHaveBeenNthCalledWith(4, "spec");
+      expect(reloadDocumentMock).toHaveBeenNthCalledWith(5, "plan");
+      expect(reloadDocumentMock).toHaveBeenNthCalledWith(6, "qa");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("reloads documents when document summary timestamps change without task updatedAt changing", async () => {
+    const baseArgs = createBaseArgs();
+    const harness = createHookHarness(baseArgs);
+
+    try {
+      await harness.mount();
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(3);
+
+      await harness.update({
+        ...baseArgs,
+        selectedTask: createTaskCardFixture({
+          id: "task-1",
+          updatedAt: baseArgs.selectedTask?.updatedAt ?? "2026-02-22T08:00:00.000Z",
+          documentSummary: {
+            spec: {
+              has: true,
+              updatedAt: "2026-02-22T08:45:00.000Z",
+            },
+            plan: {
+              has: false,
+            },
+            qaReport: {
+              has: false,
+              verdict: "not_reviewed",
+            },
+          },
+        }),
+      });
+
       expect(reloadDocumentMock).toHaveBeenCalledTimes(6);
       expect(reloadDocumentMock).toHaveBeenNthCalledWith(4, "spec");
       expect(reloadDocumentMock).toHaveBeenNthCalledWith(5, "plan");
@@ -281,6 +323,45 @@ describe("useAgentStudioDocuments", () => {
       expect(applyDocumentUpdateMock).not.toHaveBeenCalled();
       expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
       expect(reloadDocumentMock).toHaveBeenCalledWith("plan");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("reuses optimistic update when completion timestamp is unavailable", async () => {
+    setTaskDocumentsState({
+      planDoc: createDocumentState({
+        markdown: "",
+        updatedAt: null,
+        isLoading: false,
+      }),
+    });
+
+    const activeSession = createAgentSessionFixture({
+      sessionId: "session-3",
+      messages: [
+        createCompletedToolMessage({
+          tool: "odt_set_plan",
+          input: { markdown: "# Saved plan" },
+          output: "done",
+        }),
+      ],
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      selectedTask: null,
+      activeSession,
+    });
+
+    try {
+      await harness.mount();
+      expect(applyDocumentUpdateMock).toHaveBeenCalledTimes(1);
+      expect(applyDocumentUpdateMock).toHaveBeenCalledWith("plan", {
+        markdown: "# Saved plan",
+        updatedAt: expect.any(String),
+      });
+      expect(reloadDocumentMock).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
@@ -29,11 +29,27 @@ export function useAgentStudioDocuments({
   const processedDocumentToolEventsRef = useRef(new Set<string>());
   const documentReloadAttemptsRef = useRef(new Map<string, number>());
   const refreshedTaskVersionsRef = useRef(new Set<string>());
+  const taskDocumentVersionKey =
+    taskId && selectedTask
+      ? [
+          activeRepo ?? "",
+          taskId,
+          selectedTask.updatedAt,
+          selectedTask.documentSummary.spec.has ? "1" : "0",
+          selectedTask.documentSummary.spec.updatedAt ?? "",
+          selectedTask.documentSummary.plan.has ? "1" : "0",
+          selectedTask.documentSummary.plan.updatedAt ?? "",
+          selectedTask.documentSummary.qaReport.has ? "1" : "0",
+          selectedTask.documentSummary.qaReport.updatedAt ?? "",
+          selectedTask.documentSummary.qaReport.verdict ?? "",
+        ].join(":")
+      : null;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Context key intentionally controls reset boundary.
   useEffect(() => {
     processedDocumentToolEventsRef.current.clear();
     documentReloadAttemptsRef.current.clear();
+    refreshedTaskVersionsRef.current.clear();
   }, [documentContextKey]);
 
   useEffect(() => {
@@ -46,20 +62,19 @@ export function useAgentStudioDocuments({
   }, [ensureDocumentLoaded, taskId]);
 
   useEffect(() => {
-    if (!taskId || !selectedTask) {
+    if (!taskId || taskDocumentVersionKey === null) {
       return;
     }
 
-    const taskVersionKey = `${activeRepo ?? ""}:${taskId}:${selectedTask.updatedAt}`;
-    if (refreshedTaskVersionsRef.current.has(taskVersionKey)) {
+    if (refreshedTaskVersionsRef.current.has(taskDocumentVersionKey)) {
       return;
     }
 
-    refreshedTaskVersionsRef.current.add(taskVersionKey);
-    reloadDocument("spec");
-    reloadDocument("plan");
-    reloadDocument("qa");
-  }, [activeRepo, reloadDocument, selectedTask, taskId]);
+    const accepted = [reloadDocument("spec"), reloadDocument("plan"), reloadDocument("qa")];
+    if (accepted.every(Boolean)) {
+      refreshedTaskVersionsRef.current.add(taskDocumentVersionKey);
+    }
+  }, [reloadDocument, taskDocumentVersionKey, taskId]);
 
   useEffect(() => {
     if (!activeSession || !taskId) {
@@ -100,9 +115,10 @@ export function useAgentStudioDocuments({
           ? (meta.input as Record<string, unknown>)
           : null;
       const inputMarkdown = toolInput?.[target.inputKey];
+      const hasInputMarkdown = typeof inputMarkdown === "string" && inputMarkdown.trim().length > 0;
 
       let effectiveUpdatedAtTimestamp = parseTimestamp(target.state.updatedAt);
-      if (typeof inputMarkdown === "string" && inputMarkdown.trim().length > 0) {
+      if (hasInputMarkdown) {
         const shouldApplyOptimisticDocument =
           target.state.markdown.trim() !== inputMarkdown.trim() ||
           (completionInfo !== null &&
@@ -122,6 +138,12 @@ export function useAgentStudioDocuments({
         effectiveUpdatedAtTimestamp !== null &&
         effectiveUpdatedAtTimestamp >= completionInfo.timestamp
       ) {
+        processedDocumentToolEventsRef.current.add(eventKey);
+        documentReloadAttemptsRef.current.delete(eventKey);
+        continue;
+      }
+
+      if (hasInputMarkdown) {
         processedDocumentToolEventsRef.current.add(eventKey);
         documentReloadAttemptsRef.current.delete(eventKey);
         continue;

--- a/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
@@ -62,11 +62,14 @@ const documentsModel = {
 };
 
 const diffModel: AgentStudioGitPanelModel = {
+  contextMode: "worktree",
   branch: "feature/task-12",
   worktreePath: "/tmp/worktree/task-12",
   targetBranch: "origin/main",
   diffScope: "target",
   commitsAheadBehind: null,
+  upstreamAheadBehind: null,
+  upstreamStatus: "tracking",
   fileDiffs: [],
   fileStatuses: [],
   uncommittedFileCount: 0,

--- a/apps/desktop/src/pages/agents/use-agent-studio-worktree-resolution.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-worktree-resolution.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { errorMessage } from "@/lib/errors";
 import { host } from "@/state/operations/host";
 
@@ -28,6 +28,7 @@ type UseAgentStudioWorktreeResolutionInput = {
   repoPath: string | null;
   sessionWorkingDirectory: string | null;
   sessionRunId: string | null;
+  runCompletionRecoverySignal?: number;
 };
 
 type WorktreeResolutionResult = {
@@ -78,11 +79,15 @@ export function useAgentStudioWorktreeResolution({
   repoPath,
   sessionWorkingDirectory,
   sessionRunId,
+  runCompletionRecoverySignal,
 }: UseAgentStudioWorktreeResolutionInput): WorktreeResolutionResult {
   const [worktreeResolutionState, setWorktreeResolutionState] = useState<WorktreeResolutionState>(
     IDLE_WORKTREE_RESOLUTION_STATE,
   );
   const [worktreeResolutionRetryToken, setWorktreeResolutionRetryToken] = useState(0);
+  const lastHandledRunCompletionRecoverySignalRef = useRef<number | null>(null);
+  const pendingRunCompletionRecoverySignalRef = useRef<number | null>(null);
+  const lastRunCompletionRecoveryContextKeyRef = useRef<string | null>(null);
 
   const directWorktreePath =
     sessionWorkingDirectory && sessionWorkingDirectory !== repoPath
@@ -124,9 +129,80 @@ export function useAgentStudioWorktreeResolution({
     worktreeResolutionRepoPath != null && worktreeResolutionRunId != null
       ? `${worktreeResolutionRepoPath}::${worktreeResolutionRunId}::${worktreeResolutionRetryToken}`
       : null;
+  const worktreeResolutionContextKey =
+    worktreeResolutionRepoPath != null && worktreeResolutionRunId != null
+      ? `${worktreeResolutionRepoPath}::${worktreeResolutionRunId}`
+      : null;
   const retryWorktreeResolution = useCallback((): void => {
     setWorktreeResolutionRetryToken((previous) => previous + 1);
   }, []);
+
+  useEffect(() => {
+    if (lastRunCompletionRecoveryContextKeyRef.current !== worktreeResolutionContextKey) {
+      lastRunCompletionRecoveryContextKeyRef.current = worktreeResolutionContextKey;
+      lastHandledRunCompletionRecoverySignalRef.current = null;
+      pendingRunCompletionRecoverySignalRef.current = null;
+    }
+
+    if (runCompletionRecoverySignal == null) {
+      lastHandledRunCompletionRecoverySignalRef.current = null;
+      pendingRunCompletionRecoverySignalRef.current = null;
+      return;
+    }
+
+    const pendingSignal = pendingRunCompletionRecoverySignalRef.current;
+    if (pendingSignal != null && !isWorktreeResolutionResolving) {
+      pendingRunCompletionRecoverySignalRef.current = null;
+      lastHandledRunCompletionRecoverySignalRef.current = pendingSignal;
+
+      if (
+        worktreeResolutionRepoPath == null ||
+        worktreeResolutionRunId == null ||
+        hasResolvedWorktreeForCurrentContext
+      ) {
+        return;
+      }
+
+      setWorktreeResolutionRetryToken((previous) => previous + 1);
+      return;
+    }
+
+    if (lastHandledRunCompletionRecoverySignalRef.current === null) {
+      lastHandledRunCompletionRecoverySignalRef.current = runCompletionRecoverySignal;
+      return;
+    }
+
+    if (
+      runCompletionRecoverySignal === lastHandledRunCompletionRecoverySignalRef.current ||
+      runCompletionRecoverySignal === pendingRunCompletionRecoverySignalRef.current
+    ) {
+      return;
+    }
+
+    if (
+      worktreeResolutionRepoPath == null ||
+      worktreeResolutionRunId == null ||
+      hasResolvedWorktreeForCurrentContext
+    ) {
+      lastHandledRunCompletionRecoverySignalRef.current = runCompletionRecoverySignal;
+      return;
+    }
+
+    if (isWorktreeResolutionResolving) {
+      pendingRunCompletionRecoverySignalRef.current = runCompletionRecoverySignal;
+      return;
+    }
+
+    lastHandledRunCompletionRecoverySignalRef.current = runCompletionRecoverySignal;
+    setWorktreeResolutionRetryToken((previous) => previous + 1);
+  }, [
+    hasResolvedWorktreeForCurrentContext,
+    isWorktreeResolutionResolving,
+    runCompletionRecoverySignal,
+    worktreeResolutionContextKey,
+    worktreeResolutionRepoPath,
+    worktreeResolutionRunId,
+  ]);
 
   useEffect(() => {
     if (!worktreeResolutionRequestKey || !worktreeResolutionRepoPath || !worktreeResolutionRunId) {

--- a/apps/desktop/src/state/app-state-contexts.ts
+++ b/apps/desktop/src/state/app-state-contexts.ts
@@ -60,8 +60,16 @@ export type WorkspaceOperationsContextValue = {
   clearBranchData: () => void;
 };
 
+export type RunCompletionSignal = {
+  runId: string;
+  eventType: RunEvent["type"];
+  version: number;
+};
+
 export type DelegationEventsContextValue = {
   setEvents: Dispatch<SetStateAction<RunEvent[]>>;
+  runCompletionSignal: RunCompletionSignal | null;
+  setRunCompletionSignal: (runId: string, eventType: RunEvent["type"]) => void;
 };
 
 export const ActiveRepoContext = createContext<ActiveRepoContextValue | null>(null);

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -10,6 +10,7 @@ import { prependRunEvent, shouldLoadChecks } from "./app-lifecycle-model";
 type UseAppLifecycleArgs = {
   activeRepo: string | null;
   setEvents: Dispatch<SetStateAction<RunEvent[]>>;
+  setRunCompletionSignal: (runId: string, eventType: RunEvent["type"]) => void;
   refreshWorkspaces: () => Promise<void>;
   refreshBranches: (force?: boolean) => Promise<void>;
   refreshRuntimeCheck: (force?: boolean) => Promise<unknown>;
@@ -39,6 +40,7 @@ type UseAppLifecycleArgs = {
 export function useAppLifecycle({
   activeRepo,
   setEvents,
+  setRunCompletionSignal,
   refreshWorkspaces,
   refreshBranches,
   refreshRuntimeCheck,
@@ -82,6 +84,13 @@ export function useAppLifecycle({
       }
 
       setEvents((current) => prependRunEvent(current, parsed.data));
+      if (
+        parsed.data.type === "run_finished" ||
+        parsed.data.type === "ready_for_manual_done_confirmation" ||
+        parsed.data.type === "error"
+      ) {
+        setRunCompletionSignal(parsed.data.runId, parsed.data.type);
+      }
     })
       .then((cleanup) => {
         unsubscribe = cleanup;
@@ -95,7 +104,7 @@ export function useAppLifecycle({
     return () => {
       unsubscribe?.();
     };
-  }, [refreshRuntimeCheck, refreshWorkspaces, setEvents]);
+  }, [refreshRuntimeCheck, refreshWorkspaces, setEvents, setRunCompletionSignal]);
 
   useEffect(() => {
     if (!activeRepo) {

--- a/apps/desktop/src/state/operations/permission-policy.ts
+++ b/apps/desktop/src/state/operations/permission-policy.ts
@@ -82,7 +82,10 @@ const isReadOnlyShellSegment = (value: string): boolean => {
   return SAFE_READ_SHELL_PATTERNS.some((pattern) => pattern.test(segment));
 };
 
-const isReadOnlyShellCommand = (command: string): boolean => {
+export const isSafeReadToolName = (toolName: string): boolean =>
+  SAFE_READ_TOOL_NAMES.has(toolName.trim().toLowerCase());
+
+export const isReadOnlyShellCommand = (command: string): boolean => {
   const normalized = command.trim().toLowerCase();
   if (normalized.length === 0) {
     return false;

--- a/apps/desktop/src/state/operations/use-workspace-operations.ts
+++ b/apps/desktop/src/state/operations/use-workspace-operations.ts
@@ -60,6 +60,7 @@ export function useWorkspaceOperations({
   const lastProbeErrorSignatureRef = useRef<string | null>(null);
   const lastKnownBranchNameRef = useRef<string | null>(null);
   const lastKnownDetachedRef = useRef<boolean | null>(null);
+  const lastKnownRevisionRef = useRef<string | null>(null);
   const activeRepoRef = useRef(activeRepo);
   const previousActiveRepoRef = useRef(activeRepo);
   const probeGatesRef = useRef({
@@ -78,6 +79,7 @@ export function useWorkspaceOperations({
       setBranches(allBranches);
       lastKnownBranchNameRef.current = current.name ?? null;
       lastKnownDetachedRef.current = current.detached;
+      lastKnownRevisionRef.current = current.revision ?? null;
       setBranchSyncDegraded(false);
     },
     [],
@@ -90,6 +92,7 @@ export function useWorkspaceOperations({
     lastProbeErrorSignatureRef.current = null;
     lastKnownBranchNameRef.current = null;
     lastKnownDetachedRef.current = null;
+    lastKnownRevisionRef.current = null;
     setBranches([]);
     setActiveBranch(null);
     setBranchSyncDegraded(false);
@@ -191,6 +194,7 @@ export function useWorkspaceOperations({
         setActiveBranch(previousBranch);
         lastKnownBranchNameRef.current = previousBranch?.name ?? null;
         lastKnownDetachedRef.current = previousBranch?.detached ?? null;
+        lastKnownRevisionRef.current = previousBranch?.revision ?? null;
 
         toast.error("Failed to switch branch", {
           description: errorMessage(error),
@@ -267,6 +271,7 @@ export function useWorkspaceOperations({
         current,
         lastKnownBranchNameRef.current,
         lastKnownDetachedRef.current,
+        lastKnownRevisionRef.current,
       );
 
       if (hasChanged) {

--- a/apps/desktop/src/state/operations/workspace-operations-model.test.ts
+++ b/apps/desktop/src/state/operations/workspace-operations-model.test.ts
@@ -12,9 +12,14 @@ import {
   shouldSkipBranchSwitch,
 } from "./workspace-operations-model";
 
-const branch = (name: string | undefined, detached = false): GitCurrentBranch => ({
+const branch = (
+  name: string | undefined,
+  detached = false,
+  revision?: string,
+): GitCurrentBranch => ({
   name,
   detached,
+  revision,
 });
 
 describe("workspace-operations-model", () => {
@@ -45,9 +50,12 @@ describe("workspace-operations-model", () => {
   });
 
   test("detects branch identity changes", () => {
-    expect(hasBranchIdentityChanged(branch("main", false), "main", false)).toBe(false);
-    expect(hasBranchIdentityChanged(branch("feature", false), "main", false)).toBe(true);
-    expect(hasBranchIdentityChanged(branch(undefined, true), null, false)).toBe(true);
+    expect(hasBranchIdentityChanged(branch("main", false), "main", false, null)).toBe(false);
+    expect(hasBranchIdentityChanged(branch("feature", false), "main", false, null)).toBe(true);
+    expect(hasBranchIdentityChanged(branch(undefined, true), null, false, null)).toBe(true);
+    expect(hasBranchIdentityChanged(branch(undefined, true, "abc123"), null, true, null)).toBe(
+      true,
+    );
   });
 
   test("skips no-op branch switch when already attached", () => {

--- a/apps/desktop/src/state/operations/workspace-operations-model.ts
+++ b/apps/desktop/src/state/operations/workspace-operations-model.ts
@@ -64,7 +64,11 @@ export const hasBranchIdentityChanged = (
   current: GitCurrentBranch,
   lastKnownName: string | null,
   lastKnownDetached: boolean | null,
-): boolean => (current.name ?? null) !== lastKnownName || current.detached !== lastKnownDetached;
+  lastKnownRevision: string | null,
+): boolean =>
+  (current.name ?? null) !== lastKnownName ||
+  current.detached !== lastKnownDetached ||
+  (current.revision ?? null) !== lastKnownRevision;
 
 export const shouldSkipBranchSwitch = (
   activeBranch: GitCurrentBranch | null,

--- a/apps/desktop/src/state/providers/app-lifecycle-state-provider.tsx
+++ b/apps/desktop/src/state/providers/app-lifecycle-state-provider.tsx
@@ -23,11 +23,12 @@ export function AppLifecycleStateProvider({ children }: PropsWithChildren): Reac
     hasCachedRepoOpencodeHealth,
   } = useChecksOperationsContext();
   const { refreshTaskData, clearTaskData, setIsLoadingTasks } = useTaskControlContext();
-  const { setEvents } = useDelegationEventsContext();
+  const { setEvents, setRunCompletionSignal } = useDelegationEventsContext();
 
   useAppLifecycle({
     activeRepo,
     setEvents,
+    setRunCompletionSignal,
     refreshWorkspaces,
     refreshBranches,
     refreshRuntimeCheck,

--- a/apps/desktop/src/state/providers/delegation-state-provider.tsx
+++ b/apps/desktop/src/state/providers/delegation-state-provider.tsx
@@ -1,10 +1,11 @@
 import type { RunEvent } from "@openducktor/contracts";
-import { type PropsWithChildren, type ReactElement, useMemo, useState } from "react";
+import { type PropsWithChildren, type ReactElement, useCallback, useMemo, useState } from "react";
 import { buildDelegationStateValue } from "../app-state-context-values";
 import {
   DelegationEventsContext,
   type DelegationEventsContextValue,
   DelegationStateContext,
+  type RunCompletionSignal,
   useActiveRepoContext,
   useTaskControlContext,
 } from "../app-state-contexts";
@@ -14,6 +15,17 @@ export function DelegationStateProvider({ children }: PropsWithChildren): ReactE
   const { activeRepo } = useActiveRepoContext();
   const { refreshTaskData } = useTaskControlContext();
   const [events, setEvents] = useState<RunEvent[]>([]);
+  const [runCompletionSignal, setRunCompletionSignalState] = useState<RunCompletionSignal | null>(
+    null,
+  );
+  const setRunCompletionSignal = useCallback((runId: string, eventType: RunEvent["type"]) => {
+    setRunCompletionSignalState((previousRunCompletionSignal) => ({
+      runId,
+      eventType,
+      version: (previousRunCompletionSignal?.version ?? 0) + 1,
+    }));
+  }, []);
+
   const { delegateTask, delegateRespond, delegateStop, delegateCleanup } = useDelegationOperations({
     activeRepo,
     refreshTaskData,
@@ -34,8 +46,10 @@ export function DelegationStateProvider({ children }: PropsWithChildren): ReactE
   const delegationEventsValue = useMemo<DelegationEventsContextValue>(
     () => ({
       setEvents,
+      runCompletionSignal,
+      setRunCompletionSignal,
     }),
-    [],
+    [runCompletionSignal, setRunCompletionSignal],
   );
 
   return (

--- a/packages/contracts/src/git-schemas.ts
+++ b/packages/contracts/src/git-schemas.ts
@@ -18,6 +18,7 @@ export type GitBranch = z.infer<typeof gitBranchSchema>;
 export const gitCurrentBranchSchema = z.object({
   name: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
   detached: z.boolean(),
+  revision: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
 });
 export type GitCurrentBranch = z.infer<typeof gitCurrentBranchSchema>;
 


### PR DESCRIPTION
## Summary
- base Builder worktrees on the configured target branch and restore document/worktree refresh behavior during agent updates
- split the Agent Studio git panel into repository/worktree semantics, compare repository mode against upstream, and keep branch/compare state synchronized with sidebar branch switches
- disable session creation from the header while a session is starting without adding another inline loader

## Testing
- bun run --filter @openducktor/desktop test && bun run --filter @openducktor/desktop typecheck
- cargo test -p host-application
- cargo test -p host-infra-system
- bun run lint && bun run build
