### PR TITLE
fix(desktop): harden browser diff rendering and layout

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -238,7 +238,10 @@ impl GitCliPort {
     }
 
     pub(super) fn get_status_unchecked(&self, repo_path: &Path) -> Result<Vec<GitFileStatus>> {
-        let output = self.run_git(repo_path, &["status", "--porcelain=v1"])?;
+        let output = self.run_git(
+            repo_path,
+            &["status", "--porcelain=v1", "--untracked-files=all"],
+        )?;
         Ok(parse_status_porcelain(&output))
     }
 
@@ -491,20 +494,73 @@ fn build_untracked_file_diffs(
     existing_files: &HashSet<String>,
 ) -> Result<Vec<GitFileDiff>> {
     let mut results = Vec::new();
+    let mut seen_files = existing_files.clone();
 
     for status in file_statuses {
-        if status.status != "untracked" || existing_files.contains(&status.path) {
+        if status.status != "untracked" {
             continue;
         }
 
-        results.push(build_untracked_file_diff(
-            git,
-            repo_path,
-            status.path.as_str(),
-        )?);
+        for file_path in expand_untracked_status_paths(git, repo_path, status.path.as_str())? {
+            if seen_files.contains(&file_path) {
+                continue;
+            }
+
+            results.push(build_untracked_file_diff(
+                git,
+                repo_path,
+                file_path.as_str(),
+            )?);
+            seen_files.insert(file_path);
+        }
     }
 
     Ok(results)
+}
+
+fn expand_untracked_status_paths(
+    git: &GitCliPort,
+    repo_path: &Path,
+    status_path: &str,
+) -> Result<Vec<String>> {
+    let trimmed_path = status_path.trim();
+    if trimmed_path.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    if !repo_path.join(trimmed_path).is_dir() {
+        return Ok(vec![trimmed_path.to_string()]);
+    }
+
+    let args = [
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "--",
+        trimmed_path,
+    ];
+    let (ok, stdout, stderr) = git.run_git_allow_failure(repo_path, &args)?;
+    if !ok {
+        return Err(anyhow!(
+            "git ls-files --others --exclude-standard -- {trimmed_path} failed: {}",
+            combine_output(stdout, stderr)
+        ));
+    }
+
+    let file_paths = stdout
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+
+    if file_paths.is_empty() {
+        return Err(anyhow!(
+            "git ls-files --others --exclude-standard -- {trimmed_path} returned no files"
+        ));
+    }
+
+    Ok(file_paths)
 }
 
 fn build_untracked_file_diff(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -3,7 +3,7 @@ use host_domain::{
     GitAheadBehind, GitDiffScope, GitFileDiff, GitFileStatus, GitFileStatusCounts,
     GitUpstreamAheadBehind, GitWorktreeStatusData, GitWorktreeStatusSummaryData,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use super::util::{combine_output, normalize_non_empty};
@@ -49,7 +49,8 @@ impl GitCliPort {
         target_branch: Option<&str>,
     ) -> Result<Vec<GitFileDiff>> {
         self.ensure_repository(repo_path)?;
-        self.get_diff_unchecked(repo_path, target_branch)
+        let file_statuses = self.get_status_unchecked(repo_path)?;
+        self.get_diff_unchecked(repo_path, target_branch, file_statuses.as_slice())
     }
 
     pub(super) fn commits_ahead_behind_impl(
@@ -88,10 +89,10 @@ impl GitCliPort {
                     rayon::join(
                         || self.get_status_unchecked(repo_path),
                         || match diff_scope {
-                            GitDiffScope::Target if effective_target_branch.is_none() => {
-                                Ok(Vec::new())
-                            }
-                            _ => self.get_diff_unchecked(repo_path, diff_target),
+                            GitDiffScope::Target if effective_target_branch.is_none() => Ok(None),
+                            _ => self
+                                .load_diff_payload_unchecked(repo_path, diff_target)
+                                .map(Some),
                         },
                     )
                 },
@@ -116,9 +117,20 @@ impl GitCliPort {
             )
         })?;
 
-        let ((file_statuses, file_diffs), (target_ahead_behind, upstream_target_result)) = joined;
+        let ((file_statuses, raw_diff_payload), (target_ahead_behind, upstream_target_result)) =
+            joined;
         let file_statuses = file_statuses?;
-        let file_diffs = file_diffs?;
+        let raw_diff_payload = raw_diff_payload?;
+        let file_diffs = match raw_diff_payload {
+            Some((numstat_stdout, diff_stdout)) => build_file_diffs(
+                self,
+                repo_path,
+                file_statuses.as_slice(),
+                &numstat_stdout,
+                &diff_stdout,
+            )?,
+            None => Vec::new(),
+        };
         let target_ahead_behind = target_ahead_behind?;
 
         let upstream_ahead_behind = match upstream_target_result {
@@ -234,7 +246,25 @@ impl GitCliPort {
         &self,
         repo_path: &Path,
         target_branch: Option<&str>,
+        file_statuses: &[GitFileStatus],
     ) -> Result<Vec<GitFileDiff>> {
+        let (numstat_stdout, diff_stdout) =
+            self.load_diff_payload_unchecked(repo_path, target_branch)?;
+
+        build_file_diffs(
+            self,
+            repo_path,
+            file_statuses,
+            &numstat_stdout,
+            &diff_stdout,
+        )
+    }
+
+    fn load_diff_payload_unchecked(
+        &self,
+        repo_path: &Path,
+        target_branch: Option<&str>,
+    ) -> Result<(String, String)> {
         let diff_spec = target_branch
             .map(|value| value.trim().to_string())
             .unwrap_or_default();
@@ -264,7 +294,7 @@ impl GitCliPort {
             ));
         }
 
-        Ok(build_file_diffs(&numstat_stdout, &diff_stdout))
+        Ok((numstat_stdout, diff_stdout))
     }
 
     pub(super) fn commits_ahead_behind_unchecked(
@@ -347,7 +377,13 @@ fn porcelain_char_to_status(ch: char) -> String {
     .to_string()
 }
 
-fn build_file_diffs(numstat: &str, full_diff: &str) -> Vec<GitFileDiff> {
+fn build_file_diffs(
+    git: &GitCliPort,
+    repo_path: &Path,
+    file_statuses: &[GitFileStatus],
+    numstat: &str,
+    full_diff: &str,
+) -> Result<Vec<GitFileDiff>> {
     let stats: HashMap<String, (u32, u32)> = numstat
         .lines()
         .filter_map(|line| {
@@ -357,7 +393,7 @@ fn build_file_diffs(numstat: &str, full_diff: &str) -> Vec<GitFileDiff> {
             }
             let adds = parts[0].parse::<u32>().unwrap_or(0);
             let dels = parts[1].parse::<u32>().unwrap_or(0);
-            let file = parts[2..].join("\t");
+            let file = normalize_numstat_file_path(parts[2..].join("\t"));
             Some((file, (adds, dels)))
         })
         .collect();
@@ -389,8 +425,153 @@ fn build_file_diffs(numstat: &str, full_diff: &str) -> Vec<GitFileDiff> {
         }
     }
 
+    let existing_files = results
+        .iter()
+        .map(|diff| diff.file.clone())
+        .collect::<HashSet<_>>();
+    results.extend(build_untracked_file_diffs(
+        git,
+        repo_path,
+        file_statuses,
+        &existing_files,
+    )?);
+
     results.sort_by(|a, b| a.file.cmp(&b.file));
-    results
+    Ok(results)
+}
+
+fn normalize_numstat_file_path(file: String) -> String {
+    let mut normalized = file.trim().to_string();
+
+    while let Some(start) = normalized.find('{') {
+        let Some(relative_end) = normalized[start..].find('}') else {
+            break;
+        };
+        let end = start + relative_end;
+        let segment = &normalized[start + 1..end];
+        let Some((_, replacement)) = segment.split_once(" => ") else {
+            break;
+        };
+
+        normalized = format!(
+            "{}{}{}",
+            &normalized[..start],
+            replacement,
+            &normalized[end + 1..]
+        );
+    }
+
+    if let Some(stripped) = normalized.strip_prefix("/dev/null => ") {
+        return stripped.to_string();
+    }
+
+    if let Some(stripped) = normalized.strip_suffix(" => /dev/null") {
+        return stripped.to_string();
+    }
+
+    if normalized.contains(" => ") {
+        let mut parts = normalized.rsplitn(2, " => ");
+        let right = parts.next().unwrap_or_default();
+        let left = parts.next().unwrap_or_default();
+        if !right.is_empty() {
+            return right.to_string();
+        }
+        if !left.is_empty() {
+            return left.to_string();
+        }
+    }
+
+    normalized
+}
+
+fn build_untracked_file_diffs(
+    git: &GitCliPort,
+    repo_path: &Path,
+    file_statuses: &[GitFileStatus],
+    existing_files: &HashSet<String>,
+) -> Result<Vec<GitFileDiff>> {
+    let mut results = Vec::new();
+
+    for status in file_statuses {
+        if status.status != "untracked" || existing_files.contains(&status.path) {
+            continue;
+        }
+
+        results.push(build_untracked_file_diff(
+            git,
+            repo_path,
+            status.path.as_str(),
+        )?);
+    }
+
+    Ok(results)
+}
+
+fn build_untracked_file_diff(
+    git: &GitCliPort,
+    repo_path: &Path,
+    file_path: &str,
+) -> Result<GitFileDiff> {
+    let (numstat_stdout, diff_stdout) = load_no_index_diff_payload(git, repo_path, file_path)?;
+    let diffs = build_file_diffs(git, repo_path, &[], &numstat_stdout, &diff_stdout)?;
+    let diff = diffs
+        .into_iter()
+        .find(|candidate| candidate.file == file_path)
+        .ok_or_else(|| {
+            anyhow!("git diff --no-index produced no matching diff entry for {file_path}")
+        })?;
+
+    Ok(diff)
+}
+
+fn load_no_index_diff_payload(
+    git: &GitCliPort,
+    repo_path: &Path,
+    file_path: &str,
+) -> Result<(String, String)> {
+    let numstat_args = [
+        "diff",
+        "--no-index",
+        "--numstat",
+        "--",
+        "/dev/null",
+        file_path,
+    ];
+    let (numstat_ok, numstat_stdout, numstat_stderr) =
+        git.run_git_allow_failure(repo_path, &numstat_args)?;
+    let numstat_stdout = ensure_non_index_diff_output(
+        numstat_ok,
+        numstat_stdout,
+        numstat_stderr,
+        format!("git diff --no-index --numstat /dev/null {file_path}"),
+    )?;
+
+    let diff_args = ["diff", "--no-index", "--", "/dev/null", file_path];
+    let (diff_ok, diff_stdout, diff_stderr) = git.run_git_allow_failure(repo_path, &diff_args)?;
+    let diff_stdout = ensure_non_index_diff_output(
+        diff_ok,
+        diff_stdout,
+        diff_stderr,
+        format!("git diff --no-index /dev/null {file_path}"),
+    )?;
+
+    Ok((numstat_stdout, diff_stdout))
+}
+
+fn ensure_non_index_diff_output(
+    ok: bool,
+    stdout: String,
+    stderr: String,
+    command_description: String,
+) -> Result<String> {
+    if ok || !stdout.trim().is_empty() {
+        return Ok(stdout);
+    }
+
+    Err(anyhow!(
+        "{command_description} failed: {}",
+        combine_output(stdout, stderr)
+    ))
 }
 
 fn split_diff_by_file(full_diff: &str) -> Vec<(String, String)> {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
@@ -249,6 +249,9 @@ fn get_worktree_status_honors_diff_scope_uncommitted_vs_target() {
     .expect("tracked uncommitted file should write");
     fs::write(repo.path.join("untracked_only.txt"), "new file\n")
         .expect("untracked file should write");
+    fs::create_dir_all(repo.path.join("dir")).expect("untracked directory should write");
+    fs::write(repo.path.join("dir/nested.txt"), "nested file\n")
+        .expect("nested untracked file should write");
 
     let git = GitCliPort::new();
     let target_scope = git
@@ -282,6 +285,15 @@ fn get_worktree_status_honors_diff_scope_uncommitted_vs_target() {
         "target scope should include untracked working tree files"
     );
     assert!(
+        target_scope.file_diffs.iter().any(|diff| {
+            diff.file == "dir/nested.txt"
+                && diff.diff_type == "added"
+                && diff.additions == 1
+                && diff.deletions == 0
+        }),
+        "target scope should expand untracked directories into file diffs"
+    );
+    assert!(
         uncommitted_scope
             .file_diffs
             .iter()
@@ -299,11 +311,35 @@ fn get_worktree_status_honors_diff_scope_uncommitted_vs_target() {
         "uncommitted scope should include untracked file diffs"
     );
     assert!(
+        uncommitted_scope.file_diffs.iter().any(|diff| {
+            diff.file == "dir/nested.txt"
+                && diff.diff_type == "added"
+                && diff.additions == 1
+                && diff.deletions == 0
+                && diff.diff.contains("+++ b/dir/nested.txt")
+        }),
+        "uncommitted scope should expand untracked directories into file diffs"
+    );
+    assert!(
         !uncommitted_scope
             .file_diffs
             .iter()
             .any(|diff| diff.file == "committed_only.txt"),
         "uncommitted scope should exclude already committed feature-only changes"
+    );
+    assert!(
+        uncommitted_scope
+            .file_statuses
+            .iter()
+            .any(|status| status.path == "dir/nested.txt" && status.status == "untracked"),
+        "status output should report untracked files individually"
+    );
+    assert!(
+        !uncommitted_scope
+            .file_statuses
+            .iter()
+            .any(|status| status.path == "dir/"),
+        "status output should not collapse untracked directories"
     );
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
@@ -247,6 +247,8 @@ fn get_worktree_status_honors_diff_scope_uncommitted_vs_target() {
         "# OpenDucktor\ntracked-uncommitted-change\n",
     )
     .expect("tracked uncommitted file should write");
+    fs::write(repo.path.join("untracked_only.txt"), "new file\n")
+        .expect("untracked file should write");
 
     let git = GitCliPort::new();
     let target_scope = git
@@ -271,11 +273,30 @@ fn get_worktree_status_honors_diff_scope_uncommitted_vs_target() {
         "target scope should include tracked uncommitted working tree changes"
     );
     assert!(
+        target_scope.file_diffs.iter().any(|diff| {
+            diff.file == "untracked_only.txt"
+                && diff.diff_type == "added"
+                && diff.additions == 1
+                && diff.deletions == 0
+        }),
+        "target scope should include untracked working tree files"
+    );
+    assert!(
         uncommitted_scope
             .file_diffs
             .iter()
             .any(|diff| diff.file == "README.md"),
         "uncommitted scope should include tracked working tree changes"
+    );
+    assert!(
+        uncommitted_scope.file_diffs.iter().any(|diff| {
+            diff.file == "untracked_only.txt"
+                && diff.diff_type == "added"
+                && diff.additions == 1
+                && diff.deletions == 0
+                && diff.diff.contains("+++ b/untracked_only.txt")
+        }),
+        "uncommitted scope should include untracked file diffs"
     );
     assert!(
         !uncommitted_scope

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,10 +1,10 @@
 import { lazy, type ReactElement, Suspense } from "react";
-import { Navigate, Outlet, Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 import { AppShell } from "@/components/layout/app-shell";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { loadAgentsPage, loadKanbanPage, loadNotFoundPage } from "@/pages";
-import { AppStateProvider, useWorkspaceState } from "@/state";
+import { AppStateProvider } from "@/state";
 
 const AgentsPage = lazy(loadAgentsPage);
 
@@ -24,14 +24,6 @@ function withRouteFallback(element: ReactElement): ReactElement {
   return <Suspense fallback={<RouteFallback />}>{element}</Suspense>;
 }
 
-function RequireRepository(): ReactElement {
-  const { activeRepo } = useWorkspaceState();
-  if (!activeRepo) {
-    return <Navigate to="/kanban" replace />;
-  }
-  return <Outlet />;
-}
-
 export function App(): ReactElement {
   return (
     <ThemeProvider>
@@ -40,11 +32,9 @@ export function App(): ReactElement {
           <Route element={<AppShell />}>
             <Route path="/" element={<Navigate to="/kanban" replace />} />
             <Route path="/kanban" element={withRouteFallback(<KanbanPage />)} />
-            <Route element={<RequireRepository />}>
-              <Route path="/agents" element={withRouteFallback(<AgentsPage />)} />
-              <Route path="/planner" element={<Navigate to="/agents?agent=planner" replace />} />
-              <Route path="/builder" element={<Navigate to="/agents?agent=build" replace />} />
-            </Route>
+            <Route path="/agents" element={withRouteFallback(<AgentsPage />)} />
+            <Route path="/planner" element={<Navigate to="/agents?agent=planner" replace />} />
+            <Route path="/builder" element={<Navigate to="/agents?agent=build" replace />} />
             <Route path="*" element={withRouteFallback(<NotFoundPage />)} />
           </Route>
         </Routes>

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
@@ -52,7 +52,7 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
 
   return (
     <div className="my-1.5 overflow-hidden rounded-lg border border-border bg-card text-xs">
-      {data.diff ? <PierreDiffPreloader patch={data.diff} /> : null}
+      {data.diff ? <PierreDiffPreloader patch={data.diff} filePath={data.filePath} /> : null}
 
       {/* Header */}
       <button
@@ -89,7 +89,7 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
       {/* Diff — uses shared PierreDiffViewer, split view for inline chat */}
       {isExpanded && data.diff ? (
         <div className="overflow-auto max-h-[60vh]">
-          <PierreDiffViewer patch={data.diff} diffStyle="split" />
+          <PierreDiffViewer patch={data.diff} filePath={data.filePath} diffStyle="split" />
         </div>
       ) : null}
     </div>

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -851,7 +851,7 @@ describe("agent-chat-message-card-model", () => {
 
       expect(data).toEqual({
         filePath: "src/app.ts",
-        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n+line",
+        diff: "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n+line\n",
         additions: 2,
         deletions: 1,
       });
@@ -872,7 +872,7 @@ describe("agent-chat-message-card-model", () => {
 
       expect(data).toEqual({
         filePath: "apps/web/src/contexts/AuthContext.tsx",
-        diff: "--- a/apps/web/src/contexts/AuthContext.tsx\n+++ b/apps/web/src/contexts/AuthContext.tsx\n@@ -1 +1 @@\n-old\n+new",
+        diff: "--- a/apps/web/src/contexts/AuthContext.tsx\n+++ b/apps/web/src/contexts/AuthContext.tsx\n@@ -1 +1 @@\n-old\n+new\n",
         additions: 1,
         deletions: 1,
       });
@@ -888,7 +888,7 @@ describe("agent-chat-message-card-model", () => {
       );
       expect(fromPatch).toEqual({
         filePath: "src/patch.ts",
-        diff: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new",
+        diff: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new\n",
         additions: 1,
         deletions: 1,
       });
@@ -900,8 +900,48 @@ describe("agent-chat-message-card-model", () => {
       );
       expect(fromOutput).toEqual({
         filePath: "src/output.ts",
-        diff: "Updated the following files: M src/output.ts\n@@ -1 +1 @@\n-old\n+new",
+        diff: "--- a/src/output.ts\n+++ b/src/output.ts\n@@ -1 +1 @@\n-old\n+new\n",
         additions: 1,
+        deletions: 1,
+      });
+    });
+
+    test("selects the matching file diff from a multi-file patch", () => {
+      const data = extractFileEditData(
+        createToolMeta({
+          input: { filePath: "src/second.ts" },
+          metadata: {
+            diff:
+              "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+              "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+          },
+        }),
+      );
+
+      expect(data).toEqual({
+        filePath: "src/second.ts",
+        diff: "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+        additions: 2,
+        deletions: 1,
+      });
+    });
+
+    test("extracts a single classic diff section for the current file", () => {
+      const data = extractFileEditData(
+        createToolMeta({
+          input: { filePath: "src/second.ts" },
+          metadata: {
+            diff:
+              "Index: src/first.ts\n==================================================\n--- src/first.ts\n+++ src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+              "Index: src/second.ts\n==================================================\n--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+          },
+        }),
+      );
+
+      expect(data).toEqual({
+        filePath: "src/second.ts",
+        diff: "--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+        additions: 2,
         deletions: 1,
       });
     });

--- a/apps/desktop/src/components/features/agents/agent-chat/file-edit-tool.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/file-edit-tool.ts
@@ -1,3 +1,4 @@
+import { selectRenderableDiff } from "../renderable-patch";
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 import { extractPathFromInput } from "./tool-input-utils";
 import { relativizeDisplayPath } from "./tool-path-utils";
@@ -55,7 +56,7 @@ export const extractFileEditData = (
 
   filePath = relativizeDisplayPath(filePath, workingDirectory);
 
-  const diff =
+  const rawDiff =
     typeof meta.metadata?.diff === "string"
       ? meta.metadata.diff
       : typeof meta.input?.patch === "string"
@@ -63,6 +64,8 @@ export const extractFileEditData = (
         : typeof meta.output === "string" && meta.output.includes("@@")
           ? meta.output
           : null;
+
+  const diff = rawDiff ? selectRenderableDiff(rawDiff, filePath) : null;
 
   let additions = 0;
   let deletions = 0;

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -1279,7 +1279,7 @@ describe("AgentStudioGitPanel", () => {
     const root = getRoot(renderer);
     expect(countByTestId(root, "agent-studio-git-file-conflict-indicator")).toBe(1);
     expect(countByTestId(root, "agent-studio-git-file-conflict-slot")).toBe(1);
-    expect(getNodeText(findButtonByText(root, "AGENTS.md"))).toContain("M");
+    expect(getNodeText(findButtonByText(root, "AGENTS.md"))).not.toContain("M");
 
     await act(async () => {
       ensureRenderer(renderer).unmount();
@@ -1318,7 +1318,7 @@ describe("AgentStudioGitPanel", () => {
 
     const root = getRoot(renderer);
     expect(countByTestId(root, "agent-studio-git-file-conflict-slot")).toBe(0);
-    const fileRowButton = findButtonByText(root, "src/main.ts");
+    const fileRowButton = findButtonByText(root, "main.ts");
 
     const rootText = getNodeText(root);
     expect(rootText).toContain("1 changed file");
@@ -1333,11 +1333,84 @@ describe("AgentStudioGitPanel", () => {
     expect(countByTestId(root, "mock-pierre-diff-viewer")).toBe(1);
 
     await act(async () => {
-      findButtonByText(root, "src/main.ts").props.onClick();
+      findButtonByText(root, "main.ts").props.onClick();
       await flush();
     });
 
     expect(countByTestId(root, "mock-pierre-diff-viewer")).toBe(0);
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+
+  test("shows basename-first file paths with the full path in the tooltip", async () => {
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(AgentStudioGitPanel, {
+          model: baseModel({
+            diffScope: "uncommitted",
+            fileDiffs: [
+              {
+                file: "apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx",
+                type: "modified",
+                additions: 3,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+new\n",
+              },
+            ],
+            fileStatuses: [
+              {
+                path: "apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx",
+                staged: false,
+                status: "modified",
+              },
+            ],
+          }),
+        }),
+      );
+      await flush();
+    });
+
+    const root = getRoot(renderer);
+    const headerNode = findByTestId(root, "agent-studio-git-list-header");
+    const pathNode = findByTestId(root, "agent-studio-git-file-path");
+
+    expect(headerNode.props.className).toContain("flex-wrap");
+    expect(headerNode.props.className).toContain("min-w-0");
+    expect(pathNode.props.title).toBe(
+      "apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx",
+    );
+    expect(pathNode.props.className).toContain("flex-col");
+    expect(pathNode.props.className).toContain("overflow-hidden");
+    expect(getNodeText(pathNode)).toContain("file-diff-entry.tsx");
+    expect(getNodeText(pathNode)).toContain(
+      "apps/desktop/src/components/features/agents/agent-studio-git-panel",
+    );
+
+    const fileNameNode = pathNode.findAll(
+      (node) => typeof node.type === "string" && node.children.includes("file-diff-entry.tsx"),
+    )[0];
+    const dirNameNode = pathNode.findAll(
+      (node) =>
+        typeof node.type === "string" &&
+        node.children.includes(
+          "apps/desktop/src/components/features/agents/agent-studio-git-panel",
+        ),
+    )[0];
+
+    expect(fileNameNode?.props.className).toContain("block truncate");
+    expect(dirNameNode?.props.className).toContain("block truncate");
+
+    const statsNode = findByTestId(root, "agent-studio-git-file-stats");
+    expect(statsNode.props.className).toContain("min-w-[4.75rem]");
+    expect(statsNode.props.className).toContain("shrink-0");
+    expect(statsNode.props.className).not.toContain("border-l");
+    expect(getNodeText(statsNode)).toContain("+3");
+    expect(getNodeText(statsNode)).toContain("-1");
+    expect(getNodeText(statsNode)).not.toContain("M");
 
     await act(async () => {
       ensureRenderer(renderer).unmount();

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/agent-studio-git-panel.tsx
@@ -23,10 +23,12 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
   const [diffStyle, setDiffStyle] = useState<PierreDiffStyle>("unified");
   const [isRebaseConflictModalOpen, setIsRebaseConflictModalOpen] = useState(false);
+  const [selectedFileNotificationTick, setSelectedFileNotificationTick] = useState(0);
   const hasRebaseConflict = model.rebaseConflict != null;
   const hasInitializedConflictModalSyncRef = useRef(false);
   const previousAutoOpenNonceRef = useRef(0);
   const previousCloseNonceRef = useRef(0);
+  const pendingSelectedFilesRef = useRef<Array<string | null>>([]);
   const uncommittedFileCount = model.uncommittedFileCount;
   const hasUncommittedFiles = uncommittedFileCount > 0;
   const hasFiles = model.fileDiffs.length > 0;
@@ -40,22 +42,33 @@ export const AgentStudioGitPanel = memo(function AgentStudioGitPanel({
     [model.fileStatuses],
   );
 
-  const toggleFile = useCallback(
-    (filePath: string): void => {
-      setExpandedFiles((previous) => {
-        const next = new Set(previous);
-        if (next.has(filePath)) {
-          next.delete(filePath);
-          model.setSelectedFile(null);
-        } else {
-          next.add(filePath);
-          model.setSelectedFile(filePath);
-        }
-        return next;
-      });
-    },
-    [model.setSelectedFile],
-  );
+  const toggleFile = useCallback((filePath: string): void => {
+    setExpandedFiles((previous) => {
+      const next = new Set(previous);
+      if (next.has(filePath)) {
+        next.delete(filePath);
+        pendingSelectedFilesRef.current.push(null);
+      } else {
+        next.add(filePath);
+        pendingSelectedFilesRef.current.push(filePath);
+      }
+      return next;
+    });
+    setSelectedFileNotificationTick((current) => current + 1);
+  }, []);
+
+  useEffect(() => {
+    if (selectedFileNotificationTick === 0 || pendingSelectedFilesRef.current.length === 0) {
+      return;
+    }
+
+    const nextSelectedFiles = pendingSelectedFilesRef.current;
+    pendingSelectedFilesRef.current = [];
+
+    for (const nextSelectedFile of nextSelectedFiles) {
+      model.setSelectedFile(nextSelectedFile);
+    }
+  }, [model.setSelectedFile, selectedFileNotificationTick]);
 
   const handleDiffScopeChange = useCallback(
     (scope: DiffScope): void => {

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/diff-preload-queue.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/diff-preload-queue.tsx
@@ -55,7 +55,7 @@ export const DiffPreloadQueue = memo(function DiffPreloadQueue({
   return (
     <>
       {preloadEntries.map((entry) => (
-        <PierreDiffPreloader key={entry.file} patch={entry.diff} />
+        <PierreDiffPreloader key={entry.file} patch={entry.diff} filePath={entry.file} />
       ))}
     </>
   );

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx
@@ -6,9 +6,8 @@ import {
   PierreDiffPreloader,
   PierreDiffViewer,
 } from "@/components/features/agents/pierre-diff-viewer";
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { FILE_STATUS_BADGE, FILE_STATUS_COLOR, FILE_STATUS_ICON } from "./constants";
+import { FILE_STATUS_COLOR, FILE_STATUS_ICON } from "./constants";
 
 const areFileDiffsEqual = (left: FileDiff, right: FileDiff): boolean =>
   left.file === right.file &&
@@ -36,19 +35,20 @@ function FileDiffEntry({
 }: FileDiffEntryProps): ReactElement {
   const StatusIcon = FILE_STATUS_ICON[diff.type] ?? FileText;
   const statusColor = FILE_STATUS_COLOR[diff.type] ?? "text-muted-foreground";
-  const statusBadge = FILE_STATUS_BADGE[diff.type] ?? "?";
 
   const fileName = diff.file.split("/").pop() ?? diff.file;
   const dirName = diff.file.includes("/") ? diff.file.slice(0, diff.file.lastIndexOf("/")) : "";
   const hasDiffContent = diff.diff.trim().length > 0;
 
   return (
-    <div>
-      {isExpanded && hasDiffContent ? <PierreDiffPreloader patch={diff.diff} /> : null}
+    <div className="min-w-0 max-w-full">
+      {isExpanded && hasDiffContent ? (
+        <PierreDiffPreloader patch={diff.diff} filePath={diff.file} />
+      ) : null}
 
       <button
         type="button"
-        className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-muted/50"
+        className="flex w-full min-w-0 max-w-full cursor-pointer items-center gap-2 overflow-hidden px-3 py-1.5 text-left text-xs transition-colors hover:bg-muted/50"
         onClick={() => onToggle(diff.file)}
       >
         {isExpanded ? (
@@ -68,25 +68,38 @@ function FileDiffEntry({
             data-testid="agent-studio-git-file-conflict-slot"
           />
         ) : null}
-        <span className="flex-1 truncate">
-          {dirName ? <span className="text-muted-foreground">{dirName}/</span> : null}
-          <span className="font-medium">{fileName}</span>
+        <span
+          className="flex min-w-0 flex-1 flex-col gap-0.5 overflow-hidden"
+          data-testid="agent-studio-git-file-path"
+          title={diff.file}
+        >
+          <span className="block truncate font-medium leading-tight" title={fileName}>
+            {fileName}
+          </span>
+          {dirName ? (
+            <span
+              className="block truncate text-[10px] leading-tight text-muted-foreground"
+              title={dirName}
+            >
+              {dirName}
+            </span>
+          ) : null}
         </span>
-        <div className="ml-auto flex items-center gap-2">
-          <span className="flex items-center gap-1 text-[10px] font-mono">
+        <div
+          className="ml-2 flex min-w-[4.75rem] shrink-0 items-center justify-end"
+          data-testid="agent-studio-git-file-stats"
+        >
+          <span className="flex min-w-[4.75rem] shrink-0 items-center justify-end gap-1 whitespace-nowrap text-[10px] font-mono tabular-nums">
             {diff.additions > 0 ? <span className="text-green-400">+{diff.additions}</span> : null}
             {diff.deletions > 0 ? <span className="text-red-400">-{diff.deletions}</span> : null}
           </span>
-          <Badge variant="outline" className={cn("px-1 py-0 text-[10px] font-mono", statusColor)}>
-            {statusBadge}
-          </Badge>
         </div>
       </button>
 
       {isExpanded ? (
         <div className="border-t border-border/50">
           {hasDiffContent ? (
-            <PierreDiffViewer patch={diff.diff} diffStyle={diffStyle} />
+            <PierreDiffViewer patch={diff.diff} filePath={diff.file} diffStyle={diffStyle} />
           ) : (
             <div className="p-3 text-xs italic text-muted-foreground">
               No diff content available for {diff.file}

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-list.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-list.tsx
@@ -73,19 +73,16 @@ export const FileDiffList = memo(function FileDiffList({
   const reserveConflictSlot = conflictedFiles.size > 0;
 
   return (
-    <div className="divide-y divide-border/50">
-      <div className="flex items-center justify-between px-3 py-2 text-xs text-muted-foreground">
-        <span>
+    <div className="w-0 min-w-full max-w-full divide-y divide-border/50 overflow-hidden">
+      <div
+        className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-2 px-3 py-2 text-xs text-muted-foreground"
+        data-testid="agent-studio-git-list-header"
+      >
+        <span className="shrink-0">
           {fileDiffs.length} changed file{fileDiffs.length > 1 ? "s" : ""}
         </span>
-        <div className="flex items-center gap-2">
-          <span className="font-mono">
-            {totalAdditions > 0 ? (
-              <span className="mr-1.5 text-green-400">+{totalAdditions}</span>
-            ) : null}
-            {totalDeletions > 0 ? <span className="text-red-400">-{totalDeletions}</span> : null}
-          </span>
-          <div className="flex items-center overflow-hidden rounded-md border border-border/50">
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <div className="flex shrink-0 items-center overflow-hidden rounded-md border border-border/50">
             <DiffStyleToggleButton
               icon={SplitSquareHorizontal}
               isActive={diffStyle === "split"}
@@ -99,6 +96,12 @@ export const FileDiffList = memo(function FileDiffList({
               onClick={() => setDiffStyle("unified")}
             />
           </div>
+          <span className="shrink-0 whitespace-nowrap font-mono">
+            {totalAdditions > 0 ? (
+              <span className="mr-1.5 text-green-400">+{totalAdditions}</span>
+            ) : null}
+            {totalDeletions > 0 ? <span className="text-red-400">-{totalDeletions}</span> : null}
+          </span>
         </div>
       </div>
 

--- a/apps/desktop/src/components/features/agents/pierre-diff-viewer.test.tsx
+++ b/apps/desktop/src/components/features/agents/pierre-diff-viewer.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { getRenderableFileDiff } from "./pierre-diff-viewer";
+
+describe("getRenderableFileDiff", () => {
+  test("parses valid git patches", () => {
+    const patch =
+      "diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n";
+
+    const result = getRenderableFileDiff(patch, "src/app.ts");
+
+    expect(result.normalizedPatch).toBe(patch);
+    expect(result.fallbackPatch).toBe(patch);
+    expect(result.fileDiff?.name.endsWith("src/app.ts")).toBe(true);
+  });
+
+  test("normalizes hunk-only patches with the current file path", () => {
+    const result = getRenderableFileDiff("@@ -1 +1 @@\n-old\n+new\n", "src/hunk.ts");
+
+    expect(result.normalizedPatch).toBe(
+      "--- a/src/hunk.ts\n+++ b/src/hunk.ts\n@@ -1 +1 @@\n-old\n+new\n",
+    );
+    expect(result.fileDiff?.name.endsWith("src/hunk.ts")).toBe(true);
+  });
+
+  test("keeps normalized raw diff text when parsing still fails", () => {
+    const result = getRenderableFileDiff(
+      "Index: src/app.ts\n=====\ninvalid diff body",
+      "src/app.ts",
+    );
+
+    expect(result.fileDiff).toBeNull();
+    expect(result.fallbackPatch).toBe("Index: src/app.ts\n=====\ninvalid diff body\n");
+  });
+});

--- a/apps/desktop/src/components/features/agents/pierre-diff-viewer.tsx
+++ b/apps/desktop/src/components/features/agents/pierre-diff-viewer.tsx
@@ -1,7 +1,8 @@
 import { getSingularPatch } from "@pierre/diffs";
-import { PatchDiff, useWorkerPool } from "@pierre/diffs/react";
+import { FileDiff, useWorkerPool } from "@pierre/diffs/react";
 import { type CSSProperties, memo, type ReactElement, useEffect, useMemo } from "react";
 import { useTheme } from "@/components/layout/theme-provider";
+import { selectRenderableDiff } from "./renderable-patch";
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
 
@@ -10,6 +11,7 @@ export type PierreDiffStyle = "split" | "unified";
 export type PierreDiffViewerProps = {
   /** Raw unified diff / patch string (e.g. from `git diff`). */
   patch: string;
+  filePath: string;
   /** Split (side-by-side) or unified (single-column) view. */
   diffStyle?: PierreDiffStyle;
   /** Enable click-to-select on line numbers. */
@@ -20,6 +22,7 @@ export type PierreDiffViewerProps = {
 
 type PierreDiffPreloaderProps = {
   patch: string;
+  filePath: string;
 };
 
 const DIFF_THEME = { dark: "pierre-dark", light: "pierre-light" } as const;
@@ -28,12 +31,37 @@ const DIFF_WRAPPER_STYLE = {
   "--diffs-line-height": "1.5",
   "--diffs-tab-size": 2,
 } as CSSProperties;
+const RAW_DIFF_FALLBACK_CLASS_NAME =
+  "overflow-x-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11px] leading-5 text-foreground";
+
+const tryGetSingularPatch = (patch: string) => {
+  try {
+    return getSingularPatch(patch);
+  } catch {
+    return null;
+  }
+};
+
+export const getRenderableFileDiff = (patch: string, filePath: string) => {
+  const normalizedPatch = selectRenderableDiff(patch, filePath);
+  const fileDiff = normalizedPatch ? tryGetSingularPatch(normalizedPatch) : null;
+
+  return {
+    fileDiff,
+    normalizedPatch,
+    fallbackPatch: normalizedPatch ?? patch,
+  };
+};
 
 export const PierreDiffPreloader = memo(function PierreDiffPreloader({
   patch,
+  filePath,
 }: PierreDiffPreloaderProps): null {
   const workerPool = useWorkerPool();
-  const fileDiff = useMemo(() => getSingularPatch(patch), [patch]);
+  const { fileDiff, normalizedPatch } = useMemo(
+    () => getRenderableFileDiff(patch, filePath),
+    [filePath, patch],
+  );
   const preloadRenderer = useMemo(
     () => ({
       onHighlightSuccess: (_diff: unknown, _result: unknown, _options: unknown) => undefined,
@@ -43,7 +71,7 @@ export const PierreDiffPreloader = memo(function PierreDiffPreloader({
   );
 
   useEffect(() => {
-    if (workerPool == null || patch.trim().length === 0) {
+    if (workerPool == null || fileDiff == null || normalizedPatch == null) {
       return;
     }
     if (workerPool.getDiffResultCache(fileDiff) != null) {
@@ -51,28 +79,25 @@ export const PierreDiffPreloader = memo(function PierreDiffPreloader({
     }
 
     workerPool.highlightDiffAST(preloadRenderer, fileDiff);
-  }, [fileDiff, patch, preloadRenderer, workerPool]);
+  }, [fileDiff, normalizedPatch, preloadRenderer, workerPool]);
 
   return null;
 });
 
 // ─── Component ─────────────────────────────────────────────────────────────────
 
-/**
- * Thin wrapper around Pierre's `PatchDiff` React component.
- *
- * Renders a unified diff / patch string with syntax highlighting,
- * line numbers, and inline change highlighting.
- *
- * @see https://diffs.com/docs#react-api
- */
 export const PierreDiffViewer = memo(function PierreDiffViewer({
   patch,
+  filePath,
   diffStyle = "split",
   enableLineSelection = false,
   className,
 }: PierreDiffViewerProps): ReactElement {
   const { theme } = useTheme();
+  const { fileDiff, fallbackPatch } = useMemo(
+    () => getRenderableFileDiff(patch, filePath),
+    [filePath, patch],
+  );
   const lineDiffType: "word-alt" | "none" = diffStyle === "split" ? "word-alt" : "none";
   const options = useMemo(
     () => ({
@@ -88,10 +113,13 @@ export const PierreDiffViewer = memo(function PierreDiffViewer({
     }),
     [diffStyle, enableLineSelection, lineDiffType, theme],
   );
-
   return (
     <div className={className} style={DIFF_WRAPPER_STYLE}>
-      <PatchDiff patch={patch} options={options} />
+      {fileDiff ? (
+        <FileDiff fileDiff={fileDiff} options={options} />
+      ) : (
+        <pre className={RAW_DIFF_FALLBACK_CLASS_NAME}>{fallbackPatch}</pre>
+      )}
     </div>
   );
 });

--- a/apps/desktop/src/components/features/agents/renderable-patch.test.ts
+++ b/apps/desktop/src/components/features/agents/renderable-patch.test.ts
@@ -21,6 +21,16 @@ describe("selectRenderableDiff", () => {
       "--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
     );
   });
+
+  test("ignores file path mentions inside hunk bodies when matching sections", () => {
+    const diff =
+      'diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-import "./old"\n+import "src/target.ts"\n' +
+      "diff --git a/src/target.ts b/src/target.ts\n--- a/src/target.ts\n+++ b/src/target.ts\n@@ -1 +1 @@\n-old\n+new\n";
+
+    expect(selectRenderableDiff(diff, "src/target.ts")).toBe(
+      "diff --git a/src/target.ts b/src/target.ts\n--- a/src/target.ts\n+++ b/src/target.ts\n@@ -1 +1 @@\n-old\n+new\n",
+    );
+  });
 });
 
 describe("normalizePatchCandidate", () => {

--- a/apps/desktop/src/components/features/agents/renderable-patch.test.ts
+++ b/apps/desktop/src/components/features/agents/renderable-patch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { normalizePatchCandidate, selectRenderableDiff } from "./renderable-patch";
+
+describe("selectRenderableDiff", () => {
+  test("chooses the matching file section from a multi-file patch", () => {
+    const diff =
+      "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+      "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n";
+
+    expect(selectRenderableDiff(diff, "src/second.ts")).toBe(
+      "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+    );
+  });
+
+  test("normalizes classic diff sections for the current file", () => {
+    const diff =
+      "Index: src/first.ts\n==================================================\n--- src/first.ts\n+++ src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+      "Index: src/second.ts\n==================================================\n--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n";
+
+    expect(selectRenderableDiff(diff, "src/second.ts")).toBe(
+      "--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+    );
+  });
+});
+
+describe("normalizePatchCandidate", () => {
+  test("synthesizes file headers for hunk-only diffs", () => {
+    expect(normalizePatchCandidate("@@ -1 +1 @@\n-old\n+new\n", "src/app.ts")).toBe(
+      "--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1 +1 @@\n-old\n+new\n",
+    );
+  });
+});

--- a/apps/desktop/src/components/features/agents/renderable-patch.ts
+++ b/apps/desktop/src/components/features/agents/renderable-patch.ts
@@ -50,7 +50,17 @@ export function patchMatchesFile(candidate: string, filePath: string): boolean {
   const normalizedPath = filePath.replaceAll("\\", "/");
   const quotedPath = normalizedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const suffixPattern = new RegExp(`(^|[\\s"'])((a|b)/)?${quotedPath}($|[\\s"'])`, "m");
-  return suffixPattern.test(candidate.replaceAll("\\", "/"));
+  const headerLines: string[] = [];
+
+  for (const line of candidate.replaceAll("\\", "/").split("\n")) {
+    if (line.startsWith("@@ ")) {
+      break;
+    }
+
+    headerLines.push(line);
+  }
+
+  return suffixPattern.test(headerLines.join("\n"));
 }
 
 function canParseSingularPatch(candidate: string, filePath: string): boolean {

--- a/apps/desktop/src/components/features/agents/renderable-patch.ts
+++ b/apps/desktop/src/components/features/agents/renderable-patch.ts
@@ -1,0 +1,95 @@
+import { getSingularPatch } from "@pierre/diffs";
+
+const GIT_DIFF_HEADER = /^diff --git /m;
+const CLASSIC_DIFF_HEADER = /^Index: /m;
+
+export function normalizePatchCandidate(candidate: string, filePath: string): string {
+  const trimmed = candidate.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+
+  const lines = trimmed.split("\n");
+  const markerIndex = lines.findIndex(
+    (line) => line.startsWith("diff --git ") || line.startsWith("--- ") || line.startsWith("@@ "),
+  );
+  const relevantLines = markerIndex >= 0 ? lines.slice(markerIndex) : lines;
+  const normalized = relevantLines.join("\n").trim();
+
+  if (normalized.startsWith("@@ ")) {
+    return `--- a/${filePath}\n+++ b/${filePath}\n${normalized}\n`;
+  }
+
+  return `${normalized}\n`;
+}
+
+export function splitPatchCandidates(rawDiff: string): string[] {
+  const trimmed = rawDiff.trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+
+  if (GIT_DIFF_HEADER.test(trimmed)) {
+    return trimmed
+      .split(/(?=^diff --git )/m)
+      .map((chunk) => chunk.trim())
+      .filter((chunk) => chunk.length > 0);
+  }
+
+  if (CLASSIC_DIFF_HEADER.test(trimmed)) {
+    return trimmed
+      .split(/(?=^Index: )/m)
+      .map((chunk) => chunk.trim())
+      .filter((chunk) => chunk.length > 0);
+  }
+
+  return [trimmed];
+}
+
+export function patchMatchesFile(candidate: string, filePath: string): boolean {
+  const normalizedPath = filePath.replaceAll("\\", "/");
+  const quotedPath = normalizedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const suffixPattern = new RegExp(`(^|[\\s"'])((a|b)/)?${quotedPath}($|[\\s"'])`, "m");
+  return suffixPattern.test(candidate.replaceAll("\\", "/"));
+}
+
+function canParseSingularPatch(candidate: string, filePath: string): boolean {
+  if (candidate.trim().length === 0) {
+    return false;
+  }
+
+  try {
+    getSingularPatch(normalizePatchCandidate(candidate, filePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function selectRenderableDiff(rawDiff: string, filePath: string): string | null {
+  const candidates = splitPatchCandidates(rawDiff);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const matchingCandidate = candidates.find((candidate) => patchMatchesFile(candidate, filePath));
+  if (matchingCandidate) {
+    return normalizePatchCandidate(matchingCandidate, filePath);
+  }
+
+  const singularCandidate = candidates.find((candidate) =>
+    canParseSingularPatch(candidate, filePath),
+  );
+  if (singularCandidate) {
+    return normalizePatchCandidate(singularCandidate, filePath);
+  }
+
+  for (const candidate of candidates) {
+    const normalizedCandidate = normalizePatchCandidate(candidate, filePath);
+    if (normalizedCandidate.trim().length > 0) {
+      return normalizedCandidate;
+    }
+  }
+
+  return null;
+}

--- a/apps/desktop/src/components/ui/border-ray-model.test.ts
+++ b/apps/desktop/src/components/ui/border-ray-model.test.ts
@@ -33,8 +33,8 @@ describe("border-ray-model", () => {
     const styles = readFileSync(stylesPath, "utf8");
 
     const durationMatch = styles.match(/--odt-border-ray-turn-duration:\s*([\d.]+)ms\s*;/);
-    const perimeterMatch = styles.match(/--odt-border-ray-perimeter:\s*([\d.]+)\s*;/);
-    const lengthMatch = styles.match(/--odt-border-ray-length:\s*([\d.]+)\s*;/);
+    const perimeterMatch = styles.match(/--odt-border-ray-perimeter:\s*([\d.]+)px\s*;/);
+    const lengthMatch = styles.match(/--odt-border-ray-length:\s*([\d.]+)px\s*;/);
 
     expect(durationMatch).not.toBeNull();
     expect(perimeterMatch).not.toBeNull();

--- a/apps/desktop/src/components/ui/border-ray.test.tsx
+++ b/apps/desktop/src/components/ui/border-ray.test.tsx
@@ -16,8 +16,8 @@ describe("BorderRay", () => {
     expect(html).toContain(
       `--odt-border-ray-turn-duration:${BORDER_RAY_DEFAULT_TURN_DURATION_MS}ms`,
     );
-    expect(html).toContain(`--odt-border-ray-perimeter:${BORDER_RAY_DEFAULT_PERIMETER}`);
-    expect(html).toContain(`--odt-border-ray-length:${BORDER_RAY_DEFAULT_LENGTH}`);
+    expect(html).toContain(`--odt-border-ray-perimeter:${BORDER_RAY_DEFAULT_PERIMETER}px`);
+    expect(html).toContain(`--odt-border-ray-length:${BORDER_RAY_DEFAULT_LENGTH}px`);
     expect(html).toContain(`--odt-border-ray-stroke-width:${BORDER_RAY_DEFAULT_STROKE_WIDTH}`);
     expect(html).not.toContain("--kanban-ray-");
   });

--- a/apps/desktop/src/components/ui/border-ray.tsx
+++ b/apps/desktop/src/components/ui/border-ray.tsx
@@ -241,8 +241,8 @@ export function BorderRay({
     pointerEvents: "none",
     zIndex: 2,
     ["--odt-border-ray-turn-duration" as string]: `${Math.max(turnDurationMs, 1)}ms`,
-    ["--odt-border-ray-perimeter" as string]: `${pathMetrics.perimeter}`,
-    ["--odt-border-ray-length" as string]: `${pathMetrics.rayLength}`,
+    ["--odt-border-ray-perimeter" as string]: `${pathMetrics.perimeter}px`,
+    ["--odt-border-ray-length" as string]: `${pathMetrics.rayLength}px`,
     ["--odt-border-ray-stroke-width" as string]: `${Math.max(strokeWidth, 0.5)}`,
     ...(color ? { ["--odt-border-ray-color" as string]: color } : {}),
   };

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -373,8 +373,8 @@ pre {
 .odt-border-ray {
   overflow: visible;
   --odt-border-ray-turn-duration: 3000ms;
-  --odt-border-ray-perimeter: 1000;
-  --odt-border-ray-length: 190;
+  --odt-border-ray-perimeter: 1000px;
+  --odt-border-ray-length: 190px;
   --odt-border-ray-stroke-width: 4.4;
   --odt-border-ray-color: rgba(56, 189, 248, 1);
 }


### PR DESCRIPTION
## Summary
- fix the browser-only BorderRay regression by emitting CSS length units for the animated SVG variables
- harden Agent Studio diff rendering, deep links, and git panel layout so malformed patches and narrow panels no longer break the workspace
- include untracked files in host worktree diffs so new files show up with generated patches and line counts

## Testing
- [x] bun run --filter @openducktor/desktop test
- [x] bun run --filter @openducktor/desktop typecheck
- [x] bun run --filter @openducktor/desktop lint
- [x] cargo test -p host-infra-system
