### PR TITLE
refactor(desktop): extract and harden agent studio diff controller

### DIFF
--- a/apps/desktop/src/pages/agents/agent-studio-diff-data-model.test.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-diff-data-model.test.ts
@@ -55,7 +55,8 @@ describe("agent-studio-diff-data-model", () => {
       createScopeSummaryFields({ diffHash: "diff-2" }),
     );
 
-    expect(decision.hashesChanged).toBe(true);
+    expect(decision.sharedHashesChanged).toBe(false);
+    expect(decision.scopeHashesChanged).toBe(true);
     expect(decision.shouldReloadFullScope).toBe(false);
   });
 
@@ -70,8 +71,50 @@ describe("agent-studio-diff-data-model", () => {
       createScopeSummaryFields({ statusHash: "status-2" }),
     );
 
-    expect(decision.hashesChanged).toBe(true);
+    expect(decision.sharedHashesChanged).toBe(true);
+    expect(decision.scopeHashesChanged).toBe(true);
     expect(decision.shouldReloadFullScope).toBe(true);
+  });
+
+  test("does not invalidate the inactive scope when only the active scope diff hash changes", () => {
+    const state = createInitialDiffBatchState();
+    state.byScope.target = createScopeSnapshot();
+    state.byScope.uncommitted = createScopeSnapshot({
+      fileDiffs: [
+        {
+          file: "src/worktree.ts",
+          type: "modified",
+          additions: 2,
+          deletions: 0,
+          diff: "@@ -1 +1,2 @@",
+        },
+      ],
+      diffHash: "worktree-diff-1",
+    });
+    state.loadedByScope.target = true;
+    state.loadedByScope.uncommitted = true;
+
+    const { nextState, shouldReloadFullScope } = applySummarySnapshot({
+      state,
+      scope: "target",
+      summaryFields: createScopeSummaryFields({
+        diffHash: "diff-2",
+      }),
+      requestSequence: 2,
+      latestSharedSequence: 1,
+    });
+
+    expect(shouldReloadFullScope).toBe(true);
+    expect(nextState.loadedByScope.uncommitted).toBe(true);
+    expect(nextState.byScope.uncommitted.fileDiffs).toEqual([
+      {
+        file: "src/worktree.ts",
+        type: "modified",
+        additions: 2,
+        deletions: 0,
+        diff: "@@ -1 +1,2 @@",
+      },
+    ]);
   });
 
   test("invalidates the inactive scope cache when summary hashes change", () => {
@@ -107,6 +150,7 @@ describe("agent-studio-diff-data-model", () => {
     expect(shouldReloadFullScope).toBe(true);
     expect(nextState.loadedByScope.uncommitted).toBe(false);
     expect(nextState.byScope.uncommitted.fileDiffs).toEqual([]);
+    expect(nextState.byScope.uncommitted.diffHash).toBeNull();
     expect(nextState.byScope.uncommitted.branch).toBe("feature/task-11");
   });
 });

--- a/apps/desktop/src/pages/agents/agent-studio-diff-data-model.test.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-diff-data-model.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import type { ScopeSnapshot, ScopeSummaryFields } from "./agent-studio-diff-data-model";
+import {
+  applySummarySnapshot,
+  createInitialDiffBatchState,
+  getSummaryReloadDecision,
+} from "./agent-studio-diff-data-model";
+
+const createScopeSnapshot = (overrides: Partial<ScopeSnapshot> = {}): ScopeSnapshot => ({
+  branch: "feature/task-10",
+  fileDiffs: [
+    {
+      file: "src/main.ts",
+      type: "modified",
+      additions: 1,
+      deletions: 0,
+      diff: "@@ -1 +1 @@",
+    },
+  ],
+  fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+  uncommittedFileCount: 1,
+  commitsAheadBehind: { ahead: 0, behind: 0 },
+  upstreamAheadBehind: { ahead: 1, behind: 0 },
+  upstreamStatus: "tracking",
+  error: null,
+  hashVersion: 1,
+  statusHash: "status-1",
+  diffHash: "diff-1",
+  ...overrides,
+});
+
+const createScopeSummaryFields = (
+  overrides: Partial<ScopeSummaryFields> = {},
+): ScopeSummaryFields => ({
+  branch: "feature/task-10",
+  uncommittedFileCount: 1,
+  commitsAheadBehind: { ahead: 0, behind: 0 },
+  upstreamAheadBehind: { ahead: 1, behind: 0 },
+  upstreamStatus: "tracking",
+  error: null,
+  hashVersion: 1,
+  statusHash: "status-1",
+  diffHash: "diff-1",
+  ...overrides,
+});
+
+describe("agent-studio-diff-data-model", () => {
+  test("does not request a full reload when the active scope is not loaded", () => {
+    const state = createInitialDiffBatchState();
+    state.byScope.target = createScopeSnapshot();
+
+    const decision = getSummaryReloadDecision(
+      state,
+      "target",
+      createScopeSummaryFields({ diffHash: "diff-2" }),
+    );
+
+    expect(decision.hashesChanged).toBe(true);
+    expect(decision.shouldReloadFullScope).toBe(false);
+  });
+
+  test("requests a full reload when the loaded active scope hash changes", () => {
+    const state = createInitialDiffBatchState();
+    state.byScope.target = createScopeSnapshot();
+    state.loadedByScope.target = true;
+
+    const decision = getSummaryReloadDecision(
+      state,
+      "target",
+      createScopeSummaryFields({ statusHash: "status-2" }),
+    );
+
+    expect(decision.hashesChanged).toBe(true);
+    expect(decision.shouldReloadFullScope).toBe(true);
+  });
+
+  test("invalidates the inactive scope cache when summary hashes change", () => {
+    const state = createInitialDiffBatchState();
+    state.byScope.target = createScopeSnapshot();
+    state.byScope.uncommitted = createScopeSnapshot({
+      fileDiffs: [
+        {
+          file: "src/worktree.ts",
+          type: "modified",
+          additions: 2,
+          deletions: 0,
+          diff: "@@ -1 +1,2 @@",
+        },
+      ],
+      diffHash: "worktree-diff-1",
+    });
+    state.loadedByScope.target = true;
+    state.loadedByScope.uncommitted = true;
+
+    const { nextState, shouldReloadFullScope } = applySummarySnapshot({
+      state,
+      scope: "target",
+      summaryFields: createScopeSummaryFields({
+        branch: "feature/task-11",
+        statusHash: "status-2",
+        diffHash: "diff-2",
+      }),
+      requestSequence: 2,
+      latestSharedSequence: 1,
+    });
+
+    expect(shouldReloadFullScope).toBe(true);
+    expect(nextState.loadedByScope.uncommitted).toBe(false);
+    expect(nextState.byScope.uncommitted.fileDiffs).toEqual([]);
+    expect(nextState.byScope.uncommitted.branch).toBe("feature/task-11");
+  });
+});

--- a/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
@@ -73,6 +73,11 @@ export type ScopeSummaryFields = Pick<
   | "diffHash"
 >;
 
+export type SummaryReloadDecision = {
+  hashesChanged: boolean;
+  shouldReloadFullScope: boolean;
+};
+
 export const EMPTY_DIFFS: FileDiff[] = [];
 export const EMPTY_STATUSES: FileStatus[] = [];
 
@@ -321,12 +326,12 @@ export const applySummarySnapshot = ({
   nextLatestSharedSequence: number;
   shouldReloadFullScope: boolean;
 } => {
+  const { hashesChanged, shouldReloadFullScope } = getSummaryReloadDecision(
+    state,
+    scope,
+    summaryFields,
+  );
   const previousSummarySnapshot = state.byScope[scope];
-  const hashesChanged =
-    previousSummarySnapshot.hashVersion !== summaryFields.hashVersion ||
-    previousSummarySnapshot.statusHash !== summaryFields.statusHash ||
-    previousSummarySnapshot.diffHash !== summaryFields.diffHash;
-  const shouldReloadFullScope = state.loadedByScope[scope] && hashesChanged;
 
   let didChange = false;
   const nextByScope: Record<DiffScope, ScopeSnapshot> = {
@@ -388,6 +393,23 @@ export const applySummarySnapshot = ({
     nextState: finalizeCompletedState(state, nextByScope, nextLoadedByScope, didChange),
     nextLatestSharedSequence,
     shouldReloadFullScope,
+  };
+};
+
+export const getSummaryReloadDecision = (
+  state: DiffBatchState,
+  scope: DiffScope,
+  summaryFields: ScopeSummaryFields,
+): SummaryReloadDecision => {
+  const previousSummarySnapshot = state.byScope[scope];
+  const hashesChanged =
+    previousSummarySnapshot.hashVersion !== summaryFields.hashVersion ||
+    previousSummarySnapshot.statusHash !== summaryFields.statusHash ||
+    previousSummarySnapshot.diffHash !== summaryFields.diffHash;
+
+  return {
+    hashesChanged,
+    shouldReloadFullScope: state.loadedByScope[scope] && hashesChanged,
   };
 };
 

--- a/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
@@ -74,7 +74,8 @@ export type ScopeSummaryFields = Pick<
 >;
 
 export type SummaryReloadDecision = {
-  hashesChanged: boolean;
+  sharedHashesChanged: boolean;
+  scopeHashesChanged: boolean;
   shouldReloadFullScope: boolean;
 };
 
@@ -326,7 +327,7 @@ export const applySummarySnapshot = ({
   nextLatestSharedSequence: number;
   shouldReloadFullScope: boolean;
 } => {
-  const { hashesChanged, shouldReloadFullScope } = getSummaryReloadDecision(
+  const { sharedHashesChanged, shouldReloadFullScope } = getSummaryReloadDecision(
     state,
     scope,
     summaryFields,
@@ -368,10 +369,11 @@ export const applySummarySnapshot = ({
         didChange = true;
       }
 
-      if (hashesChanged && state.loadedByScope[otherScope]) {
+      if (sharedHashesChanged && state.loadedByScope[otherScope]) {
         const invalidatedOtherScopeSnapshot: ScopeSnapshot = {
           ...nextByScope[otherScope],
           fileDiffs: EMPTY_DIFFS,
+          diffHash: null,
         };
         if (!scopeSnapshotEqual(nextByScope[otherScope], invalidatedOtherScopeSnapshot)) {
           nextByScope[otherScope] = invalidatedOtherScopeSnapshot;
@@ -402,14 +404,16 @@ export const getSummaryReloadDecision = (
   summaryFields: ScopeSummaryFields,
 ): SummaryReloadDecision => {
   const previousSummarySnapshot = state.byScope[scope];
-  const hashesChanged =
+  const sharedHashesChanged =
     previousSummarySnapshot.hashVersion !== summaryFields.hashVersion ||
-    previousSummarySnapshot.statusHash !== summaryFields.statusHash ||
-    previousSummarySnapshot.diffHash !== summaryFields.diffHash;
+    previousSummarySnapshot.statusHash !== summaryFields.statusHash;
+  const scopeHashesChanged =
+    sharedHashesChanged || previousSummarySnapshot.diffHash !== summaryFields.diffHash;
 
   return {
-    hashesChanged,
-    shouldReloadFullScope: state.loadedByScope[scope] && hashesChanged,
+    sharedHashesChanged,
+    scopeHashesChanged,
+    shouldReloadFullScope: state.loadedByScope[scope] && scopeHashesChanged,
   };
 };
 

--- a/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
@@ -1,0 +1,509 @@
+import type {
+  CommitsAheadBehind,
+  FileDiff,
+  FileStatus,
+  GitWorktreeStatus,
+  GitWorktreeStatusSummary,
+} from "@openducktor/contracts";
+
+export type DiffDataState = {
+  branch: string | null;
+  worktreePath: string | null;
+  targetBranch: string;
+  diffScope: DiffScope;
+  commitsAheadBehind: CommitsAheadBehind | null;
+  upstreamAheadBehind: CommitsAheadBehind | null;
+  upstreamStatus: "tracking" | "untracked" | "error";
+  fileDiffs: FileDiff[];
+  fileStatuses: FileStatus[];
+  statusSnapshotKey?: string | null;
+  uncommittedFileCount: number;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+  selectedFile: string | null;
+  setSelectedFile: (path: string | null) => void;
+  setDiffScope: (scope: DiffScope) => void;
+};
+
+export type DiffScope = "target" | "uncommitted";
+
+export type UseAgentStudioDiffDataInput = {
+  repoPath: string | null;
+  sessionWorkingDirectory: string | null;
+  sessionRunId: string | null;
+  defaultTargetBranch: string;
+  branchIdentityKey?: string | null;
+  enablePolling: boolean;
+  runCompletionRecoverySignal?: number;
+};
+
+export type DiffBatchState = {
+  byScope: Record<DiffScope, ScopeSnapshot>;
+  loadedByScope: Record<DiffScope, boolean>;
+  isLoading: boolean;
+};
+
+export type ScopeSnapshot = {
+  branch: string | null;
+  fileDiffs: FileDiff[];
+  fileStatuses: FileStatus[];
+  uncommittedFileCount: number;
+  commitsAheadBehind: CommitsAheadBehind | null;
+  upstreamAheadBehind: CommitsAheadBehind | null;
+  upstreamStatus: "tracking" | "untracked" | "error";
+  error: string | null;
+  hashVersion: number | null;
+  statusHash: string | null;
+  diffHash: string | null;
+};
+
+export type LoadDataMode = "full" | "summary";
+
+export type ScopeSummaryFields = Pick<
+  ScopeSnapshot,
+  | "branch"
+  | "uncommittedFileCount"
+  | "commitsAheadBehind"
+  | "upstreamAheadBehind"
+  | "upstreamStatus"
+  | "error"
+  | "hashVersion"
+  | "statusHash"
+  | "diffHash"
+>;
+
+export const EMPTY_DIFFS: FileDiff[] = [];
+export const EMPTY_STATUSES: FileStatus[] = [];
+
+const EMPTY_SCOPE_SNAPSHOT: ScopeSnapshot = {
+  branch: null,
+  fileDiffs: EMPTY_DIFFS,
+  fileStatuses: EMPTY_STATUSES,
+  uncommittedFileCount: 0,
+  commitsAheadBehind: null,
+  upstreamAheadBehind: null,
+  upstreamStatus: "tracking",
+  error: null,
+  hashVersion: null,
+  statusHash: null,
+  diffHash: null,
+};
+
+export const ALL_SCOPES: DiffScope[] = ["target", "uncommitted"];
+export const ALL_LOAD_DATA_MODES: LoadDataMode[] = ["full", "summary"];
+
+export const createInitialDiffBatchState = (): DiffBatchState => ({
+  byScope: {
+    target: EMPTY_SCOPE_SNAPSHOT,
+    uncommitted: EMPTY_SCOPE_SNAPSHOT,
+  },
+  loadedByScope: {
+    target: false,
+    uncommitted: false,
+  },
+  isLoading: false,
+});
+
+const arraysEqual = <T>(a: T[], b: T[], areItemsEqual: (left: T, right: T) => boolean): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let index = 0; index < a.length; index += 1) {
+    const left = a[index];
+    const right = b[index];
+    if (left === undefined || right === undefined) {
+      return false;
+    }
+    if (!areItemsEqual(left, right)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const fileDiffEqual = (left: FileDiff, right: FileDiff): boolean =>
+  left.file === right.file &&
+  left.type === right.type &&
+  left.additions === right.additions &&
+  left.deletions === right.deletions &&
+  left.diff === right.diff;
+
+const fileStatusEqual = (left: FileStatus, right: FileStatus): boolean =>
+  left.path === right.path && left.status === right.status && left.staged === right.staged;
+
+const aheadBehindEqual = (
+  left: CommitsAheadBehind | null,
+  right: CommitsAheadBehind | null,
+): boolean => {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+  return left.ahead === right.ahead && left.behind === right.behind;
+};
+
+const hashMetadataEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean =>
+  left.hashVersion === right.hashVersion &&
+  left.statusHash === right.statusHash &&
+  left.diffHash === right.diffHash;
+
+export const scopeSnapshotEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean => {
+  const canUseHashShortCircuit =
+    left.hashVersion !== null &&
+    right.hashVersion !== null &&
+    left.hashVersion === right.hashVersion &&
+    left.statusHash !== null &&
+    right.statusHash !== null &&
+    left.diffHash !== null &&
+    right.diffHash !== null;
+
+  if (canUseHashShortCircuit) {
+    const hashesMatch = left.statusHash === right.statusHash && left.diffHash === right.diffHash;
+    const contentReferencesMatch =
+      left.fileDiffs === right.fileDiffs && left.fileStatuses === right.fileStatuses;
+    if (hashesMatch && left.error === right.error && contentReferencesMatch) {
+      return true;
+    }
+  }
+
+  return (
+    left.branch === right.branch &&
+    arraysEqual(left.fileDiffs, right.fileDiffs, fileDiffEqual) &&
+    arraysEqual(left.fileStatuses, right.fileStatuses, fileStatusEqual) &&
+    left.uncommittedFileCount === right.uncommittedFileCount &&
+    aheadBehindEqual(left.commitsAheadBehind, right.commitsAheadBehind) &&
+    aheadBehindEqual(left.upstreamAheadBehind, right.upstreamAheadBehind) &&
+    left.upstreamStatus === right.upstreamStatus &&
+    left.error === right.error &&
+    hashMetadataEqual(left, right)
+  );
+};
+
+const toUpstreamState = (
+  upstreamAheadBehind: GitWorktreeStatus["upstreamAheadBehind"],
+): {
+  upstreamAheadBehind: CommitsAheadBehind | null;
+  upstreamStatus: "tracking" | "untracked" | "error";
+  error: string | null;
+} => {
+  if (upstreamAheadBehind.outcome === "tracking") {
+    return {
+      upstreamAheadBehind: {
+        ahead: upstreamAheadBehind.ahead,
+        behind: upstreamAheadBehind.behind,
+      },
+      upstreamStatus: "tracking",
+      error: null,
+    };
+  }
+
+  if (upstreamAheadBehind.outcome === "untracked") {
+    return {
+      upstreamAheadBehind: {
+        ahead: upstreamAheadBehind.ahead,
+        behind: 0,
+      },
+      upstreamStatus: "untracked",
+      error: null,
+    };
+  }
+
+  return {
+    upstreamAheadBehind: null,
+    upstreamStatus: "error",
+    error: `Upstream status unavailable: ${upstreamAheadBehind.message}`,
+  };
+};
+
+export const toScopeSnapshot = (snapshot: GitWorktreeStatus): ScopeSnapshot => {
+  const { upstreamAheadBehind, upstreamStatus, error } = toUpstreamState(
+    snapshot.upstreamAheadBehind,
+  );
+  return {
+    branch: snapshot.currentBranch.name ?? null,
+    fileDiffs: snapshot.fileDiffs,
+    fileStatuses: snapshot.fileStatuses,
+    uncommittedFileCount: snapshot.fileStatuses.length,
+    commitsAheadBehind: snapshot.targetAheadBehind,
+    upstreamAheadBehind,
+    upstreamStatus,
+    error,
+    hashVersion: snapshot.snapshot.hashVersion,
+    statusHash: snapshot.snapshot.statusHash,
+    diffHash: snapshot.snapshot.diffHash,
+  };
+};
+
+export const toScopeSummaryFields = (summary: GitWorktreeStatusSummary): ScopeSummaryFields => {
+  const { upstreamAheadBehind, upstreamStatus, error } = toUpstreamState(
+    summary.upstreamAheadBehind,
+  );
+  return {
+    branch: summary.currentBranch.name ?? null,
+    uncommittedFileCount: summary.fileStatusCounts.total,
+    commitsAheadBehind: summary.targetAheadBehind,
+    upstreamAheadBehind,
+    upstreamStatus,
+    error,
+    hashVersion: summary.snapshot.hashVersion,
+    statusHash: summary.snapshot.statusHash,
+    diffHash: summary.snapshot.diffHash,
+  };
+};
+
+const mergeSharedSnapshotFields = (base: ScopeSnapshot, source: ScopeSnapshot): ScopeSnapshot => ({
+  ...base,
+  branch: source.branch,
+  fileStatuses: source.fileStatuses,
+  uncommittedFileCount: source.uncommittedFileCount,
+  commitsAheadBehind: source.commitsAheadBehind,
+  upstreamAheadBehind: source.upstreamAheadBehind,
+  upstreamStatus: source.upstreamStatus,
+  error: source.error,
+  hashVersion: source.hashVersion,
+  statusHash: source.statusHash,
+});
+
+const mergeSharedSummaryFields = (
+  base: ScopeSnapshot,
+  source: ScopeSummaryFields,
+): ScopeSnapshot => ({
+  ...base,
+  branch: source.branch,
+  uncommittedFileCount: source.uncommittedFileCount,
+  commitsAheadBehind: source.commitsAheadBehind,
+  upstreamAheadBehind: source.upstreamAheadBehind,
+  upstreamStatus: source.upstreamStatus,
+  error: source.error,
+  hashVersion: source.hashVersion,
+  statusHash: source.statusHash,
+});
+
+const finalizeCompletedState = (
+  previousState: DiffBatchState,
+  nextByScope: Record<DiffScope, ScopeSnapshot>,
+  nextLoadedByScope: Record<DiffScope, boolean>,
+  didChange: boolean,
+): DiffBatchState => {
+  if (!didChange && nextLoadedByScope === previousState.loadedByScope && !previousState.isLoading) {
+    return previousState;
+  }
+
+  return {
+    byScope: nextByScope,
+    loadedByScope: nextLoadedByScope,
+    isLoading: false,
+  };
+};
+
+export const applySummarySnapshot = ({
+  state,
+  scope,
+  summaryFields,
+  requestSequence,
+  latestSharedSequence,
+}: {
+  state: DiffBatchState;
+  scope: DiffScope;
+  summaryFields: ScopeSummaryFields;
+  requestSequence: number;
+  latestSharedSequence: number;
+}): {
+  nextState: DiffBatchState;
+  nextLatestSharedSequence: number;
+  shouldReloadFullScope: boolean;
+} => {
+  const previousSummarySnapshot = state.byScope[scope];
+  const hashesChanged =
+    previousSummarySnapshot.hashVersion !== summaryFields.hashVersion ||
+    previousSummarySnapshot.statusHash !== summaryFields.statusHash ||
+    previousSummarySnapshot.diffHash !== summaryFields.diffHash;
+  const shouldReloadFullScope = state.loadedByScope[scope] && hashesChanged;
+
+  let didChange = false;
+  const nextByScope: Record<DiffScope, ScopeSnapshot> = {
+    ...state.byScope,
+  };
+  const nextFetchedScopeSnapshot: ScopeSnapshot = {
+    ...previousSummarySnapshot,
+    ...summaryFields,
+  };
+
+  if (!scopeSnapshotEqual(previousSummarySnapshot, nextFetchedScopeSnapshot)) {
+    nextByScope[scope] = nextFetchedScopeSnapshot;
+    didChange = true;
+  }
+
+  let nextLoadedByScope = state.loadedByScope;
+  let nextLatestSharedSequence = latestSharedSequence;
+  if (requestSequence >= latestSharedSequence) {
+    nextLatestSharedSequence = requestSequence;
+
+    for (const otherScope of ALL_SCOPES) {
+      if (otherScope === scope) {
+        continue;
+      }
+
+      const previousOtherScopeSnapshot = nextByScope[otherScope];
+      const nextOtherScopeSnapshot = mergeSharedSummaryFields(
+        previousOtherScopeSnapshot,
+        summaryFields,
+      );
+
+      if (!scopeSnapshotEqual(previousOtherScopeSnapshot, nextOtherScopeSnapshot)) {
+        nextByScope[otherScope] = nextOtherScopeSnapshot;
+        didChange = true;
+      }
+
+      if (hashesChanged && state.loadedByScope[otherScope]) {
+        const invalidatedOtherScopeSnapshot: ScopeSnapshot = {
+          ...nextByScope[otherScope],
+          fileDiffs: EMPTY_DIFFS,
+        };
+        if (!scopeSnapshotEqual(nextByScope[otherScope], invalidatedOtherScopeSnapshot)) {
+          nextByScope[otherScope] = invalidatedOtherScopeSnapshot;
+          didChange = true;
+        }
+
+        if (nextLoadedByScope[otherScope]) {
+          nextLoadedByScope = {
+            ...nextLoadedByScope,
+            [otherScope]: false,
+          };
+          didChange = true;
+        }
+      }
+    }
+  }
+
+  return {
+    nextState: finalizeCompletedState(state, nextByScope, nextLoadedByScope, didChange),
+    nextLatestSharedSequence,
+    shouldReloadFullScope,
+  };
+};
+
+export const applyFullSnapshot = ({
+  state,
+  scope,
+  snapshot,
+  requestSequence,
+  latestSharedSequence,
+}: {
+  state: DiffBatchState;
+  scope: DiffScope;
+  snapshot: ScopeSnapshot;
+  requestSequence: number;
+  latestSharedSequence: number;
+}): {
+  nextState: DiffBatchState;
+  nextLatestSharedSequence: number;
+} => {
+  let didChange = false;
+  const nextByScope: Record<DiffScope, ScopeSnapshot> = {
+    ...state.byScope,
+  };
+  const previousFetchedScopeSnapshot = state.byScope[scope];
+
+  if (!scopeSnapshotEqual(previousFetchedScopeSnapshot, snapshot)) {
+    nextByScope[scope] = snapshot;
+    didChange = true;
+  }
+
+  let nextLoadedByScope = state.loadedByScope;
+  if (!state.loadedByScope[scope]) {
+    nextLoadedByScope = {
+      ...state.loadedByScope,
+      [scope]: true,
+    };
+    didChange = true;
+  }
+
+  let nextLatestSharedSequence = latestSharedSequence;
+  if (requestSequence >= latestSharedSequence) {
+    nextLatestSharedSequence = requestSequence;
+
+    for (const otherScope of ALL_SCOPES) {
+      if (otherScope === scope) {
+        continue;
+      }
+
+      const previousOtherScopeSnapshot = nextByScope[otherScope];
+      const nextOtherScopeSnapshot = mergeSharedSnapshotFields(
+        previousOtherScopeSnapshot,
+        snapshot,
+      );
+
+      if (!scopeSnapshotEqual(previousOtherScopeSnapshot, nextOtherScopeSnapshot)) {
+        nextByScope[otherScope] = nextOtherScopeSnapshot;
+        didChange = true;
+      }
+    }
+  }
+
+  return {
+    nextState: finalizeCompletedState(state, nextByScope, nextLoadedByScope, didChange),
+    nextLatestSharedSequence,
+  };
+};
+
+export const applyScopeError = ({
+  state,
+  scope,
+  mode,
+  error,
+}: {
+  state: DiffBatchState;
+  scope: DiffScope;
+  mode: LoadDataMode;
+  error: string;
+}): DiffBatchState => {
+  const previousScopeSnapshot = state.byScope[scope];
+  const nextScopeSnapshot: ScopeSnapshot = {
+    ...previousScopeSnapshot,
+    error,
+    hashVersion: null,
+    statusHash: null,
+    diffHash: null,
+  };
+
+  let nextLoadedByScope = state.loadedByScope;
+  if (mode === "full" && !state.loadedByScope[scope]) {
+    nextLoadedByScope = {
+      ...state.loadedByScope,
+      [scope]: true,
+    };
+  }
+
+  const snapshotsEqual = scopeSnapshotEqual(previousScopeSnapshot, nextScopeSnapshot);
+  if (snapshotsEqual && nextLoadedByScope === state.loadedByScope && !state.isLoading) {
+    return state;
+  }
+
+  return {
+    byScope: {
+      ...state.byScope,
+      [scope]: nextScopeSnapshot,
+    },
+    loadedByScope: nextLoadedByScope,
+    isLoading: false,
+  };
+};
+
+export const toStatusSnapshotKey = (snapshot: ScopeSnapshot): string | null => {
+  if (snapshot.fileStatuses.length === 0) {
+    return "<empty>";
+  }
+
+  return snapshot.fileStatuses
+    .map((fileStatus) => `${fileStatus.path}:${fileStatus.status}:${fileStatus.staged ? 1 : 0}`)
+    .join("|");
+};

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
@@ -9,7 +9,6 @@ import {
   createInitialDiffBatchState,
   type DiffBatchState,
   type DiffScope,
-  getSummaryReloadDecision,
   type LoadDataMode,
   type ScopeSnapshot,
   toScopeSnapshot,
@@ -38,6 +37,12 @@ type InFlightRequestContext = LoadRequestContext & {
   requestKey: string;
   requestSequence: number;
   version: number;
+};
+
+type DiffControllerState = {
+  batchState: DiffBatchState;
+  latestSharedSequence: number;
+  pendingFullReloads: LoadRequestContext[];
 };
 
 type UseAgentStudioDiffControllerArgs = {
@@ -75,6 +80,28 @@ const createQueuedReloadState = (): Record<DiffScope, boolean> => ({
   uncommitted: false,
 });
 
+const createInitialControllerState = (): DiffControllerState => ({
+  batchState: createInitialDiffBatchState(),
+  latestSharedSequence: 0,
+  pendingFullReloads: [],
+});
+
+const sameLoadRequestContext = (left: LoadRequestContext, right: LoadRequestContext): boolean =>
+  left.repoPath === right.repoPath &&
+  left.scope === right.scope &&
+  left.targetBranch === right.targetBranch &&
+  left.workingDir === right.workingDir;
+
+const enqueuePendingFullReload = (
+  queue: LoadRequestContext[],
+  nextLoadContext: LoadRequestContext,
+): LoadRequestContext[] => {
+  if (queue.some((loadContext) => sameLoadRequestContext(loadContext, nextLoadContext))) {
+    return queue;
+  }
+  return [...queue, nextLoadContext];
+};
+
 export function useAgentStudioDiffController({
   repoPath,
   targetBranch,
@@ -84,15 +111,13 @@ export function useAgentStudioDiffController({
   shouldBlockDiffLoading,
   onContextReset,
 }: UseAgentStudioDiffControllerArgs): UseAgentStudioDiffControllerResult {
-  const [state, setState] = useState<DiffBatchState>(createInitialDiffBatchState);
-  const stateRef = useRef(state);
-  stateRef.current = state;
-
+  const [controllerState, setControllerState] = useState<DiffControllerState>(
+    createInitialControllerState,
+  );
   const [diffScope, setDiffScope] = useState<DiffScope>("target");
 
   const versionByScopeAndModeRef = useRef(createVersionState());
   const requestSequenceRef = useRef(0);
-  const latestSharedSequenceRef = useRef(0);
   const inFlightScopeRequestRef = useRef(createInFlightState());
   const queuedFullReloadByScopeRef = useRef(createQueuedReloadState());
   const requestContextKeyRef = useRef<string | null>(null);
@@ -115,13 +140,12 @@ export function useAgentStudioDiffController({
       queuedFullReloadByScopeRef.current[scope] = false;
     }
     requestSequenceRef.current = 0;
-    latestSharedSequenceRef.current = 0;
   }, []);
 
   const resetControllerState = useCallback(
     (notifyContextReset: boolean): void => {
       resetRequestTracking();
-      setState(createInitialDiffBatchState());
+      setControllerState(createInitialControllerState());
       if (notifyContextReset) {
         onContextReset?.();
       }
@@ -137,52 +161,6 @@ export function useAgentStudioDiffController({
     [],
   );
 
-  const commitSummaryLoad = useCallback(
-    (
-      scope: DiffScope,
-      summaryFields: ReturnType<typeof toScopeSummaryFields>,
-      requestSequence: number,
-    ) => {
-      const shouldReloadFullScope = getSummaryReloadDecision(
-        stateRef.current,
-        scope,
-        summaryFields,
-      ).shouldReloadFullScope;
-
-      setState((previousState) => {
-        const { nextState, nextLatestSharedSequence } = applySummarySnapshot({
-          state: previousState,
-          scope,
-          summaryFields,
-          requestSequence,
-          latestSharedSequence: latestSharedSequenceRef.current,
-        });
-        latestSharedSequenceRef.current = nextLatestSharedSequence;
-        return nextState;
-      });
-
-      return shouldReloadFullScope;
-    },
-    [],
-  );
-
-  const commitFullLoad = useCallback(
-    (scope: DiffScope, snapshot: ScopeSnapshot, requestSequence: number): void => {
-      setState((previousState) => {
-        const { nextState, nextLatestSharedSequence } = applyFullSnapshot({
-          state: previousState,
-          scope,
-          snapshot,
-          requestSequence,
-          latestSharedSequence: latestSharedSequenceRef.current,
-        });
-        latestSharedSequenceRef.current = nextLatestSharedSequence;
-        return nextState;
-      });
-    },
-    [],
-  );
-
   const runSummaryLoad = useCallback(
     async ({
       repoPath: activeRepoPath,
@@ -191,7 +169,7 @@ export function useAgentStudioDiffController({
       targetBranch: activeTargetBranch,
       version,
       workingDir: nextWorkingDir,
-    }: InFlightRequestContext): Promise<boolean> => {
+    }: InFlightRequestContext): Promise<void> => {
       const summary = await host.gitGetWorktreeStatusSummary(
         activeRepoPath,
         activeTargetBranch,
@@ -200,16 +178,51 @@ export function useAgentStudioDiffController({
       );
 
       if (hasLoadContextChanged(activeRepoPath, activeTargetBranch, nextWorkingDir)) {
-        return false;
+        return;
       }
 
       if (versionByScopeAndModeRef.current[scope].summary !== version) {
-        return false;
+        return;
       }
 
-      return commitSummaryLoad(scope, toScopeSummaryFields(summary), requestSequence);
+      const summaryFields = toScopeSummaryFields(summary);
+      const loadContext: LoadRequestContext = {
+        repoPath: activeRepoPath,
+        scope,
+        targetBranch: activeTargetBranch,
+        workingDir: nextWorkingDir,
+      };
+
+      setControllerState((previousState) => {
+        const { nextState, nextLatestSharedSequence, shouldReloadFullScope } = applySummarySnapshot(
+          {
+            state: previousState.batchState,
+            scope,
+            summaryFields,
+            requestSequence,
+            latestSharedSequence: previousState.latestSharedSequence,
+          },
+        );
+        const nextPendingFullReloads = shouldReloadFullScope
+          ? enqueuePendingFullReload(previousState.pendingFullReloads, loadContext)
+          : previousState.pendingFullReloads;
+
+        if (
+          nextState === previousState.batchState &&
+          nextLatestSharedSequence === previousState.latestSharedSequence &&
+          nextPendingFullReloads === previousState.pendingFullReloads
+        ) {
+          return previousState;
+        }
+
+        return {
+          batchState: nextState,
+          latestSharedSequence: nextLatestSharedSequence,
+          pendingFullReloads: nextPendingFullReloads,
+        };
+      });
     },
-    [commitSummaryLoad, hasLoadContextChanged],
+    [hasLoadContextChanged],
   );
 
   const runFullLoad = useCallback(
@@ -236,9 +249,31 @@ export function useAgentStudioDiffController({
         return;
       }
 
-      commitFullLoad(scope, toScopeSnapshot(snapshot), requestSequence);
+      const nextScopeSnapshot = toScopeSnapshot(snapshot);
+      setControllerState((previousState) => {
+        const { nextState, nextLatestSharedSequence } = applyFullSnapshot({
+          state: previousState.batchState,
+          scope,
+          snapshot: nextScopeSnapshot,
+          requestSequence,
+          latestSharedSequence: previousState.latestSharedSequence,
+        });
+
+        if (
+          nextState === previousState.batchState &&
+          nextLatestSharedSequence === previousState.latestSharedSequence
+        ) {
+          return previousState;
+        }
+
+        return {
+          ...previousState,
+          batchState: nextState,
+          latestSharedSequence: nextLatestSharedSequence,
+        };
+      });
     },
-    [commitFullLoad, hasLoadContextChanged],
+    [hasLoadContextChanged],
   );
 
   const loadData = useCallback(
@@ -277,8 +312,13 @@ export function useAgentStudioDiffController({
       const requestSequence = ++requestSequenceRef.current;
 
       if (showLoading) {
-        setState((previousState) =>
-          previousState.isLoading ? previousState : { ...previousState, isLoading: true },
+        setControllerState((previousState) =>
+          previousState.batchState.isLoading
+            ? previousState
+            : {
+                ...previousState,
+                batchState: { ...previousState.batchState, isLoading: true },
+              },
         );
       }
 
@@ -292,16 +332,7 @@ export function useAgentStudioDiffController({
         };
 
         if (mode === "summary") {
-          const shouldReloadFullScope = await runSummaryLoad(inFlightRequestContext);
-          if (shouldReloadFullScope) {
-            void loadData(false, {
-              repoPath: loadContext.repoPath,
-              targetBranch: loadContext.targetBranch,
-              workingDir: loadContext.workingDir,
-              scope: loadContext.scope,
-              mode: "full",
-            });
-          }
+          await runSummaryLoad(inFlightRequestContext);
           return;
         }
 
@@ -318,14 +349,23 @@ export function useAgentStudioDiffController({
         }
 
         if (versionByScopeAndModeRef.current[loadContext.scope][mode] === version) {
-          setState((previousState) =>
-            applyScopeError({
-              state: previousState,
+          setControllerState((previousState) => {
+            const nextBatchState = applyScopeError({
+              state: previousState.batchState,
               scope: loadContext.scope,
               mode,
               error: String(error),
-            }),
-          );
+            });
+
+            if (nextBatchState === previousState.batchState) {
+              return previousState;
+            }
+
+            return {
+              ...previousState,
+              batchState: nextBatchState,
+            };
+          });
         }
       } finally {
         if (inFlightScopeRequestRef.current[loadContext.scope][mode] === requestKey) {
@@ -348,6 +388,37 @@ export function useAgentStudioDiffController({
     },
     [hasLoadContextChanged, runFullLoad, runSummaryLoad],
   );
+
+  const pendingFullReload = controllerState.pendingFullReloads[0];
+
+  useEffect(() => {
+    if (!pendingFullReload) {
+      return;
+    }
+
+    setControllerState((previousState) => {
+      const nextPendingFullReload = previousState.pendingFullReloads[0];
+      if (
+        !nextPendingFullReload ||
+        !sameLoadRequestContext(nextPendingFullReload, pendingFullReload)
+      ) {
+        return previousState;
+      }
+
+      return {
+        ...previousState,
+        pendingFullReloads: previousState.pendingFullReloads.slice(1),
+      };
+    });
+
+    void loadData(false, {
+      repoPath: pendingFullReload.repoPath,
+      targetBranch: pendingFullReload.targetBranch,
+      workingDir: pendingFullReload.workingDir,
+      scope: pendingFullReload.scope,
+      mode: "full",
+    });
+  }, [loadData, pendingFullReload]);
 
   useEffect(() => {
     const previousContextKey = requestContextKeyRef.current;
@@ -393,7 +464,7 @@ export function useAgentStudioDiffController({
       return;
     }
 
-    if (state.loadedByScope[diffScope]) {
+    if (controllerState.batchState.loadedByScope[diffScope]) {
       return;
     }
 
@@ -404,11 +475,11 @@ export function useAgentStudioDiffController({
       scope: diffScope,
     });
   }, [
+    controllerState.batchState.loadedByScope,
     diffScope,
     loadData,
     repoPath,
     shouldBlockDiffLoading,
-    state.loadedByScope,
     targetBranch,
     workingDir,
   ]);
@@ -465,13 +536,13 @@ export function useAgentStudioDiffController({
     [loadData, shouldBlockDiffLoading],
   );
 
-  const activeScopeState = state.byScope[diffScope];
+  const activeScopeState = controllerState.batchState.byScope[diffScope];
 
   return {
     activeScopeState,
     diffScope,
     setDiffScope,
-    state,
+    state: controllerState.batchState,
     statusSnapshotKey: toStatusSnapshotKey(activeScopeState),
     refreshActiveScope,
     reloadActiveScope,

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
@@ -9,6 +9,7 @@ import {
   createInitialDiffBatchState,
   type DiffBatchState,
   type DiffScope,
+  getSummaryReloadDecision,
   type LoadDataMode,
   type ScopeSnapshot,
   toScopeSnapshot,
@@ -27,6 +28,18 @@ type LoadDataContext = {
   replayIfInFlight?: boolean;
 };
 
+type LoadRequestContext = Required<Pick<LoadDataContext, "targetBranch" | "scope">> & {
+  repoPath: string;
+  workingDir: string | null;
+};
+
+type InFlightRequestContext = LoadRequestContext & {
+  mode: LoadDataMode;
+  requestKey: string;
+  requestSequence: number;
+  version: number;
+};
+
 type UseAgentStudioDiffControllerArgs = {
   repoPath: string | null;
   targetBranch: string;
@@ -34,6 +47,7 @@ type UseAgentStudioDiffControllerArgs = {
   requestContextKey: string | null;
   enablePolling: boolean;
   shouldBlockDiffLoading: boolean;
+  onContextReset?: () => void;
 };
 
 type UseAgentStudioDiffControllerResult = {
@@ -44,7 +58,6 @@ type UseAgentStudioDiffControllerResult = {
   statusSnapshotKey: string | null;
   refreshActiveScope: () => void;
   reloadActiveScope: (showLoading?: boolean) => void;
-  contextResetVersion: number;
 };
 
 const createVersionState = (): Record<DiffScope, Record<LoadDataMode, number>> => ({
@@ -69,13 +82,13 @@ export function useAgentStudioDiffController({
   requestContextKey,
   enablePolling,
   shouldBlockDiffLoading,
+  onContextReset,
 }: UseAgentStudioDiffControllerArgs): UseAgentStudioDiffControllerResult {
   const [state, setState] = useState<DiffBatchState>(createInitialDiffBatchState);
   const stateRef = useRef(state);
   stateRef.current = state;
 
   const [diffScope, setDiffScope] = useState<DiffScope>("target");
-  const [contextResetVersion, setContextResetVersion] = useState(0);
 
   const versionByScopeAndModeRef = useRef(createVersionState());
   const requestSequenceRef = useRef(0);
@@ -105,152 +118,236 @@ export function useAgentStudioDiffController({
     latestSharedSequenceRef.current = 0;
   }, []);
 
-  const loadData = useCallback(async (showLoading = false, context?: LoadDataContext) => {
-    const path = context?.repoPath ?? repoPathRef.current;
-    if (!path) {
-      return;
-    }
-
-    const scope = context?.scope ?? diffScopeRef.current;
-    const target = context?.targetBranch ?? targetBranchRef.current;
-    const nextWorkingDir = context?.workingDir ?? workingDirRef.current;
-    const mode = context?.mode ?? "full";
-    const replayIfInFlight = context?.replayIfInFlight === true;
-    const requestKey = `${path}::${target}::${nextWorkingDir ?? ""}`;
-
-    if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
-      if (mode === "full" && replayIfInFlight) {
-        queuedFullReloadByScopeRef.current[scope] = true;
+  const resetControllerState = useCallback(
+    (notifyContextReset: boolean): void => {
+      resetRequestTracking();
+      setState(createInitialDiffBatchState());
+      if (notifyContextReset) {
+        onContextReset?.();
       }
-      return;
-    }
+    },
+    [onContextReset, resetRequestTracking],
+  );
 
-    if (mode === "summary" && inFlightScopeRequestRef.current[scope].full === requestKey) {
-      return;
-    }
+  const hasLoadContextChanged = useCallback(
+    (path: string, nextTargetBranch: string, nextWorkingDir: string | null): boolean =>
+      repoPathRef.current !== path ||
+      targetBranchRef.current !== nextTargetBranch ||
+      (workingDirRef.current ?? null) !== nextWorkingDir,
+    [],
+  );
 
-    inFlightScopeRequestRef.current[scope][mode] = requestKey;
-    const version = ++versionByScopeAndModeRef.current[scope][mode];
-    const requestSequence = ++requestSequenceRef.current;
+  const commitSummaryLoad = useCallback(
+    (
+      scope: DiffScope,
+      summaryFields: ReturnType<typeof toScopeSummaryFields>,
+      requestSequence: number,
+    ) => {
+      const shouldReloadFullScope = getSummaryReloadDecision(
+        stateRef.current,
+        scope,
+        summaryFields,
+      ).shouldReloadFullScope;
 
-    if (showLoading) {
-      setState((previousState) =>
-        previousState.isLoading ? previousState : { ...previousState, isLoading: true },
-      );
-    }
-
-    try {
-      const hostWorkingDir = nextWorkingDir ?? undefined;
-
-      if (mode === "summary") {
-        const summary = await host.gitGetWorktreeStatusSummary(path, target, scope, hostWorkingDir);
-        const hasContextChanged =
-          repoPathRef.current !== path ||
-          targetBranchRef.current !== target ||
-          (workingDirRef.current ?? null) !== nextWorkingDir;
-        if (hasContextChanged) {
-          return;
-        }
-
-        if (versionByScopeAndModeRef.current[scope][mode] !== version) {
-          return;
-        }
-
-        const summaryFields = toScopeSummaryFields(summary);
-        const previousSummaryState = stateRef.current;
-        const shouldReloadFullScope =
-          previousSummaryState.loadedByScope[scope] &&
-          (previousSummaryState.byScope[scope].hashVersion !== summaryFields.hashVersion ||
-            previousSummaryState.byScope[scope].statusHash !== summaryFields.statusHash ||
-            previousSummaryState.byScope[scope].diffHash !== summaryFields.diffHash);
-
-        setState((previousState) => {
-          const { nextState, nextLatestSharedSequence } = applySummarySnapshot({
-            state: previousState,
-            scope,
-            summaryFields,
-            requestSequence,
-            latestSharedSequence: latestSharedSequenceRef.current,
-          });
-          latestSharedSequenceRef.current = nextLatestSharedSequence;
-          return nextState;
-        });
-
-        if (shouldReloadFullScope) {
-          void loadData(false, {
-            repoPath: path,
-            targetBranch: target,
-            workingDir: nextWorkingDir,
-            scope,
-            mode: "full",
-          });
-        }
-        return;
-      }
-
-      const snapshot = await host.gitGetWorktreeStatus(path, target, scope, hostWorkingDir);
-      const hasContextChanged =
-        repoPathRef.current !== path ||
-        targetBranchRef.current !== target ||
-        (workingDirRef.current ?? null) !== nextWorkingDir;
-      if (hasContextChanged) {
-        return;
-      }
-
-      if (versionByScopeAndModeRef.current[scope][mode] !== version) {
-        return;
-      }
-
-      const nextScopeSnapshot = toScopeSnapshot(snapshot);
       setState((previousState) => {
-        const { nextState, nextLatestSharedSequence } = applyFullSnapshot({
+        const { nextState, nextLatestSharedSequence } = applySummarySnapshot({
           state: previousState,
           scope,
-          snapshot: nextScopeSnapshot,
+          summaryFields,
           requestSequence,
           latestSharedSequence: latestSharedSequenceRef.current,
         });
         latestSharedSequenceRef.current = nextLatestSharedSequence;
         return nextState;
       });
-    } catch (error) {
-      const hasContextChanged =
-        repoPathRef.current !== path ||
-        targetBranchRef.current !== target ||
-        (workingDirRef.current ?? null) !== nextWorkingDir;
-      if (hasContextChanged) {
+
+      return shouldReloadFullScope;
+    },
+    [],
+  );
+
+  const commitFullLoad = useCallback(
+    (scope: DiffScope, snapshot: ScopeSnapshot, requestSequence: number): void => {
+      setState((previousState) => {
+        const { nextState, nextLatestSharedSequence } = applyFullSnapshot({
+          state: previousState,
+          scope,
+          snapshot,
+          requestSequence,
+          latestSharedSequence: latestSharedSequenceRef.current,
+        });
+        latestSharedSequenceRef.current = nextLatestSharedSequence;
+        return nextState;
+      });
+    },
+    [],
+  );
+
+  const runSummaryLoad = useCallback(
+    async ({
+      repoPath: activeRepoPath,
+      requestSequence,
+      scope,
+      targetBranch: activeTargetBranch,
+      version,
+      workingDir: nextWorkingDir,
+    }: InFlightRequestContext): Promise<boolean> => {
+      const summary = await host.gitGetWorktreeStatusSummary(
+        activeRepoPath,
+        activeTargetBranch,
+        scope,
+        nextWorkingDir ?? undefined,
+      );
+
+      if (hasLoadContextChanged(activeRepoPath, activeTargetBranch, nextWorkingDir)) {
+        return false;
+      }
+
+      if (versionByScopeAndModeRef.current[scope].summary !== version) {
+        return false;
+      }
+
+      return commitSummaryLoad(scope, toScopeSummaryFields(summary), requestSequence);
+    },
+    [commitSummaryLoad, hasLoadContextChanged],
+  );
+
+  const runFullLoad = useCallback(
+    async ({
+      repoPath: activeRepoPath,
+      requestSequence,
+      scope,
+      targetBranch: activeTargetBranch,
+      version,
+      workingDir: nextWorkingDir,
+    }: InFlightRequestContext): Promise<void> => {
+      const snapshot = await host.gitGetWorktreeStatus(
+        activeRepoPath,
+        activeTargetBranch,
+        scope,
+        nextWorkingDir ?? undefined,
+      );
+
+      if (hasLoadContextChanged(activeRepoPath, activeTargetBranch, nextWorkingDir)) {
         return;
       }
 
-      if (versionByScopeAndModeRef.current[scope][mode] === version) {
-        setState((previousState) =>
-          applyScopeError({
-            state: previousState,
-            scope,
-            mode,
-            error: String(error),
-          }),
-        );
-      }
-    } finally {
-      if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
-        inFlightScopeRequestRef.current[scope][mode] = null;
+      if (versionByScopeAndModeRef.current[scope].full !== version) {
+        return;
       }
 
-      if (mode === "full" && queuedFullReloadByScopeRef.current[scope]) {
-        queuedFullReloadByScopeRef.current[scope] = false;
-        globalThis.queueMicrotask(() => {
-          void loadData(false, {
-            repoPath: path,
-            targetBranch: target,
-            workingDir: nextWorkingDir,
-            scope,
-            mode: "full",
-          });
-        });
+      commitFullLoad(scope, toScopeSnapshot(snapshot), requestSequence);
+    },
+    [commitFullLoad, hasLoadContextChanged],
+  );
+
+  const loadData = useCallback(
+    async (showLoading = false, context?: LoadDataContext) => {
+      const activeRepoPath = context?.repoPath ?? repoPathRef.current;
+      if (!activeRepoPath) {
+        return;
       }
-    }
-  }, []);
+
+      const loadContext: LoadRequestContext = {
+        repoPath: activeRepoPath,
+        scope: context?.scope ?? diffScopeRef.current,
+        targetBranch: context?.targetBranch ?? targetBranchRef.current,
+        workingDir: context?.workingDir ?? workingDirRef.current,
+      };
+      const mode = context?.mode ?? "full";
+      const replayIfInFlight = context?.replayIfInFlight === true;
+      const requestKey = `${loadContext.repoPath}::${loadContext.targetBranch}::${loadContext.workingDir ?? ""}`;
+
+      if (inFlightScopeRequestRef.current[loadContext.scope][mode] === requestKey) {
+        if (mode === "full" && replayIfInFlight) {
+          queuedFullReloadByScopeRef.current[loadContext.scope] = true;
+        }
+        return;
+      }
+
+      if (
+        mode === "summary" &&
+        inFlightScopeRequestRef.current[loadContext.scope].full === requestKey
+      ) {
+        return;
+      }
+
+      inFlightScopeRequestRef.current[loadContext.scope][mode] = requestKey;
+      const version = ++versionByScopeAndModeRef.current[loadContext.scope][mode];
+      const requestSequence = ++requestSequenceRef.current;
+
+      if (showLoading) {
+        setState((previousState) =>
+          previousState.isLoading ? previousState : { ...previousState, isLoading: true },
+        );
+      }
+
+      try {
+        const inFlightRequestContext: InFlightRequestContext = {
+          ...loadContext,
+          mode,
+          requestKey,
+          requestSequence,
+          version,
+        };
+
+        if (mode === "summary") {
+          const shouldReloadFullScope = await runSummaryLoad(inFlightRequestContext);
+          if (shouldReloadFullScope) {
+            void loadData(false, {
+              repoPath: loadContext.repoPath,
+              targetBranch: loadContext.targetBranch,
+              workingDir: loadContext.workingDir,
+              scope: loadContext.scope,
+              mode: "full",
+            });
+          }
+          return;
+        }
+
+        await runFullLoad(inFlightRequestContext);
+      } catch (error) {
+        if (
+          hasLoadContextChanged(
+            loadContext.repoPath,
+            loadContext.targetBranch,
+            loadContext.workingDir,
+          )
+        ) {
+          return;
+        }
+
+        if (versionByScopeAndModeRef.current[loadContext.scope][mode] === version) {
+          setState((previousState) =>
+            applyScopeError({
+              state: previousState,
+              scope: loadContext.scope,
+              mode,
+              error: String(error),
+            }),
+          );
+        }
+      } finally {
+        if (inFlightScopeRequestRef.current[loadContext.scope][mode] === requestKey) {
+          inFlightScopeRequestRef.current[loadContext.scope][mode] = null;
+        }
+
+        if (mode === "full" && queuedFullReloadByScopeRef.current[loadContext.scope]) {
+          queuedFullReloadByScopeRef.current[loadContext.scope] = false;
+          globalThis.queueMicrotask(() => {
+            void loadData(false, {
+              repoPath: loadContext.repoPath,
+              targetBranch: loadContext.targetBranch,
+              workingDir: loadContext.workingDir,
+              scope: loadContext.scope,
+              mode: "full",
+            });
+          });
+        }
+      }
+    },
+    [hasLoadContextChanged, runFullLoad, runSummaryLoad],
+  );
 
   useEffect(() => {
     const previousContextKey = requestContextKeyRef.current;
@@ -260,9 +357,7 @@ export function useAgentStudioDiffController({
 
     if (repoPath && !shouldBlockDiffLoading) {
       if (hasContextChanged) {
-        resetRequestTracking();
-        setState(createInitialDiffBatchState());
-        setContextResetVersion((version) => version + 1);
+        resetControllerState(true);
       }
 
       void loadData(true, {
@@ -276,25 +371,18 @@ export function useAgentStudioDiffController({
 
     if (repoPath) {
       if (hasContextChanged) {
-        resetRequestTracking();
-        setState(createInitialDiffBatchState());
-        setContextResetVersion((version) => version + 1);
+        resetControllerState(true);
       }
       return;
     }
 
-    const hadActiveContext = previousContextKey !== null;
-    resetRequestTracking();
     requestContextKeyRef.current = null;
-    setState(createInitialDiffBatchState());
-    if (hadActiveContext) {
-      setContextResetVersion((version) => version + 1);
-    }
+    resetControllerState(previousContextKey !== null);
   }, [
     loadData,
     repoPath,
     requestContextKey,
-    resetRequestTracking,
+    resetControllerState,
     shouldBlockDiffLoading,
     targetBranch,
     workingDir,
@@ -387,6 +475,5 @@ export function useAgentStudioDiffController({
     statusSnapshotKey: toStatusSnapshotKey(activeScopeState),
     refreshActiveScope,
     reloadActiveScope,
-    contextResetVersion,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
@@ -1,0 +1,392 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { host } from "@/state/operations/host";
+import {
+  ALL_LOAD_DATA_MODES,
+  ALL_SCOPES,
+  applyFullSnapshot,
+  applyScopeError,
+  applySummarySnapshot,
+  createInitialDiffBatchState,
+  type DiffBatchState,
+  type DiffScope,
+  type LoadDataMode,
+  type ScopeSnapshot,
+  toScopeSnapshot,
+  toScopeSummaryFields,
+  toStatusSnapshotKey,
+} from "./agent-studio-diff-data-model";
+
+const POLL_INTERVAL_MS = 30_000;
+
+type LoadDataContext = {
+  repoPath: string | null;
+  targetBranch: string;
+  workingDir: string | null;
+  scope: DiffScope;
+  mode?: LoadDataMode;
+  replayIfInFlight?: boolean;
+};
+
+type UseAgentStudioDiffControllerArgs = {
+  repoPath: string | null;
+  targetBranch: string;
+  workingDir: string | null;
+  requestContextKey: string | null;
+  enablePolling: boolean;
+  shouldBlockDiffLoading: boolean;
+};
+
+type UseAgentStudioDiffControllerResult = {
+  activeScopeState: ScopeSnapshot;
+  diffScope: DiffScope;
+  setDiffScope: (scope: DiffScope) => void;
+  state: DiffBatchState;
+  statusSnapshotKey: string | null;
+  refreshActiveScope: () => void;
+  reloadActiveScope: (showLoading?: boolean) => void;
+  contextResetVersion: number;
+};
+
+const createVersionState = (): Record<DiffScope, Record<LoadDataMode, number>> => ({
+  target: { full: 0, summary: 0 },
+  uncommitted: { full: 0, summary: 0 },
+});
+
+const createInFlightState = (): Record<DiffScope, Record<LoadDataMode, string | null>> => ({
+  target: { full: null, summary: null },
+  uncommitted: { full: null, summary: null },
+});
+
+const createQueuedReloadState = (): Record<DiffScope, boolean> => ({
+  target: false,
+  uncommitted: false,
+});
+
+export function useAgentStudioDiffController({
+  repoPath,
+  targetBranch,
+  workingDir,
+  requestContextKey,
+  enablePolling,
+  shouldBlockDiffLoading,
+}: UseAgentStudioDiffControllerArgs): UseAgentStudioDiffControllerResult {
+  const [state, setState] = useState<DiffBatchState>(createInitialDiffBatchState);
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const [diffScope, setDiffScope] = useState<DiffScope>("target");
+  const [contextResetVersion, setContextResetVersion] = useState(0);
+
+  const versionByScopeAndModeRef = useRef(createVersionState());
+  const requestSequenceRef = useRef(0);
+  const latestSharedSequenceRef = useRef(0);
+  const inFlightScopeRequestRef = useRef(createInFlightState());
+  const queuedFullReloadByScopeRef = useRef(createQueuedReloadState());
+  const requestContextKeyRef = useRef<string | null>(null);
+
+  const repoPathRef = useRef(repoPath);
+  repoPathRef.current = repoPath;
+  const targetBranchRef = useRef(targetBranch);
+  targetBranchRef.current = targetBranch;
+  const diffScopeRef = useRef(diffScope);
+  diffScopeRef.current = diffScope;
+  const workingDirRef = useRef(workingDir);
+  workingDirRef.current = workingDir;
+
+  const resetRequestTracking = useCallback((): void => {
+    for (const scope of ALL_SCOPES) {
+      for (const mode of ALL_LOAD_DATA_MODES) {
+        versionByScopeAndModeRef.current[scope][mode] += 1;
+        inFlightScopeRequestRef.current[scope][mode] = null;
+      }
+      queuedFullReloadByScopeRef.current[scope] = false;
+    }
+    requestSequenceRef.current = 0;
+    latestSharedSequenceRef.current = 0;
+  }, []);
+
+  const loadData = useCallback(async (showLoading = false, context?: LoadDataContext) => {
+    const path = context?.repoPath ?? repoPathRef.current;
+    if (!path) {
+      return;
+    }
+
+    const scope = context?.scope ?? diffScopeRef.current;
+    const target = context?.targetBranch ?? targetBranchRef.current;
+    const nextWorkingDir = context?.workingDir ?? workingDirRef.current;
+    const mode = context?.mode ?? "full";
+    const replayIfInFlight = context?.replayIfInFlight === true;
+    const requestKey = `${path}::${target}::${nextWorkingDir ?? ""}`;
+
+    if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
+      if (mode === "full" && replayIfInFlight) {
+        queuedFullReloadByScopeRef.current[scope] = true;
+      }
+      return;
+    }
+
+    if (mode === "summary" && inFlightScopeRequestRef.current[scope].full === requestKey) {
+      return;
+    }
+
+    inFlightScopeRequestRef.current[scope][mode] = requestKey;
+    const version = ++versionByScopeAndModeRef.current[scope][mode];
+    const requestSequence = ++requestSequenceRef.current;
+
+    if (showLoading) {
+      setState((previousState) =>
+        previousState.isLoading ? previousState : { ...previousState, isLoading: true },
+      );
+    }
+
+    try {
+      const hostWorkingDir = nextWorkingDir ?? undefined;
+
+      if (mode === "summary") {
+        const summary = await host.gitGetWorktreeStatusSummary(path, target, scope, hostWorkingDir);
+        const hasContextChanged =
+          repoPathRef.current !== path ||
+          targetBranchRef.current !== target ||
+          (workingDirRef.current ?? null) !== nextWorkingDir;
+        if (hasContextChanged) {
+          return;
+        }
+
+        if (versionByScopeAndModeRef.current[scope][mode] !== version) {
+          return;
+        }
+
+        const summaryFields = toScopeSummaryFields(summary);
+        const previousSummaryState = stateRef.current;
+        const shouldReloadFullScope =
+          previousSummaryState.loadedByScope[scope] &&
+          (previousSummaryState.byScope[scope].hashVersion !== summaryFields.hashVersion ||
+            previousSummaryState.byScope[scope].statusHash !== summaryFields.statusHash ||
+            previousSummaryState.byScope[scope].diffHash !== summaryFields.diffHash);
+
+        setState((previousState) => {
+          const { nextState, nextLatestSharedSequence } = applySummarySnapshot({
+            state: previousState,
+            scope,
+            summaryFields,
+            requestSequence,
+            latestSharedSequence: latestSharedSequenceRef.current,
+          });
+          latestSharedSequenceRef.current = nextLatestSharedSequence;
+          return nextState;
+        });
+
+        if (shouldReloadFullScope) {
+          void loadData(false, {
+            repoPath: path,
+            targetBranch: target,
+            workingDir: nextWorkingDir,
+            scope,
+            mode: "full",
+          });
+        }
+        return;
+      }
+
+      const snapshot = await host.gitGetWorktreeStatus(path, target, scope, hostWorkingDir);
+      const hasContextChanged =
+        repoPathRef.current !== path ||
+        targetBranchRef.current !== target ||
+        (workingDirRef.current ?? null) !== nextWorkingDir;
+      if (hasContextChanged) {
+        return;
+      }
+
+      if (versionByScopeAndModeRef.current[scope][mode] !== version) {
+        return;
+      }
+
+      const nextScopeSnapshot = toScopeSnapshot(snapshot);
+      setState((previousState) => {
+        const { nextState, nextLatestSharedSequence } = applyFullSnapshot({
+          state: previousState,
+          scope,
+          snapshot: nextScopeSnapshot,
+          requestSequence,
+          latestSharedSequence: latestSharedSequenceRef.current,
+        });
+        latestSharedSequenceRef.current = nextLatestSharedSequence;
+        return nextState;
+      });
+    } catch (error) {
+      const hasContextChanged =
+        repoPathRef.current !== path ||
+        targetBranchRef.current !== target ||
+        (workingDirRef.current ?? null) !== nextWorkingDir;
+      if (hasContextChanged) {
+        return;
+      }
+
+      if (versionByScopeAndModeRef.current[scope][mode] === version) {
+        setState((previousState) =>
+          applyScopeError({
+            state: previousState,
+            scope,
+            mode,
+            error: String(error),
+          }),
+        );
+      }
+    } finally {
+      if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
+        inFlightScopeRequestRef.current[scope][mode] = null;
+      }
+
+      if (mode === "full" && queuedFullReloadByScopeRef.current[scope]) {
+        queuedFullReloadByScopeRef.current[scope] = false;
+        globalThis.queueMicrotask(() => {
+          void loadData(false, {
+            repoPath: path,
+            targetBranch: target,
+            workingDir: nextWorkingDir,
+            scope,
+            mode: "full",
+          });
+        });
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const previousContextKey = requestContextKeyRef.current;
+    const hasContextChanged =
+      previousContextKey !== null && previousContextKey !== requestContextKey;
+    requestContextKeyRef.current = requestContextKey;
+
+    if (repoPath && !shouldBlockDiffLoading) {
+      if (hasContextChanged) {
+        resetRequestTracking();
+        setState(createInitialDiffBatchState());
+        setContextResetVersion((version) => version + 1);
+      }
+
+      void loadData(true, {
+        repoPath,
+        targetBranch,
+        workingDir,
+        scope: diffScopeRef.current,
+      });
+      return;
+    }
+
+    if (repoPath) {
+      if (hasContextChanged) {
+        resetRequestTracking();
+        setState(createInitialDiffBatchState());
+        setContextResetVersion((version) => version + 1);
+      }
+      return;
+    }
+
+    const hadActiveContext = previousContextKey !== null;
+    resetRequestTracking();
+    requestContextKeyRef.current = null;
+    setState(createInitialDiffBatchState());
+    if (hadActiveContext) {
+      setContextResetVersion((version) => version + 1);
+    }
+  }, [
+    loadData,
+    repoPath,
+    requestContextKey,
+    resetRequestTracking,
+    shouldBlockDiffLoading,
+    targetBranch,
+    workingDir,
+  ]);
+
+  useEffect(() => {
+    if (!repoPath || shouldBlockDiffLoading) {
+      return;
+    }
+
+    if (state.loadedByScope[diffScope]) {
+      return;
+    }
+
+    void loadData(true, {
+      repoPath,
+      targetBranch,
+      workingDir,
+      scope: diffScope,
+    });
+  }, [
+    diffScope,
+    loadData,
+    repoPath,
+    shouldBlockDiffLoading,
+    state.loadedByScope,
+    targetBranch,
+    workingDir,
+  ]);
+
+  useEffect(() => {
+    if (!enablePolling || !repoPath || shouldBlockDiffLoading) {
+      return;
+    }
+
+    const intervalId = globalThis.setInterval(() => {
+      void loadData(false, {
+        repoPath,
+        targetBranch: targetBranchRef.current,
+        workingDir: workingDirRef.current,
+        scope: diffScopeRef.current,
+        mode: "summary",
+      });
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      globalThis.clearInterval(intervalId);
+    };
+  }, [enablePolling, loadData, repoPath, shouldBlockDiffLoading]);
+
+  const refreshActiveScope = useCallback((): void => {
+    if (shouldBlockDiffLoading || !repoPathRef.current) {
+      return;
+    }
+
+    void loadData(true, {
+      repoPath: repoPathRef.current,
+      targetBranch: targetBranchRef.current,
+      workingDir: workingDirRef.current,
+      scope: diffScopeRef.current,
+      replayIfInFlight: true,
+    });
+  }, [loadData, shouldBlockDiffLoading]);
+
+  const reloadActiveScope = useCallback(
+    (showLoading = false): void => {
+      if (shouldBlockDiffLoading || !repoPathRef.current) {
+        return;
+      }
+
+      void loadData(showLoading, {
+        repoPath: repoPathRef.current,
+        targetBranch: targetBranchRef.current,
+        workingDir: workingDirRef.current,
+        scope: diffScopeRef.current,
+        mode: "full",
+        replayIfInFlight: true,
+      });
+    },
+    [loadData, shouldBlockDiffLoading],
+  );
+
+  const activeScopeState = state.byScope[diffScope];
+
+  return {
+    activeScopeState,
+    diffScope,
+    setDiffScope,
+    state,
+    statusSnapshotKey: toStatusSnapshotKey(activeScopeState),
+    refreshActiveScope,
+    reloadActiveScope,
+    contextResetVersion,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -347,6 +347,67 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("clears selected file when repository context changes", async () => {
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      repoPath: "/repo-a",
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      await harness.run((state) => {
+        state.setSelectedFile("src/main.ts");
+      });
+      await harness.waitFor((state) => state.selectedFile === "src/main.ts");
+
+      await harness.update({
+        ...createBaseArgs(),
+        repoPath: "/repo-b",
+      });
+
+      await harness.waitFor((state) => state.selectedFile === null);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("clears selected file when the resolved run context changes", async () => {
+    runsListMock.mockImplementation(async () => [
+      { runId: "run-1", worktreePath: "/repo/.worktrees/run-1" },
+    ]);
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      sessionRunId: "run-1",
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.worktreePath === "/repo/.worktrees/run-1");
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      await harness.run((state) => {
+        state.setSelectedFile("src/main.ts");
+      });
+      await harness.waitFor((state) => state.selectedFile === "src/main.ts");
+
+      runsListMock.mockImplementation(async () => [
+        { runId: "run-2", worktreePath: "/repo/.worktrees/run-2" },
+      ]);
+      await harness.update({
+        ...createBaseArgs(),
+        sessionRunId: "run-2",
+      });
+
+      await harness.waitFor((state) => state.selectedFile === null);
+      await harness.waitFor((state) => state.worktreePath === "/repo/.worktrees/run-2");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("refresh syncs shared branch/upstream fields for cached inactive scope", async () => {
     const harness = createHookHarness(createBaseArgs());
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
@@ -1,334 +1,20 @@
-import type {
-  CommitsAheadBehind,
-  FileDiff,
-  FileStatus,
-  GitWorktreeStatus,
-  GitWorktreeStatusSummary,
-} from "@openducktor/contracts";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { normalizeCanonicalTargetBranch } from "@/lib/target-branch";
-import { host } from "@/state/operations/host";
+import type { DiffDataState, UseAgentStudioDiffDataInput } from "./agent-studio-diff-data-model";
+
+export type {
+  DiffDataState,
+  DiffScope,
+  UseAgentStudioDiffDataInput,
+} from "./agent-studio-diff-data-model";
+
+import { useAgentStudioDiffController } from "./use-agent-studio-diff-controller";
 import { useAgentStudioWorktreeResolution } from "./use-agent-studio-worktree-resolution";
 
-const POLL_INTERVAL_MS = 30_000;
-
-// ─── Public types ──────────────────────────────────────────────────────────────
-
-export type DiffDataState = {
-  /** Current branch name (fetched via git). */
-  branch: string | null;
-  /** Path to the worktree directory (if separate from main repo). */
-  worktreePath: string | null;
-  /** Target branch for ahead/behind comparison. */
-  targetBranch: string;
-  diffScope: DiffScope;
-  /** Commits ahead/behind the target branch. */
-  commitsAheadBehind: CommitsAheadBehind | null;
-  upstreamAheadBehind: CommitsAheadBehind | null;
-  upstreamStatus: "tracking" | "untracked" | "error";
-  /** Changed files with diff content. */
-  fileDiffs: FileDiff[];
-  /** File status from `git status`. */
-  fileStatuses: FileStatus[];
-  /** Snapshot token for the current scope status/diff payloads. */
-  statusSnapshotKey?: string | null;
-  /** Total changed files from lightweight worktree polling summaries. */
-  uncommittedFileCount: number;
-  /** Whether data is currently loading. */
-  isLoading: boolean;
-  /** Last error message, if any. */
-  error: string | null;
-  /** Refresh all data manually. */
-  refresh: () => void;
-  /** Currently selected file path for single-file view. */
-  selectedFile: string | null;
-  /** Select a file to view its diff. */
-  setSelectedFile: (path: string | null) => void;
-  setDiffScope: (scope: DiffScope) => void;
+type SelectedFileState = {
+  path: string | null;
+  contextResetVersion: number;
 };
-
-export type DiffScope = "target" | "uncommitted";
-
-export type UseAgentStudioDiffDataInput = {
-  /** Configured repo path (must be in Tauri workspace allowlist). */
-  repoPath: string | null;
-  /** Session working directory — used as informational worktree path only. */
-  sessionWorkingDirectory: string | null;
-  /** Run ID from the session — used to look up the actual worktree path from the backend. */
-  sessionRunId: string | null;
-  /** Default target branch from repo settings. */
-  defaultTargetBranch: string;
-  branchIdentityKey?: string | null;
-  /** Whether to enable polling (only when builder session is active). */
-  enablePolling: boolean;
-  /** Optional run completion signal to force worktree-resolution refresh. */
-  runCompletionRecoverySignal?: number;
-};
-
-// ─── Batched internal state ────────────────────────────────────────────────────
-
-type DiffBatchState = {
-  byScope: Record<DiffScope, ScopeSnapshot>;
-  loadedByScope: Record<DiffScope, boolean>;
-  isLoading: boolean;
-};
-
-type ScopeSnapshot = {
-  branch: string | null;
-  fileDiffs: FileDiff[];
-  fileStatuses: FileStatus[];
-  uncommittedFileCount: number;
-  commitsAheadBehind: CommitsAheadBehind | null;
-  upstreamAheadBehind: CommitsAheadBehind | null;
-  upstreamStatus: "tracking" | "untracked" | "error";
-  error: string | null;
-  hashVersion: number | null;
-  statusHash: string | null;
-  diffHash: string | null;
-};
-
-type LoadDataContext = {
-  repoPath: string | null;
-  targetBranch: string;
-  workingDir: string | null;
-  scope: DiffScope;
-  mode?: LoadDataMode;
-  replayIfInFlight?: boolean;
-};
-
-type LoadDataMode = "full" | "summary";
-
-/** Stable empty arrays hoisted outside the component (rerender-memo-with-default-value). */
-const EMPTY_DIFFS: FileDiff[] = [];
-const EMPTY_STATUSES: FileStatus[] = [];
-
-const EMPTY_SCOPE_SNAPSHOT: ScopeSnapshot = {
-  branch: null,
-  fileDiffs: EMPTY_DIFFS,
-  fileStatuses: EMPTY_STATUSES,
-  uncommittedFileCount: 0,
-  commitsAheadBehind: null,
-  upstreamAheadBehind: null,
-  upstreamStatus: "tracking",
-  error: null,
-  hashVersion: null,
-  statusHash: null,
-  diffHash: null,
-};
-
-const createInitialState = (): DiffBatchState => ({
-  byScope: {
-    target: EMPTY_SCOPE_SNAPSHOT,
-    uncommitted: EMPTY_SCOPE_SNAPSHOT,
-  },
-  loadedByScope: {
-    target: false,
-    uncommitted: false,
-  },
-  isLoading: false,
-});
-
-const ALL_SCOPES: DiffScope[] = ["target", "uncommitted"];
-const ALL_LOAD_DATA_MODES: LoadDataMode[] = ["full", "summary"];
-
-// ─── Structural equality helpers ───────────────────────────────────────────────
-
-const arraysEqual = <T>(a: T[], b: T[], areItemsEqual: (left: T, right: T) => boolean): boolean => {
-  if (a === b) return true;
-  if (a.length !== b.length) return false;
-
-  for (let index = 0; index < a.length; index += 1) {
-    const left = a[index];
-    const right = b[index];
-    if (left === undefined || right === undefined) {
-      return false;
-    }
-    if (!areItemsEqual(left, right)) {
-      return false;
-    }
-  }
-
-  return true;
-};
-
-const fileDiffEqual = (left: FileDiff, right: FileDiff): boolean =>
-  left.file === right.file &&
-  left.type === right.type &&
-  left.additions === right.additions &&
-  left.deletions === right.deletions &&
-  left.diff === right.diff;
-
-const fileStatusEqual = (left: FileStatus, right: FileStatus): boolean =>
-  left.path === right.path && left.status === right.status && left.staged === right.staged;
-
-const aheadBehindEqual = (a: CommitsAheadBehind | null, b: CommitsAheadBehind | null): boolean => {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  return a.ahead === b.ahead && a.behind === b.behind;
-};
-
-const hashMetadataEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean =>
-  left.hashVersion === right.hashVersion &&
-  left.statusHash === right.statusHash &&
-  left.diffHash === right.diffHash;
-
-const scopeSnapshotEqual = (left: ScopeSnapshot, right: ScopeSnapshot): boolean =>
-  (() => {
-    const canUseHashShortCircuit =
-      left.hashVersion !== null &&
-      right.hashVersion !== null &&
-      left.hashVersion === right.hashVersion &&
-      left.statusHash !== null &&
-      right.statusHash !== null &&
-      left.diffHash !== null &&
-      right.diffHash !== null;
-
-    if (canUseHashShortCircuit) {
-      const hashesMatch = left.statusHash === right.statusHash && left.diffHash === right.diffHash;
-      const contentReferencesMatch =
-        left.fileDiffs === right.fileDiffs && left.fileStatuses === right.fileStatuses;
-      if (hashesMatch && left.error === right.error && contentReferencesMatch) {
-        return true;
-      }
-    }
-
-    return (
-      left.branch === right.branch &&
-      arraysEqual(left.fileDiffs, right.fileDiffs, fileDiffEqual) &&
-      arraysEqual(left.fileStatuses, right.fileStatuses, fileStatusEqual) &&
-      left.uncommittedFileCount === right.uncommittedFileCount &&
-      aheadBehindEqual(left.commitsAheadBehind, right.commitsAheadBehind) &&
-      aheadBehindEqual(left.upstreamAheadBehind, right.upstreamAheadBehind) &&
-      left.upstreamStatus === right.upstreamStatus &&
-      left.error === right.error &&
-      hashMetadataEqual(left, right)
-    );
-  })();
-
-const toUpstreamAndError = (
-  upstreamAheadBehind: GitWorktreeStatus["upstreamAheadBehind"],
-): {
-  upstreamAheadBehind: CommitsAheadBehind | null;
-  upstreamStatus: "tracking" | "untracked" | "error";
-  error: string | null;
-} => {
-  if (upstreamAheadBehind.outcome === "tracking") {
-    return {
-      upstreamAheadBehind: {
-        ahead: upstreamAheadBehind.ahead,
-        behind: upstreamAheadBehind.behind,
-      },
-      upstreamStatus: "tracking",
-      error: null,
-    };
-  }
-
-  if (upstreamAheadBehind.outcome === "untracked") {
-    return {
-      upstreamAheadBehind: {
-        ahead: upstreamAheadBehind.ahead,
-        behind: 0,
-      },
-      upstreamStatus: "untracked",
-      error: null,
-    };
-  }
-
-  return {
-    upstreamAheadBehind: null,
-    upstreamStatus: "error",
-    error: `Upstream status unavailable: ${upstreamAheadBehind.message}`,
-  };
-};
-
-const toScopeSnapshot = (snapshot: GitWorktreeStatus): ScopeSnapshot => {
-  const { upstreamAheadBehind, upstreamStatus, error } = toUpstreamAndError(
-    snapshot.upstreamAheadBehind,
-  );
-  return {
-    branch: snapshot.currentBranch.name ?? null,
-    fileDiffs: snapshot.fileDiffs,
-    fileStatuses: snapshot.fileStatuses,
-    uncommittedFileCount: snapshot.fileStatuses.length,
-    commitsAheadBehind: snapshot.targetAheadBehind,
-    upstreamAheadBehind,
-    upstreamStatus,
-    error,
-    hashVersion: snapshot.snapshot.hashVersion,
-    statusHash: snapshot.snapshot.statusHash,
-    diffHash: snapshot.snapshot.diffHash,
-  };
-};
-
-type ScopeSummaryFields = Pick<
-  ScopeSnapshot,
-  | "branch"
-  | "uncommittedFileCount"
-  | "commitsAheadBehind"
-  | "upstreamAheadBehind"
-  | "upstreamStatus"
-  | "error"
-  | "hashVersion"
-  | "statusHash"
-  | "diffHash"
->;
-
-const toScopeSummaryFields = (summary: GitWorktreeStatusSummary): ScopeSummaryFields => {
-  const { upstreamAheadBehind, upstreamStatus, error } = toUpstreamAndError(
-    summary.upstreamAheadBehind,
-  );
-  return {
-    branch: summary.currentBranch.name ?? null,
-    uncommittedFileCount: summary.fileStatusCounts.total,
-    commitsAheadBehind: summary.targetAheadBehind,
-    upstreamAheadBehind,
-    upstreamStatus,
-    error,
-    hashVersion: summary.snapshot.hashVersion,
-    statusHash: summary.snapshot.statusHash,
-    diffHash: summary.snapshot.diffHash,
-  };
-};
-
-const mergeSharedSnapshotFields = (base: ScopeSnapshot, source: ScopeSnapshot): ScopeSnapshot => ({
-  ...base,
-  branch: source.branch,
-  fileStatuses: source.fileStatuses,
-  uncommittedFileCount: source.uncommittedFileCount,
-  commitsAheadBehind: source.commitsAheadBehind,
-  upstreamAheadBehind: source.upstreamAheadBehind,
-  upstreamStatus: source.upstreamStatus,
-  error: source.error,
-  hashVersion: source.hashVersion,
-  statusHash: source.statusHash,
-});
-
-const mergeSharedSummaryFields = (
-  base: ScopeSnapshot,
-  source: ScopeSummaryFields,
-): ScopeSnapshot => ({
-  ...base,
-  branch: source.branch,
-  uncommittedFileCount: source.uncommittedFileCount,
-  commitsAheadBehind: source.commitsAheadBehind,
-  upstreamAheadBehind: source.upstreamAheadBehind,
-  upstreamStatus: source.upstreamStatus,
-  error: source.error,
-  hashVersion: source.hashVersion,
-  statusHash: source.statusHash,
-});
-
-const toStatusSnapshotKey = (snapshot: ScopeSnapshot): string | null => {
-  if (snapshot.fileStatuses.length === 0) {
-    return "<empty>";
-  }
-
-  return snapshot.fileStatuses
-    .map((fileStatus) => `${fileStatus.path}:${fileStatus.status}:${fileStatus.staged ? 1 : 0}`)
-    .join("|");
-};
-
-// ─── Hook ──────────────────────────────────────────────────────────────────────
 
 export function useAgentStudioDiffData({
   repoPath,
@@ -339,29 +25,6 @@ export function useAgentStudioDiffData({
   enablePolling,
   runCompletionRecoverySignal,
 }: UseAgentStudioDiffDataInput): DiffDataState {
-  const [state, setState] = useState<DiffBatchState>(createInitialState);
-  const stateRef = useRef(state);
-  stateRef.current = state;
-  const [selectedFile, setSelectedFileState] = useState<string | null>(null);
-  const [diffScope, setDiffScope] = useState<DiffScope>("target");
-
-  const versionByScopeAndModeRef = useRef<Record<DiffScope, Record<LoadDataMode, number>>>({
-    target: { full: 0, summary: 0 },
-    uncommitted: { full: 0, summary: 0 },
-  });
-  const requestSequenceRef = useRef(0);
-  const latestSharedSequenceRef = useRef(0);
-  const inFlightScopeRequestRef = useRef<Record<DiffScope, Record<LoadDataMode, string | null>>>({
-    target: { full: null, summary: null },
-    uncommitted: { full: null, summary: null },
-  });
-  const queuedFullReloadByScopeRef = useRef<Record<DiffScope, boolean>>({
-    target: false,
-    uncommitted: false,
-  });
-  const requestContextKeyRef = useRef<string | null>(null);
-
-  // Derive stable primitives
   const targetBranch = normalizeCanonicalTargetBranch(defaultTargetBranch);
   const {
     worktreePath,
@@ -377,413 +40,42 @@ export function useAgentStudioDiffData({
     ...(runCompletionRecoverySignal == null ? {} : { runCompletionRecoverySignal }),
   });
 
-  // Stable refs for use in callbacks (advanced-event-handler-refs)
-  const repoPathRef = useRef(repoPath);
-  repoPathRef.current = repoPath;
-  const targetBranchRef = useRef(targetBranch);
-  targetBranchRef.current = targetBranch;
-  const diffScopeRef = useRef(diffScope);
-  diffScopeRef.current = diffScope;
-  // Use the resolved worktree path as the actual working directory for git commands
-  const workingDirRef = useRef(worktreePath);
-  workingDirRef.current = worktreePath;
-
-  const loadData = useCallback(async (showLoading = false, context?: LoadDataContext) => {
-    const path = context?.repoPath ?? repoPathRef.current;
-    if (!path) {
-      return;
+  const requestContextKey = useMemo(() => {
+    if (!repoPath) {
+      return null;
     }
 
-    const scope = context?.scope ?? diffScopeRef.current;
-    const target = context?.targetBranch ?? targetBranchRef.current;
-    const workingDir = context?.workingDir ?? workingDirRef.current;
-    const mode = context?.mode ?? "full";
-    const replayIfInFlight = context?.replayIfInFlight === true;
-    const requestKey = `${path}::${target}::${workingDir ?? ""}`;
+    return `${repoPath}::${targetBranch}::${worktreePath ?? ""}::${worktreeResolutionRunId ?? ""}::${
+      branchIdentityKey ?? ""
+    }`;
+  }, [branchIdentityKey, repoPath, targetBranch, worktreePath, worktreeResolutionRunId]);
 
-    if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
-      if (mode === "full" && replayIfInFlight) {
-        queuedFullReloadByScopeRef.current[scope] = true;
-      }
-      return;
-    }
-
-    if (mode === "summary" && inFlightScopeRequestRef.current[scope].full === requestKey) {
-      return;
-    }
-
-    inFlightScopeRequestRef.current[scope][mode] = requestKey;
-    const version = ++versionByScopeAndModeRef.current[scope][mode];
-    const requestSequence = ++requestSequenceRef.current;
-
-    // Only show loading indicator on initial load / manual refresh — NOT on polling
-    if (showLoading) {
-      setState((prev) => (prev.isLoading ? prev : { ...prev, isLoading: true }));
-    }
-
-    try {
-      const wd = workingDir ?? undefined;
-
-      if (mode === "summary") {
-        const summary = await host.gitGetWorktreeStatusSummary(path, target, scope, wd);
-
-        const hasContextChanged =
-          repoPathRef.current !== path ||
-          targetBranchRef.current !== target ||
-          (workingDirRef.current ?? null) !== workingDir;
-        if (hasContextChanged) {
-          return;
-        }
-
-        // Stale response guard
-        if (versionByScopeAndModeRef.current[scope][mode] !== version) {
-          return;
-        }
-
-        const previousSummarySnapshot = stateRef.current.byScope[scope];
-        const nextSummaryFields = toScopeSummaryFields(summary);
-        const hashesChanged =
-          previousSummarySnapshot.hashVersion !== nextSummaryFields.hashVersion ||
-          previousSummarySnapshot.statusHash !== nextSummaryFields.statusHash ||
-          previousSummarySnapshot.diffHash !== nextSummaryFields.diffHash;
-        const shouldReloadFullScope = stateRef.current.loadedByScope[scope] && hashesChanged;
-
-        setState((prev) => {
-          const previousFetchedScopeSnapshot = prev.byScope[scope];
-          const nextFetchedScopeSnapshot: ScopeSnapshot = {
-            ...previousFetchedScopeSnapshot,
-            ...nextSummaryFields,
-          };
-          let didChange = false;
-          const nextByScope: Record<DiffScope, ScopeSnapshot> = {
-            ...prev.byScope,
-          };
-
-          if (!scopeSnapshotEqual(previousFetchedScopeSnapshot, nextFetchedScopeSnapshot)) {
-            nextByScope[scope] = nextFetchedScopeSnapshot;
-            didChange = true;
-          }
-
-          if (requestSequence >= latestSharedSequenceRef.current) {
-            latestSharedSequenceRef.current = requestSequence;
-            let nextLoadedByScope = prev.loadedByScope;
-            for (const otherScope of ALL_SCOPES) {
-              if (otherScope === scope) {
-                continue;
-              }
-
-              const previousOtherScopeSnapshot = nextByScope[otherScope];
-              const nextOtherScopeSnapshot = mergeSharedSummaryFields(
-                previousOtherScopeSnapshot,
-                nextSummaryFields,
-              );
-
-              if (!scopeSnapshotEqual(previousOtherScopeSnapshot, nextOtherScopeSnapshot)) {
-                nextByScope[otherScope] = nextOtherScopeSnapshot;
-                didChange = true;
-              }
-
-              if (hashesChanged && prev.loadedByScope[otherScope]) {
-                const invalidatedOtherScopeSnapshot: ScopeSnapshot = {
-                  ...nextByScope[otherScope],
-                  fileDiffs: EMPTY_DIFFS,
-                };
-                if (!scopeSnapshotEqual(nextByScope[otherScope], invalidatedOtherScopeSnapshot)) {
-                  nextByScope[otherScope] = invalidatedOtherScopeSnapshot;
-                  didChange = true;
-                }
-                if (nextLoadedByScope[otherScope]) {
-                  nextLoadedByScope = {
-                    ...nextLoadedByScope,
-                    [otherScope]: false,
-                  };
-                  didChange = true;
-                }
-              }
-            }
-
-            if (!didChange && !prev.isLoading) {
-              return prev;
-            }
-
-            return {
-              byScope: nextByScope,
-              loadedByScope: nextLoadedByScope,
-              isLoading: false,
-            };
-          }
-
-          if (!didChange && !prev.isLoading) {
-            return prev;
-          }
-
-          return {
-            byScope: nextByScope,
-            loadedByScope: prev.loadedByScope,
-            isLoading: false,
-          };
-        });
-
-        if (shouldReloadFullScope) {
-          void loadData(false, {
-            repoPath: path,
-            targetBranch: target,
-            workingDir,
-            scope,
-            mode: "full",
-          });
-        }
-        return;
-      }
-
-      const snapshot = await host.gitGetWorktreeStatus(path, target, scope, wd);
-
-      const hasContextChanged =
-        repoPathRef.current !== path ||
-        targetBranchRef.current !== target ||
-        (workingDirRef.current ?? null) !== workingDir;
-      if (hasContextChanged) {
-        return;
-      }
-
-      // Stale response guard
-      if (versionByScopeAndModeRef.current[scope][mode] !== version) {
-        return;
-      }
-
-      setState((prev) => {
-        const nextFetchedScopeSnapshot = toScopeSnapshot(snapshot);
-        const previousFetchedScopeSnapshot = prev.byScope[scope];
-        let didChange = false;
-        const nextByScope: Record<DiffScope, ScopeSnapshot> = {
-          ...prev.byScope,
-        };
-
-        if (!scopeSnapshotEqual(previousFetchedScopeSnapshot, nextFetchedScopeSnapshot)) {
-          nextByScope[scope] = nextFetchedScopeSnapshot;
-          didChange = true;
-        }
-
-        let nextLoadedByScope = prev.loadedByScope;
-        if (!prev.loadedByScope[scope]) {
-          nextLoadedByScope = {
-            ...prev.loadedByScope,
-            [scope]: true,
-          };
-          didChange = true;
-        }
-
-        if (requestSequence >= latestSharedSequenceRef.current) {
-          latestSharedSequenceRef.current = requestSequence;
-          for (const otherScope of ALL_SCOPES) {
-            if (otherScope === scope) {
-              continue;
-            }
-
-            const previousOtherScopeSnapshot = nextByScope[otherScope];
-            const nextOtherScopeSnapshot = mergeSharedSnapshotFields(
-              previousOtherScopeSnapshot,
-              nextFetchedScopeSnapshot,
-            );
-
-            if (!scopeSnapshotEqual(previousOtherScopeSnapshot, nextOtherScopeSnapshot)) {
-              nextByScope[otherScope] = nextOtherScopeSnapshot;
-              didChange = true;
-            }
-          }
-        }
-
-        if (!didChange && !prev.isLoading) {
-          return prev;
-        }
-
-        return {
-          byScope: nextByScope,
-          loadedByScope: nextLoadedByScope,
-          isLoading: false,
-        };
-      });
-    } catch (err) {
-      const hasContextChanged =
-        repoPathRef.current !== path ||
-        targetBranchRef.current !== target ||
-        (workingDirRef.current ?? null) !== workingDir;
-      if (hasContextChanged) {
-        return;
-      }
-
-      if (versionByScopeAndModeRef.current[scope][mode] === version) {
-        setState((prev) => {
-          const previousScopeSnapshot = prev.byScope[scope];
-          const nextScopeSnapshot: ScopeSnapshot = {
-            ...previousScopeSnapshot,
-            error: String(err),
-            hashVersion: null,
-            statusHash: null,
-            diffHash: null,
-          };
-
-          let nextLoadedByScope = prev.loadedByScope;
-          if (mode === "full" && !prev.loadedByScope[scope]) {
-            nextLoadedByScope = {
-              ...prev.loadedByScope,
-              [scope]: true,
-            };
-          }
-
-          const snapshotsEqual = scopeSnapshotEqual(previousScopeSnapshot, nextScopeSnapshot);
-          const loadedByScopeUnchanged = nextLoadedByScope === prev.loadedByScope;
-          if (snapshotsEqual && loadedByScopeUnchanged && !prev.isLoading) {
-            return prev;
-          }
-
-          return {
-            byScope: {
-              ...prev.byScope,
-              [scope]: nextScopeSnapshot,
-            },
-            loadedByScope: nextLoadedByScope,
-            isLoading: false,
-          };
-        });
-      }
-    } finally {
-      if (inFlightScopeRequestRef.current[scope][mode] === requestKey) {
-        inFlightScopeRequestRef.current[scope][mode] = null;
-      }
-
-      if (mode === "full" && queuedFullReloadByScopeRef.current[scope]) {
-        queuedFullReloadByScopeRef.current[scope] = false;
-        globalThis.queueMicrotask(() => {
-          void loadData(false, {
-            repoPath: path,
-            targetBranch: target,
-            workingDir,
-            scope,
-            mode: "full",
-          });
-        });
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    const contextKey = `${repoPath ?? ""}::${targetBranch}::${worktreePath ?? ""}::${
-      worktreeResolutionRunId ?? ""
-    }::${branchIdentityKey ?? ""}`;
-    const hasContextChanged =
-      requestContextKeyRef.current !== null && requestContextKeyRef.current !== contextKey;
-    requestContextKeyRef.current = contextKey;
-
-    if (repoPath && !shouldBlockDiffLoading) {
-      if (hasContextChanged) {
-        for (const scope of ALL_SCOPES) {
-          for (const mode of ALL_LOAD_DATA_MODES) {
-            versionByScopeAndModeRef.current[scope][mode] += 1;
-            inFlightScopeRequestRef.current[scope][mode] = null;
-          }
-          queuedFullReloadByScopeRef.current[scope] = false;
-        }
-        requestSequenceRef.current = 0;
-        latestSharedSequenceRef.current = 0;
-        setState(createInitialState());
-        setSelectedFileState(null);
-      }
-
-      void loadData(true, {
-        repoPath,
-        targetBranch,
-        workingDir: worktreePath,
-        scope: diffScopeRef.current,
-      });
-      return;
-    }
-
-    if (repoPath) {
-      if (hasContextChanged) {
-        for (const scope of ALL_SCOPES) {
-          for (const mode of ALL_LOAD_DATA_MODES) {
-            versionByScopeAndModeRef.current[scope][mode] += 1;
-            inFlightScopeRequestRef.current[scope][mode] = null;
-          }
-          queuedFullReloadByScopeRef.current[scope] = false;
-        }
-        requestSequenceRef.current = 0;
-        latestSharedSequenceRef.current = 0;
-        setState(createInitialState());
-        setSelectedFileState(null);
-      }
-      return;
-    }
-
-    for (const scope of ALL_SCOPES) {
-      for (const mode of ALL_LOAD_DATA_MODES) {
-        versionByScopeAndModeRef.current[scope][mode] += 1;
-        inFlightScopeRequestRef.current[scope][mode] = null;
-      }
-      queuedFullReloadByScopeRef.current[scope] = false;
-    }
-    requestSequenceRef.current = 0;
-    latestSharedSequenceRef.current = 0;
-    requestContextKeyRef.current = null;
-    setState(createInitialState());
-    setSelectedFileState(null);
-  }, [
-    repoPath,
-    worktreePath,
-    targetBranch,
-    worktreeResolutionRunId,
-    branchIdentityKey,
-    shouldBlockDiffLoading,
-    loadData,
-  ]);
-
-  useEffect(() => {
-    if (!repoPath || shouldBlockDiffLoading) {
-      return;
-    }
-
-    if (state.loadedByScope[diffScope]) {
-      return;
-    }
-
-    void loadData(true, { repoPath, targetBranch, workingDir: worktreePath, scope: diffScope });
-  }, [
-    repoPath,
-    worktreePath,
-    targetBranch,
+  const {
+    activeScopeState,
+    contextResetVersion,
     diffScope,
-    state.loadedByScope,
+    refreshActiveScope,
+    reloadActiveScope,
+    setDiffScope,
+    state,
+    statusSnapshotKey,
+  } = useAgentStudioDiffController({
+    repoPath,
+    targetBranch,
+    workingDir: worktreePath,
+    requestContextKey,
+    enablePolling,
     shouldBlockDiffLoading,
-    loadData,
-  ]);
+  });
 
-  // Polling — stable interval since loadData doesn't change
-  useEffect(() => {
-    if (!enablePolling || !repoPath || shouldBlockDiffLoading) {
-      return;
-    }
+  const [selectedFileState, setSelectedFileState] = useState<SelectedFileState>({
+    path: null,
+    contextResetVersion: 0,
+  });
 
-    const intervalId = globalThis.setInterval(() => {
-      const polledScope = diffScopeRef.current;
-      void loadData(false, {
-        repoPath,
-        targetBranch: targetBranchRef.current,
-        workingDir: workingDirRef.current,
-        scope: polledScope,
-        mode: "summary",
-      });
-    }, POLL_INTERVAL_MS);
+  const selectedFile =
+    selectedFileState.contextResetVersion === contextResetVersion ? selectedFileState.path : null;
 
-    return () => {
-      globalThis.clearInterval(intervalId);
-    };
-  }, [enablePolling, repoPath, shouldBlockDiffLoading, loadData]);
-
-  const activeScopeState = state.byScope[diffScope];
-  const statusSnapshotKey = toStatusSnapshotKey(activeScopeState);
-  const displayError = worktreeResolutionError ?? activeScopeState.error;
-  const isLoading = state.isLoading || isWorktreeResolutionResolving;
   const refresh = useCallback((): void => {
     if (worktreeResolutionError != null) {
       retryWorktreeResolution();
@@ -794,41 +86,33 @@ export function useAgentStudioDiffData({
       return;
     }
 
-    void loadData(true, {
-      repoPath: repoPathRef.current,
-      targetBranch: targetBranchRef.current,
-      workingDir: workingDirRef.current,
-      scope: diffScopeRef.current,
-      replayIfInFlight: true,
-    });
-  }, [loadData, retryWorktreeResolution, shouldBlockDiffLoading, worktreeResolutionError]);
+    refreshActiveScope();
+  }, [
+    refreshActiveScope,
+    retryWorktreeResolution,
+    shouldBlockDiffLoading,
+    worktreeResolutionError,
+  ]);
 
   const setSelectedFile = useCallback(
     (path: string | null): void => {
-      setSelectedFileState(path);
+      setSelectedFileState({
+        path,
+        contextResetVersion,
+      });
 
       if (path === null || shouldBlockDiffLoading) {
         return;
       }
 
-      const selectedRepoPath = repoPathRef.current;
-      if (!selectedRepoPath) {
-        return;
-      }
-
-      void loadData(false, {
-        repoPath: selectedRepoPath,
-        targetBranch: targetBranchRef.current,
-        workingDir: workingDirRef.current,
-        scope: diffScopeRef.current,
-        mode: "full",
-        replayIfInFlight: true,
-      });
+      reloadActiveScope();
     },
-    [loadData, shouldBlockDiffLoading],
+    [contextResetVersion, reloadActiveScope, shouldBlockDiffLoading],
   );
 
-  // Memoize return value to prevent parent re-renders (rerender-memo-with-default-value)
+  const displayError = worktreeResolutionError ?? activeScopeState.error;
+  const isLoading = state.isLoading || isWorktreeResolutionResolving;
+
   return useMemo<DiffDataState>(
     () => ({
       branch: activeScopeState.branch,
@@ -850,16 +134,17 @@ export function useAgentStudioDiffData({
       setDiffScope,
     }),
     [
-      worktreePath,
-      targetBranch,
+      activeScopeState,
+      displayError,
       diffScope,
       isLoading,
-      displayError,
-      statusSnapshotKey,
-      activeScopeState,
       refresh,
       selectedFile,
+      setDiffScope,
       setSelectedFile,
+      statusSnapshotKey,
+      targetBranch,
+      worktreePath,
     ],
   );
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.ts
@@ -11,11 +11,6 @@ export type {
 import { useAgentStudioDiffController } from "./use-agent-studio-diff-controller";
 import { useAgentStudioWorktreeResolution } from "./use-agent-studio-worktree-resolution";
 
-type SelectedFileState = {
-  path: string | null;
-  contextResetVersion: number;
-};
-
 export function useAgentStudioDiffData({
   repoPath,
   sessionWorkingDirectory,
@@ -50,9 +45,13 @@ export function useAgentStudioDiffData({
     }`;
   }, [branchIdentityKey, repoPath, targetBranch, worktreePath, worktreeResolutionRunId]);
 
+  const [selectedFileState, setSelectedFileState] = useState<string | null>(null);
+  const handleContextReset = useCallback((): void => {
+    setSelectedFileState(null);
+  }, []);
+
   const {
     activeScopeState,
-    contextResetVersion,
     diffScope,
     refreshActiveScope,
     reloadActiveScope,
@@ -66,15 +65,10 @@ export function useAgentStudioDiffData({
     requestContextKey,
     enablePolling,
     shouldBlockDiffLoading,
+    onContextReset: handleContextReset,
   });
 
-  const [selectedFileState, setSelectedFileState] = useState<SelectedFileState>({
-    path: null,
-    contextResetVersion: 0,
-  });
-
-  const selectedFile =
-    selectedFileState.contextResetVersion === contextResetVersion ? selectedFileState.path : null;
+  const selectedFile = selectedFileState;
 
   const refresh = useCallback((): void => {
     if (worktreeResolutionError != null) {
@@ -96,10 +90,7 @@ export function useAgentStudioDiffData({
 
   const setSelectedFile = useCallback(
     (path: string | null): void => {
-      setSelectedFileState({
-        path,
-        contextResetVersion,
-      });
+      setSelectedFileState(path);
 
       if (path === null || shouldBlockDiffLoading) {
         return;
@@ -107,7 +98,7 @@ export function useAgentStudioDiffData({
 
       reloadActiveScope();
     },
-    [contextResetVersion, reloadActiveScope, shouldBlockDiffLoading],
+    [reloadActiveScope, shouldBlockDiffLoading],
   );
 
   const displayError = worktreeResolutionError ?? activeScopeState.error;


### PR DESCRIPTION
## Summary
- extract the agent studio diff polling/reconciliation state machine into a dedicated controller hook
- centralize summary reload decisions in the diff model and make selection reset an explicit context-reset boundary
- add focused model and hook coverage for invalidation and selected-file reset behavior

## Testing
- bun test apps/desktop/src/pages/agents/agent-studio-diff-data-model.test.ts apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint