### PR TITLE
Refactor AgentStudioGitPanel dialogs and conflict actions

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
@@ -76,7 +76,7 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
     void model.askBuilderToResolveRebaseConflict?.();
   }, [model.askBuilderToResolveRebaseConflict]);
 
-  const rebaseConflictActions = useMemo(
+  const stripRebaseConflictActions = useMemo(
     () =>
       createRebaseConflictActionsModel({
         isHandlingRebaseConflict: model.isHandlingRebaseConflict ?? false,
@@ -91,6 +91,24 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
     [
       model.abortRebase,
       model.askBuilderToResolveRebaseConflict,
+      model.isHandlingRebaseConflict,
+      model.rebaseConflictAction,
+    ],
+  );
+
+  const modalRebaseConflictActions = useMemo(
+    () =>
+      createRebaseConflictActionsModel({
+        isHandlingRebaseConflict: model.isHandlingRebaseConflict ?? false,
+        rebaseConflictAction: model.rebaseConflictAction,
+        onAbort: () => {
+          void model.abortRebase?.();
+        },
+        onAskBuilder: handleAskBuilderFromConflictModal,
+      }),
+    [
+      handleAskBuilderFromConflictModal,
+      model.abortRebase,
       model.isHandlingRebaseConflict,
       model.rebaseConflictAction,
     ],
@@ -187,7 +205,7 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
         {model.rebaseConflict ? (
           <RebaseConflictStrip
             conflict={model.rebaseConflict}
-            actions={rebaseConflictActions}
+            actions={stripRebaseConflictActions}
             onViewDetails={() => setIsRebaseConflictModalOpen(true)}
           />
         ) : null}
@@ -232,8 +250,7 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
           conflict={model.rebaseConflict ?? null}
           open={hasRebaseConflict && isRebaseConflictModalOpen}
           onOpenChange={setIsRebaseConflictModalOpen}
-          onAskBuilder={handleAskBuilderFromConflictModal}
-          actions={rebaseConflictActions}
+          actions={modalRebaseConflictActions}
         />
 
         <ForcePushDialog

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
@@ -1,28 +1,19 @@
-import { ArrowDown, ArrowUp, LoaderCircle, RotateCcw, Sparkles } from "lucide-react";
 import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { PierreDiffStyle } from "@/components/features/agents/pierre-diff-viewer";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { DiffScope } from "@/pages/agents/use-agent-studio-diff-data";
 import { CommitComposer } from "./commit-composer";
 import { EmptyDiffState } from "./empty-diff-state";
 import { FileDiffList } from "./file-diff-list";
+import { ForcePushDialog } from "./force-push-dialog";
 import { GitInfoHeader } from "./git-info-header";
+import { PullRebaseDialog } from "./pull-rebase-dialog";
+import { createRebaseConflictActionsModel } from "./rebase-conflict-actions";
+import { RebaseConflictDialog } from "./rebase-conflict-dialog";
+import { RebaseConflictStrip } from "./rebase-conflict-strip";
 import { ReviewActions } from "./review-actions";
 import type { AgentStudioGitPanelModel } from "./types";
-
-const inlineCodeClassName =
-  "rounded-md border border-border bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-foreground";
 
 export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
   model,
@@ -39,7 +30,6 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
   const uncommittedFileCount = model.uncommittedFileCount;
   const hasUncommittedFiles = uncommittedFileCount > 0;
   const hasFiles = model.fileDiffs.length > 0;
-  const conflictedFileCount = model.rebaseConflict?.conflictedFiles.length ?? 0;
   const conflictedFiles = useMemo(
     () =>
       new Set(
@@ -49,19 +39,6 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
       ),
     [model.fileStatuses],
   );
-  const rebaseConflictLabel =
-    model.rebaseConflict?.operation === "pull_rebase" ? "Pull with rebase" : "Rebase";
-  const isHandlingRebaseConflict = model.isHandlingRebaseConflict ?? false;
-  const isAbortPending = model.rebaseConflictAction === "abort";
-  const isAskBuilderPending = model.rebaseConflictAction === "ask_builder";
-  const rebaseConflictDescription =
-    model.rebaseConflict?.operation === "pull_rebase"
-      ? `The pull with rebase onto \`${model.rebaseConflict.targetBranch}\` is paused on conflicts.`
-      : `The rebase onto \`${model.rebaseConflict?.targetBranch ?? "target"}\` is paused on conflicts.`;
-  const rebaseConflictModalDescription =
-    model.rebaseConflict?.operation === "pull_rebase"
-      ? `The pull with rebase onto \`${model.rebaseConflict.targetBranch}\` stopped on conflicts. Abort the rebase or send the conflict to Builder for resolution.`
-      : `The rebase onto \`${model.rebaseConflict?.targetBranch ?? "target"}\` stopped on conflicts. Abort the rebase or send the conflict to Builder for resolution.`;
 
   const toggleFile = useCallback(
     (filePath: string): void => {
@@ -98,6 +75,26 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
     setIsRebaseConflictModalOpen(false);
     void model.askBuilderToResolveRebaseConflict?.();
   }, [model.askBuilderToResolveRebaseConflict]);
+
+  const rebaseConflictActions = useMemo(
+    () =>
+      createRebaseConflictActionsModel({
+        isHandlingRebaseConflict: model.isHandlingRebaseConflict ?? false,
+        rebaseConflictAction: model.rebaseConflictAction,
+        onAbort: () => {
+          void model.abortRebase?.();
+        },
+        onAskBuilder: () => {
+          void model.askBuilderToResolveRebaseConflict?.();
+        },
+      }),
+    [
+      model.abortRebase,
+      model.askBuilderToResolveRebaseConflict,
+      model.isHandlingRebaseConflict,
+      model.rebaseConflictAction,
+    ],
+  );
 
   useEffect(() => {
     setExpandedFiles((previous) => {
@@ -188,73 +185,11 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
         ) : null}
 
         {model.rebaseConflict ? (
-          <div
-            className="border-b border-border bg-amber-50 px-3 py-3 text-sm text-amber-900 dark:bg-amber-950/30 dark:text-amber-100"
-            data-testid="agent-studio-git-rebase-strip"
-          >
-            <div className="space-y-3">
-              <div className="space-y-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="font-medium">{rebaseConflictLabel} in progress</p>
-                  <Badge
-                    variant="warning"
-                    className="px-2 py-0.5 text-[10px]"
-                    data-testid="agent-studio-git-rebase-conflict-count-badge"
-                  >
-                    {conflictedFileCount} conflicted file{conflictedFileCount === 1 ? "" : "s"}
-                  </Badge>
-                </div>
-                <p className="text-xs text-amber-800 dark:text-amber-200">
-                  {rebaseConflictDescription}
-                </p>
-              </div>
-
-              <div className="flex flex-nowrap items-center gap-2 overflow-x-auto pb-0.5">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="shrink-0"
-                  onClick={() => setIsRebaseConflictModalOpen(true)}
-                  disabled={isHandlingRebaseConflict}
-                  data-testid="agent-studio-git-view-conflict-details-button"
-                >
-                  View details
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="shrink-0"
-                  onClick={() => void model.abortRebase?.()}
-                  disabled={isHandlingRebaseConflict}
-                  data-testid="agent-studio-git-abort-rebase-strip-button"
-                >
-                  {isAbortPending ? (
-                    <LoaderCircle className="size-4 animate-spin" />
-                  ) : (
-                    <RotateCcw className="size-4" />
-                  )}
-                  {isAbortPending ? "Aborting..." : "Abort rebase"}
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  className="shrink-0"
-                  onClick={() => void model.askBuilderToResolveRebaseConflict?.()}
-                  disabled={isHandlingRebaseConflict}
-                  data-testid="agent-studio-git-ask-builder-strip-button"
-                >
-                  {isAskBuilderPending ? (
-                    <LoaderCircle className="size-4 animate-spin" />
-                  ) : (
-                    <Sparkles className="size-4" />
-                  )}
-                  {isAskBuilderPending ? "Sending to Builder..." : "Ask Builder to resolve"}
-                </Button>
-              </div>
-            </div>
-          </div>
+          <RebaseConflictStrip
+            conflict={model.rebaseConflict}
+            actions={rebaseConflictActions}
+            onViewDetails={() => setIsRebaseConflictModalOpen(true)}
+          />
         ) : null}
 
         <ScrollArea className="min-h-0 flex-1">
@@ -293,243 +228,27 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
           />
         ) : null}
 
-        <Dialog
+        <RebaseConflictDialog
+          conflict={model.rebaseConflict ?? null}
           open={hasRebaseConflict && isRebaseConflictModalOpen}
           onOpenChange={setIsRebaseConflictModalOpen}
-        >
-          <DialogContent className="max-w-xl" data-testid="agent-studio-git-rebase-conflict-modal">
-            <DialogHeader>
-              <DialogTitle>{rebaseConflictLabel} conflict detected</DialogTitle>
-              <DialogDescription>{rebaseConflictModalDescription}</DialogDescription>
-            </DialogHeader>
+          onAskBuilder={handleAskBuilderFromConflictModal}
+          actions={rebaseConflictActions}
+        />
 
-            {model.rebaseConflict ? (
-              <div className="space-y-4">
-                <div>
-                  <p className="text-sm font-medium text-foreground">Conflicted files</p>
-                  <ul
-                    className="mt-2 max-h-40 list-disc space-y-1 overflow-auto pl-5 text-sm text-muted-foreground"
-                    data-testid="agent-studio-git-rebase-conflict-files"
-                  >
-                    {model.rebaseConflict.conflictedFiles.map((file) => (
-                      <li key={file}>{file}</li>
-                    ))}
-                  </ul>
-                </div>
+        <ForcePushDialog
+          pendingForcePush={model.pendingForcePush ?? null}
+          isPushing={model.isPushing ?? false}
+          onCancel={() => model.cancelForcePush?.()}
+          onConfirm={() => void model.confirmForcePush?.()}
+        />
 
-                <div>
-                  <p className="text-sm font-medium text-foreground">Git output</p>
-                  <pre className="mt-2 max-h-48 overflow-auto rounded-md bg-muted p-3 text-xs text-foreground whitespace-pre-wrap">
-                    {model.rebaseConflict.output}
-                  </pre>
-                </div>
-              </div>
-            ) : null}
-
-            <DialogFooter className="mt-6 flex flex-row items-center justify-between gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setIsRebaseConflictModalOpen(false)}
-                disabled={isHandlingRebaseConflict}
-                data-testid="agent-studio-git-close-rebase-conflict-modal-button"
-              >
-                Close
-              </Button>
-
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => void model.abortRebase?.()}
-                  disabled={isHandlingRebaseConflict}
-                  data-testid="agent-studio-git-abort-rebase-button"
-                >
-                  {isAbortPending ? (
-                    <LoaderCircle className="size-4 animate-spin" />
-                  ) : (
-                    <RotateCcw className="size-4" />
-                  )}
-                  {isAbortPending ? "Aborting..." : "Abort rebase"}
-                </Button>
-                <Button
-                  type="button"
-                  onClick={handleAskBuilderFromConflictModal}
-                  disabled={isHandlingRebaseConflict}
-                  data-testid="agent-studio-git-ask-builder-button"
-                >
-                  {isAskBuilderPending ? (
-                    <LoaderCircle className="size-4 animate-spin" />
-                  ) : (
-                    <Sparkles className="size-4" />
-                  )}
-                  {isAskBuilderPending ? "Sending to Builder..." : "Ask Builder to resolve"}
-                </Button>
-              </div>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
-        <Dialog
-          open={model.pendingForcePush != null}
-          onOpenChange={(open) => {
-            if (!open) {
-              model.cancelForcePush?.();
-            }
-          }}
-        >
-          <DialogContent
-            className="max-w-xl overflow-hidden p-0"
-            data-testid="agent-studio-git-force-push-modal"
-          >
-            <div className="space-y-6 px-6 py-6 sm:px-7 sm:py-7">
-              <DialogHeader className="space-y-3 pr-10">
-                <DialogTitle>Confirm force push</DialogTitle>
-                <DialogDescription className="max-w-[38rem] text-[15px] leading-7">
-                  The remote rejected a normal push because the upstream branch moved. Continue only
-                  if you intend to rewrite the remote branch history.
-                </DialogDescription>
-              </DialogHeader>
-
-              <div className="rounded-xl border border-border bg-muted/35 px-4 py-4">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                  Branch
-                </p>
-                <div className="mt-2">
-                  <code className={inlineCodeClassName}>
-                    {model.pendingForcePush?.branch ?? ""}
-                  </code>
-                </div>
-              </div>
-
-              <div
-                className="rounded-xl border border-border bg-muted/50 px-4 py-4"
-                data-testid="agent-studio-git-force-push-safety-note"
-              >
-                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                  Retry mode
-                </p>
-                <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                  The retry uses <code className={inlineCodeClassName}>--force-with-lease</code>.
-                  Git checks that the remote branch still points to the commit you last fetched. If
-                  someone pushed in the meantime, the retry fails instead of overwriting their work.
-                  This panel never uses <code className={inlineCodeClassName}>--force</code>.
-                </p>
-              </div>
-
-              {model.pendingForcePush ? (
-                <div className="rounded-xl border border-border bg-muted/40 px-4 py-4">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                    Git output
-                  </p>
-                  <pre className="mt-3 max-h-40 overflow-auto rounded-lg border border-border bg-background/80 p-3 text-xs whitespace-pre-wrap text-foreground">
-                    {model.pendingForcePush.output}
-                  </pre>
-                </div>
-              ) : null}
-            </div>
-
-            <DialogFooter className="mt-0 flex flex-row items-center justify-between border-t border-border px-6 py-5 sm:px-7">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={model.cancelForcePush}
-                disabled={model.isPushing ?? false}
-                data-testid="agent-studio-git-cancel-force-push-button"
-              >
-                Close
-              </Button>
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  onClick={() => void model.confirmForcePush?.()}
-                  disabled={model.isPushing ?? false}
-                  data-testid="agent-studio-git-confirm-force-push-button"
-                >
-                  {model.isPushing ? (
-                    <LoaderCircle className="size-4 animate-spin" />
-                  ) : (
-                    <ArrowUp className="size-4" />
-                  )}
-                  {model.isPushing ? "Force pushing..." : "Force push with lease"}
-                </Button>
-              </div>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
-        <Dialog
-          open={model.pendingPullRebase != null}
-          onOpenChange={(open) => {
-            if (model.isRebasing ?? false) {
-              return;
-            }
-            if (!open) {
-              model.cancelPullRebase?.();
-            }
-          }}
-        >
-          <DialogContent
-            className="max-w-xl overflow-hidden p-0"
-            data-testid="agent-studio-git-pull-rebase-modal"
-          >
-            <div className="space-y-6 px-6 py-6 sm:px-7 sm:py-7">
-              <DialogHeader className="space-y-3 pr-10">
-                <DialogTitle>Confirm pull with rebase</DialogTitle>
-                <DialogDescription className="max-w-[38rem] text-[15px] leading-7">
-                  Pulling{" "}
-                  <code className={inlineCodeClassName}>
-                    {model.pendingPullRebase?.branch ?? ""}
-                  </code>{" "}
-                  will run <code className={inlineCodeClassName}>git pull --rebase</code> before
-                  integrating upstream changes.
-                </DialogDescription>
-              </DialogHeader>
-
-              <div
-                className="rounded-xl border border-border bg-muted/50 px-4 py-4"
-                data-testid="agent-studio-git-pull-rebase-safety-note"
-              >
-                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                  Rebase effect
-                </p>
-                <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                  This will replay {model.pendingPullRebase?.localAhead ?? 0} local commit
-                  {(model.pendingPullRebase?.localAhead ?? 0) === 1 ? "" : "s"} on top of{" "}
-                  {model.pendingPullRebase?.upstreamBehind ?? 0} upstream commit
-                  {(model.pendingPullRebase?.upstreamBehind ?? 0) === 1 ? "" : "s"}.
-                </p>
-              </div>
-            </div>
-
-            <DialogFooter className="mt-0 flex flex-row items-center justify-between border-t border-border px-6 py-5 sm:px-7">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={model.cancelPullRebase}
-                disabled={model.isRebasing ?? false}
-                data-testid="agent-studio-git-cancel-pull-rebase-button"
-              >
-                Close
-              </Button>
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  onClick={() => void model.confirmPullRebase?.()}
-                  disabled={model.isRebasing ?? false}
-                  data-testid="agent-studio-git-confirm-pull-rebase-button"
-                >
-                  {model.isRebasing ? (
-                    <LoaderCircle className="size-4 animate-spin" />
-                  ) : (
-                    <ArrowDown className="size-4" />
-                  )}
-                  {model.isRebasing ? "Pulling..." : "Pull with rebase"}
-                </Button>
-              </div>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+        <PullRebaseDialog
+          pendingPullRebase={model.pendingPullRebase ?? null}
+          isRebasing={model.isRebasing ?? false}
+          onCancel={() => model.cancelPullRebase?.()}
+          onConfirm={() => void model.confirmPullRebase?.()}
+        />
       </div>
     </TooltipProvider>
   );

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/constants.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/constants.ts
@@ -37,3 +37,6 @@ export const DIFF_SCOPE_OPTIONS: Array<{
 ];
 
 export const PRELOAD_DIFF_LIMIT = 12;
+
+export const INLINE_CODE_CLASS_NAME =
+  "rounded-md border border-border bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-foreground";

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/dialog-guards.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/dialog-guards.test.tsx
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const TEST_RENDERER_DEPRECATION_WARNING = "react-test-renderer is deprecated";
+const originalConsoleError = console.error;
+
+mock.module("@/components/ui/dialog", () => ({
+  Dialog: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => createElement("div", { "data-testid": "dialog-root", open, onOpenChange }, children),
+  DialogContent: ({ children, ...props }: { children: React.ReactNode; [key: string]: unknown }) =>
+    createElement("div", props, children),
+  DialogHeader: ({ children }: { children: React.ReactNode }) =>
+    createElement("div", null, children),
+  DialogTitle: ({ children }: { children: React.ReactNode }) =>
+    createElement("div", null, children),
+  DialogDescription: ({ children }: { children: React.ReactNode }) =>
+    createElement("div", null, children),
+  DialogFooter: ({ children }: { children: React.ReactNode }) =>
+    createElement("div", null, children),
+}));
+
+type ForcePushDialogComponent = typeof import("./force-push-dialog")["ForcePushDialog"];
+type RebaseConflictDialogComponent =
+  typeof import("./rebase-conflict-dialog")["RebaseConflictDialog"];
+type RebaseConflictActionsModel = import("./rebase-conflict-actions").RebaseConflictActionsModel;
+
+let ForcePushDialog: ForcePushDialogComponent;
+let RebaseConflictDialog: RebaseConflictDialogComponent;
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const ensureRenderer = (
+  renderer: TestRenderer.ReactTestRenderer | null,
+): TestRenderer.ReactTestRenderer => {
+  if (!renderer) {
+    throw new Error("Dialog guard test renderer is not initialized");
+  }
+
+  return renderer;
+};
+
+const findByTestId = (
+  root: TestRenderer.ReactTestInstance,
+  testId: string,
+): TestRenderer.ReactTestInstance => {
+  const matches = root.findAll(
+    (node) => node.props["data-testid"] === testId && typeof node.type === "string",
+  );
+
+  if (matches.length !== 1) {
+    throw new Error(`Expected one host node for data-testid=${testId}, got ${matches.length}`);
+  }
+
+  const match = matches[0];
+  if (!match) {
+    throw new Error(`Missing host node for data-testid=${testId}`);
+  }
+
+  return match;
+};
+
+describe("Git panel dialog guards", () => {
+  beforeEach(async () => {
+    console.error = (...args: unknown[]): void => {
+      if (typeof args[0] === "string" && args[0].includes(TEST_RENDERER_DEPRECATION_WARNING)) {
+        return;
+      }
+      originalConsoleError(...args);
+    };
+
+    ({ ForcePushDialog } = await import("./force-push-dialog"));
+    ({ RebaseConflictDialog } = await import("./rebase-conflict-dialog"));
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  test("keeps the force-push dialog open while a push is in flight", async () => {
+    const cancel = mock(() => {});
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(ForcePushDialog, {
+          pendingForcePush: {
+            remote: "origin",
+            branch: "feature/task-11",
+            output: "non-fast-forward",
+          },
+          isPushing: true,
+          onCancel: cancel,
+          onConfirm: () => {},
+        }),
+      );
+      await flush();
+    });
+
+    const dialogRoot = findByTestId(ensureRenderer(renderer).root, "dialog-root");
+    dialogRoot.props.onOpenChange(false);
+
+    expect(cancel).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+
+  test("blocks implicit rebase-conflict dialog dismissal while an action is in flight", async () => {
+    const onOpenChange = mock((_open: boolean) => {});
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    const actions: RebaseConflictActionsModel = {
+      isDisabled: true,
+      abort: {
+        isPending: true,
+        label: "Aborting...",
+        onClick: () => {},
+      },
+      askBuilder: {
+        isPending: false,
+        label: "Ask Builder to resolve",
+        onClick: () => {},
+      },
+    };
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(RebaseConflictDialog, {
+          conflict: {
+            operation: "rebase",
+            currentBranch: "feature/task-11",
+            targetBranch: "origin/main",
+            conflictedFiles: ["AGENTS.md"],
+            output: "CONFLICT (content): Merge conflict in AGENTS.md",
+            workingDir: "/tmp/worktree",
+          },
+          open: true,
+          onOpenChange,
+          actions,
+        }),
+      );
+      await flush();
+    });
+
+    const root = ensureRenderer(renderer).root;
+    const dialogRoot = findByTestId(root, "dialog-root");
+    dialogRoot.props.onOpenChange(false);
+
+    expect(onOpenChange).toHaveBeenCalledTimes(0);
+
+    const codeNodes = root.findAll((node) => node.type === "code");
+    expect(codeNodes.length).toBe(1);
+    expect(codeNodes[0]?.children.join("")).toBe("origin/main");
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
@@ -21,6 +21,9 @@ export const ForcePushDialog = memo(function ForcePushDialog({
     <GitConfirmationDialog
       open={pendingForcePush != null}
       onOpenChange={(open) => {
+        if (isPushing) {
+          return;
+        }
         if (!open) {
           onCancel();
         }

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
@@ -1,0 +1,82 @@
+import { ArrowUp } from "lucide-react";
+import { memo, type ReactElement } from "react";
+import type { AgentStudioPendingForcePush } from "@/pages/agents/use-agent-studio-git-actions";
+import { INLINE_CODE_CLASS_NAME } from "./constants";
+import { GitConfirmationDialog } from "./git-confirmation-dialog";
+
+type ForcePushDialogProps = {
+  pendingForcePush: AgentStudioPendingForcePush | null;
+  isPushing: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export const ForcePushDialog = memo(function ForcePushDialog({
+  pendingForcePush,
+  isPushing,
+  onCancel,
+  onConfirm,
+}: ForcePushDialogProps): ReactElement {
+  return (
+    <GitConfirmationDialog
+      open={pendingForcePush != null}
+      onOpenChange={(open) => {
+        if (!open) {
+          onCancel();
+        }
+      }}
+      title="Confirm force push"
+      description={
+        <>
+          The remote rejected a normal push because the upstream branch moved. Continue only if you
+          intend to rewrite the remote branch history.
+        </>
+      }
+      closeDisabled={isPushing}
+      onClose={onCancel}
+      closeTestId="agent-studio-git-cancel-force-push-button"
+      confirmLabel="Force push with lease"
+      confirmPendingLabel="Force pushing..."
+      confirmDisabled={isPushing}
+      onConfirm={onConfirm}
+      confirmTestId="agent-studio-git-confirm-force-push-button"
+      confirmIcon={ArrowUp}
+      contentTestId="agent-studio-git-force-push-modal"
+    >
+      <div className="rounded-xl border border-border bg-muted/35 px-4 py-4">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          Branch
+        </p>
+        <div className="mt-2">
+          <code className={INLINE_CODE_CLASS_NAME}>{pendingForcePush?.branch ?? ""}</code>
+        </div>
+      </div>
+
+      <div
+        className="rounded-xl border border-border bg-muted/50 px-4 py-4"
+        data-testid="agent-studio-git-force-push-safety-note"
+      >
+        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          Retry mode
+        </p>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          The retry uses <code className={INLINE_CODE_CLASS_NAME}>--force-with-lease</code>. Git
+          checks that the remote branch still points to the commit you last fetched. If someone
+          pushed in the meantime, the retry fails instead of overwriting their work. This panel
+          never uses <code className={INLINE_CODE_CLASS_NAME}>--force</code>.
+        </p>
+      </div>
+
+      {pendingForcePush ? (
+        <div className="rounded-xl border border-border bg-muted/40 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            Git output
+          </p>
+          <pre className="mt-3 max-h-40 overflow-auto rounded-lg border border-border bg-background/80 p-3 text-xs whitespace-pre-wrap text-foreground">
+            {pendingForcePush.output}
+          </pre>
+        </div>
+      ) : null}
+    </GitConfirmationDialog>
+  );
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
@@ -37,6 +37,7 @@ export const ForcePushDialog = memo(function ForcePushDialog({
       closeTestId="agent-studio-git-cancel-force-push-button"
       confirmLabel="Force push with lease"
       confirmPendingLabel="Force pushing..."
+      confirmPending={isPushing}
       confirmDisabled={isPushing}
       onConfirm={onConfirm}
       confirmTestId="agent-studio-git-confirm-force-push-button"

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-confirmation-dialog.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-confirmation-dialog.test.tsx
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ArrowUp } from "lucide-react";
+import { createElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const TEST_RENDERER_DEPRECATION_WARNING = "react-test-renderer is deprecated";
+const originalConsoleError = console.error;
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const getNodeText = (node: TestRenderer.ReactTestInstance): string => {
+  return (node.children as unknown[])
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child);
+      }
+      if (child != null && typeof child === "object" && "children" in child) {
+        return getNodeText(child as TestRenderer.ReactTestInstance);
+      }
+      return "";
+    })
+    .join("");
+};
+
+const ensureRenderer = (
+  renderer: TestRenderer.ReactTestRenderer | null,
+): TestRenderer.ReactTestRenderer => {
+  if (!renderer) {
+    throw new Error("GitConfirmationDialog renderer is not initialized");
+  }
+
+  return renderer;
+};
+
+const findByTestId = (
+  root: TestRenderer.ReactTestInstance,
+  testId: string,
+): TestRenderer.ReactTestInstance => {
+  const matches = root.findAll(
+    (node) => node.props["data-testid"] === testId && typeof node.type === "string",
+  );
+
+  if (matches.length !== 1) {
+    throw new Error(`Expected one host node for data-testid=${testId}, got ${matches.length}`);
+  }
+
+  const match = matches[0];
+  if (!match) {
+    throw new Error(`Missing host node for data-testid=${testId}`);
+  }
+
+  return match;
+};
+
+describe("GitConfirmationDialog", () => {
+  let GitConfirmationDialog: typeof import("./git-confirmation-dialog")["GitConfirmationDialog"];
+
+  beforeEach(async () => {
+    console.error = (...args: unknown[]): void => {
+      if (typeof args[0] === "string" && args[0].includes(TEST_RENDERER_DEPRECATION_WARNING)) {
+        return;
+      }
+      originalConsoleError(...args);
+    };
+
+    ({ GitConfirmationDialog } = await import("./git-confirmation-dialog"));
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  test("keeps the normal confirm label when disabled but not pending", async () => {
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(
+          GitConfirmationDialog,
+          {
+            open: true,
+            onOpenChange: () => {},
+            title: "Confirm force push",
+            description: "Force push description",
+            closeDisabled: false,
+            onClose: () => {},
+            closeTestId: "close-button",
+            confirmLabel: "Force push with lease",
+            confirmPendingLabel: "Force pushing...",
+            confirmPending: false,
+            confirmDisabled: true,
+            onConfirm: () => {},
+            confirmTestId: "confirm-button",
+            confirmIcon: ArrowUp,
+            contentTestId: "dialog",
+          },
+          createElement("div", null, "Body"),
+        ),
+      );
+      await flush();
+    });
+
+    const root = ensureRenderer(renderer).root;
+    const confirmButton = findByTestId(root, "confirm-button");
+
+    expect(getNodeText(confirmButton)).toContain("Force push with lease");
+    expect(getNodeText(confirmButton)).not.toContain("Force pushing...");
+    expect(Boolean(confirmButton.props.disabled)).toBe(true);
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+
+  test("shows the pending confirm label only when pending is true", async () => {
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(
+          GitConfirmationDialog,
+          {
+            open: true,
+            onOpenChange: () => {},
+            title: "Confirm force push",
+            description: "Force push description",
+            closeDisabled: false,
+            onClose: () => {},
+            closeTestId: "close-button",
+            confirmLabel: "Force push with lease",
+            confirmPendingLabel: "Force pushing...",
+            confirmPending: true,
+            confirmDisabled: true,
+            onConfirm: () => {},
+            confirmTestId: "confirm-button",
+            confirmIcon: ArrowUp,
+            contentTestId: "dialog",
+          },
+          createElement("div", null, "Body"),
+        ),
+      );
+      await flush();
+    });
+
+    const root = ensureRenderer(renderer).root;
+    const confirmButton = findByTestId(root, "confirm-button");
+
+    expect(getNodeText(confirmButton)).toContain("Force pushing...");
+    expect(Boolean(confirmButton.props.disabled)).toBe(true);
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-confirmation-dialog.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-confirmation-dialog.test.tsx
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { ArrowUp } from "lucide-react";
-import { createElement } from "react";
 import TestRenderer, { act } from "react-test-renderer";
 
 (
@@ -84,27 +83,25 @@ describe("GitConfirmationDialog", () => {
 
     await act(async () => {
       renderer = TestRenderer.create(
-        createElement(
-          GitConfirmationDialog,
-          {
-            open: true,
-            onOpenChange: () => {},
-            title: "Confirm force push",
-            description: "Force push description",
-            closeDisabled: false,
-            onClose: () => {},
-            closeTestId: "close-button",
-            confirmLabel: "Force push with lease",
-            confirmPendingLabel: "Force pushing...",
-            confirmPending: false,
-            confirmDisabled: true,
-            onConfirm: () => {},
-            confirmTestId: "confirm-button",
-            confirmIcon: ArrowUp,
-            contentTestId: "dialog",
-          },
-          createElement("div", null, "Body"),
-        ),
+        <GitConfirmationDialog
+          open
+          onOpenChange={() => {}}
+          title="Confirm force push"
+          description="Force push description"
+          closeDisabled={false}
+          onClose={() => {}}
+          closeTestId="close-button"
+          confirmLabel="Force push with lease"
+          confirmPendingLabel="Force pushing..."
+          confirmPending={false}
+          confirmDisabled
+          onConfirm={() => {}}
+          confirmTestId="confirm-button"
+          confirmIcon={ArrowUp}
+          contentTestId="dialog"
+        >
+          <div>Body</div>
+        </GitConfirmationDialog>,
       );
       await flush();
     });
@@ -127,27 +124,25 @@ describe("GitConfirmationDialog", () => {
 
     await act(async () => {
       renderer = TestRenderer.create(
-        createElement(
-          GitConfirmationDialog,
-          {
-            open: true,
-            onOpenChange: () => {},
-            title: "Confirm force push",
-            description: "Force push description",
-            closeDisabled: false,
-            onClose: () => {},
-            closeTestId: "close-button",
-            confirmLabel: "Force push with lease",
-            confirmPendingLabel: "Force pushing...",
-            confirmPending: true,
-            confirmDisabled: true,
-            onConfirm: () => {},
-            confirmTestId: "confirm-button",
-            confirmIcon: ArrowUp,
-            contentTestId: "dialog",
-          },
-          createElement("div", null, "Body"),
-        ),
+        <GitConfirmationDialog
+          open
+          onOpenChange={() => {}}
+          title="Confirm force push"
+          description="Force push description"
+          closeDisabled={false}
+          onClose={() => {}}
+          closeTestId="close-button"
+          confirmLabel="Force push with lease"
+          confirmPendingLabel="Force pushing..."
+          confirmPending
+          confirmDisabled
+          onConfirm={() => {}}
+          confirmTestId="confirm-button"
+          confirmIcon={ArrowUp}
+          contentTestId="dialog"
+        >
+          <div>Body</div>
+        </GitConfirmationDialog>,
       );
       await flush();
     });

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-confirmation-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-confirmation-dialog.tsx
@@ -1,0 +1,94 @@
+import type { LucideIcon } from "lucide-react";
+import { LoaderCircle } from "lucide-react";
+import { memo, type ReactElement, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+type GitConfirmationDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: ReactNode;
+  children: ReactNode;
+  closeLabel?: string;
+  closeDisabled: boolean;
+  onClose: () => void;
+  closeTestId: string;
+  confirmLabel: string;
+  confirmPendingLabel: string;
+  confirmDisabled: boolean;
+  onConfirm: () => void;
+  confirmTestId: string;
+  confirmIcon: LucideIcon;
+  contentTestId: string;
+};
+
+export const GitConfirmationDialog = memo(function GitConfirmationDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  closeLabel = "Close",
+  closeDisabled,
+  onClose,
+  closeTestId,
+  confirmLabel,
+  confirmPendingLabel,
+  confirmDisabled,
+  onConfirm,
+  confirmTestId,
+  confirmIcon: ConfirmIcon,
+  contentTestId,
+}: GitConfirmationDialogProps): ReactElement {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl overflow-hidden p-0" data-testid={contentTestId}>
+        <div className="space-y-6 px-6 py-6 sm:px-7 sm:py-7">
+          <DialogHeader className="space-y-3 pr-10">
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription className="max-w-[38rem] text-[15px] leading-7">
+              {description}
+            </DialogDescription>
+          </DialogHeader>
+
+          {children}
+        </div>
+
+        <DialogFooter className="mt-0 flex flex-row items-center justify-between border-t border-border px-6 py-5 sm:px-7">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={closeDisabled}
+            data-testid={closeTestId}
+          >
+            {closeLabel}
+          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              onClick={onConfirm}
+              disabled={confirmDisabled}
+              data-testid={confirmTestId}
+            >
+              {confirmDisabled ? (
+                <LoaderCircle className="size-4 animate-spin" />
+              ) : (
+                <ConfirmIcon className="size-4" />
+              )}
+              {confirmDisabled ? confirmPendingLabel : confirmLabel}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-confirmation-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-confirmation-dialog.tsx
@@ -23,6 +23,7 @@ type GitConfirmationDialogProps = {
   closeTestId: string;
   confirmLabel: string;
   confirmPendingLabel: string;
+  confirmPending: boolean;
   confirmDisabled: boolean;
   onConfirm: () => void;
   confirmTestId: string;
@@ -42,6 +43,7 @@ export const GitConfirmationDialog = memo(function GitConfirmationDialog({
   closeTestId,
   confirmLabel,
   confirmPendingLabel,
+  confirmPending,
   confirmDisabled,
   onConfirm,
   confirmTestId,
@@ -79,12 +81,12 @@ export const GitConfirmationDialog = memo(function GitConfirmationDialog({
               disabled={confirmDisabled}
               data-testid={confirmTestId}
             >
-              {confirmDisabled ? (
+              {confirmPending ? (
                 <LoaderCircle className="size-4 animate-spin" />
               ) : (
                 <ConfirmIcon className="size-4" />
               )}
-              {confirmDisabled ? confirmPendingLabel : confirmLabel}
+              {confirmPending ? confirmPendingLabel : confirmLabel}
             </Button>
           </div>
         </DialogFooter>

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/pull-rebase-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/pull-rebase-dialog.tsx
@@ -1,0 +1,67 @@
+import { ArrowDown } from "lucide-react";
+import { memo, type ReactElement } from "react";
+import type { AgentStudioPendingPullRebase } from "@/pages/agents/use-agent-studio-git-actions";
+import { INLINE_CODE_CLASS_NAME } from "./constants";
+import { GitConfirmationDialog } from "./git-confirmation-dialog";
+
+type PullRebaseDialogProps = {
+  pendingPullRebase: AgentStudioPendingPullRebase | null;
+  isRebasing: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export const PullRebaseDialog = memo(function PullRebaseDialog({
+  pendingPullRebase,
+  isRebasing,
+  onCancel,
+  onConfirm,
+}: PullRebaseDialogProps): ReactElement {
+  const localAhead = pendingPullRebase?.localAhead ?? 0;
+  const upstreamBehind = pendingPullRebase?.upstreamBehind ?? 0;
+
+  return (
+    <GitConfirmationDialog
+      open={pendingPullRebase != null}
+      onOpenChange={(open) => {
+        if (isRebasing) {
+          return;
+        }
+        if (!open) {
+          onCancel();
+        }
+      }}
+      title="Confirm pull with rebase"
+      description={
+        <>
+          Pulling <code className={INLINE_CODE_CLASS_NAME}>{pendingPullRebase?.branch ?? ""}</code>{" "}
+          will run <code className={INLINE_CODE_CLASS_NAME}>git pull --rebase</code> before
+          integrating upstream changes.
+        </>
+      }
+      closeDisabled={isRebasing}
+      onClose={onCancel}
+      closeTestId="agent-studio-git-cancel-pull-rebase-button"
+      confirmLabel="Pull with rebase"
+      confirmPendingLabel="Pulling..."
+      confirmDisabled={isRebasing}
+      onConfirm={onConfirm}
+      confirmTestId="agent-studio-git-confirm-pull-rebase-button"
+      confirmIcon={ArrowDown}
+      contentTestId="agent-studio-git-pull-rebase-modal"
+    >
+      <div
+        className="rounded-xl border border-border bg-muted/50 px-4 py-4"
+        data-testid="agent-studio-git-pull-rebase-safety-note"
+      >
+        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          Rebase effect
+        </p>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          This will replay {localAhead} local commit{localAhead === 1 ? "" : "s"} on top of{" "}
+          {upstreamBehind} upstream commit{upstreamBehind === 1 ? "" : "s"}.
+        </p>
+      </div>
+    </GitConfirmationDialog>
+  );
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/pull-rebase-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/pull-rebase-dialog.tsx
@@ -44,6 +44,7 @@ export const PullRebaseDialog = memo(function PullRebaseDialog({
       closeTestId="agent-studio-git-cancel-pull-rebase-button"
       confirmLabel="Pull with rebase"
       confirmPendingLabel="Pulling..."
+      confirmPending={isRebasing}
       confirmDisabled={isRebasing}
       onConfirm={onConfirm}
       confirmTestId="agent-studio-git-confirm-pull-rebase-button"

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-actions.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-actions.test.tsx
@@ -1,0 +1,24 @@
+import { expect, mock, test } from "bun:test";
+import { createRebaseConflictActionsModel } from "./rebase-conflict-actions";
+
+test("createRebaseConflictActionsModel supports modal-specific handlers without mutating shared labels", () => {
+  const abort = mock(() => {});
+  const askBuilder = mock(() => {});
+
+  const actions = createRebaseConflictActionsModel({
+    isHandlingRebaseConflict: true,
+    rebaseConflictAction: "ask_builder",
+    onAbort: abort,
+    onAskBuilder: askBuilder,
+  });
+
+  expect(actions.isDisabled).toBe(true);
+  expect(actions.abort.label).toBe("Abort rebase");
+  expect(actions.askBuilder.label).toBe("Sending to Builder...");
+
+  actions.abort.onClick();
+  actions.askBuilder.onClick();
+
+  expect(abort).toHaveBeenCalledTimes(1);
+  expect(askBuilder).toHaveBeenCalledTimes(1);
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-actions.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-actions.tsx
@@ -1,0 +1,93 @@
+import { LoaderCircle, RotateCcw, Sparkles } from "lucide-react";
+import { memo, type ReactElement } from "react";
+import { Button } from "@/components/ui/button";
+import type { AgentStudioRebaseConflictAction } from "@/pages/agents/use-agent-studio-git-actions";
+
+export type RebaseConflictActionsModel = {
+  isDisabled: boolean;
+  abort: {
+    isPending: boolean;
+    label: string;
+    onClick: () => void;
+  };
+  askBuilder: {
+    isPending: boolean;
+    label: string;
+    onClick: () => void;
+  };
+};
+
+type RebaseConflictActionsProps = {
+  actions: RebaseConflictActionsModel;
+  abortTestId: string;
+  askBuilderTestId: string;
+  size?: "default" | "sm" | "lg" | "icon";
+  className?: string;
+};
+
+export const createRebaseConflictActionsModel = ({
+  isHandlingRebaseConflict,
+  rebaseConflictAction,
+  onAbort,
+  onAskBuilder,
+}: {
+  isHandlingRebaseConflict: boolean;
+  rebaseConflictAction: AgentStudioRebaseConflictAction | undefined;
+  onAbort: () => void;
+  onAskBuilder: () => void;
+}): RebaseConflictActionsModel => ({
+  isDisabled: isHandlingRebaseConflict,
+  abort: {
+    isPending: rebaseConflictAction === "abort",
+    label: rebaseConflictAction === "abort" ? "Aborting..." : "Abort rebase",
+    onClick: onAbort,
+  },
+  askBuilder: {
+    isPending: rebaseConflictAction === "ask_builder",
+    label:
+      rebaseConflictAction === "ask_builder" ? "Sending to Builder..." : "Ask Builder to resolve",
+    onClick: onAskBuilder,
+  },
+});
+
+export const RebaseConflictActions = memo(function RebaseConflictActions({
+  actions,
+  abortTestId,
+  askBuilderTestId,
+  size = "sm",
+  className,
+}: RebaseConflictActionsProps): ReactElement {
+  return (
+    <div className={className}>
+      <Button
+        type="button"
+        variant="outline"
+        size={size}
+        onClick={actions.abort.onClick}
+        disabled={actions.isDisabled}
+        data-testid={abortTestId}
+      >
+        {actions.abort.isPending ? (
+          <LoaderCircle className="size-4 animate-spin" />
+        ) : (
+          <RotateCcw className="size-4" />
+        )}
+        {actions.abort.label}
+      </Button>
+      <Button
+        type="button"
+        size={size}
+        onClick={actions.askBuilder.onClick}
+        disabled={actions.isDisabled}
+        data-testid={askBuilderTestId}
+      >
+        {actions.askBuilder.isPending ? (
+          <LoaderCircle className="size-4 animate-spin" />
+        ) : (
+          <Sparkles className="size-4" />
+        )}
+        {actions.askBuilder.label}
+      </Button>
+    </div>
+  );
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-dialog.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactElement } from "react";
+import { memo, type ReactElement, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { AgentStudioRebaseConflict } from "@/pages/agents/use-agent-studio-git-actions";
+import { INLINE_CODE_CLASS_NAME } from "./constants";
 import { RebaseConflictActions, type RebaseConflictActionsModel } from "./rebase-conflict-actions";
 
 type RebaseConflictDialogProps = {
@@ -21,12 +22,16 @@ type RebaseConflictDialogProps = {
 const toConflictTitle = (conflict: AgentStudioRebaseConflict): string =>
   `${conflict.operation === "pull_rebase" ? "Pull with rebase" : "Rebase"} conflict detected`;
 
-const toConflictDescription = (conflict: AgentStudioRebaseConflict): string => {
-  if (conflict.operation === "pull_rebase") {
-    return `The pull with rebase onto \`${conflict.targetBranch}\` stopped on conflicts. Abort the rebase or send the conflict to Builder for resolution.`;
-  }
+const toConflictDescription = (conflict: AgentStudioRebaseConflict): ReactNode => {
+  const operationLabel = conflict.operation === "pull_rebase" ? "pull with rebase" : "rebase";
 
-  return `The rebase onto \`${conflict.targetBranch}\` stopped on conflicts. Abort the rebase or send the conflict to Builder for resolution.`;
+  return (
+    <>
+      The {operationLabel} onto{" "}
+      <code className={INLINE_CODE_CLASS_NAME}>{conflict.targetBranch}</code> stopped on conflicts.
+      Abort the rebase or send the conflict to Builder for resolution.
+    </>
+  );
 };
 
 export const RebaseConflictDialog = memo(function RebaseConflictDialog({
@@ -36,7 +41,15 @@ export const RebaseConflictDialog = memo(function RebaseConflictDialog({
   actions,
 }: RebaseConflictDialogProps): ReactElement {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && actions.isDisabled) {
+          return;
+        }
+        onOpenChange(nextOpen);
+      }}
+    >
       <DialogContent className="max-w-xl" data-testid="agent-studio-git-rebase-conflict-modal">
         <DialogHeader>
           <DialogTitle>

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-dialog.tsx
@@ -15,7 +15,6 @@ type RebaseConflictDialogProps = {
   conflict: AgentStudioRebaseConflict | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onAskBuilder: () => void;
   actions: RebaseConflictActionsModel;
 };
 
@@ -34,7 +33,6 @@ export const RebaseConflictDialog = memo(function RebaseConflictDialog({
   conflict,
   open,
   onOpenChange,
-  onAskBuilder,
   actions,
 }: RebaseConflictDialogProps): ReactElement {
   return (
@@ -82,13 +80,7 @@ export const RebaseConflictDialog = memo(function RebaseConflictDialog({
           </Button>
 
           <RebaseConflictActions
-            actions={{
-              ...actions,
-              askBuilder: {
-                ...actions.askBuilder,
-                onClick: onAskBuilder,
-              },
-            }}
+            actions={actions}
             abortTestId="agent-studio-git-abort-rebase-button"
             askBuilderTestId="agent-studio-git-ask-builder-button"
             size="default"

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-dialog.tsx
@@ -1,0 +1,101 @@
+import { memo, type ReactElement } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { AgentStudioRebaseConflict } from "@/pages/agents/use-agent-studio-git-actions";
+import { RebaseConflictActions, type RebaseConflictActionsModel } from "./rebase-conflict-actions";
+
+type RebaseConflictDialogProps = {
+  conflict: AgentStudioRebaseConflict | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAskBuilder: () => void;
+  actions: RebaseConflictActionsModel;
+};
+
+const toConflictTitle = (conflict: AgentStudioRebaseConflict): string =>
+  `${conflict.operation === "pull_rebase" ? "Pull with rebase" : "Rebase"} conflict detected`;
+
+const toConflictDescription = (conflict: AgentStudioRebaseConflict): string => {
+  if (conflict.operation === "pull_rebase") {
+    return `The pull with rebase onto \`${conflict.targetBranch}\` stopped on conflicts. Abort the rebase or send the conflict to Builder for resolution.`;
+  }
+
+  return `The rebase onto \`${conflict.targetBranch}\` stopped on conflicts. Abort the rebase or send the conflict to Builder for resolution.`;
+};
+
+export const RebaseConflictDialog = memo(function RebaseConflictDialog({
+  conflict,
+  open,
+  onOpenChange,
+  onAskBuilder,
+  actions,
+}: RebaseConflictDialogProps): ReactElement {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl" data-testid="agent-studio-git-rebase-conflict-modal">
+        <DialogHeader>
+          <DialogTitle>
+            {conflict ? toConflictTitle(conflict) : "Rebase conflict detected"}
+          </DialogTitle>
+          <DialogDescription>{conflict ? toConflictDescription(conflict) : null}</DialogDescription>
+        </DialogHeader>
+
+        {conflict ? (
+          <div className="space-y-4">
+            <div>
+              <p className="text-sm font-medium text-foreground">Conflicted files</p>
+              <ul
+                className="mt-2 max-h-40 list-disc space-y-1 overflow-auto pl-5 text-sm text-muted-foreground"
+                data-testid="agent-studio-git-rebase-conflict-files"
+              >
+                {conflict.conflictedFiles.map((file) => (
+                  <li key={file}>{file}</li>
+                ))}
+              </ul>
+            </div>
+
+            <div>
+              <p className="text-sm font-medium text-foreground">Git output</p>
+              <pre className="mt-2 max-h-48 overflow-auto rounded-md bg-muted p-3 text-xs text-foreground whitespace-pre-wrap">
+                {conflict.output}
+              </pre>
+            </div>
+          </div>
+        ) : null}
+
+        <DialogFooter className="mt-6 flex flex-row items-center justify-between gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={actions.isDisabled}
+            data-testid="agent-studio-git-close-rebase-conflict-modal-button"
+          >
+            Close
+          </Button>
+
+          <RebaseConflictActions
+            actions={{
+              ...actions,
+              askBuilder: {
+                ...actions.askBuilder,
+                onClick: onAskBuilder,
+              },
+            }}
+            abortTestId="agent-studio-git-abort-rebase-button"
+            askBuilderTestId="agent-studio-git-ask-builder-button"
+            size="default"
+            className="flex items-center gap-2"
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-strip.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-strip.tsx
@@ -1,0 +1,74 @@
+import { memo, type ReactElement } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { AgentStudioRebaseConflict } from "@/pages/agents/use-agent-studio-git-actions";
+import { RebaseConflictActions, type RebaseConflictActionsModel } from "./rebase-conflict-actions";
+
+type RebaseConflictStripProps = {
+  conflict: AgentStudioRebaseConflict;
+  actions: RebaseConflictActionsModel;
+  onViewDetails: () => void;
+};
+
+const toConflictDescription = (conflict: AgentStudioRebaseConflict): string => {
+  if (conflict.operation === "pull_rebase") {
+    return `The pull with rebase onto \`${conflict.targetBranch}\` is paused on conflicts.`;
+  }
+
+  return `The rebase onto \`${conflict.targetBranch}\` is paused on conflicts.`;
+};
+
+export const RebaseConflictStrip = memo(function RebaseConflictStrip({
+  conflict,
+  actions,
+  onViewDetails,
+}: RebaseConflictStripProps): ReactElement {
+  const label = conflict.operation === "pull_rebase" ? "Pull with rebase" : "Rebase";
+  const conflictedFileCount = conflict.conflictedFiles.length;
+
+  return (
+    <div
+      className="border-b border-border bg-amber-50 px-3 py-3 text-sm text-amber-900 dark:bg-amber-950/30 dark:text-amber-100"
+      data-testid="agent-studio-git-rebase-strip"
+    >
+      <div className="space-y-3">
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="font-medium">{label} in progress</p>
+            <Badge
+              variant="warning"
+              className="px-2 py-0.5 text-[10px]"
+              data-testid="agent-studio-git-rebase-conflict-count-badge"
+            >
+              {conflictedFileCount} conflicted file{conflictedFileCount === 1 ? "" : "s"}
+            </Badge>
+          </div>
+          <p className="text-xs text-amber-800 dark:text-amber-200">
+            {toConflictDescription(conflict)}
+          </p>
+        </div>
+
+        <div className="flex flex-nowrap items-center gap-2 overflow-x-auto pb-0.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={onViewDetails}
+            disabled={actions.isDisabled}
+            data-testid="agent-studio-git-view-conflict-details-button"
+          >
+            View details
+          </Button>
+          <RebaseConflictActions
+            actions={actions}
+            abortTestId="agent-studio-git-abort-rebase-strip-button"
+            askBuilderTestId="agent-studio-git-ask-builder-strip-button"
+            size="sm"
+            className="flex items-center gap-2"
+          />
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-strip.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-strip.tsx
@@ -1,7 +1,8 @@
-import { memo, type ReactElement } from "react";
+import { memo, type ReactElement, type ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { AgentStudioRebaseConflict } from "@/pages/agents/use-agent-studio-git-actions";
+import { INLINE_CODE_CLASS_NAME } from "./constants";
 import { RebaseConflictActions, type RebaseConflictActionsModel } from "./rebase-conflict-actions";
 
 type RebaseConflictStripProps = {
@@ -10,12 +11,16 @@ type RebaseConflictStripProps = {
   onViewDetails: () => void;
 };
 
-const toConflictDescription = (conflict: AgentStudioRebaseConflict): string => {
-  if (conflict.operation === "pull_rebase") {
-    return `The pull with rebase onto \`${conflict.targetBranch}\` is paused on conflicts.`;
-  }
+const toConflictDescription = (conflict: AgentStudioRebaseConflict): ReactNode => {
+  const operationLabel = conflict.operation === "pull_rebase" ? "pull with rebase" : "rebase";
 
-  return `The rebase onto \`${conflict.targetBranch}\` is paused on conflicts.`;
+  return (
+    <>
+      The {operationLabel} onto{" "}
+      <code className={INLINE_CODE_CLASS_NAME}>{conflict.targetBranch}</code> is paused on
+      conflicts.
+    </>
+  );
 };
 
 export const RebaseConflictStrip = memo(function RebaseConflictStrip({


### PR DESCRIPTION
## Summary
- split `AgentStudioGitPanel` into dedicated components for the rebase conflict strip/modal and the force-push and pull-rebase confirmation dialogs
- centralize rebase conflict CTA state in a shared action model/component so the strip and modal stay aligned on labels, loading state, and handlers
- harden the shared confirmation dialog API by separating pending/loading from disabled state and add focused tests for the extracted abstractions

## Details
- keeps `AgentStudioGitPanel` as the composition layer while moving dialog-specific rendering into focused presentational components
- removes the modal's inline redefinition of the ask-builder action by deriving explicit strip and modal action models in the panel
- adds direct test coverage for the shared confirmation dialog and rebase conflict action factory alongside the existing panel integration tests

## Testing
- `bun test apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx apps/desktop/src/components/features/agents/agent-studio-git-panel/git-confirmation-dialog.test.tsx apps/desktop/src/components/features/agents/agent-studio-git-panel/rebase-conflict-actions.test.tsx`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop typecheck`