### PR TITLE
fix: validate persisted sessions and surface hydration failures

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
@@ -69,7 +69,7 @@ impl AppService {
         let sessions = self.agent_sessions_list(repo_path.as_str(), task_id)?;
         let latest_builder_session = sessions
             .into_iter()
-            .filter(|session| session.role == "build")
+            .filter(|session| TaskAgentRole::parse(session.role.trim()) == Some(TaskAgentRole::Build))
             .max_by(|left, right| {
                 session_sort_key(left)
                     .cmp(&session_sort_key(right))
@@ -103,46 +103,90 @@ fn session_sort_key(session: &AgentSessionDocument) -> (&str, &str) {
     )
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TaskAgentRole {
+    Spec,
+    Planner,
+    Build,
+    Qa,
+}
+
+impl TaskAgentRole {
+    fn parse(raw_role: &str) -> Option<Self> {
+        match raw_role {
+            "spec" => Some(Self::Spec),
+            "planner" => Some(Self::Planner),
+            "build" => Some(Self::Build),
+            "qa" => Some(Self::Qa),
+            _ => None,
+        }
+    }
+}
+
 fn validate_task_agent_session(
     service: &AppService,
     repo_path: &str,
     session: &AgentSessionDocument,
 ) -> Result<()> {
-    let role = session.role.trim();
-    if !matches!(role, "spec" | "planner" | "build" | "qa") {
-        return Err(anyhow!(
+    TaskAgentRole::parse(session.role.trim()).ok_or_else(|| {
+        anyhow!(
             "Agent session role must be one of spec, planner, build, or qa. Received: {}",
             session.role
-        ));
-    }
+        )
+    })?;
 
     let working_directory = session.working_directory.trim();
     if working_directory.is_empty() {
         return Err(anyhow!("Agent session workingDirectory is required"));
     }
 
-    let normalized_repo = normalize_path_for_comparison(repo_path);
-    let normalized_working_directory = normalize_path_for_comparison(working_directory);
-    if normalized_working_directory.starts_with(&normalized_repo) {
+    let canonical_repo = canonicalize_existing_path(
+        repo_path,
+        "Repository path for agent session validation must exist and be accessible",
+    )?;
+    let canonical_working_directory = canonicalize_existing_path(
+        working_directory,
+        "Agent session workingDirectory must exist and be accessible",
+    )?;
+    if canonical_working_directory.starts_with(&canonical_repo) {
         return Ok(());
     }
 
     let effective_worktree_base_path = service
         .workspace_list()?
         .into_iter()
-        .find(|workspace| normalize_path_for_comparison(workspace.path.as_str()) == normalized_repo)
+        .find(|workspace| {
+            try_canonicalize_existing_path(workspace.path.as_str())
+                .is_some_and(|workspace_path| workspace_path == canonical_repo)
+        })
         .and_then(|workspace| workspace.effective_worktree_base_path);
 
     if let Some(worktree_base_path) = effective_worktree_base_path {
-        let normalized_worktree_base_path = normalize_path_for_comparison(&worktree_base_path);
-        if normalized_working_directory.starts_with(&normalized_worktree_base_path) {
-            return Ok(());
+        if let Some(canonical_worktree_base_path) =
+            try_canonicalize_existing_path(&worktree_base_path)
+        {
+            if canonical_working_directory.starts_with(&canonical_worktree_base_path) {
+                return Ok(());
+            }
         }
     }
 
     Err(anyhow!(
         "Agent session workingDirectory must stay inside repository {repo_path} or its effective worktree base. Received: {working_directory}"
     ))
+}
+
+fn canonicalize_existing_path(path: &str, error_message: &str) -> Result<PathBuf> {
+    fs::canonicalize(path.trim()).with_context(|| format!("{error_message}: {}", path.trim()))
+}
+
+fn try_canonicalize_existing_path(path: &str) -> Option<PathBuf> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    fs::canonicalize(trimmed).ok()
 }
 
 fn normalize_path_for_comparison(path: &str) -> PathBuf {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
@@ -23,6 +23,7 @@ impl AppService {
         if session.task_id.as_deref() != Some(task_id) {
             session.task_id = Some(task_id.to_string());
         }
+        validate_task_agent_session(self, repo_path.as_str(), &session)?;
         self.task_store
             .upsert_agent_session(Path::new(&repo_path), task_id, session)
             .with_context(|| format!("Failed to persist agent session for {task_id}"))?;
@@ -100,6 +101,48 @@ fn session_sort_key(session: &AgentSessionDocument) -> (&str, &str) {
             .unwrap_or(session.started_at.as_str()),
         session.started_at.as_str(),
     )
+}
+
+fn validate_task_agent_session(
+    service: &AppService,
+    repo_path: &str,
+    session: &AgentSessionDocument,
+) -> Result<()> {
+    let role = session.role.trim();
+    if !matches!(role, "spec" | "planner" | "build" | "qa") {
+        return Err(anyhow!(
+            "Agent session role must be one of spec, planner, build, or qa. Received: {}",
+            session.role
+        ));
+    }
+
+    let working_directory = session.working_directory.trim();
+    if working_directory.is_empty() {
+        return Err(anyhow!("Agent session workingDirectory is required"));
+    }
+
+    let normalized_repo = normalize_path_for_comparison(repo_path);
+    let normalized_working_directory = normalize_path_for_comparison(working_directory);
+    if normalized_working_directory.starts_with(&normalized_repo) {
+        return Ok(());
+    }
+
+    let effective_worktree_base_path = service
+        .workspace_list()?
+        .into_iter()
+        .find(|workspace| normalize_path_for_comparison(workspace.path.as_str()) == normalized_repo)
+        .and_then(|workspace| workspace.effective_worktree_base_path);
+
+    if let Some(worktree_base_path) = effective_worktree_base_path {
+        let normalized_worktree_base_path = normalize_path_for_comparison(&worktree_base_path);
+        if normalized_working_directory.starts_with(&normalized_worktree_base_path) {
+            return Ok(());
+        }
+    }
+
+    Err(anyhow!(
+        "Agent session workingDirectory must stay inside repository {repo_path} or its effective worktree base. Received: {working_directory}"
+    ))
 }
 
 fn normalize_path_for_comparison(path: &str) -> PathBuf {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -1464,3 +1464,126 @@ fn agent_sessions_list_and_upsert_flow_through_store() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn agent_session_upsert_rejects_working_directory_outside_repo_and_worktree_base() -> Result<()> {
+    let repo_root = unique_temp_path("session-upsert-invalid-workdir");
+    let repo = repo_root.join("repo");
+    init_git_repo(&repo)?;
+    let external = repo_root.join("external");
+    fs::create_dir_all(&external)?;
+
+    let config_store = AppConfigStore::from_path(repo_root.join("config.json"));
+    let repo_path = fs::canonicalize(&repo)?.to_string_lossy().to_string();
+    let (service, task_state, _git_state) = build_service_with_store(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+
+    let mut session = make_session("task-1", "session-invalid");
+    session.working_directory = external.to_string_lossy().to_string();
+
+    let error = service
+        .agent_session_upsert(repo_path.as_str(), "task-1", session)
+        .expect_err("upsert should reject working directories outside repo/worktree base");
+
+    assert!(error.to_string().contains("must stay inside repository"));
+    assert!(task_state
+        .lock()
+        .expect("task lock poisoned")
+        .upserted_sessions
+        .is_empty());
+    Ok(())
+}
+
+#[test]
+fn agent_session_upsert_accepts_working_directory_inside_effective_worktree_base() -> Result<()> {
+    let repo_root = unique_temp_path("session-upsert-worktree-base");
+    let repo = repo_root.join("repo");
+    let worktree_base = repo_root.join("worktrees");
+    let worktree = worktree_base.join("task-1");
+    init_git_repo(&repo)?;
+    fs::create_dir_all(&worktree)?;
+
+    let config_store = AppConfigStore::from_path(repo_root.join("config.json"));
+    let repo_path = fs::canonicalize(&repo)?.to_string_lossy().to_string();
+    let (service, task_state, _git_state) = build_service_with_store(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            ..RepoConfig::default()
+        },
+    )?;
+
+    let mut session = make_session("task-1", "session-worktree");
+    session.working_directory = worktree.to_string_lossy().to_string();
+
+    let upserted = service.agent_session_upsert(repo_path.as_str(), "task-1", session)?;
+    assert!(upserted);
+    assert_eq!(
+        task_state
+            .lock()
+            .expect("task lock poisoned")
+            .upserted_sessions
+            .len(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
+fn agent_session_upsert_rejects_unknown_role() -> Result<()> {
+    let repo_root = unique_temp_path("session-upsert-invalid-role");
+    let repo = repo_root.join("repo");
+    init_git_repo(&repo)?;
+
+    let config_store = AppConfigStore::from_path(repo_root.join("config.json"));
+    let repo_path = fs::canonicalize(&repo)?.to_string_lossy().to_string();
+    let (service, task_state, _git_state) = build_service_with_store(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+
+    let mut session = make_session("task-1", "session-invalid-role");
+    session.role = "workspace".to_string();
+    session.working_directory = repo_path.clone();
+
+    let error = service
+        .agent_session_upsert(repo_path.as_str(), "task-1", session)
+        .expect_err("upsert should reject unknown agent session roles");
+
+    assert!(error.to_string().contains("role must be one of spec, planner, build, or qa"));
+    assert!(
+        task_state
+            .lock()
+            .expect("task lock poisoned")
+            .upserted_sessions
+            .is_empty()
+    );
+    Ok(())
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -1430,6 +1430,8 @@ fn qa_rejected_rejects_non_ai_review_tasks() {
 #[test]
 fn agent_sessions_list_and_upsert_flow_through_store() -> Result<()> {
     let repo_path = "/tmp/odt-repo-sessions";
+    fs::create_dir_all(repo_path)?;
+    init_git_repo(Path::new(repo_path))?;
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
@@ -1439,20 +1441,21 @@ fn agent_sessions_list_and_upsert_flow_through_store() -> Result<()> {
             revision: None,
         },
     );
+    service.workspace_add(repo_path)?;
     {
         let mut state = task_state.lock().expect("task lock poisoned");
-        state.agent_sessions = vec![make_session("task-1", "session-1")];
+        let mut existing_session = make_session("task-1", "session-1");
+        existing_session.working_directory = repo_path.to_string();
+        state.agent_sessions = vec![existing_session];
     }
 
     let sessions = service.agent_sessions_list(repo_path, "task-1")?;
     assert_eq!(sessions.len(), 1);
     assert_eq!(sessions[0].session_id, "session-1");
 
-    let upserted = service.agent_session_upsert(
-        repo_path,
-        "task-1",
-        make_session("wrong-task", "session-2"),
-    )?;
+    let mut upsert_session = make_session("wrong-task", "session-2");
+    upsert_session.working_directory = repo_path.to_string();
+    let upserted = service.agent_session_upsert(repo_path, "task-1", upsert_session)?;
     assert!(upserted);
 
     let task_state = task_state.lock().expect("task lock poisoned");
@@ -1493,6 +1496,48 @@ fn agent_session_upsert_rejects_working_directory_outside_repo_and_worktree_base
     let error = service
         .agent_session_upsert(repo_path.as_str(), "task-1", session)
         .expect_err("upsert should reject working directories outside repo/worktree base");
+
+    assert!(error.to_string().contains("must stay inside repository"));
+    assert!(task_state
+        .lock()
+        .expect("task lock poisoned")
+        .upserted_sessions
+        .is_empty());
+    Ok(())
+}
+
+#[test]
+fn agent_session_upsert_rejects_parent_directory_traversal_working_directory() -> Result<()> {
+    let repo_root = unique_temp_path("session-upsert-parent-traversal");
+    let repo = repo_root.join("repo");
+    let external = repo_root.join("external");
+    init_git_repo(&repo)?;
+    fs::create_dir_all(&external)?;
+
+    let config_store = AppConfigStore::from_path(repo_root.join("config.json"));
+    let repo_path = fs::canonicalize(&repo)?.to_string_lossy().to_string();
+    let (service, task_state, _git_state) = build_service_with_store(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+
+    let mut session = make_session("task-1", "session-parent-traversal");
+    session.working_directory = repo
+        .join("..")
+        .join("external")
+        .to_string_lossy()
+        .to_string();
+
+    let error = service
+        .agent_session_upsert(repo_path.as_str(), "task-1", session)
+        .expect_err("upsert should reject lexical traversal outside the repo");
 
     assert!(error.to_string().contains("must stay inside repository"));
     assert!(task_state
@@ -1577,13 +1622,13 @@ fn agent_session_upsert_rejects_unknown_role() -> Result<()> {
         .agent_session_upsert(repo_path.as_str(), "task-1", session)
         .expect_err("upsert should reject unknown agent session roles");
 
-    assert!(error.to_string().contains("role must be one of spec, planner, build, or qa"));
-    assert!(
-        task_state
-            .lock()
-            .expect("task lock poisoned")
-            .upserted_sessions
-            .is_empty()
-    );
+    assert!(error
+        .to_string()
+        .contains("role must be one of spec, planner, build, or qa"));
+    assert!(task_state
+        .lock()
+        .expect("task lock poisoned")
+        .upserted_sessions
+        .is_empty());
     Ok(())
 }

--- a/apps/desktop/src/pages/agents/agents-page.tsx
+++ b/apps/desktop/src/pages/agents/agents-page.tsx
@@ -445,6 +445,8 @@ type BuildAgentsPageOrchestrationContextsArgs = {
   contextSwitchVersion: AgentStudioOrchestrationSelectionContext["contextSwitchVersion"];
   isLoadingTasks: AgentStudioOrchestrationSelectionContext["isLoadingTasks"];
   isActiveTaskHydrated: AgentStudioOrchestrationSelectionContext["isActiveTaskHydrated"];
+  isActiveTaskHydrationFailed: AgentStudioOrchestrationSelectionContext["isActiveTaskHydrationFailed"];
+  isViewSessionHistoryHydrationFailed: AgentStudioOrchestrationSelectionContext["isViewSessionHistoryHydrationFailed"];
   isViewSessionHistoryHydrating: AgentStudioOrchestrationSelectionContext["isViewSessionHistoryHydrating"];
   onCreateTab: AgentStudioOrchestrationSelectionContext["onCreateTab"];
   onCloseTab: AgentStudioOrchestrationSelectionContext["onCloseTab"];
@@ -480,6 +482,8 @@ function buildAgentsPageOrchestrationContexts({
   contextSwitchVersion,
   isLoadingTasks,
   isActiveTaskHydrated,
+  isActiveTaskHydrationFailed,
+  isViewSessionHistoryHydrationFailed,
   isViewSessionHistoryHydrating,
   onCreateTab,
   onCloseTab,
@@ -517,6 +521,8 @@ function buildAgentsPageOrchestrationContexts({
       contextSwitchVersion,
       isLoadingTasks,
       isActiveTaskHydrated,
+      isActiveTaskHydrationFailed,
+      isViewSessionHistoryHydrationFailed,
       isViewSessionHistoryHydrating,
       onCreateTab,
       onCloseTab,
@@ -633,13 +639,13 @@ export function AgentsPage(): ReactElement {
   }, [selection.viewSelectedTask]);
   const handleDetectPullRequest = useCallback(
     (taskId: string): void => {
-      void syncPullRequests(taskId).catch(() => undefined);
+      void syncPullRequests(taskId);
     },
     [syncPullRequests],
   );
   const handleUnlinkPullRequest = useCallback(
     (taskId: string): void => {
-      void unlinkPullRequest(taskId).catch(() => undefined);
+      void unlinkPullRequest(taskId);
     },
     [unlinkPullRequest],
   );
@@ -685,6 +691,8 @@ export function AgentsPage(): ReactElement {
       contextSwitchVersion,
       isLoadingTasks,
       isActiveTaskHydrated: selection.isActiveTaskHydrated,
+      isActiveTaskHydrationFailed: selection.isActiveTaskHydrationFailed,
+      isViewSessionHistoryHydrationFailed: selection.isViewSessionHistoryHydrationFailed,
       isViewSessionHistoryHydrating: selection.isViewSessionHistoryHydrating,
       onCreateTab: selection.handleCreateTab,
       onCloseTab: selection.handleCloseTab,

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -110,6 +110,7 @@ describe("buildAgentStudioPageModelsArgs", () => {
 
     expect(mapped.core.role).toBe("planner");
     expect(mapped.core.contextSwitchVersion).toBe(4);
+    expect(mapped.core.isSessionHistoryHydrationFailed).toBe(false);
     expect(mapped.taskTabs.onCreateTab).toBe(onCreateTab);
     expect(mapped.taskTabs.onCloseTab).toBe(onCloseTab);
     expect(mapped.documents.planDoc.markdown).toBe("# doc");
@@ -186,6 +187,18 @@ describe("buildAgentStudioPageModelsArgs", () => {
     });
 
     expect(failed.core.isTaskHydrating).toBe(false);
+  });
+
+  test("forwards explicit session history hydration failures into page-model core", () => {
+    const failed = buildAgentStudioPageModelsArgs({
+      ...baseArgs,
+      view: {
+        ...baseArgs.view,
+        isViewSessionHistoryHydrationFailed: true,
+      },
+    });
+
+    expect(failed.core.isSessionHistoryHydrationFailed).toBe(true);
   });
 
   test("derives contextSessionsLength from the sessions context size", () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -33,6 +33,8 @@ const baseArgs: BuildArgs = {
     viewSelectedTask: task,
     contextSwitchVersion: 4,
     isActiveTaskHydrated: true,
+    isActiveTaskHydrationFailed: false,
+    isViewSessionHistoryHydrationFailed: false,
     isViewSessionHistoryHydrating: false,
   },
   sessions: {
@@ -171,6 +173,19 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(hydrating.core.isTaskHydrating).toBe(true);
     expect(hydrated.core.isTaskHydrating).toBe(false);
     expect(noTaskSelected.core.isTaskHydrating).toBe(false);
+  });
+
+  test("stops reporting task hydration after hydration fails", () => {
+    const failed = buildAgentStudioPageModelsArgs({
+      ...baseArgs,
+      view: {
+        ...baseArgs.view,
+        isActiveTaskHydrated: false,
+        isActiveTaskHydrationFailed: true,
+      },
+    });
+
+    expect(failed.core.isTaskHydrating).toBe(false);
   });
 
   test("derives contextSessionsLength from the sessions context size", () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -31,6 +31,8 @@ export type AgentStudioOrchestrationSelectionContext = {
   contextSwitchVersion: number;
   isLoadingTasks: boolean;
   isActiveTaskHydrated: boolean;
+  isActiveTaskHydrationFailed: boolean;
+  isViewSessionHistoryHydrationFailed: boolean;
   isViewSessionHistoryHydrating: boolean;
   onCreateTab: (taskId: string) => void;
   onCloseTab: (taskId: string) => void;
@@ -90,6 +92,8 @@ type AgentStudioPageModelsViewContext = Pick<
   | "viewSelectedTask"
   | "contextSwitchVersion"
   | "isActiveTaskHydrated"
+  | "isActiveTaskHydrationFailed"
+  | "isViewSessionHistoryHydrationFailed"
   | "isViewSessionHistoryHydrating"
 >;
 
@@ -172,7 +176,9 @@ export const buildAgentStudioPageModelsArgs = ({
       sessionsForTask: sessions.viewSessionsForTask,
       contextSessionsLength: sessions.viewSessionsForTask.length,
       activeSession: sessions.viewActiveSession,
-      isTaskHydrating: Boolean(view.viewTaskId && !view.isActiveTaskHydrated),
+      isTaskHydrating: Boolean(
+        view.viewTaskId && !view.isActiveTaskHydrated && !view.isActiveTaskHydrationFailed,
+      ),
       isSessionHistoryHydrating: view.isViewSessionHistoryHydrating,
       contextSwitchVersion: view.contextSwitchVersion,
     },
@@ -313,6 +319,8 @@ export function useAgentStudioOrchestrationController({
       viewSelectedTask,
       contextSwitchVersion,
       isActiveTaskHydrated,
+      isActiveTaskHydrationFailed: selection.isActiveTaskHydrationFailed,
+      isViewSessionHistoryHydrationFailed: selection.isViewSessionHistoryHydrationFailed,
       isViewSessionHistoryHydrating: selection.isViewSessionHistoryHydrating,
     },
     sessions: {

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -180,6 +180,7 @@ export const buildAgentStudioPageModelsArgs = ({
         view.viewTaskId && !view.isActiveTaskHydrated && !view.isActiveTaskHydrationFailed,
       ),
       isSessionHistoryHydrating: view.isViewSessionHistoryHydrating,
+      isSessionHistoryHydrationFailed: view.isViewSessionHistoryHydrationFailed,
       contextSwitchVersion: view.contextSwitchVersion,
     },
     taskTabs,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -83,6 +83,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     selectedTask: createTask(),
     isTaskHydrating: false,
     isSessionHistoryHydrating: false,
+    isSessionHistoryHydrationFailed: false,
     contextSwitchVersion: 0,
     ...overrides.core,
     sessionsForTask,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -67,6 +67,7 @@ type AgentStudioCoreContext = {
   activeSession: AgentSessionState | null;
   isTaskHydrating: boolean;
   isSessionHistoryHydrating: boolean;
+  isSessionHistoryHydrationFailed: boolean;
   contextSwitchVersion: number;
 };
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -42,7 +42,9 @@ type UseAgentStudioSelectionControllerResult = {
   viewRole: AgentRole;
   viewScenario: AgentScenario;
   isActiveTaskHydrated: boolean;
+  isActiveTaskHydrationFailed: boolean;
   isViewSessionHistoryHydrated: boolean;
+  isViewSessionHistoryHydrationFailed: boolean;
   isViewSessionHistoryHydrating: boolean;
 };
 
@@ -261,7 +263,9 @@ export function useAgentStudioSelectionController({
 
   const {
     hydratedTasksByRepoAndTask,
+    isActiveTaskHydrationFailed,
     isActiveSessionHistoryHydrated,
+    isActiveSessionHistoryHydrationFailed,
     isActiveSessionHistoryHydrating,
   } = useAgentStudioTaskHydration({
     activeRepo,
@@ -294,7 +298,9 @@ export function useAgentStudioSelectionController({
     viewRole,
     viewScenario,
     isActiveTaskHydrated,
+    isActiveTaskHydrationFailed,
     isViewSessionHistoryHydrated: isActiveSessionHistoryHydrated,
+    isViewSessionHistoryHydrationFailed: isActiveSessionHistoryHydrationFailed,
     isViewSessionHistoryHydrating: isActiveSessionHistoryHydrating,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -157,6 +157,7 @@ describe("useAgentStudioTaskHydration", () => {
     try {
       await harness.mount();
       await harness.waitFor(() => loadAgentSessions.mock.calls.length === 1);
+      expect(harness.getLatest().isActiveTaskHydrationFailed).toBe(true);
       expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(true);
       expect(harness.getLatest().isActiveSessionHistoryHydrated).toBe(false);
       expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(false);

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -204,4 +204,52 @@ describe("useAgentStudioTaskHydration", () => {
       await harness.unmount();
     }
   });
+
+  test("retries task hydration after a cancelled in-flight load clears its pending state", async () => {
+    const firstTaskLoad = createDeferred<void>();
+    const secondTaskLoad = createDeferred<void>();
+    let taskOneLoadCount = 0;
+    const loadAgentSessions = mock(async (taskId: string) => {
+      if (taskId === "task-1") {
+        taskOneLoadCount += 1;
+        return taskOneLoadCount === 1 ? firstTaskLoad.promise : secondTaskLoad.promise;
+      }
+    });
+    const harness = createHookHarness(createBaseArgs({ loadAgentSessions }));
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => loadAgentSessions.mock.calls.length === 1);
+
+      await harness.update(
+        createBaseArgs({
+          activeTaskId: "task-2",
+          loadAgentSessions,
+        }),
+      );
+      await harness.waitFor(() => loadAgentSessions.mock.calls.length === 2);
+
+      await harness.update(createBaseArgs({ loadAgentSessions }));
+      expect(loadAgentSessions.mock.calls.length).toBe(2);
+
+      await harness.run(async () => {
+        firstTaskLoad.resolve(undefined);
+        await firstTaskLoad.promise;
+      });
+
+      await harness.waitFor(() => loadAgentSessions.mock.calls.length === 3);
+
+      await harness.run(async () => {
+        secondTaskLoad.resolve(undefined);
+        await secondTaskLoad.promise;
+      });
+
+      await harness.waitFor((state) => state.hydratedTasksByRepoAndTask["/repo-a:task-1"] === true);
+      expect(harness.getLatest().isActiveTaskHydrationFailed).toBe(false);
+    } finally {
+      firstTaskLoad.resolve(undefined);
+      secondTaskLoad.resolve(undefined);
+      await harness.unmount();
+    }
+  });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -120,6 +120,7 @@ describe("useAgentStudioTaskHydration", () => {
       await harness.mount();
       await harness.waitFor(() => loadAgentSessions.mock.calls.length === 1);
       expect(harness.getLatest().hydratedTasksByRepoAndTask["/repo-a:task-1"]).toBeUndefined();
+      expect(harness.getLatest().isActiveTaskHydrationFailed).toBe(true);
       expect(loadAgentSessions).toHaveBeenCalledTimes(1);
 
       await harness.update(
@@ -134,6 +135,31 @@ describe("useAgentStudioTaskHydration", () => {
       await harness.update(args);
       await harness.waitFor(() => loadAgentSessions.mock.calls.length === 3);
       expect(harness.getLatest().hydratedTasksByRepoAndTask["/repo-a:task-1"]).toBe(true);
+      expect(harness.getLatest().isActiveTaskHydrationFailed).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("marks session history hydration as failed when loading history rejects", async () => {
+    const loadAgentSessions = mock(async (_taskId: string, options?: AgentSessionLoadOptions) => {
+      if (options?.hydrateHistoryForSessionId === "session-1") {
+        throw new Error("history failed");
+      }
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeSessionId: "session-1",
+        loadAgentSessions,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => loadAgentSessions.mock.calls.length === 1);
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(true);
+      expect(harness.getLatest().isActiveSessionHistoryHydrated).toBe(false);
+      expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(false);
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -10,7 +10,9 @@ type UseAgentStudioTaskHydrationParams = {
 
 type UseAgentStudioTaskHydrationResult = {
   hydratedTasksByRepoAndTask: Record<string, boolean>;
+  isActiveTaskHydrationFailed: boolean;
   isActiveSessionHistoryHydrated: boolean;
+  isActiveSessionHistoryHydrationFailed: boolean;
   isActiveSessionHistoryHydrating: boolean;
 };
 
@@ -27,8 +29,11 @@ export function useAgentStudioTaskHydration({
   const [hydratedTasksByRepoAndTask, setHydratedTasksByRepoAndTask] = useState<
     Record<string, boolean>
   >({});
+  const [taskHydrationStatusByRepoKey, setTaskHydrationStatusByRepoKey] = useState<
+    Record<string, "hydrating" | "hydrated" | "failed">
+  >({});
   const [sessionHistoryStatusByRepoKey, setSessionHistoryStatusByRepoKey] = useState<
-    Record<string, "hydrating" | "hydrated">
+    Record<string, "hydrating" | "hydrated" | "failed">
   >({});
 
   useEffect(() => {
@@ -40,6 +45,7 @@ export function useAgentStudioTaskHydration({
     hydratingSessionHistoriesByRepoRef.current.clear();
     hydratedSessionHistoriesByRepoRef.current.clear();
     setHydratedTasksByRepoAndTask({});
+    setTaskHydrationStatusByRepoKey({});
     setSessionHistoryStatusByRepoKey({});
   }, [activeRepo]);
 
@@ -57,6 +63,10 @@ export function useAgentStudioTaskHydration({
     }
 
     hydratingTasksByRepoRef.current.add(hydrationKey);
+    setTaskHydrationStatusByRepoKey((current) => ({
+      ...current,
+      [hydrationKey]: "hydrating",
+    }));
     let cancelled = false;
     void loadAgentSessions(activeTaskId)
       .then(() => {
@@ -72,9 +82,19 @@ export function useAgentStudioTaskHydration({
             [hydrationKey]: true,
           };
         });
+        setTaskHydrationStatusByRepoKey((current) => ({
+          ...current,
+          [hydrationKey]: "hydrated",
+        }));
       })
       .catch(() => {
-        // Keep task unhydrated so callers can retry after load failures.
+        if (cancelled) {
+          return;
+        }
+        setTaskHydrationStatusByRepoKey((current) => ({
+          ...current,
+          [hydrationKey]: "failed",
+        }));
       })
       .finally(() => {
         hydratingTasksByRepoRef.current.delete(hydrationKey);
@@ -121,6 +141,10 @@ export function useAgentStudioTaskHydration({
             [taskHydrationKey]: true,
           };
         });
+        setTaskHydrationStatusByRepoKey((current) => ({
+          ...current,
+          [taskHydrationKey]: "hydrated",
+        }));
         hydratedSessionHistoriesByRepoRef.current.add(sessionHydrationKey);
         setSessionHistoryStatusByRepoKey((current) => ({
           ...current,
@@ -128,10 +152,14 @@ export function useAgentStudioTaskHydration({
         }));
       })
       .catch(() => {
-        // Keep history unhydrated so callers can retry after load failures.
+        if (cancelled) {
+          return;
+        }
         setSessionHistoryStatusByRepoKey((current) => {
-          const { [sessionHydrationKey]: _removed, ...rest } = current;
-          return rest;
+          return {
+            ...current,
+            [sessionHydrationKey]: "failed",
+          };
         });
       })
       .finally(() => {
@@ -150,10 +178,16 @@ export function useAgentStudioTaskHydration({
   const activeSessionHistoryStatus = activeSessionHistoryKey
     ? sessionHistoryStatusByRepoKey[activeSessionHistoryKey]
     : undefined;
+  const activeTaskHydrationKey = activeRepo && activeTaskId ? `${activeRepo}:${activeTaskId}` : "";
+  const activeTaskHydrationStatus = activeTaskHydrationKey
+    ? taskHydrationStatusByRepoKey[activeTaskHydrationKey]
+    : undefined;
 
   return {
     hydratedTasksByRepoAndTask,
+    isActiveTaskHydrationFailed: activeTaskHydrationStatus === "failed",
     isActiveSessionHistoryHydrated: activeSessionHistoryStatus === "hydrated",
+    isActiveSessionHistoryHydrationFailed: activeSessionHistoryStatus === "failed",
     isActiveSessionHistoryHydrating: activeSessionHistoryStatus === "hydrating",
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from "react";
 import { errorMessage } from "@/lib/errors";
 import type { AgentSessionLoadOptions } from "@/types/agent-orchestrator";
 
@@ -17,6 +17,21 @@ type UseAgentStudioTaskHydrationResult = {
   isActiveSessionHistoryHydrating: boolean;
 };
 
+type HydrationStatus = "hydrating" | "hydrated" | "failed";
+
+const clearHydrationStatus = (
+  key: string,
+  setStatus: Dispatch<SetStateAction<Record<string, HydrationStatus>>>,
+): void => {
+  setStatus((current) => {
+    if (current[key] !== "hydrating") {
+      return current;
+    }
+    const { [key]: _removed, ...rest } = current;
+    return rest;
+  });
+};
+
 export function useAgentStudioTaskHydration({
   activeRepo,
   activeTaskId,
@@ -31,11 +46,12 @@ export function useAgentStudioTaskHydration({
     Record<string, boolean>
   >({});
   const [taskHydrationStatusByRepoKey, setTaskHydrationStatusByRepoKey] = useState<
-    Record<string, "hydrating" | "hydrated" | "failed">
+    Record<string, HydrationStatus>
   >({});
   const [sessionHistoryStatusByRepoKey, setSessionHistoryStatusByRepoKey] = useState<
-    Record<string, "hydrating" | "hydrated" | "failed">
+    Record<string, HydrationStatus>
   >({});
+  const [hydrationRetryVersion, setHydrationRetryVersion] = useState(0);
 
   useEffect(() => {
     if (previousRepoRef.current === activeRepo) {
@@ -50,12 +66,18 @@ export function useAgentStudioTaskHydration({
     setSessionHistoryStatusByRepoKey({});
   }, [activeRepo]);
 
+  const activeTaskHydrationKey = activeRepo && activeTaskId ? `${activeRepo}:${activeTaskId}` : "";
+  const activeSessionHistoryKey =
+    activeRepo && activeTaskId && activeSessionId
+      ? `${activeRepo}:${activeTaskId}:${activeSessionId}`
+      : "";
+
   useEffect(() => {
     if (!activeRepo || !activeTaskId || activeSessionId) {
       return;
     }
 
-    const hydrationKey = `${activeRepo}:${activeTaskId}`;
+    const hydrationKey = activeTaskHydrationKey;
     if (hydratedTasksByRepoAndTask[hydrationKey]) {
       return;
     }
@@ -68,6 +90,7 @@ export function useAgentStudioTaskHydration({
       ...current,
       [hydrationKey]: "hydrating",
     }));
+    const currentHydrationRetryVersion = hydrationRetryVersion;
     let cancelled = false;
     void loadAgentSessions(activeTaskId)
       .then(() => {
@@ -102,20 +125,34 @@ export function useAgentStudioTaskHydration({
       })
       .finally(() => {
         hydratingTasksByRepoRef.current.delete(hydrationKey);
+        if (cancelled) {
+          clearHydrationStatus(hydrationKey, setTaskHydrationStatusByRepoKey);
+          setHydrationRetryVersion((current) =>
+            current === currentHydrationRetryVersion ? current + 1 : current,
+          );
+        }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [activeRepo, activeSessionId, activeTaskId, hydratedTasksByRepoAndTask, loadAgentSessions]);
+  }, [
+    activeRepo,
+    activeSessionId,
+    activeTaskHydrationKey,
+    activeTaskId,
+    hydrationRetryVersion,
+    hydratedTasksByRepoAndTask,
+    loadAgentSessions,
+  ]);
 
   useEffect(() => {
     if (!activeRepo || !activeTaskId || !activeSessionId) {
       return;
     }
 
-    const taskHydrationKey = `${activeRepo}:${activeTaskId}`;
-    const sessionHydrationKey = `${activeRepo}:${activeTaskId}:${activeSessionId}`;
+    const taskHydrationKey = activeTaskHydrationKey;
+    const sessionHydrationKey = activeSessionHistoryKey;
     if (hydratedSessionHistoriesByRepoRef.current.has(sessionHydrationKey)) {
       return;
     }
@@ -128,6 +165,7 @@ export function useAgentStudioTaskHydration({
       ...current,
       [sessionHydrationKey]: "hydrating",
     }));
+    const currentHydrationRetryVersion = hydrationRetryVersion;
     let cancelled = false;
     void loadAgentSessions(activeTaskId, {
       hydrateHistoryForSessionId: activeSessionId,
@@ -180,23 +218,32 @@ export function useAgentStudioTaskHydration({
       })
       .finally(() => {
         hydratingSessionHistoriesByRepoRef.current.delete(sessionHydrationKey);
+        if (cancelled) {
+          clearHydrationStatus(sessionHydrationKey, setSessionHistoryStatusByRepoKey);
+          setHydrationRetryVersion((current) =>
+            current === currentHydrationRetryVersion ? current + 1 : current,
+          );
+        }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [activeRepo, activeSessionId, activeTaskId, loadAgentSessions]);
+  }, [
+    activeRepo,
+    activeSessionHistoryKey,
+    activeSessionId,
+    activeTaskHydrationKey,
+    activeTaskId,
+    hydrationRetryVersion,
+    loadAgentSessions,
+  ]);
 
-  const activeSessionHistoryKey =
-    activeRepo && activeTaskId && activeSessionId
-      ? `${activeRepo}:${activeTaskId}:${activeSessionId}`
-      : "";
-  const activeSessionHistoryStatus = activeSessionHistoryKey
-    ? sessionHistoryStatusByRepoKey[activeSessionHistoryKey]
-    : undefined;
-  const activeTaskHydrationKey = activeRepo && activeTaskId ? `${activeRepo}:${activeTaskId}` : "";
   const activeTaskHydrationStatus = activeTaskHydrationKey
     ? taskHydrationStatusByRepoKey[activeTaskHydrationKey]
+    : undefined;
+  const activeSessionHistoryStatus = activeSessionHistoryKey
+    ? sessionHistoryStatusByRepoKey[activeSessionHistoryKey]
     : undefined;
 
   return {

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { errorMessage } from "@/lib/errors";
 import type { AgentSessionLoadOptions } from "@/types/agent-orchestrator";
 
 type UseAgentStudioTaskHydrationParams = {
@@ -87,10 +88,13 @@ export function useAgentStudioTaskHydration({
           [hydrationKey]: "hydrated",
         }));
       })
-      .catch(() => {
+      .catch((error) => {
         if (cancelled) {
           return;
         }
+        console.warn(
+          `Failed to hydrate task session context for ${activeTaskId}: ${errorMessage(error)}`,
+        );
         setTaskHydrationStatusByRepoKey((current) => ({
           ...current,
           [hydrationKey]: "failed",
@@ -151,10 +155,22 @@ export function useAgentStudioTaskHydration({
           [sessionHydrationKey]: "hydrated",
         }));
       })
-      .catch(() => {
+      .catch((error) => {
         if (cancelled) {
           return;
         }
+        console.warn(
+          `Failed to hydrate session history for ${activeSessionId}: ${errorMessage(error)}`,
+        );
+        setTaskHydrationStatusByRepoKey((current) => {
+          if (current[taskHydrationKey] === "hydrated") {
+            return current;
+          }
+          return {
+            ...current,
+            [taskHydrationKey]: "failed",
+          };
+        });
         setSessionHistoryStatusByRepoKey((current) => {
           return {
             ...current,

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
@@ -68,13 +68,13 @@ export function useKanbanPageModels({ onOpenDetails }: UseKanbanPageModelsArgs):
   }, [refreshTasks]);
   const onDetectPullRequest = useCallback(
     (taskId: string): void => {
-      void syncPullRequests(taskId).catch(() => undefined);
+      void syncPullRequests(taskId);
     },
     [syncPullRequests],
   );
   const onUnlinkPullRequest = useCallback(
     (taskId: string): void => {
-      void unlinkPullRequest(taskId).catch(() => undefined);
+      void unlinkPullRequest(taskId);
     },
     [unlinkPullRequest],
   );

--- a/apps/desktop/src/state/operations/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-task-operations.test.tsx
@@ -552,6 +552,42 @@ describe("use-task-operations", () => {
     }
   });
 
+  test("syncPullRequests reports missing workspace selection without rethrowing", async () => {
+    const taskPullRequestDetect = mock(async () => {
+      throw new Error("taskPullRequestDetect should not be called without an active workspace");
+    });
+    const toastError = mock(() => "");
+    const originalTaskPullRequestDetect = host.taskPullRequestDetect;
+    const originalToastError = toast.error;
+    host.taskPullRequestDetect = taskPullRequestDetect;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const harness = createHookHarness({
+      activeRepo: null,
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: null,
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.run(async (value) => {
+        await value.syncPullRequests("A");
+      });
+
+      expect(taskPullRequestDetect).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith("Failed to detect pull request", {
+        description: "Select a workspace first.",
+      });
+    } finally {
+      await harness.unmount();
+      host.taskPullRequestDetect = originalTaskPullRequestDetect;
+      toast.error = originalToastError;
+    }
+  });
+
   test("unlinkPullRequest reports unlink errors without rethrowing", async () => {
     const taskPullRequestUnlink = mock(async () => {
       throw new Error("unlink failed");

--- a/apps/desktop/src/state/operations/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/use-task-operations.test.tsx
@@ -504,7 +504,7 @@ describe("use-task-operations", () => {
     }
   });
 
-  test("syncPullRequests fails fast when pull request detection errors", async () => {
+  test("syncPullRequests reports pull request detection errors without rethrowing", async () => {
     const taskPullRequestDetect = mock(async () => {
       throw new Error("gh auth expired");
     });
@@ -519,6 +519,9 @@ describe("use-task-operations", () => {
     host.taskPullRequestDetect = taskPullRequestDetect;
     host.tasksList = tasksList;
     host.runsList = runsList;
+    const originalToastError = toast.error;
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
 
     const harness = createHookHarness({
       activeRepo: "/repo",
@@ -531,24 +534,70 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
-      let caughtError: unknown = null;
       await harness.run(async (value) => {
-        try {
-          await value.syncPullRequests("A");
-        } catch (error) {
-          caughtError = error;
-        }
+        await value.syncPullRequests("A");
       });
 
-      expect(caughtError).toBeInstanceOf(Error);
-      expect((caughtError as Error).message).toBe("gh auth expired");
       expect(taskPullRequestDetect).toHaveBeenCalledWith("/repo", "A");
       expect(tasksList).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith("Failed to detect pull request", {
+        description: "gh auth expired",
+      });
     } finally {
       await harness.unmount();
       host.taskPullRequestDetect = original.taskPullRequestDetect;
       host.tasksList = original.tasksList;
       host.runsList = original.runsList;
+      toast.error = originalToastError;
+    }
+  });
+
+  test("unlinkPullRequest reports unlink errors without rethrowing", async () => {
+    const taskPullRequestUnlink = mock(async () => {
+      throw new Error("unlink failed");
+    });
+    const tasksList = mock(async () => [makeTask("A", "human_review")]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+
+    const original = {
+      taskPullRequestUnlink: host.taskPullRequestUnlink,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+    };
+    host.taskPullRequestUnlink = taskPullRequestUnlink;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+    const originalToastError = toast.error;
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.run(async (value) => {
+        await value.unlinkPullRequest("A");
+      });
+
+      expect(taskPullRequestUnlink).toHaveBeenCalledWith("/repo", "A");
+      expect(tasksList).not.toHaveBeenCalled();
+      expect(runsList).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith("Failed to unlink pull request", {
+        description: "unlink failed",
+      });
+    } finally {
+      await harness.unmount();
+      host.taskPullRequestUnlink = original.taskPullRequestUnlink;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+      toast.error = originalToastError;
     }
   });
 

--- a/apps/desktop/src/state/operations/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/use-task-operations.ts
@@ -179,7 +179,6 @@ export function useTaskOperations({
         toast.error("Failed to detect pull request", {
           description: errorMessage(error),
         });
-        throw error;
       } finally {
         setDetectingPullRequestTaskId((currentTaskId) =>
           currentTaskId === taskId ? null : currentTaskId,
@@ -193,14 +192,18 @@ export function useTaskOperations({
     async (taskId: string): Promise<void> => {
       setUnlinkingPullRequestTaskId(taskId);
       try {
-        await runTaskMutation({
-          run: async (repoPath) => {
-            await host.taskPullRequestUnlink(repoPath, taskId);
-          },
-          successTitle: "Pull request unlinked",
-          successDescription: taskId,
-          failureTitle: "Failed to unlink pull request",
-        });
+        try {
+          await runTaskMutation({
+            run: async (repoPath) => {
+              await host.taskPullRequestUnlink(repoPath, taskId);
+            },
+            successTitle: "Pull request unlinked",
+            successDescription: taskId,
+            failureTitle: "Failed to unlink pull request",
+          });
+        } catch {
+          return;
+        }
       } finally {
         setUnlinkingPullRequestTaskId((currentTaskId) =>
           currentTaskId === taskId ? null : currentTaskId,

--- a/apps/desktop/src/state/operations/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/use-task-operations.ts
@@ -86,8 +86,8 @@ export function useTaskOperations({
       successDescription: string;
       failureTitle: string;
     }): Promise<void> => {
-      const repoPath = requireActiveRepo(activeRepo);
       try {
+        const repoPath = requireActiveRepo(activeRepo);
         await options.run(repoPath);
         await Promise.all([
           appQueryClient.invalidateQueries({
@@ -152,10 +152,9 @@ export function useTaskOperations({
 
   const syncPullRequests = useCallback(
     async (taskId: string): Promise<void> => {
-      const repoPath = requireActiveRepo(activeRepo);
-
       setDetectingPullRequestTaskId(taskId);
       try {
+        const repoPath = requireActiveRepo(activeRepo);
         const result = await host.taskPullRequestDetect(repoPath, taskId);
         if (result.outcome === "linked") {
           await Promise.all([
@@ -192,18 +191,16 @@ export function useTaskOperations({
     async (taskId: string): Promise<void> => {
       setUnlinkingPullRequestTaskId(taskId);
       try {
-        try {
-          await runTaskMutation({
-            run: async (repoPath) => {
-              await host.taskPullRequestUnlink(repoPath, taskId);
-            },
-            successTitle: "Pull request unlinked",
-            successDescription: taskId,
-            failureTitle: "Failed to unlink pull request",
-          });
-        } catch {
-          return;
-        }
+        await runTaskMutation({
+          run: async (repoPath) => {
+            await host.taskPullRequestUnlink(repoPath, taskId);
+          },
+          successTitle: "Pull request unlinked",
+          successDescription: taskId,
+          failureTitle: "Failed to unlink pull request",
+        }).catch(() => {
+          // runTaskMutation already surfaced the actionable error to the user.
+        });
       } finally {
         setUnlinkingPullRequestTaskId((currentTaskId) =>
           currentTaskId === taskId ? null : currentTaskId,


### PR DESCRIPTION
## Summary
- validate persisted task agent sessions at the host boundary before they are written
- reject task session roles outside the supported workflow roles and block working directories outside the repo or effective worktree base
- surface Agent Studio task/session hydration failures explicitly instead of masking them with silent catches or endless loading state
- remove fire-and-forget PR link call-site catch wrappers by making the task operations report actionable errors directly

## What changed
### Host session persistence hardening
- tightened `agent_session_upsert` validation in `session_service.rs`
- added integration coverage for invalid external working directories, valid worktree-base directories, and invalid roles in `workflow_docs.rs`

### Desktop hydration and PR action cleanup
- changed task PR sync/unlink operations to report toast errors without requiring UI callers to swallow rejections
- removed empty `.catch(() => undefined)` wrappers from Agents and Kanban page handlers
- introduced explicit hydration failure state for task hydration and session history hydration so the UI stops reading failures as perpetual loading
- added frontend regression coverage for the new failure-state behavior and non-rethrowing PR action paths

## Verification
### Bun
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run --filter @openducktor/desktop test -- src/state/operations/use-task-operations.test.tsx src/pages/agents/use-agent-studio-task-hydration.test.tsx src/pages/agents/use-agent-studio-orchestration-controller.test.ts`

### Cargo
- `cargo check`
- `cargo test`
- `cargo test -p host-application agent_session_upsert -- --nocapture`
- `cargo test -p host-application qa_review_target_get -- --nocapture`
- `cargo fmt --all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validate agent sessions before saving (enforces allowed roles and working-directory constraints).
  * Track and expose hydration-failure states for active tasks and session history in page models.

* **Bug Fixes**
  * Surface pull-request and unlink errors to users instead of swallowing them; show task operation errors via toasts.

* **Tests**
  * Expanded tests for session validation, working-directory boundaries, role validation, and hydration-failure workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->