### PR TITLE
Refactor Agent Studio page orchestration and reset modal request state

### DIFF
--- a/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.test.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.test.tsx
@@ -1,30 +1,16 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test";
-import { createElement, type ReactElement, type ReactNode } from "react";
-import { act, create, type ReactTestRenderer } from "react-test-renderer";
-import { createAgentSessionFixture, enableReactActEnvironment } from "./agent-studio-test-utils";
+import { describe, expect, test } from "bun:test";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useRebaseConflictResolutionModalState } from "./agents-page-rebase-conflict-modal";
 import type { PendingRebaseConflictResolutionRequest } from "./use-agent-studio-rebase-conflict-resolution";
 
 enableReactActEnvironment();
 
-mock.module("@/components/ui/dialog", () => ({
-  Dialog: ({ children }: { children: ReactNode }): ReactElement =>
-    createElement("mock-dialog", undefined, children),
-  DialogContent: ({ children }: { children: ReactNode }): ReactElement =>
-    createElement("mock-dialog-content", undefined, children),
-  DialogDescription: ({ children }: { children: ReactNode }): ReactElement =>
-    createElement("mock-dialog-description", undefined, children),
-  DialogFooter: ({ children }: { children: ReactNode }): ReactElement =>
-    createElement("mock-dialog-footer", undefined, children),
-  DialogHeader: ({ children }: { children: ReactNode }): ReactElement =>
-    createElement("mock-dialog-header", undefined, children),
-  DialogTitle: ({ children }: { children: ReactNode }): ReactElement =>
-    createElement("mock-dialog-title", undefined, children),
-}));
-
-type RebaseConflictResolutionModalComponent =
-  typeof import("./agents-page-rebase-conflict-modal")["RebaseConflictResolutionModal"];
-
-let RebaseConflictResolutionModal: RebaseConflictResolutionModalComponent;
+const createHookHarness = (initialProps: PendingRebaseConflictResolutionRequest) =>
+  createSharedHookHarness(useRebaseConflictResolutionModalState, initialProps);
 
 const builderSession = createAgentSessionFixture({
   runtimeKind: "opencode",
@@ -52,66 +38,23 @@ const createRequest = (requestId: string): PendingRebaseConflictResolutionReques
   defaultSessionId: "build-1",
 });
 
-const readNodeText = (value: ReactNode): string => {
-  if (Array.isArray(value)) {
-    return value.map((entry) => readNodeText(entry)).join("");
-  }
-  if (value === null || value === undefined || typeof value === "boolean") {
-    return "";
-  }
-  return String(value);
-};
-
-beforeAll(async () => {
-  ({ RebaseConflictResolutionModal } = await import("./agents-page-rebase-conflict-modal"));
-});
-
-describe("RebaseConflictResolutionModal", () => {
+describe("useRebaseConflictResolutionModalState", () => {
   test("resets local mode when a new request replaces the current one", async () => {
-    const onResolve = mock(() => {});
-    let renderer!: ReactTestRenderer;
-
-    await act(async () => {
-      renderer = create(
-        createElement(RebaseConflictResolutionModal, {
-          request: createRequest("rebase-conflict-0"),
-          onResolve,
-        }),
-      );
-    });
+    const harness = createHookHarness(createRequest("rebase-conflict-0"));
 
     try {
-      const newSessionButton = renderer.root.findByProps({
-        "data-testid": "agent-studio-rebase-conflict-new-session-option",
-      });
-      await act(async () => {
-        newSessionButton.props.onClick();
-      });
+      await harness.mount();
 
-      const confirmButtonAfterToggle = renderer.root.findByProps({
-        "data-testid": "agent-studio-rebase-conflict-confirm-button",
+      await harness.run((state) => {
+        state.setMode("new");
       });
-      expect(readNodeText(confirmButtonAfterToggle.props.children)).toBe("Start new session");
+      expect(harness.getLatest().mode).toBe("new");
 
-      await act(async () => {
-        renderer.update(
-          createElement(RebaseConflictResolutionModal, {
-            request: createRequest("rebase-conflict-1"),
-            onResolve,
-          }),
-        );
-      });
-
-      const confirmButtonAfterReplacement = renderer.root.findByProps({
-        "data-testid": "agent-studio-rebase-conflict-confirm-button",
-      });
-      expect(readNodeText(confirmButtonAfterReplacement.props.children)).toBe(
-        "Use selected session",
-      );
+      await harness.update(createRequest("rebase-conflict-1"));
+      expect(harness.getLatest().mode).toBe("existing");
+      expect(harness.getLatest().selectedSessionId).toBe("build-1");
     } finally {
-      await act(async () => {
-        renderer.unmount();
-      });
+      await harness.unmount();
     }
   });
 });

--- a/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.test.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.test.tsx
@@ -1,0 +1,117 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactElement, type ReactNode } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { createAgentSessionFixture, enableReactActEnvironment } from "./agent-studio-test-utils";
+import type { PendingRebaseConflictResolutionRequest } from "./use-agent-studio-rebase-conflict-resolution";
+
+enableReactActEnvironment();
+
+mock.module("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: ReactNode }): ReactElement =>
+    createElement("mock-dialog", undefined, children),
+  DialogContent: ({ children }: { children: ReactNode }): ReactElement =>
+    createElement("mock-dialog-content", undefined, children),
+  DialogDescription: ({ children }: { children: ReactNode }): ReactElement =>
+    createElement("mock-dialog-description", undefined, children),
+  DialogFooter: ({ children }: { children: ReactNode }): ReactElement =>
+    createElement("mock-dialog-footer", undefined, children),
+  DialogHeader: ({ children }: { children: ReactNode }): ReactElement =>
+    createElement("mock-dialog-header", undefined, children),
+  DialogTitle: ({ children }: { children: ReactNode }): ReactElement =>
+    createElement("mock-dialog-title", undefined, children),
+}));
+
+type RebaseConflictResolutionModalComponent =
+  typeof import("./agents-page-rebase-conflict-modal")["RebaseConflictResolutionModal"];
+
+let RebaseConflictResolutionModal: RebaseConflictResolutionModalComponent;
+
+const builderSession = createAgentSessionFixture({
+  runtimeKind: "opencode",
+  sessionId: "build-1",
+  taskId: "task-1",
+  role: "build",
+  scenario: "build_implementation_start",
+  status: "running",
+});
+
+const createRequest = (requestId: string): PendingRebaseConflictResolutionRequest => ({
+  requestId,
+  conflict: {
+    operation: "rebase",
+    currentBranch: "feature/task-1",
+    targetBranch: "origin/main",
+    conflictedFiles: ["src/conflict.ts"],
+    output: "CONFLICT (content): Merge conflict in src/conflict.ts",
+    workingDir: "/repo/worktrees/task-1",
+  },
+  builderSessions: [builderSession],
+  currentWorktreePath: "/repo/worktrees/task-1",
+  currentViewSessionId: null,
+  defaultMode: "existing",
+  defaultSessionId: "build-1",
+});
+
+const readNodeText = (value: ReactNode): string => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => readNodeText(entry)).join("");
+  }
+  if (value === null || value === undefined || typeof value === "boolean") {
+    return "";
+  }
+  return String(value);
+};
+
+beforeAll(async () => {
+  ({ RebaseConflictResolutionModal } = await import("./agents-page-rebase-conflict-modal"));
+});
+
+describe("RebaseConflictResolutionModal", () => {
+  test("resets local mode when a new request replaces the current one", async () => {
+    const onResolve = mock(() => {});
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        createElement(RebaseConflictResolutionModal, {
+          request: createRequest("rebase-conflict-0"),
+          onResolve,
+        }),
+      );
+    });
+
+    try {
+      const newSessionButton = renderer.root.findByProps({
+        "data-testid": "agent-studio-rebase-conflict-new-session-option",
+      });
+      await act(async () => {
+        newSessionButton.props.onClick();
+      });
+
+      const confirmButtonAfterToggle = renderer.root.findByProps({
+        "data-testid": "agent-studio-rebase-conflict-confirm-button",
+      });
+      expect(readNodeText(confirmButtonAfterToggle.props.children)).toBe("Start new session");
+
+      await act(async () => {
+        renderer.update(
+          createElement(RebaseConflictResolutionModal, {
+            request: createRequest("rebase-conflict-1"),
+            onResolve,
+          }),
+        );
+      });
+
+      const confirmButtonAfterReplacement = renderer.root.findByProps({
+        "data-testid": "agent-studio-rebase-conflict-confirm-button",
+      });
+      expect(readNodeText(confirmButtonAfterReplacement.props.children)).toBe(
+        "Use selected session",
+      );
+    } finally {
+      await act(async () => {
+        renderer.unmount();
+      });
+    }
+  });
+});

--- a/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.tsx
@@ -40,7 +40,7 @@ export function RebaseConflictResolutionModal({
   useEffect(() => {
     setMode(request.defaultMode);
     setSelectedSessionId(request.defaultSessionId ?? "");
-  }, [request.defaultMode, request.defaultSessionId]);
+  }, [request]);
 
   return (
     <Dialog

--- a/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.tsx
@@ -20,6 +20,15 @@ type RebaseConflictResolutionModalProps = {
   onResolve: (decision: RebaseConflictResolutionDecision) => void;
 };
 
+type UseRebaseConflictResolutionModalStateResult = {
+  mode: "existing" | "new";
+  selectedSessionId: string;
+  hasExistingSessions: boolean;
+  confirmDisabled: boolean;
+  setMode: (mode: "existing" | "new") => void;
+  setSelectedSessionId: (sessionId: string) => void;
+};
+
 const formatConflictResolutionSessionMeta = (session: AgentSessionState): string => {
   const startedAt = new Date(session.startedAt);
   const startedAtLabel = Number.isNaN(startedAt.getTime())
@@ -28,10 +37,9 @@ const formatConflictResolutionSessionMeta = (session: AgentSessionState): string
   return `${startedAtLabel} · ${session.status} · ${session.sessionId.slice(0, 8)}`;
 };
 
-export function RebaseConflictResolutionModal({
-  request,
-  onResolve,
-}: RebaseConflictResolutionModalProps): ReactElement {
+export function useRebaseConflictResolutionModalState(
+  request: PendingRebaseConflictResolutionRequest,
+): UseRebaseConflictResolutionModalStateResult {
   const [mode, setMode] = useState<"existing" | "new">(request.defaultMode);
   const [selectedSessionId, setSelectedSessionId] = useState(request.defaultSessionId ?? "");
   const hasExistingSessions = request.builderSessions.length > 0;
@@ -41,6 +49,29 @@ export function RebaseConflictResolutionModal({
     setMode(request.defaultMode);
     setSelectedSessionId(request.defaultSessionId ?? "");
   }, [request]);
+
+  return {
+    mode,
+    selectedSessionId,
+    hasExistingSessions,
+    confirmDisabled,
+    setMode,
+    setSelectedSessionId,
+  };
+}
+
+export function RebaseConflictResolutionModal({
+  request,
+  onResolve,
+}: RebaseConflictResolutionModalProps): ReactElement {
+  const {
+    mode,
+    selectedSessionId,
+    hasExistingSessions,
+    confirmDisabled,
+    setMode,
+    setSelectedSessionId,
+  } = useRebaseConflictResolutionModalState(request);
 
   return (
     <Dialog

--- a/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-rebase-conflict-modal.tsx
@@ -1,0 +1,157 @@
+import { type ReactElement, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { SCENARIO_LABELS } from "./agents-page-constants";
+import type {
+  PendingRebaseConflictResolutionRequest,
+  RebaseConflictResolutionDecision,
+} from "./use-agent-studio-rebase-conflict-resolution";
+
+type RebaseConflictResolutionModalProps = {
+  request: PendingRebaseConflictResolutionRequest;
+  onResolve: (decision: RebaseConflictResolutionDecision) => void;
+};
+
+const formatConflictResolutionSessionMeta = (session: AgentSessionState): string => {
+  const startedAt = new Date(session.startedAt);
+  const startedAtLabel = Number.isNaN(startedAt.getTime())
+    ? session.startedAt
+    : startedAt.toLocaleString();
+  return `${startedAtLabel} · ${session.status} · ${session.sessionId.slice(0, 8)}`;
+};
+
+export function RebaseConflictResolutionModal({
+  request,
+  onResolve,
+}: RebaseConflictResolutionModalProps): ReactElement {
+  const [mode, setMode] = useState<"existing" | "new">(request.defaultMode);
+  const [selectedSessionId, setSelectedSessionId] = useState(request.defaultSessionId ?? "");
+  const hasExistingSessions = request.builderSessions.length > 0;
+  const confirmDisabled = mode === "existing" && selectedSessionId.trim().length === 0;
+
+  useEffect(() => {
+    setMode(request.defaultMode);
+    setSelectedSessionId(request.defaultSessionId ?? "");
+  }, [request.defaultMode, request.defaultSessionId]);
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onResolve(null);
+        }
+      }}
+    >
+      <DialogContent className="max-w-2xl overflow-hidden p-0">
+        <div className="space-y-6 px-6 py-6 sm:px-7 sm:py-7">
+          <DialogHeader className="space-y-3 pr-10">
+            <DialogTitle>Resolve rebase conflict with Builder</DialogTitle>
+            <DialogDescription className="max-w-[42rem] text-[15px] leading-7">
+              Choose an existing Builder session for this task, or start a new conflict-resolution
+              Builder session in the current worktree.
+            </DialogDescription>
+          </DialogHeader>
+
+          {hasExistingSessions ? (
+            <div className="space-y-3">
+              <p className="text-[11px] font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+                Existing session
+              </p>
+              <div className="space-y-2">
+                {request.builderSessions.map((session) => {
+                  const isSelected = mode === "existing" && selectedSessionId === session.sessionId;
+                  const isCurrentViewSession = session.sessionId === request.currentViewSessionId;
+                  return (
+                    <button
+                      key={session.sessionId}
+                      type="button"
+                      className={`flex w-full cursor-pointer items-start justify-between rounded-xl border px-4 py-3 text-left transition-colors ${
+                        isSelected
+                          ? "border-primary bg-primary/5"
+                          : "border-border bg-card hover:bg-muted/40"
+                      }`}
+                      onClick={() => {
+                        setMode("existing");
+                        setSelectedSessionId(session.sessionId);
+                      }}
+                      data-testid={`agent-studio-rebase-conflict-session-option-${session.sessionId}`}
+                    >
+                      <div className="min-w-0 space-y-1">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {SCENARIO_LABELS[session.scenario] ?? session.scenario}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatConflictResolutionSessionMeta(session)}
+                        </p>
+                      </div>
+                      {isCurrentViewSession ? (
+                        <span className="rounded-md border border-border bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          Current view
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="space-y-3">
+            <p className="text-[11px] font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+              New session
+            </p>
+            <button
+              type="button"
+              className={`flex w-full cursor-pointer items-start justify-between rounded-xl border px-4 py-3 text-left transition-colors ${
+                mode === "new"
+                  ? "border-primary bg-primary/5"
+                  : "border-border bg-card hover:bg-muted/40"
+              }`}
+              onClick={() => setMode("new")}
+              data-testid="agent-studio-rebase-conflict-new-session-option"
+            >
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">
+                  Start a new Builder session in the current worktree
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  The new session will attach to{" "}
+                  <code className="font-mono">{request.currentWorktreePath}</code>.
+                </p>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        <DialogFooter className="mt-0 flex flex-row items-center justify-between border-t border-border px-6 py-5 sm:px-7">
+          <Button type="button" variant="outline" onClick={() => onResolve(null)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={confirmDisabled}
+            onClick={() => {
+              if (mode === "existing" && selectedSessionId.trim().length > 0) {
+                onResolve({ mode: "existing", sessionId: selectedSessionId });
+                return;
+              }
+              onResolve({ mode: "new" });
+            }}
+            data-testid="agent-studio-rebase-conflict-confirm-button"
+          >
+            {mode === "existing" ? "Use selected session" : "Start new session"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.test.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.test.tsx
@@ -6,7 +6,9 @@ import { createTaskCardFixture, enableReactActEnvironment } from "./agent-studio
 enableReactActEnvironment();
 
 const openStartModalMock = mock(() => {});
+const replacementOpenStartModalMock = mock(() => {});
 const closeStartModalMock = mock(() => {});
+let currentOpenStartModal = openStartModalMock;
 
 mock.module("@/components/features/agents", () => ({
   SessionStartModal: ({ model }: { model: Record<string, unknown> }): ReactElement =>
@@ -30,7 +32,7 @@ mock.module("../shared/use-session-start-modal-coordinator", () => ({
     modelOptions: [],
     modelGroups: [],
     variantOptions: [],
-    openStartModal: openStartModalMock,
+    openStartModal: currentOpenStartModal,
     closeStartModal: closeStartModalMock,
     handleSelectRuntime: mock(() => {}),
     handleSelectAgent: mock(() => {}),
@@ -56,7 +58,9 @@ const createRequest = (requestId: string) => ({
 
 beforeEach(async () => {
   openStartModalMock.mockClear();
+  replacementOpenStartModalMock.mockClear();
   closeStartModalMock.mockClear();
+  currentOpenStartModal = openStartModalMock;
 
   ({ AgentStudioSessionStartModalBridge } = await import(
     "./agents-page-session-start-modal-bridge"
@@ -102,6 +106,45 @@ describe("AgentStudioSessionStartModalBridge", () => {
           scenario: "build_implementation_start",
         }),
       );
+    } finally {
+      await act(async () => {
+        renderer.unmount();
+      });
+    }
+  });
+
+  test("does not reopen the modal when only the coordinator callback identity changes", async () => {
+    const onResolve = mock(() => {});
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        createElement(AgentStudioSessionStartModalBridge, {
+          request: createRequest("session-start-0"),
+          activeRepo: "/repo",
+          repoSettings: null,
+          onResolve,
+        }),
+      );
+    });
+
+    try {
+      expect(openStartModalMock).toHaveBeenCalledTimes(1);
+
+      currentOpenStartModal = replacementOpenStartModalMock;
+      await act(async () => {
+        renderer.update(
+          createElement(AgentStudioSessionStartModalBridge, {
+            request: createRequest("session-start-0"),
+            activeRepo: "/repo",
+            repoSettings: null,
+            onResolve,
+          }),
+        );
+      });
+
+      expect(openStartModalMock).toHaveBeenCalledTimes(1);
+      expect(replacementOpenStartModalMock).toHaveBeenCalledTimes(0);
     } finally {
       await act(async () => {
         renderer.unmount();

--- a/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.test.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.test.tsx
@@ -1,54 +1,21 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { createElement, type ReactElement } from "react";
-import { act, create, type ReactTestRenderer } from "react-test-renderer";
-import { createTaskCardFixture, enableReactActEnvironment } from "./agent-studio-test-utils";
+import { describe, expect, mock, test } from "bun:test";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useSessionStartModalRequestActivation } from "./agents-page-session-start-modal-bridge";
 
 enableReactActEnvironment();
 
-const openStartModalMock = mock(() => {});
-const replacementOpenStartModalMock = mock(() => {});
-const closeStartModalMock = mock(() => {});
-let currentOpenStartModal = openStartModalMock;
+type UseSessionStartModalRequestActivationHook = typeof useSessionStartModalRequestActivation;
+type HookArgs = Parameters<UseSessionStartModalRequestActivationHook>[0];
 
-mock.module("@/components/features/agents", () => ({
-  SessionStartModal: ({ model }: { model: Record<string, unknown> }): ReactElement =>
-    createElement("mock-session-start-modal", model),
-}));
-
-mock.module("../shared/use-session-start-modal-coordinator", () => ({
-  buildSessionStartModalDescription: () => "description",
-  buildSessionStartModalTitle: () => "title",
-  toSessionStartPostAction: () => "none",
-  useSessionStartModalCoordinator: () => ({
-    intent: null,
-    isOpen: true,
-    selection: null,
-    selectedRuntimeKind: "opencode",
-    runtimeOptions: [],
-    supportsProfiles: false,
-    supportsVariants: false,
-    isCatalogLoading: false,
-    agentOptions: [],
-    modelOptions: [],
-    modelGroups: [],
-    variantOptions: [],
-    openStartModal: currentOpenStartModal,
-    closeStartModal: closeStartModalMock,
-    handleSelectRuntime: mock(() => {}),
-    handleSelectAgent: mock(() => {}),
-    handleSelectModel: mock(() => {}),
-    handleSelectVariant: mock(() => {}),
-  }),
-}));
-
-type AgentStudioSessionStartModalBridgeComponent =
-  typeof import("./agents-page-session-start-modal-bridge")["AgentStudioSessionStartModalBridge"];
-
-let AgentStudioSessionStartModalBridge: AgentStudioSessionStartModalBridgeComponent;
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useSessionStartModalRequestActivation, initialProps);
 
 const createRequest = (requestId: string) => ({
   requestId,
-  taskId: createTaskCardFixture({ id: "task-1" }).id,
+  taskId: "task-1",
   role: "build" as const,
   scenario: "build_implementation_start" as const,
   startMode: "fresh" as const,
@@ -56,49 +23,25 @@ const createRequest = (requestId: string) => ({
   selectedModel: null,
 });
 
-beforeEach(async () => {
-  openStartModalMock.mockClear();
-  replacementOpenStartModalMock.mockClear();
-  closeStartModalMock.mockClear();
-  currentOpenStartModal = openStartModalMock;
-
-  ({ AgentStudioSessionStartModalBridge } = await import(
-    "./agents-page-session-start-modal-bridge"
-  ));
-});
-
-describe("AgentStudioSessionStartModalBridge", () => {
+describe("useSessionStartModalRequestActivation", () => {
   test("reopens the modal coordinator when a replacement request arrives", async () => {
-    const onResolve = mock(() => {});
-    let renderer!: ReactTestRenderer;
-
-    await act(async () => {
-      renderer = create(
-        createElement(AgentStudioSessionStartModalBridge, {
-          request: createRequest("session-start-0"),
-          activeRepo: "/repo",
-          repoSettings: null,
-          onResolve,
-        }),
-      );
+    const openStartModal = mock(() => {});
+    const harness = createHookHarness({
+      request: createRequest("session-start-0"),
+      openStartModal,
     });
 
     try {
-      expect(openStartModalMock).toHaveBeenCalledTimes(1);
+      await harness.mount();
+      expect(openStartModal).toHaveBeenCalledTimes(1);
 
-      await act(async () => {
-        renderer.update(
-          createElement(AgentStudioSessionStartModalBridge, {
-            request: createRequest("session-start-1"),
-            activeRepo: "/repo",
-            repoSettings: null,
-            onResolve,
-          }),
-        );
+      await harness.update({
+        request: createRequest("session-start-1"),
+        openStartModal,
       });
 
-      expect(openStartModalMock).toHaveBeenCalledTimes(2);
-      expect(openStartModalMock).toHaveBeenNthCalledWith(
+      expect(openStartModal).toHaveBeenCalledTimes(2);
+      expect(openStartModal).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
           taskId: "task-1",
@@ -107,48 +50,31 @@ describe("AgentStudioSessionStartModalBridge", () => {
         }),
       );
     } finally {
-      await act(async () => {
-        renderer.unmount();
-      });
+      await harness.unmount();
     }
   });
 
   test("does not reopen the modal when only the coordinator callback identity changes", async () => {
-    const onResolve = mock(() => {});
-    let renderer!: ReactTestRenderer;
-
-    await act(async () => {
-      renderer = create(
-        createElement(AgentStudioSessionStartModalBridge, {
-          request: createRequest("session-start-0"),
-          activeRepo: "/repo",
-          repoSettings: null,
-          onResolve,
-        }),
-      );
+    const openStartModal = mock(() => {});
+    const replacementOpenStartModal = mock(() => {});
+    const harness = createHookHarness({
+      request: createRequest("session-start-0"),
+      openStartModal,
     });
 
     try {
-      expect(openStartModalMock).toHaveBeenCalledTimes(1);
+      await harness.mount();
+      expect(openStartModal).toHaveBeenCalledTimes(1);
 
-      currentOpenStartModal = replacementOpenStartModalMock;
-      await act(async () => {
-        renderer.update(
-          createElement(AgentStudioSessionStartModalBridge, {
-            request: createRequest("session-start-0"),
-            activeRepo: "/repo",
-            repoSettings: null,
-            onResolve,
-          }),
-        );
+      await harness.update({
+        request: createRequest("session-start-0"),
+        openStartModal: replacementOpenStartModal,
       });
 
-      expect(openStartModalMock).toHaveBeenCalledTimes(1);
-      expect(replacementOpenStartModalMock).toHaveBeenCalledTimes(0);
+      expect(openStartModal).toHaveBeenCalledTimes(1);
+      expect(replacementOpenStartModal).toHaveBeenCalledTimes(0);
     } finally {
-      await act(async () => {
-        renderer.unmount();
-      });
+      await harness.unmount();
     }
   });
 });

--- a/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.test.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.test.tsx
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { createTaskCardFixture, enableReactActEnvironment } from "./agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+const openStartModalMock = mock(() => {});
+const closeStartModalMock = mock(() => {});
+
+mock.module("@/components/features/agents", () => ({
+  SessionStartModal: ({ model }: { model: Record<string, unknown> }): ReactElement =>
+    createElement("mock-session-start-modal", model),
+}));
+
+mock.module("../shared/use-session-start-modal-coordinator", () => ({
+  buildSessionStartModalDescription: () => "description",
+  buildSessionStartModalTitle: () => "title",
+  toSessionStartPostAction: () => "none",
+  useSessionStartModalCoordinator: () => ({
+    intent: null,
+    isOpen: true,
+    selection: null,
+    selectedRuntimeKind: "opencode",
+    runtimeOptions: [],
+    supportsProfiles: false,
+    supportsVariants: false,
+    isCatalogLoading: false,
+    agentOptions: [],
+    modelOptions: [],
+    modelGroups: [],
+    variantOptions: [],
+    openStartModal: openStartModalMock,
+    closeStartModal: closeStartModalMock,
+    handleSelectRuntime: mock(() => {}),
+    handleSelectAgent: mock(() => {}),
+    handleSelectModel: mock(() => {}),
+    handleSelectVariant: mock(() => {}),
+  }),
+}));
+
+type AgentStudioSessionStartModalBridgeComponent =
+  typeof import("./agents-page-session-start-modal-bridge")["AgentStudioSessionStartModalBridge"];
+
+let AgentStudioSessionStartModalBridge: AgentStudioSessionStartModalBridgeComponent;
+
+const createRequest = (requestId: string) => ({
+  requestId,
+  taskId: createTaskCardFixture({ id: "task-1" }).id,
+  role: "build" as const,
+  scenario: "build_implementation_start" as const,
+  startMode: "fresh" as const,
+  reason: "scenario_kickoff" as const,
+  selectedModel: null,
+});
+
+beforeEach(async () => {
+  openStartModalMock.mockClear();
+  closeStartModalMock.mockClear();
+
+  ({ AgentStudioSessionStartModalBridge } = await import(
+    "./agents-page-session-start-modal-bridge"
+  ));
+});
+
+describe("AgentStudioSessionStartModalBridge", () => {
+  test("reopens the modal coordinator when a replacement request arrives", async () => {
+    const onResolve = mock(() => {});
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        createElement(AgentStudioSessionStartModalBridge, {
+          request: createRequest("session-start-0"),
+          activeRepo: "/repo",
+          repoSettings: null,
+          onResolve,
+        }),
+      );
+    });
+
+    try {
+      expect(openStartModalMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        renderer.update(
+          createElement(AgentStudioSessionStartModalBridge, {
+            request: createRequest("session-start-1"),
+            activeRepo: "/repo",
+            repoSettings: null,
+            onResolve,
+          }),
+        );
+      });
+
+      expect(openStartModalMock).toHaveBeenCalledTimes(2);
+      expect(openStartModalMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_implementation_start",
+        }),
+      );
+    } finally {
+      await act(async () => {
+        renderer.unmount();
+      });
+    }
+  });
+});

--- a/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect } from "react";
+import { type ReactElement, useEffect, useRef } from "react";
 import { SessionStartModal } from "@/components/features/agents";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
@@ -23,6 +23,7 @@ export function AgentStudioSessionStartModalBridge({
   repoSettings,
   onResolve,
 }: AgentStudioSessionStartModalBridgeProps): ReactElement {
+  const openedRequestIdRef = useRef<string | null>(null);
   const {
     intent,
     isOpen,
@@ -48,6 +49,11 @@ export function AgentStudioSessionStartModalBridge({
   });
 
   useEffect(() => {
+    if (openedRequestIdRef.current === request.requestId) {
+      return;
+    }
+    openedRequestIdRef.current = request.requestId;
+
     openStartModal({
       source: "agent_studio",
       taskId: request.taskId,

--- a/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.tsx
@@ -4,6 +4,7 @@ import type { RepoSettingsInput } from "@/types/state-slices";
 import {
   buildSessionStartModalDescription,
   buildSessionStartModalTitle,
+  type SessionStartModalOpenRequest,
   toSessionStartPostAction,
   useSessionStartModalCoordinator,
 } from "../shared/use-session-start-modal-coordinator";
@@ -17,13 +18,40 @@ type AgentStudioSessionStartModalBridgeProps = {
   onResolve: (decision: NewSessionStartDecision) => void;
 };
 
+type UseSessionStartModalRequestActivationArgs = {
+  request: PendingSessionStartRequest;
+  openStartModal: (request: SessionStartModalOpenRequest) => void;
+};
+
+export function useSessionStartModalRequestActivation({
+  request,
+  openStartModal,
+}: UseSessionStartModalRequestActivationArgs): void {
+  const openedRequestIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (openedRequestIdRef.current === request.requestId) {
+      return;
+    }
+    openedRequestIdRef.current = request.requestId;
+
+    openStartModal({
+      source: "agent_studio",
+      taskId: request.taskId,
+      role: request.role,
+      scenario: request.scenario,
+      startMode: request.startMode,
+      selectedModel: request.selectedModel,
+      postStartAction: toSessionStartPostAction(request.reason),
+    });
+  }, [openStartModal, request]);
+}
+
 export function AgentStudioSessionStartModalBridge({
   request,
   activeRepo,
   repoSettings,
   onResolve,
 }: AgentStudioSessionStartModalBridgeProps): ReactElement {
-  const openedRequestIdRef = useRef<string | null>(null);
   const {
     intent,
     isOpen,
@@ -48,22 +76,7 @@ export function AgentStudioSessionStartModalBridge({
     repoSettings,
   });
 
-  useEffect(() => {
-    if (openedRequestIdRef.current === request.requestId) {
-      return;
-    }
-    openedRequestIdRef.current = request.requestId;
-
-    openStartModal({
-      source: "agent_studio",
-      taskId: request.taskId,
-      role: request.role,
-      scenario: request.scenario,
-      startMode: request.startMode,
-      selectedModel: request.selectedModel,
-      postStartAction: toSessionStartPostAction(request.reason),
-    });
-  }, [openStartModal, request]);
+  useSessionStartModalRequestActivation({ request, openStartModal });
 
   return (
     <SessionStartModal

--- a/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useRef } from "react";
+import { type ReactElement, useEffect } from "react";
 import { SessionStartModal } from "@/components/features/agents";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
@@ -7,13 +7,11 @@ import {
   toSessionStartPostAction,
   useSessionStartModalCoordinator,
 } from "../shared/use-session-start-modal-coordinator";
-import type {
-  NewSessionStartDecision,
-  NewSessionStartRequest,
-} from "./use-agent-studio-session-actions";
+import type { NewSessionStartDecision } from "./use-agent-studio-session-actions";
+import type { PendingSessionStartRequest } from "./use-agent-studio-session-start-request";
 
 type AgentStudioSessionStartModalBridgeProps = {
-  request: NewSessionStartRequest;
+  request: PendingSessionStartRequest;
   activeRepo: string | null;
   repoSettings: RepoSettingsInput | null;
   onResolve: (decision: NewSessionStartDecision) => void;
@@ -25,7 +23,6 @@ export function AgentStudioSessionStartModalBridge({
   repoSettings,
   onResolve,
 }: AgentStudioSessionStartModalBridgeProps): ReactElement {
-  const initializedRequestKeyRef = useRef<string | null>(null);
   const {
     intent,
     isOpen,
@@ -51,22 +48,6 @@ export function AgentStudioSessionStartModalBridge({
   });
 
   useEffect(() => {
-    const requestKey = [
-      request.taskId,
-      request.role,
-      request.scenario,
-      request.startMode,
-      request.reason,
-      request.selectedModel?.providerId ?? "",
-      request.selectedModel?.modelId ?? "",
-      request.selectedModel?.variant ?? "",
-      request.selectedModel?.profileId ?? "",
-    ].join(":");
-    if (initializedRequestKeyRef.current === requestKey) {
-      return;
-    }
-    initializedRequestKeyRef.current = requestKey;
-
     openStartModal({
       source: "agent_studio",
       taskId: request.taskId,

--- a/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-session-start-modal-bridge.tsx
@@ -1,0 +1,121 @@
+import { type ReactElement, useEffect, useRef } from "react";
+import { SessionStartModal } from "@/components/features/agents";
+import type { RepoSettingsInput } from "@/types/state-slices";
+import {
+  buildSessionStartModalDescription,
+  buildSessionStartModalTitle,
+  toSessionStartPostAction,
+  useSessionStartModalCoordinator,
+} from "../shared/use-session-start-modal-coordinator";
+import type {
+  NewSessionStartDecision,
+  NewSessionStartRequest,
+} from "./use-agent-studio-session-actions";
+
+type AgentStudioSessionStartModalBridgeProps = {
+  request: NewSessionStartRequest;
+  activeRepo: string | null;
+  repoSettings: RepoSettingsInput | null;
+  onResolve: (decision: NewSessionStartDecision) => void;
+};
+
+export function AgentStudioSessionStartModalBridge({
+  request,
+  activeRepo,
+  repoSettings,
+  onResolve,
+}: AgentStudioSessionStartModalBridgeProps): ReactElement {
+  const initializedRequestKeyRef = useRef<string | null>(null);
+  const {
+    intent,
+    isOpen,
+    selection,
+    selectedRuntimeKind,
+    runtimeOptions,
+    supportsProfiles,
+    supportsVariants,
+    isCatalogLoading,
+    agentOptions,
+    modelOptions,
+    modelGroups,
+    variantOptions,
+    openStartModal,
+    closeStartModal,
+    handleSelectRuntime,
+    handleSelectAgent,
+    handleSelectModel,
+    handleSelectVariant,
+  } = useSessionStartModalCoordinator({
+    activeRepo,
+    repoSettings,
+  });
+
+  useEffect(() => {
+    const requestKey = [
+      request.taskId,
+      request.role,
+      request.scenario,
+      request.startMode,
+      request.reason,
+      request.selectedModel?.providerId ?? "",
+      request.selectedModel?.modelId ?? "",
+      request.selectedModel?.variant ?? "",
+      request.selectedModel?.profileId ?? "",
+    ].join(":");
+    if (initializedRequestKeyRef.current === requestKey) {
+      return;
+    }
+    initializedRequestKeyRef.current = requestKey;
+
+    openStartModal({
+      source: "agent_studio",
+      taskId: request.taskId,
+      role: request.role,
+      scenario: request.scenario,
+      startMode: request.startMode,
+      selectedModel: request.selectedModel,
+      postStartAction: toSessionStartPostAction(request.reason),
+    });
+  }, [openStartModal, request]);
+
+  return (
+    <SessionStartModal
+      model={{
+        open: isOpen,
+        title: intent?.title ?? buildSessionStartModalTitle(request.role),
+        description:
+          intent?.description ??
+          buildSessionStartModalDescription({
+            scenario: request.scenario,
+            startMode: request.startMode,
+          }),
+        confirmLabel: "Start session",
+        selectedModelSelection: selection,
+        selectedRuntimeKind,
+        runtimeOptions,
+        supportsProfiles,
+        supportsVariants,
+        isSelectionCatalogLoading: isCatalogLoading,
+        agentOptions,
+        modelOptions,
+        modelGroups,
+        variantOptions,
+        onSelectRuntime: handleSelectRuntime,
+        onSelectAgent: handleSelectAgent,
+        onSelectModel: handleSelectModel,
+        onSelectVariant: handleSelectVariant,
+        allowRunInBackground: false,
+        isStarting: false,
+        onOpenChange: (nextOpen) => {
+          if (!nextOpen) {
+            closeStartModal();
+            onResolve(null);
+          }
+        },
+        onConfirm: (_runInBackground) => {
+          onResolve({ selectedModel: selection ?? null });
+        },
+      }}
+    />
+  );
+}

--- a/apps/desktop/src/pages/agents/agents-page-shell.test.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-shell.test.tsx
@@ -1,98 +1,40 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test";
-import { createElement, type ReactElement, type ReactNode } from "react";
-import { act, create, type ReactTestRenderer } from "react-test-renderer";
-import { enableReactActEnvironment } from "./agent-studio-test-utils";
-
-enableReactActEnvironment();
-
-mock.module("@/components/ui/button", () => ({
-  Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }): ReactElement =>
-    createElement("button", { type: "button", onClick }, children),
-}));
-
-mock.module("@/components/ui/tabs", () => ({
-  Tabs: ({ children }: { children: ReactNode }): ReactElement =>
-    createElement("mock-tabs", undefined, children),
-  TabsContent: ({ children }: { children: ReactNode }): ReactElement =>
-    createElement("mock-tabs-content", undefined, children),
-}));
-
-type AgentsPageShellComponent = typeof import("./agents-page-shell")["AgentsPageShell"];
-
-let AgentsPageShell: AgentsPageShellComponent;
-
-const flattenText = (value: ReactNode): string => {
-  if (Array.isArray(value)) {
-    return value.map((entry) => flattenText(entry)).join("");
-  }
-  if (value === null || value === undefined || typeof value === "boolean") {
-    return "";
-  }
-  return String(value);
-};
-
-beforeAll(async () => {
-  ({ AgentsPageShell } = await import("./agents-page-shell"));
-});
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AgentsPageShell } from "./agents-page-shell";
 
 describe("AgentsPageShell", () => {
-  test("renders the navigation restore error state instead of the workspace", async () => {
-    let renderer!: ReactTestRenderer;
+  test("renders the navigation restore error state instead of the workspace", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentsPageShell, {
+        activeRepo: "/repo",
+        navigationPersistenceError: new Error("restore failed"),
+        activeTabValue: "task-1",
+        onRetryNavigationPersistence: () => {},
+        onTabValueChange: () => {},
+        taskTabs: createElement("div", undefined, "tabs"),
+        workspace: createElement("div", undefined, "workspace"),
+      }),
+    );
 
-    await act(async () => {
-      renderer = create(
-        createElement(AgentsPageShell, {
-          activeRepo: "/repo",
-          navigationPersistenceError: new Error("restore failed"),
-          activeTabValue: "task-1",
-          onRetryNavigationPersistence: () => {},
-          onTabValueChange: () => {},
-          taskTabs: createElement("div", undefined, "tabs"),
-          workspace: createElement("div", undefined, "workspace"),
-        }),
-      );
-    });
-
-    try {
-      const paragraphs = renderer.root.findAllByType("p");
-      const rendered = paragraphs.map((entry) => flattenText(entry.props.children)).join(" ");
-      expect(rendered.includes("restore failed")).toBe(true);
-      expect(rendered.includes("workspace")).toBe(false);
-    } finally {
-      await act(async () => {
-        renderer.unmount();
-      });
-    }
+    expect(html).toContain("restore failed");
+    expect(html).not.toContain("workspace");
   });
 
-  test("renders the workspace when no navigation error is present", async () => {
-    let renderer!: ReactTestRenderer;
+  test("renders the workspace when no navigation error is present", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentsPageShell, {
+        activeRepo: "/repo",
+        navigationPersistenceError: null,
+        activeTabValue: "task-1",
+        onRetryNavigationPersistence: () => {},
+        onTabValueChange: () => {},
+        taskTabs: createElement("div", undefined, "tabs"),
+        workspace: createElement("div", undefined, "workspace"),
+      }),
+    );
 
-    await act(async () => {
-      renderer = create(
-        createElement(AgentsPageShell, {
-          activeRepo: "/repo",
-          navigationPersistenceError: null,
-          activeTabValue: "task-1",
-          onRetryNavigationPersistence: () => {},
-          onTabValueChange: () => {},
-          taskTabs: createElement("div", undefined, "tabs"),
-          workspace: createElement("div", undefined, "workspace"),
-        }),
-      );
-    });
-
-    try {
-      const rendered = renderer.root
-        .findAllByType("div")
-        .map((entry) => flattenText(entry.props.children))
-        .join(" ");
-      expect(rendered.includes("workspace")).toBe(true);
-      expect(rendered.includes("tabs")).toBe(true);
-    } finally {
-      await act(async () => {
-        renderer.unmount();
-      });
-    }
+    expect(html).toContain("workspace");
+    expect(html).toContain("tabs");
   });
 });

--- a/apps/desktop/src/pages/agents/agents-page-shell.test.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-shell.test.tsx
@@ -1,0 +1,98 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactElement, type ReactNode } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { enableReactActEnvironment } from "./agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+mock.module("@/components/ui/button", () => ({
+  Button: ({ children, onClick }: { children: ReactNode; onClick?: () => void }): ReactElement =>
+    createElement("button", { type: "button", onClick }, children),
+}));
+
+mock.module("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: { children: ReactNode }): ReactElement =>
+    createElement("mock-tabs", undefined, children),
+  TabsContent: ({ children }: { children: ReactNode }): ReactElement =>
+    createElement("mock-tabs-content", undefined, children),
+}));
+
+type AgentsPageShellComponent = typeof import("./agents-page-shell")["AgentsPageShell"];
+
+let AgentsPageShell: AgentsPageShellComponent;
+
+const flattenText = (value: ReactNode): string => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => flattenText(entry)).join("");
+  }
+  if (value === null || value === undefined || typeof value === "boolean") {
+    return "";
+  }
+  return String(value);
+};
+
+beforeAll(async () => {
+  ({ AgentsPageShell } = await import("./agents-page-shell"));
+});
+
+describe("AgentsPageShell", () => {
+  test("renders the navigation restore error state instead of the workspace", async () => {
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        createElement(AgentsPageShell, {
+          activeRepo: "/repo",
+          navigationPersistenceError: new Error("restore failed"),
+          activeTabValue: "task-1",
+          onRetryNavigationPersistence: () => {},
+          onTabValueChange: () => {},
+          taskTabs: createElement("div", undefined, "tabs"),
+          workspace: createElement("div", undefined, "workspace"),
+        }),
+      );
+    });
+
+    try {
+      const paragraphs = renderer.root.findAllByType("p");
+      const rendered = paragraphs.map((entry) => flattenText(entry.props.children)).join(" ");
+      expect(rendered.includes("restore failed")).toBe(true);
+      expect(rendered.includes("workspace")).toBe(false);
+    } finally {
+      await act(async () => {
+        renderer.unmount();
+      });
+    }
+  });
+
+  test("renders the workspace when no navigation error is present", async () => {
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        createElement(AgentsPageShell, {
+          activeRepo: "/repo",
+          navigationPersistenceError: null,
+          activeTabValue: "task-1",
+          onRetryNavigationPersistence: () => {},
+          onTabValueChange: () => {},
+          taskTabs: createElement("div", undefined, "tabs"),
+          workspace: createElement("div", undefined, "workspace"),
+        }),
+      );
+    });
+
+    try {
+      const rendered = renderer.root
+        .findAllByType("div")
+        .map((entry) => flattenText(entry.props.children))
+        .join(" ");
+      expect(rendered.includes("workspace")).toBe(true);
+      expect(rendered.includes("tabs")).toBe(true);
+    } finally {
+      await act(async () => {
+        renderer.unmount();
+      });
+    }
+  });
+});

--- a/apps/desktop/src/pages/agents/agents-page-shell.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-shell.tsx
@@ -1,0 +1,71 @@
+import { AlertTriangle, RefreshCcw } from "lucide-react";
+import type { ReactElement, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
+
+type AgentsPageShellProps = {
+  activeRepo: string | null;
+  navigationPersistenceError: Error | null;
+  activeTabValue: string;
+  onRetryNavigationPersistence: () => void;
+  onTabValueChange: (value: string) => void;
+  taskTabs: ReactNode;
+  workspace: ReactNode;
+  modalContent?: ReactNode;
+};
+
+export function AgentsPageShell({
+  activeRepo,
+  navigationPersistenceError,
+  activeTabValue,
+  onRetryNavigationPersistence,
+  onTabValueChange,
+  taskTabs,
+  workspace,
+  modalContent = null,
+}: AgentsPageShellProps): ReactElement {
+  if (navigationPersistenceError) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center bg-card p-4">
+        <div className="flex w-full max-w-2xl flex-col gap-4 rounded-xl border border-destructive-border bg-destructive-surface px-4 py-4 text-sm text-destructive-muted">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 size-5 shrink-0" />
+            <div className="min-w-0 space-y-2">
+              <p className="font-medium text-destructive">
+                Agent Studio couldn&apos;t restore saved navigation context.
+              </p>
+              <p>{`Repository: ${activeRepo}`}</p>
+              <p className="break-words font-mono text-xs">{navigationPersistenceError.message}</p>
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="border-destructive-border bg-card text-destructive-muted hover:bg-destructive-surface"
+              onClick={onRetryNavigationPersistence}
+            >
+              <RefreshCcw className="size-3.5" />
+              Retry restore
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <Tabs
+      value={activeTabValue}
+      onValueChange={onTabValueChange}
+      className="h-full min-h-0 max-h-full gap-0 overflow-hidden bg-card"
+    >
+      {taskTabs}
+      <TabsContent value={activeTabValue} className="m-0 min-h-0 flex-1 bg-card p-0">
+        {workspace}
+      </TabsContent>
+      {modalContent}
+    </Tabs>
+  );
+}

--- a/apps/desktop/src/pages/agents/agents-page.tsx
+++ b/apps/desktop/src/pages/agents/agents-page.tsx
@@ -1,4 +1,3 @@
-import { AlertTriangle, RefreshCcw } from "lucide-react";
 import {
   type ReactElement,
   startTransition,
@@ -9,58 +8,31 @@ import {
   useState,
 } from "react";
 import { useSearchParams } from "react-router-dom";
-import { toast } from "sonner";
 import {
   AgentChat,
   AgentStudioHeader,
   AgentStudioRightPanel,
   AgentStudioTaskTabs,
-  SessionStartModal,
 } from "@/components/features/agents";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
-import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { DiffWorkerProvider } from "@/contexts/DiffWorkerProvider";
-import { errorMessage } from "@/lib/errors";
 import { UPSTREAM_TARGET_BRANCH } from "@/lib/target-branch";
 import { useAgentState, useChecksState, useTasksState, useWorkspaceState } from "@/state";
 import {
   useDelegationEventsContext,
   useRuntimeDefinitionsContext,
 } from "@/state/app-state-contexts";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
-import type { RepoSettingsInput } from "@/types/state-slices";
-import { loadEffectivePromptOverrides } from "../../state/operations/prompt-overrides";
-import {
-  buildSessionStartModalDescription,
-  buildSessionStartModalTitle,
-  toSessionStartPostAction,
-  useSessionStartModalCoordinator,
-} from "../shared/use-session-start-modal-coordinator";
 import type { AgentStudioQueryUpdate } from "./agent-studio-navigation";
-import { buildRebaseConflictResolutionPrompt, SCENARIO_LABELS } from "./agents-page-constants";
 import {
   buildAgentStudioGitPanelBranchIdentityKey,
   resolveAgentStudioGitPanelBranch,
 } from "./agents-page-git-panel";
-import {
-  resolveAgentStudioBuilderSessionForTask,
-  resolveAgentStudioBuilderSessionsForTask,
-} from "./agents-page-selection";
+import { RebaseConflictResolutionModal } from "./agents-page-rebase-conflict-modal";
+import { AgentStudioSessionStartModalBridge } from "./agents-page-session-start-modal-bridge";
+import { AgentsPageShell } from "./agents-page-shell";
 import { useAgentStudioBuildWorktreeRefresh } from "./use-agent-studio-build-worktree-refresh";
 import { useAgentStudioDiffData } from "./use-agent-studio-diff-data";
-import {
-  type AgentStudioRebaseConflict,
-  useAgentStudioGitActions,
-} from "./use-agent-studio-git-actions";
+import { useAgentStudioGitActions } from "./use-agent-studio-git-actions";
 import {
   type AgentStudioOrchestrationActionsContext,
   type AgentStudioOrchestrationComposerContext,
@@ -71,285 +43,10 @@ import {
 } from "./use-agent-studio-orchestration-controller";
 import { useAgentStudioQuerySessionSync } from "./use-agent-studio-query-session-sync";
 import { useAgentStudioQuerySync } from "./use-agent-studio-query-sync";
+import { useAgentStudioRebaseConflictResolution } from "./use-agent-studio-rebase-conflict-resolution";
 import { buildAgentStudioRightPanelModel } from "./use-agent-studio-right-panel";
 import { useAgentStudioSelectionController } from "./use-agent-studio-selection-controller";
-import type {
-  NewSessionStartDecision,
-  NewSessionStartRequest,
-} from "./use-agent-studio-session-actions";
 import { useAgentStudioSessionStartRequest } from "./use-agent-studio-session-start-request";
-
-type AgentStudioSessionStartModalProps = {
-  request: NewSessionStartRequest;
-  activeRepo: string | null;
-  repoSettings: RepoSettingsInput | null;
-  onCancel: () => void;
-  onConfirm: (decision: NonNullable<NewSessionStartDecision>) => void;
-};
-
-type RebaseConflictResolutionDecision =
-  | {
-      mode: "existing";
-      sessionId: string;
-    }
-  | {
-      mode: "new";
-    }
-  | null;
-
-type PendingRebaseConflictResolutionRequest = {
-  conflict: AgentStudioRebaseConflict;
-  builderSessions: AgentSessionState[];
-  currentWorktreePath: string;
-  currentViewSessionId: string | null;
-  defaultMode: "existing" | "new";
-  defaultSessionId: string | null;
-};
-
-type RebaseConflictResolutionModalProps = {
-  request: PendingRebaseConflictResolutionRequest;
-  onCancel: () => void;
-  onConfirm: (decision: NonNullable<RebaseConflictResolutionDecision>) => void;
-};
-
-const formatConflictResolutionSessionMeta = (session: AgentSessionState): string => {
-  const startedAt = new Date(session.startedAt);
-  const startedAtLabel = Number.isNaN(startedAt.getTime())
-    ? session.startedAt
-    : startedAt.toLocaleString();
-  return `${startedAtLabel} · ${session.status} · ${session.sessionId.slice(0, 8)}`;
-};
-
-function RebaseConflictResolutionModal({
-  request,
-  onCancel,
-  onConfirm,
-}: RebaseConflictResolutionModalProps): ReactElement {
-  const [mode, setMode] = useState<"existing" | "new">(request.defaultMode);
-  const [selectedSessionId, setSelectedSessionId] = useState(request.defaultSessionId ?? "");
-  const hasExistingSessions = request.builderSessions.length > 0;
-  const confirmDisabled = mode === "existing" && selectedSessionId.trim().length === 0;
-
-  useEffect(() => {
-    setMode(request.defaultMode);
-    setSelectedSessionId(request.defaultSessionId ?? "");
-  }, [request.defaultMode, request.defaultSessionId]);
-
-  return (
-    <Dialog
-      open
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen) {
-          onCancel();
-        }
-      }}
-    >
-      <DialogContent className="max-w-2xl overflow-hidden p-0">
-        <div className="space-y-6 px-6 py-6 sm:px-7 sm:py-7">
-          <DialogHeader className="space-y-3 pr-10">
-            <DialogTitle>Resolve rebase conflict with Builder</DialogTitle>
-            <DialogDescription className="max-w-[42rem] text-[15px] leading-7">
-              Choose an existing Builder session for this task, or start a new conflict-resolution
-              Builder session in the current worktree.
-            </DialogDescription>
-          </DialogHeader>
-
-          {hasExistingSessions ? (
-            <div className="space-y-3">
-              <p className="text-[11px] font-semibold tracking-[0.14em] text-muted-foreground uppercase">
-                Existing session
-              </p>
-              <div className="space-y-2">
-                {request.builderSessions.map((session) => {
-                  const isSelected = mode === "existing" && selectedSessionId === session.sessionId;
-                  const isCurrentViewSession = session.sessionId === request.currentViewSessionId;
-                  return (
-                    <button
-                      key={session.sessionId}
-                      type="button"
-                      className={`flex w-full cursor-pointer items-start justify-between rounded-xl border px-4 py-3 text-left transition-colors ${
-                        isSelected
-                          ? "border-primary bg-primary/5"
-                          : "border-border bg-card hover:bg-muted/40"
-                      }`}
-                      onClick={() => {
-                        setMode("existing");
-                        setSelectedSessionId(session.sessionId);
-                      }}
-                      data-testid={`agent-studio-rebase-conflict-session-option-${session.sessionId}`}
-                    >
-                      <div className="min-w-0 space-y-1">
-                        <p className="truncate text-sm font-medium text-foreground">
-                          {SCENARIO_LABELS[session.scenario] ?? session.scenario}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {formatConflictResolutionSessionMeta(session)}
-                        </p>
-                      </div>
-                      {isCurrentViewSession ? (
-                        <span className="rounded-md border border-border bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
-                          Current view
-                        </span>
-                      ) : null}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          ) : null}
-
-          <div className="space-y-3">
-            <p className="text-[11px] font-semibold tracking-[0.14em] text-muted-foreground uppercase">
-              New session
-            </p>
-            <button
-              type="button"
-              className={`flex w-full cursor-pointer items-start justify-between rounded-xl border px-4 py-3 text-left transition-colors ${
-                mode === "new"
-                  ? "border-primary bg-primary/5"
-                  : "border-border bg-card hover:bg-muted/40"
-              }`}
-              onClick={() => setMode("new")}
-              data-testid="agent-studio-rebase-conflict-new-session-option"
-            >
-              <div className="space-y-1">
-                <p className="text-sm font-medium text-foreground">
-                  Start a new Builder session in the current worktree
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  The new session will attach to{" "}
-                  <code className="font-mono">{request.currentWorktreePath}</code>.
-                </p>
-              </div>
-            </button>
-          </div>
-        </div>
-
-        <DialogFooter className="mt-0 flex flex-row items-center justify-between border-t border-border px-6 py-5 sm:px-7">
-          <Button type="button" variant="outline" onClick={onCancel}>
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            disabled={confirmDisabled}
-            onClick={() => {
-              if (mode === "existing" && selectedSessionId.trim().length > 0) {
-                onConfirm({ mode: "existing", sessionId: selectedSessionId });
-                return;
-              }
-              onConfirm({ mode: "new" });
-            }}
-            data-testid="agent-studio-rebase-conflict-confirm-button"
-          >
-            {mode === "existing" ? "Use selected session" : "Start new session"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function AgentStudioSessionStartModal({
-  request,
-  activeRepo,
-  repoSettings,
-  onCancel,
-  onConfirm,
-}: AgentStudioSessionStartModalProps): ReactElement {
-  const initializedRequestKeyRef = useRef<string | null>(null);
-  const {
-    intent,
-    isOpen,
-    selection,
-    selectedRuntimeKind,
-    runtimeOptions,
-    supportsProfiles,
-    supportsVariants,
-    isCatalogLoading,
-    agentOptions,
-    modelOptions,
-    modelGroups,
-    variantOptions,
-    openStartModal,
-    closeStartModal,
-    handleSelectRuntime,
-    handleSelectAgent,
-    handleSelectModel,
-    handleSelectVariant,
-  } = useSessionStartModalCoordinator({
-    activeRepo,
-    repoSettings,
-  });
-
-  useEffect(() => {
-    const requestKey = [
-      request.taskId,
-      request.role,
-      request.scenario,
-      request.startMode,
-      request.reason,
-      request.selectedModel?.providerId ?? "",
-      request.selectedModel?.modelId ?? "",
-      request.selectedModel?.variant ?? "",
-      request.selectedModel?.profileId ?? "",
-    ].join(":");
-    if (initializedRequestKeyRef.current === requestKey) {
-      return;
-    }
-    initializedRequestKeyRef.current = requestKey;
-
-    openStartModal({
-      source: "agent_studio",
-      taskId: request.taskId,
-      role: request.role,
-      scenario: request.scenario,
-      startMode: request.startMode,
-      selectedModel: request.selectedModel,
-      postStartAction: toSessionStartPostAction(request.reason),
-    });
-  }, [openStartModal, request]);
-
-  return (
-    <SessionStartModal
-      model={{
-        open: isOpen,
-        title: intent?.title ?? buildSessionStartModalTitle(request.role),
-        description:
-          intent?.description ??
-          buildSessionStartModalDescription({
-            scenario: request.scenario,
-            startMode: request.startMode,
-          }),
-        confirmLabel: "Start session",
-        selectedModelSelection: selection,
-        selectedRuntimeKind,
-        runtimeOptions,
-        supportsProfiles,
-        supportsVariants,
-        isSelectionCatalogLoading: isCatalogLoading,
-        agentOptions,
-        modelOptions,
-        modelGroups,
-        variantOptions,
-        onSelectRuntime: handleSelectRuntime,
-        onSelectAgent: handleSelectAgent,
-        onSelectModel: handleSelectModel,
-        onSelectVariant: handleSelectVariant,
-        allowRunInBackground: false,
-        isStarting: false,
-        onOpenChange: (nextOpen) => {
-          if (!nextOpen) {
-            closeStartModal();
-            onCancel();
-          }
-        },
-        onConfirm: (_runInBackground) => {
-          onConfirm({ selectedModel: selection ?? null });
-        },
-      }}
-    />
-  );
-}
 
 export function AgentsPage(): ReactElement {
   const { activeRepo, activeBranch, loadRepoSettings } = useWorkspaceState();
@@ -373,11 +70,6 @@ export function AgentsPage(): ReactElement {
   const [contextSwitchVersion, setContextSwitchVersion] = useState(0);
   const [runCompletionRecoverySignal, setRunCompletionRecoverySignal] = useState(0);
   const latestRunCompletionSignalVersionRef = useRef<number | null>(null);
-  const [pendingRebaseConflictResolutionRequest, setPendingRebaseConflictResolutionRequest] =
-    useState<PendingRebaseConflictResolutionRequest | null>(null);
-  const pendingRebaseConflictResolutionResolverRef = useRef<
-    ((decision: RebaseConflictResolutionDecision) => void) | null
-  >(null);
   const { runCompletionSignal } = useDelegationEventsContext();
   const { pendingSessionStartRequest, requestNewSessionStart, resolvePendingSessionStart } =
     useAgentStudioSessionStartRequest();
@@ -403,27 +95,6 @@ export function AgentsPage(): ReactElement {
       });
     },
     [updateQuery],
-  );
-  const requestRebaseConflictResolutionChoice = useCallback(
-    (
-      request: PendingRebaseConflictResolutionRequest,
-    ): Promise<RebaseConflictResolutionDecision> => {
-      pendingRebaseConflictResolutionResolverRef.current?.(null);
-      return new Promise((resolve) => {
-        pendingRebaseConflictResolutionResolverRef.current = resolve;
-        setPendingRebaseConflictResolutionRequest(request);
-      });
-    },
-    [],
-  );
-  const resolvePendingRebaseConflictResolution = useCallback(
-    (decision: RebaseConflictResolutionDecision): void => {
-      const resolver = pendingRebaseConflictResolutionResolverRef.current;
-      pendingRebaseConflictResolutionResolverRef.current = null;
-      setPendingRebaseConflictResolutionRequest(null);
-      resolver?.(decision);
-    },
-    [],
   );
 
   const clearComposerInput = useCallback((): void => {
@@ -615,144 +286,26 @@ export function AgentsPage(): ReactElement {
     selection.viewActiveSession?.role === "build" &&
     (selection.viewActiveSession.status === "running" ||
       selection.viewActiveSession.status === "starting");
-  const handleResolveRebaseConflict = useCallback(
-    async (conflict: AgentStudioRebaseConflict): Promise<boolean> => {
-      if (!activeRepo) {
-        throw new Error("Cannot resolve rebase conflict because no repository is selected.");
-      }
-      if (!selection.viewTaskId) {
-        throw new Error("Cannot resolve rebase conflict because no task is selected.");
-      }
-
-      const builderSessions = resolveAgentStudioBuilderSessionsForTask({
-        taskId: selection.viewTaskId,
-        viewActiveSession: selection.viewActiveSession,
-        activeSession: selection.activeSession,
-        selectedSessionById: selection.selectedSessionById,
-        viewSessionsForTask: selection.viewSessionsForTask,
-        sessionsForTask: selection.sessionsForTask,
-      });
-      const defaultBuilderSession = resolveAgentStudioBuilderSessionForTask({
-        taskId: selection.viewTaskId,
-        viewActiveSession: selection.viewActiveSession,
-        activeSession: selection.activeSession,
-        selectedSessionById: selection.selectedSessionById,
-        viewSessionsForTask: selection.viewSessionsForTask,
-        sessionsForTask: selection.sessionsForTask,
-      });
-      const currentWorktreePath = (conflict.workingDir ?? activeRepo)?.trim() ?? "";
-      if (!currentWorktreePath) {
-        throw new Error(
-          "Cannot resolve rebase conflict because the current worktree path is unavailable.",
-        );
-      }
-
-      const decision = await requestRebaseConflictResolutionChoice({
-        conflict,
-        builderSessions,
-        currentWorktreePath,
-        currentViewSessionId:
-          selection.viewActiveSession?.role === "build"
-            ? selection.viewActiveSession.sessionId
-            : null,
-        defaultMode: defaultBuilderSession ? "existing" : "new",
-        defaultSessionId: defaultBuilderSession?.sessionId ?? null,
-      });
-      if (!decision) {
-        return false;
-      }
-
-      const promptOverrides = await loadEffectivePromptOverrides(activeRepo);
-      const message = buildRebaseConflictResolutionPrompt(selection.viewTaskId, {
-        overrides: promptOverrides,
-        ...(selection.viewSelectedTask
-          ? {
-              task: {
-                title: selection.viewSelectedTask.title,
-                issueType: selection.viewSelectedTask.issueType,
-                status: selection.viewSelectedTask.status,
-                qaRequired: selection.viewSelectedTask.aiReviewEnabled,
-                description: selection.viewSelectedTask.description,
-                acceptanceCriteria: selection.viewSelectedTask.acceptanceCriteria,
-              },
-            }
-          : {}),
-        git: {
-          ...(conflict.currentBranch ? { currentBranch: conflict.currentBranch } : {}),
-          targetBranch: conflict.targetBranch,
-          conflictedFiles: conflict.conflictedFiles,
-          rebaseOutput: conflict.output,
-        },
-      });
-
-      if (decision.mode === "existing") {
-        const builderSession = builderSessions.find(
-          (session) => session.sessionId === decision.sessionId,
-        );
-        if (!builderSession) {
-          throw new Error("Selected Builder session is no longer available for this task.");
-        }
-
-        if (
-          selection.viewActiveSession?.sessionId !== builderSession.sessionId ||
-          selection.viewActiveSession?.role !== builderSession.role
-        ) {
-          signalContextSwitchIntent();
-          scheduleQueryUpdate({
-            task: builderSession.taskId,
-            session: builderSession.sessionId,
-            agent: builderSession.role,
-          });
-        }
-
-        void sendAgentMessage(builderSession.sessionId, message).catch((error) => {
-          toast.error("Failed to send Builder conflict resolution request", {
-            description: errorMessage(error),
-          });
-        });
-        return true;
-      }
-
-      const sessionId = await startAgentSession({
-        taskId: selection.viewTaskId,
-        role: "build",
-        scenario: "build_rebase_conflict_resolution",
-        selectedModel: defaultBuilderSession?.selectedModel ?? null,
-        sendKickoff: false,
-        startMode: "fresh",
-        requireModelReady: true,
-        workingDirectoryOverride: currentWorktreePath,
-      });
-
-      signalContextSwitchIntent();
-      scheduleQueryUpdate({
-        task: selection.viewTaskId,
-        session: sessionId,
-        agent: "build",
-      });
-      void sendAgentMessage(sessionId, message).catch((error) => {
-        toast.error("Failed to send Builder conflict resolution request", {
-          description: errorMessage(error),
-        });
-      });
-      return true;
+  const {
+    pendingRebaseConflictResolutionRequest,
+    resolvePendingRebaseConflictResolution,
+    handleResolveRebaseConflict,
+  } = useAgentStudioRebaseConflictResolution({
+    activeRepo,
+    selection: {
+      viewTaskId: selection.viewTaskId,
+      viewSelectedTask: selection.viewSelectedTask,
+      viewActiveSession: selection.viewActiveSession,
+      activeSession: selection.activeSession,
+      selectedSessionById: selection.selectedSessionById,
+      viewSessionsForTask: selection.viewSessionsForTask,
+      sessionsForTask: selection.sessionsForTask,
     },
-    [
-      activeRepo,
-      requestRebaseConflictResolutionChoice,
-      scheduleQueryUpdate,
-      selection.viewActiveSession,
-      selection.activeSession,
-      selection.selectedSessionById,
-      selection.viewSelectedTask,
-      selection.viewSessionsForTask,
-      selection.sessionsForTask,
-      selection.viewTaskId,
-      sendAgentMessage,
-      signalContextSwitchIntent,
-      startAgentSession,
-    ],
-  );
+    scheduleQueryUpdate,
+    onContextSwitchIntent: signalContextSwitchIntent,
+    startAgentSession,
+    sendAgentMessage,
+  });
   const gitActions = useAgentStudioGitActions({
     repoPath: activeRepo,
     workingDir: diffData.worktreePath,
@@ -785,46 +338,21 @@ export function AgentsPage(): ReactElement {
       }),
     [diffModel, orchestration.agentStudioWorkspaceSidebarModel, orchestration.rightPanel.panelKind],
   );
-  const content = navigationPersistenceError ? (
-    <div className="flex h-full min-h-0 items-center justify-center bg-card p-4">
-      <div className="flex w-full max-w-2xl flex-col gap-4 rounded-xl border border-destructive-border bg-destructive-surface px-4 py-4 text-sm text-destructive-muted">
-        <div className="flex items-start gap-3">
-          <AlertTriangle className="mt-0.5 size-5 shrink-0" />
-          <div className="min-w-0 space-y-2">
-            <p className="font-medium text-destructive">
-              Agent Studio couldn&apos;t restore saved navigation context.
-            </p>
-            <p>{`Repository: ${activeRepo}`}</p>
-            <p className="break-words font-mono text-xs">{navigationPersistenceError.message}</p>
-          </div>
-        </div>
-        <div className="flex justify-end">
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="border-destructive-border bg-card text-destructive-muted hover:bg-destructive-surface"
-            onClick={retryNavigationPersistence}
-          >
-            <RefreshCcw className="size-3.5" />
-            Retry restore
-          </Button>
-        </div>
-      </div>
-    </div>
-  ) : (
-    <Tabs
-      value={orchestration.activeTabValue}
-      onValueChange={selection.handleSelectTab}
-      className="h-full min-h-0 max-h-full gap-0 overflow-hidden bg-card"
-    >
-      <AgentStudioTaskTabs
-        model={orchestration.agentStudioTaskTabsModel}
-        rightPanelToggleModel={orchestration.rightPanel.rightPanelToggleModel}
-      />
-
-      <TabsContent value={orchestration.activeTabValue} className="m-0 min-h-0 flex-1 bg-card p-0">
-        {selection.viewTaskId ? (
+  const content = (
+    <AgentsPageShell
+      activeRepo={activeRepo}
+      navigationPersistenceError={navigationPersistenceError}
+      activeTabValue={orchestration.activeTabValue}
+      onRetryNavigationPersistence={retryNavigationPersistence}
+      onTabValueChange={selection.handleSelectTab}
+      taskTabs={
+        <AgentStudioTaskTabs
+          model={orchestration.agentStudioTaskTabsModel}
+          rightPanelToggleModel={orchestration.rightPanel.rightPanelToggleModel}
+        />
+      }
+      workspace={
+        selection.viewTaskId ? (
           <ResizablePanelGroup direction="horizontal" className="h-full min-h-0 overflow-hidden">
             <ResizablePanel defaultSize={63} minSize={35}>
               <AgentChat
@@ -845,25 +373,27 @@ export function AgentsPage(): ReactElement {
           <div className="flex h-full min-h-0 items-center justify-center border border-dashed border-input bg-card text-sm text-muted-foreground">
             Open a task tab to start a workspace.
           </div>
-        )}
-      </TabsContent>
-      {pendingRebaseConflictResolutionRequest ? (
-        <RebaseConflictResolutionModal
-          request={pendingRebaseConflictResolutionRequest}
-          onCancel={() => resolvePendingRebaseConflictResolution(null)}
-          onConfirm={resolvePendingRebaseConflictResolution}
-        />
-      ) : null}
-      {pendingSessionStartRequest ? (
-        <AgentStudioSessionStartModal
-          request={pendingSessionStartRequest}
-          activeRepo={activeRepo}
-          repoSettings={orchestration.repoSettings}
-          onCancel={() => resolvePendingSessionStart(null)}
-          onConfirm={resolvePendingSessionStart}
-        />
-      ) : null}
-    </Tabs>
+        )
+      }
+      modalContent={
+        <>
+          {pendingRebaseConflictResolutionRequest ? (
+            <RebaseConflictResolutionModal
+              request={pendingRebaseConflictResolutionRequest}
+              onResolve={resolvePendingRebaseConflictResolution}
+            />
+          ) : null}
+          {pendingSessionStartRequest ? (
+            <AgentStudioSessionStartModalBridge
+              request={pendingSessionStartRequest}
+              activeRepo={activeRepo}
+              repoSettings={orchestration.repoSettings}
+              onResolve={resolvePendingSessionStart}
+            />
+          ) : null}
+        </>
+      }
+    />
   );
 
   return <DiffWorkerProvider>{content}</DiffWorkerProvider>;

--- a/apps/desktop/src/pages/agents/agents-page.tsx
+++ b/apps/desktop/src/pages/agents/agents-page.tsx
@@ -379,12 +379,14 @@ export function AgentsPage(): ReactElement {
         <>
           {pendingRebaseConflictResolutionRequest ? (
             <RebaseConflictResolutionModal
+              key={pendingRebaseConflictResolutionRequest.requestId}
               request={pendingRebaseConflictResolutionRequest}
               onResolve={resolvePendingRebaseConflictResolution}
             />
           ) : null}
           {pendingSessionStartRequest ? (
             <AgentStudioSessionStartModalBridge
+              key={pendingSessionStartRequest.requestId}
               request={pendingSessionStartRequest}
               activeRepo={activeRepo}
               repoSettings={orchestration.repoSettings}

--- a/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.test.tsx
@@ -123,6 +123,9 @@ describe("useAgentStudioRebaseConflictResolution", () => {
       expect(harness.getLatest().pendingRebaseConflictResolutionRequest?.defaultSessionId).toBe(
         "build-1",
       );
+      expect(harness.getLatest().pendingRebaseConflictResolutionRequest?.requestId).toBe(
+        "rebase-conflict-0",
+      );
 
       await harness.run((state) => {
         state.resolvePendingRebaseConflictResolution({
@@ -166,6 +169,9 @@ describe("useAgentStudioRebaseConflictResolution", () => {
       });
 
       await harness.waitFor((state) => state.pendingRebaseConflictResolutionRequest !== null);
+      expect(harness.getLatest().pendingRebaseConflictResolutionRequest?.requestId).toBe(
+        "rebase-conflict-0",
+      );
 
       await harness.run((state) => {
         state.resolvePendingRebaseConflictResolution({ mode: "new" });
@@ -216,6 +222,9 @@ describe("useAgentStudioRebaseConflictResolution", () => {
       });
 
       await harness.waitFor((state) => state.pendingRebaseConflictResolutionRequest !== null);
+      expect(harness.getLatest().pendingRebaseConflictResolutionRequest?.requestId).toBe(
+        "rebase-conflict-0",
+      );
       await harness.run((state) => {
         state.resolvePendingRebaseConflictResolution(null);
       });

--- a/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.test.tsx
@@ -1,32 +1,15 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import {
   createAgentSessionFixture,
   createHookHarness as createSharedHookHarness,
   createTaskCardFixture,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
+import { useAgentStudioRebaseConflictResolution } from "./use-agent-studio-rebase-conflict-resolution";
 
 enableReactActEnvironment();
 
-const loadEffectivePromptOverridesMock = mock(async () => ({}));
-const toastErrorMock = mock(() => {});
-
-mock.module("../../state/operations/prompt-overrides", () => ({
-  loadEffectivePromptOverrides: loadEffectivePromptOverridesMock,
-}));
-
-mock.module("sonner", () => ({
-  toast: {
-    error: toastErrorMock,
-  },
-}));
-
-type UseAgentStudioRebaseConflictResolutionHook =
-  typeof import("./use-agent-studio-rebase-conflict-resolution")["useAgentStudioRebaseConflictResolution"];
-
-let useAgentStudioRebaseConflictResolution: UseAgentStudioRebaseConflictResolutionHook;
-
-type HookArgs = Parameters<UseAgentStudioRebaseConflictResolutionHook>[0];
+type HookArgs = Parameters<typeof useAgentStudioRebaseConflictResolution>[0];
 
 const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useAgentStudioRebaseConflictResolution, initialProps);
@@ -88,21 +71,10 @@ const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => {
     onContextSwitchIntent: mock(() => {}),
     startAgentSession: mock(async () => "build-new-1"),
     sendAgentMessage: mock(async () => {}),
+    loadPromptOverrides: mock(async () => ({})),
     ...overrides,
   };
 };
-
-beforeAll(async () => {
-  ({ useAgentStudioRebaseConflictResolution } = await import(
-    "./use-agent-studio-rebase-conflict-resolution"
-  ));
-});
-
-beforeEach(() => {
-  loadEffectivePromptOverridesMock.mockClear();
-  toastErrorMock.mockClear();
-  loadEffectivePromptOverridesMock.mockImplementation(async () => ({}));
-});
 
 describe("useAgentStudioRebaseConflictResolution", () => {
   test("routes conflict resolution to an existing Builder session", async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.test.tsx
@@ -1,0 +1,235 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  createAgentSessionFixture,
+  createHookHarness as createSharedHookHarness,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+const loadEffectivePromptOverridesMock = mock(async () => ({}));
+const toastErrorMock = mock(() => {});
+
+mock.module("../../state/operations/prompt-overrides", () => ({
+  loadEffectivePromptOverrides: loadEffectivePromptOverridesMock,
+}));
+
+mock.module("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+  },
+}));
+
+type UseAgentStudioRebaseConflictResolutionHook =
+  typeof import("./use-agent-studio-rebase-conflict-resolution")["useAgentStudioRebaseConflictResolution"];
+
+let useAgentStudioRebaseConflictResolution: UseAgentStudioRebaseConflictResolutionHook;
+
+type HookArgs = Parameters<UseAgentStudioRebaseConflictResolutionHook>[0];
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioRebaseConflictResolution, initialProps);
+
+const buildSession = (overrides: Partial<ReturnType<typeof createAgentSessionFixture>> = {}) =>
+  createAgentSessionFixture({
+    runtimeKind: "opencode",
+    taskId: "task-1",
+    role: "build",
+    scenario: "build_implementation_start",
+    status: "running",
+    ...overrides,
+  });
+
+const createConflict = (overrides: Record<string, unknown> = {}) => ({
+  operation: "rebase" as const,
+  currentBranch: "feature/task-1",
+  targetBranch: "origin/main",
+  conflictedFiles: ["src/conflict.ts"],
+  output: "CONFLICT (content): Merge conflict in src/conflict.ts",
+  workingDir: "/repo/worktrees/task-1",
+  ...overrides,
+});
+
+const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => {
+  const builderSession = buildSession({
+    sessionId: "build-1",
+    selectedModel: {
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+    },
+  });
+  const plannerSession = createAgentSessionFixture({
+    runtimeKind: "opencode",
+    sessionId: "planner-1",
+    taskId: "task-1",
+    role: "planner",
+    scenario: "planner_initial",
+    status: "running",
+  });
+
+  return {
+    activeRepo: "/repo",
+    selection: {
+      viewTaskId: "task-1",
+      viewSelectedTask: createTaskCardFixture({
+        id: "task-1",
+        title: "Resolve rebase conflict",
+        description: "Fix the branch divergence.",
+      }),
+      viewActiveSession: plannerSession,
+      activeSession: plannerSession,
+      selectedSessionById: null,
+      viewSessionsForTask: [builderSession],
+      sessionsForTask: [builderSession],
+    },
+    scheduleQueryUpdate: mock(() => {}),
+    onContextSwitchIntent: mock(() => {}),
+    startAgentSession: mock(async () => "build-new-1"),
+    sendAgentMessage: mock(async () => {}),
+    ...overrides,
+  };
+};
+
+beforeAll(async () => {
+  ({ useAgentStudioRebaseConflictResolution } = await import(
+    "./use-agent-studio-rebase-conflict-resolution"
+  ));
+});
+
+beforeEach(() => {
+  loadEffectivePromptOverridesMock.mockClear();
+  toastErrorMock.mockClear();
+  loadEffectivePromptOverridesMock.mockImplementation(async () => ({}));
+});
+
+describe("useAgentStudioRebaseConflictResolution", () => {
+  test("routes conflict resolution to an existing Builder session", async () => {
+    const args = createBaseArgs();
+    const harness = createHookHarness(args);
+
+    try {
+      await harness.mount();
+
+      let resolved = false;
+      await harness.run((state) => {
+        void state.handleResolveRebaseConflict(createConflict()).then((result) => {
+          resolved = result;
+        });
+      });
+
+      await harness.waitFor((state) => state.pendingRebaseConflictResolutionRequest !== null);
+      expect(harness.getLatest().pendingRebaseConflictResolutionRequest?.defaultSessionId).toBe(
+        "build-1",
+      );
+
+      await harness.run((state) => {
+        state.resolvePendingRebaseConflictResolution({
+          mode: "existing",
+          sessionId: "build-1",
+        });
+      });
+
+      await harness.waitFor((_state) => resolved === true);
+      expect(args.scheduleQueryUpdate).toHaveBeenCalledWith({
+        task: "task-1",
+        session: "build-1",
+        agent: "build",
+      });
+      expect(args.onContextSwitchIntent).toHaveBeenCalledTimes(1);
+      expect(args.startAgentSession).toHaveBeenCalledTimes(0);
+      expect(args.sendAgentMessage).toHaveBeenCalledTimes(1);
+      expect(args.sendAgentMessage).toHaveBeenCalledWith(
+        "build-1",
+        expect.stringContaining("task-1"),
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("starts a new Builder session when the user selects a new conflict workflow", async () => {
+    const args = createBaseArgs({
+      startAgentSession: mock(async () => "build-new-9"),
+    });
+    const harness = createHookHarness(args);
+
+    try {
+      await harness.mount();
+
+      let resolved = false;
+      await harness.run((state) => {
+        void state.handleResolveRebaseConflict(createConflict()).then((result) => {
+          resolved = result;
+        });
+      });
+
+      await harness.waitFor((state) => state.pendingRebaseConflictResolutionRequest !== null);
+
+      await harness.run((state) => {
+        state.resolvePendingRebaseConflictResolution({ mode: "new" });
+      });
+
+      await harness.waitFor((_state) => resolved === true);
+      expect(args.startAgentSession).toHaveBeenCalledWith({
+        taskId: "task-1",
+        role: "build",
+        scenario: "build_rebase_conflict_resolution",
+        selectedModel: {
+          runtimeKind: "opencode",
+          providerId: "openai",
+          modelId: "gpt-5",
+        },
+        sendKickoff: false,
+        startMode: "fresh",
+        requireModelReady: true,
+        workingDirectoryOverride: "/repo/worktrees/task-1",
+      });
+      expect(args.scheduleQueryUpdate).toHaveBeenCalledWith({
+        task: "task-1",
+        session: "build-new-9",
+        agent: "build",
+      });
+      expect(args.onContextSwitchIntent).toHaveBeenCalledTimes(1);
+      expect(args.sendAgentMessage).toHaveBeenCalledWith(
+        "build-new-9",
+        expect.stringContaining("task-1"),
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("returns false without starting work when the conflict dialog is cancelled", async () => {
+    const args = createBaseArgs();
+    const harness = createHookHarness(args);
+
+    try {
+      await harness.mount();
+
+      let resolution: boolean | null = null;
+      await harness.run((state) => {
+        void state.handleResolveRebaseConflict(createConflict()).then((result) => {
+          resolution = result;
+        });
+      });
+
+      await harness.waitFor((state) => state.pendingRebaseConflictResolutionRequest !== null);
+      await harness.run((state) => {
+        state.resolvePendingRebaseConflictResolution(null);
+      });
+
+      await harness.waitFor((_state) => resolution !== null);
+      if (resolution === null) {
+        throw new Error("Expected cancellation resolution");
+      }
+      expect(resolution === false).toBe(true);
+      expect(args.startAgentSession).toHaveBeenCalledTimes(0);
+      expect(args.sendAgentMessage).toHaveBeenCalledTimes(0);
+      expect(args.scheduleQueryUpdate).toHaveBeenCalledTimes(0);
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
@@ -24,6 +24,7 @@ export type RebaseConflictResolutionDecision =
   | null;
 
 export type PendingRebaseConflictResolutionRequest = {
+  requestId: string;
   conflict: AgentStudioRebaseConflict;
   builderSessions: AgentSessionState[];
   currentWorktreePath: string;
@@ -31,6 +32,11 @@ export type PendingRebaseConflictResolutionRequest = {
   defaultMode: "existing" | "new";
   defaultSessionId: string | null;
 };
+
+type RebaseConflictResolutionRequestInput = Omit<
+  PendingRebaseConflictResolutionRequest,
+  "requestId"
+>;
 
 type AgentStudioRebaseConflictResolutionSelectionContext = {
   viewTaskId: string;
@@ -70,6 +76,7 @@ export function useAgentStudioRebaseConflictResolution({
   const pendingRebaseConflictResolutionResolverRef = useRef<
     ((decision: RebaseConflictResolutionDecision) => void) | null
   >(null);
+  const requestSequenceRef = useRef(0);
 
   const resolvePendingRebaseConflictResolution = useCallback(
     (decision: RebaseConflictResolutionDecision): void => {
@@ -82,13 +89,16 @@ export function useAgentStudioRebaseConflictResolution({
   );
 
   const requestRebaseConflictResolutionChoice = useCallback(
-    (
-      request: PendingRebaseConflictResolutionRequest,
-    ): Promise<RebaseConflictResolutionDecision> => {
+    (request: RebaseConflictResolutionRequestInput): Promise<RebaseConflictResolutionDecision> => {
       pendingRebaseConflictResolutionResolverRef.current?.(null);
       return new Promise((resolve) => {
         pendingRebaseConflictResolutionResolverRef.current = resolve;
-        setPendingRebaseConflictResolutionRequest(request);
+        const requestId = `rebase-conflict-${requestSequenceRef.current}`;
+        requestSequenceRef.current += 1;
+        setPendingRebaseConflictResolutionRequest({
+          ...request,
+          requestId,
+        });
       });
     },
     [],

--- a/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
@@ -1,0 +1,245 @@
+import type { TaskCard } from "@openducktor/contracts";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { errorMessage } from "@/lib/errors";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentStateContextValue } from "@/types/state-slices";
+import { loadEffectivePromptOverrides } from "../../state/operations/prompt-overrides";
+import type { AgentStudioQueryUpdate } from "./agent-studio-navigation";
+import { buildRebaseConflictResolutionPrompt } from "./agents-page-constants";
+import {
+  resolveAgentStudioBuilderSessionForTask,
+  resolveAgentStudioBuilderSessionsForTask,
+} from "./agents-page-selection";
+import type { AgentStudioRebaseConflict } from "./use-agent-studio-git-actions";
+
+export type RebaseConflictResolutionDecision =
+  | {
+      mode: "existing";
+      sessionId: string;
+    }
+  | {
+      mode: "new";
+    }
+  | null;
+
+export type PendingRebaseConflictResolutionRequest = {
+  conflict: AgentStudioRebaseConflict;
+  builderSessions: AgentSessionState[];
+  currentWorktreePath: string;
+  currentViewSessionId: string | null;
+  defaultMode: "existing" | "new";
+  defaultSessionId: string | null;
+};
+
+type AgentStudioRebaseConflictResolutionSelectionContext = {
+  viewTaskId: string;
+  viewSelectedTask: TaskCard | null;
+  viewActiveSession: AgentSessionState | null;
+  activeSession: AgentSessionState | null;
+  selectedSessionById: AgentSessionState | null;
+  viewSessionsForTask: AgentSessionState[];
+  sessionsForTask: AgentSessionState[];
+};
+
+type UseAgentStudioRebaseConflictResolutionArgs = {
+  activeRepo: string | null;
+  selection: AgentStudioRebaseConflictResolutionSelectionContext;
+  scheduleQueryUpdate: (updates: AgentStudioQueryUpdate) => void;
+  onContextSwitchIntent: () => void;
+  startAgentSession: AgentStateContextValue["startAgentSession"];
+  sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
+};
+
+type UseAgentStudioRebaseConflictResolutionResult = {
+  pendingRebaseConflictResolutionRequest: PendingRebaseConflictResolutionRequest | null;
+  resolvePendingRebaseConflictResolution: (decision: RebaseConflictResolutionDecision) => void;
+  handleResolveRebaseConflict: (conflict: AgentStudioRebaseConflict) => Promise<boolean>;
+};
+
+export function useAgentStudioRebaseConflictResolution({
+  activeRepo,
+  selection,
+  scheduleQueryUpdate,
+  onContextSwitchIntent,
+  startAgentSession,
+  sendAgentMessage,
+}: UseAgentStudioRebaseConflictResolutionArgs): UseAgentStudioRebaseConflictResolutionResult {
+  const [pendingRebaseConflictResolutionRequest, setPendingRebaseConflictResolutionRequest] =
+    useState<PendingRebaseConflictResolutionRequest | null>(null);
+  const pendingRebaseConflictResolutionResolverRef = useRef<
+    ((decision: RebaseConflictResolutionDecision) => void) | null
+  >(null);
+
+  const resolvePendingRebaseConflictResolution = useCallback(
+    (decision: RebaseConflictResolutionDecision): void => {
+      const resolver = pendingRebaseConflictResolutionResolverRef.current;
+      pendingRebaseConflictResolutionResolverRef.current = null;
+      setPendingRebaseConflictResolutionRequest(null);
+      resolver?.(decision);
+    },
+    [],
+  );
+
+  const requestRebaseConflictResolutionChoice = useCallback(
+    (
+      request: PendingRebaseConflictResolutionRequest,
+    ): Promise<RebaseConflictResolutionDecision> => {
+      pendingRebaseConflictResolutionResolverRef.current?.(null);
+      return new Promise((resolve) => {
+        pendingRebaseConflictResolutionResolverRef.current = resolve;
+        setPendingRebaseConflictResolutionRequest(request);
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      pendingRebaseConflictResolutionResolverRef.current?.(null);
+      pendingRebaseConflictResolutionResolverRef.current = null;
+    };
+  }, []);
+
+  const sendConflictResolutionMessage = useCallback(
+    (sessionId: string, message: string): void => {
+      void sendAgentMessage(sessionId, message).catch((error) => {
+        toast.error("Failed to send Builder conflict resolution request", {
+          description: errorMessage(error),
+        });
+      });
+    },
+    [sendAgentMessage],
+  );
+
+  const handleResolveRebaseConflict = useCallback(
+    async (conflict: AgentStudioRebaseConflict): Promise<boolean> => {
+      if (!activeRepo) {
+        throw new Error("Cannot resolve rebase conflict because no repository is selected.");
+      }
+      if (!selection.viewTaskId) {
+        throw new Error("Cannot resolve rebase conflict because no task is selected.");
+      }
+
+      const builderSessions = resolveAgentStudioBuilderSessionsForTask({
+        taskId: selection.viewTaskId,
+        viewActiveSession: selection.viewActiveSession,
+        activeSession: selection.activeSession,
+        selectedSessionById: selection.selectedSessionById,
+        viewSessionsForTask: selection.viewSessionsForTask,
+        sessionsForTask: selection.sessionsForTask,
+      });
+      const defaultBuilderSession = resolveAgentStudioBuilderSessionForTask({
+        taskId: selection.viewTaskId,
+        viewActiveSession: selection.viewActiveSession,
+        activeSession: selection.activeSession,
+        selectedSessionById: selection.selectedSessionById,
+        viewSessionsForTask: selection.viewSessionsForTask,
+        sessionsForTask: selection.sessionsForTask,
+      });
+      const currentWorktreePath = (conflict.workingDir ?? activeRepo)?.trim() ?? "";
+      if (!currentWorktreePath) {
+        throw new Error(
+          "Cannot resolve rebase conflict because the current worktree path is unavailable.",
+        );
+      }
+
+      const decision = await requestRebaseConflictResolutionChoice({
+        conflict,
+        builderSessions,
+        currentWorktreePath,
+        currentViewSessionId:
+          selection.viewActiveSession?.role === "build"
+            ? selection.viewActiveSession.sessionId
+            : null,
+        defaultMode: defaultBuilderSession ? "existing" : "new",
+        defaultSessionId: defaultBuilderSession?.sessionId ?? null,
+      });
+      if (!decision) {
+        return false;
+      }
+
+      const promptOverrides = await loadEffectivePromptOverrides(activeRepo);
+      const message = buildRebaseConflictResolutionPrompt(selection.viewTaskId, {
+        overrides: promptOverrides,
+        ...(selection.viewSelectedTask
+          ? {
+              task: {
+                title: selection.viewSelectedTask.title,
+                issueType: selection.viewSelectedTask.issueType,
+                status: selection.viewSelectedTask.status,
+                qaRequired: selection.viewSelectedTask.aiReviewEnabled,
+                description: selection.viewSelectedTask.description,
+                acceptanceCriteria: selection.viewSelectedTask.acceptanceCriteria,
+              },
+            }
+          : {}),
+        git: {
+          ...(conflict.currentBranch ? { currentBranch: conflict.currentBranch } : {}),
+          targetBranch: conflict.targetBranch,
+          conflictedFiles: conflict.conflictedFiles,
+          rebaseOutput: conflict.output,
+        },
+      });
+
+      if (decision.mode === "existing") {
+        const builderSession = builderSessions.find(
+          (session) => session.sessionId === decision.sessionId,
+        );
+        if (!builderSession) {
+          throw new Error("Selected Builder session is no longer available for this task.");
+        }
+
+        if (
+          selection.viewActiveSession?.sessionId !== builderSession.sessionId ||
+          selection.viewActiveSession?.role !== builderSession.role
+        ) {
+          onContextSwitchIntent();
+          scheduleQueryUpdate({
+            task: builderSession.taskId,
+            session: builderSession.sessionId,
+            agent: builderSession.role,
+          });
+        }
+
+        sendConflictResolutionMessage(builderSession.sessionId, message);
+        return true;
+      }
+
+      const sessionId = await startAgentSession({
+        taskId: selection.viewTaskId,
+        role: "build",
+        scenario: "build_rebase_conflict_resolution",
+        selectedModel: defaultBuilderSession?.selectedModel ?? null,
+        sendKickoff: false,
+        startMode: "fresh",
+        requireModelReady: true,
+        workingDirectoryOverride: currentWorktreePath,
+      });
+
+      onContextSwitchIntent();
+      scheduleQueryUpdate({
+        task: selection.viewTaskId,
+        session: sessionId,
+        agent: "build",
+      });
+      sendConflictResolutionMessage(sessionId, message);
+      return true;
+    },
+    [
+      activeRepo,
+      onContextSwitchIntent,
+      requestRebaseConflictResolutionChoice,
+      scheduleQueryUpdate,
+      selection,
+      sendConflictResolutionMessage,
+      startAgentSession,
+    ],
+  );
+
+  return {
+    pendingRebaseConflictResolutionRequest,
+    resolvePendingRebaseConflictResolution,
+    handleResolveRebaseConflict,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-rebase-conflict-resolution.ts
@@ -1,4 +1,4 @@
-import type { TaskCard } from "@openducktor/contracts";
+import type { RepoPromptOverrides, TaskCard } from "@openducktor/contracts";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
@@ -55,6 +55,7 @@ type UseAgentStudioRebaseConflictResolutionArgs = {
   onContextSwitchIntent: () => void;
   startAgentSession: AgentStateContextValue["startAgentSession"];
   sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
+  loadPromptOverrides?: (repoPath: string) => Promise<RepoPromptOverrides>;
 };
 
 type UseAgentStudioRebaseConflictResolutionResult = {
@@ -70,6 +71,7 @@ export function useAgentStudioRebaseConflictResolution({
   onContextSwitchIntent,
   startAgentSession,
   sendAgentMessage,
+  loadPromptOverrides = loadEffectivePromptOverrides,
 }: UseAgentStudioRebaseConflictResolutionArgs): UseAgentStudioRebaseConflictResolutionResult {
   const [pendingRebaseConflictResolutionRequest, setPendingRebaseConflictResolutionRequest] =
     useState<PendingRebaseConflictResolutionRequest | null>(null);
@@ -169,7 +171,7 @@ export function useAgentStudioRebaseConflictResolution({
         return false;
       }
 
-      const promptOverrides = await loadEffectivePromptOverrides(activeRepo);
+      const promptOverrides = await loadPromptOverrides(activeRepo);
       const message = buildRebaseConflictResolutionPrompt(selection.viewTaskId, {
         overrides: promptOverrides,
         ...(selection.viewSelectedTask
@@ -244,6 +246,7 @@ export function useAgentStudioRebaseConflictResolution({
       selection,
       sendConflictResolutionMessage,
       startAgentSession,
+      loadPromptOverrides,
     ],
   );
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-request.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-request.test.tsx
@@ -34,6 +34,7 @@ describe("useAgentStudioSessionStartRequest", () => {
       });
 
       expect(harness.getLatest().pendingSessionStartRequest?.taskId).toBe("task-1");
+      expect(harness.getLatest().pendingSessionStartRequest?.requestId).toBe("session-start-0");
 
       await harness.run((state) => {
         state.resolvePendingSessionStart({ selectedModel: null });
@@ -70,6 +71,7 @@ describe("useAgentStudioSessionStartRequest", () => {
       await harness.waitFor(() => firstDecision !== undefined);
       expect(firstDecision).toBeNull();
       expect(harness.getLatest().pendingSessionStartRequest?.taskId).toBe("task-2");
+      expect(harness.getLatest().pendingSessionStartRequest?.requestId).toBe("session-start-1");
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-request.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-request.ts
@@ -4,16 +4,21 @@ import type {
   NewSessionStartRequest,
 } from "./use-agent-studio-session-actions";
 
+export type PendingSessionStartRequest = NewSessionStartRequest & {
+  requestId: string;
+};
+
 export function useAgentStudioSessionStartRequest(): {
-  pendingSessionStartRequest: NewSessionStartRequest | null;
+  pendingSessionStartRequest: PendingSessionStartRequest | null;
   requestNewSessionStart: (request: NewSessionStartRequest) => Promise<NewSessionStartDecision>;
   resolvePendingSessionStart: (decision: NewSessionStartDecision) => void;
 } {
   const [pendingSessionStartRequest, setPendingSessionStartRequest] =
-    useState<NewSessionStartRequest | null>(null);
+    useState<PendingSessionStartRequest | null>(null);
   const pendingSessionStartResolverRef = useRef<
     ((decision: NewSessionStartDecision) => void) | null
   >(null);
+  const requestSequenceRef = useRef(0);
 
   const resolvePendingSessionStart = useCallback((decision: NewSessionStartDecision): void => {
     const resolver = pendingSessionStartResolverRef.current;
@@ -27,7 +32,12 @@ export function useAgentStudioSessionStartRequest(): {
       pendingSessionStartResolverRef.current?.(null);
       return new Promise((resolve) => {
         pendingSessionStartResolverRef.current = resolve;
-        setPendingSessionStartRequest(request);
+        const requestId = `session-start-${requestSequenceRef.current}`;
+        requestSequenceRef.current += 1;
+        setPendingSessionStartRequest({
+          ...request,
+          requestId,
+        });
       });
     },
     [],


### PR DESCRIPTION
## Summary
- split the Agent Studio page into focused shell, modal, and orchestration modules so `AgentsPage` becomes a coordinator instead of a page-level god component
- extract the rebase-conflict resolution workflow into its own hook and modal flow, preserving the existing Builder handoff behavior
- add explicit request identities for rebase-conflict and session-start modal requests so replacement requests reset state cleanly instead of inheriting in-progress UI selections
- add regression coverage for the new request-boundary behavior and for the extracted page shell composition

## Details
This PR packages the original Agent Studio orchestration refactor together with the review follow-up that fixed modal request replacement state.

The first commit reduces the size and responsibility of `AgentsPage` by moving page shell composition, the session-start bridge, and the rebase-conflict workflow out into dedicated modules.

The second commit addresses the state-reset issue found during review by giving pending modal requests explicit identities and adding tests that exercise request replacement while components stay mounted.

## Testing
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop test -- src/pages/agents`
