### PR TITLE
fix: return task descriptions from odt_read_task

### DIFF
--- a/packages/openducktor-mcp/src/contracts.ts
+++ b/packages/openducktor-mcp/src/contracts.ts
@@ -9,12 +9,9 @@ export type PlanSubtaskInput = {
   description?: string | undefined;
 };
 
-export type TaskCard = Omit<
-  Pick<
-    CanonicalTaskCard,
-    "id" | "title" | "description" | "status" | "issueType" | "aiReviewEnabled"
-  >,
-  "description"
+export type TaskCard = Pick<
+  CanonicalTaskCard,
+  "id" | "title" | "status" | "issueType" | "aiReviewEnabled"
 > & {
   description?: CanonicalTaskCard["description"];
   parentId?: string;

--- a/packages/openducktor-mcp/src/contracts.ts
+++ b/packages/openducktor-mcp/src/contracts.ts
@@ -9,16 +9,21 @@ export type PlanSubtaskInput = {
   description?: string | undefined;
 };
 
-export type TaskCard = Pick<
-  CanonicalTaskCard,
-  "id" | "title" | "status" | "issueType" | "aiReviewEnabled"
+export type TaskCard = Omit<
+  Pick<
+    CanonicalTaskCard,
+    "id" | "title" | "description" | "status" | "issueType" | "aiReviewEnabled"
+  >,
+  "description"
 > & {
+  description?: CanonicalTaskCard["description"];
   parentId?: string;
 };
 
 export type RawIssue = {
   id: string;
   title: string;
+  description?: string;
   status: unknown;
   issue_type?: unknown;
   parent?: string | null;

--- a/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
@@ -7,6 +7,7 @@ import type { TaskDocumentPort } from "./task-document-store";
 const makeTask = (): TaskCard => ({
   id: "task-1",
   title: "Task 1",
+  description: "",
   status: "open",
   issueType: "feature",
   aiReviewEnabled: true,
@@ -17,6 +18,7 @@ describe("OdtTaskStore composition", () => {
     const issue: RawIssue = {
       id: "task-1",
       title: "Task 1",
+      description: "Read the task description from Beads.",
       status: "open",
       issue_type: "feature",
       metadata: {
@@ -79,6 +81,7 @@ describe("OdtTaskStore composition", () => {
     };
 
     expect(result.task.aiReviewEnabled).toBe(false);
+    expect(result.task.description).toBe("Read the task description from Beads.");
     expect(result.documents.spec.markdown).toBe("spec");
   });
 

--- a/packages/openducktor-mcp/src/task-mapping.test.ts
+++ b/packages/openducktor-mcp/src/task-mapping.test.ts
@@ -29,6 +29,25 @@ describe("task mapping entry parsers", () => {
     );
   });
 
+  test("issueToTaskCard preserves task descriptions from Beads issues", () => {
+    const issue: RawIssue = {
+      id: "task-7",
+      title: "Read task description",
+      description: "Return the task description to MCP clients.",
+      status: "open",
+      issue_type: "task",
+    };
+
+    expect(issueToTaskCard(issue, "openducktor")).toMatchObject({
+      id: "task-7",
+      title: "Read task description",
+      description: "Return the task description to MCP clients.",
+      status: "open",
+      issueType: "task",
+      aiReviewEnabled: true,
+    });
+  });
+
   test("parseMarkdownEntries returns only valid markdown metadata entries", () => {
     const parsed = parseMarkdownEntries([
       {

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -103,6 +103,7 @@ export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): Tas
   return {
     id: issue.id,
     title: issue.title,
+    ...(typeof issue.description === "string" ? { description: issue.description } : {}),
     status: parseBeadsTaskStatus(issue.id, issue.status),
     issueType,
     aiReviewEnabled: qaRequired,


### PR DESCRIPTION
## Summary
- thread Beads issue descriptions through the MCP task contracts and `issueToTaskCard` mapper
- keep the MCP-side task type aligned with the optional description shape returned by `odt_read_task`
- add regression coverage for description mapping and `readTask` composition

## Testing
- bun run --filter @openducktor/openducktor-mcp test
- bun run --filter @openducktor/openducktor-mcp typecheck