### PR TITLE
refactor: continue desloppify backlog cleanup

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { buildMessage } from "./agent-chat-test-fixtures";
+import { AgentChatThreadRow } from "./agent-chat-thread-row";
+import type { AgentChatVirtualRow } from "./agent-chat-thread-virtualization";
+
+const baseProps = {
+  sessionAgentColors: {},
+  sessionRole: "spec" as const,
+  sessionSelectedModel: null,
+  sessionWorkingDirectory: "/repo",
+};
+
+describe("AgentChatThreadRow", () => {
+  test("renders turn duration rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatThreadRow, {
+        ...baseProps,
+        row: { kind: "turn_duration", key: "duration-1", durationMs: 1200 },
+      }),
+    );
+
+    expect(html).toContain("1.2s");
+  });
+
+  test("renders message rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatThreadRow, {
+        ...baseProps,
+        row: {
+          kind: "message",
+          key: "message-1",
+          message: buildMessage("user", "Ship it"),
+        },
+      }),
+    );
+
+    expect(html).toContain("Ship it");
+  });
+
+  test("throws for unknown row kinds", () => {
+    const render = () =>
+      renderToStaticMarkup(
+        createElement(AgentChatThreadRow, {
+          ...baseProps,
+          row: { kind: "unexpected", key: "broken" } as unknown as AgentChatVirtualRow,
+        }),
+      );
+
+    expect(render).toThrow("Unhandled agent chat row");
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-row.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { assertNever } from "@/lib/assert-never";
 import { cn } from "@/lib/utils";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { AgentChatMessageCard } from "./agent-chat-message-card";
@@ -38,5 +39,7 @@ export function AgentChatThreadRow({
         </div>
       );
     }
+    default:
+      return assertNever(row, "Unhandled agent chat row");
   }
 }

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-lifecycle.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-lifecycle.ts
@@ -21,10 +21,7 @@ const hasMeaningfulInputValue = (value: unknown): boolean => {
 };
 
 export const hasNonEmptyInput = (input: Record<string, unknown> | undefined): boolean => {
-  if (!input) {
-    return false;
-  }
-  return Object.values(input).some((value) => hasMeaningfulInputValue(value));
+  return input ? Object.values(input).some((value) => hasMeaningfulInputValue(value)) : false;
 };
 
 export const hasNonEmptyText = (value: unknown): value is string => {

--- a/apps/desktop/src/components/features/kanban/kanban-task-badges.test.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-badges.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import type { RunSummary } from "@openducktor/contracts";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { RunStateBadge } from "./kanban-task-badges";
+
+const RUN_STATES: Array<{ state: RunSummary["state"]; label: string }> = [
+  { state: "starting", label: "Starting" },
+  { state: "running", label: "Running" },
+  { state: "blocked", label: "Blocked" },
+  { state: "awaiting_done_confirmation", label: "Awaiting confirm" },
+  { state: "completed", label: "Completed" },
+  { state: "failed", label: "Failed" },
+  { state: "stopped", label: "Stopped" },
+];
+
+describe("RunStateBadge", () => {
+  test("renders labels for every supported run state", () => {
+    for (const { state, label } of RUN_STATES) {
+      const html = renderToStaticMarkup(createElement(RunStateBadge, { runState: state }));
+      expect(html).toContain(label);
+    }
+  });
+
+  test("throws for unknown run states", () => {
+    const render = () =>
+      renderToStaticMarkup(
+        createElement(RunStateBadge, {
+          runState: "unexpected" as RunSummary["state"],
+        }),
+      );
+
+    expect(render).toThrow("Unhandled run state");
+  });
+});

--- a/apps/desktop/src/components/features/kanban/kanban-task-badges.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-badges.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { memo, type ReactElement } from "react";
 import { Badge } from "@/components/ui/badge";
+import { assertNever } from "@/lib/assert-never";
 import { isQaRejectedTask } from "@/lib/task-qa";
 
 const ISSUE_TYPE_STYLES: Record<
@@ -125,6 +126,8 @@ const runStateLabel = (value: RunSummary["state"]): string => {
       return "Failed";
     case "stopped":
       return "Stopped";
+    default:
+      return assertNever(value, "Unhandled run state");
   }
 };
 

--- a/apps/desktop/src/lib/assert-never.ts
+++ b/apps/desktop/src/lib/assert-never.ts
@@ -1,0 +1,3 @@
+export const assertNever = (value: never, label = "Unhandled variant"): never => {
+  throw new Error(`${label}: ${JSON.stringify(value)}`);
+};

--- a/apps/desktop/src/lib/host-client.ts
+++ b/apps/desktop/src/lib/host-client.ts
@@ -33,6 +33,8 @@ export const createHostClient = (): TauriHostClient => {
   });
 };
 
+export const hostClient = createHostClient();
+
 export const subscribeRunEvents = async (
   listener: (payload: unknown) => void,
 ): Promise<() => void> => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-model-builders.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-model-builders.ts
@@ -49,10 +49,7 @@ export type WorkflowModelContext = {
 };
 
 const isTaskAwaitingHumanFeedback = (task: TaskCard | null): boolean => {
-  if (!task) {
-    return false;
-  }
-  return task.status === "human_review";
+  return task?.status === "human_review";
 };
 
 export const buildWorkflowModelContext = ({

--- a/apps/desktop/src/pages/kanban/kanban-human-review-feedback.ts
+++ b/apps/desktop/src/pages/kanban/kanban-human-review-feedback.ts
@@ -1,0 +1,161 @@
+import type { TaskCard } from "@openducktor/contracts";
+import { toast } from "sonner";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type {
+  HumanReviewFeedbackModalModel,
+  KanbanSessionStartIntent,
+} from "./kanban-page-model-types";
+import {
+  buildHumanReviewMessage,
+  type RequestChangesBuildScenario,
+  resolveRequestChangesScenario,
+} from "./kanban-session-start-actions";
+
+export const NEW_BUILDER_SESSION_TARGET = "new_session";
+
+export type HumanReviewFeedbackState = {
+  taskId: string;
+  scenario: RequestChangesBuildScenario;
+  message: string;
+  builderSessions: AgentSessionState[];
+  selectedTarget: string;
+};
+
+export type PendingHumanReviewHydration = {
+  taskId: string;
+  baselineSessions: AgentSessionState[];
+};
+
+export const createHumanReviewFeedbackState = (
+  tasks: TaskCard[],
+  taskId: string,
+  builderSessions: AgentSessionState[],
+): HumanReviewFeedbackState => {
+  const task = tasks.find((entry) => entry.id === taskId);
+  const scenario = resolveRequestChangesScenario(task);
+
+  return {
+    taskId,
+    scenario,
+    message: buildHumanReviewMessage(task, taskId, scenario),
+    builderSessions,
+    selectedTarget: builderSessions[0]?.sessionId ?? NEW_BUILDER_SESSION_TARGET,
+  };
+};
+
+type ConfirmHumanReviewFeedbackFlowInput = {
+  state: HumanReviewFeedbackState;
+  humanRequestChangesTask: (taskId: string, note?: string) => Promise<void>;
+  loadAgentSessions: (
+    taskId: string,
+    options?: { hydrateHistoryForSessionId?: string },
+  ) => Promise<void>;
+  openSessionStartModal: (intent: KanbanSessionStartIntent) => void;
+  openAgentStudioSession: (taskId: string, session: AgentSessionState) => void;
+  sendAgentMessage: (sessionId: string, message: string) => Promise<void>;
+  onDismiss: () => void;
+};
+
+export const confirmHumanReviewFeedbackFlow = async ({
+  state,
+  humanRequestChangesTask,
+  loadAgentSessions,
+  openSessionStartModal,
+  openAgentStudioSession,
+  sendAgentMessage,
+  onDismiss,
+}: ConfirmHumanReviewFeedbackFlowInput): Promise<void> => {
+  const trimmedMessage = state.message.trim();
+  if (trimmedMessage.length === 0) {
+    toast.error("Feedback message is required.");
+    return;
+  }
+
+  if (state.selectedTarget === NEW_BUILDER_SESSION_TARGET) {
+    onDismiss();
+    openSessionStartModal({
+      taskId: state.taskId,
+      role: "build",
+      scenario: state.scenario,
+      startMode: "fresh",
+      postStartAction: "send_message",
+      message: trimmedMessage,
+      beforeStartAction: {
+        action: "human_request_changes",
+        note: trimmedMessage,
+      },
+    });
+    return;
+  }
+
+  const existingBuilderSession = state.builderSessions.find(
+    (session) => session.sessionId === state.selectedTarget,
+  );
+  if (!existingBuilderSession) {
+    toast.error("The selected builder session is no longer available for this task.");
+    return;
+  }
+
+  await humanRequestChangesTask(state.taskId, trimmedMessage);
+  await loadAgentSessions(state.taskId, {
+    hydrateHistoryForSessionId: existingBuilderSession.sessionId,
+  });
+  onDismiss();
+  openAgentStudioSession(state.taskId, existingBuilderSession);
+
+  try {
+    await sendAgentMessage(existingBuilderSession.sessionId, trimmedMessage);
+  } catch {
+    toast.error("Changes requested, but feedback message failed.");
+  }
+};
+
+type BuildHumanReviewFeedbackModalModelInput = {
+  state: HumanReviewFeedbackState;
+  isSubmitting: boolean;
+  onDismiss: () => void;
+  onTargetChange: (selectedTarget: string) => void;
+  onMessageChange: (message: string) => void;
+  onConfirm: () => void;
+};
+
+export const buildHumanReviewFeedbackModalModel = ({
+  state,
+  isSubmitting,
+  onDismiss,
+  onTargetChange,
+  onMessageChange,
+  onConfirm,
+}: BuildHumanReviewFeedbackModalModelInput): HumanReviewFeedbackModalModel => {
+  const targetOptions = [
+    {
+      value: NEW_BUILDER_SESSION_TARGET,
+      label: "Start a new builder session",
+      description:
+        "Open session setup, pick the model, then send this feedback as the first message.",
+    },
+    ...state.builderSessions.map((session, index) => ({
+      value: session.sessionId,
+      label: `Builder session ${session.sessionId.slice(0, 8)}`,
+      description: `Started ${new Date(session.startedAt).toLocaleString()} (${session.status}).`,
+      ...(index === 0 ? { secondaryLabel: "Latest" } : {}),
+    })),
+  ];
+
+  return {
+    open: true,
+    taskId: state.taskId,
+    selectedTarget: state.selectedTarget,
+    targetOptions,
+    message: state.message,
+    isSubmitting,
+    onOpenChange: (nextOpen: boolean) => {
+      if (!nextOpen) {
+        onDismiss();
+      }
+    },
+    onTargetChange,
+    onMessageChange,
+    onConfirm,
+  };
+};

--- a/apps/desktop/src/pages/kanban/kanban-session-start-actions.ts
+++ b/apps/desktop/src/pages/kanban/kanban-session-start-actions.ts
@@ -1,0 +1,169 @@
+import type { TaskCard } from "@openducktor/contracts";
+import type { AgentModelSelection, AgentRole } from "@openducktor/core";
+import { assertAgentKickoffScenario } from "@openducktor/core";
+import { toast } from "sonner";
+import type { AgentStateContextValue } from "@/types/state-slices";
+import { loadEffectivePromptOverrides } from "../../state/operations/prompt-overrides";
+import { kickoffPromptForScenario } from "../shared/session-start-prompts";
+import type { KanbanSessionStartIntent } from "./kanban-page-model-types";
+import { renderSessionStartedToastAction } from "./session-started-toast-action";
+
+export type RequestChangesBuildScenario =
+  | "build_after_human_request_changes"
+  | "build_after_qa_rejected";
+
+export const toPromptTaskContext = (task: TaskCard | undefined) => {
+  if (!task) {
+    return {};
+  }
+
+  return {
+    title: task.title,
+    issueType: task.issueType,
+    status: task.status,
+    qaRequired: task.aiReviewEnabled,
+    description: task.description,
+  };
+};
+
+export const resolveRequestChangesScenario = (
+  task: TaskCard | undefined,
+): RequestChangesBuildScenario => {
+  return task?.status === "human_review"
+    ? "build_after_human_request_changes"
+    : "build_after_qa_rejected";
+};
+
+export const buildHumanReviewMessage = (
+  task: TaskCard | undefined,
+  taskId: string,
+  scenario: RequestChangesBuildScenario,
+): string => {
+  return kickoffPromptForScenario("build", scenario, taskId, {
+    task: toPromptTaskContext(task),
+  });
+};
+
+type StartKanbanSessionFlowInput = {
+  activeRepo: string | null;
+  intent: KanbanSessionStartIntent;
+  selection: AgentModelSelection | null;
+  startInBackground: boolean;
+  tasks: TaskCard[];
+  roleLabels: Record<AgentRole, string>;
+  startAgentSession: AgentStateContextValue["startAgentSession"];
+  updateAgentSessionModel: AgentStateContextValue["updateAgentSessionModel"];
+  humanRequestChangesTask: (taskId: string, note?: string) => Promise<void>;
+  closeStartModal: () => void;
+  openSessionInAgentStudio: (intent: KanbanSessionStartIntent, sessionId: string) => void;
+  sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
+};
+
+export const startKanbanSessionFlow = async ({
+  activeRepo,
+  intent,
+  selection,
+  startInBackground,
+  tasks,
+  roleLabels,
+  startAgentSession,
+  updateAgentSessionModel,
+  humanRequestChangesTask,
+  closeStartModal,
+  openSessionInAgentStudio,
+  sendAgentMessage,
+}: StartKanbanSessionFlowInput): Promise<void> => {
+  const sessionId = await startAgentSession({
+    taskId: intent.taskId,
+    role: intent.role,
+    scenario: intent.scenario,
+    selectedModel: selection,
+    sendKickoff: false,
+    startMode: intent.startMode,
+    requireModelReady: true,
+  });
+
+  if (selection) {
+    updateAgentSessionModel(sessionId, selection);
+  }
+
+  if (intent.beforeStartAction?.action === "human_request_changes") {
+    try {
+      await humanRequestChangesTask(intent.taskId, intent.beforeStartAction.note);
+    } catch {
+      closeStartModal();
+
+      if (startInBackground) {
+        const roleLabel = roleLabels[intent.role] ?? intent.role.toUpperCase();
+        toast.error(`Started ${roleLabel} session, but requesting changes failed.`, {
+          duration: 10000,
+          description: renderSessionStartedToastAction(intent, sessionId, openSessionInAgentStudio),
+        });
+      } else {
+        openSessionInAgentStudio(intent, sessionId);
+        toast.error("Session started, but requesting changes failed.");
+      }
+
+      return;
+    }
+  }
+
+  closeStartModal();
+
+  if (startInBackground) {
+    const roleLabel = roleLabels[intent.role] ?? intent.role.toUpperCase();
+    toast.success(`Started ${roleLabel} session in background for ${intent.taskId}.`, {
+      duration: 10000,
+      description: renderSessionStartedToastAction(intent, sessionId, openSessionInAgentStudio),
+    });
+  } else {
+    openSessionInAgentStudio(intent, sessionId);
+  }
+
+  const effectivePostStartAction =
+    startInBackground && intent.postStartAction === "none" ? "kickoff" : intent.postStartAction;
+
+  if (effectivePostStartAction === "none") {
+    return;
+  }
+
+  const buildPostStartMessage = async (): Promise<string> => {
+    if (effectivePostStartAction === "send_message") {
+      const message = intent.message?.trim() ?? "";
+      if (!message) {
+        throw new Error("Feedback message is required before sending.");
+      }
+      return message;
+    }
+
+    const promptOverrides = activeRepo ? await loadEffectivePromptOverrides(activeRepo) : undefined;
+    const intentTask = tasks.find((entry) => entry.id === intent.taskId);
+    const kickoffScenario = assertAgentKickoffScenario(intent.scenario);
+    return kickoffPromptForScenario(intent.role, kickoffScenario, intent.taskId, {
+      overrides: promptOverrides ?? {},
+      task: toPromptTaskContext(intentTask),
+    });
+  };
+
+  const failureMessage =
+    effectivePostStartAction === "kickoff"
+      ? "Session started, but kickoff message failed."
+      : "Session started, but feedback message failed.";
+
+  if (startInBackground) {
+    void (async () => {
+      try {
+        await sendAgentMessage(sessionId, await buildPostStartMessage());
+      } catch {
+        toast.error(failureMessage);
+      }
+    })();
+    return;
+  }
+
+  try {
+    await sendAgentMessage(sessionId, await buildPostStartMessage());
+  } catch {
+    toast.error(failureMessage);
+  }
+};

--- a/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
@@ -1,6 +1,5 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentRole, AgentScenario } from "@openducktor/core";
-import { assertAgentKickoffScenario } from "@openducktor/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { NavigateFunction } from "react-router-dom";
 import { toast } from "sonner";
@@ -8,31 +7,20 @@ import type { SessionStartModalModel } from "@/components/features/agents";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentStateContextValue, RepoSettingsInput } from "@/types/state-slices";
-import { loadEffectivePromptOverrides } from "../../state/operations/prompt-overrides";
-import { firstScenario, kickoffPromptForScenario } from "../shared/session-start-prompts";
+import { firstScenario } from "../shared/session-start-prompts";
 import { useSessionStartModalCoordinator } from "../shared/use-session-start-modal-coordinator";
+import {
+  buildHumanReviewFeedbackModalModel,
+  confirmHumanReviewFeedbackFlow,
+  createHumanReviewFeedbackState,
+  type HumanReviewFeedbackState,
+  type PendingHumanReviewHydration,
+} from "./kanban-human-review-feedback";
 import type {
   HumanReviewFeedbackModalModel,
   KanbanSessionStartIntent,
 } from "./kanban-page-model-types";
-import { renderSessionStartedToastAction } from "./session-started-toast-action";
-
-const NEW_BUILDER_SESSION_TARGET = "new_session";
-
-type RequestChangesBuildScenario = "build_after_human_request_changes" | "build_after_qa_rejected";
-
-type HumanReviewFeedbackState = {
-  taskId: string;
-  scenario: RequestChangesBuildScenario;
-  message: string;
-  builderSessions: AgentSessionState[];
-  selectedTarget: string;
-};
-
-type PendingHumanReviewHydration = {
-  taskId: string;
-  baselineSessions: AgentSessionState[];
-};
+import { startKanbanSessionFlow } from "./kanban-session-start-actions";
 
 type UseKanbanSessionStartFlowArgs = {
   activeRepo: string | null;
@@ -86,53 +74,6 @@ export const resolveKanbanPlanningStartPreference = (
   }
   const task = tasks.find((entry) => entry.id === taskId);
   return task?.status === "spec_ready" ? "continue" : "fresh";
-};
-
-const toPromptTaskContext = (task: TaskCard | undefined) => {
-  if (!task) {
-    return {};
-  }
-
-  return {
-    title: task.title,
-    issueType: task.issueType,
-    status: task.status,
-    qaRequired: task.aiReviewEnabled,
-    description: task.description,
-  };
-};
-
-const resolveRequestChangesScenario = (task: TaskCard | undefined): RequestChangesBuildScenario => {
-  return task?.status === "human_review"
-    ? "build_after_human_request_changes"
-    : "build_after_qa_rejected";
-};
-
-const buildHumanReviewMessage = (
-  task: TaskCard | undefined,
-  taskId: string,
-  scenario: RequestChangesBuildScenario,
-): string => {
-  return kickoffPromptForScenario("build", scenario, taskId, {
-    task: toPromptTaskContext(task),
-  });
-};
-
-const createHumanReviewFeedbackState = (
-  tasks: TaskCard[],
-  taskId: string,
-  builderSessions: AgentSessionState[],
-): HumanReviewFeedbackState => {
-  const task = tasks.find((entry) => entry.id === taskId);
-  const scenario = resolveRequestChangesScenario(task);
-
-  return {
-    taskId,
-    scenario,
-    message: buildHumanReviewMessage(task, taskId, scenario),
-    builderSessions,
-    selectedTarget: builderSessions[0]?.sessionId ?? NEW_BUILDER_SESSION_TARGET,
-  };
 };
 
 export function useKanbanSessionStartFlow({
@@ -298,108 +239,20 @@ export function useKanbanSessionStartFlow({
       void (async () => {
         setIsStartingSession(true);
         try {
-          const sessionId = await startAgentSession({
-            taskId: intent.taskId,
-            role: intent.role,
-            scenario: intent.scenario,
-            selectedModel: selection,
-            sendKickoff: false,
-            startMode: intent.startMode,
-            requireModelReady: true,
+          await startKanbanSessionFlow({
+            activeRepo,
+            intent,
+            selection,
+            startInBackground,
+            tasks,
+            roleLabels,
+            startAgentSession,
+            updateAgentSessionModel,
+            humanRequestChangesTask,
+            closeStartModal,
+            openSessionInAgentStudio,
+            sendAgentMessage,
           });
-
-          if (selection) {
-            updateAgentSessionModel(sessionId, selection);
-          }
-
-          if (intent.beforeStartAction?.action === "human_request_changes") {
-            try {
-              await humanRequestChangesTask(intent.taskId, intent.beforeStartAction.note);
-            } catch {
-              closeStartModal();
-
-              if (startInBackground) {
-                const roleLabel = roleLabels[intent.role] ?? intent.role.toUpperCase();
-                toast.error(`Started ${roleLabel} session, but requesting changes failed.`, {
-                  duration: 10000,
-                  description: renderSessionStartedToastAction(
-                    intent,
-                    sessionId,
-                    openSessionInAgentStudio,
-                  ),
-                });
-              } else {
-                openSessionInAgentStudio(intent, sessionId);
-                toast.error("Session started, but requesting changes failed.");
-              }
-
-              return;
-            }
-          }
-
-          closeStartModal();
-
-          if (startInBackground) {
-            const roleLabel = roleLabels[intent.role] ?? intent.role.toUpperCase();
-            toast.success(`Started ${roleLabel} session in background for ${intent.taskId}.`, {
-              duration: 10000,
-              description: renderSessionStartedToastAction(
-                intent,
-                sessionId,
-                openSessionInAgentStudio,
-              ),
-            });
-          } else {
-            openSessionInAgentStudio(intent, sessionId);
-          }
-
-          const effectivePostStartAction =
-            startInBackground && intent.postStartAction === "none"
-              ? "kickoff"
-              : intent.postStartAction;
-
-          if (effectivePostStartAction !== "none") {
-            const buildPostStartMessage = async (): Promise<string> => {
-              if (effectivePostStartAction === "send_message") {
-                const message = intent.message?.trim() ?? "";
-                if (!message) {
-                  throw new Error("Feedback message is required before sending.");
-                }
-                return message;
-              }
-
-              const promptOverrides = activeRepo
-                ? await loadEffectivePromptOverrides(activeRepo)
-                : undefined;
-              const intentTask = tasks.find((entry) => entry.id === intent.taskId);
-              const kickoffScenario = assertAgentKickoffScenario(intent.scenario);
-              return kickoffPromptForScenario(intent.role, kickoffScenario, intent.taskId, {
-                overrides: promptOverrides ?? {},
-                task: toPromptTaskContext(intentTask),
-              });
-            };
-
-            const failureMessage =
-              effectivePostStartAction === "kickoff"
-                ? "Session started, but kickoff message failed."
-                : "Session started, but feedback message failed.";
-
-            if (startInBackground) {
-              void (async () => {
-                try {
-                  await sendAgentMessage(sessionId, await buildPostStartMessage());
-                } catch {
-                  toast.error(failureMessage);
-                }
-              })();
-            } else {
-              try {
-                await sendAgentMessage(sessionId, await buildPostStartMessage());
-              } catch {
-                toast.error(failureMessage);
-              }
-            }
-          }
         } catch {
           toast.error("Failed to start the session.");
         } finally {
@@ -551,51 +404,20 @@ export function useKanbanSessionStartFlow({
       return;
     }
 
-    const trimmedMessage = humanReviewFeedbackState.message.trim();
-    if (trimmedMessage.length === 0) {
-      toast.error("Feedback message is required.");
-      return;
-    }
-
-    if (humanReviewFeedbackState.selectedTarget === NEW_BUILDER_SESSION_TARGET) {
-      setHumanReviewFeedbackState(null);
-      openSessionStartModal({
-        taskId: humanReviewFeedbackState.taskId,
-        role: "build",
-        scenario: humanReviewFeedbackState.scenario,
-        startMode: "fresh",
-        postStartAction: "send_message",
-        message: trimmedMessage,
-        beforeStartAction: {
-          action: "human_request_changes",
-          note: trimmedMessage,
-        },
-      });
-      return;
-    }
-
-    const existingBuilderSession = humanReviewFeedbackState.builderSessions.find(
-      (session) => session.sessionId === humanReviewFeedbackState.selectedTarget,
-    );
-    if (!existingBuilderSession) {
-      toast.error("The selected builder session is no longer available for this task.");
-      return;
-    }
-
     void (async () => {
       setIsSubmittingHumanReviewFeedback(true);
       try {
-        await humanRequestChangesTask(humanReviewFeedbackState.taskId, trimmedMessage);
-        await loadAgentSessions(humanReviewFeedbackState.taskId, {
-          hydrateHistoryForSessionId: existingBuilderSession.sessionId,
+        await confirmHumanReviewFeedbackFlow({
+          state: humanReviewFeedbackState,
+          humanRequestChangesTask,
+          loadAgentSessions,
+          openSessionStartModal,
+          openAgentStudioSession,
+          sendAgentMessage,
+          onDismiss: () => {
+            setHumanReviewFeedbackState(null);
+          },
         });
-        setHumanReviewFeedbackState(null);
-        openAgentStudioSession(humanReviewFeedbackState.taskId, existingBuilderSession);
-        try {
-          await sendAgentMessage(existingBuilderSession.sessionId, trimmedMessage);
-        } catch {
-          toast.error("Changes requested, but feedback message failed.");
-        }
       } finally {
         setIsSubmittingHumanReviewFeedback(false);
       }
@@ -614,33 +436,10 @@ export function useKanbanSessionStartFlow({
       return null;
     }
 
-    const targetOptions = [
-      {
-        value: NEW_BUILDER_SESSION_TARGET,
-        label: "Start a new builder session",
-        description:
-          "Open session setup, pick the model, then send this feedback as the first message.",
-      },
-      ...humanReviewFeedbackState.builderSessions.map((session, index) => ({
-        value: session.sessionId,
-        label: `Builder session ${session.sessionId.slice(0, 8)}`,
-        description: `Started ${new Date(session.startedAt).toLocaleString()} (${session.status}).`,
-        ...(index === 0 ? { secondaryLabel: "Latest" } : {}),
-      })),
-    ];
-
-    return {
-      open: true,
-      taskId: humanReviewFeedbackState.taskId,
-      selectedTarget: humanReviewFeedbackState.selectedTarget,
-      targetOptions,
-      message: humanReviewFeedbackState.message,
+    return buildHumanReviewFeedbackModalModel({
+      state: humanReviewFeedbackState,
       isSubmitting: isSubmittingHumanReviewFeedback,
-      onOpenChange: (nextOpen: boolean) => {
-        if (!nextOpen) {
-          closeHumanReviewFeedbackModal();
-        }
-      },
+      onDismiss: closeHumanReviewFeedbackModal,
       onTargetChange: (selectedTarget: string) => {
         setHumanReviewFeedbackState((current: HumanReviewFeedbackState | null) =>
           current ? { ...current, selectedTarget } : current,
@@ -652,7 +451,7 @@ export function useKanbanSessionStartFlow({
         );
       },
       onConfirm: confirmHumanReviewFeedback,
-    };
+    });
   }, [
     closeHumanReviewFeedbackModal,
     confirmHumanReviewFeedback,

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
@@ -49,4 +49,120 @@ export type AttachAgentSessionListenerParams = {
   ) => Promise<void>;
 };
 
-export type SessionEventContext = AttachAgentSessionListenerParams;
+export type SessionStoreContext = Pick<
+  AttachAgentSessionListenerParams,
+  "sessionId" | "sessionsRef" | "updateSession"
+>;
+
+export type SessionDraftContext = Pick<
+  AttachAgentSessionListenerParams,
+  | "sessionId"
+  | "draftRawBySessionRef"
+  | "draftSourceBySessionRef"
+  | "draftMessageIdBySessionRef"
+  | "draftFlushTimeoutBySessionRef"
+>;
+
+export type SessionTurnContext = Pick<
+  AttachAgentSessionListenerParams,
+  | "sessionId"
+  | "turnStartedAtBySessionRef"
+  | "turnModelBySessionRef"
+  | "resolveTurnDurationMs"
+  | "clearTurnDuration"
+>;
+
+export type SessionPermissionContext = Pick<AttachAgentSessionListenerParams, "adapter">;
+
+export type SessionRefreshContext = Pick<
+  AttachAgentSessionListenerParams,
+  "repoPath" | "refreshTaskData" | "loadSessionTodos"
+>;
+
+export type SessionLifecycleEventContext = {
+  store: SessionStoreContext;
+  drafts: SessionDraftContext;
+  turn: SessionTurnContext;
+  permissions: SessionPermissionContext;
+};
+
+export type SessionPartEventContext = {
+  store: SessionStoreContext;
+  drafts: SessionDraftContext;
+  turn: SessionTurnContext;
+  refresh: SessionRefreshContext;
+};
+
+export type SessionToolPartEventContext = Pick<SessionPartEventContext, "store" | "refresh">;
+
+export type SessionEventHandlerContext = {
+  lifecycle: SessionLifecycleEventContext;
+  parts: SessionPartEventContext;
+};
+
+export const createSessionEventHandlerContext = (
+  context: AttachAgentSessionListenerParams,
+): SessionEventHandlerContext => ({
+  lifecycle: {
+    store: {
+      sessionId: context.sessionId,
+      sessionsRef: context.sessionsRef,
+      updateSession: context.updateSession,
+    },
+    drafts: {
+      sessionId: context.sessionId,
+      draftRawBySessionRef: context.draftRawBySessionRef,
+      draftSourceBySessionRef: context.draftSourceBySessionRef,
+      ...(context.draftMessageIdBySessionRef
+        ? { draftMessageIdBySessionRef: context.draftMessageIdBySessionRef }
+        : {}),
+      ...(context.draftFlushTimeoutBySessionRef
+        ? { draftFlushTimeoutBySessionRef: context.draftFlushTimeoutBySessionRef }
+        : {}),
+    },
+    turn: {
+      sessionId: context.sessionId,
+      turnStartedAtBySessionRef: context.turnStartedAtBySessionRef,
+      ...(context.turnModelBySessionRef
+        ? { turnModelBySessionRef: context.turnModelBySessionRef }
+        : {}),
+      resolveTurnDurationMs: context.resolveTurnDurationMs,
+      clearTurnDuration: context.clearTurnDuration,
+    },
+    permissions: {
+      adapter: context.adapter,
+    },
+  },
+  parts: {
+    store: {
+      sessionId: context.sessionId,
+      sessionsRef: context.sessionsRef,
+      updateSession: context.updateSession,
+    },
+    drafts: {
+      sessionId: context.sessionId,
+      draftRawBySessionRef: context.draftRawBySessionRef,
+      draftSourceBySessionRef: context.draftSourceBySessionRef,
+      ...(context.draftMessageIdBySessionRef
+        ? { draftMessageIdBySessionRef: context.draftMessageIdBySessionRef }
+        : {}),
+      ...(context.draftFlushTimeoutBySessionRef
+        ? { draftFlushTimeoutBySessionRef: context.draftFlushTimeoutBySessionRef }
+        : {}),
+    },
+    turn: {
+      sessionId: context.sessionId,
+      turnStartedAtBySessionRef: context.turnStartedAtBySessionRef,
+      ...(context.turnModelBySessionRef
+        ? { turnModelBySessionRef: context.turnModelBySessionRef }
+        : {}),
+      resolveTurnDurationMs: context.resolveTurnDurationMs,
+      clearTurnDuration: context.clearTurnDuration,
+    },
+    refresh: {
+      repoPath: context.repoPath,
+      refreshTaskData: context.refreshTaskData,
+      loadSessionTodos: context.loadSessionTodos,
+    },
+  },
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -1,8 +1,9 @@
 import type {
   AttachAgentSessionListenerParams,
   SessionEvent,
-  SessionEventContext,
+  SessionEventHandlerContext,
 } from "./session-event-types";
+import { createSessionEventHandlerContext } from "./session-event-types";
 import {
   handleAssistantMessage,
   handlePermissionRequired,
@@ -18,40 +19,40 @@ import { handleAssistantDelta, handleAssistantPart } from "./session-parts";
 
 const SESSION_EVENT_BATCH_WINDOW_MS = process.env.NODE_ENV === "test" ? 0 : 200;
 
-const handleSessionEvent = (context: SessionEventContext, event: SessionEvent): void => {
+const handleSessionEvent = (context: SessionEventHandlerContext, event: SessionEvent): void => {
   switch (event.type) {
     case "session_started":
-      handleSessionStarted(context, event);
+      handleSessionStarted(context.lifecycle, event);
       return;
     case "assistant_delta":
-      handleAssistantDelta(context, event);
+      handleAssistantDelta(context.parts, event);
       return;
     case "assistant_part":
-      handleAssistantPart(context, event);
+      handleAssistantPart(context.parts, event);
       return;
     case "assistant_message":
-      handleAssistantMessage(context, event);
+      handleAssistantMessage(context.lifecycle, event);
       return;
     case "session_status":
-      handleSessionStatus(context, event);
+      handleSessionStatus(context.lifecycle, event);
       return;
     case "permission_required":
-      handlePermissionRequired(context, event);
+      handlePermissionRequired(context.lifecycle, event);
       return;
     case "question_required":
-      handleQuestionRequired(context, event);
+      handleQuestionRequired(context.lifecycle, event);
       return;
     case "session_todos_updated":
-      handleSessionTodosUpdated(context, event);
+      handleSessionTodosUpdated(context.lifecycle, event);
       return;
     case "session_error":
-      handleSessionError(context, event);
+      handleSessionError(context.lifecycle, event);
       return;
     case "session_idle":
-      handleSessionIdle(context, event);
+      handleSessionIdle(context.lifecycle, event);
       return;
     case "session_finished":
-      handleSessionFinished(context, event);
+      handleSessionFinished(context.lifecycle, event);
       return;
     case "tool_call":
     case "tool_result":
@@ -82,6 +83,7 @@ const isImmediateSessionEvent = (event: SessionEvent): boolean => {
 export const attachAgentSessionListener = (
   context: AttachAgentSessionListenerParams,
 ): (() => void) => {
+  const handlerContext = createSessionEventHandlerContext(context);
   let queuedEvents: SessionEvent[] = [];
   let batchTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -98,7 +100,7 @@ export const attachAgentSessionListener = (
     const eventsToHandle = queuedEvents;
     queuedEvents = [];
     for (const queuedEvent of eventsToHandle) {
-      handleSessionEvent(context, queuedEvent);
+      handleSessionEvent(handlerContext, queuedEvent);
     }
   };
 
@@ -119,7 +121,7 @@ export const attachAgentSessionListener = (
   const unsubscribe = context.adapter.subscribeEvents(context.sessionId, (event) => {
     if (isImmediateSessionEvent(event)) {
       flushQueuedEvents();
-      handleSessionEvent(context, event);
+      handleSessionEvent(handlerContext, event);
       return;
     }
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-helpers.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-helpers.ts
@@ -5,8 +5,9 @@ import { finalizeDraftAssistantMessage, sanitizeStreamingText } from "../support
 import type {
   DraftChannel,
   DraftChannelValueMap,
-  SessionEventContext,
+  SessionLifecycleEventContext,
   SessionPart,
+  SessionPartEventContext,
 } from "./session-event-types";
 
 const DRAFT_FLUSH_DELAY_MS = 32;
@@ -17,18 +18,20 @@ export const inferToolPartStatus = (
   return part.status;
 };
 
-export const clearDraftBuffers = (context: SessionEventContext): void => {
-  const timeoutId = context.draftFlushTimeoutBySessionRef?.current[context.sessionId];
+export const clearDraftBuffers = (
+  context: Pick<SessionLifecycleEventContext, "drafts" | "store">,
+): void => {
+  const timeoutId = context.drafts.draftFlushTimeoutBySessionRef?.current[context.store.sessionId];
   if (timeoutId !== undefined) {
     clearTimeout(timeoutId);
   }
-  if (context.draftFlushTimeoutBySessionRef) {
-    delete context.draftFlushTimeoutBySessionRef.current[context.sessionId];
+  if (context.drafts.draftFlushTimeoutBySessionRef) {
+    delete context.drafts.draftFlushTimeoutBySessionRef.current[context.store.sessionId];
   }
-  delete context.draftRawBySessionRef.current[context.sessionId];
-  delete context.draftSourceBySessionRef.current[context.sessionId];
-  if (context.draftMessageIdBySessionRef) {
-    delete context.draftMessageIdBySessionRef.current[context.sessionId];
+  delete context.drafts.draftRawBySessionRef.current[context.store.sessionId];
+  delete context.drafts.draftSourceBySessionRef.current[context.store.sessionId];
+  if (context.drafts.draftMessageIdBySessionRef) {
+    delete context.drafts.draftMessageIdBySessionRef.current[context.store.sessionId];
   }
 };
 
@@ -48,21 +51,24 @@ const resolveDraftFieldState = (
   return { text, messageId };
 };
 
-export const flushDraftBuffers = (context: SessionEventContext): void => {
-  const timeoutId = context.draftFlushTimeoutBySessionRef?.current[context.sessionId];
+export const flushDraftBuffers = (
+  context: Pick<SessionLifecycleEventContext, "drafts" | "store">,
+): void => {
+  const timeoutId = context.drafts.draftFlushTimeoutBySessionRef?.current[context.store.sessionId];
   if (timeoutId !== undefined) {
     clearTimeout(timeoutId);
-    if (context.draftFlushTimeoutBySessionRef) {
-      delete context.draftFlushTimeoutBySessionRef.current[context.sessionId];
+    if (context.drafts.draftFlushTimeoutBySessionRef) {
+      delete context.drafts.draftFlushTimeoutBySessionRef.current[context.store.sessionId];
     }
   }
 
-  const rawByChannel = context.draftRawBySessionRef.current[context.sessionId];
-  const messageIdByChannel = context.draftMessageIdBySessionRef?.current[context.sessionId];
+  const rawByChannel = context.drafts.draftRawBySessionRef.current[context.store.sessionId];
+  const messageIdByChannel =
+    context.drafts.draftMessageIdBySessionRef?.current[context.store.sessionId];
   const reasoningDraft = resolveDraftFieldState("reasoning", rawByChannel, messageIdByChannel);
 
-  context.updateSession(
-    context.sessionId,
+  context.store.updateSession(
+    context.store.sessionId,
     (current) => ({
       ...current,
       draftAssistantText: "",
@@ -74,20 +80,22 @@ export const flushDraftBuffers = (context: SessionEventContext): void => {
   );
 };
 
-export const scheduleDraftFlush = (context: SessionEventContext): void => {
-  const draftFlushTimeoutBySessionRef = context.draftFlushTimeoutBySessionRef;
+export const scheduleDraftFlush = (
+  context: Pick<SessionLifecycleEventContext, "drafts" | "store">,
+): void => {
+  const draftFlushTimeoutBySessionRef = context.drafts.draftFlushTimeoutBySessionRef;
   if (!draftFlushTimeoutBySessionRef) {
     flushDraftBuffers(context);
     return;
   }
 
-  const existingTimeoutId = draftFlushTimeoutBySessionRef.current[context.sessionId];
+  const existingTimeoutId = draftFlushTimeoutBySessionRef.current[context.store.sessionId];
   if (existingTimeoutId !== undefined) {
     clearTimeout(existingTimeoutId);
   }
 
-  draftFlushTimeoutBySessionRef.current[context.sessionId] = setTimeout(() => {
-    delete draftFlushTimeoutBySessionRef.current[context.sessionId];
+  draftFlushTimeoutBySessionRef.current[context.store.sessionId] = setTimeout(() => {
+    delete draftFlushTimeoutBySessionRef.current[context.store.sessionId];
     flushDraftBuffers(context);
   }, DRAFT_FLUSH_DELAY_MS);
 };
@@ -126,13 +134,16 @@ const shouldClearTurnFromCurrentState = (current: AgentSessionState): boolean =>
   );
 };
 
-export const settleDraftToIdle = (context: SessionEventContext, timestamp: string): boolean => {
+export const settleDraftToIdle = (
+  context: Pick<SessionLifecycleEventContext, "store" | "turn">,
+  timestamp: string,
+): boolean => {
   let shouldClear = false;
-  context.updateSession(context.sessionId, (current) => {
+  context.store.updateSession(context.store.sessionId, (current) => {
     const finalized = finalizeDraftAssistantMessage(
       current,
       timestamp,
-      context.resolveTurnDurationMs(context.sessionId, timestamp, current.messages),
+      context.turn.resolveTurnDurationMs(context.store.sessionId, timestamp, current.messages),
     );
     shouldClear = shouldClearTurnFromCurrentState(current);
     return {
@@ -171,21 +182,23 @@ export const createPrePartTodoSettlement = (
   };
 };
 
-export const refreshTodosFromSessionRef = (context: SessionEventContext): void => {
-  const session = context.sessionsRef.current[context.sessionId];
+export const refreshTodosFromSessionRef = (
+  context: Pick<SessionPartEventContext, "store" | "refresh">,
+): void => {
+  const session = context.store.sessionsRef.current[context.store.sessionId];
   if (!session) {
     return;
   }
   const runtimeKind = session.runtimeKind ?? session.selectedModel?.runtimeKind;
   if (!runtimeKind) {
     throw new Error(
-      `Runtime kind is required to refresh todos for session '${context.sessionId}'.`,
+      `Runtime kind is required to refresh todos for session '${context.store.sessionId}'.`,
     );
   }
   runOrchestratorSideEffect(
     "session-events-refresh-todos",
-    context.loadSessionTodos(
-      context.sessionId,
+    context.refresh.loadSessionTodos(
+      context.store.sessionId,
       runtimeKind,
       {
         endpoint: session.runtimeEndpoint,
@@ -195,8 +208,8 @@ export const refreshTodosFromSessionRef = (context: SessionEventContext): void =
     ),
     {
       tags: {
-        repoPath: context.repoPath,
-        sessionId: context.sessionId,
+        repoPath: context.refresh.repoPath,
+        sessionId: context.store.sessionId,
         taskId: session.taskId,
         role: session.role,
         externalSessionId: session.externalSessionId,

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-helpers.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-helpers.ts
@@ -119,10 +119,7 @@ const hasMeaningfulToolInputValue = (value: unknown): boolean => {
 };
 
 export const hasMeaningfulToolInput = (input: Record<string, unknown> | undefined): boolean => {
-  if (!input) {
-    return false;
-  }
-  return Object.values(input).some((value) => hasMeaningfulToolInputValue(value));
+  return input ? Object.values(input).some((value) => hasMeaningfulToolInputValue(value)) : false;
 };
 
 const shouldClearTurnFromCurrentState = (current: AgentSessionState): boolean => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -14,7 +14,7 @@ import {
   toSessionContextUsage,
   upsertMessage,
 } from "../support/utils";
-import type { SessionEvent, SessionEventContext } from "./session-event-types";
+import type { SessionEvent, SessionLifecycleEventContext } from "./session-event-types";
 import {
   clearDraftBuffers,
   eventTimestampMs,
@@ -22,9 +22,11 @@ import {
   settleDraftToIdle,
 } from "./session-helpers";
 
-const clearTurnModelSnapshot = (context: SessionEventContext): void => {
-  if (context.turnModelBySessionRef) {
-    delete context.turnModelBySessionRef.current[context.sessionId];
+const clearTurnModelSnapshot = (
+  context: Pick<SessionLifecycleEventContext, "turn" | "store">,
+): void => {
+  if (context.turn.turnModelBySessionRef) {
+    delete context.turn.turnModelBySessionRef.current[context.store.sessionId];
   }
 };
 
@@ -38,7 +40,7 @@ const toPendingPermission = (event: PermissionRequiredEvent) => ({
 });
 
 const findExistingAssistantMessageIndex = (
-  messages: SessionEventContext["sessionsRef"]["current"][string]["messages"],
+  messages: SessionLifecycleEventContext["store"]["sessionsRef"]["current"][string]["messages"],
   event: Extract<SessionEvent, { type: "assistant_message" }>,
 ): number => {
   const byIdIndex = messages.findIndex((entry) => entry.id === event.messageId);
@@ -87,14 +89,15 @@ const shouldAutoRejectPermission = (
 };
 
 const autoRejectMutatingPermission = (
-  context: SessionEventContext,
+  context: SessionLifecycleEventContext,
   event: PermissionRequiredEvent,
   role: AgentRole,
 ): void => {
   const pendingPermission = toPendingPermission(event);
-  const promptOverrides = context.sessionsRef.current[context.sessionId]?.promptOverrides;
+  const promptOverrides =
+    context.store.sessionsRef.current[context.store.sessionId]?.promptOverrides;
   const markManualResponseRequired = (error: unknown): void => {
-    context.updateSession(context.sessionId, (current) => ({
+    context.store.updateSession(context.store.sessionId, (current) => ({
       ...current,
       pendingPermissions: [
         ...current.pendingPermissions.filter((entry) => entry.requestId !== event.requestId),
@@ -123,15 +126,15 @@ const autoRejectMutatingPermission = (
     return;
   }
 
-  void context.adapter
+  void context.permissions.adapter
     .replyPermission({
-      sessionId: context.sessionId,
+      sessionId: context.store.sessionId,
       requestId: event.requestId,
       reply: "reject",
       message: rejectionMessage,
     })
     .then(() => {
-      context.updateSession(context.sessionId, (current) => ({
+      context.store.updateSession(context.store.sessionId, (current) => ({
         ...current,
         pendingPermissions: current.pendingPermissions.filter(
           (entry) => entry.requestId !== event.requestId,
@@ -153,10 +156,10 @@ const autoRejectMutatingPermission = (
 };
 
 export const handleSessionStarted = (
-  context: SessionEventContext,
+  context: Pick<SessionLifecycleEventContext, "store">,
   event: Extract<SessionEvent, { type: "session_started" }>,
 ): void => {
-  context.updateSession(context.sessionId, (current) => ({
+  context.store.updateSession(context.store.sessionId, (current) => ({
     ...current,
     status: "running",
     messages: [
@@ -172,19 +175,19 @@ export const handleSessionStarted = (
 };
 
 export const handleAssistantMessage = (
-  context: SessionEventContext,
+  context: SessionLifecycleEventContext,
   event: Extract<SessionEvent, { type: "assistant_message" }>,
 ): void => {
   flushDraftBuffers(context);
   clearDraftBuffers(context);
-  context.updateSession(context.sessionId, (current) => {
+  context.store.updateSession(context.store.sessionId, (current) => {
     const settledMessages = settleDanglingTodoToolMessages(current.messages, event.timestamp);
     const existingMessageIndex = findExistingAssistantMessageIndex(settledMessages, event);
     const messageAlreadyPresent =
       existingMessageIndex >= 0 ||
       isDuplicateAssistantMessage(settledMessages, event.message, event.timestamp);
-    const durationMs = context.resolveTurnDurationMs(
-      context.sessionId,
+    const durationMs = context.turn.resolveTurnDurationMs(
+      context.store.sessionId,
       event.timestamp,
       settledMessages,
     );
@@ -211,24 +214,24 @@ export const handleAssistantMessage = (
         : [...settledMessages, nextAssistantMessage],
     };
   });
-  context.clearTurnDuration(context.sessionId);
+  context.turn.clearTurnDuration(context.store.sessionId);
   clearTurnModelSnapshot(context);
 };
 
 export const handleSessionStatus = (
-  context: SessionEventContext,
+  context: SessionLifecycleEventContext,
   event: Extract<SessionEvent, { type: "session_status" }>,
 ): void => {
   const status = event.status;
 
   if (status.type === "busy") {
-    if (context.turnStartedAtBySessionRef.current[context.sessionId] === undefined) {
-      context.turnStartedAtBySessionRef.current[context.sessionId] = eventTimestampMs(
+    if (context.turn.turnStartedAtBySessionRef.current[context.store.sessionId] === undefined) {
+      context.turn.turnStartedAtBySessionRef.current[context.store.sessionId] = eventTimestampMs(
         event.timestamp,
       );
     }
-    context.updateSession(
-      context.sessionId,
+    context.store.updateSession(
+      context.store.sessionId,
       (current) =>
         current.status === "error"
           ? current
@@ -243,8 +246,8 @@ export const handleSessionStatus = (
 
   if (status.type === "retry") {
     const retryMessage = normalizeRetryStatusMessage(status.message);
-    context.updateSession(
-      context.sessionId,
+    context.store.updateSession(
+      context.store.sessionId,
       (current) =>
         current.status === "error"
           ? current
@@ -264,24 +267,24 @@ export const handleSessionStatus = (
   }
 
   if (settleDraftToIdle(context, event.timestamp)) {
-    context.clearTurnDuration(context.sessionId);
+    context.turn.clearTurnDuration(context.store.sessionId);
     clearTurnModelSnapshot(context);
   }
 };
 
 export const handlePermissionRequired = (
-  context: SessionEventContext,
+  context: SessionLifecycleEventContext,
   event: PermissionRequiredEvent,
 ): void => {
   flushDraftBuffers(context);
-  const role = context.sessionsRef.current[context.sessionId]?.role;
+  const role = context.store.sessionsRef.current[context.store.sessionId]?.role;
 
   if (role && shouldAutoRejectPermission(role, event)) {
     autoRejectMutatingPermission(context, event, role);
     return;
   }
 
-  context.updateSession(context.sessionId, (current) => ({
+  context.store.updateSession(context.store.sessionId, (current) => ({
     ...current,
     pendingPermissions: [
       ...current.pendingPermissions.filter((entry) => entry.requestId !== event.requestId),
@@ -291,11 +294,11 @@ export const handlePermissionRequired = (
 };
 
 export const handleQuestionRequired = (
-  context: SessionEventContext,
+  context: Pick<SessionLifecycleEventContext, "store" | "drafts">,
   event: Extract<SessionEvent, { type: "question_required" }>,
 ): void => {
   flushDraftBuffers(context);
-  context.updateSession(context.sessionId, (current) => ({
+  context.store.updateSession(context.store.sessionId, (current) => ({
     ...current,
     pendingQuestions: [
       ...current.pendingQuestions.filter((entry) => entry.requestId !== event.requestId),
@@ -308,11 +311,11 @@ export const handleQuestionRequired = (
 };
 
 export const handleSessionTodosUpdated = (
-  context: SessionEventContext,
+  context: Pick<SessionLifecycleEventContext, "store">,
   event: Extract<SessionEvent, { type: "session_todos_updated" }>,
 ): void => {
-  context.updateSession(
-    context.sessionId,
+  context.store.updateSession(
+    context.store.sessionId,
     (current) => ({
       ...current,
       todos: mergeTodoListPreservingOrder(current.todos, event.todos),
@@ -323,17 +326,21 @@ export const handleSessionTodosUpdated = (
 };
 
 export const handleSessionError = (
-  context: SessionEventContext,
+  context: SessionLifecycleEventContext,
   event: Extract<SessionEvent, { type: "session_error" }>,
 ): void => {
   flushDraftBuffers(context);
   clearDraftBuffers(context);
   const sessionErrorMessage = normalizeSessionErrorMessage(event.message);
-  context.updateSession(context.sessionId, (current) => {
+  context.store.updateSession(context.store.sessionId, (current) => {
     const finalized = finalizeDraftAssistantMessage(
       current,
       event.timestamp,
-      context.resolveTurnDurationMs(context.sessionId, event.timestamp, current.messages),
+      context.turn.resolveTurnDurationMs(
+        context.store.sessionId,
+        event.timestamp,
+        current.messages,
+      ),
     );
     const settledMessages = settleDanglingTodoToolMessages(finalized.messages, event.timestamp, {
       outcome: "error",
@@ -355,33 +362,37 @@ export const handleSessionError = (
       ],
     };
   });
-  context.clearTurnDuration(context.sessionId);
+  context.turn.clearTurnDuration(context.store.sessionId);
   clearTurnModelSnapshot(context);
 };
 
 export const handleSessionIdle = (
-  context: SessionEventContext,
+  context: SessionLifecycleEventContext,
   event: Extract<SessionEvent, { type: "session_idle" }>,
 ): void => {
   flushDraftBuffers(context);
   clearDraftBuffers(context);
   if (settleDraftToIdle(context, event.timestamp)) {
-    context.clearTurnDuration(context.sessionId);
+    context.turn.clearTurnDuration(context.store.sessionId);
     clearTurnModelSnapshot(context);
   }
 };
 
 export const handleSessionFinished = (
-  context: SessionEventContext,
+  context: SessionLifecycleEventContext,
   event: Extract<SessionEvent, { type: "session_finished" }>,
 ): void => {
   flushDraftBuffers(context);
   clearDraftBuffers(context);
-  context.updateSession(context.sessionId, (current) => {
+  context.store.updateSession(context.store.sessionId, (current) => {
     const finalized = finalizeDraftAssistantMessage(
       current,
       event.timestamp,
-      context.resolveTurnDurationMs(context.sessionId, event.timestamp, current.messages),
+      context.turn.resolveTurnDurationMs(
+        context.store.sessionId,
+        event.timestamp,
+        current.messages,
+      ),
     );
     return {
       ...finalized,
@@ -391,6 +402,6 @@ export const handleSessionFinished = (
       status: "stopped",
     };
   });
-  context.clearTurnDuration(context.sessionId);
+  context.turn.clearTurnDuration(context.store.sessionId);
   clearTurnModelSnapshot(context);
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-parts.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-parts.ts
@@ -4,9 +4,9 @@ import { sanitizeStreamingText, toAssistantMessageMeta, upsertMessage } from "..
 import type {
   DraftChannel,
   SessionEvent,
-  SessionEventContext,
   SessionPart,
   SessionPartEvent,
+  SessionPartEventContext,
 } from "./session-event-types";
 import {
   createPrePartTodoSettlement,
@@ -17,9 +17,9 @@ import { handleToolPart } from "./session-tool-parts";
 
 type PrepareCurrent = (current: AgentSessionState) => AgentSessionState;
 
-const markSessionRunning = (context: SessionEventContext): void => {
-  context.updateSession(
-    context.sessionId,
+const markSessionRunning = (context: SessionPartEventContext): void => {
+  context.store.updateSession(
+    context.store.sessionId,
     (current) =>
       current.status === "running"
         ? current
@@ -32,27 +32,29 @@ const markSessionRunning = (context: SessionEventContext): void => {
 };
 
 const updateDraftChannelBuffer = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   channel: DraftChannel,
   raw: string,
   messageId: string | undefined,
   source: "delta" | "part",
 ): void => {
-  const currentRaw = context.draftRawBySessionRef.current[context.sessionId] ?? {};
-  context.draftRawBySessionRef.current[context.sessionId] = {
+  const currentRaw = context.drafts.draftRawBySessionRef.current[context.store.sessionId] ?? {};
+  context.drafts.draftRawBySessionRef.current[context.store.sessionId] = {
     ...currentRaw,
     [channel]: raw,
   };
 
-  const currentSource = context.draftSourceBySessionRef.current[context.sessionId] ?? {};
-  context.draftSourceBySessionRef.current[context.sessionId] = {
+  const currentSource =
+    context.drafts.draftSourceBySessionRef.current[context.store.sessionId] ?? {};
+  context.drafts.draftSourceBySessionRef.current[context.store.sessionId] = {
     ...currentSource,
     [channel]: source,
   };
 
-  if (context.draftMessageIdBySessionRef) {
-    const currentMessageIds = context.draftMessageIdBySessionRef.current[context.sessionId] ?? {};
-    context.draftMessageIdBySessionRef.current[context.sessionId] = {
+  if (context.drafts.draftMessageIdBySessionRef) {
+    const currentMessageIds =
+      context.drafts.draftMessageIdBySessionRef.current[context.store.sessionId] ?? {};
+    context.drafts.draftMessageIdBySessionRef.current[context.store.sessionId] = {
       ...currentMessageIds,
       ...(messageId ? { [channel]: messageId } : {}),
     };
@@ -60,28 +62,30 @@ const updateDraftChannelBuffer = (
 };
 
 const clearDraftChannelBuffer = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   channel: DraftChannel,
   source?: "delta" | "part",
   messageId?: string,
 ): void => {
   if (channel === "reasoning") {
-    const timeoutId = context.draftFlushTimeoutBySessionRef?.current[context.sessionId];
+    const timeoutId =
+      context.drafts.draftFlushTimeoutBySessionRef?.current[context.store.sessionId];
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);
-      if (context.draftFlushTimeoutBySessionRef) {
-        delete context.draftFlushTimeoutBySessionRef.current[context.sessionId];
+      if (context.drafts.draftFlushTimeoutBySessionRef) {
+        delete context.drafts.draftFlushTimeoutBySessionRef.current[context.store.sessionId];
       }
     }
   }
 
-  const currentRaw = context.draftRawBySessionRef.current[context.sessionId] ?? {};
+  const currentRaw = context.drafts.draftRawBySessionRef.current[context.store.sessionId] ?? {};
   const nextRaw = { ...currentRaw };
   delete nextRaw[channel];
-  context.draftRawBySessionRef.current[context.sessionId] = nextRaw;
+  context.drafts.draftRawBySessionRef.current[context.store.sessionId] = nextRaw;
 
-  const currentSource = context.draftSourceBySessionRef.current[context.sessionId] ?? {};
-  context.draftSourceBySessionRef.current[context.sessionId] =
+  const currentSource =
+    context.drafts.draftSourceBySessionRef.current[context.store.sessionId] ?? {};
+  context.drafts.draftSourceBySessionRef.current[context.store.sessionId] =
     source === undefined
       ? Object.fromEntries(Object.entries(currentSource).filter(([key]) => key !== channel))
       : {
@@ -89,9 +93,10 @@ const clearDraftChannelBuffer = (
           [channel]: source,
         };
 
-  if (context.draftMessageIdBySessionRef) {
-    const currentMessageIds = context.draftMessageIdBySessionRef.current[context.sessionId] ?? {};
-    context.draftMessageIdBySessionRef.current[context.sessionId] =
+  if (context.drafts.draftMessageIdBySessionRef) {
+    const currentMessageIds =
+      context.drafts.draftMessageIdBySessionRef.current[context.store.sessionId] ?? {};
+    context.drafts.draftMessageIdBySessionRef.current[context.store.sessionId] =
       messageId === undefined
         ? Object.fromEntries(Object.entries(currentMessageIds).filter(([key]) => key !== channel))
         : {
@@ -104,7 +109,7 @@ const clearDraftChannelBuffer = (
 const toReasoningMessageId = (messageId: string): string => `thinking:${messageId}`;
 
 const resolvePartModelSelection = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   current: AgentSessionState,
   messageId: string,
 ): AgentSessionState["selectedModel"] | null => {
@@ -124,7 +129,7 @@ const resolvePartModelSelection = (
     };
   }
 
-  const turnModel = context.turnModelBySessionRef?.current[context.sessionId];
+  const turnModel = context.turn.turnModelBySessionRef?.current[context.store.sessionId];
   return turnModel ?? current.selectedModel ?? null;
 };
 
@@ -174,7 +179,7 @@ const upsertLiveAssistantMessage = ({
 };
 
 export const handleAssistantDelta = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   event: Extract<SessionEvent, { type: "assistant_delta" }>,
 ): void => {
   if (event.channel === "text") {
@@ -184,8 +189,8 @@ export const handleAssistantDelta = (
     const messageId = event.messageId;
     markSessionRunning(context);
     clearDraftChannelBuffer(context, "text");
-    context.updateSession(
-      context.sessionId,
+    context.store.updateSession(
+      context.store.sessionId,
       (current) => {
         const existingMessage = current.messages.find((entry) => entry.id === messageId);
         const baseContent = existingMessage?.role === "assistant" ? existingMessage.content : "";
@@ -205,11 +210,14 @@ export const handleAssistantDelta = (
     return;
   }
 
-  if (context.draftSourceBySessionRef.current[context.sessionId]?.[event.channel] === "part") {
+  if (
+    context.drafts.draftSourceBySessionRef.current[context.store.sessionId]?.[event.channel] ===
+    "part"
+  ) {
     return;
   }
   const nextRaw = `${
-    context.draftRawBySessionRef.current[context.sessionId]?.[event.channel] ?? ""
+    context.drafts.draftRawBySessionRef.current[context.store.sessionId]?.[event.channel] ?? ""
   }${event.delta}`;
   updateDraftChannelBuffer(context, event.channel, nextRaw, event.messageId, "delta");
   markSessionRunning(context);
@@ -217,11 +225,11 @@ export const handleAssistantDelta = (
 };
 
 const settleSessionBeforeDraftUpdate = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   prepareCurrent: PrepareCurrent,
 ): void => {
-  context.updateSession(
-    context.sessionId,
+  context.store.updateSession(
+    context.store.sessionId,
     (current) => {
       const prepared = prepareCurrent(current);
       return prepared.status === "running"
@@ -236,7 +244,7 @@ const settleSessionBeforeDraftUpdate = (
 };
 
 const handleTextPart = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   event: SessionPartEvent,
   part: Extract<SessionPart, { kind: "text" }>,
   prepareCurrent: PrepareCurrent,
@@ -245,8 +253,8 @@ const handleTextPart = (
     return;
   }
   clearDraftChannelBuffer(context, "text");
-  context.updateSession(
-    context.sessionId,
+  context.store.updateSession(
+    context.store.sessionId,
     (current) => {
       const prepared = prepareCurrent(current);
       if (part.text.trim().length === 0) {
@@ -274,7 +282,7 @@ const handleTextPart = (
 };
 
 const handleReasoningPart = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   event: SessionPartEvent,
   part: Extract<SessionPart, { kind: "reasoning" }>,
   prepareCurrent: PrepareCurrent,
@@ -288,8 +296,8 @@ const handleReasoningPart = (
   }
 
   clearDraftChannelBuffer(context, "reasoning");
-  context.updateSession(
-    context.sessionId,
+  context.store.updateSession(
+    context.store.sessionId,
     (current) => {
       const prepared = prepareCurrent(current);
       const messageId = toReasoningMessageId(part.messageId);
@@ -328,14 +336,14 @@ const handleReasoningPart = (
 };
 
 const handleSubtaskPart = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   event: SessionPartEvent,
   part: Extract<SessionPart, { kind: "subtask" }>,
   streamMessageKey: string,
   prepareCurrent: PrepareCurrent,
 ): void => {
-  context.updateSession(
-    context.sessionId,
+  context.store.updateSession(
+    context.store.sessionId,
     (current) => {
       const prepared = prepareCurrent(current);
       return {
@@ -361,7 +369,7 @@ const handleSubtaskPart = (
 };
 
 const handleStepPart = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   part: Extract<SessionPart, { kind: "step" }>,
   prepareCurrent: PrepareCurrent,
 ): void => {
@@ -369,8 +377,8 @@ const handleStepPart = (
     return;
   }
 
-  context.updateSession(
-    context.sessionId,
+  context.store.updateSession(
+    context.store.sessionId,
     (current) => {
       const prepared = prepareCurrent(current);
       const model = resolvePartModelSelection(context, prepared, part.messageId);
@@ -395,7 +403,7 @@ const handleStepPart = (
 };
 
 export const handleAssistantPart = (
-  context: SessionEventContext,
+  context: SessionPartEventContext,
   event: SessionPartEvent,
 ): void => {
   const part = event.part;

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
@@ -11,7 +11,11 @@ import {
   resolveToolMessageId,
   upsertMessage,
 } from "../support/utils";
-import type { SessionEventContext, SessionPart, SessionPartEvent } from "./session-event-types";
+import type {
+  SessionPart,
+  SessionPartEvent,
+  SessionToolPartEventContext,
+} from "./session-event-types";
 import {
   eventTimestampMs,
   hasMeaningfulToolInput,
@@ -196,7 +200,7 @@ const composeToolPartSessionUpdate = ({
 };
 
 export const handleToolPart = (
-  context: SessionEventContext,
+  context: SessionToolPartEventContext,
   event: SessionPartEvent,
   part: ToolPart,
   streamMessageKey: string,
@@ -211,8 +215,8 @@ export const handleToolPart = (
   let shouldRefreshTaskData = false;
   let shouldRefreshSessionTodos = false;
 
-  context.updateSession(
-    context.sessionId,
+  context.store.updateSession(
+    context.store.sessionId,
     (current) => {
       const { nextState, refreshDecision } = composeToolPartSessionUpdate({
         current,
@@ -239,11 +243,11 @@ export const handleToolPart = (
   if (shouldRefreshTaskData) {
     runOrchestratorSideEffect(
       "session-events-refresh-task-data",
-      context.refreshTaskData(context.repoPath),
+      context.refresh.refreshTaskData(context.refresh.repoPath),
       {
         tags: {
-          repoPath: context.repoPath,
-          sessionId: context.sessionId,
+          repoPath: context.refresh.repoPath,
+          sessionId: context.store.sessionId,
           tool: part.tool,
         },
       },

--- a/apps/desktop/src/state/operations/host.ts
+++ b/apps/desktop/src/state/operations/host.ts
@@ -1,3 +1,1 @@
-import { createHostClient } from "@/lib/host-client";
-
-export const host = createHostClient();
+export { hostClient as host } from "@/lib/host-client";

--- a/apps/desktop/src/state/operations/index.ts
+++ b/apps/desktop/src/state/operations/index.ts
@@ -1,7 +1,7 @@
+export { loadRepoRuntimeCatalog } from "../read-models/runtime-catalog-client";
 export {
   configureRuntimeCatalogOperations,
   createHostRuntimeCatalogOperations,
-  loadRepoRuntimeCatalog,
 } from "./runtime-catalog";
 export { useAgentOrchestratorOperations } from "./use-agent-orchestrator-operations";
 export { useChecks } from "./use-checks";

--- a/apps/desktop/src/state/operations/permission-policy.ts
+++ b/apps/desktop/src/state/operations/permission-policy.ts
@@ -99,11 +99,7 @@ export const isReadOnlyShellCommand = (command: string): boolean => {
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0);
 
-  if (segments.length === 0) {
-    return false;
-  }
-
-  return segments.every((segment) => isReadOnlyShellSegment(segment));
+  return segments.length > 0 && segments.every((segment) => isReadOnlyShellSegment(segment));
 };
 
 export const isMutatingPermission = (

--- a/apps/desktop/src/state/operations/runtime-catalog.ts
+++ b/apps/desktop/src/state/operations/runtime-catalog.ts
@@ -7,6 +7,7 @@ import type {
 import type { AgentEnginePort, AgentModelCatalog } from "@openducktor/core";
 import { errorMessage } from "@/lib/errors";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
+import { configureRuntimeCatalogClient } from "../read-models/runtime-catalog-client";
 import { host } from "./host";
 
 type RuntimeMcpServerStatus = {
@@ -357,7 +358,7 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
   };
 };
 
-type RuntimeCatalogOperations = ReturnType<typeof createRuntimeCatalogOperations>;
+export type RuntimeCatalogOperations = ReturnType<typeof createRuntimeCatalogOperations>;
 
 export const createHostRuntimeCatalogOperations = (
   getAdapter: (runtimeKind: RuntimeKind) => RuntimeCatalogAdapter,
@@ -382,26 +383,10 @@ export const createHostRuntimeCatalogOperations = (
       getAdapter(runtimeKind).shouldRestartRuntimeForMcpStatusError(message),
   });
 
-let configuredRuntimeCatalogOperations: RuntimeCatalogOperations | null = null;
-
 export const configureRuntimeCatalogOperations = (operations: RuntimeCatalogOperations): void => {
-  configuredRuntimeCatalogOperations = operations;
-};
-
-const getConfiguredRuntimeCatalogOperations = (): RuntimeCatalogOperations => {
-  if (!configuredRuntimeCatalogOperations) {
-    throw new Error(
-      "Runtime catalog operations are not configured. Initialize them from AppStateProvider before use.",
-    );
-  }
-  return configuredRuntimeCatalogOperations;
-};
-
-export const loadRepoRuntimeCatalog = (
-  repoPath: string,
-  runtimeKind: RuntimeKind,
-): Promise<AgentModelCatalog> => {
-  return getConfiguredRuntimeCatalogOperations().loadRepoRuntimeCatalog(repoPath, runtimeKind);
+  configureRuntimeCatalogClient({
+    loadRepoRuntimeCatalog: operations.loadRepoRuntimeCatalog,
+  });
 };
 
 const resolveRuntimeEndpoint = (runtimeRoute: RuntimeRoute): string => {

--- a/apps/desktop/src/state/operations/task-operations-model.ts
+++ b/apps/desktop/src/state/operations/task-operations-model.ts
@@ -1,4 +1,5 @@
-import type { TaskCard, TaskUpdatePatch } from "@openducktor/contracts";
+import type { TaskUpdatePatch } from "@openducktor/contracts";
+import { toVisibleTasks } from "../read-models/task-read-model";
 
 export const WORKSPACE_REQUIRED_ERROR = "Select a workspace first.";
 export const DEFERRED_BY_USER_REASON = "Deferred by user";
@@ -10,8 +11,7 @@ export const requireActiveRepo = (activeRepo: string | null): string => {
   return activeRepo;
 };
 
-export const toVisibleTasks = (taskList: TaskCard[]): TaskCard[] =>
-  taskList.filter((task) => task.status !== "deferred");
+export { toVisibleTasks };
 
 export const toNormalizedTitle = (title: string): string => title.trim();
 

--- a/apps/desktop/src/state/queries/runtime-catalog.ts
+++ b/apps/desktop/src/state/queries/runtime-catalog.ts
@@ -1,7 +1,7 @@
 import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import { queryOptions } from "@tanstack/react-query";
-import { loadRepoRuntimeCatalog } from "../operations/runtime-catalog";
+import { loadRepoRuntimeCatalog } from "../read-models/runtime-catalog-client";
 
 const RUNTIME_CATALOG_STALE_TIME_MS = 5 * 60_000;
 

--- a/apps/desktop/src/state/queries/tasks.ts
+++ b/apps/desktop/src/state/queries/tasks.ts
@@ -1,7 +1,7 @@
 import type { RunSummary, TaskCard } from "@openducktor/contracts";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
-import { host } from "../operations/host";
-import { toVisibleTasks } from "../operations/task-operations-model";
+import { hostClient as host } from "@/lib/host-client";
+import { toVisibleTasks } from "../read-models/task-read-model";
 
 const TASK_DATA_STALE_TIME_MS = 30_000;
 const RUN_DATA_STALE_TIME_MS = 30_000;

--- a/apps/desktop/src/state/queries/workspace.ts
+++ b/apps/desktop/src/state/queries/workspace.ts
@@ -1,9 +1,9 @@
 import type { RepoConfig, SettingsSnapshot, WorkspaceRecord } from "@openducktor/contracts";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { hostClient as host } from "@/lib/host-client";
 import { normalizeTargetBranch } from "@/lib/target-branch";
 import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 import type { RepoSettingsInput } from "@/types/state-slices";
-import { host } from "../operations/host";
 
 const SETTINGS_SNAPSHOT_STALE_TIME_MS = 15 * 60_000;
 const REPO_CONFIG_STALE_TIME_MS = 10 * 60_000;

--- a/apps/desktop/src/state/read-models/runtime-catalog-client.ts
+++ b/apps/desktop/src/state/read-models/runtime-catalog-client.ts
@@ -1,0 +1,30 @@
+import type { RuntimeKind } from "@openducktor/contracts";
+import type { AgentModelCatalog } from "@openducktor/core";
+
+export type RuntimeCatalogClient = {
+  loadRepoRuntimeCatalog: (
+    repoPath: string,
+    runtimeKind: RuntimeKind,
+  ) => Promise<AgentModelCatalog>;
+};
+
+let configuredRuntimeCatalogClient: RuntimeCatalogClient | null = null;
+
+export const configureRuntimeCatalogClient = (client: RuntimeCatalogClient): void => {
+  configuredRuntimeCatalogClient = client;
+};
+
+const getConfiguredRuntimeCatalogClient = (): RuntimeCatalogClient => {
+  if (!configuredRuntimeCatalogClient) {
+    throw new Error(
+      "Runtime catalog client is not configured. Initialize it from AppStateProvider before use.",
+    );
+  }
+  return configuredRuntimeCatalogClient;
+};
+
+export const loadRepoRuntimeCatalog = (
+  repoPath: string,
+  runtimeKind: RuntimeKind,
+): Promise<AgentModelCatalog> =>
+  getConfiguredRuntimeCatalogClient().loadRepoRuntimeCatalog(repoPath, runtimeKind);

--- a/apps/desktop/src/state/read-models/task-read-model.ts
+++ b/apps/desktop/src/state/read-models/task-read-model.ts
@@ -1,0 +1,4 @@
+import type { TaskCard } from "@openducktor/contracts";
+
+export const toVisibleTasks = (taskList: TaskCard[]): TaskCard[] =>
+  taskList.filter((task) => task.status !== "deferred");

--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
@@ -91,7 +91,7 @@ export const getMcpStatus = async (
   const payload = unwrapData(response, "get mcp status");
   const statusPayload = asUnknownRecord(payload);
   if (!statusPayload) {
-    return {};
+    throw new Error("Invalid MCP status payload: expected an object keyed by server name.");
   }
 
   const statusByServer: Record<string, McpServerStatus> = {};

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1645,6 +1645,23 @@ describe("OpencodeSdkAdapter", () => {
     });
   });
 
+  test("getMcpStatus rejects malformed payloads instead of returning an empty map", async () => {
+    const mock = makeMockClient({
+      mcpStatusResponse: "not-an-object",
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    await expect(
+      adapter.getMcpStatus({
+        runtimeEndpoint: "http://127.0.0.1:12345",
+        workingDirectory: "/repo",
+      }),
+    ).rejects.toThrow("Invalid MCP status payload");
+  });
+
   test("connectMcpServer forwards server name and directory", async () => {
     const mock = makeMockClient({});
     const adapter = new OpencodeSdkAdapter({

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1117,7 +1117,7 @@ describe("TauriHostClient", () => {
     });
   });
 
-  test("agentSessionsList normalizes legacy scenarios and strips invalid scenario values", async () => {
+  test("agentSessionsList normalizes legacy scenarios", async () => {
     const { client } = createClient((command) => {
       if (command === "task_metadata_get") {
         return {
@@ -1157,6 +1157,27 @@ describe("TauriHostClient", () => {
               workingDirectory: "/repo",
               selectedModel: null,
             },
+          ],
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const sessions = await client.agentSessionsList("/repo", "task-1");
+
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0]?.scenario).toBe("spec_initial");
+    expect(sessions[1]?.scenario).toBe("planner_initial");
+  });
+
+  test("agentSessionsList rejects invalid persisted agent session entries", async () => {
+    const { client } = createClient((command) => {
+      if (command === "task_metadata_get") {
+        return {
+          spec: { markdown: "", updatedAt: null },
+          plan: { markdown: "", updatedAt: null },
+          qaReport: null,
+          agentSessions: [
             {
               sessionId: "bad-entry",
               externalSessionId: "legacy-ext-3",
@@ -1179,12 +1200,9 @@ describe("TauriHostClient", () => {
       throw new Error(`Unexpected command: ${command}`);
     });
 
-    const sessions = await client.agentSessionsList("/repo", "task-1");
-
-    expect(sessions).toHaveLength(3);
-    expect(sessions[0]?.scenario).toBe("spec_initial");
-    expect(sessions[1]?.scenario).toBe("planner_initial");
-    expect(sessions[2]?.scenario).toBe(undefined);
+    await expect(client.agentSessionsList("/repo", "task-1")).rejects.toThrow(
+      "Task metadata for task-1 contains invalid persisted agent sessions",
+    );
   });
 
   test("spec, plan, qa, and session reads share one metadata IPC call per task", async () => {

--- a/packages/adapters-tauri-host/src/task-metadata-cache.ts
+++ b/packages/adapters-tauri-host/src/task-metadata-cache.ts
@@ -1,7 +1,6 @@
 import {
   type AgentSessionRecord,
   agentSessionRecordSchema,
-  agentSessionScenarioSchema,
   type TaskMetadataPayload,
   taskMetadataPayloadSchema,
 } from "@openducktor/contracts";
@@ -22,11 +21,7 @@ const normalizeAgentSessionScenario = (entry: unknown): unknown => {
   }
   const normalizedScenario = LEGACY_AGENT_SESSION_SCENARIO_MAP[candidate.scenario];
   if (!normalizedScenario) {
-    if (agentSessionScenarioSchema.safeParse(candidate.scenario).success) {
-      return entry;
-    }
-    const { scenario: _ignoredScenario, ...rest } = entry as Record<string, unknown>;
-    return rest;
+    return entry;
   }
   return {
     ...entry,
@@ -38,14 +33,28 @@ export type ParsedTaskMetadata = Omit<TaskMetadataPayload, "agentSessions"> & {
   agentSessions: AgentSessionRecord[];
 };
 
-const parseAgentSessions = (entries: unknown[]): AgentSessionRecord[] => {
+const parseAgentSessions = (entries: unknown[], taskId: string): AgentSessionRecord[] => {
   const sessions: AgentSessionRecord[] = [];
-  for (const entry of entries) {
+  const invalidEntries: string[] = [];
+
+  for (const [index, entry] of entries.entries()) {
     const parsed = agentSessionRecordSchema.safeParse(normalizeAgentSessionScenario(entry));
     if (parsed.success) {
       sessions.push(parsed.data);
+      continue;
     }
+
+    invalidEntries.push(
+      `agentSessions[${index}]: ${parsed.error.issues.map((issue) => issue.message).join("; ")}`,
+    );
   }
+
+  if (invalidEntries.length > 0) {
+    throw new Error(
+      `Task metadata for ${taskId} contains invalid persisted agent sessions: ${invalidEntries.join(" | ")}`,
+    );
+  }
+
   return sessions;
 };
 
@@ -93,7 +102,7 @@ export class TaskMetadataCache {
         const parsed = taskMetadataPayloadSchema.parse(payload);
         const metadata = {
           ...parsed,
-          agentSessions: parseAgentSessions(parsed.agentSessions),
+          agentSessions: parseAgentSessions(parsed.agentSessions, taskId),
         };
 
         if (this.inFlight.get(cacheKey) === next) {


### PR DESCRIPTION
## Summary
- continue the manual `desloppify` backlog cleanup after the queue stalled again
- harden frontend and adapter contract edges so invalid data stops looking like successful empty states
- split more orchestration-heavy UI and state code into smaller, narrower units with targeted regression coverage

## What changed
### Session and query architecture cleanup
- split agent session event handling into narrower capability contexts instead of threading one broad context bag through every handler
- decoupled query read models from operations by moving shared read helpers into neutral read-model modules
- extracted Kanban session-start workflow actions and human-review feedback flow out of the main modal-state hook

### Fail-fast contract hardening
- reject invalid persisted task session metadata in the Tauri host adapter instead of silently dropping malformed entries
- reject malformed MCP status payloads in the OpenCode adapter instead of treating them as a legitimate empty status set
- keep UI state exhaustive for agent chat rows and run states with explicit `assertNever` guards

### Readability and maintenance cleanup
- simplified repeated boolean helper branches in predicate-heavy desktop modules without changing behavior
- added focused tests for the new exhaustive guards and adapter validation paths

## Verification
### Bun
- `bun run lint`
- `bun run typecheck`
- `bun run test`

### Cargo
- `cargo fmt --all --check`
- `cargo check`
- `cargo test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human review feedback flow for Kanban tasks and a unified session start experience, including optional new builder sessions.

* **Bug Fixes**
  * Better error reporting for invalid runtime/catalog and persisted session payloads.
  * Stricter handling of unknown UI states (agent chat rows, run states) to surface errors earlier.

* **Tests**
  * Added tests for agent chat thread rendering and run state badges.

* **Refactor**
  * Reworked session event handling for more reliable session lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->