### PR TITLE
perf(desktop): stop reloading Agent Studio diffs while browsing files

### DIFF
--- a/apps/desktop/src/features/agent-studio-git/agent-studio-diff-data-model.ts
+++ b/apps/desktop/src/features/agent-studio-git/agent-studio-diff-data-model.ts
@@ -303,6 +303,7 @@ export const applySummarySnapshot = ({
   requestSequence: number;
   latestSharedSequence: number;
 }): {
+  invalidatedScopes: DiffScope[];
   nextState: DiffBatchState;
   nextLatestSharedSequence: number;
   shouldReloadFullScope: boolean;
@@ -328,6 +329,7 @@ export const applySummarySnapshot = ({
     didChange = true;
   }
 
+  const invalidatedScopes: DiffScope[] = shouldReloadFullScope ? [scope] : [];
   let nextLoadedByScope = state.loadedByScope;
   let nextLatestSharedSequence = latestSharedSequence;
   if (requestSequence >= latestSharedSequence) {
@@ -365,6 +367,7 @@ export const applySummarySnapshot = ({
             ...nextLoadedByScope,
             [otherScope]: false,
           };
+          invalidatedScopes.push(otherScope);
           didChange = true;
         }
       }
@@ -372,6 +375,7 @@ export const applySummarySnapshot = ({
   }
 
   return {
+    invalidatedScopes,
     nextState: finalizeCompletedState(state, nextByScope, nextLoadedByScope, didChange),
     nextLatestSharedSequence,
     shouldReloadFullScope,

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
@@ -28,6 +28,7 @@ type LoadDataContext = {
   workingDir: string | null;
   scope: DiffScope;
   mode?: LoadDataMode;
+  force?: boolean;
   replayIfInFlight?: boolean;
 };
 
@@ -249,19 +250,21 @@ export function useAgentStudioDiffController({
 
   const runFullLoad = useCallback(
     async ({
+      force = false,
       repoPath: activeRepoPath,
       requestSequence,
       scope,
       targetBranch: activeTargetBranch,
       version,
       workingDir: nextWorkingDir,
-    }: InFlightRequestContext): Promise<void> => {
+    }: InFlightRequestContext & { force?: boolean }): Promise<void> => {
       const snapshot = await loadWorktreeStatusFromQuery(
         appQueryClient,
         activeRepoPath,
         activeTargetBranch,
         scope,
         nextWorkingDir,
+        { force },
       );
 
       if (hasLoadContextChanged(activeRepoPath, activeTargetBranch, nextWorkingDir)) {
@@ -313,6 +316,7 @@ export function useAgentStudioDiffController({
         workingDir: context?.workingDir ?? workingDirRef.current,
       };
       const mode = context?.mode ?? "full";
+      const force = context?.force === true;
       const replayIfInFlight = context?.replayIfInFlight === true;
       const requestKey = `${loadContext.repoPath}::${loadContext.targetBranch}::${loadContext.workingDir ?? ""}`;
 
@@ -353,7 +357,7 @@ export function useAgentStudioDiffController({
           return;
         }
 
-        await runFullLoad(inFlightRequestContext);
+        await runFullLoad({ ...inFlightRequestContext, force });
       } catch (error) {
         if (
           hasLoadContextChanged(
@@ -403,6 +407,7 @@ export function useAgentStudioDiffController({
               workingDir: loadContext.workingDir,
               scope: loadContext.scope,
               mode: "full",
+              force,
             });
           });
         }
@@ -439,6 +444,7 @@ export function useAgentStudioDiffController({
       workingDir: pendingFullReload.workingDir,
       scope: pendingFullReload.scope,
       mode: "full",
+      force: true,
     });
   }, [loadData, pendingFullReload]);
 
@@ -458,6 +464,7 @@ export function useAgentStudioDiffController({
         targetBranch,
         workingDir,
         scope: diffScopeRef.current,
+        force: true,
       });
       return;
     }
@@ -495,6 +502,7 @@ export function useAgentStudioDiffController({
       targetBranch,
       workingDir,
       scope: diffScope,
+      force: true,
     });
   }, [
     controllerState.batchState.loadedByScope,
@@ -536,6 +544,7 @@ export function useAgentStudioDiffController({
       targetBranch: targetBranchRef.current,
       workingDir: workingDirRef.current,
       scope: diffScopeRef.current,
+      force: true,
       replayIfInFlight: true,
     });
   }, [loadData, shouldBlockDiffLoading]);
@@ -552,6 +561,7 @@ export function useAgentStudioDiffController({
         workingDir: workingDirRef.current,
         scope: diffScopeRef.current,
         mode: "full",
+        force: true,
         replayIfInFlight: true,
       });
     },

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
@@ -223,18 +223,14 @@ export function useAgentStudioDiffController({
       };
 
       setControllerState((previousState) => {
-        const {
-          invalidatedScopes,
-          nextState,
-          nextLatestSharedSequence,
-          shouldReloadFullScope,
-        } = applySummarySnapshot({
-          state: previousState.batchState,
-          scope,
-          summaryFields,
-          requestSequence,
-          latestSharedSequence: previousState.latestSharedSequence,
-        });
+        const { invalidatedScopes, nextState, nextLatestSharedSequence, shouldReloadFullScope } =
+          applySummarySnapshot({
+            state: previousState.batchState,
+            scope,
+            summaryFields,
+            requestSequence,
+            latestSharedSequence: previousState.latestSharedSequence,
+          });
         const nextPendingFullReloads = shouldReloadFullScope
           ? enqueuePendingFullReload(previousState.pendingFullReloads, loadContext)
           : previousState.pendingFullReloads;

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
@@ -157,7 +157,7 @@ export function useAgentStudioDiffController({
       }
       queuedFullReloadByScopeRef.current[scope] = false;
       queuedFullReloadForceByScopeRef.current[scope] = false;
-      invalidatedFullReloadByScopeRef.current[scope] = false;
+      invalidatedFullReloadByScopeRef.current[scope] = true;
     }
     latestLoadingRequestSequenceRef.current = null;
   }, []);
@@ -284,6 +284,7 @@ export function useAgentStudioDiffController({
         return;
       }
 
+      invalidatedFullReloadByScopeRef.current[scope] = false;
       const nextScopeSnapshot = toScopeSnapshot(snapshot);
       setControllerState((previousState) => {
         const { nextState, nextLatestSharedSequence } = applyFullSnapshot({
@@ -511,7 +512,6 @@ export function useAgentStudioDiffController({
     }
 
     const shouldForce = invalidatedFullReloadByScopeRef.current[diffScope];
-    invalidatedFullReloadByScopeRef.current[diffScope] = false;
 
     void loadData(true, {
       repoPath,

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
@@ -57,7 +57,6 @@ type UseAgentStudioDiffControllerArgs = {
   requestContextKey: string | null;
   enablePolling: boolean;
   shouldBlockDiffLoading: boolean;
-  onContextReset?: () => void;
 };
 
 type UseAgentStudioDiffControllerResult = {
@@ -81,6 +80,16 @@ const createInFlightState = (): Record<DiffScope, Record<LoadDataMode, string | 
 });
 
 const createQueuedReloadState = (): Record<DiffScope, boolean> => ({
+  target: false,
+  uncommitted: false,
+});
+
+const createQueuedReloadForceState = (): Record<DiffScope, boolean> => ({
+  target: false,
+  uncommitted: false,
+});
+
+const createInvalidatedFullReloadState = (): Record<DiffScope, boolean> => ({
   target: false,
   uncommitted: false,
 });
@@ -114,7 +123,6 @@ export function useAgentStudioDiffController({
   requestContextKey,
   enablePolling,
   shouldBlockDiffLoading,
-  onContextReset,
 }: UseAgentStudioDiffControllerArgs): UseAgentStudioDiffControllerResult {
   const [controllerState, setControllerState] = useState<DiffControllerState>(
     createInitialControllerState,
@@ -127,6 +135,8 @@ export function useAgentStudioDiffController({
   const requestSequenceRef = useRef(0);
   const inFlightScopeRequestRef = useRef(createInFlightState());
   const queuedFullReloadByScopeRef = useRef(createQueuedReloadState());
+  const queuedFullReloadForceByScopeRef = useRef(createQueuedReloadForceState());
+  const invalidatedFullReloadByScopeRef = useRef(createInvalidatedFullReloadState());
   const latestLoadingRequestSequenceRef = useRef<number | null>(null);
   const requestContextKeyRef = useRef<string | null>(null);
 
@@ -146,6 +156,8 @@ export function useAgentStudioDiffController({
         inFlightScopeRequestRef.current[scope][mode] = null;
       }
       queuedFullReloadByScopeRef.current[scope] = false;
+      queuedFullReloadForceByScopeRef.current[scope] = false;
+      invalidatedFullReloadByScopeRef.current[scope] = false;
     }
     latestLoadingRequestSequenceRef.current = null;
   }, []);
@@ -164,16 +176,10 @@ export function useAgentStudioDiffController({
     );
   }, []);
 
-  const resetControllerState = useCallback(
-    (notifyContextReset: boolean): void => {
-      resetRequestTracking();
-      setControllerState(createInitialControllerState());
-      if (notifyContextReset) {
-        onContextReset?.();
-      }
-    },
-    [onContextReset, resetRequestTracking],
-  );
+  const resetControllerState = useCallback((): void => {
+    resetRequestTracking();
+    setControllerState(createInitialControllerState());
+  }, [resetRequestTracking]);
 
   const hasLoadContextChanged = useCallback(
     (path: string, nextTargetBranch: string, nextWorkingDir: string | null): boolean =>
@@ -217,18 +223,25 @@ export function useAgentStudioDiffController({
       };
 
       setControllerState((previousState) => {
-        const { nextState, nextLatestSharedSequence, shouldReloadFullScope } = applySummarySnapshot(
-          {
-            state: previousState.batchState,
-            scope,
-            summaryFields,
-            requestSequence,
-            latestSharedSequence: previousState.latestSharedSequence,
-          },
-        );
+        const {
+          invalidatedScopes,
+          nextState,
+          nextLatestSharedSequence,
+          shouldReloadFullScope,
+        } = applySummarySnapshot({
+          state: previousState.batchState,
+          scope,
+          summaryFields,
+          requestSequence,
+          latestSharedSequence: previousState.latestSharedSequence,
+        });
         const nextPendingFullReloads = shouldReloadFullScope
           ? enqueuePendingFullReload(previousState.pendingFullReloads, loadContext)
           : previousState.pendingFullReloads;
+
+        for (const invalidatedScope of invalidatedScopes) {
+          invalidatedFullReloadByScopeRef.current[invalidatedScope] = true;
+        }
 
         if (
           nextState === previousState.batchState &&
@@ -323,6 +336,8 @@ export function useAgentStudioDiffController({
       if (inFlightScopeRequestRef.current[loadContext.scope][mode] === requestKey) {
         if (mode === "full" && replayIfInFlight) {
           queuedFullReloadByScopeRef.current[loadContext.scope] = true;
+          queuedFullReloadForceByScopeRef.current[loadContext.scope] =
+            queuedFullReloadForceByScopeRef.current[loadContext.scope] || force;
         }
         return;
       }
@@ -400,6 +415,8 @@ export function useAgentStudioDiffController({
 
         if (mode === "full" && queuedFullReloadByScopeRef.current[loadContext.scope]) {
           queuedFullReloadByScopeRef.current[loadContext.scope] = false;
+          const queuedForce = queuedFullReloadForceByScopeRef.current[loadContext.scope];
+          queuedFullReloadForceByScopeRef.current[loadContext.scope] = false;
           globalThis.queueMicrotask(() => {
             void loadData(false, {
               repoPath: loadContext.repoPath,
@@ -407,7 +424,7 @@ export function useAgentStudioDiffController({
               workingDir: loadContext.workingDir,
               scope: loadContext.scope,
               mode: "full",
-              force,
+              force: queuedForce,
             });
           });
         }
@@ -456,7 +473,7 @@ export function useAgentStudioDiffController({
 
     if (repoPath && !shouldBlockDiffLoading) {
       if (hasContextChanged) {
-        resetControllerState(true);
+        resetControllerState();
       }
 
       void loadData(true, {
@@ -464,20 +481,20 @@ export function useAgentStudioDiffController({
         targetBranch,
         workingDir,
         scope: diffScopeRef.current,
-        force: true,
+        force: hasContextChanged,
       });
       return;
     }
 
     if (repoPath) {
       if (hasContextChanged) {
-        resetControllerState(true);
+        resetControllerState();
       }
       return;
     }
 
     requestContextKeyRef.current = null;
-    resetControllerState(previousContextKey !== null);
+    resetControllerState();
   }, [
     loadData,
     repoPath,
@@ -497,12 +514,15 @@ export function useAgentStudioDiffController({
       return;
     }
 
+    const shouldForce = invalidatedFullReloadByScopeRef.current[diffScope];
+    invalidatedFullReloadByScopeRef.current[diffScope] = false;
+
     void loadData(true, {
       repoPath,
       targetBranch,
       workingDir,
       scope: diffScope,
-      force: true,
+      force: shouldForce,
     });
   }, [
     controllerState.batchState.loadedByScope,

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
@@ -77,8 +77,8 @@ const gitGetWorktreeStatusSummaryMock = mock(
   },
 );
 
-mock.module("@/lib/host-client", () => ({
-  hostClient: {
+mock.module("@/state/operations/host", () => ({
+  host: {
     runsList: runsListMock,
     gitGetWorktreeStatus: gitGetWorktreeStatusMock,
     gitGetWorktreeStatusSummary: gitGetWorktreeStatusSummaryMock,
@@ -88,6 +88,8 @@ mock.module("@/lib/host-client", () => ({
 mock.module("@/lib/host-client", () => ({
   hostClient: {
     runsList: runsListMock,
+    gitGetWorktreeStatus: gitGetWorktreeStatusMock,
+    gitGetWorktreeStatusSummary: gitGetWorktreeStatusSummaryMock,
   },
 }));
 

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
@@ -85,6 +85,12 @@ mock.module("@/lib/host-client", () => ({
   },
 }));
 
+mock.module("@/lib/host-client", () => ({
+  hostClient: {
+    runsList: runsListMock,
+  },
+}));
+
 type UseAgentStudioDiffDataHook =
   typeof import("./use-agent-studio-diff-data")["useAgentStudioDiffData"];
 
@@ -320,7 +326,7 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
-  test("selected file triggers on-demand full reload for the active scope", async () => {
+  test("selected file updates local selection without reloading the active scope", async () => {
     const harness = createHookHarness(createBaseArgs());
 
     try {
@@ -335,15 +341,8 @@ describe("useAgentStudioDiffData", () => {
       await harness.run((state) => {
         state.setSelectedFile("src/main.ts");
       });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 3);
-
-      expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
-        3,
-        "/repo",
-        "origin/main",
-        "uncommitted",
-        undefined,
-      );
+      await harness.waitFor((state) => state.selectedFile === "src/main.ts");
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
     } finally {
       await harness.unmount();
     }
@@ -959,7 +958,7 @@ describe("useAgentStudioDiffData", () => {
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
 
       await harness.run((state) => {
-        state.setSelectedFile("src/full.ts");
+        state.refresh();
       });
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
 
@@ -1015,7 +1014,9 @@ describe("useAgentStudioDiffData", () => {
   test("polling persists hash metadata changes even when derived shared fields stay equal", async () => {
     const originalSetInterval = globalThis.setInterval;
     const originalClearInterval = globalThis.clearInterval;
+    const originalDateNow = Date.now;
     let intervalCallback: (() => void) | null = null;
+    let nowMs = 1_731_000_000_000;
 
     const setIntervalMock = mock((callback: TimerHandler, _delay?: number) => {
       if (typeof callback !== "function") {
@@ -1135,6 +1136,7 @@ describe("useAgentStudioDiffData", () => {
 
     globalThis.setInterval = setIntervalMock as unknown as typeof globalThis.setInterval;
     globalThis.clearInterval = clearIntervalMock as unknown as typeof globalThis.clearInterval;
+    Date.now = () => nowMs;
 
     const harness = createHookHarness({
       ...createBaseArgs(),
@@ -1162,6 +1164,7 @@ describe("useAgentStudioDiffData", () => {
       expect(secondState.upstreamAheadBehind).toEqual({ ahead: 1, behind: 0 });
       expect(secondState).not.toBe(firstState);
 
+      nowMs += 6_000;
       await harness.run(() => {
         runTick();
       });
@@ -1172,6 +1175,7 @@ describe("useAgentStudioDiffData", () => {
       await harness.unmount();
       globalThis.setInterval = originalSetInterval;
       globalThis.clearInterval = originalClearInterval;
+      Date.now = originalDateNow;
     }
   });
 

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
@@ -561,6 +561,101 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("forces the first inactive-scope reload after branch identity changes", async () => {
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      defaultTargetBranch: { branch: "@{upstream}" },
+      branchIdentityKey: "branch:main",
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      await harness.run((state) => {
+        state.setDiffScope("uncommitted");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+
+      await harness.run((state) => {
+        state.setDiffScope("target");
+      });
+      await harness.waitFor((state) => state.diffScope === "target");
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
+
+      gitGetWorktreeStatusMock.mockImplementation(
+        async (
+          _repoPath: string,
+          targetBranch: string,
+          diffScope?: "target" | "uncommitted",
+          workingDir?: string,
+        ): Promise<GitWorktreeStatus> =>
+          withSnapshotHashes({
+            currentBranch: { name: "feature/switched", detached: false },
+            fileStatuses:
+              (diffScope ?? "target") === "target"
+                ? [{ path: "src/switched.ts", status: "M", staged: false }]
+                : [{ path: "src/worktree-switched.ts", status: "M", staged: false }],
+            fileDiffs:
+              (diffScope ?? "target") === "target"
+                ? [
+                    {
+                      file: "src/switched.ts",
+                      type: "modified",
+                      additions: 5,
+                      deletions: 1,
+                      diff: "@@ -1 +1,5 @@",
+                    },
+                  ]
+                : [
+                    {
+                      file: "src/worktree-switched.ts",
+                      type: "modified",
+                      additions: 3,
+                      deletions: 0,
+                      diff: "@@ -1 +1,3 @@",
+                    },
+                  ],
+            targetAheadBehind: { ahead: 2, behind: 0 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 2, behind: 0 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000300,
+            },
+          }),
+      );
+
+      await harness.update({
+        ...createBaseArgs(),
+        defaultTargetBranch: { branch: "@{upstream}" },
+        branchIdentityKey: "branch:feature/switched",
+      });
+
+      await harness.waitFor((state) => state.branch === "feature/switched");
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(3);
+
+      await harness.run((state) => {
+        state.setDiffScope("uncommitted");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 4);
+      await harness.waitFor((state) => state.diffScope === "uncommitted");
+
+      expect(harness.getLatest().fileDiffs).toEqual([
+        {
+          file: "src/worktree-switched.ts",
+          type: "modified",
+          additions: 3,
+          deletions: 0,
+          diff: "@@ -1 +1,3 @@",
+        },
+      ]);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("refresh syncs upstream status changes across cached inactive scope", async () => {
     const harness = createHookHarness({
       ...createBaseArgs(),

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
@@ -302,6 +302,25 @@ describe("useAgentStudioDiffData", () => {
     }
   });
 
+  test("reuses the cached full snapshot when remounting within the stale window", async () => {
+    const firstHarness = createHookHarness(createBaseArgs());
+    const secondHarness = createHookHarness(createBaseArgs());
+
+    try {
+      await firstHarness.mount();
+      await firstHarness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      await firstHarness.unmount();
+
+      await secondHarness.mount();
+      await secondHarness.waitFor((state) => state.fileDiffs.length === 1);
+
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(1);
+    } finally {
+      await firstHarness.unmount();
+      await secondHarness.unmount();
+    }
+  });
+
   test("manual refresh updates active scope without extra background scope call", async () => {
     const harness = createHookHarness(createBaseArgs());
 

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
@@ -89,12 +89,9 @@ export function useAgentStudioDiffData({
     worktreeResolutionError,
   ]);
 
-  const setSelectedFile = useCallback(
-    (path: string | null): void => {
-      setSelectedFileState(path);
-    },
-    [],
-  );
+  const setSelectedFile = useCallback((path: string | null): void => {
+    setSelectedFileState(path);
+  }, []);
 
   const displayError = worktreeResolutionError ?? activeScopeState.error;
   const isLoading = state.isLoading || isWorktreeResolutionResolving;

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
@@ -43,9 +43,6 @@ export function useAgentStudioDiffData({
 
   const [selectedFileState, setSelectedFileState] = useState<string | null>(null);
   const previousRequestContextKeyRef = useRef<string | null>(null);
-  const handleContextReset = useCallback((): void => {
-    setSelectedFileState(null);
-  }, []);
 
   useEffect(() => {
     const previousRequestContextKey = previousRequestContextKeyRef.current;
@@ -70,7 +67,6 @@ export function useAgentStudioDiffData({
     requestContextKey,
     enablePolling,
     shouldBlockDiffLoading,
-    onContextReset: handleContextReset,
   });
 
   const selectedFile = selectedFileState;

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { canonicalTargetBranch } from "@/lib/target-branch";
 import type { UseAgentStudioDiffDataInput } from "./agent-studio-diff-data-model";
 import type { DiffDataState } from "./contracts";
@@ -42,15 +42,24 @@ export function useAgentStudioDiffData({
   }, [branchIdentityKey, repoPath, targetBranch, worktreePath, worktreeResolutionRunId]);
 
   const [selectedFileState, setSelectedFileState] = useState<string | null>(null);
+  const previousRequestContextKeyRef = useRef<string | null>(null);
   const handleContextReset = useCallback((): void => {
     setSelectedFileState(null);
   }, []);
+
+  useEffect(() => {
+    const previousRequestContextKey = previousRequestContextKeyRef.current;
+    previousRequestContextKeyRef.current = requestContextKey;
+
+    if (previousRequestContextKey !== null && previousRequestContextKey !== requestContextKey) {
+      setSelectedFileState(null);
+    }
+  }, [requestContextKey]);
 
   const {
     activeScopeState,
     diffScope,
     refreshActiveScope,
-    reloadActiveScope,
     setDiffScope,
     state,
     statusSnapshotKey,
@@ -87,14 +96,8 @@ export function useAgentStudioDiffData({
   const setSelectedFile = useCallback(
     (path: string | null): void => {
       setSelectedFileState(path);
-
-      if (path === null || shouldBlockDiffLoading) {
-        return;
-      }
-
-      reloadActiveScope();
     },
-    [reloadActiveScope, shouldBlockDiffLoading],
+    [],
   );
 
   const displayError = worktreeResolutionError ?? activeScopeState.error;

--- a/apps/desktop/src/state/queries/git.ts
+++ b/apps/desktop/src/state/queries/git.ts
@@ -8,7 +8,7 @@ import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { hostClient as host } from "@/lib/host-client";
 
 const BRANCH_DATA_STALE_TIME_MS = 60_000;
-const WORKTREE_STATUS_STALE_TIME_MS = 0;
+const WORKTREE_STATUS_STALE_TIME_MS = 5_000;
 
 export const gitQueryKeys = {
   all: ["git"] as const,
@@ -100,8 +100,21 @@ export const loadWorktreeStatusFromQuery = (
   targetBranch: string,
   diffScope: "target" | "uncommitted",
   workingDir: string | null,
-): Promise<GitWorktreeStatus> =>
-  queryClient.fetchQuery(worktreeStatusQueryOptions(repoPath, targetBranch, diffScope, workingDir));
+  options?: {
+    force?: boolean;
+  },
+): Promise<GitWorktreeStatus> => {
+  const queryKey = gitQueryKeys.worktreeStatus(repoPath, targetBranch, diffScope, workingDir);
+
+  if (options?.force === true) {
+    void queryClient.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
+  }
+
+  return queryClient.fetchQuery({
+    ...worktreeStatusQueryOptions(repoPath, targetBranch, diffScope, workingDir),
+    staleTime: options?.force === true ? 0 : WORKTREE_STATUS_STALE_TIME_MS,
+  });
+};
 
 export const loadWorktreeStatusSummaryFromQuery = (
   queryClient: QueryClient,
@@ -109,7 +122,23 @@ export const loadWorktreeStatusSummaryFromQuery = (
   targetBranch: string,
   diffScope: "target" | "uncommitted",
   workingDir: string | null,
-): Promise<GitWorktreeStatusSummary> =>
-  queryClient.fetchQuery(
-    worktreeStatusSummaryQueryOptions(repoPath, targetBranch, diffScope, workingDir),
+  options?: {
+    force?: boolean;
+  },
+): Promise<GitWorktreeStatusSummary> => {
+  const queryKey = gitQueryKeys.worktreeStatusSummary(
+    repoPath,
+    targetBranch,
+    diffScope,
+    workingDir,
   );
+
+  if (options?.force === true) {
+    void queryClient.invalidateQueries({ queryKey, exact: true, refetchType: "none" });
+  }
+
+  return queryClient.fetchQuery({
+    ...worktreeStatusSummaryQueryOptions(repoPath, targetBranch, diffScope, workingDir),
+    staleTime: options?.force === true ? 0 : WORKTREE_STATUS_STALE_TIME_MS,
+  });
+};


### PR DESCRIPTION
## Summary
- stop triggering full diff reloads when selecting or expanding files in Agent Studio
- restore cache reuse semantics so passive same-key diff reads can use the short TanStack Query stale window
- keep explicit refreshes and summary-hash invalidations on forced refetch paths, and align the mirrored feature-hook tests with the production host seams

## Details
The original change removed the reload-on-expand behavior, but the first follow-up forced nearly every full diff load and accidentally neutralized most of the intended cache reuse. This PR narrows forced fetches to the cases that actually require them: explicit user refreshes, queued refresh replays, context changes that must bypass stale cache, and summary-hash invalidations.

To make the stale window observable in real UI flows, the controller now tracks which scopes were invalidated by summary polling and only forces those reloads when they are revisited. Passive full snapshot reads can reuse cached data when the key is unchanged and still within the stale window. Selected-file reset ownership is also kept in the diff-data hook instead of being split across the hook and controller.

The PR also fixes the mirrored `src/features/agent-studio-git` test harness so it mocks the same host seams used by the production query layer. That was necessary to keep the full Bun workspace suite green after the cache semantics changed.

## Validation
### Bun
- `bun run test`
- `bun run lint`
- `bun run typecheck`
- `bun run build`

### Cargo
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a force option to trigger full reloads and per-scope forced-reload tracking.
  * Summary processing now reports which scopes were invalidated for targeted refreshes.

* **Bug Fixes**
  * Ensures pending and context-change reloads honor force signals to avoid stale results.

* **Performance**
  * Increased stale window and improved snapshot reuse across remounts to reduce fetches.

* **Refactor**
  * Simplified reset behavior and removed an unused context reset callback.

* **Tests**
  * Expanded time-, polling-, remount- and branch-change test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->