### PR TITLE
feat(desktop): adopt TanStack Query for shared reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,21 @@ Prefer light shades for backgrounds (`bg-sky-50`) and dark for text (`text-sky-7
 - For async form submissions: disable the full form scope, show in-button loading, and preserve pending/error/success feedback.
 - Avoid nested ternaries in app and test code. Prefer named booleans, helper functions, lookup maps, or explicit `if`/`else` control flow so state rules stay readable.
 
+### TanStack Query Rules
+
+- TanStack Query is the default cache and deduplication layer for frontend reads that come from the backend or host adapters.
+- MUST use TanStack Query for server-owned read data that can be requested from multiple places, reused across screens, refreshed, invalidated after mutations, or deduplicated in flight.
+- MUST use TanStack Query for stable host reads such as settings snapshots, repo config, runtime definitions, tasks/runs lists, branches/current branch, diagnostics, session lists, and git status snapshots unless there is a documented exception.
+- MUST define query keys and query option builders in focused modules under `apps/desktop/src/state/queries`.
+- MUST use `useQuery` / `useQueries` / `useSuspenseQuery` in React render paths that read backend-owned data.
+- MUST use `queryClient.fetchQuery`, `ensureQueryData`, `prefetchQuery`, or cache invalidation APIs for imperative backend reads outside render paths.
+- MUST invalidate or update the relevant TanStack Query cache entries after any mutation that changes cached server data.
+- MUST prefer deriving UI state from query results over copying query data into local component state unless the copied state is a true user-editable draft.
+- MUST NOT add new ad hoc request caches, singleton in-flight maps, or `useEffect`+`useState` fetch loops for backend reads when TanStack Query can own that data.
+- MUST NOT use TanStack Query as the primary store for transient UI state, local form drafts, modal visibility, optimistic text input, or event-stream assembly.
+- MUST NOT move live streaming agent transcript state, in-progress tool output, pending permission/question interactions, or other event-driven session state into TanStack Query unless the underlying data becomes request/response based.
+- When adapting existing provider APIs, it is acceptable to keep the provider contract stable while making the underlying read path use TanStack Query.
+
 ## Backend / Tauri
 
 - Register every Tauri command in `tauri::generate_handler!`.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-virtual": "^3.13.21",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -19,6 +19,14 @@ use std::time::{Duration, Instant};
 const RUNTIME_CHECK_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 const GH_NON_INTERACTIVE_ENV: [(&str, &str); 1] = [("GH_PROMPT_DISABLED", "1")];
 
+type SettingsSnapshotTuple = (
+    String,
+    GlobalGitConfig,
+    ChatSettings,
+    HashMap<String, RepoConfig>,
+    PromptOverrides,
+);
+
 fn resolve_execution_path(repo_path: &str, working_dir: Option<&str>) -> String {
     working_dir
         .map(str::trim)
@@ -224,13 +232,7 @@ impl AppService {
 
     pub fn workspace_get_settings_snapshot(
         &self,
-    ) -> Result<(
-        String,
-        GlobalGitConfig,
-        ChatSettings,
-        HashMap<String, RepoConfig>,
-        PromptOverrides,
-    )> {
+    ) -> Result<SettingsSnapshotTuple> {
         let config = self.config_store.load()?;
         Ok((
             config.theme,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -225,6 +225,7 @@ impl AppService {
     pub fn workspace_get_settings_snapshot(
         &self,
     ) -> Result<(
+        String,
         GlobalGitConfig,
         ChatSettings,
         HashMap<String, RepoConfig>,
@@ -232,6 +233,7 @@ impl AppService {
     )> {
         let config = self.config_store.load()?;
         Ok((
+            config.theme,
             config.git,
             config.chat,
             config.repos,
@@ -245,6 +247,7 @@ impl AppService {
 
     pub(super) fn workspace_persist_settings_snapshot(
         &self,
+        theme: String,
         git: GlobalGitConfig,
         chat: ChatSettings,
         repos: HashMap<String, RepoConfig>,
@@ -259,6 +262,7 @@ impl AppService {
             }
         }
 
+        config.theme = theme;
         config.git = git;
         config.chat = chat;
         config.global_prompt_overrides = global_prompt_overrides;
@@ -298,10 +302,6 @@ impl AppService {
 
         self.config_store
             .set_repo_trust_hooks(repo_path, false, None)
-    }
-
-    pub fn get_theme(&self) -> Result<String> {
-        self.config_store.get_theme()
     }
 
     pub fn set_theme(&self, theme: &str) -> Result<()> {
@@ -774,7 +774,7 @@ mod tests {
     fn workspace_get_settings_snapshot_returns_defaulted_chat_settings() {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
 
-        let (_git, chat, repos, global_prompt_overrides) = service
+        let (_theme, _git, chat, repos, global_prompt_overrides) = service
             .workspace_get_settings_snapshot()
             .expect("settings snapshot should load");
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -220,6 +220,7 @@ impl AppService {
 
     pub fn workspace_save_settings_snapshot<P: HookTrustConfirmationPort + ?Sized>(
         &self,
+        theme: String,
         git: host_infra_system::GlobalGitConfig,
         chat: ChatSettings,
         mut repos: HashMap<String, RepoConfig>,
@@ -243,7 +244,13 @@ impl AppService {
             repo_config.trusted_hooks_fingerprint = trusted_hooks_fingerprint;
         }
 
-        self.workspace_persist_settings_snapshot(git, chat, repos, global_prompt_overrides)?;
+        self.workspace_persist_settings_snapshot(
+            theme,
+            git,
+            chat,
+            repos,
+            global_prompt_overrides,
+        )?;
         self.workspace_list()
     }
 
@@ -658,7 +665,7 @@ mod tests {
         );
         let confirmation = RecordingHookTrustConfirmationPort::default();
 
-        let (git, mut chat, mut repos, mut global_prompt_overrides) =
+        let (theme, git, mut chat, mut repos, mut global_prompt_overrides) =
             fixture.service.workspace_get_settings_snapshot()?;
         chat.show_thinking_messages = true;
         global_prompt_overrides.insert(
@@ -681,6 +688,7 @@ mod tests {
         repo_config.trusted_hooks_fingerprint = None;
 
         fixture.service.workspace_save_settings_snapshot(
+            theme,
             git,
             chat,
             repos,
@@ -711,12 +719,13 @@ mod tests {
         let fixture = setup_fixture("snapshot-chat-roundtrip", HookSet::default());
         let confirmation = RecordingHookTrustConfirmationPort::default();
 
-        let (git, mut chat, repos, global_prompt_overrides) =
+        let (theme, git, mut chat, repos, global_prompt_overrides) =
             fixture.service.workspace_get_settings_snapshot()?;
         assert_eq!(chat, ChatSettings::default());
         chat.show_thinking_messages = true;
 
         fixture.service.workspace_save_settings_snapshot(
+            theme,
             git,
             chat,
             repos,
@@ -724,7 +733,13 @@ mod tests {
             &confirmation,
         )?;
 
-        let (_persisted_git, persisted_chat, _persisted_repos, _persisted_global_prompt_overrides) =
+        let (
+            _persisted_theme,
+            _persisted_git,
+            persisted_chat,
+            _persisted_repos,
+            _persisted_global_prompt_overrides,
+        ) =
             fixture.service.workspace_get_settings_snapshot()?;
         assert!(persisted_chat.show_thinking_messages);
         assert_eq!(confirmation.request_count(), 0);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -377,7 +377,7 @@ fn workspace_record_from_repo(
 ) -> Result<WorkspaceRecord> {
     let default_worktree_base_path = match default_worktree_base_path(workspace_key) {
         Ok(path) => Some(path),
-        Err(error) if repo.worktree_base_path.is_some() => None,
+        Err(_error) if repo.worktree_base_path.is_some() => None,
         Err(error) => {
             return Err(error).with_context(|| {
                 format!(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -233,10 +233,6 @@ impl AppConfigStore {
         })
     }
 
-    pub fn get_theme(&self) -> Result<String> {
-        Ok(self.load()?.theme)
-    }
-
     pub fn set_theme(&self, theme: &str) -> Result<()> {
         self.update_config(|config| {
             config.theme = theme.to_string();

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -131,9 +131,10 @@ pub async fn workspace_detect_github_repository(
 pub async fn workspace_get_settings_snapshot(
     state: State<'_, AppState>,
 ) -> Result<SettingsSnapshotResponsePayload, String> {
-    let (git, chat, repos, global_prompt_overrides) =
+    let (theme, git, chat, repos, global_prompt_overrides) =
         as_error(state.service.workspace_get_settings_snapshot())?;
     Ok(SettingsSnapshotResponsePayload {
+        theme,
         git,
         chat,
         repos,
@@ -163,6 +164,7 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
     snapshot: SettingsSnapshotPayload,
 ) -> Result<Vec<host_domain::WorkspaceRecord>, String> {
     let SettingsSnapshotPayload {
+        theme,
         git,
         chat,
         repos,
@@ -174,6 +176,7 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
     as_error(
         run_service_blocking("workspace_save_settings_snapshot", move || {
             service.workspace_save_settings_snapshot(
+                theme,
                 git,
                 chat,
                 repos,
@@ -211,11 +214,6 @@ pub async fn workspace_set_trusted_hooks<R: tauri::Runtime>(
         })
         .await,
     )
-}
-
-#[tauri::command]
-pub async fn get_theme(state: State<'_, AppState>) -> Result<String, String> {
-    as_error(state.service.get_theme())
 }
 
 #[tauri::command]
@@ -717,11 +715,12 @@ mod tests {
             Some(false),
         );
 
-        let (git, chat, repos, global_prompt_overrides) = fixture
+        let (theme, git, chat, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
         let mut snapshot = SettingsSnapshotPayload {
+            theme,
             git,
             chat,
             repos,
@@ -766,11 +765,12 @@ mod tests {
             Some(true),
         );
 
-        let (git, chat, repos, global_prompt_overrides) = fixture
+        let (theme, git, chat, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
         let mut snapshot = SettingsSnapshotPayload {
+            theme,
             git,
             chat,
             repos,
@@ -826,7 +826,7 @@ mod tests {
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
         assert_eq!(
-            config.0.default_merge_method,
+            config.1.default_merge_method,
             host_infra_system::GitMergeMethod::Squash
         );
         Ok(())
@@ -895,11 +895,12 @@ mod tests {
         let fixture =
             setup_workspace_command_fixture("snapshot-ipc-shared-prompts", HookSet::default());
 
-        let (git, chat, repos, global_prompt_overrides) = fixture
+        let (theme, git, chat, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
         let mut snapshot = SettingsSnapshotPayload {
+            theme,
             git,
             chat,
             repos,
@@ -948,6 +949,7 @@ mod tests {
 
         let payload = json!({
             "snapshot": {
+                "theme": snapshot.theme,
                 "git": snapshot.git,
                 "chat": snapshot.chat,
                 "repos": snapshot.repos,
@@ -965,7 +967,7 @@ mod tests {
             "snapshot save response should include workspace records"
         );
 
-        let (_persisted_git, persisted_chat, persisted_repos, persisted_global) = fixture
+        let (_persisted_theme, _persisted_git, persisted_chat, persisted_repos, persisted_global) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -1009,7 +1011,7 @@ mod tests {
         let fixture =
             setup_workspace_command_fixture("snapshot-default-chat", HookSet::default());
 
-        let (_git, chat, _repos, _global_prompt_overrides) = fixture
+        let (_theme, _git, chat, _repos, _global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -1024,13 +1026,14 @@ mod tests {
         let fixture =
             setup_workspace_command_fixture("snapshot-chat-roundtrip", HookSet::default());
 
-        let (git, _chat, repos, global_prompt_overrides) = fixture
+        let (theme, git, _chat, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
 
         let payload_without_chat = json!({
             "snapshot": {
+                "theme": theme.clone(),
                 "git": git.clone(),
                 "repos": repos.clone(),
                 "globalPromptOverrides": global_prompt_overrides.clone(),
@@ -1045,6 +1048,7 @@ mod tests {
 
         let payload_with_chat = json!({
             "snapshot": {
+                "theme": theme,
                 "git": git,
                 "chat": {
                     "showThinkingMessages": true
@@ -1056,7 +1060,7 @@ mod tests {
         invoke_workspace_save_settings_snapshot_ipc(&fixture, payload_with_chat)
             .expect("IPC snapshot save should persist chat settings");
 
-        let (_reloaded_git, reloaded_chat, _reloaded_repos, _reloaded_global) = fixture
+        let (_reloaded_theme, _reloaded_git, reloaded_chat, _reloaded_repos, _reloaded_global) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;

--- a/apps/desktop/src-tauri/src/headless.rs
+++ b/apps/desktop/src-tauri/src/headless.rs
@@ -721,7 +721,6 @@ async fn dispatch_workspace_command(
             Some(handle_workspace_save_settings_snapshot(state, args).await)
         }
         "workspace_set_trusted_hooks" => Some(handle_workspace_set_trusted_hooks(state, args).await),
-        "get_theme" => Some(handle_get_theme(state)),
         "set_theme" => Some(handle_set_theme(state, args)),
         _ => None,
     }
@@ -955,11 +954,12 @@ fn handle_workspace_update_repo_hooks(state: &HeadlessState, args: Value) -> Com
 }
 
 fn handle_workspace_get_settings_snapshot(state: &HeadlessState) -> CommandResult {
-    let (git, chat, repos, global_prompt_overrides) = state
+    let (theme, git, chat, repos, global_prompt_overrides) = state
         .service
         .workspace_get_settings_snapshot()
         .map_err(service_error)?;
     serialize_value(SettingsSnapshotResponsePayload {
+        theme,
         git,
         chat,
         repos,
@@ -989,6 +989,7 @@ async fn handle_workspace_save_settings_snapshot(
     let service = state.service.clone();
     let confirmation_port = HeadlessHookTrustConfirmationPort;
     let SettingsSnapshotPayload {
+        theme,
         git,
         chat,
         repos,
@@ -997,6 +998,7 @@ async fn handle_workspace_save_settings_snapshot(
     serialize_value(
         run_service_blocking_tokio("workspace_save_settings_snapshot", move || {
             service.workspace_save_settings_snapshot(
+                theme,
                 git,
                 chat,
                 repos,
@@ -1046,10 +1048,6 @@ fn handle_set_theme(state: &HeadlessState, args: Value) -> CommandResult {
     let ThemeArgs { theme } = deserialize_args(args)?;
     state.service.set_theme(&theme).map_err(service_error)?;
     Ok(Value::Null)
-}
-
-fn handle_get_theme(state: &HeadlessState) -> CommandResult {
-    serialize_value(state.service.get_theme().map_err(service_error)?)
 }
 
 fn handle_git_get_current_branch(state: &HeadlessState, args: Value) -> CommandResult {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -144,6 +144,7 @@ pub(crate) struct RepoSettingsPayload {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SettingsSnapshotPayload {
+    theme: String,
     git: host_infra_system::GlobalGitConfig,
     chat: host_infra_system::ChatSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
@@ -153,6 +154,7 @@ pub(crate) struct SettingsSnapshotPayload {
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SettingsSnapshotResponsePayload {
+    theme: String,
     git: host_infra_system::GlobalGitConfig,
     chat: host_infra_system::ChatSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
@@ -328,7 +330,6 @@ fn startup_phase_command_registration(
         runtime_ensure,
         agent_sessions_list,
         agent_session_upsert,
-        get_theme,
         set_theme
     ])
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import { AppShell } from "@/components/layout/app-shell";
 import { ThemeProvider } from "@/components/layout/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { QueryProvider } from "@/lib/query-provider";
 import { loadAgentsPage, loadKanbanPage, loadNotFoundPage } from "@/pages";
 import { AppStateProvider } from "@/state";
 
@@ -26,20 +27,22 @@ function withRouteFallback(element: ReactElement): ReactElement {
 
 export function App(): ReactElement {
   return (
-    <ThemeProvider>
-      <AppStateProvider>
-        <Routes>
-          <Route element={<AppShell />}>
-            <Route path="/" element={<Navigate to="/kanban" replace />} />
-            <Route path="/kanban" element={withRouteFallback(<KanbanPage />)} />
-            <Route path="/agents" element={withRouteFallback(<AgentsPage />)} />
-            <Route path="/planner" element={<Navigate to="/agents?agent=planner" replace />} />
-            <Route path="/builder" element={<Navigate to="/agents?agent=build" replace />} />
-            <Route path="*" element={withRouteFallback(<NotFoundPage />)} />
-          </Route>
-        </Routes>
-        <Toaster />
-      </AppStateProvider>
-    </ThemeProvider>
+    <QueryProvider>
+      <ThemeProvider>
+        <AppStateProvider>
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/" element={<Navigate to="/kanban" replace />} />
+              <Route path="/kanban" element={withRouteFallback(<KanbanPage />)} />
+              <Route path="/agents" element={withRouteFallback(<AgentsPage />)} />
+              <Route path="/planner" element={<Navigate to="/agents?agent=planner" replace />} />
+              <Route path="/builder" element={<Navigate to="/agents?agent=build" replace />} />
+              <Route path="*" element={withRouteFallback(<NotFoundPage />)} />
+            </Route>
+          </Routes>
+          <Toaster />
+        </AppStateProvider>
+      </ThemeProvider>
+    </QueryProvider>
   );
 }

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -10,6 +10,7 @@ import { AgentSessionPermissionCard } from "./agent-session-permission-card";
 import { AgentSessionQuestionCard } from "./agent-session-question-card";
 import { AgentSessionTodoPanel } from "./agent-session-todo-panel";
 import { useAgentChatAutoScroll } from "./use-agent-chat-auto-scroll";
+import { useAgentChatLoadingOverlay } from "./use-agent-chat-loading-overlay";
 import { useAgentChatRowMotion } from "./use-agent-chat-row-motion";
 import { useAgentChatVirtualization } from "./use-agent-chat-virtualization";
 
@@ -90,6 +91,14 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     shouldVirtualize,
     virtualRowsCount: virtualRows.length,
     virtualizer,
+  });
+  const showLoadingOverlay = useAgentChatLoadingOverlay({
+    sessionId: activeSessionId,
+    isSessionViewLoading,
+    hasRenderableSessionRows,
+    hasSessionHistory,
+    isPreparingVirtualization,
+    isJumpingToLatest,
   });
   const sessionRole = session?.role ?? null;
   const sessionSelectedModel = session?.selectedModel ?? null;
@@ -266,11 +275,11 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
         ))}
       </div>
 
-      {isSessionViewLoading || isPreparingVirtualization || isJumpingToLatest ? (
+      {showLoadingOverlay ? (
         <div className="absolute inset-0 z-30 flex items-center justify-center bg-muted">
           <div className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm">
             <LoaderCircle className="size-3.5 animate-spin" />
-            Loading session history...
+            Preparing chat...
           </div>
         </div>
       ) : null}

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-loading-overlay.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-loading-overlay.test.tsx
@@ -226,7 +226,7 @@ describe("useAgentChatLoadingOverlay", () => {
       renderer?.update(
         createElement(Harness, {
           sessionId: "session-2",
-          isSessionViewLoading: true,
+          isSessionViewLoading: false,
           hasRenderableSessionRows: false,
           hasSessionHistory: false,
           isPreparingVirtualization: false,

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-loading-overlay.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-loading-overlay.test.tsx
@@ -1,0 +1,246 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import TestRenderer, { act } from "react-test-renderer";
+import { useAgentChatLoadingOverlay } from "./use-agent-chat-loading-overlay";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type OverlayHookProps = {
+  sessionId: string | null;
+  isSessionViewLoading: boolean;
+  hasRenderableSessionRows: boolean;
+  hasSessionHistory: boolean;
+  isPreparingVirtualization: boolean;
+  isJumpingToLatest: boolean;
+};
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("useAgentChatLoadingOverlay", () => {
+  test("keeps the overlay visible through the full session-display pipeline", async () => {
+    const latestVisibleRef: { current: boolean | null } = { current: null };
+
+    const Harness = (props: OverlayHookProps): null => {
+      latestVisibleRef.current = useAgentChatLoadingOverlay(props);
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(Harness, {
+          sessionId: "session-1",
+          isSessionViewLoading: true,
+          hasRenderableSessionRows: false,
+          hasSessionHistory: false,
+          isPreparingVirtualization: false,
+          isJumpingToLatest: false,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(true);
+
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, {
+          sessionId: "session-1",
+          isSessionViewLoading: false,
+          hasRenderableSessionRows: false,
+          hasSessionHistory: false,
+          isPreparingVirtualization: true,
+          isJumpingToLatest: false,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(true);
+
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, {
+          sessionId: "session-1",
+          isSessionViewLoading: false,
+          hasRenderableSessionRows: false,
+          hasSessionHistory: false,
+          isPreparingVirtualization: false,
+          isJumpingToLatest: true,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(true);
+
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, {
+          sessionId: "session-1",
+          isSessionViewLoading: false,
+          hasRenderableSessionRows: true,
+          hasSessionHistory: true,
+          isPreparingVirtualization: false,
+          isJumpingToLatest: false,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(false);
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+
+  test("does not re-show the overlay for later non-initial same-session jumps", async () => {
+    const latestVisibleRef: { current: boolean | null } = { current: null };
+
+    const Harness = (props: OverlayHookProps): null => {
+      latestVisibleRef.current = useAgentChatLoadingOverlay(props);
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(Harness, {
+          sessionId: "session-1",
+          isSessionViewLoading: false,
+          hasRenderableSessionRows: true,
+          hasSessionHistory: true,
+          isPreparingVirtualization: false,
+          isJumpingToLatest: false,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(false);
+
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, {
+          sessionId: "session-1",
+          isSessionViewLoading: false,
+          hasRenderableSessionRows: true,
+          hasSessionHistory: true,
+          isPreparingVirtualization: false,
+          isJumpingToLatest: true,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(false);
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+
+  test("starts a new loading cycle when the selected session changes", async () => {
+    const latestVisibleRef: { current: boolean | null } = { current: null };
+
+    const Harness = (props: OverlayHookProps): null => {
+      latestVisibleRef.current = useAgentChatLoadingOverlay(props);
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(Harness, {
+          sessionId: "session-1",
+          isSessionViewLoading: false,
+          hasRenderableSessionRows: true,
+          hasSessionHistory: true,
+          isPreparingVirtualization: false,
+          isJumpingToLatest: false,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(false);
+
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, {
+          sessionId: "session-2",
+          isSessionViewLoading: true,
+          hasRenderableSessionRows: false,
+          hasSessionHistory: false,
+          isPreparingVirtualization: false,
+          isJumpingToLatest: false,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(true);
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+
+  test("shows the overlay immediately when the selected session changes before rows are ready", async () => {
+    const latestVisibleRef: { current: boolean | null } = { current: null };
+
+    const Harness = (props: OverlayHookProps): null => {
+      latestVisibleRef.current = useAgentChatLoadingOverlay(props);
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(Harness, {
+          sessionId: "session-1",
+          isSessionViewLoading: false,
+          hasRenderableSessionRows: true,
+          hasSessionHistory: true,
+          isPreparingVirtualization: false,
+          isJumpingToLatest: false,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(false);
+
+    await act(async () => {
+      renderer?.update(
+        createElement(Harness, {
+          sessionId: "session-2",
+          isSessionViewLoading: true,
+          hasRenderableSessionRows: false,
+          hasSessionHistory: false,
+          isPreparingVirtualization: false,
+          isJumpingToLatest: false,
+        }),
+      );
+      await flush();
+    });
+
+    expect(latestVisibleRef.current).toBe(true);
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-loading-overlay.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-loading-overlay.ts
@@ -1,0 +1,55 @@
+import { useLayoutEffect, useState } from "react";
+
+type UseAgentChatLoadingOverlayArgs = {
+  sessionId: string | null;
+  isSessionViewLoading: boolean;
+  hasRenderableSessionRows: boolean;
+  hasSessionHistory: boolean;
+  isPreparingVirtualization: boolean;
+  isJumpingToLatest: boolean;
+};
+
+const isReadyToDisplay = ({
+  sessionId,
+  isSessionViewLoading,
+  hasRenderableSessionRows,
+  hasSessionHistory,
+  isPreparingVirtualization,
+  isJumpingToLatest,
+}: UseAgentChatLoadingOverlayArgs): boolean => {
+  if (isSessionViewLoading || isPreparingVirtualization || isJumpingToLatest) {
+    return false;
+  }
+
+  if (sessionId === null) {
+    return true;
+  }
+
+  return hasRenderableSessionRows || hasSessionHistory;
+};
+
+const resolveInitialSettledSessionId = (args: UseAgentChatLoadingOverlayArgs): string | null => {
+  return isReadyToDisplay(args) ? args.sessionId : null;
+};
+
+export function useAgentChatLoadingOverlay(args: UseAgentChatLoadingOverlayArgs): boolean {
+  const [settledSessionId, setSettledSessionId] = useState<string | null>(() =>
+    resolveInitialSettledSessionId(args),
+  );
+  const ready = isReadyToDisplay(args);
+  const isPendingSessionDisplay = args.sessionId !== settledSessionId;
+
+  useLayoutEffect(() => {
+    if (!ready) {
+      return;
+    }
+
+    if (settledSessionId === args.sessionId) {
+      return;
+    }
+
+    setSettledSessionId(args.sessionId);
+  }, [args.sessionId, ready, settledSessionId]);
+
+  return isPendingSessionDisplay;
+}

--- a/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { SettingsModalContent } from "./settings-modal-content";
 
 const createMockSnapshot = (overrides: Partial<SettingsSnapshot> = {}): SettingsSnapshot => ({
+  theme: "light",
   git: { defaultMergeMethod: "merge_commit" },
   chat: { showThinkingMessages: false },
   repos: {},

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
@@ -208,6 +208,7 @@ describe("settings-modal-normalization", () => {
         enabled: false,
       },
     });
+    expect(snapshot.theme).toBe("light");
   });
 
   test("selects initial repo using active repo when available", () => {

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
@@ -180,6 +180,7 @@ describe("settings-modal-normalization", () => {
 
   test("normalizes snapshot repo map and global prompt overrides", () => {
     const snapshot = normalizeSnapshotForSave({
+      theme: "light",
       git: {
         defaultMergeMethod: "merge_commit",
       },
@@ -211,6 +212,7 @@ describe("settings-modal-normalization", () => {
 
   test("selects initial repo using active repo when available", () => {
     const snapshot = {
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit" as const,
       },
@@ -229,6 +231,7 @@ describe("settings-modal-normalization", () => {
     expect(
       pickInitialRepoPath(
         {
+          theme: "light" as const,
           git: {
             defaultMergeMethod: "merge_commit" as const,
           },

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
@@ -105,6 +105,7 @@ export const normalizeSnapshotForSave = (snapshot: SettingsSnapshot): SettingsSn
   );
 
   return {
+    theme: snapshot.theme,
     git: normalizeGlobalGitConfigForSave(snapshot.git),
     chat: snapshot.chat,
     repos,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-branches-state.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-branches-state.ts
@@ -23,7 +23,6 @@ export const useSettingsModalBranchesState = ({
     data: selectedRepoBranches = [],
     error,
     isLoading,
-    refetch,
   } = useQuery({
     ...(selectedRepoPath
       ? repoBranchesQueryOptions(selectedRepoPath)
@@ -39,7 +38,6 @@ export const useSettingsModalBranchesState = ({
     void queryClient.invalidateQueries({
       queryKey: repoBranchesQueryOptions(selectedRepoPath).queryKey,
     });
-    void refetch();
   };
 
   return {

--- a/apps/desktop/src/components/features/settings/use-settings-modal-branches-state.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-branches-state.ts
@@ -1,7 +1,6 @@
 import type { GitBranch } from "@openducktor/contracts";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { errorMessage } from "@/lib/errors";
-import { loadRepoBranches } from "@/state/operations";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { repoBranchesQueryOptions } from "@/state/queries/git";
 
 type UseSettingsModalBranchesStateArgs = {
   open: boolean;
@@ -19,87 +18,35 @@ export const useSettingsModalBranchesState = ({
   open,
   selectedRepoPath,
 }: UseSettingsModalBranchesStateArgs): SettingsModalBranchesState => {
-  const [repoBranchesByPath, setRepoBranchesByPath] = useState<Record<string, GitBranch[]>>({});
-  const [isLoadingRepoBranchesByPath, setIsLoadingRepoBranchesByPath] = useState<
-    Record<string, boolean>
-  >({});
-  const [repoBranchesErrorByPath, setRepoBranchesErrorByPath] = useState<
-    Record<string, string | undefined>
-  >({});
+  const queryClient = useQueryClient();
+  const {
+    data: selectedRepoBranches = [],
+    error,
+    isLoading,
+    refetch,
+  } = useQuery({
+    ...(selectedRepoPath
+      ? repoBranchesQueryOptions(selectedRepoPath)
+      : repoBranchesQueryOptions("")),
+    enabled: open && Boolean(selectedRepoPath),
+  });
 
-  useEffect(() => {
-    if (open) {
-      return;
-    }
-    setRepoBranchesByPath({});
-    setIsLoadingRepoBranchesByPath({});
-    setRepoBranchesErrorByPath({});
-  }, [open]);
-
-  const selectedRepoBranches = useMemo(
-    () => (selectedRepoPath ? (repoBranchesByPath[selectedRepoPath] ?? []) : []),
-    [repoBranchesByPath, selectedRepoPath],
-  );
-  const isLoadingSelectedRepoBranches = selectedRepoPath
-    ? Boolean(isLoadingRepoBranchesByPath[selectedRepoPath])
-    : false;
-  const selectedRepoBranchesError = selectedRepoPath
-    ? (repoBranchesErrorByPath[selectedRepoPath] ?? null)
-    : null;
-
-  useEffect(() => {
-    if (!open || !selectedRepoPath) {
-      return;
-    }
-
-    if (
-      repoBranchesByPath[selectedRepoPath] ||
-      isLoadingRepoBranchesByPath[selectedRepoPath] ||
-      repoBranchesErrorByPath[selectedRepoPath]
-    ) {
-      return;
-    }
-
-    setIsLoadingRepoBranchesByPath((current) => ({ ...current, [selectedRepoPath]: true }));
-
-    void loadRepoBranches(selectedRepoPath)
-      .then((branches) => {
-        setRepoBranchesByPath((current) => ({ ...current, [selectedRepoPath]: branches }));
-        setRepoBranchesErrorByPath((current) => ({ ...current, [selectedRepoPath]: undefined }));
-      })
-      .catch((error: unknown) => {
-        setRepoBranchesErrorByPath((current) => ({
-          ...current,
-          [selectedRepoPath]: errorMessage(error),
-        }));
-      })
-      .finally(() => {
-        setIsLoadingRepoBranchesByPath((current) => ({ ...current, [selectedRepoPath]: false }));
-      });
-  }, [
-    isLoadingRepoBranchesByPath,
-    open,
-    repoBranchesByPath,
-    repoBranchesErrorByPath,
-    selectedRepoPath,
-  ]);
-
-  const retrySelectedRepoBranchesLoad = useCallback((): void => {
+  const retrySelectedRepoBranchesLoad = (): void => {
     if (!selectedRepoPath) {
       return;
     }
 
-    setRepoBranchesErrorByPath((current) => ({ ...current, [selectedRepoPath]: undefined }));
-    setRepoBranchesByPath((current) => {
-      const { [selectedRepoPath]: _ignored, ...remaining } = current;
-      return remaining;
+    void queryClient.invalidateQueries({
+      queryKey: repoBranchesQueryOptions(selectedRepoPath).queryKey,
     });
-  }, [selectedRepoPath]);
+    void refetch();
+  };
 
   return {
-    selectedRepoBranches,
-    isLoadingSelectedRepoBranches,
-    selectedRepoBranchesError,
+    selectedRepoBranches: open && selectedRepoPath ? selectedRepoBranches : [],
+    isLoadingSelectedRepoBranches: open && selectedRepoPath ? isLoading : false,
+    selectedRepoBranchesError:
+      open && selectedRepoPath && error instanceof Error ? error.message : null,
     retrySelectedRepoBranchesLoad,
   };
 };

--- a/apps/desktop/src/components/features/settings/use-settings-modal-catalog-state.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-catalog-state.ts
@@ -1,8 +1,8 @@
 import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
-import { useEffect, useMemo, useState } from "react";
-import { errorMessage } from "@/lib/errors";
-import { loadRepoRuntimeCatalog } from "@/state/operations";
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { repoRuntimeCatalogQueryOptions } from "@/state/queries/runtime-catalog";
 
 type UseSettingsModalCatalogStateArgs = {
   open: boolean;
@@ -25,69 +25,38 @@ export const useSettingsModalCatalogState = ({
   selectedRepoPath,
   runtimeDefinitions,
 }: UseSettingsModalCatalogStateArgs): SettingsModalCatalogState => {
-  const [catalogsByRuntime, setCatalogsByRuntime] = useState<
-    Record<string, AgentModelCatalog | null>
-  >({});
-  const [catalogErrorsByRuntime, setCatalogErrorsByRuntime] = useState<
-    Record<string, string | null>
-  >({});
-  const [loadingRuntimeKinds, setLoadingRuntimeKinds] = useState<RuntimeKind[]>([]);
   const runtimeKinds = useMemo(
     () => runtimeDefinitions.map((definition) => definition.kind),
     [runtimeDefinitions],
   );
 
-  useEffect(() => {
-    if (!open || !selectedRepoPath || runtimeKinds.length === 0) {
-      setCatalogsByRuntime({});
-      setCatalogErrorsByRuntime({});
-      setLoadingRuntimeKinds([]);
-      return;
-    }
+  const catalogQueries = useQueries({
+    queries: runtimeKinds.map((runtimeKind) => ({
+      ...(selectedRepoPath
+        ? repoRuntimeCatalogQueryOptions(selectedRepoPath, runtimeKind)
+        : repoRuntimeCatalogQueryOptions("", runtimeKind)),
+      enabled: open && Boolean(selectedRepoPath),
+    })),
+  });
 
-    let cancelled = false;
-    setCatalogErrorsByRuntime({});
-    setLoadingRuntimeKinds(runtimeKinds);
+  const catalogsByRuntime = useMemo<Record<string, AgentModelCatalog | null>>(() => {
+    return Object.fromEntries(
+      runtimeKinds.map((runtimeKind, index) => [runtimeKind, catalogQueries[index]?.data ?? null]),
+    );
+  }, [catalogQueries, runtimeKinds]);
 
-    for (const runtimeKind of runtimeKinds) {
-      void loadRepoRuntimeCatalog(selectedRepoPath, runtimeKind)
-        .then((nextCatalog) => {
-          if (cancelled) {
-            return;
-          }
-          setCatalogsByRuntime((current) => ({
-            ...current,
-            [runtimeKind]: nextCatalog,
-          }));
-          setCatalogErrorsByRuntime((current) => ({
-            ...current,
-            [runtimeKind]: null,
-          }));
-        })
-        .catch((error: unknown) => {
-          if (cancelled) {
-            return;
-          }
-          setCatalogsByRuntime((current) => ({
-            ...current,
-            [runtimeKind]: null,
-          }));
-          setCatalogErrorsByRuntime((current) => ({
-            ...current,
-            [runtimeKind]: errorMessage(error),
-          }));
-        })
-        .finally(() => {
-          if (!cancelled) {
-            setLoadingRuntimeKinds((current) => current.filter((entry) => entry !== runtimeKind));
-          }
-        });
-    }
+  const catalogErrorsByRuntime = useMemo<Record<string, string | null>>(() => {
+    return Object.fromEntries(
+      runtimeKinds.map((runtimeKind, index) => {
+        const queryError = catalogQueries[index]?.error;
+        return [runtimeKind, queryError instanceof Error ? queryError.message : null];
+      }),
+    );
+  }, [catalogQueries, runtimeKinds]);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [open, runtimeKinds, selectedRepoPath]);
+  const loadingRuntimeKinds = useMemo<RuntimeKind[]>(() => {
+    return runtimeKinds.filter((_runtimeKind, index) => catalogQueries[index]?.isLoading);
+  }, [catalogQueries, runtimeKinds]);
 
   return {
     catalogsByRuntime,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
@@ -4,12 +4,11 @@ import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "@/pages/agents/agent-studio-test-utils";
-import { SETTINGS_SNAPSHOT_UPDATED_EVENT } from "@/pages/agents/use-agent-studio-chat-settings";
-import { REPO_SETTINGS_UPDATED_EVENT } from "@/pages/agents/use-agent-studio-repo-settings";
 
 enableReactActEnvironment();
 
 const createSettingsSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
   git: {
     defaultMergeMethod: "merge_commit",
   },
@@ -130,62 +129,39 @@ describe("useSettingsModalController", () => {
     await harness.unmount();
   });
 
-  test("saves chat-only edits through settings snapshot without repo update events", async () => {
+  test("saves chat-only edits through the settings snapshot query path", async () => {
     refreshChecks = mock(async () => {});
     saveGlobalGitConfig = mock(async () => {});
     saveSettingsSnapshot = mock(async () => {});
     loadSettingsSnapshot.mockClear();
 
-    const dispatchEvent = mock((_event: Event) => true);
-    const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
-    Object.defineProperty(globalThis, "window", {
-      configurable: true,
-      writable: true,
-      value: {
-        dispatchEvent,
+    const harness = createHookHarness(true);
+    await harness.mount();
+    await harness.waitFor((state) => state.snapshotDraft !== null);
+
+    await harness.run((state) => {
+      state.updateGlobalChatSettings((chat) => ({
+        ...chat,
+        showThinkingMessages: true,
+      }));
+    });
+
+    let didSave = false;
+    await harness.run(async (state) => {
+      didSave = await state.submit();
+    });
+
+    expect(didSave).toBe(true);
+    expect(saveGlobalGitConfig).toHaveBeenCalledTimes(0);
+    expect(saveSettingsSnapshot).toHaveBeenCalledTimes(1);
+    expect(saveSettingsSnapshot).toHaveBeenCalledWith({
+      ...createSettingsSnapshot(),
+      chat: {
+        showThinkingMessages: true,
       },
     });
 
-    try {
-      const harness = createHookHarness(true);
-      await harness.mount();
-      await harness.waitFor((state) => state.snapshotDraft !== null);
-
-      await harness.run((state) => {
-        state.updateGlobalChatSettings((chat) => ({
-          ...chat,
-          showThinkingMessages: true,
-        }));
-      });
-
-      let didSave = false;
-      await harness.run(async (state) => {
-        didSave = await state.submit();
-      });
-
-      expect(didSave).toBe(true);
-      expect(saveGlobalGitConfig).toHaveBeenCalledTimes(0);
-      expect(saveSettingsSnapshot).toHaveBeenCalledTimes(1);
-      expect(saveSettingsSnapshot).toHaveBeenCalledWith({
-        ...createSettingsSnapshot(),
-        chat: {
-          showThinkingMessages: true,
-        },
-      });
-      expect(dispatchEvent).toHaveBeenCalledTimes(1);
-      const dispatchedEvent = dispatchEvent.mock.calls[0]?.[0];
-      expect(dispatchedEvent).toBeInstanceOf(CustomEvent);
-      expect((dispatchedEvent as Event).type).toBe(SETTINGS_SNAPSHOT_UPDATED_EVENT);
-      expect((dispatchedEvent as Event).type).not.toBe(REPO_SETTINGS_UPDATED_EVENT);
-
-      await harness.unmount();
-    } finally {
-      if (originalWindowDescriptor) {
-        Object.defineProperty(globalThis, "window", originalWindowDescriptor);
-      } else {
-        delete (globalThis as typeof globalThis & { window?: unknown }).window;
-      }
-    }
+    await harness.unmount();
   });
 
   test("keeps the override blank when unset and exposes the effective worktree path", async () => {

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
@@ -15,8 +15,6 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { pickRepositoryDirectory } from "@/lib/repo-directory";
-import { SETTINGS_SNAPSHOT_UPDATED_EVENT } from "@/pages/agents/use-agent-studio-chat-settings";
-import { REPO_SETTINGS_UPDATED_EVENT } from "@/pages/agents/use-agent-studio-repo-settings";
 import { useChecksState, useWorkspaceState } from "@/state";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import type { PromptRoleTabId, SettingsSectionId } from "./settings-modal-constants";
@@ -381,10 +379,6 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
         !dirtySections.globalPromptOverrides &&
         !dirtySections.repoSettings;
 
-      const shouldDispatchRepoSettingsUpdated =
-        Boolean(activeRepo) && (dirtySections.globalPromptOverrides || dirtySections.repoSettings);
-      let didSaveSettingsSnapshot = false;
-
       if (shouldUseGlobalGitSave) {
         const normalizedGit = normalizeGlobalGitConfigForSave(snapshotDraft.git);
         const loadedGit = loadedSnapshot
@@ -398,23 +392,6 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
       } else {
         const normalizedSnapshot = normalizeSnapshotForSave(snapshotDraft);
         await saveSettingsSnapshot(normalizedSnapshot);
-        didSaveSettingsSnapshot = true;
-      }
-
-      if (typeof window !== "undefined" && didSaveSettingsSnapshot) {
-        window.dispatchEvent(new CustomEvent(SETTINGS_SNAPSHOT_UPDATED_EVENT));
-      }
-
-      if (
-        typeof window !== "undefined" &&
-        shouldDispatchRepoSettingsUpdated &&
-        didSaveSettingsSnapshot
-      ) {
-        window.dispatchEvent(
-          new CustomEvent(REPO_SETTINGS_UPDATED_EVENT, {
-            detail: { repoPath: activeRepo },
-          }),
-        );
       }
 
       return true;
@@ -429,7 +406,6 @@ export const useSettingsModalController = (open: boolean): SettingsModalControll
       setIsSaving(false);
     }
   }, [
-    activeRepo,
     dirtySections.chat,
     dirtySections.globalGit,
     dirtySections.globalPromptOverrides,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
@@ -15,6 +15,7 @@ type HarnessArgs = {
 };
 
 const createInitialSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
   git: {
     defaultMergeMethod: "merge_commit",
   },

--- a/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
@@ -14,6 +14,7 @@ const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useSettingsModalPromptValidation, initialProps);
 
 const createSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
   git: {
     defaultMergeMethod: "merge_commit",
   },

--- a/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  formatManagedSessionCleanupLoadingMessage,
   formatManagedSessionCleanupMessage,
   formatUnknownManagedSessionCleanupMessage,
 } from "./task-delete-confirm-dialog";
@@ -25,5 +26,11 @@ describe("TaskDeleteConfirmDialog", () => {
     expect(message).toContain("may also be deleted");
     expect(message).toContain("related local branches");
     expect(message).toContain("uncommitted changes");
+  });
+
+  test("uses explicit loading wording while cleanup impact is still resolving", () => {
+    const message = formatManagedSessionCleanupLoadingMessage();
+
+    expect(message).toContain("Checking linked task worktree cleanup impact");
   });
 });

--- a/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.tsx
+++ b/apps/desktop/src/components/features/task-details/task-delete-confirm-dialog.tsx
@@ -18,6 +18,7 @@ type TaskDeleteConfirmDialogProps = {
   taskId: string;
   subtasksCount: number;
   hasSubtasks: boolean;
+  isLoadingImpact: boolean;
   hasManagedSessionCleanup: boolean;
   managedWorktreeCount: number;
   impactError: string | null;
@@ -36,6 +37,9 @@ export const formatManagedSessionCleanupMessage = (managedWorktreeCount: number)
 export const formatUnknownManagedSessionCleanupMessage = (): string =>
   "Linked task worktrees and their related local branches may also be deleted. Any uncommitted changes in those worktrees will be lost.";
 
+export const formatManagedSessionCleanupLoadingMessage = (): string =>
+  "Checking linked task worktree cleanup impact before deletion.";
+
 export function TaskDeleteConfirmDialog({
   open,
   onOpenChange,
@@ -44,6 +48,7 @@ export function TaskDeleteConfirmDialog({
   taskId,
   subtasksCount,
   hasSubtasks,
+  isLoadingImpact,
   hasManagedSessionCleanup,
   managedWorktreeCount,
   impactError,
@@ -67,7 +72,9 @@ export function TaskDeleteConfirmDialog({
           {hasSubtasks ? (
             <p>Direct subtasks will also be deleted to avoid orphaned children in the workflow.</p>
           ) : null}
-          {impactError ? (
+          {isLoadingImpact ? (
+            <p>{formatManagedSessionCleanupLoadingMessage()}</p>
+          ) : impactError ? (
             <p>{formatUnknownManagedSessionCleanupMessage()}</p>
           ) : hasManagedSessionCleanup ? (
             <p>{formatManagedSessionCleanupMessage(managedWorktreeCount)}</p>
@@ -90,16 +97,16 @@ export function TaskDeleteConfirmDialog({
             type="button"
             variant="destructive"
             className="w-[132px] justify-center disabled:bg-rose-400 disabled:text-rose-50 disabled:opacity-100"
-            disabled={isDeletePending}
-            aria-busy={isDeletePending}
+            disabled={isDeletePending || isLoadingImpact}
+            aria-busy={isDeletePending || isLoadingImpact}
             onClick={onConfirm}
           >
-            {isDeletePending ? (
+            {isDeletePending || isLoadingImpact ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (
               <Trash2 className="size-4" />
             )}
-            {isDeletePending ? "Deleting..." : "Delete"}
+            {isDeletePending ? "Deleting..." : isLoadingImpact ? "Checking..." : "Delete"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/desktop/src/components/features/task-details/task-details-sheet.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet.test.tsx
@@ -24,6 +24,7 @@ const viewModelMock = {
   isDeleteDialogOpen: false,
   isDeletePending: false,
   deleteError: null,
+  isLoadingDeleteImpact: false,
   hasManagedSessionCleanup: false,
   managedWorktreeCount: 0,
   impactError: null,

--- a/apps/desktop/src/components/features/task-details/task-details-sheet.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet.tsx
@@ -159,6 +159,7 @@ export function TaskDetailsSheet({
           taskId={viewModel.taskId}
           subtasksCount={viewModel.subtasks.length}
           hasSubtasks={viewModel.subtasks.length > 0}
+          isLoadingImpact={viewModel.isLoadingDeleteImpact}
           hasManagedSessionCleanup={viewModel.hasManagedSessionCleanup}
           managedWorktreeCount={viewModel.managedWorktreeCount}
           impactError={viewModel.impactError}

--- a/apps/desktop/src/components/features/task-details/use-task-delete-impact.test.tsx
+++ b/apps/desktop/src/components/features/task-details/use-task-delete-impact.test.tsx
@@ -52,6 +52,7 @@ describe("getManagedTaskDeleteImpact", () => {
       hasManagedSessionCleanup: true,
       managedWorktreeCount: 2,
       impactError: null,
+      isLoadingImpact: false,
     });
   });
 
@@ -71,6 +72,7 @@ describe("getManagedTaskDeleteImpact", () => {
       hasManagedSessionCleanup: false,
       managedWorktreeCount: 0,
       impactError: null,
+      isLoadingImpact: false,
     });
   });
 
@@ -84,6 +86,7 @@ describe("getManagedTaskDeleteImpact", () => {
       hasManagedSessionCleanup: true,
       managedWorktreeCount: 1,
       impactError: null,
+      isLoadingImpact: false,
     });
   });
 

--- a/apps/desktop/src/components/features/task-details/use-task-delete-impact.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-delete-impact.ts
@@ -8,12 +8,14 @@ export type TaskDeleteImpact = {
   hasManagedSessionCleanup: boolean;
   managedWorktreeCount: number;
   impactError: string | null;
+  isLoadingImpact: boolean;
 };
 
 const EMPTY_DELETE_IMPACT: TaskDeleteImpact = {
   hasManagedSessionCleanup: false,
   managedWorktreeCount: 0,
   impactError: null,
+  isLoadingImpact: false,
 };
 
 const normalizePathForComparison = (path: string): string => {
@@ -52,6 +54,7 @@ export const getManagedTaskDeleteImpact = (
     hasManagedSessionCleanup: managedWorktrees.size > 0,
     managedWorktreeCount: managedWorktrees.size,
     impactError: null,
+    isLoadingImpact: false,
   };
 };
 
@@ -84,11 +87,15 @@ export function useTaskDeleteImpact(taskIds: string[], open: boolean): TaskDelet
         hasManagedSessionCleanup: false,
         managedWorktreeCount: 0,
         impactError: TASK_DELETE_IMPACT_ERROR_MESSAGE,
+        isLoadingImpact: false,
       };
     }
 
     if (taskSessionQueries.some((query) => query.isLoading)) {
-      return EMPTY_DELETE_IMPACT;
+      return {
+        ...EMPTY_DELETE_IMPACT,
+        isLoadingImpact: true,
+      };
     }
 
     return getManagedTaskDeleteImpactFromTasks(

--- a/apps/desktop/src/components/features/task-details/use-task-delete-impact.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-delete-impact.ts
@@ -1,7 +1,8 @@
 import type { AgentSessionRecord } from "@openducktor/contracts";
-import { useEffect, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useWorkspaceState } from "@/state";
-import { host } from "@/state/operations/host";
+import { agentSessionListQueryOptions } from "@/state/queries/agent-sessions";
 
 export type TaskDeleteImpact = {
   hasManagedSessionCleanup: boolean;
@@ -63,37 +64,36 @@ export const TASK_DELETE_IMPACT_ERROR_MESSAGE = "Unable to load linked worktree 
 
 export function useTaskDeleteImpact(taskIds: string[], open: boolean): TaskDeleteImpact {
   const { activeRepo } = useWorkspaceState();
-  const [impact, setImpact] = useState<TaskDeleteImpact>(EMPTY_DELETE_IMPACT);
+  const taskSessionQueries = useQueries({
+    queries: taskIds.map((taskId) => ({
+      ...(activeRepo
+        ? agentSessionListQueryOptions(activeRepo, taskId)
+        : agentSessionListQueryOptions("", taskId)),
+      enabled: open && Boolean(activeRepo),
+    })),
+  });
 
-  useEffect(() => {
+  return useMemo((): TaskDeleteImpact => {
     if (taskIds.length === 0 || !open || !activeRepo) {
-      setImpact(EMPTY_DELETE_IMPACT);
-      return;
+      return EMPTY_DELETE_IMPACT;
     }
 
-    let cancelled = false;
-    void Promise.all(taskIds.map((taskId) => host.agentSessionsList(activeRepo, taskId)))
-      .then((taskSessions: AgentSessionRecord[][]) => {
-        if (cancelled) {
-          return;
-        }
-        setImpact(getManagedTaskDeleteImpactFromTasks(activeRepo, taskSessions));
-      })
-      .catch(() => {
-        if (cancelled) {
-          return;
-        }
-        setImpact({
-          hasManagedSessionCleanup: false,
-          managedWorktreeCount: 0,
-          impactError: TASK_DELETE_IMPACT_ERROR_MESSAGE,
-        });
-      });
+    const failedQuery = taskSessionQueries.find((query) => query.error != null);
+    if (failedQuery) {
+      return {
+        hasManagedSessionCleanup: false,
+        managedWorktreeCount: 0,
+        impactError: TASK_DELETE_IMPACT_ERROR_MESSAGE,
+      };
+    }
 
-    return () => {
-      cancelled = true;
-    };
-  }, [activeRepo, open, taskIds]);
+    if (taskSessionQueries.some((query) => query.isLoading)) {
+      return EMPTY_DELETE_IMPACT;
+    }
 
-  return impact;
+    return getManagedTaskDeleteImpactFromTasks(
+      activeRepo,
+      taskSessionQueries.map((query) => query.data ?? []),
+    );
+  }, [activeRepo, open, taskIds, taskSessionQueries]);
 }

--- a/apps/desktop/src/components/features/task-details/use-task-details-sheet-view-model.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-details-sheet-view-model.ts
@@ -38,6 +38,7 @@ type TaskDetailsSheetViewModel = {
   isDeleteDialogOpen: boolean;
   isDeletePending: boolean;
   deleteError: string | null;
+  isLoadingDeleteImpact: boolean;
   hasManagedSessionCleanup: boolean;
   managedWorktreeCount: number;
   impactError: string | null;
@@ -88,10 +89,8 @@ export function useTaskDetailsSheetViewModel({
     () => collectDeleteImpactTaskIds(task, taskById),
     [task, taskById],
   );
-  const { hasManagedSessionCleanup, managedWorktreeCount, impactError } = useTaskDeleteImpact(
-    deleteImpactTaskIds,
-    open,
-  );
+  const { hasManagedSessionCleanup, managedWorktreeCount, impactError, isLoadingImpact } =
+    useTaskDeleteImpact(deleteImpactTaskIds, open);
   const subtasks = useMemo(() => toSubtasks(task, taskById), [task, taskById]);
   const hasSubtasks = subtasks.length > 0;
   const shouldRenderSubtasks = task?.issueType === "epic";
@@ -188,6 +187,7 @@ export function useTaskDetailsSheetViewModel({
     isDeleteDialogOpen,
     isDeletePending,
     deleteError,
+    isLoadingDeleteImpact: isLoadingImpact,
     hasManagedSessionCleanup,
     managedWorktreeCount,
     impactError,

--- a/apps/desktop/src/components/layout/theme-dom.ts
+++ b/apps/desktop/src/components/layout/theme-dom.ts
@@ -1,4 +1,4 @@
-export type Theme = "dark" | "light";
+import type { Theme } from "@openducktor/contracts";
 
 const THEME_CLASS_NAMES = ["light", "dark"] as const;
 

--- a/apps/desktop/src/components/layout/theme-dom.ts
+++ b/apps/desktop/src/components/layout/theme-dom.ts
@@ -1,0 +1,32 @@
+export type Theme = "dark" | "light";
+
+const THEME_CLASS_NAMES = ["light", "dark"] as const;
+
+export const normalizeTheme = (value: string | null | undefined, fallback: Theme): Theme =>
+  value === "dark" ? "dark" : value === "light" ? "light" : fallback;
+
+export const readDocumentTheme = (fallback: Theme): Theme => {
+  if (typeof document === "undefined") {
+    return fallback;
+  }
+
+  const root = document.documentElement;
+  if (root.classList.contains("dark")) {
+    return "dark";
+  }
+  if (root.classList.contains("light")) {
+    return "light";
+  }
+
+  return fallback;
+};
+
+export const applyThemeToDocument = (theme: Theme): void => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const root = document.documentElement;
+  root.classList.remove(...THEME_CLASS_NAMES);
+  root.classList.add(theme);
+};

--- a/apps/desktop/src/components/layout/theme-provider.tsx
+++ b/apps/desktop/src/components/layout/theme-provider.tsx
@@ -1,9 +1,9 @@
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import type { SettingsSnapshot, Theme } from "@openducktor/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createContext, useContext, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { createHostClient } from "@/lib/host-client";
 import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
-import { applyThemeToDocument, readDocumentTheme, type Theme } from "./theme-dom";
+import { applyThemeToDocument, readDocumentTheme } from "./theme-dom";
 
 type ThemeProviderProps = {
   children: React.ReactNode;
@@ -35,7 +35,7 @@ export function ThemeProvider({ children, defaultTheme = "light", ...props }: Th
     }
 
     const resolved = settingsSnapshot.theme === "dark" ? "dark" : "light";
-    setThemeState((current) => (current === resolved ? current : resolved));
+    setThemeState((current: Theme) => (current === resolved ? current : resolved));
   }, [settingsSnapshot]);
 
   useLayoutEffect(() => {
@@ -46,6 +46,10 @@ export function ThemeProvider({ children, defaultTheme = "light", ...props }: Th
     () => ({
       theme,
       setTheme: (newTheme: Theme) => {
+        const previousTheme = theme;
+        const previousSnapshot = queryClient.getQueryData<SettingsSnapshot>(
+          settingsSnapshotQueryOptions().queryKey,
+        );
         setThemeState(newTheme);
         queryClient.setQueryData(
           settingsSnapshotQueryOptions().queryKey,
@@ -60,7 +64,13 @@ export function ThemeProvider({ children, defaultTheme = "light", ...props }: Th
             };
           },
         );
-        void hostClient.setTheme(newTheme);
+        void hostClient.setTheme(newTheme).catch((error) => {
+          console.error("Failed to persist theme change.", error);
+          setThemeState(previousTheme);
+          if (previousSnapshot) {
+            queryClient.setQueryData(settingsSnapshotQueryOptions().queryKey, previousSnapshot);
+          }
+        });
       },
     }),
     [queryClient, theme],

--- a/apps/desktop/src/components/layout/theme-provider.tsx
+++ b/apps/desktop/src/components/layout/theme-provider.tsx
@@ -1,7 +1,9 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import type { SettingsSnapshot } from "@openducktor/contracts";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createContext, useContext, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { createHostClient } from "@/lib/host-client";
-
-type Theme = "dark" | "light";
+import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
+import { applyThemeToDocument, readDocumentTheme, type Theme } from "./theme-dom";
 
 type ThemeProviderProps = {
   children: React.ReactNode;
@@ -23,39 +25,46 @@ const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 const hostClient = createHostClient();
 
 export function ThemeProvider({ children, defaultTheme = "light", ...props }: ThemeProviderProps) {
-  const [theme, setThemeState] = useState<Theme>(defaultTheme);
+  const [theme, setThemeState] = useState<Theme>(() => readDocumentTheme(defaultTheme));
+  const queryClient = useQueryClient();
+  const { data: settingsSnapshot } = useQuery(settingsSnapshotQueryOptions());
 
-  // Load theme from config file on mount
   useEffect(() => {
-    hostClient
-      .getTheme()
-      .then((stored) => {
-        const resolved = stored === "dark" ? "dark" : "light";
-        setThemeState(resolved);
-      })
-      .catch(() => {
-        // Fallback to default if config unavailable (e.g. outside Tauri runtime)
-      });
-  }, []);
+    if (!settingsSnapshot) {
+      return;
+    }
 
-  // Apply theme class to <html>
-  useEffect(() => {
-    const root = window.document.documentElement;
-    root.classList.remove("light", "dark");
-    root.classList.add(theme);
+    const resolved = settingsSnapshot.theme === "dark" ? "dark" : "light";
+    setThemeState((current) => (current === resolved ? current : resolved));
+  }, [settingsSnapshot]);
+
+  useLayoutEffect(() => {
+    applyThemeToDocument(theme);
   }, [theme]);
 
-  const value = {
-    theme,
-    setTheme: (newTheme: Theme) => {
-      setThemeState(newTheme);
-      // Persist to config file (fire-and-forget)
-      hostClient.setTheme(newTheme).catch(() => {
-        // Fallback: at least keep localStorage for non-Tauri envs
-        localStorage.setItem("openducktor-ui-theme", newTheme);
-      });
-    },
-  };
+  const value = useMemo(
+    () => ({
+      theme,
+      setTheme: (newTheme: Theme) => {
+        setThemeState(newTheme);
+        queryClient.setQueryData(
+          settingsSnapshotQueryOptions().queryKey,
+          (current: SettingsSnapshot | undefined) => {
+            if (!current) {
+              return current;
+            }
+
+            return {
+              ...current,
+              theme: newTheme,
+            };
+          },
+        );
+        void hostClient.setTheme(newTheme);
+      },
+    }),
+    [queryClient, theme],
+  );
 
   return (
     <ThemeProviderContext.Provider {...props} value={value}>

--- a/apps/desktop/src/lib/query-client.ts
+++ b/apps/desktop/src/lib/query-client.ts
@@ -1,0 +1,26 @@
+import { QueryClient } from "@tanstack/react-query";
+
+const MINUTE_MS = 60_000;
+
+export const createQueryClient = (): QueryClient =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: MINUTE_MS,
+        gcTime: 10 * MINUTE_MS,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+export const appQueryClient = createQueryClient();
+
+export const clearAppQueryClient = async (): Promise<void> => {
+  await appQueryClient.cancelQueries();
+  appQueryClient.clear();
+};

--- a/apps/desktop/src/lib/query-provider.tsx
+++ b/apps/desktop/src/lib/query-provider.tsx
@@ -1,0 +1,16 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { type PropsWithChildren, type ReactElement, useState } from "react";
+import { appQueryClient, createQueryClient } from "./query-client";
+
+type QueryProviderProps = PropsWithChildren<{
+  useIsolatedClient?: boolean;
+}>;
+
+export function QueryProvider({
+  children,
+  useIsolatedClient = false,
+}: QueryProviderProps): ReactElement {
+  const [queryClient] = useState(() => (useIsolatedClient ? createQueryClient() : appQueryClient));
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -23,9 +23,14 @@ const renderApp = (): void => {
 };
 
 const bootstrap = async (): Promise<void> => {
-  const settingsSnapshot = await loadSettingsSnapshotFromQuery(appQueryClient);
-  applyThemeToDocument(settingsSnapshot.theme);
-  renderApp();
+  try {
+    const settingsSnapshot = await loadSettingsSnapshotFromQuery(appQueryClient);
+    applyThemeToDocument(settingsSnapshot.theme);
+  } catch (error) {
+    console.error("Failed to preload settings snapshot before app bootstrap.", error);
+  } finally {
+    renderApp();
+  }
 };
 
 void bootstrap();

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,6 +1,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { applyThemeToDocument } from "@/components/layout/theme-dom";
+import { appQueryClient } from "@/lib/query-client";
+import { loadSettingsSnapshotFromQuery } from "@/state/queries/workspace";
 import { App } from "./App";
 import "./styles.css";
 
@@ -9,10 +12,20 @@ if (!rootElement) {
   throw new Error("Root element not found");
 }
 
-createRoot(rootElement).render(
-  <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </StrictMode>,
-);
+const renderApp = (): void => {
+  createRoot(rootElement).render(
+    <StrictMode>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </StrictMode>,
+  );
+};
+
+const bootstrap = async (): Promise<void> => {
+  const settingsSnapshot = await loadSettingsSnapshotFromQuery(appQueryClient);
+  applyThemeToDocument(settingsSnapshot.theme);
+  renderApp();
+};
+
+void bootstrap();

--- a/apps/desktop/src/pages/agents/agent-studio-test-utils.tsx
+++ b/apps/desktop/src/pages/agents/agent-studio-test-utils.tsx
@@ -1,6 +1,7 @@
 import type { TaskCard } from "@openducktor/contracts";
 import { createElement, type ReactElement } from "react";
 import TestRenderer, { act } from "react-test-renderer";
+import { QueryProvider } from "@/lib/query-provider";
 import {
   createAgentSessionFixture as createSharedAgentSessionFixture,
   createDeferred as createSharedDeferred,
@@ -60,7 +61,13 @@ export const createHookHarness = <Props, State>(
 
   const mount = async (): Promise<void> => {
     await act(async () => {
-      renderer = TestRenderer.create(createElement(Harness, { hookProps: currentProps }));
+      renderer = TestRenderer.create(
+        createElement(
+          QueryProvider,
+          { useIsolatedClient: true },
+          createElement(Harness, { hookProps: currentProps }),
+        ),
+      );
       await flushMicrotasks();
     });
   };
@@ -68,7 +75,13 @@ export const createHookHarness = <Props, State>(
   const update = async (nextProps: Props): Promise<void> => {
     currentProps = nextProps;
     await act(async () => {
-      renderer?.update(createElement(Harness, { hookProps: currentProps }));
+      renderer?.update(
+        createElement(
+          QueryProvider,
+          { useIsolatedClient: true },
+          createElement(Harness, { hookProps: currentProps }),
+        ),
+      );
       await flushMicrotasks();
     });
   };

--- a/apps/desktop/src/pages/agents/agents-page.tsx
+++ b/apps/desktop/src/pages/agents/agents-page.tsx
@@ -128,7 +128,7 @@ export function AgentsPage(): ReactElement {
     sessionParam,
     hasExplicitRoleParam,
     roleFromQuery,
-    updateQuery,
+    updateQuery: scheduleQueryUpdate,
     loadAgentSessions,
     clearComposerInput,
     onContextSwitchIntent: signalContextSwitchIntent,
@@ -265,7 +265,7 @@ export function AgentsPage(): ReactElement {
   } satisfies AgentStudioOrchestrationComposerContext;
 
   const orchestrationActions = {
-    updateQuery,
+    updateQuery: scheduleQueryUpdate,
     onContextSwitchIntent: signalContextSwitchIntent,
     startAgentSession,
     sendAgentMessage,
@@ -295,18 +295,21 @@ export function AgentsPage(): ReactElement {
     gitPanelContextMode === "repository"
       ? { branch: UPSTREAM_TARGET_BRANCH }
       : (orchestration.repoSettings?.defaultTargetBranch ?? normalizeTargetBranch(null));
+  const shouldLoadVisibleDiffPanel =
+    selection.viewRole === "build" &&
+    orchestration.rightPanel.panelKind === "diff" &&
+    orchestration.rightPanel.isPanelOpen;
 
   const diffData = useAgentStudioDiffData({
-    repoPath: activeRepo,
-    sessionWorkingDirectory: selection.viewActiveSession?.workingDirectory ?? null,
-    sessionRunId: selection.viewActiveSession?.runId ?? null,
+    repoPath: shouldLoadVisibleDiffPanel ? activeRepo : null,
+    sessionWorkingDirectory: shouldLoadVisibleDiffPanel
+      ? (selection.viewActiveSession?.workingDirectory ?? null)
+      : null,
+    sessionRunId: shouldLoadVisibleDiffPanel ? (selection.viewActiveSession?.runId ?? null) : null,
     runCompletionRecoverySignal,
     defaultTargetBranch: diffComparisonTarget,
     branchIdentityKey: repositoryBranchIdentityKey,
-    enablePolling:
-      selection.viewRole === "build" &&
-      Boolean(selection.viewActiveSession) &&
-      orchestration.rightPanel.isPanelOpen,
+    enablePolling: shouldLoadVisibleDiffPanel && Boolean(selection.viewActiveSession),
   });
   const resolvedGitPanelBranch = resolveAgentStudioGitPanelBranch({
     contextMode: gitPanelContextMode,

--- a/apps/desktop/src/pages/agents/agents-page.tsx
+++ b/apps/desktop/src/pages/agents/agents-page.tsx
@@ -54,7 +54,7 @@ import { useAgentStudioSelectionController } from "./use-agent-studio-selection-
 import { useAgentStudioSessionStartRequest } from "./use-agent-studio-session-start-request";
 
 export function AgentsPage(): ReactElement {
-  const { activeRepo, activeBranch, loadRepoSettings, loadSettingsSnapshot } = useWorkspaceState();
+  const { activeRepo, activeBranch } = useWorkspaceState();
   const { runtimeDefinitions, isLoadingRuntimeDefinitions, runtimeDefinitionsError } =
     useRuntimeDefinitionsContext();
   const { runtimeHealthByRuntime, isLoadingChecks, refreshChecks } = useChecksState();
@@ -230,8 +230,6 @@ export function AgentsPage(): ReactElement {
 
   const orchestrationWorkspace = {
     activeRepo,
-    loadSettingsSnapshot,
-    loadRepoSettings,
   } satisfies AgentStudioOrchestrationWorkspaceContext;
 
   const orchestrationSelection = {

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.test.tsx
@@ -58,8 +58,32 @@ beforeEach(() => {
 });
 
 describe("useAgentStudioBuildWorktreeRefresh", () => {
-  test("refreshes worktree for newly completed mutating build tools", async () => {
+  test("does not refresh immediately for historical completed tool messages on session open", async () => {
     const harness = createHookHarness(createBaseArgs());
+
+    try {
+      await harness.mount();
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...createBaseArgs(),
+        activeSession: createCompletedToolSession("apply_patch", "tool-1"),
+      });
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("refreshes worktree for newly completed mutating build tools", async () => {
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession: createAgentSessionFixture({
+        sessionId: "build-session-1",
+        role: "build",
+        messages: [],
+      }),
+    });
 
     try {
       await harness.mount();
@@ -89,15 +113,20 @@ describe("useAgentStudioBuildWorktreeRefresh", () => {
   });
 
   test("deduplicates completed tool messages within the same session", async () => {
+    const initialSession = createAgentSessionFixture({
+      sessionId: "build-session-1",
+      role: "build",
+      messages: [],
+    });
     const activeSession = createCompletedToolSession("apply_patch", "tool-1");
     const harness = createHookHarness({
       ...createBaseArgs(),
-      activeSession,
+      activeSession: initialSession,
     });
 
     try {
       await harness.mount();
-      expect(refreshWorktreeMock).toHaveBeenCalledTimes(1);
+      expect(refreshWorktreeMock).not.toHaveBeenCalled();
 
       await harness.update({
         ...createBaseArgs(),

--- a/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-build-worktree-refresh.ts
@@ -77,7 +77,17 @@ export function useAgentStudioBuildWorktreeRefresh({
 
     if (previousSessionIdRef.current !== activeSession.sessionId) {
       previousSessionIdRef.current = activeSession.sessionId;
-      processedToolMessageKeysRef.current.clear();
+      processedToolMessageKeysRef.current = new Set(
+        activeSession.messages.flatMap((message) => {
+          const meta = message.meta;
+          if (!meta || meta.kind !== "tool" || meta.status !== "completed") {
+            return [];
+          }
+
+          return [`${activeSession.sessionId}:${message.id}`];
+        }),
+      );
+      return;
     }
 
     let shouldRefresh = false;

--- a/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
@@ -1,14 +1,31 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { SettingsSnapshot } from "@openducktor/contracts";
 import {
-  createDeferred,
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
-import {
-  SETTINGS_SNAPSHOT_UPDATED_EVENT,
-  useAgentStudioChatSettings,
-} from "./use-agent-studio-chat-settings";
+
+const hostMock = {
+  workspaceGetSettingsSnapshot: mock(
+    async (): Promise<SettingsSnapshot> => ({
+      theme: "light",
+      git: {
+        defaultMergeMethod: "merge_commit",
+      },
+      chat: {
+        showThinkingMessages: false,
+      },
+      repos: {},
+      globalPromptOverrides: {},
+    }),
+  ),
+};
+
+mock.module("@/state/operations/host", () => ({
+  host: hostMock,
+}));
+
+const { useAgentStudioChatSettings } = await import("./use-agent-studio-chat-settings");
 
 enableReactActEnvironment();
 
@@ -19,6 +36,7 @@ const createSettingsSnapshot = (
   includeChat = true,
 ): SettingsSnapshot =>
   ({
+    theme: "light",
     git: {
       defaultMergeMethod: "merge_commit",
     },
@@ -32,29 +50,32 @@ const createHookHarness = (initialProps: HookArgs) =>
 
 describe("useAgentStudioChatSettings", () => {
   test("loads chat settings when a repository is active", async () => {
-    const loadSettingsSnapshot = mock(
+    hostMock.workspaceGetSettingsSnapshot.mockClear();
+    hostMock.workspaceGetSettingsSnapshot.mockImplementation(
       async (): Promise<SettingsSnapshot> => createSettingsSnapshot(true),
     );
+
     const harness = createHookHarness({
       activeRepo: "/repo",
-      loadSettingsSnapshot,
     });
 
     await harness.mount();
+    await harness.waitFor((state) => state.showThinkingMessages === true);
 
-    expect(loadSettingsSnapshot).toHaveBeenCalledTimes(1);
+    expect(hostMock.workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(1);
     expect(harness.getLatest().showThinkingMessages).toBe(true);
 
     await harness.unmount();
   });
 
   test("surfaces malformed snapshots that omit chat settings", async () => {
-    const loadSettingsSnapshot = mock(
+    hostMock.workspaceGetSettingsSnapshot.mockClear();
+    hostMock.workspaceGetSettingsSnapshot.mockImplementation(
       async (): Promise<SettingsSnapshot> => createSettingsSnapshot(false, false),
     );
+
     const harness = createHookHarness({
       activeRepo: "/repo",
-      loadSettingsSnapshot,
     });
 
     await harness.mount();
@@ -68,199 +89,58 @@ describe("useAgentStudioChatSettings", () => {
     await harness.unmount();
   });
 
-  test("surfaces settings load failures instead of silently resetting chat visibility", async () => {
-    const loadSettingsSnapshot = mock(async (): Promise<SettingsSnapshot> => {
-      throw new Error("settings read failed");
-    });
+  test("surfaces settings load failures and retries through the canonical query", async () => {
+    hostMock.workspaceGetSettingsSnapshot.mockClear();
+    let loadCount = 0;
+    hostMock.workspaceGetSettingsSnapshot.mockImplementation(
+      async (): Promise<SettingsSnapshot> => {
+        loadCount += 1;
+        if (loadCount === 1) {
+          throw new Error("settings read failed");
+        }
+
+        return createSettingsSnapshot(true);
+      },
+    );
+
     const harness = createHookHarness({
       activeRepo: "/repo",
-      loadSettingsSnapshot,
     });
 
     await harness.mount();
-
     await harness.waitFor((state) => state.chatSettingsLoadError !== null);
     expect(harness.getLatest().showThinkingMessages).toBe(false);
     expect(harness.getLatest().chatSettingsLoadError?.message).toContain("settings read failed");
+
+    await harness.run((state) => {
+      state.retryChatSettingsLoad();
+    });
+
+    await harness.waitFor((state) => state.showThinkingMessages === true);
+    expect(hostMock.workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(2);
+    expect(harness.getLatest().chatSettingsLoadError).toBeNull();
 
     await harness.unmount();
   });
 
   test("resets to false when the active repo becomes unavailable", async () => {
-    const loadSettingsSnapshot = mock(
+    hostMock.workspaceGetSettingsSnapshot.mockClear();
+    hostMock.workspaceGetSettingsSnapshot.mockImplementation(
       async (): Promise<SettingsSnapshot> => createSettingsSnapshot(true),
     );
+
     const harness = createHookHarness({
       activeRepo: "/repo",
-      loadSettingsSnapshot,
     });
 
     await harness.mount();
+    await harness.waitFor((state) => state.showThinkingMessages === true);
     expect(harness.getLatest().showThinkingMessages).toBe(true);
 
-    await harness.update({ activeRepo: null, loadSettingsSnapshot });
+    await harness.update({ activeRepo: null });
 
     expect(harness.getLatest().showThinkingMessages).toBe(false);
 
     await harness.unmount();
-  });
-
-  test("reloads chat settings when the settings snapshot update event is dispatched", async () => {
-    const globalWithWindow = globalThis as typeof globalThis & {
-      window?: EventTarget;
-    };
-    const originalWindow = globalWithWindow.window;
-    const eventWindow = new EventTarget();
-    Object.defineProperty(globalWithWindow, "window", {
-      configurable: true,
-      value: eventWindow,
-    });
-
-    let loadCount = 0;
-    const loadSettingsSnapshot = mock(async (): Promise<SettingsSnapshot> => {
-      loadCount += 1;
-      return loadCount === 1 ? createSettingsSnapshot(false) : createSettingsSnapshot(true);
-    });
-    const harness = createHookHarness({
-      activeRepo: "/repo",
-      loadSettingsSnapshot,
-    });
-
-    try {
-      await harness.mount();
-      expect(harness.getLatest().showThinkingMessages).toBe(false);
-      expect(harness.getLatest().chatSettingsLoadError).toBeNull();
-
-      await harness.run(() => {
-        eventWindow.dispatchEvent(new CustomEvent(SETTINGS_SNAPSHOT_UPDATED_EVENT));
-      });
-
-      await harness.waitFor((state) => state.showThinkingMessages === true);
-      expect(loadSettingsSnapshot).toHaveBeenCalledTimes(2);
-      expect(harness.getLatest().showThinkingMessages).toBe(true);
-      expect(harness.getLatest().chatSettingsLoadError).toBeNull();
-    } finally {
-      await harness.unmount();
-
-      if (typeof originalWindow === "undefined") {
-        Reflect.deleteProperty(globalWithWindow, "window");
-      } else {
-        Object.defineProperty(globalWithWindow, "window", {
-          configurable: true,
-          value: originalWindow,
-        });
-      }
-    }
-  });
-
-  test("keeps the latest reload result when concurrent loads resolve out of order", async () => {
-    const globalWithWindow = globalThis as typeof globalThis & {
-      window?: EventTarget;
-    };
-    const originalWindow = globalWithWindow.window;
-    const eventWindow = new EventTarget();
-    Object.defineProperty(globalWithWindow, "window", {
-      configurable: true,
-      value: eventWindow,
-    });
-
-    const firstLoad = createDeferred<SettingsSnapshot>();
-    const secondLoad = createDeferred<SettingsSnapshot>();
-    let loadCount = 0;
-    const loadSettingsSnapshot = mock((): Promise<SettingsSnapshot> => {
-      loadCount += 1;
-      return loadCount === 1 ? firstLoad.promise : secondLoad.promise;
-    });
-    const harness = createHookHarness({
-      activeRepo: "/repo",
-      loadSettingsSnapshot,
-    });
-
-    try {
-      await harness.mount();
-
-      await harness.run(() => {
-        eventWindow.dispatchEvent(new CustomEvent(SETTINGS_SNAPSHOT_UPDATED_EVENT));
-      });
-
-      await harness.run(async () => {
-        secondLoad.resolve(createSettingsSnapshot(true));
-        await secondLoad.promise;
-      });
-      await harness.waitFor((state) => state.showThinkingMessages === true);
-
-      await harness.run(async () => {
-        firstLoad.resolve(createSettingsSnapshot(false));
-        await firstLoad.promise;
-      });
-
-      expect(loadSettingsSnapshot).toHaveBeenCalledTimes(2);
-      expect(harness.getLatest().showThinkingMessages).toBe(true);
-    } finally {
-      firstLoad.resolve(createSettingsSnapshot(false));
-      secondLoad.resolve(createSettingsSnapshot(true));
-      await harness.unmount();
-
-      if (typeof originalWindow === "undefined") {
-        Reflect.deleteProperty(globalWithWindow, "window");
-      } else {
-        Object.defineProperty(globalWithWindow, "window", {
-          configurable: true,
-          value: originalWindow,
-        });
-      }
-    }
-  });
-
-  test("keeps the previous visibility setting when a reload fails and clears the error after retry", async () => {
-    const firstLoad = createDeferred<SettingsSnapshot>();
-    const secondLoad = createDeferred<SettingsSnapshot>();
-    let loadCount = 0;
-    const loadSettingsSnapshot = mock((): Promise<SettingsSnapshot> => {
-      loadCount += 1;
-      if (loadCount === 1) {
-        return firstLoad.promise;
-      }
-      if (loadCount === 2) {
-        return Promise.reject(new Error("refresh failed"));
-      }
-      return secondLoad.promise;
-    });
-    const harness = createHookHarness({
-      activeRepo: "/repo",
-      loadSettingsSnapshot,
-    });
-
-    try {
-      await harness.mount();
-      await harness.run(async () => {
-        firstLoad.resolve(createSettingsSnapshot(true));
-        await firstLoad.promise;
-      });
-      expect(harness.getLatest().showThinkingMessages).toBe(true);
-
-      await harness.run(() => {
-        harness.getLatest().retryChatSettingsLoad();
-      });
-
-      await harness.waitFor((state) => state.chatSettingsLoadError !== null);
-      expect(harness.getLatest().showThinkingMessages).toBe(true);
-      expect(harness.getLatest().chatSettingsLoadError?.message).toContain("refresh failed");
-
-      await harness.run(async () => {
-        harness.getLatest().retryChatSettingsLoad();
-        secondLoad.resolve(createSettingsSnapshot(false));
-        await secondLoad.promise;
-      });
-
-      await harness.waitFor(
-        (state) => state.showThinkingMessages === false && state.chatSettingsLoadError === null,
-      );
-      expect(loadSettingsSnapshot).toHaveBeenCalledTimes(3);
-    } finally {
-      firstLoad.resolve(createSettingsSnapshot(true));
-      secondLoad.resolve(createSettingsSnapshot(false));
-      await harness.unmount();
-    }
   });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.ts
@@ -1,8 +1,8 @@
 import type { SettingsSnapshot } from "@openducktor/contracts";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback } from "react";
 import { errorMessage } from "@/lib/errors";
-
-export const SETTINGS_SNAPSHOT_UPDATED_EVENT = "odt:settings-snapshot-updated";
+import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
 
 const DEFAULT_SHOW_THINKING_MESSAGES = false;
 
@@ -17,75 +17,36 @@ const createChatSettingsLoadError = (activeRepo: string, cause: unknown): Error 
   );
 };
 
-export function useAgentStudioChatSettings(args: {
-  activeRepo: string | null;
-  loadSettingsSnapshot: () => Promise<SettingsSnapshot>;
-}): {
+export function useAgentStudioChatSettings(args: { activeRepo: string | null }): {
   showThinkingMessages: boolean;
   chatSettingsLoadError: Error | null;
   retryChatSettingsLoad: () => void;
 } {
-  const { activeRepo, loadSettingsSnapshot } = args;
-  const [showThinkingMessages, setShowThinkingMessages] = useState(DEFAULT_SHOW_THINKING_MESSAGES);
-  const [chatSettingsLoadError, setChatSettingsLoadError] = useState<Error | null>(null);
-  const latestReloadIdRef = useRef(0);
+  const { activeRepo } = args;
 
-  const reloadChatSettings = useCallback(() => {
-    if (!activeRepo) {
-      latestReloadIdRef.current += 1;
-      setShowThinkingMessages(DEFAULT_SHOW_THINKING_MESSAGES);
-      setChatSettingsLoadError(null);
-      return () => {};
-    }
-
-    const repoPath = activeRepo;
-    const reloadId = latestReloadIdRef.current + 1;
-    latestReloadIdRef.current = reloadId;
-    let cancelled = false;
-
-    void loadSettingsSnapshot()
-      .then((snapshot) => {
-        if (!cancelled && reloadId === latestReloadIdRef.current) {
-          setShowThinkingMessages(readShowThinkingMessages(snapshot));
-          setChatSettingsLoadError(null);
-        }
-      })
-      .catch((cause) => {
-        if (!cancelled && reloadId === latestReloadIdRef.current) {
-          setChatSettingsLoadError(createChatSettingsLoadError(repoPath, cause));
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeRepo, loadSettingsSnapshot]);
+  const {
+    data: showThinkingMessages = DEFAULT_SHOW_THINKING_MESSAGES,
+    error,
+    refetch,
+  } = useQuery({
+    ...settingsSnapshotQueryOptions(),
+    enabled: activeRepo !== null,
+    select: readShowThinkingMessages,
+  });
 
   const retryChatSettingsLoad = useCallback((): void => {
-    reloadChatSettings();
-  }, [reloadChatSettings]);
-
-  useEffect(() => {
-    return reloadChatSettings();
-  }, [reloadChatSettings]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
+    if (!activeRepo) {
       return;
     }
 
-    const handleSettingsSnapshotUpdated = () => {
-      reloadChatSettings();
-    };
+    void refetch();
+  }, [activeRepo, refetch]);
 
-    window.addEventListener(SETTINGS_SNAPSHOT_UPDATED_EVENT, handleSettingsSnapshotUpdated);
-    return () => {
-      window.removeEventListener(SETTINGS_SNAPSHOT_UPDATED_EVENT, handleSettingsSnapshotUpdated);
-    };
-  }, [reloadChatSettings]);
+  const chatSettingsLoadError =
+    activeRepo && error ? createChatSettingsLoadError(activeRepo, error) : null;
 
   return {
-    showThinkingMessages,
+    showThinkingMessages: activeRepo ? showThinkingMessages : DEFAULT_SHOW_THINKING_MESSAGES,
     chatSettingsLoadError,
     retryChatSettingsLoad,
   };

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-controller.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { host } from "@/state/operations/host";
+import { appQueryClient } from "@/lib/query-client";
+import {
+  loadWorktreeStatusFromQuery,
+  loadWorktreeStatusSummaryFromQuery,
+} from "@/state/queries/git";
 import {
   ALL_LOAD_DATA_MODES,
   ALL_SCOPES,
@@ -187,11 +191,12 @@ export function useAgentStudioDiffController({
       version,
       workingDir: nextWorkingDir,
     }: InFlightRequestContext): Promise<void> => {
-      const summary = await host.gitGetWorktreeStatusSummary(
+      const summary = await loadWorktreeStatusSummaryFromQuery(
+        appQueryClient,
         activeRepoPath,
         activeTargetBranch,
         scope,
-        nextWorkingDir ?? undefined,
+        nextWorkingDir,
       );
 
       if (hasLoadContextChanged(activeRepoPath, activeTargetBranch, nextWorkingDir)) {
@@ -251,11 +256,12 @@ export function useAgentStudioDiffController({
       version,
       workingDir: nextWorkingDir,
     }: InFlightRequestContext): Promise<void> => {
-      const snapshot = await host.gitGetWorktreeStatus(
+      const snapshot = await loadWorktreeStatusFromQuery(
+        appQueryClient,
         activeRepoPath,
         activeTargetBranch,
         scope,
-        nextWorkingDir ?? undefined,
+        nextWorkingDir,
       );
 
       if (hasLoadContextChanged(activeRepoPath, activeTargetBranch, nextWorkingDir)) {

--- a/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-diff-data.test.tsx
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { GitWorktreeStatus, GitWorktreeStatusSummary } from "@openducktor/contracts";
+import { clearAppQueryClient } from "@/lib/query-client";
 import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
@@ -171,7 +172,8 @@ beforeAll(async () => {
   ({ useAgentStudioDiffData } = await import("./use-agent-studio-diff-data"));
 });
 
-beforeEach(() => {
+beforeEach(async () => {
+  await clearAppQueryClient();
   runsListMock.mockClear();
   gitGetWorktreeStatusMock.mockClear();
   gitGetWorktreeStatusSummaryMock.mockClear();

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -353,7 +353,7 @@ describe("useAgentStudioModelSelection", () => {
     );
 
     await harness.mount();
-    await harness.waitFor((state) => state.agentOptions.length > 0);
+    await harness.waitFor((state) => state.isSelectionCatalogLoading === false);
 
     const state = harness.getLatest();
     expect(state.isSelectionCatalogLoading).toBe(false);
@@ -490,6 +490,7 @@ describe("useAgentStudioModelSelection", () => {
       await harness.mount();
       await harness.waitFor(
         (state) =>
+          state.isSelectionCatalogLoading === false &&
           state.selectedModelSelection?.modelId === "gpt-5" &&
           state.selectedModelSelection.variant === "high",
       );
@@ -562,13 +563,7 @@ describe("useAgentStudioModelSelection", () => {
       await harness.update(
         createBaseProps({
           activeRepo: "/repo-b",
-          repoSettings: createRepoSettings({
-            runtimeKind: "opencode",
-            providerId: "openai",
-            modelId: "gpt-5",
-            variant: "high",
-            profileId: "build-agent",
-          }),
+          repoSettings: null,
           loadCatalog: async () => {
             throw new Error("catalog unavailable");
           },

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -1,5 +1,6 @@
 import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   resolveAgentAccentColor,
@@ -10,6 +11,7 @@ import {
 import type { ComboboxOption } from "@/components/ui/combobox";
 import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import { loadRepoRuntimeCatalog } from "@/state/operations";
+import { repoRuntimeCatalogQueryOptions } from "@/state/queries/runtime-catalog";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
@@ -69,8 +71,6 @@ export function useAgentStudioModelSelection({
   const previousActiveRepoRef = useRef<string | null>(activeRepo);
   const previousRepoForDefaultsRef = useRef<string | null>(activeRepo);
   const previousRepoSettingsRef = useRef<RepoSettingsInput | null>(repoSettings);
-  const [composerCatalog, setComposerCatalog] = useState<AgentModelCatalog | null>(null);
-  const [isLoadingComposerCatalog, setIsLoadingComposerCatalog] = useState(false);
   const [isAwaitingRepoSettingsForActiveRepo, setIsAwaitingRepoSettingsForActiveRepo] =
     useState(false);
   const [draftSelectionByRole, setDraftSelectionByRole] =
@@ -110,7 +110,7 @@ export function useAgentStudioModelSelection({
     if (previousRepoForDefaultsRef.current !== activeRepo) {
       previousRepoForDefaultsRef.current = activeRepo;
       previousRepoSettingsRef.current = repoSettings;
-      setIsAwaitingRepoSettingsForActiveRepo(Boolean(activeRepo));
+      setIsAwaitingRepoSettingsForActiveRepo(Boolean(activeRepo) && repoSettings == null);
       return;
     }
 
@@ -119,43 +119,30 @@ export function useAgentStudioModelSelection({
       return;
     }
 
-    if (previousRepoSettingsRef.current !== repoSettings) {
+    if (repoSettings != null) {
       previousRepoSettingsRef.current = repoSettings;
       setIsAwaitingRepoSettingsForActiveRepo(false);
     }
   }, [activeRepo, isAwaitingRepoSettingsForActiveRepo, repoSettings]);
 
-  useEffect(() => {
-    if (!activeRepo) {
-      setComposerCatalog(null);
-      setIsLoadingComposerCatalog(false);
-      return;
-    }
-    let cancelled = false;
-    setComposerCatalog(null);
-    setIsLoadingComposerCatalog(true);
-    void loadCatalog(activeRepo, composerRuntimeKind)
-      .then((catalog) => {
-        if (!cancelled) {
-          setComposerCatalog(catalog);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setComposerCatalog(null);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoadingComposerCatalog(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeRepo, composerRuntimeKind, loadCatalog]);
-  const isDraftSelectionTouched = draftSelectionTouchedByRole[role];
+  const composerCatalogQuery = useQuery({
+    ...(activeRepo
+      ? repoRuntimeCatalogQueryOptions(activeRepo, composerRuntimeKind)
+      : repoRuntimeCatalogQueryOptions("", composerRuntimeKind)),
+    enabled: activeRepo !== null && (activeSession == null || activeSession.modelCatalog == null),
+    queryFn: async (): Promise<AgentModelCatalog> => {
+      if (!activeRepo) {
+        throw new Error("No repository selected.");
+      }
+      return loadCatalog(activeRepo, composerRuntimeKind);
+    },
+  });
+  const composerCatalog = composerCatalogQuery.data ?? null;
+  const isLoadingComposerCatalog = composerCatalogQuery.isLoading;
+  const hasDraftSelectionForActiveRepo = previousActiveRepoRef.current === activeRepo;
+  const isDraftSelectionTouched = hasDraftSelectionForActiveRepo
+    ? draftSelectionTouchedByRole[role]
+    : false;
 
   useEffect(() => {
     if (activeSession) {
@@ -214,7 +201,7 @@ export function useAgentStudioModelSelection({
     updateAgentSessionModel(activeSession.sessionId, preferredSelection);
   }, [activeSession, roleDefaultSelection, updateAgentSessionModel]);
 
-  const draftSelection = draftSelectionByRole[role];
+  const draftSelection = hasDraftSelectionForActiveRepo ? draftSelectionByRole[role] : null;
   const roleDefaultSelectionForComposer = useMemo<AgentModelSelection | null>(() => {
     if (activeSession) {
       return roleDefaultSelection;

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -201,7 +201,7 @@ export function useAgentStudioOrchestrationController({
   composer,
   actions,
 }: UseAgentStudioOrchestrationControllerArgs): UseAgentStudioOrchestrationControllerResult {
-  const { activeRepo, loadRepoSettings, loadSettingsSnapshot } = workspace;
+  const { activeRepo } = workspace;
   const {
     viewTaskId,
     viewRole,
@@ -232,15 +232,9 @@ export function useAgentStudioOrchestrationController({
     requestNewSessionStart,
   } = actions;
 
-  const { repoSettings } = useAgentStudioRepoSettings({
-    activeRepo,
-    loadRepoSettings,
-  });
+  const { repoSettings } = useAgentStudioRepoSettings({ activeRepo });
   const { showThinkingMessages, chatSettingsLoadError, retryChatSettingsLoad } =
-    useAgentStudioChatSettings({
-      activeRepo,
-      loadSettingsSnapshot,
-    });
+    useAgentStudioChatSettings({ activeRepo });
 
   const { specDoc, planDoc, qaDoc } = useAgentStudioDocuments({
     activeRepo,

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -1,4 +1,4 @@
-import type { SettingsSnapshot, TaskCard } from "@openducktor/contracts";
+import type { TaskCard } from "@openducktor/contracts";
 import type { AgentRole, AgentScenario } from "@openducktor/core";
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
@@ -16,8 +16,6 @@ import type { RequestNewSessionStart } from "./use-agent-studio-session-start-ty
 
 export type AgentStudioOrchestrationWorkspaceContext = {
   activeRepo: string | null;
-  loadSettingsSnapshot: () => Promise<SettingsSnapshot>;
-  loadRepoSettings: () => Promise<RepoSettingsInput>;
 };
 
 export type AgentStudioOrchestrationSelectionContext = {

--- a/apps/desktop/src/pages/agents/use-agent-studio-repo-settings.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-repo-settings.test.tsx
@@ -1,196 +1,122 @@
 import { describe, expect, mock, test } from "bun:test";
-import type { RepoSettingsInput } from "@/types/state-slices";
+import type { RepoConfig } from "@openducktor/contracts";
 import {
-  createDeferred,
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
-import {
-  REPO_SETTINGS_UPDATED_EVENT,
-  useAgentStudioRepoSettings,
-} from "./use-agent-studio-repo-settings";
+
+const hostMock = {
+  workspaceGetRepoConfig: mock(
+    async (_repoPath: string): Promise<RepoConfig> => ({
+      defaultRuntimeKind: "opencode",
+      worktreeBasePath: "/worktrees",
+      branchPrefix: "codex/",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: { providers: {} },
+      trustedHooks: false,
+      trustedHooksFingerprint: undefined,
+      hooks: { preStart: [], postComplete: [] },
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    }),
+  ),
+};
+
+mock.module("@/state/operations/host", () => ({
+  host: hostMock,
+}));
+
+const { useAgentStudioRepoSettings } = await import("./use-agent-studio-repo-settings");
 
 enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioRepoSettings>[0];
 
-const createSettings = (): RepoSettingsInput => ({
-  defaultRuntimeKind: "opencode" as const,
-  worktreeBasePath: "/worktrees",
-  branchPrefix: "codex/",
-  defaultTargetBranch: { remote: "origin", branch: "main" },
-  trustedHooks: false,
-  preStartHooks: [],
-  postCompleteHooks: [],
-  worktreeFileCopies: [],
-  agentDefaults: {
-    spec: null,
-    planner: null,
-    build: null,
-    qa: null,
-  },
-});
-
 const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useAgentStudioRepoSettings, initialProps);
 
 describe("useAgentStudioRepoSettings", () => {
-  test("loads repo settings when repository is active", async () => {
-    const settings = createSettings();
-    const loadRepoSettings = mock(async (): Promise<RepoSettingsInput> => settings);
+  test("loads repo settings from the canonical repo config query", async () => {
+    hostMock.workspaceGetRepoConfig.mockClear();
 
     const harness = createHookHarness({
       activeRepo: "/repo",
-      loadRepoSettings,
     });
 
     await harness.mount();
+    await harness.waitFor((state) => state.repoSettings !== null);
 
-    expect(loadRepoSettings).toHaveBeenCalledTimes(1);
-    expect(harness.getLatest().repoSettings).toEqual(settings);
+    expect(hostMock.workspaceGetRepoConfig).toHaveBeenCalledWith("/repo");
+    expect(harness.getLatest().repoSettings).toEqual({
+      defaultRuntimeKind: "opencode",
+      worktreeBasePath: "/worktrees",
+      branchPrefix: "codex/",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      trustedHooks: false,
+      preStartHooks: [],
+      postCompleteHooks: [],
+      worktreeFileCopies: [],
+      agentDefaults: {
+        spec: null,
+        planner: null,
+        build: null,
+        qa: null,
+      },
+    });
 
     await harness.unmount();
   });
 
   test("resets settings when active repo becomes null", async () => {
-    const settings = createSettings();
-    const loadRepoSettings = mock(async (): Promise<RepoSettingsInput> => settings);
+    hostMock.workspaceGetRepoConfig.mockClear();
 
     const harness = createHookHarness({
       activeRepo: "/repo",
-      loadRepoSettings,
     });
 
     await harness.mount();
-    expect(harness.getLatest().repoSettings).toEqual(settings);
+    await harness.waitFor((state) => state.repoSettings !== null);
 
-    await harness.update({ activeRepo: null, loadRepoSettings });
+    await harness.update({ activeRepo: null });
+
     expect(harness.getLatest().repoSettings).toBeNull();
 
     await harness.unmount();
   });
 
-  test("reloads settings when repo settings update event is dispatched", async () => {
-    const globalWithWindow = globalThis as typeof globalThis & {
-      window?: EventTarget;
-    };
-    const originalWindow = globalWithWindow.window;
-    const eventWindow = new EventTarget();
-    Object.defineProperty(globalWithWindow, "window", {
-      configurable: true,
-      value: eventWindow,
-    });
-
-    const firstSettings = createSettings();
-    const secondSettings: RepoSettingsInput = {
-      ...createSettings(),
-      branchPrefix: "feature/",
-    };
-
-    let loadCount = 0;
-    const loadRepoSettings = mock(async (): Promise<RepoSettingsInput> => {
-      loadCount += 1;
-      return loadCount === 1 ? firstSettings : secondSettings;
-    });
+  test("switches to the next repository key instead of reusing stale derived state", async () => {
+    hostMock.workspaceGetRepoConfig.mockClear();
+    hostMock.workspaceGetRepoConfig.mockImplementation(
+      async (repoPath: string): Promise<RepoConfig> => ({
+        defaultRuntimeKind: "opencode",
+        worktreeBasePath: repoPath === "/repo-a" ? "/worktrees/a" : "/worktrees/b",
+        branchPrefix: repoPath === "/repo-a" ? "feature-a/" : "feature-b/",
+        defaultTargetBranch: { remote: "origin", branch: "main" },
+        git: { providers: {} },
+        trustedHooks: false,
+        trustedHooksFingerprint: undefined,
+        hooks: { preStart: [], postComplete: [] },
+        worktreeFileCopies: [],
+        promptOverrides: {},
+        agentDefaults: {},
+      }),
+    );
 
     const harness = createHookHarness({
-      activeRepo: "/repo",
-      loadRepoSettings,
+      activeRepo: "/repo-a",
     });
 
     await harness.mount();
-    expect(harness.getLatest().repoSettings).toEqual(firstSettings);
+    await harness.waitFor((state) => state.repoSettings?.branchPrefix === "feature-a/");
 
-    await harness.run(() => {
-      eventWindow.dispatchEvent(
-        new CustomEvent(REPO_SETTINGS_UPDATED_EVENT, {
-          detail: { repoPath: "/repo" },
-        }),
-      );
-    });
+    await harness.update({ activeRepo: "/repo-b" });
+    await harness.waitFor((state) => state.repoSettings?.branchPrefix === "feature-b/");
 
-    await harness.waitFor((state) => state.repoSettings?.branchPrefix === "feature/");
-    expect(loadRepoSettings).toHaveBeenCalledTimes(2);
-    expect(harness.getLatest().repoSettings).toEqual(secondSettings);
+    expect(hostMock.workspaceGetRepoConfig).toHaveBeenCalledWith("/repo-a");
+    expect(hostMock.workspaceGetRepoConfig).toHaveBeenCalledWith("/repo-b");
+    expect(harness.getLatest().repoSettings?.worktreeBasePath).toBe("/worktrees/b");
 
     await harness.unmount();
-
-    if (typeof originalWindow === "undefined") {
-      Reflect.deleteProperty(globalWithWindow, "window");
-    } else {
-      Object.defineProperty(globalWithWindow, "window", {
-        configurable: true,
-        value: originalWindow,
-      });
-    }
-  });
-
-  test("keeps the latest event reload result when concurrent loads resolve out of order", async () => {
-    const globalWithWindow = globalThis as typeof globalThis & {
-      window?: EventTarget;
-    };
-    const originalWindow = globalWithWindow.window;
-    const eventWindow = new EventTarget();
-    Object.defineProperty(globalWithWindow, "window", {
-      configurable: true,
-      value: eventWindow,
-    });
-
-    const firstSettings = createSettings();
-    const secondSettings: RepoSettingsInput = {
-      ...createSettings(),
-      branchPrefix: "feature/latest",
-    };
-    const firstLoad = createDeferred<RepoSettingsInput>();
-    const secondLoad = createDeferred<RepoSettingsInput>();
-    let loadCount = 0;
-    const loadRepoSettings = mock((): Promise<RepoSettingsInput> => {
-      loadCount += 1;
-      return loadCount === 1 ? firstLoad.promise : secondLoad.promise;
-    });
-
-    const harness = createHookHarness({
-      activeRepo: "/repo",
-      loadRepoSettings,
-    });
-
-    try {
-      await harness.mount();
-
-      await harness.run(() => {
-        eventWindow.dispatchEvent(
-          new CustomEvent(REPO_SETTINGS_UPDATED_EVENT, {
-            detail: { repoPath: "/repo" },
-          }),
-        );
-      });
-
-      await harness.run(async () => {
-        secondLoad.resolve(secondSettings);
-        await secondLoad.promise;
-      });
-      await harness.waitFor((state) => state.repoSettings?.branchPrefix === "feature/latest");
-
-      await harness.run(async () => {
-        firstLoad.resolve(firstSettings);
-        await firstLoad.promise;
-      });
-
-      expect(loadRepoSettings).toHaveBeenCalledTimes(2);
-      expect(harness.getLatest().repoSettings).toEqual(secondSettings);
-    } finally {
-      firstLoad.resolve(firstSettings);
-      secondLoad.resolve(secondSettings);
-      await harness.unmount();
-
-      if (typeof originalWindow === "undefined") {
-        Reflect.deleteProperty(globalWithWindow, "window");
-      } else {
-        Object.defineProperty(globalWithWindow, "window", {
-          configurable: true,
-          value: originalWindow,
-        });
-      }
-    }
   });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-repo-settings.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-repo-settings.ts
@@ -1,75 +1,18 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { repoConfigQueryOptions, toRepoSettingsInput } from "@/state/queries/workspace";
 import type { RepoSettingsInput } from "@/types/state-slices";
 
-export const REPO_SETTINGS_UPDATED_EVENT = "odt:repo-settings-updated";
-
-type RepoSettingsUpdatedEventDetail = {
-  repoPath: string;
-};
-
-export function useAgentStudioRepoSettings(args: {
-  activeRepo: string | null;
-  loadRepoSettings: () => Promise<RepoSettingsInput>;
-}): {
+export function useAgentStudioRepoSettings(args: { activeRepo: string | null }): {
   repoSettings: RepoSettingsInput | null;
 } {
-  const { activeRepo, loadRepoSettings } = args;
-  const [repoSettings, setRepoSettings] = useState<RepoSettingsInput | null>(null);
-  const latestReloadIdRef = useRef(0);
-
-  const reloadRepoSettings = useCallback(() => {
-    if (!activeRepo) {
-      latestReloadIdRef.current += 1;
-      setRepoSettings(null);
-      return () => {};
-    }
-
-    const reloadId = latestReloadIdRef.current + 1;
-    latestReloadIdRef.current = reloadId;
-    let cancelled = false;
-    void loadRepoSettings()
-      .then((settings) => {
-        if (!cancelled && reloadId === latestReloadIdRef.current) {
-          setRepoSettings(settings);
-        }
-      })
-      .catch(() => {
-        if (!cancelled && reloadId === latestReloadIdRef.current) {
-          setRepoSettings(null);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeRepo, loadRepoSettings]);
-
-  useEffect(() => {
-    return reloadRepoSettings();
-  }, [reloadRepoSettings]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const handleRepoSettingsUpdated = (event: Event) => {
-      const customEvent = event as CustomEvent<RepoSettingsUpdatedEventDetail>;
-      const repoPath = customEvent.detail?.repoPath;
-      if (!repoPath || !activeRepo || repoPath !== activeRepo) {
-        return;
-      }
-
-      reloadRepoSettings();
-    };
-
-    window.addEventListener(REPO_SETTINGS_UPDATED_EVENT, handleRepoSettingsUpdated);
-    return () => {
-      window.removeEventListener(REPO_SETTINGS_UPDATED_EVENT, handleRepoSettingsUpdated);
-    };
-  }, [activeRepo, reloadRepoSettings]);
+  const { activeRepo } = args;
+  const { data: repoSettings } = useQuery({
+    ...(activeRepo ? repoConfigQueryOptions(activeRepo) : repoConfigQueryOptions("")),
+    enabled: activeRepo !== null,
+    select: toRepoSettingsInput,
+  });
 
   return {
-    repoSettings,
+    repoSettings: repoSettings ?? null,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { clearAppQueryClient } from "@/lib/query-client";
 import { host } from "@/state/operations/host";
 import {
   createAgentSessionFixture,
@@ -11,6 +12,10 @@ import { kickoffPromptForScenario } from "./agents-page-constants";
 import { useAgentStudioSessionActions } from "./use-agent-studio-session-actions";
 
 enableReactActEnvironment();
+
+beforeEach(async () => {
+  await clearAppQueryClient();
+});
 
 type HookArgs = Parameters<typeof useAgentStudioSessionActions>[0];
 
@@ -59,6 +64,7 @@ describe("useAgentStudioSessionActions", () => {
         promptOverrides: {},
       }) as Awaited<ReturnType<typeof host.workspaceGetRepoConfig>>;
     host.workspaceGetSettingsSnapshot = async () => ({
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit",
       },

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { clearAppQueryClient } from "@/lib/query-client";
 import { host } from "@/state/operations/host";
 import {
   createAgentSessionFixture,
@@ -10,6 +11,10 @@ import { kickoffPromptForScenario } from "./agents-page-constants";
 import { useAgentStudioSessionStartFlow as useSessionStartFlow } from "./use-agent-studio-session-start-flow";
 
 enableReactActEnvironment();
+
+beforeEach(async () => {
+  await clearAppQueryClient();
+});
 
 type HookArgs = Parameters<typeof useSessionStartFlow>[0];
 
@@ -55,6 +60,7 @@ describe("useAgentStudioSessionStartFlow", () => {
         promptOverrides: {},
       }) as Awaited<ReturnType<typeof host.workspaceGetRepoConfig>>;
     host.workspaceGetSettingsSnapshot = async () => ({
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit",
       },

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -71,12 +71,13 @@ describe("useAgentStudioTaskHydration", () => {
     try {
       await harness.mount();
 
-      expect(loadAgentSessions).toHaveBeenCalledTimes(2);
-      expect(loadAgentSessions.mock.calls[0]).toEqual(["task-1"]);
-      expect(loadAgentSessions.mock.calls[1]).toEqual([
+      expect(loadAgentSessions).toHaveBeenCalledTimes(1);
+      expect(loadAgentSessions.mock.calls[0]).toEqual([
         "task-1",
         { hydrateHistoryForSessionId: "session-1" },
       ]);
+      await harness.waitFor((state) => state.hydratedTasksByRepoAndTask["/repo-a:task-1"] === true);
+      expect(harness.getLatest().isActiveSessionHistoryHydrated).toBe(true);
 
       await harness.update(
         createBaseArgs({
@@ -84,7 +85,7 @@ describe("useAgentStudioTaskHydration", () => {
           loadAgentSessions,
         }),
       );
-      expect(loadAgentSessions).toHaveBeenCalledTimes(2);
+      expect(loadAgentSessions).toHaveBeenCalledTimes(1);
 
       await harness.update(
         createBaseArgs({
@@ -93,8 +94,8 @@ describe("useAgentStudioTaskHydration", () => {
         }),
       );
 
-      expect(loadAgentSessions).toHaveBeenCalledTimes(3);
-      expect(loadAgentSessions.mock.calls[2]).toEqual([
+      expect(loadAgentSessions).toHaveBeenCalledTimes(2);
+      expect(loadAgentSessions.mock.calls[1]).toEqual([
         "task-1",
         { hydrateHistoryForSessionId: "session-2" },
       ]);

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -44,7 +44,7 @@ export function useAgentStudioTaskHydration({
   }, [activeRepo]);
 
   useEffect(() => {
-    if (!activeRepo || !activeTaskId) {
+    if (!activeRepo || !activeTaskId || activeSessionId) {
       return;
     }
 
@@ -83,13 +83,14 @@ export function useAgentStudioTaskHydration({
     return () => {
       cancelled = true;
     };
-  }, [activeRepo, activeTaskId, hydratedTasksByRepoAndTask, loadAgentSessions]);
+  }, [activeRepo, activeSessionId, activeTaskId, hydratedTasksByRepoAndTask, loadAgentSessions]);
 
   useEffect(() => {
     if (!activeRepo || !activeTaskId || !activeSessionId) {
       return;
     }
 
+    const taskHydrationKey = `${activeRepo}:${activeTaskId}`;
     const sessionHydrationKey = `${activeRepo}:${activeTaskId}:${activeSessionId}`;
     if (hydratedSessionHistoriesByRepoRef.current.has(sessionHydrationKey)) {
       return;
@@ -111,6 +112,15 @@ export function useAgentStudioTaskHydration({
         if (cancelled) {
           return;
         }
+        setHydratedTasksByRepoAndTask((current) => {
+          if (current[taskHydrationKey] === true) {
+            return current;
+          }
+          return {
+            ...current,
+            [taskHydrationKey]: true,
+          };
+        });
         hydratedSessionHistoriesByRepoRef.current.add(sessionHydrationKey);
         setSessionHistoryStatusByRepoKey((current) => ({
           ...current,

--- a/apps/desktop/src/pages/agents/use-agent-studio-worktree-resolution.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-worktree-resolution.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { errorMessage } from "@/lib/errors";
-import { host } from "@/state/operations/host";
+import { appQueryClient } from "@/lib/query-client";
+import { loadRepoRunsFromQuery, taskQueryKeys } from "@/state/queries/tasks";
 
 const WORKTREE_RESOLUTION_TIMEOUT_MS = 5_000;
 
@@ -231,8 +232,14 @@ export function useAgentStudioWorktreeResolution({
 
     void (async () => {
       try {
+        await appQueryClient.cancelQueries({
+          queryKey: taskQueryKeys.runs(worktreeResolutionRepoPath),
+        });
+        await appQueryClient.invalidateQueries({
+          queryKey: taskQueryKeys.runs(worktreeResolutionRepoPath),
+        });
         const runs = await withTimeout(
-          host.runsList(worktreeResolutionRepoPath),
+          loadRepoRunsFromQuery(appQueryClient, worktreeResolutionRepoPath),
           WORKTREE_RESOLUTION_TIMEOUT_MS,
           `Timed out after ${WORKTREE_RESOLUTION_TIMEOUT_MS}ms while loading runs list.`,
         );

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -1,8 +1,14 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { OPENCODE_RUNTIME_DESCRIPTOR, type RepoPromptOverrides } from "@openducktor/contracts";
+import {
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type RepoConfig,
+  type RepoPromptOverrides,
+} from "@openducktor/contracts";
 import { isValidElement, type ReactElement } from "react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { clearAppQueryClient } from "@/lib/query-client";
+import { QueryProvider } from "@/lib/query-provider";
 import type { AgentSessionLoadOptions } from "@/types/agent-orchestrator";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
@@ -25,12 +31,9 @@ const deferTaskMock = mock(async () => {});
 const resumeDeferredTaskMock = mock(async () => {});
 const toastSuccessMock = mock(() => {});
 const toastErrorMock = mock(() => {});
-const workspaceGetRepoConfigMock = mock(
-  async (): Promise<{ promptOverrides: RepoPromptOverrides }> => ({
-    promptOverrides: {},
-  }),
-);
+const workspaceGetRepoConfigMock = mock(async (): Promise<RepoConfig> => createRepoConfigFixture());
 const workspaceGetSettingsSnapshotMock = mock(async () => ({
+  theme: "light" as const,
   git: {
     defaultMergeMethod: "merge_commit" as const,
   },
@@ -115,6 +118,42 @@ const REPO_SETTINGS_FIXTURE: RepoSettingsInput = {
     qa: null,
   },
 };
+
+const createRepoConfigFixture = (promptOverrides: RepoPromptOverrides = {}): RepoConfig => ({
+  defaultRuntimeKind: "opencode",
+  worktreeBasePath: undefined,
+  branchPrefix: "codex/",
+  defaultTargetBranch: { remote: "origin", branch: "main" },
+  git: {
+    providers: {},
+  },
+  trustedHooks: false,
+  trustedHooksFingerprint: undefined,
+  hooks: {
+    preStart: [],
+    postComplete: [],
+  },
+  worktreeFileCopies: [],
+  promptOverrides,
+  agentDefaults: {
+    spec: {
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    },
+    planner: undefined,
+    build: {
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+      profileId: "build-agent",
+    },
+    qa: undefined,
+  },
+});
 
 mock.module("sonner", () => ({
   toast: {
@@ -211,17 +250,20 @@ const renderPage = async (): Promise<ReactTestRenderer> => {
   let renderer!: ReactTestRenderer;
   await act(async () => {
     renderer = create(
-      <MemoryRouter initialEntries={["/"]}>
-        <LocationProbe />
-        <KanbanPage />
-      </MemoryRouter>,
+      <QueryProvider useIsolatedClient>
+        <MemoryRouter initialEntries={["/"]}>
+          <LocationProbe />
+          <KanbanPage />
+        </MemoryRouter>
+      </QueryProvider>,
     );
   });
   return renderer;
 };
 
 describe("KanbanPage session start modal flow", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await clearAppQueryClient();
     currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "open" });
     currentSessionsFixture = [
       {
@@ -278,10 +320,9 @@ describe("KanbanPage session start modal flow", () => {
     toastErrorMock.mockClear();
     workspaceGetRepoConfigMock.mockClear();
     workspaceGetSettingsSnapshotMock.mockClear();
-    workspaceGetRepoConfigMock.mockImplementation(async () => ({
-      promptOverrides: {},
-    }));
+    workspaceGetRepoConfigMock.mockImplementation(async () => createRepoConfigFixture());
     workspaceGetSettingsSnapshotMock.mockImplementation(async () => ({
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit" as const,
       },
@@ -484,14 +525,12 @@ describe("KanbanPage session start modal flow", () => {
 
   test("malformed kickoff override still reports kickoff error after session start", async () => {
     workspaceGetRepoConfigMock.mockImplementation(async () => {
-      return {
-        promptOverrides: {
-          "kickoff.build_implementation_start": {
-            template: "Kickoff {{unsupported.token}}",
-            baseVersion: 1,
-          },
+      return createRepoConfigFixture({
+        "kickoff.build_implementation_start": {
+          template: "Kickoff {{unsupported.token}}",
+          baseVersion: 1,
         },
-      };
+      });
     });
 
     const renderer = await renderPage();

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
@@ -13,7 +13,7 @@ type UseKanbanPageModelsArgs = {
 };
 
 export function useKanbanPageModels({ onOpenDetails }: UseKanbanPageModelsArgs): KanbanPageModels {
-  const { activeRepo, isSwitchingWorkspace, loadRepoSettings } = useWorkspaceState();
+  const { activeRepo, isSwitchingWorkspace } = useWorkspaceState();
   const {
     sessions,
     loadAgentSessions,
@@ -38,10 +38,7 @@ export function useKanbanPageModels({ onOpenDetails }: UseKanbanPageModelsArgs):
   } = useTasksState();
   const navigate = useNavigate();
 
-  const { repoSettings } = useAgentStudioRepoSettings({
-    activeRepo,
-    loadRepoSettings,
-  });
+  const { repoSettings } = useAgentStudioRepoSettings({ activeRepo });
 
   const sessionStartFlow = useKanbanSessionStartFlow({
     activeRepo,

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { TaskApprovalContext } from "@openducktor/contracts";
 import type { ReactElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { clearAppQueryClient } from "@/lib/query-client";
 import {
   createAgentSessionFixture,
   createTaskCardFixture,
@@ -57,6 +58,7 @@ mock.module("@/state/operations/host", () => ({
     qaGetReport: async () => ({ markdown: "", updatedAt: null }),
     workspaceGetRepoConfig: async () => ({ promptOverrides: {} }),
     workspaceGetSettingsSnapshot: async () => ({
+      theme: "light" as const,
       git: { defaultMergeMethod: "merge_commit" as const },
       chat: { showThinkingMessages: false },
       repos: {},
@@ -103,7 +105,8 @@ function createDeferred<TValue>() {
 }
 
 describe("useTaskApprovalFlow", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await clearAppQueryClient();
     latestHarnessValue = null;
     taskApprovalContextGetMock.mockClear();
     taskDirectMergeMock.mockClear();

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -4,9 +4,17 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { openExternalUrl } from "@/lib/open-external-url";
+import { appQueryClient } from "@/lib/query-client";
 import { canonicalTargetBranch, checkoutTargetBranch } from "@/lib/target-branch";
 import { host } from "@/state/operations/host";
 import { loadEffectivePromptOverrides } from "@/state/operations/prompt-overrides";
+import { loadAgentSessionListFromQuery } from "@/state/queries/agent-sessions";
+import {
+  loadPlanDocumentFromQuery,
+  loadQaReportDocumentFromQuery,
+  loadSpecDocumentFromQuery,
+} from "@/state/queries/documents";
+import { loadTaskApprovalContextFromQuery } from "@/state/queries/task-approval";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { TaskApprovalModalModel } from "./kanban-page-model-types";
 
@@ -122,7 +130,11 @@ export function useTaskApprovalFlow({
 
       void (async () => {
         try {
-          const approvalContext = await host.taskApprovalContextGet(activeRepo, taskId);
+          const approvalContext = await loadTaskApprovalContextFromQuery(
+            appQueryClient,
+            activeRepo,
+            taskId,
+          );
           if (approvalRequestVersionRef.current !== requestVersion) {
             return;
           }
@@ -208,7 +220,7 @@ export function useTaskApprovalFlow({
       }
 
       const latestBuilderRecord = (
-        await host.agentSessionsList(activeRepo, currentState.taskId)
+        await loadAgentSessionListFromQuery(appQueryClient, activeRepo, currentState.taskId)
       ).find((entry) => entry.role === "build");
       if (!latestBuilderRecord) {
         throw new Error("No Builder session is available to fork for pull request drafting.");
@@ -221,9 +233,9 @@ export function useTaskApprovalFlow({
       const [task, overrides, spec, plan, qa] = await Promise.all([
         Promise.resolve(tasks.find((entry) => entry.id === currentState.taskId) ?? null),
         loadEffectivePromptOverrides(activeRepo),
-        host.specGet(activeRepo, currentState.taskId),
-        host.planGet(activeRepo, currentState.taskId),
-        host.qaGetReport(activeRepo, currentState.taskId),
+        loadSpecDocumentFromQuery(appQueryClient, activeRepo, currentState.taskId),
+        loadPlanDocumentFromQuery(appQueryClient, activeRepo, currentState.taskId),
+        loadQaReportDocumentFromQuery(appQueryClient, activeRepo, currentState.taskId),
       ]);
       if (!task) {
         throw new Error(`Task not found: ${currentState.taskId}`);

--- a/apps/desktop/src/pages/shared/use-session-start-modal-state.ts
+++ b/apps/desktop/src/pages/shared/use-session-start-modal-state.ts
@@ -5,6 +5,7 @@ import type {
   AgentRole,
   AgentScenario,
 } from "@openducktor/core";
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { resolveAgentAccentColor } from "@/components/features/agents/agent-accent-color";
 import {
@@ -20,6 +21,7 @@ import {
   toAgentRuntimeOptions,
 } from "@/lib/agent-runtime";
 import { loadRepoRuntimeCatalog } from "@/state/operations";
+import { repoRuntimeCatalogQueryOptions } from "@/state/queries/runtime-catalog";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import {
   isSameSelection,
@@ -127,8 +129,6 @@ export function useSessionStartModalState({
   const [intent, setIntent] = useState<SessionStartModalIntent | null>(null);
   const [selection, setSelection] = useState<AgentModelSelection | null>(null);
   const [selectedRuntimeKind, setSelectedRuntimeKind] = useState<RuntimeKind>(DEFAULT_RUNTIME_KIND);
-  const [catalog, setCatalog] = useState<AgentModelCatalog | null>(initialCatalog ?? null);
-  const [isCatalogLoading, setIsCatalogLoading] = useState(false);
   const activeRole = intent?.role ?? null;
   const runtimeOptions = useMemo(
     () => toAgentRuntimeOptions(runtimeDefinitions),
@@ -149,44 +149,24 @@ export function useSessionStartModalState({
     }
   }, [runtimeDefinitions, selectedRuntimeKind]);
 
-  useEffect(() => {
-    if (initialCatalog !== undefined) {
-      setCatalog(initialCatalog);
-      setIsCatalogLoading(false);
-      return;
-    }
+  const catalogQuery = useQuery({
+    ...(activeRepo
+      ? repoRuntimeCatalogQueryOptions(activeRepo, selectedRuntimeKind)
+      : repoRuntimeCatalogQueryOptions("", selectedRuntimeKind)),
+    enabled: initialCatalog === undefined && Boolean(activeRepo) && intent !== null,
+    queryFn: async (): Promise<AgentModelCatalog> => {
+      if (!activeRepo) {
+        throw new Error("No repository selected.");
+      }
+      return loadCatalog(activeRepo, selectedRuntimeKind);
+    },
+  });
 
-    if (!activeRepo) {
-      setCatalog(null);
-      setIsCatalogLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setCatalog(null);
-    setIsCatalogLoading(true);
-    void Promise.resolve()
-      .then(() => loadCatalog(activeRepo, selectedRuntimeKind))
-      .then((nextCatalog) => {
-        if (!cancelled) {
-          setCatalog(nextCatalog);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setCatalog(null);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsCatalogLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeRepo, initialCatalog, loadCatalog, selectedRuntimeKind]);
+  const catalog = initialCatalog ?? catalogQuery.data ?? null;
+  const isCatalogLoading =
+    initialCatalog === undefined && intent !== null && activeRepo !== null
+      ? catalogQuery.isLoading
+      : false;
 
   const closeStartModal = useCallback(() => {
     setIntent(null);

--- a/apps/desktop/src/state/app-state-context-values.test.ts
+++ b/apps/desktop/src/state/app-state-context-values.test.ts
@@ -61,6 +61,7 @@ describe("app-state-context-values", () => {
       }),
       saveRepoSettings: async () => {},
       loadSettingsSnapshot: async () => ({
+        theme: "light" as const,
         git: {
           defaultMergeMethod: "merge_commit",
         },

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { AgentModelSelection } from "@openducktor/core";
+import { clearAppQueryClient } from "@/lib/query-client";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
 import { createDeferred, createTaskCardFixture, withTimeout } from "../test-utils";
@@ -22,6 +23,10 @@ const taskFixture = createTaskCardFixture({
 });
 
 describe("agent-orchestrator/handlers/start-session", () => {
+  beforeEach(async () => {
+    await clearAppQueryClient();
+  });
+
   test("throws when no active repo is selected", () => {
     const start = createStartAgentSessionWithFlatDeps({
       activeRepo: null,
@@ -1532,6 +1537,8 @@ describe("agent-orchestrator/handlers/start-session", () => {
       qaMarkdown: string;
     }>();
     let runtimeCalls = 0;
+    const runtimeStarted = createDeferred<void>();
+    const defaultModelStarted = createDeferred<void>();
     let defaultModelCalls = 0;
 
     const adapter = new OpencodeSdkAdapter();
@@ -1561,6 +1568,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       attachSessionListener: () => {},
       ensureRuntime: async () => {
         runtimeCalls += 1;
+        runtimeStarted.resolve();
         return {
           kind: "opencode",
           runtimeId: null,
@@ -1572,6 +1580,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       loadTaskDocuments: async () => docsDeferred.promise,
       loadRepoDefaultModel: async () => {
         defaultModelCalls += 1;
+        defaultModelStarted.resolve();
         return null;
       },
       loadRepoPromptOverrides: async () => ({}),
@@ -1585,7 +1594,10 @@ describe("agent-orchestrator/handlers/start-session", () => {
 
     try {
       const startPromise = start({ taskId: "task-1", role: "build" });
-      await Promise.resolve();
+      await withTimeout(
+        Promise.all([runtimeStarted.promise, defaultModelStarted.promise]).then(() => undefined),
+        50,
+      );
 
       expect(runtimeCalls).toBe(1);
       expect(defaultModelCalls).toBe(1);

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -3,9 +3,10 @@ import type { AgentModelSelection, AgentScenario } from "@openducktor/core";
 import { assertAgentKickoffScenario, buildAgentSystemPrompt } from "@openducktor/core";
 import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import { errorMessage } from "@/lib/errors";
+import { appQueryClient } from "@/lib/query-client";
 import { isRoleAvailableForTask, unavailableRoleErrorMessage } from "@/lib/task-agent-workflows";
+import { loadAgentSessionListFromQuery } from "@/state/queries/agent-sessions";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { host } from "../../host";
 import { requireActiveRepo } from "../../task-operations-model";
 import { type RuntimeInfo, resolveRuntimeConnection } from "../runtime/runtime";
 import {
@@ -372,7 +373,11 @@ const createOrReuseSession = async ({
       }
     }
 
-    const persistedSessions = await host.agentSessionsList(ctx.repoPath, ctx.taskId);
+    const persistedSessions = await loadAgentSessionListFromQuery(
+      appQueryClient,
+      ctx.repoPath,
+      ctx.taskId,
+    );
     throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
     const latestPersistedSession = pickLatestSession(
       persistedSessions.filter((entry) => entry.role === ctx.role),

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -5,7 +5,7 @@ import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import { errorMessage } from "@/lib/errors";
 import { appQueryClient } from "@/lib/query-client";
 import { isRoleAvailableForTask, unavailableRoleErrorMessage } from "@/lib/task-agent-workflows";
-import { loadAgentSessionListFromQuery } from "@/state/queries/agent-sessions";
+import { agentSessionListQueryOptions } from "@/state/queries/agent-sessions";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { requireActiveRepo } from "../../task-operations-model";
 import { type RuntimeInfo, resolveRuntimeConnection } from "../runtime/runtime";
@@ -373,11 +373,10 @@ const createOrReuseSession = async ({
       }
     }
 
-    const persistedSessions = await loadAgentSessionListFromQuery(
-      appQueryClient,
-      ctx.repoPath,
-      ctx.taskId,
-    );
+    const persistedSessions = await appQueryClient.fetchQuery({
+      ...agentSessionListQueryOptions(ctx.repoPath, ctx.taskId),
+      staleTime: 0,
+    });
     throwIfRepoStale(ctx.isStaleRepoOperation, STALE_START_ERROR);
     const latestPersistedSession = pickLatestSession(
       persistedSessions.filter((entry) => entry.role === ctx.role),

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import type { AgentSessionRecord } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { clearAppQueryClient } from "@/lib/query-client";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { createDeferred, createTaskCardFixture } from "../test-utils";
 import { createLoadAgentSessions } from "./load-sessions";
@@ -8,6 +9,10 @@ import { createLoadAgentSessions } from "./load-sessions";
 const taskFixture = createTaskCardFixture({ title: "Task" });
 
 describe("agent-orchestrator-load-sessions", () => {
+  beforeEach(async () => {
+    await clearAppQueryClient();
+  });
+
   test("no-ops when active repo is missing", async () => {
     let setCalled = false;
     const loadAgentSessions = createLoadAgentSessions({

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -13,6 +13,10 @@ import {
 } from "@openducktor/core";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
+import { appQueryClient } from "@/lib/query-client";
+import { loadAgentSessionListFromQuery } from "@/state/queries/agent-sessions";
+import { loadRuntimeListFromQuery } from "@/state/queries/runtime";
+import { loadRepoRunsFromQuery } from "@/state/queries/tasks";
 import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../host";
 import {
@@ -141,7 +145,7 @@ export const createLoadAgentSessions = ({
     };
 
     const [persisted, repoPromptOverrides] = await Promise.all([
-      host.agentSessionsList(repoPath, taskId),
+      loadAgentSessionListFromQuery(appQueryClient, repoPath, taskId),
       loadRepoPromptOverrides(repoPath),
     ]);
     if (isStaleRepoOperation()) {
@@ -228,7 +232,7 @@ export const createLoadAgentSessions = ({
       runtimeKindsToHydrate.map(async (runtimeKind) => {
         const runtimes = await captureOrchestratorFallback(
           "load-sessions-list-runtimes",
-          async () => host.runtimeList(runtimeKind, repoPath),
+          async () => loadRuntimeListFromQuery(appQueryClient, runtimeKind, repoPath),
           {
             tags: { repoPath, taskId, runtimeKind },
             logLevel: "warn",
@@ -245,7 +249,7 @@ export const createLoadAgentSessions = ({
     )
       ? await captureOrchestratorFallback(
           "load-sessions-list-runs",
-          async () => host.runsList(repoPath),
+          async () => loadRepoRunsFromQuery(appQueryClient, repoPath),
           {
             tags: { repoPath, taskId },
             logLevel: "warn",

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -232,7 +232,7 @@ export const createLoadAgentSessions = ({
       runtimeKindsToHydrate.map(async (runtimeKind) => {
         const runtimes = await captureOrchestratorFallback(
           "load-sessions-list-runtimes",
-          async () => loadRuntimeListFromQuery(appQueryClient, runtimeKind, repoPath),
+          () => loadRuntimeListFromQuery(appQueryClient, runtimeKind, repoPath),
           {
             tags: { repoPath, taskId, runtimeKind },
             logLevel: "warn",
@@ -249,7 +249,7 @@ export const createLoadAgentSessions = ({
     )
       ? await captureOrchestratorFallback(
           "load-sessions-list-runs",
-          async () => loadRepoRunsFromQuery(appQueryClient, repoPath),
+          () => loadRepoRunsFromQuery(appQueryClient, repoPath),
           {
             tags: { repoPath, taskId },
             logLevel: "warn",

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { RunSummary } from "@openducktor/contracts";
 import { agentPromptTemplateIdValues, OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { clearAppQueryClient } from "@/lib/query-client";
 import { host } from "../../host";
 import { createDeferred, withTimeout } from "../test-utils";
 import {
@@ -28,7 +29,8 @@ const runningRunFixture: RunSummary = {
 };
 
 describe("agent-orchestrator-runtime", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await clearAppQueryClient();
     host.workspaceGetRepoConfig = async () => ({
       defaultRuntimeKind: "opencode",
       branchPrefix: "obp",
@@ -433,6 +435,7 @@ describe("agent-orchestrator-runtime", () => {
       agentDefaults: {},
     });
     host.workspaceGetSettingsSnapshot = async () => ({
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit",
       },
@@ -502,6 +505,7 @@ describe("agent-orchestrator-runtime", () => {
       agentDefaults: {},
     });
     host.workspaceGetSettingsSnapshot = async () => ({
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit",
       },

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -7,6 +7,13 @@ import type {
 } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole, AgentRuntimeConnection } from "@openducktor/core";
 import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
+import { appQueryClient } from "@/lib/query-client";
+import {
+  loadPlanDocumentFromQuery,
+  loadQaReportDocumentFromQuery,
+  loadSpecDocumentFromQuery,
+} from "../../../queries/documents";
+import { loadRepoConfigFromQuery } from "../../../queries/workspace";
 import { host } from "../../host";
 import { loadEffectivePromptOverrides } from "../../prompt-overrides";
 import { runOrchestratorSideEffect } from "../support/async-side-effects";
@@ -53,9 +60,9 @@ export const loadTaskDocuments = async (
   taskId: string,
 ): Promise<TaskDocuments> => {
   const [spec, plan, qa] = await Promise.all([
-    host.specGet(repoPath, taskId).then((spec) => spec.markdown),
-    host.planGet(repoPath, taskId).then((plan) => plan.markdown),
-    host.qaGetReport(repoPath, taskId).then((qa) => qa.markdown),
+    loadSpecDocumentFromQuery(appQueryClient, repoPath, taskId).then((spec) => spec.markdown),
+    loadPlanDocumentFromQuery(appQueryClient, repoPath, taskId).then((plan) => plan.markdown),
+    loadQaReportDocumentFromQuery(appQueryClient, repoPath, taskId).then((qa) => qa.markdown),
   ]);
 
   return {
@@ -69,7 +76,7 @@ export const loadRepoDefaultModel = async (
   repoPath: string,
   role: AgentRole,
 ): Promise<AgentModelSelection | null> => {
-  const config = await host.workspaceGetRepoConfig(repoPath);
+  const config = await loadRepoConfigFromQuery(appQueryClient, repoPath);
   const roleDefault = config?.agentDefaults?.[role];
   if (!roleDefault) {
     return null;
@@ -99,7 +106,7 @@ export const loadRepoDefaultRuntimeKind = async (
   repoPath: string,
   role: AgentRole,
 ): Promise<RuntimeKind> => {
-  const config = await host.workspaceGetRepoConfig(repoPath);
+  const config = await loadRepoConfigFromQuery(appQueryClient, repoPath);
   const roleDefault = config?.agentDefaults?.[role];
   return roleDefault?.runtimeKind ?? config?.defaultRuntimeKind ?? DEFAULT_RUNTIME_KIND;
 };

--- a/apps/desktop/src/state/operations/prompt-overrides.test.ts
+++ b/apps/desktop/src/state/operations/prompt-overrides.test.ts
@@ -1,0 +1,94 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { RepoConfig, SettingsSnapshot } from "@openducktor/contracts";
+import { clearAppQueryClient } from "@/lib/query-client";
+
+const createRepoConfig = (): RepoConfig => ({
+  defaultRuntimeKind: "opencode",
+  branchPrefix: "odt/",
+  defaultTargetBranch: {
+    remote: "origin",
+    branch: "main",
+  },
+  git: {
+    providers: {},
+  },
+  trustedHooks: false,
+  hooks: { preStart: [], postComplete: [] },
+  promptOverrides: {
+    "kickoff.planner_initial": {
+      template: "repo planner {{task.id}}",
+      baseVersion: 1,
+      enabled: true,
+    },
+  },
+  worktreeFileCopies: [],
+  agentDefaults: {},
+});
+
+const createSettingsSnapshot = (): SettingsSnapshot => ({
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  repos: {},
+  chat: { showThinkingMessages: false },
+  globalPromptOverrides: {
+    "kickoff.spec_initial": {
+      template: "global kickoff {{task.id}}",
+      baseVersion: 1,
+      enabled: true,
+    },
+  },
+});
+
+const workspaceGetRepoConfigMock = mock(
+  async (_repoPath: string): Promise<RepoConfig> => createRepoConfig(),
+);
+
+const workspaceGetSettingsSnapshotMock = mock(
+  async (): Promise<SettingsSnapshot> => createSettingsSnapshot(),
+);
+
+mock.module("./host", () => ({
+  host: {
+    workspaceGetRepoConfig: workspaceGetRepoConfigMock,
+    workspaceGetSettingsSnapshot: workspaceGetSettingsSnapshotMock,
+  },
+}));
+
+let loadEffectivePromptOverrides: typeof import("./prompt-overrides")["loadEffectivePromptOverrides"];
+
+beforeAll(async () => {
+  ({ loadEffectivePromptOverrides } = await import("./prompt-overrides"));
+});
+
+beforeEach(async () => {
+  workspaceGetRepoConfigMock.mockClear();
+  workspaceGetSettingsSnapshotMock.mockClear();
+  await clearAppQueryClient();
+});
+
+describe("loadEffectivePromptOverrides", () => {
+  test("deduplicates concurrent loads for the same repo", async () => {
+    const repoDeferred = Promise.withResolvers<RepoConfig>();
+    const settingsDeferred = Promise.withResolvers<SettingsSnapshot>();
+
+    workspaceGetRepoConfigMock.mockImplementationOnce(async () => repoDeferred.promise);
+    workspaceGetSettingsSnapshotMock.mockImplementationOnce(async () => settingsDeferred.promise);
+
+    const firstLoad = loadEffectivePromptOverrides("/repo");
+    const secondLoad = loadEffectivePromptOverrides("/repo");
+
+    expect(workspaceGetRepoConfigMock).toHaveBeenCalledTimes(1);
+    expect(workspaceGetSettingsSnapshotMock).toHaveBeenCalledTimes(1);
+
+    repoDeferred.resolve(createRepoConfig());
+    settingsDeferred.resolve(createSettingsSnapshot());
+
+    const [firstResult, secondResult] = await Promise.all([firstLoad, secondLoad]);
+
+    expect(firstResult).toEqual(secondResult);
+    expect(firstResult["kickoff.spec_initial"]?.template).toBe("global kickoff {{task.id}}");
+    expect(firstResult["kickoff.planner_initial"]?.template).toBe("repo planner {{task.id}}");
+  });
+});

--- a/apps/desktop/src/state/operations/prompt-overrides.test.ts
+++ b/apps/desktop/src/state/operations/prompt-overrides.test.ts
@@ -79,16 +79,26 @@ describe("loadEffectivePromptOverrides", () => {
     const firstLoad = loadEffectivePromptOverrides("/repo");
     const secondLoad = loadEffectivePromptOverrides("/repo");
 
-    expect(workspaceGetRepoConfigMock).toHaveBeenCalledTimes(1);
-    expect(workspaceGetSettingsSnapshotMock).toHaveBeenCalledTimes(1);
-
     repoDeferred.resolve(createRepoConfig());
     settingsDeferred.resolve(createSettingsSnapshot());
 
     const [firstResult, secondResult] = await Promise.all([firstLoad, secondLoad]);
 
+    expect(workspaceGetRepoConfigMock).toHaveBeenCalledTimes(1);
+    expect(workspaceGetSettingsSnapshotMock).toHaveBeenCalledTimes(1);
     expect(firstResult).toEqual(secondResult);
     expect(firstResult["kickoff.spec_initial"]?.template).toBe("global kickoff {{task.id}}");
     expect(firstResult["kickoff.planner_initial"]?.template).toBe("repo planner {{task.id}}");
+  });
+
+  test("normalizes repo paths before deduplicating concurrent loads", async () => {
+    const [firstResult, secondResult] = await Promise.all([
+      loadEffectivePromptOverrides("/repo"),
+      loadEffectivePromptOverrides(" /repo "),
+    ]);
+
+    expect(workspaceGetRepoConfigMock).toHaveBeenCalledTimes(1);
+    expect(workspaceGetSettingsSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(firstResult).toEqual(secondResult);
   });
 });

--- a/apps/desktop/src/state/operations/prompt-overrides.ts
+++ b/apps/desktop/src/state/operations/prompt-overrides.ts
@@ -1,13 +1,15 @@
 import type { RepoPromptOverrides } from "@openducktor/contracts";
 import { mergePromptOverrides } from "@openducktor/core";
-import { host } from "./host";
+import { appQueryClient } from "@/lib/query-client";
+import { loadRepoConfigFromQuery, loadSettingsSnapshotFromQuery } from "../queries/workspace";
 
 export const loadEffectivePromptOverrides = async (
   repoPath: string,
 ): Promise<RepoPromptOverrides> => {
+  const normalizedRepoPath = repoPath.trim();
   const [repoConfig, snapshot] = await Promise.all([
-    host.workspaceGetRepoConfig(repoPath),
-    host.workspaceGetSettingsSnapshot(),
+    loadRepoConfigFromQuery(appQueryClient, normalizedRepoPath),
+    loadSettingsSnapshotFromQuery(appQueryClient),
   ]);
 
   return mergePromptOverrides({

--- a/apps/desktop/src/state/operations/repo-branches.ts
+++ b/apps/desktop/src/state/operations/repo-branches.ts
@@ -1,5 +1,6 @@
 import type { GitBranch } from "@openducktor/contracts";
-import { host } from "./host";
+import { appQueryClient } from "@/lib/query-client";
+import { loadRepoBranchesFromQuery } from "../queries/git";
 
 export const loadRepoBranches = async (repoPath: string): Promise<GitBranch[]> => {
   const normalizedRepoPath = repoPath.trim();
@@ -7,5 +8,5 @@ export const loadRepoBranches = async (repoPath: string): Promise<GitBranch[]> =
     throw new Error("Cannot load repository branches: repository path is empty.");
   }
 
-  return host.gitGetBranches(normalizedRepoPath);
+  return loadRepoBranchesFromQuery(appQueryClient, normalizedRepoPath);
 };

--- a/apps/desktop/src/state/operations/runtime-catalog.ts
+++ b/apps/desktop/src/state/operations/runtime-catalog.ts
@@ -291,11 +291,6 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
     };
   };
 
-  const catalogCache = new Map<string, AgentModelCatalog>();
-
-  const toCatalogCacheKey = (repoPath: string, runtimeKind: RuntimeKind): string =>
-    `${runtimeKind}::${repoPath}`;
-
   const fetchCatalog = async (
     repoPath: string,
     runtimeKind: RuntimeKind,
@@ -311,20 +306,7 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
   const loadRepoRuntimeCatalog = async (
     repoPath: string,
     runtimeKind: RuntimeKind,
-  ): Promise<AgentModelCatalog> => {
-    const cacheKey = toCatalogCacheKey(repoPath, runtimeKind);
-    const cached = catalogCache.get(cacheKey);
-    if (cached) {
-      void fetchCatalog(repoPath, runtimeKind)
-        .then((fresh) => catalogCache.set(cacheKey, fresh))
-        .catch(() => {});
-      return cached;
-    }
-
-    const catalog = await fetchCatalog(repoPath, runtimeKind);
-    catalogCache.set(cacheKey, catalog);
-    return catalog;
-  };
+  ): Promise<AgentModelCatalog> => fetchCatalog(repoPath, runtimeKind);
 
   const checkRepoRuntimeHealth = async (
     repoPath: string,

--- a/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-agent-orchestrator-operations.test.tsx
@@ -3,6 +3,7 @@ import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { AgentSessionRecord, RunSummary, TaskCard } from "@openducktor/contracts";
 import TestRenderer, { act } from "react-test-renderer";
 import { toast } from "sonner";
+import { clearAppQueryClient } from "@/lib/query-client";
 import { host } from "./host";
 import { useAgentOrchestratorOperations } from "./use-agent-orchestrator-operations";
 
@@ -41,6 +42,10 @@ const taskFixture: TaskCard = {
   updatedAt: "2026-02-22T08:00:00.000Z",
   createdAt: "2026-02-22T08:00:00.000Z",
 };
+
+beforeEach(async () => {
+  await clearAppQueryClient();
+});
 
 const persistedSessionFixture: AgentSessionRecord = {
   runtimeKind: "opencode",
@@ -213,6 +218,7 @@ describe("use-agent-orchestrator-operations", () => {
         promptOverrides: {},
       }) as Awaited<ReturnType<typeof host.workspaceGetRepoConfig>>;
     host.workspaceGetSettingsSnapshot = async () => ({
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit",
       },

--- a/apps/desktop/src/state/operations/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/use-checks.test.tsx
@@ -8,6 +8,7 @@ import {
 import { createElement } from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { clearAppQueryClient } from "@/lib/query-client";
+import { QueryProvider } from "@/lib/query-provider";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import { host } from "./host";
 
@@ -105,7 +106,13 @@ const createHookHarness = (initialArgs: HookHarnessArgs) => {
   return {
     mount: async () => {
       await act(async () => {
-        renderer = TestRenderer.create(createElement(Harness, { args: currentArgs }));
+        renderer = TestRenderer.create(
+          createElement(
+            QueryProvider,
+            { useIsolatedClient: true },
+            createElement(Harness, { args: currentArgs }),
+          ),
+        );
       });
       await flush();
     },
@@ -117,7 +124,13 @@ const createHookHarness = (initialArgs: HookHarnessArgs) => {
           nextArgs.checkRepoRuntimeHealth ?? currentArgs.checkRepoRuntimeHealth,
       };
       await act(async () => {
-        renderer?.update(createElement(Harness, { args: currentArgs }));
+        renderer?.update(
+          createElement(
+            QueryProvider,
+            { useIsolatedClient: true },
+            createElement(Harness, { args: currentArgs }),
+          ),
+        );
       });
       await flush();
     },

--- a/apps/desktop/src/state/operations/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/use-checks.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@openducktor/contracts";
 import { createElement } from "react";
 import TestRenderer, { act } from "react-test-renderer";
+import { clearAppQueryClient } from "@/lib/query-client";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import { host } from "./host";
 
@@ -148,7 +149,8 @@ beforeAll(async () => {
   ({ useChecks } = await import("./use-checks"));
 });
 
-beforeEach(() => {
+beforeEach(async () => {
+  await clearAppQueryClient();
   toastError.mockClear();
   toastSuccess.mockClear();
   checkRepoRuntimeHealthMock.mockClear();

--- a/apps/desktop/src/state/operations/use-checks.ts
+++ b/apps/desktop/src/state/operations/use-checks.ts
@@ -4,10 +4,20 @@ import type {
   RuntimeDescriptor,
   RuntimeKind,
 } from "@openducktor/contracts";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
+import { appQueryClient } from "@/lib/query-client";
 import type { RepoRuntimeHealthCheck, RepoRuntimeHealthMap } from "@/types/diagnostics";
+import {
+  beadsCheckQueryOptions,
+  checksQueryKeys,
+  loadBeadsCheckFromQuery,
+  loadRepoRuntimeHealthFromQuery,
+  loadRuntimeCheckFromQuery,
+  repoRuntimeHealthQueryOptions,
+  runtimeCheckQueryOptions,
+} from "../queries/checks";
 import { host } from "./host";
 
 type UseChecksArgs = {
@@ -39,21 +49,10 @@ type UseChecksResult = {
   clearActiveRepoRuntimeHealth: () => void;
 };
 
-const toRuntimeHealthCacheKey = (repoPath: string, runtimeKind: RuntimeKind): string =>
-  `${runtimeKind}::${repoPath}`;
-
-const buildRuntimeHealthMap = (
+const buildEmptyRuntimeHealthMap = (
   runtimeDefinitions: RuntimeDescriptor[],
-  cache: Map<string, RepoRuntimeHealthCheck>,
-  repoPath: string,
-): RepoRuntimeHealthMap => {
-  return Object.fromEntries(
-    runtimeDefinitions.map((definition) => [
-      definition.kind,
-      cache.get(toRuntimeHealthCacheKey(repoPath, definition.kind)) ?? null,
-    ]),
-  );
-};
+): RepoRuntimeHealthMap =>
+  Object.fromEntries(runtimeDefinitions.map((definition) => [definition.kind, null]));
 
 export function useChecks({
   activeRepo,
@@ -65,30 +64,34 @@ export function useChecks({
   const [activeRepoRuntimeHealthByRuntime, setActiveRepoRuntimeHealthByRuntime] =
     useState<RepoRuntimeHealthMap>({});
   const [isLoadingChecks, setIsLoadingChecks] = useState(false);
-  const runtimeCheckRef = useRef<RuntimeCheck | null>(null);
-  const beadsCheckCacheRef = useRef<Map<string, BeadsCheck>>(new Map());
-  const runtimeHealthCacheRef = useRef<Map<string, RepoRuntimeHealthCheck>>(new Map());
 
   const refreshRuntimeCheck = useCallback(async (force = false): Promise<RuntimeCheck> => {
-    if (!force && runtimeCheckRef.current) {
-      return runtimeCheckRef.current;
+    if (force) {
+      const check = await host.runtimeCheck(true);
+      appQueryClient.setQueryData(checksQueryKeys.runtime(), check);
+      setRuntimeCheck(check);
+      return check;
     }
 
-    const check = await host.runtimeCheck(force);
-    runtimeCheckRef.current = check;
+    const check = await loadRuntimeCheckFromQuery(appQueryClient);
     setRuntimeCheck(check);
     return check;
   }, []);
 
   const refreshBeadsCheckForRepo = useCallback(
     async (repoPath: string, force = false): Promise<BeadsCheck> => {
-      const cached = beadsCheckCacheRef.current.get(repoPath);
-      if (cached && !force) {
-        return cached;
+      if (force) {
+        const check = await host.beadsCheck(repoPath);
+        appQueryClient.setQueryData(checksQueryKeys.beads(repoPath), check);
+
+        if (repoPath === activeRepo) {
+          setActiveBeadsCheck(check);
+        }
+
+        return check;
       }
 
-      const check = await host.beadsCheck(repoPath);
-      beadsCheckCacheRef.current.set(repoPath, check);
+      const check = await loadBeadsCheckFromQuery(appQueryClient, repoPath);
 
       if (repoPath === activeRepo) {
         setActiveBeadsCheck(check);
@@ -108,33 +111,24 @@ export function useChecks({
         return {};
       }
 
-      const hasAllCached = runtimeDefinitions.every((definition) =>
-        runtimeHealthCacheRef.current.has(toRuntimeHealthCacheKey(repoPath, definition.kind)),
+      const queryOptions = repoRuntimeHealthQueryOptions(
+        repoPath,
+        runtimeDefinitions,
+        checkRepoRuntimeHealth,
       );
-      if (hasAllCached && !force) {
-        const cached = buildRuntimeHealthMap(
-          runtimeDefinitions,
-          runtimeHealthCacheRef.current,
-          repoPath,
-        );
-        if (repoPath === activeRepo) {
-          setActiveRepoRuntimeHealthByRuntime(cached);
-        }
-        return cached;
+
+      if (force) {
+        await appQueryClient.invalidateQueries({
+          queryKey: queryOptions.queryKey,
+        });
       }
 
-      const checks = await Promise.all(
-        runtimeDefinitions.map(async (definition) => {
-          const check = await checkRepoRuntimeHealth(repoPath, definition.kind);
-          runtimeHealthCacheRef.current.set(
-            toRuntimeHealthCacheKey(repoPath, definition.kind),
-            check,
-          );
-          return [definition.kind, check] as const;
-        }),
+      const runtimeHealthByRuntime = await loadRepoRuntimeHealthFromQuery(
+        appQueryClient,
+        repoPath,
+        runtimeDefinitions,
+        checkRepoRuntimeHealth,
       );
-
-      const runtimeHealthByRuntime = Object.fromEntries(checks) as RepoRuntimeHealthMap;
 
       if (repoPath === activeRepo) {
         setActiveRepoRuntimeHealthByRuntime(runtimeHealthByRuntime);
@@ -197,20 +191,21 @@ export function useChecks({
   ]);
 
   const hasCachedBeadsCheck = useCallback((repoPath: string): boolean => {
-    return beadsCheckCacheRef.current.has(repoPath);
+    return appQueryClient.getQueryData(beadsCheckQueryOptions(repoPath).queryKey) !== undefined;
   }, []);
 
   const hasCachedRepoRuntimeHealth = useCallback(
     (repoPath: string, runtimeKinds: RuntimeKind[]): boolean => {
-      return runtimeKinds.every((runtimeKind) =>
-        runtimeHealthCacheRef.current.has(toRuntimeHealthCacheKey(repoPath, runtimeKind)),
+      return (
+        appQueryClient.getQueryData(checksQueryKeys.runtimeHealth(repoPath, runtimeKinds)) !==
+        undefined
       );
     },
     [],
   );
 
   const hasRuntimeCheck = useCallback((): boolean => {
-    return runtimeCheckRef.current !== null;
+    return appQueryClient.getQueryData(runtimeCheckQueryOptions().queryKey) !== undefined;
   }, []);
 
   const clearActiveBeadsCheck = useCallback(() => {
@@ -228,9 +223,18 @@ export function useChecks({
       return;
     }
 
-    setActiveBeadsCheck(beadsCheckCacheRef.current.get(activeRepo) ?? null);
+    setActiveBeadsCheck(
+      (appQueryClient.getQueryData(beadsCheckQueryOptions(activeRepo).queryKey) as
+        | BeadsCheck
+        | undefined) ?? null,
+    );
     setActiveRepoRuntimeHealthByRuntime(
-      buildRuntimeHealthMap(runtimeDefinitions, runtimeHealthCacheRef.current, activeRepo),
+      (appQueryClient.getQueryData(
+        checksQueryKeys.runtimeHealth(
+          activeRepo,
+          runtimeDefinitions.map((definition) => definition.kind),
+        ),
+      ) as RepoRuntimeHealthMap | undefined) ?? buildEmptyRuntimeHealthMap(runtimeDefinitions),
     );
   }, [activeRepo, runtimeDefinitions]);
 

--- a/apps/desktop/src/state/operations/use-checks.ts
+++ b/apps/desktop/src/state/operations/use-checks.ts
@@ -4,10 +4,10 @@ import type {
   RuntimeDescriptor,
   RuntimeKind,
 } from "@openducktor/contracts";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
-import { appQueryClient } from "@/lib/query-client";
 import type { RepoRuntimeHealthCheck, RepoRuntimeHealthMap } from "@/types/diagnostics";
 import {
   beadsCheckQueryOptions,
@@ -59,30 +59,34 @@ export function useChecks({
   runtimeDefinitions,
   checkRepoRuntimeHealth,
 }: UseChecksArgs): UseChecksResult {
+  const queryClient = useQueryClient();
   const [runtimeCheck, setRuntimeCheck] = useState<RuntimeCheck | null>(null);
   const [activeBeadsCheck, setActiveBeadsCheck] = useState<BeadsCheck | null>(null);
   const [activeRepoRuntimeHealthByRuntime, setActiveRepoRuntimeHealthByRuntime] =
     useState<RepoRuntimeHealthMap>({});
   const [isLoadingChecks, setIsLoadingChecks] = useState(false);
 
-  const refreshRuntimeCheck = useCallback(async (force = false): Promise<RuntimeCheck> => {
-    if (force) {
-      const check = await host.runtimeCheck(true);
-      appQueryClient.setQueryData(checksQueryKeys.runtime(), check);
+  const refreshRuntimeCheck = useCallback(
+    async (force = false): Promise<RuntimeCheck> => {
+      if (force) {
+        const check = await host.runtimeCheck(true);
+        queryClient.setQueryData(checksQueryKeys.runtime(), check);
+        setRuntimeCheck(check);
+        return check;
+      }
+
+      const check = await loadRuntimeCheckFromQuery(queryClient);
       setRuntimeCheck(check);
       return check;
-    }
-
-    const check = await loadRuntimeCheckFromQuery(appQueryClient);
-    setRuntimeCheck(check);
-    return check;
-  }, []);
+    },
+    [queryClient],
+  );
 
   const refreshBeadsCheckForRepo = useCallback(
     async (repoPath: string, force = false): Promise<BeadsCheck> => {
       if (force) {
         const check = await host.beadsCheck(repoPath);
-        appQueryClient.setQueryData(checksQueryKeys.beads(repoPath), check);
+        queryClient.setQueryData(checksQueryKeys.beads(repoPath), check);
 
         if (repoPath === activeRepo) {
           setActiveBeadsCheck(check);
@@ -91,7 +95,7 @@ export function useChecks({
         return check;
       }
 
-      const check = await loadBeadsCheckFromQuery(appQueryClient, repoPath);
+      const check = await loadBeadsCheckFromQuery(queryClient, repoPath);
 
       if (repoPath === activeRepo) {
         setActiveBeadsCheck(check);
@@ -99,7 +103,7 @@ export function useChecks({
 
       return check;
     },
-    [activeRepo],
+    [activeRepo, queryClient],
   );
 
   const refreshRepoRuntimeHealthForRepo = useCallback(
@@ -118,13 +122,13 @@ export function useChecks({
       );
 
       if (force) {
-        await appQueryClient.invalidateQueries({
+        await queryClient.invalidateQueries({
           queryKey: queryOptions.queryKey,
         });
       }
 
       const runtimeHealthByRuntime = await loadRepoRuntimeHealthFromQuery(
-        appQueryClient,
+        queryClient,
         repoPath,
         runtimeDefinitions,
         checkRepoRuntimeHealth,
@@ -136,7 +140,7 @@ export function useChecks({
 
       return runtimeHealthByRuntime;
     },
-    [activeRepo, checkRepoRuntimeHealth, runtimeDefinitions],
+    [activeRepo, checkRepoRuntimeHealth, queryClient, runtimeDefinitions],
   );
 
   const refreshChecks = useCallback(async (): Promise<void> => {
@@ -190,23 +194,26 @@ export function useChecks({
     runtimeDefinitions,
   ]);
 
-  const hasCachedBeadsCheck = useCallback((repoPath: string): boolean => {
-    return appQueryClient.getQueryData(beadsCheckQueryOptions(repoPath).queryKey) !== undefined;
-  }, []);
+  const hasCachedBeadsCheck = useCallback(
+    (repoPath: string): boolean => {
+      return queryClient.getQueryData(beadsCheckQueryOptions(repoPath).queryKey) !== undefined;
+    },
+    [queryClient],
+  );
 
   const hasCachedRepoRuntimeHealth = useCallback(
     (repoPath: string, runtimeKinds: RuntimeKind[]): boolean => {
       return (
-        appQueryClient.getQueryData(checksQueryKeys.runtimeHealth(repoPath, runtimeKinds)) !==
+        queryClient.getQueryData(checksQueryKeys.runtimeHealth(repoPath, runtimeKinds)) !==
         undefined
       );
     },
-    [],
+    [queryClient],
   );
 
   const hasRuntimeCheck = useCallback((): boolean => {
-    return appQueryClient.getQueryData(runtimeCheckQueryOptions().queryKey) !== undefined;
-  }, []);
+    return queryClient.getQueryData(runtimeCheckQueryOptions().queryKey) !== undefined;
+  }, [queryClient]);
 
   const clearActiveBeadsCheck = useCallback(() => {
     setActiveBeadsCheck(null);
@@ -217,6 +224,11 @@ export function useChecks({
   }, []);
 
   useEffect(() => {
+    setRuntimeCheck(
+      (queryClient.getQueryData(runtimeCheckQueryOptions().queryKey) as RuntimeCheck | undefined) ??
+        null,
+    );
+
     if (!activeRepo) {
       setActiveBeadsCheck(null);
       setActiveRepoRuntimeHealthByRuntime({});
@@ -224,19 +236,19 @@ export function useChecks({
     }
 
     setActiveBeadsCheck(
-      (appQueryClient.getQueryData(beadsCheckQueryOptions(activeRepo).queryKey) as
+      (queryClient.getQueryData(beadsCheckQueryOptions(activeRepo).queryKey) as
         | BeadsCheck
         | undefined) ?? null,
     );
     setActiveRepoRuntimeHealthByRuntime(
-      (appQueryClient.getQueryData(
+      (queryClient.getQueryData(
         checksQueryKeys.runtimeHealth(
           activeRepo,
           runtimeDefinitions.map((definition) => definition.kind),
         ),
       ) as RepoRuntimeHealthMap | undefined) ?? buildEmptyRuntimeHealthMap(runtimeDefinitions),
     );
-  }, [activeRepo, runtimeDefinitions]);
+  }, [activeRepo, queryClient, runtimeDefinitions]);
 
   return {
     runtimeCheck,

--- a/apps/desktop/src/state/operations/use-repo-settings-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-repo-settings-operations.test.tsx
@@ -1,7 +1,9 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { agentPromptTemplateIdValues } from "@openducktor/contracts";
 import { createElement } from "react";
 import TestRenderer, { act } from "react-test-renderer";
+import { clearAppQueryClient } from "@/lib/query-client";
+import { QueryProvider } from "@/lib/query-provider";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import { host } from "./host";
 import { useRepoSettingsOperations } from "./use-repo-settings-operations";
@@ -32,7 +34,9 @@ const createHookHarness = (initialArgs: HookArgs) => {
   return {
     mount: async () => {
       await act(async () => {
-        renderer = TestRenderer.create(createElement(Harness, { args: initialArgs }));
+        renderer = TestRenderer.create(
+          createElement(QueryProvider, undefined, createElement(Harness, { args: initialArgs })),
+        );
       });
       await flush();
     },
@@ -93,6 +97,68 @@ const inputFixture: RepoSettingsInput = {
 };
 
 describe("use-repo-settings-operations", () => {
+  beforeEach(async () => {
+    await clearAppQueryClient();
+  });
+
+  test("caches settings snapshot reads across repeated calls", async () => {
+    const applyWorkspaceRecords = mock(() => {});
+    const applyWorkspaceRecord = mock(() => {});
+    const workspaceGetSettingsSnapshot = mock(async () => ({
+      theme: "light" as const,
+      git: {
+        defaultMergeMethod: "merge_commit" as const,
+      },
+      chat: {
+        showThinkingMessages: false,
+      },
+      repos: {},
+      globalPromptOverrides: {},
+    }));
+
+    const original = {
+      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
+    };
+    host.workspaceGetSettingsSnapshot = workspaceGetSettingsSnapshot;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      applyWorkspaceRecords,
+      applyWorkspaceRecord,
+    });
+
+    try {
+      await harness.mount();
+      await expect(harness.getLatest().loadSettingsSnapshot()).resolves.toEqual({
+        theme: "light",
+        git: {
+          defaultMergeMethod: "merge_commit",
+        },
+        chat: {
+          showThinkingMessages: false,
+        },
+        repos: {},
+        globalPromptOverrides: {},
+      });
+      await expect(harness.getLatest().loadSettingsSnapshot()).resolves.toEqual({
+        theme: "light",
+        git: {
+          defaultMergeMethod: "merge_commit",
+        },
+        chat: {
+          showThinkingMessages: false,
+        },
+        repos: {},
+        globalPromptOverrides: {},
+      });
+      expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.unmount();
+      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+      await clearAppQueryClient();
+    }
+  });
+
   test("throws when loading without an active workspace", async () => {
     const applyWorkspaceRecords = mock(() => {});
     const applyWorkspaceRecord = mock(() => {});
@@ -315,9 +381,11 @@ describe("use-repo-settings-operations", () => {
   });
 
   test("loads settings snapshot through atomic IPC route", async () => {
+    await clearAppQueryClient();
     const applyWorkspaceRecords = mock(() => {});
     const applyWorkspaceRecord = mock(() => {});
     const workspaceGetSettingsSnapshot = mock(async () => ({
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit" as const,
       },
@@ -342,6 +410,7 @@ describe("use-repo-settings-operations", () => {
     try {
       await harness.mount();
       await expect(harness.getLatest().loadSettingsSnapshot()).resolves.toEqual({
+        theme: "light",
         git: {
           defaultMergeMethod: "merge_commit",
         },
@@ -355,18 +424,33 @@ describe("use-repo-settings-operations", () => {
     } finally {
       await harness.unmount();
       host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+      await clearAppQueryClient();
     }
   });
 
   test("saves settings snapshot atomically and applies returned workspaces", async () => {
+    await clearAppQueryClient();
     const applyWorkspaceRecords = mock(() => {});
     const applyWorkspaceRecord = mock(() => {});
     const workspaceSaveSettingsSnapshot = mock(async () => [createWorkspaceRecord()]);
+    const workspaceGetSettingsSnapshot = mock(async () => ({
+      theme: "light" as const,
+      git: {
+        defaultMergeMethod: "merge_commit" as const,
+      },
+      chat: {
+        showThinkingMessages: false,
+      },
+      repos: {},
+      globalPromptOverrides: {},
+    }));
 
     const original = {
       workspaceSaveSettingsSnapshot: host.workspaceSaveSettingsSnapshot,
+      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
     };
     host.workspaceSaveSettingsSnapshot = workspaceSaveSettingsSnapshot;
+    host.workspaceGetSettingsSnapshot = workspaceGetSettingsSnapshot;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -374,6 +458,7 @@ describe("use-repo-settings-operations", () => {
       applyWorkspaceRecord,
     });
     const snapshot = {
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit" as const,
       },
@@ -389,9 +474,13 @@ describe("use-repo-settings-operations", () => {
       await harness.getLatest().saveSettingsSnapshot(snapshot);
       expect(workspaceSaveSettingsSnapshot).toHaveBeenCalledWith(snapshot);
       expect(applyWorkspaceRecords).toHaveBeenCalledWith([createWorkspaceRecord()]);
+      await expect(harness.getLatest().loadSettingsSnapshot()).resolves.toEqual(snapshot);
+      expect(workspaceGetSettingsSnapshot).not.toHaveBeenCalled();
     } finally {
       await harness.unmount();
       host.workspaceSaveSettingsSnapshot = original.workspaceSaveSettingsSnapshot;
+      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+      await clearAppQueryClient();
     }
   });
 
@@ -435,6 +524,7 @@ describe("use-repo-settings-operations", () => {
       ]),
     );
     const snapshot = {
+      theme: "light" as const,
       git: {
         defaultMergeMethod: "merge_commit" as const,
       },

--- a/apps/desktop/src/state/operations/use-repo-settings-operations.ts
+++ b/apps/desktop/src/state/operations/use-repo-settings-operations.ts
@@ -4,10 +4,18 @@ import type {
   SettingsSnapshot,
   WorkspaceRecord,
 } from "@openducktor/contracts";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { normalizeTargetBranch } from "@/lib/target-branch";
 import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
-import type { RepoSettingsInput } from "@/types/state-slices";
+import type { RepoAgentDefaultInput, RepoSettingsInput } from "@/types/state-slices";
+import {
+  loadRepoConfigFromQuery,
+  loadSettingsSnapshotFromQuery,
+  settingsSnapshotQueryOptions,
+  toRepoSettingsInput,
+  workspaceQueryKeys,
+} from "../queries/workspace";
 import { host } from "./host";
 import { requireActiveRepo } from "./task-operations-model";
 
@@ -31,81 +39,30 @@ export function useRepoSettingsOperations({
   applyWorkspaceRecords,
   applyWorkspaceRecord,
 }: UseRepoSettingsOperationsArgs): UseRepoSettingsOperationsResult {
-  const toInputDefault = useCallback(
-    (
-      entry:
-        | {
-            runtimeKind?: string;
-            providerId: string;
-            modelId: string;
-            variant?: string | undefined;
-            profileId?: string | undefined;
-          }
-        | null
-        | undefined,
-    ) => {
-      if (!entry) {
-        return null;
-      }
-      return {
-        runtimeKind: entry.runtimeKind ?? DEFAULT_RUNTIME_KIND,
-        providerId: entry.providerId,
-        modelId: entry.modelId,
-        variant: entry.variant ?? "",
-        profileId: entry.profileId ?? "",
-      };
-    },
-    [],
-  );
+  const queryClient = useQueryClient();
 
-  const toConfigDefault = useCallback(
-    (
-      entry: {
-        runtimeKind?: string;
-        providerId: string;
-        modelId: string;
-        variant: string;
-        profileId: string;
-      } | null,
-    ) => {
-      if (!entry || !entry.providerId.trim() || !entry.modelId.trim()) {
-        return undefined;
-      }
+  const toConfigDefault = useCallback((entry: RepoAgentDefaultInput | null) => {
+    if (!entry || !entry.providerId.trim() || !entry.modelId.trim()) {
+      return undefined;
+    }
 
-      const runtimeKind = entry.runtimeKind?.trim() || DEFAULT_RUNTIME_KIND;
+    const runtimeKind = entry.runtimeKind?.trim() || DEFAULT_RUNTIME_KIND;
 
-      return {
-        runtimeKind,
-        providerId: entry.providerId.trim(),
-        modelId: entry.modelId.trim(),
-        ...(entry.variant.trim() ? { variant: entry.variant.trim() } : {}),
-        ...(entry.profileId.trim() ? { profileId: entry.profileId.trim() } : {}),
-      };
-    },
-    [],
-  );
+    return {
+      runtimeKind,
+      providerId: entry.providerId.trim(),
+      modelId: entry.modelId.trim(),
+      ...(entry.variant.trim() ? { variant: entry.variant.trim() } : {}),
+      ...(entry.profileId.trim() ? { profileId: entry.profileId.trim() } : {}),
+    };
+  }, []);
 
   const loadRepoSettings = useCallback(async (): Promise<RepoSettingsInput> => {
     const repo = requireActiveRepo(activeRepo);
 
-    const config = await host.workspaceGetRepoConfig(repo);
-    return {
-      defaultRuntimeKind: config.defaultRuntimeKind,
-      worktreeBasePath: config.worktreeBasePath ?? "",
-      branchPrefix: config.branchPrefix,
-      defaultTargetBranch: normalizeTargetBranch(config.defaultTargetBranch),
-      trustedHooks: config.trustedHooks,
-      preStartHooks: config.hooks.preStart,
-      postCompleteHooks: config.hooks.postComplete,
-      worktreeFileCopies: config.worktreeFileCopies ?? [],
-      agentDefaults: {
-        spec: toInputDefault(config.agentDefaults.spec),
-        planner: toInputDefault(config.agentDefaults.planner),
-        build: toInputDefault(config.agentDefaults.build),
-        qa: toInputDefault(config.agentDefaults.qa),
-      },
-    };
-  }, [activeRepo, toInputDefault]);
+    const config = await loadRepoConfigFromQuery(queryClient, repo);
+    return toRepoSettingsInput(config);
+  }, [activeRepo, queryClient]);
 
   const saveRepoSettings = useCallback(
     async (input: RepoSettingsInput) => {
@@ -139,14 +96,17 @@ export function useRepoSettingsOperations({
         agentDefaults,
       });
 
+      await queryClient.invalidateQueries({
+        queryKey: workspaceQueryKeys.repoConfig(repo),
+      });
       applyWorkspaceRecord(workspace);
     },
-    [activeRepo, applyWorkspaceRecord, toConfigDefault],
+    [activeRepo, applyWorkspaceRecord, queryClient, toConfigDefault],
   );
 
   const loadSettingsSnapshot = useCallback(async (): Promise<SettingsSnapshot> => {
-    return host.workspaceGetSettingsSnapshot();
-  }, []);
+    return loadSettingsSnapshotFromQuery(queryClient);
+  }, [queryClient]);
 
   const detectGithubRepository = useCallback(
     async (repoPath: string): Promise<GitProviderRepository | null> => {
@@ -162,9 +122,10 @@ export function useRepoSettingsOperations({
   const saveSettingsSnapshot = useCallback(
     async (snapshot: SettingsSnapshot): Promise<void> => {
       const workspaces = await host.workspaceSaveSettingsSnapshot(snapshot);
+      queryClient.setQueryData(settingsSnapshotQueryOptions().queryKey, snapshot);
       applyWorkspaceRecords(workspaces);
     },
-    [applyWorkspaceRecords],
+    [applyWorkspaceRecords, queryClient],
   );
 
   return {

--- a/apps/desktop/src/state/operations/use-repo-settings-operations.ts
+++ b/apps/desktop/src/state/operations/use-repo-settings-operations.ts
@@ -40,6 +40,19 @@ export function useRepoSettingsOperations({
   applyWorkspaceRecord,
 }: UseRepoSettingsOperationsArgs): UseRepoSettingsOperationsResult {
   const queryClient = useQueryClient();
+  const settingsSnapshotQueryKey = settingsSnapshotQueryOptions().queryKey;
+  const repoConfigQueryKeyPrefix = [...workspaceQueryKeys.all, "repo-config"] as const;
+
+  const syncWorkspaceListRecord = useCallback(
+    (workspace: WorkspaceRecord): void => {
+      queryClient.setQueryData(
+        workspaceQueryKeys.list(),
+        (current: WorkspaceRecord[] | undefined) =>
+          current?.map((entry) => (entry.path === workspace.path ? workspace : entry)) ?? current,
+      );
+    },
+    [queryClient],
+  );
 
   const toConfigDefault = useCallback((entry: RepoAgentDefaultInput | null) => {
     if (!entry || !entry.providerId.trim() || !entry.modelId.trim()) {
@@ -99,9 +112,10 @@ export function useRepoSettingsOperations({
       await queryClient.invalidateQueries({
         queryKey: workspaceQueryKeys.repoConfig(repo),
       });
+      syncWorkspaceListRecord(workspace);
       applyWorkspaceRecord(workspace);
     },
-    [activeRepo, applyWorkspaceRecord, queryClient, toConfigDefault],
+    [activeRepo, applyWorkspaceRecord, queryClient, syncWorkspaceListRecord, toConfigDefault],
   );
 
   const loadSettingsSnapshot = useCallback(async (): Promise<SettingsSnapshot> => {
@@ -115,17 +129,37 @@ export function useRepoSettingsOperations({
     [],
   );
 
-  const saveGlobalGitConfig = useCallback(async (git: GlobalGitConfig): Promise<void> => {
-    await host.workspaceUpdateGlobalGitConfig(git);
-  }, []);
+  const saveGlobalGitConfig = useCallback(
+    async (git: GlobalGitConfig): Promise<void> => {
+      await host.workspaceUpdateGlobalGitConfig(git);
+      queryClient.setQueryData(
+        settingsSnapshotQueryKey,
+        (current: SettingsSnapshot | undefined): SettingsSnapshot | undefined =>
+          current
+            ? {
+                ...current,
+                git,
+              }
+            : current,
+      );
+    },
+    [queryClient, settingsSnapshotQueryKey],
+  );
 
   const saveSettingsSnapshot = useCallback(
     async (snapshot: SettingsSnapshot): Promise<void> => {
       const workspaces = await host.workspaceSaveSettingsSnapshot(snapshot);
-      queryClient.setQueryData(settingsSnapshotQueryOptions().queryKey, snapshot);
+      queryClient.setQueryData(settingsSnapshotQueryKey, snapshot);
+      for (const [repoPath, repoConfig] of Object.entries(snapshot.repos)) {
+        queryClient.setQueryData(workspaceQueryKeys.repoConfig(repoPath), repoConfig);
+      }
+      await queryClient.invalidateQueries({
+        queryKey: repoConfigQueryKeyPrefix,
+      });
+      queryClient.setQueryData(workspaceQueryKeys.list(), workspaces);
       applyWorkspaceRecords(workspaces);
     },
-    [applyWorkspaceRecords, queryClient],
+    [applyWorkspaceRecords, queryClient, repoConfigQueryKeyPrefix, settingsSnapshotQueryKey],
   );
 
   return {

--- a/apps/desktop/src/state/operations/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-spec-operations.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 import { defaultSpecTemplateMarkdown } from "@openducktor/contracts";
 import { createElement } from "react";
 import TestRenderer, { act } from "react-test-renderer";
+import { QueryProvider } from "@/lib/query-provider";
 import { host } from "./host";
 import { useSpecOperations } from "./use-spec-operations";
 
@@ -31,7 +32,13 @@ const createHookHarness = (initialArgs: HookArgs) => {
   return {
     mount: async () => {
       await act(async () => {
-        renderer = TestRenderer.create(createElement(Harness, { args: initialArgs }));
+        renderer = TestRenderer.create(
+          createElement(
+            QueryProvider,
+            { useIsolatedClient: true },
+            createElement(Harness, { args: initialArgs }),
+          ),
+        );
       });
       await flush();
     },

--- a/apps/desktop/src/state/operations/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/use-spec-operations.ts
@@ -1,5 +1,12 @@
 import { defaultSpecTemplateMarkdown, validateSpecMarkdown } from "@openducktor/contracts";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import {
+  documentQueryKeys,
+  loadPlanDocumentFromQuery,
+  loadQaReportDocumentFromQuery,
+  loadSpecDocumentFromQuery,
+} from "../queries/documents";
 import { host } from "./host";
 import { requireActiveRepo } from "./task-operations-model";
 
@@ -18,40 +25,30 @@ type UseSpecOperationsResult = {
 };
 
 export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpecOperationsResult {
+  const queryClient = useQueryClient();
+
   const loadSpecDocument = useCallback(
     async (taskId: string): Promise<{ markdown: string; updatedAt: string | null }> => {
       const repo = requireActiveRepo(activeRepo);
-      const spec = await host.specGet(repo, taskId);
-      return {
-        markdown: spec.markdown,
-        updatedAt: spec.updatedAt,
-      };
+      return loadSpecDocumentFromQuery(queryClient, repo, taskId);
     },
-    [activeRepo],
+    [activeRepo, queryClient],
   );
 
   const loadPlanDocument = useCallback(
     async (taskId: string): Promise<{ markdown: string; updatedAt: string | null }> => {
       const repo = requireActiveRepo(activeRepo);
-      const plan = await host.planGet(repo, taskId);
-      return {
-        markdown: plan.markdown,
-        updatedAt: plan.updatedAt,
-      };
+      return loadPlanDocumentFromQuery(queryClient, repo, taskId);
     },
-    [activeRepo],
+    [activeRepo, queryClient],
   );
 
   const loadQaReportDocument = useCallback(
     async (taskId: string): Promise<{ markdown: string; updatedAt: string | null }> => {
       const repo = requireActiveRepo(activeRepo);
-      const report = await host.qaGetReport(repo, taskId);
-      return {
-        markdown: report.markdown,
-        updatedAt: report.updatedAt,
-      };
+      return loadQaReportDocumentFromQuery(queryClient, repo, taskId);
     },
-    [activeRepo],
+    [activeRepo, queryClient],
   );
 
   const loadSpec = useCallback(
@@ -72,25 +69,36 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       }
 
       const saved = await host.setSpec({ repoPath: repo, taskId, markdown });
+      await queryClient.invalidateQueries({
+        queryKey: documentQueryKeys.spec(repo, taskId),
+      });
       return saved;
     },
-    [activeRepo],
+    [activeRepo, queryClient],
   );
 
   const saveSpecDocument = useCallback(
     async (taskId: string, markdown: string): Promise<{ updatedAt: string }> => {
       const repo = requireActiveRepo(activeRepo);
-      return host.saveSpecDocument(repo, taskId, markdown);
+      const saved = await host.saveSpecDocument(repo, taskId, markdown);
+      await queryClient.invalidateQueries({
+        queryKey: documentQueryKeys.spec(repo, taskId),
+      });
+      return saved;
     },
-    [activeRepo],
+    [activeRepo, queryClient],
   );
 
   const savePlanDocument = useCallback(
     async (taskId: string, markdown: string): Promise<{ updatedAt: string }> => {
       const repo = requireActiveRepo(activeRepo);
-      return host.savePlanDocument(repo, taskId, markdown);
+      const saved = await host.savePlanDocument(repo, taskId, markdown);
+      await queryClient.invalidateQueries({
+        queryKey: documentQueryKeys.plan(repo, taskId),
+      });
+      return saved;
     },
-    [activeRepo],
+    [activeRepo, queryClient],
   );
 
   return {

--- a/apps/desktop/src/state/operations/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/use-task-operations.ts
@@ -9,14 +9,15 @@ import type {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
+import { appQueryClient } from "@/lib/query-client";
 import { summarizeTaskLoadError } from "@/state/tasks/task-load-errors";
+import { loadRepoTaskDataFromQuery, taskQueryKeys } from "../queries/tasks";
 import { host } from "./host";
 import {
   DEFERRED_BY_USER_REASON,
   requireActiveRepo,
   toNormalizedTitle,
   toUpdateSuccessDescription,
-  toVisibleTasks,
 } from "./task-operations-model";
 
 type UseTaskOperationsArgs = {
@@ -67,14 +68,14 @@ export function useTaskOperations({
   }, [activeRepo]);
 
   const refreshTaskData = useCallback(async (repoPath: string): Promise<void> => {
-    const [taskList, runList] = await Promise.all([
-      host.tasksList(repoPath),
-      host.runsList(repoPath),
-    ]);
+    const { tasks: taskList, runs: runList } = await loadRepoTaskDataFromQuery(
+      appQueryClient,
+      repoPath,
+    );
     if (activeRepoRef.current !== repoPath) {
       return;
     }
-    setTasks(toVisibleTasks(taskList));
+    setTasks(taskList);
     setRuns(runList);
   }, []);
 
@@ -88,6 +89,14 @@ export function useTaskOperations({
       const repoPath = requireActiveRepo(activeRepo);
       try {
         await options.run(repoPath);
+        await Promise.all([
+          appQueryClient.invalidateQueries({
+            queryKey: taskQueryKeys.repoData(repoPath),
+          }),
+          appQueryClient.invalidateQueries({
+            queryKey: taskQueryKeys.runs(repoPath),
+          }),
+        ]);
         await refreshTaskData(repoPath);
         if (options.successTitle) {
           toast.success(options.successTitle, {
@@ -123,6 +132,14 @@ export function useTaskOperations({
       } catch (error) {
         console.warn("Pull request sync failed during task refresh", errorMessage(error));
       }
+      await Promise.all([
+        appQueryClient.invalidateQueries({
+          queryKey: taskQueryKeys.repoData(activeRepo),
+        }),
+        appQueryClient.invalidateQueries({
+          queryKey: taskQueryKeys.runs(activeRepo),
+        }),
+      ]);
       await refreshTaskData(activeRepo);
     } catch (error) {
       toast.error("Failed to refresh tasks", {
@@ -141,6 +158,14 @@ export function useTaskOperations({
       try {
         const result = await host.taskPullRequestDetect(repoPath, taskId);
         if (result.outcome === "linked") {
+          await Promise.all([
+            appQueryClient.invalidateQueries({
+              queryKey: taskQueryKeys.repoData(repoPath),
+            }),
+            appQueryClient.invalidateQueries({
+              queryKey: taskQueryKeys.runs(repoPath),
+            }),
+          ]);
           await refreshTaskData(repoPath);
           toast.success("Pull request linked", {
             description: `PR #${result.pullRequest.number}`,

--- a/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-workspace-operations.test.tsx
@@ -1,9 +1,10 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { WorkspaceRecord } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { createElement, useEffect, useRef, useState } from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import { toast } from "sonner";
+import { clearAppQueryClient } from "@/lib/query-client";
 import { host } from "./host";
 import { useWorkspaceOperations } from "./use-workspace-operations";
 
@@ -81,6 +82,10 @@ const withTimeout = async <T,>(promise: Promise<T>, timeoutMs: number): Promise<
     }),
   ]);
 };
+
+beforeEach(async () => {
+  await clearAppQueryClient();
+});
 
 type HookArgs = Parameters<typeof useWorkspaceOperations>[0];
 

--- a/apps/desktop/src/state/operations/use-workspace-operations.ts
+++ b/apps/desktop/src/state/operations/use-workspace-operations.ts
@@ -2,7 +2,18 @@ import type { GitBranch, GitCurrentBranch, WorkspaceRecord } from "@openducktor/
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
+import { appQueryClient } from "@/lib/query-client";
 import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
+import {
+  gitQueryKeys,
+  loadCurrentBranchFromQuery,
+  loadRepoBranchesFromQuery,
+} from "../queries/git";
+import {
+  loadRepoConfigFromQuery,
+  loadWorkspaceListFromQuery,
+  workspaceQueryKeys,
+} from "../queries/workspace";
 import { host } from "./host";
 import {
   BRANCH_PROBE_ERROR_TOAST_THROTTLE_MS,
@@ -179,9 +190,17 @@ export function useWorkspaceOperations({
       setIsLoadingBranches(true);
 
       try {
+        await Promise.all([
+          appQueryClient.invalidateQueries({
+            queryKey: gitQueryKeys.currentBranch(repoPath),
+          }),
+          appQueryClient.invalidateQueries({
+            queryKey: gitQueryKeys.branches(repoPath),
+          }),
+        ]);
         const [current, allBranches] = await Promise.all([
-          host.gitGetCurrentBranch(repoPath),
-          host.gitGetBranches(repoPath),
+          loadCurrentBranchFromQuery(appQueryClient, repoPath),
+          loadRepoBranchesFromQuery(appQueryClient, repoPath),
         ]);
 
         if (
@@ -242,6 +261,8 @@ export function useWorkspaceOperations({
       try {
         const current = await host.gitSwitchBranch(activeRepo, branchName);
         const allBranches = await host.gitGetBranches(activeRepo);
+        appQueryClient.setQueryData(gitQueryKeys.currentBranch(activeRepo), current);
+        appQueryClient.setQueryData(gitQueryKeys.branches(activeRepo), allBranches);
 
         if (branchRequestVersionRef.current !== requestVersion) {
           return;
@@ -412,7 +433,7 @@ export function useWorkspaceOperations({
   }, [activeRepo, syncExternalBranchChange]);
 
   const refreshWorkspaces = useCallback(async (): Promise<void> => {
-    const data = await host.workspaceList();
+    const data = await loadWorkspaceListFromQuery(appQueryClient);
     applyWorkspaceRecords(data);
   }, [applyWorkspaceRecords]);
 
@@ -424,6 +445,9 @@ export function useWorkspaceOperations({
       }
 
       const workspace = await host.workspaceAdd(normalizedRepoPath);
+      await appQueryClient.invalidateQueries({
+        queryKey: workspaceQueryKeys.list(),
+      });
       await refreshWorkspaces();
       toast.success("Repository added", {
         description: workspace.path,
@@ -441,6 +465,9 @@ export function useWorkspaceOperations({
 
       try {
         await host.workspaceSelect(repoPath);
+        await appQueryClient.invalidateQueries({
+          queryKey: workspaceQueryKeys.list(),
+        });
         if (workspaceSwitchVersionRef.current !== switchVersion) {
           return;
         }
@@ -454,8 +481,7 @@ export function useWorkspaceOperations({
         };
         setActiveRepo(repoPath);
 
-        void host
-          .workspaceGetRepoConfig(repoPath)
+        void loadRepoConfigFromQuery(appQueryClient, repoPath)
           .then((repoConfig) =>
             host.runtimeEnsure(repoConfig?.defaultRuntimeKind ?? DEFAULT_RUNTIME_KIND, repoPath),
           )

--- a/apps/desktop/src/state/providers/app-runtime-provider.tsx
+++ b/apps/desktop/src/state/providers/app-runtime-provider.tsx
@@ -1,13 +1,6 @@
 import type { RuntimeDescriptor } from "@openducktor/contracts";
-import {
-  type PropsWithChildren,
-  type ReactElement,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import { validateRuntimeDefinitionsForOpenDucktor } from "@/lib/agent-runtime";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { type PropsWithChildren, type ReactElement, useMemo, useState } from "react";
 import { errorMessage } from "@/lib/errors";
 import {
   ActiveRepoContext,
@@ -15,25 +8,17 @@ import {
   RuntimeDefinitionsContext,
   type RuntimeDefinitionsContextValue,
 } from "../app-state-contexts";
-import { host } from "../operations/host";
+import { runtimeDefinitionsQueryOptions, runtimeQueryKeys } from "../queries/runtime";
 
 export function AppRuntimeProvider({ children }: PropsWithChildren): ReactElement {
   const [activeRepo, setActiveRepo] = useState<string | null>(null);
-  const [runtimeDefinitions, setRuntimeDefinitions] = useState<RuntimeDescriptor[]>([]);
-  const [isLoadingRuntimeDefinitions, setIsLoadingRuntimeDefinitions] = useState(true);
-  const [runtimeDefinitionsError, setRuntimeDefinitionsError] = useState<string | null>(null);
-
-  const requireCompatibleRuntimeDefinitions = useCallback(
-    (runtimeDefinitions: RuntimeDescriptor[]): RuntimeDescriptor[] => {
-      const validationErrors = validateRuntimeDefinitionsForOpenDucktor(runtimeDefinitions);
-      if (validationErrors.length > 0) {
-        throw new Error(validationErrors.join("; "));
-      }
-
-      return runtimeDefinitions;
-    },
-    [],
-  );
+  const queryClient = useQueryClient();
+  const {
+    data: runtimeDefinitions = [],
+    error,
+    isPending: isLoadingRuntimeDefinitions,
+    refetch,
+  } = useQuery(runtimeDefinitionsQueryOptions());
 
   const activeRepoValue = useMemo<ActiveRepoContextValue>(
     () => ({
@@ -43,66 +28,28 @@ export function AppRuntimeProvider({ children }: PropsWithChildren): ReactElemen
     [activeRepo],
   );
 
-  const refreshRuntimeDefinitions = useCallback(async (): Promise<RuntimeDescriptor[]> => {
-    setIsLoadingRuntimeDefinitions(true);
-    setRuntimeDefinitionsError(null);
-    try {
-      const nextDefinitions = requireCompatibleRuntimeDefinitions(
-        await host.runtimeDefinitionsList(),
-      );
-      setRuntimeDefinitions(nextDefinitions);
-      return nextDefinitions;
-    } catch (error) {
-      const message = errorMessage(error);
-      setRuntimeDefinitions([]);
-      setRuntimeDefinitionsError(message);
-      throw error;
-    } finally {
-      setIsLoadingRuntimeDefinitions(false);
-    }
-  }, [requireCompatibleRuntimeDefinitions]);
-
-  useEffect(() => {
-    let cancelled = false;
-    setIsLoadingRuntimeDefinitions(true);
-    setRuntimeDefinitionsError(null);
-
-    void host
-      .runtimeDefinitionsList()
-      .then((nextDefinitions) => {
-        if (cancelled) {
-          return;
-        }
-        setRuntimeDefinitions(requireCompatibleRuntimeDefinitions(nextDefinitions));
-      })
-      .catch((error) => {
-        if (cancelled) {
-          return;
-        }
-        setRuntimeDefinitions([]);
-        setRuntimeDefinitionsError(errorMessage(error));
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoadingRuntimeDefinitions(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [requireCompatibleRuntimeDefinitions]);
+  const runtimeDefinitionsError = error ? errorMessage(error) : null;
 
   const runtimeDefinitionsValue = useMemo<RuntimeDefinitionsContextValue>(
     () => ({
       runtimeDefinitions,
       isLoadingRuntimeDefinitions,
       runtimeDefinitionsError,
-      refreshRuntimeDefinitions,
+      refreshRuntimeDefinitions: async (): Promise<RuntimeDescriptor[]> => {
+        await queryClient.invalidateQueries({
+          queryKey: runtimeQueryKeys.definitions(),
+        });
+        const refreshResult = await refetch();
+        if (refreshResult.error) {
+          throw refreshResult.error;
+        }
+        return refreshResult.data ?? [];
+      },
     }),
     [
       isLoadingRuntimeDefinitions,
-      refreshRuntimeDefinitions,
+      queryClient,
+      refetch,
       runtimeDefinitions,
       runtimeDefinitionsError,
     ],

--- a/apps/desktop/src/state/queries/agent-sessions.ts
+++ b/apps/desktop/src/state/queries/agent-sessions.ts
@@ -1,0 +1,25 @@
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { host } from "../operations/host";
+
+const AGENT_SESSION_LIST_STALE_TIME_MS = 30_000;
+
+export const agentSessionQueryKeys = {
+  all: ["agent-sessions"] as const,
+  list: (repoPath: string, taskId: string) =>
+    [...agentSessionQueryKeys.all, "list", repoPath, taskId] as const,
+};
+
+export const agentSessionListQueryOptions = (repoPath: string, taskId: string) =>
+  queryOptions({
+    queryKey: agentSessionQueryKeys.list(repoPath, taskId),
+    queryFn: (): Promise<AgentSessionRecord[]> => host.agentSessionsList(repoPath, taskId),
+    staleTime: AGENT_SESSION_LIST_STALE_TIME_MS,
+  });
+
+export const loadAgentSessionListFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): Promise<AgentSessionRecord[]> =>
+  queryClient.fetchQuery(agentSessionListQueryOptions(repoPath, taskId));

--- a/apps/desktop/src/state/queries/checks.ts
+++ b/apps/desktop/src/state/queries/checks.ts
@@ -1,0 +1,90 @@
+import type {
+  BeadsCheck,
+  RuntimeCheck,
+  RuntimeDescriptor,
+  RuntimeKind,
+} from "@openducktor/contracts";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import type { RepoRuntimeHealthCheck, RepoRuntimeHealthMap } from "@/types/diagnostics";
+import { host } from "../operations/host";
+
+const RUNTIME_CHECK_STALE_TIME_MS = 5 * 60_000;
+const BEADS_CHECK_STALE_TIME_MS = 60_000;
+const RUNTIME_HEALTH_STALE_TIME_MS = 60_000;
+
+const normalizeRuntimeKinds = (runtimeKinds: RuntimeKind[]): RuntimeKind[] =>
+  [...runtimeKinds].sort();
+
+export const checksQueryKeys = {
+  all: ["checks"] as const,
+  runtime: () => [...checksQueryKeys.all, "runtime"] as const,
+  beads: (repoPath: string) => [...checksQueryKeys.all, "beads", repoPath] as const,
+  runtimeHealth: (repoPath: string, runtimeKinds: RuntimeKind[]) =>
+    [
+      ...checksQueryKeys.all,
+      "runtime-health",
+      repoPath,
+      ...normalizeRuntimeKinds(runtimeKinds),
+    ] as const,
+};
+
+export const runtimeCheckQueryOptions = () =>
+  queryOptions({
+    queryKey: checksQueryKeys.runtime(),
+    queryFn: (): Promise<RuntimeCheck> => host.runtimeCheck(false),
+    staleTime: RUNTIME_CHECK_STALE_TIME_MS,
+  });
+
+export const beadsCheckQueryOptions = (repoPath: string) =>
+  queryOptions({
+    queryKey: checksQueryKeys.beads(repoPath),
+    queryFn: (): Promise<BeadsCheck> => host.beadsCheck(repoPath),
+    staleTime: BEADS_CHECK_STALE_TIME_MS,
+  });
+
+export const repoRuntimeHealthQueryOptions = (
+  repoPath: string,
+  runtimeDefinitions: RuntimeDescriptor[],
+  checkRepoRuntimeHealth: (
+    repoPath: string,
+    runtimeKind: RuntimeKind,
+  ) => Promise<RepoRuntimeHealthCheck>,
+) =>
+  queryOptions({
+    queryKey: checksQueryKeys.runtimeHealth(
+      repoPath,
+      runtimeDefinitions.map((definition) => definition.kind),
+    ),
+    queryFn: async (): Promise<RepoRuntimeHealthMap> => {
+      const checks = await Promise.all(
+        runtimeDefinitions.map(async (definition) => {
+          const check = await checkRepoRuntimeHealth(repoPath, definition.kind);
+          return [definition.kind, check] as const;
+        }),
+      );
+
+      return Object.fromEntries(checks) as RepoRuntimeHealthMap;
+    },
+    staleTime: RUNTIME_HEALTH_STALE_TIME_MS,
+  });
+
+export const loadRuntimeCheckFromQuery = (queryClient: QueryClient): Promise<RuntimeCheck> =>
+  queryClient.fetchQuery(runtimeCheckQueryOptions());
+
+export const loadBeadsCheckFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+): Promise<BeadsCheck> => queryClient.fetchQuery(beadsCheckQueryOptions(repoPath));
+
+export const loadRepoRuntimeHealthFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  runtimeDefinitions: RuntimeDescriptor[],
+  checkRepoRuntimeHealth: (
+    repoPath: string,
+    runtimeKind: RuntimeKind,
+  ) => Promise<RepoRuntimeHealthCheck>,
+): Promise<RepoRuntimeHealthMap> =>
+  queryClient.fetchQuery(
+    repoRuntimeHealthQueryOptions(repoPath, runtimeDefinitions, checkRepoRuntimeHealth),
+  );

--- a/apps/desktop/src/state/queries/documents.ts
+++ b/apps/desktop/src/state/queries/documents.ts
@@ -1,0 +1,76 @@
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { host } from "../operations/host";
+
+const TASK_DOCUMENT_STALE_TIME_MS = 60_000;
+
+type TaskDocument = {
+  markdown: string;
+  updatedAt: string | null;
+};
+
+export const documentQueryKeys = {
+  all: ["task-documents"] as const,
+  spec: (repoPath: string, taskId: string) =>
+    [...documentQueryKeys.all, "spec", repoPath, taskId] as const,
+  plan: (repoPath: string, taskId: string) =>
+    [...documentQueryKeys.all, "plan", repoPath, taskId] as const,
+  qaReport: (repoPath: string, taskId: string) =>
+    [...documentQueryKeys.all, "qa-report", repoPath, taskId] as const,
+};
+
+export const specDocumentQueryOptions = (repoPath: string, taskId: string) =>
+  queryOptions({
+    queryKey: documentQueryKeys.spec(repoPath, taskId),
+    queryFn: async (): Promise<TaskDocument> => {
+      const spec = await host.specGet(repoPath, taskId);
+      return {
+        markdown: spec.markdown,
+        updatedAt: spec.updatedAt,
+      };
+    },
+    staleTime: TASK_DOCUMENT_STALE_TIME_MS,
+  });
+
+export const planDocumentQueryOptions = (repoPath: string, taskId: string) =>
+  queryOptions({
+    queryKey: documentQueryKeys.plan(repoPath, taskId),
+    queryFn: async (): Promise<TaskDocument> => {
+      const plan = await host.planGet(repoPath, taskId);
+      return {
+        markdown: plan.markdown,
+        updatedAt: plan.updatedAt,
+      };
+    },
+    staleTime: TASK_DOCUMENT_STALE_TIME_MS,
+  });
+
+export const qaReportDocumentQueryOptions = (repoPath: string, taskId: string) =>
+  queryOptions({
+    queryKey: documentQueryKeys.qaReport(repoPath, taskId),
+    queryFn: async (): Promise<TaskDocument> => {
+      const report = await host.qaGetReport(repoPath, taskId);
+      return {
+        markdown: report.markdown,
+        updatedAt: report.updatedAt,
+      };
+    },
+    staleTime: TASK_DOCUMENT_STALE_TIME_MS,
+  });
+
+export const loadSpecDocumentFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): Promise<TaskDocument> => queryClient.fetchQuery(specDocumentQueryOptions(repoPath, taskId));
+
+export const loadPlanDocumentFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): Promise<TaskDocument> => queryClient.fetchQuery(planDocumentQueryOptions(repoPath, taskId));
+
+export const loadQaReportDocumentFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): Promise<TaskDocument> => queryClient.fetchQuery(qaReportDocumentQueryOptions(repoPath, taskId));

--- a/apps/desktop/src/state/queries/git.ts
+++ b/apps/desktop/src/state/queries/git.ts
@@ -1,0 +1,115 @@
+import type {
+  GitBranch,
+  GitCurrentBranch,
+  GitWorktreeStatus,
+  GitWorktreeStatusSummary,
+} from "@openducktor/contracts";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { host } from "../operations/host";
+
+const BRANCH_DATA_STALE_TIME_MS = 60_000;
+const WORKTREE_STATUS_STALE_TIME_MS = 0;
+
+export const gitQueryKeys = {
+  all: ["git"] as const,
+  branches: (repoPath: string) => [...gitQueryKeys.all, "branches", repoPath] as const,
+  currentBranch: (repoPath: string) => [...gitQueryKeys.all, "current-branch", repoPath] as const,
+  worktreeStatus: (
+    repoPath: string,
+    targetBranch: string,
+    diffScope: "target" | "uncommitted",
+    workingDir: string | null,
+  ) =>
+    [
+      ...gitQueryKeys.all,
+      "worktree-status",
+      repoPath,
+      targetBranch,
+      diffScope,
+      workingDir ?? "",
+    ] as const,
+  worktreeStatusSummary: (
+    repoPath: string,
+    targetBranch: string,
+    diffScope: "target" | "uncommitted",
+    workingDir: string | null,
+  ) =>
+    [
+      ...gitQueryKeys.all,
+      "worktree-status-summary",
+      repoPath,
+      targetBranch,
+      diffScope,
+      workingDir ?? "",
+    ] as const,
+};
+
+export const repoBranchesQueryOptions = (repoPath: string) =>
+  queryOptions({
+    queryKey: gitQueryKeys.branches(repoPath),
+    queryFn: (): Promise<GitBranch[]> => host.gitGetBranches(repoPath),
+    staleTime: BRANCH_DATA_STALE_TIME_MS,
+  });
+
+export const currentBranchQueryOptions = (repoPath: string) =>
+  queryOptions({
+    queryKey: gitQueryKeys.currentBranch(repoPath),
+    queryFn: (): Promise<GitCurrentBranch> => host.gitGetCurrentBranch(repoPath),
+    staleTime: BRANCH_DATA_STALE_TIME_MS,
+  });
+
+export const worktreeStatusQueryOptions = (
+  repoPath: string,
+  targetBranch: string,
+  diffScope: "target" | "uncommitted",
+  workingDir: string | null,
+) =>
+  queryOptions({
+    queryKey: gitQueryKeys.worktreeStatus(repoPath, targetBranch, diffScope, workingDir),
+    queryFn: (): Promise<GitWorktreeStatus> =>
+      host.gitGetWorktreeStatus(repoPath, targetBranch, diffScope, workingDir ?? undefined),
+    staleTime: WORKTREE_STATUS_STALE_TIME_MS,
+  });
+
+export const worktreeStatusSummaryQueryOptions = (
+  repoPath: string,
+  targetBranch: string,
+  diffScope: "target" | "uncommitted",
+  workingDir: string | null,
+) =>
+  queryOptions({
+    queryKey: gitQueryKeys.worktreeStatusSummary(repoPath, targetBranch, diffScope, workingDir),
+    queryFn: (): Promise<GitWorktreeStatusSummary> =>
+      host.gitGetWorktreeStatusSummary(repoPath, targetBranch, diffScope, workingDir ?? undefined),
+    staleTime: WORKTREE_STATUS_STALE_TIME_MS,
+  });
+
+export const loadRepoBranchesFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+): Promise<GitBranch[]> => queryClient.fetchQuery(repoBranchesQueryOptions(repoPath));
+
+export const loadCurrentBranchFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+): Promise<GitCurrentBranch> => queryClient.fetchQuery(currentBranchQueryOptions(repoPath));
+
+export const loadWorktreeStatusFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  targetBranch: string,
+  diffScope: "target" | "uncommitted",
+  workingDir: string | null,
+): Promise<GitWorktreeStatus> =>
+  queryClient.fetchQuery(worktreeStatusQueryOptions(repoPath, targetBranch, diffScope, workingDir));
+
+export const loadWorktreeStatusSummaryFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  targetBranch: string,
+  diffScope: "target" | "uncommitted",
+  workingDir: string | null,
+): Promise<GitWorktreeStatusSummary> =>
+  queryClient.fetchQuery(
+    worktreeStatusSummaryQueryOptions(repoPath, targetBranch, diffScope, workingDir),
+  );

--- a/apps/desktop/src/state/queries/runtime-catalog.ts
+++ b/apps/desktop/src/state/queries/runtime-catalog.ts
@@ -1,0 +1,26 @@
+import type { RuntimeKind } from "@openducktor/contracts";
+import type { AgentModelCatalog } from "@openducktor/core";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { loadRepoRuntimeCatalog } from "../operations/runtime-catalog";
+
+const RUNTIME_CATALOG_STALE_TIME_MS = 5 * 60_000;
+
+export const runtimeCatalogQueryKeys = {
+  all: ["runtime-catalog"] as const,
+  repo: (repoPath: string, runtimeKind: RuntimeKind) =>
+    [...runtimeCatalogQueryKeys.all, repoPath, runtimeKind] as const,
+};
+
+export const repoRuntimeCatalogQueryOptions = (repoPath: string, runtimeKind: RuntimeKind) =>
+  queryOptions({
+    queryKey: runtimeCatalogQueryKeys.repo(repoPath, runtimeKind),
+    queryFn: (): Promise<AgentModelCatalog> => loadRepoRuntimeCatalog(repoPath, runtimeKind),
+    staleTime: RUNTIME_CATALOG_STALE_TIME_MS,
+  });
+
+export const loadRepoRuntimeCatalogFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  runtimeKind: RuntimeKind,
+): Promise<AgentModelCatalog> =>
+  queryClient.fetchQuery(repoRuntimeCatalogQueryOptions(repoPath, runtimeKind));

--- a/apps/desktop/src/state/queries/runtime.ts
+++ b/apps/desktop/src/state/queries/runtime.ts
@@ -1,0 +1,50 @@
+import type {
+  RuntimeDescriptor,
+  RuntimeInstanceSummary,
+  RuntimeKind,
+} from "@openducktor/contracts";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { validateRuntimeDefinitionsForOpenDucktor } from "@/lib/agent-runtime";
+import { host } from "../operations/host";
+
+const RUNTIME_DEFINITIONS_STALE_TIME_MS = 30 * 60_000;
+const RUNTIME_LIST_STALE_TIME_MS = 10_000;
+
+const requireCompatibleRuntimeDefinitions = (
+  runtimeDefinitions: RuntimeDescriptor[],
+): RuntimeDescriptor[] => {
+  const validationErrors = validateRuntimeDefinitionsForOpenDucktor(runtimeDefinitions);
+  if (validationErrors.length > 0) {
+    throw new Error(validationErrors.join("; "));
+  }
+
+  return runtimeDefinitions;
+};
+
+export const runtimeQueryKeys = {
+  all: ["runtime"] as const,
+  definitions: () => [...runtimeQueryKeys.all, "definitions"] as const,
+  list: (runtimeKind: RuntimeKind, repoPath: string) =>
+    [...runtimeQueryKeys.all, "list", runtimeKind, repoPath] as const,
+};
+
+export const runtimeDefinitionsQueryOptions = () =>
+  queryOptions({
+    queryKey: runtimeQueryKeys.definitions(),
+    queryFn: async () => requireCompatibleRuntimeDefinitions(await host.runtimeDefinitionsList()),
+    staleTime: RUNTIME_DEFINITIONS_STALE_TIME_MS,
+  });
+
+export const runtimeListQueryOptions = (runtimeKind: RuntimeKind, repoPath: string) =>
+  queryOptions({
+    queryKey: runtimeQueryKeys.list(runtimeKind, repoPath),
+    queryFn: (): Promise<RuntimeInstanceSummary[]> => host.runtimeList(runtimeKind, repoPath),
+    staleTime: RUNTIME_LIST_STALE_TIME_MS,
+  });
+
+export const loadRuntimeListFromQuery = (
+  queryClient: QueryClient,
+  runtimeKind: RuntimeKind,
+  repoPath: string,
+): Promise<RuntimeInstanceSummary[]> =>
+  queryClient.fetchQuery(runtimeListQueryOptions(runtimeKind, repoPath));

--- a/apps/desktop/src/state/queries/task-approval.ts
+++ b/apps/desktop/src/state/queries/task-approval.ts
@@ -1,0 +1,25 @@
+import type { TaskApprovalContext } from "@openducktor/contracts";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { host } from "../operations/host";
+
+const TASK_APPROVAL_CONTEXT_STALE_TIME_MS = 60_000;
+
+export const taskApprovalQueryKeys = {
+  all: ["task-approval"] as const,
+  context: (repoPath: string, taskId: string) =>
+    [...taskApprovalQueryKeys.all, "context", repoPath, taskId] as const,
+};
+
+export const taskApprovalContextQueryOptions = (repoPath: string, taskId: string) =>
+  queryOptions({
+    queryKey: taskApprovalQueryKeys.context(repoPath, taskId),
+    queryFn: (): Promise<TaskApprovalContext> => host.taskApprovalContextGet(repoPath, taskId),
+    staleTime: TASK_APPROVAL_CONTEXT_STALE_TIME_MS,
+  });
+
+export const loadTaskApprovalContextFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): Promise<TaskApprovalContext> =>
+  queryClient.fetchQuery(taskApprovalContextQueryOptions(repoPath, taskId));

--- a/apps/desktop/src/state/queries/tasks.ts
+++ b/apps/desktop/src/state/queries/tasks.ts
@@ -1,0 +1,67 @@
+import type { RunSummary, TaskCard } from "@openducktor/contracts";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { host } from "../operations/host";
+import { toVisibleTasks } from "../operations/task-operations-model";
+
+const TASK_DATA_STALE_TIME_MS = 30_000;
+const RUN_DATA_STALE_TIME_MS = 30_000;
+
+export type RepoTaskData = {
+  tasks: TaskCard[];
+  runs: RunSummary[];
+};
+
+export const taskQueryKeys = {
+  all: ["tasks"] as const,
+  repoData: (repoPath: string) => [...taskQueryKeys.all, "repo-data", repoPath] as const,
+  runs: (repoPath: string) => [...taskQueryKeys.all, "runs", repoPath] as const,
+};
+
+export const repoTaskDataQueryOptions = (repoPath: string) =>
+  queryOptions({
+    queryKey: taskQueryKeys.repoData(repoPath),
+    queryFn: async (): Promise<RepoTaskData> => {
+      const [taskList, runList] = await Promise.all([
+        host.tasksList(repoPath),
+        host.runsList(repoPath),
+      ]);
+
+      return {
+        tasks: toVisibleTasks(taskList),
+        runs: runList,
+      };
+    },
+    staleTime: TASK_DATA_STALE_TIME_MS,
+  });
+
+export const repoRunsQueryOptions = (repoPath: string) =>
+  queryOptions({
+    queryKey: taskQueryKeys.runs(repoPath),
+    queryFn: (): Promise<RunSummary[]> => host.runsList(repoPath),
+    staleTime: RUN_DATA_STALE_TIME_MS,
+  });
+
+export const loadRepoTaskDataFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+): Promise<RepoTaskData> =>
+  queryClient.fetchQuery({
+    ...repoTaskDataQueryOptions(repoPath),
+    queryFn: async (): Promise<RepoTaskData> => {
+      const [taskList, runList] = await Promise.all([
+        host.tasksList(repoPath),
+        host.runsList(repoPath),
+      ]);
+      const repoTaskData = {
+        tasks: toVisibleTasks(taskList),
+        runs: runList,
+      };
+      queryClient.setQueryData(taskQueryKeys.runs(repoPath), repoTaskData.runs);
+      return repoTaskData;
+    },
+  });
+
+export const loadRepoRunsFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+): Promise<RunSummary[]> => queryClient.fetchQuery(repoRunsQueryOptions(repoPath));

--- a/apps/desktop/src/state/queries/workspace.ts
+++ b/apps/desktop/src/state/queries/workspace.ts
@@ -1,0 +1,99 @@
+import type { RepoConfig, SettingsSnapshot, WorkspaceRecord } from "@openducktor/contracts";
+import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { normalizeTargetBranch } from "@/lib/target-branch";
+import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
+import type { RepoSettingsInput } from "@/types/state-slices";
+import { host } from "../operations/host";
+
+const SETTINGS_SNAPSHOT_STALE_TIME_MS = 15 * 60_000;
+const REPO_CONFIG_STALE_TIME_MS = 10 * 60_000;
+const WORKSPACE_LIST_STALE_TIME_MS = 5 * 60_000;
+
+export const workspaceQueryKeys = {
+  all: ["workspace"] as const,
+  settingsSnapshot: () => [...workspaceQueryKeys.all, "settings-snapshot"] as const,
+  repoConfig: (repoPath: string) => [...workspaceQueryKeys.all, "repo-config", repoPath] as const,
+  list: () => [...workspaceQueryKeys.all, "list"] as const,
+};
+
+export const toRepoSettingsInput = (config: RepoConfig): RepoSettingsInput => ({
+  defaultRuntimeKind: config.defaultRuntimeKind,
+  worktreeBasePath: config.worktreeBasePath ?? "",
+  branchPrefix: config.branchPrefix,
+  defaultTargetBranch: normalizeTargetBranch(config.defaultTargetBranch),
+  trustedHooks: config.trustedHooks,
+  preStartHooks: config.hooks.preStart,
+  postCompleteHooks: config.hooks.postComplete,
+  worktreeFileCopies: config.worktreeFileCopies ?? [],
+  agentDefaults: {
+    spec: config.agentDefaults.spec
+      ? {
+          runtimeKind: config.agentDefaults.spec.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+          providerId: config.agentDefaults.spec.providerId,
+          modelId: config.agentDefaults.spec.modelId,
+          variant: config.agentDefaults.spec.variant ?? "",
+          profileId: config.agentDefaults.spec.profileId ?? "",
+        }
+      : null,
+    planner: config.agentDefaults.planner
+      ? {
+          runtimeKind: config.agentDefaults.planner.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+          providerId: config.agentDefaults.planner.providerId,
+          modelId: config.agentDefaults.planner.modelId,
+          variant: config.agentDefaults.planner.variant ?? "",
+          profileId: config.agentDefaults.planner.profileId ?? "",
+        }
+      : null,
+    build: config.agentDefaults.build
+      ? {
+          runtimeKind: config.agentDefaults.build.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+          providerId: config.agentDefaults.build.providerId,
+          modelId: config.agentDefaults.build.modelId,
+          variant: config.agentDefaults.build.variant ?? "",
+          profileId: config.agentDefaults.build.profileId ?? "",
+        }
+      : null,
+    qa: config.agentDefaults.qa
+      ? {
+          runtimeKind: config.agentDefaults.qa.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+          providerId: config.agentDefaults.qa.providerId,
+          modelId: config.agentDefaults.qa.modelId,
+          variant: config.agentDefaults.qa.variant ?? "",
+          profileId: config.agentDefaults.qa.profileId ?? "",
+        }
+      : null,
+  },
+});
+
+export const settingsSnapshotQueryOptions = () =>
+  queryOptions({
+    queryKey: workspaceQueryKeys.settingsSnapshot(),
+    queryFn: () => host.workspaceGetSettingsSnapshot(),
+    staleTime: SETTINGS_SNAPSHOT_STALE_TIME_MS,
+  });
+
+export const repoConfigQueryOptions = (repoPath: string) =>
+  queryOptions({
+    queryKey: workspaceQueryKeys.repoConfig(repoPath),
+    queryFn: () => host.workspaceGetRepoConfig(repoPath),
+    staleTime: REPO_CONFIG_STALE_TIME_MS,
+  });
+
+export const workspaceListQueryOptions = () =>
+  queryOptions({
+    queryKey: workspaceQueryKeys.list(),
+    queryFn: (): Promise<WorkspaceRecord[]> => host.workspaceList(),
+    staleTime: WORKSPACE_LIST_STALE_TIME_MS,
+  });
+
+export const loadSettingsSnapshotFromQuery = (
+  queryClient: QueryClient,
+): Promise<SettingsSnapshot> => queryClient.ensureQueryData(settingsSnapshotQueryOptions());
+
+export const loadRepoConfigFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+): Promise<RepoConfig> => queryClient.ensureQueryData(repoConfigQueryOptions(repoPath));
+
+export const loadWorkspaceListFromQuery = (queryClient: QueryClient): Promise<WorkspaceRecord[]> =>
+  queryClient.fetchQuery(workspaceListQueryOptions());

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tabs": "^1.1.13",
+        "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-virtual": "^3.13.21",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",
@@ -529,6 +530,10 @@
     "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.1", "", { "dependencies": { "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "tailwindcss": "4.2.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.21", "", { "dependencies": { "@tanstack/virtual-core": "3.13.21" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-SYXFrmrbPgXBvf+HsOsKhFgqSe4M6B29VHOsX9Jih9TlNkNkDWx0hWMiMLUghMEzyUz772ndzdEeCEBx+3GIZw=="],
 

--- a/docs/tanstack-query-cache-strategy.md
+++ b/docs/tanstack-query-cache-strategy.md
@@ -1,0 +1,134 @@
+# TanStack Query Cache Strategy
+
+This document describes the cache and stale-time strategy used in `apps/desktop`.
+
+## Global defaults
+
+Defined in [apps/desktop/src/lib/query-client.ts](../apps/desktop/src/lib/query-client.ts):
+
+- `retry: false`
+- `refetchOnWindowFocus: false`
+- `refetchOnReconnect: false`
+- default `staleTime: 60_000`
+- default `gcTime: 10 * 60_000`
+
+These defaults match the desktop/browser-live host model:
+
+- we do not want silent retries masking host failures
+- we do not want focus or reconnect to trigger surprise backend traffic
+- we want a short shared cache by default, then override by domain
+
+## Strategy by data class
+
+### Long-lived configuration
+
+Used for shared, read-mostly configuration that changes rarely and should be invalidated explicitly after writes.
+
+- settings snapshot: `15 min`
+- repo config: `10 min`
+- workspace list: `5 min`
+- runtime definitions: `30 min`
+- runtime catalog: `5 min`
+
+Files:
+
+- [apps/desktop/src/state/queries/workspace.ts](../apps/desktop/src/state/queries/workspace.ts)
+- [apps/desktop/src/state/queries/runtime.ts](../apps/desktop/src/state/queries/runtime.ts)
+- [apps/desktop/src/state/queries/runtime-catalog.ts](../apps/desktop/src/state/queries/runtime-catalog.ts)
+
+### Medium-lived operational reads
+
+Used for workflow data that can change during a session, but where we still want deduplication across repeated reads.
+
+- task list plus runs bundle: `30 sec`
+- runs only: `30 sec`
+- agent session list: `30 sec`
+- task documents: `60 sec`
+- task approval context: `60 sec`
+- runtime instance list: `10 sec`
+
+Files:
+
+- [apps/desktop/src/state/queries/tasks.ts](../apps/desktop/src/state/queries/tasks.ts)
+- [apps/desktop/src/state/queries/agent-sessions.ts](../apps/desktop/src/state/queries/agent-sessions.ts)
+- [apps/desktop/src/state/queries/documents.ts](../apps/desktop/src/state/queries/documents.ts)
+- [apps/desktop/src/state/queries/task-approval.ts](../apps/desktop/src/state/queries/task-approval.ts)
+- [apps/desktop/src/state/queries/runtime.ts](../apps/desktop/src/state/queries/runtime.ts)
+
+### Diagnostics and health
+
+Used for checks that are somewhat volatile, but still should not refetch constantly.
+
+- runtime check: `5 min`
+- beads check: `60 sec`
+- repo runtime health: `60 sec`
+
+File:
+
+- [apps/desktop/src/state/queries/checks.ts](../apps/desktop/src/state/queries/checks.ts)
+
+### Git state
+
+Used for repository state where some values are stable and some are intentionally treated as immediately stale.
+
+- branches: `60 sec`
+- current branch: `60 sec`
+- worktree status: `0`
+- worktree status summary: `0`
+
+`worktree status` is intentionally `0` because we want request deduplication and keyed caching, but we do not want the UI to trust an old diff snapshot once control returns to the caller.
+
+File:
+
+- [apps/desktop/src/state/queries/git.ts](../apps/desktop/src/state/queries/git.ts)
+
+## Read patterns
+
+We use two main imperative read patterns:
+
+### `ensureQueryData`
+
+Used for canonical configuration reads that should return fresh cached data if available, otherwise fetch.
+
+Examples:
+
+- `loadSettingsSnapshotFromQuery(...)`
+- `loadRepoConfigFromQuery(...)`
+
+### `fetchQuery`
+
+Used for imperative operational reads where callers want the shared query behavior and in-flight deduplication, while still driving the read explicitly.
+
+Examples:
+
+- task/runs refreshes
+- session hydration reads
+- document reads
+- worktree status reads
+
+## Mutation strategy
+
+We do not depend on background refetch heuristics for correctness.
+
+Instead, mutations must do one of:
+
+- `invalidateQueries(...)` when server truth changed and should be reloaded
+- `setQueryData(...)` when the new canonical value is already known locally
+
+Examples:
+
+- saving settings snapshot updates the settings snapshot cache directly
+- saving repo settings invalidates repo config
+- task mutations invalidate repo task data and runs
+
+## Non-goals
+
+TanStack Query is not the source of truth for:
+
+- streaming agent transcript assembly
+- pending permission/question state
+- composer input state
+- event-driven orchestration state
+- imperative mutation flows like `runtimeEnsure`, `buildStart`, `gitPushBranch`, or `taskTransition`
+
+These remain outside Query on purpose.

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -426,6 +426,7 @@ describe("TauriHostClient", () => {
 
     const snapshot = await client.workspaceGetSettingsSnapshot();
 
+    expect(snapshot.theme).toBe("light");
     expect(Object.keys(snapshot.repos)).toEqual(["/repo"]);
     expect(calls).toEqual([
       {

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -141,7 +141,6 @@ describe("TauriHostClient", () => {
       "workspaceSaveSettingsSnapshot",
       "workspacePrepareTrustedHooksChallenge",
       "workspaceSetTrustedHooks",
-      "getTheme",
       "setTheme",
       "tasksList",
       "taskCreate",
@@ -397,6 +396,7 @@ describe("TauriHostClient", () => {
     const { client, calls } = createClient((command) => {
       if (command === "workspace_get_settings_snapshot") {
         return {
+          theme: "light",
           git: {
             defaultMergeMethod: "merge_commit",
           },
@@ -453,6 +453,7 @@ describe("TauriHostClient", () => {
     });
 
     const result = await client.workspaceSaveSettingsSnapshot({
+      theme: "light",
       git: {
         defaultMergeMethod: "merge_commit",
       },
@@ -483,6 +484,7 @@ describe("TauriHostClient", () => {
         command: "workspace_save_settings_snapshot",
         args: {
           snapshot: {
+            theme: "light",
             git: {
               defaultMergeMethod: "merge_commit",
             },

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -26,7 +26,6 @@ const WORKSPACE_METHODS = [
   "workspaceSaveSettingsSnapshot",
   "workspacePrepareTrustedHooksChallenge",
   "workspaceSetTrustedHooks",
-  "getTheme",
   "setTheme",
 ] as const satisfies readonly MethodName<TauriWorkspaceClient>[];
 

--- a/packages/adapters-tauri-host/src/workspace-client.ts
+++ b/packages/adapters-tauri-host/src/workspace-client.ts
@@ -188,10 +188,6 @@ export const workspacePrepareTrustedHooksChallenge = async (
   return invokeFn("workspace_prepare_trusted_hooks_challenge", { repoPath });
 };
 
-export const getTheme = async (invokeFn: InvokeFn): Promise<string> => {
-  return invokeFn<string>("get_theme");
-};
-
 export const setTheme = async (invokeFn: InvokeFn, theme: string): Promise<void> => {
   await invokeFn<void>("set_theme", { theme });
 };
@@ -262,10 +258,6 @@ export class TauriWorkspaceClient {
     challenge?: TrustedHooksProof,
   ): Promise<WorkspaceRecord> {
     return workspaceSetTrustedHooks(this.invokeFn, repoPath, trusted, challenge);
-  }
-
-  async getTheme(): Promise<string> {
-    return getTheme(this.invokeFn);
   }
 
   async setTheme(theme: string): Promise<void> {

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -12,6 +12,7 @@ const DEFAULT_SOFT_GUARDRAILS = {
 const DEFAULT_CHAT_SETTINGS = {
   showThinkingMessages: false,
 } as const;
+const DEFAULT_THEME = "light" as const;
 
 const nullableToOptional = <T extends z.ZodTypeAny>(schema: T) =>
   z.preprocess((value) => (value === null ? undefined : value), schema.optional());
@@ -76,9 +77,15 @@ export const chatSettingsSchema = z.object({
 });
 export type ChatSettings = z.infer<typeof chatSettingsSchema>;
 
+const themeValueSchema = z.enum(["light", "dark"]);
+
+export const themeSchema = themeValueSchema.default(DEFAULT_THEME);
+export type Theme = z.infer<typeof themeValueSchema>;
+
 export const globalConfigSchema = z.object({
   version: z.literal(1),
   activeRepo: z.string().optional(),
+  theme: themeSchema,
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
   chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
   repos: z.record(z.string(), repoConfigSchema).default({}),
@@ -88,6 +95,7 @@ export const globalConfigSchema = z.object({
 export type GlobalConfig = z.infer<typeof globalConfigSchema>;
 
 export const settingsSnapshotSchema = z.object({
+  theme: themeValueSchema,
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
   chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
   repos: z.record(z.string(), repoConfigSchema).default({}),

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -184,6 +184,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "taskPrioritySchema",
   "taskStatusSchema",
   "taskUpdatePatchSchema",
+  "themeSchema",
   "pullRequestSchema",
   "validatePromptTemplatePlaceholders",
   "validateSpecMarkdown",
@@ -270,6 +271,7 @@ describe("contracts exports contract", () => {
 
   test("defaults missing chat settings to disabled thinking messages", () => {
     const parsedSnapshot = contracts.settingsSnapshotSchema.parse({
+      theme: "light",
       git: {
         defaultMergeMethod: "merge_commit",
       },
@@ -278,5 +280,17 @@ describe("contracts exports contract", () => {
     });
 
     expect(parsedSnapshot.chat.showThinkingMessages).toBe(false);
+  });
+
+  test("rejects settings snapshots without a theme", () => {
+    expect(() =>
+      contracts.settingsSnapshotSchema.parse({
+        git: {
+          defaultMergeMethod: "merge_commit",
+        },
+        repos: {},
+        globalPromptOverrides: {},
+      }),
+    ).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- adopt TanStack Query for shared desktop backend reads and move shared workspace/runtime/task/git/document loaders onto canonical query modules
- tighten Agent Studio performance by making role switches transition-based, cleaning duplicate read paths, and stabilizing the chat loading overlay/session readiness flow
- move theme to the canonical settings snapshot, remove the orphaned standalone get_theme read path, and document query usage rules and cache strategy

## Verification
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- cd apps/desktop/src-tauri && cargo check
- cd apps/desktop/src-tauri && cargo test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now uses a centralized query/cache layer for faster, more consistent data loading; theme is stored in workspace settings and applied at startup.

* **Bug Fixes / UX**
  * Loading overlay message updated to "Preparing chat..." with improved display logic.
  * Task delete dialog shows a "Checking..."/disabled state while impact is evaluated.

* **Documentation**
  * Added TanStack Query cache strategy and frontend query guidance.

* **Refactor**
  * Many data flows migrated to a query-driven architecture for better caching and invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->