### PR TITLE
refactor(agent-runtime): align runtime instance hydration and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Package manager: **Bun** (not npm/yarn). All workspace commands use `bun run`.
 
 - Treat runtime definitions, runtime routes, and runtime connections as different layers.
 - Shared host-visible runtime/run payloads live in `packages/contracts/src/run-schemas.ts`; update Rust host types in `apps/desktop/src-tauri/crates/host-domain/src/runtime.rs` in the same change.
-- `AgentRuntimeSummary` is live runtime-instance metadata only: keep `kind`, `runtimeId`, `repoPath`, nullable `taskId`, `role`, `workingDirectory`, `runtimeRoute`, `startedAt`, and `descriptor`. Do not reintroduce top-level `endpoint`, `port`, or duplicate `capabilities` fields there.
+- `RuntimeInstanceSummary` is live runtime-instance metadata only: keep `kind`, `runtimeId`, `repoPath`, nullable `taskId`, `role`, `workingDirectory`, `runtimeRoute`, `startedAt`, and `descriptor`. Do not reintroduce top-level `endpoint`, `port`, or duplicate `capabilities` fields there.
 - Request-scoped agent engine operations use `runtimeConnection` objects, not raw shared `runtimeEndpoint` strings. Build adapter-local client inputs from the connection at the adapter boundary.
 - Persisted session records/documents must not store live runtime route data (`runtimeEndpoint`, `baseUrl`, `runtimeTransport`). Persist durable identifiers plus `workingDirectory`, then resolve a live route during hydration.
 - Keep runtime routing fail-fast. Never fall back from a session/build runtime to the repo default runtime when loading session history, todos, diff, or file status.

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -21,6 +21,16 @@ struct BuildRunRegistration {
     emitter: RunEmitter,
 }
 
+struct BuildModeStartInput<'a> {
+    runtime_kind: AgentRuntimeKind,
+    prerequisites: BuildPrerequisites,
+    prepared_worktree: PreparedBuildWorktree,
+    spawned_agent: SpawnedBuildAgent,
+    task_id: &'a str,
+    run_id: &'a str,
+    emitter: RunEmitter,
+}
+
 impl AppService {
     pub fn build_start(
         &self,
@@ -46,15 +56,15 @@ impl AppService {
             startup_policy,
         )?;
 
-        self.initiate_build_mode(
+        self.initiate_build_mode(BuildModeStartInput {
             runtime_kind,
             prerequisites,
             prepared_worktree,
             spawned_agent,
             task_id,
-            run_id.as_str(),
+            run_id: run_id.as_str(),
             emitter,
-        )
+        })
     }
 
     pub fn build_respond(
@@ -254,16 +264,16 @@ impl AppService {
         Ok(summary)
     }
 
-    fn initiate_build_mode(
-        &self,
-        runtime_kind: AgentRuntimeKind,
-        prerequisites: BuildPrerequisites,
-        prepared_worktree: PreparedBuildWorktree,
-        mut spawned_agent: SpawnedBuildAgent,
-        task_id: &str,
-        run_id: &str,
-        emitter: RunEmitter,
-    ) -> Result<RunSummary> {
+    fn initiate_build_mode(&self, input: BuildModeStartInput<'_>) -> Result<RunSummary> {
+        let BuildModeStartInput {
+            runtime_kind,
+            prerequisites,
+            prepared_worktree,
+            mut spawned_agent,
+            task_id,
+            run_id,
+            emitter,
+        } = input;
         self.task_transition(
             prerequisites.repo_path.as_str(),
             task_id,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -7,7 +7,7 @@ use super::super::{
 use super::build_runtime_setup::{BuildPrerequisites, PreparedBuildWorktree, SpawnedBuildAgent};
 use super::BuildResponseAction;
 use anyhow::{anyhow, Context, Result};
-use host_domain::{now_rfc3339, RunEvent, RunState, RunSummary, TaskStatus};
+use host_domain::{now_rfc3339, AgentRuntimeKind, RunEvent, RunState, RunSummary, TaskStatus};
 use std::process::{ChildStderr, ChildStdout};
 use uuid::Uuid;
 
@@ -26,8 +26,10 @@ impl AppService {
         &self,
         repo_path: &str,
         task_id: &str,
+        runtime_kind: &str,
         emitter: RunEmitter,
     ) -> Result<RunSummary> {
+        let runtime_kind = Self::resolve_supported_runtime_kind(runtime_kind)?;
         let run_id = format!("run-{}", Uuid::new_v4().simple());
         let prerequisites = self.validate_build_prerequisites(repo_path, task_id)?;
         let startup_policy = self.resolve_build_startup_policy(
@@ -45,6 +47,7 @@ impl AppService {
         )?;
 
         self.initiate_build_mode(
+            runtime_kind,
             prerequisites,
             prepared_worktree,
             spawned_agent,
@@ -253,6 +256,7 @@ impl AppService {
 
     fn initiate_build_mode(
         &self,
+        runtime_kind: AgentRuntimeKind,
         prerequisites: BuildPrerequisites,
         prepared_worktree: PreparedBuildWorktree,
         mut spawned_agent: SpawnedBuildAgent,
@@ -279,16 +283,15 @@ impl AppService {
 
         let summary = RunSummary {
             run_id: run_id_string.clone(),
-            runtime_kind: host_domain::AgentRuntimeKind::Opencode,
-            runtime_route: host_domain::AgentRuntimeKind::Opencode
-                .route_for_port(spawned_agent.port),
+            runtime_kind,
+            runtime_route: runtime_kind.route_for_port(spawned_agent.port),
             repo_path: prerequisites.repo_path.clone(),
             task_id: task_id_string.clone(),
             branch: prerequisites.branch.clone(),
             worktree_path: worktree_path.clone(),
             port: spawned_agent.port,
             state: RunState::Running,
-            last_message: Some("Opencode server running".to_string()),
+            last_message: Some(format!("{} runtime running", runtime_kind.as_str())),
             started_at: now_rfc3339(),
         };
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use fs2::FileExt;
 use host_domain::{
-    AgentRuntimeSummary, GitPort, RunEvent, RunSummary, RuntimeCheck, RuntimeRole, TaskCard,
+    RuntimeInstanceSummary, GitPort, RunEvent, RunSummary, RuntimeCheck, RuntimeRole, TaskCard,
     TaskStore,
 };
 use host_infra_system::{AppConfigStore, GitCliPort, RepoConfig, RuntimeConfigStore};

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -5,7 +5,7 @@ mod startup;
 use super::AppService;
 use anyhow::{anyhow, Result};
 use host_domain::{
-    AgentRuntimeKind, AgentRuntimeRole, AgentRuntimeSummary, RunSummary, RuntimeDescriptor,
+    AgentRuntimeKind, AgentRuntimeRole, RunSummary, RuntimeDescriptor, RuntimeInstanceSummary,
     RuntimeRole,
 };
 use std::collections::HashSet;
@@ -38,7 +38,7 @@ pub(super) struct RuntimeStartInput<'a> {
 }
 
 pub(super) enum RuntimePrerequisiteResolution {
-    Existing(AgentRuntimeSummary),
+    Existing(RuntimeInstanceSummary),
     Ready(RuntimePrerequisites),
 }
 
@@ -63,17 +63,21 @@ impl AppService {
         &self,
         runtime_kind: &str,
         repo_path: Option<&str>,
-    ) -> Result<Vec<AgentRuntimeSummary>> {
-        Self::ensure_supported_runtime_kind(runtime_kind)?;
-        self.list_registered_runtimes(repo_path)
+    ) -> Result<Vec<RuntimeInstanceSummary>> {
+        let supported_kind = Self::resolve_supported_runtime_kind(runtime_kind)?;
+        Ok(self
+            .list_registered_runtimes(repo_path)?
+            .into_iter()
+            .filter(|runtime| runtime.kind == supported_kind)
+            .collect())
     }
 
     pub fn runtime_ensure(
         &self,
         runtime_kind: &str,
         repo_path: &str,
-    ) -> Result<AgentRuntimeSummary> {
-        Self::ensure_supported_runtime_kind(runtime_kind)?;
+    ) -> Result<RuntimeInstanceSummary> {
+        Self::resolve_supported_runtime_kind(runtime_kind)?;
         self.ensure_workspace_runtime(repo_path)
     }
 
@@ -83,8 +87,8 @@ impl AppService {
         repo_path: &str,
         task_id: &str,
         role: AgentRuntimeRole,
-    ) -> Result<AgentRuntimeSummary> {
-        Self::ensure_supported_runtime_kind(runtime_kind)?;
+    ) -> Result<RuntimeInstanceSummary> {
+        Self::resolve_supported_runtime_kind(runtime_kind)?;
         self.start_task_runtime(repo_path, task_id, role)
     }
 
@@ -131,7 +135,7 @@ impl AppService {
         Ok(list)
     }
 
-    fn ensure_workspace_runtime(&self, repo_path: &str) -> Result<AgentRuntimeSummary> {
+    fn ensure_workspace_runtime(&self, repo_path: &str) -> Result<RuntimeInstanceSummary> {
         let repo_key = self.resolve_initialized_repo_path(repo_path)?;
         let repo_path = repo_key.as_str();
 
@@ -193,7 +197,7 @@ impl AppService {
         repo_path: &str,
         task_id: &str,
         role: AgentRuntimeRole,
-    ) -> Result<AgentRuntimeSummary> {
+    ) -> Result<RuntimeInstanceSummary> {
         let repo_key = self.resolve_initialized_repo_path(repo_path)?;
         let repo_path = repo_key.as_str();
         let runtime_role = RuntimeRole::from(role);
@@ -242,14 +246,14 @@ impl AppService {
     fn spawn_and_register_runtime(
         &self,
         input: RuntimeStartInput<'_>,
-    ) -> Result<AgentRuntimeSummary> {
+    ) -> Result<RuntimeInstanceSummary> {
         let spawned_server = self.spawn_runtime_server(&input)?;
         self.attach_runtime_session(input, spawned_server)
     }
 
-    fn ensure_supported_runtime_kind(runtime_kind: &str) -> Result<()> {
+    pub(super) fn resolve_supported_runtime_kind(runtime_kind: &str) -> Result<AgentRuntimeKind> {
         match runtime_kind.trim() {
-            "opencode" => Ok(()),
+            "opencode" => Ok(AgentRuntimeKind::Opencode),
             other => Err(anyhow!("Unsupported agent runtime kind: {other}")),
         }
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -24,6 +24,7 @@ pub(super) struct RuntimePostStartPolicy<'a> {
 }
 
 pub(super) struct RuntimeStartInput<'a> {
+    runtime_kind: AgentRuntimeKind,
     startup_scope: &'a str,
     repo_path: &'a str,
     repo_key: String,
@@ -77,8 +78,8 @@ impl AppService {
         runtime_kind: &str,
         repo_path: &str,
     ) -> Result<RuntimeInstanceSummary> {
-        Self::resolve_supported_runtime_kind(runtime_kind)?;
-        self.ensure_workspace_runtime(repo_path)
+        let runtime_kind = Self::resolve_supported_runtime_kind(runtime_kind)?;
+        self.ensure_workspace_runtime(runtime_kind, repo_path)
     }
 
     pub fn runtime_start(
@@ -88,8 +89,8 @@ impl AppService {
         task_id: &str,
         role: AgentRuntimeRole,
     ) -> Result<RuntimeInstanceSummary> {
-        Self::resolve_supported_runtime_kind(runtime_kind)?;
-        self.start_task_runtime(repo_path, task_id, role)
+        let runtime_kind = Self::resolve_supported_runtime_kind(runtime_kind)?;
+        self.start_task_runtime(runtime_kind, repo_path, task_id, role)
     }
 
     pub fn runtime_stop(&self, runtime_id: &str) -> Result<bool> {
@@ -135,7 +136,11 @@ impl AppService {
         Ok(list)
     }
 
-    fn ensure_workspace_runtime(&self, repo_path: &str) -> Result<RuntimeInstanceSummary> {
+    fn ensure_workspace_runtime(
+        &self,
+        runtime_kind: AgentRuntimeKind,
+        repo_path: &str,
+    ) -> Result<RuntimeInstanceSummary> {
         let repo_key = self.resolve_initialized_repo_path(repo_path)?;
         let repo_path = repo_key.as_str();
 
@@ -158,8 +163,10 @@ impl AppService {
             }
         }
 
-        let startup_error_context =
-            format!("OpenCode workspace runtime failed to start for {repo_path}");
+        let startup_error_context = format!(
+            "{} workspace runtime failed to start for {repo_path}",
+            runtime_kind.as_str()
+        );
         let startup_policy = self.resolve_runtime_startup_policy(
             "workspace_runtime",
             repo_path,
@@ -169,6 +176,7 @@ impl AppService {
         )?;
 
         self.spawn_and_register_runtime(RuntimeStartInput {
+            runtime_kind,
             startup_scope: "workspace_runtime",
             repo_path,
             repo_key: repo_key.clone(),
@@ -194,6 +202,7 @@ impl AppService {
 
     fn start_task_runtime(
         &self,
+        runtime_kind: AgentRuntimeKind,
         repo_path: &str,
         task_id: &str,
         role: AgentRuntimeRole,
@@ -206,7 +215,10 @@ impl AppService {
         {
             return Ok(existing);
         }
-        let startup_error_context = format!("OpenCode runtime failed to start for task {task_id}");
+        let startup_error_context = format!(
+            "{} runtime failed to start for task {task_id}",
+            runtime_kind.as_str()
+        );
         let startup_policy = self.resolve_runtime_startup_policy(
             "agent_runtime",
             repo_path,
@@ -220,6 +232,7 @@ impl AppService {
         };
 
         self.spawn_and_register_runtime(RuntimeStartInput {
+            runtime_kind,
             startup_scope: "agent_runtime",
             repo_path,
             repo_key: repo_key.clone(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/prerequisites.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/prerequisites.rs
@@ -1,7 +1,7 @@
 use super::super::{qa_worktree::prepare_qa_worktree, AppService, RuntimeCleanupTarget};
 use super::{RuntimeExistingLookup, RuntimePrerequisiteResolution, RuntimePrerequisites};
 use anyhow::{anyhow, Result};
-use host_domain::{AgentRuntimeRole, AgentRuntimeSummary, RuntimeRole};
+use host_domain::{AgentRuntimeRole, RuntimeInstanceSummary, RuntimeRole};
 use std::path::Path;
 
 impl AppService {
@@ -10,7 +10,7 @@ impl AppService {
         repo_key: &str,
         role: RuntimeRole,
         task_id: &str,
-    ) -> Result<Option<AgentRuntimeSummary>> {
+    ) -> Result<Option<RuntimeInstanceSummary>> {
         let mut runtimes = self
             .agent_runtimes
             .lock()

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/lifecycle.rs
@@ -3,7 +3,7 @@ use super::super::super::{
 };
 use super::super::{RuntimePostStartPolicy, RuntimeStartInput, SpawnedRuntimeServer};
 use anyhow::{anyhow, Result};
-use host_domain::{now_rfc3339, AgentRuntimeKind, AgentRuntimeSummary};
+use host_domain::{now_rfc3339, AgentRuntimeKind, RuntimeInstanceSummary};
 use std::collections::HashMap;
 use std::process::Child;
 use std::sync::MutexGuard;
@@ -13,7 +13,7 @@ impl AppService {
         &self,
         input: RuntimeStartInput<'_>,
         mut spawned_server: SpawnedRuntimeServer,
-    ) -> Result<AgentRuntimeSummary> {
+    ) -> Result<RuntimeInstanceSummary> {
         let RuntimeStartInput {
             startup_scope,
             repo_key,
@@ -26,7 +26,7 @@ impl AppService {
         } = input;
 
         let descriptor = AgentRuntimeKind::Opencode.descriptor();
-        let summary = AgentRuntimeSummary {
+        let summary = RuntimeInstanceSummary {
             kind: AgentRuntimeKind::Opencode,
             runtime_id: spawned_server.runtime_id.clone(),
             repo_path: repo_key,
@@ -86,7 +86,7 @@ impl AppService {
         startup_scope: &str,
         child: &mut Child,
         cleanup_target: Option<&RuntimeCleanupTarget>,
-    ) -> Result<Option<AgentRuntimeSummary>> {
+    ) -> Result<Option<RuntimeInstanceSummary>> {
         let Some(post_start_policy) = post_start_policy else {
             return Ok(None);
         };

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/lifecycle.rs
@@ -3,7 +3,7 @@ use super::super::super::{
 };
 use super::super::{RuntimePostStartPolicy, RuntimeStartInput, SpawnedRuntimeServer};
 use anyhow::{anyhow, Result};
-use host_domain::{now_rfc3339, AgentRuntimeKind, RuntimeInstanceSummary};
+use host_domain::{now_rfc3339, RuntimeInstanceSummary};
 use std::collections::HashMap;
 use std::process::Child;
 use std::sync::MutexGuard;
@@ -15,6 +15,7 @@ impl AppService {
         mut spawned_server: SpawnedRuntimeServer,
     ) -> Result<RuntimeInstanceSummary> {
         let RuntimeStartInput {
+            runtime_kind,
             startup_scope,
             repo_key,
             task_id,
@@ -25,15 +26,15 @@ impl AppService {
             ..
         } = input;
 
-        let descriptor = AgentRuntimeKind::Opencode.descriptor();
+        let descriptor = runtime_kind.descriptor();
         let summary = RuntimeInstanceSummary {
-            kind: AgentRuntimeKind::Opencode,
+            kind: runtime_kind,
             runtime_id: spawned_server.runtime_id.clone(),
             repo_path: repo_key,
             task_id: (role != host_domain::RuntimeRole::Workspace).then(|| task_id.to_string()),
             role,
             working_directory,
-            runtime_route: AgentRuntimeKind::Opencode.route_for_port(spawned_server.port),
+            runtime_route: runtime_kind.route_for_port(spawned_server.port),
             started_at: now_rfc3339(),
             descriptor,
         };

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/query.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/query.rs
@@ -1,14 +1,14 @@
 use super::super::super::{AgentRuntimeProcess, AppService};
 use super::super::RuntimeExistingLookup;
 use anyhow::{anyhow, Result};
-use host_domain::AgentRuntimeSummary;
+use host_domain::RuntimeInstanceSummary;
 use std::collections::{HashMap, HashSet};
 
 impl AppService {
     pub(in crate::app_service::runtime_orchestrator) fn list_registered_runtimes(
         &self,
         repo_path: Option<&str>,
-    ) -> Result<Vec<AgentRuntimeSummary>> {
+    ) -> Result<Vec<RuntimeInstanceSummary>> {
         let repo_key_filter = repo_path
             .map(|path| self.ensure_repo_authorized(path))
             .transpose()?;
@@ -51,7 +51,7 @@ impl AppService {
     pub(in crate::app_service::runtime_orchestrator) fn find_existing_runtime(
         runtimes: &HashMap<String, AgentRuntimeProcess>,
         lookup: RuntimeExistingLookup<'_>,
-    ) -> Option<AgentRuntimeSummary> {
+    ) -> Option<RuntimeInstanceSummary> {
         runtimes
             .values()
             .find(|runtime| {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
@@ -33,7 +33,7 @@ pub(crate) struct RunProcess {
 }
 
 pub(crate) struct AgentRuntimeProcess {
-    pub(super) summary: AgentRuntimeSummary,
+    pub(super) summary: RuntimeInstanceSummary,
     pub(super) child: Child,
     pub(super) _opencode_process_guard: Option<TrackedOpencodeProcessGuard>,
     pub(super) cleanup_target: Option<RuntimeCleanupTarget>,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -17,14 +17,14 @@ use super::{
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeSummary, AgentSessionDocument, AgentWorkflows, CreateTaskInput, GitAheadBehind,
-    GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope,
-    GitFileDiff, GitFileStatus, GitFileStatusCounts, GitPort, GitPullRequest, GitPullResult,
-    GitPushResult, GitRebaseAbortRequest, GitRebaseAbortResult, GitRebaseBranchRequest,
-    GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatusData,
-    GitWorktreeStatusSummaryData, IssueType, PlanSubtaskInput, QaReportDocument, QaVerdict,
-    QaWorkflowVerdict, RunEvent, RunState, RunSummary, SpecDocument, TaskAction, TaskCard,
-    TaskDocumentSummary, TaskMetadata, TaskStatus, TaskStore, UpdateTaskPatch,
+    AgentSessionDocument, AgentWorkflows, CreateTaskInput, GitAheadBehind, GitBranch,
+    GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitFileDiff,
+    GitFileStatus, GitFileStatusCounts, GitPort, GitPullRequest, GitPullResult, GitPushResult,
+    GitRebaseAbortRequest, GitRebaseAbortResult, GitRebaseBranchRequest, GitRebaseBranchResult,
+    GitUpstreamAheadBehind, GitWorktreeStatusData, GitWorktreeStatusSummaryData, IssueType,
+    PlanSubtaskInput, QaReportDocument, QaVerdict, QaWorkflowVerdict, RunEvent, RunState,
+    RunSummary, RuntimeInstanceSummary, SpecDocument, TaskAction, TaskCard, TaskDocumentSummary,
+    TaskMetadata, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{
     AppConfigStore, GlobalConfig, HookSet, OpencodeStartupReadinessConfig, RepoConfig,
@@ -899,8 +899,6 @@ pub(crate) fn make_session(task_id: &str, session_id: &str) -> AgentSessionDocum
         updated_at: Some("2026-02-20T12:00:10Z".to_string()),
         ended_at: None,
         runtime_kind: "opencode".to_string(),
-        runtime_id: Some("runtime-1".to_string()),
-        run_id: Some("run-1".to_string()),
         working_directory: "/tmp/repo".to_string(),
         selected_model: None,
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeKind, AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch,
+    AgentRuntimeKind, RuntimeInstanceSummary, AgentSessionDocument, CreateTaskInput, GitBranch,
     GitCurrentBranch, GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState,
     RunSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
@@ -107,7 +107,7 @@ fn build_start_respond_and_cleanup_success_flow() -> Result<()> {
     let events = Arc::new(Mutex::new(Vec::<RunEvent>::new()));
     let emitter = make_emitter(events.clone());
 
-    let run = service.build_start(repo_path.as_str(), "task-1", emitter.clone())?;
+    let run = service.build_start(repo_path.as_str(), "task-1", "opencode", emitter.clone())?;
     assert!(matches!(run.state, RunState::Running));
     assert_eq!(service.runs_list(Some(repo_path.as_str()))?.len(), 1);
 
@@ -245,7 +245,7 @@ fn build_start_bases_worktree_on_configured_target_branch() -> Result<()> {
 
     let events = Arc::new(Mutex::new(Vec::<RunEvent>::new()));
     let emitter = make_emitter(events.clone());
-    let run = service.build_start(repo_path.as_str(), "task-1", emitter.clone())?;
+    let run = service.build_start(repo_path.as_str(), "task-1", "opencode", emitter.clone())?;
     let worktree_path = Path::new(run.worktree_path.as_str());
     assert!(worktree_path.join("develop-only.txt").exists());
     assert!(!worktree_path.join("main-only.txt").exists());
@@ -398,6 +398,7 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
         .build_start(
             repo_path.as_str(),
             "task-1",
+            "opencode",
             make_emitter(Arc::new(Mutex::new(Vec::new()))),
         )
         .expect_err("pre-start failure should fail");
@@ -427,7 +428,7 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
 
     let events = Arc::new(Mutex::new(Vec::<RunEvent>::new()));
     let emitter = make_emitter(events.clone());
-    let run = service.build_start(repo_path.as_str(), "task-2", emitter.clone())?;
+    let run = service.build_start(repo_path.as_str(), "task-2", "opencode", emitter.clone())?;
     let cleaned =
         service.build_cleanup(run.run_id.as_str(), CleanupMode::Success, emitter.clone())?;
     assert!(!cleaned, "post-hook failure should report false");
@@ -507,6 +508,7 @@ fn build_start_requires_worktree_base_path() -> Result<()> {
         .build_start(
             repo_path.as_str(),
             "task-1",
+            "opencode",
             make_emitter(Arc::new(Mutex::new(Vec::new()))),
         )
         .expect_err("build_start should require worktree base");
@@ -559,6 +561,7 @@ fn build_start_rejects_untrusted_hooks_configuration() -> Result<()> {
         .build_start(
             repo_path.as_str(),
             "task-1",
+            "opencode",
             make_emitter(Arc::new(Mutex::new(Vec::new()))),
         )
         .expect_err("hooks should be rejected when not trusted");
@@ -611,6 +614,7 @@ fn build_start_rejects_existing_worktree_directory() -> Result<()> {
         .build_start(
             repo_path.as_str(),
             "task-1",
+            "opencode",
             make_emitter(Arc::new(Mutex::new(Vec::new()))),
         )
         .expect_err("existing worktree path should be rejected");
@@ -668,6 +672,7 @@ fn build_start_reports_opencode_startup_failure() -> Result<()> {
         .build_start(
             repo_path.as_str(),
             "task-1",
+            "opencode",
             make_emitter(Arc::new(Mutex::new(Vec::new()))),
         )
         .expect_err("startup failure should bubble up");
@@ -722,6 +727,7 @@ fn build_start_fails_on_invalid_startup_config_before_worktree_creation() -> Res
         .build_start(
             repo_path.as_str(),
             "task-1",
+            "opencode",
             make_emitter(Arc::new(Mutex::new(Vec::new()))),
         )
         .expect_err("invalid config should fail build start before worktree preparation");
@@ -790,6 +796,7 @@ fn build_start_stops_spawned_child_when_run_state_lock_is_poisoned() -> Result<(
             service.build_start(
                 repo_path.as_str(),
                 "task-1",
+                "opencode",
                 make_emitter(Arc::new(Mutex::new(Vec::new()))),
             )
         });

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitAheadBehind, GitBranch,
+    RuntimeInstanceSummary, AgentSessionDocument, CreateTaskInput, GitAheadBehind, GitBranch,
     GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitFileDiff,
     GitFileStatus, GitPort, GitPullRequest, GitPullResult, GitRebaseBranchRequest,
     GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatusData, PlanSubtaskInput,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -2,9 +2,10 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeKind, AgentRuntimeRole, AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput,
-    GitBranch, GitCurrentBranch, GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent,
-    RunState, RunSummary, RuntimeRole, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    AgentRuntimeKind, AgentRuntimeRole, AgentSessionDocument, CreateTaskInput, GitBranch,
+    GitCurrentBranch, GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState,
+    RunSummary, RuntimeInstanceSummary, RuntimeRole, TaskAction, TaskStatus, TaskStore,
+    UpdateTaskPatch,
 };
 use host_infra_system::{hook_set_fingerprint, AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -44,8 +45,8 @@ fn runtime_summary_fixture(
     role: RuntimeRole,
     working_directory: &str,
     port: u16,
-) -> AgentRuntimeSummary {
-    AgentRuntimeSummary {
+) -> RuntimeInstanceSummary {
+    RuntimeInstanceSummary {
         kind: AgentRuntimeKind::Opencode,
         runtime_id: runtime_id.to_string(),
         repo_path: repo_path.to_string(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -544,7 +544,7 @@ fn runtime_start_surfaces_cleanup_failure_after_startup_error() -> Result<()> {
         )
         .expect_err("startup cleanup failure should be surfaced");
     let message = error.to_string();
-    assert!(message.contains("OpenCode runtime failed to start for task task-1"));
+    assert!(message.contains("opencode runtime failed to start for task task-1"));
     assert!(message.contains("Failed removing QA worktree runtime"));
 
     let _ = fs::remove_dir_all(root);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/repo_authorization.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/repo_authorization.rs
@@ -165,6 +165,7 @@ fn build_rejects_repo_path_not_in_workspace_allowlist() {
         .build_start(
             "/tmp/odt-repo-unauthorized-build",
             "task-1",
+            "opencode",
             make_emitter(events),
         )
         .expect_err("unconfigured repo path should be rejected");

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
+    RuntimeInstanceSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
     GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
     TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -2,9 +2,9 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeKind, AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch,
-    GitCurrentBranch, GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState,
-    RunSummary, RuntimeRole, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    AgentRuntimeKind, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch, GitPort,
+    PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    RuntimeInstanceSummary, RuntimeRole, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -42,8 +42,8 @@ fn runtime_summary_fixture(
     role: RuntimeRole,
     working_directory: &str,
     port: u16,
-) -> AgentRuntimeSummary {
-    AgentRuntimeSummary {
+) -> RuntimeInstanceSummary {
+    RuntimeInstanceSummary {
         kind: AgentRuntimeKind::Opencode,
         runtime_id: runtime_id.to_string(),
         repo_path: repo_path.to_string(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
+    RuntimeInstanceSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
     GitPort, IssueType, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState,
     RunSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -527,11 +527,11 @@ fn resolve_runtime_startup_policy_emits_config_failure_metrics() -> Result<()> {
             "/tmp/repo",
             "task-42",
             RuntimeRole::Qa,
-            "OpenCode runtime failed to start for task task-42",
+            "opencode runtime failed to start for task task-42",
         )
         .expect_err("invalid config should fail runtime startup policy resolution");
     let message = format!("{error:#}");
-    assert!(message.contains("OpenCode runtime failed to start for task task-42"));
+    assert!(message.contains("opencode runtime failed to start for task task-42"));
     assert!(message.contains("Failed loading OpenCode startup readiness config"));
 
     let metrics = service.startup_metrics_snapshot()?;

--- a/apps/desktop/src-tauri/crates/host-domain/src/document.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/document.rs
@@ -113,6 +113,8 @@ pub struct QaReportDocument {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentSessionModelSelection {
+    #[serde(default = "default_runtime_kind")]
+    pub runtime_kind: String,
     pub provider_id: String,
     pub model_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -146,10 +148,6 @@ pub struct AgentSessionDocument {
     pub ended_at: Option<String>,
     #[serde(default = "default_runtime_kind")]
     pub runtime_kind: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub runtime_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub run_id: Option<String>,
     pub working_directory: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selected_model: Option<AgentSessionModelSelection>,

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -19,7 +19,7 @@ pub use git::{
     GitWorktreeStatusSummaryData, GitWorktreeSummary,
 };
 pub use runtime::{
-    AgentRuntimeKind, AgentRuntimeRole, AgentRuntimeSummary, RunEvent, RunState, RunSummary,
+    AgentRuntimeKind, AgentRuntimeRole, RuntimeInstanceSummary, RunEvent, RunState, RunSummary,
     RuntimeCapabilities, RuntimeDescriptor, RuntimeProvisioningMode, RuntimeRole,
 };
 pub use store::TaskStore;
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn public_api_exports_compile() {
         use super::{
-            AgentRuntimeRole, AgentRuntimeSummary, AgentSessionDocument,
+            AgentRuntimeRole, RuntimeInstanceSummary, AgentSessionDocument,
             AgentSessionModelSelection, AgentWorkflowState, AgentWorkflows, BeadsCheck,
             CreateTaskInput, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
             GitDiffScope, GitFileStatusCounts, GitPort, GitPullRequest, GitPullResult,
@@ -120,7 +120,7 @@ mod tests {
         }
 
         check_types_exported!(
-            AgentRuntimeSummary,
+            RuntimeInstanceSummary,
             AgentSessionDocument,
             AgentSessionModelSelection,
             AgentWorkflowState,

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
@@ -211,7 +211,7 @@ pub struct RunSummary {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AgentRuntimeSummary {
+pub struct RuntimeInstanceSummary {
     pub kind: AgentRuntimeKind,
     pub runtime_id: String,
     pub repo_path: String,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -34,13 +34,10 @@ impl BeadsTaskStore {
             return Err(anyhow!("Agent session workingDirectory is required"));
         }
 
-        session.external_session_id = None;
         session.task_id = None;
         session.status = None;
         session.updated_at = None;
         session.ended_at = None;
-        session.runtime_id = None;
-        session.run_id = None;
 
         Ok(session)
     }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -238,8 +238,6 @@ fn make_session(session_id: &str, started_at: &str, status: &str) -> AgentSessio
         updated_at: Some(started_at.to_string()),
         ended_at: None,
         runtime_kind: "opencode".to_string(),
-        runtime_id: Some("runtime-1".to_string()),
-        run_id: None,
         working_directory: "/repo".to_string(),
         selected_model: None,
     }
@@ -1753,6 +1751,10 @@ fn upsert_agent_session_updates_existing_session_without_duplication() -> Result
         .find(|entry| entry["sessionId"] == Value::String("session-1".to_string()))
         .expect("session-1 missing");
     assert!(session_1.get("status").is_none());
+    assert_eq!(
+        session_1.get("externalSessionId").and_then(Value::as_str),
+        Some("external-session-1")
+    );
     assert_eq!(
         session_1.get("scenario").and_then(Value::as_str),
         Some("build_default")

--- a/apps/desktop/src-tauri/src/commands/build.rs
+++ b/apps/desktop/src-tauri/src/commands/build.rs
@@ -1,6 +1,6 @@
 use crate::{as_error, run_emitter, run_service_blocking, AppState, BuildCompletePayload};
 use host_application::{BuildResponseAction, CleanupMode};
-use host_domain::{RunSummary, RuntimeKind, TaskCard};
+use host_domain::{AgentRuntimeKind, RunSummary, TaskCard};
 use tauri::{AppHandle, State};
 
 #[tauri::command]
@@ -9,7 +9,7 @@ pub async fn build_start(
     app: AppHandle,
     repo_path: String,
     task_id: String,
-    runtime_kind: RuntimeKind,
+    runtime_kind: AgentRuntimeKind,
 ) -> Result<RunSummary, String> {
     let service = state.service.clone();
     let emitter = run_emitter(app);

--- a/apps/desktop/src-tauri/src/commands/build.rs
+++ b/apps/desktop/src-tauri/src/commands/build.rs
@@ -1,6 +1,6 @@
 use crate::{as_error, run_emitter, run_service_blocking, AppState, BuildCompletePayload};
 use host_application::{BuildResponseAction, CleanupMode};
-use host_domain::{RunSummary, TaskCard};
+use host_domain::{RunSummary, RuntimeKind, TaskCard};
 use tauri::{AppHandle, State};
 
 #[tauri::command]
@@ -9,11 +9,12 @@ pub async fn build_start(
     app: AppHandle,
     repo_path: String,
     task_id: String,
+    runtime_kind: RuntimeKind,
 ) -> Result<RunSummary, String> {
     let service = state.service.clone();
     let emitter = run_emitter(app);
     let result = run_service_blocking("build_start", move || {
-        service.build_start(&repo_path, &task_id, emitter)
+        service.build_start(&repo_path, &task_id, runtime_kind.as_str(), emitter)
     })
     .await;
     as_error(result)

--- a/apps/desktop/src-tauri/src/commands/runtime.rs
+++ b/apps/desktop/src-tauri/src/commands/runtime.rs
@@ -1,6 +1,6 @@
 use crate::{as_error, run_service_blocking, AppState};
 use host_domain::{
-    AgentRuntimeRole, AgentRuntimeSummary, BeadsCheck, RuntimeCheck, RuntimeDescriptor, SystemCheck,
+    AgentRuntimeRole, RuntimeInstanceSummary, BeadsCheck, RuntimeCheck, RuntimeDescriptor, SystemCheck,
 };
 use tauri::State;
 
@@ -44,7 +44,7 @@ pub async fn runtime_list(
     state: State<'_, AppState>,
     runtime_kind: String,
     repo_path: Option<String>,
-) -> Result<Vec<AgentRuntimeSummary>, String> {
+) -> Result<Vec<RuntimeInstanceSummary>, String> {
     as_error(
         state
             .service
@@ -59,7 +59,7 @@ pub async fn runtime_start(
     repo_path: String,
     task_id: String,
     role: AgentRuntimeRole,
-) -> Result<AgentRuntimeSummary, String> {
+) -> Result<RuntimeInstanceSummary, String> {
     let service = state.service.clone();
     let result = run_service_blocking("runtime_start", move || {
         service.runtime_start(&runtime_kind, &repo_path, &task_id, role)
@@ -86,7 +86,7 @@ pub async fn runtime_ensure(
     state: State<'_, AppState>,
     runtime_kind: String,
     repo_path: String,
-) -> Result<AgentRuntimeSummary, String> {
+) -> Result<RuntimeInstanceSummary, String> {
     let service = state.service.clone();
     let result = run_service_blocking("runtime_ensure", move || {
         service.runtime_ensure(&runtime_kind, &repo_path)

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import type { AgentRuntimeSummary, RuntimeDescriptor } from "@openducktor/contracts";
+import type { RuntimeDescriptor, RuntimeInstanceSummary } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { buildDiagnosticsPanelModel } from "./diagnostics-panel-model";
 
 const runtimeDefinitions: RuntimeDescriptor[] = [OPENCODE_RUNTIME_DESCRIPTOR];
 
-const runtimeSummary: AgentRuntimeSummary = {
+const runtimeSummary: RuntimeInstanceSummary = {
   kind: "opencode",
   runtimeId: "runtime-1",
   repoPath: "/repo",

--- a/apps/desktop/src/state/agent-runtime-registry.ts
+++ b/apps/desktop/src/state/agent-runtime-registry.ts
@@ -85,7 +85,9 @@ class RuntimeRegistryAgentEngine implements AgentEnginePort {
   }
 
   listAvailableModels(input: Parameters<AgentEnginePort["listAvailableModels"]>[0]) {
-    return this.getAdapter(input.runtimeKind ?? this.defaultRuntimeKind).listAvailableModels(input);
+    return this.getAdapter(
+      this.requireInputRuntimeKind(input.runtimeKind, "model catalog"),
+    ).listAvailableModels(input);
   }
 
   hasSession(sessionId: string): boolean {
@@ -93,11 +95,15 @@ class RuntimeRegistryAgentEngine implements AgentEnginePort {
   }
 
   loadSessionHistory(input: Parameters<AgentEnginePort["loadSessionHistory"]>[0]) {
-    return this.getAdapter(input.runtimeKind ?? this.defaultRuntimeKind).loadSessionHistory(input);
+    return this.getAdapter(
+      this.requireInputRuntimeKind(input.runtimeKind, "session history"),
+    ).loadSessionHistory(input);
   }
 
   loadSessionTodos(input: Parameters<AgentEnginePort["loadSessionTodos"]>[0]) {
-    return this.getAdapter(input.runtimeKind ?? this.defaultRuntimeKind).loadSessionTodos(input);
+    return this.getAdapter(
+      this.requireInputRuntimeKind(input.runtimeKind, "session todos"),
+    ).loadSessionTodos(input);
   }
 
   sendUserMessage(input: Parameters<AgentEnginePort["sendUserMessage"]>[0]) {
@@ -126,11 +132,25 @@ class RuntimeRegistryAgentEngine implements AgentEnginePort {
   }
 
   loadSessionDiff(input: Parameters<AgentEnginePort["loadSessionDiff"]>[0]) {
-    return this.getAdapter(input.runtimeKind ?? this.defaultRuntimeKind).loadSessionDiff(input);
+    return this.getAdapter(
+      this.requireInputRuntimeKind(input.runtimeKind, "session diff"),
+    ).loadSessionDiff(input);
   }
 
   loadFileStatus(input: Parameters<AgentEnginePort["loadFileStatus"]>[0]) {
-    return this.getAdapter(input.runtimeKind ?? this.defaultRuntimeKind).loadFileStatus(input);
+    return this.getAdapter(
+      this.requireInputRuntimeKind(input.runtimeKind, "file status"),
+    ).loadFileStatus(input);
+  }
+
+  private requireInputRuntimeKind(
+    runtimeKind: RuntimeKind | undefined,
+    operation: string,
+  ): RuntimeKind {
+    if (runtimeKind) {
+      return runtimeKind;
+    }
+    throw new Error(`Runtime kind is required for ${operation} requests.`);
   }
 
   private resolveRuntimeKind(

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
@@ -34,6 +34,7 @@ export type AttachAgentSessionListenerParams = {
   refreshTaskData: (repoPath: string) => Promise<void>;
   loadSessionTodos: (
     sessionId: string,
+    runtimeKind: string,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ) => Promise<void>;

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-helpers.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-helpers.ts
@@ -103,10 +103,17 @@ export const refreshTodosFromSessionRef = (context: SessionEventContext): void =
   if (!session) {
     return;
   }
+  const runtimeKind = session.runtimeKind ?? session.selectedModel?.runtimeKind;
+  if (!runtimeKind) {
+    throw new Error(
+      `Runtime kind is required to refresh todos for session '${context.sessionId}'.`,
+    );
+  }
   runOrchestratorSideEffect(
     "session-events-refresh-todos",
     context.loadSessionTodos(
       context.sessionId,
+      runtimeKind,
       {
         endpoint: session.runtimeEndpoint,
         workingDirectory: session.workingDirectory,

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -41,11 +41,13 @@ type SessionActionsDependencies = {
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
   loadSessionTodos: (
     sessionId: string,
+    runtimeKind: string,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ) => Promise<void>;
   loadSessionModelCatalog: (
     sessionId: string,
+    runtimeKind: string,
     runtimeConnection: AgentRuntimeConnection,
   ) => Promise<void>;
   loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -475,11 +475,16 @@ const warmSessionData = ({
 }): void => {
   const tags = createSessionStartTags(startedCtx);
   const runtimeConnection = resolveRuntimeConnection(runtimeInfo);
+  const runtimeKind = runtimeInfo.runtimeKind ?? startedCtx.summary.runtimeKind;
+  if (!runtimeKind) {
+    throw new Error(`Runtime kind is required to warm session '${startedCtx.summary.sessionId}'.`);
+  }
 
   runOrchestratorSideEffect(
     "start-session-warm-session-todos",
     model.loadSessionTodos(
       startedCtx.summary.sessionId,
+      runtimeKind,
       runtimeConnection,
       startedCtx.summary.externalSessionId,
     ),
@@ -493,7 +498,7 @@ const warmSessionData = ({
 
   runOrchestratorSideEffect(
     "start-session-warm-session-model-catalog",
-    model.loadSessionModelCatalog(startedCtx.summary.sessionId, runtimeConnection),
+    model.loadSessionModelCatalog(startedCtx.summary.sessionId, runtimeKind, runtimeConnection),
     { tags },
   );
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
@@ -59,11 +59,13 @@ export type ModelDependencies = {
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
   loadSessionTodos: (
     sessionId: string,
+    runtimeKind: string,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ) => Promise<void>;
   loadSessionModelCatalog: (
     sessionId: string,
+    runtimeKind: string,
     runtimeConnection: AgentRuntimeConnection,
   ) => Promise<void>;
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -49,11 +49,13 @@ type EnsureSessionReadyDependencies = {
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
   loadSessionTodos: (
     sessionId: string,
+    runtimeKind: string,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ) => Promise<void>;
   loadSessionModelCatalog: (
     sessionId: string,
+    runtimeKind: string,
     runtimeConnection: AgentRuntimeConnection,
   ) => Promise<void>;
 };
@@ -137,6 +139,11 @@ export const createEnsureSessionReady = ({
       loadRepoPromptOverrides(repoPath),
     ]);
     assertNotStale();
+    const resolvedRuntimeKind =
+      runtime.runtimeKind ??
+      session.selectedModel?.runtimeKind ??
+      session.runtimeKind ??
+      DEFAULT_RUNTIME_KIND;
     const systemPrompt = buildAgentSystemPrompt({
       role: session.role,
       scenario: session.scenario,
@@ -159,8 +166,7 @@ export const createEnsureSessionReady = ({
       sessionId: session.sessionId,
       externalSessionId: session.externalSessionId,
       repoPath,
-      runtimeKind:
-        runtime.runtimeKind ?? session.selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+      runtimeKind: resolvedRuntimeKind,
       runtimeConnection: resolveRuntimeConnection(runtime),
       workingDirectory: runtime.workingDirectory,
       taskId: session.taskId,
@@ -192,6 +198,7 @@ export const createEnsureSessionReady = ({
       status: "idle",
       pendingPermissions: [],
       pendingQuestions: [],
+      runtimeKind: resolvedRuntimeKind,
       runtimeId: runtime.runtimeId,
       runId: runtime.runId,
       runtimeEndpoint: runtime.runtimeEndpoint,
@@ -206,9 +213,19 @@ export const createEnsureSessionReady = ({
     const activeSession = sessionsRef.current[sessionId];
     const runtimeConnection = resolveRuntimeConnection(runtime);
     const warmSessionData = (targetSession: AgentSessionState): void => {
+      const targetRuntimeKind =
+        targetSession.runtimeKind ?? targetSession.selectedModel?.runtimeKind;
+      if (!targetRuntimeKind) {
+        throw new Error(`Runtime kind is required to warm session '${sessionId}'.`);
+      }
       runOrchestratorSideEffect(
         "ensure-ready-warm-session-todos",
-        loadSessionTodos(sessionId, runtimeConnection, targetSession.externalSessionId),
+        loadSessionTodos(
+          sessionId,
+          targetRuntimeKind,
+          runtimeConnection,
+          targetSession.externalSessionId,
+        ),
         {
           tags: {
             repoPath,
@@ -222,7 +239,7 @@ export const createEnsureSessionReady = ({
       if (!targetSession.modelCatalog && !targetSession.isLoadingModelCatalog) {
         runOrchestratorSideEffect(
           "ensure-ready-warm-session-model-catalog",
-          loadSessionModelCatalog(sessionId, runtimeConnection),
+          loadSessionModelCatalog(sessionId, targetRuntimeKind, runtimeConnection),
           {
             tags: {
               repoPath,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -406,6 +406,128 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(state["session-1"]?.messages[0]?.id).toBe("history:session-start:session-1");
   });
 
+  test("rehydrates build sessions through a shared runtime when the persisted working directory is an override", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    let observedRuntimeEndpoint: string | null = null;
+    const ensuredRuntimeKinds: string[] = [];
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      const next = updater(current);
+      observedRuntimeEndpoint = next.runtimeEndpoint;
+      state = {
+        ...state,
+        [sessionId]: next,
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: {
+        loadSessionHistory: async () => [],
+      },
+      repoEpochRef: { current: 2 },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    const hostModule = await import("../../host");
+    const originalList = hostModule.host.agentSessionsList;
+    const originalRuntimeList = hostModule.host.runtimeList;
+    const originalRunsList = hostModule.host.runsList;
+    const originalEnsure = hostModule.host.runtimeEnsure;
+    hostModule.host.agentSessionsList = async () => [
+      {
+        runtimeKind: "opencode",
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        taskId: "task-1",
+        role: "build",
+        scenario: "build_implementation_start",
+        status: "running",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+        workingDirectory: "/tmp/repo/conflict-worktree",
+      },
+    ];
+    hostModule.host.runtimeList = async () => [
+      {
+        kind: "opencode",
+        runtimeId: "runtime-shared",
+        repoPath: "/tmp/repo",
+        taskId: "repo-main",
+        role: "planner",
+        workingDirectory: "/tmp/repo/shared",
+        runtimeRoute: {
+          type: "local_http",
+          endpoint: "http://127.0.0.1:4666",
+        },
+        startedAt: "2026-02-22T08:00:00.000Z",
+        descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      },
+    ];
+    hostModule.host.runsList = async () => [];
+    hostModule.host.runtimeEnsure = async (runtimeKind) => {
+      ensuredRuntimeKinds.push(runtimeKind);
+      return {
+        kind: runtimeKind,
+        runtimeId: "runtime-shared",
+        repoPath: "/tmp/repo",
+        taskId: "repo-main",
+        role: "planner",
+        workingDirectory: "/tmp/repo/shared",
+        runtimeRoute: {
+          type: "local_http" as const,
+          endpoint: "http://127.0.0.1:4666",
+        },
+        startedAt: "2026-02-22T08:00:00.000Z",
+        descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      };
+    };
+
+    try {
+      await loadAgentSessions("task-1", { hydrateHistoryForSessionId: "session-1" });
+    } finally {
+      hostModule.host.agentSessionsList = originalList;
+      hostModule.host.runtimeList = originalRuntimeList;
+      hostModule.host.runsList = originalRunsList;
+      hostModule.host.runtimeEnsure = originalEnsure;
+    }
+
+    expect(ensuredRuntimeKinds).toEqual(["opencode"]);
+    if (observedRuntimeEndpoint === null) {
+      throw new Error("Expected shared runtime hydration to set a runtime endpoint");
+    }
+    if (observedRuntimeEndpoint !== "http://127.0.0.1:4666") {
+      throw new Error(`Unexpected shared runtime endpoint: ${observedRuntimeEndpoint}`);
+    }
+    expect(state["session-1"]?.workingDirectory).toBe("/tmp/repo/conflict-worktree");
+    expect(state["session-1"]?.messages[0]?.id).toBe("history:session-start:session-1");
+  });
+
   test("skips hydration when repo epoch changes while loading persisted sessions", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     const repoEpochRef = { current: 2 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -98,9 +98,6 @@ describe("agent-orchestrator-load-sessions", () => {
         status: "running",
         startedAt: "2026-02-22T08:00:00.000Z",
         updatedAt: "2026-02-22T08:00:00.000Z",
-        runtimeId: "runtime-1",
-        runId: "run-1",
-        runtimeEndpoint: "http://127.0.0.1:4444",
         workingDirectory: "/tmp/repo",
       },
     ];
@@ -160,9 +157,6 @@ describe("agent-orchestrator-load-sessions", () => {
         status: "running",
         startedAt: "2026-02-22T08:00:00.000Z",
         updatedAt: "2026-02-22T08:00:00.000Z",
-        runtimeId: "runtime-1",
-        runId: "run-1",
-        runtimeEndpoint: "http://127.0.0.1:4444",
         workingDirectory: "/tmp/repo",
       },
     ];
@@ -226,7 +220,6 @@ describe("agent-orchestrator-load-sessions", () => {
         status: "running",
         startedAt: "2026-02-22T08:00:00.000Z",
         updatedAt: "2026-02-22T08:00:00.000Z",
-        runtimeId: "runtime-1",
         workingDirectory: "/tmp/repo",
         selectedModel: {
           runtimeKind: "claude-code",
@@ -379,9 +372,7 @@ describe("agent-orchestrator-load-sessions", () => {
         status: "running",
         startedAt: "2026-02-22T08:00:00.000Z",
         updatedAt: "2026-02-22T08:00:00.000Z",
-        runtimeId: "runtime-1",
-        runId: "run-1",
-        workingDirectory: "/tmp/repo",
+        workingDirectory: "/tmp/repo/worktree",
       },
     ];
     hostModule.host.runsList = async () => [
@@ -481,8 +472,6 @@ describe("agent-orchestrator-load-sessions", () => {
           status: "running",
           startedAt: "2026-02-22T08:00:00.000Z",
           updatedAt: "2026-02-22T08:00:00.000Z",
-          runtimeId: "runtime-1",
-          runId: "run-1",
           workingDirectory: "/tmp/repo",
         },
       ]);
@@ -564,8 +553,6 @@ describe("agent-orchestrator-load-sessions", () => {
         status: "running",
         startedAt: "2026-02-22T08:00:00.000Z",
         updatedAt: "2026-02-22T08:00:00.000Z",
-        runtimeId: "runtime-1",
-        runId: "run-1",
         workingDirectory: "/tmp/repo",
       },
     ];

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -315,7 +315,8 @@ export const createLoadAgentSessions = ({
       }
 
       const shouldEnsureWorkspaceRuntime =
-        (record.role === "spec" || record.role === "planner") && workingDirectory === repoPath;
+        record.role === "build" ||
+        ((record.role === "spec" || record.role === "planner") && workingDirectory === repoPath);
       if (shouldEnsureWorkspaceRuntime) {
         const workspaceRuntime = await ensureWorkspaceRuntime(runtimeKind);
         if (!workspaceRuntime) {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -1,7 +1,7 @@
 import type {
-  AgentRuntimeSummary,
   RepoPromptOverrides,
   RunSummary,
+  RuntimeInstanceSummary,
   RuntimeKind,
   RuntimeRoute,
   TaskCard,
@@ -67,11 +67,13 @@ type CreateLoadAgentSessionsArgs = {
   updateSession: UpdateSession;
   loadSessionTodos: (
     sessionId: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ) => Promise<void>;
   loadSessionModelCatalog: (
     sessionId: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
   ) => Promise<void>;
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
@@ -110,12 +112,13 @@ export const createLoadAgentSessions = ({
 
     const warmSessionData = (
       targetSessionId: string,
+      runtimeKind: RuntimeKind,
       runtimeConnection: AgentRuntimeConnection,
       externalSessionId: string,
     ): void => {
       runOrchestratorSideEffect(
         "load-sessions-warm-session-todos",
-        loadSessionTodos(targetSessionId, runtimeConnection, externalSessionId),
+        loadSessionTodos(targetSessionId, runtimeKind, runtimeConnection, externalSessionId),
         {
           tags: {
             repoPath,
@@ -126,7 +129,7 @@ export const createLoadAgentSessions = ({
       );
       runOrchestratorSideEffect(
         "load-sessions-warm-session-model-catalog",
-        loadSessionModelCatalog(targetSessionId, runtimeConnection),
+        loadSessionModelCatalog(targetSessionId, runtimeKind, runtimeConnection),
         {
           tags: {
             repoPath,
@@ -198,8 +201,13 @@ export const createLoadAgentSessions = ({
           endpoint: requestedSession.runtimeEndpoint,
           workingDirectory: requestedSession.workingDirectory,
         } satisfies AgentRuntimeConnection;
+        const requestedRuntimeKind =
+          requestedSession.runtimeKind ??
+          requestedSession.selectedModel?.runtimeKind ??
+          DEFAULT_RUNTIME_KIND;
         warmSessionData(
           requestedSession.sessionId,
+          requestedRuntimeKind,
           runtimeConnection,
           requestedSession.externalSessionId,
         );
@@ -223,20 +231,15 @@ export const createLoadAgentSessions = ({
           {
             tags: { repoPath, taskId, runtimeKind },
             logLevel: "warn",
-            fallback: () => [] as AgentRuntimeSummary[],
+            fallback: () => [] as RuntimeInstanceSummary[],
           },
         );
         return [runtimeKind, runtimes] as const;
       }),
     );
-    const runtimesById = new Map<string, AgentRuntimeSummary>();
-    for (const [, runtimes] of runtimeLists) {
-      for (const runtime of runtimes) {
-        runtimesById.set(runtime.runtimeId, runtime);
-      }
-    }
+    const runtimesByKind = new Map(runtimeLists);
 
-    const liveRuns = recordsToHydrate.some((record) => (record.runId?.trim().length ?? 0) > 0)
+    const liveRuns = recordsToHydrate.some((record) => record.role === "build")
       ? await captureOrchestratorFallback(
           "load-sessions-list-runs",
           async () => host.runsList(repoPath),
@@ -247,12 +250,11 @@ export const createLoadAgentSessions = ({
           },
         )
       : [];
-    const runsById = new Map(liveRuns.map((run) => [run.runId, run] as const));
-    const ensuredWorkspaceRuntimes = new Map<RuntimeKind, AgentRuntimeSummary | null>();
+    const ensuredWorkspaceRuntimes = new Map<RuntimeKind, RuntimeInstanceSummary | null>();
 
     const ensureWorkspaceRuntime = async (
       runtimeKind: RuntimeKind,
-    ): Promise<AgentRuntimeSummary | null> => {
+    ): Promise<RuntimeInstanceSummary | null> => {
       if (ensuredWorkspaceRuntimes.has(runtimeKind)) {
         return ensuredWorkspaceRuntimes.get(runtimeKind) ?? null;
       }
@@ -265,11 +267,27 @@ export const createLoadAgentSessions = ({
           fallback: () => null,
         },
       );
-      if (runtime) {
-        runtimesById.set(runtime.runtimeId, runtime);
-      }
       ensuredWorkspaceRuntimes.set(runtimeKind, runtime);
       return runtime;
+    };
+
+    const findRuntimeByWorkingDirectory = (
+      runtimeKind: RuntimeKind,
+      workingDirectory: string,
+    ): RuntimeInstanceSummary | null => {
+      const runtimes = runtimesByKind.get(runtimeKind) ?? [];
+      return runtimes.find((runtime) => runtime.workingDirectory === workingDirectory) ?? null;
+    };
+
+    const findRunByWorkingDirectory = (
+      runtimeKind: RuntimeKind,
+      workingDirectory: string,
+    ): RunSummary | null => {
+      return (
+        liveRuns.find(
+          (run) => run.runtimeKind === runtimeKind && run.worktreePath === workingDirectory,
+        ) ?? null
+      );
     };
 
     const resolveLiveRuntimeEndpoint = async (
@@ -277,46 +295,44 @@ export const createLoadAgentSessions = ({
     ): Promise<{ ok: true; endpoint: string } | { ok: false; reason: string }> => {
       const runtimeKind =
         record.runtimeKind ?? record.selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND;
-      const runId = record.runId?.trim();
-      if (runId) {
-        const run = runsById.get(runId);
-        if (!run) {
+      const workingDirectory = record.workingDirectory;
+      if (record.role === "build") {
+        const run = findRunByWorkingDirectory(runtimeKind, workingDirectory);
+        if (run) {
           return {
-            ok: false,
-            reason: `Build runtime ${runId} is no longer available.`,
+            ok: true,
+            endpoint: resolveRuntimeRouteEndpoint(run.runtimeRoute),
           };
         }
-        return {
-          ok: true,
-          endpoint: resolveRuntimeRouteEndpoint(run.runtimeRoute),
-        };
       }
 
-      const runtimeId = record.runtimeId?.trim();
-      if (runtimeId) {
-        const runtime = runtimesById.get(runtimeId);
-        if (!runtime) {
-          return {
-            ok: false,
-            reason: `Runtime ${runtimeId} is no longer available.`,
-          };
-        }
+      const runtime = findRuntimeByWorkingDirectory(runtimeKind, workingDirectory);
+      if (runtime) {
         return {
           ok: true,
           endpoint: resolveRuntimeRouteEndpoint(runtime.runtimeRoute),
         };
       }
 
-      const workspaceRuntime = await ensureWorkspaceRuntime(runtimeKind);
-      if (!workspaceRuntime) {
+      const shouldEnsureWorkspaceRuntime =
+        (record.role === "spec" || record.role === "planner") && workingDirectory === repoPath;
+      if (shouldEnsureWorkspaceRuntime) {
+        const workspaceRuntime = await ensureWorkspaceRuntime(runtimeKind);
+        if (!workspaceRuntime) {
+          return {
+            ok: false,
+            reason: `Runtime ${runtimeKind} is unavailable for session hydration.`,
+          };
+        }
         return {
-          ok: false,
-          reason: `Runtime ${runtimeKind} is unavailable for session hydration.`,
+          ok: true,
+          endpoint: resolveRuntimeRouteEndpoint(workspaceRuntime.runtimeRoute),
         };
       }
+
       return {
-        ok: true,
-        endpoint: resolveRuntimeRouteEndpoint(workspaceRuntime.runtimeRoute),
+        ok: false,
+        reason: `No live runtime found for working directory ${workingDirectory}.`,
       };
     };
     if (isStaleRepoOperation()) {
@@ -330,13 +346,15 @@ export const createLoadAgentSessions = ({
 
       const existingSession = sessionsRef.current[record.sessionId];
       const workingDirectory = record.workingDirectory;
+      const recordRuntimeKind =
+        record.runtimeKind ?? record.selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND;
       const runtimeResolution = await resolveLiveRuntimeEndpoint(record);
       if (!runtimeResolution.ok) {
         updateSession(
           record.sessionId,
           (current) => ({
             ...current,
-            runtimeKind: record.runtimeKind ?? current.runtimeKind,
+            runtimeKind: recordRuntimeKind,
             runtimeEndpoint: "",
             workingDirectory,
             promptOverrides: repoPromptOverrides,
@@ -369,14 +387,14 @@ export const createLoadAgentSessions = ({
           record.sessionId,
           (current) => ({
             ...current,
-            runtimeKind: record.runtimeKind ?? current.runtimeKind,
+            runtimeKind: recordRuntimeKind,
             runtimeEndpoint,
             workingDirectory,
             promptOverrides: repoPromptOverrides,
           }),
           { persist: false },
         );
-        warmSessionData(record.sessionId, runtimeConnection, externalSessionId);
+        warmSessionData(record.sessionId, recordRuntimeKind, runtimeConnection, externalSessionId);
         return;
       }
 
@@ -384,6 +402,7 @@ export const createLoadAgentSessions = ({
         "load-sessions-load-history",
         async () => {
           const history = await adapter.loadSessionHistory({
+            runtimeKind: recordRuntimeKind,
             runtimeConnection,
             externalSessionId,
             limit: INITIAL_SESSION_HISTORY_LIMIT,
@@ -458,6 +477,7 @@ export const createLoadAgentSessions = ({
           record.sessionId,
           (current) => ({
             ...current,
+            runtimeKind: recordRuntimeKind,
             runtimeEndpoint,
             workingDirectory,
             promptOverrides: repoPromptOverrides,
@@ -470,7 +490,7 @@ export const createLoadAgentSessions = ({
           }),
           { persist: false },
         );
-        warmSessionData(record.sessionId, runtimeConnection, externalSessionId);
+        warmSessionData(record.sessionId, recordRuntimeKind, runtimeConnection, externalSessionId);
         return;
       }
 
@@ -478,7 +498,7 @@ export const createLoadAgentSessions = ({
         record.sessionId,
         (current) => ({
           ...current,
-          runtimeKind: record.runtimeKind ?? current.runtimeKind,
+          runtimeKind: recordRuntimeKind,
           runtimeEndpoint,
           workingDirectory,
           promptOverrides: repoPromptOverrides,
@@ -492,7 +512,7 @@ export const createLoadAgentSessions = ({
         }),
         { persist: false },
       );
-      warmSessionData(record.sessionId, runtimeConnection, externalSessionId);
+      warmSessionData(record.sessionId, recordRuntimeKind, runtimeConnection, externalSessionId);
     };
 
     for (

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/session-loaders.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/session-loaders.test.ts
@@ -102,7 +102,7 @@ describe("agent-orchestrator/lifecycle/session-loaders", () => {
       updateSession: harness.updateSession,
     });
 
-    const loadPromise = loadSessionModelCatalog("session-1", runtimeConnection);
+    const loadPromise = loadSessionModelCatalog("session-1", "opencode", runtimeConnection);
 
     expect(harness.getState()["session-1"]?.isLoadingModelCatalog).toBe(true);
 
@@ -132,7 +132,7 @@ describe("agent-orchestrator/lifecycle/session-loaders", () => {
       updateSession: harness.updateSession,
     });
 
-    await loadSessionModelCatalog("session-1", runtimeConnection);
+    await loadSessionModelCatalog("session-1", "opencode", runtimeConnection);
 
     const session = harness.getState()["session-1"];
     expect(session?.isLoadingModelCatalog).toBe(false);
@@ -154,7 +154,7 @@ describe("agent-orchestrator/lifecycle/session-loaders", () => {
       updateSession: harness.updateSession,
     });
 
-    await loadSessionModelCatalog("session-1", {
+    await loadSessionModelCatalog("session-1", "opencode", {
       endpoint: "https://example.com:4444",
       workingDirectory: "/tmp/repo",
     });
@@ -186,7 +186,7 @@ describe("agent-orchestrator/lifecycle/session-loaders", () => {
       updateSession: harness.updateSession,
     });
 
-    await loadSessionTodos("session-1", runtimeConnection, "external-1");
+    await loadSessionTodos("session-1", "opencode", runtimeConnection, "external-1");
 
     const mergedTodos = harness.getState()["session-1"]?.todos ?? [];
     expect(mergedTodos.map((entry) => entry.id)).toEqual(["a", "b", "c"]);
@@ -211,6 +211,7 @@ describe("agent-orchestrator/lifecycle/session-loaders", () => {
     await expect(
       loadSessionTodos(
         "session-1",
+        "opencode",
         {
           endpoint: "http://127.0.0.1:4444",
           workingDirectory: "/tmp/repo/../escape",

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts
@@ -101,9 +101,14 @@ export const createLoadSessionModelCatalog = ({
   updateSession,
 }: CreateSessionLoadersArgs): ((
   sessionId: string,
+  runtimeKind: string,
   runtimeConnection: AgentRuntimeConnection,
 ) => Promise<void>) => {
-  return async (sessionId: string, runtimeConnection: AgentRuntimeConnection): Promise<void> => {
+  return async (
+    sessionId: string,
+    runtimeKind: string,
+    runtimeConnection: AgentRuntimeConnection,
+  ): Promise<void> => {
     updateSession(
       sessionId,
       (current) => ({
@@ -116,6 +121,7 @@ export const createLoadSessionModelCatalog = ({
     try {
       const validatedRuntimeConnection = validateRuntimeConnection(runtimeConnection);
       const catalog = await adapter.listAvailableModels({
+        runtimeKind,
         runtimeConnection: validatedRuntimeConnection,
       });
       updateSession(
@@ -154,16 +160,19 @@ export const createLoadSessionTodos = ({
   updateSession,
 }: CreateSessionLoadersArgs): ((
   sessionId: string,
+  runtimeKind: string,
   runtimeConnection: AgentRuntimeConnection,
   externalSessionId: string,
 ) => Promise<void>) => {
   return async (
     sessionId: string,
+    runtimeKind: string,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ): Promise<void> => {
     const validatedRuntimeConnection = validateRuntimeConnection(runtimeConnection);
     const todos = await adapter.loadSessionTodos({
+      runtimeKind,
       runtimeConnection: validatedRuntimeConnection,
       externalSessionId,
     });

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -87,7 +87,7 @@ export const loadRepoPromptOverrides = async (repoPath: string): Promise<RepoPro
   return loadEffectivePromptOverrides(repoPath);
 };
 
-const loadRepoDefaultRuntimeKind = async (
+export const loadRepoDefaultRuntimeKind = async (
   repoPath: string,
   role: AgentRole,
 ): Promise<RuntimeKind> => {
@@ -167,7 +167,7 @@ export const createEnsureRuntime = ({ runsRef, refreshTaskData }: EnsureRuntimeD
           entry.repoPath === repoPath && entry.taskId === taskId && runningStates.has(entry.state),
       );
       if (!run) {
-        run = await host.buildStart(repoPath, taskId);
+        run = await host.buildStart(repoPath, taskId, runtimeKind);
         runOrchestratorSideEffect(
           "runtime-refresh-task-data-after-build-start",
           refreshTaskData(repoPath),

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -17,8 +17,6 @@ const recordFixture: AgentSessionRecord = {
   status: "running",
   startedAt: "2026-02-22T08:00:00.000Z",
   updatedAt: "2026-02-22T08:00:00.000Z",
-  runtimeId: "runtime-1",
-  runId: "run-1",
   workingDirectory: "/tmp/repo/worktree",
   selectedModel: {
     runtimeKind: "opencode",
@@ -32,6 +30,8 @@ describe("agent-orchestrator/support/persistence", () => {
     const hydrated = fromPersistedSessionRecord(recordFixture, "task-1");
     expect(hydrated.status).toBe("stopped");
     expect(hydrated.runtimeKind).toBe("opencode");
+    expect(hydrated.runtimeId).toBeNull();
+    expect(hydrated.runId).toBeNull();
     expect(hydrated.selectedModel?.modelId).toBe("gpt-5");
   });
 
@@ -44,6 +44,8 @@ describe("agent-orchestrator/support/persistence", () => {
     expect(persisted.scenario).toBe("build_implementation_start");
     expect(persisted.runtimeKind).toBe("opencode");
     expect(persisted.endedAt).toBeUndefined();
+    expect("runtimeId" in persisted).toBe(false);
+    expect("runId" in persisted).toBe(false);
     expect("runtimeEndpoint" in persisted).toBe(false);
     expect("runtimeTransport" in persisted).toBe(false);
   });

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -22,8 +22,6 @@ export const toPersistedSessionRecord = (session: AgentSessionState): AgentSessi
   status: session.status,
   startedAt: session.startedAt,
   runtimeKind: session.runtimeKind ?? session.selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
-  ...(session.runtimeId ? { runtimeId: session.runtimeId } : {}),
-  ...(session.runId ? { runId: session.runId } : {}),
   workingDirectory: session.workingDirectory,
   selectedModel: session.selectedModel
     ? {
@@ -66,8 +64,8 @@ export const fromPersistedSessionRecord = (
     status: normalizedStatus,
     startedAt: session.startedAt,
     runtimeKind: session.runtimeKind ?? session.selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
-    runtimeId: session.runtimeId ?? null,
-    runId: session.runId ?? null,
+    runtimeId: null,
+    runId: null,
     runtimeEndpoint: "",
     workingDirectory: session.workingDirectory,
     messages: [],

--- a/apps/desktop/src/state/operations/runtime-catalog.ts
+++ b/apps/desktop/src/state/operations/runtime-catalog.ts
@@ -1,4 +1,4 @@
-import type { AgentRuntimeSummary, RuntimeKind, RuntimeRoute } from "@openducktor/contracts";
+import type { RuntimeInstanceSummary, RuntimeKind, RuntimeRoute } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentModelCatalog } from "@openducktor/core";
 import { errorMessage } from "@/lib/errors";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
@@ -23,7 +23,7 @@ export type RuntimeCatalogAdapter = Pick<AgentEnginePort, "listAvailableModels">
 };
 
 type RuntimeCatalogDependencies = {
-  ensureRuntime: (runtimeKind: RuntimeKind, repoPath: string) => Promise<AgentRuntimeSummary>;
+  ensureRuntime: (runtimeKind: RuntimeKind, repoPath: string) => Promise<RuntimeInstanceSummary>;
   stopRuntime: (runtimeId: string) => Promise<{ ok: boolean }>;
   listAvailableModels: (input: ListCatalogInput) => Promise<AgentModelCatalog>;
   listAvailableToolIds: (input: ListCatalogInput) => Promise<string[]>;
@@ -35,7 +35,7 @@ type RuntimeCatalogDependencies = {
 type RuntimeProbeResult =
   | {
       ok: true;
-      runtime: AgentRuntimeSummary;
+      runtime: RuntimeInstanceSummary;
       runtimeInput: ListCatalogInput;
     }
   | {
@@ -46,7 +46,7 @@ type RuntimeProbeResult =
 type McpProbeResult =
   | {
       ok: true;
-      runtime: AgentRuntimeSummary;
+      runtime: RuntimeInstanceSummary;
       runtimeInput: ListCatalogInput;
       statusByServer: Record<string, RuntimeMcpServerStatus>;
     }
@@ -63,7 +63,7 @@ type NormalizedMcpStatus = {
 const ODT_MCP_SERVER_NAME = "openducktor";
 const toNowIso = (): string => new Date().toISOString();
 const toRuntimeInput = (
-  runtime: AgentRuntimeSummary,
+  runtime: RuntimeInstanceSummary,
   runtimeKind: RuntimeKind,
 ): ListCatalogInput => ({
   runtimeKind,
@@ -95,7 +95,7 @@ const toRuntimeUnavailableHealthCheck = (
 };
 
 const toMcpStatusFailedHealthCheck = (
-  runtime: AgentRuntimeSummary,
+  runtime: RuntimeInstanceSummary,
   mcpError: string,
   checkedAt: string,
 ): RepoRuntimeHealthCheck => {
@@ -121,7 +121,7 @@ const toRepoRuntimeHealthCheck = ({
   mcpServerError,
   checkedAt,
 }: {
-  runtime: AgentRuntimeSummary;
+  runtime: RuntimeInstanceSummary;
   availableToolIds: string[];
   checkedAt: string;
 } & NormalizedMcpStatus): RepoRuntimeHealthCheck => {
@@ -211,7 +211,7 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
         };
       }
 
-      let restartedRuntime: AgentRuntimeSummary | null = null;
+      let restartedRuntime: RuntimeInstanceSummary | null = null;
       try {
         await deps.stopRuntime(runtimeProbe.runtime.runtimeId);
         restartedRuntime = await deps.ensureRuntime(runtimeKind, repoPath);

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
@@ -53,8 +53,6 @@ const persistedSessionFixture: AgentSessionRecord = {
   status: "running",
   startedAt: "2026-02-22T08:00:00.000Z",
   updatedAt: "2026-02-22T08:00:00.000Z",
-  runtimeId: "runtime-1",
-  runId: "run-1",
   workingDirectory: "/tmp/repo",
 };
 

--- a/apps/desktop/src/state/operations/use-delegation-operations.ts
+++ b/apps/desktop/src/state/operations/use-delegation-operations.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { loadRepoDefaultRuntimeKind } from "./agent-orchestrator/runtime/runtime";
 import { host } from "./host";
 import { requireActiveRepo } from "./task-operations-model";
 
@@ -25,8 +26,9 @@ export function useDelegationOperations({
   const delegateTask = useCallback(
     async (taskId: string): Promise<void> => {
       const repo = requireActiveRepo(activeRepo);
+      const runtimeKind = await loadRepoDefaultRuntimeKind(repo, "build");
 
-      await host.buildStart(repo, taskId);
+      await host.buildStart(repo, taskId, runtimeKind);
       await refreshTaskData(repo);
     },
     [activeRepo, refreshTaskData],

--- a/apps/desktop/src/types/diagnostics.ts
+++ b/apps/desktop/src/types/diagnostics.ts
@@ -1,9 +1,9 @@
-import type { AgentRuntimeSummary } from "@openducktor/contracts";
+import type { RuntimeInstanceSummary } from "@openducktor/contracts";
 
 export type RepoRuntimeHealthCheck = {
   runtimeOk: boolean;
   runtimeError: string | null;
-  runtime: AgentRuntimeSummary | null;
+  runtime: RuntimeInstanceSummary | null;
   mcpOk: boolean;
   mcpError: string | null;
   mcpServerName: string;

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -41,10 +41,10 @@ Key boundary:
 2. `start-session.ts` enforces in-flight dedupe and reuse policy (in-memory latest, then persisted metadata session, else new).
 3. For new sessions it concurrently loads task docs, resolves runtime, and loads repo default model.
 4. Runtime acquisition:
-- `build` role: `host.buildStart` creates worktree + OpenCode runtime.
-- `qa` role: `host.runtimeStart("opencode", repo, task, "qa")` creates role/task runtime.
-- `spec`/`planner`: `host.runtimeEnsure("opencode", repo)` ensures shared workspace runtime.
-5. Rust host spawns OpenCode with `OPENCODE_CONFIG_CONTENT` containing MCP server `openducktor` and env (`ODT_REPO_PATH`, `ODT_BEADS_DIR`, `ODT_METADATA_NAMESPACE`).
+ - `build` role: `host.buildStart(repo, task, runtimeKind)` creates a build worktree and starts the configured build runtime; today only `opencode` is implemented.
+ - `qa` role: `host.runtimeStart(runtimeKind, repo, task, "qa")` creates a task runtime for the selected kind.
+ - `spec`/`planner`: `host.runtimeEnsure(runtimeKind, repo)` ensures a shared workspace runtime for the selected kind.
+5. Rust host resolves the requested runtime kind, then runs runtime-specific startup. Today that startup path still spawns OpenCode with `OPENCODE_CONFIG_CONTENT` containing MCP server `openducktor` and env (`ODT_REPO_PATH`, `ODT_BEADS_DIR`, `ODT_METADATA_NAMESPACE`).
 6. `OpencodeSdkAdapter` (`AgentEnginePort` implementation) starts/resumes session and subscribes to OpenCode stream events.
 7. On prompt send, adapter applies role-scoped tool gating from `AGENT_ROLE_TOOL_POLICY` (core) and runtime tool IDs, then sends `tools` selection to OpenCode.
 8. Session snapshots are persisted via `host.agentSessionUpsert` into task metadata for restart/reuse continuity.
@@ -100,6 +100,7 @@ Concrete adapters today:
 
 ## Related Docs
 - `docs/agent-orchestrator-module-map.md`
+- `docs/runtime-integration-guide.md`
 - `docs/task-workflow-status-model.md`
 - `docs/task-workflow-actions.md`
 - `docs/task-workflow-transition-matrix.md`

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -1,0 +1,403 @@
+# Runtime Integration Guide
+
+## Purpose
+
+This document explains how to add a new agent runtime to OpenDucktor.
+
+Use it when you need to:
+
+- add a new runtime kind,
+- understand the runtime capability contract,
+- verify whether a runtime is eligible for integration,
+- and implement the required changes across contracts, adapters, desktop orchestration, and the Rust host.
+
+## Runtime Vocabulary
+
+OpenDucktor uses several runtime-related payloads. Each one describes a different layer of the system.
+
+### `RuntimeDescriptor`
+
+Defined in `packages/contracts/src/agent-runtime-schemas.ts` and mirrored in `apps/desktop/src-tauri/crates/host-domain/src/runtime.rs`.
+
+It is the stable definition of a runtime kind:
+
+- `kind`
+- `label`
+- `description`
+- `capabilities`
+
+Descriptors are static metadata. They are not live runtime instances.
+
+### `RuntimeInstanceSummary`
+
+Defined in `packages/contracts/src/run-schemas.ts` and mirrored in Rust runtime domain types.
+
+It is live runtime-instance metadata only:
+
+- `kind`
+- `runtimeId`
+- `repoPath`
+- nullable `taskId`
+- `role`
+- `workingDirectory`
+- `runtimeRoute`
+- `startedAt`
+- `descriptor`
+
+The host returns this payload after listing, ensuring, or starting a runtime. It tells the frontend which runtime instance is running, which repo/task scope it belongs to, where its working directory is, how to reach it through `runtimeRoute`, and which static runtime definition it comes from through `descriptor`.
+
+### `RuntimeRoute`
+
+Live host-visible route information for a running runtime.
+
+Supported shape:
+
+- `{ type: "local_http", endpoint }`
+
+This is a live route, not a persisted identifier.
+
+### `RuntimeConnection`
+
+Request-scoped adapter input used by the TypeScript runtime adapter boundary.
+
+Defined in `packages/contracts/src/agent-runtime-schemas.ts` as `runtimeTransportSchema` and consumed through `packages/core/src/services/runtime-connections.ts`.
+
+Supported shape:
+
+- `endpoint?: string`
+- `workingDirectory: string`
+
+The adapter boundary turns this payload into runtime-specific client input. Generic orchestration code uses `RuntimeConnection` to describe where a request should run and which working directory it applies to.
+
+### Persisted session record
+
+Defined in `packages/contracts/src/session-schemas.ts` and mirrored by `apps/desktop/src-tauri/crates/host-domain/src/document.rs`.
+
+Persisted records keep durable identity only:
+
+- `runtimeKind`
+- `workingDirectory`
+- `externalSessionId`
+- optional `selectedModel`
+
+Persisted records store durable session context. Live route fields such as `runtimeEndpoint`, `baseUrl`, or `runtimeTransport` are resolved again when the session is loaded.
+
+### Session routing behavior
+
+Session-scoped operations use the session's runtime kind when loading:
+
+- history,
+- todos,
+- diff,
+- file status,
+- model catalog.
+
+If the runtime kind is missing, or hydration resolves to a runtime with a different kind or working directory than the stored session context, the operation returns an actionable error instead of silently switching runtimes.
+
+## Runtime Capability Reference
+
+Canonical capability schema: `packages/contracts/src/agent-runtime-schemas.ts`
+
+| Capability | Meaning | Where it matters | How the integration uses it |
+|---|---|---|---|
+| `supportsSessionLifecycle` | Runtime can start, resume, and stop sessions | Session orchestration | Session flows use this when the runtime participates in agent sessions |
+| `supportsStreamingEvents` | Runtime emits incremental session events | Session event stream | Live chat and event-driven UI use this to decide whether streaming is available |
+| `supportsModelCatalog` | Runtime can list models, profiles, and variants | Session start flow and runtime catalog loads | Catalog loading and picker UIs rely on this surface |
+| `supportsProfiles` | Runtime supports named profiles or agents | Session start flow and repo settings | Profile selectors read this before showing profile choices |
+| `supportsVariants` | Runtime supports model variants | Session start flow and repo settings | Variant selectors read this before showing variant choices |
+| `supportsWorkflowTools` | Runtime can execute ODT workflow tools | Workflow roles and tool policy | Workflow roles rely on this when the runtime runs ODT tools |
+| `supportsPermissionRequests` | Runtime can emit permission prompts | Session event handling | Permission reply flows depend on this prompt type existing |
+| `supportsQuestionRequests` | Runtime can emit question prompts | Session event handling | Question reply flows depend on this prompt type existing |
+| `supportsHistory` | Runtime can load historical messages | Session hydration | Session restore uses this to rebuild prior conversation state |
+| `supportsTodos` | Runtime can list session todo items | Session warmup and event refresh | Todo warmup and refresh logic read from this surface |
+| `supportsDiff` | Runtime can provide session diff data | Diff inspection | Diff views call this when showing runtime-produced changes |
+| `supportsFileStatus` | Runtime can provide file status data | File-status inspection | File-status inspection calls this when showing workspace state |
+| `supportsDiagnostics` | Runtime supports diagnostics reporting | Diagnostics panel | Diagnostics views query this surface |
+| `supportsWorkspaceRuntime` | Runtime supports shared workspace instances | Workspace runtime provisioning | Workspace roles such as `spec` and `planner` use this provisioning mode |
+| `supportsTaskRuntime` | Runtime supports task-scoped runtime instances | Task runtime provisioning | Task-scoped roles such as `qa` use this provisioning mode |
+| `supportsBuildRuntime` | Runtime supports build worktree execution | Build orchestration | Build routing uses this when selecting a runtime for `build` |
+| `supportsMcpStatus` | Runtime exposes MCP status info | Diagnostics and health checks | Diagnostics and MCP health checks read this before querying MCP status |
+| `supportsMcpConnect` | Runtime can connect to MCP endpoints | MCP integration contract | MCP connection flows use this when wiring runtime MCP support |
+| `provisioningMode` | Whether runtime is `host_managed` or `external` | Host/runtime startup model | Startup flows use this to decide whether the host starts the runtime or connects to one that already exists |
+
+Capability flags are part of the runtime descriptor. They describe which runtime surfaces are implemented and which parts of the product can rely on them.
+
+## Eligibility Model
+
+The current OpenDucktor runtime model expects the following pieces to exist for a runtime integration.
+
+### Data-contract support
+
+A runtime is represented through:
+
+- a stable `runtimeKind`,
+- a `RuntimeDescriptor` that describes its implemented capabilities,
+- a live `RuntimeRoute` compatible with current host-visible route schemas,
+- a request-scoped `RuntimeConnection`,
+- persisted session records that keep `runtimeKind`, `externalSessionId`, and `workingDirectory`.
+
+### Transport behavior
+
+The current transport model assumes:
+
+- live routes are `local_http`,
+- endpoints use `http`,
+- endpoints are loopback/localhost,
+- working directories are absolute and non-traversing.
+
+Runtimes that do not expose a local loopback HTTP surface extend:
+
+- `runtimeRouteSchema` in `packages/contracts/src/run-schemas.ts`,
+- Rust `RuntimeRoute` in `apps/desktop/src-tauri/crates/host-domain/src/runtime.rs`,
+- session loader validation in `apps/desktop/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts`,
+- and any adapter/runtime connection helpers that reconstruct local HTTP clients.
+
+### Runtime behavior
+
+Within that model, runtime behavior looks like this:
+
+- honor the selected model/profile/variant when capabilities claim support,
+- support session hydration from persisted `runtimeKind`, `workingDirectory`, and model/session context,
+- fail fast when a requested operation is unsupported,
+- resolve session-scoped reads from the session runtime rather than the repo default runtime,
+- expose capability flags that match the adapter and host behavior.
+
+### Workflow compatibility
+
+Workflow roles map onto the runtime system like this:
+
+- `spec` and `planner` flow through workspace runtime provisioning,
+- `qa` flows through task runtime provisioning,
+- `build` is separate and goes through the build orchestrator, not `runtime_start`.
+
+This is why `agentRuntimeStartRoleSchema` excludes `build` in `packages/contracts/src/run-schemas.ts`.
+
+## Files to Change When Adding a Runtime
+
+This is the minimum checklist for a new runtime integration.
+
+### 1. Shared contracts
+
+Update all runtime-visible schemas first:
+
+- `packages/contracts/src/agent-runtime-schemas.ts`
+- `packages/contracts/src/runtime-descriptors.ts`
+- `packages/contracts/src/run-schemas.ts`
+- `packages/contracts/src/session-schemas.ts`
+- `packages/contracts/src/config-schemas.ts`
+
+What to add:
+
+- the new `runtimeKind` in any curated constant lists,
+- a descriptor constant whose capabilities describe implemented behavior,
+- any new route or transport schema support if the runtime is not `local_http`,
+- config/session schema support for runtime-aware model defaults.
+
+These schemas are mirrored across TypeScript and Rust, so contributors typically update them together.
+
+### 2. Core runtime boundary
+
+Review these files:
+
+- `packages/core/src/ports/agent-engine.ts`
+- `packages/core/src/services/runtime-connections.ts`
+- `packages/core/src/types/agent-orchestrator.ts`
+
+The runtime adapter implements the `AgentEnginePort` surface used by session orchestration and workspace inspection, especially:
+
+- session start/resume/stop,
+- streaming events,
+- history,
+- todos,
+- model catalog,
+- diff,
+- file status.
+
+If a runtime does not implement one of these surfaces, the descriptor and adapter surface should reflect that so unsupported operations fail explicitly.
+
+### 3. Runtime adapter implementation
+
+Reference implementation:
+
+- `packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts`
+
+Related mapping files:
+
+- `packages/adapters-opencode-sdk/src/payload-mappers.ts`
+- `packages/adapters-opencode-sdk/src/session-runtime-utils.ts`
+
+This is the layer where `RuntimeConnection` becomes runtime-specific client input. Generic orchestrator code passes connection data in, and the adapter builds the runtime-specific client from it.
+
+### 4. Desktop runtime registration and orchestration
+
+Update the runtime registry and orchestration entrypoints:
+
+- `apps/desktop/src/state/agent-runtime-registry.ts`
+- `apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts`
+- `apps/desktop/src/state/operations/runtime-catalog.ts`
+- `apps/desktop/src/state/operations/use-delegation-operations.ts`
+
+This layer is where runtime selection is applied to real frontend operations:
+
+- session-scoped reads carry explicit `runtimeKind`,
+- build startup carries explicit runtime kind,
+- persisted session hydration fails on runtime-kind mismatches.
+
+These behaviors are what keep runtime routing deterministic across fresh sessions and restored sessions.
+
+### 5. Session hydration and persistence
+
+Update and verify:
+
+- `apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts`
+- `apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts`
+- `apps/desktop/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts`
+- `apps/desktop/src/state/operations/agent-orchestrator/events/session-helpers.ts`
+- `apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts`
+- `apps/desktop/src-tauri/crates/host-domain/src/document.rs`
+- `apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs`
+
+These files own session persistence and hydration. This part of the integration reconnects stored sessions to a live runtime route.
+
+This layer is usually verified by checking that:
+
+- persisted session records keep `runtimeKind`, `externalSessionId`, `workingDirectory`, and `selectedModel.runtimeKind`,
+- hydration re-resolves a live route from `runtimeKind` and `workingDirectory`,
+- mismatched runtime kind and resolved live instance are rejected,
+- session-scoped reads continue to resolve from the stored session runtime instead of the repo default runtime.
+
+### 6. Settings and UI capability consumers
+
+Update capability-driven UI surfaces:
+
+- `apps/desktop/src/pages/shared/use-session-start-modal-state.ts`
+- `apps/desktop/src/components/features/settings/settings-repository-agents-section.tsx`
+- `apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts`
+- `apps/desktop/src/state/operations/use-checks.ts`
+
+Concrete consumers to keep in mind:
+
+- `supportsProfiles` and `supportsVariants` drive session-start and repo-settings controls,
+- `supportsMcpStatus` drives diagnostics sections and MCP health checks.
+
+When contributors add new capability-driven UI behavior, the capability information comes from runtime descriptors rather than per-session state.
+
+### 7. Rust host integration
+
+Host-visible runtime support spans:
+
+- `apps/desktop/src-tauri/crates/host-domain/src/runtime.rs`
+- `apps/desktop/src-tauri/src/commands/runtime.rs`
+- `apps/desktop/src-tauri/src/commands/build.rs`
+- `apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs`
+- `apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs`
+- `apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/prerequisites.rs`
+- `apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/query.rs`
+- `apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/lifecycle.rs`
+- `apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs`
+
+Host integration work:
+
+- add the runtime kind to Rust domain enums and descriptors,
+- make `runtime_list`, `runtime_ensure`, and `runtime_start` understand it,
+- implement host-managed startup if `provisioningMode` is `host_managed`,
+- implement build startup support if `supportsBuildRuntime` is true.
+
+## Build Runtime Rules
+
+Build runtime support is separate from the generic runtime-start path.
+
+Build runtime routing is separate from the generic runtime-start path:
+
+- `runtime_start(runtime_kind, repo, task, role)` is for task runtimes such as `qa`,
+- `runtime_ensure(runtime_kind, repo)` is for workspace runtimes such as `spec` and `planner`,
+- `build_start(repo, task, runtimeKind)` is the build-specific path.
+
+For a new runtime, the build path works like this:
+
+- when `supportsBuildRuntime` is false, build role stays on another runtime,
+- when `supportsBuildRuntime` is true, the build orchestrator starts that runtime for build worktrees,
+- if the host does not know how to start that runtime yet, build startup returns an error instead of launching a different runtime.
+
+## Verification Checklist
+
+Before you consider a new runtime integrated, verify all of the following.
+
+### Contracts
+
+- TypeScript and Rust schemas agree on descriptor, route, run summary, and persisted session fields.
+- `selectedModel.runtimeKind` survives round-trip through the host store.
+
+### Desktop/runtime orchestration
+
+- session hydration reloads history from the persisted runtime kind,
+- todo/model-catalog warmups use the session runtime kind,
+- event-driven todo refresh uses the session runtime kind,
+- diff and file-status requests route through the correct adapter.
+
+### Host/runtime orchestration
+
+- `runtime_list(runtime_kind, ...)` only returns that kind,
+- `runtime_ensure` and `runtime_start` reject unsupported kinds,
+- build startup rejects unsupported runtime kinds,
+- persisted session context is enough to re-resolve the live runtime route.
+
+### Suggested checks
+
+From repo root:
+
+```sh
+bun run --filter @openducktor/desktop typecheck
+bun run --filter @openducktor/desktop test
+bun run lint
+bun run build
+```
+
+From `apps/desktop/src-tauri`:
+
+```sh
+cargo test -p host-domain
+cargo test -p host-infra-beads
+cargo test -p host-application
+```
+
+Add targeted tests for:
+
+- persisted non-default runtime session hydration,
+- runtime-kind mismatch rejection,
+- build runtime fail-fast behavior,
+- selected-model runtime kind round-trip,
+- capability-driven UI gating.
+
+## Integration Constraints
+
+These constraints describe the current integration surface. If a runtime does not fit them, the integration work extends the abstraction in the same change set.
+
+### Reference implementation
+
+The built-in runtime implementation is `opencode`. Its adapter, runtime registry wiring, and Rust host startup path are the concrete example of how the current abstraction is implemented end-to-end.
+
+### Host-managed startup
+
+For `host_managed` runtimes, the Rust host contains the startup and readiness logic. Generic runtime commands call into that per-runtime implementation when a workspace runtime, task runtime, or build runtime is started.
+
+### Transport model
+
+`RuntimeRoute` and several validation paths assume loopback HTTP. Runtimes that use sockets, stdio, remote HTTPS, or non-local transports extend the route and transport abstractions as part of the integration.
+
+### Capability interpretation
+
+Some screens inspect only a subset of capability flags, but the descriptor still represents the full runtime surface. Runtime descriptors therefore describe implemented behavior for the whole integration, not only the parts that a specific screen reads.
+
+## Related Files and Docs
+
+- `docs/architecture-overview.md`
+- `docs/agent-runtime-implementation-plan.md`
+- `packages/contracts/src/agent-runtime-schemas.ts`
+- `packages/contracts/src/run-schemas.ts`
+- `packages/contracts/src/session-schemas.ts`
+- `packages/core/src/ports/agent-engine.ts`
+- `apps/desktop/src/state/agent-runtime-registry.ts`
+- `apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts`
+- `apps/desktop/src-tauri/crates/host-domain/src/runtime.rs`
+- `apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs`

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -1,16 +1,16 @@
 import {
   type AgentRuntimeStartRole,
-  type AgentRuntimeSummary,
-  agentRuntimeSummarySchema,
   type BeadsCheck,
   beadsCheckSchema,
   type RunSummary,
   type RuntimeCheck,
   type RuntimeDescriptor,
+  type RuntimeInstanceSummary,
   type RuntimeKind,
   runSummarySchema,
   runtimeCheckSchema,
   runtimeDescriptorSchema,
+  runtimeInstanceSummarySchema,
   type SystemCheck,
   systemCheckSchema,
   type TaskCard,
@@ -47,9 +47,9 @@ export const runtimeList = async (
   invokeFn: InvokeFn,
   runtimeKind: RuntimeKind,
   repoPath?: string,
-): Promise<AgentRuntimeSummary[]> => {
+): Promise<RuntimeInstanceSummary[]> => {
   const payload = await invokeFn<unknown>("runtime_list", { repoPath, runtimeKind });
-  return parseArray(agentRuntimeSummarySchema, payload);
+  return parseArray(runtimeInstanceSummarySchema, payload);
 };
 
 export const runtimeDefinitionsList = async (invokeFn: InvokeFn): Promise<RuntimeDescriptor[]> => {
@@ -63,14 +63,14 @@ export const runtimeStart = async (
   repoPath: string,
   taskId: string,
   role: RuntimeRole,
-): Promise<AgentRuntimeSummary> => {
+): Promise<RuntimeInstanceSummary> => {
   const payload = await invokeFn<unknown>("runtime_start", {
     runtimeKind,
     repoPath,
     taskId,
     role,
   });
-  return agentRuntimeSummarySchema.parse(payload);
+  return runtimeInstanceSummarySchema.parse(payload);
 };
 
 export const runtimeStop = async (
@@ -86,20 +86,21 @@ export const runtimeEnsure = async (
   invokeFn: InvokeFn,
   runtimeKind: RuntimeKind,
   repoPath: string,
-): Promise<AgentRuntimeSummary> => {
+): Promise<RuntimeInstanceSummary> => {
   const payload = await invokeFn<unknown>("runtime_ensure", {
     runtimeKind,
     repoPath,
   });
-  return agentRuntimeSummarySchema.parse(payload);
+  return runtimeInstanceSummarySchema.parse(payload);
 };
 
 export const buildStart = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
+  runtimeKind: RuntimeKind,
 ): Promise<RunSummary> => {
-  const payload = await invokeFn<unknown>("build_start", { repoPath, taskId });
+  const payload = await invokeFn<unknown>("build_start", { repoPath, taskId, runtimeKind });
   return runSummarySchema.parse(payload);
 };
 
@@ -209,7 +210,10 @@ export class TauriAgentClient {
     return runsList(this.invokeFn, repoPath);
   }
 
-  async runtimeList(runtimeKind: RuntimeKind, repoPath?: string): Promise<AgentRuntimeSummary[]> {
+  async runtimeList(
+    runtimeKind: RuntimeKind,
+    repoPath?: string,
+  ): Promise<RuntimeInstanceSummary[]> {
     return runtimeList(this.invokeFn, runtimeKind, repoPath);
   }
 
@@ -222,7 +226,7 @@ export class TauriAgentClient {
     repoPath: string,
     taskId: string,
     role: RuntimeRole,
-  ): Promise<AgentRuntimeSummary> {
+  ): Promise<RuntimeInstanceSummary> {
     return runtimeStart(this.invokeFn, runtimeKind, repoPath, taskId, role);
   }
 
@@ -230,12 +234,16 @@ export class TauriAgentClient {
     return runtimeStop(this.invokeFn, runtimeId);
   }
 
-  async runtimeEnsure(runtimeKind: RuntimeKind, repoPath: string): Promise<AgentRuntimeSummary> {
+  async runtimeEnsure(runtimeKind: RuntimeKind, repoPath: string): Promise<RuntimeInstanceSummary> {
     return runtimeEnsure(this.invokeFn, runtimeKind, repoPath);
   }
 
-  async buildStart(repoPath: string, taskId: string): Promise<RunSummary> {
-    return buildStart(this.invokeFn, repoPath, taskId);
+  async buildStart(
+    repoPath: string,
+    taskId: string,
+    runtimeKind: RuntimeKind,
+  ): Promise<RunSummary> {
+    return buildStart(this.invokeFn, repoPath, taskId, runtimeKind);
   }
 
   async buildBlocked(repoPath: string, taskId: string, reason: string): Promise<TaskCard> {

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -5,8 +5,6 @@ import type {
   AgentPromptTemplateId,
   AgentRole,
   AgentRuntimeStartRole,
-  AgentRuntimeSummary,
-  AgentRuntimeSummaryRole,
   AgentScenario,
   AgentSessionModelSelection,
   AgentSessionRecord,
@@ -47,6 +45,8 @@ import type {
   RunState,
   RunSummary,
   RuntimeCheck,
+  RuntimeInstanceSummary,
+  RuntimeInstanceSummaryRole,
   SettingsSnapshot,
   SoftGuardrails,
   SystemCheck,
@@ -77,8 +77,8 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "agentToolNameSchema",
   "agentToolNameValues",
   "agentRuntimeStartRoleSchema",
-  "agentRuntimeSummarySchema",
-  "agentRuntimeSummaryRoleSchema",
+  "runtimeInstanceSummarySchema",
+  "runtimeInstanceSummaryRoleSchema",
   "agentPromptOverrideSchema",
   "agentPromptPlaceholderSchema",
   "agentPromptPlaceholderValues",
@@ -166,8 +166,8 @@ type ExportedTypeContract = {
   AgentPromptTemplateId: AgentPromptTemplateId;
   AgentScenario: AgentScenario;
   AgentRuntimeStartRole: AgentRuntimeStartRole;
-  AgentRuntimeSummary: AgentRuntimeSummary;
-  AgentRuntimeSummaryRole: AgentRuntimeSummaryRole;
+  RuntimeInstanceSummary: RuntimeInstanceSummary;
+  RuntimeInstanceSummaryRole: RuntimeInstanceSummaryRole;
   AgentSessionModelSelection: AgentSessionModelSelection;
   AgentSessionTodoPayloadRecord: AgentSessionTodoPayloadRecord;
   AgentSessionRecord: AgentSessionRecord;

--- a/packages/contracts/src/run-schemas.ts
+++ b/packages/contracts/src/run-schemas.ts
@@ -69,30 +69,30 @@ export const runSummarySchema = z.object({
 });
 export type RunSummary = z.infer<typeof runSummarySchema>;
 
-export const agentRuntimeSummaryRoleSchema = z.enum([
+export const runtimeInstanceSummaryRoleSchema = z.enum([
   "workspace",
   "spec",
   "planner",
   "build",
   "qa",
 ]);
-export type AgentRuntimeSummaryRole = z.infer<typeof agentRuntimeSummaryRoleSchema>;
+export type RuntimeInstanceSummaryRole = z.infer<typeof runtimeInstanceSummaryRoleSchema>;
 
 export const agentRuntimeStartRoleSchema = z.enum(["spec", "planner", "qa"]);
 export type AgentRuntimeStartRole = z.infer<typeof agentRuntimeStartRoleSchema>;
 
-export const agentRuntimeSummarySchema = z.object({
+export const runtimeInstanceSummarySchema = z.object({
   kind: runtimeKindSchema,
   runtimeId: z.string(),
   repoPath: z.string(),
   taskId: z.string().nullable(),
-  role: agentRuntimeSummaryRoleSchema,
+  role: runtimeInstanceSummaryRoleSchema,
   workingDirectory: z.string(),
   runtimeRoute: runtimeRouteSchema,
   startedAt: z.string(),
   descriptor: runtimeDescriptorSchema,
 });
-export type AgentRuntimeSummary = z.infer<typeof agentRuntimeSummarySchema>;
+export type RuntimeInstanceSummary = z.infer<typeof runtimeInstanceSummarySchema>;
 
 export const runEventSchema = z.discriminatedUnion("type", [
   z.object({

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -2,8 +2,6 @@
 import { describe, expect, test } from "bun:test";
 import {
   agentRuntimeStartRoleSchema,
-  agentRuntimeSummaryRoleSchema,
-  agentRuntimeSummarySchema,
   agentSessionRecordSchema,
   gitBranchSchema,
   gitCommitAllRequestSchema,
@@ -22,6 +20,8 @@ import {
   OPENCODE_RUNTIME_DESCRIPTOR,
   repoConfigSchema,
   runEventSchema,
+  runtimeInstanceSummaryRoleSchema,
+  runtimeInstanceSummarySchema,
   taskCardSchema,
 } from "./index";
 
@@ -488,7 +488,7 @@ describe("runtime schemas", () => {
   });
 
   test("agent runtime summary parses host payload", () => {
-    const parsed = agentRuntimeSummarySchema.parse({
+    const parsed = runtimeInstanceSummarySchema.parse({
       kind: "opencode",
       runtimeId: "runtime-1",
       repoPath: "/repo",
@@ -508,7 +508,7 @@ describe("runtime schemas", () => {
   });
 
   test("agent runtime role schemas enforce summary vs start boundaries", () => {
-    expect(agentRuntimeSummaryRoleSchema.parse("workspace")).toBe("workspace");
+    expect(runtimeInstanceSummaryRoleSchema.parse("workspace")).toBe("workspace");
     expect(agentRuntimeStartRoleSchema.parse("spec")).toBe("spec");
     expect(() => agentRuntimeStartRoleSchema.parse("workspace")).toThrow();
   });

--- a/packages/contracts/src/session-schemas.ts
+++ b/packages/contracts/src/session-schemas.ts
@@ -36,8 +36,6 @@ export const agentSessionRecordSchema = z.object({
   updatedAt: optionalStringFromNullable,
   endedAt: optionalStringFromNullable,
   runtimeKind: runtimeKindSchema.default("opencode"),
-  runtimeId: optionalStringFromNullable,
-  runId: optionalStringFromNullable,
   workingDirectory: z.string(),
   selectedModel: optionalFromNullable(agentSessionModelSelectionSchema),
 });


### PR DESCRIPTION
## Summary
- align runtime session hydration with the actual persisted Beads model by resolving sessions from `runtimeKind` and `workingDirectory` instead of persisted runtime instance IDs
- rename the live runtime payload from `AgentRuntimeSummary` to `RuntimeInstanceSummary` across TypeScript, Rust, tests, and docs to make the runtime model clearer for contributors
- add and refine `docs/runtime-integration-guide.md`, plus update `docs/architecture-overview.md`, so OSS contributors can understand how runtime descriptors, runtime instances, routing, persistence, and build/runtime provisioning fit together

## Verification
- `bun run --filter @openducktor/desktop typecheck`
- `cargo test -p host-domain`
- `cargo test -p host-infra-beads`
- `cargo test -p host-application`
- `bun run test`
- `bun run lint`
- `bun run build`
