### PR TITLE
Improve agent chat tool previews

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -187,6 +187,7 @@ export type MessageBodyProps = {
   assistantAccentColor: string | undefined;
   timeLabel: string;
   systemPromptBody: string;
+  sessionWorkingDirectory?: string | null | undefined;
 };
 
 export const MessageBody = ({
@@ -195,6 +196,7 @@ export const MessageBody = ({
   assistantAccentColor,
   timeLabel,
   systemPromptBody,
+  sessionWorkingDirectory,
 }: MessageBodyProps): ReactElement => {
   const meta = message.meta;
 
@@ -210,7 +212,13 @@ export const MessageBody = ({
 
   if (meta?.kind === "tool") {
     if (isOdtWorkflowMutationToolName(meta.tool)) {
-      return <WorkflowToolMessage meta={meta} messageTimestamp={message.timestamp} />;
+      return (
+        <WorkflowToolMessage
+          meta={meta}
+          messageTimestamp={message.timestamp}
+          sessionWorkingDirectory={sessionWorkingDirectory}
+        />
+      );
     }
     return (
       <RegularToolMessage
@@ -218,6 +226,7 @@ export const MessageBody = ({
         messageContent={message.content}
         messageTimestamp={message.timestamp}
         timeLabel={timeLabel}
+        sessionWorkingDirectory={sessionWorkingDirectory}
       />
     );
   }

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -439,6 +439,32 @@ describe("agent-chat-message-card-model", () => {
       expect(titleSummary.length).toBeLessThanOrEqual(163);
     });
 
+    test("prefers preview hints over tool titles and output, but keeps errors first", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "bash",
+            preview: "bun run test --filter @openducktor/desktop",
+            title: "Run desktop tests",
+            output: "completed shell execution",
+          }),
+          "",
+        ),
+      ).toBe("bun run test --filter @openducktor/desktop");
+
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "skill",
+            status: "error",
+            preview: "clean-ddd-hexagonal",
+            error: "Skill not found",
+          }),
+          "",
+        ),
+      ).toBe("Skill not found");
+    });
+
     test("builds search and path summaries", () => {
       expect(
         buildToolSummary(
@@ -831,6 +857,27 @@ describe("agent-chat-message-card-model", () => {
       });
     });
 
+    test("normalizes file edit paths relative to the session working directory", () => {
+      const data = extractFileEditData(
+        createToolMeta({
+          input: {
+            filePath: "/repo/apps/web/src/contexts/AuthContext.tsx",
+          },
+          metadata: {
+            diff: "--- a/apps/web/src/contexts/AuthContext.tsx\n+++ b/apps/web/src/contexts/AuthContext.tsx\n@@ -1 +1 @@\n-old\n+new",
+          },
+        }),
+        "/repo",
+      );
+
+      expect(data).toEqual({
+        filePath: "apps/web/src/contexts/AuthContext.tsx",
+        diff: "--- a/apps/web/src/contexts/AuthContext.tsx\n+++ b/apps/web/src/contexts/AuthContext.tsx\n@@ -1 +1 @@\n-old\n+new",
+        additions: 1,
+        deletions: 1,
+      });
+    });
+
     test("extracts apply_patch file path and output fallback path", () => {
       const fromPatch = extractFileEditData(
         createToolMeta({
@@ -868,6 +915,91 @@ describe("agent-chat-message-card-model", () => {
           }),
         ),
       ).toBeNull();
+    });
+  });
+
+  describe("tool summary helpers", () => {
+    test("uses input taskId for read_task summaries", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "odt_read_task",
+            input: { taskId: "task-77" },
+            output: '{"task":{"id":"task-77","title":"Improve chat tool previews"}}',
+          }),
+          "",
+        ),
+      ).toBe("task-77");
+    });
+
+    test("preserves read_task error summaries when taskId is present", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "odt_read_task",
+            status: "error",
+            input: { taskId: "task-77" },
+            error: "Task not found",
+          }),
+          "",
+        ),
+      ).toBe("Task not found");
+    });
+
+    test("normalizes read tool paths relative to the session working directory", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "read",
+            preview: "/repo/apps/web/src/contexts/AuthContext.tsx",
+            input: { path: "/repo/apps/web/src/contexts/AuthContext.tsx" },
+          }),
+          "",
+          "/repo",
+        ),
+      ).toBe("apps/web/src/contexts/AuthContext.tsx");
+    });
+
+    test("normalizes lsp diagnostic paths relative to the session working directory", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "lsp_diagnostics",
+            preview: "/repo/apps/web/src/contexts/AuthContext.tsx",
+            input: { path: "/repo/apps/web/src/contexts/AuthContext.tsx" },
+          }),
+          "",
+          "/repo",
+        ),
+      ).toBe("apps/web/src/contexts/AuthContext.tsx");
+    });
+
+    test("normalizes search-style path summaries for ast_grep_search", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "ast_grep_search",
+            preview: "useState in /repo/apps/web/src",
+            input: { query: "useState", path: "/repo/apps/web/src" },
+          }),
+          "",
+          "/repo",
+        ),
+      ).toBe("useState in apps/web/src");
+    });
+
+    test("normalizes look_at paths relative to the session working directory", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "look_at",
+            preview: "/repo/apps/web/src/contexts/AuthContext.tsx",
+            input: { path: "/repo/apps/web/src/contexts/AuthContext.tsx" },
+          }),
+          "",
+          "/repo",
+        ),
+      ).toBe("apps/web/src/contexts/AuthContext.tsx");
     });
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
@@ -29,6 +29,7 @@ import {
 } from "./agent-chat-message-card-model";
 import type { ToolMeta } from "./agent-chat-message-card-types";
 import { formatAgentDuration } from "./format-agent-duration";
+import { relativizeDisplayPathsInValue } from "./tool-path-utils";
 
 export const assistantRoleIcon = (role: AgentRole): ReactElement => {
   if (role === "spec") {
@@ -103,14 +104,23 @@ const ToolJsonDetails = ({
   );
 };
 
+const formatToolInput = (
+  input: Record<string, unknown>,
+  workingDirectory?: string | null,
+): string => {
+  return JSON.stringify(relativizeDisplayPathsInValue(input, workingDirectory), null, 2);
+};
+
 type WorkflowToolMessageProps = {
   meta: ToolMeta;
   messageTimestamp: string;
+  sessionWorkingDirectory?: string | null | undefined;
 };
 
 export const WorkflowToolMessage = ({
   meta,
   messageTimestamp,
+  sessionWorkingDirectory,
 }: WorkflowToolMessageProps): ReactElement => {
   const durationMs = getToolDuration(meta, messageTimestamp);
   const hasInput = hasNonEmptyInput(meta.input);
@@ -173,7 +183,7 @@ export const WorkflowToolMessage = ({
                 Input
               </summary>
               <pre className="overflow-x-auto whitespace-pre-wrap px-2 pb-2 text-[11px] text-current">
-                {JSON.stringify(meta.input, null, 2)}
+                {formatToolInput(meta.input, sessionWorkingDirectory)}
               </pre>
             </details>
           ) : null}
@@ -204,6 +214,7 @@ type RegularToolMessageProps = {
   messageContent: string;
   messageTimestamp: string;
   timeLabel: string;
+  sessionWorkingDirectory?: string | null | undefined;
 };
 
 export const RegularToolMessage = ({
@@ -211,9 +222,10 @@ export const RegularToolMessage = ({
   messageContent,
   messageTimestamp,
   timeLabel,
+  sessionWorkingDirectory,
 }: RegularToolMessageProps): ReactElement => {
   const lifecyclePhase = getToolLifecyclePhase(meta);
-  const summary = buildToolSummary(meta, messageContent);
+  const summary = buildToolSummary(meta, messageContent, sessionWorkingDirectory);
   const summaryText =
     summary.length > 0
       ? summary
@@ -281,7 +293,7 @@ export const RegularToolMessage = ({
                   Input
                 </summary>
                 <pre className="overflow-x-auto whitespace-pre-wrap px-2 pb-2 text-[11px] text-foreground">
-                  {JSON.stringify(meta.input, null, 2)}
+                  {formatToolInput(meta.input, sessionWorkingDirectory)}
                 </pre>
               </details>
             ) : null}
@@ -336,7 +348,7 @@ export const RegularToolMessage = ({
 
       {isFileEditTool(meta.tool) &&
         (() => {
-          const fileEditData = extractFileEditData(meta);
+          const fileEditData = extractFileEditData(meta, sessionWorkingDirectory);
           return fileEditData ? <AgentChatFileEditCard data={fileEditData} /> : null;
         })()}
     </div>

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -96,6 +96,36 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).toContain("fairnest-97f");
   });
 
+  test("renders file tool summaries relative to the session working directory", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-relative-path",
+          role: "tool",
+          content: "Tool read completed",
+          timestamp: "2026-02-22T10:20:35.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-relative-path",
+            callId: "call-relative-path",
+            tool: "read",
+            status: "completed",
+            preview: "/repo/apps/web/src/contexts/AuthContext.tsx",
+            input: { path: "/repo/apps/web/src/contexts/AuthContext.tsx" },
+            output: "file contents",
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+        sessionWorkingDirectory: "/repo",
+      }),
+    );
+
+    expect(html).toContain("apps/web/src/contexts/AuthContext.tsx");
+    expect(html).not.toContain("/repo/apps/web/src/contexts/AuthContext.tsx");
+  });
+
   test("renders workflow tool executing state with blue styling and running label", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
@@ -9,6 +9,7 @@ type AgentChatMessageCardProps = {
   sessionRole: AgentRole | null;
   sessionSelectedModel: AgentModelSelection | null;
   sessionAgentColors?: Record<string, string>;
+  sessionWorkingDirectory?: string | null | undefined;
 };
 
 export function AgentChatMessageCard({
@@ -16,6 +17,7 @@ export function AgentChatMessageCard({
   sessionRole,
   sessionSelectedModel,
   sessionAgentColors,
+  sessionWorkingDirectory,
 }: AgentChatMessageCardProps): ReactElement | null {
   const vm = buildAgentChatMessageCardViewModel({
     message,
@@ -45,6 +47,7 @@ export function AgentChatMessageCard({
         assistantAccentColor={vm.assistantAccentColor}
         timeLabel={vm.timeLabel}
         systemPromptBody={vm.systemPromptBody}
+        sessionWorkingDirectory={sessionWorkingDirectory}
       />
     </article>
   );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
@@ -10,6 +10,7 @@ type AgentChatVirtualRowProps = {
   sessionAgentColors: Record<string, string>;
   sessionRole: AgentSessionState["role"] | null;
   sessionSelectedModel: AgentSessionState["selectedModel"] | null;
+  sessionWorkingDirectory: AgentSessionState["workingDirectory"] | null;
 };
 
 export function AgentChatThreadRow({
@@ -17,6 +18,7 @@ export function AgentChatThreadRow({
   sessionAgentColors,
   sessionRole,
   sessionSelectedModel,
+  sessionWorkingDirectory,
 }: AgentChatVirtualRowProps): ReactElement {
   switch (row.kind) {
     case "turn_duration": {
@@ -31,6 +33,7 @@ export function AgentChatThreadRow({
             sessionRole={sessionRole}
             sessionSelectedModel={sessionSelectedModel}
             sessionAgentColors={sessionAgentColors}
+            sessionWorkingDirectory={sessionWorkingDirectory}
           />
         </div>
       );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -90,6 +90,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   });
   const sessionRole = session?.role ?? null;
   const sessionSelectedModel = session?.selectedModel ?? null;
+  const sessionWorkingDirectory = session?.workingDirectory ?? null;
   const rowKeys = useMemo(() => virtualRows.map((row) => row.key), [virtualRows]);
   const rowRefByKeyRef = useRef<Map<string, (element: HTMLDivElement | null) => void>>(new Map());
   const shouldRenderVirtualizedThread = canRenderVirtualRows && typeof window !== "undefined";
@@ -131,6 +132,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
           sessionRole={sessionRole}
           sessionSelectedModel={sessionSelectedModel}
           sessionAgentColors={sessionAgentColors}
+          sessionWorkingDirectory={sessionWorkingDirectory}
         />
       </div>
     );

--- a/apps/desktop/src/components/features/agents/agent-chat/file-edit-tool.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/file-edit-tool.ts
@@ -1,5 +1,6 @@
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 import { extractPathFromInput } from "./tool-input-utils";
+import { relativizeDisplayPath } from "./tool-path-utils";
 
 const FILE_EDIT_TOOLS = new Set([
   "edit",
@@ -26,7 +27,10 @@ export type FileEditData = {
   deletions: number;
 };
 
-export const extractFileEditData = (meta: ToolMeta): FileEditData | null => {
+export const extractFileEditData = (
+  meta: ToolMeta,
+  workingDirectory?: string | null,
+): FileEditData | null => {
   let filePath = extractPathFromInput(meta.input);
 
   if (!filePath && typeof meta.input?.patch === "string") {
@@ -48,6 +52,8 @@ export const extractFileEditData = (meta: ToolMeta): FileEditData | null => {
   if (!filePath) {
     return null;
   }
+
+  filePath = relativizeDisplayPath(filePath, workingDirectory);
 
   const diff =
     typeof meta.metadata?.diff === "string"

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-path-utils.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-path-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { relativizeDisplayPathsInValue } from "./tool-path-utils";
+
+describe("tool-path-utils", () => {
+  test("relativizes string arrays for plural path keys", () => {
+    expect(
+      relativizeDisplayPathsInValue(
+        {
+          files: ["/repo/src/a.ts", "/repo/src/b.ts"],
+          paths: ["/repo/docs/spec.md"],
+        },
+        "/repo",
+      ),
+    ).toEqual({
+      files: ["src/a.ts", "src/b.ts"],
+      paths: ["docs/spec.md"],
+    });
+  });
+
+  test("preserves non-path arrays when the parent key is not path-like", () => {
+    expect(
+      relativizeDisplayPathsInValue(
+        {
+          labels: ["/repo/src/a.ts", "/repo/src/b.ts"],
+        },
+        "/repo",
+      ),
+    ).toEqual({
+      labels: ["/repo/src/a.ts", "/repo/src/b.ts"],
+    });
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-path-utils.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-path-utils.ts
@@ -3,7 +3,9 @@ const DISPLAY_PATH_KEYS = new Set([
   "filePath",
   "file_path",
   "path",
+  "paths",
   "file",
+  "files",
   "filename",
   "cwd",
   "directory",
@@ -74,7 +76,7 @@ export const relativizeDisplayPathsInValue = (
       : value;
   }
   if (Array.isArray(value)) {
-    return value.map((entry) => relativizeDisplayPathsInValue(entry, workingDirectory));
+    return value.map((entry) => relativizeDisplayPathsInValue(entry, workingDirectory, key));
   }
   if (!value || typeof value !== "object") {
     return value;

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-path-utils.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-path-utils.ts
@@ -1,0 +1,89 @@
+const normalizeSlashes = (value: string): string => value.replace(/\\/g, "/");
+const DISPLAY_PATH_KEYS = new Set([
+  "filePath",
+  "file_path",
+  "path",
+  "file",
+  "filename",
+  "cwd",
+  "directory",
+  "root",
+  "basePath",
+  "workingDir",
+  "workingDirectory",
+]);
+
+const trimTrailingSlash = (value: string): string => {
+  if (value === "/") {
+    return value;
+  }
+  return value.replace(/\/+$/, "");
+};
+
+const normalizeAbsolutePath = (value: string): string => trimTrailingSlash(normalizeSlashes(value));
+
+export const relativizeDisplayPath = (
+  filePath: string,
+  workingDirectory?: string | null,
+): string => {
+  const trimmedPath = filePath.trim();
+  const trimmedWorkingDirectory = workingDirectory?.trim() ?? "";
+  if (trimmedPath.length === 0 || trimmedWorkingDirectory.length === 0) {
+    return trimmedPath;
+  }
+
+  const normalizedPath = normalizeAbsolutePath(trimmedPath);
+  if (!normalizedPath.startsWith("/")) {
+    return trimmedPath;
+  }
+
+  const normalizedWorkingDirectory = normalizeAbsolutePath(trimmedWorkingDirectory);
+  if (normalizedPath === normalizedWorkingDirectory) {
+    return ".";
+  }
+  if (!normalizedPath.startsWith(`${normalizedWorkingDirectory}/`)) {
+    return trimmedPath;
+  }
+
+  return normalizedPath.slice(normalizedWorkingDirectory.length + 1);
+};
+
+export const relativizeSearchSummary = (
+  summary: string,
+  workingDirectory?: string | null,
+): string => {
+  const marker = " in ";
+  const markerIndex = summary.lastIndexOf(marker);
+  if (markerIndex === -1) {
+    return relativizeDisplayPath(summary, workingDirectory);
+  }
+
+  const prefix = summary.slice(0, markerIndex + marker.length);
+  const path = summary.slice(markerIndex + marker.length);
+  return `${prefix}${relativizeDisplayPath(path, workingDirectory)}`;
+};
+
+export const relativizeDisplayPathsInValue = (
+  value: unknown,
+  workingDirectory?: string | null,
+  key?: string,
+): unknown => {
+  if (typeof value === "string") {
+    return key && DISPLAY_PATH_KEYS.has(key)
+      ? relativizeDisplayPath(value, workingDirectory)
+      : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => relativizeDisplayPathsInValue(entry, workingDirectory));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([entryKey, entryValue]) => [
+      entryKey,
+      relativizeDisplayPathsInValue(entryValue, workingDirectory, entryKey),
+    ]),
+  );
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
@@ -1,6 +1,7 @@
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 import { extractPathFromInput, readInputString } from "./tool-input-utils";
 import { getToolLifecyclePhase, hasNonEmptyText } from "./tool-lifecycle";
+import { relativizeDisplayPath, relativizeSearchSummary } from "./tool-path-utils";
 import { compactText, stripToolPrefix } from "./tool-text-utils";
 
 const OUTPUT_IGNORED_TOOL_NAMES = new Set([
@@ -12,6 +13,40 @@ const OUTPUT_IGNORED_TOOL_NAMES = new Set([
   "list",
   "ls",
   "distill",
+]);
+
+const SEARCH_PATH_DISPLAY_TOOL_NAMES = new Set([
+  "glob",
+  "grep",
+  "find",
+  "search",
+  "ast_grep_search",
+]);
+
+const PATH_DISPLAY_TOOL_NAMES = new Set([
+  "read",
+  "cat",
+  "view",
+  "list",
+  "ls",
+  "edit",
+  "multiedit",
+  "write",
+  "create",
+  "file_write",
+  "apply_patch",
+  "str_replace",
+  "str_replace_based_edit_tool",
+  "patch",
+  "insert",
+  "replace",
+  "lsp_diagnostic",
+  "lsp_diagnostics",
+  "lsp_find_references",
+  "lsp_goto_definition",
+  "lsp_prepare_rename",
+  "lsp_symbols",
+  "look_at",
 ]);
 
 const REGULAR_TOOL_SUMMARY_FROM_OUTPUT_TOOL_NAMES = new Set(["task", "subtask", "delegate"]);
@@ -142,10 +177,47 @@ const countTodosFromOutput = (output: string | undefined): number | null => {
   }
 };
 
-export const buildToolSummary = (meta: ToolMeta, content: string): string => {
+const normalizeDisplaySummary = (
+  tool: string,
+  summary: string,
+  workingDirectory?: string | null,
+): string => {
+  if (SEARCH_PATH_DISPLAY_TOOL_NAMES.has(tool)) {
+    return relativizeSearchSummary(summary, workingDirectory);
+  }
+  if (!PATH_DISPLAY_TOOL_NAMES.has(tool)) {
+    return summary;
+  }
+  return relativizeDisplayPath(summary, workingDirectory);
+};
+
+const extractTaskId = (input: Record<string, unknown> | undefined): string | null => {
+  const taskId = input?.taskId;
+  return typeof taskId === "string" && taskId.trim().length > 0 ? taskId.trim() : null;
+};
+
+export const buildToolSummary = (
+  meta: ToolMeta,
+  content: string,
+  workingDirectory?: string | null,
+): string => {
   const lowerTool = meta.tool.toLowerCase();
   const isTodoTool = isTodoToolName(lowerTool);
   const lifecyclePhase = getToolLifecyclePhase(meta);
+
+  if (
+    lowerTool === "read_task" ||
+    lowerTool === "odt_read_task" ||
+    lowerTool.endsWith("_odt_read_task")
+  ) {
+    if (meta.status === "error" && hasNonEmptyText(meta.error)) {
+      return compactText(meta.error, 220);
+    }
+    const taskId = extractTaskId(meta.input);
+    if (taskId) {
+      return taskId;
+    }
+  }
 
   if (isTodoTool) {
     const todoCount = countTodosFromOutput(meta.output) ?? countTodosFromInput(meta.input);
@@ -174,17 +246,21 @@ export const buildToolSummary = (meta: ToolMeta, content: string): string => {
     return compactText(meta.error, 220);
   }
 
+  if (typeof meta.preview === "string" && meta.preview.trim().length > 0) {
+    return compactText(normalizeDisplaySummary(lowerTool, meta.preview, workingDirectory), 160);
+  }
+
   if (meta.title && meta.title.trim().length > 0) {
-    return compactText(meta.title, 160);
+    return compactText(normalizeDisplaySummary(lowerTool, meta.title, workingDirectory), 160);
   }
 
   const path = extractPathFromInput(meta.input);
   const searchSummary = summarizeSearchToolInput(lowerTool, meta.input);
   if (searchSummary) {
-    return compactText(searchSummary, 160);
+    return compactText(relativizeSearchSummary(searchSummary, workingDirectory), 160);
   }
   if (path && lowerTool !== "glob" && lowerTool !== "grep") {
-    return compactText(path, 160);
+    return compactText(relativizeDisplayPath(path, workingDirectory), 160);
   }
 
   const command = meta.input?.command;

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
@@ -103,6 +103,7 @@ const composeToolMessageMeta = (
     callId: part.callId,
     tool: part.tool,
     status,
+    ...(part.preview ? { preview: part.preview } : {}),
     ...(part.title ? { title: part.title } : {}),
     ...(input ? { input } : {}),
     ...(output ? { output } : {}),

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -222,6 +222,7 @@ const historyPartToChatMessage = (
           callId: part.callId,
           tool: part.tool,
           status: part.status,
+          ...(part.preview ? { preview: part.preview } : {}),
           ...(part.title ? { title: part.title } : {}),
           ...(input ? { input } : {}),
           ...(output ? { output } : {}),

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -19,6 +19,7 @@ export type AgentChatMessageMeta =
       callId: string;
       tool: string;
       status: "pending" | "running" | "completed" | "error";
+      preview?: string;
       title?: string;
       input?: Record<string, unknown>;
       output?: string;

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -58,6 +58,93 @@ const createToolPart = ({
 };
 
 describe("stream-part-mapper", () => {
+  test("derives preview hints for current tool families", () => {
+    const scenarios = [
+      {
+        label: "shell",
+        part: createToolPart({
+          id: "preview-shell",
+          tool: "bash",
+          status: "running",
+          input: { command: "bun run test --filter @openducktor/desktop" },
+          title: "Run desktop tests",
+        }),
+        expectedPreview: "bun run test --filter @openducktor/desktop",
+      },
+      {
+        label: "skill",
+        part: createToolPart({
+          id: "preview-skill",
+          tool: "skill",
+          status: "completed",
+          input: { name: "clean-ddd-hexagonal" },
+          output: "loaded skill output",
+        }),
+        expectedPreview: "clean-ddd-hexagonal",
+      },
+      {
+        label: "odt read task",
+        part: createToolPart({
+          id: "preview-odt-read",
+          tool: "odt_read_task",
+          status: "completed",
+          input: { taskId: "task-77" },
+          output: {
+            task: {
+              id: "task-77",
+              title: "Improve chat tool previews",
+            },
+          },
+        }),
+        expectedPreview: "task-77",
+      },
+      {
+        label: "question",
+        part: createToolPart({
+          id: "preview-question",
+          tool: "question",
+          status: "completed",
+          input: {
+            questions: [{ question: "Which runtime should we use?" }],
+          },
+        }),
+        expectedPreview: "Which runtime should we use?",
+      },
+      {
+        label: "web",
+        part: createToolPart({
+          id: "preview-web",
+          tool: "webfetch",
+          status: "completed",
+          input: { url: "https://example.com/docs" },
+        }),
+        expectedPreview: "https://example.com/docs",
+      },
+      {
+        label: "context7",
+        part: createToolPart({
+          id: "preview-context7",
+          tool: "context7_query-docs",
+          status: "completed",
+          input: {
+            libraryId: "/vercel/next.js",
+            query: "app router metadata examples",
+          },
+        }),
+        expectedPreview: "app router metadata examples",
+      },
+    ] as const;
+
+    for (const scenario of scenarios) {
+      const mapped = mapPartToAgentStreamPart(scenario.part);
+      expect(mapped).toBeTruthy();
+      if (!mapped || mapped.kind !== "tool") {
+        throw new Error(`Expected mapped tool part for ${scenario.label}.`);
+      }
+      expect(mapped.preview).toBe(scenario.expectedPreview);
+    }
+  });
+
   test("maps completed MCP tool output with isError as tool error part and omits title", () => {
     const part = createToolPart({
       id: "tool-1",
@@ -162,6 +249,7 @@ describe("stream-part-mapper", () => {
       input: {
         todos: [{ id: "todo-1", content: "A" }],
       },
+      preview: "1 todo",
       startedAtMs: 1,
       endedAtMs: 2,
     });

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -174,6 +174,7 @@ describe("stream-part-mapper", () => {
       tool: "openducktor_odt_set_spec",
       status: "error",
       input: { taskId: "task-1" },
+      preview: "task-1",
       error: "Task not found",
       metadata: {
         scope: "mcp",
@@ -211,6 +212,7 @@ describe("stream-part-mapper", () => {
       tool: "openducktor_odt_set_spec",
       status: "error",
       input: { taskId: "task-1" },
+      preview: "task-1",
       error: "set_spec is only allowed from open/spec_ready/ready_for_dev (current: in_progress)",
       metadata: {
         structuredContent: {

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -8,6 +8,7 @@ import {
   readUnknownProp,
 } from "./guards";
 import { toTokenTotal } from "./message-normalizers";
+import { deriveToolPreview } from "./tool-preview";
 
 const toDisplayText = (value: unknown): string | undefined => {
   if (typeof value === "string") {
@@ -146,6 +147,12 @@ const buildToolStreamPart = (
   timing: ReturnType<typeof extractPartTiming>,
   metadata: Record<string, unknown> | undefined,
 ): ToolStreamPart => {
+  const preview = deriveToolPreview({
+    tool: part.tool,
+    rawInput: readUnknownProp(toolState, "input"),
+    rawOutput: readUnknownProp(toolState, "output"),
+    ...(metadata ? { metadata } : {}),
+  });
   const base: ToolStreamPart = {
     kind: "tool",
     messageId: part.messageID,
@@ -154,6 +161,7 @@ const buildToolStreamPart = (
     tool: part.tool,
     status: normalizedStatus,
     input: part.state.input,
+    ...(preview ? { preview } : {}),
     ...(metadata ? { metadata } : {}),
     ...timing,
   };

--- a/packages/adapters-opencode-sdk/src/tool-preview.test.ts
+++ b/packages/adapters-opencode-sdk/src/tool-preview.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { deriveToolPreview } from "./tool-preview";
+
+describe("deriveToolPreview", () => {
+  test("derives previews for namespaced ODT tool ids", () => {
+    expect(
+      deriveToolPreview({
+        tool: "functions.openducktor_odt_set_plan",
+        rawInput: {
+          taskId: "task-42",
+          subtasks: [{ id: "1" }, { id: "2" }],
+        },
+        rawOutput: undefined,
+      }),
+    ).toBe("task-42 · 2 subtasks");
+  });
+
+  test("handles singular lsp_diagnostic tool ids like other lsp tools", () => {
+    expect(
+      deriveToolPreview({
+        tool: "lsp_diagnostic",
+        rawInput: {
+          symbol: "AuthContext",
+          path: "/repo/apps/web/src/contexts/AuthContext.tsx",
+        },
+        rawOutput: undefined,
+      }),
+    ).toBe("AuthContext");
+  });
+
+  test("does not treat substring matches as question tools", () => {
+    expect(
+      deriveToolPreview({
+        tool: "question_parser",
+        rawInput: {
+          name: "parse-questions",
+          questions: [{ question: "Which runtime should we use?" }],
+        },
+        rawOutput: undefined,
+      }),
+    ).toBe("parse-questions");
+  });
+});

--- a/packages/adapters-opencode-sdk/src/tool-preview.ts
+++ b/packages/adapters-opencode-sdk/src/tool-preview.ts
@@ -1,0 +1,319 @@
+import { asUnknownRecord } from "./guards";
+
+const SHELL_TOOL_NAMES = new Set(["bash", "shell", "exec", "command"]);
+const READ_TOOL_NAMES = new Set(["read", "cat", "view"]);
+const LIST_TOOL_NAMES = new Set(["list", "ls"]);
+const SEARCH_TOOL_NAMES = new Set(["glob", "grep", "find", "search", "ast_grep_search"]);
+const TODO_TOOL_NAMES = new Set(["todowrite", "todoread"]);
+const TASK_TOOL_NAMES = new Set(["task", "delegate", "subtask"]);
+const SESSION_TOOL_NAMES = new Set([
+  "session_info",
+  "session_list",
+  "session_read",
+  "session_search",
+]);
+const LSP_TOOL_NAMES = new Set([
+  "lsp_diagnostics",
+  "lsp_find_references",
+  "lsp_goto_definition",
+  "lsp_prepare_rename",
+  "lsp_symbols",
+]);
+
+const compactText = (value: string, maxLength = 160): string => {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength)}...`;
+};
+
+const readTrimmedString = (
+  source: Record<string, unknown> | undefined,
+  keys: string[],
+): string | null => {
+  if (!source) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+};
+
+const extractPathFromInput = (input: Record<string, unknown> | undefined): string | null => {
+  return readTrimmedString(input, ["filePath", "file_path", "path", "file", "filename"]);
+};
+
+const extractBaseName = (value: string): string => {
+  const normalized = value.replace(/\\/g, "/");
+  const lastSegment = normalized.split("/").filter(Boolean).at(-1) ?? normalized;
+  return lastSegment.replace(/\.[^.]+$/, "");
+};
+
+const summarizeSearchInput = (
+  tool: string,
+  input: Record<string, unknown> | undefined,
+): string | null => {
+  if (!input) {
+    return null;
+  }
+  const pattern = readTrimmedString(input, [
+    "pattern",
+    "query",
+    "regex",
+    "glob",
+    "expression",
+    "name",
+    "rule",
+  ]);
+  const path = readTrimmedString(input, ["path", "cwd", "directory", "root", "basePath"]);
+  const normalizedPath = path && path !== "." ? path : null;
+
+  if (pattern && normalizedPath) {
+    return `${pattern} in ${normalizedPath}`;
+  }
+  if (pattern) {
+    return pattern;
+  }
+  if (normalizedPath) {
+    return normalizedPath;
+  }
+  if (tool === "find" && path === ".") {
+    return "workspace";
+  }
+  return null;
+};
+
+const countCollectionItems = (value: unknown): number | null => {
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  const record = asUnknownRecord(value);
+  if (!record) {
+    return null;
+  }
+  if (Array.isArray(record.todos)) {
+    return record.todos.length;
+  }
+  if (Array.isArray(record.items)) {
+    return record.items.length;
+  }
+  if (Array.isArray(record.questions)) {
+    return record.questions.length;
+  }
+  if (Array.isArray(record.summary)) {
+    return record.summary.length;
+  }
+  return null;
+};
+
+const summarizeTodoTool = (
+  input: Record<string, unknown> | undefined,
+  output: unknown,
+): string | null => {
+  const count = countCollectionItems(output) ?? countCollectionItems(input?.todos ?? input?.items);
+  if (count === null) {
+    return null;
+  }
+  return `${count} todo${count === 1 ? "" : "s"}`;
+};
+
+const summarizeQuestionTool = (
+  input: Record<string, unknown> | undefined,
+  metadata: Record<string, unknown> | undefined,
+  output: unknown,
+): string | null => {
+  const sources = [input, metadata, asUnknownRecord(output)];
+  for (const source of sources) {
+    const questions = source?.questions;
+    if (!Array.isArray(questions) || questions.length === 0) {
+      continue;
+    }
+    const firstQuestion = asUnknownRecord(questions[0]);
+    const prompt = readTrimmedString(firstQuestion, ["question", "prompt", "label"]);
+    if (prompt) {
+      return prompt;
+    }
+    return `${questions.length} question${questions.length === 1 ? "" : "s"}`;
+  }
+  return null;
+};
+
+const summarizeTaskTool = (
+  input: Record<string, unknown> | undefined,
+  metadata: Record<string, unknown> | undefined,
+  output: unknown,
+): string | null => {
+  const summaryCount = countCollectionItems(metadata?.summary);
+  if (summaryCount !== null) {
+    return `${summaryCount} subagent result${summaryCount === 1 ? "" : "s"}`;
+  }
+
+  const sessionId = readTrimmedString(metadata, ["sessionId"]);
+  if (sessionId) {
+    return `Subagent session ${sessionId.slice(0, 8)}`;
+  }
+
+  return (
+    readTrimmedString(input, ["agent", "description", "prompt"]) ??
+    readTrimmedString(asUnknownRecord(output), ["message", "result", "description"])
+  );
+};
+
+const summarizeOdtReadTask = (
+  input: Record<string, unknown> | undefined,
+  output: unknown,
+): string | null => {
+  const taskId = readTrimmedString(input, ["taskId"]);
+  if (taskId) {
+    return taskId;
+  }
+
+  const outputRecord = asUnknownRecord(output);
+  const taskRecord =
+    asUnknownRecord(outputRecord?.task) ??
+    asUnknownRecord(asUnknownRecord(outputRecord?.structuredContent)?.task);
+  const title = readTrimmedString(taskRecord, ["title", "name"]);
+  if (title) {
+    return title;
+  }
+  return null;
+};
+
+const summarizeOdtMutation = (
+  tool: string,
+  input: Record<string, unknown> | undefined,
+): string | null => {
+  if (tool === "odt_build_blocked") {
+    return readTrimmedString(input, ["reason", "taskId"]);
+  }
+  if (tool === "odt_build_completed") {
+    return readTrimmedString(input, ["summary", "taskId"]);
+  }
+  if (tool === "odt_set_plan") {
+    const subtaskCount = countCollectionItems(input?.subtasks);
+    if (subtaskCount !== null) {
+      const taskId = readTrimmedString(input, ["taskId"]);
+      return taskId
+        ? `${taskId} · ${subtaskCount} subtask${subtaskCount === 1 ? "" : "s"}`
+        : `${subtaskCount} subtask${subtaskCount === 1 ? "" : "s"}`;
+    }
+  }
+  return readTrimmedString(input, ["taskId"]);
+};
+
+const summarizeSkillTool = (input: Record<string, unknown> | undefined): string | null => {
+  const direct =
+    readTrimmedString(input, ["name", "skillName", "skill", "id"]) ??
+    readTrimmedString(asUnknownRecord(input?.skill), ["name", "id"]);
+  if (direct) {
+    return direct;
+  }
+
+  const path = readTrimmedString(input, ["path", "filePath"]);
+  return path ? extractBaseName(path) : null;
+};
+
+const summarizeWebTool = (
+  tool: string,
+  input: Record<string, unknown> | undefined,
+): string | null => {
+  if (tool === "webfetch") {
+    return readTrimmedString(input, ["url", "href"]);
+  }
+  return readTrimmedString(input, ["query", "q", "url"]);
+};
+
+const summarizeContextTool = (
+  tool: string,
+  input: Record<string, unknown> | undefined,
+): string | null => {
+  if (tool === "context7_resolve-library-id") {
+    return readTrimmedString(input, ["libraryName", "query"]);
+  }
+  if (tool === "context7_query-docs") {
+    return readTrimmedString(input, ["query", "libraryId"]);
+  }
+  return null;
+};
+
+const summarizeGithubSearchTool = (input: Record<string, unknown> | undefined): string | null => {
+  const query = readTrimmedString(input, ["query"]);
+  const repo = readTrimmedString(input, ["repo"]);
+  if (query && repo) {
+    return `${query} in ${repo}`;
+  }
+  return query ?? repo;
+};
+
+const summarizeLspTool = (input: Record<string, unknown> | undefined): string | null => {
+  return (
+    readTrimmedString(input, ["symbol", "name", "query"]) ??
+    extractPathFromInput(input) ??
+    readTrimmedString(input, ["word"])
+  );
+};
+
+const summarizeSessionTool = (input: Record<string, unknown> | undefined): string | null => {
+  return (
+    readTrimmedString(input, ["sessionId", "query"]) ?? readTrimmedString(input, ["id", "name"])
+  );
+};
+
+const summarizeGenericInput = (input: Record<string, unknown> | undefined): string | null => {
+  return (
+    readTrimmedString(input, ["url", "query", "pattern", "symbol", "libraryId", "libraryName"]) ??
+    extractPathFromInput(input) ??
+    readTrimmedString(input, ["name", "id", "prompt", "description"])
+  );
+};
+
+export const deriveToolPreview = (input: {
+  tool: string;
+  rawInput: unknown;
+  rawOutput: unknown;
+  metadata?: Record<string, unknown>;
+}): string | undefined => {
+  const tool = input.tool.trim().toLowerCase();
+  const rawInput = asUnknownRecord(input.rawInput);
+
+  const preview =
+    (SHELL_TOOL_NAMES.has(tool) ? readTrimmedString(rawInput, ["command"]) : null) ??
+    (READ_TOOL_NAMES.has(tool) ? extractPathFromInput(rawInput) : null) ??
+    (LIST_TOOL_NAMES.has(tool)
+      ? (readTrimmedString(rawInput, ["path", "cwd", "directory"]) ?? null)
+      : null) ??
+    (SEARCH_TOOL_NAMES.has(tool) ? summarizeSearchInput(tool, rawInput) : null) ??
+    ((tool === "skill" && summarizeSkillTool(rawInput)) || null) ??
+    (TODO_TOOL_NAMES.has(tool) || tool.endsWith("_todowrite") || tool.endsWith("_todoread")
+      ? summarizeTodoTool(rawInput, input.rawOutput)
+      : null) ??
+    (tool === "question" || tool.endsWith("_question") || tool.includes("question")
+      ? summarizeQuestionTool(rawInput, input.metadata, input.rawOutput)
+      : null) ??
+    (TASK_TOOL_NAMES.has(tool)
+      ? summarizeTaskTool(rawInput, input.metadata, input.rawOutput)
+      : null) ??
+    (tool === "odt_read_task" ? summarizeOdtReadTask(rawInput, input.rawOutput) : null) ??
+    (tool.startsWith("odt_") ? summarizeOdtMutation(tool, rawInput) : null) ??
+    (tool === "webfetch" || tool.startsWith("websearch")
+      ? summarizeWebTool(tool, rawInput)
+      : null) ??
+    (tool.startsWith("context7_") ? summarizeContextTool(tool, rawInput) : null) ??
+    (tool === "grep_app_searchgithub" ? summarizeGithubSearchTool(rawInput) : null) ??
+    (LSP_TOOL_NAMES.has(tool) ? summarizeLspTool(rawInput) : null) ??
+    (SESSION_TOOL_NAMES.has(tool) ? summarizeSessionTool(rawInput) : null) ??
+    (tool === "look_at" || tool === "distill" || tool === "prune" || tool === "background_output"
+      ? summarizeGenericInput(rawInput)
+      : null) ??
+    summarizeGenericInput(rawInput);
+
+  if (!preview) {
+    return undefined;
+  }
+  return compactText(preview, tool === "bash" ? 120 : 160);
+};

--- a/packages/adapters-opencode-sdk/src/tool-preview.ts
+++ b/packages/adapters-opencode-sdk/src/tool-preview.ts
@@ -13,12 +13,23 @@ const SESSION_TOOL_NAMES = new Set([
   "session_search",
 ]);
 const LSP_TOOL_NAMES = new Set([
+  "lsp_diagnostic",
   "lsp_diagnostics",
   "lsp_find_references",
   "lsp_goto_definition",
   "lsp_prepare_rename",
   "lsp_symbols",
 ]);
+
+const normalizeToolName = (value: string): string => {
+  const trimmed = value.trim().toLowerCase();
+  const withoutFunctionsNamespace = trimmed.startsWith("functions.")
+    ? trimmed.slice("functions.".length)
+    : trimmed;
+  return withoutFunctionsNamespace.startsWith("openducktor_odt_")
+    ? withoutFunctionsNamespace.slice("openducktor_".length)
+    : withoutFunctionsNamespace;
+};
 
 const compactText = (value: string, maxLength = 160): string => {
   const normalized = value.replace(/\s+/g, " ").trim();
@@ -278,7 +289,7 @@ export const deriveToolPreview = (input: {
   rawOutput: unknown;
   metadata?: Record<string, unknown>;
 }): string | undefined => {
-  const tool = input.tool.trim().toLowerCase();
+  const tool = normalizeToolName(input.tool);
   const rawInput = asUnknownRecord(input.rawInput);
 
   const preview =
@@ -292,7 +303,7 @@ export const deriveToolPreview = (input: {
     (TODO_TOOL_NAMES.has(tool) || tool.endsWith("_todowrite") || tool.endsWith("_todoread")
       ? summarizeTodoTool(rawInput, input.rawOutput)
       : null) ??
-    (tool === "question" || tool.endsWith("_question") || tool.includes("question")
+    (tool === "question" || tool.endsWith("_question")
       ? summarizeQuestionTool(rawInput, input.metadata, input.rawOutput)
       : null) ??
     (TASK_TOOL_NAMES.has(tool)
@@ -307,9 +318,6 @@ export const deriveToolPreview = (input: {
     (tool === "grep_app_searchgithub" ? summarizeGithubSearchTool(rawInput) : null) ??
     (LSP_TOOL_NAMES.has(tool) ? summarizeLspTool(rawInput) : null) ??
     (SESSION_TOOL_NAMES.has(tool) ? summarizeSessionTool(rawInput) : null) ??
-    (tool === "look_at" || tool === "distill" || tool === "prune" || tool === "background_output"
-      ? summarizeGenericInput(rawInput)
-      : null) ??
     summarizeGenericInput(rawInput);
 
   if (!preview) {

--- a/packages/core/src/types/agent-orchestrator.ts
+++ b/packages/core/src/types/agent-orchestrator.ts
@@ -172,6 +172,7 @@ export type AgentStreamPart =
       callId: string;
       tool: string;
       status: "pending" | "running" | "completed" | "error";
+      preview?: string;
       title?: string;
       input?: Record<string, unknown>;
       output?: string;


### PR DESCRIPTION
## Summary
- derive stable tool preview strings in the OpenCode stream mapper and carry them through the agent chat models
- render file, read, search, and edit paths relative to the session working directory in chat summaries and presenters
- add desktop and adapter coverage for preview derivation, relative path rendering, and the new preview field contract

## Testing
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/adapters-opencode-sdk test
- bun run --filter @openducktor/adapters-opencode-sdk typecheck
- bun run --filter @openducktor/adapters-opencode-sdk lint
- bun run --filter @openducktor/core test
- bun run --filter @openducktor/core typecheck
- bun run --filter @openducktor/core lint