### PR TITLE
fix(desktop): preserve startup branch hydration

### DIFF
--- a/apps/desktop/src/components/layout/sidebar/branch-switcher.test.tsx
+++ b/apps/desktop/src/components/layout/sidebar/branch-switcher.test.tsx
@@ -3,6 +3,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 let branchSyncDegraded = false;
+let isSwitchingWorkspace = false;
 
 mock.module("@/state", () => ({
   useWorkspaceState: () => ({
@@ -18,6 +19,7 @@ mock.module("@/state", () => ({
       name: "main",
       detached: false,
     },
+    isSwitchingWorkspace,
     isLoadingBranches: false,
     isSwitchingBranch: false,
     branchSyncDegraded,
@@ -28,6 +30,7 @@ mock.module("@/state", () => ({
 describe("BranchSwitcher", () => {
   test("shows degraded sync status when branch probe failures are active", async () => {
     branchSyncDegraded = true;
+    isSwitchingWorkspace = false;
     const { BranchSwitcher } = await import("./branch-switcher");
     const html = renderToStaticMarkup(createElement(BranchSwitcher));
 
@@ -36,9 +39,19 @@ describe("BranchSwitcher", () => {
 
   test("hides degraded sync status when branch probe health is restored", async () => {
     branchSyncDegraded = false;
+    isSwitchingWorkspace = false;
     const { BranchSwitcher } = await import("./branch-switcher");
     const html = renderToStaticMarkup(createElement(BranchSwitcher));
 
     expect(html).not.toContain("Branch sync degraded. Auto-refresh may be stale.");
+  });
+
+  test("disables branch selection while switching repositories", async () => {
+    branchSyncDegraded = false;
+    isSwitchingWorkspace = true;
+    const { BranchSwitcher } = await import("./branch-switcher");
+    const html = renderToStaticMarkup(createElement(BranchSwitcher));
+
+    expect(html).toContain('disabled=""');
   });
 });

--- a/apps/desktop/src/components/layout/sidebar/branch-switcher.tsx
+++ b/apps/desktop/src/components/layout/sidebar/branch-switcher.tsx
@@ -8,6 +8,7 @@ export function BranchSwitcher(): ReactElement | null {
     activeRepo,
     branches,
     activeBranch,
+    isSwitchingWorkspace,
     isLoadingBranches,
     isSwitchingBranch,
     branchSyncDegraded,
@@ -26,7 +27,7 @@ export function BranchSwitcher(): ReactElement | null {
   }
 
   const isBranchPickerDisabled =
-    isLoadingBranches || isSwitchingBranch || branchOptions.length === 0;
+    isSwitchingWorkspace || isLoadingBranches || isSwitchingBranch || branchOptions.length === 0;
   const branchPlaceholder = activeBranch?.detached
     ? "Detached HEAD"
     : isLoadingBranches

--- a/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { WorkspaceRecord } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
-import { createElement, useEffect } from "react";
+import { createElement, useEffect, useRef, useState } from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { toast } from "sonner";
 import { host } from "./host";
@@ -418,6 +418,456 @@ describe("use-workspace-operations", () => {
       host.runtimeEnsure = original.runtimeEnsure;
       host.workspaceGetRepoConfig = original.workspaceGetRepoConfig;
       host.workspaceList = original.workspaceList;
+    }
+  });
+
+  test("hydrates branches after switching between real repositories", async () => {
+    const workspaceSelectDeferred = createDeferred<WorkspaceRecord>();
+    const workspaceSelect = mock(
+      async (): Promise<WorkspaceRecord> => workspaceSelectDeferred.promise,
+    );
+    const workspaceList = mock(
+      async (): Promise<WorkspaceRecord[]> => [workspace("/repo-a", true)],
+    );
+    const workspaceGetRepoConfig = mock(async () => ({
+      defaultRuntimeKind: "opencode" as const,
+      branchPrefix: "obp",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: {
+        providers: {},
+      },
+      trustedHooks: false,
+      hooks: {
+        preStart: [],
+        postComplete: [],
+      },
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    }));
+    const runtimeEnsure = mock(async () => ({
+      kind: "opencode",
+      runtimeId: "runtime-1",
+      repoPath: "/repo-a",
+      taskId: null,
+      role: "workspace" as const,
+      workingDirectory: "/tmp/repo-a",
+      runtimeRoute: {
+        type: "local_http" as const,
+        endpoint: "http://127.0.0.1:3030",
+      },
+      startedAt: "2026-02-22T08:00:00.000Z",
+      descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+    }));
+    const gitGetCurrentBranch = mock(async () => ({
+      name: "main",
+      detached: false,
+    }));
+    const gitGetBranches = mock(async () => [
+      {
+        name: "main",
+        isCurrent: true,
+        isRemote: false,
+      },
+      {
+        name: "feature/repo-switch",
+        isCurrent: false,
+        isRemote: false,
+      },
+    ]);
+
+    const originalWorkspaceSelect = host.workspaceSelect;
+    const originalWorkspaceList = host.workspaceList;
+    const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
+    const originalRuntimeEnsure = host.runtimeEnsure;
+    const originalGitGetCurrentBranch = host.gitGetCurrentBranch;
+    const originalGitGetBranches = host.gitGetBranches;
+    host.workspaceSelect = workspaceSelect;
+    host.workspaceList = workspaceList;
+    host.workspaceGetRepoConfig = workspaceGetRepoConfig;
+    host.runtimeEnsure = runtimeEnsure;
+    host.gitGetCurrentBranch = gitGetCurrentBranch;
+    host.gitGetBranches = gitGetBranches;
+
+    let latest: ReturnType<typeof useWorkspaceOperations> | null = null;
+    let latestActiveRepo: string | null = null;
+
+    const Harness = () => {
+      const [activeRepo, setActiveRepo] = useState<string | null>("/repo-old");
+      const value = useWorkspaceOperations({
+        activeRepo,
+        setActiveRepo,
+        clearTaskData: () => {},
+        clearActiveBeadsCheck: () => {},
+      });
+      const previousRepoRef = useRef(activeRepo);
+
+      latest = value;
+      latestActiveRepo = activeRepo;
+
+      useEffect(() => {
+        if (previousRepoRef.current === activeRepo) {
+          return;
+        }
+
+        previousRepoRef.current = activeRepo;
+
+        if (!activeRepo) {
+          return;
+        }
+
+        void value.refreshBranches();
+      }, [activeRepo, value.refreshBranches]);
+
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    try {
+      await act(async () => {
+        renderer = TestRenderer.create(createElement(Harness));
+      });
+      await flush();
+
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      const latestValueBeforeSelect: ReturnType<typeof useWorkspaceOperations> = latest;
+
+      let selectPromise: Promise<void> | null = null;
+      await act(async () => {
+        selectPromise = latestValueBeforeSelect.selectWorkspace("/repo-a");
+      });
+      await flush();
+
+      expect(latestActiveRepo === "/repo-old").toBe(true);
+      expect(gitGetCurrentBranch).not.toHaveBeenCalled();
+      expect(gitGetBranches).not.toHaveBeenCalled();
+
+      if (!selectPromise) {
+        throw new Error("selectWorkspace promise was not captured");
+      }
+
+      await act(async () => {
+        workspaceSelectDeferred.resolve(workspace("/repo-a", true));
+        await selectPromise;
+      });
+      await flush();
+
+      const currentActiveRepo: string | null = latestActiveRepo;
+      expect(currentActiveRepo === "/repo-a").toBe(true);
+      expect(gitGetCurrentBranch).toHaveBeenCalledWith("/repo-a");
+      expect(gitGetBranches).toHaveBeenCalledWith("/repo-a");
+      expect(workspaceList).toHaveBeenCalled();
+      expect(runtimeEnsure).toHaveBeenCalledWith("opencode", "/repo-a");
+
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      const latestValue: ReturnType<typeof useWorkspaceOperations> = latest;
+
+      expect(latestValue.activeBranch).toEqual({
+        name: "main",
+        detached: false,
+      });
+      expect(latestValue.branches).toEqual([
+        {
+          name: "main",
+          isCurrent: true,
+          isRemote: false,
+        },
+        {
+          name: "feature/repo-switch",
+          isCurrent: false,
+          isRemote: false,
+        },
+      ]);
+    } finally {
+      workspaceSelectDeferred.resolve(workspace("/repo-a", true));
+      await act(async () => {
+        renderer?.unmount();
+      });
+      host.workspaceSelect = originalWorkspaceSelect;
+      host.workspaceList = originalWorkspaceList;
+      host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
+      host.runtimeEnsure = originalRuntimeEnsure;
+      host.gitGetCurrentBranch = originalGitGetCurrentBranch;
+      host.gitGetBranches = originalGitGetBranches;
+    }
+  });
+
+  test("preserves current repo branch state when workspace selection fails", async () => {
+    const setActiveRepo = mock(() => {});
+    const clearTaskData = mock(() => {});
+    const clearActiveBeadsCheck = mock(() => {});
+    const workspaceSelect = mock(async (): Promise<WorkspaceRecord> => {
+      throw new Error("workspace switch failed");
+    });
+    const gitGetCurrentBranch = mock(async () => ({
+      name: "main",
+      detached: false,
+    }));
+    const gitGetBranches = mock(async () => [
+      {
+        name: "main",
+        isCurrent: true,
+        isRemote: false,
+      },
+      {
+        name: "feature/current-repo",
+        isCurrent: false,
+        isRemote: false,
+      },
+    ]);
+
+    const originalWorkspaceSelect = host.workspaceSelect;
+    const originalGitGetCurrentBranch = host.gitGetCurrentBranch;
+    const originalGitGetBranches = host.gitGetBranches;
+    host.workspaceSelect = workspaceSelect;
+    host.gitGetCurrentBranch = gitGetCurrentBranch;
+    host.gitGetBranches = gitGetBranches;
+
+    const originalToastError = toast.error;
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-old",
+      setActiveRepo,
+      clearTaskData,
+      clearActiveBeadsCheck,
+    });
+
+    try {
+      await harness.mount();
+
+      await harness.run(async (value) => {
+        await value.refreshBranches();
+      });
+
+      expect(harness.getLatest().activeBranch).toEqual({
+        name: "main",
+        detached: false,
+      });
+
+      let thrown: unknown = null;
+      await harness.run(async (value) => {
+        try {
+          await value.selectWorkspace("/repo-a");
+        } catch (error) {
+          thrown = error;
+        }
+      });
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(workspaceSelect).toHaveBeenCalledWith("/repo-a");
+      expect(setActiveRepo).not.toHaveBeenCalledWith("/repo-a");
+      expect(clearTaskData).not.toHaveBeenCalled();
+      expect(clearActiveBeadsCheck).not.toHaveBeenCalled();
+      expect(harness.getLatest().activeBranch).toEqual({
+        name: "main",
+        detached: false,
+      });
+      expect(harness.getLatest().branches).toEqual([
+        {
+          name: "main",
+          isCurrent: true,
+          isRemote: false,
+        },
+        {
+          name: "feature/current-repo",
+          isCurrent: false,
+          isRemote: false,
+        },
+      ]);
+      expect(toastError).toHaveBeenCalledWith("Failed to switch repository", {
+        description: "workspace switch failed",
+      });
+    } finally {
+      await harness.unmount();
+      host.workspaceSelect = originalWorkspaceSelect;
+      host.gitGetCurrentBranch = originalGitGetCurrentBranch;
+      host.gitGetBranches = originalGitGetBranches;
+      (toast as { error: typeof toast.error }).error = originalToastError;
+    }
+  });
+
+  test("keeps switched repo active when workspace refresh fails after a successful switch", async () => {
+    const workspaceSelect = mock(async (): Promise<WorkspaceRecord> => workspace("/repo-a", true));
+    const workspaceList = mock(async (): Promise<WorkspaceRecord[]> => {
+      throw new Error("workspace list failed");
+    });
+    const workspaceGetRepoConfig = mock(async () => ({
+      defaultRuntimeKind: "opencode" as const,
+      branchPrefix: "obp",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: {
+        providers: {},
+      },
+      trustedHooks: false,
+      hooks: {
+        preStart: [],
+        postComplete: [],
+      },
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    }));
+    const runtimeEnsure = mock(async () => ({
+      kind: "opencode",
+      runtimeId: "runtime-1",
+      repoPath: "/repo-a",
+      taskId: null,
+      role: "workspace" as const,
+      workingDirectory: "/tmp/repo-a",
+      runtimeRoute: {
+        type: "local_http" as const,
+        endpoint: "http://127.0.0.1:3030",
+      },
+      startedAt: "2026-02-22T08:00:00.000Z",
+      descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+    }));
+    const gitGetCurrentBranch = mock(async () => ({
+      name: "main",
+      detached: false,
+    }));
+    const gitGetBranches = mock(async () => [
+      {
+        name: "main",
+        isCurrent: true,
+        isRemote: false,
+      },
+      {
+        name: "feature/repo-switch",
+        isCurrent: false,
+        isRemote: false,
+      },
+    ]);
+
+    const originalWorkspaceSelect = host.workspaceSelect;
+    const originalWorkspaceList = host.workspaceList;
+    const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
+    const originalRuntimeEnsure = host.runtimeEnsure;
+    const originalGitGetCurrentBranch = host.gitGetCurrentBranch;
+    const originalGitGetBranches = host.gitGetBranches;
+    host.workspaceSelect = workspaceSelect;
+    host.workspaceList = workspaceList;
+    host.workspaceGetRepoConfig = workspaceGetRepoConfig;
+    host.runtimeEnsure = runtimeEnsure;
+    host.gitGetCurrentBranch = gitGetCurrentBranch;
+    host.gitGetBranches = gitGetBranches;
+
+    const originalToastError = toast.error;
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    let latest: ReturnType<typeof useWorkspaceOperations> | null = null;
+    let latestActiveRepo: string | null = null;
+
+    const Harness = () => {
+      const [activeRepo, setActiveRepo] = useState<string | null>("/repo-old");
+      const value = useWorkspaceOperations({
+        activeRepo,
+        setActiveRepo,
+        clearTaskData: () => {},
+        clearActiveBeadsCheck: () => {},
+      });
+      const previousRepoRef = useRef(activeRepo);
+      const hasSeededWorkspacesRef = useRef(false);
+
+      latest = value;
+      latestActiveRepo = activeRepo;
+
+      useEffect(() => {
+        if (hasSeededWorkspacesRef.current) {
+          return;
+        }
+
+        hasSeededWorkspacesRef.current = true;
+        value.applyWorkspaceRecords([workspace("/repo-old", true), workspace("/repo-a", false)]);
+      }, [value]);
+
+      useEffect(() => {
+        if (previousRepoRef.current === activeRepo) {
+          return;
+        }
+
+        previousRepoRef.current = activeRepo;
+
+        if (!activeRepo) {
+          return;
+        }
+
+        void value.refreshBranches();
+      }, [activeRepo, value.refreshBranches]);
+
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    try {
+      await act(async () => {
+        renderer = TestRenderer.create(createElement(Harness));
+      });
+      await flush();
+
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      const latestValueBeforeSelect: ReturnType<typeof useWorkspaceOperations> = latest;
+      await act(async () => {
+        await latestValueBeforeSelect.selectWorkspace("/repo-a");
+      });
+      await flush();
+
+      expect(latestActiveRepo === "/repo-a").toBe(true);
+      expect(gitGetCurrentBranch).toHaveBeenCalledWith("/repo-a");
+      expect(gitGetBranches).toHaveBeenCalledWith("/repo-a");
+      expect(toastError).toHaveBeenCalledWith("Repository switched, but workspace refresh failed", {
+        description: "workspace list failed",
+      });
+
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      const latestValue: ReturnType<typeof useWorkspaceOperations> = latest;
+      expect(latestValue.activeBranch).toEqual({
+        name: "main",
+        detached: false,
+      });
+      expect(latestValue.branches).toEqual([
+        {
+          name: "main",
+          isCurrent: true,
+          isRemote: false,
+        },
+        {
+          name: "feature/repo-switch",
+          isCurrent: false,
+          isRemote: false,
+        },
+      ]);
+      expect(latestValue.workspaces).toEqual([
+        workspace("/repo-old", false),
+        workspace("/repo-a", true),
+      ]);
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+      });
+      host.workspaceSelect = originalWorkspaceSelect;
+      host.workspaceList = originalWorkspaceList;
+      host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
+      host.runtimeEnsure = originalRuntimeEnsure;
+      host.gitGetCurrentBranch = originalGitGetCurrentBranch;
+      host.gitGetBranches = originalGitGetBranches;
+      (toast as { error: typeof toast.error }).error = originalToastError;
     }
   });
 

--- a/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
@@ -160,10 +160,8 @@ describe("use-workspace-operations", () => {
       },
     ]);
 
-    const original = {
-      gitGetCurrentBranch: host.gitGetCurrentBranch,
-      gitGetBranches: host.gitGetBranches,
-    };
+    const originalGitGetCurrentBranch = host.gitGetCurrentBranch;
+    const originalGitGetBranches = host.gitGetBranches;
     host.gitGetCurrentBranch = gitGetCurrentBranch;
     host.gitGetBranches = gitGetBranches;
 
@@ -247,8 +245,8 @@ describe("use-workspace-operations", () => {
       await act(async () => {
         renderer?.unmount();
       });
-      host.gitGetCurrentBranch = original.gitGetCurrentBranch;
-      host.gitGetBranches = original.gitGetBranches;
+      host.gitGetCurrentBranch = originalGitGetCurrentBranch;
+      host.gitGetBranches = originalGitGetBranches;
     }
   });
 

--- a/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { WorkspaceRecord } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
-import { createElement } from "react";
+import { createElement, useEffect } from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { toast } from "sonner";
 import { host } from "./host";
@@ -141,6 +141,117 @@ const workspace = (path: string, isActive = false): WorkspaceRecord => ({
 });
 
 describe("use-workspace-operations", () => {
+  test("hydrates branches when startup activates the persisted repository", async () => {
+    const setActiveRepo = mock(() => {});
+    const gitGetCurrentBranch = mock(async () => ({
+      name: "main",
+      detached: false,
+    }));
+    const gitGetBranches = mock(async () => [
+      {
+        name: "main",
+        isCurrent: true,
+        isRemote: false,
+      },
+      {
+        name: "feature/startup",
+        isCurrent: false,
+        isRemote: false,
+      },
+    ]);
+
+    const original = {
+      gitGetCurrentBranch: host.gitGetCurrentBranch,
+      gitGetBranches: host.gitGetBranches,
+    };
+    host.gitGetCurrentBranch = gitGetCurrentBranch;
+    host.gitGetBranches = gitGetBranches;
+
+    type LifecycleHarnessArgs = HookArgs;
+
+    let latest: ReturnType<typeof useWorkspaceOperations> | null = null;
+    let currentArgs: LifecycleHarnessArgs = {
+      activeRepo: null,
+      setActiveRepo,
+      clearTaskData: () => {},
+      clearActiveBeadsCheck: () => {},
+    };
+
+    const StartupBranchLoader = ({
+      activeRepo,
+      value,
+    }: {
+      activeRepo: string | null;
+      value: ReturnType<typeof useWorkspaceOperations>;
+    }) => {
+      useEffect(() => {
+        if (!activeRepo) {
+          return;
+        }
+        void value.refreshBranches();
+      }, [activeRepo, value.refreshBranches]);
+
+      return null;
+    };
+
+    const Harness = ({ args }: { args: LifecycleHarnessArgs }) => {
+      latest = useWorkspaceOperations(args);
+      return createElement(StartupBranchLoader, {
+        activeRepo: args.activeRepo,
+        value: latest,
+      });
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+    try {
+      await act(async () => {
+        renderer = TestRenderer.create(createElement(Harness, { args: currentArgs }));
+      });
+      await flush();
+
+      currentArgs = {
+        ...currentArgs,
+        activeRepo: "/repo-a",
+      };
+
+      await act(async () => {
+        renderer?.update(createElement(Harness, { args: currentArgs }));
+      });
+      await flush();
+
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      const latestValue: ReturnType<typeof useWorkspaceOperations> = latest;
+
+      expect(latestValue.activeBranch).toEqual({
+        name: "main",
+        detached: false,
+      });
+      expect(latestValue.branches).toEqual([
+        {
+          name: "main",
+          isCurrent: true,
+          isRemote: false,
+        },
+        {
+          name: "feature/startup",
+          isCurrent: false,
+          isRemote: false,
+        },
+      ]);
+      expect(latestValue.isLoadingBranches).toBe(false);
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+      });
+      host.gitGetCurrentBranch = original.gitGetCurrentBranch;
+      host.gitGetBranches = original.gitGetBranches;
+    }
+  });
+
   test("refreshWorkspaces updates list and active repo", async () => {
     const setActiveRepo = mock(() => {});
     const workspaceList = mock(

--- a/apps/desktop/src/state/operations/use-workspace-operations.ts
+++ b/apps/desktop/src/state/operations/use-workspace-operations.ts
@@ -67,6 +67,10 @@ export function useWorkspaceOperations({
   const lastKnownRevisionRef = useRef<string | null>(null);
   const activeRepoRef = useRef(activeRepo);
   const previousActiveRepoRef = useRef(activeRepo);
+  const preparedRepoSwitchRef = useRef<{
+    previousRepo: string | null;
+    nextRepo: string;
+  } | null>(null);
   const probeGatesRef = useRef({
     isSwitchingWorkspace,
     isLoadingBranches,
@@ -106,14 +110,44 @@ export function useWorkspaceOperations({
 
   useEffect(() => {
     const previousActiveRepo = previousActiveRepoRef.current;
+    const preparedRepoSwitch = preparedRepoSwitchRef.current;
+    const shouldSkipPreparedRepoReset =
+      preparedRepoSwitch?.previousRepo === previousActiveRepo &&
+      preparedRepoSwitch.nextRepo === activeRepo;
+
+    preparedRepoSwitchRef.current = null;
 
     previousActiveRepoRef.current = activeRepo;
     activeRepoRef.current = activeRepo;
 
-    if (shouldResetBranchStateForRepoChange(previousActiveRepo, activeRepo)) {
+    if (
+      !shouldSkipPreparedRepoReset &&
+      shouldResetBranchStateForRepoChange(previousActiveRepo, activeRepo)
+    ) {
       clearBranchData();
     }
   }, [activeRepo, clearBranchData]);
+
+  const markWorkspaceActiveLocally = useCallback((repoPath: string): void => {
+    setWorkspaces((current) => {
+      let hasMatch = false;
+      const next = current.map((workspace) => {
+        const isActive = workspace.path === repoPath;
+        hasMatch ||= isActive;
+
+        if (workspace.isActive === isActive) {
+          return workspace;
+        }
+
+        return {
+          ...workspace,
+          isActive,
+        };
+      });
+
+      return hasMatch ? next : current;
+    });
+  }, []);
 
   const applyWorkspaceRecords = useCallback(
     (records: WorkspaceRecord[]): void => {
@@ -400,17 +434,26 @@ export function useWorkspaceOperations({
 
   const selectWorkspace = useCallback(
     async (repoPath: string): Promise<void> => {
-      const previousRepo = activeRepo;
       const switchVersion = ++workspaceSwitchVersionRef.current;
+      const previousRepo = activeRepoRef.current;
 
-      setActiveRepo(repoPath);
-      clearTaskData();
-      clearActiveBeadsCheck();
-      clearBranchData();
       setIsSwitchingWorkspace(true);
 
       try {
         await host.workspaceSelect(repoPath);
+        if (workspaceSwitchVersionRef.current !== switchVersion) {
+          return;
+        }
+
+        clearTaskData();
+        clearActiveBeadsCheck();
+        clearBranchData();
+        preparedRepoSwitchRef.current = {
+          previousRepo,
+          nextRepo: repoPath,
+        };
+        setActiveRepo(repoPath);
+
         void host
           .workspaceGetRepoConfig(repoPath)
           .then((repoConfig) =>
@@ -427,7 +470,19 @@ export function useWorkspaceOperations({
         if (workspaceSwitchVersionRef.current !== switchVersion) {
           return;
         }
-        await refreshWorkspaces();
+
+        try {
+          await refreshWorkspaces();
+        } catch (error) {
+          if (workspaceSwitchVersionRef.current !== switchVersion) {
+            return;
+          }
+
+          markWorkspaceActiveLocally(repoPath);
+          toast.error("Repository switched, but workspace refresh failed", {
+            description: errorMessage(error),
+          });
+        }
       } catch (error) {
         if (workspaceSwitchVersionRef.current !== switchVersion) {
           return;
@@ -436,7 +491,6 @@ export function useWorkspaceOperations({
           description: errorMessage(error),
         });
         setIsSwitchingWorkspace(false);
-        setActiveRepo(previousRepo ?? null);
         throw error;
       } finally {
         if (workspaceSwitchVersionRef.current === switchVersion) {
@@ -445,10 +499,10 @@ export function useWorkspaceOperations({
       }
     },
     [
-      activeRepo,
       clearBranchData,
       clearTaskData,
       clearActiveBeadsCheck,
+      markWorkspaceActiveLocally,
       refreshWorkspaces,
       setActiveRepo,
     ],

--- a/apps/desktop/src/state/operations/use-workspace-operations.ts
+++ b/apps/desktop/src/state/operations/use-workspace-operations.ts
@@ -15,6 +15,7 @@ import {
   normalizeRepoPath,
   shouldProbeExternalBranchChange,
   shouldReportBranchProbeError,
+  shouldResetBranchStateForRepoChange,
   shouldSkipBranchSwitch,
 } from "./workspace-operations-model";
 
@@ -106,12 +107,12 @@ export function useWorkspaceOperations({
   useEffect(() => {
     const previousActiveRepo = previousActiveRepoRef.current;
 
-    if (previousActiveRepo !== activeRepo) {
-      clearBranchData();
-    }
-
     previousActiveRepoRef.current = activeRepo;
     activeRepoRef.current = activeRepo;
+
+    if (shouldResetBranchStateForRepoChange(previousActiveRepo, activeRepo)) {
+      clearBranchData();
+    }
   }, [activeRepo, clearBranchData]);
 
   const applyWorkspaceRecords = useCallback(

--- a/apps/desktop/src/state/operations/workspace-operations-model.test.ts
+++ b/apps/desktop/src/state/operations/workspace-operations-model.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeRepoPath,
   shouldProbeExternalBranchChange,
   shouldReportBranchProbeError,
+  shouldResetBranchStateForRepoChange,
   shouldSkipBranchSwitch,
 } from "./workspace-operations-model";
 
@@ -47,6 +48,17 @@ describe("workspace-operations-model", () => {
         isSyncInFlight: false,
       }),
     ).toBe(false);
+  });
+
+  test("does not reset branch state for initial persisted repo hydration", () => {
+    expect(shouldResetBranchStateForRepoChange(null, "/repo")).toBe(false);
+    expect(shouldResetBranchStateForRepoChange(null, null)).toBe(false);
+  });
+
+  test("resets branch state for real repo transitions", () => {
+    expect(shouldResetBranchStateForRepoChange("/repo-a", "/repo-b")).toBe(true);
+    expect(shouldResetBranchStateForRepoChange("/repo-a", null)).toBe(true);
+    expect(shouldResetBranchStateForRepoChange("/repo-a", "/repo-a")).toBe(false);
   });
 
   test("detects branch identity changes", () => {

--- a/apps/desktop/src/state/operations/workspace-operations-model.ts
+++ b/apps/desktop/src/state/operations/workspace-operations-model.ts
@@ -44,6 +44,11 @@ export type BranchProbeOutcome =
 
 export const normalizeRepoPath = (repoPath: string): string => repoPath.trim();
 
+export const shouldResetBranchStateForRepoChange = (
+  previousActiveRepo: string | null,
+  nextActiveRepo: string | null,
+): boolean => previousActiveRepo !== null && previousActiveRepo !== nextActiveRepo;
+
 export const shouldProbeExternalBranchChange = ({
   activeRepo,
   isSwitchingWorkspace,


### PR DESCRIPTION
## Summary
- preserve startup branch hydration by treating the initial persisted repo activation as hydration instead of a repo-switch reset
- keep branch invalidation for real repo transitions so stale branch state still gets cleared when changing repositories
- add regression coverage for the pure reset policy and the hook-level startup branch loading path

## Verification
- bun run test
- bun run lint
- bun run typecheck
- cargo test
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
