### PR TITLE
Move workspace trust policy below Tauri commands

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use fs2::FileExt;
 use host_domain::{
-    RuntimeInstanceSummary, GitPort, RunEvent, RunSummary, RuntimeCheck, RuntimeRole, TaskCard,
+    GitPort, RunEvent, RunSummary, RuntimeCheck, RuntimeInstanceSummary, RuntimeRole, TaskCard,
     TaskStore,
 };
 use host_infra_system::{AppConfigStore, GitCliPort, RepoConfig, RuntimeConfigStore};
@@ -33,6 +33,7 @@ mod task_workflow;
 #[cfg(test)]
 pub(crate) mod test_support;
 mod workflow_rules;
+mod workspace_policy;
 
 pub(crate) use events::{emit_event, spawn_output_forwarder};
 pub(crate) use hook_security::{run_parsed_hook_command_allow_failure, validate_hook_trust};
@@ -64,6 +65,10 @@ pub(crate) use startup_metrics::{
 };
 pub(crate) use workflow_rules::{
     derive_agent_workflows, derive_available_actions, validate_transition,
+};
+pub use workspace_policy::{
+    HookTrustConfirmationPort, HookTrustConfirmationRequest, PreparedHookTrustChallenge,
+    RepoConfigUpdate, RepoSettingsUpdate,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
@@ -1,5 +1,6 @@
 use super::process_registry::TrackedOpencodeProcessGuard;
 use super::startup_metrics::OpencodeStartupMetrics;
+use super::workspace_policy::HookTrustChallenge;
 use super::*;
 
 pub type RunEmitter = Arc<dyn Fn(RunEvent) + Send + Sync + 'static>;
@@ -20,6 +21,7 @@ pub struct AppService {
     pub(super) startup_cancel_epoch: StartupCancelEpoch,
     pub(super) startup_metrics: Arc<Mutex<OpencodeStartupMetrics>>,
     pub(super) enforce_repo_allowlist: bool,
+    pub(super) hook_trust_challenges: Arc<Mutex<HashMap<String, HookTrustChallenge>>>,
 }
 
 pub(crate) struct RunProcess {
@@ -95,6 +97,7 @@ impl AppService {
             startup_cancel_epoch: Arc::new(AtomicU64::new(0)),
             startup_metrics: Arc::new(Mutex::new(OpencodeStartupMetrics::default())),
             enforce_repo_allowlist,
+            hook_trust_challenges: Arc::new(Mutex::new(HashMap::new())),
         };
         if let Err(error) = service.reconcile_opencode_process_registry_on_startup() {
             eprintln!(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -206,7 +206,7 @@ impl AppService {
         Ok((config.repos, config.global_prompt_overrides))
     }
 
-    pub fn workspace_save_settings_snapshot(
+    pub fn workspace_persist_settings_snapshot(
         &self,
         repos: HashMap<String, RepoConfig>,
         global_prompt_overrides: PromptOverrides,
@@ -227,7 +227,7 @@ impl AppService {
         self.config_store.save(&config)
     }
 
-    pub fn workspace_set_trusted_hooks(
+    pub fn workspace_persist_trusted_hooks(
         &self,
         repo_path: &str,
         trusted: bool,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -206,7 +206,7 @@ impl AppService {
         Ok((config.repos, config.global_prompt_overrides))
     }
 
-    pub fn workspace_persist_settings_snapshot(
+    pub(super) fn workspace_persist_settings_snapshot(
         &self,
         repos: HashMap<String, RepoConfig>,
         global_prompt_overrides: PromptOverrides,
@@ -227,7 +227,7 @@ impl AppService {
         self.config_store.save(&config)
     }
 
-    pub fn workspace_persist_trusted_hooks(
+    pub(super) fn workspace_persist_trusted_hooks(
         &self,
         repo_path: &str,
         trusted: bool,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -2,9 +2,9 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentRuntimeKind, RuntimeInstanceSummary, AgentSessionDocument, CreateTaskInput, GitBranch,
-    GitCurrentBranch, GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState,
-    RunSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    AgentRuntimeKind, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch, GitPort,
+    PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    RuntimeInstanceSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{hook_set_fingerprint, AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
@@ -2,11 +2,11 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    RuntimeInstanceSummary, AgentSessionDocument, CreateTaskInput, GitAheadBehind, GitBranch,
-    GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitFileDiff,
-    GitFileStatus, GitPort, GitPullRequest, GitPullResult, GitRebaseBranchRequest,
-    GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatusData, PlanSubtaskInput,
-    QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, TaskAction, TaskStatus, TaskStore,
+    AgentSessionDocument, CreateTaskInput, GitAheadBehind, GitBranch, GitCommitAllRequest,
+    GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitFileDiff, GitFileStatus, GitPort,
+    GitPullRequest, GitPullResult, GitRebaseBranchRequest, GitRebaseBranchResult,
+    GitUpstreamAheadBehind, GitWorktreeStatusData, PlanSubtaskInput, QaReportDocument, QaVerdict,
+    RunEvent, RunState, RunSummary, RuntimeInstanceSummary, TaskAction, TaskStatus, TaskStore,
     UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/runtime_checks.rs
@@ -2,8 +2,8 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    RuntimeInstanceSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
-    GitPort, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch, GitPort, PlanSubtaskInput,
+    QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary, RuntimeInstanceSummary,
     TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
@@ -127,12 +127,12 @@ fn runtime_beads_system_and_workspace_paths_are_exercised() -> Result<()> {
         .workspace_get_repo_config_optional(repo_path.as_str())?
         .is_some());
     let stale_trust_error = service
-        .workspace_set_trusted_hooks(repo_path.as_str(), true, Some("stale-fingerprint"))
+        .workspace_persist_trusted_hooks(repo_path.as_str(), true, Some("stale-fingerprint"))
         .expect_err("stale fingerprint should be rejected");
     assert!(stale_trust_error
         .to_string()
         .contains("Hook trust challenge is stale"));
-    let trusted = service.workspace_set_trusted_hooks(
+    let trusted = service.workspace_persist_trusted_hooks(
         repo_path.as_str(),
         true,
         Some(host_infra_system::hook_set_fingerprint(&config.hooks).as_str()),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -2,9 +2,9 @@
 
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    RuntimeInstanceSummary, AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch,
-    GitPort, IssueType, PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState,
-    RunSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch, GitPort, IssueType,
+    PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
+    RuntimeInstanceSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -1,0 +1,936 @@
+use super::AppService;
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use host_domain::WorkspaceRecord;
+use host_infra_system::{
+    hook_set_fingerprint, AgentDefaults, HookSet, PromptOverrides, RepoConfig,
+};
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+use uuid::Uuid;
+
+const HOOK_TRUST_CHALLENGE_TTL: Duration = Duration::from_secs(120);
+
+#[derive(Debug, Clone, Default)]
+pub struct RepoConfigUpdate {
+    pub default_runtime_kind: Option<String>,
+    pub worktree_base_path: Option<String>,
+    pub branch_prefix: Option<String>,
+    pub default_target_branch: Option<String>,
+    pub worktree_file_copies: Option<Vec<String>>,
+    pub prompt_overrides: Option<PromptOverrides>,
+    pub agent_defaults: Option<AgentDefaults>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RepoSettingsUpdate {
+    pub default_runtime_kind: Option<String>,
+    pub worktree_base_path: Option<String>,
+    pub branch_prefix: Option<String>,
+    pub default_target_branch: Option<String>,
+    pub trusted_hooks: bool,
+    pub hooks: Option<HookSet>,
+    pub worktree_file_copies: Option<Vec<String>>,
+    pub prompt_overrides: Option<PromptOverrides>,
+    pub agent_defaults: Option<AgentDefaults>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HookTrustConfirmationRequest {
+    pub repo_path: String,
+    pub hooks: HookSet,
+}
+
+pub trait HookTrustConfirmationPort {
+    fn confirm_trusted_hooks(&self, request: &HookTrustConfirmationRequest) -> Result<()>;
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreparedHookTrustChallenge {
+    pub nonce: String,
+    pub repo_path: String,
+    pub fingerprint: String,
+    pub expires_at: DateTime<Utc>,
+    pub pre_start_count: usize,
+    pub post_complete_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct HookTrustChallenge {
+    repo_path: String,
+    fingerprint: String,
+    expires_at: SystemTime,
+}
+
+impl AppService {
+    pub fn workspace_merge_repo_config(
+        &self,
+        repo_path: &str,
+        update: RepoConfigUpdate,
+    ) -> Result<WorkspaceRecord> {
+        let existing = self.workspace_get_repo_config_optional(repo_path)?;
+        let defaults = RepoConfig::default();
+        let repo_config = RepoConfig {
+            default_runtime_kind: update
+                .default_runtime_kind
+                .or_else(|| {
+                    existing
+                        .as_ref()
+                        .map(|entry| entry.default_runtime_kind.clone())
+                })
+                .unwrap_or(defaults.default_runtime_kind),
+            worktree_base_path: update.worktree_base_path.or_else(|| {
+                existing
+                    .as_ref()
+                    .and_then(|entry| entry.worktree_base_path.clone())
+            }),
+            branch_prefix: update
+                .branch_prefix
+                .or_else(|| existing.as_ref().map(|entry| entry.branch_prefix.clone()))
+                .unwrap_or(defaults.branch_prefix),
+            default_target_branch: update
+                .default_target_branch
+                .or_else(|| {
+                    existing
+                        .as_ref()
+                        .map(|entry| entry.default_target_branch.clone())
+                })
+                .unwrap_or(defaults.default_target_branch),
+            trusted_hooks: existing.as_ref().is_some_and(|entry| entry.trusted_hooks),
+            trusted_hooks_fingerprint: existing
+                .as_ref()
+                .and_then(|entry| entry.trusted_hooks_fingerprint.clone()),
+            hooks: existing
+                .as_ref()
+                .map(|entry| entry.hooks.clone())
+                .unwrap_or_default(),
+            worktree_file_copies: update
+                .worktree_file_copies
+                .or_else(|| {
+                    existing
+                        .as_ref()
+                        .map(|entry| entry.worktree_file_copies.clone())
+                })
+                .unwrap_or_default(),
+            prompt_overrides: update
+                .prompt_overrides
+                .or_else(|| {
+                    existing
+                        .as_ref()
+                        .map(|entry| entry.prompt_overrides.clone())
+                })
+                .unwrap_or_default(),
+            agent_defaults: update
+                .agent_defaults
+                .or_else(|| existing.as_ref().map(|entry| entry.agent_defaults.clone()))
+                .unwrap_or_default(),
+        };
+
+        self.workspace_update_repo_config(repo_path, repo_config)
+    }
+
+    pub fn workspace_save_repo_settings<P: HookTrustConfirmationPort + ?Sized>(
+        &self,
+        repo_path: &str,
+        settings: RepoSettingsUpdate,
+        confirmation_port: &P,
+    ) -> Result<WorkspaceRecord> {
+        let existing = self
+            .workspace_get_repo_config_optional(repo_path)?
+            .unwrap_or_default();
+
+        let (normalized_hooks, trusted_hooks_fingerprint) = self
+            .normalize_hooks_with_trust_confirmation(
+                repo_path,
+                &existing,
+                settings.trusted_hooks,
+                settings.hooks.unwrap_or_else(|| existing.hooks.clone()),
+                confirmation_port,
+            )?;
+
+        let final_repo_config = RepoConfig {
+            default_runtime_kind: normalize_runtime_kind(settings.default_runtime_kind)?
+                .unwrap_or(existing.default_runtime_kind),
+            worktree_base_path: settings.worktree_base_path.or(existing.worktree_base_path),
+            branch_prefix: settings.branch_prefix.unwrap_or(existing.branch_prefix),
+            default_target_branch: settings
+                .default_target_branch
+                .unwrap_or(existing.default_target_branch),
+            trusted_hooks: settings.trusted_hooks,
+            trusted_hooks_fingerprint,
+            hooks: normalized_hooks,
+            worktree_file_copies: settings
+                .worktree_file_copies
+                .unwrap_or(existing.worktree_file_copies),
+            prompt_overrides: settings
+                .prompt_overrides
+                .unwrap_or(existing.prompt_overrides),
+            agent_defaults: settings.agent_defaults.unwrap_or(existing.agent_defaults),
+        };
+
+        self.workspace_update_repo_config(repo_path, final_repo_config)
+    }
+
+    pub fn workspace_prepare_trusted_hooks_challenge(
+        &self,
+        repo_path: &str,
+    ) -> Result<PreparedHookTrustChallenge> {
+        let repo_config = self.workspace_get_repo_config(repo_path)?;
+        let canonical_repo_path = canonical_repo_key(repo_path);
+        let fingerprint = hook_set_fingerprint(&repo_config.hooks);
+        let nonce = format!("hooks-trust-{}", Uuid::new_v4().simple());
+        let expires_at = SystemTime::now()
+            .checked_add(HOOK_TRUST_CHALLENGE_TTL)
+            .ok_or_else(|| anyhow!("Failed to allocate hook trust challenge window."))?;
+
+        {
+            let mut challenges = self.hook_trust_challenges.lock().map_err(|_| {
+                anyhow!("Hook trust challenge lock poisoned in `workspace_prepare_trusted_hooks_challenge`")
+            })?;
+            prune_expired_hook_trust_challenges(&mut challenges);
+            challenges.insert(
+                nonce.clone(),
+                HookTrustChallenge {
+                    repo_path: canonical_repo_path.clone(),
+                    fingerprint: fingerprint.clone(),
+                    expires_at,
+                },
+            );
+        }
+
+        Ok(PreparedHookTrustChallenge {
+            nonce,
+            repo_path: canonical_repo_path,
+            fingerprint,
+            expires_at: DateTime::<Utc>::from(expires_at),
+            pre_start_count: repo_config.hooks.pre_start.len(),
+            post_complete_count: repo_config.hooks.post_complete.len(),
+        })
+    }
+
+    pub fn workspace_save_settings_snapshot<P: HookTrustConfirmationPort + ?Sized>(
+        &self,
+        mut repos: HashMap<String, RepoConfig>,
+        global_prompt_overrides: PromptOverrides,
+        confirmation_port: &P,
+    ) -> Result<Vec<WorkspaceRecord>> {
+        for (repo_path, repo_config) in repos.iter_mut() {
+            let existing = self
+                .workspace_get_repo_config_optional(repo_path)?
+                .unwrap_or_default();
+            let submitted_hooks = std::mem::take(&mut repo_config.hooks);
+            let (normalized_hooks, trusted_hooks_fingerprint) = self
+                .normalize_hooks_with_trust_confirmation(
+                    repo_path,
+                    &existing,
+                    repo_config.trusted_hooks,
+                    submitted_hooks,
+                    confirmation_port,
+                )?;
+            repo_config.hooks = normalized_hooks;
+            repo_config.trusted_hooks_fingerprint = trusted_hooks_fingerprint;
+        }
+
+        self.workspace_persist_settings_snapshot(repos, global_prompt_overrides)?;
+        self.workspace_list()
+    }
+
+    pub fn workspace_set_trusted_hooks<P: HookTrustConfirmationPort + ?Sized>(
+        &self,
+        repo_path: &str,
+        trusted: bool,
+        challenge_nonce: Option<&str>,
+        challenge_fingerprint: Option<&str>,
+        confirmation_port: &P,
+    ) -> Result<WorkspaceRecord> {
+        if !trusted {
+            return self.workspace_persist_trusted_hooks(repo_path, false, None);
+        }
+
+        let nonce = challenge_nonce
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("Hook trust confirmation requires challenge nonce."))?;
+        let expected_fingerprint = challenge_fingerprint
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("Hook trust confirmation requires challenge fingerprint."))?;
+
+        let canonical_repo_path = canonical_repo_key(repo_path);
+        let challenge = {
+            let mut challenges = self.hook_trust_challenges.lock().map_err(|_| {
+                anyhow!("Hook trust challenge lock poisoned in `workspace_set_trusted_hooks`")
+            })?;
+            prune_expired_hook_trust_challenges(&mut challenges);
+            let Some(challenge) = challenges.remove(nonce) else {
+                return Err(anyhow!(
+                    "Hook trust challenge is missing or expired. Retry confirmation."
+                ));
+            };
+
+            validate_trust_challenge_entry(
+                &challenge,
+                canonical_repo_path.as_str(),
+                expected_fingerprint,
+                SystemTime::now(),
+            )?;
+
+            challenge
+        };
+
+        let repo_config = self.workspace_get_repo_config(repo_path)?;
+        let latest_fingerprint = hook_set_fingerprint(&repo_config.hooks);
+        if latest_fingerprint != challenge.fingerprint {
+            return Err(anyhow!(
+                "Hook commands changed after challenge generation. Request trust confirmation again."
+            ));
+        }
+
+        confirmation_port.confirm_trusted_hooks(&HookTrustConfirmationRequest {
+            repo_path: canonical_repo_path,
+            hooks: repo_config.hooks.clone(),
+        })?;
+
+        self.workspace_persist_trusted_hooks(repo_path, true, Some(challenge.fingerprint.as_str()))
+    }
+
+    fn normalize_hooks_with_trust_confirmation<P: HookTrustConfirmationPort + ?Sized>(
+        &self,
+        repo_path: &str,
+        existing: &RepoConfig,
+        trusted_hooks: bool,
+        hooks: HookSet,
+        confirmation_port: &P,
+    ) -> Result<(HookSet, Option<String>)> {
+        let normalized_hooks = normalize_hook_set(hooks);
+        let hooks_fingerprint = hook_set_fingerprint(&normalized_hooks);
+        let trust_already_approved_for_same_hooks = existing.trusted_hooks
+            && existing.hooks == normalized_hooks
+            && existing.trusted_hooks_fingerprint.as_deref() == Some(hooks_fingerprint.as_str());
+
+        if trusted_hooks && !trust_already_approved_for_same_hooks {
+            confirmation_port.confirm_trusted_hooks(&HookTrustConfirmationRequest {
+                repo_path: canonical_repo_key(repo_path),
+                hooks: normalized_hooks.clone(),
+            })?;
+        }
+
+        let trusted_hooks_fingerprint = if trusted_hooks {
+            Some(hooks_fingerprint)
+        } else {
+            None
+        };
+
+        Ok((normalized_hooks, trusted_hooks_fingerprint))
+    }
+}
+
+fn normalize_runtime_kind(value: Option<String>) -> Result<Option<String>> {
+    let Some(runtime_kind) = value else {
+        return Ok(None);
+    };
+
+    let trimmed = runtime_kind.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("defaultRuntimeKind cannot be blank"));
+    }
+
+    Ok(Some(trimmed.to_string()))
+}
+
+fn canonical_repo_key(repo_path: &str) -> String {
+    std::fs::canonicalize(Path::new(repo_path))
+        .ok()
+        .and_then(|path| path.to_str().map(|value| value.to_string()))
+        .unwrap_or_else(|| repo_path.trim().to_string())
+}
+
+fn prune_expired_hook_trust_challenges(challenges: &mut HashMap<String, HookTrustChallenge>) {
+    let now = SystemTime::now();
+    challenges.retain(|_, challenge| challenge.expires_at > now);
+}
+
+fn validate_trust_challenge_entry(
+    challenge: &HookTrustChallenge,
+    canonical_repo_path: &str,
+    expected_fingerprint: &str,
+    now: SystemTime,
+) -> Result<()> {
+    if challenge.repo_path != canonical_repo_path {
+        return Err(anyhow!(
+            "Hook trust challenge repository mismatch. Retry confirmation."
+        ));
+    }
+    if challenge.fingerprint != expected_fingerprint {
+        return Err(anyhow!(
+            "Hook trust challenge fingerprint mismatch. Retry confirmation."
+        ));
+    }
+    if challenge.expires_at <= now {
+        return Err(anyhow!("Hook trust challenge expired. Retry confirmation."));
+    }
+    Ok(())
+}
+
+fn normalize_hook_set(mut hooks: HookSet) -> HookSet {
+    normalize_hook_commands(&mut hooks.pre_start);
+    normalize_hook_commands(&mut hooks.post_complete);
+    hooks
+}
+
+fn normalize_hook_commands(commands: &mut Vec<String>) {
+    *commands = std::mem::take(commands)
+        .into_iter()
+        .filter_map(|command| {
+            let trimmed = command.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .collect();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        canonical_repo_key, normalize_hook_set, validate_trust_challenge_entry, AppService,
+        HookTrustChallenge, RepoConfigUpdate, RepoSettingsUpdate,
+    };
+    use crate::app_service::test_support::{unique_temp_path, FakeTaskStore, TaskStoreState};
+    use anyhow::{anyhow, Result};
+    use host_domain::TaskStore;
+    use host_infra_system::{
+        hook_set_fingerprint, AppConfigStore, GitCliPort, HookSet, PromptOverride, RepoConfig,
+    };
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, SystemTime};
+
+    use super::{HookTrustConfirmationPort, HookTrustConfirmationRequest};
+
+    #[derive(Default)]
+    struct RecordingHookTrustConfirmationPort {
+        requests: Mutex<Vec<HookTrustConfirmationRequest>>,
+        next_error: Mutex<Option<String>>,
+    }
+
+    impl RecordingHookTrustConfirmationPort {
+        fn with_error(message: &str) -> Self {
+            Self {
+                requests: Mutex::new(Vec::new()),
+                next_error: Mutex::new(Some(message.to_string())),
+            }
+        }
+
+        fn request_count(&self) -> usize {
+            self.requests.lock().expect("request lock poisoned").len()
+        }
+    }
+
+    impl HookTrustConfirmationPort for RecordingHookTrustConfirmationPort {
+        fn confirm_trusted_hooks(&self, request: &HookTrustConfirmationRequest) -> Result<()> {
+            self.requests
+                .lock()
+                .expect("request lock poisoned")
+                .push(request.clone());
+            if let Some(error) = self.next_error.lock().expect("error lock poisoned").take() {
+                return Err(anyhow!(error));
+            }
+            Ok(())
+        }
+    }
+
+    struct WorkspacePolicyFixture {
+        service: AppService,
+        repo_path: String,
+        root: PathBuf,
+    }
+
+    impl Drop for WorkspacePolicyFixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn setup_fixture(prefix: &str, hooks: HookSet) -> WorkspacePolicyFixture {
+        let root = unique_temp_path(prefix);
+        let repo = root.join("repo");
+        fs::create_dir_all(repo.join(".git")).expect("fake git workspace should exist");
+        let repo_path = repo.to_string_lossy().to_string();
+
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        config_store
+            .add_workspace(repo_path.as_str())
+            .expect("workspace should be allowlisted");
+        config_store
+            .update_repo_hooks(repo_path.as_str(), hooks)
+            .expect("hooks should persist");
+
+        let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore {
+            state: Arc::new(Mutex::new(TaskStoreState::default())),
+        });
+        let service =
+            AppService::with_git_port(task_store, config_store, Arc::new(GitCliPort::new()));
+
+        WorkspacePolicyFixture {
+            service,
+            repo_path,
+            root,
+        }
+    }
+
+    fn insert_challenge(
+        service: &AppService,
+        nonce: &str,
+        challenge: HookTrustChallenge,
+    ) -> Result<()> {
+        let mut challenges = service
+            .hook_trust_challenges
+            .lock()
+            .map_err(|_| anyhow!("challenge lock poisoned"))?;
+        challenges.insert(nonce.to_string(), challenge);
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_merge_repo_config_preserves_existing_trust_and_hooks() -> Result<()> {
+        let fixture = setup_fixture(
+            "merge-repo-config",
+            HookSet {
+                pre_start: vec!["echo pre".to_string()],
+                post_complete: vec!["echo post".to_string()],
+            },
+        );
+        let trusted_fingerprint = hook_set_fingerprint(
+            &fixture
+                .service
+                .workspace_get_repo_config(&fixture.repo_path)?
+                .hooks,
+        );
+        fixture.service.workspace_update_repo_config(
+            fixture.repo_path.as_str(),
+            RepoConfig {
+                trusted_hooks: true,
+                trusted_hooks_fingerprint: Some(trusted_fingerprint.clone()),
+                branch_prefix: "abc".to_string(),
+                ..fixture
+                    .service
+                    .workspace_get_repo_config(&fixture.repo_path)?
+            },
+        )?;
+
+        fixture.service.workspace_merge_repo_config(
+            fixture.repo_path.as_str(),
+            RepoConfigUpdate {
+                default_target_branch: Some("release".to_string()),
+                ..RepoConfigUpdate::default()
+            },
+        )?;
+
+        let updated = fixture
+            .service
+            .workspace_get_repo_config(&fixture.repo_path)?;
+        assert_eq!(updated.default_target_branch, "origin/release");
+        assert_eq!(updated.branch_prefix, "abc");
+        assert!(updated.trusted_hooks);
+        assert_eq!(
+            updated.trusted_hooks_fingerprint.as_deref(),
+            Some(trusted_fingerprint.as_str())
+        );
+        assert_eq!(updated.hooks.pre_start, vec!["echo pre".to_string()]);
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_save_repo_settings_rejects_blank_default_runtime_kind() {
+        let fixture = setup_fixture("blank-runtime-kind", HookSet::default());
+        let confirmation = RecordingHookTrustConfirmationPort::default();
+
+        let error = fixture
+            .service
+            .workspace_save_repo_settings(
+                fixture.repo_path.as_str(),
+                RepoSettingsUpdate {
+                    default_runtime_kind: Some("   ".to_string()),
+                    worktree_base_path: None,
+                    branch_prefix: None,
+                    default_target_branch: None,
+                    trusted_hooks: false,
+                    hooks: None,
+                    worktree_file_copies: None,
+                    prompt_overrides: None,
+                    agent_defaults: None,
+                },
+                &confirmation,
+            )
+            .expect_err("blank runtime kind should fail");
+
+        assert!(error
+            .to_string()
+            .contains("defaultRuntimeKind cannot be blank"));
+    }
+
+    #[test]
+    fn workspace_save_repo_settings_trims_runtime_kind() -> Result<()> {
+        let fixture = setup_fixture("trim-runtime-kind", HookSet::default());
+        let confirmation = RecordingHookTrustConfirmationPort::default();
+
+        fixture.service.workspace_save_repo_settings(
+            fixture.repo_path.as_str(),
+            RepoSettingsUpdate {
+                default_runtime_kind: Some("  claude-code  ".to_string()),
+                worktree_base_path: None,
+                branch_prefix: None,
+                default_target_branch: None,
+                trusted_hooks: false,
+                hooks: None,
+                worktree_file_copies: None,
+                prompt_overrides: None,
+                agent_defaults: None,
+            },
+            &confirmation,
+        )?;
+
+        let persisted = fixture
+            .service
+            .workspace_get_repo_config(&fixture.repo_path)?;
+        assert_eq!(persisted.default_runtime_kind, "claude-code");
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_save_repo_settings_requires_trust_confirmation() -> Result<()> {
+        let fixture = setup_fixture(
+            "repo-settings-trust",
+            HookSet {
+                pre_start: vec![" echo pre ".to_string()],
+                post_complete: vec!["echo post".to_string()],
+            },
+        );
+        let confirmation = RecordingHookTrustConfirmationPort::with_error(
+            "Hook trust confirmation was cancelled by the user.",
+        );
+
+        let error = fixture
+            .service
+            .workspace_save_repo_settings(
+                fixture.repo_path.as_str(),
+                RepoSettingsUpdate {
+                    default_runtime_kind: None,
+                    worktree_base_path: None,
+                    branch_prefix: None,
+                    default_target_branch: None,
+                    trusted_hooks: true,
+                    hooks: Some(HookSet {
+                        pre_start: vec!["  echo pre  ".to_string()],
+                        post_complete: vec!["echo post".to_string()],
+                    }),
+                    worktree_file_copies: None,
+                    prompt_overrides: None,
+                    agent_defaults: None,
+                },
+                &confirmation,
+            )
+            .expect_err("trust enable should require confirmation");
+
+        assert!(error.to_string().contains("cancelled"));
+        assert_eq!(confirmation.request_count(), 1);
+
+        let persisted = fixture
+            .service
+            .workspace_get_repo_config(&fixture.repo_path)?;
+        assert!(!persisted.trusted_hooks);
+        assert!(persisted.trusted_hooks_fingerprint.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_save_settings_snapshot_persists_trusted_fingerprint_after_confirmation(
+    ) -> Result<()> {
+        let fixture = setup_fixture(
+            "snapshot-save-trust",
+            HookSet {
+                pre_start: vec![" echo pre ".to_string()],
+                post_complete: vec!["echo post".to_string()],
+            },
+        );
+        let confirmation = RecordingHookTrustConfirmationPort::default();
+
+        let (mut repos, mut global_prompt_overrides) =
+            fixture.service.workspace_get_settings_snapshot()?;
+        global_prompt_overrides.insert(
+            "system.shared.workflow_guards".to_string(),
+            PromptOverride {
+                template: "global workflow guards".to_string(),
+                base_version: 1,
+                enabled: true,
+            },
+        );
+        let repo_key = canonical_repo_key(fixture.repo_path.as_str());
+        let repo_config = repos
+            .get_mut(repo_key.as_str())
+            .ok_or_else(|| anyhow!("repo config missing"))?;
+        repo_config.trusted_hooks = true;
+        repo_config.hooks = HookSet {
+            pre_start: vec!["  echo pre  ".to_string()],
+            post_complete: vec!["echo post".to_string()],
+        };
+        repo_config.trusted_hooks_fingerprint = None;
+
+        fixture.service.workspace_save_settings_snapshot(
+            repos,
+            global_prompt_overrides,
+            &confirmation,
+        )?;
+
+        let persisted = fixture
+            .service
+            .workspace_get_repo_config(&fixture.repo_path)?;
+        let normalized_hooks = HookSet {
+            pre_start: vec!["echo pre".to_string()],
+            post_complete: vec!["echo post".to_string()],
+        };
+        let expected_fingerprint = hook_set_fingerprint(&normalized_hooks);
+        assert!(persisted.trusted_hooks);
+        assert_eq!(persisted.hooks, normalized_hooks);
+        assert_eq!(
+            persisted.trusted_hooks_fingerprint.as_deref(),
+            Some(expected_fingerprint.as_str())
+        );
+        assert_eq!(confirmation.request_count(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_rejects_expired_challenge_entries() -> Result<()> {
+        let fixture = setup_fixture("expired-challenge", HookSet::default());
+        let confirmation = RecordingHookTrustConfirmationPort::default();
+        let nonce = "expired-nonce";
+        let fingerprint = hook_set_fingerprint(&HookSet::default());
+        insert_challenge(
+            &fixture.service,
+            nonce,
+            HookTrustChallenge {
+                repo_path: canonical_repo_key(fixture.repo_path.as_str()),
+                fingerprint: fingerprint.clone(),
+                expires_at: SystemTime::now()
+                    .checked_sub(Duration::from_secs(1))
+                    .ok_or_else(|| anyhow!("expired time should be valid"))?,
+            },
+        )?;
+
+        let error = fixture
+            .service
+            .workspace_set_trusted_hooks(
+                fixture.repo_path.as_str(),
+                true,
+                Some(nonce),
+                Some(fingerprint.as_str()),
+                &confirmation,
+            )
+            .expect_err("expired challenge should fail");
+        assert!(error.to_string().contains("missing or expired"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_rejects_repository_mismatch_and_consumes_nonce() -> Result<()> {
+        let fixture = setup_fixture("repo-mismatch", HookSet::default());
+        let confirmation = RecordingHookTrustConfirmationPort::default();
+        let nonce = "nonce-repo-mismatch";
+        let fingerprint = hook_set_fingerprint(&HookSet::default());
+        insert_challenge(
+            &fixture.service,
+            nonce,
+            HookTrustChallenge {
+                repo_path: "/tmp/not-the-same-repo".to_string(),
+                fingerprint: fingerprint.clone(),
+                expires_at: SystemTime::now()
+                    .checked_add(Duration::from_secs(60))
+                    .ok_or_else(|| anyhow!("future time should be valid"))?,
+            },
+        )?;
+
+        let mismatch = fixture
+            .service
+            .workspace_set_trusted_hooks(
+                fixture.repo_path.as_str(),
+                true,
+                Some(nonce),
+                Some(fingerprint.as_str()),
+                &confirmation,
+            )
+            .expect_err("repo mismatch should fail");
+        assert!(mismatch.to_string().contains("repository mismatch"));
+
+        let replay = fixture
+            .service
+            .workspace_set_trusted_hooks(
+                fixture.repo_path.as_str(),
+                true,
+                Some(nonce),
+                Some(fingerprint.as_str()),
+                &confirmation,
+            )
+            .expect_err("nonce should be consumed");
+        assert!(replay.to_string().contains("missing or expired"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_accepts_valid_challenge_and_persists_trust() -> Result<()> {
+        let fixture = setup_fixture(
+            "trust-happy-path",
+            HookSet {
+                pre_start: vec!["echo pre".to_string()],
+                post_complete: vec!["echo post".to_string()],
+            },
+        );
+        let confirmation = RecordingHookTrustConfirmationPort::default();
+        let challenge = fixture
+            .service
+            .workspace_prepare_trusted_hooks_challenge(fixture.repo_path.as_str())?;
+
+        fixture.service.workspace_set_trusted_hooks(
+            fixture.repo_path.as_str(),
+            true,
+            Some(challenge.nonce.as_str()),
+            Some(challenge.fingerprint.as_str()),
+            &confirmation,
+        )?;
+
+        let repo_config = fixture
+            .service
+            .workspace_get_repo_config(&fixture.repo_path)?;
+        assert!(repo_config.trusted_hooks);
+        assert_eq!(
+            repo_config.trusted_hooks_fingerprint.as_deref(),
+            Some(challenge.fingerprint.as_str())
+        );
+        assert_eq!(confirmation.request_count(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_rejects_stale_challenge_after_hook_changes() -> Result<()> {
+        let original_hooks = HookSet {
+            pre_start: vec!["echo pre".to_string()],
+            post_complete: Vec::new(),
+        };
+        let fixture = setup_fixture("stale-trust-challenge", original_hooks);
+        let confirmation = RecordingHookTrustConfirmationPort::default();
+        let challenge = fixture
+            .service
+            .workspace_prepare_trusted_hooks_challenge(fixture.repo_path.as_str())?;
+
+        fixture.service.workspace_update_repo_hooks(
+            fixture.repo_path.as_str(),
+            HookSet {
+                pre_start: vec!["echo changed".to_string()],
+                post_complete: Vec::new(),
+            },
+        )?;
+
+        let stale = fixture
+            .service
+            .workspace_set_trusted_hooks(
+                fixture.repo_path.as_str(),
+                true,
+                Some(challenge.nonce.as_str()),
+                Some(challenge.fingerprint.as_str()),
+                &confirmation,
+            )
+            .expect_err("stale challenge should fail");
+        assert!(stale
+            .to_string()
+            .contains("Hook commands changed after challenge generation"));
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_set_trusted_hooks_disables_without_challenge() -> Result<()> {
+        let hooks = HookSet {
+            pre_start: vec!["echo pre".to_string()],
+            post_complete: Vec::new(),
+        };
+        let fixture = setup_fixture("disable-trust", hooks.clone());
+        let confirmation = RecordingHookTrustConfirmationPort::default();
+        let fingerprint = hook_set_fingerprint(&hooks);
+        fixture.service.workspace_persist_trusted_hooks(
+            fixture.repo_path.as_str(),
+            true,
+            Some(fingerprint.as_str()),
+        )?;
+
+        fixture.service.workspace_set_trusted_hooks(
+            fixture.repo_path.as_str(),
+            false,
+            None,
+            None,
+            &confirmation,
+        )?;
+
+        let repo_config = fixture
+            .service
+            .workspace_get_repo_config(&fixture.repo_path)?;
+        assert!(!repo_config.trusted_hooks);
+        assert!(repo_config.trusted_hooks_fingerprint.is_none());
+        assert_eq!(confirmation.request_count(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn normalize_hook_set_trims_and_removes_blank_commands() {
+        let normalized = normalize_hook_set(HookSet {
+            pre_start: vec!["  echo pre  ".to_string(), "   ".to_string()],
+            post_complete: vec!["".to_string(), " echo post ".to_string()],
+        });
+        assert_eq!(normalized.pre_start, vec!["echo pre".to_string()]);
+        assert_eq!(normalized.post_complete, vec!["echo post".to_string()]);
+    }
+
+    #[test]
+    fn validate_trust_challenge_entry_checks_repo_and_fingerprint_and_expiry() -> Result<()> {
+        let now = SystemTime::now();
+        let challenge = HookTrustChallenge {
+            repo_path: "/repo".to_string(),
+            fingerprint: "abc".to_string(),
+            expires_at: now
+                .checked_add(Duration::from_secs(5))
+                .ok_or_else(|| anyhow!("challenge expiry"))?,
+        };
+        assert!(validate_trust_challenge_entry(&challenge, "/repo", "abc", now).is_ok());
+
+        let repo_error = validate_trust_challenge_entry(&challenge, "/repo-2", "abc", now)
+            .expect_err("repo mismatch should fail");
+        assert!(repo_error.to_string().contains("repository mismatch"));
+
+        let fingerprint_error = validate_trust_challenge_entry(&challenge, "/repo", "def", now)
+            .expect_err("fingerprint mismatch should fail");
+        assert!(fingerprint_error
+            .to_string()
+            .contains("fingerprint mismatch"));
+
+        let expired = HookTrustChallenge {
+            expires_at: now
+                .checked_sub(Duration::from_secs(1))
+                .ok_or_else(|| anyhow!("expired instant"))?,
+            ..challenge
+        };
+        let expired_error = validate_trust_challenge_entry(&expired, "/repo", "abc", now)
+            .expect_err("expired challenge should fail");
+        assert!(expired_error.to_string().contains("expired"));
+        Ok(())
+    }
+
+    #[test]
+    fn canonical_repo_key_keeps_input_when_path_does_not_exist() {
+        let missing_path = "/this/path/should/not/exist-for-openducktor";
+        assert_eq!(canonical_repo_key(missing_path), missing_path.to_string());
+    }
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use host_domain::WorkspaceRecord;
 use host_infra_system::{
-    hook_set_fingerprint, AgentDefaults, HookSet, PromptOverrides, RepoConfig,
+    hook_set_fingerprint, normalize_hook_set, AgentDefaults, HookSet, PromptOverrides, RepoConfig,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -372,26 +372,6 @@ fn validate_trust_challenge_entry(
         return Err(anyhow!("Hook trust challenge expired. Retry confirmation."));
     }
     Ok(())
-}
-
-fn normalize_hook_set(mut hooks: HookSet) -> HookSet {
-    normalize_hook_commands(&mut hooks.pre_start);
-    normalize_hook_commands(&mut hooks.post_complete);
-    hooks
-}
-
-fn normalize_hook_commands(commands: &mut Vec<String>) {
-    *commands = std::mem::take(commands)
-        .into_iter()
-        .filter_map(|command| {
-            let trimmed = command.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            }
-        })
-        .collect();
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -42,7 +42,7 @@ pub struct HookTrustConfirmationRequest {
     pub hooks: HookSet,
 }
 
-pub trait HookTrustConfirmationPort {
+pub trait HookTrustConfirmationPort: Send {
     fn confirm_trusted_hooks(&self, request: &HookTrustConfirmationRequest) -> Result<()>;
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/lib.rs
@@ -1,4 +1,7 @@
 mod app_service;
 
 pub use app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
-pub use app_service::{AppService, RunEmitter};
+pub use app_service::{
+    AppService, HookTrustConfirmationPort, HookTrustConfirmationRequest,
+    PreparedHookTrustChallenge, RepoConfigUpdate, RepoSettingsUpdate, RunEmitter,
+};

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -19,8 +19,8 @@ pub use git::{
     GitWorktreeStatusSummaryData, GitWorktreeSummary,
 };
 pub use runtime::{
-    AgentRuntimeKind, AgentRuntimeRole, RuntimeInstanceSummary, RunEvent, RunState, RunSummary,
-    RuntimeCapabilities, RuntimeDescriptor, RuntimeProvisioningMode, RuntimeRole,
+    AgentRuntimeKind, AgentRuntimeRole, RunEvent, RunState, RunSummary, RuntimeCapabilities,
+    RuntimeDescriptor, RuntimeInstanceSummary, RuntimeProvisioningMode, RuntimeRole,
 };
 pub use store::TaskStore;
 pub use system::{BeadsCheck, RuntimeCheck, RuntimeHealth, SystemCheck, WorkspaceRecord};
@@ -97,16 +97,16 @@ mod tests {
     #[test]
     fn public_api_exports_compile() {
         use super::{
-            AgentRuntimeRole, RuntimeInstanceSummary, AgentSessionDocument,
-            AgentSessionModelSelection, AgentWorkflowState, AgentWorkflows, BeadsCheck,
-            CreateTaskInput, GitBranch, GitCommitAllRequest, GitCommitAllResult, GitCurrentBranch,
-            GitDiffScope, GitFileStatusCounts, GitPort, GitPullRequest, GitPullResult,
-            GitPushResult, GitRebaseAbortRequest, GitRebaseAbortResult, GitRebaseBranchRequest,
-            GitRebaseBranchResult, GitUpstreamAheadBehind, GitWorktreeStatus,
-            GitWorktreeStatusData, GitWorktreeStatusSnapshot, GitWorktreeStatusSummary,
-            GitWorktreeStatusSummaryData, GitWorktreeSummary, IssueType, PlanSubtaskInput,
-            QaReportDocument, QaVerdict, QaWorkflowVerdict, RunEvent, RunState, RunSummary,
-            RuntimeCheck, RuntimeRole, SpecDocument, SystemCheck, TaskAction, TaskCard,
+            AgentRuntimeRole, AgentSessionDocument, AgentSessionModelSelection, AgentWorkflowState,
+            AgentWorkflows, BeadsCheck, CreateTaskInput, GitBranch, GitCommitAllRequest,
+            GitCommitAllResult, GitCurrentBranch, GitDiffScope, GitFileStatusCounts, GitPort,
+            GitPullRequest, GitPullResult, GitPushResult, GitRebaseAbortRequest,
+            GitRebaseAbortResult, GitRebaseBranchRequest, GitRebaseBranchResult,
+            GitUpstreamAheadBehind, GitWorktreeStatus, GitWorktreeStatusData,
+            GitWorktreeStatusSnapshot, GitWorktreeStatusSummary, GitWorktreeStatusSummaryData,
+            GitWorktreeSummary, IssueType, PlanSubtaskInput, QaReportDocument, QaVerdict,
+            QaWorkflowVerdict, RunEvent, RunState, RunSummary, RuntimeCheck,
+            RuntimeInstanceSummary, RuntimeRole, SpecDocument, SystemCheck, TaskAction, TaskCard,
             TaskDocumentPresence, TaskDocumentSummary, TaskMetadata, TaskQaDocumentPresence,
             TaskStatus, TaskStore, UpdateTaskPatch, WorkspaceRecord,
         };

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -5,6 +5,7 @@ mod security;
 mod store;
 mod types;
 
+pub use normalize::normalize_hook_set;
 pub use store::{AppConfigStore, RuntimeConfigStore};
 pub use types::{
     hook_set_fingerprint, AgentDefaults, AgentModelDefault, GlobalConfig, HookSet,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
@@ -1,6 +1,7 @@
 use super::types::{
     default_branch_prefix, default_target_branch, hook_set_fingerprint, AgentModelDefault,
-    GlobalConfig, OpencodeStartupReadinessConfig, PromptOverrides, RepoConfig, RuntimeConfig,
+    GlobalConfig, HookSet, OpencodeStartupReadinessConfig, PromptOverrides, RepoConfig,
+    RuntimeConfig,
 };
 
 fn normalize_optional_non_empty(value: Option<String>) -> Option<String> {
@@ -73,6 +74,12 @@ fn canonicalize_default_target_branch(value: &str) -> String {
     format!("origin/{trimmed}")
 }
 
+pub fn normalize_hook_set(mut hooks: HookSet) -> HookSet {
+    normalize_hook_commands(&mut hooks.pre_start);
+    normalize_hook_commands(&mut hooks.post_complete);
+    hooks
+}
+
 pub(super) fn normalize_repo_config(repo: &mut RepoConfig) {
     repo.worktree_base_path = normalize_optional_non_empty(repo.worktree_base_path.take());
     let branch_prefix = repo.branch_prefix.trim();
@@ -82,8 +89,7 @@ pub(super) fn normalize_repo_config(repo: &mut RepoConfig) {
         branch_prefix.to_string()
     };
     repo.default_target_branch = canonicalize_default_target_branch(&repo.default_target_branch);
-    normalize_hook_commands(&mut repo.hooks.pre_start);
-    normalize_hook_commands(&mut repo.hooks.post_complete);
+    repo.hooks = normalize_hook_set(std::mem::take(&mut repo.hooks));
     normalize_hook_commands(&mut repo.worktree_file_copies);
     let current_fingerprint = hook_set_fingerprint(&repo.hooks);
     if repo.trusted_hooks {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -6,9 +6,9 @@ mod worktree;
 
 pub use beads::{compute_repo_id, compute_repo_slug, resolve_central_beads_dir};
 pub use config::{
-    hook_set_fingerprint, AgentDefaults, AgentModelDefault, AppConfigStore, GlobalConfig, HookSet,
-    OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides, RepoConfig, RuntimeConfig,
-    RuntimeConfigStore, SchedulerConfig, SoftGuardrails,
+    hook_set_fingerprint, normalize_hook_set, AgentDefaults, AgentModelDefault, AppConfigStore,
+    GlobalConfig, HookSet, OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides,
+    RepoConfig, RuntimeConfig, RuntimeConfigStore, SchedulerConfig, SoftGuardrails,
 };
 pub use git::GitCliPort;
 pub use process::{

--- a/apps/desktop/src-tauri/src/commands/git/authorization/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/git/authorization/mod.rs
@@ -7,8 +7,6 @@ pub(crate) use cache::invalidate_worktree_resolution_cache_for_repo;
 pub(crate) use resolution::resolve_working_dir;
 
 #[cfg(test)]
-pub(crate) use cache::{
-    authorized_worktree_cache, cache_key, AuthorizedWorktreeCacheEntry,
-};
+pub(crate) use cache::{authorized_worktree_cache, cache_key, AuthorizedWorktreeCacheEntry};
 #[cfg(test)]
 pub(crate) use metadata::{read_git_common_dir, read_worktree_state_token};

--- a/apps/desktop/src-tauri/src/commands/git/tests/fixtures/app.rs
+++ b/apps/desktop/src-tauri/src/commands/git/tests/fixtures/app.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     path::PathBuf,
     sync::{Arc, Mutex},
 };
@@ -106,7 +105,6 @@ pub(crate) fn setup_command_git_fixture_with_summary(
     let app = mock_builder()
         .manage(AppState {
             service,
-            hook_trust_challenges: Mutex::new(HashMap::new()),
             hook_trust_dialog_test_response: Mutex::new(None),
         })
         .invoke_handler(tauri::generate_handler![

--- a/apps/desktop/src-tauri/src/commands/runtime.rs
+++ b/apps/desktop/src-tauri/src/commands/runtime.rs
@@ -1,6 +1,7 @@
 use crate::{as_error, run_service_blocking, AppState};
 use host_domain::{
-    AgentRuntimeRole, RuntimeInstanceSummary, BeadsCheck, RuntimeCheck, RuntimeDescriptor, SystemCheck,
+    AgentRuntimeRole, BeadsCheck, RuntimeCheck, RuntimeDescriptor, RuntimeInstanceSummary,
+    SystemCheck,
 };
 use tauri::State;
 

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -604,13 +604,15 @@ mod tests {
         };
         let fixture = setup_workspace_command_fixture("disable-without-challenge", hooks.clone());
         let fingerprint = hook_set_fingerprint(&hooks);
+        let mut repo_config = fixture
+            .service
+            .workspace_get_repo_config(fixture.repo_path.as_str())
+            .map_err(|error| error.to_string())?;
+        repo_config.trusted_hooks = true;
+        repo_config.trusted_hooks_fingerprint = Some(fingerprint);
         fixture
             .service
-            .workspace_persist_trusted_hooks(
-                fixture.repo_path.as_str(),
-                true,
-                Some(fingerprint.as_str()),
-            )
+            .workspace_update_repo_config(fixture.repo_path.as_str(), repo_config)
             .map_err(|error| error.to_string())?;
 
         let updated = run_workspace_set_trusted_hooks(&fixture, false, None, None)

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -562,6 +562,30 @@ mod tests {
     }
 
     #[test]
+    fn workspace_set_trusted_hooks_rejects_fingerprint_mismatch_from_prepared_challenge(
+    ) -> Result<(), String> {
+        let hooks = HookSet {
+            pre_start: vec!["echo pre".to_string()],
+            post_complete: Vec::new(),
+        };
+        let fixture = setup_workspace_command_fixture("fingerprint-mismatch", hooks);
+        let challenge = run_workspace_prepare_trusted_hooks_challenge(&fixture)?;
+
+        let error = run_workspace_set_trusted_hooks(
+            &fixture,
+            true,
+            Some(challenge.nonce),
+            Some("different-fingerprint".to_string()),
+        )
+        .expect_err("fingerprint mismatch should fail");
+        assert!(
+            error.contains("fingerprint mismatch"),
+            "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn workspace_set_trusted_hooks_accepts_prepared_challenge_and_persists_trust(
     ) -> Result<(), String> {
         let hooks = HookSet {

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -1,27 +1,16 @@
 use crate::{
-    as_error, run_service_blocking, AppState, HookTrustChallenge, RepoConfigPayload,
-    RepoSettingsPayload, SettingsSnapshotPayload, SettingsSnapshotResponsePayload,
-    HOOK_TRUST_CHALLENGE_TTL,
+    as_error, run_service_blocking, AppState, RepoConfigPayload, RepoSettingsPayload,
+    SettingsSnapshotPayload, SettingsSnapshotResponsePayload,
 };
-use host_infra_system::{hook_set_fingerprint, HookSet, RepoConfig};
-use std::path::Path;
-use std::time::SystemTime;
+use host_application::{
+    HookTrustConfirmationPort, HookTrustConfirmationRequest, PreparedHookTrustChallenge,
+    RepoConfigUpdate, RepoSettingsUpdate,
+};
+use host_infra_system::HookSet;
 #[cfg(test)]
 use tauri::Manager;
 use tauri::{AppHandle, State};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
-use uuid::Uuid;
-
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct HookTrustChallengePayload {
-    nonce: String,
-    repo_path: String,
-    fingerprint: String,
-    expires_at: String,
-    pre_start_count: usize,
-    post_complete_count: usize,
-}
 
 #[tauri::command]
 pub async fn workspace_list(
@@ -54,72 +43,18 @@ pub async fn workspace_update_repo_config(
     repo_path: String,
     config: RepoConfigPayload,
 ) -> Result<host_domain::WorkspaceRecord, String> {
-    let existing = as_error(state.service.workspace_get_repo_config_optional(&repo_path))?;
-
-    let repo_config = RepoConfig {
-        default_runtime_kind: config
-            .default_runtime_kind
-            .or_else(|| {
-                existing
-                    .as_ref()
-                    .map(|entry| entry.default_runtime_kind.clone())
-            })
-            .unwrap_or_else(|| "opencode".to_string()),
-        worktree_base_path: config.worktree_base_path.or_else(|| {
-            existing
-                .as_ref()
-                .and_then(|entry| entry.worktree_base_path.clone())
-        }),
-        branch_prefix: config
-            .branch_prefix
-            .or_else(|| existing.as_ref().map(|entry| entry.branch_prefix.clone()))
-            .unwrap_or_else(|| "obp".to_string()),
-        default_target_branch: config
-            .default_target_branch
-            .or_else(|| {
-                existing
-                    .as_ref()
-                    .map(|entry| entry.default_target_branch.clone())
-            })
-            .unwrap_or_else(|| "origin/main".to_string()),
-        trusted_hooks: existing
-            .as_ref()
-            .map(|entry| entry.trusted_hooks)
-            .unwrap_or(false),
-        trusted_hooks_fingerprint: existing
-            .as_ref()
-            .and_then(|entry| entry.trusted_hooks_fingerprint.clone()),
-        hooks: existing
-            .as_ref()
-            .map(|entry| entry.hooks.clone())
-            .unwrap_or_default(),
-        worktree_file_copies: config
-            .worktree_file_copies
-            .or_else(|| {
-                existing
-                    .as_ref()
-                    .map(|entry| entry.worktree_file_copies.clone())
-            })
-            .unwrap_or_default(),
-        prompt_overrides: config
-            .prompt_overrides
-            .or_else(|| {
-                existing
-                    .as_ref()
-                    .map(|entry| entry.prompt_overrides.clone())
-            })
-            .unwrap_or_default(),
-        agent_defaults: config
-            .agent_defaults
-            .or_else(|| existing.as_ref().map(|entry| entry.agent_defaults.clone()))
-            .unwrap_or_default(),
-    };
-
-    as_error(
-        state
-            .service
-            .workspace_update_repo_config(&repo_path, repo_config),
-    )
+    as_error(state.service.workspace_merge_repo_config(
+        &repo_path,
+        RepoConfigUpdate {
+            default_runtime_kind: config.default_runtime_kind,
+            worktree_base_path: config.worktree_base_path,
+            branch_prefix: config.branch_prefix,
+            default_target_branch: config.default_target_branch,
+            worktree_file_copies: config.worktree_file_copies,
+            prompt_overrides: config.prompt_overrides,
+            agent_defaults: config.agent_defaults,
+        },
+    ))
 }
 
 // Generic runtime keeps this command testable under MockRuntime without changing
@@ -131,52 +66,25 @@ pub async fn workspace_save_repo_settings<R: tauri::Runtime>(
     repo_path: String,
     settings: RepoSettingsPayload,
 ) -> Result<host_domain::WorkspaceRecord, String> {
-    let existing =
-        as_error(state.service.workspace_get_repo_config_optional(&repo_path))?.unwrap_or_default();
-
-    let (normalized_hooks, trusted_hooks_fingerprint) = normalize_hooks_with_trust_confirmation(
-        &app,
-        repo_path.as_str(),
-        &existing,
-        settings.trusted_hooks,
-        settings.hooks.unwrap_or_else(|| existing.hooks.clone()),
-    )
-    .await?;
-
-    let final_repo_config = RepoConfig {
-        default_runtime_kind: settings
-            .default_runtime_kind
-            .map(|runtime_kind| runtime_kind.trim().to_string())
-            .map(|runtime_kind| {
-                if runtime_kind.is_empty() {
-                    Err("defaultRuntimeKind cannot be blank".to_string())
-                } else {
-                    Ok(runtime_kind)
-                }
-            })
-            .transpose()?
-            .unwrap_or(existing.default_runtime_kind),
-        worktree_base_path: settings.worktree_base_path.or(existing.worktree_base_path),
-        branch_prefix: settings.branch_prefix.unwrap_or(existing.branch_prefix),
-        default_target_branch: settings
-            .default_target_branch
-            .unwrap_or(existing.default_target_branch),
+    let service = state.service.clone();
+    let confirmation_port = TauriHookTrustConfirmationPort::new(app);
+    let update = RepoSettingsUpdate {
+        default_runtime_kind: settings.default_runtime_kind,
+        worktree_base_path: settings.worktree_base_path,
+        branch_prefix: settings.branch_prefix,
+        default_target_branch: settings.default_target_branch,
         trusted_hooks: settings.trusted_hooks,
-        trusted_hooks_fingerprint,
-        hooks: normalized_hooks,
-        worktree_file_copies: settings
-            .worktree_file_copies
-            .unwrap_or(existing.worktree_file_copies),
-        prompt_overrides: settings
-            .prompt_overrides
-            .unwrap_or(existing.prompt_overrides),
-        agent_defaults: settings.agent_defaults.unwrap_or(existing.agent_defaults),
+        hooks: settings.hooks,
+        worktree_file_copies: settings.worktree_file_copies,
+        prompt_overrides: settings.prompt_overrides,
+        agent_defaults: settings.agent_defaults,
     };
 
     as_error(
-        state
-            .service
-            .workspace_update_repo_config(&repo_path, final_repo_config),
+        run_service_blocking("workspace_save_repo_settings", move || {
+            service.workspace_save_repo_settings(&repo_path, update, &confirmation_port)
+        })
+        .await,
     )
 }
 
@@ -193,39 +101,12 @@ pub async fn workspace_update_repo_hooks(
 pub async fn workspace_prepare_trusted_hooks_challenge(
     state: State<'_, AppState>,
     repo_path: String,
-) -> Result<HookTrustChallengePayload, String> {
-    let repo_config = as_error(state.service.workspace_get_repo_config(&repo_path))?;
-    let canonical_repo_path = canonical_repo_key(&repo_path);
-    let fingerprint = hook_set_fingerprint(&repo_config.hooks);
-    let nonce = format!("hooks-trust-{}", Uuid::new_v4().simple());
-    let expires_at = SystemTime::now()
-        .checked_add(HOOK_TRUST_CHALLENGE_TTL)
-        .ok_or_else(|| "Failed to allocate hook trust challenge window.".to_string())?;
-
-    {
-        let mut challenges = state
-            .hook_trust_challenges
-            .lock()
-            .map_err(|_| "Hook trust challenge lock poisoned".to_string())?;
-        prune_expired_hook_trust_challenges(&mut challenges);
-        challenges.insert(
-            nonce.clone(),
-            HookTrustChallenge {
-                repo_path: canonical_repo_path.clone(),
-                fingerprint: fingerprint.clone(),
-                expires_at,
-            },
-        );
-    }
-
-    Ok(HookTrustChallengePayload {
-        nonce,
-        repo_path: canonical_repo_path,
-        fingerprint,
-        expires_at: chrono::DateTime::<chrono::Utc>::from(expires_at).to_rfc3339(),
-        pre_start_count: repo_config.hooks.pre_start.len(),
-        post_complete_count: repo_config.hooks.post_complete.len(),
-    })
+) -> Result<PreparedHookTrustChallenge, String> {
+    as_error(
+        state
+            .service
+            .workspace_prepare_trusted_hooks_challenge(&repo_path),
+    )
 }
 
 #[tauri::command]
@@ -255,33 +136,22 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
     snapshot: SettingsSnapshotPayload,
 ) -> Result<Vec<host_domain::WorkspaceRecord>, String> {
     let SettingsSnapshotPayload {
-        mut repos,
+        repos,
         global_prompt_overrides,
     } = snapshot;
-
-    for (repo_path, repo_config) in repos.iter_mut() {
-        let existing = as_error(state.service.workspace_get_repo_config_optional(repo_path))?
-            .unwrap_or_default();
-        let submitted_hooks = std::mem::take(&mut repo_config.hooks);
-        let (normalized_hooks, trusted_hooks_fingerprint) =
-            normalize_hooks_with_trust_confirmation(
-                &app,
-                repo_path.as_str(),
-                &existing,
-                repo_config.trusted_hooks,
-                submitted_hooks,
-            )
-            .await?;
-        repo_config.hooks = normalized_hooks;
-        repo_config.trusted_hooks_fingerprint = trusted_hooks_fingerprint;
-    }
+    let service = state.service.clone();
+    let confirmation_port = TauriHookTrustConfirmationPort::new(app);
 
     as_error(
-        state
-            .service
-            .workspace_save_settings_snapshot(repos, global_prompt_overrides),
-    )?;
-    as_error(state.service.workspace_list())
+        run_service_blocking("workspace_save_settings_snapshot", move || {
+            service.workspace_save_settings_snapshot(
+                repos,
+                global_prompt_overrides,
+                &confirmation_port,
+            )
+        })
+        .await,
+    )
 }
 
 // Generic runtime keeps this command testable under MockRuntime without changing
@@ -295,60 +165,21 @@ pub async fn workspace_set_trusted_hooks<R: tauri::Runtime>(
     challenge_nonce: Option<String>,
     challenge_fingerprint: Option<String>,
 ) -> Result<host_domain::WorkspaceRecord, String> {
-    if !trusted {
-        return as_error(
-            state
-                .service
-                .workspace_set_trusted_hooks(&repo_path, false, None),
-        );
-    }
+    let service = state.service.clone();
+    let confirmation_port = TauriHookTrustConfirmationPort::new(app);
 
-    let nonce = challenge_nonce
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| "Hook trust confirmation requires challenge nonce.".to_string())?;
-    let expected_fingerprint = challenge_fingerprint
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| "Hook trust confirmation requires challenge fingerprint.".to_string())?;
-
-    let canonical_repo_path = canonical_repo_key(&repo_path);
-    let challenge = {
-        let mut challenges = state
-            .hook_trust_challenges
-            .lock()
-            .map_err(|_| "Hook trust challenge lock poisoned".to_string())?;
-        prune_expired_hook_trust_challenges(&mut challenges);
-        let Some(challenge) = challenges.remove(&nonce) else {
-            return Err(
-                "Hook trust challenge is missing or expired. Retry confirmation.".to_string(),
-            );
-        };
-
-        validate_trust_challenge_entry(
-            &challenge,
-            canonical_repo_path.as_str(),
-            expected_fingerprint.as_str(),
-            SystemTime::now(),
-        )?;
-
-        challenge
-    };
-
-    let repo_config = as_error(state.service.workspace_get_repo_config(&repo_path))?;
-    let latest_fingerprint = hook_set_fingerprint(&repo_config.hooks);
-    if latest_fingerprint != challenge.fingerprint {
-        return Err(
-            "Hook commands changed after challenge generation. Request trust confirmation again."
-                .to_string(),
-        );
-    }
-
-    confirm_hook_trust_dialog(&app, canonical_repo_path.as_str(), &repo_config.hooks).await?;
-
-    as_error(state.service.workspace_set_trusted_hooks(
-        &repo_path,
-        true,
-        Some(challenge.fingerprint.as_str()),
-    ))
+    as_error(
+        run_service_blocking("workspace_set_trusted_hooks", move || {
+            service.workspace_set_trusted_hooks(
+                &repo_path,
+                trusted,
+                challenge_nonce.as_deref(),
+                challenge_fingerprint.as_deref(),
+                &confirmation_port,
+            )
+        })
+        .await,
+    )
 }
 
 #[tauri::command]
@@ -359,20 +190,6 @@ pub async fn get_theme(state: State<'_, AppState>) -> Result<String, String> {
 #[tauri::command]
 pub async fn set_theme(state: State<'_, AppState>, theme: String) -> Result<(), String> {
     as_error(state.service.set_theme(&theme))
-}
-
-fn canonical_repo_key(repo_path: &str) -> String {
-    std::fs::canonicalize(Path::new(repo_path))
-        .ok()
-        .and_then(|path| path.to_str().map(|value| value.to_string()))
-        .unwrap_or_else(|| repo_path.trim().to_string())
-}
-
-fn prune_expired_hook_trust_challenges(
-    challenges: &mut std::collections::HashMap<String, HookTrustChallenge>,
-) {
-    let now = SystemTime::now();
-    challenges.retain(|_, challenge| challenge.expires_at > now);
 }
 
 fn format_hook_list(commands: &[String]) -> String {
@@ -412,145 +229,84 @@ fn sanitize_hook_preview(command: &str) -> String {
     escaped
 }
 
-// Generic runtime keeps dialog plumbing compatible with command tests that run
-// under MockRuntime.
-async fn confirm_hook_trust_dialog<R: tauri::Runtime>(
-    app: &AppHandle<R>,
-    repo_path: &str,
-    hooks: &HookSet,
-) -> Result<(), String> {
-    #[cfg(test)]
-    {
-        let test_response = {
-            let state = app.state::<AppState>();
-            let response = state
-                .hook_trust_dialog_test_response
-                .lock()
-                .map_err(|_| "Hook trust dialog test response lock poisoned".to_string())?;
-            *response
-        };
-        if let Some(confirmed) = test_response {
-            if !confirmed {
-                return Err("Hook trust confirmation was cancelled by the user.".to_string());
+struct TauriHookTrustConfirmationPort<R: tauri::Runtime> {
+    app: AppHandle<R>,
+}
+
+impl<R: tauri::Runtime> TauriHookTrustConfirmationPort<R> {
+    fn new(app: AppHandle<R>) -> Self {
+        Self { app }
+    }
+}
+
+impl<R: tauri::Runtime> HookTrustConfirmationPort for TauriHookTrustConfirmationPort<R> {
+    fn confirm_trusted_hooks(&self, request: &HookTrustConfirmationRequest) -> anyhow::Result<()> {
+        #[cfg(test)]
+        {
+            let test_response = {
+                let state = self.app.state::<AppState>();
+                let response = state.hook_trust_dialog_test_response.lock().map_err(|_| {
+                    anyhow::anyhow!("Hook trust dialog test response lock poisoned")
+                })?;
+                *response
+            };
+            if let Some(confirmed) = test_response {
+                if !confirmed {
+                    return Err(anyhow::anyhow!(
+                        "Hook trust confirmation was cancelled by the user."
+                    ));
+                }
+                return Ok(());
             }
-            return Ok(());
         }
+
+        let dialog_message = format!(
+            "Approve trusted scripts for this workspace?\n\nRepository:\n{repo}\n\nWorktree setup script commands:\n{pre}\n\nWorktree cleanup script commands:\n{post}\n\nTrusted scripts can execute shell commands on this machine.",
+            repo = request.repo_path,
+            pre = format_hook_list(&request.hooks.pre_start),
+            post = format_hook_list(&request.hooks.post_complete),
+        );
+
+        let confirmed = self
+            .app
+            .dialog()
+            .message(dialog_message)
+            .title("Trust Workspace Scripts")
+            .kind(MessageDialogKind::Warning)
+            .buttons(MessageDialogButtons::OkCancelCustom(
+                "Trust scripts".to_string(),
+                "Cancel".to_string(),
+            ))
+            .blocking_show();
+
+        if !confirmed {
+            return Err(anyhow::anyhow!(
+                "Hook trust confirmation was cancelled by the user."
+            ));
+        }
+
+        Ok(())
     }
-
-    let dialog_message = format!(
-        "Approve trusted scripts for this workspace?\n\nRepository:\n{repo}\n\nWorktree setup script commands:\n{pre}\n\nWorktree cleanup script commands:\n{post}\n\nTrusted scripts can execute shell commands on this machine.",
-        repo = repo_path,
-        pre = format_hook_list(&hooks.pre_start),
-        post = format_hook_list(&hooks.post_complete),
-    );
-
-    let app_handle = app.clone();
-    let confirmed = as_error(
-        run_service_blocking("workspace_set_trusted_hooks_confirm", move || {
-            Ok(app_handle
-                .dialog()
-                .message(dialog_message)
-                .title("Trust Workspace Scripts")
-                .kind(MessageDialogKind::Warning)
-                .buttons(MessageDialogButtons::OkCancelCustom(
-                    "Trust scripts".to_string(),
-                    "Cancel".to_string(),
-                ))
-                .blocking_show())
-        })
-        .await,
-    )?;
-
-    if !confirmed {
-        return Err("Hook trust confirmation was cancelled by the user.".to_string());
-    }
-
-    Ok(())
-}
-
-fn validate_trust_challenge_entry(
-    challenge: &HookTrustChallenge,
-    canonical_repo_path: &str,
-    expected_fingerprint: &str,
-    now: SystemTime,
-) -> Result<(), String> {
-    if challenge.repo_path != canonical_repo_path {
-        return Err("Hook trust challenge repository mismatch. Retry confirmation.".to_string());
-    }
-    if challenge.fingerprint != expected_fingerprint {
-        return Err("Hook trust challenge fingerprint mismatch. Retry confirmation.".to_string());
-    }
-    if challenge.expires_at <= now {
-        return Err("Hook trust challenge expired. Retry confirmation.".to_string());
-    }
-    Ok(())
-}
-
-fn normalize_hook_set(mut hooks: HookSet) -> HookSet {
-    normalize_hook_commands(&mut hooks.pre_start);
-    normalize_hook_commands(&mut hooks.post_complete);
-    hooks
-}
-
-async fn normalize_hooks_with_trust_confirmation<R: tauri::Runtime>(
-    app: &AppHandle<R>,
-    repo_path: &str,
-    existing: &RepoConfig,
-    trusted_hooks: bool,
-    hooks: HookSet,
-) -> Result<(HookSet, Option<String>), String> {
-    let normalized_hooks = normalize_hook_set(hooks);
-    let hooks_fingerprint = hook_set_fingerprint(&normalized_hooks);
-    let trust_already_approved_for_same_hooks = existing.trusted_hooks
-        && existing.hooks == normalized_hooks
-        && existing.trusted_hooks_fingerprint.as_deref() == Some(hooks_fingerprint.as_str());
-
-    if trusted_hooks && !trust_already_approved_for_same_hooks {
-        confirm_hook_trust_dialog(app, repo_path, &normalized_hooks).await?;
-    }
-
-    let trusted_hooks_fingerprint = if trusted_hooks {
-        Some(hooks_fingerprint)
-    } else {
-        None
-    };
-
-    Ok((normalized_hooks, trusted_hooks_fingerprint))
-}
-
-fn normalize_hook_commands(commands: &mut Vec<String>) {
-    *commands = std::mem::take(commands)
-        .into_iter()
-        .filter_map(|command| {
-            let trimmed = command.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            }
-        })
-        .collect();
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        canonical_repo_key, format_hook_list, normalize_hook_set, sanitize_hook_preview,
-        validate_trust_challenge_entry, workspace_save_repo_settings,
-        workspace_save_settings_snapshot, workspace_set_trusted_hooks, HookSet, HookTrustChallenge,
+        format_hook_list, sanitize_hook_preview, workspace_prepare_trusted_hooks_challenge,
+        workspace_save_repo_settings, workspace_save_settings_snapshot,
+        workspace_set_trusted_hooks, HookSet,
     };
     use crate::{AppState, RepoSettingsPayload, SettingsSnapshotPayload};
-    use host_application::AppService;
+    use host_application::{AppService, PreparedHookTrustChallenge};
     use host_domain::{TaskStore, WorkspaceRecord, TASK_METADATA_NAMESPACE};
     use host_infra_beads::BeadsTaskStore;
     use host_infra_system::{hook_set_fingerprint, AppConfigStore, GitCliPort, PromptOverride};
     use serde_json::{json, Value};
     use std::{
-        collections::HashMap,
         fs,
         path::PathBuf,
         sync::{Arc, Mutex},
-        time::{Duration, SystemTime, UNIX_EPOCH},
+        time::{SystemTime, UNIX_EPOCH},
     };
     use tauri::{
         ipc::{CallbackFn, InvokeBody},
@@ -617,12 +373,12 @@ mod tests {
         let app = mock_builder()
             .manage(AppState {
                 service: service.clone(),
-                hook_trust_challenges: Mutex::new(HashMap::new()),
                 hook_trust_dialog_test_response: Mutex::new(dialog_response),
             })
             .invoke_handler(tauri::generate_handler![
+                workspace_prepare_trusted_hooks_challenge,
                 workspace_set_trusted_hooks,
-                workspace_save_settings_snapshot
+                workspace_save_settings_snapshot,
             ])
             .build(mock_context(noop_assets()))
             .expect("test app should build");
@@ -633,6 +389,13 @@ mod tests {
             repo_path,
             root,
         }
+    }
+
+    fn canonical_repo_path(fixture: &WorkspaceCommandFixture) -> String {
+        fs::canonicalize(&fixture.repo_path)
+            .expect("repo path should canonicalize")
+            .to_string_lossy()
+            .to_string()
     }
 
     fn run_workspace_set_trusted_hooks(
@@ -678,18 +441,14 @@ mod tests {
         ))
     }
 
-    fn insert_challenge(
+    fn run_workspace_prepare_trusted_hooks_challenge(
         fixture: &WorkspaceCommandFixture,
-        nonce: &str,
-        challenge: HookTrustChallenge,
-    ) -> Result<(), String> {
+    ) -> Result<PreparedHookTrustChallenge, String> {
         let state = fixture.app.state::<AppState>();
-        let mut map = state
-            .hook_trust_challenges
-            .lock()
-            .map_err(|_| "challenge lock poisoned".to_string())?;
-        map.insert(nonce.to_string(), challenge);
-        Ok(())
+        tauri::async_runtime::block_on(workspace_prepare_trusted_hooks_challenge(
+            state,
+            fixture.repo_path.clone(),
+        ))
     }
 
     fn invoke_workspace_set_trusted_hooks_ipc(
@@ -803,109 +562,8 @@ mod tests {
     }
 
     #[test]
-    fn workspace_set_trusted_hooks_rejects_expired_challenge_entries() -> Result<(), String> {
-        let fixture = setup_workspace_command_fixture("expired-challenge", HookSet::default());
-        let nonce = "expired-nonce".to_string();
-        let fingerprint = hook_set_fingerprint(&HookSet::default());
-        insert_challenge(
-            &fixture,
-            nonce.as_str(),
-            HookTrustChallenge {
-                repo_path: canonical_repo_key(fixture.repo_path.as_str()),
-                fingerprint: fingerprint.clone(),
-                expires_at: SystemTime::now()
-                    .checked_sub(Duration::from_secs(1))
-                    .ok_or_else(|| "expired time should be valid".to_string())?,
-            },
-        )?;
-
-        let error = run_workspace_set_trusted_hooks(&fixture, true, Some(nonce), Some(fingerprint))
-            .expect_err("expired challenge should fail");
-        assert!(
-            error.contains("missing or expired"),
-            "unexpected error: {error}"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn workspace_set_trusted_hooks_rejects_fingerprint_mismatch() -> Result<(), String> {
-        let hooks = HookSet {
-            pre_start: vec!["echo pre".to_string()],
-            post_complete: Vec::new(),
-        };
-        let fixture = setup_workspace_command_fixture("fingerprint-mismatch", hooks.clone());
-        let nonce = "nonce-fp-mismatch".to_string();
-        let expected_fingerprint = hook_set_fingerprint(&hooks);
-        insert_challenge(
-            &fixture,
-            nonce.as_str(),
-            HookTrustChallenge {
-                repo_path: canonical_repo_key(fixture.repo_path.as_str()),
-                fingerprint: expected_fingerprint,
-                expires_at: SystemTime::now()
-                    .checked_add(Duration::from_secs(60))
-                    .ok_or_else(|| "future time should be valid".to_string())?,
-            },
-        )?;
-
-        let error = run_workspace_set_trusted_hooks(
-            &fixture,
-            true,
-            Some(nonce),
-            Some("different-fingerprint".to_string()),
-        )
-        .expect_err("fingerprint mismatch should fail");
-        assert!(
-            error.contains("fingerprint mismatch"),
-            "unexpected error: {error}"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn workspace_set_trusted_hooks_rejects_repository_mismatch_and_consumes_nonce(
+    fn workspace_set_trusted_hooks_accepts_prepared_challenge_and_persists_trust(
     ) -> Result<(), String> {
-        let fixture = setup_workspace_command_fixture("repo-mismatch", HookSet::default());
-        let nonce = "nonce-repo-mismatch".to_string();
-        let fingerprint = hook_set_fingerprint(&HookSet::default());
-        insert_challenge(
-            &fixture,
-            nonce.as_str(),
-            HookTrustChallenge {
-                repo_path: "/tmp/not-the-same-repo".to_string(),
-                fingerprint: fingerprint.clone(),
-                expires_at: SystemTime::now()
-                    .checked_add(Duration::from_secs(60))
-                    .ok_or_else(|| "future time should be valid".to_string())?,
-            },
-        )?;
-
-        let mismatch_error = run_workspace_set_trusted_hooks(
-            &fixture,
-            true,
-            Some(nonce.clone()),
-            Some(fingerprint.clone()),
-        )
-        .expect_err("repository mismatch should fail");
-        assert!(
-            mismatch_error.contains("repository mismatch"),
-            "unexpected mismatch error: {mismatch_error}"
-        );
-
-        let replay_error =
-            run_workspace_set_trusted_hooks(&fixture, true, Some(nonce), Some(fingerprint))
-                .expect_err("challenge nonce should be consumed after mismatch");
-        assert!(
-            replay_error.contains("missing or expired"),
-            "unexpected replay error: {replay_error}"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn workspace_set_trusted_hooks_accepts_valid_challenge_and_persists_trust() -> Result<(), String>
-    {
         let hooks = HookSet {
             pre_start: vec!["echo pre".to_string()],
             post_complete: vec!["echo post".to_string()],
@@ -915,24 +573,16 @@ mod tests {
             hooks.clone(),
             Some(true),
         );
-        let nonce = "nonce-trust-success".to_string();
-        let fingerprint = hook_set_fingerprint(&hooks);
-        insert_challenge(
-            &fixture,
-            nonce.as_str(),
-            HookTrustChallenge {
-                repo_path: canonical_repo_key(fixture.repo_path.as_str()),
-                fingerprint: fingerprint.clone(),
-                expires_at: SystemTime::now()
-                    .checked_add(Duration::from_secs(60))
-                    .ok_or_else(|| "future time should be valid".to_string())?,
-            },
-        )?;
+        let challenge = run_workspace_prepare_trusted_hooks_challenge(&fixture)?;
 
-        let updated =
-            run_workspace_set_trusted_hooks(&fixture, true, Some(nonce), Some(fingerprint.clone()))
-                .expect("valid challenge should trust hooks");
-        assert_eq!(updated.path, canonical_repo_key(fixture.repo_path.as_str()));
+        let updated = run_workspace_set_trusted_hooks(
+            &fixture,
+            true,
+            Some(challenge.nonce.clone()),
+            Some(challenge.fingerprint.clone()),
+        )
+        .expect("valid challenge should trust hooks");
+        assert_eq!(updated.path, canonical_repo_path(&fixture));
 
         let repo_config = fixture
             .service
@@ -941,66 +591,7 @@ mod tests {
         assert!(repo_config.trusted_hooks);
         assert_eq!(
             repo_config.trusted_hooks_fingerprint.as_deref(),
-            Some(fingerprint.as_str())
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn workspace_set_trusted_hooks_consumes_nonce_and_rejects_replay_after_hook_changes(
-    ) -> Result<(), String> {
-        let original_hooks = HookSet {
-            pre_start: vec!["echo pre".to_string()],
-            post_complete: Vec::new(),
-        };
-        let fixture = setup_workspace_command_fixture("replay-and-stale", original_hooks.clone());
-        let nonce = "nonce-replay".to_string();
-        let challenge_fingerprint = hook_set_fingerprint(&original_hooks);
-        insert_challenge(
-            &fixture,
-            nonce.as_str(),
-            HookTrustChallenge {
-                repo_path: canonical_repo_key(fixture.repo_path.as_str()),
-                fingerprint: challenge_fingerprint.clone(),
-                expires_at: SystemTime::now()
-                    .checked_add(Duration::from_secs(60))
-                    .ok_or_else(|| "future time should be valid".to_string())?,
-            },
-        )?;
-
-        fixture
-            .service
-            .workspace_update_repo_hooks(
-                fixture.repo_path.as_str(),
-                HookSet {
-                    pre_start: vec!["echo changed".to_string()],
-                    post_complete: Vec::new(),
-                },
-            )
-            .map_err(|error| error.to_string())?;
-
-        let stale_error = run_workspace_set_trusted_hooks(
-            &fixture,
-            true,
-            Some(nonce.clone()),
-            Some(challenge_fingerprint),
-        )
-        .expect_err("stale hook challenge should fail");
-        assert!(
-            stale_error.contains("Hook commands changed after challenge generation"),
-            "unexpected stale challenge error: {stale_error}"
-        );
-
-        let replay_error = run_workspace_set_trusted_hooks(
-            &fixture,
-            true,
-            Some(nonce),
-            Some("ignored".to_string()),
-        )
-        .expect_err("replay should fail after nonce consumption");
-        assert!(
-            replay_error.contains("missing or expired"),
-            "unexpected replay error: {replay_error}"
+            Some(challenge.fingerprint.as_str())
         );
         Ok(())
     }
@@ -1015,7 +606,7 @@ mod tests {
         let fingerprint = hook_set_fingerprint(&hooks);
         fixture
             .service
-            .workspace_set_trusted_hooks(
+            .workspace_persist_trusted_hooks(
                 fixture.repo_path.as_str(),
                 true,
                 Some(fingerprint.as_str()),
@@ -1024,7 +615,7 @@ mod tests {
 
         let updated = run_workspace_set_trusted_hooks(&fixture, false, None, None)
             .expect("disabling trust should succeed");
-        assert_eq!(updated.path, canonical_repo_key(fixture.repo_path.as_str()));
+        assert_eq!(updated.path, canonical_repo_path(&fixture));
 
         let repo_config = fixture
             .service
@@ -1056,7 +647,7 @@ mod tests {
             repos,
             global_prompt_overrides,
         };
-        let repo_key = canonical_repo_key(fixture.repo_path.as_str());
+        let repo_key = canonical_repo_path(&fixture);
         let repo_config = snapshot
             .repos
             .get_mut(repo_key.as_str())
@@ -1103,7 +694,7 @@ mod tests {
             repos,
             global_prompt_overrides,
         };
-        let repo_key = canonical_repo_key(fixture.repo_path.as_str());
+        let repo_key = canonical_repo_path(&fixture);
         let repo_config = snapshot
             .repos
             .get_mut(repo_key.as_str())
@@ -1223,7 +814,7 @@ mod tests {
             },
         );
 
-        let repo_key = canonical_repo_key(fixture.repo_path.as_str());
+        let repo_key = canonical_repo_path(&fixture);
         let repo_config = snapshot
             .repos
             .get_mut(repo_key.as_str())
@@ -1327,57 +918,5 @@ mod tests {
         let formatted = format_hook_list(&hooks);
         assert!(formatted.contains("- echo b\\nline"));
         assert!(formatted.contains("... and 1 more"));
-    }
-
-    #[test]
-    fn normalize_hook_set_trims_and_removes_blank_commands() {
-        let normalized = normalize_hook_set(HookSet {
-            pre_start: vec!["  echo pre  ".to_string(), "   ".to_string()],
-            post_complete: vec!["".to_string(), " echo post ".to_string()],
-        });
-        assert_eq!(normalized.pre_start, vec!["echo pre".to_string()]);
-        assert_eq!(normalized.post_complete, vec!["echo post".to_string()]);
-    }
-
-    #[test]
-    fn validate_trust_challenge_entry_checks_repo_and_fingerprint_and_expiry() -> Result<(), String>
-    {
-        let now = SystemTime::now();
-        let challenge = HookTrustChallenge {
-            repo_path: "/repo".to_string(),
-            fingerprint: "abc".to_string(),
-            expires_at: now
-                .checked_add(Duration::from_secs(5))
-                .ok_or_else(|| "challenge expiry".to_string())?,
-        };
-        assert!(
-            validate_trust_challenge_entry(&challenge, "/repo", "abc", now).is_ok(),
-            "valid challenge should pass"
-        );
-
-        let repo_error = validate_trust_challenge_entry(&challenge, "/repo-2", "abc", now)
-            .expect_err("repo mismatch should fail");
-        assert!(repo_error.contains("repository mismatch"));
-
-        let fingerprint_error = validate_trust_challenge_entry(&challenge, "/repo", "def", now)
-            .expect_err("fingerprint mismatch should fail");
-        assert!(fingerprint_error.contains("fingerprint mismatch"));
-
-        let expired = HookTrustChallenge {
-            expires_at: now
-                .checked_sub(Duration::from_secs(1))
-                .ok_or_else(|| "expired instant".to_string())?,
-            ..challenge
-        };
-        let expired_error = validate_trust_challenge_entry(&expired, "/repo", "abc", now)
-            .expect_err("expired challenge should fail");
-        assert!(expired_error.contains("expired"));
-        Ok(())
-    }
-
-    #[test]
-    fn canonical_repo_key_keeps_input_when_path_does_not_exist() {
-        let missing_path = "/this/path/should/not/exist-for-openducktor";
-        assert_eq!(canonical_repo_key(missing_path), missing_path.to_string());
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,7 +8,10 @@ use host_infra_system::{AppConfigStore, RuntimeConfigStore};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(test)]
+use std::sync::Mutex;
+use std::sync::{Arc, OnceLock};
+#[cfg(test)]
 use std::time::SystemTime;
 use tauri::{AppHandle, Emitter, RunEvent as TauriRunEvent};
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 use tauri::{AppHandle, Emitter, RunEvent as TauriRunEvent};
 
 mod commands;
@@ -24,20 +24,10 @@ use commands::workspace::*;
 
 struct AppState {
     service: Arc<AppService>,
-    hook_trust_challenges: Mutex<HashMap<String, HookTrustChallenge>>,
     #[cfg(test)]
     hook_trust_dialog_test_response: Mutex<Option<bool>>,
 }
-
-const HOOK_TRUST_CHALLENGE_TTL: Duration = Duration::from_secs(120);
 static TRACING_INITIALIZED: OnceLock<()> = OnceLock::new();
-
-#[derive(Debug, Clone)]
-struct HookTrustChallenge {
-    repo_path: String,
-    fingerprint: String,
-    expires_at: SystemTime,
-}
 
 fn init_tracing_subscriber() {
     TRACING_INITIALIZED.get_or_init(|| {
@@ -309,7 +299,6 @@ fn startup_phase_build_tauri_app(
         .plugin(tauri_plugin_dialog::init())
         .manage(AppState {
             service,
-            hook_trust_challenges: Mutex::new(HashMap::new()),
             #[cfg(test)]
             hook_trust_dialog_test_response: Mutex::new(None),
         });


### PR DESCRIPTION
## Summary
- move workspace settings merge, hook trust orchestration, and challenge handling out of the Tauri command layer into a dedicated `host-application` workspace policy service
- introduce an explicit confirmation port for trusted-hook approval so Tauri only maps payloads and dialog UI concerns
- tighten the follow-up boundary by making low-level persistence helpers internal and reusing the canonical hook normalizer from `host-infra-system`

## What Changed
- added `workspace_policy.rs` in `host-application` with policy-shaped inputs and operations for repo config merge, repo settings save, trusted-hook challenge preparation, trusted-hook enable/disable, and settings snapshot save
- moved hook-trust challenge state into `AppService` and re-exported the new application-layer types needed by the Tauri adapter
- simplified `src/commands/workspace.rs` so commands delegate to `AppService` and use a small `HookTrustConfirmationPort` adapter for the confirmation dialog
- restricted direct persistence helpers so callers cannot bypass the trust-flow boundary from outside the application layer
- exported a shared `normalize_hook_set` helper from `host-infra-system` and removed the duplicate hook normalization logic from `host-application`
- updated Rust tests to cover the new application policy module and the Tauri command integration paths

## Verification
- `cd apps/desktop/src-tauri && cargo test -p host-infra-system --lib`
- `cd apps/desktop/src-tauri && cargo test -p host-application workspace_policy --lib`
- `cd apps/desktop/src-tauri && cargo test -p openducktor-desktop workspace_ --lib`