### PR TITLE
feat: add live browser dev mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,14 @@ Keep this contract stable. If you change any item below, update all related laye
 - Frontend tests are required for touched behavior.
 - Always run relevant checks before finishing — see Commands section above.
 
+### Browser App Testing
+
+- For end-to-end UI validation in browser mode, use `agent-browser` against the live app served by the real OpenDucktor backend.
+- Treat browser mode as the default way to validate UI work in this repo when browser automation is sufficient.
+- Do **not** run `bun run browser:dev` yourself.
+- Ask the user to start `bun run browser:dev`, then connect to the running app in the browser.
+
 ## Workflow
 
-- Conventional Commits, `codex/` branch prefix.
+- Use Conventional Commits.
 - Verify touched areas with relevant checks before finishing.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:browser": "VITE_ODT_APP_MODE=browser VITE_ODT_BROWSER_BACKEND_URL=http://127.0.0.1:14327 vite",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -83,6 +83,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1435,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1840,6 +1899,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,6 +2201,7 @@ name = "openducktor-desktop"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "ctrlc",
  "host-application",
@@ -2149,6 +2215,8 @@ dependencies = [
  "tauri-plugin-dialog",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2785,6 +2853,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +3019,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,6 +3056,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3726,6 +3823,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3847,6 +3956,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3885,6 +3995,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,12 +23,15 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 anyhow = "1"
+axum = { version = "0.8", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "process", "sync", "macros", "time"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+tower-http = { version = "0.6", features = ["cors"] }
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }

--- a/apps/desktop/src-tauri/src/bin/browser_backend.rs
+++ b/apps/desktop/src-tauri/src/bin/browser_backend.rs
@@ -1,0 +1,12 @@
+#[tokio::main]
+async fn main() {
+    let port = std::env::var("ODT_BROWSER_BACKEND_PORT")
+        .ok()
+        .and_then(|raw| raw.parse::<u16>().ok())
+        .unwrap_or(14327);
+
+    if let Err(error) = openducktor_desktop_lib::run_browser_backend(port).await {
+        eprintln!("OpenDucktor browser backend failed to start: {error:#}");
+        std::process::exit(1);
+    }
+}

--- a/apps/desktop/src-tauri/src/commands/documents.rs
+++ b/apps/desktop/src-tauri/src/commands/documents.rs
@@ -23,7 +23,7 @@ fn map_plan_subtask_payload(
     })
 }
 
-fn map_plan_subtasks(
+pub(crate) fn map_plan_subtasks(
     subtasks: Option<Vec<PlanSubtaskPayload>>,
 ) -> Result<Option<Vec<PlanSubtaskInput>>, String> {
     subtasks

--- a/apps/desktop/src-tauri/src/commands/git/command_handlers.rs
+++ b/apps/desktop/src-tauri/src/commands/git/command_handlers.rs
@@ -14,7 +14,7 @@ use super::{
     },
 };
 
-pub(super) fn parse_diff_scope(
+pub(crate) fn parse_diff_scope(
     diff_scope: Option<&str>,
 ) -> Result<host_domain::GitDiffScope, String> {
     match diff_scope.unwrap_or("target") {
@@ -26,7 +26,7 @@ pub(super) fn parse_diff_scope(
     }
 }
 
-pub(super) fn require_target_branch(target_branch: &str) -> Result<&str, String> {
+pub(crate) fn require_target_branch(target_branch: &str) -> Result<&str, String> {
     let trimmed_target = target_branch.trim();
     if trimmed_target.is_empty() {
         return Err("targetBranch is required".to_string());

--- a/apps/desktop/src-tauri/src/commands/git/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/git/mod.rs
@@ -2,7 +2,13 @@ mod authorization;
 mod command_handlers;
 mod snapshot;
 
-pub(crate) use authorization::invalidate_worktree_resolution_cache_for_repo;
+pub(crate) use authorization::{invalidate_worktree_resolution_cache_for_repo, resolve_working_dir};
+pub(crate) use command_handlers::{parse_diff_scope, require_target_branch};
+pub(crate) use snapshot::{
+    build_worktree_status_summary_with_snapshot, build_worktree_status_with_snapshot,
+    hash_worktree_diff_payload, hash_worktree_diff_summary_payload, hash_worktree_status_payload,
+    WorktreeSnapshotMetadata, GIT_WORKTREE_HASH_VERSION,
+};
 pub use command_handlers::{
     git_commit_all, git_commits_ahead_behind, git_create_worktree, git_get_branches,
     git_get_current_branch, git_get_diff, git_get_status, git_get_worktree_status,

--- a/apps/desktop/src-tauri/src/commands/git/snapshot.rs
+++ b/apps/desktop/src-tauri/src/commands/git/snapshot.rs
@@ -4,7 +4,7 @@ use host_domain::{
     GitWorktreeStatusSnapshot, GitWorktreeStatusSummary,
 };
 
-pub(super) const GIT_WORKTREE_HASH_VERSION: u32 = 1;
+pub(crate) const GIT_WORKTREE_HASH_VERSION: u32 = 1;
 const FNV1A_64_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV1A_64_PRIME: u64 = 0x100000001b3;
 
@@ -85,7 +85,7 @@ fn hash_upstream_ahead_behind(
     }
 }
 
-pub(super) fn hash_worktree_status_payload(
+pub(crate) fn hash_worktree_status_payload(
     current_branch: &GitCurrentBranch,
     file_statuses: &[GitFileStatus],
     target_ahead_behind: &GitAheadBehind,
@@ -111,7 +111,7 @@ pub(super) fn hash_worktree_status_payload(
     hasher.finish_hex()
 }
 
-pub(super) fn hash_worktree_diff_payload(file_diffs: &[GitFileDiff]) -> String {
+pub(crate) fn hash_worktree_diff_payload(file_diffs: &[GitFileDiff]) -> String {
     let mut hasher = Fnv1a64Hasher::new();
     hasher.update_u64(file_diffs.len() as u64);
 
@@ -126,7 +126,7 @@ pub(super) fn hash_worktree_diff_payload(file_diffs: &[GitFileDiff]) -> String {
     hasher.finish_hex()
 }
 
-pub(super) fn hash_worktree_diff_summary_payload(
+pub(crate) fn hash_worktree_diff_summary_payload(
     diff_scope: &GitDiffScope,
     target_ahead_behind: &GitAheadBehind,
     file_status_counts: &GitFileStatusCounts,
@@ -147,14 +147,14 @@ pub(super) fn hash_worktree_diff_summary_payload(
     hasher.finish_hex()
 }
 
-pub(super) struct WorktreeSnapshotMetadata {
-    pub(super) effective_working_dir: String,
-    pub(super) target_branch: String,
-    pub(super) diff_scope: GitDiffScope,
-    pub(super) observed_at_ms: u64,
-    pub(super) hash_version: u32,
-    pub(super) status_hash: String,
-    pub(super) diff_hash: String,
+pub(crate) struct WorktreeSnapshotMetadata {
+    pub(crate) effective_working_dir: String,
+    pub(crate) target_branch: String,
+    pub(crate) diff_scope: GitDiffScope,
+    pub(crate) observed_at_ms: u64,
+    pub(crate) hash_version: u32,
+    pub(crate) status_hash: String,
+    pub(crate) diff_hash: String,
 }
 
 fn snapshot_from_metadata(
@@ -171,7 +171,7 @@ fn snapshot_from_metadata(
     }
 }
 
-pub(super) fn build_worktree_status_with_snapshot(
+pub(crate) fn build_worktree_status_with_snapshot(
     status_data: GitWorktreeStatusData,
     snapshot_metadata: WorktreeSnapshotMetadata,
 ) -> GitWorktreeStatus {
@@ -185,7 +185,7 @@ pub(super) fn build_worktree_status_with_snapshot(
     }
 }
 
-pub(super) fn build_worktree_status_summary_with_snapshot(
+pub(crate) fn build_worktree_status_summary_with_snapshot(
     current_branch: GitCurrentBranch,
     file_status_counts: GitFileStatusCounts,
     target_ahead_behind: GitAheadBehind,

--- a/apps/desktop/src-tauri/src/commands/tasks.rs
+++ b/apps/desktop/src-tauri/src/commands/tasks.rs
@@ -3,7 +3,7 @@ use crate::{as_error, AppState, TaskCreatePayload, TaskUpdatePayload};
 use host_domain::{CreateTaskInput, TaskCard, TaskStatus, UpdateTaskPatch};
 use tauri::State;
 
-fn map_task_create_payload(input: TaskCreatePayload) -> Result<CreateTaskInput, String> {
+pub(crate) fn map_task_create_payload(input: TaskCreatePayload) -> Result<CreateTaskInput, String> {
     Ok(CreateTaskInput {
         title: input.title,
         issue_type: parse_issue_type(&input.issue_type, "issueType")?,
@@ -16,7 +16,7 @@ fn map_task_create_payload(input: TaskCreatePayload) -> Result<CreateTaskInput, 
     })
 }
 
-fn map_task_update_payload(patch: TaskUpdatePayload) -> Result<UpdateTaskPatch, String> {
+pub(crate) fn map_task_update_payload(patch: TaskUpdatePayload) -> Result<UpdateTaskPatch, String> {
     let issue_type = match patch.issue_type {
         Some(issue_type) => Some(parse_issue_type(&issue_type, "issueType")?),
         None => None,

--- a/apps/desktop/src-tauri/src/headless.rs
+++ b/apps/desktop/src-tauri/src/headless.rs
@@ -8,16 +8,16 @@ use crate::commands::git::{
 };
 use crate::commands::tasks::{map_task_create_payload, map_task_update_payload};
 use crate::{
-    run_service_blocking, startup_phase_service_bootstrap, startup_phase_shutdown_hooks,
-    startup_phase_tracing, BuildCompletePayload, MarkdownPayload, PlanPayload,
+    run_service_blocking_tokio, startup_phase_service_bootstrap,
+    startup_phase_shutdown_hooks, startup_phase_tracing, BuildCompletePayload,
+    MarkdownPayload, PlanPayload,
     PullRequestContentPayload, RepoConfigPayload, RepoSettingsPayload, SettingsSnapshotPayload,
     SettingsSnapshotResponsePayload, TaskCreatePayload, TaskUpdatePayload,
 };
 use anyhow::{anyhow, Context};
 use axum::extract::{Path, State};
 use axum::http::header;
-use axum::http::StatusCode;
-use axum::http::Method;
+use axum::http::{HeaderMap, HeaderValue, Method, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
@@ -30,20 +30,126 @@ use host_domain::{AgentRuntimeKind, GitMergeMethod};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use std::collections::VecDeque;
 use std::convert::Infallible;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
 use tower_http::cors::CorsLayer;
 
 const DEFAULT_BROWSER_BACKEND_HOST: &str = "127.0.0.1";
+const DEFAULT_BROWSER_FRONTEND_ORIGINS: [&str; 2] =
+    ["http://localhost:1420", "http://127.0.0.1:1420"];
+const BROWSER_FRONTEND_ORIGIN_ENV: &str = "ODT_BROWSER_FRONTEND_ORIGIN";
+const EVENT_BUFFER_CAPACITY: usize = 256;
 
 #[derive(Clone)]
 struct HeadlessState {
     service: Arc<AppService>,
-    events: broadcast::Sender<String>,
+    events: HeadlessEventBus,
+}
+
+#[derive(Clone, Debug)]
+struct HeadlessEvent {
+    id: u64,
+    payload: String,
+}
+
+#[derive(Clone)]
+struct HeadlessEventBus {
+    capacity: usize,
+    next_id: Arc<AtomicU64>,
+    recent: Arc<Mutex<VecDeque<HeadlessEvent>>>,
+    sender: broadcast::Sender<HeadlessEvent>,
+}
+
+impl HeadlessEventBus {
+    fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+        Self {
+            capacity,
+            next_id: Arc::new(AtomicU64::new(0)),
+            recent: Arc::new(Mutex::new(VecDeque::with_capacity(capacity))),
+            sender,
+        }
+    }
+
+    fn emit(&self, payload: String) {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst) + 1;
+        let event = HeadlessEvent { id, payload };
+        {
+            let mut recent = self.recent.lock().expect("browser event buffer should lock");
+            recent.push_back(event.clone());
+            if recent.len() > self.capacity {
+                recent.pop_front();
+            }
+        }
+        let _ = self.sender.send(event);
+    }
+
+    fn replay_since(&self, last_seen_id: Option<u64>) -> Vec<HeadlessEvent> {
+        let Some(last_seen_id) = last_seen_id else {
+            return Vec::new();
+        };
+
+        self.recent
+            .lock()
+            .expect("browser event buffer should lock")
+            .iter()
+            .filter(|event| event.id > last_seen_id)
+            .cloned()
+            .collect()
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<HeadlessEvent> {
+        self.sender.subscribe()
+    }
+}
+
+#[derive(Debug)]
+struct HeadlessCommandError {
+    message: String,
+    status: StatusCode,
+}
+
+impl HeadlessCommandError {
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            status: StatusCode::BAD_REQUEST,
+        }
+    }
+
+    fn internal(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            status: StatusCode::NOT_FOUND,
+        }
+    }
+}
+
+impl IntoResponse for HeadlessCommandError {
+    fn into_response(self) -> axum::response::Response {
+        (
+            self.status,
+            Json(json!({
+                "error": self.message,
+            })),
+        )
+            .into_response()
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -370,22 +476,12 @@ pub async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
     startup_phase_tracing();
     let service = startup_phase_service_bootstrap()?;
     startup_phase_shutdown_hooks(service.clone());
-    let (events, _) = broadcast::channel::<String>(256);
+    let events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
     let app = Router::new()
         .route("/health", get(health_handler))
         .route("/events", get(events_handler))
         .route("/invoke/{command}", post(invoke_handler))
-        .layer(
-            CorsLayer::new()
-                .allow_origin([
-                    "http://localhost:1420".parse().expect("valid localhost origin"),
-                    "http://127.0.0.1:1420"
-                        .parse()
-                        .expect("valid loopback origin"),
-                ])
-                .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
-                .allow_headers([header::CONTENT_TYPE]),
-        )
+        .layer(browser_backend_cors_layer()?)
         .with_state(HeadlessState { service, events });
 
     let listener = TcpListener::bind((DEFAULT_BROWSER_BACKEND_HOST, port))
@@ -410,13 +506,30 @@ async fn health_handler() -> impl IntoResponse {
 
 async fn events_handler(
     State(state): State<HeadlessState>,
-) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
-    let stream = BroadcastStream::new(state.events.subscribe()).map(|message| match message {
-        Ok(payload) => Ok(Event::default().data(payload)),
-        Err(_) => Ok(Event::default().comment("lagged")),
-    });
+    headers: HeaderMap,
+) -> Result<Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>>, HeadlessCommandError>
+{
+    let last_event_id = parse_last_event_id(&headers)?;
+    let replay_stream = tokio_stream::iter(
+        state
+            .events
+            .replay_since(last_event_id)
+            .into_iter()
+            .map(|event| to_sse_event(&event)),
+    );
+    let live_stream =
+        BroadcastStream::new(state.events.subscribe()).map(|message| match message {
+            Ok(event) => to_sse_event(&event),
+            Err(BroadcastStreamRecvError::Lagged(skipped)) => Ok(
+                Event::default()
+                    .event("stream-warning")
+                    .data(format!(
+                        "Browser event stream skipped {skipped} events; reconnect will replay buffered events."
+                    )),
+            ),
+        });
 
-    Sse::new(stream).keep_alive(KeepAlive::default())
+    Ok(Sse::new(replay_stream.chain(live_stream)).keep_alive(KeepAlive::default()))
 }
 
 async fn invoke_handler(
@@ -426,29 +539,26 @@ async fn invoke_handler(
 ) -> impl IntoResponse {
     match dispatch_command(&state, &command, args).await {
         Ok(payload) => (StatusCode::OK, Json(payload)).into_response(),
-        Err(error) => (
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "error": error,
-            })),
-        )
-            .into_response(),
+        Err(error) => error.into_response(),
     }
 }
 
-fn deserialize_args<T: DeserializeOwned>(args: Value) -> Result<T, String> {
-    serde_json::from_value(args).map_err(|error| format!("Invalid arguments: {error}"))
+fn deserialize_args<T: DeserializeOwned>(args: Value) -> Result<T, HeadlessCommandError> {
+    serde_json::from_value(args)
+        .map_err(|error| HeadlessCommandError::bad_request(format!("Invalid arguments: {error}")))
 }
 
-fn serialize_value<T: serde::Serialize>(value: T) -> Result<Value, String> {
-    serde_json::to_value(value).map_err(|error| format!("Failed to serialize response: {error}"))
+fn serialize_value<T: serde::Serialize>(value: T) -> Result<Value, HeadlessCommandError> {
+    serde_json::to_value(value).map_err(|error| {
+        HeadlessCommandError::internal(format!("Failed to serialize response: {error}"))
+    })
 }
 
-fn make_emitter(sender: broadcast::Sender<String>) -> RunEmitter {
+fn make_emitter(events: HeadlessEventBus) -> RunEmitter {
     Arc::new(move |event| {
         match serde_json::to_string(&event) {
             Ok(payload) => {
-                let _ = sender.send(payload);
+                events.emit(payload);
             }
             Err(error) => {
                 tracing::warn!(
@@ -461,949 +571,1262 @@ fn make_emitter(sender: broadcast::Sender<String>) -> RunEmitter {
     })
 }
 
+fn browser_backend_cors_layer() -> anyhow::Result<CorsLayer> {
+    let layer = if let Ok(origin) = std::env::var(BROWSER_FRONTEND_ORIGIN_ENV) {
+        let origin = origin.trim();
+        if origin.is_empty() {
+            CorsLayer::new()
+                .allow_origin(parse_default_frontend_origins()?)
+                .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+                .allow_headers([header::CONTENT_TYPE])
+        } else {
+            CorsLayer::new()
+                .allow_origin(parse_origin_header(origin)?)
+                .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+                .allow_headers([header::CONTENT_TYPE])
+        }
+    } else {
+        CorsLayer::new()
+            .allow_origin(parse_default_frontend_origins()?)
+            .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+            .allow_headers([header::CONTENT_TYPE])
+    };
+
+    Ok(layer)
+}
+
+fn parse_default_frontend_origins() -> anyhow::Result<Vec<HeaderValue>> {
+    DEFAULT_BROWSER_FRONTEND_ORIGINS
+        .iter()
+        .map(|origin| parse_origin_header(origin))
+        .collect()
+}
+
+fn parse_origin_header(origin: &str) -> anyhow::Result<HeaderValue> {
+    origin
+        .parse::<HeaderValue>()
+        .with_context(|| format!("invalid browser frontend origin configured: {origin}"))
+}
+
+fn parse_last_event_id(headers: &HeaderMap) -> Result<Option<u64>, HeadlessCommandError> {
+    let Some(last_event_id) = headers.get("last-event-id") else {
+        return Ok(None);
+    };
+    let value = last_event_id.to_str().map_err(|error| {
+        HeadlessCommandError::bad_request(format!("Invalid Last-Event-ID header: {error}"))
+    })?;
+    value
+        .parse::<u64>()
+        .map(Some)
+        .map_err(|error| HeadlessCommandError::bad_request(format!("Invalid Last-Event-ID header: {error}")))
+}
+
+fn to_sse_event(event: &HeadlessEvent) -> Result<Event, Infallible> {
+    Ok(Event::default()
+        .id(event.id.to_string())
+        .data(event.payload.clone()))
+}
+
+fn service_error(error: anyhow::Error) -> HeadlessCommandError {
+    HeadlessCommandError::internal(format!("{error:#}"))
+}
+
+fn request_error(error: impl std::fmt::Display) -> HeadlessCommandError {
+    HeadlessCommandError::bad_request(error.to_string())
+}
+
+fn current_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn resolve_authorized_working_dir(
+    state: &HeadlessState,
+    repo_path: &str,
+    working_dir: Option<&str>,
+) -> Result<String, HeadlessCommandError> {
+    state
+        .service
+        .ensure_repo_authorized(repo_path)
+        .map_err(request_error)?;
+    resolve_working_dir(repo_path, working_dir).map_err(request_error)
+}
+
 async fn dispatch_command(
     state: &HeadlessState,
     command: &str,
     args: Value,
-) -> Result<Value, String> {
+) -> Result<Value, HeadlessCommandError> {
+    if let Some(result) = dispatch_workspace_command(state, command, args.clone()).await {
+        return result;
+    }
+    if let Some(result) = dispatch_git_command(state, command, args.clone()).await {
+        return result;
+    }
+    if let Some(result) = dispatch_task_command(state, command, args.clone()).await {
+        return result;
+    }
+    if let Some(result) = dispatch_runtime_command(state, command, args).await {
+        return result;
+    }
+
+    Err(HeadlessCommandError::not_found(format!(
+        "Unsupported browser backend command: {command}"
+    )))
+}
+
+type CommandResult = Result<Value, HeadlessCommandError>;
+
+async fn dispatch_workspace_command(
+    state: &HeadlessState,
+    command: &str,
+    args: Value,
+) -> Option<CommandResult> {
     match command {
-        "system_check" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            serialize_value(state.service.system_check(&repo_path).map_err(|e| format!("{e:#}"))?)
-        }
-        "runtime_check" => {
-            let RuntimeCheckArgs { force } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .runtime_check_with_refresh(force.unwrap_or(false))
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "beads_check" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            serialize_value(state.service.beads_check(&repo_path).map_err(|e| format!("{e:#}"))?)
-        }
-        "workspace_list" => serialize_value(state.service.workspace_list().map_err(|e| format!("{e:#}"))?),
-        "workspace_add" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            serialize_value(state.service.workspace_add(&repo_path).map_err(|e| format!("{e:#}"))?)
-        }
-        "workspace_select" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            let selected = state
+        "system_check" => Some(handle_repo_path_operation(args, |repo_path| {
+            state.service.system_check(&repo_path)
+        })),
+        "runtime_check" => Some(handle_runtime_check(state, args)),
+        "beads_check" => Some(handle_repo_path_operation(args, |repo_path| {
+            state.service.beads_check(&repo_path)
+        })),
+        "workspace_list" => Some(handle_workspace_list(state)),
+        "workspace_add" => Some(handle_repo_path_operation(args, |repo_path| {
+            state.service.workspace_add(&repo_path)
+        })),
+        "workspace_select" => Some(handle_workspace_select(state, args).await),
+        "workspace_update_repo_config" => Some(handle_workspace_update_repo_config(state, args)),
+        "workspace_save_repo_settings" => Some(handle_workspace_save_repo_settings(state, args).await),
+        "workspace_update_repo_hooks" => Some(handle_workspace_update_repo_hooks(state, args)),
+        "workspace_prepare_trusted_hooks_challenge" => Some(handle_repo_path_operation(args, |repo_path| {
+            state
                 .service
-                .workspace_select(&repo_path)
-                .map_err(|e| format!("{e:#}"))?;
-            invalidate_worktree_resolution_cache_for_repo(&repo_path).map_err(|e| e.to_string())?;
-            serialize_value(selected)
-        }
-        "workspace_update_repo_config" => {
-            let WorkspaceUpdateRepoConfigArgs { repo_path, config } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .workspace_merge_repo_config(
-                        &repo_path,
-                        RepoConfigUpdate {
-                            default_runtime_kind: config.default_runtime_kind,
-                            worktree_base_path: config.worktree_base_path,
-                            branch_prefix: config.branch_prefix,
-                            default_target_branch: config.default_target_branch,
-                            git: config.git,
-                            worktree_file_copies: config.worktree_file_copies,
-                            prompt_overrides: config.prompt_overrides,
-                            agent_defaults: config.agent_defaults,
-                        },
-                    )
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "workspace_save_repo_settings" => {
-            let WorkspaceSaveRepoSettingsArgs { repo_path, settings } = deserialize_args(args)?;
-            let service = state.service.clone();
-            let confirmation_port = HeadlessHookTrustConfirmationPort;
-            let update = RepoSettingsUpdate {
-                default_runtime_kind: settings.default_runtime_kind,
-                worktree_base_path: settings.worktree_base_path,
-                branch_prefix: settings.branch_prefix,
-                default_target_branch: settings.default_target_branch,
-                git: settings.git,
-                trusted_hooks: settings.trusted_hooks,
-                hooks: settings.hooks,
-                worktree_file_copies: settings.worktree_file_copies,
-                prompt_overrides: settings.prompt_overrides,
-                agent_defaults: settings.agent_defaults,
-            };
-            serialize_value(
-                run_service_blocking("workspace_save_repo_settings", move || {
-                    service.workspace_save_repo_settings(&repo_path, update, &confirmation_port)
-                })
-                .await
-                .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "workspace_update_repo_hooks" => {
-            let WorkspaceUpdateRepoHooksArgs { repo_path, hooks } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .workspace_update_repo_hooks(&repo_path, hooks)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "workspace_prepare_trusted_hooks_challenge" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .workspace_prepare_trusted_hooks_challenge(&repo_path)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "workspace_get_repo_config" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .workspace_get_repo_config(&repo_path)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "workspace_detect_github_repository" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .workspace_detect_github_repository(&repo_path)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "workspace_get_settings_snapshot" => {
-            let (git, chat, repos, global_prompt_overrides) = state
+                .workspace_prepare_trusted_hooks_challenge(&repo_path)
+        })),
+        "workspace_get_repo_config" => Some(handle_repo_path_operation(args, |repo_path| {
+            state.service.workspace_get_repo_config(&repo_path)
+        })),
+        "workspace_detect_github_repository" => Some(handle_repo_path_operation(args, |repo_path| {
+            state
                 .service
-                .workspace_get_settings_snapshot()
-                .map_err(|e| format!("{e:#}"))?;
-            serialize_value(SettingsSnapshotResponsePayload {
-                git,
-                chat,
-                repos,
-                global_prompt_overrides,
-            })
-        }
+                .workspace_detect_github_repository(&repo_path)
+        })),
+        "workspace_get_settings_snapshot" => Some(handle_workspace_get_settings_snapshot(state)),
         "workspace_update_global_git_config" => {
-            let WorkspaceUpdateGlobalGitConfigArgs { git } = deserialize_args(args)?;
-            let service = state.service.clone();
-            run_service_blocking("workspace_update_global_git_config", move || {
-                service.workspace_update_global_git_config(git)
-            })
-            .await
-            .map_err(|e| format!("{e:#}"))?;
-            Ok(Value::Null)
+            Some(handle_workspace_update_global_git_config(state, args).await)
         }
         "workspace_save_settings_snapshot" => {
-            let WorkspaceSaveSettingsSnapshotArgs { snapshot } = deserialize_args(args)?;
-            let service = state.service.clone();
-            let confirmation_port = HeadlessHookTrustConfirmationPort;
-            let SettingsSnapshotPayload {
+            Some(handle_workspace_save_settings_snapshot(state, args).await)
+        }
+        "workspace_set_trusted_hooks" => Some(handle_workspace_set_trusted_hooks(state, args).await),
+        "get_theme" => Some(handle_get_theme(state)),
+        "set_theme" => Some(handle_set_theme(state, args)),
+        _ => None,
+    }
+}
+
+async fn dispatch_git_command(
+    state: &HeadlessState,
+    command: &str,
+    args: Value,
+) -> Option<CommandResult> {
+    match command {
+        "git_get_branches" => Some(handle_repo_path_operation(args, |repo_path| {
+            state.service.git_get_branches(&repo_path)
+        })),
+        "git_get_current_branch" => Some(handle_git_get_current_branch(state, args)),
+        "git_switch_branch" => Some(handle_git_switch_branch(state, args)),
+        "git_create_worktree" => Some(handle_git_create_worktree(state, args)),
+        "git_remove_worktree" => Some(handle_git_remove_worktree(state, args)),
+        "git_push_branch" => Some(handle_git_push_branch(state, args)),
+        "git_get_status" => Some(handle_git_get_status(state, args)),
+        "git_get_diff" => Some(handle_git_get_diff(state, args)),
+        "git_commits_ahead_behind" => Some(handle_git_commits_ahead_behind(state, args)),
+        "git_get_worktree_status" => Some(handle_git_get_worktree_status(state, args)),
+        "git_get_worktree_status_summary" => Some(handle_git_get_worktree_status_summary(state, args)),
+        "git_commit_all" => Some(handle_git_commit_all(state, args)),
+        "git_pull_branch" => Some(handle_git_pull_branch(state, args)),
+        "git_rebase_branch" => Some(handle_git_rebase_branch(state, args)),
+        "git_rebase_abort" => Some(handle_git_rebase_abort(state, args)),
+        _ => None,
+    }
+}
+
+async fn dispatch_task_command(
+    state: &HeadlessState,
+    command: &str,
+    args: Value,
+) -> Option<CommandResult> {
+    match command {
+        "tasks_list" => Some(handle_repo_path_operation(args, |repo_path| {
+            state.service.tasks_list(&repo_path)
+        })),
+        "task_create" => Some(handle_task_create(state, args)),
+        "task_update" => Some(handle_task_update(state, args)),
+        "task_delete" => Some(handle_task_delete(state, args)),
+        "task_transition" => Some(handle_task_transition(state, args)),
+        "task_defer" => Some(handle_task_defer(state, args)),
+        "task_resume_deferred" => Some(handle_task_resume_deferred(state, args)),
+        "spec_get" => Some(handle_spec_get(state, args)),
+        "task_metadata_get" => Some(handle_task_metadata_get(state, args)),
+        "set_spec" => Some(handle_set_spec(state, args)),
+        "spec_save_document" => Some(handle_spec_save_document(state, args)),
+        "plan_get" => Some(handle_plan_get(state, args)),
+        "set_plan" => Some(handle_set_plan(state, args)),
+        "plan_save_document" => Some(handle_plan_save_document(state, args)),
+        "qa_get_report" => Some(handle_qa_get_report(state, args)),
+        "qa_approved" => Some(handle_qa_approved(state, args)),
+        "qa_rejected" => Some(handle_qa_rejected(state, args)),
+        "build_blocked" => Some(handle_build_blocked(state, args)),
+        "build_resumed" => Some(handle_build_resumed(state, args)),
+        "build_completed" => Some(handle_build_completed(state, args)),
+        "task_approval_context_get" => Some(handle_task_approval_context_get(state, args)),
+        "task_direct_merge" => Some(handle_task_direct_merge(state, args)),
+        "task_pull_request_upsert" => Some(handle_task_pull_request_upsert(state, args)),
+        "task_pull_request_unlink" => Some(handle_task_pull_request_unlink(state, args)),
+        "task_pull_request_detect" => Some(handle_task_pull_request_detect(state, args)),
+        "repo_pull_request_sync" => Some(handle_repo_pull_request_sync(state, args)),
+        "human_request_changes" => Some(handle_human_request_changes(state, args)),
+        "human_approve" => Some(handle_human_approve(state, args)),
+        _ => None,
+    }
+}
+
+async fn dispatch_runtime_command(
+    state: &HeadlessState,
+    command: &str,
+    args: Value,
+) -> Option<CommandResult> {
+    match command {
+        "build_start" => Some(handle_build_start(state, args).await),
+        "build_respond" => Some(handle_build_respond(state, args)),
+        "build_stop" => Some(handle_build_stop(state, args)),
+        "build_cleanup" => Some(handle_build_cleanup(state, args)),
+        "runs_list" => Some(handle_runs_list(state, args)),
+        "runtime_definitions_list" => Some(handle_runtime_definitions_list(state)),
+        "runtime_list" => Some(handle_runtime_list(state, args)),
+        "qa_review_target_get" => Some(handle_qa_review_target_get(state, args).await),
+        "runtime_stop" => Some(handle_runtime_stop(state, args)),
+        "runtime_ensure" => Some(handle_runtime_ensure(state, args).await),
+        "agent_sessions_list" => Some(handle_agent_sessions_list(state, args)),
+        "agent_session_upsert" => Some(handle_agent_session_upsert(state, args)),
+        _ => None,
+    }
+}
+
+fn handle_repo_path_operation<T, F>(args: Value, operation: F) -> CommandResult
+where
+    T: serde::Serialize,
+    F: FnOnce(String) -> anyhow::Result<T>,
+{
+    let RepoPathArgs { repo_path } = deserialize_args(args)?;
+    serialize_value(operation(repo_path).map_err(service_error)?)
+}
+
+fn handle_repo_task_operation<T, F>(args: Value, operation: F) -> CommandResult
+where
+    T: serde::Serialize,
+    F: FnOnce(String, String) -> anyhow::Result<T>,
+{
+    let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+    serialize_value(operation(repo_path, task_id).map_err(service_error)?)
+}
+
+fn handle_repo_task_reason_operation<T, F>(args: Value, operation: F) -> CommandResult
+where
+    T: serde::Serialize,
+    F: FnOnce(String, String, Option<String>) -> anyhow::Result<T>,
+{
+    let RepoTaskReasonArgs {
+        repo_path,
+        task_id,
+        reason,
+    } = deserialize_args(args)?;
+    serialize_value(operation(repo_path, task_id, reason).map_err(service_error)?)
+}
+
+fn build_worktree_snapshot_metadata(
+    effective_working_dir: String,
+    target_branch: &str,
+    diff_scope: host_domain::GitDiffScope,
+    status_hash: String,
+    diff_hash: String,
+) -> WorktreeSnapshotMetadata {
+    WorktreeSnapshotMetadata {
+        effective_working_dir,
+        target_branch: target_branch.to_string(),
+        diff_scope,
+        observed_at_ms: current_timestamp_ms(),
+        hash_version: GIT_WORKTREE_HASH_VERSION,
+        status_hash,
+        diff_hash,
+    }
+}
+
+fn invalidate_repo_worktree_cache(repo_path: &str) -> Result<(), HeadlessCommandError> {
+    invalidate_worktree_resolution_cache_for_repo(repo_path)
+        .map_err(|error| HeadlessCommandError::internal(error.to_string()))
+}
+
+fn handle_runtime_check(state: &HeadlessState, args: Value) -> CommandResult {
+    let RuntimeCheckArgs { force } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .runtime_check_with_refresh(force.unwrap_or(false))
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_workspace_list(state: &HeadlessState) -> CommandResult {
+    serialize_value(state.service.workspace_list().map_err(service_error)?)
+}
+
+async fn handle_workspace_select(state: &HeadlessState, args: Value) -> CommandResult {
+    let RepoPathArgs { repo_path } = deserialize_args(args)?;
+    let selected = state
+        .service
+        .workspace_select(&repo_path)
+        .map_err(service_error)?;
+    invalidate_repo_worktree_cache(&repo_path)?;
+    serialize_value(selected)
+}
+
+fn handle_workspace_update_repo_config(state: &HeadlessState, args: Value) -> CommandResult {
+    let WorkspaceUpdateRepoConfigArgs { repo_path, config } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .workspace_merge_repo_config(
+                &repo_path,
+                RepoConfigUpdate {
+                    default_runtime_kind: config.default_runtime_kind,
+                    worktree_base_path: config.worktree_base_path,
+                    branch_prefix: config.branch_prefix,
+                    default_target_branch: config.default_target_branch,
+                    git: config.git,
+                    worktree_file_copies: config.worktree_file_copies,
+                    prompt_overrides: config.prompt_overrides,
+                    agent_defaults: config.agent_defaults,
+                },
+            )
+            .map_err(service_error)?,
+    )
+}
+
+async fn handle_workspace_save_repo_settings(
+    state: &HeadlessState,
+    args: Value,
+) -> CommandResult {
+    let WorkspaceSaveRepoSettingsArgs { repo_path, settings } = deserialize_args(args)?;
+    let service = state.service.clone();
+    let confirmation_port = HeadlessHookTrustConfirmationPort;
+    let update = RepoSettingsUpdate {
+        default_runtime_kind: settings.default_runtime_kind,
+        worktree_base_path: settings.worktree_base_path,
+        branch_prefix: settings.branch_prefix,
+        default_target_branch: settings.default_target_branch,
+        git: settings.git,
+        trusted_hooks: settings.trusted_hooks,
+        hooks: settings.hooks,
+        worktree_file_copies: settings.worktree_file_copies,
+        prompt_overrides: settings.prompt_overrides,
+        agent_defaults: settings.agent_defaults,
+    };
+    serialize_value(
+        run_service_blocking_tokio("workspace_save_repo_settings", move || {
+            service.workspace_save_repo_settings(&repo_path, update, &confirmation_port)
+        })
+        .await
+        .map_err(service_error)?,
+    )
+}
+
+fn handle_workspace_update_repo_hooks(state: &HeadlessState, args: Value) -> CommandResult {
+    let WorkspaceUpdateRepoHooksArgs { repo_path, hooks } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .workspace_update_repo_hooks(&repo_path, hooks)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_workspace_get_settings_snapshot(state: &HeadlessState) -> CommandResult {
+    let (git, chat, repos, global_prompt_overrides) = state
+        .service
+        .workspace_get_settings_snapshot()
+        .map_err(service_error)?;
+    serialize_value(SettingsSnapshotResponsePayload {
+        git,
+        chat,
+        repos,
+        global_prompt_overrides,
+    })
+}
+
+async fn handle_workspace_update_global_git_config(
+    state: &HeadlessState,
+    args: Value,
+) -> CommandResult {
+    let WorkspaceUpdateGlobalGitConfigArgs { git } = deserialize_args(args)?;
+    let service = state.service.clone();
+    run_service_blocking_tokio("workspace_update_global_git_config", move || {
+        service.workspace_update_global_git_config(git)
+    })
+    .await
+    .map_err(service_error)?;
+    Ok(Value::Null)
+}
+
+async fn handle_workspace_save_settings_snapshot(
+    state: &HeadlessState,
+    args: Value,
+) -> CommandResult {
+    let WorkspaceSaveSettingsSnapshotArgs { snapshot } = deserialize_args(args)?;
+    let service = state.service.clone();
+    let confirmation_port = HeadlessHookTrustConfirmationPort;
+    let SettingsSnapshotPayload {
+        git,
+        chat,
+        repos,
+        global_prompt_overrides,
+    } = snapshot;
+    serialize_value(
+        run_service_blocking_tokio("workspace_save_settings_snapshot", move || {
+            service.workspace_save_settings_snapshot(
                 git,
                 chat,
                 repos,
                 global_prompt_overrides,
-            } = snapshot;
-            serialize_value(
-                run_service_blocking("workspace_save_settings_snapshot", move || {
-                    service.workspace_save_settings_snapshot(
-                        git,
-                        chat,
-                        repos,
-                        global_prompt_overrides,
-                        &confirmation_port,
-                    )
-                })
-                .await
-                .map_err(|e| format!("{e:#}"))?,
+                &confirmation_port,
             )
-        }
-        "workspace_set_trusted_hooks" => {
-            let WorkspaceSetTrustedHooksArgs {
-                repo_path,
+        })
+        .await
+        .map_err(service_error)?,
+    )
+}
+
+async fn handle_workspace_set_trusted_hooks(
+    state: &HeadlessState,
+    args: Value,
+) -> CommandResult {
+    let WorkspaceSetTrustedHooksArgs {
+        repo_path,
+        trusted,
+        challenge_nonce,
+        challenge_fingerprint,
+    } = deserialize_args(args)?;
+    let service = state.service.clone();
+    let confirmation_port = HeadlessHookTrustConfirmationPort;
+    serialize_value(
+        run_service_blocking_tokio("workspace_set_trusted_hooks", move || {
+            service.workspace_set_trusted_hooks(
+                &repo_path,
                 trusted,
-                challenge_nonce,
-                challenge_fingerprint,
-            } = deserialize_args(args)?;
-            let service = state.service.clone();
-            let confirmation_port = HeadlessHookTrustConfirmationPort;
-            serialize_value(
-                run_service_blocking("workspace_set_trusted_hooks", move || {
-                    service.workspace_set_trusted_hooks(
-                        &repo_path,
-                        trusted,
-                        challenge_nonce.as_deref(),
-                        challenge_fingerprint.as_deref(),
-                        &confirmation_port,
-                    )
-                })
-                .await
-                .map_err(|e| format!("{e:#}"))?,
+                challenge_nonce.as_deref(),
+                challenge_fingerprint.as_deref(),
+                &confirmation_port,
             )
-        }
-        "git_get_branches" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .git_get_branches(&repo_path)
-                    .map_err(|e| format!("{e:#}"))?,
+        })
+        .await
+        .map_err(service_error)?,
+    )
+}
+
+fn handle_set_theme(state: &HeadlessState, args: Value) -> CommandResult {
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ThemeArgs {
+        theme: String,
+    }
+
+    let ThemeArgs { theme } = deserialize_args(args)?;
+    state.service.set_theme(&theme).map_err(service_error)?;
+    Ok(Value::Null)
+}
+
+fn handle_get_theme(state: &HeadlessState) -> CommandResult {
+    serialize_value(state.service.get_theme().map_err(service_error)?)
+}
+
+fn handle_git_get_current_branch(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitCurrentBranchArgs {
+        repo_path,
+        working_dir,
+    } = deserialize_args(args)?;
+    let effective = resolve_authorized_working_dir(state, &repo_path, working_dir.as_deref())?;
+    serialize_value(
+        state
+            .service
+            .git_port()
+            .get_current_branch(std::path::Path::new(&effective))
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_git_switch_branch(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitSwitchBranchArgs {
+        repo_path,
+        branch,
+        create,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .git_switch_branch(&repo_path, &branch, create.unwrap_or(false))
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_git_create_worktree(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitCreateWorktreeArgs {
+        repo_path,
+        worktree_path,
+        branch,
+        create_branch,
+    } = deserialize_args(args)?;
+    let summary = state
+        .service
+        .git_create_worktree(
+            &repo_path,
+            &worktree_path,
+            &branch,
+            create_branch.unwrap_or(false),
+        )
+        .map_err(service_error)?;
+    invalidate_repo_worktree_cache(&repo_path)?;
+    serialize_value(summary)
+}
+
+fn handle_git_remove_worktree(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitRemoveWorktreeArgs {
+        repo_path,
+        worktree_path,
+        force,
+    } = deserialize_args(args)?;
+    let removed = state
+        .service
+        .git_remove_worktree(&repo_path, &worktree_path, force.unwrap_or(false))
+        .map_err(service_error)?;
+    invalidate_repo_worktree_cache(&repo_path)?;
+    Ok(json!({ "ok": removed }))
+}
+
+fn handle_git_push_branch(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitPushBranchArgs {
+        repo_path,
+        branch,
+        working_dir,
+        remote,
+        set_upstream,
+        force_with_lease,
+    } = deserialize_args(args)?;
+    let effective = resolve_authorized_working_dir(state, &repo_path, working_dir.as_deref())?;
+    serialize_value(
+        state
+            .service
+            .git_push_branch(
+                &repo_path,
+                Some(effective.as_str()),
+                remote.as_deref(),
+                &branch,
+                set_upstream.unwrap_or(false),
+                force_with_lease.unwrap_or(false),
             )
-        }
-        "git_get_current_branch" => {
-            let GitCurrentBranchArgs {
-                repo_path,
-                working_dir,
-            } = deserialize_args(args)?;
-            state
-                .service
-                .ensure_repo_authorized(&repo_path)
-                .map_err(|e| e.to_string())?;
-            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-            serialize_value(
-                state
-                    .service
-                    .git_port()
-                    .get_current_branch(std::path::Path::new(&effective))
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "git_switch_branch" => {
-            let GitSwitchBranchArgs {
-                repo_path,
-                branch,
-                create,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .git_switch_branch(&repo_path, &branch, create.unwrap_or(false))
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "git_create_worktree" => {
-            let GitCreateWorktreeArgs {
-                repo_path,
-                worktree_path,
-                branch,
-                create_branch,
-            } = deserialize_args(args)?;
-            let summary = state
-                .service
-                .git_create_worktree(
-                    &repo_path,
-                    &worktree_path,
-                    &branch,
-                    create_branch.unwrap_or(false),
-                )
-                .map_err(|e| format!("{e:#}"))?;
-            invalidate_worktree_resolution_cache_for_repo(&repo_path).map_err(|e| e.to_string())?;
-            serialize_value(summary)
-        }
-        "git_remove_worktree" => {
-            let GitRemoveWorktreeArgs {
-                repo_path,
-                worktree_path,
-                force,
-            } = deserialize_args(args)?;
-            let removed = state
-                .service
-                .git_remove_worktree(&repo_path, &worktree_path, force.unwrap_or(false))
-                .map_err(|e| format!("{e:#}"))?;
-            invalidate_worktree_resolution_cache_for_repo(&repo_path).map_err(|e| e.to_string())?;
-            Ok(json!({ "ok": removed }))
-        }
-        "git_push_branch" => {
-            let GitPushBranchArgs {
-                repo_path,
-                branch,
-                working_dir,
-                remote,
-                set_upstream,
-                force_with_lease,
-            } = deserialize_args(args)?;
-            state
-                .service
-                .ensure_repo_authorized(&repo_path)
-                .map_err(|e| e.to_string())?;
-            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-            serialize_value(
-                state
-                    .service
-                    .git_push_branch(
-                        &repo_path,
-                        Some(effective.as_str()),
-                        remote.as_deref(),
-                        &branch,
-                        set_upstream.unwrap_or(false),
-                        force_with_lease.unwrap_or(false),
-                    )
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "git_get_status" => {
-            let GitStatusArgs {
-                repo_path,
-                working_dir,
-            } = deserialize_args(args)?;
-            state
-                .service
-                .ensure_repo_authorized(&repo_path)
-                .map_err(|e| e.to_string())?;
-            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-            serialize_value(
-                state
-                    .service
-                    .git_port()
-                    .get_status(std::path::Path::new(&effective))
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "git_get_diff" => {
-            let GitDiffArgs {
-                repo_path,
-                target_branch,
-                working_dir,
-            } = deserialize_args(args)?;
-            state
-                .service
-                .ensure_repo_authorized(&repo_path)
-                .map_err(|e| e.to_string())?;
-            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-            serialize_value(
-                state
-                    .service
-                    .git_port()
-                    .get_diff(std::path::Path::new(&effective), target_branch.as_deref())
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "git_commits_ahead_behind" => {
-            let GitAheadBehindArgs {
-                repo_path,
-                target_branch,
-                working_dir,
-            } = deserialize_args(args)?;
-            state
-                .service
-                .ensure_repo_authorized(&repo_path)
-                .map_err(|e| e.to_string())?;
-            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-            serialize_value(
-                state
-                    .service
-                    .git_port()
-                    .commits_ahead_behind(std::path::Path::new(&effective), &target_branch)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "git_get_worktree_status" => {
-            let GitWorktreeStatusArgs {
-                repo_path,
-                target_branch,
-                diff_scope,
-                working_dir,
-            } = deserialize_args(args)?;
-            let trimmed_target = require_target_branch(&target_branch)?;
-            let scope = parse_diff_scope(diff_scope.as_deref())?;
-            state
-                .service
-                .ensure_repo_authorized(&repo_path)
-                .map_err(|e| e.to_string())?;
-            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-            let repo = std::path::Path::new(&effective);
-            let worktree_status = state
-                .service
-                .git_port()
-                .get_worktree_status(repo, trimmed_target, scope.clone())
-                .map_err(|e| format!("{e:#}"))?;
-            let observed_at_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
-            let status_hash = hash_worktree_status_payload(
-                &worktree_status.current_branch,
-                worktree_status.file_statuses.as_slice(),
-                &worktree_status.target_ahead_behind,
-                &worktree_status.upstream_ahead_behind,
-            );
-            let diff_hash = hash_worktree_diff_payload(worktree_status.file_diffs.as_slice());
-            serialize_value(build_worktree_status_with_snapshot(
-                worktree_status,
-                WorktreeSnapshotMetadata {
-                    effective_working_dir: effective,
-                    target_branch: trimmed_target.to_string(),
-                    diff_scope: scope,
-                    observed_at_ms,
-                    hash_version: GIT_WORKTREE_HASH_VERSION,
-                    status_hash,
-                    diff_hash,
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_git_get_status(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitStatusArgs {
+        repo_path,
+        working_dir,
+    } = deserialize_args(args)?;
+    let effective = resolve_authorized_working_dir(state, &repo_path, working_dir.as_deref())?;
+    serialize_value(
+        state
+            .service
+            .git_port()
+            .get_status(std::path::Path::new(&effective))
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_git_get_diff(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitDiffArgs {
+        repo_path,
+        target_branch,
+        working_dir,
+    } = deserialize_args(args)?;
+    let effective = resolve_authorized_working_dir(state, &repo_path, working_dir.as_deref())?;
+    serialize_value(
+        state
+            .service
+            .git_port()
+            .get_diff(std::path::Path::new(&effective), target_branch.as_deref())
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_git_commits_ahead_behind(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitAheadBehindArgs {
+        repo_path,
+        target_branch,
+        working_dir,
+    } = deserialize_args(args)?;
+    let effective = resolve_authorized_working_dir(state, &repo_path, working_dir.as_deref())?;
+    serialize_value(
+        state
+            .service
+            .git_port()
+            .commits_ahead_behind(std::path::Path::new(&effective), &target_branch)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_git_get_worktree_status(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitWorktreeStatusArgs {
+        repo_path,
+        target_branch,
+        diff_scope,
+        working_dir,
+    } = deserialize_args(args)?;
+    let trimmed_target = require_target_branch(&target_branch).map_err(request_error)?;
+    let scope = parse_diff_scope(diff_scope.as_deref()).map_err(request_error)?;
+    let effective = resolve_authorized_working_dir(state, &repo_path, working_dir.as_deref())?;
+    let repo = std::path::Path::new(&effective);
+    let worktree_status = state
+        .service
+        .git_port()
+        .get_worktree_status(repo, trimmed_target, scope.clone())
+        .map_err(service_error)?;
+    let status_hash = hash_worktree_status_payload(
+        &worktree_status.current_branch,
+        worktree_status.file_statuses.as_slice(),
+        &worktree_status.target_ahead_behind,
+        &worktree_status.upstream_ahead_behind,
+    );
+    let diff_hash = hash_worktree_diff_payload(worktree_status.file_diffs.as_slice());
+    serialize_value(build_worktree_status_with_snapshot(
+        worktree_status,
+        build_worktree_snapshot_metadata(
+            effective,
+            trimmed_target,
+            scope,
+            status_hash,
+            diff_hash,
+        ),
+    ))
+}
+
+fn handle_git_get_worktree_status_summary(state: &HeadlessState, args: Value) -> CommandResult {
+    let GitWorktreeStatusArgs {
+        repo_path,
+        target_branch,
+        diff_scope,
+        working_dir,
+    } = deserialize_args(args)?;
+    let trimmed_target = require_target_branch(&target_branch).map_err(request_error)?;
+    let scope = parse_diff_scope(diff_scope.as_deref()).map_err(request_error)?;
+    let effective = resolve_authorized_working_dir(state, &repo_path, working_dir.as_deref())?;
+    let repo = std::path::Path::new(&effective);
+    let summary = state
+        .service
+        .git_port()
+        .get_worktree_status_summary(repo, trimmed_target, scope.clone())
+        .map_err(service_error)?;
+    let status_hash = hash_worktree_status_payload(
+        &summary.current_branch,
+        summary.file_statuses.as_slice(),
+        &summary.target_ahead_behind,
+        &summary.upstream_ahead_behind,
+    );
+    let diff_hash = hash_worktree_diff_summary_payload(
+        &scope,
+        &summary.target_ahead_behind,
+        &summary.file_status_counts,
+    );
+    serialize_value(build_worktree_status_summary_with_snapshot(
+        summary.current_branch,
+        summary.file_status_counts,
+        summary.target_ahead_behind,
+        summary.upstream_ahead_behind,
+        build_worktree_snapshot_metadata(
+            effective,
+            trimmed_target,
+            scope,
+            status_hash,
+            diff_hash,
+        ),
+    ))
+}
+
+fn handle_git_commit_all(state: &HeadlessState, args: Value) -> CommandResult {
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GitCommitAllArgs {
+        repo_path: String,
+        working_dir: Option<String>,
+        message: String,
+    }
+
+    let request: GitCommitAllArgs = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .git_commit_all(
+                &request.repo_path,
+                host_domain::GitCommitAllRequest {
+                    working_dir: request.working_dir,
+                    message: request.message,
                 },
-            ))
-        }
-        "git_get_worktree_status_summary" => {
-            let GitWorktreeStatusArgs {
-                repo_path,
-                target_branch,
-                diff_scope,
-                working_dir,
-            } = deserialize_args(args)?;
-            let trimmed_target = require_target_branch(&target_branch)?;
-            let scope = parse_diff_scope(diff_scope.as_deref())?;
-            state
-                .service
-                .ensure_repo_authorized(&repo_path)
-                .map_err(|e| e.to_string())?;
-            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-            let repo = std::path::Path::new(&effective);
-            let summary = state
-                .service
-                .git_port()
-                .get_worktree_status_summary(repo, trimmed_target, scope.clone())
-                .map_err(|e| format!("{e:#}"))?;
-            let observed_at_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
-            let status_hash = hash_worktree_status_payload(
-                &summary.current_branch,
-                summary.file_statuses.as_slice(),
-                &summary.target_ahead_behind,
-                &summary.upstream_ahead_behind,
-            );
-            let diff_hash = hash_worktree_diff_summary_payload(
-                &scope,
-                &summary.target_ahead_behind,
-                &summary.file_status_counts,
-            );
-            serialize_value(build_worktree_status_summary_with_snapshot(
-                summary.current_branch,
-                summary.file_status_counts,
-                summary.target_ahead_behind,
-                summary.upstream_ahead_behind,
-                WorktreeSnapshotMetadata {
-                    effective_working_dir: effective,
-                    target_branch: trimmed_target.to_string(),
-                    diff_scope: scope,
-                    observed_at_ms,
-                    hash_version: GIT_WORKTREE_HASH_VERSION,
-                    status_hash,
-                    diff_hash,
+            )
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_git_pull_branch(state: &HeadlessState, args: Value) -> CommandResult {
+    let request: GitPullBranchArgs = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .git_pull_branch(
+                &request.repo_path,
+                host_domain::GitPullRequest {
+                    working_dir: request.working_dir,
                 },
-            ))
-        }
-        "git_commit_all" => {
-            #[derive(Debug, Deserialize)]
-            #[serde(rename_all = "camelCase")]
-            struct GitCommitAllArgs {
-                repo_path: String,
-                working_dir: Option<String>,
-                message: String,
-            }
-            let request: GitCommitAllArgs = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .git_commit_all(
-                        &request.repo_path,
-                        host_domain::GitCommitAllRequest {
-                            working_dir: request.working_dir,
-                            message: request.message,
-                        },
-                    )
-                    .map_err(|e| format!("{e:#}"))?,
             )
-        }
-        "git_pull_branch" => {
-            let request: GitPullBranchArgs = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .git_pull_branch(
-                        &request.repo_path,
-                        host_domain::GitPullRequest {
-                            working_dir: request.working_dir,
-                        },
-                    )
-                    .map_err(|e| format!("{e:#}"))?,
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_git_rebase_branch(state: &HeadlessState, args: Value) -> CommandResult {
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GitRebaseBranchArgs {
+        repo_path: String,
+        target_branch: String,
+        working_dir: Option<String>,
+    }
+
+    let request: GitRebaseBranchArgs = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .git_rebase_branch(
+                &request.repo_path,
+                host_domain::GitRebaseBranchRequest {
+                    working_dir: request.working_dir,
+                    target_branch: request.target_branch,
+                },
             )
-        }
-        "git_rebase_branch" => {
-            #[derive(Debug, Deserialize)]
-            #[serde(rename_all = "camelCase")]
-            struct GitRebaseBranchArgs {
-                repo_path: String,
-                target_branch: String,
-                working_dir: Option<String>,
-            }
-            let request: GitRebaseBranchArgs = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .git_rebase_branch(
-                        &request.repo_path,
-                        host_domain::GitRebaseBranchRequest {
-                            working_dir: request.working_dir,
-                            target_branch: request.target_branch,
-                        },
-                    )
-                    .map_err(|e| format!("{e:#}"))?,
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_git_rebase_abort(state: &HeadlessState, args: Value) -> CommandResult {
+    let request: GitRebaseAbortArgs = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .git_rebase_abort(
+                &request.repo_path,
+                host_domain::GitRebaseAbortRequest {
+                    working_dir: request.working_dir,
+                },
             )
-        }
-        "git_rebase_abort" => {
-            let request: GitRebaseAbortArgs = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .git_rebase_abort(
-                        &request.repo_path,
-                        host_domain::GitRebaseAbortRequest {
-                            working_dir: request.working_dir,
-                        },
-                    )
-                    .map_err(|e| format!("{e:#}"))?,
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_task_create(state: &HeadlessState, args: Value) -> CommandResult {
+    let TaskCreateArgs { repo_path, input } = deserialize_args(args)?;
+    let create = map_task_create_payload(input).map_err(request_error)?;
+    serialize_value(
+        state
+            .service
+            .task_create(&repo_path, create)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_task_update(state: &HeadlessState, args: Value) -> CommandResult {
+    let TaskUpdateArgs {
+        repo_path,
+        task_id,
+        patch,
+    } = deserialize_args(args)?;
+    let mapped = map_task_update_payload(patch).map_err(request_error)?;
+    serialize_value(
+        state
+            .service
+            .task_update(&repo_path, &task_id, mapped)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_task_delete(state: &HeadlessState, args: Value) -> CommandResult {
+    let TaskDeleteArgs {
+        repo_path,
+        task_id,
+        delete_subtasks,
+    } = deserialize_args(args)?;
+    let ok = state
+        .service
+        .task_delete(&repo_path, &task_id, delete_subtasks.unwrap_or(false))
+        .map(|()| true)
+        .map_err(service_error)?;
+    Ok(json!({ "ok": ok }))
+}
+
+fn handle_task_transition(state: &HeadlessState, args: Value) -> CommandResult {
+    let TaskTransitionArgs {
+        repo_path,
+        task_id,
+        status,
+        reason,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .task_transition(&repo_path, &task_id, status, reason.as_deref())
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_task_defer(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_reason_operation(args, |repo_path, task_id, reason| {
+        state.service.task_defer(&repo_path, &task_id, reason.as_deref())
+    })
+}
+
+fn handle_task_resume_deferred(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.task_resume_deferred(&repo_path, &task_id)
+    })
+}
+
+fn handle_spec_get(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.spec_get(&repo_path, &task_id)
+    })
+}
+
+fn handle_task_metadata_get(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.task_metadata_get(&repo_path, &task_id)
+    })
+}
+
+fn handle_set_spec(state: &HeadlessState, args: Value) -> CommandResult {
+    let SetSpecArgs {
+        repo_path,
+        task_id,
+        markdown,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .set_spec(&repo_path, &task_id, &markdown)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_spec_save_document(state: &HeadlessState, args: Value) -> CommandResult {
+    let SetSpecArgs {
+        repo_path,
+        task_id,
+        markdown,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .save_spec_document(&repo_path, &task_id, &markdown)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_plan_get(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.plan_get(&repo_path, &task_id)
+    })
+}
+
+fn handle_set_plan(state: &HeadlessState, args: Value) -> CommandResult {
+    let SetPlanArgs {
+        repo_path,
+        task_id,
+        input,
+    } = deserialize_args(args)?;
+    let mapped_subtasks = map_plan_subtasks(input.subtasks).map_err(request_error)?;
+    serialize_value(
+        state
+            .service
+            .set_plan(&repo_path, &task_id, &input.markdown, mapped_subtasks)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_plan_save_document(state: &HeadlessState, args: Value) -> CommandResult {
+    let SetSpecArgs {
+        repo_path,
+        task_id,
+        markdown,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .save_plan_document(&repo_path, &task_id, &markdown)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_qa_get_report(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.qa_get_report(&repo_path, &task_id)
+    })
+}
+
+fn handle_qa_approved(state: &HeadlessState, args: Value) -> CommandResult {
+    let MarkdownInputArgs {
+        repo_path,
+        task_id,
+        input,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .qa_approved(&repo_path, &task_id, &input.markdown)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_qa_rejected(state: &HeadlessState, args: Value) -> CommandResult {
+    let MarkdownInputArgs {
+        repo_path,
+        task_id,
+        input,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .qa_rejected(&repo_path, &task_id, &input.markdown)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_build_blocked(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_reason_operation(args, |repo_path, task_id, reason| {
+        state
+            .service
+            .build_blocked(&repo_path, &task_id, reason.as_deref())
+    })
+}
+
+fn handle_build_resumed(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.build_resumed(&repo_path, &task_id)
+    })
+}
+
+fn handle_build_completed(state: &HeadlessState, args: Value) -> CommandResult {
+    let BuildCompletedArgs {
+        repo_path,
+        task_id,
+        input,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .build_completed(
+                &repo_path,
+                &task_id,
+                input.as_ref().and_then(|entry| entry.summary.as_deref()),
             )
-        }
-        "tasks_list" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            serialize_value(state.service.tasks_list(&repo_path).map_err(|e| format!("{e:#}"))?)
-        }
-        "task_create" => {
-            let TaskCreateArgs { repo_path, input } = deserialize_args(args)?;
-            let create = map_task_create_payload(input)?;
-            serialize_value(state.service.task_create(&repo_path, create).map_err(|e| format!("{e:#}"))?)
-        }
-        "task_update" => {
-            let TaskUpdateArgs {
-                repo_path,
-                task_id,
-                patch,
-            } = deserialize_args(args)?;
-            let mapped = map_task_update_payload(patch)?;
-            serialize_value(
-                state
-                    .service
-                    .task_update(&repo_path, &task_id, mapped)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "task_delete" => {
-            let TaskDeleteArgs {
-                repo_path,
-                task_id,
-                delete_subtasks,
-            } = deserialize_args(args)?;
-            let ok = state
-                .service
-                .task_delete(&repo_path, &task_id, delete_subtasks.unwrap_or(false))
-                .map(|()| true)
-                .map_err(|e| format!("{e:#}"))?;
-            Ok(json!({ "ok": ok }))
-        }
-        "task_transition" => {
-            let TaskTransitionArgs {
-                repo_path,
-                task_id,
-                status,
-                reason,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .task_transition(&repo_path, &task_id, status, reason.as_deref())
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "task_defer" => {
-            let RepoTaskReasonArgs {
-                repo_path,
-                task_id,
-                reason,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .task_defer(&repo_path, &task_id, reason.as_deref())
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "task_resume_deferred" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .task_resume_deferred(&repo_path, &task_id)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "spec_get" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(state.service.spec_get(&repo_path, &task_id).map_err(|e| format!("{e:#}"))?)
-        }
-        "task_metadata_get" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .task_metadata_get(&repo_path, &task_id)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "set_spec" => {
-            let SetSpecArgs {
-                repo_path,
-                task_id,
-                markdown,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .set_spec(&repo_path, &task_id, &markdown)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "spec_save_document" => {
-            let SetSpecArgs {
-                repo_path,
-                task_id,
-                markdown,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .save_spec_document(&repo_path, &task_id, &markdown)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "plan_get" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(state.service.plan_get(&repo_path, &task_id).map_err(|e| format!("{e:#}"))?)
-        }
-        "set_plan" => {
-            let SetPlanArgs {
-                repo_path,
-                task_id,
-                input,
-            } = deserialize_args(args)?;
-            let mapped_subtasks = map_plan_subtasks(input.subtasks)?;
-            serialize_value(
-                state
-                    .service
-                    .set_plan(&repo_path, &task_id, &input.markdown, mapped_subtasks)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "plan_save_document" => {
-            let SetSpecArgs {
-                repo_path,
-                task_id,
-                markdown,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .save_plan_document(&repo_path, &task_id, &markdown)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "qa_get_report" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .qa_get_report(&repo_path, &task_id)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "qa_approved" => {
-            let MarkdownInputArgs {
-                repo_path,
-                task_id,
-                input,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .qa_approved(&repo_path, &task_id, &input.markdown)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "qa_rejected" => {
-            let MarkdownInputArgs {
-                repo_path,
-                task_id,
-                input,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .qa_rejected(&repo_path, &task_id, &input.markdown)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "build_start" => {
-            let BuildStartArgs {
-                repo_path,
-                task_id,
-                runtime_kind,
-            } = deserialize_args(args)?;
-            let service = state.service.clone();
-            let emitter = make_emitter(state.events.clone());
-            serialize_value(
-                run_service_blocking("build_start", move || {
-                    service.build_start(&repo_path, &task_id, runtime_kind.as_str(), emitter)
-                })
-                .await
-                .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "build_respond" => {
-            let BuildRespondArgs {
-                run_id,
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_task_approval_context_get(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.task_approval_context_get(&repo_path, &task_id)
+    })
+}
+
+fn handle_task_direct_merge(state: &HeadlessState, args: Value) -> CommandResult {
+    let TaskDirectMergeArgs {
+        repo_path,
+        task_id,
+        merge_method,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .task_direct_merge(&repo_path, &task_id, merge_method)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_task_pull_request_upsert(state: &HeadlessState, args: Value) -> CommandResult {
+    let TaskPullRequestUpsertArgs {
+        repo_path,
+        task_id,
+        input,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .task_pull_request_upsert(&repo_path, &task_id, &input.title, &input.body)
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_task_pull_request_unlink(state: &HeadlessState, args: Value) -> CommandResult {
+    let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+    Ok(json!({
+        "ok": state
+            .service
+            .task_pull_request_unlink(&repo_path, &task_id)
+            .map_err(service_error)?
+    }))
+}
+
+fn handle_task_pull_request_detect(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.task_pull_request_detect(&repo_path, &task_id)
+    })
+}
+
+fn handle_repo_pull_request_sync(state: &HeadlessState, args: Value) -> CommandResult {
+    let RepoPathArgs { repo_path } = deserialize_args(args)?;
+    Ok(json!({
+        "ok": state
+            .service
+            .repo_pull_request_sync(&repo_path)
+            .map_err(service_error)?
+    }))
+}
+
+fn handle_human_request_changes(state: &HeadlessState, args: Value) -> CommandResult {
+    let HumanRequestChangesArgs {
+        repo_path,
+        task_id,
+        note,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .human_request_changes(&repo_path, &task_id, note.as_deref())
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_human_approve(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.human_approve(&repo_path, &task_id)
+    })
+}
+
+async fn handle_build_start(state: &HeadlessState, args: Value) -> CommandResult {
+    let BuildStartArgs {
+        repo_path,
+        task_id,
+        runtime_kind,
+    } = deserialize_args(args)?;
+    let service = state.service.clone();
+    let emitter = make_emitter(state.events.clone());
+    serialize_value(
+        run_service_blocking_tokio("build_start", move || {
+            service.build_start(&repo_path, &task_id, runtime_kind.as_str(), emitter)
+        })
+        .await
+        .map_err(service_error)?,
+    )
+}
+
+fn handle_build_respond(state: &HeadlessState, args: Value) -> CommandResult {
+    let BuildRespondArgs {
+        run_id,
+        action,
+        payload,
+    } = deserialize_args(args)?;
+    Ok(json!({
+        "ok": state
+            .service
+            .build_respond(
+                &run_id,
                 action,
-                payload,
-            } = deserialize_args(args)?;
-            Ok(json!({
-                "ok": state
-                    .service
-                    .build_respond(&run_id, action, payload.as_deref(), make_emitter(state.events.clone()))
-                    .map_err(|e| format!("{e:#}"))?
-            }))
-        }
-        "build_stop" => {
-            let BuildStopArgs { run_id } = deserialize_args(args)?;
-            Ok(json!({
-                "ok": state
-                    .service
-                    .build_stop(&run_id, make_emitter(state.events.clone()))
-                    .map_err(|e| format!("{e:#}"))?
-            }))
-        }
-        "build_cleanup" => {
-            let BuildCleanupArgs { run_id, mode } = deserialize_args(args)?;
-            Ok(json!({
-                "ok": state
-                    .service
-                    .build_cleanup(&run_id, mode, make_emitter(state.events.clone()))
-                    .map_err(|e| format!("{e:#}"))?
-            }))
-        }
-        "build_blocked" => {
-            let RepoTaskReasonArgs {
-                repo_path,
-                task_id,
-                reason,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .build_blocked(&repo_path, &task_id, reason.as_deref())
-                    .map_err(|e| format!("{e:#}"))?,
+                payload.as_deref(),
+                make_emitter(state.events.clone()),
             )
-        }
-        "build_resumed" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .build_resumed(&repo_path, &task_id)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "build_completed" => {
-            let BuildCompletedArgs {
-                repo_path,
-                task_id,
-                input,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .build_completed(
-                        &repo_path,
-                        &task_id,
-                        input.as_ref().and_then(|entry| entry.summary.as_deref()),
-                    )
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "task_approval_context_get" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .task_approval_context_get(&repo_path, &task_id)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "task_direct_merge" => {
-            let TaskDirectMergeArgs {
-                repo_path,
-                task_id,
-                merge_method,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .task_direct_merge(&repo_path, &task_id, merge_method)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "task_pull_request_upsert" => {
-            let TaskPullRequestUpsertArgs {
-                repo_path,
-                task_id,
-                input,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .task_pull_request_upsert(&repo_path, &task_id, &input.title, &input.body)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "task_pull_request_unlink" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            Ok(json!({
-                "ok": state
-                    .service
-                    .task_pull_request_unlink(&repo_path, &task_id)
-                    .map_err(|e| format!("{e:#}"))?
-            }))
-        }
-        "task_pull_request_detect" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .task_pull_request_detect(&repo_path, &task_id)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "repo_pull_request_sync" => {
-            let RepoPathArgs { repo_path } = deserialize_args(args)?;
-            Ok(json!({
-                "ok": state
-                    .service
-                    .repo_pull_request_sync(&repo_path)
-                    .map_err(|e| format!("{e:#}"))?
-            }))
-        }
-        "human_request_changes" => {
-            let HumanRequestChangesArgs {
-                repo_path,
-                task_id,
-                note,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .human_request_changes(&repo_path, &task_id, note.as_deref())
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "human_approve" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .human_approve(&repo_path, &task_id)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "runs_list" => {
-            let OptionalRepoPathArgs { repo_path } = deserialize_args(args)?;
-            serialize_value(state.service.runs_list(repo_path.as_deref()).map_err(|e| format!("{e:#}"))?)
-        }
-        "runtime_definitions_list" => {
-            serialize_value(state.service.runtime_definitions_list().map_err(|e| format!("{e:#}"))?)
-        }
-        "runtime_list" => {
-            let RuntimeListArgs {
-                runtime_kind,
-                repo_path,
-            } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .runtime_list(&runtime_kind, repo_path.as_deref())
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "qa_review_target_get" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            let service = state.service.clone();
-            serialize_value(
-                run_service_blocking("qa_review_target_get", move || {
-                    service.qa_review_target_get(&repo_path, &task_id)
-                })
-                .await
-                .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "runtime_stop" => {
-            let RuntimeStopArgs { runtime_id } = deserialize_args(args)?;
-            Ok(json!({
-                "ok": state
-                    .service
-                    .runtime_stop(&runtime_id)
-                    .map_err(|e| format!("{e:#}"))?
-            }))
-        }
-        "runtime_ensure" => {
-            let RuntimeEnsureArgs {
-                runtime_kind,
-                repo_path,
-            } = deserialize_args(args)?;
-            let service = state.service.clone();
-            serialize_value(
-                run_service_blocking("runtime_ensure", move || {
-                    service.runtime_ensure(&runtime_kind, &repo_path)
-                })
-                .await
-                .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "agent_sessions_list" => {
-            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
-            serialize_value(
-                state
-                    .service
-                    .agent_sessions_list(&repo_path, &task_id)
-                    .map_err(|e| format!("{e:#}"))?,
-            )
-        }
-        "agent_session_upsert" => {
-            let AgentSessionUpsertArgs {
-                repo_path,
-                task_id,
-                session,
-            } = deserialize_args(args)?;
-            Ok(json!({
-                "ok": state
-                    .service
-                    .agent_session_upsert(&repo_path, &task_id, session)
-                    .map_err(|e| format!("{e:#}"))?
-            }))
-        }
-        "get_theme" => serialize_value(state.service.get_theme().map_err(|e| format!("{e:#}"))?),
-        "set_theme" => {
-            #[derive(Debug, Deserialize)]
-            #[serde(rename_all = "camelCase")]
-            struct ThemeArgs {
-                theme: String,
-            }
-            let ThemeArgs { theme } = deserialize_args(args)?;
-            state.service.set_theme(&theme).map_err(|e| format!("{e:#}"))?;
-            Ok(Value::Null)
-        }
-        unknown => Err(format!("Unsupported browser backend command: {unknown}")),
+            .map_err(service_error)?
+    }))
+}
+
+fn handle_build_stop(state: &HeadlessState, args: Value) -> CommandResult {
+    let BuildStopArgs { run_id } = deserialize_args(args)?;
+    Ok(json!({
+        "ok": state
+            .service
+            .build_stop(&run_id, make_emitter(state.events.clone()))
+            .map_err(service_error)?
+    }))
+}
+
+fn handle_build_cleanup(state: &HeadlessState, args: Value) -> CommandResult {
+    let BuildCleanupArgs { run_id, mode } = deserialize_args(args)?;
+    Ok(json!({
+        "ok": state
+            .service
+            .build_cleanup(&run_id, mode, make_emitter(state.events.clone()))
+            .map_err(service_error)?
+    }))
+}
+
+fn handle_runs_list(state: &HeadlessState, args: Value) -> CommandResult {
+    let OptionalRepoPathArgs { repo_path } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .runs_list(repo_path.as_deref())
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_runtime_definitions_list(state: &HeadlessState) -> CommandResult {
+    serialize_value(
+        state
+            .service
+            .runtime_definitions_list()
+            .map_err(service_error)?,
+    )
+}
+
+fn handle_runtime_list(state: &HeadlessState, args: Value) -> CommandResult {
+    let RuntimeListArgs {
+        runtime_kind,
+        repo_path,
+    } = deserialize_args(args)?;
+    serialize_value(
+        state
+            .service
+            .runtime_list(&runtime_kind, repo_path.as_deref())
+            .map_err(service_error)?,
+    )
+}
+
+async fn handle_qa_review_target_get(state: &HeadlessState, args: Value) -> CommandResult {
+    let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+    let service = state.service.clone();
+    serialize_value(
+        run_service_blocking_tokio("qa_review_target_get", move || {
+            service.qa_review_target_get(&repo_path, &task_id)
+        })
+        .await
+        .map_err(service_error)?,
+    )
+}
+
+fn handle_runtime_stop(state: &HeadlessState, args: Value) -> CommandResult {
+    let RuntimeStopArgs { runtime_id } = deserialize_args(args)?;
+    Ok(json!({
+        "ok": state
+            .service
+            .runtime_stop(&runtime_id)
+            .map_err(service_error)?
+    }))
+}
+
+async fn handle_runtime_ensure(state: &HeadlessState, args: Value) -> CommandResult {
+    let RuntimeEnsureArgs {
+        runtime_kind,
+        repo_path,
+    } = deserialize_args(args)?;
+    let service = state.service.clone();
+    serialize_value(
+        run_service_blocking_tokio("runtime_ensure", move || {
+            service.runtime_ensure(&runtime_kind, &repo_path)
+        })
+        .await
+        .map_err(service_error)?,
+    )
+}
+
+fn handle_agent_sessions_list(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation(args, |repo_path, task_id| {
+        state.service.agent_sessions_list(&repo_path, &task_id)
+    })
+}
+
+fn handle_agent_session_upsert(state: &HeadlessState, args: Value) -> CommandResult {
+    let AgentSessionUpsertArgs {
+        repo_path,
+        task_id,
+        session,
+    } = deserialize_args(args)?;
+    Ok(json!({
+        "ok": state
+            .service
+            .agent_session_upsert(&repo_path, &task_id, session)
+            .map_err(service_error)?
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_last_event_id_accepts_valid_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("last-event-id", HeaderValue::from_static("42"));
+
+        let parsed = parse_last_event_id(&headers).expect("header should parse");
+
+        assert_eq!(parsed, Some(42));
+    }
+
+    #[test]
+    fn parse_last_event_id_rejects_invalid_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("last-event-id", HeaderValue::from_static("abc"));
+
+        let error = parse_last_event_id(&headers).expect_err("invalid header should fail");
+
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert!(error.message.contains("Invalid Last-Event-ID header"));
+    }
+
+    #[test]
+    fn headless_event_bus_replays_buffered_events_after_last_seen_id() {
+        let bus = HeadlessEventBus::new(2);
+        bus.emit("first".to_string());
+        bus.emit("second".to_string());
+        bus.emit("third".to_string());
+
+        let replayed = bus.replay_since(Some(1));
+
+        assert_eq!(replayed.len(), 2);
+        assert_eq!(replayed[0].id, 2);
+        assert_eq!(replayed[0].payload, "second");
+        assert_eq!(replayed[1].id, 3);
+        assert_eq!(replayed[1].payload, "third");
+    }
+
+    #[test]
+    fn to_sse_event_sets_event_id() {
+        let event = HeadlessEvent {
+            id: 7,
+            payload: "{\"ok\":true}".to_string(),
+        };
+
+        let sse = to_sse_event(&event).expect("event should serialize");
+
+        let debug = format!("{sse:?}");
+        assert!(debug.contains("id"), "expected event debug output to mention id: {debug}");
+        assert!(debug.contains("7"), "expected event debug output to contain id value: {debug}");
     }
 }

--- a/apps/desktop/src-tauri/src/headless.rs
+++ b/apps/desktop/src-tauri/src/headless.rs
@@ -1,0 +1,1409 @@
+use crate::commands::documents::map_plan_subtasks;
+use crate::commands::git::{
+    build_worktree_status_summary_with_snapshot, build_worktree_status_with_snapshot,
+    hash_worktree_diff_payload, hash_worktree_diff_summary_payload,
+    hash_worktree_status_payload, invalidate_worktree_resolution_cache_for_repo,
+    parse_diff_scope, require_target_branch, resolve_working_dir, WorktreeSnapshotMetadata,
+    GIT_WORKTREE_HASH_VERSION,
+};
+use crate::commands::tasks::{map_task_create_payload, map_task_update_payload};
+use crate::{
+    run_service_blocking, startup_phase_service_bootstrap, startup_phase_shutdown_hooks,
+    startup_phase_tracing, BuildCompletePayload, MarkdownPayload, PlanPayload,
+    PullRequestContentPayload, RepoConfigPayload, RepoSettingsPayload, SettingsSnapshotPayload,
+    SettingsSnapshotResponsePayload, TaskCreatePayload, TaskUpdatePayload,
+};
+use anyhow::{anyhow, Context};
+use axum::extract::{Path, State};
+use axum::http::header;
+use axum::http::StatusCode;
+use axum::http::Method;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use host_application::{
+    AppService, BuildResponseAction, CleanupMode, HookTrustConfirmationPort,
+    HookTrustConfirmationRequest, RepoConfigUpdate, RepoSettingsUpdate, RunEmitter,
+};
+use host_domain::{AgentRuntimeKind, GitMergeMethod};
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::convert::Infallible;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
+use tower_http::cors::CorsLayer;
+
+const DEFAULT_BROWSER_BACKEND_HOST: &str = "127.0.0.1";
+
+#[derive(Clone)]
+struct HeadlessState {
+    service: Arc<AppService>,
+    events: broadcast::Sender<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RepoPathArgs {
+    repo_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OptionalRepoPathArgs {
+    repo_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RepoTaskArgs {
+    repo_path: String,
+    task_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RepoTaskReasonArgs {
+    repo_path: String,
+    task_id: String,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeCheckArgs {
+    force: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeListArgs {
+    runtime_kind: String,
+    repo_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeEnsureArgs {
+    runtime_kind: String,
+    repo_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RuntimeStopArgs {
+    runtime_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceUpdateRepoConfigArgs {
+    repo_path: String,
+    config: RepoConfigPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceSaveRepoSettingsArgs {
+    repo_path: String,
+    settings: RepoSettingsPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceUpdateRepoHooksArgs {
+    repo_path: String,
+    hooks: host_infra_system::HookSet,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceSaveSettingsSnapshotArgs {
+    snapshot: SettingsSnapshotPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceUpdateGlobalGitConfigArgs {
+    git: host_infra_system::GlobalGitConfig,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceSetTrustedHooksArgs {
+    repo_path: String,
+    trusted: bool,
+    challenge_nonce: Option<String>,
+    challenge_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitCurrentBranchArgs {
+    repo_path: String,
+    working_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitSwitchBranchArgs {
+    repo_path: String,
+    branch: String,
+    create: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitCreateWorktreeArgs {
+    repo_path: String,
+    worktree_path: String,
+    branch: String,
+    create_branch: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitRemoveWorktreeArgs {
+    repo_path: String,
+    worktree_path: String,
+    force: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitPushBranchArgs {
+    repo_path: String,
+    branch: String,
+    working_dir: Option<String>,
+    remote: Option<String>,
+    set_upstream: Option<bool>,
+    force_with_lease: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitStatusArgs {
+    repo_path: String,
+    working_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitDiffArgs {
+    repo_path: String,
+    target_branch: Option<String>,
+    working_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitAheadBehindArgs {
+    repo_path: String,
+    target_branch: String,
+    working_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitPullBranchArgs {
+    repo_path: String,
+    working_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitRebaseAbortArgs {
+    repo_path: String,
+    working_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GitWorktreeStatusArgs {
+    repo_path: String,
+    target_branch: String,
+    diff_scope: Option<String>,
+    working_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskCreateArgs {
+    repo_path: String,
+    input: TaskCreatePayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskUpdateArgs {
+    repo_path: String,
+    task_id: String,
+    patch: TaskUpdatePayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskDeleteArgs {
+    repo_path: String,
+    task_id: String,
+    delete_subtasks: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskTransitionArgs {
+    repo_path: String,
+    task_id: String,
+    status: host_domain::TaskStatus,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetSpecArgs {
+    repo_path: String,
+    task_id: String,
+    markdown: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetPlanArgs {
+    repo_path: String,
+    task_id: String,
+    input: PlanPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MarkdownInputArgs {
+    repo_path: String,
+    task_id: String,
+    input: MarkdownPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BuildStartArgs {
+    repo_path: String,
+    task_id: String,
+    runtime_kind: AgentRuntimeKind,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BuildRespondArgs {
+    run_id: String,
+    action: BuildResponseAction,
+    payload: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BuildStopArgs {
+    run_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BuildCleanupArgs {
+    run_id: String,
+    mode: CleanupMode,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BuildCompletedArgs {
+    repo_path: String,
+    task_id: String,
+    input: Option<BuildCompletePayload>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskDirectMergeArgs {
+    repo_path: String,
+    task_id: String,
+    merge_method: GitMergeMethod,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskPullRequestUpsertArgs {
+    repo_path: String,
+    task_id: String,
+    input: PullRequestContentPayload,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HumanRequestChangesArgs {
+    repo_path: String,
+    task_id: String,
+    note: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentSessionUpsertArgs {
+    repo_path: String,
+    task_id: String,
+    session: host_domain::AgentSessionDocument,
+}
+
+struct HeadlessHookTrustConfirmationPort;
+
+impl HookTrustConfirmationPort for HeadlessHookTrustConfirmationPort {
+    fn confirm_trusted_hooks(&self, request: &HookTrustConfirmationRequest) -> anyhow::Result<()> {
+        Err(anyhow!(
+            "Trusted hook confirmation for '{}' requires the desktop shell. Browser mode cannot open the native confirmation dialog.",
+            request.repo_path
+        ))
+    }
+}
+
+pub async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
+    startup_phase_tracing();
+    let service = startup_phase_service_bootstrap()?;
+    startup_phase_shutdown_hooks(service.clone());
+    let (events, _) = broadcast::channel::<String>(256);
+    let app = Router::new()
+        .route("/health", get(health_handler))
+        .route("/events", get(events_handler))
+        .route("/invoke/{command}", post(invoke_handler))
+        .layer(
+            CorsLayer::new()
+                .allow_origin([
+                    "http://localhost:1420".parse().expect("valid localhost origin"),
+                    "http://127.0.0.1:1420"
+                        .parse()
+                        .expect("valid loopback origin"),
+                ])
+                .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+                .allow_headers([header::CONTENT_TYPE]),
+        )
+        .with_state(HeadlessState { service, events });
+
+    let listener = TcpListener::bind((DEFAULT_BROWSER_BACKEND_HOST, port))
+        .await
+        .with_context(|| format!("failed to bind browser backend on {DEFAULT_BROWSER_BACKEND_HOST}:{port}"))?;
+
+    tracing::info!(
+        target: "openducktor.browser-backend",
+        host = DEFAULT_BROWSER_BACKEND_HOST,
+        port,
+        "OpenDucktor browser backend listening"
+    );
+
+    axum::serve(listener, app)
+        .await
+        .context("browser backend server terminated unexpectedly")
+}
+
+async fn health_handler() -> impl IntoResponse {
+    Json(json!({ "ok": true }))
+}
+
+async fn events_handler(
+    State(state): State<HeadlessState>,
+) -> Sse<impl tokio_stream::Stream<Item = Result<Event, Infallible>>> {
+    let stream = BroadcastStream::new(state.events.subscribe()).map(|message| match message {
+        Ok(payload) => Ok(Event::default().data(payload)),
+        Err(_) => Ok(Event::default().comment("lagged")),
+    });
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
+}
+
+async fn invoke_handler(
+    Path(command): Path<String>,
+    State(state): State<HeadlessState>,
+    Json(args): Json<Value>,
+) -> impl IntoResponse {
+    match dispatch_command(&state, &command, args).await {
+        Ok(payload) => (StatusCode::OK, Json(payload)).into_response(),
+        Err(error) => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": error,
+            })),
+        )
+            .into_response(),
+    }
+}
+
+fn deserialize_args<T: DeserializeOwned>(args: Value) -> Result<T, String> {
+    serde_json::from_value(args).map_err(|error| format!("Invalid arguments: {error}"))
+}
+
+fn serialize_value<T: serde::Serialize>(value: T) -> Result<Value, String> {
+    serde_json::to_value(value).map_err(|error| format!("Failed to serialize response: {error}"))
+}
+
+fn make_emitter(sender: broadcast::Sender<String>) -> RunEmitter {
+    Arc::new(move |event| {
+        match serde_json::to_string(&event) {
+            Ok(payload) => {
+                let _ = sender.send(payload);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    target: "openducktor.browser-backend",
+                    error = %error,
+                    "Failed to serialize run event for browser SSE"
+                );
+            }
+        }
+    })
+}
+
+async fn dispatch_command(
+    state: &HeadlessState,
+    command: &str,
+    args: Value,
+) -> Result<Value, String> {
+    match command {
+        "system_check" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            serialize_value(state.service.system_check(&repo_path).map_err(|e| format!("{e:#}"))?)
+        }
+        "runtime_check" => {
+            let RuntimeCheckArgs { force } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .runtime_check_with_refresh(force.unwrap_or(false))
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "beads_check" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            serialize_value(state.service.beads_check(&repo_path).map_err(|e| format!("{e:#}"))?)
+        }
+        "workspace_list" => serialize_value(state.service.workspace_list().map_err(|e| format!("{e:#}"))?),
+        "workspace_add" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            serialize_value(state.service.workspace_add(&repo_path).map_err(|e| format!("{e:#}"))?)
+        }
+        "workspace_select" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            let selected = state
+                .service
+                .workspace_select(&repo_path)
+                .map_err(|e| format!("{e:#}"))?;
+            invalidate_worktree_resolution_cache_for_repo(&repo_path).map_err(|e| e.to_string())?;
+            serialize_value(selected)
+        }
+        "workspace_update_repo_config" => {
+            let WorkspaceUpdateRepoConfigArgs { repo_path, config } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .workspace_merge_repo_config(
+                        &repo_path,
+                        RepoConfigUpdate {
+                            default_runtime_kind: config.default_runtime_kind,
+                            worktree_base_path: config.worktree_base_path,
+                            branch_prefix: config.branch_prefix,
+                            default_target_branch: config.default_target_branch,
+                            git: config.git,
+                            worktree_file_copies: config.worktree_file_copies,
+                            prompt_overrides: config.prompt_overrides,
+                            agent_defaults: config.agent_defaults,
+                        },
+                    )
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "workspace_save_repo_settings" => {
+            let WorkspaceSaveRepoSettingsArgs { repo_path, settings } = deserialize_args(args)?;
+            let service = state.service.clone();
+            let confirmation_port = HeadlessHookTrustConfirmationPort;
+            let update = RepoSettingsUpdate {
+                default_runtime_kind: settings.default_runtime_kind,
+                worktree_base_path: settings.worktree_base_path,
+                branch_prefix: settings.branch_prefix,
+                default_target_branch: settings.default_target_branch,
+                git: settings.git,
+                trusted_hooks: settings.trusted_hooks,
+                hooks: settings.hooks,
+                worktree_file_copies: settings.worktree_file_copies,
+                prompt_overrides: settings.prompt_overrides,
+                agent_defaults: settings.agent_defaults,
+            };
+            serialize_value(
+                run_service_blocking("workspace_save_repo_settings", move || {
+                    service.workspace_save_repo_settings(&repo_path, update, &confirmation_port)
+                })
+                .await
+                .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "workspace_update_repo_hooks" => {
+            let WorkspaceUpdateRepoHooksArgs { repo_path, hooks } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .workspace_update_repo_hooks(&repo_path, hooks)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "workspace_prepare_trusted_hooks_challenge" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .workspace_prepare_trusted_hooks_challenge(&repo_path)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "workspace_get_repo_config" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .workspace_get_repo_config(&repo_path)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "workspace_detect_github_repository" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .workspace_detect_github_repository(&repo_path)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "workspace_get_settings_snapshot" => {
+            let (git, chat, repos, global_prompt_overrides) = state
+                .service
+                .workspace_get_settings_snapshot()
+                .map_err(|e| format!("{e:#}"))?;
+            serialize_value(SettingsSnapshotResponsePayload {
+                git,
+                chat,
+                repos,
+                global_prompt_overrides,
+            })
+        }
+        "workspace_update_global_git_config" => {
+            let WorkspaceUpdateGlobalGitConfigArgs { git } = deserialize_args(args)?;
+            let service = state.service.clone();
+            run_service_blocking("workspace_update_global_git_config", move || {
+                service.workspace_update_global_git_config(git)
+            })
+            .await
+            .map_err(|e| format!("{e:#}"))?;
+            Ok(Value::Null)
+        }
+        "workspace_save_settings_snapshot" => {
+            let WorkspaceSaveSettingsSnapshotArgs { snapshot } = deserialize_args(args)?;
+            let service = state.service.clone();
+            let confirmation_port = HeadlessHookTrustConfirmationPort;
+            let SettingsSnapshotPayload {
+                git,
+                chat,
+                repos,
+                global_prompt_overrides,
+            } = snapshot;
+            serialize_value(
+                run_service_blocking("workspace_save_settings_snapshot", move || {
+                    service.workspace_save_settings_snapshot(
+                        git,
+                        chat,
+                        repos,
+                        global_prompt_overrides,
+                        &confirmation_port,
+                    )
+                })
+                .await
+                .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "workspace_set_trusted_hooks" => {
+            let WorkspaceSetTrustedHooksArgs {
+                repo_path,
+                trusted,
+                challenge_nonce,
+                challenge_fingerprint,
+            } = deserialize_args(args)?;
+            let service = state.service.clone();
+            let confirmation_port = HeadlessHookTrustConfirmationPort;
+            serialize_value(
+                run_service_blocking("workspace_set_trusted_hooks", move || {
+                    service.workspace_set_trusted_hooks(
+                        &repo_path,
+                        trusted,
+                        challenge_nonce.as_deref(),
+                        challenge_fingerprint.as_deref(),
+                        &confirmation_port,
+                    )
+                })
+                .await
+                .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_get_branches" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .git_get_branches(&repo_path)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_get_current_branch" => {
+            let GitCurrentBranchArgs {
+                repo_path,
+                working_dir,
+            } = deserialize_args(args)?;
+            state
+                .service
+                .ensure_repo_authorized(&repo_path)
+                .map_err(|e| e.to_string())?;
+            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+            serialize_value(
+                state
+                    .service
+                    .git_port()
+                    .get_current_branch(std::path::Path::new(&effective))
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_switch_branch" => {
+            let GitSwitchBranchArgs {
+                repo_path,
+                branch,
+                create,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .git_switch_branch(&repo_path, &branch, create.unwrap_or(false))
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_create_worktree" => {
+            let GitCreateWorktreeArgs {
+                repo_path,
+                worktree_path,
+                branch,
+                create_branch,
+            } = deserialize_args(args)?;
+            let summary = state
+                .service
+                .git_create_worktree(
+                    &repo_path,
+                    &worktree_path,
+                    &branch,
+                    create_branch.unwrap_or(false),
+                )
+                .map_err(|e| format!("{e:#}"))?;
+            invalidate_worktree_resolution_cache_for_repo(&repo_path).map_err(|e| e.to_string())?;
+            serialize_value(summary)
+        }
+        "git_remove_worktree" => {
+            let GitRemoveWorktreeArgs {
+                repo_path,
+                worktree_path,
+                force,
+            } = deserialize_args(args)?;
+            let removed = state
+                .service
+                .git_remove_worktree(&repo_path, &worktree_path, force.unwrap_or(false))
+                .map_err(|e| format!("{e:#}"))?;
+            invalidate_worktree_resolution_cache_for_repo(&repo_path).map_err(|e| e.to_string())?;
+            Ok(json!({ "ok": removed }))
+        }
+        "git_push_branch" => {
+            let GitPushBranchArgs {
+                repo_path,
+                branch,
+                working_dir,
+                remote,
+                set_upstream,
+                force_with_lease,
+            } = deserialize_args(args)?;
+            state
+                .service
+                .ensure_repo_authorized(&repo_path)
+                .map_err(|e| e.to_string())?;
+            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+            serialize_value(
+                state
+                    .service
+                    .git_push_branch(
+                        &repo_path,
+                        Some(effective.as_str()),
+                        remote.as_deref(),
+                        &branch,
+                        set_upstream.unwrap_or(false),
+                        force_with_lease.unwrap_or(false),
+                    )
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_get_status" => {
+            let GitStatusArgs {
+                repo_path,
+                working_dir,
+            } = deserialize_args(args)?;
+            state
+                .service
+                .ensure_repo_authorized(&repo_path)
+                .map_err(|e| e.to_string())?;
+            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+            serialize_value(
+                state
+                    .service
+                    .git_port()
+                    .get_status(std::path::Path::new(&effective))
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_get_diff" => {
+            let GitDiffArgs {
+                repo_path,
+                target_branch,
+                working_dir,
+            } = deserialize_args(args)?;
+            state
+                .service
+                .ensure_repo_authorized(&repo_path)
+                .map_err(|e| e.to_string())?;
+            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+            serialize_value(
+                state
+                    .service
+                    .git_port()
+                    .get_diff(std::path::Path::new(&effective), target_branch.as_deref())
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_commits_ahead_behind" => {
+            let GitAheadBehindArgs {
+                repo_path,
+                target_branch,
+                working_dir,
+            } = deserialize_args(args)?;
+            state
+                .service
+                .ensure_repo_authorized(&repo_path)
+                .map_err(|e| e.to_string())?;
+            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+            serialize_value(
+                state
+                    .service
+                    .git_port()
+                    .commits_ahead_behind(std::path::Path::new(&effective), &target_branch)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_get_worktree_status" => {
+            let GitWorktreeStatusArgs {
+                repo_path,
+                target_branch,
+                diff_scope,
+                working_dir,
+            } = deserialize_args(args)?;
+            let trimmed_target = require_target_branch(&target_branch)?;
+            let scope = parse_diff_scope(diff_scope.as_deref())?;
+            state
+                .service
+                .ensure_repo_authorized(&repo_path)
+                .map_err(|e| e.to_string())?;
+            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+            let repo = std::path::Path::new(&effective);
+            let worktree_status = state
+                .service
+                .git_port()
+                .get_worktree_status(repo, trimmed_target, scope.clone())
+                .map_err(|e| format!("{e:#}"))?;
+            let observed_at_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            let status_hash = hash_worktree_status_payload(
+                &worktree_status.current_branch,
+                worktree_status.file_statuses.as_slice(),
+                &worktree_status.target_ahead_behind,
+                &worktree_status.upstream_ahead_behind,
+            );
+            let diff_hash = hash_worktree_diff_payload(worktree_status.file_diffs.as_slice());
+            serialize_value(build_worktree_status_with_snapshot(
+                worktree_status,
+                WorktreeSnapshotMetadata {
+                    effective_working_dir: effective,
+                    target_branch: trimmed_target.to_string(),
+                    diff_scope: scope,
+                    observed_at_ms,
+                    hash_version: GIT_WORKTREE_HASH_VERSION,
+                    status_hash,
+                    diff_hash,
+                },
+            ))
+        }
+        "git_get_worktree_status_summary" => {
+            let GitWorktreeStatusArgs {
+                repo_path,
+                target_branch,
+                diff_scope,
+                working_dir,
+            } = deserialize_args(args)?;
+            let trimmed_target = require_target_branch(&target_branch)?;
+            let scope = parse_diff_scope(diff_scope.as_deref())?;
+            state
+                .service
+                .ensure_repo_authorized(&repo_path)
+                .map_err(|e| e.to_string())?;
+            let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+            let repo = std::path::Path::new(&effective);
+            let summary = state
+                .service
+                .git_port()
+                .get_worktree_status_summary(repo, trimmed_target, scope.clone())
+                .map_err(|e| format!("{e:#}"))?;
+            let observed_at_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            let status_hash = hash_worktree_status_payload(
+                &summary.current_branch,
+                summary.file_statuses.as_slice(),
+                &summary.target_ahead_behind,
+                &summary.upstream_ahead_behind,
+            );
+            let diff_hash = hash_worktree_diff_summary_payload(
+                &scope,
+                &summary.target_ahead_behind,
+                &summary.file_status_counts,
+            );
+            serialize_value(build_worktree_status_summary_with_snapshot(
+                summary.current_branch,
+                summary.file_status_counts,
+                summary.target_ahead_behind,
+                summary.upstream_ahead_behind,
+                WorktreeSnapshotMetadata {
+                    effective_working_dir: effective,
+                    target_branch: trimmed_target.to_string(),
+                    diff_scope: scope,
+                    observed_at_ms,
+                    hash_version: GIT_WORKTREE_HASH_VERSION,
+                    status_hash,
+                    diff_hash,
+                },
+            ))
+        }
+        "git_commit_all" => {
+            #[derive(Debug, Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            struct GitCommitAllArgs {
+                repo_path: String,
+                working_dir: Option<String>,
+                message: String,
+            }
+            let request: GitCommitAllArgs = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .git_commit_all(
+                        &request.repo_path,
+                        host_domain::GitCommitAllRequest {
+                            working_dir: request.working_dir,
+                            message: request.message,
+                        },
+                    )
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_pull_branch" => {
+            let request: GitPullBranchArgs = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .git_pull_branch(
+                        &request.repo_path,
+                        host_domain::GitPullRequest {
+                            working_dir: request.working_dir,
+                        },
+                    )
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_rebase_branch" => {
+            #[derive(Debug, Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            struct GitRebaseBranchArgs {
+                repo_path: String,
+                target_branch: String,
+                working_dir: Option<String>,
+            }
+            let request: GitRebaseBranchArgs = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .git_rebase_branch(
+                        &request.repo_path,
+                        host_domain::GitRebaseBranchRequest {
+                            working_dir: request.working_dir,
+                            target_branch: request.target_branch,
+                        },
+                    )
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "git_rebase_abort" => {
+            let request: GitRebaseAbortArgs = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .git_rebase_abort(
+                        &request.repo_path,
+                        host_domain::GitRebaseAbortRequest {
+                            working_dir: request.working_dir,
+                        },
+                    )
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "tasks_list" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            serialize_value(state.service.tasks_list(&repo_path).map_err(|e| format!("{e:#}"))?)
+        }
+        "task_create" => {
+            let TaskCreateArgs { repo_path, input } = deserialize_args(args)?;
+            let create = map_task_create_payload(input)?;
+            serialize_value(state.service.task_create(&repo_path, create).map_err(|e| format!("{e:#}"))?)
+        }
+        "task_update" => {
+            let TaskUpdateArgs {
+                repo_path,
+                task_id,
+                patch,
+            } = deserialize_args(args)?;
+            let mapped = map_task_update_payload(patch)?;
+            serialize_value(
+                state
+                    .service
+                    .task_update(&repo_path, &task_id, mapped)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "task_delete" => {
+            let TaskDeleteArgs {
+                repo_path,
+                task_id,
+                delete_subtasks,
+            } = deserialize_args(args)?;
+            let ok = state
+                .service
+                .task_delete(&repo_path, &task_id, delete_subtasks.unwrap_or(false))
+                .map(|()| true)
+                .map_err(|e| format!("{e:#}"))?;
+            Ok(json!({ "ok": ok }))
+        }
+        "task_transition" => {
+            let TaskTransitionArgs {
+                repo_path,
+                task_id,
+                status,
+                reason,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .task_transition(&repo_path, &task_id, status, reason.as_deref())
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "task_defer" => {
+            let RepoTaskReasonArgs {
+                repo_path,
+                task_id,
+                reason,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .task_defer(&repo_path, &task_id, reason.as_deref())
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "task_resume_deferred" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .task_resume_deferred(&repo_path, &task_id)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "spec_get" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(state.service.spec_get(&repo_path, &task_id).map_err(|e| format!("{e:#}"))?)
+        }
+        "task_metadata_get" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .task_metadata_get(&repo_path, &task_id)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "set_spec" => {
+            let SetSpecArgs {
+                repo_path,
+                task_id,
+                markdown,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .set_spec(&repo_path, &task_id, &markdown)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "spec_save_document" => {
+            let SetSpecArgs {
+                repo_path,
+                task_id,
+                markdown,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .save_spec_document(&repo_path, &task_id, &markdown)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "plan_get" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(state.service.plan_get(&repo_path, &task_id).map_err(|e| format!("{e:#}"))?)
+        }
+        "set_plan" => {
+            let SetPlanArgs {
+                repo_path,
+                task_id,
+                input,
+            } = deserialize_args(args)?;
+            let mapped_subtasks = map_plan_subtasks(input.subtasks)?;
+            serialize_value(
+                state
+                    .service
+                    .set_plan(&repo_path, &task_id, &input.markdown, mapped_subtasks)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "plan_save_document" => {
+            let SetSpecArgs {
+                repo_path,
+                task_id,
+                markdown,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .save_plan_document(&repo_path, &task_id, &markdown)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "qa_get_report" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .qa_get_report(&repo_path, &task_id)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "qa_approved" => {
+            let MarkdownInputArgs {
+                repo_path,
+                task_id,
+                input,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .qa_approved(&repo_path, &task_id, &input.markdown)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "qa_rejected" => {
+            let MarkdownInputArgs {
+                repo_path,
+                task_id,
+                input,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .qa_rejected(&repo_path, &task_id, &input.markdown)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "build_start" => {
+            let BuildStartArgs {
+                repo_path,
+                task_id,
+                runtime_kind,
+            } = deserialize_args(args)?;
+            let service = state.service.clone();
+            let emitter = make_emitter(state.events.clone());
+            serialize_value(
+                run_service_blocking("build_start", move || {
+                    service.build_start(&repo_path, &task_id, runtime_kind.as_str(), emitter)
+                })
+                .await
+                .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "build_respond" => {
+            let BuildRespondArgs {
+                run_id,
+                action,
+                payload,
+            } = deserialize_args(args)?;
+            Ok(json!({
+                "ok": state
+                    .service
+                    .build_respond(&run_id, action, payload.as_deref(), make_emitter(state.events.clone()))
+                    .map_err(|e| format!("{e:#}"))?
+            }))
+        }
+        "build_stop" => {
+            let BuildStopArgs { run_id } = deserialize_args(args)?;
+            Ok(json!({
+                "ok": state
+                    .service
+                    .build_stop(&run_id, make_emitter(state.events.clone()))
+                    .map_err(|e| format!("{e:#}"))?
+            }))
+        }
+        "build_cleanup" => {
+            let BuildCleanupArgs { run_id, mode } = deserialize_args(args)?;
+            Ok(json!({
+                "ok": state
+                    .service
+                    .build_cleanup(&run_id, mode, make_emitter(state.events.clone()))
+                    .map_err(|e| format!("{e:#}"))?
+            }))
+        }
+        "build_blocked" => {
+            let RepoTaskReasonArgs {
+                repo_path,
+                task_id,
+                reason,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .build_blocked(&repo_path, &task_id, reason.as_deref())
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "build_resumed" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .build_resumed(&repo_path, &task_id)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "build_completed" => {
+            let BuildCompletedArgs {
+                repo_path,
+                task_id,
+                input,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .build_completed(
+                        &repo_path,
+                        &task_id,
+                        input.as_ref().and_then(|entry| entry.summary.as_deref()),
+                    )
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "task_approval_context_get" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .task_approval_context_get(&repo_path, &task_id)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "task_direct_merge" => {
+            let TaskDirectMergeArgs {
+                repo_path,
+                task_id,
+                merge_method,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .task_direct_merge(&repo_path, &task_id, merge_method)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "task_pull_request_upsert" => {
+            let TaskPullRequestUpsertArgs {
+                repo_path,
+                task_id,
+                input,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .task_pull_request_upsert(&repo_path, &task_id, &input.title, &input.body)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "task_pull_request_unlink" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            Ok(json!({
+                "ok": state
+                    .service
+                    .task_pull_request_unlink(&repo_path, &task_id)
+                    .map_err(|e| format!("{e:#}"))?
+            }))
+        }
+        "task_pull_request_detect" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .task_pull_request_detect(&repo_path, &task_id)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "repo_pull_request_sync" => {
+            let RepoPathArgs { repo_path } = deserialize_args(args)?;
+            Ok(json!({
+                "ok": state
+                    .service
+                    .repo_pull_request_sync(&repo_path)
+                    .map_err(|e| format!("{e:#}"))?
+            }))
+        }
+        "human_request_changes" => {
+            let HumanRequestChangesArgs {
+                repo_path,
+                task_id,
+                note,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .human_request_changes(&repo_path, &task_id, note.as_deref())
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "human_approve" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .human_approve(&repo_path, &task_id)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "runs_list" => {
+            let OptionalRepoPathArgs { repo_path } = deserialize_args(args)?;
+            serialize_value(state.service.runs_list(repo_path.as_deref()).map_err(|e| format!("{e:#}"))?)
+        }
+        "runtime_definitions_list" => {
+            serialize_value(state.service.runtime_definitions_list().map_err(|e| format!("{e:#}"))?)
+        }
+        "runtime_list" => {
+            let RuntimeListArgs {
+                runtime_kind,
+                repo_path,
+            } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .runtime_list(&runtime_kind, repo_path.as_deref())
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "qa_review_target_get" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            let service = state.service.clone();
+            serialize_value(
+                run_service_blocking("qa_review_target_get", move || {
+                    service.qa_review_target_get(&repo_path, &task_id)
+                })
+                .await
+                .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "runtime_stop" => {
+            let RuntimeStopArgs { runtime_id } = deserialize_args(args)?;
+            Ok(json!({
+                "ok": state
+                    .service
+                    .runtime_stop(&runtime_id)
+                    .map_err(|e| format!("{e:#}"))?
+            }))
+        }
+        "runtime_ensure" => {
+            let RuntimeEnsureArgs {
+                runtime_kind,
+                repo_path,
+            } = deserialize_args(args)?;
+            let service = state.service.clone();
+            serialize_value(
+                run_service_blocking("runtime_ensure", move || {
+                    service.runtime_ensure(&runtime_kind, &repo_path)
+                })
+                .await
+                .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "agent_sessions_list" => {
+            let RepoTaskArgs { repo_path, task_id } = deserialize_args(args)?;
+            serialize_value(
+                state
+                    .service
+                    .agent_sessions_list(&repo_path, &task_id)
+                    .map_err(|e| format!("{e:#}"))?,
+            )
+        }
+        "agent_session_upsert" => {
+            let AgentSessionUpsertArgs {
+                repo_path,
+                task_id,
+                session,
+            } = deserialize_args(args)?;
+            Ok(json!({
+                "ok": state
+                    .service
+                    .agent_session_upsert(&repo_path, &task_id, session)
+                    .map_err(|e| format!("{e:#}"))?
+            }))
+        }
+        "get_theme" => serialize_value(state.service.get_theme().map_err(|e| format!("{e:#}"))?),
+        "set_theme" => {
+            #[derive(Debug, Deserialize)]
+            #[serde(rename_all = "camelCase")]
+            struct ThemeArgs {
+                theme: String,
+            }
+            let ThemeArgs { theme } = deserialize_args(args)?;
+            state.service.set_theme(&theme).map_err(|e| format!("{e:#}"))?;
+            Ok(Value::Null)
+        }
+        unknown => Err(format!("Unsupported browser backend command: {unknown}")),
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -178,6 +178,19 @@ where
         .map_err(|error| anyhow!("{operation_name} worker join failure: {error}"))?
 }
 
+pub(crate) async fn run_service_blocking_tokio<T, F>(
+    operation_name: &'static str,
+    operation: F,
+) -> anyhow::Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> anyhow::Result<T> + Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|error| anyhow!("{operation_name} worker join failure: {error}"))?
+}
+
 fn validate_startup_config(
     config_store: &AppConfigStore,
     runtime_config_store: &RuntimeConfigStore,
@@ -490,6 +503,26 @@ mod tests {
         ));
         let error = result.expect_err("panic in worker should map to join failure");
         assert!(error.to_string().contains("test-join worker join failure"));
+    }
+
+    #[tokio::test]
+    async fn run_service_blocking_tokio_propagates_operation_error() {
+        let result = run_service_blocking_tokio("tokio-test-op", || -> anyhow::Result<()> {
+            Err(anyhow!("service failure"))
+        })
+        .await;
+        let error = result.expect_err("service error should propagate");
+        assert!(error.to_string().contains("service failure"));
+    }
+
+    #[tokio::test]
+    async fn run_service_blocking_tokio_maps_join_failures() {
+        let result = run_service_blocking_tokio("tokio-test-join", || -> anyhow::Result<()> {
+            panic!("simulated join panic")
+        })
+        .await;
+        let error = result.expect_err("panic in worker should map to join failure");
+        assert!(error.to_string().contains("tokio-test-join worker join failure"));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ use std::time::SystemTime;
 use tauri::{AppHandle, Emitter, RunEvent as TauriRunEvent};
 
 mod commands;
+mod headless;
 
 use commands::agent_sessions::*;
 use commands::build::*;
@@ -26,14 +27,14 @@ use commands::system::*;
 use commands::tasks::*;
 use commands::workspace::*;
 
-struct AppState {
+pub(crate) struct AppState {
     service: Arc<AppService>,
     #[cfg(test)]
     hook_trust_dialog_test_response: Mutex<Option<bool>>,
 }
 static TRACING_INITIALIZED: OnceLock<()> = OnceLock::new();
 
-fn init_tracing_subscriber() {
+pub(crate) fn init_tracing_subscriber() {
     TRACING_INITIALIZED.get_or_init(|| {
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
@@ -54,7 +55,7 @@ fn init_tracing_subscriber() {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct TaskCreatePayload {
+pub(crate) struct TaskCreatePayload {
     title: String,
     issue_type: String,
     priority: i32,
@@ -67,7 +68,7 @@ struct TaskCreatePayload {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct TaskUpdatePayload {
+pub(crate) struct TaskUpdatePayload {
     title: Option<String>,
     description: Option<String>,
     acceptance_criteria: Option<String>,
@@ -81,20 +82,20 @@ struct TaskUpdatePayload {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct MarkdownPayload {
+pub(crate) struct MarkdownPayload {
     markdown: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct PlanPayload {
+pub(crate) struct PlanPayload {
     markdown: String,
     subtasks: Option<Vec<PlanSubtaskPayload>>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct PlanSubtaskPayload {
+pub(crate) struct PlanSubtaskPayload {
     title: String,
     issue_type: Option<String>,
     priority: Option<i32>,
@@ -103,20 +104,20 @@ struct PlanSubtaskPayload {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct BuildCompletePayload {
+pub(crate) struct BuildCompletePayload {
     summary: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct PullRequestContentPayload {
+pub(crate) struct PullRequestContentPayload {
     title: String,
     body: String,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct RepoConfigPayload {
+pub(crate) struct RepoConfigPayload {
     default_runtime_kind: Option<String>,
     worktree_base_path: Option<String>,
     branch_prefix: Option<String>,
@@ -129,7 +130,7 @@ struct RepoConfigPayload {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct RepoSettingsPayload {
+pub(crate) struct RepoSettingsPayload {
     default_runtime_kind: Option<String>,
     worktree_base_path: Option<String>,
     branch_prefix: Option<String>,
@@ -144,7 +145,7 @@ struct RepoSettingsPayload {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct SettingsSnapshotPayload {
+pub(crate) struct SettingsSnapshotPayload {
     git: host_infra_system::GlobalGitConfig,
     chat: host_infra_system::ChatSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
@@ -153,18 +154,21 @@ struct SettingsSnapshotPayload {
 
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-struct SettingsSnapshotResponsePayload {
+pub(crate) struct SettingsSnapshotResponsePayload {
     git: host_infra_system::GlobalGitConfig,
     chat: host_infra_system::ChatSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
     global_prompt_overrides: host_infra_system::PromptOverrides,
 }
 
-fn as_error<T>(result: anyhow::Result<T>) -> Result<T, String> {
+pub(crate) fn as_error<T>(result: anyhow::Result<T>) -> Result<T, String> {
     result.map_err(|error| format!("{error:#}"))
 }
 
-async fn run_service_blocking<T, F>(operation_name: &'static str, operation: F) -> anyhow::Result<T>
+pub(crate) async fn run_service_blocking<T, F>(
+    operation_name: &'static str,
+    operation: F,
+) -> anyhow::Result<T>
 where
     T: Send + 'static,
     F: FnOnce() -> anyhow::Result<T> + Send + 'static,
@@ -192,17 +196,17 @@ fn validate_startup_config(
     })?;
     Ok(())
 }
-fn run_emitter(app: AppHandle) -> RunEmitter {
+pub(crate) fn run_emitter(app: AppHandle) -> RunEmitter {
     Arc::new(move |event: RunEvent| {
         let _ = app.emit("openducktor://run-event", event);
     })
 }
 
-fn startup_phase_tracing() {
+pub(crate) fn startup_phase_tracing() {
     init_tracing_subscriber();
 }
 
-fn startup_phase_service_bootstrap() -> anyhow::Result<Arc<AppService>> {
+pub(crate) fn startup_phase_service_bootstrap() -> anyhow::Result<Arc<AppService>> {
     let config_store = AppConfigStore::new().context("failed to initialize config store")?;
     let runtime_config_store = RuntimeConfigStore::from_user_settings_store(&config_store);
     validate_startup_config(&config_store, &runtime_config_store)?;
@@ -233,7 +237,7 @@ fn install_shutdown_signal_handler(service: Arc<AppService>) {
     }
 }
 
-fn startup_phase_shutdown_hooks(service: Arc<AppService>) {
+pub(crate) fn startup_phase_shutdown_hooks(service: Arc<AppService>) {
     install_shutdown_signal_handler(service);
 }
 
@@ -356,6 +360,10 @@ pub fn run() -> anyhow::Result<()> {
     startup_phase_build_tauri_app(service)?.run(startup_phase_exit_shutdown_handler(app_service));
 
     Ok(())
+}
+
+pub async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
+    headless::run_browser_backend(port).await
 }
 
 #[cfg(test)]

--- a/apps/desktop/src/lib/browser-live-client.ts
+++ b/apps/desktop/src/lib/browser-live-client.ts
@@ -1,0 +1,64 @@
+import { createTauriHostClient, type TauriHostClient } from "@openducktor/adapters-tauri-host";
+import { getBrowserBackendUrl } from "@/lib/browser-mode";
+
+const toErrorMessage = async (response: Response): Promise<string> => {
+  try {
+    const payload = (await response.json()) as { error?: unknown };
+    if (typeof payload.error === "string" && payload.error.trim()) {
+      return payload.error;
+    }
+  } catch {}
+
+  const text = await response.text().catch(() => "");
+  if (text.trim()) {
+    return text.trim();
+  }
+
+  return `Browser backend request failed with status ${response.status}.`;
+};
+
+const createHttpInvoke = () => {
+  const baseUrl = getBrowserBackendUrl().replace(/\/$/, "");
+
+  return async <T>(command: string, args?: Record<string, unknown>): Promise<T> => {
+    const response = await fetch(`${baseUrl}/invoke/${command}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(args ?? {}),
+    });
+
+    if (!response.ok) {
+      throw new Error(await toErrorMessage(response));
+    }
+
+    return (await response.json()) as T;
+  };
+};
+
+export const createBrowserLiveHostClient = (): TauriHostClient => {
+  return createTauriHostClient(createHttpInvoke());
+};
+
+export const subscribeBrowserLiveRunEvents = async (
+  listener: (payload: unknown) => void,
+): Promise<() => void> => {
+  const baseUrl = getBrowserBackendUrl().replace(/\/$/, "");
+  const eventSource = new EventSource(`${baseUrl}/events`);
+
+  const handleMessage = (event: MessageEvent<string>): void => {
+    try {
+      listener(JSON.parse(event.data));
+    } catch {
+      listener(event.data);
+    }
+  };
+
+  eventSource.addEventListener("message", handleMessage as EventListener);
+
+  return () => {
+    eventSource.removeEventListener("message", handleMessage as EventListener);
+    eventSource.close();
+  };
+};

--- a/apps/desktop/src/lib/browser-mode.ts
+++ b/apps/desktop/src/lib/browser-mode.ts
@@ -1,0 +1,12 @@
+const browserEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env;
+
+export const BROWSER_APP_MODE = "browser";
+const DEFAULT_BROWSER_BACKEND_URL = "http://127.0.0.1:14327";
+
+export const isBrowserAppMode = (): boolean => {
+  return browserEnv?.VITE_ODT_APP_MODE === BROWSER_APP_MODE;
+};
+
+export const getBrowserBackendUrl = (): string => {
+  return browserEnv?.VITE_ODT_BROWSER_BACKEND_URL?.trim() || DEFAULT_BROWSER_BACKEND_URL;
+};

--- a/apps/desktop/src/lib/host-client.ts
+++ b/apps/desktop/src/lib/host-client.ts
@@ -1,4 +1,9 @@
 import { createTauriHostClient, type TauriHostClient } from "@openducktor/adapters-tauri-host";
+import {
+  createBrowserLiveHostClient,
+  subscribeBrowserLiveRunEvents,
+} from "@/lib/browser-live-client";
+import { isBrowserAppMode } from "@/lib/browser-mode";
 import { isTauriRuntime } from "@/lib/runtime";
 
 let tauriCoreModulePromise: Promise<typeof import("@tauri-apps/api/core")> | null = null;
@@ -16,6 +21,9 @@ const notAvailable = async <T>(): Promise<T> => {
 
 export const createHostClient = (): TauriHostClient => {
   if (!isTauriRuntime()) {
+    if (isBrowserAppMode()) {
+      return createBrowserLiveHostClient();
+    }
     return createTauriHostClient(notAvailable);
   }
 
@@ -28,6 +36,10 @@ export const createHostClient = (): TauriHostClient => {
 export const subscribeRunEvents = async (
   listener: (payload: unknown) => void,
 ): Promise<() => void> => {
+  if (isBrowserAppMode()) {
+    return subscribeBrowserLiveRunEvents(listener);
+  }
+
   if (!isTauriRuntime()) {
     return () => {};
   }

--- a/apps/desktop/src/lib/repo-directory.ts
+++ b/apps/desktop/src/lib/repo-directory.ts
@@ -1,4 +1,5 @@
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { isBrowserAppMode } from "@/lib/browser-mode";
 import { assertTauriRuntime } from "@/lib/runtime";
 
 const DIRECTORY_PICKER_TITLE = "Select Repository";
@@ -26,6 +27,14 @@ const openTauriDirectoryPicker = async (): Promise<DirectorySelection> => {
 };
 
 export const pickRepositoryDirectory = async (): Promise<string | null> => {
+  if (isBrowserAppMode()) {
+    if (typeof window === "undefined") {
+      throw new Error("Browser mode directory picker requires a window environment.");
+    }
+    const value = window.prompt("Repository path");
+    return value?.trim() ? value.trim() : null;
+  }
+
   assertTauriRuntime("Directory picker");
 
   const selected = await openTauriDirectoryPicker();

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "dev": "bun run --filter @openducktor/desktop dev",
+    "browser:dev": "bun run scripts/browser-dev.ts",
     "tauri": "cd apps/desktop && bun run tauri",
     "tauri:dev": "cd apps/desktop && bun run tauri:dev",
     "tauri:build": "cd apps/desktop && bun run tauri:build",

--- a/scripts/browser-dev.ts
+++ b/scripts/browser-dev.ts
@@ -1,0 +1,73 @@
+const repoRoot = "/Users/20017260/projects/perso/openducktor";
+const backendPort = process.env.ODT_BROWSER_BACKEND_PORT ?? "14327";
+const backendUrl = `http://127.0.0.1:${backendPort}`;
+
+const backendProcess = Bun.spawn({
+  cmd: ["cargo", "run", "--bin", "browser_backend"],
+  cwd: `${repoRoot}/apps/desktop/src-tauri`,
+  env: {
+    ...process.env,
+    ODT_BROWSER_BACKEND_PORT: backendPort,
+  },
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+let frontendProcess: Bun.Subprocess | null = null;
+
+const stopChildren = () => {
+  backendProcess.kill();
+  frontendProcess?.kill();
+};
+
+process.on("SIGINT", () => {
+  stopChildren();
+  process.exit(130);
+});
+
+process.on("SIGTERM", () => {
+  stopChildren();
+  process.exit(143);
+});
+
+const waitForBackend = async (): Promise<void> => {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 60_000) {
+    try {
+      const response = await fetch(`${backendUrl}/health`);
+      if (response.ok) {
+        return;
+      }
+    } catch {}
+
+    await Bun.sleep(500);
+  }
+
+  throw new Error(`Timed out waiting for browser backend at ${backendUrl}.`);
+};
+
+try {
+  await waitForBackend();
+
+  frontendProcess = Bun.spawn({
+    cmd: ["bun", "run", "--filter", "@openducktor/desktop", "dev:browser"],
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      VITE_ODT_BROWSER_BACKEND_URL: backendUrl,
+    },
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+
+  const [backendExitCode, frontendExitCode] = await Promise.all([
+    backendProcess.exited,
+    frontendProcess.exited,
+  ]);
+
+  process.exit(frontendExitCode || backendExitCode);
+} catch (error) {
+  stopChildren();
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}

--- a/scripts/browser-dev.ts
+++ b/scripts/browser-dev.ts
@@ -1,4 +1,6 @@
-const repoRoot = "/Users/20017260/projects/perso/openducktor";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "..");
 const backendPort = process.env.ODT_BROWSER_BACKEND_PORT ?? "14327";
 const backendUrl = `http://127.0.0.1:${backendPort}`;
 
@@ -14,8 +16,13 @@ const backendProcess = Bun.spawn({
 });
 
 let frontendProcess: Bun.Subprocess | null = null;
+let stoppingChildren = false;
 
 const stopChildren = () => {
+  if (stoppingChildren) {
+    return;
+  }
+  stoppingChildren = true;
   backendProcess.kill();
   frontendProcess?.kill();
 };
@@ -47,7 +54,12 @@ const waitForBackend = async (): Promise<void> => {
 };
 
 try {
-  await waitForBackend();
+  await Promise.race([
+    waitForBackend(),
+    backendProcess.exited.then((exitCode) => {
+      throw new Error(`Browser backend exited before startup completed with code ${exitCode}.`);
+    }),
+  ]);
 
   frontendProcess = Bun.spawn({
     cmd: ["bun", "run", "--filter", "@openducktor/desktop", "dev:browser"],
@@ -60,12 +72,26 @@ try {
     stderr: "inherit",
   });
 
-  const [backendExitCode, frontendExitCode] = await Promise.all([
-    backendProcess.exited,
-    frontendProcess.exited,
+  const firstExit = await Promise.race([
+    backendProcess.exited.then((exitCode) => ({
+      exitCode,
+      processName: "backend" as const,
+    })),
+    frontendProcess.exited.then((exitCode) => ({
+      exitCode,
+      processName: "frontend" as const,
+    })),
   ]);
 
-  process.exit(frontendExitCode || backendExitCode);
+  stopChildren();
+
+  if (firstExit.processName === "backend") {
+    await frontendProcess.exited;
+  } else {
+    await backendProcess.exited;
+  }
+
+  process.exit(firstExit.exitCode);
 } catch (error) {
   stopChildren();
   console.error(error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
## Summary
- add a headless Rust browser backend so `bun run browser:dev` can run the real OpenDucktor backend without the Tauri window
- route the browser frontend through the live HTTP/SSE bridge and update browser repo-picking behavior
- document in `AGENTS.md` that agents should use `agent-browser` for browser-mode validation and should not start `bun run browser:dev` themselves
- address PR review feedback by making the launcher portable, using a headless-safe blocking runtime, splitting the browser command bridge into grouped handlers, improving HTTP error semantics, and adding replayable SSE event ids

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `cd apps/desktop/src-tauri && cargo check`
- `cd apps/desktop/src-tauri && cargo test`
