### PR TITLE
fix: enforce read-only runtime tool blocking

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -923,13 +923,24 @@ pub(crate) fn write_executable_script(path: &Path, script: &str) -> Result<()> {
     }
     let mut file = fs::File::create(path)?;
     file.write_all(script.as_bytes())?;
-    let status = Command::new("chmod")
-        .arg("+x")
-        .arg(path)
-        .status()
-        .map_err(|error| anyhow!("failed running chmod: {error}"))?;
-    if !status.success() {
-        return Err(anyhow!("chmod +x failed for {}", path.display()));
+    file.sync_all()?;
+    drop(file);
+
+    #[cfg(unix)]
+    {
+        fs::set_permissions(path, Permissions::from_mode(0o755))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let status = Command::new("chmod")
+            .arg("+x")
+            .arg(path)
+            .status()
+            .map_err(|error| anyhow!("failed running chmod: {error}"))?;
+        if !status.success() {
+            return Err(anyhow!("chmod +x failed for {}", path.display()));
+        }
     }
     Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/runtime.rs
@@ -32,6 +32,13 @@ impl AgentRuntimeKind {
                 kind: self,
                 label: "OpenCode".to_string(),
                 description: "OpenCode local runtime with OpenDucktor MCP integration.".to_string(),
+                read_only_role_blocked_tools: vec![
+                    "edit".to_string(),
+                    "write".to_string(),
+                    "apply_patch".to_string(),
+                    "ast_grep_replace".to_string(),
+                    "lsp_rename".to_string(),
+                ],
                 capabilities: RuntimeCapabilities {
                     supports_profiles: true,
                     supports_variants: true,
@@ -154,6 +161,7 @@ pub struct RuntimeDescriptor {
     pub kind: AgentRuntimeKind,
     pub label: String,
     pub description: String,
+    pub read_only_role_blocked_tools: Vec<String>,
     pub capabilities: RuntimeCapabilities,
 }
 
@@ -367,6 +375,12 @@ mod tests {
             descriptor.capabilities.supported_scopes,
             REQUIRED_RUNTIME_SUPPORTED_SCOPES.to_vec()
         );
+        assert!(descriptor
+            .read_only_role_blocked_tools
+            .contains(&"apply_patch".to_string()));
+        assert!(!descriptor
+            .read_only_role_blocked_tools
+            .contains(&"bash".to_string()));
         assert!(descriptor.capabilities.supports_all_workflow_scopes());
     }
 
@@ -376,6 +390,7 @@ mod tests {
             kind: AgentRuntimeKind::Opencode,
             label: "OpenCode".to_string(),
             description: "desc".to_string(),
+            read_only_role_blocked_tools: vec![],
             capabilities: RuntimeCapabilities {
                 supports_profiles: true,
                 supports_variants: true,

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -24,9 +24,12 @@ It is the stable definition of a runtime kind:
 - `kind`
 - `label`
 - `description`
+- `readOnlyRoleBlockedTools`
 - `capabilities`
 
 Descriptors are static metadata. They are not live runtime instances.
+
+`readOnlyRoleBlockedTools` is the runtime-owned list of native tool IDs that must be denied for read-only OpenDucktor roles (`spec`, `planner`, `qa`). This list is runtime-specific. OpenDucktor must not hardcode another runtime's tool names in generic orchestration code or in a different runtime adapter.
 
 ### `RuntimeInstanceSummary`
 
@@ -120,6 +123,20 @@ The current codebase treats runtime integration in three layers:
 
 The current schema does not yet model runtime-specific custom slash commands. If that surface is added later, it belongs in the `Optional enhancement` category: the app can function without it, and the UI should treat it as additive capability rather than a baseline runtime requirement.
 
+## Read-Only Tool Policy
+
+Read-only role tool blocking is part of the runtime definition, not the generic role policy.
+
+Rules:
+
+- `AGENT_ROLE_TOOL_POLICY` continues to define which `odt_*` workflow tools each role may call.
+- Each runtime descriptor must declare `readOnlyRoleBlockedTools` for that runtime's native mutating tool IDs.
+- Runtime adapters must consume `readOnlyRoleBlockedTools` both when constructing runtime permission rules and when building the runtime `tools` selection sent on prompt turns for `spec`, `planner`, and `qa`.
+- Do not hardcode OpenCode tool IDs in generic orchestration code or assume another runtime uses the same tool names.
+- Do not block `bash` generically for read-only roles. Read-only roles still need shell access for inspections, tests, and lint commands; mutation control for shell commands remains a runtime/permission-flow concern.
+
+For OpenCode today, the blocked list is sourced from the runtime's native tool inventory and currently includes edit-style tools such as `edit`, `write`, `apply_patch`, `ast_grep_replace`, and `lsp_rename`.
+
 ## Eligibility Model
 
 The current OpenDucktor runtime model expects the following pieces to exist for a runtime integration.
@@ -130,6 +147,7 @@ A runtime is represented through:
 
 - a stable `runtimeKind`,
 - a `RuntimeDescriptor` that describes its implemented capabilities,
+- a runtime-owned `readOnlyRoleBlockedTools` list for native mutating tools,
 - a live `RuntimeRoute` compatible with current host-visible route schemas,
 - a request-scoped `RuntimeConnection`,
 - persisted session records that keep `runtimeKind`, `externalSessionId`, and `workingDirectory`.
@@ -191,6 +209,7 @@ What to add:
 
 - the new `runtimeKind` in any curated constant lists,
 - a descriptor constant whose capabilities describe implemented behavior,
+- a descriptor-level `readOnlyRoleBlockedTools` list for that runtime's native mutating tool IDs,
 - any new route or transport schema support if the runtime is not `local_http`,
 - config/session schema support for runtime-aware model defaults.
 
@@ -203,6 +222,7 @@ Review these files:
 - `packages/core/src/ports/agent-engine.ts`
 - `packages/core/src/services/runtime-connections.ts`
 - `packages/core/src/types/agent-orchestrator.ts`
+- `packages/contracts/src/runtime-descriptors.ts`
 
 The runtime adapter implements the `AgentEnginePort` surface used by session orchestration and workspace inspection, especially:
 
@@ -221,6 +241,7 @@ If a runtime does not implement one of these surfaces, the descriptor and adapte
 Reference implementation:
 
 - `packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts`
+- `packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts`
 
 Related mapping files:
 

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -430,7 +430,37 @@ describe("OpencodeSdkAdapter", () => {
       permission?: Array<{ permission: string; pattern: string; action: string }>;
     };
     const permissionRules = createInput.permission ?? [];
-    expect(permissionRules[0]).toEqual({
+    expect(permissionRules).toContainEqual({
+      permission: "edit",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).toContainEqual({
+      permission: "write",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).toContainEqual({
+      permission: "apply_patch",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).toContainEqual({
+      permission: "ast_grep_replace",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).toContainEqual({
+      permission: "lsp_rename",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).not.toContainEqual({
+      permission: "bash",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).toContainEqual({
       permission: "openducktor_odt_*",
       pattern: "*",
       action: "deny",
@@ -510,6 +540,11 @@ describe("OpencodeSdkAdapter", () => {
       variant: "high",
       agent: "hephaestus",
       tools: {
+        edit: false,
+        write: false,
+        apply_patch: false,
+        ast_grep_replace: false,
+        lsp_rename: false,
         openducktor_odt_read_task: true,
         openducktor_odt_set_spec: true,
         openducktor_odt_set_plan: false,
@@ -521,6 +556,8 @@ describe("OpencodeSdkAdapter", () => {
       },
       parts: [{ type: "text", text: "Write and persist spec" }],
     });
+    expect(mock.tool.idsCalls).toEqual([{ directory: "/repo" }]);
+    expect(mock.mcp.statusCalls).toEqual([{ directory: "/repo" }]);
     expect(events.some((event) => event.type === "assistant_message")).toBe(true);
     const assistantMessage = events.find((event) => event.type === "assistant_message");
     expect(assistantMessage).toMatchObject({
@@ -530,7 +567,7 @@ describe("OpencodeSdkAdapter", () => {
     expect(events.some((event) => event.type === "session_idle")).toBe(true);
   });
 
-  test("sendUserMessage never calls deprecated workflow tool discovery on prompt", async () => {
+  test("sendUserMessage caches workflow tool discovery across prompts for the same model", async () => {
     const mock = makeMockClient({});
     const adapter = new OpencodeSdkAdapter({
       createClient: () => mock.client,
@@ -556,8 +593,8 @@ describe("OpencodeSdkAdapter", () => {
       model: selectedModel,
     });
 
-    expect(mock.tool.idsCalls).toEqual([]);
-    expect(mock.mcp.statusCalls).toEqual([]);
+    expect(mock.tool.idsCalls).toEqual([{ directory: "/repo" }]);
+    expect(mock.mcp.statusCalls).toEqual([{ directory: "/repo" }]);
     expect(mock.session.promptCalls).toHaveLength(2);
   });
 

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -58,6 +58,7 @@ type MockSession = {
 
 type MockTool = {
   idsCalls: unknown[];
+  listCalls: unknown[];
 };
 
 type MockMcp = {
@@ -110,6 +111,7 @@ type MakeMockClientInput = {
   providerResponse?: unknown;
   agentsResponse?: unknown;
   toolIdsResponse?: unknown;
+  modelToolsResponse?: unknown;
   mcpStatusResponse?: unknown;
 };
 
@@ -148,6 +150,7 @@ const makeMockClient = ({
   },
   agentsResponse = [],
   toolIdsResponse = [...DEFAULT_ODT_RUNTIME_TOOL_IDS],
+  modelToolsResponse = [],
   mcpStatusResponse = { openducktor: { status: "connected" } },
 }: MakeMockClientInput): {
   client: OpencodeClient;
@@ -174,6 +177,7 @@ const makeMockClient = ({
   };
   const tool: MockTool = {
     idsCalls: [],
+    listCalls: [],
   };
   const mcp: MockMcp = {
     statusCalls: [],
@@ -297,6 +301,13 @@ const makeMockClient = ({
           error: undefined,
         };
       },
+      list: async (input: unknown) => {
+        tool.listCalls.push(input);
+        return {
+          data: modelToolsResponse,
+          error: undefined,
+        };
+      },
     },
     mcp: {
       status: async (input: unknown) => {
@@ -333,6 +344,12 @@ const startDefaultSession = async (
   adapter: OpencodeSdkAdapter,
   sessionId = "session-1",
   role: "spec" | "planner" | "build" | "qa" = "spec",
+  model?: {
+    providerId: string;
+    modelId: string;
+    variant?: string;
+    profileId?: string;
+  },
 ): Promise<void> => {
   const scenario =
     role === "qa"
@@ -352,6 +369,7 @@ const startDefaultSession = async (
     scenario,
     systemPrompt: "system prompt",
     runtimeConnection: defaultRuntimeConnection,
+    ...(model ? { model } : {}),
   });
 };
 
@@ -430,31 +448,20 @@ describe("OpencodeSdkAdapter", () => {
       permission?: Array<{ permission: string; pattern: string; action: string }>;
     };
     const permissionRules = createInput.permission ?? [];
-    expect(permissionRules).toContainEqual({
-      permission: "edit",
-      pattern: "*",
-      action: "deny",
-    });
-    expect(permissionRules).toContainEqual({
-      permission: "write",
-      pattern: "*",
-      action: "deny",
-    });
-    expect(permissionRules).toContainEqual({
-      permission: "apply_patch",
-      pattern: "*",
-      action: "deny",
-    });
-    expect(permissionRules).toContainEqual({
-      permission: "ast_grep_replace",
-      pattern: "*",
-      action: "deny",
-    });
-    expect(permissionRules).toContainEqual({
-      permission: "lsp_rename",
-      pattern: "*",
-      action: "deny",
-    });
+    const deniedNativeTools = [
+      "edit",
+      "write",
+      "apply_patch",
+      "ast_grep_replace",
+      "lsp_rename",
+    ] as const;
+    for (const toolName of deniedNativeTools) {
+      expect(permissionRules).toContainEqual({
+        permission: toolName,
+        pattern: "*",
+        action: "deny",
+      });
+    }
     expect(permissionRules).not.toContainEqual({
       permission: "bash",
       pattern: "*",
@@ -596,6 +603,47 @@ describe("OpencodeSdkAdapter", () => {
     expect(mock.tool.idsCalls).toEqual([{ directory: "/repo" }]);
     expect(mock.mcp.statusCalls).toEqual([{ directory: "/repo" }]);
     expect(mock.session.promptCalls).toHaveLength(2);
+  });
+
+  test("sendUserMessage falls back to the session model for model-scoped tool discovery", async () => {
+    const mock = makeMockClient({
+      toolIdsResponse: ["bash", "read", "glob"],
+      modelToolsResponse: [{ id: "openducktor_odt_read_task" }, { id: "openducktor_odt_set_spec" }],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    await startDefaultSession(adapter, "session-1", "spec", {
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+    });
+
+    await adapter.sendUserMessage({
+      sessionId: "session-1",
+      content: "Use the saved model",
+    });
+
+    expect(mock.tool.listCalls).toEqual([
+      {
+        directory: "/repo",
+        provider: "openai",
+        model: "gpt-5",
+      },
+    ]);
+    expect(mock.session.promptCalls[0]).toMatchObject({
+      tools: {
+        edit: false,
+        write: false,
+        apply_patch: false,
+        ast_grep_replace: false,
+        lsp_rename: false,
+        openducktor_odt_read_task: true,
+        openducktor_odt_set_spec: true,
+      },
+    });
   });
 
   test("loadSessionHistory preserves message model metadata and maps streamed parts", async () => {

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -1,6 +1,5 @@
 import type {
   AgentEvent,
-  AgentRole,
   AgentSessionHistoryMessage,
   AgentSessionTodoItem,
   AgentStreamPart,
@@ -8,7 +7,6 @@ import type {
   ReplyQuestionInput,
   SendAgentUserMessageInput,
 } from "@openducktor/core";
-import { AGENT_ROLE_TOOL_POLICY, ODT_WORKFLOW_TOOL_NAMES } from "@openducktor/core";
 import { unwrapData } from "./data-utils";
 import {
   extractMessageTotalTokens,
@@ -78,17 +76,6 @@ const normalizeTodoRequestFailure = (
         : {}),
     ...(errorCode ? { code: errorCode } : {}),
   };
-};
-
-const buildRoleScopedPromptToolSelection = (role: AgentRole) => {
-  const allowedTools = new Set(AGENT_ROLE_TOOL_POLICY[role]);
-  const selection: Record<string, boolean> = {};
-
-  for (const tool of ODT_WORKFLOW_TOOL_NAMES) {
-    selection[`openducktor_${tool}`] = allowedTools.has(tool);
-  }
-
-  return selection;
 };
 
 export const loadSessionHistory = async (
@@ -185,12 +172,12 @@ export const loadSessionTodos = async (
 export const sendUserMessage = async (input: {
   session: SessionRecord;
   request: SendAgentUserMessageInput;
+  tools: Record<string, boolean>;
   now: () => string;
   emit: (event: AgentEvent) => void;
 }): Promise<void> => {
   const model = input.request.model ?? input.session.input.model;
   const modelInput = normalizeModelInput(model);
-  const tools = buildRoleScopedPromptToolSelection(input.session.input.role);
 
   const response = await input.session.client.session.prompt({
     sessionID: input.session.externalSessionId,
@@ -201,7 +188,7 @@ export const sendUserMessage = async (input: {
     ...(modelInput.model ? { model: modelInput.model } : {}),
     ...(modelInput.variant ? { variant: modelInput.variant } : {}),
     ...(modelInput.agent ? { agent: modelInput.agent } : {}),
-    tools,
+    tools: input.tools,
     parts: [{ type: "text", text: input.request.content }],
   });
   const responseData = unwrapData(response, "prompt session");

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -61,7 +61,9 @@ import type {
   OpencodeSdkAdapterOptions,
   SessionRecord,
 } from "./types";
-import { buildRoleScopedOdtPermissionRules } from "./workflow-tool-permissions";
+import { WORKFLOW_TOOL_CACHE_TTL_MS } from "./types";
+import { buildRoleScopedPermissionRules } from "./workflow-tool-permissions";
+import { resolveWorkflowToolSelection } from "./workflow-tool-selection";
 
 export class OpencodeSdkAdapter
   implements AgentCatalogPort, AgentSessionPort, AgentWorkspaceInspectionPort
@@ -87,13 +89,17 @@ export class OpencodeSdkAdapter
   }
 
   async startSession(input: StartAgentSessionInput): Promise<AgentSessionSummary> {
+    const runtimeDefinition = this.getRuntimeDefinition();
     const client = this.createClient(
       toRuntimeClientInput(input.runtimeConnection, "start session"),
     );
     const created = await client.session.create({
       directory: input.workingDirectory,
       title: `${input.role.toUpperCase()} ${input.taskId}`,
-      permission: buildRoleScopedOdtPermissionRules(input.role),
+      permission: buildRoleScopedPermissionRules({
+        role: input.role,
+        runtimeDescriptor: runtimeDefinition,
+      }),
     });
     const createdData = unwrapData(created, "create session");
     const externalSessionId = createdData.id;
@@ -211,9 +217,11 @@ export class OpencodeSdkAdapter
 
   async sendUserMessage(input: SendAgentUserMessageInput): Promise<void> {
     const session = requireSession(this.sessions, input.sessionId);
+    const tools = await this.resolveSessionToolSelection(session, input.model);
     await sendUserMessage({
       session,
       request: input,
+      tools,
       now: this.now,
       emit: (event) => this.emit(session.summary.sessionId, event),
     });
@@ -267,5 +275,36 @@ export class OpencodeSdkAdapter
 
   private emit(sessionId: string, event: AgentEvent): void {
     emitSessionEvent(this.listeners, sessionId, event);
+  }
+
+  private async resolveSessionToolSelection(
+    session: SessionRecord,
+    model: SendAgentUserMessageInput["model"],
+  ): Promise<Record<string, boolean>> {
+    const providerId = model?.providerId?.trim() ?? "";
+    const modelId = model?.modelId?.trim() ?? "";
+    const modelKey = providerId && modelId ? `${providerId}/${modelId}` : "";
+    const nowMs = Date.now();
+    if (
+      session.workflowToolSelectionCache &&
+      typeof session.workflowToolSelectionCachedAt === "number" &&
+      nowMs - session.workflowToolSelectionCachedAt < WORKFLOW_TOOL_CACHE_TTL_MS &&
+      (session.workflowToolSelectionCacheModelKey ?? "") === modelKey
+    ) {
+      return session.workflowToolSelectionCache;
+    }
+
+    const selection = await resolveWorkflowToolSelection({
+      client: session.client,
+      role: session.input.role,
+      runtimeDescriptor: this.getRuntimeDefinition(),
+      workingDirectory: session.input.workingDirectory,
+      ...(providerId && modelId ? { model: { providerId, modelId } } : {}),
+    });
+
+    session.workflowToolSelectionCache = selection;
+    session.workflowToolSelectionCachedAt = nowMs;
+    session.workflowToolSelectionCacheModelKey = modelKey;
+    return selection;
   }
 }

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -281,8 +281,9 @@ export class OpencodeSdkAdapter
     session: SessionRecord,
     model: SendAgentUserMessageInput["model"],
   ): Promise<Record<string, boolean>> {
-    const providerId = model?.providerId?.trim() ?? "";
-    const modelId = model?.modelId?.trim() ?? "";
+    const effectiveModel = model ?? session.input.model;
+    const providerId = effectiveModel?.providerId?.trim() ?? "";
+    const modelId = effectiveModel?.modelId?.trim() ?? "";
     const modelKey = providerId && modelId ? `${providerId}/${modelId}` : "";
     const nowMs = Date.now();
     if (

--- a/packages/adapters-opencode-sdk/src/read-only-roles.ts
+++ b/packages/adapters-opencode-sdk/src/read-only-roles.ts
@@ -1,0 +1,5 @@
+import type { AgentRole } from "@openducktor/core";
+
+const READ_ONLY_ROLES = new Set<AgentRole>(["spec", "planner", "qa"]);
+
+export const isReadOnlyRole = (role: AgentRole): boolean => READ_ONLY_ROLES.has(role);

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
@@ -1,12 +1,29 @@
 import { describe, expect, test } from "bun:test";
-import { buildRoleScopedOdtPermissionRules } from "./workflow-tool-permissions";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { buildRoleScopedPermissionRules } from "./workflow-tool-permissions";
 
 describe("workflow-tool-permissions", () => {
-  test("builds deny-first, allow-specific permissions for spec role", () => {
-    const rules = buildRoleScopedOdtPermissionRules("spec");
+  test("builds runtime-provided read-only permission rules plus allow-specific odt permissions for spec role", () => {
+    const rules = buildRoleScopedPermissionRules({
+      role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+    });
 
-    expect(rules[0]).toEqual({ permission: "openducktor_odt_*", pattern: "*", action: "deny" });
-
+    expect(rules).toContainEqual({ permission: "edit", pattern: "*", action: "deny" });
+    expect(rules).toContainEqual({ permission: "write", pattern: "*", action: "deny" });
+    expect(rules).toContainEqual({ permission: "apply_patch", pattern: "*", action: "deny" });
+    expect(rules).toContainEqual({
+      permission: "ast_grep_replace",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(rules).toContainEqual({ permission: "lsp_rename", pattern: "*", action: "deny" });
+    expect(rules).not.toContainEqual({ permission: "bash", pattern: "*", action: "deny" });
+    expect(rules).toContainEqual({
+      permission: "openducktor_odt_*",
+      pattern: "*",
+      action: "deny",
+    });
     expect(rules).toContainEqual({
       permission: "openducktor_odt_read_task",
       pattern: "*",
@@ -19,6 +36,22 @@ describe("workflow-tool-permissions", () => {
     });
     expect(rules).not.toContainEqual({
       permission: "openducktor_odt_set_plan",
+      pattern: "*",
+      action: "allow",
+    });
+  });
+
+  test("does not inject read-only native tool denies for build role", () => {
+    const rules = buildRoleScopedPermissionRules({
+      role: "build",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+    });
+
+    expect(rules).not.toContainEqual({ permission: "edit", pattern: "*", action: "deny" });
+    expect(rules).not.toContainEqual({ permission: "write", pattern: "*", action: "deny" });
+    expect(rules).not.toContainEqual({ permission: "apply_patch", pattern: "*", action: "deny" });
+    expect(rules).toContainEqual({
+      permission: "openducktor_odt_build_completed",
       pattern: "*",
       action: "allow",
     });

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
@@ -9,15 +9,20 @@ describe("workflow-tool-permissions", () => {
       runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
     });
 
-    expect(rules).toContainEqual({ permission: "edit", pattern: "*", action: "deny" });
-    expect(rules).toContainEqual({ permission: "write", pattern: "*", action: "deny" });
-    expect(rules).toContainEqual({ permission: "apply_patch", pattern: "*", action: "deny" });
-    expect(rules).toContainEqual({
-      permission: "ast_grep_replace",
-      pattern: "*",
-      action: "deny",
-    });
-    expect(rules).toContainEqual({ permission: "lsp_rename", pattern: "*", action: "deny" });
+    const deniedNativeTools = [
+      "edit",
+      "write",
+      "apply_patch",
+      "ast_grep_replace",
+      "lsp_rename",
+    ] as const;
+    for (const toolName of deniedNativeTools) {
+      expect(rules).toContainEqual({
+        permission: toolName,
+        pattern: "*",
+        action: "deny",
+      });
+    }
     expect(rules).not.toContainEqual({ permission: "bash", pattern: "*", action: "deny" });
     expect(rules).toContainEqual({
       permission: "openducktor_odt_*",

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
@@ -1,5 +1,6 @@
 import type { RuntimeDescriptor } from "@openducktor/contracts";
 import { AGENT_ROLE_TOOL_POLICY, type AgentRole, ODT_WORKFLOW_TOOL_NAMES } from "@openducktor/core";
+import { isReadOnlyRole } from "./read-only-roles";
 
 type PermissionAction = "allow" | "deny" | "ask";
 
@@ -10,8 +11,6 @@ export type OpencodePermissionRule = {
 };
 
 const ODT_WORKFLOW_PERMISSION_WILDCARD = "openducktor_odt_*";
-const isReadOnlyRole = (role: AgentRole): boolean =>
-  role === "spec" || role === "planner" || role === "qa";
 
 export const buildRoleScopedPermissionRules = (input: {
   role: AgentRole;
@@ -22,17 +21,7 @@ export const buildRoleScopedPermissionRules = (input: {
   const rules: OpencodePermissionRule[] = [];
 
   if (isReadOnlyRole(role)) {
-    // OpenCode's umbrella edit permission governs edit/write/patch-style file mutations.
-    rules.push({
-      permission: "edit",
-      pattern: "*",
-      action: "deny",
-    });
-
     for (const toolId of new Set(runtimeDescriptor.readOnlyRoleBlockedTools)) {
-      if (toolId === "edit") {
-        continue;
-      }
       rules.push({
         permission: toolId,
         pattern: "*",

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
@@ -1,3 +1,4 @@
+import type { RuntimeDescriptor } from "@openducktor/contracts";
 import { AGENT_ROLE_TOOL_POLICY, type AgentRole, ODT_WORKFLOW_TOOL_NAMES } from "@openducktor/core";
 
 type PermissionAction = "allow" | "deny" | "ask";
@@ -9,19 +10,42 @@ export type OpencodePermissionRule = {
 };
 
 const ODT_WORKFLOW_PERMISSION_WILDCARD = "openducktor_odt_*";
+const isReadOnlyRole = (role: AgentRole): boolean =>
+  role === "spec" || role === "planner" || role === "qa";
 
-export const buildRoleScopedOdtPermissionRules = (role: AgentRole): OpencodePermissionRule[] => {
+export const buildRoleScopedPermissionRules = (input: {
+  role: AgentRole;
+  runtimeDescriptor: RuntimeDescriptor;
+}): OpencodePermissionRule[] => {
+  const { role, runtimeDescriptor } = input;
   const allowedTools = new Set(AGENT_ROLE_TOOL_POLICY[role]);
+  const rules: OpencodePermissionRule[] = [];
 
-  // OpenCode permission checks normalize MCP tool IDs to openducktor_odt_*.
-  // Keep a single namespace to avoid redundant aliases and drift.
-  const rules: OpencodePermissionRule[] = [
-    {
-      permission: ODT_WORKFLOW_PERMISSION_WILDCARD,
+  if (isReadOnlyRole(role)) {
+    // OpenCode's umbrella edit permission governs edit/write/patch-style file mutations.
+    rules.push({
+      permission: "edit",
       pattern: "*",
       action: "deny",
-    },
-  ];
+    });
+
+    for (const toolId of new Set(runtimeDescriptor.readOnlyRoleBlockedTools)) {
+      if (toolId === "edit") {
+        continue;
+      }
+      rules.push({
+        permission: toolId,
+        pattern: "*",
+        action: "deny",
+      });
+    }
+  }
+
+  rules.push({
+    permission: ODT_WORKFLOW_PERMISSION_WILDCARD,
+    pattern: "*",
+    action: "deny",
+  });
 
   for (const toolName of ODT_WORKFLOW_TOOL_NAMES) {
     if (!allowedTools.has(toolName)) {

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { resolveWorkflowToolSelection } from "./workflow-tool-selection";
 
 const makeClient = (input: {
@@ -56,6 +57,7 @@ describe("workflow-tool-selection", () => {
         ],
       }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
     });
 
@@ -77,6 +79,7 @@ describe("workflow-tool-selection", () => {
         ],
       }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
     });
 
@@ -94,6 +97,7 @@ describe("workflow-tool-selection", () => {
         toolIds: ["odt_read_task", "odt_set_spec", "odt_set_plan"],
       }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
     });
 
@@ -113,6 +117,7 @@ describe("workflow-tool-selection", () => {
         ],
       }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
       model: {
         providerId: "openai",
@@ -132,6 +137,7 @@ describe("workflow-tool-selection", () => {
     const selection = await resolveWorkflowToolSelection({
       client: makeClient({ throwOnIds: true }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
     }).catch((error: unknown) => error);
 
@@ -146,6 +152,7 @@ describe("workflow-tool-selection", () => {
         throwOnList: true,
       }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
       model: {
         providerId: "openai",
@@ -164,6 +171,7 @@ describe("workflow-tool-selection", () => {
         mcpStatusResponse: { openducktor: { status: "failed", error: "connection closed" } },
       }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
     }).catch((error: unknown) => error);
 
@@ -179,6 +187,7 @@ describe("workflow-tool-selection", () => {
         throwOnMcpStatus: true,
       }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
     }).catch((error: unknown) => error);
 
@@ -192,6 +201,7 @@ describe("workflow-tool-selection", () => {
         toolIds: ["odt_read_task", "odt_set_plan"],
       }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
     });
 
@@ -212,6 +222,7 @@ describe("workflow-tool-selection", () => {
         ],
       }),
       role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
       workingDirectory: "/repo",
     });
 
@@ -220,5 +231,8 @@ describe("workflow-tool-selection", () => {
     expect(selection.openducktor_odt_set_spec_extra).toBeUndefined();
     expect(selection.customprefix_odt_set_plan).toBeUndefined();
     expect(selection.OpenDucktor_ODT_SET_SPEC).toBeUndefined();
+    expect(selection.edit).toBe(false);
+    expect(selection.apply_patch).toBe(false);
+    expect(selection.bash).toBeUndefined();
   });
 });

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
@@ -1,4 +1,5 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import type { RuntimeDescriptor } from "@openducktor/contracts";
 import { type AgentRole, buildRoleScopedOdtToolSelection } from "@openducktor/core";
 import { unwrapData } from "./data-utils";
 import { asUnknownRecord, readStringProp } from "./guards";
@@ -11,6 +12,9 @@ type ModelScopedToolInput = {
   providerId: string;
   modelId: string;
 };
+
+const isReadOnlyRole = (role: AgentRole): boolean =>
+  role === "spec" || role === "planner" || role === "qa";
 
 const assertTrustedOdtMcpServerConnected = async (input: {
   client: OpencodeClient;
@@ -117,6 +121,7 @@ const listModelScopedToolIds = async (input: {
 export const resolveWorkflowToolSelection = async (input: {
   client: OpencodeClient;
   role: AgentRole;
+  runtimeDescriptor: RuntimeDescriptor;
   workingDirectory: string;
   model?: ModelScopedToolInput;
 }): Promise<Record<string, boolean>> => {
@@ -144,6 +149,12 @@ export const resolveWorkflowToolSelection = async (input: {
     includeCanonicalDefaults: true,
     runtimeToolIds,
   });
+
+  if (isReadOnlyRole(input.role)) {
+    for (const toolId of input.runtimeDescriptor.readOnlyRoleBlockedTools) {
+      selection[toolId] = false;
+    }
+  }
 
   return selection;
 };

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
@@ -4,6 +4,7 @@ import { type AgentRole, buildRoleScopedOdtToolSelection } from "@openducktor/co
 import { unwrapData } from "./data-utils";
 import { asUnknownRecord, readStringProp } from "./guards";
 import { toToolIdList } from "./payload-mappers";
+import { isReadOnlyRole } from "./read-only-roles";
 
 const TRUSTED_ODT_MCP_SERVER_NAME = "openducktor";
 const CONNECTED_MCP_SERVER_STATUSES = new Set(["connected"]);
@@ -12,9 +13,6 @@ type ModelScopedToolInput = {
   providerId: string;
   modelId: string;
 };
-
-const isReadOnlyRole = (role: AgentRole): boolean =>
-  role === "spec" || role === "planner" || role === "qa";
 
 const assertTrustedOdtMcpServerConnected = async (input: {
   client: OpencodeClient;

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -832,6 +832,13 @@ describe("TauriHostClient", () => {
             kind: "opencode",
             label: "OpenCode",
             description: "OpenCode local runtime with OpenDucktor MCP integration.",
+            readOnlyRoleBlockedTools: [
+              "edit",
+              "write",
+              "apply_patch",
+              "ast_grep_replace",
+              "lsp_rename",
+            ],
             capabilities: {
               supportsProfiles: true,
               supportsVariants: true,

--- a/packages/contracts/src/agent-runtime-schemas.ts
+++ b/packages/contracts/src/agent-runtime-schemas.ts
@@ -107,10 +107,18 @@ export const runtimeRefSchema = z.object({
 });
 export type RuntimeRef = z.infer<typeof runtimeRefSchema>;
 
+const runtimeToolIdSchema = z.string().trim().min(1);
+const runtimeReadOnlyRoleBlockedToolsSchema = z
+  .array(runtimeToolIdSchema)
+  .refine((toolIds) => new Set(toolIds).size === toolIds.length, {
+    message: "Read-only blocked runtime tool IDs must be unique.",
+  });
+
 export const runtimeDescriptorSchema = z.object({
   kind: runtimeKindSchema,
   label: z.string().min(1),
   description: z.string().min(1),
+  readOnlyRoleBlockedTools: runtimeReadOnlyRoleBlockedToolsSchema,
   capabilities: runtimeCapabilitiesSchema,
 });
 export type RuntimeDescriptor = z.infer<typeof runtimeDescriptorSchema>;

--- a/packages/contracts/src/runtime-descriptors.ts
+++ b/packages/contracts/src/runtime-descriptors.ts
@@ -4,6 +4,14 @@ import {
   requiredRuntimeSupportedScopes,
 } from "./agent-runtime-schemas";
 
+const OPENCODE_READ_ONLY_ROLE_BLOCKED_TOOLS = [
+  "edit",
+  "write",
+  "apply_patch",
+  "ast_grep_replace",
+  "lsp_rename",
+] as const;
+
 export const OPENCODE_RUNTIME_CAPABILITIES = {
   supportsProfiles: true,
   supportsVariants: true,
@@ -22,5 +30,6 @@ export const OPENCODE_RUNTIME_DESCRIPTOR = {
   kind: "opencode",
   label: "OpenCode",
   description: "OpenCode local runtime with OpenDucktor MCP integration.",
+  readOnlyRoleBlockedTools: [...OPENCODE_READ_ONLY_ROLE_BLOCKED_TOOLS],
   capabilities: OPENCODE_RUNTIME_CAPABILITIES,
 } as const satisfies RuntimeDescriptor;

--- a/packages/contracts/src/runtime-schemas.test.ts
+++ b/packages/contracts/src/runtime-schemas.test.ts
@@ -506,6 +506,8 @@ describe("runtime schemas", () => {
 
     expect(parsed.runtimeId).toBe("runtime-1");
     expect(parsed.runtimeRoute.endpoint).toBe("http://127.0.0.1:4100");
+    expect(parsed.descriptor.readOnlyRoleBlockedTools).toContain("apply_patch");
+    expect(parsed.descriptor.readOnlyRoleBlockedTools).not.toContain("bash");
   });
 
   test("agent runtime role schemas and qa review target schema enforce boundaries", () => {


### PR DESCRIPTION
## Summary
- add a runtime-owned `readOnlyRoleBlockedTools` contract and mirror it in the Rust runtime descriptor
- apply read-only tool blocking on the actual OpenCode prompt tool-selection path while keeping `bash` available
- update runtime integration docs and add regression coverage for runtime descriptors, adapter permissions, and prompt tool selection

## Verification
- bun test packages/contracts/src/runtime-schemas.test.ts packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts packages/adapters-opencode-sdk/src/index.test.ts packages/adapters-tauri-host/src/index.test.ts apps/desktop/src/lib/agent-runtime.test.ts
- bun run --filter @openducktor/contracts typecheck
- bun run --filter @openducktor/adapters-opencode-sdk typecheck
- bun run --filter @openducktor/adapters-opencode-sdk lint
- bun run --filter @openducktor/adapters-tauri-host typecheck
- bun run --filter @openducktor/desktop typecheck
- cd apps/desktop/src-tauri && cargo test -p host-domain