### PR TITLE
docs: prepare repository for public contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report a reproducible defect in OpenDucktor.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        Before filing, please confirm:
+        - the issue is reproducible
+        - you reviewed the current README and CONTRIBUTING guide
+        - this is not a security vulnerability requiring private reporting
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is wrong?
+      placeholder: A clear, short description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide a minimal, deterministic reproduction.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS
+        - Windows
+        - Linux
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: app_mode
+    attributes:
+      label: App mode
+      description: For example `tauri:dev`, packaged app, or browser dev mode.
+      placeholder: bun run tauri:dev
+  - type: textarea
+    id: tooling
+    attributes:
+      label: Tooling versions
+      description: Include Bun, Rust, `bd`, `opencode`, and OS version if relevant.
+      placeholder: |
+        Bun:
+        Rust:
+        bd:
+        opencode:
+        macOS:
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste relevant logs or attach screenshots.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I verified this is not a security issue requiring private reporting.
+          required: true
+        - label: I searched for existing issues before opening this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security policy
+    url: https://github.com/Maxsky5/openducktor/blob/main/SECURITY.md
+    about: Please read this before reporting a potential vulnerability.
+  - name: Contribution guide
+    url: https://github.com/Maxsky5/openducktor/blob/main/CONTRIBUTING.md
+    about: Read the project constraints and contribution expectations first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Propose an improvement aligned with the current project direction.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion.
+
+        OpenDucktor is still early and intentionally focused. Please frame requests in terms of a concrete problem and the current product constraints:
+        - macOS first
+        - OpenCode only today
+        - Codex planned next
+        - open source runtimes only
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+      placeholder: As a contributor or user, I need ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What do you want to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What alternatives or workarounds have you considered?
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and impact
+      description: Which area does this affect and why is it worth prioritizing now?
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I reviewed the current README and CONTRIBUTING guide.
+          required: true
+        - label: I searched for existing issues before opening this request.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,8 @@
 - [ ] `bun run typecheck`
 - [ ] `bun run test`
 - [ ] `bun run build`
-- [ ] `cd apps/desktop/src-tauri && cargo check`
-- [ ] `cd apps/desktop/src-tauri && cargo test`
+- [ ] `bun run check:rust`
+- [ ] `bun run test:rust`
 - [ ] Not applicable
 
 ## Checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+
+- What problem does this change solve?
+- What is intentionally out of scope?
+
+## Testing
+
+- [ ] `bun run lint`
+- [ ] `bun run typecheck`
+- [ ] `bun run test`
+- [ ] `bun run build`
+- [ ] `cd apps/desktop/src-tauri && cargo check`
+- [ ] `cd apps/desktop/src-tauri && cargo test`
+- [ ] Not applicable
+
+## Checklist
+
+- [ ] I updated docs when behavior, workflows, runtime contracts, or setup changed
+- [ ] I added or updated relevant tests
+- [ ] I kept failures explicit instead of adding fallback logic
+- [ ] I linked related issues or context below
+
+## Related Issues
+
+Closes #
+
+## Breaking Changes
+
+- [ ] No breaking changes
+- [ ] Breaking changes are described below
+
+## Additional Context
+
+Add screenshots, logs, migration notes, or follow-up work if needed.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer through a private GitHub contact.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+https://github.com/mozilla/diversity.
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing To OpenDucktor
+
+Thanks for contributing. This project is public, but it is still early and the codebase is moving quickly. The best contributions are narrow, well-tested, and aligned with the current product direction.
+
+## Before You Start
+
+- Read [README.md](README.md) for project scope and setup.
+- Read [docs/README.md](docs/README.md) for the documentation map.
+- Open an issue or discussion before starting large changes, new features, or architectural refactors.
+
+## Current Product Constraints
+
+Please keep these constraints in mind when proposing or implementing changes:
+
+- OpenDucktor currently focuses on macOS only.
+- The only supported agent runtime today is OpenCode (`opencode`).
+- Codex is the next planned runtime, but it is not implemented yet.
+- OpenDucktor will support open source agent runtimes only.
+- Claude Code is intentionally out of scope.
+- Beads is the V1 source of truth for tasks.
+
+## Local Setup
+
+Required local tooling:
+
+- Bun `1.3.5` or newer
+- Rust stable
+- Xcode Command Line Tools
+- `git`
+- `gh`
+- `bd`
+- `opencode`
+
+Install workspace dependencies from the repository root:
+
+```sh
+bun install
+```
+
+Run the desktop app:
+
+```sh
+bun run tauri:dev
+```
+
+Useful checks:
+
+```sh
+bun run lint
+bun run typecheck
+bun run test
+bun run build
+cd apps/desktop/src-tauri && cargo check
+cd apps/desktop/src-tauri && cargo test
+```
+
+## Development Expectations
+
+- Keep changes consistent with the current hexagonal boundaries.
+- Update shared contracts first when a cross-layer payload changes.
+- Do not add fallback logic that hides failures.
+- Prefer actionable errors over silent defaults.
+- Keep docs in sync with behavior when changing workflows, runtime contracts, or security assumptions.
+
+## Tests
+
+- Add or update tests for non-trivial behavior changes.
+- Frontend behavior changes should include frontend tests.
+- Core, adapters, MCP, and Rust host changes should include targeted tests in the touched area.
+- Run the relevant checks before opening a pull request.
+
+## Pull Requests
+
+When opening a pull request:
+
+- Explain the user-facing or maintainer-facing problem being solved.
+- Keep the change set focused.
+- Call out any follow-up work that is intentionally left out.
+- Mention any setup assumptions, migrations, or breaking changes.
+
+## Commit Messages
+
+Use Conventional Commits where practical.
+
+Examples:
+
+- `feat: add runtime capability validation for session hydration`
+- `fix: keep task workflow transitions fail-fast`
+- `docs: rewrite public README and contribution guide`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please keep these constraints in mind when proposing or implementing changes:
 - OpenDucktor currently focuses on macOS only.
 - The only supported agent runtime today is OpenCode (`opencode`).
 - Codex is the next planned runtime, but it is not implemented yet.
-- OpenDucktor will support open source agent runtimes only.
+- OpenDucktor will support open-source agent runtimes only.
 - Claude Code is intentionally out of scope.
 - Beads is the V1 source of truth for tasks.
 
@@ -23,7 +23,7 @@ Please keep these constraints in mind when proposing or implementing changes:
 
 Required local tooling:
 
-- Bun `1.3.5` or newer
+- Bun `1.3.5`
 - Rust stable
 - Xcode Command Line Tools
 - `git`
@@ -50,8 +50,8 @@ bun run lint
 bun run typecheck
 bun run test
 bun run build
-cd apps/desktop/src-tauri && cargo check
-cd apps/desktop/src-tauri && cargo test
+bun run check:rust
+bun run test:rust
 ```
 
 ## Development Expectations

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets.)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ If you want to follow the project, treat the current codebase as an active proto
 - Supported task backend: Beads.
 - Supported agent runtime today: OpenCode (`opencode`) only.
 - Next planned runtime: Codex.
-- Runtime policy: OpenDucktor will support open source agent runtimes only (I'm watching you Claude Code).
+- Runtime policy: OpenDucktor will support open-source agent runtimes only.
+- Explicitly out of scope: Claude Code.
 
 ## What OpenDucktor Does
 
@@ -48,7 +49,7 @@ OpenDucktor is built around a workflow where tasks live in Beads and agent work 
 
 OpenDucktor currently targets local macOS development.
 
-- Bun `1.3.5` or newer
+- Bun `1.3.5`
 - Rust stable toolchain
 - Xcode Command Line Tools
 - `git`
@@ -83,8 +84,8 @@ bun run lint
 bun run typecheck
 bun run test
 bun run build
-cd apps/desktop/src-tauri && cargo check
-cd apps/desktop/src-tauri && cargo test
+bun run check:rust
+bun run test:rust
 ```
 
 ### Local Data And Config

--- a/README.md
+++ b/README.md
@@ -1,165 +1,133 @@
-# OpenDucktor V1
+# OpenDucktor
 
-OpenDucktor is a macOS-first Tauri v2 desktop app with a Bun monorepo, React frontend, and Rust host runtime.
+OpenDucktor is a desktop app for AI-assisted software delivery. It combines a Tauri v2 host, a React frontend, a Rust application layer, and Beads as the task source of truth to orchestrate spec, planning, build, and QA workflows around real repository work.
 
-## Monorepo Layout
+## Status
 
-- `apps/desktop`: React + Vite desktop frontend and Tauri host.
-- `packages/contracts`: Shared runtime schemas and DTO contracts.
-- `packages/core`: Hexagonal domain services and ports.
-- `packages/adapters-opencode-sdk`: `AgentEnginePort` adapter.
-- `packages/adapters-tauri-host`: Frontend IPC client adapter.
+OpenDucktor is still very early.
 
-## Hexagonal Boundaries
+- The repository is public so the work can be inspected, discussed, and improved in the open.
+- It is not production-ready yet.
+- Breaking changes should be expected.
+- Setup is still manual in places, and contributor ergonomics are still being improved.
 
-Replaceable ports:
+If you want to follow the project, treat the current codebase as an active prototype rather than a stable product.
 
-- `AgentEnginePort` in `packages/core/src/ports/agent-engine.ts`
-- `TaskStore` trait in `apps/desktop/src-tauri/crates/host-domain/src/store.rs` (re-exported by `apps/desktop/src-tauri/crates/host-domain/src/lib.rs`)
+## Current Scope
 
-Current adapters:
+- Platform support today: macOS only.
+- Planned later: Windows and Linux, after the project reaches a first stable version.
+- Supported task backend: Beads.
+- Supported agent runtime today: OpenCode (`opencode`) only.
+- Next planned runtime: Codex.
+- Runtime policy: OpenDucktor will support open source agent runtimes only (I'm watching you Claude Code).
 
-- Opencode adapter: `packages/adapters-opencode-sdk/src/index.ts`
-- Beads adapter: `apps/desktop/src-tauri/crates/host-infra-beads/src/lib.rs`
+## What OpenDucktor Does
 
-## Architecture Docs
+OpenDucktor is built around a workflow where tasks live in Beads and agent work stays connected to those tasks.
 
-- End-to-end architecture and runtime data flow: [docs/architecture-overview.md](docs/architecture-overview.md)
-- Agent orchestrator internals: [docs/agent-orchestrator-module-map.md](docs/agent-orchestrator-module-map.md)
-- Workflow lifecycle/status contract: [docs/task-workflow-status-model.md](docs/task-workflow-status-model.md)
-- Workflow actions: [docs/task-workflow-actions.md](docs/task-workflow-actions.md)
-- Workflow transition matrix: [docs/task-workflow-transition-matrix.md](docs/task-workflow-transition-matrix.md)
+- Beads is the lifecycle source of truth.
+- OpenDucktor manages spec, plan, build, and QA workflows on top of that task model.
+- Agent-authored documents are stored as task metadata instead of being scattered across ad hoc files.
+- The desktop app coordinates repository checks, runtime startup, task transitions, and local workflow tooling.
 
-## Home Config
+## Repository Layout
 
-OpenDucktor stores config at:
+- `apps/desktop`: React + Vite frontend and Tauri desktop app.
+- `apps/desktop/src-tauri`: Rust host application and infrastructure crates.
+- `packages/contracts`: Shared TypeScript contracts and schemas.
+- `packages/core`: Core domain services and ports.
+- `packages/adapters-opencode-sdk`: OpenCode runtime adapter for the TypeScript agent engine boundary.
+- `packages/adapters-tauri-host`: Frontend adapter for typed Tauri IPC.
+- `packages/openducktor-mcp`: MCP server exposing the `odt_*` workflow tools.
+- `docs/`: architecture, workflow, runtime, and security documentation.
+
+## Running Locally
+
+### Prerequisites
+
+OpenDucktor currently targets local macOS development.
+
+- Bun `1.3.5` or newer
+- Rust stable toolchain
+- Xcode Command Line Tools
+- `git`
+- `gh`
+- `bd` (Beads CLI)
+- `opencode` (OpenCode CLI/runtime)
+
+OpenDucktor resolves `opencode` from `PATH` first, then falls back to `~/.opencode/bin/opencode`. You can also override the binary path with `OPENDUCKTOR_OPENCODE_BINARY`.
+
+### Install Dependencies
+
+```sh
+bun install
+```
+
+### Start The Desktop App
+
+```sh
+bun run tauri:dev
+```
+
+### Start in Browser Mode (allow agents to test what they are doing)
+
+```sh
+bun run browser:dev
+```
+
+### Useful Checks
+
+```sh
+bun run lint
+bun run typecheck
+bun run test
+bun run build
+cd apps/desktop/src-tauri && cargo check
+cd apps/desktop/src-tauri && cargo test
+```
+
+### Local Data And Config
+
+OpenDucktor stores local config at:
 
 - `~/.openducktor/config.json`
 
-Example:
+Beads storage is managed centrally per repository in:
 
-```json
-{
-  "version": 1,
-  "activeRepo": "/abs/path/repo-a",
-  "repos": {
-    "/abs/path/repo-a": {
-      "worktreeBasePath": "/abs/path/outside/repo-a",
-      "branchPrefix": "obp",
-      "trustedHooks": true,
-      "hooks": {
-        "preStart": ["bun install --frozen-lockfile"],
-        "postComplete": ["bun run test", "bun run lint"]
-      }
-    }
-  },
-  "recentRepos": ["/abs/path/repo-a"],
-  "scheduler": {
-    "softGuardrails": {
-      "cpuHighWatermarkPercent": 85,
-      "minFreeMemoryMb": 2048,
-      "backoffSeconds": 30
-    }
-  }
-}
-```
+- `~/.openducktor/beads/`
 
-## Beads Storage Policy (V1)
+The app initializes and uses a central Beads directory for each repository. Existing repo-local `.beads` folders are not the V1 source of truth.
 
-Beads storage is centrally managed per repository and is not user-configurable in V1.
+## Contributing
 
-- Base directory: `~/.openducktor/beads/`
-- Per repo store: `~/.openducktor/beads/<repo-id>/.beads`
-- `repo-id`: `<slug>-<short-hash>` derived from canonical absolute repo path
+Contributions are welcome, but this repository is still changing quickly. Before spending time on a large change, open an issue or start a discussion so the direction is aligned first.
 
-Behavior:
+Short version:
 
-- On repository add/select, OpenDucktor auto-initializes Beads if needed.
-- OpenDucktor always sets `BEADS_DIR` for `bd` commands.
-- Existing repo-local `.beads` is ignored in V1 (no migration yet).
+1. Fork the repo and create a branch.
+2. Install the required local tooling, including `bd` and `opencode`.
+3. Make the smallest coherent change that solves one problem.
+4. Add or update tests for touched behavior.
+5. Run the relevant checks before opening a pull request.
+6. Use Conventional Commits for commit messages.
 
-## Planner Rules
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor workflow and expectations.
 
-Spec markdown is canonical in Beads task `description`.
+## Documentation
 
-Required sections:
+Start here:
 
-1. `Purpose`
-2. `Problem`
-3. `Goals`
-4. `Non-goals`
-5. `Scope`
-6. `API / Interfaces`
-7. `Risks`
-8. `Test Plan`
+- [docs/README.md](docs/README.md)
 
-Task document commands are `spec_get`, `set_spec`, `spec_save_document`, `plan_get`, `set_plan`, and `plan_save_document`.
+Key references:
 
-## Commands
+- [docs/architecture-overview.md](docs/architecture-overview.md)
+- [docs/runtime-integration-guide.md](docs/runtime-integration-guide.md)
+- [docs/task-workflow-status-model.md](docs/task-workflow-status-model.md)
+- [docs/task-workflow-actions.md](docs/task-workflow-actions.md)
+- [docs/task-workflow-transition-matrix.md](docs/task-workflow-transition-matrix.md)
 
-```bash
-bun install
-bun run typecheck
-bun run build
-bun run test
-bun run deps:check
-bun run deps:audit:hono
-bun run deps:unused
-bun run deps:outdated
+## License
 
-# frontend (browser only)
-bun run --filter @openducktor/desktop dev
-
-# tauri CLI/version
-bun run tauri -- --version
-
-# desktop app (frontend + rust host)
-bun run tauri:dev
-
-# tauri host rust check only
-cd apps/desktop/src-tauri && cargo check
-```
-
-## Dependency Hygiene
-
-- All-in-one blocking hygiene check: `bun run deps:check`
-- Included unused dependency check: `bun run deps:unused:deps`
-- Included high/critical advisory gate: `bun run deps:audit:high`
-- Included targeted vulnerability check (Hono GHSA-`xh87-mx6m-69f3`): `bun run deps:audit:hono`
-- Non-blocking unused export report: `bun run deps:unused`
-- Outdated dependency report: `bun run deps:outdated`
-- Automated update PRs: `.github/dependabot.yml`
-- Dedicated CI automation: `.github/workflows/dependency-hygiene.yml`
-- Review and upgrade cadence: `docs/dependency-hygiene.md`
-- MCP runtime transport and threat assumptions: `docs/mcp-runtime-security.md`
-
-## IPC Commands (Implemented)
-
-- Runtime/system:
-  - `system_check`, `runtime_check`, `beads_check`
-- Workspace/config:
-  - `workspace_list`, `workspace_add`, `workspace_select`
-  - `workspace_update_repo_config`, `workspace_save_repo_settings`, `workspace_update_repo_hooks`
-  - `workspace_prepare_trusted_hooks_challenge`, `workspace_get_repo_config`, `workspace_set_trusted_hooks`
-- Git:
-  - `git_get_branches`, `git_get_current_branch`, `git_switch_branch`
-  - `git_create_worktree`, `git_remove_worktree`, `git_push_branch`
-- Tasks:
-  - `tasks_list`, `task_create`, `task_update`, `task_delete`
-  - `task_transition`, `task_defer`, `task_resume_deferred`
-- Documents/workflow:
-  - `spec_get`, `task_metadata_get`, `set_spec`, `spec_save_document`
-  - `plan_get`, `set_plan`, `plan_save_document`
-  - `qa_get_report`, `qa_approved`, `qa_rejected`
-  - `build_start`, `build_respond`, `build_stop`, `build_cleanup`
-  - `build_blocked`, `build_resumed`, `build_completed`
-  - `human_request_changes`, `human_approve`
-- Runs/runtimes:
-  - `runs_list`
-  - `runtime_definitions_list`, `runtime_list`, `runtime_start`, `runtime_stop`, `runtime_ensure`
-- Agent sessions:
-  - `agent_sessions_list`, `agent_session_upsert`
-- Theme:
-  - `get_theme`, `set_theme`
-
-Run events emit on `openducktor://run-event`.
+This repository is licensed under the Apache License 2.0. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+OpenDucktor is still early and does not have stable releases yet.
+
+At the moment, security fixes should be assumed to land on the default branch only:
+
+| Version | Supported |
+|---|---|
+| `main` | Yes |
+| Tagged releases | No stable support policy yet |
+
+## Reporting A Vulnerability
+
+Please do not open public GitHub issues for security vulnerabilities.
+
+At the time this policy was written, GitHub private vulnerability reporting was not enabled for this repository. Until that changes:
+
+1. Report the issue privately to the repository owner through GitHub.
+2. Include a clear description, impact, affected commit or branch, reproduction steps, and any suggested remediation.
+3. Give maintainers reasonable time to investigate and prepare a fix before public disclosure.
+
+If private vulnerability reporting is enabled later, use that channel instead of public issues.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,4 +33,4 @@ This folder contains the project documentation that explains how OpenDucktor is 
 - OpenDucktor is still early, macOS-first, and not ready for general use yet.
 - The only supported runtime today is OpenCode (`opencode`).
 - Codex is the next planned runtime.
-- OpenDucktor will support open source agent runtimes only; Claude Code is out of scope.
+- OpenDucktor will support open-source agent runtimes only; Claude Code is out of scope.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,36 @@
+# Documentation Guide
+
+This folder contains the project documentation that explains how OpenDucktor is built today and how it is expected to evolve.
+
+## Read This First
+
+- [../README.md](../README.md): public project overview, current scope, local setup, and contribution entry point.
+- [architecture-overview.md](architecture-overview.md): high-level map of the system and how data moves across layers.
+- [runtime-integration-guide.md](runtime-integration-guide.md): how runtimes fit into OpenDucktor and what a new runtime integration requires.
+
+## Workflow Docs
+
+- [task-workflow-status-model.md](task-workflow-status-model.md): canonical task statuses, metadata ownership, and issue-type rules.
+- [task-workflow-actions.md](task-workflow-actions.md): canonical workflow actions and UI rendering expectations.
+- [task-workflow-transition-matrix.md](task-workflow-transition-matrix.md): allowed transitions, guards, and invalid examples.
+
+## Runtime And Architecture Docs
+
+- [agent-orchestrator-module-map.md](agent-orchestrator-module-map.md): maintainer map for the desktop agent orchestration modules.
+- [agent-runtime-implementation-plan.md](agent-runtime-implementation-plan.md): runtime abstraction plan and guardrails.
+- [agent-ui-library-evaluation.md](agent-ui-library-evaluation.md): reasoning behind the current agent UI approach.
+- [runtime-integration-guide.md](runtime-integration-guide.md): runtime vocabulary, capability model, integration checklist, and verification path.
+
+## Security And Maintenance Docs
+
+- [mcp-runtime-security.md](mcp-runtime-security.md): current MCP transport and threat assumptions.
+- [desktop-csp-hardening.md](desktop-csp-hardening.md): current desktop CSP baseline and hardening plan.
+- [dependency-hygiene.md](dependency-hygiene.md): dependency update and audit policy.
+
+## Notes On Scope
+
+- These docs describe the current codebase, not a stable public product contract.
+- OpenDucktor is still early, macOS-first, and not ready for general use yet.
+- The only supported runtime today is OpenCode (`opencode`).
+- Codex is the next planned runtime.
+- OpenDucktor will support open source agent runtimes only; Claude Code is out of scope.

--- a/docs/agent-runtime-implementation-plan.md
+++ b/docs/agent-runtime-implementation-plan.md
@@ -11,6 +11,13 @@ Make `AgentRuntime` a first-class concept across OpenDucktor so that adding a ne
 
 OpenCode-specific behavior must remain isolated to adapter/infra layers.
 
+Current product reality:
+
+- The only supported runtime today is OpenCode (`opencode`).
+- Codex is the next planned runtime.
+- OpenDucktor will support open source agent runtimes only.
+- Claude Code is out of scope.
+
 ## Core Domain Model
 
 ### Runtime identity

--- a/docs/agent-runtime-implementation-plan.md
+++ b/docs/agent-runtime-implementation-plan.md
@@ -15,7 +15,7 @@ Current product reality:
 
 - The only supported runtime today is OpenCode (`opencode`).
 - Codex is the next planned runtime.
-- OpenDucktor will support open source agent runtimes only.
+- OpenDucktor will support open-source agent runtimes only.
 - Claude Code is out of scope.
 
 ## Core Domain Model

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -8,6 +8,11 @@ Use it to answer:
 - where to change code safely,
 - what runtime path a user action follows.
 
+Current scope note:
+
+- The only supported runtime today is OpenCode (`opencode`).
+- OpenDucktor is currently macOS-first and early-stage.
+
 ## Layer Map
 | Layer | Primary modules | Owns | Must not own |
 |---|---|---|---|

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -17,7 +17,7 @@ This guide describes the integration model, not the list of runtimes that are al
 
 - The only supported runtime today is OpenCode (`opencode`).
 - Codex is the next planned runtime.
-- OpenDucktor will support open source agent runtimes only.
+- OpenDucktor will support open-source agent runtimes only.
 - Claude Code is intentionally out of scope.
 
 ## Runtime Vocabulary

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -11,6 +11,15 @@ Use it when you need to:
 - verify whether a runtime is eligible for integration,
 - and implement the required changes across contracts, adapters, desktop orchestration, and the Rust host.
 
+## Current Support Policy
+
+This guide describes the integration model, not the list of runtimes that are already supported in production.
+
+- The only supported runtime today is OpenCode (`opencode`).
+- Codex is the next planned runtime.
+- OpenDucktor will support open source agent runtimes only.
+- Claude Code is intentionally out of scope.
+
 ## Runtime Vocabulary
 
 OpenDucktor uses several runtime-related payloads. Each one describes a different layer of the system.
@@ -106,6 +115,7 @@ Canonical capability schema: `packages/contracts/src/agent-runtime-schemas.ts`
 | `supportsProfiles` | Optional enhancement | Runtime supports named profiles or agents | Session start flow and repo settings | Profile selectors read this before showing profile choices |
 | `supportsVariants` | Optional enhancement | Runtime supports model variants | Session start flow and repo settings | Variant selectors read this before showing variant choices |
 | `supportsOdtWorkflowTools` | Product-required capability | Runtime can execute ODT workflow tools | Workflow roles and tool policy | Built-in OpenDucktor roles rely on this when the runtime runs ODT tools |
+| `supportsSessionFork` | Product-required capability | Runtime can fork or branch an existing session | Session controls and workflow continuity | Runtime validation rejects integrations that cannot support OpenDucktor's fork-capable session model |
 | `supportsPermissionRequests` | Optional enhancement | Runtime can emit permission prompts | Session event handling | Permission reply flows are only needed if the runtime emits permission prompts |
 | `supportsQuestionRequests` | Optional enhancement | Runtime can emit question prompts | Session event handling | Question reply flows are only needed if the runtime emits question prompts |
 | `supportsTodos` | Optional enhancement | Runtime can list session todo items | Session warmup and event refresh | Todo warmup and refresh logic read from this surface |
@@ -117,7 +127,7 @@ Canonical capability schema: `packages/contracts/src/agent-runtime-schemas.ts`
 
 The current codebase treats runtime integration in three layers:
 
-- `Baseline runtime contract`: session lifecycle, streaming events, model catalog, history, and runtime diagnostics are treated as part of the required OpenDucktor runtime surface rather than as capability toggles.
+- `Baseline runtime contract`: session lifecycle, streaming events, model catalog, history, runtime diagnostics, and session fork support are treated as part of the required OpenDucktor runtime surface rather than as optional capability toggles.
 - `Required workflow scope coverage`: `supportedScopes` must include `workspace`, `task`, and `build`. OpenDucktor does not support runtimes that cover only a subset of roles.
 - `Optional enhancement`: the application can work without these. The UI and runtime-health flow gate these features explicitly instead of assuming support.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "tauri": "cd apps/desktop && bun run tauri",
     "tauri:dev": "cd apps/desktop && bun run tauri:dev",
     "tauri:build": "cd apps/desktop && bun run tauri:build",
+    "check:rust": "cd apps/desktop/src-tauri && cargo check",
+    "test:rust": "cd apps/desktop/src-tauri && cargo test",
     "build": "bun run --workspaces build",
     "typecheck": "bun run --workspaces typecheck",
     "test": "bun run --workspaces test",


### PR DESCRIPTION
## Summary
- rewrite the README for a public early-stage open source audience
- add contribution, security, code of conduct, license, and issue/PR template files
- tighten docs around current runtime support and public project scope

## Testing
- not run (documentation-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with clearer overview and local setup instructions.
  * Added CONTRIBUTING and docs index plus architecture/runtime notes reflecting current scope.
  * Added runtime integration guidance including session fork capability.

* **Chores**
  * Added Apache 2.0 license and Code of Conduct.
  * Added standardized issue and pull request templates and issue configuration (disables blank issues, adds contact links).
  * Added security policy.
  * Added scripts for Rust checks/tests to project tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->