### PR TITLE
Reduce Kanban virtualization observer overhead

### DIFF
--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -74,21 +74,19 @@ const MeasuredTaskCard = memo(function MeasuredTaskCard({
       }
     };
 
-    reportHeight();
-
-    if (typeof ResizeObserver === "undefined") {
+    if (typeof window === "undefined") {
+      reportHeight();
       return;
     }
 
-    const observer = new ResizeObserver(() => {
+    const frameHandle = window.requestAnimationFrame(() => {
       reportHeight();
     });
 
-    observer.observe(element);
     return () => {
-      observer.disconnect();
+      window.cancelAnimationFrame(frameHandle);
     };
-  }, [onMeasuredHeight, task.id]);
+  }, [activeSessions, onMeasuredHeight, runState, task, task.id]);
 
   return (
     <div ref={taskWrapperRef}>

--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -62,10 +62,38 @@ const MeasuredTaskCard = memo(function MeasuredTaskCard({
   onMeasuredHeight: (taskId: string, height: number) => void;
 } & TaskCardHandlers): ReactElement {
   const taskWrapperRef = useRef<HTMLDivElement | null>(null);
+  const taskMeasurementKey = [
+    task.updatedAt ?? "",
+    task.title,
+    task.status,
+    task.issueType,
+    task.priority,
+    task.subtaskIds.join(","),
+    task.availableActions.join(","),
+    task.pullRequest?.number ?? "",
+    task.pullRequest?.state ?? "",
+    task.pullRequest?.url ?? "",
+  ].join("|");
+  const activeSessionsMeasurementKey =
+    activeSessions
+      ?.map(
+        (session) => `${session.sessionId}:${session.role}:${session.scenario}:${session.status}`,
+      )
+      .join("|") ?? "";
+  const measurementTrigger = [
+    measurementVersion,
+    runState ?? "",
+    taskMeasurementKey,
+    activeSessionsMeasurementKey,
+  ].join("::");
 
   useEffect(() => {
     const element = taskWrapperRef.current;
     if (!element) {
+      return;
+    }
+
+    if (measurementTrigger.length === 0) {
       return;
     }
 
@@ -88,7 +116,7 @@ const MeasuredTaskCard = memo(function MeasuredTaskCard({
     return () => {
       window.cancelAnimationFrame(frameHandle);
     };
-  }, [activeSessions, measurementVersion, onMeasuredHeight, runState, task, task.id]);
+  }, [measurementTrigger, onMeasuredHeight, task.id]);
 
   return (
     <div ref={taskWrapperRef}>

--- a/apps/desktop/src/components/features/kanban/kanban-column.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-column.tsx
@@ -44,6 +44,7 @@ const MeasuredTaskCard = memo(function MeasuredTaskCard({
   task,
   runState,
   activeSessions,
+  measurementVersion,
   onMeasuredHeight,
   onOpenDetails,
   onDelegate,
@@ -57,6 +58,7 @@ const MeasuredTaskCard = memo(function MeasuredTaskCard({
   task: KanbanColumnData["tasks"][number];
   runState: RunSummary["state"] | undefined;
   activeSessions: RunningTaskSessions | undefined;
+  measurementVersion: number;
   onMeasuredHeight: (taskId: string, height: number) => void;
 } & TaskCardHandlers): ReactElement {
   const taskWrapperRef = useRef<HTMLDivElement | null>(null);
@@ -86,7 +88,7 @@ const MeasuredTaskCard = memo(function MeasuredTaskCard({
     return () => {
       window.cancelAnimationFrame(frameHandle);
     };
-  }, [activeSessions, onMeasuredHeight, runState, task, task.id]);
+  }, [activeSessions, measurementVersion, onMeasuredHeight, runState, task, task.id]);
 
   return (
     <div ref={taskWrapperRef}>
@@ -167,6 +169,7 @@ export function KanbanColumn({
   const {
     containerRef: cardsViewportRef,
     renderModel,
+    measurementVersion,
     onMeasuredHeight: handleMeasuredHeight,
   } = useKanbanVirtualization({
     tasks: column.tasks,
@@ -196,6 +199,7 @@ export function KanbanColumn({
                   task={task}
                   runState={runStateByTaskId.get(task.id)}
                   activeSessions={activeSessionsByTaskId.get(task.id) ?? EMPTY_ACTIVE_SESSIONS}
+                  measurementVersion={measurementVersion}
                   onMeasuredHeight={handleMeasuredHeight}
                   onOpenDetails={onOpenDetails}
                   onDelegate={onDelegate}

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
@@ -184,6 +184,46 @@ const installMockWindow = () => {
   };
 };
 
+const installMockResizeObserver = () => {
+  const globalWithResizeObserver = globalThis as typeof globalThis & {
+    ResizeObserver?: typeof ResizeObserver;
+  };
+  const previousResizeObserver = globalWithResizeObserver.ResizeObserver;
+  const callbacks: ResizeObserverCallback[] = [];
+
+  class MockResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      callbacks.push(callback);
+    }
+
+    observe(_target: Element): void {}
+
+    unobserve(_target: Element): void {}
+
+    disconnect(): void {}
+  }
+
+  globalWithResizeObserver.ResizeObserver =
+    MockResizeObserver as unknown as typeof ResizeObserver;
+
+  const trigger = (): void => {
+    for (const callback of callbacks) {
+      callback([], {} as ResizeObserver);
+    }
+  };
+
+  const restore = (): void => {
+    if (typeof previousResizeObserver === "undefined") {
+      delete globalWithResizeObserver.ResizeObserver;
+      return;
+    }
+
+    globalWithResizeObserver.ResizeObserver = previousResizeObserver;
+  };
+
+  return { trigger, restore };
+};
+
 describe("useKanbanVirtualization", () => {
   test("returns a simple render model when virtualization threshold is not met", async () => {
     const harness = createHarness({ tasks: createTasks(5) });
@@ -321,8 +361,41 @@ describe("useKanbanVirtualization", () => {
     }
   });
 
+  test("invalidates visible-card measurements when the lane container resizes", async () => {
+    const resizeObserver = installMockResizeObserver();
+    const harness = createHarness({ tasks: createTasks(30) });
+
+    try {
+      await harness.mount();
+      await attachContainer(harness);
+
+      const initialMeasurementVersion = harness.getLatest().measurementVersion;
+
+      await harness.run(() => {
+        resizeObserver.trigger();
+      });
+
+      expect(harness.getLatest().measurementVersion).toBe(initialMeasurementVersion + 1);
+    } finally {
+      await harness.unmount();
+      resizeObserver.restore();
+    }
+  });
+
   test("shares global viewport listeners across multiple virtualized lanes", async () => {
     const mockWindow = installMockWindow();
+    const scrollContainerAddEventListener = mock(
+      (_type: string, _listener: EventListenerOrEventListenerObject, _options?: unknown) => {},
+    );
+    const scrollContainerRemoveEventListener = mock(
+      (_type: string, _listener: EventListenerOrEventListenerObject, _options?: unknown) => {},
+    );
+    const scrollContainer = {
+      addEventListener: scrollContainerAddEventListener,
+      removeEventListener: scrollContainerRemoveEventListener,
+      getBoundingClientRect: () => ({ top: 0 }),
+      clientHeight: 900,
+    } as unknown as HTMLElement;
     const harness = createMultiHarness([{ tasks: createTasks(30) }, { tasks: createTasks(30) }]);
 
     try {
@@ -331,17 +404,19 @@ describe("useKanbanVirtualization", () => {
         for (const state of harness.getLatestStates()) {
           state.containerRef({
             getBoundingClientRect: () => ({ top: 0 }),
-            closest: () => null,
-          } as HTMLDivElement);
+            closest: () => scrollContainer,
+          } as unknown as HTMLDivElement);
         }
       });
 
       expect(mockWindow.addEventListener).toHaveBeenCalledTimes(2);
       expect(mockWindow.requestAnimationFrame).toHaveBeenCalledTimes(1);
+      expect(scrollContainerAddEventListener).toHaveBeenCalledTimes(1);
       expect(harness.getLatestStates()).toHaveLength(2);
 
       await harness.unmount();
       expect(mockWindow.removeEventListener).toHaveBeenCalledTimes(2);
+      expect(scrollContainerRemoveEventListener).toHaveBeenCalledTimes(1);
     } finally {
       await harness.unmount();
       mockWindow.restore();

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
@@ -90,6 +90,59 @@ const createHarness = (initialProps: HookArgs) => {
   return { mount, update, run, getLatest, unmount };
 };
 
+const attachContainer = async (
+  harness: Pick<ReturnType<typeof createHarness>, "getLatest" | "run">,
+  container?: Partial<HTMLDivElement>,
+): Promise<void> => {
+  await harness.run(() => {
+    harness.getLatest().containerRef({
+      getBoundingClientRect: () => ({ top: 0 }),
+      closest: () => null,
+      ...container,
+    } as HTMLDivElement);
+  });
+};
+
+const createMultiHarness = (initialPropsList: HookArgs[]) => {
+  let latestStates: HookState[] = [];
+
+  const HarnessGroup = ({ hooks }: { hooks: HookArgs[] }): ReactElement | null => {
+    latestStates = hooks.map((hookProps) => useKanbanVirtualization(hookProps));
+    return null;
+  };
+
+  let renderer: TestRenderer.ReactTestRenderer | null = null;
+
+  const mount = async (): Promise<void> => {
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(HarnessGroup, { hooks: initialPropsList }));
+      await flush();
+    });
+  };
+
+  const getLatestStates = (): HookState[] => latestStates;
+
+  const run = async (fn: () => void): Promise<void> => {
+    await act(async () => {
+      fn();
+      await flush();
+    });
+  };
+
+  const unmount = async (): Promise<void> => {
+    if (!renderer) {
+      return;
+    }
+
+    await act(async () => {
+      renderer?.unmount();
+      await flush();
+    });
+  };
+
+  return { mount, getLatestStates, run, unmount };
+};
+
 const installMockWindow = () => {
   const globalWithWindow = globalThis as typeof globalThis & {
     window?: Window & typeof globalThis;
@@ -222,6 +275,7 @@ describe("useKanbanVirtualization", () => {
 
     try {
       await harness.mount();
+      await attachContainer(harness);
       expect(mockWindow.addEventListener).toHaveBeenCalledTimes(2);
       expect(mockWindow.requestAnimationFrame).toHaveBeenCalledTimes(1);
 
@@ -247,10 +301,10 @@ describe("useKanbanVirtualization", () => {
       await harness.mount();
 
       await harness.run(() => {
-        harness.getLatest().containerRef.current = {
+        harness.getLatest().containerRef({
           getBoundingClientRect,
           closest: () => null,
-        } as unknown as HTMLDivElement;
+        } as unknown as HTMLDivElement);
       });
 
       const callsBeforeMeasure = getBoundingClientRect.mock.calls.length;
@@ -261,6 +315,33 @@ describe("useKanbanVirtualization", () => {
 
       expect(getBoundingClientRect.mock.calls.length).toBeGreaterThan(callsBeforeMeasure);
       expect(mockWindow.addEventListener).toHaveBeenCalledTimes(2);
+    } finally {
+      await harness.unmount();
+      mockWindow.restore();
+    }
+  });
+
+  test("shares global viewport listeners across multiple virtualized lanes", async () => {
+    const mockWindow = installMockWindow();
+    const harness = createMultiHarness([{ tasks: createTasks(30) }, { tasks: createTasks(30) }]);
+
+    try {
+      await harness.mount();
+      await harness.run(() => {
+        for (const state of harness.getLatestStates()) {
+          state.containerRef({
+            getBoundingClientRect: () => ({ top: 0 }),
+            closest: () => null,
+          } as HTMLDivElement);
+        }
+      });
+
+      expect(mockWindow.addEventListener).toHaveBeenCalledTimes(2);
+      expect(mockWindow.requestAnimationFrame).toHaveBeenCalledTimes(1);
+      expect(harness.getLatestStates()).toHaveLength(2);
+
+      await harness.unmount();
+      expect(mockWindow.removeEventListener).toHaveBeenCalledTimes(2);
     } finally {
       await harness.unmount();
       mockWindow.restore();

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
@@ -103,11 +103,19 @@ const attachContainer = async (
   });
 };
 
-const createMultiHarness = (initialPropsList: HookArgs[]) => {
+const createPairHarness = (initialPropsList: [HookArgs, HookArgs]) => {
   let latestStates: HookState[] = [];
 
-  const HarnessGroup = ({ hooks }: { hooks: HookArgs[] }): ReactElement | null => {
-    latestStates = hooks.map((hookProps) => useKanbanVirtualization(hookProps));
+  const HarnessGroup = ({
+    firstHook,
+    secondHook,
+  }: {
+    firstHook: HookArgs;
+    secondHook: HookArgs;
+  }): ReactElement | null => {
+    const firstState = useKanbanVirtualization(firstHook);
+    const secondState = useKanbanVirtualization(secondHook);
+    latestStates = [firstState, secondState];
     return null;
   };
 
@@ -115,7 +123,12 @@ const createMultiHarness = (initialPropsList: HookArgs[]) => {
 
   const mount = async (): Promise<void> => {
     await act(async () => {
-      renderer = TestRenderer.create(createElement(HarnessGroup, { hooks: initialPropsList }));
+      renderer = TestRenderer.create(
+        createElement(HarnessGroup, {
+          firstHook: initialPropsList[0],
+          secondHook: initialPropsList[1],
+        }),
+      );
       await flush();
     });
   };
@@ -143,7 +156,11 @@ const createMultiHarness = (initialPropsList: HookArgs[]) => {
   return { mount, getLatestStates, run, unmount };
 };
 
-const installMockWindow = () => {
+const installMockWindow = ({
+  runAnimationFrameCallbacks = false,
+}: {
+  runAnimationFrameCallbacks?: boolean;
+} = {}) => {
   const globalWithWindow = globalThis as typeof globalThis & {
     window?: Window & typeof globalThis;
   };
@@ -155,7 +172,12 @@ const installMockWindow = () => {
   const removeEventListener = mock(
     (_type: string, _listener: EventListenerOrEventListenerObject, _options?: unknown) => {},
   );
-  const requestAnimationFrame = mock((_callback: FrameRequestCallback): number => 1);
+  const requestAnimationFrame = mock((callback: FrameRequestCallback): number => {
+    if (runAnimationFrameCallbacks) {
+      callback(0);
+    }
+    return 1;
+  });
   const cancelAnimationFrame = mock((_handle: number) => {});
 
   globalWithWindow.window = {
@@ -189,25 +211,30 @@ const installMockResizeObserver = () => {
     ResizeObserver?: typeof ResizeObserver;
   };
   const previousResizeObserver = globalWithResizeObserver.ResizeObserver;
-  const callbacks: ResizeObserverCallback[] = [];
+  const activeCallbacks = new Set<ResizeObserverCallback>();
 
   class MockResizeObserver {
+    private callback: ResizeObserverCallback;
+
     constructor(callback: ResizeObserverCallback) {
-      callbacks.push(callback);
+      this.callback = callback;
     }
 
-    observe(_target: Element): void {}
+    observe(_target: Element): void {
+      activeCallbacks.add(this.callback);
+    }
 
     unobserve(_target: Element): void {}
 
-    disconnect(): void {}
+    disconnect(): void {
+      activeCallbacks.delete(this.callback);
+    }
   }
 
-  globalWithResizeObserver.ResizeObserver =
-    MockResizeObserver as unknown as typeof ResizeObserver;
+  globalWithResizeObserver.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
 
   const trigger = (): void => {
-    for (const callback of callbacks) {
+    for (const callback of [...activeCallbacks]) {
       callback([], {} as ResizeObserver);
     }
   };
@@ -382,6 +409,35 @@ describe("useKanbanVirtualization", () => {
     }
   });
 
+  test("recomputes the virtual window when the lane container resizes", async () => {
+    const mockWindow = installMockWindow({ runAnimationFrameCallbacks: true });
+    const resizeObserver = installMockResizeObserver();
+    const harness = createHarness({ tasks: createTasks(30) });
+    const getBoundingClientRect = mock(() => ({ top: 120 }));
+
+    try {
+      await harness.mount();
+      await harness.run(() => {
+        harness.getLatest().containerRef({
+          getBoundingClientRect,
+          closest: () => null,
+        } as unknown as HTMLDivElement);
+      });
+
+      const callsBeforeResize = getBoundingClientRect.mock.calls.length;
+
+      await harness.run(() => {
+        resizeObserver.trigger();
+      });
+
+      expect(getBoundingClientRect.mock.calls.length).toBeGreaterThan(callsBeforeResize);
+    } finally {
+      await harness.unmount();
+      resizeObserver.restore();
+      mockWindow.restore();
+    }
+  });
+
   test("shares global viewport listeners across multiple virtualized lanes", async () => {
     const mockWindow = installMockWindow();
     const scrollContainerAddEventListener = mock(
@@ -396,7 +452,7 @@ describe("useKanbanVirtualization", () => {
       getBoundingClientRect: () => ({ top: 0 }),
       clientHeight: 900,
     } as unknown as HTMLElement;
-    const harness = createMultiHarness([{ tasks: createTasks(30) }, { tasks: createTasks(30) }]);
+    const harness = createPairHarness([{ tasks: createTasks(30) }, { tasks: createTasks(30) }]);
 
     try {
       await harness.mount();

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
@@ -42,6 +42,7 @@ type KanbanVirtualizationRenderModel = KanbanSimpleRenderModel | KanbanVirtualiz
 type UseKanbanVirtualizationResult = {
   containerRef: (node: HTMLDivElement | null) => void;
   renderModel: KanbanVirtualizationRenderModel;
+  measurementVersion: number;
   onMeasuredHeight: (taskId: string, height: number) => void;
 };
 
@@ -158,6 +159,7 @@ export function useKanbanVirtualization({
   const [measuredHeightsByTaskId, setMeasuredHeightsByTaskId] = useState<Record<string, number>>(
     {},
   );
+  const [measurementVersion, setMeasurementVersion] = useState(0);
   const shouldVirtualize = tasks.length >= VIRTUALIZATION_MIN_TASK_COUNT;
   const containerRef = useCallback((node: HTMLDivElement | null): void => {
     setContainerElement(node);
@@ -267,6 +269,41 @@ export function useKanbanVirtualization({
   }, [containerElement, shouldVirtualize]);
 
   useEffect(() => {
+    if (!shouldVirtualize || !containerElement || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    let frameHandle: number | null = null;
+    const scheduleMeasurementInvalidation = (): void => {
+      if (typeof window === "undefined") {
+        setMeasurementVersion((current) => current + 1);
+        return;
+      }
+
+      if (frameHandle !== null) {
+        return;
+      }
+
+      frameHandle = window.requestAnimationFrame(() => {
+        frameHandle = null;
+        setMeasurementVersion((current) => current + 1);
+      });
+    };
+
+    const observer = new ResizeObserver(() => {
+      scheduleMeasurementInvalidation();
+    });
+
+    observer.observe(containerElement);
+    return () => {
+      observer.disconnect();
+      if (frameHandle !== null && typeof window !== "undefined") {
+        window.cancelAnimationFrame(frameHandle);
+      }
+    };
+  }, [containerElement, shouldVirtualize]);
+
+  useEffect(() => {
     if (shouldVirtualize) {
       return;
     }
@@ -373,6 +410,7 @@ export function useKanbanVirtualization({
   return {
     containerRef,
     renderModel,
+    measurementVersion,
     onMeasuredHeight,
   };
 }

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
@@ -19,6 +19,11 @@ type UseKanbanVirtualizationArgs = {
   tasks: KanbanColumnData["tasks"];
 };
 
+type KanbanViewportSubscriber = {
+  element: HTMLDivElement;
+  onSync: () => void;
+};
+
 type KanbanVirtualizedRenderModel = {
   kind: "virtualized";
   totalHeight: number;
@@ -35,7 +40,7 @@ type KanbanSimpleRenderModel = {
 type KanbanVirtualizationRenderModel = KanbanSimpleRenderModel | KanbanVirtualizedRenderModel;
 
 type UseKanbanVirtualizationResult = {
-  containerRef: { current: HTMLDivElement | null };
+  containerRef: (node: HTMLDivElement | null) => void;
   renderModel: KanbanVirtualizationRenderModel;
   onMeasuredHeight: (taskId: string, height: number) => void;
 };
@@ -46,14 +51,117 @@ type VirtualLayoutSnapshot = {
   totalHeight: number;
 };
 
+const viewportSubscribers = new Map<number, KanbanViewportSubscriber>();
+const viewportScrollContainers = new Map<HTMLElement, number>();
+let viewportSubscriptionId = 0;
+let viewportSyncFrameHandle: number | null = null;
+let hasViewportWindowListeners = false;
+
+const scheduleViewportSubscribersSync = (): void => {
+  if (typeof window === "undefined" || viewportSyncFrameHandle !== null) {
+    return;
+  }
+
+  viewportSyncFrameHandle = window.requestAnimationFrame(() => {
+    viewportSyncFrameHandle = null;
+    for (const subscriber of viewportSubscribers.values()) {
+      subscriber.onSync();
+    }
+  });
+};
+
+const onViewportWindowEvent = (): void => {
+  scheduleViewportSubscribersSync();
+};
+
+const retainViewportWindowListeners = (): void => {
+  if (typeof window === "undefined" || hasViewportWindowListeners) {
+    return;
+  }
+
+  window.addEventListener("scroll", onViewportWindowEvent, { passive: true });
+  window.addEventListener("resize", onViewportWindowEvent);
+  hasViewportWindowListeners = true;
+};
+
+const releaseViewportWindowListeners = (): void => {
+  if (
+    typeof window === "undefined" ||
+    !hasViewportWindowListeners ||
+    viewportSubscribers.size > 0 ||
+    viewportScrollContainers.size > 0
+  ) {
+    return;
+  }
+
+  window.removeEventListener("scroll", onViewportWindowEvent);
+  window.removeEventListener("resize", onViewportWindowEvent);
+  if (viewportSyncFrameHandle !== null) {
+    window.cancelAnimationFrame(viewportSyncFrameHandle);
+    viewportSyncFrameHandle = null;
+  }
+  hasViewportWindowListeners = false;
+};
+
+const retainViewportScrollContainer = (container: HTMLElement): void => {
+  const nextCount = (viewportScrollContainers.get(container) ?? 0) + 1;
+  viewportScrollContainers.set(container, nextCount);
+  if (nextCount === 1) {
+    container.addEventListener("scroll", onViewportWindowEvent, { passive: true });
+  }
+};
+
+const releaseViewportScrollContainer = (container: HTMLElement): void => {
+  const currentCount = viewportScrollContainers.get(container);
+  if (!currentCount) {
+    return;
+  }
+
+  if (currentCount === 1) {
+    viewportScrollContainers.delete(container);
+    container.removeEventListener("scroll", onViewportWindowEvent);
+    releaseViewportWindowListeners();
+    return;
+  }
+
+  viewportScrollContainers.set(container, currentCount - 1);
+};
+
+const registerViewportSubscriber = (subscriber: KanbanViewportSubscriber): (() => void) => {
+  retainViewportWindowListeners();
+
+  const scrollContainer = subscriber.element.closest(
+    "[data-main-scroll-container='true']",
+  ) as HTMLElement | null;
+  if (scrollContainer) {
+    retainViewportScrollContainer(scrollContainer);
+  }
+
+  const subscriberId = viewportSubscriptionId;
+  viewportSubscriptionId += 1;
+  viewportSubscribers.set(subscriberId, subscriber);
+  scheduleViewportSubscribersSync();
+
+  return () => {
+    viewportSubscribers.delete(subscriberId);
+    if (scrollContainer) {
+      releaseViewportScrollContainer(scrollContainer);
+    }
+    releaseViewportWindowListeners();
+  };
+};
+
 export function useKanbanVirtualization({
   tasks,
 }: UseKanbanVirtualizationArgs): UseKanbanVirtualizationResult {
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [containerElement, setContainerElement] = useState<HTMLDivElement | null>(null);
   const [measuredHeightsByTaskId, setMeasuredHeightsByTaskId] = useState<Record<string, number>>(
     {},
   );
   const shouldVirtualize = tasks.length >= VIRTUALIZATION_MIN_TASK_COUNT;
+  const containerRef = useCallback((node: HTMLDivElement | null): void => {
+    setContainerElement(node);
+  }, []);
 
   const itemHeights = useMemo(() => {
     if (!shouldVirtualize) {
@@ -106,7 +214,7 @@ export function useKanbanVirtualization({
         return;
       }
 
-      const viewportElement = containerRef.current;
+      const viewportElement = containerElement;
       if (!viewportElement) {
         return;
       }
@@ -143,57 +251,20 @@ export function useKanbanVirtualization({
         return nextRange;
       });
     };
-  }, [shouldVirtualize]);
+  }, [containerElement, shouldVirtualize]);
 
   useEffect(() => {
-    if (!shouldVirtualize || typeof window === "undefined") {
+    if (!shouldVirtualize || typeof window === "undefined" || !containerElement) {
       return;
     }
 
-    const rafRef: { current: number | null } = { current: null };
-
-    const scheduleViewportSync = (): void => {
-      if (rafRef.current !== null) {
-        return;
-      }
-
-      rafRef.current = window.requestAnimationFrame(() => {
-        rafRef.current = null;
+    return registerViewportSubscriber({
+      element: containerElement,
+      onSync: () => {
         syncViewportRef.current();
-      });
-    };
-
-    const scrollContainer = containerRef.current?.closest(
-      "[data-main-scroll-container='true']",
-    ) as HTMLElement | null;
-
-    scheduleViewportSync();
-    window.addEventListener("scroll", scheduleViewportSync, { passive: true });
-    window.addEventListener("resize", scheduleViewportSync);
-    scrollContainer?.addEventListener("scroll", scheduleViewportSync, { passive: true });
-
-    const viewportElement = containerRef.current;
-    const resizeObserver =
-      typeof ResizeObserver === "undefined"
-        ? null
-        : new ResizeObserver(() => {
-            scheduleViewportSync();
-          });
-
-    if (resizeObserver && viewportElement) {
-      resizeObserver.observe(viewportElement);
-    }
-
-    return () => {
-      window.removeEventListener("scroll", scheduleViewportSync);
-      window.removeEventListener("resize", scheduleViewportSync);
-      scrollContainer?.removeEventListener("scroll", scheduleViewportSync);
-      if (rafRef.current !== null) {
-        window.cancelAnimationFrame(rafRef.current);
-      }
-      resizeObserver?.disconnect();
-    };
-  }, [shouldVirtualize]);
+      },
+    });
+  }, [containerElement, shouldVirtualize]);
 
   useEffect(() => {
     if (shouldVirtualize) {

--- a/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
+++ b/apps/desktop/src/components/features/kanban/use-kanban-virtualization.ts
@@ -287,6 +287,7 @@ export function useKanbanVirtualization({
       frameHandle = window.requestAnimationFrame(() => {
         frameHandle = null;
         setMeasurementVersion((current) => current + 1);
+        syncViewportRef.current();
       });
     };
 


### PR DESCRIPTION
## Summary
- centralize Kanban virtualization viewport tracking behind a shared listener registry
- remove per-visible-card ResizeObserver usage and switch to coarse lane-level remeasurement invalidation
- add regression coverage for shared scroll-container dedup, cleanup, and lane resize invalidation

## Changes
- share window and main scroll-container listeners across virtualized lanes instead of attaching them per column
- keep virtual card measurement lightweight by remeasuring visible cards on mount, prop changes, and lane container resize
- add hook tests for listener stability, shared-container dedup, cleanup, and measurement invalidation

## Testing
- bun test apps/desktop/src/components/features/kanban/use-kanban-virtualization.test.tsx
- bun run --filter @openducktor/desktop typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Kanban board virtualization with improved measurement tracking and viewport synchronization to optimize layout performance across multiple lanes.
  * Updated container element handling for more efficient virtual rendering in Kanban columns.
  * Improved measurement invalidation mechanism for Kanban layout updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->