### PR TITLE
fix: tighten human review workflows

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/qa_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/qa_service.rs
@@ -48,9 +48,12 @@ impl AppService {
         verdict: QaVerdict,
     ) -> Result<TaskCard> {
         let mut context = self.load_task_context(repo_path, task_id)?;
-        if context.task.status != TaskStatus::AiReview {
+        if !matches!(
+            context.task.status,
+            TaskStatus::AiReview | TaskStatus::HumanReview
+        ) {
             return Err(anyhow!(
-                "QA outcomes are only allowed from ai_review (current: {}).",
+                "QA outcomes are only allowed from ai_review or human_review (current: {}).",
                 context.task.status.as_cli_value()
             ));
         }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -5,7 +5,8 @@ use crate::app_service::workflow_rules::{
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentSessionDocument, CreateTaskInput, TaskCard, TaskMetadata, TaskStatus, UpdateTaskPatch,
+    AgentSessionDocument, CreateTaskInput, QaWorkflowVerdict, TaskCard, TaskMetadata, TaskStatus,
+    UpdateTaskPatch,
 };
 use std::collections::HashSet;
 use std::fs;
@@ -218,7 +219,9 @@ impl AppService {
         _summary: Option<&str>,
     ) -> Result<TaskCard> {
         let context = self.load_task_context(repo_path, task_id)?;
-        let next_status = if context.task.ai_review_enabled {
+        let should_return_to_ai_review = context.task.ai_review_enabled
+            && context.task.document_summary.qa_report.verdict != QaWorkflowVerdict::Approved;
+        let next_status = if should_return_to_ai_review {
             TaskStatus::AiReview
         } else {
             TaskStatus::HumanReview

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -3,8 +3,8 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentSessionDocument, CreateTaskInput, GitBranch, GitCurrentBranch, GitPort, IssueType,
-    PlanSubtaskInput, QaReportDocument, QaVerdict, RunEvent, RunState, RunSummary,
-    RuntimeInstanceSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
+    PlanSubtaskInput, QaReportDocument, QaVerdict, QaWorkflowVerdict, RunEvent, RunState,
+    RunSummary, RuntimeInstanceSummary, TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
@@ -579,6 +579,7 @@ fn build_resumed_human_actions_and_resume_deferred_paths_work() -> Result<()> {
             make_task("task-blocked", "task", TaskStatus::Blocked),
             make_task("task-human-review", "task", TaskStatus::HumanReview),
             make_task("task-approve", "task", TaskStatus::HumanReview),
+            make_task("task-ai-approve", "task", TaskStatus::AiReview),
             deferred,
         ],
         vec![],
@@ -597,6 +598,9 @@ fn build_resumed_human_actions_and_resume_deferred_paths_work() -> Result<()> {
 
     let approved = service.human_approve(repo_path, "task-approve")?;
     assert_eq!(approved.status, TaskStatus::Closed);
+
+    let ai_review_approved = service.human_approve(repo_path, "task-ai-approve")?;
+    assert_eq!(ai_review_approved.status, TaskStatus::Closed);
 
     let resumed_deferred = service.task_resume_deferred(repo_path, "task-deferred")?;
     assert_eq!(resumed_deferred.status, TaskStatus::Open);
@@ -727,10 +731,13 @@ fn task_transition_updates_status_when_valid() -> Result<()> {
 }
 
 #[test]
-fn build_completed_routes_to_ai_review_when_enabled() -> Result<()> {
+fn build_completed_routes_to_ai_review_when_enabled_without_approved_qa() -> Result<()> {
     let repo_path = "/tmp/odt-repo-build-ai";
+    let mut task = make_task("task-1", "task", TaskStatus::InProgress);
+    task.document_summary.qa_report.has = false;
+    task.document_summary.qa_report.verdict = QaWorkflowVerdict::NotReviewed;
     let (service, task_state, _git_state) = build_service_with_git_state(
-        vec![make_task("task-1", "task", TaskStatus::InProgress)],
+        vec![task],
         vec![],
         GitCurrentBranch {
             name: Some("main".to_string()),
@@ -755,6 +762,34 @@ fn build_completed_routes_to_human_review_when_ai_is_disabled() -> Result<()> {
     let repo_path = "/tmp/odt-repo-build-human";
     let mut task = make_task("task-1", "task", TaskStatus::InProgress);
     task.ai_review_enabled = false;
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+
+    let task = service.build_completed(repo_path, "task-1", None)?;
+    assert_eq!(task.status, TaskStatus::HumanReview);
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert!(task_state
+        .updated_patches
+        .iter()
+        .any(|(_, patch)| patch.status == Some(TaskStatus::HumanReview)));
+    Ok(())
+}
+
+#[test]
+fn build_completed_routes_to_human_review_when_last_qa_was_approved() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-build-human-approved-qa";
+    let mut task = make_task("task-1", "task", TaskStatus::InProgress);
+    task.ai_review_enabled = true;
+    task.document_summary.qa_report.has = true;
+    task.document_summary.qa_report.verdict = QaWorkflowVerdict::Approved;
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![task],
         vec![],
@@ -1243,6 +1278,35 @@ fn qa_approved_appends_report_and_transitions_to_human_review() -> Result<()> {
 }
 
 #[test]
+fn qa_approved_from_human_review_stays_in_human_review() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-qa-approved-human-review";
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+
+    let task = service.qa_approved(repo_path, "task-1", "Looks good again")?;
+    assert_eq!(task.status, TaskStatus::HumanReview);
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert_eq!(
+        task_state.qa_outcome_calls,
+        vec![(
+            "task-1".to_string(),
+            TaskStatus::HumanReview,
+            "Looks good again".to_string(),
+            QaVerdict::Approved
+        )]
+    );
+    Ok(())
+}
+
+#[test]
 fn qa_approved_rejects_non_ai_review_tasks() {
     let repo_path = "/tmp/odt-repo-qa-approved-invalid";
     let (service, _task_state, _git_state) = build_service_with_git_state(
@@ -1261,7 +1325,7 @@ fn qa_approved_rejects_non_ai_review_tasks() {
 
     assert!(error
         .to_string()
-        .contains("QA outcomes are only allowed from ai_review"));
+        .contains("QA outcomes are only allowed from ai_review or human_review"));
 }
 
 #[test]
@@ -1295,6 +1359,35 @@ fn qa_rejected_appends_report_and_transitions_to_in_progress() -> Result<()> {
 }
 
 #[test]
+fn qa_rejected_from_human_review_transitions_to_in_progress() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-qa-rejected-human-review";
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+
+    let task = service.qa_rejected(repo_path, "task-1", "Needs another pass")?;
+    assert_eq!(task.status, TaskStatus::InProgress);
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert_eq!(
+        task_state.qa_outcome_calls,
+        vec![(
+            "task-1".to_string(),
+            TaskStatus::InProgress,
+            "Needs another pass".to_string(),
+            QaVerdict::Rejected
+        )]
+    );
+    Ok(())
+}
+
+#[test]
 fn qa_rejected_rejects_non_ai_review_tasks() {
     let repo_path = "/tmp/odt-repo-qa-rejected-invalid";
     let (service, _task_state, _git_state) = build_service_with_git_state(
@@ -1313,7 +1406,7 @@ fn qa_rejected_rejects_non_ai_review_tasks() {
 
     assert!(error
         .to_string()
-        .contains("QA outcomes are only allowed from ai_review"));
+        .contains("QA outcomes are only allowed from ai_review or human_review"));
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -332,12 +332,23 @@ fn qa_rejected_in_progress_tasks_expose_rework_and_open_qa_actions() {
 }
 
 #[test]
-fn ai_review_tasks_expose_qa_start_and_hide_build_start() {
+fn ai_review_tasks_expose_qa_start_request_changes_approve_and_hide_build_start() {
     let task = make_task("task-1", "task", TaskStatus::AiReview);
     let actions = derive_available_actions(&task, std::slice::from_ref(&task));
     assert!(actions.contains(&TaskAction::QaStart));
+    assert!(actions.contains(&TaskAction::HumanRequestChanges));
+    assert!(actions.contains(&TaskAction::HumanApprove));
     assert!(!actions.contains(&TaskAction::BuildStart));
     assert!(actions.contains(&TaskAction::OpenBuilder));
+}
+
+#[test]
+fn human_review_tasks_expose_qa_start_and_request_changes() {
+    let task = make_task("task-1", "task", TaskStatus::HumanReview);
+    let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+    assert!(actions.contains(&TaskAction::QaStart));
+    assert!(actions.contains(&TaskAction::HumanRequestChanges));
+    assert!(actions.contains(&TaskAction::HumanApprove));
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
@@ -46,13 +46,15 @@ fn module_derive_available_actions_exposes_resume_for_deferred_task() {
 }
 
 #[test]
-fn module_derive_available_actions_exposes_qa_start_for_ai_review() {
-    let task = make_task("task-1", "task", TaskStatus::AiReview);
+fn module_derive_available_actions_exposes_qa_start_for_review_states() {
+    for status in [TaskStatus::AiReview, TaskStatus::HumanReview] {
+        let task = make_task("task-1", "task", status);
 
-    let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+        let actions = derive_available_actions(&task, std::slice::from_ref(&task));
 
-    assert!(actions.contains(&TaskAction::QaStart));
-    assert!(!actions.contains(&TaskAction::BuildStart));
+        assert!(actions.contains(&TaskAction::QaStart));
+        assert!(!actions.contains(&TaskAction::BuildStart));
+    }
 }
 
 #[test]
@@ -66,6 +68,38 @@ fn module_derive_available_actions_exposes_rework_and_open_qa_for_qa_rejected_ta
     assert!(actions.contains(&TaskAction::BuildStart));
     assert!(actions.contains(&TaskAction::OpenBuilder));
     assert!(actions.contains(&TaskAction::OpenQa));
+}
+
+#[test]
+fn module_derive_available_actions_exposes_human_review_actions_only_during_human_review() {
+    let task = make_task("task-1", "task", TaskStatus::HumanReview);
+
+    let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+
+    assert!(actions.contains(&TaskAction::QaStart));
+    assert!(actions.contains(&TaskAction::HumanRequestChanges));
+    assert!(actions.contains(&TaskAction::HumanApprove));
+}
+
+#[test]
+fn module_derive_available_actions_exposes_review_actions_during_ai_review() {
+    let task = make_task("task-1", "task", TaskStatus::AiReview);
+
+    let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+
+    assert!(actions.contains(&TaskAction::QaStart));
+    assert!(actions.contains(&TaskAction::HumanRequestChanges));
+    assert!(actions.contains(&TaskAction::HumanApprove));
+}
+
+#[test]
+fn module_derive_available_actions_hides_human_approve_for_closed_tasks() {
+    let task = make_task("task-1", "task", TaskStatus::Closed);
+
+    let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+
+    assert!(!actions.contains(&TaskAction::HumanRequestChanges));
+    assert!(!actions.contains(&TaskAction::HumanApprove));
 }
 
 #[test]
@@ -169,6 +203,10 @@ fn module_derive_agent_workflows_qa_flags_and_completion_follow_payload() {
     assert!(!optional.qa.required);
     assert!(optional.qa.can_skip);
     assert!(optional.qa.available);
+
+    task.status = TaskStatus::HumanReview;
+    let human_review = derive_agent_workflows(&task);
+    assert!(human_review.qa.available);
 
     task.document_summary.qa_report.verdict = QaWorkflowVerdict::Rejected;
     let rejected = derive_agent_workflows(&task);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
@@ -71,25 +71,16 @@ fn module_derive_available_actions_exposes_rework_and_open_qa_for_qa_rejected_ta
 }
 
 #[test]
-fn module_derive_available_actions_exposes_human_review_actions_only_during_human_review() {
-    let task = make_task("task-1", "task", TaskStatus::HumanReview);
+fn module_derive_available_actions_exposes_review_actions_during_review_states() {
+    for status in [TaskStatus::AiReview, TaskStatus::HumanReview] {
+        let task = make_task("task-1", "task", status);
 
-    let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+        let actions = derive_available_actions(&task, std::slice::from_ref(&task));
 
-    assert!(actions.contains(&TaskAction::QaStart));
-    assert!(actions.contains(&TaskAction::HumanRequestChanges));
-    assert!(actions.contains(&TaskAction::HumanApprove));
-}
-
-#[test]
-fn module_derive_available_actions_exposes_review_actions_during_ai_review() {
-    let task = make_task("task-1", "task", TaskStatus::AiReview);
-
-    let actions = derive_available_actions(&task, std::slice::from_ref(&task));
-
-    assert!(actions.contains(&TaskAction::QaStart));
-    assert!(actions.contains(&TaskAction::HumanRequestChanges));
-    assert!(actions.contains(&TaskAction::HumanApprove));
+        assert!(actions.contains(&TaskAction::QaStart));
+        assert!(actions.contains(&TaskAction::HumanRequestChanges));
+        assert!(actions.contains(&TaskAction::HumanApprove));
+    }
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/transitions.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/transitions.rs
@@ -68,7 +68,7 @@ pub(crate) fn derive_agent_workflows(task: &TaskCard) -> AgentWorkflows {
     let qa_available = if is_closed {
         false
     } else {
-        task.status == TaskStatus::AiReview
+        matches!(task.status, TaskStatus::AiReview | TaskStatus::HumanReview)
     };
     let qa_completed = task.document_summary.qa_report.verdict == QaWorkflowVerdict::Approved;
 
@@ -143,7 +143,10 @@ pub(crate) fn allows_transition(task: &TaskCard, from: &TaskStatus, to: &TaskSta
         TaskStatus::Blocked => matches!(to, TaskStatus::InProgress | TaskStatus::Deferred),
         TaskStatus::AiReview => matches!(
             to,
-            TaskStatus::InProgress | TaskStatus::HumanReview | TaskStatus::Deferred
+            TaskStatus::InProgress
+                | TaskStatus::HumanReview
+                | TaskStatus::Closed
+                | TaskStatus::Deferred
         ),
         TaskStatus::HumanReview => matches!(
             to,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/validators.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/validators.rs
@@ -151,7 +151,7 @@ pub(crate) fn derive_available_actions(task: &TaskCard, all_tasks: &[TaskCard]) 
         actions.push(TaskAction::SetPlan);
     }
 
-    if task.status == TaskStatus::AiReview {
+    if matches!(task.status, TaskStatus::AiReview | TaskStatus::HumanReview) {
         actions.push(TaskAction::QaStart);
     } else if is_qa_rejected_rework(task)
         || (!matches!(task.status, TaskStatus::InProgress | TaskStatus::Blocked)
@@ -162,7 +162,10 @@ pub(crate) fn derive_available_actions(task: &TaskCard, all_tasks: &[TaskCard]) 
 
     if matches!(
         task.status,
-        TaskStatus::InProgress | TaskStatus::Blocked | TaskStatus::AiReview | TaskStatus::HumanReview
+        TaskStatus::InProgress
+            | TaskStatus::Blocked
+            | TaskStatus::AiReview
+            | TaskStatus::HumanReview
     ) {
         actions.push(TaskAction::OpenBuilder);
     }
@@ -179,11 +182,13 @@ pub(crate) fn derive_available_actions(task: &TaskCard, all_tasks: &[TaskCard]) 
         }
     }
 
-    if task.status == TaskStatus::HumanReview {
+    if matches!(task.status, TaskStatus::AiReview | TaskStatus::HumanReview) {
         actions.push(TaskAction::HumanRequestChanges);
     }
 
-    if validate_transition(task, all_tasks, &task.status, &TaskStatus::Closed).is_ok() {
+    if matches!(task.status, TaskStatus::AiReview | TaskStatus::HumanReview)
+        && validate_transition(task, all_tasks, &task.status, &TaskStatus::Closed).is_ok()
+    {
         actions.push(TaskAction::HumanApprove);
     }
 

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
@@ -8,7 +8,10 @@ import {
   QaRejectedBadge,
   RunStateBadge,
 } from "@/components/features/kanban/kanban-task-badges";
-import type { TaskWorkflowAction } from "@/components/features/kanban/kanban-task-workflow";
+import {
+  resolveTaskCardActions,
+  type TaskWorkflowAction,
+} from "@/components/features/kanban/kanban-task-workflow";
 import { TaskWorkflowActionGroup } from "@/components/features/kanban/task-workflow-action-group";
 import { Badge } from "@/components/ui/badge";
 import { BorderRay } from "@/components/ui/border-ray";
@@ -219,6 +222,22 @@ function TaskActions({
   onHumanApprove?: (taskId: string) => void;
   onHumanRequestChanges?: (taskId: string) => void;
 }): ReactElement {
+  const includeActions: readonly TaskWorkflowAction[] = [
+    "set_spec",
+    "set_plan",
+    "qa_start",
+    "build_start",
+    "open_builder",
+    "open_qa",
+    "human_approve",
+    "human_request_changes",
+  ];
+  const workflowActions = resolveTaskCardActions(task, { include: includeActions });
+
+  if (workflowActions.allActions.length === 0) {
+    return <></>;
+  }
+
   const runAction = (action: TaskWorkflowAction): void => {
     switch (action) {
       case "set_spec":
@@ -252,16 +271,7 @@ function TaskActions({
     <div className="mt-3 cursor-default border-t border-border pt-2.5">
       <TaskWorkflowActionGroup
         task={task}
-        includeActions={[
-          "set_spec",
-          "set_plan",
-          "qa_start",
-          "build_start",
-          "open_builder",
-          "open_qa",
-          "human_approve",
-          "human_request_changes",
-        ]}
+        includeActions={includeActions}
         onAction={runAction}
         size="sm"
         expandPrimary

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
@@ -221,7 +221,7 @@ function TaskActions({
   onDelegate: (taskId: string) => void;
   onHumanApprove?: (taskId: string) => void;
   onHumanRequestChanges?: (taskId: string) => void;
-}): ReactElement {
+}): ReactElement | null {
   const includeActions: readonly TaskWorkflowAction[] = [
     "set_spec",
     "set_plan",
@@ -235,7 +235,7 @@ function TaskActions({
   const workflowActions = resolveTaskCardActions(task, { include: includeActions });
 
   if (workflowActions.allActions.length === 0) {
-    return <></>;
+    return null;
   }
 
   const runAction = (action: TaskWorkflowAction): void => {

--- a/apps/desktop/src/components/features/kanban/kanban-task-workflow.test.ts
+++ b/apps/desktop/src/components/features/kanban/kanban-task-workflow.test.ts
@@ -88,16 +88,21 @@ describe("resolveTaskCardActions", () => {
     expect(result.primaryAction).toBe("open_builder");
   });
 
-  test("uses qa_start as primary during ai review", () => {
+  test("uses qa_start as primary during ai review when available", () => {
     const task = createTaskCardFixture({
       status: "ai_review",
       issueType: "epic",
-      availableActions: ["open_builder", "qa_start"],
+      availableActions: ["open_builder", "qa_start", "human_request_changes", "human_approve"],
     });
 
     const result = resolveTaskCardActions(task);
 
     expect(result.primaryAction).toBe("qa_start");
+    expect(result.secondaryActions).toEqual([
+      "human_approve",
+      "human_request_changes",
+      "open_builder",
+    ]);
   });
 
   test("uses build_start as primary for qa rejected in-progress tasks", () => {
@@ -122,12 +127,26 @@ describe("resolveTaskCardActions", () => {
     const task = createTaskCardFixture({
       status: "human_review",
       issueType: "epic",
-      availableActions: ["open_builder", "human_request_changes", "human_approve"],
+      availableActions: ["open_builder", "qa_start", "human_request_changes", "human_approve"],
     });
 
     const result = resolveTaskCardActions(task);
 
     expect(result.primaryAction).toBe("human_approve");
+    expect(result.secondaryActions).toContain("qa_start");
+  });
+
+  test("filters build_start from human review actions", () => {
+    const task = createTaskCardFixture({
+      status: "human_review",
+      issueType: "feature",
+      availableActions: ["human_approve", "human_request_changes", "open_builder", "build_start"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.allActions).toEqual(["human_approve", "human_request_changes", "open_builder"]);
+    expect(result.secondaryActions).not.toContain("build_start");
   });
 
   test("uses resume as primary for deferred tasks", () => {

--- a/apps/desktop/src/components/features/kanban/kanban-task-workflow.ts
+++ b/apps/desktop/src/components/features/kanban/kanban-task-workflow.ts
@@ -13,6 +13,24 @@ type ResolveTaskCardActionsOptions = {
   include?: readonly TaskWorkflowAction[];
 };
 
+const filterEnabledActions = (
+  task: TaskCard,
+  options: ResolveTaskCardActionsOptions,
+): TaskWorkflowAction[] => {
+  const includeSet = options.include ? new Set(options.include) : null;
+  const enabled = dedupeActions(
+    task.availableActions
+      .filter(isWorkflowAction)
+      .filter((action) => (includeSet ? includeSet.has(action) : true)),
+  );
+
+  if (task.status === "human_review") {
+    return enabled.filter((action) => action !== "build_start");
+  }
+
+  return enabled;
+};
+
 const ACTION_PRIORITY_BY_ISSUE_TYPE: Record<TaskCard["issueType"], TaskWorkflowAction[]> = {
   epic: [
     "set_spec",
@@ -102,12 +120,18 @@ const resolvePriorityForTask = (task: TaskCard): TaskWorkflowAction[] => {
       return prioritize(basePriority, ["open_builder", "build_start"]);
     }
     case "ai_review": {
-      return prioritize(basePriority, ["qa_start", "open_builder"]);
+      return prioritize(basePriority, [
+        "qa_start",
+        "human_approve",
+        "human_request_changes",
+        "open_builder",
+      ]);
     }
     case "human_review": {
       return prioritize(basePriority, [
         "human_approve",
         "human_request_changes",
+        "qa_start",
         "open_builder",
         "build_start",
       ]);
@@ -122,12 +146,7 @@ export const resolveTaskCardActions = (
   task: TaskCard,
   options: ResolveTaskCardActionsOptions = {},
 ): TaskCardActionState => {
-  const includeSet = options.include ? new Set(options.include) : null;
-  const enabled = dedupeActions(
-    task.availableActions
-      .filter(isWorkflowAction)
-      .filter((action) => (includeSet ? includeSet.has(action) : true)),
-  );
+  const enabled = filterEnabledActions(task, options);
   const priority = resolvePriorityForTask(task);
   const orderedEnabled = [
     ...priority.filter((action) => enabled.includes(action)),

--- a/apps/desktop/src/components/features/kanban/task-action-ui.test.ts
+++ b/apps/desktop/src/components/features/kanban/task-action-ui.test.ts
@@ -14,7 +14,7 @@ describe("taskActionLabel", () => {
     });
 
     expect(taskActionLabel("build_start", task)).toBe("Start Builder");
-    expect(taskActionLabel("qa_start", task)).toBe("Start QA");
+    expect(taskActionLabel("qa_start", task)).toBe("Request QA Review");
     expect(taskActionLabel("open_builder", task)).toBe("Open Builder");
     expect(taskActionLabel("defer_issue", task)).toBe("Defer Task");
     expect(taskActionLabel("resume_deferred", task)).toBe("Resume Task");
@@ -46,5 +46,31 @@ describe("taskActionLabel", () => {
 
     expect(taskActionLabel("build_start", task)).toBe("Address QA Feedbacks");
     expect(taskActionLabel("open_qa", task)).toBe("Open QA");
+  });
+
+  test("uses request wording for qa action during human review", () => {
+    const task = createTaskCardFixture({
+      status: "human_review",
+      documentSummary: {
+        spec: { has: false, updatedAt: undefined },
+        plan: { has: false, updatedAt: undefined },
+        qaReport: { has: true, updatedAt: "2026-03-09T10:00:00.000Z", verdict: "approved" },
+      },
+    });
+
+    expect(taskActionLabel("qa_start", task)).toBe("Request QA Review");
+  });
+
+  test("uses request wording for qa action during ai review", () => {
+    const task = createTaskCardFixture({
+      status: "ai_review",
+      documentSummary: {
+        spec: { has: false, updatedAt: undefined },
+        plan: { has: false, updatedAt: undefined },
+        qaReport: { has: false, updatedAt: undefined, verdict: "not_reviewed" },
+      },
+    });
+
+    expect(taskActionLabel("qa_start", task)).toBe("Request QA Review");
   });
 });

--- a/apps/desktop/src/components/features/kanban/task-action-ui.tsx
+++ b/apps/desktop/src/components/features/kanban/task-action-ui.tsx
@@ -31,7 +31,7 @@ export const taskActionLabel = (action: TaskWorkflowAction, task: TaskCard): str
     return isQaRejectedTask(task) ? "Address QA Feedbacks" : "Start Builder";
   }
   if (action === "qa_start") {
-    return "Start QA";
+    return "Request QA Review";
   }
   if (action === "human_approve") {
     return "Approve Task";

--- a/apps/desktop/src/components/features/kanban/task-workflow-action-group.tsx
+++ b/apps/desktop/src/components/features/kanban/task-workflow-action-group.tsx
@@ -28,6 +28,7 @@ type TaskWorkflowActionGroupProps = {
   expandPrimary?: boolean;
   compactMenuTrigger?: boolean;
   emptyLabel?: string;
+  hideWhenEmpty?: boolean;
 };
 
 export function TaskWorkflowActionGroup({
@@ -42,7 +43,8 @@ export function TaskWorkflowActionGroup({
   expandPrimary = false,
   compactMenuTrigger = false,
   emptyLabel = "No workflow action",
-}: TaskWorkflowActionGroupProps): ReactElement {
+  hideWhenEmpty = false,
+}: TaskWorkflowActionGroupProps): ReactElement | null {
   const [isMenuOpen, setMenuOpen] = useState(false);
   const { primaryAction, secondaryActions, allActions } = includeActions
     ? resolveTaskCardActions(task, { include: includeActions })
@@ -52,6 +54,10 @@ export function TaskWorkflowActionGroup({
   const hasAnyAction = hasWorkflowAction || hasExtraMenuAction;
 
   if (!hasAnyAction) {
+    if (hideWhenEmpty) {
+      return null;
+    }
+
     return (
       <Button
         type="button"
@@ -82,17 +88,7 @@ export function TaskWorkflowActionGroup({
           {TASK_ACTION_ICON[primary]}
           {taskActionLabel(primary, task)}
         </Button>
-      ) : (
-        <Button
-          type="button"
-          size={size}
-          variant="outline"
-          className={cn(expandPrimary ? "min-w-0 flex-1" : "", primaryClassName)}
-          disabled
-        >
-          {emptyLabel}
-        </Button>
-      )}
+      ) : null}
 
       {showMenu ? (
         <Popover open={isMenuOpen} onOpenChange={setMenuOpen}>

--- a/apps/desktop/src/components/features/task-details/task-details-sheet-footer.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-footer.test.tsx
@@ -1,0 +1,78 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ReactElement } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import {
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "@/pages/agents/agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+const workflowActionGroupRenderMock = mock((_: unknown) => {});
+
+mock.module("@/components/features/kanban/task-workflow-action-group", () => ({
+  TaskWorkflowActionGroup: (props: unknown): ReactElement => {
+    workflowActionGroupRenderMock(props);
+    return <div data-testid="workflow-actions" />;
+  },
+}));
+
+describe("TaskDetailsSheetFooter", () => {
+  beforeEach(() => {
+    workflowActionGroupRenderMock.mockClear();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("omits workflow action placeholder when no workflow actions are available", async () => {
+    const { TaskDetailsSheetFooter } = await import("./task-details-sheet-footer");
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TaskDetailsSheetFooter
+          task={createTaskCardFixture({ status: "closed", availableActions: [] })}
+          onOpenChange={() => {}}
+          includeActions={["human_approve", "human_request_changes", "open_builder", "build_start"]}
+          onWorkflowAction={() => {}}
+        />,
+      );
+    });
+
+    expect(workflowActionGroupRenderMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("keeps footer action menu when delete is available without workflow actions", async () => {
+    const { TaskDetailsSheetFooter } = await import("./task-details-sheet-footer");
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <TaskDetailsSheetFooter
+          task={createTaskCardFixture({ status: "closed", availableActions: [] })}
+          onOpenChange={() => {}}
+          includeActions={["human_approve", "human_request_changes", "open_builder", "build_start"]}
+          onWorkflowAction={() => {}}
+          onDeleteSelect={() => {}}
+        />,
+      );
+    });
+
+    expect(workflowActionGroupRenderMock).toHaveBeenCalledTimes(1);
+    expect(workflowActionGroupRenderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hideWhenEmpty: true,
+      }),
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+});

--- a/apps/desktop/src/components/features/task-details/task-details-sheet-footer.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-footer.tsx
@@ -1,7 +1,10 @@
 import type { TaskCard } from "@openducktor/contracts";
 import { PencilLine, Trash2 } from "lucide-react";
 import type { ReactElement } from "react";
-import type { TaskWorkflowAction } from "@/components/features/kanban/kanban-task-workflow";
+import {
+  resolveTaskCardActions,
+  type TaskWorkflowAction,
+} from "@/components/features/kanban/kanban-task-workflow";
 import { TaskWorkflowActionGroup } from "@/components/features/kanban/task-workflow-action-group";
 import { Button } from "@/components/ui/button";
 
@@ -22,6 +25,12 @@ export function TaskDetailsSheetFooter({
   onWorkflowAction,
   onDeleteSelect,
 }: TaskDetailsSheetFooterProps): ReactElement {
+  const hasWorkflowAction = Boolean(
+    includeActions && onWorkflowAction
+      ? resolveTaskCardActions(task, { include: includeActions }).allActions.length > 0
+      : false,
+  );
+
   return (
     <div className="mt-0 flex flex-none flex-wrap items-center justify-between gap-2 border-t border-border bg-card px-5 py-3">
       <div className="flex flex-wrap items-center gap-2">
@@ -36,7 +45,7 @@ export function TaskDetailsSheetFooter({
         ) : null}
       </div>
 
-      {includeActions && onWorkflowAction ? (
+      {includeActions && onWorkflowAction && (hasWorkflowAction || onDeleteSelect) ? (
         <TaskWorkflowActionGroup
           task={task}
           includeActions={includeActions}
@@ -45,6 +54,7 @@ export function TaskDetailsSheetFooter({
           className="min-w-[240px] justify-end"
           primaryClassName="font-semibold"
           emptyLabel="No available workflow action"
+          hideWhenEmpty
           {...(onDeleteSelect
             ? {
                 extraMenuActions: [

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-model-builders.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-model-builders.test.ts
@@ -116,7 +116,7 @@ describe("use-agent-studio-page-model-builders", () => {
     expect(context.createSessionDisabled).toBe(false);
   });
 
-  test("buildWorkflowModelContext includes follow-up build scenarios from QA and human feedback", () => {
+  test("buildWorkflowModelContext includes follow-up build scenario from human feedback", () => {
     const activeSession = createSession({
       runtimeKind: "opencode",
       sessionId: "spec-session",
@@ -124,8 +124,8 @@ describe("use-agent-studio-page-model-builders", () => {
       scenario: "spec_initial",
     });
     const taskWithFeedback = createTaskCardFixture({
-      status: "in_progress",
-      availableActions: ["human_request_changes"],
+      status: "human_review",
+      availableActions: ["human_request_changes", "human_approve"],
       documentSummary: {
         spec: { has: false, updatedAt: undefined },
         plan: { has: false, updatedAt: undefined },
@@ -149,10 +149,40 @@ describe("use-agent-studio-page-model-builders", () => {
     });
 
     const optionIds = context.sessionCreateOptions.map((option) => option.id);
-    expect(optionIds).toContain("build:build_after_qa_rejected:fresh");
     expect(optionIds).toContain("build:build_after_human_request_changes:fresh");
     expect(context.sessionCreateOptions.every((option) => option.disabled)).toBe(true);
     expect(context.createSessionDisabled).toBe(true);
+  });
+
+  test("buildWorkflowModelContext does not treat ai review request changes as human feedback follow-up", () => {
+    const taskInAiReview = createTaskCardFixture({
+      status: "ai_review",
+      availableActions: ["qa_start", "human_request_changes", "human_approve"],
+      documentSummary: {
+        spec: { has: false, updatedAt: undefined },
+        plan: { has: false, updatedAt: undefined },
+        qaReport: { has: true, updatedAt: "2026-02-22T10:00:00.000Z", verdict: "approved" },
+      },
+      agentWorkflows: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: true, completed: true },
+        builder: { required: true, canSkip: false, available: true, completed: false },
+        qa: { required: true, canSkip: false, available: true, completed: true },
+      },
+    });
+
+    const context = buildWorkflowModelContext({
+      selectedTask: taskInAiReview,
+      sessionsForTask: [],
+      activeSession: null,
+      role: "build",
+      isSessionWorking: false,
+      roleLabelByRole,
+    });
+
+    expect(context.sessionCreateOptions.map((option) => option.id)).not.toContain(
+      "build:build_after_human_request_changes:fresh",
+    );
   });
 
   test("does not expose qa-rejected follow-up build scenario when latest qa verdict is approved", () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-model-builders.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-model-builders.ts
@@ -52,11 +52,7 @@ const isTaskAwaitingHumanFeedback = (task: TaskCard | null): boolean => {
   if (!task) {
     return false;
   }
-  return (
-    task.status === "human_review" ||
-    task.availableActions.includes("human_request_changes") ||
-    task.availableActions.includes("human_approve")
-  );
+  return task.status === "human_review";
 };
 
 export const buildWorkflowModelContext = ({

--- a/apps/desktop/src/pages/kanban/human-review-feedback-modal.tsx
+++ b/apps/desktop/src/pages/kanban/human-review-feedback-modal.tsx
@@ -1,0 +1,87 @@
+import type { ReactElement } from "react";
+import { Button } from "@/components/ui/button";
+import { Combobox } from "@/components/ui/combobox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import type { HumanReviewFeedbackModalModel } from "./kanban-page-model-types";
+
+export function HumanReviewFeedbackModal({
+  model,
+}: {
+  model: HumanReviewFeedbackModalModel | null;
+}): ReactElement | null {
+  if (!model) {
+    return null;
+  }
+
+  const confirmDisabled = model.isSubmitting || model.message.trim().length === 0;
+
+  return (
+    <Dialog
+      open={model.open}
+      onOpenChange={(nextOpen) => {
+        if (!model.isSubmitting) {
+          model.onOpenChange(nextOpen);
+        }
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Send Human Feedback</DialogTitle>
+          <DialogDescription>
+            Choose which builder session should receive this feedback, or start a new one, then edit
+            the message that will be sent.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 pt-2">
+          <div className="space-y-2">
+            <Label htmlFor="human-review-feedback-target">Builder Session</Label>
+            <Combobox
+              value={model.selectedTarget}
+              options={model.targetOptions}
+              disabled={model.isSubmitting}
+              placeholder="Select builder session"
+              searchPlaceholder="Search builder session..."
+              onValueChange={model.onTargetChange}
+              triggerClassName="h-11"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Your feedback (will be sent as a message to the Builder agent)</Label>
+            <Textarea
+              id="human-review-feedback-message"
+              value={model.message}
+              disabled={model.isSubmitting}
+              className="min-h-48"
+              onChange={(event) => model.onMessageChange(event.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="justify-between">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={model.isSubmitting}
+            onClick={() => model.onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="button" disabled={confirmDisabled} onClick={model.onConfirm}>
+            {model.selectedTarget === "new_session" ? "Continue" : "Send Feedback"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
+++ b/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
@@ -8,7 +8,32 @@ export type KanbanSessionStartIntent = {
   role: AgentRole;
   scenario: AgentScenario;
   startMode: "fresh" | "reuse_latest";
-  sendKickoff: boolean;
+  postStartAction: "none" | "kickoff" | "send_message";
+  message?: string;
+  beforeStartAction?: {
+    action: "human_request_changes";
+    note: string;
+  };
+};
+
+export type HumanReviewFeedbackTargetOption = {
+  value: string;
+  label: string;
+  description: string;
+  secondaryLabel?: string;
+};
+
+export type HumanReviewFeedbackModalModel = {
+  open: boolean;
+  taskId: string;
+  selectedTarget: string;
+  targetOptions: HumanReviewFeedbackTargetOption[];
+  message: string;
+  isSubmitting: boolean;
+  onOpenChange: (open: boolean) => void;
+  onTargetChange: (value: string) => void;
+  onMessageChange: (message: string) => void;
+  onConfirm: () => void;
 };
 
 export type KanbanPageHeaderModel = {
@@ -61,5 +86,6 @@ export type KanbanPageModels = {
   content: KanbanPageContentModel;
   taskComposer: KanbanPageTaskComposerModel;
   taskDetailsController: KanbanPageTaskDetailsControllerModel;
+  humanReviewFeedbackModal: HumanReviewFeedbackModalModel | null;
   sessionStartModal: SessionStartModalModel | null;
 };

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -746,7 +746,9 @@ describe("KanbanPage session start modal flow", () => {
 
   test("human request changes falls back to new-session mode when no builder session exists", async () => {
     currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "human_review" });
-    currentSessionsFixture = [currentSessionsFixture[0]!];
+    const [specSession] = currentSessionsFixture;
+    expect(specSession).toBeDefined();
+    currentSessionsFixture = specSession ? [specSession] : [];
     loadAgentSessionsMock.mockImplementationOnce(async () => {
       currentSessionsFixture = [...currentSessionsFixture];
     });
@@ -770,7 +772,9 @@ describe("KanbanPage session start modal flow", () => {
 
   test("human request changes detects builder sessions loaded on demand before opening modal", async () => {
     currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "human_review" });
-    currentSessionsFixture = [currentSessionsFixture[0]!];
+    const [specSession] = currentSessionsFixture;
+    expect(specSession).toBeDefined();
+    currentSessionsFixture = specSession ? [specSession] : [];
     loadAgentSessionsMock.mockImplementation(async (taskId: string) => {
       if (taskId !== "TASK-123") {
         return;

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -3,6 +3,7 @@ import { OPENCODE_RUNTIME_DESCRIPTOR, type RepoPromptOverrides } from "@openduck
 import { isValidElement, type ReactElement } from "react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import type { AgentSessionLoadOptions } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
   createTaskCardFixture,
@@ -14,6 +15,9 @@ enableReactActEnvironment();
 const startAgentSessionMock = mock(async () => "session-1");
 const sendAgentMessageMock = mock(async () => {});
 const updateAgentSessionModelMock = mock(() => {});
+const loadAgentSessionsMock = mock(
+  async (_taskId: string, _options?: AgentSessionLoadOptions) => {},
+);
 const humanApproveTaskMock = mock(async () => {});
 const humanRequestChangesTaskMock = mock(async () => {});
 const deleteTaskMock = mock(async () => {});
@@ -32,11 +36,50 @@ const workspaceGetSettingsSnapshotMock = mock(async () => ({
 }));
 
 let latestKanbanColumnProps: Record<string, unknown> | null = null;
+let latestHumanReviewFeedbackModalModel: Record<string, unknown> | null = null;
 let latestSessionStartModalModel: Record<string, unknown> | null = null;
 let latestLocation = "/";
 const RUNTIME_DEFINITIONS = [OPENCODE_RUNTIME_DESCRIPTOR] as const;
 
 let currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "open" });
+let currentSessionsFixture = [
+  {
+    runtimeKind: "opencode",
+    sessionId: "session-spec",
+    taskId: "TASK-123",
+    role: "spec",
+    scenario: "spec_initial",
+    status: "running",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    pendingPermissions: 0,
+    pendingQuestions: 0,
+  },
+  {
+    runtimeKind: "opencode",
+    sessionId: "session-build-older",
+    taskId: "TASK-123",
+    role: "build",
+    scenario: "build_after_human_request_changes",
+    status: "running",
+    startedAt: "2026-01-01T12:00:00.000Z",
+    updatedAt: "2026-01-01T12:00:00.000Z",
+    pendingPermissions: 0,
+    pendingQuestions: 0,
+  },
+  {
+    runtimeKind: "opencode",
+    sessionId: "session-build-latest",
+    taskId: "TASK-123",
+    role: "build",
+    scenario: "build_implementation_start",
+    status: "idle",
+    startedAt: "2026-01-02T00:00:00.000Z",
+    updatedAt: "2026-01-02T00:00:00.000Z",
+    pendingPermissions: 0,
+    pendingQuestions: 0,
+  },
+];
 
 const REPO_SETTINGS_FIXTURE: RepoSettingsInput = {
   defaultRuntimeKind: "opencode" as const,
@@ -106,6 +149,17 @@ mock.module("./kanban-session-start-modal", () => ({
   },
 }));
 
+mock.module("./human-review-feedback-modal", () => ({
+  HumanReviewFeedbackModal: ({
+    model,
+  }: {
+    model: Record<string, unknown> | null;
+  }): ReactElement | null => {
+    latestHumanReviewFeedbackModalModel = model;
+    return null;
+  },
+}));
+
 mock.module("@/state", () => ({
   AppStateProvider: ({ children }: { children: ReactElement }): ReactElement => children,
   useWorkspaceState: () => ({
@@ -114,20 +168,8 @@ mock.module("@/state", () => ({
     loadRepoSettings: async () => REPO_SETTINGS_FIXTURE,
   }),
   useAgentState: () => ({
-    sessions: [
-      {
-        runtimeKind: "opencode",
-        sessionId: "session-spec",
-        taskId: "TASK-123",
-        role: "spec",
-        scenario: "spec_initial",
-        status: "running",
-        startedAt: "2026-01-01T00:00:00.000Z",
-        updatedAt: "2026-01-01T00:00:00.000Z",
-        pendingPermissions: 0,
-        pendingQuestions: 0,
-      },
-    ],
+    sessions: currentSessionsFixture,
+    loadAgentSessions: loadAgentSessionsMock,
     startAgentSession: startAgentSessionMock,
     sendAgentMessage: sendAgentMessageMock,
     updateAgentSessionModel: updateAgentSessionModelMock,
@@ -174,12 +216,52 @@ const renderPage = async (): Promise<ReactTestRenderer> => {
 describe("KanbanPage session start modal flow", () => {
   beforeEach(() => {
     currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "open" });
+    currentSessionsFixture = [
+      {
+        runtimeKind: "opencode",
+        sessionId: "session-spec",
+        taskId: "TASK-123",
+        role: "spec",
+        scenario: "spec_initial",
+        status: "running",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        pendingPermissions: 0,
+        pendingQuestions: 0,
+      },
+      {
+        runtimeKind: "opencode",
+        sessionId: "session-build-older",
+        taskId: "TASK-123",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        status: "running",
+        startedAt: "2026-01-01T12:00:00.000Z",
+        updatedAt: "2026-01-01T12:00:00.000Z",
+        pendingPermissions: 0,
+        pendingQuestions: 0,
+      },
+      {
+        runtimeKind: "opencode",
+        sessionId: "session-build-latest",
+        taskId: "TASK-123",
+        role: "build",
+        scenario: "build_implementation_start",
+        status: "idle",
+        startedAt: "2026-01-02T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+        pendingPermissions: 0,
+        pendingQuestions: 0,
+      },
+    ];
     latestKanbanColumnProps = null;
+    latestHumanReviewFeedbackModalModel = null;
     latestSessionStartModalModel = null;
     latestLocation = "/";
     startAgentSessionMock.mockClear();
     sendAgentMessageMock.mockClear();
     updateAgentSessionModelMock.mockClear();
+    loadAgentSessionsMock.mockClear();
     humanApproveTaskMock.mockClear();
     humanRequestChangesTaskMock.mockClear();
     deleteTaskMock.mockClear();
@@ -525,7 +607,8 @@ describe("KanbanPage session start modal flow", () => {
     });
   });
 
-  test("human request changes action opens modal with build follow-up scenario", async () => {
+  test("human request changes opens dedicated feedback modal before mutating", async () => {
+    currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "human_review" });
     const renderer = await renderPage();
 
     await act(async () => {
@@ -534,8 +617,98 @@ describe("KanbanPage session start modal flow", () => {
       );
     });
 
-    expect(humanRequestChangesTaskMock).toHaveBeenCalledWith("TASK-123");
+    expect(loadAgentSessionsMock).toHaveBeenCalledWith("TASK-123");
+    expect(humanRequestChangesTaskMock).not.toHaveBeenCalled();
+    expect(latestHumanReviewFeedbackModalModel?.open).toBe(true);
+    expect(latestHumanReviewFeedbackModalModel?.selectedTarget).toBe("session-build-latest");
+    expect(latestHumanReviewFeedbackModalModel?.targetOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: "new_session" }),
+        expect.objectContaining({ value: "session-build-latest", secondaryLabel: "Latest" }),
+        expect.objectContaining({ value: "session-build-older" }),
+      ]),
+    );
+    expect(typeof latestHumanReviewFeedbackModalModel?.message).toBe("string");
+    expect(String(latestHumanReviewFeedbackModalModel?.message)).toContain("TASK-123");
+    expect(latestSessionStartModalModel).toBeNull();
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("human request changes can target a selected existing builder session", async () => {
+    currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "human_review" });
+    const renderer = await renderPage();
+
+    await act(async () => {
+      await (latestKanbanColumnProps?.onHumanRequestChanges as (taskId: string) => Promise<void>)(
+        "TASK-123",
+      );
+    });
+
+    await act(async () => {
+      (latestHumanReviewFeedbackModalModel?.onTargetChange as (value: string) => void)(
+        "session-build-older",
+      );
+      (latestHumanReviewFeedbackModalModel?.onMessageChange as (message: string) => void)(
+        "Apply the requested human review changes.",
+      );
+    });
+
+    await act(async () => {
+      await (latestHumanReviewFeedbackModalModel?.onConfirm as () => Promise<void>)();
+      await Promise.resolve();
+    });
+
+    expect(humanRequestChangesTaskMock).toHaveBeenCalledWith(
+      "TASK-123",
+      "Apply the requested human review changes.",
+    );
+    expect(loadAgentSessionsMock.mock.calls).toEqual([
+      ["TASK-123"],
+      ["TASK-123", { hydrateHistoryForSessionId: "session-build-older" }],
+    ]);
+    expect(startAgentSessionMock).not.toHaveBeenCalled();
+    expect(sendAgentMessageMock).toHaveBeenCalledWith(
+      "session-build-older",
+      "Apply the requested human review changes.",
+    );
+    expect(latestLocation).toContain("/agents?task=TASK-123");
+    expect(latestLocation).toContain("session=session-build-older");
+    expect(latestLocation).toContain("agent=build");
+    expect(latestSessionStartModalModel).toBeNull();
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("human request changes can start a fresh builder session after feedback review", async () => {
+    currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "human_review" });
+    const renderer = await renderPage();
+
+    await act(async () => {
+      await (latestKanbanColumnProps?.onHumanRequestChanges as (taskId: string) => Promise<void>)(
+        "TASK-123",
+      );
+    });
+
+    await act(async () => {
+      (latestHumanReviewFeedbackModalModel?.onTargetChange as (value: string) => void)(
+        "new_session",
+      );
+      (latestHumanReviewFeedbackModalModel?.onMessageChange as (message: string) => void)(
+        "Use a fresh builder session for these changes.",
+      );
+    });
+
+    await act(async () => {
+      (latestHumanReviewFeedbackModalModel?.onConfirm as () => void)();
+    });
+
     expect(latestSessionStartModalModel?.open).toBe(true);
+    expect(humanRequestChangesTaskMock).not.toHaveBeenCalled();
 
     await act(async () => {
       (latestSessionStartModalModel?.onConfirm as () => void)();
@@ -547,8 +720,141 @@ describe("KanbanPage session start modal flow", () => {
         taskId: "TASK-123",
         role: "build",
         scenario: "build_after_human_request_changes",
-        startMode: "reuse_latest",
+        startMode: "fresh",
       }),
+    );
+    expect(humanRequestChangesTaskMock).toHaveBeenCalledWith(
+      "TASK-123",
+      "Use a fresh builder session for these changes.",
+    );
+    const startCallOrder = startAgentSessionMock.mock.invocationCallOrder[0];
+    const requestChangesCallOrder = humanRequestChangesTaskMock.mock.invocationCallOrder[0];
+    expect(startCallOrder).toBeDefined();
+    expect(requestChangesCallOrder).toBeDefined();
+    if (startCallOrder !== undefined && requestChangesCallOrder !== undefined) {
+      expect(startCallOrder).toBeLessThan(requestChangesCallOrder);
+    }
+    expect(sendAgentMessageMock).toHaveBeenCalledWith(
+      "session-1",
+      "Use a fresh builder session for these changes.",
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("human request changes falls back to new-session mode when no builder session exists", async () => {
+    currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "human_review" });
+    currentSessionsFixture = [currentSessionsFixture[0]!];
+    loadAgentSessionsMock.mockImplementationOnce(async () => {
+      currentSessionsFixture = [...currentSessionsFixture];
+    });
+    const renderer = await renderPage();
+
+    await act(async () => {
+      await (latestKanbanColumnProps?.onHumanRequestChanges as (taskId: string) => Promise<void>)(
+        "TASK-123",
+      );
+    });
+
+    expect(latestHumanReviewFeedbackModalModel?.selectedTarget).toBe("new_session");
+    expect(latestHumanReviewFeedbackModalModel?.targetOptions).toEqual([
+      expect.objectContaining({ value: "new_session" }),
+    ]);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("human request changes detects builder sessions loaded on demand before opening modal", async () => {
+    currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "human_review" });
+    currentSessionsFixture = [currentSessionsFixture[0]!];
+    loadAgentSessionsMock.mockImplementation(async (taskId: string) => {
+      if (taskId !== "TASK-123") {
+        return;
+      }
+
+      currentSessionsFixture = [
+        ...currentSessionsFixture,
+        {
+          runtimeKind: "opencode",
+          sessionId: "session-build-hydrated",
+          taskId: "TASK-123",
+          role: "build",
+          scenario: "build_implementation_start",
+          status: "idle",
+          startedAt: "2026-01-03T00:00:00.000Z",
+          updatedAt: "2026-01-03T00:00:00.000Z",
+          pendingPermissions: 0,
+          pendingQuestions: 0,
+        },
+      ];
+    });
+    const renderer = await renderPage();
+
+    await act(async () => {
+      await (latestKanbanColumnProps?.onHumanRequestChanges as (taskId: string) => Promise<void>)(
+        "TASK-123",
+      );
+    });
+
+    expect(loadAgentSessionsMock).toHaveBeenCalledWith("TASK-123");
+    expect(latestHumanReviewFeedbackModalModel?.selectedTarget).toBe("session-build-hydrated");
+    expect(latestHumanReviewFeedbackModalModel?.targetOptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ value: "new_session" }),
+        expect.objectContaining({ value: "session-build-hydrated", secondaryLabel: "Latest" }),
+      ]),
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("ai review request changes starts a fresh builder session with the QA follow-up scenario", async () => {
+    currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "ai_review" });
+    const renderer = await renderPage();
+
+    await act(async () => {
+      await (latestKanbanColumnProps?.onHumanRequestChanges as (taskId: string) => Promise<void>)(
+        "TASK-123",
+      );
+    });
+
+    await act(async () => {
+      (latestHumanReviewFeedbackModalModel?.onTargetChange as (value: string) => void)(
+        "new_session",
+      );
+      (latestHumanReviewFeedbackModalModel?.onMessageChange as (message: string) => void)(
+        "Please address the AI review feedback in a fresh session.",
+      );
+    });
+
+    await act(async () => {
+      (latestHumanReviewFeedbackModalModel?.onConfirm as () => void)();
+    });
+
+    expect(latestSessionStartModalModel?.open).toBe(true);
+
+    await act(async () => {
+      (latestSessionStartModalModel?.onConfirm as () => void)();
+      await Promise.resolve();
+    });
+
+    expect(startAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "TASK-123",
+        role: "build",
+        scenario: "build_after_qa_rejected",
+        startMode: "fresh",
+      }),
+    );
+    expect(humanRequestChangesTaskMock).toHaveBeenCalledWith(
+      "TASK-123",
+      "Please address the AI review feedback in a fresh session.",
     );
 
     await act(async () => {

--- a/apps/desktop/src/pages/kanban/kanban-page.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.tsx
@@ -4,6 +4,7 @@ import {
   TaskDetailsSheetController,
   type TaskDetailsSheetControllerHandle,
 } from "@/components/features/task-details";
+import { HumanReviewFeedbackModal } from "./human-review-feedback-modal";
 import { KanbanPageContent } from "./kanban-page-content";
 import { KanbanPageHeader } from "./kanban-page-header";
 import { KanbanSessionStartModal } from "./kanban-session-start-modal";
@@ -24,6 +25,7 @@ export function KanbanPage(): ReactElement {
       <KanbanPageContent model={models.content} />
       <TaskCreateModal {...models.taskComposer} />
       <TaskDetailsSheetController ref={taskDetailsSheetRef} {...models.taskDetailsController} />
+      <HumanReviewFeedbackModal model={models.humanReviewFeedbackModal} />
       <KanbanSessionStartModal model={models.sessionStartModal} />
     </div>
   );

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
@@ -13,8 +13,13 @@ type UseKanbanPageModelsArgs = {
 
 export function useKanbanPageModels({ onOpenDetails }: UseKanbanPageModelsArgs): KanbanPageModels {
   const { activeRepo, isSwitchingWorkspace, loadRepoSettings } = useWorkspaceState();
-  const { sessions, startAgentSession, sendAgentMessage, updateAgentSessionModel } =
-    useAgentState();
+  const {
+    sessions,
+    loadAgentSessions,
+    startAgentSession,
+    sendAgentMessage,
+    updateAgentSessionModel,
+  } = useAgentState();
   const {
     tasks,
     runs,
@@ -39,18 +44,21 @@ export function useKanbanPageModels({ onOpenDetails }: UseKanbanPageModelsArgs):
     tasks,
     sessions,
     navigate,
+    loadAgentSessions,
+    humanRequestChangesTask,
     startAgentSession,
     sendAgentMessage,
     updateAgentSessionModel,
   });
   const {
+    humanReviewFeedbackModal,
     sessionStartModal,
     onDelegate,
     onPlan,
     onQaStart,
     onQaOpen,
     onBuild,
-    openBuildAfterHumanRequestChanges,
+    onHumanRequestChanges,
   } = sessionStartFlow;
 
   const onRefreshTasks = useCallback((): void => {
@@ -62,16 +70,6 @@ export function useKanbanPageModels({ onOpenDetails }: UseKanbanPageModelsArgs):
       void humanApproveTask(taskId);
     },
     [humanApproveTask],
-  );
-
-  const onHumanRequestChanges = useCallback(
-    (taskId: string): void => {
-      void (async () => {
-        await humanRequestChangesTask(taskId);
-        openBuildAfterHumanRequestChanges(taskId);
-      })();
-    },
-    [humanRequestChangesTask, openBuildAfterHumanRequestChanges],
   );
 
   const taskDialogs = useKanbanTaskDialogs({
@@ -121,6 +119,7 @@ export function useKanbanPageModels({ onOpenDetails }: UseKanbanPageModelsArgs):
       onHumanRequestChanges,
       onDelete: (taskId, options) => deleteTask(taskId, options.deleteSubtasks),
     },
+    humanReviewFeedbackModal,
     sessionStartModal,
   };
 }

--- a/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.test.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.test.ts
@@ -5,10 +5,41 @@ import {
 } from "../agents/agent-studio-test-utils";
 import {
   findLatestSessionByRoleForTask,
+  findSessionsByRoleForTask,
   resolveKanbanPlanningStartPreference,
 } from "./use-kanban-session-start-flow";
 
 describe("use-kanban-session-start-flow helpers", () => {
+  test("findSessionsByRoleForTask returns all matching sessions newest first", () => {
+    const sessions = [
+      createAgentSessionFixture({
+        runtimeKind: "opencode",
+        sessionId: "build-older",
+        taskId: "TASK-1",
+        role: "build",
+        startedAt: "2026-02-10T10:00:00.000Z",
+      }),
+      createAgentSessionFixture({
+        runtimeKind: "opencode",
+        sessionId: "build-latest",
+        taskId: "TASK-1",
+        role: "build",
+        startedAt: "2026-02-12T10:00:00.000Z",
+      }),
+      createAgentSessionFixture({
+        runtimeKind: "opencode",
+        sessionId: "qa-latest",
+        taskId: "TASK-1",
+        role: "qa",
+        startedAt: "2026-02-11T10:00:00.000Z",
+      }),
+    ];
+
+    expect(
+      findSessionsByRoleForTask(sessions, "TASK-1", "build").map((session) => session.sessionId),
+    ).toEqual(["build-latest", "build-older"]);
+  });
+
   test("findLatestSessionByRoleForTask returns the most recent matching session", () => {
     const sessions = [
       createAgentSessionFixture({

--- a/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
@@ -1,7 +1,7 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentRole, AgentScenario } from "@openducktor/core";
 import { assertAgentKickoffScenario } from "@openducktor/core";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import { toast } from "sonner";
 import type { SessionStartModalModel } from "@/components/features/agents";
@@ -11,8 +11,28 @@ import type { AgentStateContextValue, RepoSettingsInput } from "@/types/state-sl
 import { loadEffectivePromptOverrides } from "../../state/operations/prompt-overrides";
 import { firstScenario, kickoffPromptForScenario } from "../agents/agents-page-constants";
 import { useSessionStartModalCoordinator } from "../shared/use-session-start-modal-coordinator";
-import type { KanbanSessionStartIntent } from "./kanban-page-model-types";
+import type {
+  HumanReviewFeedbackModalModel,
+  KanbanSessionStartIntent,
+} from "./kanban-page-model-types";
 import { renderSessionStartedToastAction } from "./session-started-toast-action";
+
+const NEW_BUILDER_SESSION_TARGET = "new_session";
+
+type RequestChangesBuildScenario = "build_after_human_request_changes" | "build_after_qa_rejected";
+
+type HumanReviewFeedbackState = {
+  taskId: string;
+  scenario: RequestChangesBuildScenario;
+  message: string;
+  builderSessions: AgentSessionState[];
+  selectedTarget: string;
+};
+
+type PendingHumanReviewHydration = {
+  taskId: string;
+  baselineSessions: AgentSessionState[];
+};
 
 type UseKanbanSessionStartFlowArgs = {
   activeRepo: string | null;
@@ -20,19 +40,22 @@ type UseKanbanSessionStartFlowArgs = {
   tasks: TaskCard[];
   sessions: AgentSessionState[];
   navigate: NavigateFunction;
+  loadAgentSessions: AgentStateContextValue["loadAgentSessions"];
+  humanRequestChangesTask: (taskId: string, note?: string) => Promise<void>;
   startAgentSession: AgentStateContextValue["startAgentSession"];
   sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
   updateAgentSessionModel: AgentStateContextValue["updateAgentSessionModel"];
 };
 
 type UseKanbanSessionStartFlowResult = {
+  humanReviewFeedbackModal: HumanReviewFeedbackModalModel | null;
   sessionStartModal: SessionStartModalModel | null;
   onDelegate: (taskId: string) => void;
   onPlan: (taskId: string, action: "set_spec" | "set_plan") => void;
   onQaStart: (taskId: string) => void;
   onQaOpen: (taskId: string) => void;
   onBuild: (taskId: string) => void;
-  openBuildAfterHumanRequestChanges: (taskId: string) => void;
+  onHumanRequestChanges: (taskId: string) => void;
 };
 
 export const findLatestSessionByRoleForTask = (
@@ -40,11 +63,17 @@ export const findLatestSessionByRoleForTask = (
   taskId: string,
   role: AgentRole,
 ): AgentSessionState | null => {
-  return (
-    sessions
-      .filter((session) => session.taskId === taskId && session.role === role)
-      .sort((a, b) => b.startedAt.localeCompare(a.startedAt))[0] ?? null
-  );
+  return findSessionsByRoleForTask(sessions, taskId, role)[0] ?? null;
+};
+
+export const findSessionsByRoleForTask = (
+  sessions: AgentSessionState[],
+  taskId: string,
+  role: AgentRole,
+): AgentSessionState[] => {
+  return sessions
+    .filter((session) => session.taskId === taskId && session.role === role)
+    .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
 };
 
 export const resolveKanbanPlanningStartPreference = (
@@ -59,17 +88,77 @@ export const resolveKanbanPlanningStartPreference = (
   return task?.status === "spec_ready" ? "continue" : "fresh";
 };
 
+const toPromptTaskContext = (task: TaskCard | undefined) => {
+  if (!task) {
+    return {};
+  }
+
+  return {
+    title: task.title,
+    issueType: task.issueType,
+    status: task.status,
+    qaRequired: task.aiReviewEnabled,
+    description: task.description,
+    acceptanceCriteria: task.acceptanceCriteria,
+  };
+};
+
+const resolveRequestChangesScenario = (task: TaskCard | undefined): RequestChangesBuildScenario => {
+  return task?.status === "human_review"
+    ? "build_after_human_request_changes"
+    : "build_after_qa_rejected";
+};
+
+const buildHumanReviewMessage = (
+  task: TaskCard | undefined,
+  taskId: string,
+  scenario: RequestChangesBuildScenario,
+): string => {
+  return kickoffPromptForScenario("build", scenario, taskId, {
+    task: toPromptTaskContext(task),
+  });
+};
+
+const createHumanReviewFeedbackState = (
+  tasks: TaskCard[],
+  taskId: string,
+  builderSessions: AgentSessionState[],
+): HumanReviewFeedbackState => {
+  const task = tasks.find((entry) => entry.id === taskId);
+  const scenario = resolveRequestChangesScenario(task);
+
+  return {
+    taskId,
+    scenario,
+    message: buildHumanReviewMessage(task, taskId, scenario),
+    builderSessions,
+    selectedTarget: builderSessions[0]?.sessionId ?? NEW_BUILDER_SESSION_TARGET,
+  };
+};
+
 export function useKanbanSessionStartFlow({
   activeRepo,
   repoSettings,
   tasks,
   sessions,
   navigate,
+  loadAgentSessions,
+  humanRequestChangesTask,
   startAgentSession,
   sendAgentMessage,
   updateAgentSessionModel,
 }: UseKanbanSessionStartFlowArgs): UseKanbanSessionStartFlowResult {
+  const roleLabels = AGENT_ROLE_LABELS as Record<AgentRole, string>;
+  const tasksRef = useRef(tasks);
+  const sessionsRef = useRef(sessions);
   const [isStartingSession, setIsStartingSession] = useState(false);
+  const [sessionStartBeforeAction, setSessionStartBeforeAction] =
+    useState<KanbanSessionStartIntent["beforeStartAction"]>();
+  const [pendingHumanReviewHydration, setPendingHumanReviewHydration] =
+    useState<PendingHumanReviewHydration | null>(null);
+  const [humanReviewFeedbackState, setHumanReviewFeedbackState] =
+    useState<HumanReviewFeedbackState | null>(null);
+  const [isSubmittingHumanReviewFeedback, setIsSubmittingHumanReviewFeedback] = useState(false);
 
   const {
     intent: sessionStartIntent,
@@ -94,6 +183,29 @@ export function useKanbanSessionStartFlow({
     activeRepo,
     repoSettings,
   });
+
+  useEffect(() => {
+    tasksRef.current = tasks;
+  }, [tasks]);
+
+  useEffect(() => {
+    sessionsRef.current = sessions;
+  }, [sessions]);
+
+  useEffect(() => {
+    if (!pendingHumanReviewHydration) {
+      return;
+    }
+
+    if (sessions === pendingHumanReviewHydration.baselineSessions) {
+      return;
+    }
+
+    const { taskId } = pendingHumanReviewHydration;
+    const builderSessions = findSessionsByRoleForTask(sessions, taskId, "build");
+    setHumanReviewFeedbackState(createHumanReviewFeedbackState(tasks, taskId, builderSessions));
+    setPendingHumanReviewHydration(null);
+  }, [pendingHumanReviewHydration, sessions, tasks]);
 
   const openAgents = useCallback(
     (taskId: string, role: AgentRole, scenario?: AgentScenario): void => {
@@ -130,16 +242,40 @@ export function useKanbanSessionStartFlow({
         role: intent.role,
         scenario: intent.scenario,
         startMode: intent.startMode,
-        postStartAction: intent.sendKickoff ? "kickoff" : "none",
+        postStartAction: intent.postStartAction,
+        ...(intent.message ? { message: intent.message } : {}),
       });
+      setSessionStartBeforeAction(intent.beforeStartAction);
     },
     [openStartModal],
+  );
+
+  const closeHumanReviewFeedbackModal = useCallback((): void => {
+    if (isSubmittingHumanReviewFeedback) {
+      return;
+    }
+
+    setHumanReviewFeedbackState(null);
+  }, [isSubmittingHumanReviewFeedback]);
+
+  const openAgentStudioSession = useCallback(
+    (taskId: string, session: AgentSessionState): void => {
+      const params = new URLSearchParams({
+        task: taskId,
+        session: session.sessionId,
+        agent: session.role,
+        scenario: session.scenario,
+      });
+      navigate(`/agents?${params.toString()}`);
+    },
+    [navigate],
   );
 
   const closeSessionStartModal = useCallback((): void => {
     if (isStartingSession) {
       return;
     }
+    setSessionStartBeforeAction(undefined);
     closeStartModal();
   }, [closeStartModal, isStartingSession]);
 
@@ -154,12 +290,10 @@ export function useKanbanSessionStartFlow({
         role: sessionStartIntent.role,
         scenario: sessionStartIntent.scenario,
         startMode: sessionStartIntent.startMode,
-        sendKickoff: sessionStartIntent.postStartAction === "kickoff",
+        postStartAction: sessionStartIntent.postStartAction,
+        ...(sessionStartIntent.message ? { message: sessionStartIntent.message } : {}),
+        ...(sessionStartBeforeAction ? { beforeStartAction: sessionStartBeforeAction } : {}),
       };
-      const kickoffScenario =
-        startInBackground || intent.sendKickoff
-          ? assertAgentKickoffScenario(intent.scenario)
-          : null;
 
       const selection = sessionStartSelection;
       void (async () => {
@@ -179,10 +313,35 @@ export function useKanbanSessionStartFlow({
             updateAgentSessionModel(sessionId, selection);
           }
 
+          if (intent.beforeStartAction?.action === "human_request_changes") {
+            try {
+              await humanRequestChangesTask(intent.taskId, intent.beforeStartAction.note);
+            } catch {
+              closeStartModal();
+
+              if (startInBackground) {
+                const roleLabel = roleLabels[intent.role] ?? intent.role.toUpperCase();
+                toast.error(`Started ${roleLabel} session, but requesting changes failed.`, {
+                  duration: 10000,
+                  description: renderSessionStartedToastAction(
+                    intent,
+                    sessionId,
+                    openSessionInAgentStudio,
+                  ),
+                });
+              } else {
+                openSessionInAgentStudio(intent, sessionId);
+                toast.error("Session started, but requesting changes failed.");
+              }
+
+              return;
+            }
+          }
+
           closeStartModal();
 
           if (startInBackground) {
-            const roleLabel = AGENT_ROLE_LABELS[intent.role] ?? intent.role.toUpperCase();
+            const roleLabel = roleLabels[intent.role] ?? intent.role.toUpperCase();
             toast.success(`Started ${roleLabel} session in background for ${intent.taskId}.`, {
               duration: 10000,
               description: renderSessionStartedToastAction(
@@ -195,45 +354,50 @@ export function useKanbanSessionStartFlow({
             openSessionInAgentStudio(intent, sessionId);
           }
 
-          if (startInBackground || intent.sendKickoff) {
-            const buildKickoffMessage = async (): Promise<string> => {
+          const effectivePostStartAction =
+            startInBackground && intent.postStartAction === "none"
+              ? "kickoff"
+              : intent.postStartAction;
+
+          if (effectivePostStartAction !== "none") {
+            const buildPostStartMessage = async (): Promise<string> => {
+              if (effectivePostStartAction === "send_message") {
+                const message = intent.message?.trim() ?? "";
+                if (!message) {
+                  throw new Error("Feedback message is required before sending.");
+                }
+                return message;
+              }
+
               const promptOverrides = activeRepo
                 ? await loadEffectivePromptOverrides(activeRepo)
                 : undefined;
               const intentTask = tasks.find((entry) => entry.id === intent.taskId);
-              if (!kickoffScenario) {
-                throw new Error(`Scenario "${intent.scenario}" does not support kickoff prompts.`);
-              }
+              const kickoffScenario = assertAgentKickoffScenario(intent.scenario);
               return kickoffPromptForScenario(intent.role, kickoffScenario, intent.taskId, {
                 overrides: promptOverrides ?? {},
-                task: {
-                  ...(intentTask
-                    ? {
-                        title: intentTask.title,
-                        issueType: intentTask.issueType,
-                        status: intentTask.status,
-                        qaRequired: intentTask.aiReviewEnabled,
-                        description: intentTask.description,
-                        acceptanceCriteria: intentTask.acceptanceCriteria,
-                      }
-                    : {}),
-                },
+                task: toPromptTaskContext(intentTask),
               });
             };
+
+            const failureMessage =
+              effectivePostStartAction === "kickoff"
+                ? "Session started, but kickoff message failed."
+                : "Session started, but feedback message failed.";
 
             if (startInBackground) {
               void (async () => {
                 try {
-                  await sendAgentMessage(sessionId, await buildKickoffMessage());
+                  await sendAgentMessage(sessionId, await buildPostStartMessage());
                 } catch {
-                  toast.error("Session started, but kickoff message failed.");
+                  toast.error(failureMessage);
                 }
               })();
             } else {
               try {
-                await sendAgentMessage(sessionId, await buildKickoffMessage());
+                await sendAgentMessage(sessionId, await buildPostStartMessage());
               } catch {
-                toast.error("Session started, but kickoff message failed.");
+                toast.error(failureMessage);
               }
             }
           }
@@ -254,6 +418,7 @@ export function useKanbanSessionStartFlow({
       startAgentSession,
       tasks,
       updateAgentSessionModel,
+      sessionStartBeforeAction,
     ],
   );
 
@@ -264,7 +429,7 @@ export function useKanbanSessionStartFlow({
         role: "build",
         scenario: "build_implementation_start",
         startMode: "reuse_latest",
-        sendKickoff: true,
+        postStartAction: "kickoff",
       });
     },
     [openSessionStartModal],
@@ -272,11 +437,13 @@ export function useKanbanSessionStartFlow({
 
   const onPlan = useCallback(
     (taskId: string, action: "set_spec" | "set_plan"): void => {
+      const currentTasks = tasksRef.current;
+      const currentSessions = sessionsRef.current;
       const role: AgentRole = action === "set_spec" ? "spec" : "planner";
-      const startPreference = resolveKanbanPlanningStartPreference(tasks, taskId, action);
+      const startPreference = resolveKanbanPlanningStartPreference(currentTasks, taskId, action);
 
       if (action === "set_spec" && startPreference === "continue") {
-        const latestSpecSession = findLatestSessionByRoleForTask(sessions, taskId, "spec");
+        const latestSpecSession = findLatestSessionByRoleForTask(currentSessions, taskId, "spec");
 
         if (latestSpecSession) {
           openSessionInAgentStudio(
@@ -285,7 +452,7 @@ export function useKanbanSessionStartFlow({
               role: "spec",
               scenario: firstScenario("spec"),
               startMode: "reuse_latest",
-              sendKickoff: false,
+              postStartAction: "none",
             },
             latestSpecSession.sessionId,
           );
@@ -300,10 +467,10 @@ export function useKanbanSessionStartFlow({
         role,
         scenario: firstScenario(role),
         startMode: startPreference === "fresh" ? "fresh" : "reuse_latest",
-        sendKickoff: startPreference === "fresh",
+        postStartAction: startPreference === "fresh" ? "kickoff" : "none",
       });
     },
-    [openAgents, openSessionInAgentStudio, openSessionStartModal, sessions, tasks],
+    [openAgents, openSessionInAgentStudio, openSessionStartModal],
   );
 
   const onBuild = useCallback(
@@ -320,7 +487,7 @@ export function useKanbanSessionStartFlow({
         role: "qa",
         scenario: "qa_review",
         startMode: "reuse_latest",
-        sendKickoff: true,
+        postStartAction: "kickoff",
       });
     },
     [openSessionStartModal],
@@ -328,7 +495,7 @@ export function useKanbanSessionStartFlow({
 
   const onQaOpen = useCallback(
     (taskId: string): void => {
-      const latestQaSession = findLatestSessionByRoleForTask(sessions, taskId, "qa");
+      const latestQaSession = findLatestSessionByRoleForTask(sessionsRef.current, taskId, "qa");
 
       if (latestQaSession) {
         openSessionInAgentStudio(
@@ -337,7 +504,7 @@ export function useKanbanSessionStartFlow({
             role: "qa",
             scenario: "qa_review",
             startMode: "reuse_latest",
-            sendKickoff: false,
+            postStartAction: "none",
           },
           latestQaSession.sessionId,
         );
@@ -346,21 +513,152 @@ export function useKanbanSessionStartFlow({
 
       openAgents(taskId, "qa", "qa_review");
     },
-    [openAgents, openSessionInAgentStudio, sessions],
+    [openAgents, openSessionInAgentStudio],
   );
 
-  const openBuildAfterHumanRequestChanges = useCallback(
+  const onHumanRequestChanges = useCallback(
     (taskId: string): void => {
-      openSessionStartModal({
-        taskId,
-        role: "build",
-        scenario: "build_after_human_request_changes",
-        startMode: "reuse_latest",
-        sendKickoff: true,
-      });
+      void (async () => {
+        try {
+          const baselineSessions = sessionsRef.current;
+          await loadAgentSessions(taskId);
+
+          const currentTasks = tasksRef.current;
+          const currentBuilderSessions = findSessionsByRoleForTask(
+            sessionsRef.current,
+            taskId,
+            "build",
+          );
+
+          if (currentBuilderSessions.length > 0) {
+            setHumanReviewFeedbackState(
+              createHumanReviewFeedbackState(currentTasks, taskId, currentBuilderSessions),
+            );
+            return;
+          }
+
+          setPendingHumanReviewHydration({ taskId, baselineSessions });
+        } catch {
+          setPendingHumanReviewHydration(null);
+        }
+      })();
     },
-    [openSessionStartModal],
+    [loadAgentSessions],
   );
+
+  const confirmHumanReviewFeedback = useCallback((): void => {
+    if (!humanReviewFeedbackState) {
+      return;
+    }
+
+    const trimmedMessage = humanReviewFeedbackState.message.trim();
+    if (trimmedMessage.length === 0) {
+      toast.error("Feedback message is required.");
+      return;
+    }
+
+    if (humanReviewFeedbackState.selectedTarget === NEW_BUILDER_SESSION_TARGET) {
+      setHumanReviewFeedbackState(null);
+      openSessionStartModal({
+        taskId: humanReviewFeedbackState.taskId,
+        role: "build",
+        scenario: humanReviewFeedbackState.scenario,
+        startMode: "fresh",
+        postStartAction: "send_message",
+        message: trimmedMessage,
+        beforeStartAction: {
+          action: "human_request_changes",
+          note: trimmedMessage,
+        },
+      });
+      return;
+    }
+
+    const existingBuilderSession = humanReviewFeedbackState.builderSessions.find(
+      (session) => session.sessionId === humanReviewFeedbackState.selectedTarget,
+    );
+    if (!existingBuilderSession) {
+      toast.error("The selected builder session is no longer available for this task.");
+      return;
+    }
+
+    void (async () => {
+      setIsSubmittingHumanReviewFeedback(true);
+      try {
+        await humanRequestChangesTask(humanReviewFeedbackState.taskId, trimmedMessage);
+        await loadAgentSessions(humanReviewFeedbackState.taskId, {
+          hydrateHistoryForSessionId: existingBuilderSession.sessionId,
+        });
+        setHumanReviewFeedbackState(null);
+        openAgentStudioSession(humanReviewFeedbackState.taskId, existingBuilderSession);
+        try {
+          await sendAgentMessage(existingBuilderSession.sessionId, trimmedMessage);
+        } catch {
+          toast.error("Changes requested, but feedback message failed.");
+        }
+      } finally {
+        setIsSubmittingHumanReviewFeedback(false);
+      }
+    })();
+  }, [
+    humanRequestChangesTask,
+    humanReviewFeedbackState,
+    loadAgentSessions,
+    openAgentStudioSession,
+    openSessionStartModal,
+    sendAgentMessage,
+  ]);
+
+  const humanReviewFeedbackModal = useMemo<HumanReviewFeedbackModalModel | null>(() => {
+    if (!humanReviewFeedbackState) {
+      return null;
+    }
+
+    const targetOptions = [
+      {
+        value: NEW_BUILDER_SESSION_TARGET,
+        label: "Start a new builder session",
+        description:
+          "Open session setup, pick the model, then send this feedback as the first message.",
+      },
+      ...humanReviewFeedbackState.builderSessions.map((session, index) => ({
+        value: session.sessionId,
+        label: `Builder session ${session.sessionId.slice(0, 8)}`,
+        description: `Started ${new Date(session.startedAt).toLocaleString()} (${session.status}).`,
+        ...(index === 0 ? { secondaryLabel: "Latest" } : {}),
+      })),
+    ];
+
+    return {
+      open: true,
+      taskId: humanReviewFeedbackState.taskId,
+      selectedTarget: humanReviewFeedbackState.selectedTarget,
+      targetOptions,
+      message: humanReviewFeedbackState.message,
+      isSubmitting: isSubmittingHumanReviewFeedback,
+      onOpenChange: (nextOpen: boolean) => {
+        if (!nextOpen) {
+          closeHumanReviewFeedbackModal();
+        }
+      },
+      onTargetChange: (selectedTarget: string) => {
+        setHumanReviewFeedbackState((current: HumanReviewFeedbackState | null) =>
+          current ? { ...current, selectedTarget } : current,
+        );
+      },
+      onMessageChange: (message: string) => {
+        setHumanReviewFeedbackState((current: HumanReviewFeedbackState | null) =>
+          current ? { ...current, message } : current,
+        );
+      },
+      onConfirm: confirmHumanReviewFeedback,
+    };
+  }, [
+    closeHumanReviewFeedbackModal,
+    confirmHumanReviewFeedback,
+    humanReviewFeedbackState,
+    isSubmittingHumanReviewFeedback,
+  ]);
 
   const sessionStartModal = useMemo<SessionStartModalModel | null>(() => {
     if (!sessionStartIntent) {
@@ -391,7 +689,7 @@ export function useKanbanSessionStartFlow({
       allowRunInBackground: true,
       backgroundConfirmLabel: "Run in background",
       isStarting: isStartingSession,
-      onOpenChange: (nextOpen) => {
+      onOpenChange: (nextOpen: boolean) => {
         if (!nextOpen) {
           closeSessionStartModal();
         }
@@ -421,12 +719,13 @@ export function useKanbanSessionStartFlow({
   ]);
 
   return {
+    humanReviewFeedbackModal,
     sessionStartModal,
     onDelegate,
     onPlan,
     onQaStart,
     onQaOpen,
     onBuild,
-    openBuildAfterHumanRequestChanges,
+    onHumanRequestChanges,
   };
 }

--- a/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
@@ -417,6 +417,7 @@ export function useKanbanSessionStartFlow({
       sessionStartSelection,
       startAgentSession,
       tasks,
+      humanRequestChangesTask,
       updateAgentSessionModel,
       sessionStartBeforeAction,
     ],

--- a/docs/contracts/workflow-contract-fixture.json
+++ b/docs/contracts/workflow-contract-fixture.json
@@ -1,24 +1,9 @@
 {
   "roles": {
-    "spec": [
-      "odt_read_task",
-      "odt_set_spec"
-    ],
-    "planner": [
-      "odt_read_task",
-      "odt_set_plan"
-    ],
-    "build": [
-      "odt_read_task",
-      "odt_build_blocked",
-      "odt_build_resumed",
-      "odt_build_completed"
-    ],
-    "qa": [
-      "odt_read_task",
-      "odt_qa_approved",
-      "odt_qa_rejected"
-    ]
+    "spec": ["odt_read_task", "odt_set_spec"],
+    "planner": ["odt_read_task", "odt_set_plan"],
+    "build": ["odt_read_task", "odt_build_blocked", "odt_build_resumed", "odt_build_completed"],
+    "qa": ["odt_read_task", "odt_qa_approved", "odt_qa_rejected"]
   },
   "tools": [
     "odt_read_task",
@@ -43,192 +28,56 @@
   ],
   "transitions": {
     "feature": {
-      "open": [
-        "spec_ready",
-        "deferred"
-      ],
-      "spec_ready": [
-        "ready_for_dev",
-        "deferred"
-      ],
-      "ready_for_dev": [
-        "in_progress",
-        "deferred"
-      ],
-      "in_progress": [
-        "blocked",
-        "ai_review",
-        "human_review",
-        "deferred"
-      ],
-      "blocked": [
-        "in_progress",
-        "deferred"
-      ],
-      "ai_review": [
-        "in_progress",
-        "human_review",
-        "deferred"
-      ],
-      "human_review": [
-        "in_progress",
-        "closed",
-        "deferred"
-      ],
-      "deferred": [
-        "open"
-      ],
+      "open": ["spec_ready", "deferred"],
+      "spec_ready": ["ready_for_dev", "deferred"],
+      "ready_for_dev": ["in_progress", "deferred"],
+      "in_progress": ["blocked", "ai_review", "human_review", "deferred"],
+      "blocked": ["in_progress", "deferred"],
+      "ai_review": ["in_progress", "human_review", "closed", "deferred"],
+      "human_review": ["in_progress", "closed", "deferred"],
+      "deferred": ["open"],
       "closed": []
     },
     "epic": {
-      "open": [
-        "spec_ready",
-        "deferred"
-      ],
-      "spec_ready": [
-        "ready_for_dev",
-        "deferred"
-      ],
-      "ready_for_dev": [
-        "in_progress",
-        "deferred"
-      ],
-      "in_progress": [
-        "blocked",
-        "ai_review",
-        "human_review",
-        "deferred"
-      ],
-      "blocked": [
-        "in_progress",
-        "deferred"
-      ],
-      "ai_review": [
-        "in_progress",
-        "human_review",
-        "deferred"
-      ],
-      "human_review": [
-        "in_progress",
-        "closed",
-        "deferred"
-      ],
-      "deferred": [
-        "open"
-      ],
+      "open": ["spec_ready", "deferred"],
+      "spec_ready": ["ready_for_dev", "deferred"],
+      "ready_for_dev": ["in_progress", "deferred"],
+      "in_progress": ["blocked", "ai_review", "human_review", "deferred"],
+      "blocked": ["in_progress", "deferred"],
+      "ai_review": ["in_progress", "human_review", "closed", "deferred"],
+      "human_review": ["in_progress", "closed", "deferred"],
+      "deferred": ["open"],
       "closed": []
     },
     "task": {
-      "open": [
-        "spec_ready",
-        "ready_for_dev",
-        "in_progress",
-        "deferred"
-      ],
-      "spec_ready": [
-        "ready_for_dev",
-        "in_progress",
-        "deferred"
-      ],
-      "ready_for_dev": [
-        "in_progress",
-        "deferred"
-      ],
-      "in_progress": [
-        "blocked",
-        "ai_review",
-        "human_review",
-        "deferred"
-      ],
-      "blocked": [
-        "in_progress",
-        "deferred"
-      ],
-      "ai_review": [
-        "in_progress",
-        "human_review",
-        "deferred"
-      ],
-      "human_review": [
-        "in_progress",
-        "closed",
-        "deferred"
-      ],
-      "deferred": [
-        "open"
-      ],
+      "open": ["spec_ready", "ready_for_dev", "in_progress", "deferred"],
+      "spec_ready": ["ready_for_dev", "in_progress", "deferred"],
+      "ready_for_dev": ["in_progress", "deferred"],
+      "in_progress": ["blocked", "ai_review", "human_review", "deferred"],
+      "blocked": ["in_progress", "deferred"],
+      "ai_review": ["in_progress", "human_review", "closed", "deferred"],
+      "human_review": ["in_progress", "closed", "deferred"],
+      "deferred": ["open"],
       "closed": []
     },
     "bug": {
-      "open": [
-        "spec_ready",
-        "ready_for_dev",
-        "in_progress",
-        "deferred"
-      ],
-      "spec_ready": [
-        "ready_for_dev",
-        "in_progress",
-        "deferred"
-      ],
-      "ready_for_dev": [
-        "in_progress",
-        "deferred"
-      ],
-      "in_progress": [
-        "blocked",
-        "ai_review",
-        "human_review",
-        "deferred"
-      ],
-      "blocked": [
-        "in_progress",
-        "deferred"
-      ],
-      "ai_review": [
-        "in_progress",
-        "human_review",
-        "deferred"
-      ],
-      "human_review": [
-        "in_progress",
-        "closed",
-        "deferred"
-      ],
-      "deferred": [
-        "open"
-      ],
+      "open": ["spec_ready", "ready_for_dev", "in_progress", "deferred"],
+      "spec_ready": ["ready_for_dev", "in_progress", "deferred"],
+      "ready_for_dev": ["in_progress", "deferred"],
+      "in_progress": ["blocked", "ai_review", "human_review", "deferred"],
+      "blocked": ["in_progress", "deferred"],
+      "ai_review": ["in_progress", "human_review", "closed", "deferred"],
+      "human_review": ["in_progress", "closed", "deferred"],
+      "deferred": ["open"],
       "closed": []
     }
   },
-  "setSpecAllowedStatuses": [
-    "open",
-    "spec_ready",
-    "ready_for_dev"
-  ],
+  "setSpecAllowedStatuses": ["open", "spec_ready", "ready_for_dev"],
   "setPlanAllowedStatuses": {
-    "epic": [
-      "spec_ready",
-      "ready_for_dev"
-    ],
-    "feature": [
-      "spec_ready",
-      "ready_for_dev"
-    ],
-    "task": [
-      "open",
-      "spec_ready",
-      "ready_for_dev"
-    ],
-    "bug": [
-      "open",
-      "spec_ready",
-      "ready_for_dev"
-    ]
+    "epic": ["spec_ready", "ready_for_dev"],
+    "feature": ["spec_ready", "ready_for_dev"],
+    "task": ["open", "spec_ready", "ready_for_dev"],
+    "bug": ["open", "spec_ready", "ready_for_dev"]
   },
-  "epicSubtaskReplacementAllowedStatuses": [
-    "open",
-    "spec_ready",
-    "ready_for_dev"
-  ]
+  "epicSubtaskReplacementAllowedStatuses": ["open", "spec_ready", "ready_for_dev"]
 }

--- a/docs/task-workflow-actions.md
+++ b/docs/task-workflow-actions.md
@@ -19,6 +19,8 @@ The backend is the single source of truth for which actions are currently allowe
 - `set_plan`
 - `build_start`
 - `open_builder`
+- `qa_start`
+- `open_qa`
 - `defer_issue`
 - `resume_deferred`
 - `human_request_changes`
@@ -48,6 +50,14 @@ The backend is the single source of truth for which actions are currently allowe
 - Purpose: open existing builder context/run UX.
 - Transition: none.
 
+### `qa_start`
+- Purpose: request or start a QA review loop for the current task state.
+- Transition: none directly; it opens the QA workflow from `ai_review` or `human_review`.
+
+### `open_qa`
+- Purpose: open existing QA context/run UX.
+- Transition: none.
+
 ### `defer_issue`
 - Purpose: park a task without closing it.
 - Transition: open states -> `deferred`.
@@ -60,11 +70,11 @@ The backend is the single source of truth for which actions are currently allowe
 
 ### `human_request_changes`
 - Purpose: human review rejects current output and requests a rework loop.
-- Transition: `human_review -> in_progress`.
+- Transition: `ai_review -> in_progress` or `human_review -> in_progress`.
 
 ### `human_approve`
 - Purpose: human review accepts completion.
-- Transition: `human_review -> closed`.
+- Transition: `ai_review -> closed` or `human_review -> closed`.
 - Guardrail: epic completion checks direct children and ignores deferred children.
 
 ## UI Mapping Guidance
@@ -80,6 +90,8 @@ Current card/detail primary+menu rendering uses workflow actions:
 - `set_plan`
 - `build_start`
 - `open_builder`
+- `qa_start`
+- `open_qa`
 - `defer_issue`
 - `resume_deferred`
 - `human_request_changes`

--- a/docs/task-workflow-status-model.md
+++ b/docs/task-workflow-status-model.md
@@ -65,7 +65,8 @@ Removed from OpenDucktor UI scope:
 - `task`: `true` (for now)
 - `bug`: `true` (for now)
 
-When `qaRequired=false`, transition from build completion skips `ai_review` and goes directly to `human_review`.
+When `qaRequired=true`, build completion returns to `ai_review` until the latest QA verdict is `approved`.
+When `qaRequired=false`, or when the latest QA verdict is already `approved`, build completion goes directly to `human_review`.
 
 ## Epic/Subtask Rules
 - Only `epic` can have subtasks.

--- a/docs/task-workflow-transition-matrix.md
+++ b/docs/task-workflow-transition-matrix.md
@@ -43,12 +43,12 @@ Human actions:
 | `odt_build_resumed` | `ready_for_dev` | feature/epic standard flow | `in_progress` |
 | `odt_build_resumed` | `open`, `spec_ready`, `ready_for_dev`, `blocked` | task/bug optional flow + blocked resume | `in_progress` |
 | `odt_build_blocked` | `in_progress` | reason required | `blocked` |
-| `odt_build_completed` | `in_progress` | `qaRequired=true` | `ai_review` |
-| `odt_build_completed` | `in_progress` | `qaRequired=false` | `human_review` |
-| `odt_qa_rejected` | `ai_review` | report markdown required | `in_progress` |
-| `odt_qa_approved` | `ai_review` | report markdown required | `human_review` |
-| `human_request_changes` | `human_review` | note optional | `in_progress` |
-| `human_approve` | `human_review` | epic completion guard passes | `closed` |
+| `odt_build_completed` | `in_progress` | `qaRequired=true` and latest QA verdict is not `approved` (including no QA verdict yet) | `ai_review` |
+| `odt_build_completed` | `in_progress` | `qaRequired=false` or latest QA verdict is `approved` | `human_review` |
+| `odt_qa_rejected` | `ai_review`, `human_review` | report markdown required | `in_progress` |
+| `odt_qa_approved` | `ai_review`, `human_review` | report markdown required | `human_review` |
+| `human_request_changes` | `ai_review`, `human_review` | note optional | `in_progress` |
+| `human_approve` | `ai_review`, `human_review` | epic completion guard passes | `closed` |
 | `defer_issue` | `open`, `spec_ready`, `ready_for_dev`, `in_progress`, `blocked`, `ai_review`, `human_review` | not subtask | `deferred` |
 | `resume_deferred` | `deferred` | not subtask | `open` |
 
@@ -61,7 +61,7 @@ Human actions:
 
 ## Invalid Transition Examples
 - `open -> closed` without human approval.
-- `ai_review -> closed` without QA approval + human approval.
+- `ai_review -> closed` without an explicit `human_approve` action.
 - `blocked -> closed` directly.
 - `deferred -> in_progress` directly (must resume to `open` first).
 

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -143,9 +143,9 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
 - odt_set_plan for feature/epic allowed from spec_ready/ready_for_dev.
 - odt_set_plan for task/bug allowed from open/spec_ready/ready_for_dev.
 - For odt_set_plan subtasks, priority must be an integer 0..4 (default 2).
-- odt_build_completed from in_progress transitions to ai_review when qaRequired=true, else human_review.
-- odt_qa_rejected transitions ai_review -> in_progress.
-- odt_qa_approved transitions ai_review -> human_review.`,
+- odt_build_completed from in_progress transitions to ai_review only when qaRequired=true and the latest QA verdict is not approved; otherwise it transitions to human_review.
+- odt_qa_rejected transitions ai_review/human_review -> in_progress.
+- odt_qa_approved transitions ai_review/human_review -> human_review.`,
   },
   "system.shared.tool_protocol": {
     id: "system.shared.tool_protocol",

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -855,7 +855,7 @@ describe("openducktor-mcp lib", () => {
         taskId: "task-1",
         reportMarkdown: "## QA",
       }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review");
+    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
 
     expect(metadataUpdateCalls).toBe(0);
   });
@@ -1689,7 +1689,7 @@ describe("openducktor-mcp lib", () => {
       }),
     ).rejects.toThrow("Transition not allowed");
 
-    expect(listCalls).toBe(1);
+    expect(listCalls).toBe(2);
     expect(statusUpdateCalls).toBe(0);
   });
 

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
@@ -201,12 +201,17 @@ describe("odt task workflow use cases", () => {
   test("BuildCompletedUseCase routes to ai_review when AI review is enabled", async () => {
     const inProgressTask = makeTask({ status: "in_progress", aiReviewEnabled: true });
     const aiReviewTask = makeTask({ status: "ai_review", aiReviewEnabled: true });
+    const issue = makeIssue();
     const calls: string[] = [];
 
     const useCase = new BuildCompletedUseCase({
       workflow: {
         ensureInitialized: async () => {
           calls.push("init");
+        },
+        readTaskSnapshot: async (taskId) => {
+          calls.push(`read:${taskId}`);
+          return { issue, task: inProgressTask };
         },
         resolveTaskContext: async (taskId) => {
           calls.push(`resolve:${taskId}`);
@@ -221,6 +226,16 @@ describe("odt task workflow use cases", () => {
           return aiReviewTask;
         },
       },
+      documentStore: {
+        parseDocs: (rawIssue) => {
+          calls.push(`docs:${rawIssue.id}:not_reviewed`);
+          return {
+            spec: { markdown: "", updatedAt: null },
+            implementationPlan: { markdown: "", updatedAt: null },
+            latestQaReport: { markdown: "", updatedAt: null, verdict: "not_reviewed" },
+          };
+        },
+      },
     });
 
     await expect(
@@ -233,7 +248,64 @@ describe("odt task workflow use cases", () => {
       "init",
       "resolve:task-1",
       "refresh:task-1:in_progress",
+      "read:task-1",
+      "docs:task-1:not_reviewed",
       "transition:task-1:ai_review",
+    ]);
+  });
+
+  test("BuildCompletedUseCase routes to human_review after approved QA", async () => {
+    const inProgressTask = makeTask({ status: "in_progress", aiReviewEnabled: true });
+    const humanReviewTask = makeTask({ status: "human_review", aiReviewEnabled: true });
+    const issue = makeIssue({
+      metadata: { openducktor: { documents: { qaReports: [{ verdict: "approved" }] } } },
+    });
+    const calls: string[] = [];
+
+    const useCase = new BuildCompletedUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        readTaskSnapshot: async (taskId) => {
+          calls.push(`read:${taskId}`);
+          return { issue, task: inProgressTask };
+        },
+        resolveTaskContext: async (taskId) => {
+          calls.push(`resolve:${taskId}`);
+          return { task: inProgressTask, tasks: [inProgressTask] };
+        },
+        refreshTaskContext: async (taskId, context) => {
+          calls.push(`refresh:${taskId}:${context?.task.status ?? "none"}`);
+          return { task: inProgressTask, tasks: [inProgressTask] };
+        },
+        transitionTask: async (taskId, nextStatus) => {
+          calls.push(`transition:${taskId}:${nextStatus}`);
+          return humanReviewTask;
+        },
+      },
+      documentStore: {
+        parseDocs: (rawIssue) => {
+          calls.push(`docs:${rawIssue.id}:approved`);
+          return {
+            spec: { markdown: "", updatedAt: null },
+            implementationPlan: { markdown: "", updatedAt: null },
+            latestQaReport: { markdown: "", updatedAt: null, verdict: "approved" },
+          };
+        },
+      },
+    });
+
+    await expect(useCase.execute({ taskId: "task-1" })).resolves.toEqual({
+      task: humanReviewTask,
+    });
+    expect(calls).toEqual([
+      "init",
+      "resolve:task-1",
+      "refresh:task-1:in_progress",
+      "read:task-1",
+      "docs:task-1:approved",
+      "transition:task-1:human_review",
     ]);
   });
 
@@ -341,6 +413,53 @@ describe("odt task workflow use cases", () => {
     });
   });
 
+  test("QaApprovedUseCase accepts human_review tasks", async () => {
+    const qaTask = makeTask({ status: "human_review" });
+    const issue = makeIssue({ status: "human_review" });
+    const approvedTask = makeTask({ status: "human_review" });
+    const calls: string[] = [];
+
+    const useCase = new QaApprovedUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        readTaskSnapshot: async (taskId) => {
+          calls.push(`read:${taskId}`);
+          return { issue, task: qaTask };
+        },
+        assertTransitionAllowed: () => {
+          calls.push("assert");
+        },
+        applyTaskUpdate: async (taskId, input) => {
+          calls.push(`apply:${taskId}:${input.status ?? "none"}`);
+          return approvedTask;
+        },
+      },
+      documentStore: {
+        prepareQaReportWrite: (rawIssue, markdown, verdict) => {
+          calls.push(`prepare:${rawIssue.id}:${verdict}:${markdown}`);
+          return {
+            metadataRoot: { openducktor: { documents: { qaReports: [{ verdict, markdown }] } } },
+            namespace: {},
+            root: {},
+          };
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA follow-up" }),
+    ).resolves.toEqual({ task: approvedTask });
+    expect(calls).toEqual([
+      "init",
+      "read:task-1",
+      "assert",
+      "prepare:task-1:approved:## QA follow-up",
+      "apply:task-1:human_review",
+    ]);
+  });
+
   test("QaApprovedUseCase rejects invalid transitions before preparing qa metadata", async () => {
     let prepareCalled = false;
     let updateCalled = false;
@@ -372,7 +491,7 @@ describe("odt task workflow use cases", () => {
 
     await expect(
       useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review");
+    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
     expect(prepareCalled).toBe(false);
     expect(updateCalled).toBe(false);
   });
@@ -399,7 +518,7 @@ describe("odt task workflow use cases", () => {
 
     await expect(
       useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review");
+    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
     expect(assertCalled).toBe(false);
   });
 
@@ -434,7 +553,7 @@ describe("odt task workflow use cases", () => {
 
     await expect(
       useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review");
+    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
     expect(prepareCalled).toBe(false);
     expect(updateCalled).toBe(false);
   });
@@ -461,7 +580,54 @@ describe("odt task workflow use cases", () => {
 
     await expect(
       useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review");
+    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
     expect(assertCalled).toBe(false);
+  });
+
+  test("QaRejectedUseCase accepts human_review tasks", async () => {
+    const qaTask = makeTask({ status: "human_review" });
+    const issue = makeIssue({ status: "human_review" });
+    const rejectedTask = makeTask({ status: "in_progress" });
+    const calls: string[] = [];
+
+    const useCase = new QaRejectedUseCase({
+      workflow: {
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        readTaskSnapshot: async (taskId) => {
+          calls.push(`read:${taskId}`);
+          return { issue, task: qaTask };
+        },
+        assertTransitionAllowed: () => {
+          calls.push("assert");
+        },
+        applyTaskUpdate: async (taskId, input) => {
+          calls.push(`apply:${taskId}:${input.status ?? "none"}`);
+          return rejectedTask;
+        },
+      },
+      documentStore: {
+        prepareQaReportWrite: (rawIssue, markdown, verdict) => {
+          calls.push(`prepare:${rawIssue.id}:${verdict}:${markdown}`);
+          return {
+            metadataRoot: { openducktor: { documents: { qaReports: [{ verdict, markdown }] } } },
+            namespace: {},
+            root: {},
+          };
+        },
+      },
+    });
+
+    await expect(
+      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA reject" }),
+    ).resolves.toEqual({ task: rejectedTask });
+    expect(calls).toEqual([
+      "init",
+      "read:task-1",
+      "assert",
+      "prepare:task-1:rejected:## QA reject",
+      "apply:task-1:in_progress",
+    ]);
   });
 });

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
@@ -259,17 +259,24 @@ export class BuildResumedUseCase
 type BuildCompletedUseCaseDeps = {
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
-    "ensureInitialized" | "resolveTaskContext" | "refreshTaskContext" | "transitionTask"
+    | "ensureInitialized"
+    | "readTaskSnapshot"
+    | "resolveTaskContext"
+    | "refreshTaskContext"
+    | "transitionTask"
   >;
+  documentStore: Pick<TaskDocumentPort, "parseDocs">;
 };
 
 export class BuildCompletedUseCase
   implements OdtTaskStoreUseCase<BuildCompletedInput, BuildCompletedResult>
 {
   private readonly workflow: BuildCompletedUseCaseDeps["workflow"];
+  private readonly documentStore: BuildCompletedUseCaseDeps["documentStore"];
 
   constructor(deps: BuildCompletedUseCaseDeps) {
     this.workflow = deps.workflow;
+    this.documentStore = deps.documentStore;
   }
 
   async execute(input: BuildCompletedInput): Promise<BuildCompletedResult> {
@@ -278,8 +285,13 @@ export class BuildCompletedUseCase
     const context = await this.workflow.resolveTaskContext(input.taskId);
     const refreshedContext = await this.workflow.refreshTaskContext(context.task.id, context);
     const { task } = refreshedContext;
+    const { issue } = await this.workflow.readTaskSnapshot(task.id);
+    const documents = this.documentStore.parseDocs(issue);
 
-    const nextStatus = task.aiReviewEnabled ? "ai_review" : "human_review";
+    const nextStatus =
+      task.aiReviewEnabled && documents.latestQaReport.verdict !== "approved"
+        ? "ai_review"
+        : "human_review";
     const updatedTask = await this.workflow.transitionTask(task.id, nextStatus, refreshedContext);
     return {
       task: updatedTask,
@@ -308,8 +320,10 @@ export class QaApprovedUseCase implements OdtTaskStoreUseCase<QaApprovedInput, Q
   async execute(input: QaApprovedInput): Promise<QaApprovedResult> {
     await this.workflow.ensureInitialized();
     const { issue, task } = await this.workflow.readTaskSnapshot(input.taskId);
-    if (task.status !== "ai_review") {
-      throw new Error(`QA outcomes are only allowed from ai_review (current: ${task.status}).`);
+    if (task.status !== "ai_review" && task.status !== "human_review") {
+      throw new Error(
+        `QA outcomes are only allowed from ai_review or human_review (current: ${task.status}).`,
+      );
     }
     this.workflow.assertTransitionAllowed(task, [task], "human_review");
     const preparedWrite = this.documentStore.prepareQaReportWrite(
@@ -337,8 +351,10 @@ export class QaRejectedUseCase implements OdtTaskStoreUseCase<QaRejectedInput, Q
   async execute(input: QaRejectedInput): Promise<QaRejectedResult> {
     await this.workflow.ensureInitialized();
     const { issue, task } = await this.workflow.readTaskSnapshot(input.taskId);
-    if (task.status !== "ai_review") {
-      throw new Error(`QA outcomes are only allowed from ai_review (current: ${task.status}).`);
+    if (task.status !== "ai_review" && task.status !== "human_review") {
+      throw new Error(
+        `QA outcomes are only allowed from ai_review or human_review (current: ${task.status}).`,
+      );
     }
     this.workflow.assertTransitionAllowed(task, [task], "in_progress");
     const preparedWrite = this.documentStore.prepareQaReportWrite(
@@ -384,6 +400,7 @@ export const createOdtTaskStoreUseCases = (
   }),
   buildCompleted: new BuildCompletedUseCase({
     workflow: deps.workflow,
+    documentStore: deps.documentStore,
   }),
   qaApproved: new QaApprovedUseCase({
     workflow: deps.workflow,

--- a/packages/openducktor-mcp/src/odt-task-store.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.test.ts
@@ -735,7 +735,7 @@ describe("OdtTaskStore workflow mutation paths", () => {
         taskId: "task-1",
         reportMarkdown: "## QA report",
       }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review");
+    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
 
     expect(harness.getMetadataUpdateCalls()).toHaveLength(0);
     expect(harness.getStatusUpdateCalls()).toHaveLength(0);

--- a/packages/openducktor-mcp/src/workflow-policy.ts
+++ b/packages/openducktor-mcp/src/workflow-policy.ts
@@ -10,7 +10,7 @@ const BASE_TRANSITION_RULES: Readonly<Record<TaskStatus, readonly TaskStatus[]>>
   ready_for_dev: ["in_progress", "deferred"],
   in_progress: ["blocked", "ai_review", "human_review", "deferred"],
   blocked: ["in_progress", "deferred"],
-  ai_review: ["in_progress", "human_review", "deferred"],
+  ai_review: ["in_progress", "human_review", "closed", "deferred"],
   human_review: ["in_progress", "closed", "deferred"],
   deferred: ["open"],
   closed: [],


### PR DESCRIPTION
## Summary
- tighten backend review workflow rules and MCP parity so AI review, human review, QA reruns, approvals, and build-complete routing stay consistent
- clean up Kanban and task-details workflow actions, including the dedicated Human Review feedback handoff flow with explicit builder-session targeting and safer request-changes sequencing
- sync workflow docs/contracts and expand regression coverage across Rust host tests, desktop Kanban tests, and Agent Studio follow-up builder behavior

## Testing
- cargo test -p host-application
- bun run --filter @openducktor/desktop test -- src/pages/kanban/kanban-page.test.tsx
- bun run --filter @openducktor/desktop test -- src/components/features/kanban/kanban-task-workflow.test.ts src/components/features/kanban/task-action-ui.test.ts src/pages/agents/use-agent-studio-page-model-builders.test.ts
- bun run --filter @openducktor/desktop typecheck
- bun run typecheck
- bun run build