### PR TITLE
fix(desktop): improve kanban board loading ux

### DIFF
--- a/apps/desktop/src/components/ui/skeleton.tsx
+++ b/apps/desktop/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/apps/desktop/src/pages/kanban/kanban-page-content.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page-content.test.tsx
@@ -34,11 +34,9 @@ describe("KanbanPageContent", () => {
     const html = renderToStaticMarkup(createElement(KanbanPageContent, { model }));
 
     expect(html).toContain("flex-1");
-    expect(html).toContain("h-full");
-    expect(html).toContain("overflow-hidden");
     expect(html).toContain("w-full");
     expect(html).toContain("overflow-x-auto");
-    expect(html).toContain("overflow-y-hidden");
+    expect(html).toContain("overflow-y-visible");
     expect(html).toContain("min-h-full");
   });
 

--- a/apps/desktop/src/pages/kanban/kanban-page-content.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page-content.test.tsx
@@ -54,7 +54,8 @@ describe("KanbanPageContent", () => {
     );
 
     expect(html).toContain('data-testid="kanban-loading-overlay"');
-    expect(html).toContain("Loading tasks...");
+    expect(html.match(/data-testid="kanban-loading-lane"/g)?.length).toBeGreaterThanOrEqual(5);
+    expect(html).toContain('data-slot="skeleton"');
     expect(html).not.toContain('data-testid="kanban-refresh-indicator"');
   });
 

--- a/apps/desktop/src/pages/kanban/kanban-page-content.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page-content.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ReactElement } from "react";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { KanbanPageContentModel } from "./kanban-page-model-types";
+
+mock.module("@/components/features/kanban", () => ({
+  KanbanColumn: (): ReactElement => <div data-testid="kanban-column" />,
+}));
+
+const model: KanbanPageContentModel = {
+  isLoadingTasks: false,
+  isSwitchingWorkspace: false,
+  columns: [
+    {
+      id: "open",
+      title: "Backlog",
+      tasks: [],
+    },
+  ],
+  runStateByTaskId: new Map(),
+  activeSessionsByTaskId: new Map(),
+  onOpenDetails: () => {},
+  onDelegate: () => {},
+  onPlan: () => {},
+  onBuild: () => {},
+  onHumanApprove: () => {},
+  onHumanRequestChanges: () => {},
+};
+
+describe("KanbanPageContent", () => {
+  test("keeps the horizontal scroll region stretched across the remaining page height", async () => {
+    const { KanbanPageContent } = await import("./kanban-page-content");
+    const html = renderToStaticMarkup(createElement(KanbanPageContent, { model }));
+
+    expect(html).toContain("flex-1");
+    expect(html).toContain("h-full");
+    expect(html).toContain("overflow-hidden");
+    expect(html).toContain("w-full");
+    expect(html).toContain("overflow-x-auto");
+    expect(html).toContain("overflow-y-hidden");
+    expect(html).toContain("min-h-full");
+  });
+
+  test("renders a blocking board loader while the initial task load is in progress", async () => {
+    const { KanbanPageContent } = await import("./kanban-page-content");
+    const html = renderToStaticMarkup(
+      createElement(KanbanPageContent, {
+        model: {
+          ...model,
+          isLoadingTasks: true,
+        },
+      }),
+    );
+
+    expect(html).toContain('data-testid="kanban-loading-overlay"');
+    expect(html).toContain("Loading Kanban tasks");
+    expect(html).not.toContain('data-testid="kanban-refresh-indicator"');
+  });
+
+  test("renders a non-blocking refresh indicator when tasks are already visible", async () => {
+    const { KanbanPageContent } = await import("./kanban-page-content");
+    const html = renderToStaticMarkup(
+      createElement(KanbanPageContent, {
+        model: {
+          ...model,
+          isLoadingTasks: true,
+          columns: [
+            {
+              id: "open",
+              title: "Backlog",
+              tasks: [{ id: "TASK-1" }] as (typeof model.columns)[number]["tasks"],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(html).toContain('data-testid="kanban-refresh-indicator"');
+    expect(html).toContain("Refreshing tasks...");
+    expect(html).not.toContain('data-testid="kanban-loading-overlay"');
+  });
+});

--- a/apps/desktop/src/pages/kanban/kanban-page-content.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page-content.test.tsx
@@ -54,7 +54,7 @@ describe("KanbanPageContent", () => {
     );
 
     expect(html).toContain('data-testid="kanban-loading-overlay"');
-    expect(html).toContain("Loading Kanban tasks");
+    expect(html).toContain("Loading tasks...");
     expect(html).not.toContain('data-testid="kanban-refresh-indicator"');
   });
 

--- a/apps/desktop/src/pages/kanban/kanban-page-content.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page-content.tsx
@@ -15,54 +15,60 @@ function KanbanBoardLoadingOverlay({
 }: {
   isSwitchingWorkspace: boolean;
 }): ReactElement {
-  const title = isSwitchingWorkspace ? "Switching repository" : "Loading Kanban tasks";
-  const description = isSwitchingWorkspace
-    ? "Preparing the selected repository and loading its task board."
-    : "Reading the Beads task store and preparing the board.";
+  const label = isSwitchingWorkspace ? "Switching repository..." : "Loading tasks...";
 
   return (
     <div
-      className="absolute inset-0 z-10 flex items-center justify-center px-4 pb-6"
+      className="pointer-events-none absolute inset-0 z-10 overflow-hidden px-1"
       data-testid="kanban-loading-overlay"
     >
-      <output
-        aria-live="polite"
-        className="w-full max-w-3xl rounded-[1.75rem] border border-border bg-card/95 p-5 shadow-xl shadow-foreground/5 backdrop-blur-sm"
-      >
-        <div className="flex items-start gap-4">
-          <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-border bg-muted/70">
-            <LoaderCircle className="size-5 animate-spin text-primary" />
-          </div>
-          <div className="space-y-1">
-            <p className="text-sm font-semibold text-foreground">{title}</p>
-            <p className="text-sm text-muted-foreground">{description}</p>
-          </div>
-        </div>
+      <div className="flex h-full min-h-0 flex-col">
+        <output
+          aria-live="polite"
+          className="ml-3 mt-2 inline-flex items-center gap-2 self-start rounded-full border border-border bg-card/90 px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm"
+        >
+          <LoaderCircle className="size-3.5 animate-spin text-primary" />
+          {label}
+        </output>
 
-        <div className="mt-5 grid gap-3 lg:grid-cols-3">
+        <div className="mt-4 flex min-h-0 min-w-max flex-1 items-stretch gap-4 pr-4">
           {LOADING_LANE_PREVIEW_IDS.map((previewId) => (
             <div
               key={previewId}
-              className="rounded-2xl border border-border bg-muted/55 p-3 shadow-sm"
+              className="flex w-[328px] min-w-[328px] flex-col overflow-hidden rounded-2xl border border-border bg-muted/45 shadow-sm"
             >
-              <div className="flex items-center justify-between">
-                <div className="h-2.5 w-16 rounded-full bg-muted-foreground/20" />
-                <div className="h-5 w-14 rounded-full bg-muted-foreground/15" />
-              </div>
-              <div className="mt-4 space-y-3">
-                <div className="rounded-xl border border-border/80 bg-card/80 p-3">
-                  <div className="h-2.5 w-4/5 rounded-full bg-muted-foreground/15" />
-                  <div className="mt-2 h-2.5 w-3/5 rounded-full bg-muted-foreground/10" />
+              <div className="space-y-3 border-b border-border/80 px-4 pb-3 pt-4">
+                <div className="h-1.5 w-14 rounded-full bg-muted-foreground/15" />
+                <div className="flex items-center justify-between gap-3">
+                  <div className="h-3 w-24 rounded-full bg-muted-foreground/18" />
+                  <div className="h-5 w-14 rounded-full bg-muted-foreground/12" />
                 </div>
-                <div className="rounded-xl border border-border/70 bg-card/60 p-3">
-                  <div className="h-2.5 w-3/4 rounded-full bg-muted-foreground/15" />
-                  <div className="mt-2 h-2.5 w-1/2 rounded-full bg-muted-foreground/10" />
+              </div>
+
+              <div className="space-y-3 p-3">
+                <div className="rounded-2xl border border-border/80 bg-card/75 p-3.5">
+                  <div className="h-3 w-4/5 rounded-full bg-muted-foreground/14" />
+                  <div className="mt-2 h-2.5 w-3/5 rounded-full bg-muted-foreground/10" />
+                  <div className="mt-4 flex gap-2">
+                    <div className="h-6 w-16 rounded-full bg-muted-foreground/10" />
+                    <div className="h-6 w-12 rounded-full bg-muted-foreground/8" />
+                  </div>
+                  <div className="mt-4 h-9 rounded-xl bg-muted-foreground/8" />
+                </div>
+
+                <div className="rounded-2xl border border-border/70 bg-card/60 p-3.5">
+                  <div className="h-3 w-3/4 rounded-full bg-muted-foreground/12" />
+                  <div className="mt-2 h-2.5 w-1/2 rounded-full bg-muted-foreground/9" />
+                  <div className="mt-4 h-9 rounded-xl bg-muted-foreground/7" />
                 </div>
               </div>
             </div>
           ))}
         </div>
-      </output>
+      </div>
+      <div className="sr-only" aria-live="polite">
+        {label}
+      </div>
     </div>
   );
 }
@@ -100,8 +106,8 @@ export function KanbanPageContent({ model }: KanbanPageContentProps): ReactEleme
 
       <div
         className={cn(
-          "hide-scrollbar h-full w-full max-w-full overflow-x-auto overflow-y-hidden transition-opacity duration-200",
-          showBlockingLoader ? "opacity-35" : "opacity-100",
+          "hide-scrollbar h-full w-full max-w-full overflow-x-auto overflow-y-hidden transition-opacity duration-150",
+          showBlockingLoader ? "opacity-0" : "opacity-100",
         )}
       >
         <div className="flex min-h-full min-w-max items-start gap-4 pr-4">

--- a/apps/desktop/src/pages/kanban/kanban-page-content.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page-content.tsx
@@ -129,15 +129,12 @@ export function KanbanPageContent({ model }: KanbanPageContentProps): ReactEleme
     model.isLoadingTasks && !model.isSwitchingWorkspace && totalTaskCount > 0;
 
   return (
-    <section
-      className="relative h-full min-h-0 min-w-0 flex-1 overflow-hidden"
-      aria-busy={isBoardLoading}
-    >
+    <section className="relative min-h-0 min-w-0 flex-1" aria-busy={isBoardLoading}>
       {showRefreshingIndicator ? <KanbanBoardRefreshingIndicator /> : null}
 
       <div
         className={cn(
-          "hide-scrollbar h-full w-full max-w-full overflow-x-auto overflow-y-hidden transition-opacity duration-150",
+          "hide-scrollbar min-h-full w-full max-w-full overflow-x-auto overflow-y-visible transition-opacity duration-150",
           showBlockingLoader ? "opacity-0" : "opacity-100",
         )}
       >

--- a/apps/desktop/src/pages/kanban/kanban-page-content.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page-content.tsx
@@ -1,6 +1,7 @@
 import { LoaderCircle } from "lucide-react";
 import type { ReactElement } from "react";
 import { KanbanColumn } from "@/components/features/kanban";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type { KanbanPageContentModel } from "./kanban-page-model-types";
 
@@ -8,7 +9,41 @@ type KanbanPageContentProps = {
   model: KanbanPageContentModel;
 };
 
-const LOADING_LANE_PREVIEW_IDS = ["backlog", "build", "review"] as const;
+const LOADING_LANE_PREVIEWS = [
+  {
+    id: "backlog",
+    accentClass: "bg-muted-foreground/25",
+    surfaceClass: "border-border/90 bg-muted/70 dark:border-border dark:bg-muted/45",
+    headerClass: "border-border/80",
+  },
+  {
+    id: "spec",
+    accentClass: "bg-violet-400/80 dark:bg-violet-500/70",
+    surfaceClass:
+      "border-violet-300/85 dark:border-violet-800/50 bg-violet-100/55 dark:bg-violet-950/20",
+    headerClass: "border-violet-300/75 dark:border-violet-800/40",
+  },
+  {
+    id: "ready",
+    accentClass: "bg-sky-400/80 dark:bg-sky-500/70",
+    surfaceClass: "border-sky-300/85 dark:border-sky-800/50 bg-sky-100/55 dark:bg-sky-950/20",
+    headerClass: "border-sky-300/75 dark:border-sky-800/40",
+  },
+  {
+    id: "build",
+    accentClass: "bg-amber-400/80 dark:bg-amber-500/70",
+    surfaceClass:
+      "border-amber-300/85 dark:border-amber-800/50 bg-amber-100/60 dark:bg-amber-950/20",
+    headerClass: "border-amber-300/75 dark:border-amber-800/40",
+  },
+  {
+    id: "review",
+    accentClass: "bg-indigo-400/80 dark:bg-indigo-500/70",
+    surfaceClass:
+      "border-indigo-300/85 dark:border-indigo-800/50 bg-indigo-100/55 dark:bg-indigo-950/20",
+    headerClass: "border-indigo-300/75 dark:border-indigo-800/40",
+  },
+] as const;
 
 function KanbanBoardLoadingOverlay({
   isSwitchingWorkspace,
@@ -23,43 +58,39 @@ function KanbanBoardLoadingOverlay({
       data-testid="kanban-loading-overlay"
     >
       <div className="flex h-full min-h-0 flex-col">
-        <output
-          aria-live="polite"
-          className="ml-3 mt-2 inline-flex items-center gap-2 self-start rounded-full border border-border bg-card/90 px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm"
-        >
-          <LoaderCircle className="size-3.5 animate-spin text-primary" />
-          {label}
-        </output>
-
-        <div className="mt-4 flex min-h-0 min-w-max flex-1 items-stretch gap-4 pr-4">
-          {LOADING_LANE_PREVIEW_IDS.map((previewId) => (
+        <div className="flex min-h-0 min-w-max flex-1 items-stretch gap-4 pr-4">
+          {LOADING_LANE_PREVIEWS.map((preview) => (
             <div
-              key={previewId}
-              className="flex w-[328px] min-w-[328px] flex-col overflow-hidden rounded-2xl border border-border bg-muted/45 shadow-sm"
+              key={preview.id}
+              data-testid="kanban-loading-lane"
+              className={cn(
+                "flex w-[328px] min-w-[328px] flex-col overflow-hidden rounded-2xl shadow-sm",
+                preview.surfaceClass,
+              )}
             >
-              <div className="space-y-3 border-b border-border/80 px-4 pb-3 pt-4">
-                <div className="h-1.5 w-14 rounded-full bg-muted-foreground/15" />
+              <div className={cn("space-y-3 border-b px-4 pb-3 pt-4", preview.headerClass)}>
+                <Skeleton className={cn("h-1.5 w-14 rounded-full", preview.accentClass)} />
                 <div className="flex items-center justify-between gap-3">
-                  <div className="h-3 w-24 rounded-full bg-muted-foreground/18" />
-                  <div className="h-5 w-14 rounded-full bg-muted-foreground/12" />
+                  <Skeleton className="h-3 w-24 rounded-full bg-foreground/12 dark:bg-foreground/18" />
+                  <Skeleton className="h-5 w-14 rounded-full bg-foreground/10 dark:bg-foreground/14" />
                 </div>
               </div>
 
               <div className="space-y-3 p-3">
-                <div className="rounded-2xl border border-border/80 bg-card/75 p-3.5">
-                  <div className="h-3 w-4/5 rounded-full bg-muted-foreground/14" />
-                  <div className="mt-2 h-2.5 w-3/5 rounded-full bg-muted-foreground/10" />
+                <div className="rounded-2xl border border-border/85 bg-card/88 dark:border-border/80 dark:bg-card/75 p-3.5">
+                  <Skeleton className="h-3 w-4/5 rounded-full bg-foreground/11 dark:bg-foreground/14" />
+                  <Skeleton className="mt-2 h-2.5 w-3/5 rounded-full bg-foreground/9 dark:bg-foreground/10" />
                   <div className="mt-4 flex gap-2">
-                    <div className="h-6 w-16 rounded-full bg-muted-foreground/10" />
-                    <div className="h-6 w-12 rounded-full bg-muted-foreground/8" />
+                    <Skeleton className="h-6 w-16 rounded-full bg-foreground/9 dark:bg-foreground/10" />
+                    <Skeleton className="h-6 w-12 rounded-full bg-foreground/8 dark:bg-foreground/8" />
                   </div>
-                  <div className="mt-4 h-9 rounded-xl bg-muted-foreground/8" />
+                  <Skeleton className="mt-4 h-9 rounded-xl bg-foreground/8 dark:bg-foreground/8" />
                 </div>
 
-                <div className="rounded-2xl border border-border/70 bg-card/60 p-3.5">
-                  <div className="h-3 w-3/4 rounded-full bg-muted-foreground/12" />
-                  <div className="mt-2 h-2.5 w-1/2 rounded-full bg-muted-foreground/9" />
-                  <div className="mt-4 h-9 rounded-xl bg-muted-foreground/7" />
+                <div className="rounded-2xl border border-border/80 bg-card/80 dark:border-border/70 dark:bg-card/60 p-3.5">
+                  <Skeleton className="h-3 w-3/4 rounded-full bg-foreground/10 dark:bg-foreground/12" />
+                  <Skeleton className="mt-2 h-2.5 w-1/2 rounded-full bg-foreground/8 dark:bg-foreground/9" />
+                  <Skeleton className="mt-4 h-9 rounded-xl bg-foreground/7 dark:bg-foreground/7" />
                 </div>
               </div>
             </div>

--- a/apps/desktop/src/pages/kanban/kanban-page-content.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page-content.tsx
@@ -1,16 +1,110 @@
+import { LoaderCircle } from "lucide-react";
 import type { ReactElement } from "react";
 import { KanbanColumn } from "@/components/features/kanban";
+import { cn } from "@/lib/utils";
 import type { KanbanPageContentModel } from "./kanban-page-model-types";
 
 type KanbanPageContentProps = {
   model: KanbanPageContentModel;
 };
 
-export function KanbanPageContent({ model }: KanbanPageContentProps): ReactElement {
+const LOADING_LANE_PREVIEW_IDS = ["backlog", "build", "review"] as const;
+
+function KanbanBoardLoadingOverlay({
+  isSwitchingWorkspace,
+}: {
+  isSwitchingWorkspace: boolean;
+}): ReactElement {
+  const title = isSwitchingWorkspace ? "Switching repository" : "Loading Kanban tasks";
+  const description = isSwitchingWorkspace
+    ? "Preparing the selected repository and loading its task board."
+    : "Reading the Beads task store and preparing the board.";
+
   return (
-    <section className="min-h-0 min-w-0">
-      <div className="hide-scrollbar max-w-full overflow-x-auto">
-        <div className="flex min-w-max items-start gap-4">
+    <div
+      className="absolute inset-0 z-10 flex items-center justify-center px-4 pb-6"
+      data-testid="kanban-loading-overlay"
+    >
+      <output
+        aria-live="polite"
+        className="w-full max-w-3xl rounded-[1.75rem] border border-border bg-card/95 p-5 shadow-xl shadow-foreground/5 backdrop-blur-sm"
+      >
+        <div className="flex items-start gap-4">
+          <div className="flex size-12 shrink-0 items-center justify-center rounded-2xl border border-border bg-muted/70">
+            <LoaderCircle className="size-5 animate-spin text-primary" />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-foreground">{title}</p>
+            <p className="text-sm text-muted-foreground">{description}</p>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-3 lg:grid-cols-3">
+          {LOADING_LANE_PREVIEW_IDS.map((previewId) => (
+            <div
+              key={previewId}
+              className="rounded-2xl border border-border bg-muted/55 p-3 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <div className="h-2.5 w-16 rounded-full bg-muted-foreground/20" />
+                <div className="h-5 w-14 rounded-full bg-muted-foreground/15" />
+              </div>
+              <div className="mt-4 space-y-3">
+                <div className="rounded-xl border border-border/80 bg-card/80 p-3">
+                  <div className="h-2.5 w-4/5 rounded-full bg-muted-foreground/15" />
+                  <div className="mt-2 h-2.5 w-3/5 rounded-full bg-muted-foreground/10" />
+                </div>
+                <div className="rounded-xl border border-border/70 bg-card/60 p-3">
+                  <div className="h-2.5 w-3/4 rounded-full bg-muted-foreground/15" />
+                  <div className="mt-2 h-2.5 w-1/2 rounded-full bg-muted-foreground/10" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </output>
+    </div>
+  );
+}
+
+function KanbanBoardRefreshingIndicator(): ReactElement {
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-center px-4 pt-2"
+      data-testid="kanban-refresh-indicator"
+    >
+      <output
+        aria-live="polite"
+        className="inline-flex items-center gap-2 rounded-full border border-border bg-card/95 px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm backdrop-blur-sm"
+      >
+        <LoaderCircle className="size-3.5 animate-spin text-primary" />
+        Refreshing tasks...
+      </output>
+    </div>
+  );
+}
+
+export function KanbanPageContent({ model }: KanbanPageContentProps): ReactElement {
+  const totalTaskCount = model.columns.reduce((count, column) => count + column.tasks.length, 0);
+  const isBoardLoading = model.isLoadingTasks || model.isSwitchingWorkspace;
+  const showBlockingLoader = isBoardLoading && totalTaskCount === 0;
+  const showRefreshingIndicator =
+    model.isLoadingTasks && !model.isSwitchingWorkspace && totalTaskCount > 0;
+
+  return (
+    <section
+      className="relative h-full min-h-0 min-w-0 flex-1 overflow-hidden"
+      aria-busy={isBoardLoading}
+    >
+      {showRefreshingIndicator ? <KanbanBoardRefreshingIndicator /> : null}
+
+      <div
+        className={cn(
+          "hide-scrollbar h-full w-full max-w-full overflow-x-auto overflow-y-hidden transition-opacity duration-200",
+          showBlockingLoader ? "opacity-35" : "opacity-100",
+        )}
+      >
+        <div className="flex min-h-full min-w-max items-start gap-4 pr-4">
           {model.columns.map((column) => (
             <KanbanColumn
               key={column.id}
@@ -27,6 +121,10 @@ export function KanbanPageContent({ model }: KanbanPageContentProps): ReactEleme
           ))}
         </div>
       </div>
+
+      {showBlockingLoader ? (
+        <KanbanBoardLoadingOverlay isSwitchingWorkspace={model.isSwitchingWorkspace} />
+      ) : null}
     </section>
   );
 }

--- a/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
+++ b/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
@@ -19,6 +19,8 @@ export type KanbanPageHeaderModel = {
 };
 
 export type KanbanPageContentModel = {
+  isLoadingTasks: boolean;
+  isSwitchingWorkspace: boolean;
   columns: KanbanColumnData[];
   runStateByTaskId: Map<string, RunSummary["state"]>;
   activeSessionsByTaskId: Map<string, AgentSessionState[]>;

--- a/apps/desktop/src/pages/kanban/kanban-page.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.tsx
@@ -10,7 +10,7 @@ export function KanbanPage(): ReactElement {
   const models = useKanbanPageModels();
 
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col gap-4 overflow-hidden py-4 pl-4">
+    <div className="flex h-full min-h-full min-w-0 flex-col gap-4 py-4 pl-4">
       <KanbanPageHeader model={models.header} />
       <KanbanPageContent model={models.content} />
       <TaskCreateModal {...models.taskComposer} />

--- a/apps/desktop/src/pages/kanban/kanban-page.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.tsx
@@ -10,7 +10,7 @@ export function KanbanPage(): ReactElement {
   const models = useKanbanPageModels();
 
   return (
-    <div className="grid min-h-full min-w-0 content-start gap-4 overflow-x-hidden py-4 pl-4">
+    <div className="flex h-full min-h-0 min-w-0 flex-col gap-4 overflow-hidden py-4 pl-4">
       <KanbanPageHeader model={models.header} />
       <KanbanPageContent model={models.content} />
       <TaskCreateModal {...models.taskComposer} />

--- a/apps/desktop/src/pages/kanban/use-kanban-board-model.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-board-model.ts
@@ -7,6 +7,8 @@ import type { KanbanPageContentModel } from "./kanban-page-model-types";
 const ACTIVE_SESSION_STATUS = new Set<AgentSessionState["status"]>(["starting", "running"]);
 
 type UseKanbanBoardModelArgs = {
+  isLoadingTasks: boolean;
+  isSwitchingWorkspace: boolean;
   tasks: TaskCard[];
   runs: RunSummary[];
   sessions: AgentSessionState[];
@@ -19,6 +21,8 @@ type UseKanbanBoardModelArgs = {
 };
 
 export function useKanbanBoardModel({
+  isLoadingTasks,
+  isSwitchingWorkspace,
   tasks,
   runs,
   sessions,
@@ -64,6 +68,8 @@ export function useKanbanBoardModel({
   }, [sessions]);
 
   return {
+    isLoadingTasks,
+    isSwitchingWorkspace,
     columns,
     runStateByTaskId,
     activeSessionsByTaskId,

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
@@ -80,6 +80,8 @@ export function useKanbanPageModels(): KanbanPageModels {
   });
 
   const content = useKanbanBoardModel({
+    isLoadingTasks,
+    isSwitchingWorkspace,
     tasks,
     runs,
     sessions,

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -1,0 +1,149 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createTauriHostClient } from "@openducktor/adapters-tauri-host";
+import type { ReactElement } from "react";
+import { createElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import type { RepoRuntimeHealthMap } from "@/types/diagnostics";
+
+mock.module("@/lib/host-client", () => ({
+  createHostClient: () =>
+    createTauriHostClient(async () => {
+      throw new Error("Tauri runtime not available. Run inside the desktop shell.");
+    }),
+  subscribeRunEvents: async () => () => {},
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const createDeferred = <T,>() => {
+  let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
+  let reject: ((reason?: unknown) => void) | null = null;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve: (value: T) => resolve?.(value),
+    reject: (reason?: unknown) => reject?.(reason),
+  };
+};
+
+describe("useAppLifecycle", () => {
+  test("clears task loading as soon as the repo task load finishes", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    let currentArgs!: HookArgs;
+
+    const Harness = ({ args }: { args: HookArgs }): ReactElement | null => {
+      useAppLifecycle(args);
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    const mount = async (args: HookArgs): Promise<void> => {
+      currentArgs = args;
+      await act(async () => {
+        renderer = TestRenderer.create(createElement(Harness, { args }));
+      });
+      await flush();
+    };
+    const update = async (args: HookArgs): Promise<void> => {
+      currentArgs = args;
+      await act(async () => {
+        renderer?.update(createElement(Harness, { args }));
+      });
+      await flush();
+    };
+
+    const taskLoadDeferred = createDeferred<void>();
+    const runtimeRepoCheckDeferred = createDeferred<unknown>();
+    const runtimeHealthDeferred = createDeferred<RepoRuntimeHealthMap>();
+    const branchesDeferred = createDeferred<void>();
+    const setIsLoadingTasks = mock((_value: boolean) => {});
+    const setIsLoadingChecks = mock((_value: boolean) => {});
+
+    let runtimeCheckCallCount = 0;
+    const refreshRuntimeCheck = mock(() => {
+      runtimeCheckCallCount += 1;
+      return runtimeCheckCallCount === 1
+        ? Promise.resolve({ runtimeOk: true })
+        : runtimeRepoCheckDeferred.promise;
+    });
+
+    const baseArgs: HookArgs = {
+      activeRepo: null,
+      setEvents: mock((_updater) => {}),
+      setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => branchesDeferred.promise),
+      refreshRuntimeCheck,
+      refreshBeadsCheckForRepo: mock(async () => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      })),
+      refreshRepoRuntimeHealthForRepo: mock(async () => runtimeHealthDeferred.promise),
+      runtimeKinds: ["opencode"],
+      refreshTaskData: mock(async () => taskLoadDeferred.promise),
+      clearTaskData: mock(() => {}),
+      clearBranchData: mock(() => {}),
+      clearActiveBeadsCheck: mock(() => {}),
+      clearActiveRepoRuntimeHealth: mock(() => {}),
+      setIsLoadingTasks,
+      setIsLoadingChecks,
+      hasRuntimeCheck: mock(() => false),
+      hasCachedBeadsCheck: mock((_repoPath: string) => false),
+      hasCachedRepoRuntimeHealth: mock((_repoPath: string, _runtimeKinds) => false),
+    };
+
+    try {
+      await mount(baseArgs);
+      setIsLoadingTasks.mockClear();
+      setIsLoadingChecks.mockClear();
+
+      await update({
+        ...currentArgs,
+        activeRepo: "/repo",
+      });
+
+      expect(setIsLoadingTasks).toHaveBeenCalledWith(true);
+      expect(setIsLoadingChecks).toHaveBeenCalledWith(true);
+
+      await act(async () => {
+        taskLoadDeferred.resolve();
+        await flush();
+      });
+
+      expect(setIsLoadingTasks.mock.calls.some(([value]) => value === false)).toBe(true);
+      expect(setIsLoadingChecks.mock.calls.some(([value]) => value === false)).toBe(false);
+
+      await act(async () => {
+        runtimeRepoCheckDeferred.resolve({ runtimeOk: true });
+        runtimeHealthDeferred.resolve({});
+        branchesDeferred.resolve();
+        await flush();
+      });
+
+      expect(setIsLoadingChecks.mock.calls.some(([value]) => value === false)).toBe(true);
+    } finally {
+      taskLoadDeferred.resolve();
+      runtimeRepoCheckDeferred.resolve({ runtimeOk: true });
+      runtimeHealthDeferred.resolve({});
+      branchesDeferred.resolve();
+      await act(async () => {
+        renderer?.unmount();
+      });
+    }
+  });
+});

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -129,20 +129,31 @@ export function useAppLifecycle({
       }),
     );
 
-    Promise.allSettled([
-      (async () => {
-        const beads = await refreshBeadsCheckForRepo(activeRepo, false);
-        if (!beads.beadsOk) {
-          throw new Error(
-            beads.beadsError ?? "Beads store is not initialized for this repository.",
-          );
-        }
+    const taskLoadPromise = (async () => {
+      const beads = await refreshBeadsCheckForRepo(activeRepo, false);
+      if (!beads.beadsOk) {
+        throw new Error(beads.beadsError ?? "Beads store is not initialized for this repository.");
+      }
 
-        await refreshTaskData(activeRepo);
-      })(),
-      refreshRuntimeCheck(false),
-      refreshRepoRuntimeHealthForRepo(activeRepo, false),
-      refreshBranches(false),
+      await refreshTaskData(activeRepo);
+    })();
+    const runtimeCheckPromise = refreshRuntimeCheck(false);
+    const runtimeHealthPromise = refreshRepoRuntimeHealthForRepo(activeRepo, false);
+    const branchesPromise = refreshBranches(false);
+
+    void taskLoadPromise.finally(() => {
+      if (repoLoadVersionRef.current !== loadVersion) {
+        return;
+      }
+
+      setIsLoadingTasks(false);
+    });
+
+    Promise.allSettled([
+      taskLoadPromise,
+      runtimeCheckPromise,
+      runtimeHealthPromise,
+      branchesPromise,
     ])
       .then(([tasksResult, runtimeResult, runtimeHealthResult, branchesResult]) => {
         if (repoLoadVersionRef.current !== loadVersion) {
@@ -190,7 +201,6 @@ export function useAppLifecycle({
           return;
         }
 
-        setIsLoadingTasks(false);
         setIsLoadingChecks(false);
       });
   }, [


### PR DESCRIPTION
## Summary
- fix the Kanban board height so the horizontal scroll region fills the available viewport area
- decouple repo task loading from diagnostics completion and add dedicated board-level loading states
- replace the blocking spinner overlay with animated shadcn skeleton lanes and improve light-theme contrast

## Testing
- bun test apps/desktop/src/pages/kanban/kanban-page-content.test.tsx apps/desktop/src/pages/kanban/kanban-page.test.tsx apps/desktop/src/state/operations/use-task-operations.test.tsx apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint