### PR TITLE
refactor: continue desloppify contract cleanup

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-runtime-combobox.tsx
+++ b/apps/desktop/src/components/features/agents/agent-runtime-combobox.tsx
@@ -1,9 +1,10 @@
+import type { RuntimeKind } from "@openducktor/contracts";
 import type { ReactElement } from "react";
 import { Combobox, type ComboboxOption } from "@/components/ui/combobox";
 
 type AgentRuntimeComboboxProps = {
-  value: string;
-  onValueChange: (value: string) => void;
+  value: RuntimeKind;
+  onValueChange: (value: RuntimeKind) => void;
   runtimeOptions: ComboboxOption[];
   placeholder?: string;
   disabled?: boolean;

--- a/apps/desktop/src/components/features/agents/session-start-modal.tsx
+++ b/apps/desktop/src/components/features/agents/session-start-modal.tsx
@@ -31,7 +31,7 @@ export type SessionStartModalModel = {
   modelOptions: ComboboxOption[];
   modelGroups: ComboboxGroup[];
   variantOptions: ComboboxOption[];
-  onSelectRuntime: (runtimeKind: string) => void;
+  onSelectRuntime: (runtimeKind: RuntimeKind) => void;
   onSelectAgent: (agent: string) => void;
   onSelectModel: (model: string) => void;
   onSelectVariant: (variant: string) => void;

--- a/apps/desktop/src/pages/shared/use-session-start-modal-state.ts
+++ b/apps/desktop/src/pages/shared/use-session-start-modal-state.ts
@@ -68,7 +68,7 @@ type UseSessionStartModalStateResult = {
   variantOptions: ComboboxOption[];
   openStartModal: (nextIntent: SessionStartModalIntent) => void;
   closeStartModal: () => void;
-  handleSelectRuntime: (runtimeKind: string) => void;
+  handleSelectRuntime: (runtimeKind: RuntimeKind) => void;
   handleSelectAgent: (profileId: string) => void;
   handleSelectModel: (modelKey: string) => void;
   handleSelectVariant: (variant: string) => void;
@@ -218,10 +218,10 @@ export function useSessionStartModalState({
   }, [activeRole, catalog, intent?.selectedModel, repoSettings, selectedRuntimeKind]);
 
   const handleSelectRuntime = useCallback(
-    (runtimeKindValue: string): void => {
+    (runtimeKindValue: RuntimeKind): void => {
       const runtimeKind = resolveRuntimeKindSelection({
         runtimeDefinitions,
-        requestedRuntimeKind: runtimeKindValue as RuntimeKind,
+        requestedRuntimeKind: runtimeKindValue,
       });
       setSelectedRuntimeKind(runtimeKind);
       setSelection((current) => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
@@ -1,3 +1,4 @@
+import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentRuntimeConnection } from "@openducktor/core";
 import type { MutableRefObject } from "react";
 import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
@@ -43,7 +44,7 @@ export type AttachAgentSessionListenerParams = {
   refreshTaskData: (repoPath: string) => Promise<void>;
   loadSessionTodos: (
     sessionId: string,
-    runtimeKind: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ) => Promise<void>;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -1,4 +1,4 @@
-import type { RepoPromptOverrides, TaskCard } from "@openducktor/contracts";
+import type { RepoPromptOverrides, RuntimeKind, TaskCard } from "@openducktor/contracts";
 import type {
   AgentEnginePort,
   AgentModelSelection,
@@ -46,13 +46,13 @@ type SessionActionsDependencies = {
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
   loadSessionTodos: (
     sessionId: string,
-    runtimeKind: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ) => Promise<void>;
   loadSessionModelCatalog: (
     sessionId: string,
-    runtimeKind: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
   ) => Promise<void>;
   loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
@@ -1,4 +1,4 @@
-import type { RepoPromptOverrides, TaskCard } from "@openducktor/contracts";
+import type { RepoPromptOverrides, RuntimeKind, TaskCard } from "@openducktor/contracts";
 import type {
   AgentEnginePort,
   AgentModelSelection,
@@ -60,13 +60,13 @@ export type ModelDependencies = {
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
   loadSessionTodos: (
     sessionId: string,
-    runtimeKind: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ) => Promise<void>;
   loadSessionModelCatalog: (
     sessionId: string,
-    runtimeKind: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
   ) => Promise<void>;
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -1,4 +1,4 @@
-import type { RepoPromptOverrides, TaskCard } from "@openducktor/contracts";
+import type { RepoPromptOverrides, RuntimeKind, TaskCard } from "@openducktor/contracts";
 import {
   type AgentEnginePort,
   type AgentRuntimeConnection,
@@ -49,13 +49,13 @@ type EnsureSessionReadyDependencies = {
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
   loadSessionTodos: (
     sessionId: string,
-    runtimeKind: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ) => Promise<void>;
   loadSessionModelCatalog: (
     sessionId: string,
-    runtimeKind: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
   ) => Promise<void>;
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/session-loaders.ts
@@ -1,3 +1,4 @@
+import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentRuntimeConnection } from "@openducktor/core";
 import { errorMessage } from "@/lib/errors";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
@@ -19,7 +20,7 @@ type SessionLoadersAdapter = Pick<AgentEnginePort, "listAvailableModels" | "load
 
 type CreateSessionLoadersArgs = {
   adapter: SessionLoadersAdapter;
-  supportsSessionTodos?: (runtimeKind: string) => boolean;
+  supportsSessionTodos?: (runtimeKind: RuntimeKind) => boolean;
   updateSession: UpdateSession;
 };
 
@@ -102,12 +103,12 @@ export const createLoadSessionModelCatalog = ({
   updateSession,
 }: CreateSessionLoadersArgs): ((
   sessionId: string,
-  runtimeKind: string,
+  runtimeKind: RuntimeKind,
   runtimeConnection: AgentRuntimeConnection,
 ) => Promise<void>) => {
   return async (
     sessionId: string,
-    runtimeKind: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
   ): Promise<void> => {
     updateSession(
@@ -162,13 +163,13 @@ export const createLoadSessionTodos = ({
   updateSession,
 }: CreateSessionLoadersArgs): ((
   sessionId: string,
-  runtimeKind: string,
+  runtimeKind: RuntimeKind,
   runtimeConnection: AgentRuntimeConnection,
   externalSessionId: string,
 ) => Promise<void>) => {
   return async (
     sessionId: string,
-    runtimeKind: string,
+    runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
     externalSessionId: string,
   ): Promise<void> => {

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -1,4 +1,4 @@
-import type { RepoPromptOverrides } from "@openducktor/contracts";
+import type { RepoPromptOverrides, RuntimeKind } from "@openducktor/contracts";
 import type {
   AgentModelCatalog,
   AgentModelSelection,
@@ -102,7 +102,7 @@ export type AgentSessionState = {
   sessionId: string;
   externalSessionId: string;
   taskId: string;
-  runtimeKind?: string;
+  runtimeKind?: RuntimeKind;
   role: AgentRole;
   scenario: AgentScenario;
   status: "starting" | "running" | "idle" | "error" | "stopped";

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -22,7 +22,7 @@ import {
   taskPullRequestDetectResultSchema,
 } from "@openducktor/contracts";
 import type { InvokeFn } from "./invoke-utils";
-import { parseArray } from "./invoke-utils";
+import { parseArray, parseOkResult } from "./invoke-utils";
 import type { TaskMetadataCache } from "./task-metadata-cache";
 
 export type BuildCleanupMode = "success" | "failure";
@@ -30,39 +30,23 @@ export type BuildRespondInput =
   | { action: "approve" }
   | { action: "deny" }
   | { action: "message"; message: string };
-type OkResult = { ok: boolean };
-
-const parseOkResult = (payload: unknown, command: string): OkResult => {
-  if (
-    !payload ||
-    typeof payload !== "object" ||
-    typeof (payload as { ok?: unknown }).ok !== "boolean"
-  ) {
-    throw new Error(`Expected { ok: boolean } payload from host command ${command}`);
-  }
-
-  return {
-    ok: (payload as { ok: boolean }).ok,
-  };
-};
-
 export const systemCheck = async (invokeFn: InvokeFn, repoPath: string): Promise<SystemCheck> => {
-  const payload = await invokeFn<unknown>("system_check", { repoPath });
+  const payload = await invokeFn("system_check", { repoPath });
   return systemCheckSchema.parse(payload);
 };
 
 export const runtimeCheck = async (invokeFn: InvokeFn, force = false): Promise<RuntimeCheck> => {
-  const payload = await invokeFn<unknown>("runtime_check", { force });
+  const payload = await invokeFn("runtime_check", { force });
   return runtimeCheckSchema.parse(payload);
 };
 
 export const beadsCheck = async (invokeFn: InvokeFn, repoPath: string): Promise<BeadsCheck> => {
-  const payload = await invokeFn<unknown>("beads_check", { repoPath });
+  const payload = await invokeFn("beads_check", { repoPath });
   return beadsCheckSchema.parse(payload);
 };
 
 export const runsList = async (invokeFn: InvokeFn, repoPath?: string): Promise<RunSummary[]> => {
-  const payload = await invokeFn<unknown>("runs_list", { repoPath });
+  const payload = await invokeFn("runs_list", { repoPath });
   return parseArray(runSummarySchema, payload);
 };
 
@@ -71,12 +55,12 @@ export const runtimeList = async (
   repoPath: string | undefined,
   runtimeKind: RuntimeKind,
 ): Promise<RuntimeInstanceSummary[]> => {
-  const payload = await invokeFn<unknown>("runtime_list", { repoPath, runtimeKind });
+  const payload = await invokeFn("runtime_list", { repoPath, runtimeKind });
   return parseArray(runtimeInstanceSummarySchema, payload);
 };
 
 export const runtimeDefinitionsList = async (invokeFn: InvokeFn): Promise<RuntimeDescriptor[]> => {
-  const payload = await invokeFn<unknown>("runtime_definitions_list", {});
+  const payload = await invokeFn("runtime_definitions_list", {});
   return parseArray(runtimeDescriptorSchema, payload);
 };
 
@@ -85,7 +69,7 @@ export const qaReviewTargetGet = async (
   repoPath: string,
   taskId: string,
 ): Promise<QaReviewTarget> => {
-  const payload = await invokeFn<unknown>("qa_review_target_get", {
+  const payload = await invokeFn("qa_review_target_get", {
     repoPath,
     taskId,
   });
@@ -96,7 +80,7 @@ export const runtimeStop = async (
   invokeFn: InvokeFn,
   runtimeId: string,
 ): Promise<{ ok: boolean }> => {
-  const payload = await invokeFn<unknown>("runtime_stop", {
+  const payload = await invokeFn("runtime_stop", {
     runtimeId,
   });
   return parseOkResult(payload, "runtime_stop");
@@ -107,7 +91,7 @@ export const runtimeEnsure = async (
   repoPath: string,
   runtimeKind: RuntimeKind,
 ): Promise<RuntimeInstanceSummary> => {
-  const payload = await invokeFn<unknown>("runtime_ensure", {
+  const payload = await invokeFn("runtime_ensure", {
     repoPath,
     runtimeKind,
   });
@@ -120,7 +104,7 @@ export const buildStart = async (
   taskId: string,
   runtimeKind: RuntimeKind,
 ): Promise<RunSummary> => {
-  const payload = await invokeFn<unknown>("build_start", { repoPath, taskId, runtimeKind });
+  const payload = await invokeFn("build_start", { repoPath, taskId, runtimeKind });
   return runSummarySchema.parse(payload);
 };
 
@@ -130,7 +114,7 @@ export const buildBlocked = async (
   taskId: string,
   reason: string,
 ): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("build_blocked", {
+  const payload = await invokeFn("build_blocked", {
     repoPath,
     taskId,
     reason,
@@ -143,7 +127,7 @@ export const buildResumed = async (
   repoPath: string,
   taskId: string,
 ): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("build_resumed", {
+  const payload = await invokeFn("build_resumed", {
     repoPath,
     taskId,
   });
@@ -156,7 +140,7 @@ export const buildCompleted = async (
   taskId: string,
   summary?: string,
 ): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("build_completed", {
+  const payload = await invokeFn("build_completed", {
     repoPath,
     taskId,
     input: { summary },
@@ -170,7 +154,7 @@ export const humanRequestChanges = async (
   taskId: string,
   note?: string,
 ): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("human_request_changes", {
+  const payload = await invokeFn("human_request_changes", {
     repoPath,
     taskId,
     note,
@@ -183,7 +167,7 @@ export const humanApprove = async (
   repoPath: string,
   taskId: string,
 ): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("human_approve", {
+  const payload = await invokeFn("human_approve", {
     repoPath,
     taskId,
   });
@@ -195,7 +179,7 @@ export const taskApprovalContextGet = async (
   repoPath: string,
   taskId: string,
 ) => {
-  const payload = await invokeFn<unknown>("task_approval_context_get", {
+  const payload = await invokeFn("task_approval_context_get", {
     repoPath,
     taskId,
   });
@@ -208,7 +192,7 @@ export const taskDirectMerge = async (
   taskId: string,
   mergeMethod: string,
 ): Promise<TaskCard> => {
-  const payload = await invokeFn<unknown>("task_direct_merge", {
+  const payload = await invokeFn("task_direct_merge", {
     repoPath,
     taskId,
     mergeMethod: gitMergeMethodSchema.parse(mergeMethod),
@@ -223,7 +207,7 @@ export const taskPullRequestUpsert = async (
   title: string,
   body: string,
 ) => {
-  const payload = await invokeFn<unknown>("task_pull_request_upsert", {
+  const payload = await invokeFn("task_pull_request_upsert", {
     repoPath,
     taskId,
     input: { title, body },
@@ -236,7 +220,7 @@ export const taskPullRequestUnlink = async (
   repoPath: string,
   taskId: string,
 ): Promise<{ ok: boolean }> => {
-  const payload = await invokeFn<unknown>("task_pull_request_unlink", { repoPath, taskId });
+  const payload = await invokeFn("task_pull_request_unlink", { repoPath, taskId });
   return parseOkResult(payload, "task_pull_request_unlink");
 };
 
@@ -245,7 +229,7 @@ export const taskPullRequestDetect = async (
   repoPath: string,
   taskId: string,
 ) => {
-  const payload = await invokeFn<unknown>("task_pull_request_detect", { repoPath, taskId });
+  const payload = await invokeFn("task_pull_request_detect", { repoPath, taskId });
   return taskPullRequestDetectResultSchema.parse(payload);
 };
 
@@ -253,7 +237,7 @@ export const repoPullRequestSync = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<{ ok: boolean }> => {
-  const payload = await invokeFn<unknown>("repo_pull_request_sync", { repoPath });
+  const payload = await invokeFn("repo_pull_request_sync", { repoPath });
   return parseOkResult(payload, "repo_pull_request_sync");
 };
 
@@ -262,7 +246,7 @@ export const buildRespond = async (
   runId: string,
   input: BuildRespondInput,
 ): Promise<{ ok: boolean }> => {
-  const response = await invokeFn<unknown>("build_respond", {
+  const response = await invokeFn("build_respond", {
     runId,
     action: input.action,
     ...(input.action === "message" ? { payload: input.message } : {}),
@@ -271,7 +255,7 @@ export const buildRespond = async (
 };
 
 export const buildStop = async (invokeFn: InvokeFn, runId: string): Promise<{ ok: boolean }> => {
-  const payload = await invokeFn<unknown>("build_stop", { runId });
+  const payload = await invokeFn("build_stop", { runId });
   return parseOkResult(payload, "build_stop");
 };
 
@@ -280,7 +264,7 @@ export const buildCleanup = async (
   runId: string,
   mode: BuildCleanupMode,
 ): Promise<{ ok: boolean }> => {
-  const payload = await invokeFn<unknown>("build_cleanup", { runId, mode });
+  const payload = await invokeFn("build_cleanup", { runId, mode });
   return parseOkResult(payload, "build_cleanup");
 };
 

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -47,7 +47,7 @@ export const beadsCheck = async (invokeFn: InvokeFn, repoPath: string): Promise<
 
 export const runsList = async (invokeFn: InvokeFn, repoPath?: string): Promise<RunSummary[]> => {
   const payload = await invokeFn("runs_list", { repoPath });
-  return parseArray(runSummarySchema, payload);
+  return parseArray(runSummarySchema, payload, "runs_list");
 };
 
 export const runtimeList = async (
@@ -56,12 +56,12 @@ export const runtimeList = async (
   runtimeKind: RuntimeKind,
 ): Promise<RuntimeInstanceSummary[]> => {
   const payload = await invokeFn("runtime_list", { repoPath, runtimeKind });
-  return parseArray(runtimeInstanceSummarySchema, payload);
+  return parseArray(runtimeInstanceSummarySchema, payload, "runtime_list");
 };
 
 export const runtimeDefinitionsList = async (invokeFn: InvokeFn): Promise<RuntimeDescriptor[]> => {
   const payload = await invokeFn("runtime_definitions_list", {});
-  return parseArray(runtimeDescriptorSchema, payload);
+  return parseArray(runtimeDescriptorSchema, payload, "runtime_definitions_list");
 };
 
 export const qaReviewTargetGet = async (

--- a/packages/adapters-tauri-host/src/git-client.ts
+++ b/packages/adapters-tauri-host/src/git-client.ts
@@ -39,7 +39,7 @@ export const gitGetBranches = async (
   repoPath: string,
 ): Promise<GitBranch[]> => {
   const payload = await invokeFn("git_get_branches", { repoPath });
-  return parseArray(gitBranchSchema, payload);
+  return parseArray(gitBranchSchema, payload, "git_get_branches");
 };
 
 export const gitGetCurrentBranch = async (
@@ -145,7 +145,7 @@ export const gitGetStatus = async (
     repoPath,
     workingDir: workingDir ?? null,
   });
-  return parseArray(fileStatusSchema, payload);
+  return parseArray(fileStatusSchema, payload, "git_get_status");
 };
 
 export const gitGetDiff = async (
@@ -159,7 +159,7 @@ export const gitGetDiff = async (
     targetBranch: targetBranch ?? null,
     workingDir: workingDir ?? null,
   });
-  return parseArray(fileDiffSchema, payload);
+  return parseArray(fileDiffSchema, payload, "git_get_diff");
 };
 
 export const gitCommitsAheadBehind = async (

--- a/packages/adapters-tauri-host/src/git-client.ts
+++ b/packages/adapters-tauri-host/src/git-client.ts
@@ -32,13 +32,13 @@ import {
   gitWorktreeSummarySchema,
 } from "@openducktor/contracts";
 import type { InvokeFn } from "./invoke-utils";
-import { parseArray } from "./invoke-utils";
+import { parseArray, parseOkResult } from "./invoke-utils";
 
 export const gitGetBranches = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<GitBranch[]> => {
-  const payload = await invokeFn<unknown>("git_get_branches", { repoPath });
+  const payload = await invokeFn("git_get_branches", { repoPath });
   return parseArray(gitBranchSchema, payload);
 };
 
@@ -47,7 +47,7 @@ export const gitGetCurrentBranch = async (
   repoPath: string,
   workingDir?: string,
 ): Promise<GitCurrentBranch> => {
-  const payload = await invokeFn<unknown>("git_get_current_branch", {
+  const payload = await invokeFn("git_get_current_branch", {
     repoPath,
     workingDir: workingDir ?? null,
   });
@@ -60,7 +60,7 @@ export const gitSwitchBranch = async (
   branch: string,
   options?: { create?: boolean },
 ): Promise<GitCurrentBranch> => {
-  const payload = await invokeFn<unknown>("git_switch_branch", {
+  const payload = await invokeFn("git_switch_branch", {
     repoPath,
     branch,
     create: options?.create ?? false,
@@ -75,7 +75,7 @@ export const gitCreateWorktree = async (
   branch: string,
   options?: { createBranch?: boolean },
 ): Promise<GitWorktreeSummary> => {
-  const payload = await invokeFn<unknown>("git_create_worktree", {
+  const payload = await invokeFn("git_create_worktree", {
     repoPath,
     worktreePath,
     branch,
@@ -90,11 +90,12 @@ export const gitRemoveWorktree = async (
   worktreePath: string,
   options?: { force?: boolean },
 ): Promise<{ ok: boolean }> => {
-  return invokeFn<{ ok: boolean }>("git_remove_worktree", {
+  const payload = await invokeFn("git_remove_worktree", {
     repoPath,
     worktreePath,
     force: options?.force ?? false,
   });
+  return parseOkResult(payload, "git_remove_worktree");
 };
 
 export const gitPushBranch = async (
@@ -108,7 +109,7 @@ export const gitPushBranch = async (
     workingDir?: string;
   },
 ): Promise<GitPushBranchResult> => {
-  const payload = await invokeFn<unknown>("git_push_branch", {
+  const payload = await invokeFn("git_push_branch", {
     repoPath,
     branch,
     remote: options?.remote,
@@ -128,7 +129,7 @@ export const gitPullBranch = async (
     repoPath,
     workingDir,
   };
-  const payload = await invokeFn<unknown>("git_pull_branch", {
+  const payload = await invokeFn("git_pull_branch", {
     repoPath: request.repoPath,
     workingDir: request.workingDir ?? null,
   });
@@ -140,7 +141,7 @@ export const gitGetStatus = async (
   repoPath: string,
   workingDir?: string,
 ): Promise<FileStatus[]> => {
-  const payload = await invokeFn<unknown>("git_get_status", {
+  const payload = await invokeFn("git_get_status", {
     repoPath,
     workingDir: workingDir ?? null,
   });
@@ -153,7 +154,7 @@ export const gitGetDiff = async (
   targetBranch?: string,
   workingDir?: string,
 ): Promise<FileDiff[]> => {
-  const payload = await invokeFn<unknown>("git_get_diff", {
+  const payload = await invokeFn("git_get_diff", {
     repoPath,
     targetBranch: targetBranch ?? null,
     workingDir: workingDir ?? null,
@@ -167,7 +168,7 @@ export const gitCommitsAheadBehind = async (
   targetBranch: string,
   workingDir?: string,
 ): Promise<CommitsAheadBehind> => {
-  const payload = await invokeFn<unknown>("git_commits_ahead_behind", {
+  const payload = await invokeFn("git_commits_ahead_behind", {
     repoPath,
     targetBranch,
     workingDir: workingDir ?? null,
@@ -182,7 +183,7 @@ export const gitGetWorktreeStatus = async (
   diffScope?: "target" | "uncommitted",
   workingDir?: string,
 ): Promise<GitWorktreeStatus> => {
-  const payload = await invokeFn<unknown>("git_get_worktree_status", {
+  const payload = await invokeFn("git_get_worktree_status", {
     repoPath,
     targetBranch,
     diffScope: gitDiffScopeSchema.parse(diffScope ?? "target"),
@@ -198,7 +199,7 @@ export const gitGetWorktreeStatusSummary = async (
   diffScope?: "target" | "uncommitted",
   workingDir?: string,
 ): Promise<GitWorktreeStatusSummary> => {
-  const payload = await invokeFn<unknown>("git_get_worktree_status_summary", {
+  const payload = await invokeFn("git_get_worktree_status_summary", {
     repoPath,
     targetBranch,
     diffScope: gitDiffScopeSchema.parse(diffScope ?? "target"),
@@ -218,7 +219,7 @@ export const gitCommitAll = async (
     message,
     workingDir,
   };
-  const payload = await invokeFn<unknown>("git_commit_all", {
+  const payload = await invokeFn("git_commit_all", {
     repoPath: request.repoPath,
     workingDir: request.workingDir ?? null,
     message: request.message,
@@ -237,7 +238,7 @@ export const gitRebaseBranch = async (
     targetBranch,
     workingDir,
   };
-  const payload = await invokeFn<unknown>("git_rebase_branch", {
+  const payload = await invokeFn("git_rebase_branch", {
     repoPath: request.repoPath,
     targetBranch: request.targetBranch,
     workingDir: request.workingDir ?? null,
@@ -254,7 +255,7 @@ export const gitRebaseAbort = async (
     repoPath,
     workingDir,
   };
-  const payload = await invokeFn<unknown>("git_rebase_abort", {
+  const payload = await invokeFn("git_rebase_abort", {
     repoPath: request.repoPath,
     workingDir: request.workingDir ?? null,
   });

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -991,8 +991,10 @@ describe("TauriHostClient", () => {
   });
 
   test("tasksList rejects malformed host payloads", async () => {
-    const { client } = createClient(() => [{ id: "task-1", title: "broken" }]);
-    await expect(client.tasksList("/repo")).rejects.toThrow();
+    const { client } = createClient(() => ({ tasks: [] }));
+    await expect(client.tasksList("/repo")).rejects.toThrow(
+      "Expected array payload from host command tasks_list",
+    );
   });
 
   test("runtime commands use expected IPC routes", async () => {

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -67,9 +67,9 @@ const makeTaskMetadataPayload = (specMarkdown = "Spec Body") => ({
 
 const createClient = (resolver: (command: string, args?: Record<string, unknown>) => unknown) => {
   const calls: InvokeCall[] = [];
-  const invoke = async <T>(command: string, args?: Record<string, unknown>): Promise<T> => {
+  const invoke = async (command: string, args?: Record<string, unknown>): Promise<unknown> => {
     calls.push({ command, args });
-    return resolver(command, args) as T;
+    return resolver(command, args);
   };
   const client: TauriHostClientType = createTauriHostClient(invoke);
   return { client, calls };
@@ -257,6 +257,48 @@ describe("TauriHostClient", () => {
         },
       },
     ]);
+  });
+
+  test("document mutation commands reject malformed updatedAt payloads", async () => {
+    const { client } = createClient((command) => {
+      switch (command) {
+        case "set_spec":
+          return { updatedAt: 123 };
+        case "spec_save_document":
+          return {};
+        case "set_plan":
+          return null;
+        case "plan_save_document":
+          return { updatedAt: "" };
+        default:
+          throw new Error(`Unexpected command: ${command}`);
+      }
+    });
+
+    await expect(
+      client.setSpec({ repoPath: "/repo", taskId: "task-1", markdown: "# Spec" }),
+    ).rejects.toThrow("Expected { updatedAt: string } payload from host command set_spec");
+    await expect(
+      client.saveSpecDocument({
+        repoPath: "/repo",
+        taskId: "task-1",
+        markdown: "# Spec",
+      }),
+    ).rejects.toThrow(
+      "Expected { updatedAt: string } payload from host command spec_save_document",
+    );
+    await expect(
+      client.setPlan({ repoPath: "/repo", taskId: "task-1", markdown: "## Plan" }),
+    ).rejects.toThrow("Expected { updatedAt: string } payload from host command set_plan");
+    await expect(
+      client.savePlanDocument({
+        repoPath: "/repo",
+        taskId: "task-1",
+        markdown: "## Plan",
+      }),
+    ).rejects.toThrow(
+      "Expected { updatedAt: string } payload from host command plan_save_document",
+    );
   });
 
   test("setPlan forwards markdown and subtasks payload", async () => {
@@ -597,6 +639,19 @@ describe("TauriHostClient", () => {
     ]);
   });
 
+  test("taskDelete rejects malformed ack payloads", async () => {
+    const { client } = createClient((command) => {
+      if (command === "task_delete") {
+        return { ok: "true" };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(client.taskDelete("/repo", "epic-1", true)).rejects.toThrow(
+      "Expected { ok: boolean } payload from host command task_delete",
+    );
+  });
+
   test("git commands use expected IPC routes and payloads", async () => {
     const { client, calls } = createClient((command) => {
       if (command === "git_get_branches") {
@@ -790,6 +845,19 @@ describe("TauriHostClient", () => {
       diffScope: "target",
       workingDir: "/tmp/wt/task-1",
     });
+  });
+
+  test("gitRemoveWorktree rejects malformed ack payloads", async () => {
+    const { client } = createClient((command) => {
+      if (command === "git_remove_worktree") {
+        return {};
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(client.gitRemoveWorktree("/repo", "/tmp/wt/task-1")).rejects.toThrow(
+      "Expected { ok: boolean } payload from host command git_remove_worktree",
+    );
   });
 
   test("git commit-all, pull, and rebase parse and reject malformed host payloads", async () => {

--- a/packages/adapters-tauri-host/src/invoke-utils.ts
+++ b/packages/adapters-tauri-host/src/invoke-utils.ts
@@ -1,8 +1,40 @@
-export type InvokeFn = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
+export type InvokeFn = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+export type OkResult = { ok: boolean };
+export type UpdatedAtResult = { updatedAt: string };
 
 export const parseArray = <T>(schema: { parse: (value: unknown) => T }, payload: unknown): T[] => {
   if (!Array.isArray(payload)) {
     throw new Error("Expected array payload from host command");
   }
   return payload.map((entry) => schema.parse(entry));
+};
+
+export const parseOkResult = (payload: unknown, command: string): OkResult => {
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    typeof (payload as { ok?: unknown }).ok !== "boolean"
+  ) {
+    throw new Error(`Expected { ok: boolean } payload from host command ${command}`);
+  }
+
+  return {
+    ok: (payload as { ok: boolean }).ok,
+  };
+};
+
+export const parseUpdatedAtResult = (payload: unknown, command: string): UpdatedAtResult => {
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    typeof (payload as { updatedAt?: unknown }).updatedAt !== "string" ||
+    (payload as { updatedAt: string }).updatedAt.trim().length === 0
+  ) {
+    throw new Error(`Expected { updatedAt: string } payload from host command ${command}`);
+  }
+
+  return {
+    updatedAt: (payload as { updatedAt: string }).updatedAt,
+  };
 };

--- a/packages/adapters-tauri-host/src/invoke-utils.ts
+++ b/packages/adapters-tauri-host/src/invoke-utils.ts
@@ -3,13 +3,23 @@ export type InvokeFn = (command: string, args?: Record<string, unknown>) => Prom
 export type OkResult = { ok: boolean };
 export type UpdatedAtResult = { updatedAt: string };
 
-export const parseArray = <T>(schema: { parse: (value: unknown) => T }, payload: unknown): T[] => {
+/**
+ * Parse an array payload returned by a host command and validate each entry.
+ */
+export const parseArray = <T>(
+  schema: { parse: (value: unknown) => T },
+  payload: unknown,
+  command: string,
+): T[] => {
   if (!Array.isArray(payload)) {
-    throw new Error("Expected array payload from host command");
+    throw new Error(`Expected array payload from host command ${command}`);
   }
   return payload.map((entry) => schema.parse(entry));
 };
 
+/**
+ * Parse the canonical `{ ok: boolean }` ack shape returned by host mutations.
+ */
 export const parseOkResult = (payload: unknown, command: string): OkResult => {
   if (
     !payload ||
@@ -24,6 +34,9 @@ export const parseOkResult = (payload: unknown, command: string): OkResult => {
   };
 };
 
+/**
+ * Parse the canonical `{ updatedAt: string }` document-write result from the host.
+ */
 export const parseUpdatedAtResult = (payload: unknown, command: string): UpdatedAtResult => {
   if (
     !payload ||

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -1,5 +1,6 @@
 import {
   type AgentSessionRecord,
+  type PlanSubtaskInput,
   type TaskCard,
   type TaskCreateInput,
   type TaskStatus,
@@ -24,13 +25,6 @@ export type SaveSpecDocumentInput = {
   repoPath: string;
   taskId: string;
   markdown: string;
-};
-
-export type PlanSubtaskInput = {
-  title: string;
-  issueType?: "task" | "feature" | "bug";
-  priority?: number;
-  description?: string;
 };
 
 export type SetPlanInput = {

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -63,7 +63,7 @@ export class TauriTaskClient {
 
   async tasksList(repoPath: string): Promise<TaskCard[]> {
     const payload = await this.invokeFn("tasks_list", { repoPath });
-    return parseArray(taskCardSchema, payload);
+    return parseArray(taskCardSchema, payload, "tasks_list");
   }
 
   async taskCreate(repoPath: string, input: TaskCreateInput): Promise<TaskCard> {

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -11,7 +11,7 @@ import {
 } from "@openducktor/contracts";
 import type { SetPlanOutput, SetSpecOutput } from "@openducktor/core";
 import type { InvokeFn } from "./invoke-utils";
-import { parseArray } from "./invoke-utils";
+import { parseArray, parseOkResult, parseUpdatedAtResult } from "./invoke-utils";
 import type { ParsedTaskMetadata, TaskMetadataCache } from "./task-metadata-cache";
 
 export type SetSpecInput = {
@@ -68,13 +68,13 @@ export class TauriTaskClient {
   }
 
   async tasksList(repoPath: string): Promise<TaskCard[]> {
-    const payload = await this.invokeFn<unknown>("tasks_list", { repoPath });
+    const payload = await this.invokeFn("tasks_list", { repoPath });
     return parseArray(taskCardSchema, payload);
   }
 
   async taskCreate(repoPath: string, input: TaskCreateInput): Promise<TaskCard> {
     const createInput = taskCreateInputSchema.parse(input);
-    const payload = await this.invokeFn<unknown>("task_create", {
+    const payload = await this.invokeFn("task_create", {
       repoPath,
       input: createInput,
     });
@@ -83,7 +83,7 @@ export class TauriTaskClient {
 
   async taskUpdate(repoPath: string, taskId: string, patch: TaskUpdatePatch): Promise<TaskCard> {
     const updatePatch = taskUpdatePatchSchema.parse(patch);
-    const payload = await this.invokeFn<unknown>("task_update", {
+    const payload = await this.invokeFn("task_update", {
       repoPath,
       taskId,
       patch: updatePatch,
@@ -96,13 +96,13 @@ export class TauriTaskClient {
     taskId: string,
     deleteSubtasks = false,
   ): Promise<{ ok: boolean }> {
-    const payload = await this.invokeFn<{ ok: boolean }>("task_delete", {
+    const payload = await this.invokeFn("task_delete", {
       repoPath,
       taskId,
       deleteSubtasks,
     });
     this.invalidateTaskMetadata(repoPath, taskId);
-    return payload;
+    return parseOkResult(payload, "task_delete");
   }
 
   async taskTransition(
@@ -112,7 +112,7 @@ export class TauriTaskClient {
     reason?: string,
   ): Promise<TaskCard> {
     taskStatusSchema.parse(status);
-    const payload = await this.invokeFn<unknown>("task_transition", {
+    const payload = await this.invokeFn("task_transition", {
       repoPath,
       taskId,
       status,
@@ -122,7 +122,7 @@ export class TauriTaskClient {
   }
 
   async taskDefer(repoPath: string, taskId: string, reason?: string): Promise<TaskCard> {
-    const payload = await this.invokeFn<unknown>("task_defer", {
+    const payload = await this.invokeFn("task_defer", {
       repoPath,
       taskId,
       reason,
@@ -131,7 +131,7 @@ export class TauriTaskClient {
   }
 
   async taskResumeDeferred(repoPath: string, taskId: string): Promise<TaskCard> {
-    const payload = await this.invokeFn<unknown>("task_resume_deferred", {
+    const payload = await this.invokeFn("task_resume_deferred", {
       repoPath,
       taskId,
     });
@@ -152,30 +152,30 @@ export class TauriTaskClient {
   async setSpec(input: SetSpecInput): Promise<SetSpecOutput> {
     const repoPath = this.requireRepoPath(input.repoPath, "spec");
 
-    const payload = await this.invokeFn<{ updatedAt: string }>("set_spec", {
+    const payload = await this.invokeFn("set_spec", {
       repoPath,
       taskId: input.taskId,
       markdown: input.markdown,
     });
 
     this.invalidateTaskMetadata(repoPath, input.taskId);
-    return { updatedAt: payload.updatedAt };
+    return parseUpdatedAtResult(payload, "set_spec");
   }
 
   async saveSpecDocument(input: SaveSpecDocumentInput): Promise<SetSpecOutput> {
-    const payload = await this.invokeFn<{ updatedAt: string }>("spec_save_document", {
+    const payload = await this.invokeFn("spec_save_document", {
       repoPath: input.repoPath,
       taskId: input.taskId,
       markdown: input.markdown,
     });
     this.invalidateTaskMetadata(input.repoPath, input.taskId);
-    return { updatedAt: payload.updatedAt };
+    return parseUpdatedAtResult(payload, "spec_save_document");
   }
 
   async setPlan(input: SetPlanInput): Promise<SetPlanOutput> {
     const repoPath = this.requireRepoPath(input.repoPath, "plan");
 
-    const payload = await this.invokeFn<{ updatedAt: string }>("set_plan", {
+    const payload = await this.invokeFn("set_plan", {
       repoPath,
       taskId: input.taskId,
       input: {
@@ -185,17 +185,17 @@ export class TauriTaskClient {
     });
 
     this.invalidateTaskMetadata(repoPath, input.taskId);
-    return { updatedAt: payload.updatedAt };
+    return parseUpdatedAtResult(payload, "set_plan");
   }
 
   async savePlanDocument(input: SavePlanDocumentInput): Promise<SetPlanOutput> {
-    const payload = await this.invokeFn<{ updatedAt: string }>("plan_save_document", {
+    const payload = await this.invokeFn("plan_save_document", {
       repoPath: input.repoPath,
       taskId: input.taskId,
       markdown: input.markdown,
     });
     this.invalidateTaskMetadata(input.repoPath, input.taskId);
-    return { updatedAt: payload.updatedAt };
+    return parseUpdatedAtResult(payload, "plan_save_document");
   }
 
   async planGet(
@@ -225,7 +225,7 @@ export class TauriTaskClient {
   }
 
   async qaApproved(repoPath: string, taskId: string, markdown: string): Promise<TaskCard> {
-    const payload = await this.invokeFn<unknown>("qa_approved", {
+    const payload = await this.invokeFn("qa_approved", {
       repoPath,
       taskId,
       input: { markdown },
@@ -235,7 +235,7 @@ export class TauriTaskClient {
   }
 
   async qaRejected(repoPath: string, taskId: string, markdown: string): Promise<TaskCard> {
-    const payload = await this.invokeFn<unknown>("qa_rejected", {
+    const payload = await this.invokeFn("qa_rejected", {
       repoPath,
       taskId,
       input: { markdown },
@@ -254,7 +254,7 @@ export class TauriTaskClient {
     taskId: string,
     session: AgentSessionRecord,
   ): Promise<void> {
-    await this.invokeFn<unknown>("agent_session_upsert", {
+    await this.invokeFn("agent_session_upsert", {
       repoPath,
       taskId,
       session,

--- a/packages/adapters-tauri-host/src/task-metadata-cache.ts
+++ b/packages/adapters-tauri-host/src/task-metadata-cache.ts
@@ -97,7 +97,7 @@ export class TaskMetadataCache {
       return inflight;
     }
 
-    const next = invokeFn<unknown>("task_metadata_get", { repoPath, taskId })
+    const next = invokeFn("task_metadata_get", { repoPath, taskId })
       .then((payload) => {
         const parsed = taskMetadataPayloadSchema.parse(payload);
         const metadata = {

--- a/packages/adapters-tauri-host/src/workspace-client.ts
+++ b/packages/adapters-tauri-host/src/workspace-client.ts
@@ -101,7 +101,7 @@ const parseTrustedHooksChallenge = (payload: unknown): TrustedHooksChallenge => 
 };
 
 export const workspaceList = async (invokeFn: InvokeFn): Promise<WorkspaceRecord[]> => {
-  const payload = await invokeFn<unknown>("workspace_list");
+  const payload = await invokeFn("workspace_list");
   return parseArray(workspaceRecordSchema, payload);
 };
 
@@ -109,7 +109,7 @@ export const workspaceAdd = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<WorkspaceRecord> => {
-  const payload = await invokeFn<unknown>("workspace_add", { repoPath });
+  const payload = await invokeFn("workspace_add", { repoPath });
   return workspaceRecordSchema.parse(payload);
 };
 
@@ -117,7 +117,7 @@ export const workspaceSelect = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<WorkspaceRecord> => {
-  const payload = await invokeFn<unknown>("workspace_select", { repoPath });
+  const payload = await invokeFn("workspace_select", { repoPath });
   return workspaceRecordSchema.parse(payload);
 };
 
@@ -126,7 +126,7 @@ export const workspaceUpdateRepoConfig = async (
   repoPath: string,
   config: WorkspaceRepoConfigInput,
 ): Promise<WorkspaceRecord> => {
-  const payload = await invokeFn<unknown>("workspace_update_repo_config", {
+  const payload = await invokeFn("workspace_update_repo_config", {
     repoPath,
     config,
   });
@@ -138,7 +138,7 @@ export const workspaceSaveRepoSettings = async (
   repoPath: string,
   settings: WorkspaceRepoSettingsInput,
 ): Promise<WorkspaceRecord> => {
-  const payload = await invokeFn<unknown>("workspace_save_repo_settings", {
+  const payload = await invokeFn("workspace_save_repo_settings", {
     repoPath,
     settings,
   });
@@ -150,7 +150,7 @@ export const workspaceUpdateRepoHooks = async (
   repoPath: string,
   hooks: WorkspaceRepoHooksInput,
 ): Promise<WorkspaceRecord> => {
-  const payload = await invokeFn<unknown>("workspace_update_repo_hooks", {
+  const payload = await invokeFn("workspace_update_repo_hooks", {
     repoPath,
     hooks,
   });
@@ -161,14 +161,14 @@ export const workspaceGetRepoConfig = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<RepoConfig> => {
-  const payload = await invokeFn<unknown>("workspace_get_repo_config", { repoPath });
+  const payload = await invokeFn("workspace_get_repo_config", { repoPath });
   return repoConfigSchema.parse(payload);
 };
 
 export const workspaceGetSettingsSnapshot = async (
   invokeFn: InvokeFn,
 ): Promise<SettingsSnapshot> => {
-  const payload = await invokeFn<unknown>("workspace_get_settings_snapshot");
+  const payload = await invokeFn("workspace_get_settings_snapshot");
   return settingsSnapshotSchema.parse(payload);
 };
 
@@ -176,7 +176,7 @@ export const workspaceSaveSettingsSnapshot = async (
   invokeFn: InvokeFn,
   snapshot: SettingsSnapshot,
 ): Promise<WorkspaceRecord[]> => {
-  const payload = await invokeFn<unknown>("workspace_save_settings_snapshot", { snapshot });
+  const payload = await invokeFn("workspace_save_settings_snapshot", { snapshot });
   return parseArray(workspaceRecordSchema, payload);
 };
 
@@ -184,14 +184,14 @@ export const workspaceUpdateGlobalGitConfig = async (
   invokeFn: InvokeFn,
   git: GlobalGitConfig,
 ): Promise<void> => {
-  await invokeFn<void>("workspace_update_global_git_config", { git });
+  await invokeFn("workspace_update_global_git_config", { git });
 };
 
 export const workspaceDetectGithubRepository = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<GitProviderRepository | null> => {
-  const payload = await invokeFn<unknown>("workspace_detect_github_repository", { repoPath });
+  const payload = await invokeFn("workspace_detect_github_repository", { repoPath });
   return payload === null ? null : gitProviderRepositorySchema.parse(payload);
 };
 
@@ -201,7 +201,7 @@ export const workspaceSetTrustedHooks = async (
   trusted: boolean,
   challenge?: TrustedHooksProof,
 ): Promise<WorkspaceRecord> => {
-  const payload = await invokeFn<unknown>("workspace_set_trusted_hooks", {
+  const payload = await invokeFn("workspace_set_trusted_hooks", {
     repoPath,
     trusted,
     ...(challenge
@@ -218,14 +218,14 @@ export const workspacePrepareTrustedHooksChallenge = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<TrustedHooksChallenge> => {
-  const payload = await invokeFn<unknown>("workspace_prepare_trusted_hooks_challenge", {
+  const payload = await invokeFn("workspace_prepare_trusted_hooks_challenge", {
     repoPath,
   });
   return parseTrustedHooksChallenge(payload);
 };
 
 export const setTheme = async (invokeFn: InvokeFn, theme: string): Promise<void> => {
-  await invokeFn<void>("set_theme", { theme });
+  await invokeFn("set_theme", { theme });
 };
 
 export class TauriWorkspaceClient {

--- a/packages/adapters-tauri-host/src/workspace-client.ts
+++ b/packages/adapters-tauri-host/src/workspace-client.ts
@@ -102,7 +102,7 @@ const parseTrustedHooksChallenge = (payload: unknown): TrustedHooksChallenge => 
 
 export const workspaceList = async (invokeFn: InvokeFn): Promise<WorkspaceRecord[]> => {
   const payload = await invokeFn("workspace_list");
-  return parseArray(workspaceRecordSchema, payload);
+  return parseArray(workspaceRecordSchema, payload, "workspace_list");
 };
 
 export const workspaceAdd = async (
@@ -177,7 +177,7 @@ export const workspaceSaveSettingsSnapshot = async (
   snapshot: SettingsSnapshot,
 ): Promise<WorkspaceRecord[]> => {
   const payload = await invokeFn("workspace_save_settings_snapshot", { snapshot });
-  return parseArray(workspaceRecordSchema, payload);
+  return parseArray(workspaceRecordSchema, payload, "workspace_save_settings_snapshot");
 };
 
 export const workspaceUpdateGlobalGitConfig = async (

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -36,6 +36,10 @@ import type {
   GitWorktreeSummary,
   GlobalConfig,
   IssueType,
+  PlanSubtaskInput,
+  PlanSubtaskIssueType,
+  PlanSubtaskPriority,
+  QaReportVerdict,
   QaReviewTarget,
   QaReviewTargetSource,
   QaWorkflowVerdict,
@@ -173,6 +177,9 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "settingsSnapshotSchema",
   "specTemplateSections",
   "systemCheckSchema",
+  "planSubtaskInputSchema",
+  "planSubtaskIssueTypeSchema",
+  "planSubtaskPrioritySchema",
   "taskActionSchema",
   "taskApprovalContextSchema",
   "taskCardSchema",
@@ -182,6 +189,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "taskMetadataPayloadSchema",
   "taskMetadataQaReportSchema",
   "taskPrioritySchema",
+  "qaReportVerdictSchema",
   "taskStatusSchema",
   "taskUpdatePatchSchema",
   "themeSchema",
@@ -232,6 +240,10 @@ type ExportedTypeContract = {
   GitWorktreeSummary: GitWorktreeSummary;
   GlobalConfig: GlobalConfig;
   IssueType: IssueType;
+  PlanSubtaskInput: PlanSubtaskInput;
+  PlanSubtaskIssueType: PlanSubtaskIssueType;
+  PlanSubtaskPriority: PlanSubtaskPriority;
+  QaReportVerdict: QaReportVerdict;
   QaWorkflowVerdict: QaWorkflowVerdict;
   RepoAgentDefaults: RepoAgentDefaults;
   RepoConfig: RepoConfig;

--- a/packages/contracts/src/metadata-schemas.ts
+++ b/packages/contracts/src/metadata-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { directMergeRecordSchema, pullRequestSchema } from "./git-schemas";
+import { qaReportVerdictSchema } from "./task-schemas";
 
 export const taskMetadataDocumentSchema = z.object({
   markdown: z.string().default(""),
@@ -9,7 +10,7 @@ export type TaskMetadataDocument = z.infer<typeof taskMetadataDocumentSchema>;
 
 export const taskMetadataQaReportSchema = z.object({
   markdown: z.string(),
-  verdict: z.enum(["approved", "rejected"]),
+  verdict: qaReportVerdictSchema,
   updatedAt: z.string(),
   revision: z.number().int().nonnegative(),
 });

--- a/packages/contracts/src/task-schemas.ts
+++ b/packages/contracts/src/task-schemas.ts
@@ -35,6 +35,22 @@ export type TaskAction = z.infer<typeof taskActionSchema>;
 export const taskPrioritySchema = z.number().int().min(0).max(4);
 export type TaskPriority = z.infer<typeof taskPrioritySchema>;
 
+export const planSubtaskPrioritySchema = taskPrioritySchema.describe(
+  "Subtask priority. Valid values: 0, 1, 2, 3, 4. Default is 2.",
+);
+export type PlanSubtaskPriority = z.infer<typeof planSubtaskPrioritySchema>;
+
+export const planSubtaskIssueTypeSchema = z.enum(["task", "feature", "bug"]);
+export type PlanSubtaskIssueType = z.infer<typeof planSubtaskIssueTypeSchema>;
+
+export const planSubtaskInputSchema = z.object({
+  title: z.string().trim().min(1),
+  issueType: planSubtaskIssueTypeSchema.optional(),
+  priority: planSubtaskPrioritySchema.optional(),
+  description: z.string().optional(),
+});
+export type PlanSubtaskInput = z.infer<typeof planSubtaskInputSchema>;
+
 const taskDocumentPresenceSchema = z.object({
   has: z.boolean().default(false),
   updatedAt: z.preprocess((value) => (value === null ? undefined : value), z.string().optional()),
@@ -43,6 +59,9 @@ export type TaskDocumentPresence = z.infer<typeof taskDocumentPresenceSchema>;
 
 export const qaWorkflowVerdictSchema = z.enum(["approved", "rejected", "not_reviewed"]);
 export type QaWorkflowVerdict = z.infer<typeof qaWorkflowVerdictSchema>;
+
+export const qaReportVerdictSchema = z.enum(["approved", "rejected"]);
+export type QaReportVerdict = z.infer<typeof qaReportVerdictSchema>;
 
 const taskQaDocumentPresenceSchema = taskDocumentPresenceSchema.extend({
   verdict: qaWorkflowVerdictSchema.default("not_reviewed"),

--- a/packages/openducktor-mcp/src/contracts.ts
+++ b/packages/openducktor-mcp/src/contracts.ts
@@ -1,13 +1,12 @@
-import type { TaskCard as CanonicalTaskCard, IssueType, TaskStatus } from "@openducktor/contracts";
+import type {
+  TaskCard as CanonicalTaskCard,
+  IssueType,
+  PlanSubtaskInput,
+  QaReportVerdict,
+  TaskStatus,
+} from "@openducktor/contracts";
 
-export type { IssueType, TaskStatus };
-
-export type PlanSubtaskInput = {
-  title: string;
-  issueType?: Exclude<IssueType, "epic"> | undefined;
-  priority?: number | undefined;
-  description?: string | undefined;
-};
+export type { IssueType, PlanSubtaskInput, QaReportVerdict, TaskStatus };
 
 export type TaskCard = Pick<
   CanonicalTaskCard,
@@ -43,7 +42,7 @@ export type MarkdownEntry = {
 
 export type QaEntry = {
   markdown: string;
-  verdict: "approved" | "rejected";
+  verdict: QaReportVerdict;
   updatedAt: string;
   updatedBy: string;
   sourceTool: string;

--- a/packages/openducktor-mcp/src/metadata-docs.ts
+++ b/packages/openducktor-mcp/src/metadata-docs.ts
@@ -1,3 +1,4 @@
+import type { QaReportVerdict } from "@openducktor/contracts";
 import type { JsonObject, RawIssue } from "./contracts";
 import {
   ensureObject,
@@ -18,7 +19,7 @@ export type TaskDocumentsSnapshot = {
   latestQaReport: {
     markdown: string;
     updatedAt: string | null;
-    verdict: "approved" | "rejected" | null;
+    verdict: QaReportVerdict | null;
   };
 };
 

--- a/packages/openducktor-mcp/src/task-document-store.ts
+++ b/packages/openducktor-mcp/src/task-document-store.ts
@@ -1,4 +1,4 @@
-import type { AgentToolName } from "@openducktor/contracts";
+import type { AgentToolName, QaReportVerdict } from "@openducktor/contracts";
 import type { TaskPersistencePort } from "./bd-persistence";
 import type { TimeProvider } from "./beads-runtime";
 import type { MarkdownEntry, QaEntry, RawIssue } from "./contracts";
@@ -6,7 +6,6 @@ import { parseTaskDocuments, type TaskDocumentsSnapshot } from "./metadata-docs"
 import { parseMarkdownEntries, parseQaEntries } from "./task-mapping";
 
 type MarkdownDocumentKey = "spec" | "implementationPlan";
-type QaVerdict = "approved" | "rejected";
 
 type PersistLatestMarkdownInput = {
   issue: RawIssue;
@@ -39,7 +38,7 @@ const QA_REPORT_SOURCES = {
     updatedBy: "qa-agent",
     sourceTool: "odt_qa_rejected",
   },
-} as const satisfies Record<QaVerdict, DocumentSource>;
+} as const satisfies Record<QaReportVerdict, DocumentSource>;
 
 const getNextRevision = (entries: Array<{ revision: number }>): number => {
   const maxRevision = entries.reduce((max, entry) => Math.max(max, entry.revision), 0);
@@ -61,11 +60,11 @@ export type TaskDocumentPort = {
     taskId: string,
     markdown: string,
   ): Promise<{ updatedAt: string; revision: number }>;
-  appendQaReport(taskId: string, markdown: string, verdict: QaVerdict): Promise<void>;
+  appendQaReport(taskId: string, markdown: string, verdict: QaReportVerdict): Promise<void>;
   prepareQaReportWrite(
     issue: RawIssue,
     markdown: string,
-    verdict: QaVerdict,
+    verdict: QaReportVerdict,
   ): PreparedQaReportWrite;
 };
 
@@ -111,7 +110,7 @@ export class TaskDocumentStore implements TaskDocumentPort {
     });
   }
 
-  async appendQaReport(taskId: string, markdown: string, verdict: QaVerdict): Promise<void> {
+  async appendQaReport(taskId: string, markdown: string, verdict: QaReportVerdict): Promise<void> {
     const issue = await this.persistence.showRawIssue(taskId);
     const preparedWrite = this.prepareQaReportWrite(issue, markdown, verdict);
     await this.persistence.writeNamespace(taskId, preparedWrite.root, preparedWrite.namespace);
@@ -120,7 +119,7 @@ export class TaskDocumentStore implements TaskDocumentPort {
   prepareQaReportWrite(
     issue: RawIssue,
     markdown: string,
-    verdict: QaVerdict,
+    verdict: QaReportVerdict,
   ): PreparedQaReportWrite {
     const { root, namespace, documents } = this.persistence.getNamespaceData(issue);
     const entries = parseQaEntries(documents.qaReports);

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -1,3 +1,4 @@
+import { qaReportVerdictSchema } from "@openducktor/contracts";
 import { z } from "zod";
 import { parseBeadsIssueType, parseBeadsTaskStatus } from "./beads-task-parsing";
 import type { JsonObject, MarkdownEntry, QaEntry, RawIssue, TaskCard } from "./contracts";
@@ -30,7 +31,7 @@ const MarkdownEntrySchema = z.object({
 });
 
 const QaEntrySchema = MarkdownEntrySchema.extend({
-  verdict: z.enum(["approved", "rejected"]),
+  verdict: qaReportVerdictSchema,
 });
 
 const parseTypedEntries = <T>(schema: z.ZodType<T>, value: unknown): T[] => {

--- a/packages/openducktor-mcp/src/tool-schemas.ts
+++ b/packages/openducktor-mcp/src/tool-schemas.ts
@@ -1,25 +1,5 @@
-import { type AgentToolName, issueTypeSchema } from "@openducktor/contracts";
+import { type AgentToolName, planSubtaskInputSchema } from "@openducktor/contracts";
 import { z } from "zod";
-
-const PLAN_SUBTASK_PRIORITY_VALUES = [0, 1, 2, 3, 4] as const;
-const PlanSubtaskPrioritySchema = z
-  .union([
-    z.literal(PLAN_SUBTASK_PRIORITY_VALUES[0]),
-    z.literal(PLAN_SUBTASK_PRIORITY_VALUES[1]),
-    z.literal(PLAN_SUBTASK_PRIORITY_VALUES[2]),
-    z.literal(PLAN_SUBTASK_PRIORITY_VALUES[3]),
-    z.literal(PLAN_SUBTASK_PRIORITY_VALUES[4]),
-  ])
-  .describe("Subtask priority. Valid values: 0, 1, 2, 3, 4. Default is 2.");
-
-const PlanSubtaskSchema = z.object({
-  title: z.string().trim().min(1),
-  issueType: issueTypeSchema
-    .refine((value) => value !== "epic", "Epic subtasks are not allowed.")
-    .optional(),
-  priority: PlanSubtaskPrioritySchema.optional(),
-  description: z.string().optional(),
-});
 
 export const ReadTaskInputSchema = z.object({
   taskId: z.string().trim().min(1),
@@ -33,7 +13,7 @@ export const SetSpecInputSchema = z.object({
 export const SetPlanInputSchema = z.object({
   taskId: z.string().trim().min(1),
   markdown: z.string().trim().min(1),
-  subtasks: z.array(PlanSubtaskSchema).optional(),
+  subtasks: z.array(planSubtaskInputSchema).optional(),
 });
 
 export const BuildBlockedInputSchema = z.object({


### PR DESCRIPTION
## Summary
- continue the refreshed `desloppify` backlog with contract-focused refactors
- tighten runtime and host adapter boundaries so invalid data can no longer hide behind widened strings or unchecked payload claims
- centralize shared task workflow types so MCP, contracts, and the Tauri host adapter stop drifting independently

## What changed
### Preserve canonical runtime typing in session orchestration
- threaded `RuntimeKind` through the session-start modal, orchestrator session loaders, and session state instead of widening to `string` and recovering it with casts
- removed the remaining runtime-kind cast at the session-start modal boundary
- kept the runtime selection flow aligned with the canonical contract end-to-end

### Parse Tauri host mutation payloads explicitly
- changed the Tauri host `InvokeFn` surface to return `unknown` instead of caller-asserted generics
- added shared parsers for `{ ok: boolean }` and `{ updatedAt: string }` host responses
- updated task, git, runtime, and workspace adapter methods to validate these mutation payloads before returning typed results
- added regression coverage for malformed ack and document-save payloads

### Share task workflow contracts across packages
- promoted `PlanSubtaskInput`, plan-subtask helper schemas, and `QaReportVerdict` into `@openducktor/contracts`
- removed duplicated workflow payload and QA verdict unions from `@openducktor/openducktor-mcp` and `@openducktor/adapters-tauri-host`
- updated MCP tool schemas and metadata parsing to consume the canonical contracts exports
- extended the contracts barrel export test to cover the new shared schemas and types

## Verification
### Bun
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build`

### Cargo
- `cargo fmt --all --check`
- `cargo check`
- `cargo test`
- `cargo build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit subtask input and QA verdict types enabling richer plan subtasks and QA reporting.

* **Refactor**
  * Standardized runtime kind typing across session and agent flows for more consistent behavior.
  * Centralized and improved host response parsing for safer IPC handling.

* **Tests**
  * Added validation tests to reject malformed host payloads, improving robustness and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->