### PR TITLE
fix(desktop): prevent agent diff loading from sticking

### DIFF
--- a/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
@@ -300,7 +300,7 @@ const finalizeCompletedState = (
   nextLoadedByScope: Record<DiffScope, boolean>,
   didChange: boolean,
 ): DiffBatchState => {
-  if (!didChange && nextLoadedByScope === previousState.loadedByScope && !previousState.isLoading) {
+  if (!didChange && nextLoadedByScope === previousState.loadedByScope) {
     return previousState;
   }
 
@@ -511,7 +511,7 @@ export const applyScopeError = ({
   }
 
   const snapshotsEqual = scopeSnapshotEqual(previousScopeSnapshot, nextScopeSnapshot);
-  if (snapshotsEqual && nextLoadedByScope === state.loadedByScope && !state.isLoading) {
+  if (snapshotsEqual && nextLoadedByScope === state.loadedByScope) {
     return state;
   }
 

--- a/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-diff-data-model.ts
@@ -307,7 +307,7 @@ const finalizeCompletedState = (
   return {
     byScope: nextByScope,
     loadedByScope: nextLoadedByScope,
-    isLoading: false,
+    isLoading: previousState.isLoading,
   };
 };
 
@@ -521,7 +521,7 @@ export const applyScopeError = ({
       [scope]: nextScopeSnapshot,
     },
     loadedByScope: nextLoadedByScope,
-    isLoading: false,
+    isLoading: state.isLoading,
   };
 };
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
@@ -120,6 +120,7 @@ export function useAgentStudioDiffController({
   const requestSequenceRef = useRef(0);
   const inFlightScopeRequestRef = useRef(createInFlightState());
   const queuedFullReloadByScopeRef = useRef(createQueuedReloadState());
+  const latestLoadingRequestSequenceRef = useRef<number | null>(null);
   const requestContextKeyRef = useRef<string | null>(null);
 
   const repoPathRef = useRef(repoPath);
@@ -139,7 +140,22 @@ export function useAgentStudioDiffController({
       }
       queuedFullReloadByScopeRef.current[scope] = false;
     }
+    latestLoadingRequestSequenceRef.current = null;
     requestSequenceRef.current = 0;
+  }, []);
+
+  const setBatchLoading = useCallback((isLoading: boolean): void => {
+    setControllerState((previousState) =>
+      previousState.batchState.isLoading === isLoading
+        ? previousState
+        : {
+            ...previousState,
+            batchState: {
+              ...previousState.batchState,
+              isLoading,
+            },
+          },
+    );
   }, []);
 
   const resetControllerState = useCallback(
@@ -312,14 +328,8 @@ export function useAgentStudioDiffController({
       const requestSequence = ++requestSequenceRef.current;
 
       if (showLoading) {
-        setControllerState((previousState) =>
-          previousState.batchState.isLoading
-            ? previousState
-            : {
-                ...previousState,
-                batchState: { ...previousState.batchState, isLoading: true },
-              },
-        );
+        latestLoadingRequestSequenceRef.current = requestSequence;
+        setBatchLoading(true);
       }
 
       try {
@@ -372,6 +382,14 @@ export function useAgentStudioDiffController({
           inFlightScopeRequestRef.current[loadContext.scope][mode] = null;
         }
 
+        if (
+          showLoading &&
+          latestLoadingRequestSequenceRef.current === requestSequence
+        ) {
+          latestLoadingRequestSequenceRef.current = null;
+          setBatchLoading(false);
+        }
+
         if (mode === "full" && queuedFullReloadByScopeRef.current[loadContext.scope]) {
           queuedFullReloadByScopeRef.current[loadContext.scope] = false;
           globalThis.queueMicrotask(() => {
@@ -386,7 +404,7 @@ export function useAgentStudioDiffController({
         }
       }
     },
-    [hasLoadContextChanged, runFullLoad, runSummaryLoad],
+    [hasLoadContextChanged, runFullLoad, runSummaryLoad, setBatchLoading],
   );
 
   const pendingFullReload = controllerState.pendingFullReloads[0];

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
@@ -117,6 +117,8 @@ export function useAgentStudioDiffController({
   const [diffScope, setDiffScope] = useState<DiffScope>("target");
 
   const versionByScopeAndModeRef = useRef(createVersionState());
+  // Keep this monotonic across context resets so stale completions cannot
+  // collide with a newer loading request after resetRequestTracking clears refs.
   const requestSequenceRef = useRef(0);
   const inFlightScopeRequestRef = useRef(createInFlightState());
   const queuedFullReloadByScopeRef = useRef(createQueuedReloadState());
@@ -141,7 +143,6 @@ export function useAgentStudioDiffController({
       queuedFullReloadByScopeRef.current[scope] = false;
     }
     latestLoadingRequestSequenceRef.current = null;
-    requestSequenceRef.current = 0;
   }, []);
 
   const setBatchLoading = useCallback((isLoading: boolean): void => {
@@ -382,10 +383,7 @@ export function useAgentStudioDiffController({
           inFlightScopeRequestRef.current[loadContext.scope][mode] = null;
         }
 
-        if (
-          showLoading &&
-          latestLoadingRequestSequenceRef.current === requestSequence
-        ) {
+        if (showLoading && latestLoadingRequestSequenceRef.current === requestSequence) {
           latestLoadingRequestSequenceRef.current = null;
           setBatchLoading(false);
         }

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -1886,6 +1886,111 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("keeps loading active when a stale request settles after repository context reset", async () => {
+    const firstRequest = createDeferred<GitWorktreeStatus>();
+    const secondRequest = createDeferred<GitWorktreeStatus>();
+    const queue = [firstRequest, secondRequest];
+
+    gitGetWorktreeStatusMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatus> => {
+        const deferred = queue.shift();
+        if (!deferred) {
+          throw new Error("No deferred response left");
+        }
+
+        return deferred.promise.then((snapshot) => ({
+          ...snapshot,
+          snapshot: {
+            ...snapshot.snapshot,
+            targetBranch,
+            diffScope: diffScope ?? snapshot.snapshot.diffScope,
+            effectiveWorkingDir: workingDir ?? snapshot.snapshot.effectiveWorkingDir,
+          },
+        }));
+      },
+    );
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      repoPath: "/repo-a",
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.isLoading);
+
+      await harness.update({
+        ...createBaseArgs(),
+        repoPath: "/repo-b",
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+      expect(harness.getLatest().isLoading).toBe(true);
+
+      firstRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/repo-a", detached: false },
+          fileStatuses: [{ path: "src/repo-a.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/repo-a.ts",
+              type: "modified",
+              additions: 1,
+              deletions: 0,
+              diff: "@@ -1 +1 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo-a",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000001000,
+          },
+        }),
+      );
+
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+
+      expect(harness.getLatest().isLoading).toBe(true);
+
+      secondRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/repo-b", detached: false },
+          fileStatuses: [{ path: "src/repo-b.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/repo-b.ts",
+              type: "modified",
+              additions: 2,
+              deletions: 0,
+              diff: "@@ -1 +1,2 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo-b",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000002000,
+          },
+        }),
+      );
+
+      await harness.waitFor((state) => !state.isLoading && state.branch === "feature/repo-b");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("replays queued full refreshes after an in-flight refresh settles", async () => {
     const firstRequest = createDeferred<GitWorktreeStatus>();
     const secondRequest = createDeferred<GitWorktreeStatus>();

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -1799,6 +1799,93 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("keeps loading active until the latest diff scope request settles", async () => {
+    const targetRequest = createDeferred<GitWorktreeStatus>();
+    const uncommittedRequest = createDeferred<GitWorktreeStatus>();
+
+    gitGetWorktreeStatusMock.mockImplementation(
+      async (
+        _repoPath: string,
+        targetBranch: string,
+        diffScope?: "target" | "uncommitted",
+        workingDir?: string,
+      ): Promise<GitWorktreeStatus> => {
+        const deferred = diffScope === "uncommitted" ? uncommittedRequest : targetRequest;
+        return deferred.promise.then((snapshot) => ({
+          ...snapshot,
+          snapshot: {
+            ...snapshot.snapshot,
+            targetBranch,
+            diffScope: diffScope ?? snapshot.snapshot.diffScope,
+            effectiveWorkingDir: workingDir ?? snapshot.snapshot.effectiveWorkingDir,
+          },
+        }));
+      },
+    );
+
+    const harness = createHookHarness(createBaseArgs());
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.isLoading);
+
+      await harness.run((state) => {
+        state.setDiffScope("uncommitted");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+
+      targetRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/target", detached: false },
+          fileStatuses: [{ path: "src/target.ts", status: "M", staged: false }],
+          fileDiffs: [
+            {
+              file: "src/target.ts",
+              type: "modified",
+              additions: 1,
+              deletions: 0,
+              diff: "@@ -1 +1 @@",
+            },
+          ],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000001000,
+          },
+        }),
+      );
+
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+
+      expect(harness.getLatest().isLoading).toBe(true);
+
+      uncommittedRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/uncommitted", detached: false },
+          fileStatuses: [{ path: "src/uncommitted.ts", status: "M", staged: false }],
+          fileDiffs: [],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch: "origin/main",
+            diffScope: "uncommitted",
+            observedAtMs: 1731000002000,
+          },
+        }),
+      );
+
+      await harness.waitFor((state) => !state.isLoading && state.diffScope === "uncommitted");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("replays queued full refreshes after an in-flight refresh settles", async () => {
     const firstRequest = createDeferred<GitWorktreeStatus>();
     const secondRequest = createDeferred<GitWorktreeStatus>();

--- a/apps/desktop/src/pages/kanban/session-started-toast-action.tsx
+++ b/apps/desktop/src/pages/kanban/session-started-toast-action.tsx
@@ -10,7 +10,7 @@ export const renderSessionStartedToastAction = (
     <Button
       type="button"
       variant="ghost"
-      className="h-auto w-fit p-0 text-sm font-medium !text-foreground underline underline-offset-2 hover:bg-transparent hover:!text-foreground"
+      className="h-auto w-fit p-0 text-sm font-medium text-foreground underline underline-offset-2 hover:bg-transparent hover:!text-foreground"
       onClick={() => onOpen(intent, sessionId)}
     >
       Open in Agent Studio

--- a/apps/desktop/src/pages/kanban/session-started-toast-action.tsx
+++ b/apps/desktop/src/pages/kanban/session-started-toast-action.tsx
@@ -10,7 +10,7 @@ export const renderSessionStartedToastAction = (
     <Button
       type="button"
       variant="ghost"
-      className="h-auto w-fit p-0 text-sm font-medium text-foreground underline underline-offset-2 hover:bg-transparent"
+      className="h-auto w-fit p-0 text-sm font-medium !text-foreground underline underline-offset-2 hover:bg-transparent hover:!text-foreground"
       onClick={() => onOpen(intent, sessionId)}
     >
       Open in Agent Studio


### PR DESCRIPTION
## Summary
- keep Agent Studio diff loading tied to a monotonic loading request sequence so stale requests cannot clear the spinner after a scope switch or context reset
- preserve diff batch identity on no-op snapshot and error updates, and add regression coverage for both overlapping scope loads and repo-context resets
- keep the session-started toast action readable while narrowing the hover text override to the only state that still needs it

## Testing
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- cargo rust-lint-host
- cargo rust-test-host-unit
- cargo rust-test-host-integration
- cargo rust-lint-tauri
- cargo rust-test-tauri
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml --locked

## Notes
- GitHub Actions checks are currently blocked by repository billing/account limits; the jobs never started. Local verification above passed.