### PR TITLE
feat(desktop): add chat thinking settings

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -8,8 +8,8 @@ use host_domain::{
 };
 use host_infra_system::{
     command_exists, hook_set_fingerprint, resolve_central_beads_dir,
-    run_command_allow_failure_with_env, version_command, GlobalGitConfig, HookSet, PromptOverrides,
-    RepoConfig,
+    run_command_allow_failure_with_env, version_command, ChatSettings, GlobalGitConfig, HookSet,
+    PromptOverrides, RepoConfig,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -226,11 +226,17 @@ impl AppService {
         &self,
     ) -> Result<(
         GlobalGitConfig,
+        ChatSettings,
         HashMap<String, RepoConfig>,
         PromptOverrides,
     )> {
         let config = self.config_store.load()?;
-        Ok((config.git, config.repos, config.global_prompt_overrides))
+        Ok((
+            config.git,
+            config.chat,
+            config.repos,
+            config.global_prompt_overrides,
+        ))
     }
 
     pub fn workspace_update_global_git_config(&self, git: GlobalGitConfig) -> Result<()> {
@@ -240,6 +246,7 @@ impl AppService {
     pub(super) fn workspace_persist_settings_snapshot(
         &self,
         git: GlobalGitConfig,
+        chat: ChatSettings,
         repos: HashMap<String, RepoConfig>,
         global_prompt_overrides: PromptOverrides,
     ) -> Result<()> {
@@ -253,6 +260,7 @@ impl AppService {
         }
 
         config.git = git;
+        config.chat = chat;
         config.global_prompt_overrides = global_prompt_overrides;
         for (repo_path, repo_config) in repos {
             config.repos.insert(repo_path, repo_config);
@@ -567,6 +575,7 @@ mod tests {
     use super::RUNTIME_CHECK_CACHE_TTL;
     use crate::app_service::test_support::build_service_with_state;
     use host_domain::{GitPushResult, RuntimeCheck, RuntimeHealth};
+    use host_infra_system::ChatSettings;
     use std::time::{Duration, Instant};
 
     #[test]
@@ -759,5 +768,19 @@ mod tests {
                 .and_then(|entry| entry.version.as_deref()),
             Some("cached-opencode-sentinel")
         );
+    }
+
+    #[test]
+    fn workspace_get_settings_snapshot_returns_defaulted_chat_settings() {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+
+        let (_git, chat, repos, global_prompt_overrides) = service
+            .workspace_get_settings_snapshot()
+            .expect("settings snapshot should load");
+
+        assert_eq!(chat, ChatSettings::default());
+        assert!(!chat.show_thinking_messages);
+        assert!(repos.is_empty());
+        assert!(global_prompt_overrides.is_empty());
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -3,8 +3,8 @@ use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use host_domain::WorkspaceRecord;
 use host_infra_system::{
-    hook_set_fingerprint, normalize_hook_set, AgentDefaults, GitTargetBranch, HookSet,
-    PromptOverrides, RepoConfig, RepoGitConfig,
+    hook_set_fingerprint, normalize_hook_set, AgentDefaults, ChatSettings, GitTargetBranch,
+    HookSet, PromptOverrides, RepoConfig, RepoGitConfig,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -221,6 +221,7 @@ impl AppService {
     pub fn workspace_save_settings_snapshot<P: HookTrustConfirmationPort + ?Sized>(
         &self,
         git: host_infra_system::GlobalGitConfig,
+        chat: ChatSettings,
         mut repos: HashMap<String, RepoConfig>,
         global_prompt_overrides: PromptOverrides,
         confirmation_port: &P,
@@ -242,7 +243,7 @@ impl AppService {
             repo_config.trusted_hooks_fingerprint = trusted_hooks_fingerprint;
         }
 
-        self.workspace_persist_settings_snapshot(git, repos, global_prompt_overrides)?;
+        self.workspace_persist_settings_snapshot(git, chat, repos, global_prompt_overrides)?;
         self.workspace_list()
     }
 
@@ -393,7 +394,8 @@ mod tests {
     use anyhow::{anyhow, Result};
     use host_domain::TaskStore;
     use host_infra_system::{
-        hook_set_fingerprint, AppConfigStore, GitCliPort, HookSet, PromptOverride, RepoConfig,
+        hook_set_fingerprint, AppConfigStore, ChatSettings, GitCliPort, HookSet, PromptOverride,
+        RepoConfig,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -656,8 +658,9 @@ mod tests {
         );
         let confirmation = RecordingHookTrustConfirmationPort::default();
 
-        let (git, mut repos, mut global_prompt_overrides) =
+        let (git, mut chat, mut repos, mut global_prompt_overrides) =
             fixture.service.workspace_get_settings_snapshot()?;
+        chat.show_thinking_messages = true;
         global_prompt_overrides.insert(
             "system.shared.workflow_guards".to_string(),
             PromptOverride {
@@ -679,6 +682,7 @@ mod tests {
 
         fixture.service.workspace_save_settings_snapshot(
             git,
+            chat,
             repos,
             global_prompt_overrides,
             &confirmation,
@@ -699,6 +703,31 @@ mod tests {
             Some(expected_fingerprint.as_str())
         );
         assert_eq!(confirmation.request_count(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_save_settings_snapshot_persists_chat_settings_roundtrip() -> Result<()> {
+        let fixture = setup_fixture("snapshot-chat-roundtrip", HookSet::default());
+        let confirmation = RecordingHookTrustConfirmationPort::default();
+
+        let (git, mut chat, repos, global_prompt_overrides) =
+            fixture.service.workspace_get_settings_snapshot()?;
+        assert_eq!(chat, ChatSettings::default());
+        chat.show_thinking_messages = true;
+
+        fixture.service.workspace_save_settings_snapshot(
+            git,
+            chat,
+            repos,
+            global_prompt_overrides,
+            &confirmation,
+        )?;
+
+        let (_persisted_git, persisted_chat, _persisted_repos, _persisted_global_prompt_overrides) =
+            fixture.service.workspace_get_settings_snapshot()?;
+        assert!(persisted_chat.show_thinking_messages);
+        assert_eq!(confirmation.request_count(), 0);
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -8,10 +8,10 @@ mod types;
 pub use normalize::normalize_hook_set;
 pub use store::{AppConfigStore, RuntimeConfigStore};
 pub use types::{
-    hook_set_fingerprint, AgentDefaults, AgentModelDefault, GitMergeMethod, GitProviderConfig,
-    GitProviderRepository, GitTargetBranch, GlobalConfig, GlobalGitConfig, HookSet,
-    OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides, RepoConfig, RepoGitConfig,
-    RuntimeConfig, SchedulerConfig, SoftGuardrails,
+    hook_set_fingerprint, AgentDefaults, AgentModelDefault, ChatSettings, GitMergeMethod,
+    GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig, GlobalGitConfig,
+    HookSet, OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides, RepoConfig,
+    RepoGitConfig, RuntimeConfig, SchedulerConfig, SoftGuardrails,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
@@ -11,6 +11,7 @@ fn load_missing_returns_default_config() {
     let store = harness.store();
     let config = store.load().expect("load default");
     assert_eq!(config.version, 1);
+    assert!(!config.chat.show_thinking_messages);
     assert!(config.repos.is_empty());
 }
 
@@ -196,6 +197,9 @@ fn load_normalizes_legacy_blank_repo_config_values() {
     assert_eq!(workspaces.len(), 1);
     assert!(!workspaces[0].has_config);
     assert!(workspaces[0].configured_worktree_base_path.is_none());
+
+    let config = store.load().expect("legacy config should load");
+    assert!(!config.chat.show_thinking_messages);
 
     let repo_config = store
         .repo_config(workspaces[0].path.as_str())

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -150,6 +150,13 @@ pub struct GlobalGitConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
+pub struct ChatSettings {
+    #[serde(default)]
+    pub show_thinking_messages: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct HookSet {
     #[serde(default)]
     pub pre_start: Vec<String>,
@@ -367,6 +374,8 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub git: GlobalGitConfig,
     #[serde(default)]
+    pub chat: ChatSettings,
+    #[serde(default)]
     pub global_prompt_overrides: PromptOverrides,
     #[serde(default)]
     pub repos: HashMap<String, RepoConfig>,
@@ -381,6 +390,7 @@ impl Default for GlobalConfig {
             active_repo: None,
             theme: default_theme(),
             git: GlobalGitConfig::default(),
+            chat: ChatSettings::default(),
             global_prompt_overrides: PromptOverrides::default(),
             repos: HashMap::new(),
             recent_repos: Vec::new(),

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -7,9 +7,10 @@ mod worktree;
 pub use beads::{compute_repo_id, compute_repo_slug, resolve_central_beads_dir};
 pub use config::{
     hook_set_fingerprint, normalize_hook_set, AgentDefaults, AgentModelDefault, AppConfigStore,
-    GitMergeMethod, GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig,
-    GlobalGitConfig, HookSet, OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides,
-    RepoConfig, RepoGitConfig, RuntimeConfig, RuntimeConfigStore, SchedulerConfig, SoftGuardrails,
+    ChatSettings, GitMergeMethod, GitProviderConfig, GitProviderRepository, GitTargetBranch,
+    GlobalConfig, GlobalGitConfig, HookSet, OpencodeStartupReadinessConfig, PromptOverride,
+    PromptOverrides, RepoConfig, RepoGitConfig, RuntimeConfig, RuntimeConfigStore, SchedulerConfig,
+    SoftGuardrails,
 };
 pub use git::GitCliPort;
 pub use process::{

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -131,10 +131,11 @@ pub async fn workspace_detect_github_repository(
 pub async fn workspace_get_settings_snapshot(
     state: State<'_, AppState>,
 ) -> Result<SettingsSnapshotResponsePayload, String> {
-    let (git, repos, global_prompt_overrides) =
+    let (git, chat, repos, global_prompt_overrides) =
         as_error(state.service.workspace_get_settings_snapshot())?;
     Ok(SettingsSnapshotResponsePayload {
         git,
+        chat,
         repos,
         global_prompt_overrides,
     })
@@ -163,6 +164,7 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
 ) -> Result<Vec<host_domain::WorkspaceRecord>, String> {
     let SettingsSnapshotPayload {
         git,
+        chat,
         repos,
         global_prompt_overrides,
     } = snapshot;
@@ -173,6 +175,7 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
         run_service_blocking("workspace_save_settings_snapshot", move || {
             service.workspace_save_settings_snapshot(
                 git,
+                chat,
                 repos,
                 global_prompt_overrides,
                 &confirmation_port,
@@ -330,7 +333,8 @@ mod tests {
     use host_domain::{TaskStore, WorkspaceRecord, TASK_METADATA_NAMESPACE};
     use host_infra_beads::BeadsTaskStore;
     use host_infra_system::{
-        hook_set_fingerprint, AppConfigStore, GitCliPort, GlobalGitConfig, PromptOverride,
+        hook_set_fingerprint, AppConfigStore, ChatSettings, GitCliPort, GlobalGitConfig,
+        PromptOverride,
     };
     use serde_json::{json, Value};
     use std::{
@@ -713,12 +717,13 @@ mod tests {
             Some(false),
         );
 
-        let (git, repos, global_prompt_overrides) = fixture
+        let (git, chat, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
         let mut snapshot = SettingsSnapshotPayload {
             git,
+            chat,
             repos,
             global_prompt_overrides,
         };
@@ -761,12 +766,13 @@ mod tests {
             Some(true),
         );
 
-        let (git, repos, global_prompt_overrides) = fixture
+        let (git, chat, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
         let mut snapshot = SettingsSnapshotPayload {
             git,
+            chat,
             repos,
             global_prompt_overrides,
         };
@@ -889,16 +895,18 @@ mod tests {
         let fixture =
             setup_workspace_command_fixture("snapshot-ipc-shared-prompts", HookSet::default());
 
-        let (git, repos, global_prompt_overrides) = fixture
+        let (git, chat, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
         let mut snapshot = SettingsSnapshotPayload {
             git,
+            chat,
             repos,
             global_prompt_overrides,
         };
 
+        snapshot.chat.show_thinking_messages = true;
         snapshot.global_prompt_overrides.insert(
             "system.shared.workflow_guards".to_string(),
             PromptOverride {
@@ -941,6 +949,7 @@ mod tests {
         let payload = json!({
             "snapshot": {
                 "git": snapshot.git,
+                "chat": snapshot.chat,
                 "repos": snapshot.repos,
                 "globalPromptOverrides": snapshot.global_prompt_overrides,
             }
@@ -956,7 +965,7 @@ mod tests {
             "snapshot save response should include workspace records"
         );
 
-        let (_persisted_git, persisted_repos, persisted_global) = fixture
+        let (_persisted_git, persisted_chat, persisted_repos, persisted_global) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -964,6 +973,7 @@ mod tests {
             .get(repo_key.as_str())
             .ok_or_else(|| "persisted repo config missing".to_string())?;
 
+        assert!(persisted_chat.show_thinking_messages);
         assert_eq!(
             persisted_global
                 .get("system.shared.workflow_guards")
@@ -991,6 +1001,69 @@ mod tests {
             Some(false)
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_get_settings_snapshot_returns_defaulted_chat_settings() -> Result<(), String> {
+        let fixture =
+            setup_workspace_command_fixture("snapshot-default-chat", HookSet::default());
+
+        let (_git, chat, _repos, _global_prompt_overrides) = fixture
+            .service
+            .workspace_get_settings_snapshot()
+            .map_err(|error| error.to_string())?;
+
+        assert_eq!(chat, ChatSettings::default());
+        assert!(!chat.show_thinking_messages);
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_save_settings_snapshot_ipc_defaults_missing_chat_and_roundtrips_true(
+    ) -> Result<(), String> {
+        let fixture =
+            setup_workspace_command_fixture("snapshot-chat-roundtrip", HookSet::default());
+
+        let (git, _chat, repos, global_prompt_overrides) = fixture
+            .service
+            .workspace_get_settings_snapshot()
+            .map_err(|error| error.to_string())?;
+
+        let payload_without_chat = json!({
+            "snapshot": {
+                "git": git.clone(),
+                "repos": repos.clone(),
+                "globalPromptOverrides": global_prompt_overrides.clone(),
+            }
+        });
+        invoke_workspace_save_settings_snapshot_ipc(&fixture, payload_without_chat)
+            .expect("IPC snapshot save should default missing chat settings");
+
+        let (_persisted_git, persisted_chat, persisted_repos, persisted_global) = fixture
+            .service
+            .workspace_get_settings_snapshot()
+            .map_err(|error| error.to_string())?;
+        assert!(!persisted_chat.show_thinking_messages);
+
+        let payload_with_chat = json!({
+            "snapshot": {
+                "git": git,
+                "chat": {
+                    "showThinkingMessages": true
+                },
+                "repos": persisted_repos,
+                "globalPromptOverrides": persisted_global,
+            }
+        });
+        invoke_workspace_save_settings_snapshot_ipc(&fixture, payload_with_chat)
+            .expect("IPC snapshot save should persist chat settings");
+
+        let (_reloaded_git, reloaded_chat, _reloaded_repos, _reloaded_global) = fixture
+            .service
+            .workspace_get_settings_snapshot()
+            .map_err(|error| error.to_string())?;
+        assert!(reloaded_chat.show_thinking_messages);
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -1020,8 +1020,7 @@ mod tests {
     }
 
     #[test]
-    fn workspace_save_settings_snapshot_ipc_defaults_missing_chat_and_roundtrips_true(
-    ) -> Result<(), String> {
+    fn workspace_save_settings_snapshot_ipc_rejects_missing_chat() -> Result<(), String> {
         let fixture =
             setup_workspace_command_fixture("snapshot-chat-roundtrip", HookSet::default());
 
@@ -1037,14 +1036,12 @@ mod tests {
                 "globalPromptOverrides": global_prompt_overrides.clone(),
             }
         });
-        invoke_workspace_save_settings_snapshot_ipc(&fixture, payload_without_chat)
-            .expect("IPC snapshot save should default missing chat settings");
-
-        let (_persisted_git, persisted_chat, persisted_repos, persisted_global) = fixture
-            .service
-            .workspace_get_settings_snapshot()
-            .map_err(|error| error.to_string())?;
-        assert!(!persisted_chat.show_thinking_messages);
+        let error = invoke_workspace_save_settings_snapshot_ipc(&fixture, payload_without_chat)
+            .expect_err("IPC snapshot save should reject missing chat settings");
+        assert!(
+            error.to_string().contains("missing field `chat`"),
+            "unexpected IPC error: {error}"
+        );
 
         let payload_with_chat = json!({
             "snapshot": {
@@ -1052,8 +1049,8 @@ mod tests {
                 "chat": {
                     "showThinkingMessages": true
                 },
-                "repos": persisted_repos,
-                "globalPromptOverrides": persisted_global,
+                "repos": repos,
+                "globalPromptOverrides": global_prompt_overrides,
             }
         });
         invoke_workspace_save_settings_snapshot_ipc(&fixture, payload_with_chat)

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -146,6 +146,8 @@ struct RepoSettingsPayload {
 #[serde(rename_all = "camelCase")]
 struct SettingsSnapshotPayload {
     git: host_infra_system::GlobalGitConfig,
+    #[serde(default)]
+    chat: host_infra_system::ChatSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
     global_prompt_overrides: host_infra_system::PromptOverrides,
 }
@@ -154,6 +156,7 @@ struct SettingsSnapshotPayload {
 #[serde(rename_all = "camelCase")]
 struct SettingsSnapshotResponsePayload {
     git: host_infra_system::GlobalGitConfig,
+    chat: host_infra_system::ChatSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
     global_prompt_overrides: host_infra_system::PromptOverrides,
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -146,7 +146,6 @@ struct RepoSettingsPayload {
 #[serde(rename_all = "camelCase")]
 struct SettingsSnapshotPayload {
     git: host_infra_system::GlobalGitConfig,
-    #[serde(default)]
     chat: host_infra_system::ChatSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
     global_prompt_overrides: host_infra_system::PromptOverrides,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -4,8 +4,8 @@ import {
   isOdtWorkflowMutationToolName,
 } from "@openducktor/core";
 import { Brain, Hammer, MessageSquareQuote } from "lucide-react";
-import type { ReactElement } from "react";
-import { MarkdownRenderer, type MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
+import { lazy, type ReactElement, Suspense } from "react";
+import type { MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
 import { cn } from "@/lib/utils";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import { hasMarkdownSyntaxHint } from "./agent-chat-markdown-hints";
@@ -13,13 +13,17 @@ import {
   getAssistantFooterData,
   roleLabel,
   SYSTEM_PROMPT_PREFIX,
-  toSingleLineMarkdown,
 } from "./agent-chat-message-card-model";
 import {
   assistantRoleIcon,
   RegularToolMessage,
   WorkflowToolMessage,
 } from "./agent-chat-message-card-tool-presenters";
+
+const LazyMarkdownRenderer = lazy(async () => {
+  const module = await import("@/components/ui/markdown-renderer");
+  return { default: module.MarkdownRenderer };
+});
 
 const PLAIN_TEXT_CLASSES: Record<MarkdownRendererVariant, string> = {
   compact: "whitespace-pre-wrap text-[13px] leading-relaxed text-foreground",
@@ -29,34 +33,61 @@ const PLAIN_TEXT_CLASSES: Record<MarkdownRendererVariant, string> = {
 type PlainTextMarkdownFallbackProps = {
   content: string;
   variant: MarkdownRendererVariant;
+  className?: string;
 };
 
 const PlainTextMarkdownFallback = ({
   content,
   variant,
+  className,
 }: PlainTextMarkdownFallbackProps): ReactElement => {
-  return <p className={PLAIN_TEXT_CLASSES[variant]}>{content}</p>;
+  return <p className={cn(PLAIN_TEXT_CLASSES[variant], className)}>{content}</p>;
 };
 
-type MessageMarkdownContentProps = {
+type DeferredMarkdownRendererProps = {
   markdown: string;
   variant?: MarkdownRendererVariant;
+  className?: string;
 };
 
-const MessageMarkdownContent = ({
+const DeferredMarkdownRenderer = ({
   markdown,
   variant = "document",
-}: MessageMarkdownContentProps): ReactElement | null => {
+  className,
+}: DeferredMarkdownRendererProps): ReactElement | null => {
   const content = markdown.trim();
+
   if (!content) {
     return null;
   }
 
   if (!hasMarkdownSyntaxHint(content)) {
+    if (className) {
+      return (
+        <PlainTextMarkdownFallback content={content} variant={variant} className={className} />
+      );
+    }
+
     return <PlainTextMarkdownFallback content={content} variant={variant} />;
   }
 
-  return <MarkdownRenderer markdown={content} variant={variant} />;
+  if (className) {
+    return (
+      <Suspense
+        fallback={
+          <PlainTextMarkdownFallback content={content} variant={variant} className={className} />
+        }
+      >
+        <LazyMarkdownRenderer markdown={content} variant={variant} className={className} />
+      </Suspense>
+    );
+  }
+
+  return (
+    <Suspense fallback={<PlainTextMarkdownFallback content={content} variant={variant} />}>
+      <LazyMarkdownRenderer markdown={content} variant={variant} />
+    </Suspense>
+  );
 };
 
 export type MessageHeaderProps = {
@@ -101,45 +132,31 @@ export const MessageHeader = ({
 
 type ReasoningMessageProps = {
   content: string;
-  completed: boolean;
-  timeLabel: string;
 };
 
-const ReasoningMessage = ({
-  content,
-  completed,
-  timeLabel,
-}: ReasoningMessageProps): ReactElement => {
-  if (completed) {
-    return (
-      <details className="px-1 py-0.5">
-        <summary className="flex min-h-6 cursor-pointer items-center gap-2 text-xs text-foreground">
-          <Brain className="size-3.5 shrink-0 text-muted-foreground" />
-          <span className="shrink-0 font-medium text-muted-foreground">Thinking</span>
-          <span className="min-w-0 flex-1 truncate text-muted-foreground">
-            {toSingleLineMarkdown(content || "Reasoning complete")}
-          </span>
-          {timeLabel ? (
-            <span className="shrink-0 text-[11px] text-muted-foreground">{timeLabel}</span>
-          ) : null}
-        </summary>
-        <div className="pl-6 pt-2">
-          <MessageMarkdownContent markdown={content || "Reasoning complete"} variant="compact" />
-        </div>
-      </details>
-    );
-  }
+const REASONING_MARKDOWN_CLASS_NAME = cn(
+  "italic text-muted-foreground",
+  "prose-p:my-0 prose-p:text-inherit",
+  "prose-headings:my-1 prose-headings:text-inherit",
+  "prose-ul:my-1 prose-ol:my-1",
+  "prose-li:my-0.5 prose-li:text-inherit",
+  "prose-strong:text-inherit prose-em:text-inherit prose-blockquote:text-inherit",
+  "[&_code]:not-italic [&_pre]:not-italic",
+);
 
+const ReasoningMessage = ({ content }: ReasoningMessageProps): ReactElement => {
   return (
-    <div className="space-y-1 px-1 py-0.5 text-xs text-foreground">
-      <div className="flex min-h-6 items-center gap-2">
-        <Brain className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="shrink-0 font-medium text-muted-foreground">Thinking</span>
-        {timeLabel ? (
-          <span className="ml-auto shrink-0 text-[11px] text-muted-foreground">{timeLabel}</span>
-        ) : null}
+    <div className="px-1 py-0.5 text-muted-foreground">
+      <div className="space-y-0.5 text-[13px] leading-relaxed">
+        <span className="block text-[11px] font-medium text-muted-foreground">Thinking:</span>
+        <div className="min-w-0">
+          <DeferredMarkdownRenderer
+            markdown={content || "Thinking..."}
+            variant="compact"
+            className={REASONING_MARKDOWN_CLASS_NAME}
+          />
+        </div>
       </div>
-      <MessageMarkdownContent markdown={content || "Thinking..."} variant="compact" />
     </div>
   );
 };
@@ -158,7 +175,7 @@ const AssistantMessage = ({
   const footer = getAssistantFooterData(message, sessionSelectedModel);
   return (
     <div className="space-y-2">
-      <MessageMarkdownContent markdown={message.content} variant="document" />
+      <DeferredMarkdownRenderer markdown={message.content} variant="document" />
       {footer.infoParts.length > 0 ? (
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span
@@ -192,13 +209,7 @@ export const MessageBody = ({
   const meta = message.meta;
 
   if (meta?.kind === "reasoning") {
-    return (
-      <ReasoningMessage
-        content={message.content}
-        completed={meta.completed}
-        timeLabel={timeLabel}
-      />
-    );
+    return <ReasoningMessage content={message.content} />;
   }
 
   if (meta?.kind === "tool") {
@@ -242,7 +253,7 @@ export const MessageBody = ({
           Show system prompt
         </summary>
         <div className="border-t border-border px-2 py-2">
-          <MessageMarkdownContent markdown={systemPromptBody} variant="compact" />
+          <DeferredMarkdownRenderer markdown={systemPromptBody} variant="compact" />
         </div>
       </details>
     );
@@ -275,5 +286,5 @@ export const MessageBody = ({
     );
   }
 
-  return <MessageMarkdownContent markdown={message.content} variant="document" />;
+  return <DeferredMarkdownRenderer markdown={message.content} variant="document" />;
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -56,36 +56,23 @@ const DeferredMarkdownRenderer = ({
   className,
 }: DeferredMarkdownRendererProps): ReactElement | null => {
   const content = markdown.trim();
+  const classNameProps = className ? { className } : {};
 
   if (!content) {
     return null;
   }
 
   if (!hasMarkdownSyntaxHint(content)) {
-    if (className) {
-      return (
-        <PlainTextMarkdownFallback content={content} variant={variant} className={className} />
-      );
-    }
-
-    return <PlainTextMarkdownFallback content={content} variant={variant} />;
-  }
-
-  if (className) {
-    return (
-      <Suspense
-        fallback={
-          <PlainTextMarkdownFallback content={content} variant={variant} className={className} />
-        }
-      >
-        <LazyMarkdownRenderer markdown={content} variant={variant} className={className} />
-      </Suspense>
-    );
+    return <PlainTextMarkdownFallback content={content} variant={variant} {...classNameProps} />;
   }
 
   return (
-    <Suspense fallback={<PlainTextMarkdownFallback content={content} variant={variant} />}>
-      <LazyMarkdownRenderer markdown={content} variant={variant} />
+    <Suspense
+      fallback={
+        <PlainTextMarkdownFallback content={content} variant={variant} {...classNameProps} />
+      }
+    >
+      <LazyMarkdownRenderer markdown={content} variant={variant} {...classNameProps} />
     </Suspense>
   );
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
@@ -26,6 +26,7 @@ export type AgentChatMessageCardViewModel = {
   assistantRole: AgentRole | null;
   assistantAccentColor: string | undefined;
   systemPromptBody: string;
+  showSharedHeader: boolean;
   isReasoningMessage: boolean;
   isAssistantMessage: boolean;
   isUserMessage: boolean;
@@ -68,6 +69,7 @@ const resolveUserAgentColor = (
 
 const toArticleClassName = (
   message: AgentChatMessage,
+  isReasoningMessage: boolean,
   isUserMessage: boolean,
   isToolMessage: boolean,
   isWorkflowToolMessage: boolean,
@@ -77,6 +79,10 @@ const toArticleClassName = (
   const meta = message.meta;
   const workflowToolPhase =
     isWorkflowToolMessage && meta?.kind === "tool" ? getToolLifecyclePhase(meta) : null;
+
+  if (isReasoningMessage) {
+    return "text-sm border-none bg-transparent px-0 py-0 text-muted-foreground";
+  }
 
   return cn(
     "text-sm",
@@ -130,12 +136,15 @@ export const buildAgentChatMessageCardViewModel = ({
   const systemPromptBody = isSystemPromptMessage
     ? message.content.slice(SYSTEM_PROMPT_PREFIX.length).trimStart()
     : "";
+  const showSharedHeader =
+    !isUserMessage && !isRegularToolMessage && !isReasoningMessage && !isAssistantMessage;
 
   return {
     timeLabel,
     assistantRole,
     assistantAccentColor,
     systemPromptBody,
+    showSharedHeader,
     isReasoningMessage,
     isAssistantMessage,
     isUserMessage,
@@ -147,6 +156,7 @@ export const buildAgentChatMessageCardViewModel = ({
     isRichCardMessage,
     articleClassName: toArticleClassName(
       message,
+      isReasoningMessage,
       isUserMessage,
       isToolMessage,
       isWorkflowToolMessage,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
+import { renderToReadableStream, renderToStaticMarkup } from "react-dom/server";
 import { AgentChatMessageCard } from "./agent-chat-message-card";
+
+const renderToHtml = async (element: ReturnType<typeof createElement>): Promise<string> => {
+  const stream = await renderToReadableStream(element);
+  await stream.allReady;
+  return await new Response(stream).text();
+};
 
 describe("AgentChatMessageCard tool duration", () => {
   test("uses completedAt - inputReadyAt for workflow duration display", () => {
@@ -291,6 +297,39 @@ describe("AgentChatMessageCard tool duration", () => {
 
     expect(html).toContain("Show system prompt");
     expect(html).toContain("Always validate tool inputs");
+  });
+
+  test("renders reasoning rows as inline thinking transcript text without disclosure chrome", async () => {
+    const html = await renderToHtml(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "thinking-1",
+          role: "thinking",
+          content: "Inspect the **diff** before applying.\n\n- Keep markdown output",
+          timestamp: "2026-02-22T10:22:15.000Z",
+          meta: {
+            kind: "reasoning",
+            partId: "part-thinking-1",
+            completed: true,
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("Thinking:");
+    expect(html).toContain("space-y-0.5");
+    expect(html).not.toContain("items-baseline");
+    expect(html).toContain("markdown-body");
+    expect(html).toMatch(/(<strong>diff<\/strong>|\*\*diff\*\*)/);
+    expect(html).toContain("diff");
+    expect(html).not.toContain("<details");
+    expect(html).not.toContain("cursor-pointer");
+    expect(html).not.toContain("lucide-brain");
+    expect(html).not.toContain("10:22:15");
+    expect(html).not.toContain("tracking-wide");
   });
 
   test("renders assistant footer with agent and model labels", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
@@ -32,12 +32,7 @@ export function AgentChatMessageCard({
         message={message}
         sessionRole={sessionRole}
         timeLabel={vm.timeLabel}
-        showHeader={
-          !vm.isUserMessage &&
-          !vm.isRegularToolMessage &&
-          !vm.isReasoningMessage &&
-          !vm.isAssistantMessage
-        }
+        showHeader={vm.showSharedHeader}
         assistantRole={vm.assistantRole}
         compactPadding={vm.isRichCardMessage && !vm.isRegularToolMessage}
       />

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.test.ts
@@ -48,7 +48,7 @@ describe("agent-chat-thread virtualization helpers", () => {
       pendingQuestions: [],
     });
 
-    const rows = buildAgentChatVirtualRows(session);
+    const rows = buildAgentChatVirtualRows(session, { showThinkingMessages: true });
 
     expect(rows.map((row) => row.key)).toEqual([
       "session-1:assistant-1:duration",
@@ -72,8 +72,12 @@ describe("agent-chat-thread virtualization helpers", () => {
       pendingQuestions: [],
     });
 
-    const firstKeys = buildAgentChatVirtualRows(firstSession).map((row) => row.key);
-    const secondKeys = buildAgentChatVirtualRows(secondSession).map((row) => row.key);
+    const firstKeys = buildAgentChatVirtualRows(firstSession, { showThinkingMessages: true }).map(
+      (row) => row.key,
+    );
+    const secondKeys = buildAgentChatVirtualRows(secondSession, { showThinkingMessages: true }).map(
+      (row) => row.key,
+    );
 
     expect(firstKeys).toContain("session-a:message-1");
     expect(secondKeys).toContain("session-b:message-1");
@@ -96,10 +100,12 @@ describe("agent-chat-thread virtualization helpers", () => {
 
     const baselineSignature = buildAgentChatVirtualRowsSignature(
       baseSession,
+      true,
       resolveMessageIdentityToken,
     );
     const updatedSignature = buildAgentChatVirtualRowsSignature(
       updatedSession,
+      true,
       resolveMessageIdentityToken,
     );
 
@@ -113,10 +119,15 @@ describe("agent-chat-thread virtualization helpers", () => {
 
     const previousSignature = buildAgentChatVirtualRowsSignature(
       session,
+      true,
       resolveMessageIdentityToken,
     );
     messages.push(buildMessage("assistant", "Message 2", { id: "message-2" }));
-    const nextSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+    const nextSignature = buildAgentChatVirtualRowsSignature(
+      session,
+      true,
+      resolveMessageIdentityToken,
+    );
 
     expect(nextSignature).not.toBe(previousSignature);
   });
@@ -128,10 +139,15 @@ describe("agent-chat-thread virtualization helpers", () => {
 
     const previousSignature = buildAgentChatVirtualRowsSignature(
       session,
+      true,
       resolveMessageIdentityToken,
     );
     messages[0] = buildMessage("assistant", "Message 1 updated", { id: "message-1" });
-    const nextSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+    const nextSignature = buildAgentChatVirtualRowsSignature(
+      session,
+      true,
+      resolveMessageIdentityToken,
+    );
 
     expect(nextSignature).not.toBe(previousSignature);
   });
@@ -152,6 +168,7 @@ describe("agent-chat-thread virtualization helpers", () => {
     const resolveMessageIdentityToken = createMessageIdentityResolver();
     const previousSignature = buildAgentChatVirtualRowsSignature(
       session,
+      true,
       resolveMessageIdentityToken,
     );
 
@@ -165,8 +182,64 @@ describe("agent-chat-thread virtualization helpers", () => {
     }
     assistantMessage.meta.durationMs = 2_400;
 
-    const nextSignature = buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken);
+    const nextSignature = buildAgentChatVirtualRowsSignature(
+      session,
+      true,
+      resolveMessageIdentityToken,
+    );
     expect(nextSignature).not.toBe(previousSignature);
+  });
+
+  test("buildAgentChatVirtualRows omits reasoning rows when showThinkingMessages is false", () => {
+    const session = buildSession({
+      messages: [
+        buildMessage("user", "Question", { id: "user-1" }),
+        buildMessage("thinking", "Reasoning", { id: "thinking-1" }),
+        buildMessage("assistant", "Answer", { id: "assistant-1" }),
+      ],
+      pendingQuestions: [],
+    });
+
+    const visibleRows = buildAgentChatVirtualRows(session, { showThinkingMessages: true });
+    const hiddenRows = buildAgentChatVirtualRows(session, { showThinkingMessages: false });
+
+    expect(visibleRows.map((row) => row.key)).toEqual([
+      "session-1:user-1",
+      "session-1:thinking-1",
+      "session-1:assistant-1:duration",
+      "session-1:assistant-1",
+    ]);
+    expect(hiddenRows.map((row) => row.key)).toEqual([
+      "session-1:user-1",
+      "session-1:assistant-1:duration",
+      "session-1:assistant-1",
+    ]);
+    expect(
+      hiddenRows.some((row) => row.kind === "message" && row.message.role === "thinking"),
+    ).toBe(false);
+  });
+
+  test("buildAgentChatVirtualRowsSignature changes when showThinkingMessages flips", () => {
+    const session = buildSession({
+      messages: [
+        buildMessage("thinking", "Reasoning", { id: "thinking-1" }),
+        buildMessage("assistant", "Answer", { id: "assistant-1" }),
+      ],
+    });
+    const resolveMessageIdentityToken = createMessageIdentityResolver();
+
+    const visibleSignature = buildAgentChatVirtualRowsSignature(
+      session,
+      true,
+      resolveMessageIdentityToken,
+    );
+    const hiddenSignature = buildAgentChatVirtualRowsSignature(
+      session,
+      false,
+      resolveMessageIdentityToken,
+    );
+
+    expect(hiddenSignature).not.toBe(visibleSignature);
   });
 
   test("buildAgentChatVirtualRows does not append synthetic thinking rows", () => {
@@ -177,7 +250,7 @@ describe("agent-chat-thread virtualization helpers", () => {
       status: "running",
     });
 
-    const rows = buildAgentChatVirtualRows(session);
+    const rows = buildAgentChatVirtualRows(session, { showThinkingMessages: true });
 
     expect(rows).toEqual([]);
   });
@@ -206,7 +279,7 @@ describe("agent-chat-thread virtualization helpers", () => {
       pendingQuestions: [],
     });
 
-    const rows = buildAgentChatVirtualRows(session);
+    const rows = buildAgentChatVirtualRows(session, { showThinkingMessages: true });
 
     expect(rows.map((row) => row.kind)).toEqual(["message"]);
     expect(rows[0]?.key).toBe("session-1:assistant-live");

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-virtualization.ts
@@ -43,10 +43,21 @@ export type AgentChatVirtualRow =
       message: AgentChatMessage;
     };
 
-export function buildAgentChatVirtualRows(session: AgentSessionState): AgentChatVirtualRow[] {
+type BuildAgentChatVirtualRowsOptions = {
+  showThinkingMessages: boolean;
+};
+
+export function buildAgentChatVirtualRows(
+  session: AgentSessionState,
+  { showThinkingMessages }: BuildAgentChatVirtualRowsOptions,
+): AgentChatVirtualRow[] {
   const rows: AgentChatVirtualRow[] = [];
 
   for (const message of session.messages) {
+    if (message.role === "thinking" && !showThinkingMessages) {
+      continue;
+    }
+
     const assistantMeta = message.meta?.kind === "assistant" ? message.meta : null;
     const turnDurationMs = assistantMeta?.durationMs;
     const shouldShowTurnDuration =
@@ -77,11 +88,13 @@ export function buildAgentChatVirtualRows(session: AgentSessionState): AgentChat
 
 export function buildAgentChatVirtualRowsSignature(
   session: AgentSessionState,
+  showThinkingMessages: boolean,
   resolveMessageIdentityToken: (message: AgentChatMessage) => number,
 ): string {
   const signatureParts: string[] = [
     session.sessionId,
     session.status,
+    showThinkingMessages ? "thinking:on" : "thinking:off",
     session.draftReasoningText,
     session.draftReasoningMessageId ?? "",
     String(session.pendingQuestions.length),

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -19,6 +19,7 @@ import { AgentChatThread } from "./agent-chat-thread";
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const baseModel = {
+  showThinkingMessages: false,
   isSessionViewLoading: false,
   roleOptions: TEST_ROLE_OPTIONS,
   agentStudioReady: true,
@@ -99,6 +100,50 @@ describe("AgentChatThread", () => {
     );
 
     expect(html).toContain("Loading session history...");
+  });
+
+  test("renders blank transcript area when session has messages but all were filtered (e.g., thinking-only with showThinkingMessages=false)", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatThread, {
+        model: {
+          ...baseModel,
+          showThinkingMessages: false,
+          session: buildSession({
+            status: "stopped",
+            messages: [
+              buildMessage("thinking", "Reasoning trace 1", { id: "thinking-1" }),
+              buildMessage("thinking", "Reasoning trace 2", { id: "thinking-2" }),
+            ],
+            draftAssistantText: "",
+            pendingQuestions: [],
+            pendingPermissions: [],
+          }),
+        },
+      }),
+    );
+
+    expect(html).not.toContain("Loading session history...");
+  });
+
+  test("renders pending question and permission cards below blank transcript when filtered to zero", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatThread, {
+        model: {
+          ...baseModel,
+          showThinkingMessages: false,
+          session: buildSession({
+            status: "stopped",
+            messages: [buildMessage("thinking", "Reasoning trace", { id: "thinking-1" })],
+            pendingQuestions: [buildQuestionRequest()],
+            pendingPermissions: [buildPermissionRequest()],
+          }),
+        },
+      }),
+    );
+
+    expect(html).not.toContain("Loading session history...");
+    expect(html).toContain("Input needed");
+    expect(html).toContain("Permission request");
   });
 
   test("renders initializing state while autostart session is pending", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -16,6 +16,7 @@ import { useAgentChatVirtualization } from "./use-agent-chat-virtualization";
 export function AgentChatThread({ model }: { model: AgentChatThreadModel }): ReactElement {
   const {
     session,
+    showThinkingMessages,
     isSessionViewLoading,
     agentStudioReady,
     blockedReason,
@@ -48,6 +49,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     activeSessionId,
     canRenderVirtualRows,
     hasRenderableSessionRows,
+    hasSessionHistory,
     isPreparingVirtualization,
     registerStaticMeasurementRowElement,
     shouldVirtualize,
@@ -56,6 +58,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     virtualizer,
   } = useAgentChatVirtualization({
     session,
+    showThinkingMessages,
     messagesContainerRef,
   });
   const scrollVersion = useMemo(() => {
@@ -233,7 +236,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
                 {renderThreadRow(row, { measureStaticRow: shouldVirtualize })}
               </Fragment>
             ))
-          ) : (
+          ) : hasSessionHistory ? null : (
             <div className="rounded-lg border border-dashed border-input bg-card p-4 text-sm text-muted-foreground">
               Loading session history...
             </div>

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -10,6 +10,7 @@ const buildModel = () => ({
       status: "running" as const,
       draftAssistantText: "",
     }),
+    showThinkingMessages: false,
     isSessionViewLoading: false,
     roleOptions: TEST_ROLE_OPTIONS,
     agentStudioReady: true,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -19,6 +19,7 @@ export type AgentRoleOption = {
 
 export type AgentChatThreadModel = {
   session: AgentSessionState | null;
+  showThinkingMessages: boolean;
   isSessionViewLoading: boolean;
   roleOptions: AgentRoleOption[];
   agentStudioReady: boolean;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.test.ts
@@ -92,10 +92,11 @@ describe("useAgentChatVirtualization", () => {
     const retained = resolveRetainedVirtualWindow({
       activeSessionId: "session-1",
       previousWindowState: {
-        sessionId: "session-1",
+        rowModelSignature: "session-1\u001fthinking:on",
         virtualItems: [firstWindowItem],
       },
       rowCount: 45,
+      rowModelSignature: "session-1\u001fthinking:on",
       shouldVirtualize: true,
       virtualItems: [],
     });
@@ -108,7 +109,7 @@ describe("useAgentChatVirtualization", () => {
     const retained = resolveRetainedVirtualWindow({
       activeSessionId: "session-2",
       previousWindowState: {
-        sessionId: "session-1",
+        rowModelSignature: "session-1\u001fthinking:on",
         virtualItems: [
           {
             index: 12,
@@ -121,13 +122,43 @@ describe("useAgentChatVirtualization", () => {
         ],
       },
       rowCount: 45,
+      rowModelSignature: "session-2\u001fthinking:on",
       shouldVirtualize: true,
       virtualItems: [],
     });
 
     expect(retained.resolvedVirtualItems).toEqual([]);
     expect(retained.nextWindowState).toEqual({
-      sessionId: "session-2",
+      rowModelSignature: "session-2\u001fthinking:on",
+      virtualItems: [],
+    });
+  });
+
+  test("drops a retained virtual window when the row model signature changes", () => {
+    const retained = resolveRetainedVirtualWindow({
+      activeSessionId: "session-1",
+      previousWindowState: {
+        rowModelSignature: "session-1\u001fthinking:on",
+        virtualItems: [
+          {
+            index: 12,
+            key: "row-12",
+            lane: 0,
+            size: 80,
+            start: 480,
+            end: 560,
+          } as const,
+        ],
+      },
+      rowCount: 30,
+      rowModelSignature: "session-1\u001fthinking:off",
+      shouldVirtualize: true,
+      virtualItems: [],
+    });
+
+    expect(retained.resolvedVirtualItems).toEqual([]);
+    expect(retained.nextWindowState).toEqual({
+      rowModelSignature: "session-1\u001fthinking:off",
       virtualItems: [],
     });
   });
@@ -139,6 +170,7 @@ describe("useAgentChatVirtualization", () => {
     const Harness = (): null => {
       latestStateRef.current = useAgentChatVirtualization({
         session: null,
+        showThinkingMessages: true,
         messagesContainerRef,
       }) as AgentChatVirtualizationState;
       return null;
@@ -177,6 +209,7 @@ describe("useAgentChatVirtualization", () => {
     const Harness = (): null => {
       latestStateRef.current = useAgentChatVirtualization({
         session,
+        showThinkingMessages: true,
         messagesContainerRef,
       }) as AgentChatVirtualizationState;
       return null;
@@ -217,6 +250,7 @@ describe("useAgentChatVirtualization", () => {
     const Harness = (): null => {
       latestStateRef.current = useAgentChatVirtualization({
         session,
+        showThinkingMessages: true,
         messagesContainerRef,
       }) as AgentChatVirtualizationState;
       return null;
@@ -253,6 +287,68 @@ describe("useAgentChatVirtualization", () => {
     });
   });
 
+  test("rebuilds the hook row model when showThinkingMessages flips on the same session", async () => {
+    const nonThinkingMessages = Array.from(
+      { length: AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT - 1 },
+      (_, index) => buildMessage("user", `User ${index + 1}`, { id: `user-${index + 1}` }),
+    );
+    const session = buildSession({
+      messages: [
+        buildMessage("thinking", "Reasoning 1", { id: "thinking-1" }),
+        buildMessage("thinking", "Reasoning 2", { id: "thinking-2" }),
+        ...nonThinkingMessages,
+      ],
+      status: "idle",
+    });
+    const messagesContainerRef = createRef<HTMLDivElement>();
+    const latestStateRef: { current: AgentChatVirtualizationState | null } = { current: null };
+    let showThinkingMessages = true;
+
+    const Harness = (): null => {
+      latestStateRef.current = useAgentChatVirtualization({
+        session,
+        showThinkingMessages,
+        messagesContainerRef,
+      }) as AgentChatVirtualizationState;
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Harness));
+      await flush();
+    });
+
+    const initialState = getLatestState(latestStateRef);
+    expect(initialState.shouldVirtualize).toBe(true);
+    expect(
+      initialState.virtualRows.some(
+        (row) => row.kind === "message" && row.message.role === "thinking",
+      ),
+    ).toBe(true);
+
+    showThinkingMessages = false;
+    await act(async () => {
+      renderer?.update(createElement(Harness));
+      await flush();
+    });
+
+    const hiddenState = getLatestState(latestStateRef);
+    expect(hiddenState.shouldVirtualize).toBe(false);
+    expect(
+      hiddenState.virtualRows.some(
+        (row) => row.kind === "message" && row.message.role === "thinking",
+      ),
+    ).toBe(false);
+    expect(hiddenState.virtualRows).toHaveLength(AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT - 1);
+    expect(hiddenState.virtualRowsToRender).toHaveLength(0);
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+
   test("maps virtual items only to valid row entries", async () => {
     const messages = Array.from(
       { length: AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT + 1 },
@@ -266,6 +362,7 @@ describe("useAgentChatVirtualization", () => {
     const Harness = (): null => {
       latestStateRef.current = useAgentChatVirtualization({
         session,
+        showThinkingMessages: true,
         messagesContainerRef,
       }) as AgentChatVirtualizationState;
       return null;
@@ -303,6 +400,7 @@ describe("useAgentChatVirtualization", () => {
     const Harness = (): null => {
       latestStateRef.current = useAgentChatVirtualization({
         session,
+        showThinkingMessages: true,
         messagesContainerRef,
       }) as AgentChatVirtualizationState;
       return null;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
@@ -14,6 +14,7 @@ import {
 
 type UseAgentChatVirtualizationInput = {
   session: AgentSessionState | null;
+  showThinkingMessages: boolean;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
 };
 
@@ -25,7 +26,7 @@ type AgentChatVirtualRowsToRenderEntry = {
 };
 
 type RetainedVirtualWindowState = {
-  sessionId: string | null;
+  rowModelSignature: string | null;
   virtualItems: VirtualItem[];
 };
 
@@ -33,6 +34,7 @@ type UseAgentChatVirtualizationResult = {
   activeSessionId: string | null;
   canRenderVirtualRows: boolean;
   hasRenderableSessionRows: boolean;
+  hasSessionHistory: boolean;
   isPreparingVirtualization: boolean;
   registerStaticMeasurementRowElement: (rowKey: string) => RefCallback<HTMLDivElement>;
   shouldVirtualize: boolean;
@@ -45,6 +47,12 @@ type UseAgentChatVirtualRowsResult = {
   activeSessionId: string | null;
   shouldVirtualize: boolean;
   virtualRows: AgentChatVirtualRow[];
+  virtualRowsSignature: string | null;
+};
+
+type UseAgentChatVirtualRowsInput = {
+  session: AgentSessionState | null;
+  showThinkingMessages: boolean;
 };
 
 type UseVirtualRowMeasurementsInput = {
@@ -78,9 +86,11 @@ const CHAT_VIRTUALIZATION_MAX_REVEAL_FRAMES = 24;
 
 export function useAgentChatVirtualization({
   session,
+  showThinkingMessages,
   messagesContainerRef,
 }: UseAgentChatVirtualizationInput): UseAgentChatVirtualizationResult {
-  const { activeSessionId, shouldVirtualize, virtualRows } = useAgentChatVirtualRows(session);
+  const { activeSessionId, shouldVirtualize, virtualRows, virtualRowsSignature } =
+    useAgentChatVirtualRows({ session, showThinkingMessages });
   const {
     estimateRowSize,
     measureStaticRowElement,
@@ -97,8 +107,12 @@ export function useAgentChatVirtualization({
     if (!shouldVirtualize) {
       return "";
     }
-    return [activeSessionId ?? "none", ...virtualRows.map((row) => row.key)].join("\u001f");
-  }, [activeSessionId, shouldVirtualize, virtualRows]);
+    return [
+      activeSessionId ?? "none",
+      showThinkingMessages ? "thinking:on" : "thinking:off",
+      ...virtualRows.map((row) => row.key),
+    ].join("\u001f");
+  }, [activeSessionId, shouldVirtualize, showThinkingMessages, virtualRows]);
   const staticRowElementByKeyRef = useRef<Map<string, HTMLDivElement>>(new Map());
   const staticMeasurementRefByKeyRef = useRef<Map<string, RefCallback<HTMLDivElement>>>(new Map());
   const prepareMeasurementsRafRef = useRef<number | null>(null);
@@ -122,16 +136,19 @@ export function useAgentChatVirtualization({
     activeSessionId,
     shouldVirtualize,
     virtualRows,
+    virtualRowsSignature,
     virtualItems: virtualizer.getVirtualItems(),
   });
   const canRenderVirtualRows = shouldVirtualize && virtualizationPreparationPhase === "ready";
   const hasRenderableSessionRows = virtualRows.length > 0;
+  const hasSessionHistory = session !== null && session.messages.length > 0;
   const isPreparingVirtualization =
     shouldVirtualize && !canRenderVirtualRows && typeof window !== "undefined";
 
   useEffect(() => {
     staticMeasurementRefByKeyRef.current.clear();
     staticRowElementByKeyRef.current.clear();
+    resetMeasuredRowHeights();
     setStaticMeasurementRowCount(0);
     if (prepareMeasurementsRafRef.current !== null && typeof window !== "undefined") {
       window.cancelAnimationFrame(prepareMeasurementsRafRef.current);
@@ -150,7 +167,7 @@ export function useAgentChatVirtualization({
     }
 
     setVirtualizationPreparationPhase("static");
-  }, [measurementSignature, shouldVirtualize]);
+  }, [measurementSignature, resetMeasuredRowHeights, shouldVirtualize]);
 
   useEffect(() => {
     if (
@@ -320,6 +337,7 @@ export function useAgentChatVirtualization({
     activeSessionId,
     canRenderVirtualRows,
     hasRenderableSessionRows,
+    hasSessionHistory,
     isPreparingVirtualization,
     registerStaticMeasurementRowElement,
     shouldVirtualize,
@@ -329,7 +347,10 @@ export function useAgentChatVirtualization({
   };
 }
 
-function useAgentChatVirtualRows(session: AgentSessionState | null): UseAgentChatVirtualRowsResult {
+function useAgentChatVirtualRows({
+  session,
+  showThinkingMessages,
+}: UseAgentChatVirtualRowsInput): UseAgentChatVirtualRowsResult {
   const messageIdentityTokenByMessageRef = useRef<WeakMap<AgentChatMessage, number>>(new WeakMap());
   const nextMessageIdentityTokenRef = useRef(1);
   const virtualRowsCacheRef = useRef<{ signature: string | null; rows: AgentChatVirtualRow[] }>({
@@ -348,7 +369,7 @@ function useAgentChatVirtualRows(session: AgentSessionState | null): UseAgentCha
     return nextToken;
   }, []);
   const virtualRowsSignature = session
-    ? buildAgentChatVirtualRowsSignature(session, resolveMessageIdentityToken)
+    ? buildAgentChatVirtualRowsSignature(session, showThinkingMessages, resolveMessageIdentityToken)
     : null;
   const virtualRows = useMemo(() => {
     const cached = virtualRowsCacheRef.current;
@@ -356,13 +377,13 @@ function useAgentChatVirtualRows(session: AgentSessionState | null): UseAgentCha
       return cached.rows;
     }
 
-    const nextRows = session ? buildAgentChatVirtualRows(session) : [];
+    const nextRows = session ? buildAgentChatVirtualRows(session, { showThinkingMessages }) : [];
     virtualRowsCacheRef.current = {
       signature: virtualRowsSignature,
       rows: nextRows,
     };
     return nextRows;
-  }, [session, virtualRowsSignature]);
+  }, [session, showThinkingMessages, virtualRowsSignature]);
   const shouldVirtualize =
     virtualRows.length >= AGENT_CHAT_VIRTUALIZATION_MIN_ROW_COUNT &&
     session !== null &&
@@ -373,6 +394,7 @@ function useAgentChatVirtualRows(session: AgentSessionState | null): UseAgentCha
     activeSessionId,
     shouldVirtualize,
     virtualRows,
+    virtualRowsSignature,
   };
 }
 
@@ -660,15 +682,17 @@ function useVirtualRowsToRender({
   activeSessionId,
   shouldVirtualize,
   virtualRows,
+  virtualRowsSignature,
   virtualItems,
 }: {
   activeSessionId: string | null;
   shouldVirtualize: boolean;
   virtualRows: AgentChatVirtualRow[];
+  virtualRowsSignature: string | null;
   virtualItems: VirtualItem[];
 }): AgentChatVirtualRowsToRenderEntry[] {
   const lastNonEmptyWindowRef = useRef<RetainedVirtualWindowState>({
-    sessionId: null,
+    rowModelSignature: null,
     virtualItems: [],
   });
 
@@ -677,6 +701,7 @@ function useVirtualRowsToRender({
       activeSessionId,
       previousWindowState: lastNonEmptyWindowRef.current,
       rowCount: virtualRows.length,
+      rowModelSignature: virtualRowsSignature,
       shouldVirtualize,
       virtualItems,
     });
@@ -691,19 +716,21 @@ function useVirtualRowsToRender({
         return { row, virtualItem };
       })
       .filter((entry): entry is AgentChatVirtualRowsToRenderEntry => entry !== null);
-  }, [activeSessionId, shouldVirtualize, virtualItems, virtualRows]);
+  }, [activeSessionId, shouldVirtualize, virtualItems, virtualRows, virtualRowsSignature]);
 }
 
 export function resolveRetainedVirtualWindow({
   activeSessionId,
   previousWindowState,
   rowCount,
+  rowModelSignature,
   shouldVirtualize,
   virtualItems,
 }: {
   activeSessionId: string | null;
   previousWindowState: RetainedVirtualWindowState;
   rowCount: number;
+  rowModelSignature: string | null;
   shouldVirtualize: boolean;
   virtualItems: VirtualItem[];
 }): {
@@ -713,7 +740,7 @@ export function resolveRetainedVirtualWindow({
   if (!shouldVirtualize || !activeSessionId) {
     return {
       nextWindowState: {
-        sessionId: null,
+        rowModelSignature: null,
         virtualItems: [],
       },
       resolvedVirtualItems: [],
@@ -727,17 +754,17 @@ export function resolveRetainedVirtualWindow({
   if (resolvedVirtualItems.length > 0) {
     return {
       nextWindowState: {
-        sessionId: activeSessionId,
+        rowModelSignature,
         virtualItems: resolvedVirtualItems,
       },
       resolvedVirtualItems,
     };
   }
 
-  if (previousWindowState.sessionId !== activeSessionId) {
+  if (previousWindowState.rowModelSignature !== rowModelSignature) {
     return {
       nextWindowState: {
-        sessionId: activeSessionId,
+        rowModelSignature,
         virtualItems: [],
       },
       resolvedVirtualItems: [],
@@ -749,7 +776,7 @@ export function resolveRetainedVirtualWindow({
   });
   return {
     nextWindowState: {
-      sessionId: activeSessionId,
+      rowModelSignature,
       virtualItems: retainedVirtualItems,
     },
     resolvedVirtualItems: retainedVirtualItems,

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-virtualization.ts
@@ -148,7 +148,7 @@ export function useAgentChatVirtualization({
   useEffect(() => {
     staticMeasurementRefByKeyRef.current.clear();
     staticRowElementByKeyRef.current.clear();
-    resetMeasuredRowHeights();
+    resetMeasuredRowMeasurements();
     setStaticMeasurementRowCount(0);
     if (prepareMeasurementsRafRef.current !== null && typeof window !== "undefined") {
       window.cancelAnimationFrame(prepareMeasurementsRafRef.current);
@@ -167,7 +167,7 @@ export function useAgentChatVirtualization({
     }
 
     setVirtualizationPreparationPhase("static");
-  }, [measurementSignature, resetMeasuredRowHeights, shouldVirtualize]);
+  }, [measurementSignature, resetMeasuredRowMeasurements, shouldVirtualize]);
 
   useEffect(() => {
     if (

--- a/apps/desktop/src/components/features/settings/settings-chat-section.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-chat-section.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatSettings } from "@openducktor/contracts";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SettingsChatSection } from "./settings-chat-section";
+
+describe("settings chat section", () => {
+  test("renders chat settings with thinking messages hidden by default", () => {
+    const chatSettings: ChatSettings = { showThinkingMessages: false };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsChatSection, {
+        chat: chatSettings,
+        disabled: false,
+        onUpdateChat: () => chatSettings,
+      }),
+    );
+
+    expect(html).toContain("Chat Settings");
+    expect(html).toContain("Show Thinking Messages");
+    expect(html).toContain("Thinking messages are hidden by default");
+    expect(html).toContain("Agent Studio transcript");
+  });
+
+  test("renders switch as unchecked when showThinkingMessages is false", () => {
+    const chatSettings: ChatSettings = { showThinkingMessages: false };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsChatSection, {
+        chat: chatSettings,
+        disabled: false,
+        onUpdateChat: () => chatSettings,
+      }),
+    );
+
+    expect(html).toContain('aria-checked="false"');
+  });
+
+  test("renders switch as checked when showThinkingMessages is true", () => {
+    const chatSettings: ChatSettings = { showThinkingMessages: true };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsChatSection, {
+        chat: chatSettings,
+        disabled: false,
+        onUpdateChat: () => chatSettings,
+      }),
+    );
+
+    expect(html).toContain('aria-checked="true"');
+  });
+
+  test("switch is disabled when disabled prop is true", () => {
+    const chatSettings: ChatSettings = { showThinkingMessages: false };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsChatSection, {
+        chat: chatSettings,
+        disabled: true,
+        onUpdateChat: () => chatSettings,
+      }),
+    );
+
+    expect(html).toContain("disabled");
+  });
+
+  test("displays save notice about changes taking effect after save", () => {
+    const chatSettings: ChatSettings = { showThinkingMessages: false };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsChatSection, {
+        chat: chatSettings,
+        disabled: false,
+        onUpdateChat: () => chatSettings,
+      }),
+    );
+
+    expect(html).toContain("after you save settings");
+  });
+});

--- a/apps/desktop/src/components/features/settings/settings-chat-section.tsx
+++ b/apps/desktop/src/components/features/settings/settings-chat-section.tsx
@@ -1,0 +1,48 @@
+import type { ChatSettings } from "@openducktor/contracts";
+import type { ReactElement } from "react";
+import { Switch } from "@/components/ui/switch";
+
+type SettingsChatSectionProps = {
+  chat: ChatSettings;
+  disabled: boolean;
+  onUpdateChat: (updater: (current: ChatSettings) => ChatSettings) => void;
+};
+
+export function SettingsChatSection({
+  chat,
+  disabled,
+  onUpdateChat,
+}: SettingsChatSectionProps): ReactElement {
+  return (
+    <div className="grid gap-4 p-4">
+      <div className="space-y-2">
+        <h3 className="text-sm font-semibold text-foreground">Chat Settings</h3>
+        <p className="text-xs text-muted-foreground">
+          Configure chat display behavior for Agent Studio sessions.
+        </p>
+      </div>
+
+      <div className="rounded-md border border-border bg-card p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-foreground">Show Thinking Messages</p>
+            <p className="text-xs text-muted-foreground">
+              Thinking messages are hidden by default. When enabled, they will appear in the Agent
+              Studio transcript after you save settings.
+            </p>
+          </div>
+          <Switch
+            checked={chat.showThinkingMessages}
+            onCheckedChange={(checked) => onUpdateChat(() => ({ showThinkingMessages: checked }))}
+            disabled={disabled}
+            aria-label="Show thinking messages in Agent Studio transcript"
+          />
+        </div>
+      </div>
+
+      <div className="rounded-md border border-border bg-muted/60 p-3 text-xs text-muted-foreground">
+        Changes to chat settings will take effect after you save your settings.
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/features/settings/settings-chat-section.tsx
+++ b/apps/desktop/src/components/features/settings/settings-chat-section.tsx
@@ -33,7 +33,9 @@ export function SettingsChatSection({
           </div>
           <Switch
             checked={chat.showThinkingMessages}
-            onCheckedChange={(checked) => onUpdateChat(() => ({ showThinkingMessages: checked }))}
+            onCheckedChange={(checked) =>
+              onUpdateChat((current) => ({ ...current, showThinkingMessages: checked }))
+            }
             disabled={disabled}
             aria-label="Show thinking messages in Agent Studio transcript"
           />

--- a/apps/desktop/src/components/features/settings/settings-modal-constants.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-constants.ts
@@ -1,9 +1,15 @@
 import type { AgentPromptTemplateId } from "@openducktor/contracts";
 import { agentPromptTemplateIdValues } from "@openducktor/contracts";
 import { listBuiltinAgentPromptTemplates } from "@openducktor/core";
-import { FolderGit2, type LucideIcon, MessageSquareText, SlidersHorizontal } from "lucide-react";
+import {
+  FolderGit2,
+  type LucideIcon,
+  MessageSquare,
+  MessageSquareText,
+  SlidersHorizontal,
+} from "lucide-react";
 
-export type SettingsSectionId = "general" | "git" | "repositories" | "prompts";
+export type SettingsSectionId = "general" | "git" | "repositories" | "prompts" | "chat";
 export type RepositorySectionId = "configuration" | "git" | "agents" | "prompts";
 export type PromptRoleTabId = "shared" | "spec" | "planner" | "build" | "qa";
 
@@ -18,6 +24,7 @@ export const SETTINGS_SECTIONS: ReadonlyArray<{
   { id: "git", label: "Git", icon: FolderGit2 },
   { id: "repositories", label: "Repositories", icon: FolderGit2 },
   { id: "prompts", label: "Prompts", icon: MessageSquareText },
+  { id: "chat", label: "Chat", icon: MessageSquare },
 ];
 
 export const REPOSITORY_SECTIONS: ReadonlyArray<{

--- a/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SettingsModalContent } from "./settings-modal-content";
+
+const createMockSnapshot = (overrides: Partial<SettingsSnapshot> = {}): SettingsSnapshot => ({
+  git: { defaultMergeMethod: "merge_commit" },
+  chat: { showThinkingMessages: false },
+  repos: {},
+  globalPromptOverrides: {},
+  ...overrides,
+});
+
+const createMockController = (snapshot: SettingsSnapshot) => ({
+  isLoadingSettings: false,
+  isLoadingRuntimeDefinitions: false,
+  isLoadingCatalog: false,
+  isSaving: false,
+  isPickingWorktreeBasePath: false,
+  settingsError: null,
+  runtimeDefinitionsError: null,
+  saveError: null,
+  snapshotDraft: snapshot,
+  runtimeDefinitions: [],
+  runtimeCheck: null,
+  getCatalogForRuntime: () => null,
+  getCatalogErrorForRuntime: () => null,
+  isCatalogLoadingForRuntime: () => false,
+  repoPaths: [],
+  selectedRepoPath: null,
+  selectedRepoConfig: null,
+  selectedRepoBranches: [],
+  isLoadingSelectedRepoBranches: false,
+  selectedRepoBranchesError: null,
+  promptValidationState: {
+    globalErrors: {},
+    globalErrorCount: 0,
+    repoErrorsByPath: {},
+    repoErrorCountByPath: {},
+    repoTotalErrorCount: 0,
+    totalErrorCount: 0,
+  },
+  hasPromptValidationErrors: false,
+  selectedRepoPromptValidationErrors: {},
+  selectedRepoPromptValidationErrorCount: 0,
+  globalPromptRoleTabErrorCounts: { shared: 0, spec: 0, planner: 0, build: 0, qa: 0 },
+  selectedRepoPromptRoleTabErrorCounts: { shared: 0, spec: 0, planner: 0, build: 0, qa: 0 },
+  settingsSectionErrorCountById: { general: 0, git: 0, repositories: 0, prompts: 0, chat: 0 },
+  setSelectedRepoPath: () => {},
+  retrySelectedRepoBranchesLoad: () => {},
+  detectSelectedRepoGithubRepository: async () => null,
+  updateSelectedRepoConfig: () => {},
+  updateGlobalGitConfig: () => {},
+  updateGlobalChatSettings: () => {},
+  updateGlobalPromptOverrides: () => {},
+  updateRepoPromptOverrides: () => {},
+  updateSelectedRepoAgentDefault: () => {},
+  clearSelectedRepoAgentDefault: () => {},
+  pickWorktreeBasePath: async () => {},
+  submit: async () => true,
+});
+
+describe("settings modal content", () => {
+  test("renders chat section with SettingsChatSection when section is chat", () => {
+    const snapshot = createMockSnapshot({ chat: { showThinkingMessages: true } });
+    const controller = createMockController(snapshot);
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsModalContent, {
+        section: "chat",
+        repositorySection: "configuration",
+        globalPromptRoleTab: "shared",
+        repoPromptRoleTab: "shared",
+        isInteractionDisabled: false,
+        controller,
+        onRepositorySectionChange: () => {},
+        onGlobalPromptRoleTabChange: () => {},
+        onRepoPromptRoleTabChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Chat Settings");
+    expect(html).toContain("Show Thinking Messages");
+  });
+
+  test("renders general section when section is general", () => {
+    const snapshot = createMockSnapshot();
+    const controller = createMockController(snapshot);
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsModalContent, {
+        section: "general",
+        repositorySection: "configuration",
+        globalPromptRoleTab: "shared",
+        repoPromptRoleTab: "shared",
+        isInteractionDisabled: false,
+        controller,
+        onRepositorySectionChange: () => {},
+        onGlobalPromptRoleTabChange: () => {},
+        onRepoPromptRoleTabChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("General Settings");
+  });
+
+  test("renders prompts section when section is prompts", () => {
+    const snapshot = createMockSnapshot();
+    const controller = createMockController(snapshot);
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsModalContent, {
+        section: "prompts",
+        repositorySection: "configuration",
+        globalPromptRoleTab: "shared",
+        repoPromptRoleTab: "shared",
+        isInteractionDisabled: false,
+        controller,
+        onRepositorySectionChange: () => {},
+        onGlobalPromptRoleTabChange: () => {},
+        onRepoPromptRoleTabChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Global Prompt Overrides");
+  });
+
+  test("renders git section when section is git", () => {
+    const snapshot = createMockSnapshot();
+    const controller = createMockController(snapshot);
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsModalContent, {
+        section: "git",
+        repositorySection: "configuration",
+        globalPromptRoleTab: "shared",
+        repoPromptRoleTab: "shared",
+        isInteractionDisabled: false,
+        controller,
+        onRepositorySectionChange: () => {},
+        onGlobalPromptRoleTabChange: () => {},
+        onRepoPromptRoleTabChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Git Defaults");
+  });
+
+  test("shows loading state when settings are loading", () => {
+    const controller = {
+      ...createMockController(createMockSnapshot()),
+      isLoadingSettings: true,
+      snapshotDraft: null,
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsModalContent, {
+        section: "chat",
+        repositorySection: "configuration",
+        globalPromptRoleTab: "shared",
+        repoPromptRoleTab: "shared",
+        isInteractionDisabled: false,
+        controller,
+        onRepositorySectionChange: () => {},
+        onGlobalPromptRoleTabChange: () => {},
+        onRepoPromptRoleTabChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Loading settings");
+  });
+
+  test("shows error state when settings fail to load", () => {
+    const controller = {
+      ...createMockController(createMockSnapshot()),
+      settingsError: "Failed to load",
+      snapshotDraft: null,
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsModalContent, {
+        section: "chat",
+        repositorySection: "configuration",
+        globalPromptRoleTab: "shared",
+        repoPromptRoleTab: "shared",
+        isInteractionDisabled: false,
+        controller,
+        onRepositorySectionChange: () => {},
+        onGlobalPromptRoleTabChange: () => {},
+        onRepoPromptRoleTabChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Failed to load settings");
+  });
+});

--- a/apps/desktop/src/components/features/settings/settings-modal-content.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-content.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { SettingsChatSection } from "./settings-chat-section";
 import { GeneralSettingsSection } from "./settings-general-section";
 import { SettingsGitSection } from "./settings-git-section";
 import type {
@@ -65,6 +66,7 @@ export function SettingsModalContent({
     retrySelectedRepoBranchesLoad,
     updateSelectedRepoConfig,
     updateGlobalGitConfig,
+    updateGlobalChatSettings,
     updateGlobalPromptOverrides,
     updateRepoPromptOverrides,
     updateSelectedRepoAgentDefault,
@@ -123,6 +125,16 @@ export function SettingsModalContent({
         runtimeCheck={controller.runtimeCheck}
         disabled={isInteractionDisabled}
         onUpdateGit={updateGlobalGitConfig}
+      />
+    );
+  }
+
+  if (section === "chat") {
+    return (
+      <SettingsChatSection
+        chat={snapshotDraft.chat}
+        disabled={isInteractionDisabled}
+        onUpdateChat={updateGlobalChatSettings}
       />
     );
   }

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
@@ -183,6 +183,9 @@ describe("settings-modal-normalization", () => {
       git: {
         defaultMergeMethod: "merge_commit",
       },
+      chat: {
+        showThinkingMessages: true,
+      },
       repos: {
         "/repo-a": createRepoConfig(),
       },
@@ -196,6 +199,7 @@ describe("settings-modal-normalization", () => {
     });
 
     expect(snapshot.repos["/repo-a"]?.hooks.preStart).toEqual(["npm ci"]);
+    expect(snapshot.chat.showThinkingMessages).toBe(true);
     expect(snapshot.globalPromptOverrides).toEqual({
       "kickoff.spec_initial": {
         template: "global",
@@ -209,6 +213,9 @@ describe("settings-modal-normalization", () => {
     const snapshot = {
       git: {
         defaultMergeMethod: "merge_commit" as const,
+      },
+      chat: {
+        showThinkingMessages: false,
       },
       repos: {
         "/repo-b": createRepoConfig(),
@@ -224,6 +231,9 @@ describe("settings-modal-normalization", () => {
         {
           git: {
             defaultMergeMethod: "merge_commit" as const,
+          },
+          chat: {
+            showThinkingMessages: false,
           },
           repos: {},
           globalPromptOverrides: {},

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
@@ -106,6 +106,7 @@ export const normalizeSnapshotForSave = (snapshot: SettingsSnapshot): SettingsSn
 
   return {
     git: normalizeGlobalGitConfigForSave(snapshot.git),
+    chat: snapshot.chat,
     repos,
     globalPromptOverrides: normalizePromptOverridesForSave(snapshot.globalPromptOverrides),
   };

--- a/apps/desktop/src/components/features/settings/settings-modal-sidebars.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-sidebars.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SettingsSidebar } from "./settings-modal-sidebars";
+
+describe("settings modal sidebars", () => {
+  test("renders all settings sections including chat", () => {
+    const errorCountById = {
+      general: 0,
+      git: 0,
+      repositories: 0,
+      prompts: 0,
+      chat: 0,
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsSidebar, {
+        section: "general",
+        disabled: false,
+        errorCountById,
+        onChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("General");
+    expect(html).toContain("Git");
+    expect(html).toContain("Repositories");
+    expect(html).toContain("Prompts");
+    expect(html).toContain("Chat");
+  });
+
+  test("renders chat section as active when selected", () => {
+    const errorCountById = {
+      general: 0,
+      git: 0,
+      repositories: 0,
+      prompts: 0,
+      chat: 0,
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsSidebar, {
+        section: "chat",
+        disabled: false,
+        errorCountById,
+        onChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Chat");
+  });
+
+  test("disables all buttons when disabled prop is true", () => {
+    const errorCountById = {
+      general: 0,
+      git: 0,
+      repositories: 0,
+      prompts: 0,
+      chat: 0,
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsSidebar, {
+        section: "general",
+        disabled: true,
+        errorCountById,
+        onChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("disabled");
+  });
+
+  test("displays error count for chat section when errors exist", () => {
+    const errorCountById = {
+      general: 0,
+      git: 0,
+      repositories: 0,
+      prompts: 0,
+      chat: 2,
+    };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsSidebar, {
+        section: "general",
+        disabled: false,
+        errorCountById,
+        onChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Chat");
+    expect(html).toContain("2");
+  });
+});

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
@@ -4,43 +4,50 @@ import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "@/pages/agents/agent-studio-test-utils";
+import { SETTINGS_SNAPSHOT_UPDATED_EVENT } from "@/pages/agents/use-agent-studio-chat-settings";
+import { REPO_SETTINGS_UPDATED_EVENT } from "@/pages/agents/use-agent-studio-repo-settings";
 
 enableReactActEnvironment();
 
-const loadSettingsSnapshot = mock(
-  async (): Promise<SettingsSnapshot> => ({
-    git: {
-      defaultMergeMethod: "merge_commit",
-    },
-    repos: {
-      "/repo": {
-        defaultRuntimeKind: "opencode",
-        worktreeBasePath: "/tmp/worktrees",
-        branchPrefix: "odt",
-        defaultTargetBranch: { remote: "origin", branch: "main" },
-        git: {
-          providers: {},
-        },
-        trustedHooks: false,
-        hooks: { preStart: [], postComplete: [] },
-        worktreeFileCopies: [],
-        promptOverrides: {},
-        agentDefaults: {},
+const createSettingsSnapshot = (): SettingsSnapshot => ({
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  repos: {
+    "/repo": {
+      defaultRuntimeKind: "opencode",
+      worktreeBasePath: "/tmp/worktrees",
+      branchPrefix: "odt",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: {
+        providers: {},
       },
+      trustedHooks: false,
+      hooks: { preStart: [], postComplete: [] },
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
     },
-    globalPromptOverrides: {},
-  }),
-);
+  },
+  globalPromptOverrides: {},
+});
+
+const loadSettingsSnapshot = mock(async (): Promise<SettingsSnapshot> => createSettingsSnapshot());
 
 let refreshChecks = mock(async () => {});
+let saveGlobalGitConfig = mock(async () => {});
+let saveSettingsSnapshot = mock(async () => {});
 
 mock.module("@/state", () => ({
   useWorkspaceState: () => ({
     activeRepo: "/repo",
     loadSettingsSnapshot,
     detectGithubRepository: async () => null,
-    saveGlobalGitConfig: async () => {},
-    saveSettingsSnapshot: async () => {},
+    saveGlobalGitConfig,
+    saveSettingsSnapshot,
   }),
   useChecksState: () => ({
     runtimeCheck: null,
@@ -88,6 +95,8 @@ describe("useSettingsModalController", () => {
 
   test("does not refresh diagnostics when the modal opens", async () => {
     refreshChecks = mock(async () => {});
+    saveGlobalGitConfig = mock(async () => {});
+    saveSettingsSnapshot = mock(async () => {});
     loadSettingsSnapshot.mockClear();
 
     const harness = createHookHarness(true);
@@ -109,5 +118,63 @@ describe("useSettingsModalController", () => {
     expect(nextRefreshChecks).toHaveBeenCalledTimes(0);
 
     await harness.unmount();
+  });
+
+  test("saves chat-only edits through settings snapshot without repo update events", async () => {
+    refreshChecks = mock(async () => {});
+    saveGlobalGitConfig = mock(async () => {});
+    saveSettingsSnapshot = mock(async () => {});
+    loadSettingsSnapshot.mockClear();
+
+    const dispatchEvent = mock((_event: Event) => true);
+    const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      writable: true,
+      value: {
+        dispatchEvent,
+      },
+    });
+
+    try {
+      const harness = createHookHarness(true);
+      await harness.mount();
+      await harness.waitFor((state) => state.snapshotDraft !== null);
+
+      await harness.run((state) => {
+        state.updateGlobalChatSettings((chat) => ({
+          ...chat,
+          showThinkingMessages: true,
+        }));
+      });
+
+      let didSave = false;
+      await harness.run(async (state) => {
+        didSave = await state.submit();
+      });
+
+      expect(didSave).toBe(true);
+      expect(saveGlobalGitConfig).toHaveBeenCalledTimes(0);
+      expect(saveSettingsSnapshot).toHaveBeenCalledTimes(1);
+      expect(saveSettingsSnapshot).toHaveBeenCalledWith({
+        ...createSettingsSnapshot(),
+        chat: {
+          showThinkingMessages: true,
+        },
+      });
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      const dispatchedEvent = dispatchEvent.mock.calls[0]?.[0];
+      expect(dispatchedEvent).toBeInstanceOf(CustomEvent);
+      expect((dispatchedEvent as Event).type).toBe(SETTINGS_SNAPSHOT_UPDATED_EVENT);
+      expect((dispatchedEvent as Event).type).not.toBe(REPO_SETTINGS_UPDATED_EVENT);
+
+      await harness.unmount();
+    } finally {
+      if (originalWindowDescriptor) {
+        Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+      } else {
+        delete (globalThis as typeof globalThis & { window?: unknown }).window;
+      }
+    }
   });
 });

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { pickRepositoryDirectory } from "@/lib/repo-directory";
+import { SETTINGS_SNAPSHOT_UPDATED_EVENT } from "@/pages/agents/use-agent-studio-chat-settings";
 import { REPO_SETTINGS_UPDATED_EVENT } from "@/pages/agents/use-agent-studio-repo-settings";
 import { useChecksState, useWorkspaceState } from "@/state";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
@@ -30,12 +31,14 @@ import { useSettingsModalPromptValidation } from "./use-settings-modal-prompt-va
 import { useSettingsModalSnapshotState } from "./use-settings-modal-snapshot-state";
 
 type DirtySections = {
+  chat: boolean;
   globalGit: boolean;
   globalPromptOverrides: boolean;
   repoSettings: boolean;
 };
 
 const EMPTY_DIRTY_SECTIONS: DirtySections = {
+  chat: false,
   globalGit: false,
   globalPromptOverrides: false,
   repoSettings: false,
@@ -75,6 +78,9 @@ export type SettingsModalController = {
   updateSelectedRepoConfig: (updater: (current: RepoConfig) => RepoConfig) => void;
   updateGlobalGitConfig: (
     updater: (current: SettingsSnapshot["git"]) => SettingsSnapshot["git"],
+  ) => void;
+  updateGlobalChatSettings: (
+    updater: (current: SettingsSnapshot["chat"]) => SettingsSnapshot["chat"],
   ) => void;
   updateGlobalPromptOverrides: (
     updater: (current: RepoPromptOverrides) => RepoPromptOverrides,
@@ -163,6 +169,7 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
   const {
     updateSelectedRepoConfig: applySelectedRepoConfigUpdate,
     updateGlobalGitConfig: applyGlobalGitConfigUpdate,
+    updateGlobalChatSettings: applyGlobalChatSettingsUpdate,
     updateGlobalPromptOverrides: applyGlobalPromptOverridesUpdate,
     updateRepoPromptOverrides: applyRepoPromptOverridesUpdate,
     updateSelectedRepoAgentDefault: applySelectedRepoAgentDefaultUpdate,
@@ -198,6 +205,14 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
       applyGlobalGitConfigUpdate(updater);
     },
     [applyGlobalGitConfigUpdate, markDirty],
+  );
+
+  const updateGlobalChatSettings = useCallback(
+    (updater: (current: SettingsSnapshot["chat"]) => SettingsSnapshot["chat"]): void => {
+      markDirty("chat");
+      applyGlobalChatSettingsUpdate(updater);
+    },
+    [applyGlobalChatSettingsUpdate, markDirty],
   );
 
   const updateGlobalPromptOverrides = useCallback(
@@ -329,6 +344,7 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
 
     try {
       if (
+        !dirtySections.chat &&
         !dirtySections.globalGit &&
         !dirtySections.globalPromptOverrides &&
         !dirtySections.repoSettings
@@ -338,8 +354,13 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
 
       const shouldUseGlobalGitSave =
         dirtySections.globalGit &&
+        !dirtySections.chat &&
         !dirtySections.globalPromptOverrides &&
         !dirtySections.repoSettings;
+
+      const shouldDispatchRepoSettingsUpdated =
+        Boolean(activeRepo) && (dirtySections.globalPromptOverrides || dirtySections.repoSettings);
+      let didSaveSettingsSnapshot = false;
 
       if (shouldUseGlobalGitSave) {
         const normalizedGit = normalizeGlobalGitConfigForSave(snapshotDraft.git);
@@ -354,9 +375,18 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
       } else {
         const normalizedSnapshot = normalizeSnapshotForSave(snapshotDraft);
         await saveSettingsSnapshot(normalizedSnapshot);
+        didSaveSettingsSnapshot = true;
       }
 
-      if (typeof window !== "undefined" && activeRepo && !shouldUseGlobalGitSave) {
+      if (typeof window !== "undefined" && didSaveSettingsSnapshot) {
+        window.dispatchEvent(new CustomEvent(SETTINGS_SNAPSHOT_UPDATED_EVENT));
+      }
+
+      if (
+        typeof window !== "undefined" &&
+        shouldDispatchRepoSettingsUpdated &&
+        didSaveSettingsSnapshot
+      ) {
         window.dispatchEvent(
           new CustomEvent(REPO_SETTINGS_UPDATED_EVENT, {
             detail: { repoPath: activeRepo },
@@ -377,6 +407,7 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
     }
   }, [
     activeRepo,
+    dirtySections.chat,
     dirtySections.globalGit,
     dirtySections.globalPromptOverrides,
     dirtySections.repoSettings,
@@ -421,6 +452,7 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
     detectSelectedRepoGithubRepository,
     updateSelectedRepoConfig,
     updateGlobalGitConfig,
+    updateGlobalChatSettings,
     updateGlobalPromptOverrides,
     updateRepoPromptOverrides,
     updateSelectedRepoAgentDefault,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
@@ -18,6 +18,9 @@ const createInitialSnapshot = (): SettingsSnapshot => ({
   git: {
     defaultMergeMethod: "merge_commit",
   },
+  chat: {
+    showThinkingMessages: false,
+  },
   globalPromptOverrides: {},
   repos: {
     "/repo-a": {
@@ -91,6 +94,28 @@ describe("useSettingsModalDraftActions", () => {
     expect(snapshot?.globalPromptOverrides["system.role.spec.base"]?.template).toBe(
       "global custom",
     );
+
+    await harness.unmount();
+  });
+
+  test("updates global chat settings without touching unrelated sections", async () => {
+    const harness = createHookHarness({
+      selectedRepoPath: "/repo-a",
+      initialSnapshot: createInitialSnapshot(),
+    });
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.updateGlobalChatSettings((chat) => ({
+        ...chat,
+        showThinkingMessages: true,
+      }));
+    });
+
+    const snapshot = harness.getLatest().snapshotDraft;
+    expect(snapshot?.chat.showThinkingMessages).toBe(true);
+    expect(snapshot?.git.defaultMergeMethod).toBe("merge_commit");
+    expect(snapshot?.repos["/repo-a"]?.branchPrefix).toBe("obp");
 
     await harness.unmount();
   });

--- a/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.ts
@@ -16,6 +16,9 @@ type UseSettingsModalDraftActionsArgs = {
 export type SettingsModalDraftActions = {
   updateSelectedRepoConfig: (updater: (current: RepoConfig) => RepoConfig) => void;
   updateGlobalGitConfig: (updater: (current: GlobalGitConfig) => GlobalGitConfig) => void;
+  updateGlobalChatSettings: (
+    updater: (current: SettingsSnapshot["chat"]) => SettingsSnapshot["chat"],
+  ) => void;
   updateGlobalPromptOverrides: (
     updater: (current: RepoPromptOverrides) => RepoPromptOverrides,
   ) => void;
@@ -90,6 +93,22 @@ export const useSettingsModalDraftActions = ({
     [setSnapshotDraft],
   );
 
+  const updateGlobalChatSettings = useCallback(
+    (updater: (current: SettingsSnapshot["chat"]) => SettingsSnapshot["chat"]): void => {
+      setSnapshotDraft((current) => {
+        if (!current) {
+          return current;
+        }
+
+        return {
+          ...current,
+          chat: updater(current.chat),
+        };
+      });
+    },
+    [setSnapshotDraft],
+  );
+
   const updateRepoPromptOverrides = useCallback(
     (updater: (current: RepoPromptOverrides) => RepoPromptOverrides): void => {
       updateSelectedRepoConfig((repoConfig) => ({
@@ -136,6 +155,7 @@ export const useSettingsModalDraftActions = ({
   return {
     updateSelectedRepoConfig,
     updateGlobalGitConfig,
+    updateGlobalChatSettings,
     updateGlobalPromptOverrides,
     updateRepoPromptOverrides,
     updateSelectedRepoAgentDefault,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
@@ -17,6 +17,9 @@ const createSnapshot = (): SettingsSnapshot => ({
   git: {
     defaultMergeMethod: "merge_commit",
   },
+  chat: {
+    showThinkingMessages: false,
+  },
   globalPromptOverrides: {
     "system.scenario.spec_initial": {
       template: "invalid {{task.bad}}",
@@ -79,6 +82,7 @@ describe("useSettingsModalPromptValidation", () => {
       git: 0,
       repositories: 0,
       prompts: 0,
+      chat: 0,
     });
 
     await harness.unmount();
@@ -104,6 +108,7 @@ describe("useSettingsModalPromptValidation", () => {
       git: 0,
       repositories: 1,
       prompts: 1,
+      chat: 0,
     });
     expect(latest.selectedRepoPromptValidationErrors["kickoff.build_implementation_start"]).toBe(
       "Unsupported placeholder: {{unknown.value}}.",

--- a/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.ts
@@ -91,6 +91,7 @@ export const useSettingsModalPromptValidation = ({
     git: 0,
     repositories: promptValidationState.repoTotalErrorCount,
     prompts: promptValidationState.globalErrorCount,
+    chat: 0,
   };
 
   return {

--- a/apps/desktop/src/pages/agents/agents-page-shell.test.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-shell.test.tsx
@@ -9,8 +9,10 @@ describe("AgentsPageShell", () => {
       createElement(AgentsPageShell, {
         activeRepo: "/repo",
         navigationPersistenceError: new Error("restore failed"),
+        chatSettingsLoadError: null,
         activeTabValue: "task-1",
         onRetryNavigationPersistence: () => {},
+        onRetryChatSettingsLoad: () => {},
         onTabValueChange: () => {},
         taskTabs: createElement("div", undefined, "tabs"),
         workspace: createElement("div", undefined, "workspace"),
@@ -26,8 +28,10 @@ describe("AgentsPageShell", () => {
       createElement(AgentsPageShell, {
         activeRepo: "/repo",
         navigationPersistenceError: null,
+        chatSettingsLoadError: null,
         activeTabValue: "task-1",
         onRetryNavigationPersistence: () => {},
+        onRetryChatSettingsLoad: () => {},
         onTabValueChange: () => {},
         taskTabs: createElement("div", undefined, "tabs"),
         workspace: createElement("div", undefined, "workspace"),
@@ -36,5 +40,26 @@ describe("AgentsPageShell", () => {
 
     expect(html).toContain("workspace");
     expect(html).toContain("tabs");
+  });
+
+  test("renders a retryable chat settings error banner without hiding the workspace", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentsPageShell, {
+        activeRepo: "/repo",
+        navigationPersistenceError: null,
+        chatSettingsLoadError: new Error("settings read failed"),
+        activeTabValue: "task-1",
+        onRetryNavigationPersistence: () => {},
+        onRetryChatSettingsLoad: () => {},
+        onTabValueChange: () => {},
+        taskTabs: createElement("div", undefined, "tabs"),
+        workspace: createElement("div", undefined, "workspace"),
+      }),
+    );
+
+    expect(html).toContain("Agent Studio couldn&#x27;t load chat settings.");
+    expect(html).toContain("settings read failed");
+    expect(html).toContain("Retry load");
+    expect(html).toContain("workspace");
   });
 });

--- a/apps/desktop/src/pages/agents/agents-page-shell.tsx
+++ b/apps/desktop/src/pages/agents/agents-page-shell.tsx
@@ -6,8 +6,10 @@ import { Tabs, TabsContent } from "@/components/ui/tabs";
 type AgentsPageShellProps = {
   activeRepo: string | null;
   navigationPersistenceError: Error | null;
+  chatSettingsLoadError: Error | null;
   activeTabValue: string;
   onRetryNavigationPersistence: () => void;
+  onRetryChatSettingsLoad: () => void;
   onTabValueChange: (value: string) => void;
   taskTabs: ReactNode;
   workspace: ReactNode;
@@ -17,8 +19,10 @@ type AgentsPageShellProps = {
 export function AgentsPageShell({
   activeRepo,
   navigationPersistenceError,
+  chatSettingsLoadError,
   activeTabValue,
   onRetryNavigationPersistence,
+  onRetryChatSettingsLoad,
   onTabValueChange,
   taskTabs,
   workspace,
@@ -62,6 +66,30 @@ export function AgentsPageShell({
       className="h-full min-h-0 max-h-full gap-0 overflow-hidden bg-card"
     >
       {taskTabs}
+      {chatSettingsLoadError ? (
+        <div className="mx-4 mt-4 flex items-start justify-between gap-3 rounded-lg border border-destructive-border bg-destructive-surface px-3 py-2 text-sm text-destructive-muted">
+          <div className="flex min-w-0 items-start gap-2">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <div className="min-w-0 space-y-1">
+              <p className="font-medium text-destructive">
+                Agent Studio couldn&apos;t load chat settings.
+              </p>
+              {activeRepo ? <p>{`Repository: ${activeRepo}`}</p> : null}
+              <p className="break-words font-mono text-xs">{chatSettingsLoadError.message}</p>
+            </div>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 border-destructive-border bg-card text-destructive-muted hover:bg-destructive-surface"
+            onClick={onRetryChatSettingsLoad}
+          >
+            <RefreshCcw className="size-3.5" />
+            Retry load
+          </Button>
+        </div>
+      ) : null}
       <TabsContent value={activeTabValue} className="m-0 min-h-0 flex-1 bg-card p-0">
         {workspace}
       </TabsContent>

--- a/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
@@ -232,6 +232,7 @@ describe("agents-page-view-model", () => {
 
     const model = buildAgentChatModel({
       activeSession: createSession(),
+      showThinkingMessages: true,
       isSessionViewLoading: false,
       roleOptions: [{ role: "spec", label: "Spec", icon: Sparkles }],
       agentStudioReady: true,
@@ -284,6 +285,7 @@ describe("agents-page-view-model", () => {
     });
 
     expect(model.thread.taskSelected).toBe(false);
+    expect(model.thread.showThinkingMessages).toBe(true);
     expect(model.thread.isPinnedToBottom).toBe(true);
     expect(model.composer.contextUsage).toEqual({ totalTokens: 10, contextWindow: 100 });
 

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -114,6 +114,7 @@ export const buildAgentStudioWorkspaceSidebarModel = (args: {
 
 type AgentChatThreadModelArgs = {
   activeSession: AgentSessionState | null;
+  showThinkingMessages: boolean;
   isSessionViewLoading: boolean;
   roleOptions: AgentRoleOption[];
   agentStudioReady: boolean;
@@ -177,6 +178,7 @@ export const buildAgentChatThreadModel = (
   args: AgentChatThreadModelArgs,
 ): AgentChatThreadModel => ({
   session: args.activeSession,
+  showThinkingMessages: args.showThinkingMessages,
   isSessionViewLoading: args.isSessionViewLoading,
   roleOptions: args.roleOptions,
   agentStudioReady: args.agentStudioReady,

--- a/apps/desktop/src/pages/agents/agents-page.tsx
+++ b/apps/desktop/src/pages/agents/agents-page.tsx
@@ -54,7 +54,7 @@ import { useAgentStudioSelectionController } from "./use-agent-studio-selection-
 import { useAgentStudioSessionStartRequest } from "./use-agent-studio-session-start-request";
 
 export function AgentsPage(): ReactElement {
-  const { activeRepo, activeBranch, loadRepoSettings } = useWorkspaceState();
+  const { activeRepo, activeBranch, loadRepoSettings, loadSettingsSnapshot } = useWorkspaceState();
   const { runtimeDefinitions, isLoadingRuntimeDefinitions, runtimeDefinitionsError } =
     useRuntimeDefinitionsContext();
   const { runtimeHealthByRuntime, isLoadingChecks, refreshChecks } = useChecksState();
@@ -230,6 +230,7 @@ export function AgentsPage(): ReactElement {
 
   const orchestrationWorkspace = {
     activeRepo,
+    loadSettingsSnapshot,
     loadRepoSettings,
   } satisfies AgentStudioOrchestrationWorkspaceContext;
 
@@ -396,8 +397,10 @@ export function AgentsPage(): ReactElement {
     <AgentsPageShell
       activeRepo={activeRepo}
       navigationPersistenceError={navigationPersistenceError}
+      chatSettingsLoadError={orchestration.chatSettingsLoadError}
       activeTabValue={orchestration.activeTabValue}
       onRetryNavigationPersistence={retryNavigationPersistence}
+      onRetryChatSettingsLoad={orchestration.retryChatSettingsLoad}
       onTabValueChange={selection.handleSelectTab}
       taskTabs={
         <AgentStudioTaskTabs

--- a/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
@@ -48,7 +48,7 @@ describe("useAgentStudioChatSettings", () => {
     await harness.unmount();
   });
 
-  test("defaults to false when the loaded snapshot omits chat settings", async () => {
+  test("surfaces malformed snapshots that omit chat settings", async () => {
     const loadSettingsSnapshot = mock(
       async (): Promise<SettingsSnapshot> => createSettingsSnapshot(false, false),
     );
@@ -59,8 +59,11 @@ describe("useAgentStudioChatSettings", () => {
 
     await harness.mount();
 
+    await harness.waitFor((state) => state.chatSettingsLoadError !== null);
     expect(harness.getLatest().showThinkingMessages).toBe(false);
-    expect(harness.getLatest().chatSettingsLoadError).toBeNull();
+    expect(harness.getLatest().chatSettingsLoadError?.message).toMatch(
+      /snapshot\.chat\.showThinkingMessages|undefined/,
+    );
 
     await harness.unmount();
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
@@ -1,0 +1,263 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import {
+  createDeferred,
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import {
+  SETTINGS_SNAPSHOT_UPDATED_EVENT,
+  useAgentStudioChatSettings,
+} from "./use-agent-studio-chat-settings";
+
+enableReactActEnvironment();
+
+type HookArgs = Parameters<typeof useAgentStudioChatSettings>[0];
+
+const createSettingsSnapshot = (
+  showThinkingMessages = false,
+  includeChat = true,
+): SettingsSnapshot =>
+  ({
+    git: {
+      defaultMergeMethod: "merge_commit",
+    },
+    ...(includeChat ? { chat: { showThinkingMessages } } : {}),
+    repos: {},
+    globalPromptOverrides: {},
+  }) as SettingsSnapshot;
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioChatSettings, initialProps);
+
+describe("useAgentStudioChatSettings", () => {
+  test("loads chat settings when a repository is active", async () => {
+    const loadSettingsSnapshot = mock(
+      async (): Promise<SettingsSnapshot> => createSettingsSnapshot(true),
+    );
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      loadSettingsSnapshot,
+    });
+
+    await harness.mount();
+
+    expect(loadSettingsSnapshot).toHaveBeenCalledTimes(1);
+    expect(harness.getLatest().showThinkingMessages).toBe(true);
+
+    await harness.unmount();
+  });
+
+  test("defaults to false when the loaded snapshot omits chat settings", async () => {
+    const loadSettingsSnapshot = mock(
+      async (): Promise<SettingsSnapshot> => createSettingsSnapshot(false, false),
+    );
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      loadSettingsSnapshot,
+    });
+
+    await harness.mount();
+
+    expect(harness.getLatest().showThinkingMessages).toBe(false);
+    expect(harness.getLatest().chatSettingsLoadError).toBeNull();
+
+    await harness.unmount();
+  });
+
+  test("surfaces settings load failures instead of silently resetting chat visibility", async () => {
+    const loadSettingsSnapshot = mock(async (): Promise<SettingsSnapshot> => {
+      throw new Error("settings read failed");
+    });
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      loadSettingsSnapshot,
+    });
+
+    await harness.mount();
+
+    await harness.waitFor((state) => state.chatSettingsLoadError !== null);
+    expect(harness.getLatest().showThinkingMessages).toBe(false);
+    expect(harness.getLatest().chatSettingsLoadError?.message).toContain("settings read failed");
+
+    await harness.unmount();
+  });
+
+  test("resets to false when the active repo becomes unavailable", async () => {
+    const loadSettingsSnapshot = mock(
+      async (): Promise<SettingsSnapshot> => createSettingsSnapshot(true),
+    );
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      loadSettingsSnapshot,
+    });
+
+    await harness.mount();
+    expect(harness.getLatest().showThinkingMessages).toBe(true);
+
+    await harness.update({ activeRepo: null, loadSettingsSnapshot });
+
+    expect(harness.getLatest().showThinkingMessages).toBe(false);
+
+    await harness.unmount();
+  });
+
+  test("reloads chat settings when the settings snapshot update event is dispatched", async () => {
+    const globalWithWindow = globalThis as typeof globalThis & {
+      window?: EventTarget;
+    };
+    const originalWindow = globalWithWindow.window;
+    const eventWindow = new EventTarget();
+    Object.defineProperty(globalWithWindow, "window", {
+      configurable: true,
+      value: eventWindow,
+    });
+
+    let loadCount = 0;
+    const loadSettingsSnapshot = mock(async (): Promise<SettingsSnapshot> => {
+      loadCount += 1;
+      return loadCount === 1 ? createSettingsSnapshot(false) : createSettingsSnapshot(true);
+    });
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      loadSettingsSnapshot,
+    });
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().showThinkingMessages).toBe(false);
+      expect(harness.getLatest().chatSettingsLoadError).toBeNull();
+
+      await harness.run(() => {
+        eventWindow.dispatchEvent(new CustomEvent(SETTINGS_SNAPSHOT_UPDATED_EVENT));
+      });
+
+      await harness.waitFor((state) => state.showThinkingMessages === true);
+      expect(loadSettingsSnapshot).toHaveBeenCalledTimes(2);
+      expect(harness.getLatest().showThinkingMessages).toBe(true);
+      expect(harness.getLatest().chatSettingsLoadError).toBeNull();
+    } finally {
+      await harness.unmount();
+
+      if (typeof originalWindow === "undefined") {
+        Reflect.deleteProperty(globalWithWindow, "window");
+      } else {
+        Object.defineProperty(globalWithWindow, "window", {
+          configurable: true,
+          value: originalWindow,
+        });
+      }
+    }
+  });
+
+  test("keeps the latest reload result when concurrent loads resolve out of order", async () => {
+    const globalWithWindow = globalThis as typeof globalThis & {
+      window?: EventTarget;
+    };
+    const originalWindow = globalWithWindow.window;
+    const eventWindow = new EventTarget();
+    Object.defineProperty(globalWithWindow, "window", {
+      configurable: true,
+      value: eventWindow,
+    });
+
+    const firstLoad = createDeferred<SettingsSnapshot>();
+    const secondLoad = createDeferred<SettingsSnapshot>();
+    let loadCount = 0;
+    const loadSettingsSnapshot = mock((): Promise<SettingsSnapshot> => {
+      loadCount += 1;
+      return loadCount === 1 ? firstLoad.promise : secondLoad.promise;
+    });
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      loadSettingsSnapshot,
+    });
+
+    try {
+      await harness.mount();
+
+      await harness.run(() => {
+        eventWindow.dispatchEvent(new CustomEvent(SETTINGS_SNAPSHOT_UPDATED_EVENT));
+      });
+
+      await harness.run(async () => {
+        secondLoad.resolve(createSettingsSnapshot(true));
+        await secondLoad.promise;
+      });
+      await harness.waitFor((state) => state.showThinkingMessages === true);
+
+      await harness.run(async () => {
+        firstLoad.resolve(createSettingsSnapshot(false));
+        await firstLoad.promise;
+      });
+
+      expect(loadSettingsSnapshot).toHaveBeenCalledTimes(2);
+      expect(harness.getLatest().showThinkingMessages).toBe(true);
+    } finally {
+      firstLoad.resolve(createSettingsSnapshot(false));
+      secondLoad.resolve(createSettingsSnapshot(true));
+      await harness.unmount();
+
+      if (typeof originalWindow === "undefined") {
+        Reflect.deleteProperty(globalWithWindow, "window");
+      } else {
+        Object.defineProperty(globalWithWindow, "window", {
+          configurable: true,
+          value: originalWindow,
+        });
+      }
+    }
+  });
+
+  test("keeps the previous visibility setting when a reload fails and clears the error after retry", async () => {
+    const firstLoad = createDeferred<SettingsSnapshot>();
+    const secondLoad = createDeferred<SettingsSnapshot>();
+    let loadCount = 0;
+    const loadSettingsSnapshot = mock((): Promise<SettingsSnapshot> => {
+      loadCount += 1;
+      if (loadCount === 1) {
+        return firstLoad.promise;
+      }
+      if (loadCount === 2) {
+        return Promise.reject(new Error("refresh failed"));
+      }
+      return secondLoad.promise;
+    });
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      loadSettingsSnapshot,
+    });
+
+    try {
+      await harness.mount();
+      await harness.run(async () => {
+        firstLoad.resolve(createSettingsSnapshot(true));
+        await firstLoad.promise;
+      });
+      expect(harness.getLatest().showThinkingMessages).toBe(true);
+
+      await harness.run(() => {
+        harness.getLatest().retryChatSettingsLoad();
+      });
+
+      await harness.waitFor((state) => state.chatSettingsLoadError !== null);
+      expect(harness.getLatest().showThinkingMessages).toBe(true);
+      expect(harness.getLatest().chatSettingsLoadError?.message).toContain("refresh failed");
+
+      await harness.run(async () => {
+        harness.getLatest().retryChatSettingsLoad();
+        secondLoad.resolve(createSettingsSnapshot(false));
+        await secondLoad.promise;
+      });
+
+      await harness.waitFor(
+        (state) => state.showThinkingMessages === false && state.chatSettingsLoadError === null,
+      );
+      expect(loadSettingsSnapshot).toHaveBeenCalledTimes(3);
+    } finally {
+      firstLoad.resolve(createSettingsSnapshot(true));
+      secondLoad.resolve(createSettingsSnapshot(false));
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.ts
@@ -7,7 +7,7 @@ export const SETTINGS_SNAPSHOT_UPDATED_EVENT = "odt:settings-snapshot-updated";
 const DEFAULT_SHOW_THINKING_MESSAGES = false;
 
 const readShowThinkingMessages = (snapshot: SettingsSnapshot): boolean => {
-  return snapshot.chat?.showThinkingMessages ?? DEFAULT_SHOW_THINKING_MESSAGES;
+  return snapshot.chat.showThinkingMessages;
 };
 
 const createChatSettingsLoadError = (activeRepo: string, cause: unknown): Error => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.ts
@@ -1,0 +1,92 @@
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { errorMessage } from "@/lib/errors";
+
+export const SETTINGS_SNAPSHOT_UPDATED_EVENT = "odt:settings-snapshot-updated";
+
+const DEFAULT_SHOW_THINKING_MESSAGES = false;
+
+const readShowThinkingMessages = (snapshot: SettingsSnapshot): boolean => {
+  return snapshot.chat?.showThinkingMessages ?? DEFAULT_SHOW_THINKING_MESSAGES;
+};
+
+const createChatSettingsLoadError = (activeRepo: string, cause: unknown): Error => {
+  return new Error(
+    `Failed to load Agent Studio chat settings for "${activeRepo}": ${errorMessage(cause)}`,
+    { cause },
+  );
+};
+
+export function useAgentStudioChatSettings(args: {
+  activeRepo: string | null;
+  loadSettingsSnapshot: () => Promise<SettingsSnapshot>;
+}): {
+  showThinkingMessages: boolean;
+  chatSettingsLoadError: Error | null;
+  retryChatSettingsLoad: () => void;
+} {
+  const { activeRepo, loadSettingsSnapshot } = args;
+  const [showThinkingMessages, setShowThinkingMessages] = useState(DEFAULT_SHOW_THINKING_MESSAGES);
+  const [chatSettingsLoadError, setChatSettingsLoadError] = useState<Error | null>(null);
+  const latestReloadIdRef = useRef(0);
+
+  const reloadChatSettings = useCallback(() => {
+    if (!activeRepo) {
+      latestReloadIdRef.current += 1;
+      setShowThinkingMessages(DEFAULT_SHOW_THINKING_MESSAGES);
+      setChatSettingsLoadError(null);
+      return () => {};
+    }
+
+    const repoPath = activeRepo;
+    const reloadId = latestReloadIdRef.current + 1;
+    latestReloadIdRef.current = reloadId;
+    let cancelled = false;
+
+    void loadSettingsSnapshot()
+      .then((snapshot) => {
+        if (!cancelled && reloadId === latestReloadIdRef.current) {
+          setShowThinkingMessages(readShowThinkingMessages(snapshot));
+          setChatSettingsLoadError(null);
+        }
+      })
+      .catch((cause) => {
+        if (!cancelled && reloadId === latestReloadIdRef.current) {
+          setChatSettingsLoadError(createChatSettingsLoadError(repoPath, cause));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeRepo, loadSettingsSnapshot]);
+
+  const retryChatSettingsLoad = useCallback((): void => {
+    reloadChatSettings();
+  }, [reloadChatSettings]);
+
+  useEffect(() => {
+    return reloadChatSettings();
+  }, [reloadChatSettings]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleSettingsSnapshotUpdated = () => {
+      reloadChatSettings();
+    };
+
+    window.addEventListener(SETTINGS_SNAPSHOT_UPDATED_EVENT, handleSettingsSnapshotUpdated);
+    return () => {
+      window.removeEventListener(SETTINGS_SNAPSHOT_UPDATED_EVENT, handleSettingsSnapshotUpdated);
+    };
+  }, [reloadChatSettings]);
+
+  return {
+    showThinkingMessages,
+    chatSettingsLoadError,
+    retryChatSettingsLoad,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -93,6 +93,9 @@ const baseArgs: BuildArgs = {
     permissionReplyErrorByRequestId: {},
     onReplyPermission: async () => {},
   },
+  chatSettings: {
+    showThinkingMessages: true,
+  },
   composer: {
     input: "hello",
     setInput: () => {},
@@ -111,6 +114,7 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(mapped.modelSelection.onSelectAgent).toBe(handleSelectAgent);
     expect(mapped.modelSelection.onSelectModel).toBe(handleSelectModel);
     expect(mapped.modelSelection.onSelectVariant).toBe(handleSelectVariant);
+    expect(mapped.chatSettings.showThinkingMessages).toBe(true);
     expect(mapped.composer.input).toBe("hello");
   });
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -1,10 +1,11 @@
-import type { TaskCard } from "@openducktor/contracts";
+import type { SettingsSnapshot, TaskCard } from "@openducktor/contracts";
 import type { AgentRole, AgentScenario } from "@openducktor/core";
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentStateContextValue, RepoSettingsInput } from "@/types/state-slices";
 import type { AgentStudioQueryUpdate as QueryUpdate } from "./agent-studio-navigation";
 import { useAgentSessionPermissionActions } from "./use-agent-session-permission-actions";
+import { useAgentStudioChatSettings } from "./use-agent-studio-chat-settings";
 import { useAgentStudioDocuments } from "./use-agent-studio-documents";
 import { useAgentStudioModelSelection } from "./use-agent-studio-model-selection";
 import { useAgentStudioPageModels } from "./use-agent-studio-page-models";
@@ -15,6 +16,7 @@ import type { RequestNewSessionStart } from "./use-agent-studio-session-start-ty
 
 export type AgentStudioOrchestrationWorkspaceContext = {
   activeRepo: string | null;
+  loadSettingsSnapshot: () => Promise<SettingsSnapshot>;
   loadRepoSettings: () => Promise<RepoSettingsInput>;
 };
 
@@ -71,6 +73,8 @@ type UseAgentStudioOrchestrationControllerArgs = {
 
 type UseAgentStudioOrchestrationControllerResult = {
   repoSettings: RepoSettingsInput | null;
+  chatSettingsLoadError: Error | null;
+  retryChatSettingsLoad: () => void;
   activeTabValue: string;
   agentStudioTaskTabsModel: AgentStudioTaskTabsModel;
   agentStudioHeaderModel: ReturnType<typeof useAgentStudioPageModels>["agentStudioHeaderModel"];
@@ -139,6 +143,9 @@ type BuildAgentStudioPageModelsArgsInput = {
   sessionActions: AgentStudioPageModelsSessionActionsContext;
   modelSelection: AgentStudioPageModelsModelSelectionContext;
   permissions: ReturnType<typeof useAgentSessionPermissionActions>;
+  chatSettings: {
+    showThinkingMessages: boolean;
+  };
   composer: AgentStudioOrchestrationComposerContext;
 };
 
@@ -151,6 +158,7 @@ export const buildAgentStudioPageModelsArgs = ({
   sessionActions,
   modelSelection,
   permissions,
+  chatSettings,
   composer,
 }: BuildAgentStudioPageModelsArgsInput): Parameters<typeof useAgentStudioPageModels>[0] => {
   const { activeTaskTabId, ...taskTabs } = tabs;
@@ -174,6 +182,7 @@ export const buildAgentStudioPageModelsArgs = ({
     documents,
     readiness,
     sessionActions,
+    chatSettings,
     modelSelection: {
       ...restOfModelSelection,
       onSelectAgent: handleSelectAgent,
@@ -192,7 +201,7 @@ export function useAgentStudioOrchestrationController({
   composer,
   actions,
 }: UseAgentStudioOrchestrationControllerArgs): UseAgentStudioOrchestrationControllerResult {
-  const { activeRepo, loadRepoSettings } = workspace;
+  const { activeRepo, loadRepoSettings, loadSettingsSnapshot } = workspace;
   const {
     viewTaskId,
     viewRole,
@@ -227,6 +236,11 @@ export function useAgentStudioOrchestrationController({
     activeRepo,
     loadRepoSettings,
   });
+  const { showThinkingMessages, chatSettingsLoadError, retryChatSettingsLoad } =
+    useAgentStudioChatSettings({
+      activeRepo,
+      loadSettingsSnapshot,
+    });
 
   const { specDoc, planDoc, qaDoc } = useAgentStudioDocuments({
     activeRepo,
@@ -362,6 +376,9 @@ export function useAgentStudioOrchestrationController({
       permissionReplyErrorByRequestId,
       onReplyPermission,
     },
+    chatSettings: {
+      showThinkingMessages,
+    },
     composer,
   });
 
@@ -382,6 +399,8 @@ export function useAgentStudioOrchestrationController({
 
   return {
     repoSettings,
+    chatSettingsLoadError,
+    retryChatSettingsLoad,
     activeTabValue,
     agentStudioTaskTabsModel,
     agentStudioHeaderModel,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -25,6 +25,7 @@ type HookArgsOverrides = {
   sessionActions?: Partial<HookArgs["sessionActions"]>;
   modelSelection?: Partial<HookArgs["modelSelection"]>;
   permissions?: Partial<HookArgs["permissions"]>;
+  chatSettings?: Partial<HookArgs["chatSettings"]>;
   composer?: Partial<HookArgs["composer"]>;
 };
 
@@ -150,6 +151,10 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
       onReplyPermission: async () => {},
       ...overrides.permissions,
     },
+    chatSettings: {
+      showThinkingMessages: false,
+      ...overrides.chatSettings,
+    },
     composer: {
       input: "",
       setInput: () => {},
@@ -197,6 +202,7 @@ describe("useAgentStudioPageModels", () => {
       totalTokens: 12,
       contextWindow: 100,
     });
+    expect(state.agentChatModel.thread.showThinkingMessages).toBe(false);
 
     state.agentChatModel.thread.onRefreshChecks();
     state.agentChatModel.thread.onKickoff();
@@ -520,6 +526,42 @@ describe("useAgentStudioPageModels", () => {
     expect(nextState.agentChatModel.thread).not.toBe(initialThreadModel);
     expect(nextState.agentChatModel.composer).toBe(initialComposerModel);
     expect(nextState.agentChatModel.thread.todoPanelCollapsed).toBe(true);
+
+    await harness.unmount();
+  });
+
+  test("updates thread model when showThinkingMessages changes without rebuilding composer", async () => {
+    const session = createSession("session-1", "external-1");
+    const baseProps = createHookArgs({
+      core: {
+        activeSession: session,
+        sessionsForTask: [session],
+      },
+      composer: {
+        input: "draft",
+      },
+      chatSettings: {
+        showThinkingMessages: false,
+      },
+    });
+    const harness = createHookHarness(baseProps);
+
+    await harness.mount();
+    const initialState = harness.getLatest();
+    const initialThreadModel = initialState.agentChatModel.thread;
+    const initialComposerModel = initialState.agentChatModel.composer;
+
+    await harness.update({
+      ...baseProps,
+      chatSettings: {
+        showThinkingMessages: true,
+      },
+    });
+
+    const nextState = harness.getLatest();
+    expect(nextState.agentChatModel.thread).not.toBe(initialThreadModel);
+    expect(nextState.agentChatModel.composer).toBe(initialComposerModel);
+    expect(nextState.agentChatModel.thread.showThinkingMessages).toBe(true);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -119,6 +119,10 @@ type AgentStudioComposerContext = {
   setInput: (value: string) => void;
 };
 
+type AgentStudioChatSettingsContext = {
+  showThinkingMessages: boolean;
+};
+
 type UseAgentStudioPageModelsArgs = {
   core: AgentStudioCoreContext;
   taskTabs: AgentStudioTaskTabsContext;
@@ -127,6 +131,7 @@ type UseAgentStudioPageModelsArgs = {
   sessionActions: AgentStudioSessionActionsContext;
   modelSelection: AgentStudioModelSelectionContext;
   permissions: AgentStudioPermissionContext;
+  chatSettings: AgentStudioChatSettingsContext;
   composer: AgentStudioComposerContext;
 };
 
@@ -138,6 +143,7 @@ export function useAgentStudioPageModels({
   sessionActions,
   modelSelection,
   permissions,
+  chatSettings,
   composer,
 }: UseAgentStudioPageModelsArgs): {
   activeTabValue: string;
@@ -343,11 +349,18 @@ export function useAgentStudioPageModels({
   const threadSessionContext = useMemo<AgentStudioThreadSessionContext>(
     () => ({
       threadSession,
+      showThinkingMessages: chatSettings.showThinkingMessages,
       isContextSwitching,
       taskId: core.taskId,
       activeSessionAgentColors: modelSelection.activeSessionAgentColors,
     }),
-    [core.taskId, isContextSwitching, modelSelection.activeSessionAgentColors, threadSession],
+    [
+      chatSettings.showThinkingMessages,
+      core.taskId,
+      isContextSwitching,
+      modelSelection.activeSessionAgentColors,
+      threadSession,
+    ],
   );
 
   const threadReadinessContext = useMemo<AgentStudioThreadReadinessContext>(

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodel-contracts.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodel-contracts.ts
@@ -29,6 +29,7 @@ export type WorkflowComposerContext = Pick<
 
 export type AgentStudioThreadSessionContext = {
   threadSession: AgentSessionState | null;
+  showThinkingMessages: boolean;
   isContextSwitching: boolean;
   taskId: string;
   activeSessionAgentColors: Record<string, string>;

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { createRef } from "react";
+import {
+  createHookHarness as createSharedHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useAgentStudioThreadModel } from "./use-agent-studio-page-submodels";
+
+enableReactActEnvironment();
+
+type HookArgs = Parameters<typeof useAgentStudioThreadModel>[0];
+
+const createHookArgs = (showThinkingMessages = false): HookArgs => ({
+  session: {
+    threadSession: null,
+    showThinkingMessages,
+    isContextSwitching: false,
+    taskId: "task-1",
+    activeSessionAgentColors: {},
+  },
+  readiness: {
+    agentStudioReady: true,
+    agentStudioBlockedReason: "",
+    isLoadingChecks: false,
+    refreshChecks: async () => {},
+  },
+  kickoff: {
+    canKickoffNewSession: true,
+    selectedRoleAvailable: true,
+    kickoffLabel: "Start",
+    startScenarioKickoff: async () => {},
+    isStarting: false,
+    isSending: false,
+  },
+  questions: {
+    isSubmittingQuestionByRequestId: {},
+    onSubmitQuestionAnswers: async () => {},
+  },
+  permissions: {
+    isSubmittingPermissionByRequestId: {},
+    permissionReplyErrorByRequestId: {},
+    onReplyPermission: async () => {},
+  },
+  todoPanel: {
+    todoPanelCollapsed: false,
+    onToggleTodoPanel: () => {},
+    todoPanelBottomOffset: 0,
+  },
+  scroll: {
+    isPinnedToBottom: true,
+    messagesContainerRef: createRef<HTMLDivElement>(),
+    onMessagesPointerDown: () => {},
+    onMessagesScroll: () => {},
+    onMessagesTouchMove: () => {},
+    onMessagesWheel: () => {},
+  },
+});
+
+const createHookHarness = (initialProps: HookArgs) =>
+  createSharedHookHarness(useAgentStudioThreadModel, initialProps);
+
+describe("useAgentStudioThreadModel", () => {
+  test("forwards showThinkingMessages into the thread model", async () => {
+    const harness = createHookHarness(createHookArgs(true));
+
+    await harness.mount();
+    expect(harness.getLatest().showThinkingMessages).toBe(true);
+
+    await harness.update(createHookArgs(false));
+    expect(harness.getLatest().showThinkingMessages).toBe(false);
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -134,6 +134,7 @@ export const useAgentStudioThreadModel = ({
     () =>
       buildAgentChatThreadModel({
         activeSession: session.threadSession,
+        showThinkingMessages: session.showThinkingMessages,
         isSessionViewLoading: session.isContextSwitching,
         roleOptions: ROLE_OPTIONS,
         agentStudioReady: readiness.agentStudioReady,
@@ -186,6 +187,7 @@ export const useAgentStudioThreadModel = ({
       scroll.onMessagesWheel,
       session.activeSessionAgentColors,
       session.isContextSwitching,
+      session.showThinkingMessages,
       session.taskId,
       session.threadSession,
       todoPanel.onToggleTodoPanel,

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -62,6 +62,9 @@ describe("useAgentStudioSessionActions", () => {
       git: {
         defaultMergeMethod: "merge_commit",
       },
+      chat: {
+        showThinkingMessages: false,
+      },
       repos: {},
       globalPromptOverrides: {},
     });

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -58,6 +58,9 @@ describe("useAgentStudioSessionStartFlow", () => {
       git: {
         defaultMergeMethod: "merge_commit",
       },
+      chat: {
+        showThinkingMessages: false,
+      },
       repos: {},
       globalPromptOverrides: {},
     });

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -34,6 +34,9 @@ const workspaceGetSettingsSnapshotMock = mock(async () => ({
   git: {
     defaultMergeMethod: "merge_commit" as const,
   },
+  chat: {
+    showThinkingMessages: false,
+  },
   repos: {},
   globalPromptOverrides: {} as RepoPromptOverrides,
 }));
@@ -281,6 +284,9 @@ describe("KanbanPage session start modal flow", () => {
     workspaceGetSettingsSnapshotMock.mockImplementation(async () => ({
       git: {
         defaultMergeMethod: "merge_commit" as const,
+      },
+      chat: {
+        showThinkingMessages: false,
       },
       repos: {},
       globalPromptOverrides: {},

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -58,6 +58,7 @@ mock.module("@/state/operations/host", () => ({
     workspaceGetRepoConfig: async () => ({ promptOverrides: {} }),
     workspaceGetSettingsSnapshot: async () => ({
       git: { defaultMergeMethod: "merge_commit" as const },
+      chat: { showThinkingMessages: false },
       repos: {},
       globalPromptOverrides: {},
     }),

--- a/apps/desktop/src/state/app-state-context-values.test.ts
+++ b/apps/desktop/src/state/app-state-context-values.test.ts
@@ -62,6 +62,9 @@ describe("app-state-context-values", () => {
         git: {
           defaultMergeMethod: "merge_commit",
         },
+        chat: {
+          showThinkingMessages: false,
+        },
         repos: {},
         globalPromptOverrides: {},
       }),

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -436,6 +436,9 @@ describe("agent-orchestrator-runtime", () => {
       git: {
         defaultMergeMethod: "merge_commit",
       },
+      chat: {
+        showThinkingMessages: false,
+      },
       repos: {},
       globalPromptOverrides: {
         "kickoff.spec_initial": {
@@ -501,6 +504,9 @@ describe("agent-orchestrator-runtime", () => {
     host.workspaceGetSettingsSnapshot = async () => ({
       git: {
         defaultMergeMethod: "merge_commit",
+      },
+      chat: {
+        showThinkingMessages: false,
       },
       repos: {},
       globalPromptOverrides,

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
@@ -217,6 +217,9 @@ describe("use-agent-orchestrator-operations", () => {
       git: {
         defaultMergeMethod: "merge_commit",
       },
+      chat: {
+        showThinkingMessages: false,
+      },
       repos: {},
       globalPromptOverrides: {},
     });

--- a/apps/desktop/src/state/operations/use-repo-settings-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-repo-settings-operations.test.tsx
@@ -319,6 +319,9 @@ describe("use-repo-settings-operations", () => {
       git: {
         defaultMergeMethod: "merge_commit" as const,
       },
+      chat: {
+        showThinkingMessages: false,
+      },
       repos: {},
       globalPromptOverrides: {},
     }));
@@ -339,6 +342,9 @@ describe("use-repo-settings-operations", () => {
       await expect(harness.getLatest().loadSettingsSnapshot()).resolves.toEqual({
         git: {
           defaultMergeMethod: "merge_commit",
+        },
+        chat: {
+          showThinkingMessages: false,
         },
         repos: {},
         globalPromptOverrides: {},
@@ -368,6 +374,9 @@ describe("use-repo-settings-operations", () => {
     const snapshot = {
       git: {
         defaultMergeMethod: "merge_commit" as const,
+      },
+      chat: {
+        showThinkingMessages: false,
       },
       repos: {},
       globalPromptOverrides: {},
@@ -426,6 +435,9 @@ describe("use-repo-settings-operations", () => {
     const snapshot = {
       git: {
         defaultMergeMethod: "merge_commit" as const,
+      },
+      chat: {
+        showThinkingMessages: false,
       },
       repos: {
         "/repo-a": {

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -396,10 +396,20 @@ describe("TauriHostClient", () => {
     const { client, calls } = createClient((command) => {
       if (command === "workspace_get_settings_snapshot") {
         return {
+          git: {
+            defaultMergeMethod: "merge_commit",
+          },
+          chat: {
+            showThinkingMessages: false,
+          },
           repos: {
             "/repo": {
+              defaultRuntimeKind: "opencode",
               branchPrefix: "obp",
               defaultTargetBranch: { remote: "origin", branch: "main" },
+              git: {
+                providers: {},
+              },
               trustedHooks: false,
               hooks: { preStart: [], postComplete: [] },
               worktreeFileCopies: [],
@@ -440,11 +450,20 @@ describe("TauriHostClient", () => {
     });
 
     const result = await client.workspaceSaveSettingsSnapshot({
+      git: {
+        defaultMergeMethod: "merge_commit",
+      },
+      chat: {
+        showThinkingMessages: false,
+      },
       repos: {
         "/repo": {
           defaultRuntimeKind: "opencode",
           branchPrefix: "obp",
           defaultTargetBranch: { remote: "origin", branch: "main" },
+          git: {
+            providers: {},
+          },
           trustedHooks: false,
           hooks: { preStart: [], postComplete: [] },
           worktreeFileCopies: [],
@@ -461,11 +480,20 @@ describe("TauriHostClient", () => {
         command: "workspace_save_settings_snapshot",
         args: {
           snapshot: {
+            git: {
+              defaultMergeMethod: "merge_commit",
+            },
+            chat: {
+              showThinkingMessages: false,
+            },
             repos: {
               "/repo": {
                 defaultRuntimeKind: "opencode",
                 branchPrefix: "obp",
                 defaultTargetBranch: { remote: "origin", branch: "main" },
+                git: {
+                  providers: {},
+                },
                 trustedHooks: false,
                 hooks: { preStart: [], postComplete: [] },
                 worktreeFileCopies: [],

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -9,6 +9,10 @@ const DEFAULT_SOFT_GUARDRAILS = {
   backoffSeconds: 30,
 } as const;
 
+const DEFAULT_CHAT_SETTINGS = {
+  showThinkingMessages: false,
+} as const;
+
 const nullableToOptional = <T extends z.ZodTypeAny>(schema: T) =>
   z.preprocess((value) => (value === null ? undefined : value), schema.optional());
 
@@ -67,10 +71,16 @@ export const repoConfigSchema = z.object({
 });
 export type RepoConfig = z.infer<typeof repoConfigSchema>;
 
+export const chatSettingsSchema = z.object({
+  showThinkingMessages: z.boolean().default(DEFAULT_CHAT_SETTINGS.showThinkingMessages),
+});
+export type ChatSettings = z.infer<typeof chatSettingsSchema>;
+
 export const globalConfigSchema = z.object({
   version: z.literal(1),
   activeRepo: z.string().optional(),
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
+  chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
   repos: z.record(z.string(), repoConfigSchema).default({}),
   globalPromptOverrides: repoPromptOverridesSchema.default({}),
   recentRepos: z.array(z.string()).default([]),
@@ -79,6 +89,7 @@ export type GlobalConfig = z.infer<typeof globalConfigSchema>;
 
 export const settingsSnapshotSchema = z.object({
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
+  chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
   repos: z.record(z.string(), repoConfigSchema).default({}),
   globalPromptOverrides: repoPromptOverridesSchema.default({}),
 });

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -15,6 +15,7 @@ import type {
   AgentWorkflowState,
   AgentWorkflows,
   BeadsCheck,
+  ChatSettings,
   CommitsAheadBehind,
   FileDiff,
   FileStatus,
@@ -94,6 +95,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "parseAgentSessionTodoPayloadEntry",
   "parseAgentSessionTodoPayloadList",
   "beadsCheckSchema",
+  "chatSettingsSchema",
   "gitCommitAllRequestSchema",
   "gitCommitAllResultSchema",
   "commitsAheadBehindSchema",
@@ -208,6 +210,7 @@ type ExportedTypeContract = {
   AgentWorkflowState: AgentWorkflowState;
   AgentWorkflows: AgentWorkflows;
   BeadsCheck: BeadsCheck;
+  ChatSettings: ChatSettings;
   CommitsAheadBehind: CommitsAheadBehind;
   GitCommitAllRequest: GitCommitAllRequest;
   GitCommitAllResult: GitCommitAllResult;
@@ -263,5 +266,17 @@ describe("contracts exports contract", () => {
   test("keeps canonical type exports importable from the barrel", () => {
     const compileOnlyTypeContract: ExportedTypeContract | null = null;
     expect(compileOnlyTypeContract).toBeNull();
+  });
+
+  test("defaults missing chat settings to disabled thinking messages", () => {
+    const parsedSnapshot = contracts.settingsSnapshotSchema.parse({
+      git: {
+        defaultMergeMethod: "merge_commit",
+      },
+      repos: {},
+      globalPromptOverrides: {},
+    });
+
+    expect(parsedSnapshot.chat.showThinkingMessages).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Persist `chat.showThinkingMessages` in the shared settings snapshot and expose it in the Settings modal.
- Load chat visibility into Agent Studio, including a retryable banner when settings reload fails.
- Filter and restyle reasoning transcript rows, plus a small follow-up fix for virtualization measurement reset after the rebase.

## Verification
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop test`
- `cargo test -p host-infra-system`
- `cargo test -p host-application` *(fails in this environment: integration fixtures expect an `origin` remote)*
