### PR TITLE
fix: preserve MCP tool execution errors through OpenCode

### DIFF
--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1042,6 +1042,88 @@ describe("OpencodeSdkAdapter", () => {
     expect(toolPartEvent.part.error).toContain("Task not found");
   });
 
+  test("maps flattened MCP tool error JSON output as error status", async () => {
+    const streamEvents: Event[] = [
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-1",
+            role: "assistant",
+            sessionID: "session-opencode-1",
+            time: {
+              completed: Date.parse("2026-02-17T12:00:05Z"),
+            },
+            finish: "tool-calls",
+          },
+          parts: [
+            {
+              id: "tool-1",
+              sessionID: "session-opencode-1",
+              messageID: "assistant-1",
+              callID: "call-1",
+              type: "tool",
+              tool: "openducktor_odt_set_plan",
+              state: {
+                status: "completed",
+                input: { taskId: "facebook-oauth" },
+                output: JSON.stringify(
+                  {
+                    ok: false,
+                    error: {
+                      code: "ODT_TOOL_EXECUTION_ERROR",
+                      message: "Only epics can receive subtask proposals during planning.",
+                    },
+                  },
+                  null,
+                  2,
+                ),
+              },
+            },
+          ],
+        },
+      } as unknown as Event,
+    ];
+
+    const mock = makeMockClient({
+      streamEvents,
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const events: AgentEvent[] = [];
+    adapter.subscribeEvents("session-1", (event) => {
+      events.push(event);
+    });
+
+    await startDefaultSession(adapter, "session-1", "planner");
+    await flushAsync();
+
+    const toolPartEvent = events.find((entry) => {
+      if (entry.type !== "assistant_part") {
+        return false;
+      }
+      const part = entry.part;
+      return part.kind === "tool";
+    });
+
+    expect(toolPartEvent).toBeDefined();
+    if (
+      !toolPartEvent ||
+      toolPartEvent.type !== "assistant_part" ||
+      toolPartEvent.part.kind !== "tool"
+    ) {
+      throw new Error("Expected tool part event");
+    }
+
+    expect(toolPartEvent.part.status).toBe("error");
+    expect(toolPartEvent.part.error).toContain(
+      "Only epics can receive subtask proposals during planning.",
+    );
+  });
+
   test("maps todowrite tool part with ended timing to completed even when status is pending", async () => {
     const streamEvents: Event[] = [
       {

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.test.ts
@@ -227,6 +227,39 @@ describe("stream-part-mapper", () => {
     });
   });
 
+  test("maps completed tool output containing flattened structured error JSON as tool error part", () => {
+    const part = createToolPart({
+      id: "tool-1c",
+      tool: "openducktor_odt_set_plan",
+      status: "completed",
+      input: { taskId: "task-7" },
+      output: JSON.stringify(
+        {
+          ok: false,
+          error: {
+            code: "ODT_TOOL_EXECUTION_ERROR",
+            message: "Only epics can receive subtask proposals during planning.",
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    const mapped = mapPartToAgentStreamPart(part);
+    expect(mapped).toEqual({
+      kind: "tool",
+      messageId: "assistant-tool-1c",
+      partId: "tool-1c",
+      callId: "call-tool-1c",
+      tool: "openducktor_odt_set_plan",
+      status: "error",
+      input: { taskId: "task-7" },
+      preview: "task-7",
+      error: "Only epics can receive subtask proposals during planning.",
+    });
+  });
+
   test("maps pending tool with end timing as completed", () => {
     const part = createToolPart({
       id: "tool-2",

--- a/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
+++ b/packages/adapters-opencode-sdk/src/stream-part-mapper.ts
@@ -35,6 +35,24 @@ const toDisplayText = (value: unknown): string | undefined => {
   }
 };
 
+const parseStructuredTextObject = (value: unknown): Record<string, unknown> | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return asUnknownRecord(parsed);
+  } catch {
+    return undefined;
+  }
+};
+
 const outputTextFromMcpPayload = (value: unknown): string | undefined => {
   const content = readUnknownProp(value, "content");
   if (!Array.isArray(content)) {
@@ -62,7 +80,7 @@ const readToolOutputText = (value: unknown): string | undefined => {
 };
 
 const readStructuredToolError = (value: unknown): string | undefined => {
-  const record = asUnknownRecord(value);
+  const record = asUnknownRecord(value) ?? parseStructuredTextObject(value);
   if (!record) {
     return undefined;
   }

--- a/packages/openducktor-mcp/src/index.test.js
+++ b/packages/openducktor-mcp/src/index.test.js
@@ -118,7 +118,22 @@ describe("registerOdtTool", () => {
 
     const result = await capturedHandler({ taskId: "task-1" });
     expect(result).toEqual({
-      content: [{ type: "text", text: "Task exploded" }],
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              ok: false,
+              error: {
+                code: "ODT_TOOL_EXECUTION_ERROR",
+                message: "Task exploded",
+              },
+            },
+            null,
+            2,
+          ),
+        },
+      ],
       structuredContent: {
         ok: false,
         error: {
@@ -152,7 +167,12 @@ describe("registerOdtTool", () => {
     const result = await capturedHandler({});
     expect(result.isError).toBe(true);
     expect(result.content[0].type).toBe("text");
-    expect(result.content[0].text).toContain("taskId");
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      ok: false,
+      error: {
+        code: "ODT_TOOL_INPUT_INVALID",
+      },
+    });
     expect(result.structuredContent).toMatchObject({
       ok: false,
       error: {

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -36,20 +36,21 @@ const toToolError = (error: unknown): ToolResult => {
     error instanceof Error && error.name === "ZodError"
       ? "ODT_TOOL_INPUT_INVALID"
       : "ODT_TOOL_EXECUTION_ERROR";
+  const errorPayload = {
+    ok: false,
+    error: {
+      code,
+      message,
+    },
+  };
   return {
     content: [
       {
         type: "text",
-        text: message,
+        text: JSON.stringify(errorPayload, null, 2),
       },
     ],
-    structuredContent: {
-      ok: false,
-      error: {
-        code,
-        message,
-      },
-    },
+    structuredContent: errorPayload,
     isError: true,
   };
 };


### PR DESCRIPTION
## Summary
- preserve OpenDucktor MCP tool execution errors as structured JSON text alongside MCP isError metadata
- recover flattened MCP error payloads in the OpenCode adapter so failed workflow tool calls render as failed instead of completed
- add regressions for native MCP error envelopes and flattened OpenCode tool outputs

## Verification
- bun run typecheck
- bun run lint
- bun run test
- cargo check
- cargo test