### PR TITLE
fix(desktop): smooth agent chat virtualization scrolling

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -4,8 +4,8 @@ import {
   isOdtWorkflowMutationToolName,
 } from "@openducktor/core";
 import { Brain, Hammer, MessageSquareQuote } from "lucide-react";
-import { lazy, type ReactElement, Suspense } from "react";
-import type { MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
+import type { ReactElement } from "react";
+import { MarkdownRenderer, type MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
 import { cn } from "@/lib/utils";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import { hasMarkdownSyntaxHint } from "./agent-chat-markdown-hints";
@@ -20,11 +20,6 @@ import {
   RegularToolMessage,
   WorkflowToolMessage,
 } from "./agent-chat-message-card-tool-presenters";
-
-const LazyMarkdownRenderer = lazy(async () => {
-  const module = await import("@/components/ui/markdown-renderer");
-  return { default: module.MarkdownRenderer };
-});
 
 const PLAIN_TEXT_CLASSES: Record<MarkdownRendererVariant, string> = {
   compact: "whitespace-pre-wrap text-[13px] leading-relaxed text-foreground",
@@ -43,15 +38,15 @@ const PlainTextMarkdownFallback = ({
   return <p className={PLAIN_TEXT_CLASSES[variant]}>{content}</p>;
 };
 
-type DeferredMarkdownRendererProps = {
+type MessageMarkdownContentProps = {
   markdown: string;
   variant?: MarkdownRendererVariant;
 };
 
-const DeferredMarkdownRenderer = ({
+const MessageMarkdownContent = ({
   markdown,
   variant = "document",
-}: DeferredMarkdownRendererProps): ReactElement | null => {
+}: MessageMarkdownContentProps): ReactElement | null => {
   const content = markdown.trim();
   if (!content) {
     return null;
@@ -61,11 +56,7 @@ const DeferredMarkdownRenderer = ({
     return <PlainTextMarkdownFallback content={content} variant={variant} />;
   }
 
-  return (
-    <Suspense fallback={<PlainTextMarkdownFallback content={content} variant={variant} />}>
-      <LazyMarkdownRenderer markdown={content} variant={variant} />
-    </Suspense>
-  );
+  return <MarkdownRenderer markdown={content} variant={variant} />;
 };
 
 export type MessageHeaderProps = {
@@ -133,7 +124,7 @@ const ReasoningMessage = ({
           ) : null}
         </summary>
         <div className="pl-6 pt-2">
-          <DeferredMarkdownRenderer markdown={content || "Reasoning complete"} variant="compact" />
+          <MessageMarkdownContent markdown={content || "Reasoning complete"} variant="compact" />
         </div>
       </details>
     );
@@ -148,7 +139,7 @@ const ReasoningMessage = ({
           <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">{timeLabel}</span>
         ) : null}
       </div>
-      <DeferredMarkdownRenderer markdown={content || "Thinking..."} variant="compact" />
+      <MessageMarkdownContent markdown={content || "Thinking..."} variant="compact" />
     </div>
   );
 };
@@ -167,7 +158,7 @@ const AssistantMessage = ({
   const footer = getAssistantFooterData(message, sessionSelectedModel);
   return (
     <div className="space-y-2">
-      <DeferredMarkdownRenderer markdown={message.content} variant="document" />
+      <MessageMarkdownContent markdown={message.content} variant="document" />
       {footer.infoParts.length > 0 ? (
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span
@@ -251,7 +242,7 @@ export const MessageBody = ({
           Show system prompt
         </summary>
         <div className="border-t border-border px-2 py-2">
-          <DeferredMarkdownRenderer markdown={systemPromptBody} variant="compact" />
+          <MessageMarkdownContent markdown={systemPromptBody} variant="compact" />
         </div>
       </details>
     );
@@ -284,5 +275,5 @@ export const MessageBody = ({
     );
   }
 
-  return <DeferredMarkdownRenderer markdown={message.content} variant="document" />;
+  return <MessageMarkdownContent markdown={message.content} variant="document" />;
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts
@@ -8,6 +8,8 @@ import {
   findVirtualWindowRange,
   getVirtualWindowEdgeOffsets,
   normalizeVirtualWindowRange,
+  resolveAgentChatVirtualRowGapPx,
+  resolveAgentChatVirtualRowSize,
 } from "./agent-chat-thread-virtualization";
 
 const createMessageIdentityResolver = (): ((message: AgentChatMessage) => number) => {
@@ -178,6 +180,13 @@ describe("agent-chat-thread virtualization helpers", () => {
     const rows = buildAgentChatVirtualRows(session);
 
     expect(rows).toEqual([]);
+  });
+
+  test("row size helpers include the virtual gap for every row except the last", () => {
+    expect(resolveAgentChatVirtualRowGapPx(0, 3)).toBe(4);
+    expect(resolveAgentChatVirtualRowGapPx(2, 3)).toBe(0);
+    expect(resolveAgentChatVirtualRowSize({ index: 0, rowCount: 3, rowHeight: 80 })).toBe(84);
+    expect(resolveAgentChatVirtualRowSize({ index: 2, rowCount: 3, rowHeight: 80 })).toBe(80);
   });
 
   test("buildAgentChatVirtualRows skips turn duration rows for non-final assistant messages", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.ts
@@ -103,6 +103,22 @@ export function buildAgentChatVirtualRowsSignature(
   return signatureParts.join("\u001f");
 }
 
+export const resolveAgentChatVirtualRowGapPx = (index: number, rowCount: number): number => {
+  return index < rowCount - 1 ? AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 0;
+};
+
+export const resolveAgentChatVirtualRowSize = ({
+  index,
+  rowCount,
+  rowHeight,
+}: {
+  index: number;
+  rowCount: number;
+  rowHeight: number;
+}): number => {
+  return Math.max(0, rowHeight) + resolveAgentChatVirtualRowGapPx(index, rowCount);
+};
+
 export function buildVirtualRowLayout({ itemHeights, gapPx }: BuildVirtualRowLayoutArgs): {
   itemOffsets: number[];
   totalHeight: number;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-auto-scroll.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-auto-scroll.ts
@@ -92,7 +92,6 @@ export function useAgentChatAutoScroll({
           top: clampedTop,
           behavior: "auto",
         });
-        container.scrollTop = clampedTop;
       };
 
       if (shouldVirtualize && virtualRowsCount > 0) {

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
@@ -65,14 +65,20 @@ describe("use-agent-chat-layout helpers", () => {
   });
 
   test("scrollMessagesContainerToBottom repins the latest rows after layout changes", () => {
-    const scrollTo = mock(() => {});
     const container = {
       dataset: {},
       clientHeight: 320,
       scrollHeight: 960,
-      scrollTo,
       scrollTop: 40,
     } as unknown as HTMLDivElement;
+    const scrollTo = mock((first?: ScrollToOptions | number, second?: number) => {
+      if (typeof first === "number") {
+        container.scrollTop = second ?? container.scrollTop;
+        return;
+      }
+      container.scrollTop = first?.top ?? container.scrollTop;
+    });
+    container.scrollTo = scrollTo;
 
     scrollMessagesContainerToBottom(container);
 

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -79,7 +79,6 @@ export const scrollMessagesContainerToBottom = (
     top: nextTop,
     behavior: "auto",
   });
-  container.scrollTop = nextTop;
 };
 
 const adjustMessagesContainerScrollBy = (
@@ -100,7 +99,6 @@ const adjustMessagesContainerScrollBy = (
     top: nextTop,
     behavior: "auto",
   });
-  container.scrollTop = nextTop;
 };
 
 type UseAgentChatLayoutInput = {

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
@@ -5,11 +5,11 @@ import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestr
 import { hasMarkdownSyntaxHint } from "./agent-chat-markdown-hints";
 import {
   AGENT_CHAT_VIRTUAL_OVERSCAN_ITEMS,
-  AGENT_CHAT_VIRTUAL_ROW_GAP_PX,
   AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT,
   type AgentChatVirtualRow,
   buildAgentChatVirtualRows,
   buildAgentChatVirtualRowsSignature,
+  resolveAgentChatVirtualRowSize,
 } from "./agent-chat-thread-virtualization";
 
 type UseAgentChatVirtualizationInput = {
@@ -55,14 +55,19 @@ type UseVirtualRowMeasurementsResult = {
   estimateRowSize: (index: number) => number;
   measureStaticRowElement: (rowKey: string, element: Element) => void;
   measureVirtualRowElement: (element: Element) => number;
-  resetMeasuredRowHeights: () => void;
+  resetMeasuredRowMeasurements: () => void;
   resolveRowKey: (index: number) => string | number;
 };
 
 type MeasurementBucketStats = {
   count: number;
-  maxHeight: number;
-  movingAverageHeight: number;
+  maxSize: number;
+  movingAverageSize: number;
+};
+
+type VirtualRowMetadata = {
+  index: number;
+  row: AgentChatVirtualRow;
 };
 
 type VirtualizationPreparationPhase = "idle" | "static" | "revealing" | "ready";
@@ -80,7 +85,7 @@ export function useAgentChatVirtualization({
     estimateRowSize,
     measureStaticRowElement,
     measureVirtualRowElement,
-    resetMeasuredRowHeights,
+    resetMeasuredRowMeasurements,
     resolveRowKey,
   } = useVirtualRowMeasurements({
     virtualRows,
@@ -297,7 +302,7 @@ export function useAgentChatVirtualization({
       }
 
       previousWidth = nextWidth;
-      resetMeasuredRowHeights();
+      resetMeasuredRowMeasurements();
       staticMeasurementRefByKeyRef.current.clear();
       staticRowElementByKeyRef.current.clear();
       setStaticMeasurementRowCount(0);
@@ -309,7 +314,7 @@ export function useAgentChatVirtualization({
     return () => {
       observer.disconnect();
     };
-  }, [messagesContainerRef, resetMeasuredRowHeights, shouldVirtualize, virtualizer]);
+  }, [messagesContainerRef, resetMeasuredRowMeasurements, shouldVirtualize, virtualizer]);
 
   return {
     activeSessionId,
@@ -380,53 +385,66 @@ function useVirtualRowMeasurements({
 }: UseVirtualRowMeasurementsInput): UseVirtualRowMeasurementsResult {
   const virtualRowsRef = useRef(virtualRows);
   virtualRowsRef.current = virtualRows;
-  const measuredRowHeightByKeyRef = useRef<Record<string, number>>({});
+  const rowMetadataByKeyRef = useRef<Map<string, VirtualRowMetadata>>(new Map());
+  const previousVirtualRowsRef = useRef<AgentChatVirtualRow[] | null>(null);
+  if (previousVirtualRowsRef.current !== virtualRows) {
+    rowMetadataByKeyRef.current = new Map(
+      virtualRows.map((row, index) => [row.key, { index, row }] as const),
+    );
+    previousVirtualRowsRef.current = virtualRows;
+  }
+  const measuredRowSizeByKeyRef = useRef<Record<string, number>>({});
   const measuredBucketStatsByKeyRef = useRef<Record<string, MeasurementBucketStats>>({});
-  const resolveRowByKey = useCallback((rowKey: string): AgentChatVirtualRow | undefined => {
-    return virtualRowsRef.current.find((candidateRow) => candidateRow.key === rowKey);
+  const resolveMeasuredRowSize = useCallback((rowKey: string, rowHeight: number): number => {
+    const rowMetadata = rowMetadataByKeyRef.current.get(rowKey);
+    if (!rowMetadata) {
+      return Math.max(0, rowHeight);
+    }
+    return resolveAgentChatVirtualRowSize({
+      index: rowMetadata.index,
+      rowCount: virtualRowsRef.current.length,
+      rowHeight,
+    });
   }, []);
 
-  const updateMeasuredRowHeight = useCallback(
-    (rowKey: string, measuredHeight: number): void => {
-      if (!(measuredHeight > 0)) {
-        return;
-      }
+  const updateMeasuredRowSize = useCallback((rowKey: string, measuredSize: number): void => {
+    if (!(measuredSize > 0)) {
+      return;
+    }
 
-      const previousHeight = measuredRowHeightByKeyRef.current[rowKey];
-      if (typeof previousHeight !== "number") {
-        measuredRowHeightByKeyRef.current[rowKey] = measuredHeight;
-      } else if (Math.abs(previousHeight - measuredHeight) > 0.5) {
-        measuredRowHeightByKeyRef.current[rowKey] = measuredHeight;
-      }
+    const previousSize = measuredRowSizeByKeyRef.current[rowKey];
+    if (typeof previousSize !== "number") {
+      measuredRowSizeByKeyRef.current[rowKey] = measuredSize;
+    } else if (Math.abs(previousSize - measuredSize) > 0.5) {
+      measuredRowSizeByKeyRef.current[rowKey] = measuredSize;
+    }
 
-      const row = resolveRowByKey(rowKey);
-      const measurementBucketKey = row ? resolveMeasurementBucketKey(row) : null;
-      if (!measurementBucketKey) {
-        return;
-      }
+    const row = rowMetadataByKeyRef.current.get(rowKey)?.row;
+    const measurementBucketKey = row ? resolveMeasurementBucketKey(row) : null;
+    if (!measurementBucketKey) {
+      return;
+    }
 
-      const previousStats = measuredBucketStatsByKeyRef.current[measurementBucketKey];
-      if (!previousStats) {
-        measuredBucketStatsByKeyRef.current[measurementBucketKey] = {
-          count: 1,
-          maxHeight: measuredHeight,
-          movingAverageHeight: measuredHeight,
-        };
-        return;
-      }
-
-      const nextCount = previousStats.count + 1;
-      const nextMovingAverageHeight =
-        previousStats.movingAverageHeight +
-        (measuredHeight - previousStats.movingAverageHeight) / nextCount;
+    const previousStats = measuredBucketStatsByKeyRef.current[measurementBucketKey];
+    if (!previousStats) {
       measuredBucketStatsByKeyRef.current[measurementBucketKey] = {
-        count: nextCount,
-        maxHeight: Math.max(previousStats.maxHeight, measuredHeight),
-        movingAverageHeight: nextMovingAverageHeight,
+        count: 1,
+        maxSize: measuredSize,
+        movingAverageSize: measuredSize,
       };
-    },
-    [resolveRowByKey],
-  );
+      return;
+    }
+
+    const nextCount = previousStats.count + 1;
+    const nextMovingAverageSize =
+      previousStats.movingAverageSize +
+      (measuredSize - previousStats.movingAverageSize) / nextCount;
+    measuredBucketStatsByKeyRef.current[measurementBucketKey] = {
+      count: nextCount,
+      maxSize: Math.max(previousStats.maxSize, measuredSize),
+      movingAverageSize: nextMovingAverageSize,
+    };
+  }, []);
 
   const estimateRowSize = useCallback((index: number): number => {
     const rows = virtualRowsRef.current;
@@ -434,13 +452,16 @@ function useVirtualRowMeasurements({
     if (!row) {
       return 0;
     }
-    const trailingGap = index < rows.length - 1 ? AGENT_CHAT_VIRTUAL_ROW_GAP_PX : 0;
-    const measuredHeight = measuredRowHeightByKeyRef.current[row.key];
-    if (typeof measuredHeight === "number" && measuredHeight > 0) {
-      return measuredHeight + trailingGap;
+    const measuredSize = measuredRowSizeByKeyRef.current[row.key];
+    if (typeof measuredSize === "number" && measuredSize > 0) {
+      return measuredSize;
     }
 
-    const staticEstimate = estimateVirtualRowHeight(row);
+    const staticEstimate = resolveAgentChatVirtualRowSize({
+      index,
+      rowCount: rows.length,
+      rowHeight: estimateVirtualRowHeight(row),
+    });
     const measurementBucketKey = resolveMeasurementBucketKey(row);
     const bucketStats =
       measurementBucketKey !== null
@@ -448,17 +469,20 @@ function useVirtualRowMeasurements({
         : null;
     const learnedEstimate =
       bucketStats && bucketStats.count > 0
-        ? Math.max(bucketStats.movingAverageHeight, bucketStats.maxHeight * 0.82)
+        ? Math.max(bucketStats.movingAverageSize, bucketStats.maxSize * 0.82)
         : 0;
 
-    return Math.max(staticEstimate, learnedEstimate) + trailingGap;
+    return Math.max(staticEstimate, learnedEstimate);
   }, []);
 
   const measureStaticRowElement = useCallback(
     (rowKey: string, element: Element): void => {
-      updateMeasuredRowHeight(rowKey, element.getBoundingClientRect().height);
+      updateMeasuredRowSize(
+        rowKey,
+        resolveMeasuredRowSize(rowKey, element.getBoundingClientRect().height),
+      );
     },
-    [updateMeasuredRowHeight],
+    [resolveMeasuredRowSize, updateMeasuredRowSize],
   );
 
   const measureVirtualRowElement = useCallback(
@@ -475,20 +499,25 @@ function useVirtualRowMeasurements({
         rowKey = row?.key ?? null;
       }
 
-      if (rowKey && measuredHeight > 0) {
-        updateMeasuredRowHeight(rowKey, measuredHeight);
+      const measuredSize =
+        rowKey && measuredHeight > 0
+          ? resolveMeasuredRowSize(rowKey, measuredHeight)
+          : Math.max(0, measuredHeight);
+
+      if (rowKey && measuredSize > 0) {
+        updateMeasuredRowSize(rowKey, measuredSize);
       }
-      return measuredHeight;
+      return measuredSize;
     },
-    [updateMeasuredRowHeight],
+    [resolveMeasuredRowSize, updateMeasuredRowSize],
   );
 
   const resolveRowKey = useCallback((index: number): string | number => {
     return virtualRowsRef.current[index]?.key ?? index;
   }, []);
 
-  const resetMeasuredRowHeights = useCallback((): void => {
-    measuredRowHeightByKeyRef.current = {};
+  const resetMeasuredRowMeasurements = useCallback((): void => {
+    measuredRowSizeByKeyRef.current = {};
     measuredBucketStatsByKeyRef.current = {};
   }, []);
 
@@ -496,7 +525,7 @@ function useVirtualRowMeasurements({
     estimateRowSize,
     measureStaticRowElement,
     measureVirtualRowElement,
-    resetMeasuredRowHeights,
+    resetMeasuredRowMeasurements,
     resolveRowKey,
   };
 }


### PR DESCRIPTION
## Summary
- align measured and estimated agent chat virtual row sizes so scroll anchoring stays stable while browsing history
- remove chat markdown layout swaps and redundant programmatic scroll writes that were amplifying flicker
- add regression coverage for the row sizing contract and keep the existing desktop chat UI unchanged

## Testing
- bun run --filter @openducktor/desktop test src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts src/components/features/agents/agent-chat/use-agent-chat-virtualization.test.ts src/components/features/agents/agent-chat/use-agent-chat-auto-scroll.test.ts src/components/features/agents/agent-chat/agent-chat-thread.test.ts
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop build
- bun run --filter @openducktor/desktop tauri:dev