### PR TITLE
fix: AI PR generation after session reload

### DIFF
--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -47,46 +47,75 @@ mock.module("sonner", () => ({
   },
 }));
 
-mock.module("@/state/operations/host", () => ({
-  host: {
-    taskApprovalContextGet: taskApprovalContextGetMock,
-    taskDirectMerge: taskDirectMergeMock,
-    taskPullRequestUpsert: taskPullRequestUpsertMock,
-    gitPushBranch: gitPushBranchMock,
-    agentSessionsList: async () => [{ role: "build", sessionId: "builder-session" }],
-    specGet: async () => ({ markdown: "", updatedAt: null }),
-    planGet: async () => ({ markdown: "", updatedAt: null }),
-    qaGetReport: async () => ({ markdown: "", updatedAt: null }),
-    workspaceGetRepoConfig: async () => ({ promptOverrides: {} }),
-    workspaceGetSettingsSnapshot: async () => ({
-      theme: "light" as const,
-      git: { defaultMergeMethod: "merge_commit" as const },
-      chat: { showThinkingMessages: false },
-      repos: {},
-      globalPromptOverrides: {},
-    }),
-  },
-}));
-
-mock.module("@/lib/host-client", () => ({
-  hostClient: {
-    ...createTauriHostClient(async () => {
-      throw new Error("Tauri runtime not available. Run inside the desktop shell.");
-    }),
-    workspaceGetRepoConfig: async () => ({ promptOverrides: {} }),
-    workspaceGetSettingsSnapshot: async () => ({
-      theme: "light" as const,
-      git: { defaultMergeMethod: "merge_commit" as const },
-      chat: { showThinkingMessages: false },
-      repos: {},
-      globalPromptOverrides: {},
-    }),
-  },
-}));
-
 mock.module("@/lib/open-external-url", () => ({
   openExternalUrl: async () => {},
 }));
+
+const createUnavailableHostClient = () =>
+  createTauriHostClient(async () => {
+    throw new Error("Tauri runtime not available. Run inside the desktop shell.");
+  });
+
+const buildMockedHost = () => ({
+  ...createUnavailableHostClient(),
+  taskApprovalContextGet: taskApprovalContextGetMock,
+  taskDirectMerge: taskDirectMergeMock,
+  taskPullRequestUpsert: taskPullRequestUpsertMock,
+  gitPushBranch: gitPushBranchMock,
+  agentSessionsList: async () => [{ role: "build", sessionId: "builder-session" }],
+  specGet: async () => ({ markdown: "", updatedAt: null }),
+  planGet: async () => ({ markdown: "", updatedAt: null }),
+  qaGetReport: async () => ({ markdown: "", updatedAt: null }),
+  workspaceGetRepoConfig: async () => ({ promptOverrides: {} }),
+  workspaceGetSettingsSnapshot: async () => ({
+    theme: "light" as const,
+    git: { defaultMergeMethod: "merge_commit" as const },
+    chat: { showThinkingMessages: false },
+    repos: {},
+    globalPromptOverrides: {},
+  }),
+});
+
+const HOST_METHOD_NAMES = [
+  "taskApprovalContextGet",
+  "taskDirectMerge",
+  "taskPullRequestUpsert",
+  "gitPushBranch",
+  "agentSessionsList",
+  "specGet",
+  "planGet",
+  "qaGetReport",
+  "workspaceGetRepoConfig",
+  "workspaceGetSettingsSnapshot",
+] as const;
+
+type HostMethodName = (typeof HOST_METHOD_NAMES)[number];
+type HostLike = Record<HostMethodName, unknown>;
+
+let originalHostMethods: Partial<HostLike> | null = null;
+
+const applyHostMocks = async (): Promise<void> => {
+  const hostModule = await import("@/state/operations/host");
+  const hostClientModule = await import("@/lib/host-client");
+  const mockedHost = buildMockedHost();
+  if (!originalHostMethods) {
+    originalHostMethods = Object.fromEntries(
+      HOST_METHOD_NAMES.map((name) => [name, hostClientModule.hostClient[name]]),
+    ) as Partial<HostLike>;
+  }
+  Object.assign(hostClientModule.hostClient, mockedHost);
+  Object.assign(hostModule.host, mockedHost);
+};
+
+const restoreHostMocks = async (): Promise<void> => {
+  if (!originalHostMethods) {
+    return;
+  }
+  const hostModule = await import("@/state/operations/host");
+  const hostClientModule = await import("@/lib/host-client");
+  Object.assign(hostClientModule.hostClient, originalHostMethods);
+  Object.assign(hostModule.host, originalHostMethods);
+};
 
 let latestHarnessValue: {
   taskApprovalModal: {
@@ -124,6 +153,7 @@ function createDeferred<TValue>() {
 describe("useTaskApprovalFlow", () => {
   beforeEach(async () => {
     await clearAppQueryClient();
+    await applyHostMocks();
     latestHarnessValue = null;
     taskApprovalContextGetMock.mockClear();
     taskDirectMergeMock.mockClear();
@@ -134,7 +164,8 @@ describe("useTaskApprovalFlow", () => {
     toastErrorMock.mockClear();
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    await restoreHostMocks();
     mock.restore();
   });
 
@@ -371,7 +402,14 @@ describe("useTaskApprovalFlow", () => {
       scenario: "build_implementation_start",
       status: "running",
       startedAt: "2026-03-12T12:01:00Z",
-      messages: [],
+      messages: [
+        {
+          id: "assistant-builder",
+          role: "assistant",
+          content: "Builder context",
+          timestamp: "2026-03-12T12:00:00Z",
+        },
+      ],
     });
 
     const Harness = (): ReactElement | null => {
@@ -478,7 +516,14 @@ describe("useTaskApprovalFlow", () => {
       scenario: "build_implementation_start",
       status: "idle",
       startedAt: "2026-03-12T12:01:00Z",
-      messages: [],
+      messages: [
+        {
+          id: "assistant-builder",
+          role: "assistant",
+          content: "Builder context",
+          timestamp: "2026-03-12T12:00:00Z",
+        },
+      ],
     });
 
     const Harness = (): ReactElement | null => {

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -1,4 +1,5 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createTauriHostClient } from "@openducktor/adapters-tauri-host";
 import type { TaskApprovalContext } from "@openducktor/contracts";
 import type { ReactElement } from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
@@ -56,6 +57,22 @@ mock.module("@/state/operations/host", () => ({
     specGet: async () => ({ markdown: "", updatedAt: null }),
     planGet: async () => ({ markdown: "", updatedAt: null }),
     qaGetReport: async () => ({ markdown: "", updatedAt: null }),
+    workspaceGetRepoConfig: async () => ({ promptOverrides: {} }),
+    workspaceGetSettingsSnapshot: async () => ({
+      theme: "light" as const,
+      git: { defaultMergeMethod: "merge_commit" as const },
+      chat: { showThinkingMessages: false },
+      repos: {},
+      globalPromptOverrides: {},
+    }),
+  },
+}));
+
+mock.module("@/lib/host-client", () => ({
+  hostClient: {
+    ...createTauriHostClient(async () => {
+      throw new Error("Tauri runtime not available. Run inside the desktop shell.");
+    }),
     workspaceGetRepoConfig: async () => ({ promptOverrides: {} }),
     workspaceGetSettingsSnapshot: async () => ({
       theme: "light" as const,
@@ -301,6 +318,113 @@ describe("useTaskApprovalFlow", () => {
     expect(gitPushBranchMock).not.toHaveBeenCalled();
     expect(refreshTasksMock).toHaveBeenCalledTimes(1);
     expect(latestHarnessValue?.taskApprovalModal).toBeNull();
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("creates an AI pull request when the forked reply is already present before the waiter starts", async () => {
+    const refreshTasksMock = mock(async () => {});
+    taskApprovalContextGetMock.mockResolvedValue({
+      taskId: "TASK-1",
+      taskStatus: "human_review",
+      workingDirectory: "/repo/.worktrees/task-1",
+      sourceBranch: "odt/TASK-1",
+      targetBranch: { remote: "origin", branch: "main" },
+      publishTarget: { remote: "origin", branch: "main" },
+      defaultMergeMethod: "merge_commit",
+      hasUncommittedChanges: false,
+      uncommittedFileCount: 0,
+      pullRequest: undefined,
+      providers: [
+        {
+          providerId: "github",
+          enabled: true,
+          available: true,
+          reason: undefined,
+        },
+      ],
+    } satisfies TaskApprovalContext as unknown as never);
+
+    const { useTaskApprovalFlow } = await import("./use-task-approval-flow");
+    const builderSession = createAgentSessionFixture({
+      sessionId: "builder-session",
+      taskId: "TASK-1",
+      role: "build",
+      scenario: "build_implementation_start",
+      status: "idle",
+      startedAt: "2026-03-12T12:00:00Z",
+      messages: [
+        {
+          id: "assistant-builder",
+          role: "assistant",
+          content: "Builder context",
+          timestamp: "2026-03-12T12:00:00Z",
+        },
+      ],
+    });
+    const forkedSession = createAgentSessionFixture({
+      sessionId: "forked-session",
+      taskId: "TASK-1",
+      role: "build",
+      scenario: "build_implementation_start",
+      status: "running",
+      startedAt: "2026-03-12T12:01:00Z",
+      messages: [],
+    });
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        sessions: [builderSession, forkedSession],
+        loadAgentSessions: async () => {},
+        forkAgentSession: async () => "forked-session",
+        sendAgentMessage: async () => {
+          forkedSession.messages.push({
+            id: "assistant-forked",
+            role: "assistant",
+            content: "Title: PR\nDescription: Body",
+            timestamp: "2026-03-12T12:02:00Z",
+          });
+          forkedSession.status = "stopped";
+        },
+        refreshTasks: refreshTasksMock,
+      });
+      return null;
+    };
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(<Harness />);
+    });
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onModeChange("pull_request");
+      latestHarnessValue?.taskApprovalModal?.onPullRequestDraftModeChange("generate_ai");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(taskPullRequestUpsertMock).toHaveBeenCalledWith("/repo", "TASK-1", "PR", "Body");
+    expect(refreshTasksMock).toHaveBeenCalledTimes(1);
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Pull request created",
+      expect.objectContaining({
+        id: "toast-id",
+        description: "PR #17",
+      }),
+    );
 
     await act(async () => {
       renderer.unmount();

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -171,47 +171,57 @@ export function useTaskApprovalFlow({
       await loadAgentSessions(taskId);
       for (let attempt = 0; attempt < 20; attempt += 1) {
         const parentSession = sessionsRef.current.find((entry) => entry.sessionId === sessionId);
-        if (parentSession) {
+        if (
+          parentSession &&
+          parentSession.runtimeEndpoint.trim().length > 0 &&
+          parentSession.workingDirectory.trim().length > 0
+        ) {
           return parentSession;
         }
         await delay(50);
       }
-      throw new Error("Failed to load the parent Builder session for pull request drafting.");
+      throw new Error(
+        "Failed to reconnect the parent Builder session for pull request drafting.",
+      );
     },
     [loadAgentSessions],
   );
 
-  const waitForForkedAssistantReply = useCallback(async (sessionId: string): Promise<string> => {
-    const baselineAssistantCount =
-      sessionsRef.current
-        .find((entry) => entry.sessionId === sessionId)
-        ?.messages.filter((message) => message.role === "assistant").length ?? 0;
+  const waitForForkedAssistantReply = useCallback(
+    async (sessionId: string, baselineAssistantCount: number): Promise<string> => {
+      const isSettledSessionStatus = (status: AgentSessionState["status"]): boolean =>
+        status === "idle" || status === "stopped";
 
-    for (let attempt = 0; attempt < 240; attempt += 1) {
-      const session = sessionsRef.current.find((entry) => entry.sessionId === sessionId);
-      if (!session) {
-        throw new Error(
-          "Forked Builder session disappeared before the pull request draft completed.",
-        );
+      for (let attempt = 0; attempt < 240; attempt += 1) {
+        const session = sessionsRef.current.find((entry) => entry.sessionId === sessionId);
+        if (!session) {
+          throw new Error(
+            "Forked Builder session disappeared before the pull request draft completed.",
+          );
+        }
+        if (session.status === "error") {
+          throw new Error(
+            "The forked Builder session failed while generating the pull request draft.",
+          );
+        }
+
+        const assistantMessages = session.messages.filter((message) => message.role === "assistant");
+        if (
+          assistantMessages.length > baselineAssistantCount &&
+          isSettledSessionStatus(session.status)
+        ) {
+          return assistantMessages.at(-1)?.content ?? "";
+        }
+
+        await delay(500);
       }
-      if (session.status === "error") {
-        throw new Error(
-          "The forked Builder session failed while generating the pull request draft.",
-        );
-      }
 
-      const assistantMessages = session.messages.filter((message) => message.role === "assistant");
-      if (session.status === "idle" && assistantMessages.length > baselineAssistantCount) {
-        return assistantMessages.at(-1)?.content ?? "";
-      }
-
-      await delay(500);
-    }
-
-    throw new Error(
-      "Timed out while waiting for the forked Builder session to generate the pull request draft.",
-    );
-  }, []);
+      throw new Error(
+        "Timed out while waiting for the forked Builder session to generate the pull request draft.",
+      );
+    },
+    [],
+  );
 
   const createPullRequestWithAi = useCallback(
     async (currentState: ApprovalState) => {
@@ -244,6 +254,10 @@ export function useTaskApprovalFlow({
       const forkedSessionId = await forkAgentSession({
         parentSessionId: parentSession.sessionId,
       });
+      const baselineAssistantCount =
+        sessionsRef.current
+          .find((entry) => entry.sessionId === forkedSessionId)
+          ?.messages.filter((message) => message.role === "assistant").length ?? 0;
       const prompt = buildAgentMessagePrompt({
         role: "build",
         templateId: "message.build_pull_request_draft",
@@ -263,7 +277,7 @@ export function useTaskApprovalFlow({
 
       await sendAgentMessage(forkedSessionId, prompt);
       const generated = parseGeneratedPullRequest(
-        await waitForForkedAssistantReply(forkedSessionId),
+        await waitForForkedAssistantReply(forkedSessionId, baselineAssistantCount),
       );
       const pullRequest = await host.taskPullRequestUpsert(
         activeRepo,

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -15,7 +15,7 @@ import {
   loadSpecDocumentFromQuery,
 } from "@/state/queries/documents";
 import { loadTaskApprovalContextFromQuery } from "@/state/queries/task-approval";
-import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import type { TaskApprovalModalModel } from "./kanban-page-model-types";
 
 type ApprovalState = {
@@ -37,7 +37,7 @@ type UseTaskApprovalFlowArgs = {
   activeRepo: string | null;
   tasks: TaskCard[];
   sessions: AgentSessionState[];
-  loadAgentSessions: (taskId: string) => Promise<void>;
+  loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
   forkAgentSession: (input: { parentSessionId: string }) => Promise<string>;
   sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
   refreshTasks: () => Promise<void>;
@@ -168,7 +168,9 @@ export function useTaskApprovalFlow({
 
   const waitForLoadedParentSession = useCallback(
     async (taskId: string, sessionId: string): Promise<AgentSessionState> => {
-      await loadAgentSessions(taskId);
+      await loadAgentSessions(taskId, {
+        hydrateHistoryForSessionId: sessionId,
+      });
       for (let attempt = 0; attempt < 20; attempt += 1) {
         const parentSession = sessionsRef.current.find((entry) => entry.sessionId === sessionId);
         if (
@@ -180,9 +182,7 @@ export function useTaskApprovalFlow({
         }
         await delay(50);
       }
-      throw new Error(
-        "Failed to reconnect the parent Builder session for pull request drafting.",
-      );
+      throw new Error("Failed to reconnect the parent Builder session for pull request drafting.");
     },
     [loadAgentSessions],
   );
@@ -205,7 +205,9 @@ export function useTaskApprovalFlow({
           );
         }
 
-        const assistantMessages = session.messages.filter((message) => message.role === "assistant");
+        const assistantMessages = session.messages.filter(
+          (message) => message.role === "assistant",
+        );
         if (
           assistantMessages.length > baselineAssistantCount &&
           isSettledSessionStatus(session.status)
@@ -251,13 +253,12 @@ export function useTaskApprovalFlow({
         throw new Error(`Task not found: ${currentState.taskId}`);
       }
 
+      const baselineAssistantCount = parentSession.messages.filter(
+        (message) => message.role === "assistant",
+      ).length;
       const forkedSessionId = await forkAgentSession({
         parentSessionId: parentSession.sessionId,
       });
-      const baselineAssistantCount =
-        sessionsRef.current
-          .find((entry) => entry.sessionId === forkedSessionId)
-          ?.messages.filter((message) => message.role === "assistant").length ?? 0;
       const prompt = buildAgentMessagePrompt({
         role: "build",
         templateId: "message.build_pull_request_draft",

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -5,12 +5,22 @@ import { createElement } from "react";
 import TestRenderer, { act } from "react-test-renderer";
 import type { RepoRuntimeHealthMap } from "@/types/diagnostics";
 
+let subscribedRunListener: ((payload: unknown) => void) | null = null;
+
 mock.module("@/lib/host-client", () => ({
   createHostClient: () =>
     createTauriHostClient(async () => {
       throw new Error("Tauri runtime not available. Run inside the desktop shell.");
     }),
-  subscribeRunEvents: async () => () => {},
+  hostClient: createTauriHostClient(async () => {
+    throw new Error("Tauri runtime not available. Run inside the desktop shell.");
+  }),
+  subscribeRunEvents: async (listener: (payload: unknown) => void) => {
+    subscribedRunListener = listener;
+    return () => {
+      subscribedRunListener = null;
+    };
+  },
 }));
 
 const reactActEnvironment = globalThis as typeof globalThis & {
@@ -39,6 +49,76 @@ const createDeferred = <T,>() => {
 };
 
 describe("useAppLifecycle", () => {
+  test("refreshes active repo task data when a run completion event arrives", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTaskData = mock(async (_repoPath: string) => {});
+    const setRunCompletionSignal = mock((_runId: string, _eventType) => {});
+
+    const Harness = ({ args }: { args: HookArgs }): ReactElement | null => {
+      useAppLifecycle(args);
+      return null;
+    };
+
+    let renderer: TestRenderer.ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(
+        createElement(Harness, {
+          args: {
+            activeRepo: "/repo",
+            setEvents: mock((_updater) => {}),
+            setRunCompletionSignal,
+            refreshWorkspaces: mock(async () => {}),
+            refreshBranches: mock(async () => {}),
+            refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+            refreshBeadsCheckForRepo: mock(async () => ({
+              beadsOk: true,
+              beadsPath: "/repo/.beads",
+              beadsError: null,
+            })),
+            refreshRepoRuntimeHealthForRepo: mock(async () => ({})),
+            runtimeKinds: ["opencode"],
+            refreshTaskData,
+            clearTaskData: mock(() => {}),
+            clearBranchData: mock(() => {}),
+            clearActiveBeadsCheck: mock(() => {}),
+            clearActiveRepoRuntimeHealth: mock(() => {}),
+            setIsLoadingTasks: mock((_value: boolean) => {}),
+            setIsLoadingChecks: mock((_value: boolean) => {}),
+            hasRuntimeCheck: mock(() => true),
+            hasCachedBeadsCheck: mock((_repoPath: string) => true),
+            hasCachedRepoRuntimeHealth: mock((_repoPath: string, _runtimeKinds) => true),
+          } satisfies HookArgs,
+        }),
+      );
+    });
+    await flush();
+
+    refreshTaskData.mockClear();
+    if (!subscribedRunListener) {
+      throw new Error("Expected run event listener to be registered");
+    }
+
+    await act(async () => {
+      subscribedRunListener?.({
+        type: "run_finished",
+        runId: "run-1",
+        message: "done",
+        timestamp: "2026-03-15T10:00:00.000Z",
+        success: true,
+      });
+      await flush();
+    });
+
+    expect(setRunCompletionSignal).toHaveBeenCalledWith("run-1", "run_finished");
+    expect(refreshTaskData).toHaveBeenCalledWith("/repo");
+
+    await act(async () => {
+      renderer?.unmount();
+    });
+  });
+
   test("clears task loading as soon as the repo task load finishes", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = Parameters<typeof useAppLifecycle>[0];

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -3,6 +3,8 @@ import { type Dispatch, type SetStateAction, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { subscribeRunEvents } from "@/lib/host-client";
+import { appQueryClient } from "@/lib/query-client";
+import { taskQueryKeys } from "@/state/queries/tasks";
 import { summarizeTaskLoadError } from "@/state/tasks/task-load-errors";
 import type { RepoRuntimeHealthMap } from "@/types/diagnostics";
 import { prependRunEvent, shouldLoadChecks } from "./app-lifecycle-model";
@@ -60,6 +62,13 @@ export function useAppLifecycle({
   hasCachedRepoRuntimeHealth,
 }: UseAppLifecycleArgs): void {
   const repoLoadVersionRef = useRef(0);
+  const activeRepoRef = useRef(activeRepo);
+  const refreshTaskDataRef = useRef(refreshTaskData);
+
+  useEffect(() => {
+    activeRepoRef.current = activeRepo;
+    refreshTaskDataRef.current = refreshTaskData;
+  }, [activeRepo, refreshTaskData]);
 
   useEffect(() => {
     Promise.allSettled([refreshWorkspaces(), refreshRuntimeCheck(false)]).then(
@@ -92,6 +101,23 @@ export function useAppLifecycle({
         parsed.data.type === "error"
       ) {
         setRunCompletionSignal(parsed.data.runId, parsed.data.type);
+        const repoPath = activeRepoRef.current;
+        if (repoPath) {
+          void Promise.all([
+            appQueryClient.invalidateQueries({
+              queryKey: taskQueryKeys.repoData(repoPath),
+            }),
+            appQueryClient.invalidateQueries({
+              queryKey: taskQueryKeys.runs(repoPath),
+            }),
+          ])
+            .then(() => refreshTaskDataRef.current(repoPath))
+            .catch((error: unknown) => {
+              toast.error("Failed to refresh tasks", {
+                description: summarizeTaskLoadError(error),
+              });
+            });
+        }
       }
     })
       .then((cleanup) => {

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -103,14 +103,10 @@ export function useAppLifecycle({
         setRunCompletionSignal(parsed.data.runId, parsed.data.type);
         const repoPath = activeRepoRef.current;
         if (repoPath) {
-          void Promise.all([
-            appQueryClient.invalidateQueries({
+          void appQueryClient
+            .invalidateQueries({
               queryKey: taskQueryKeys.repoData(repoPath),
-            }),
-            appQueryClient.invalidateQueries({
-              queryKey: taskQueryKeys.runs(repoPath),
-            }),
-          ])
+            })
             .then(() => refreshTaskDataRef.current(repoPath))
             .catch((error: unknown) => {
               toast.error("Failed to refresh tasks", {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -118,10 +118,11 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(state["session-1"]?.status).toBe("stopped");
   });
 
-  test("does not eagerly hydrate session history without an explicit target session", async () => {
+  test("does not eagerly hydrate session history or runtime connections without an explicit target session", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};
     let historyLoads = 0;
+    let runLoads = 0;
     const setSessionsById = (
       updater:
         | Record<string, AgentSessionState>
@@ -181,24 +182,10 @@ describe("agent-orchestrator-load-sessions", () => {
         workingDirectory: "/tmp/repo",
       },
     ];
-    hostModule.host.runsList = async () => [
-      {
-        runId: "run-1",
-        runtimeKind: "opencode",
-        runtimeRoute: {
-          type: "local_http",
-          endpoint: "http://127.0.0.1:4444",
-        },
-        repoPath: "/tmp/repo",
-        taskId: "task-1",
-        branch: "odt/task-1",
-        worktreePath: "/tmp/repo",
-        port: 4444,
-        state: "running",
-        lastMessage: null,
-        startedAt: "2026-02-22T08:00:00.000Z",
-      },
-    ];
+    hostModule.host.runsList = async () => {
+      runLoads += 1;
+      return [];
+    };
 
     try {
       await loadAgentSessions("task-1");
@@ -209,8 +196,9 @@ describe("agent-orchestrator-load-sessions", () => {
 
     expect(Object.keys(state)).toContain("session-1");
     expect(historyLoads).toBe(0);
+    expect(runLoads).toBe(0);
     expect(state["session-1"]?.messages).toEqual([]);
-    expect(state["session-1"]?.runtimeEndpoint).toBe("http://127.0.0.1:4444");
+    expect(state["session-1"]?.runtimeEndpoint).toBe("");
   });
 
   test("hydrates requested session through its persisted runtime kind when endpoint is missing", async () => {
@@ -470,6 +458,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const hostModule = await import("../../host");
     const originalList = hostModule.host.agentSessionsList;
+    const originalRuntimeList = hostModule.host.runtimeList;
     hostModule.host.agentSessionsList = async () => [
       {
         runtimeKind: "opencode",
@@ -484,11 +473,28 @@ describe("agent-orchestrator-load-sessions", () => {
         workingDirectory: "/tmp/repo",
       },
     ];
+    hostModule.host.runtimeList = async () => [
+      {
+        kind: "opencode",
+        runtimeId: "runtime-1",
+        repoPath: "/tmp/repo",
+        taskId: null,
+        role: "workspace",
+        workingDirectory: "/tmp/repo",
+        runtimeRoute: {
+          type: "local_http" as const,
+          endpoint: "http://127.0.0.1:4555",
+        },
+        startedAt: "2026-02-22T08:00:00.000Z",
+        descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      },
+    ];
 
     try {
       await loadAgentSessions("task-1", { hydrateHistoryForSessionId: "session-1" });
     } finally {
       hostModule.host.agentSessionsList = originalList;
+      hostModule.host.runtimeList = originalRuntimeList;
     }
 
     expect(todoLoads).toBe(1);

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -130,6 +130,20 @@ describe("agent-orchestrator-load-sessions", () => {
       state = typeof updater === "function" ? updater(state) : updater;
       sessionsRef.current = state;
     };
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
@@ -144,7 +158,7 @@ describe("agent-orchestrator-load-sessions", () => {
       sessionsRef,
       setSessionsById,
       taskRef: { current: [taskFixture] },
-      updateSession: () => {},
+      updateSession,
       loadSessionTodos: async () => {},
       loadSessionModelCatalog: async () => {},
       loadRepoPromptOverrides: async () => ({}),
@@ -152,6 +166,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const hostModule = await import("../../host");
     const originalList = hostModule.host.agentSessionsList;
+    const originalRunsList = hostModule.host.runsList;
     hostModule.host.agentSessionsList = async () => [
       {
         runtimeKind: "opencode",
@@ -166,16 +181,36 @@ describe("agent-orchestrator-load-sessions", () => {
         workingDirectory: "/tmp/repo",
       },
     ];
+    hostModule.host.runsList = async () => [
+      {
+        runId: "run-1",
+        runtimeKind: "opencode",
+        runtimeRoute: {
+          type: "local_http",
+          endpoint: "http://127.0.0.1:4444",
+        },
+        repoPath: "/tmp/repo",
+        taskId: "task-1",
+        branch: "odt/task-1",
+        worktreePath: "/tmp/repo",
+        port: 4444,
+        state: "running",
+        lastMessage: null,
+        startedAt: "2026-02-22T08:00:00.000Z",
+      },
+    ];
 
     try {
       await loadAgentSessions("task-1");
     } finally {
       hostModule.host.agentSessionsList = originalList;
+      hostModule.host.runsList = originalRunsList;
     }
 
     expect(Object.keys(state)).toContain("session-1");
     expect(historyLoads).toBe(0);
     expect(state["session-1"]?.messages).toEqual([]);
+    expect(state["session-1"]?.runtimeEndpoint).toBe("http://127.0.0.1:4444");
   });
 
   test("hydrates requested session through its persisted runtime kind when endpoint is missing", async () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -1,5 +1,4 @@
 import type {
-  AgentSessionRecord,
   RepoPromptOverrides,
   RunSummary,
   RuntimeInstanceSummary,
@@ -165,32 +164,6 @@ export const createLoadAgentSessions = ({
       return;
     }
 
-    const shouldRefreshRuntimeConnection = (record: AgentSessionRecord): boolean => {
-      const existingSession = sessionsRef.current[record.sessionId];
-      if (!existingSession) {
-        return true;
-      }
-
-      const recordRuntimeKind =
-        record.runtimeKind ?? record.selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND;
-      const existingRuntimeKind =
-        existingSession.runtimeKind ??
-        existingSession.selectedModel?.runtimeKind ??
-        DEFAULT_RUNTIME_KIND;
-
-      return (
-        existingSession.runtimeEndpoint.trim().length === 0 ||
-        existingSession.workingDirectory !== record.workingDirectory ||
-        existingRuntimeKind !== recordRuntimeKind
-      );
-    };
-
-    const runtimeAttachmentSessionIds = new Set(
-      persisted
-        .filter((record) => shouldRefreshRuntimeConnection(record))
-        .map((record) => record.sessionId),
-    );
-
     const historyHydrationSessionIds = new Set(
       persisted
         .filter((record) => {
@@ -206,11 +179,11 @@ export const createLoadAgentSessions = ({
         .map((record) => record.sessionId),
     );
 
-    const recordsToHydrate = persisted.filter(
-      (record) =>
-        runtimeAttachmentSessionIds.has(record.sessionId) ||
-        historyHydrationSessionIds.has(record.sessionId),
-    );
+    if (!shouldHydrateRequestedSession) {
+      return;
+    }
+
+    const recordsToHydrate = persisted.filter((record) => record.sessionId === requestedSessionId);
 
     if (recordsToHydrate.length === 0) {
       if (!shouldHydrateRequestedSession) {
@@ -436,11 +409,24 @@ export const createLoadAgentSessions = ({
       }
 
       const shouldHydrateHistory = historyHydrationSessionIds.has(record.sessionId);
-      const existingSession = sessionsRef.current[record.sessionId];
       const workingDirectory = record.workingDirectory;
       const runtimeResolution = await resolveHydrationRuntime(record);
       if (!runtimeResolution.ok) {
-        throw new Error(runtimeResolution.reason);
+        if (shouldHydrateHistory) {
+          throw new Error(runtimeResolution.reason);
+        }
+        updateSession(
+          record.sessionId,
+          (current) => ({
+            ...current,
+            runtimeKind: readPersistedRuntimeKind(record),
+            runtimeEndpoint: "",
+            workingDirectory,
+            promptOverrides: repoPromptOverrides,
+          }),
+          { persist: false },
+        );
+        return;
       }
       const { runtimeKind, runtimeConnection, runtimeEndpoint } = runtimeResolution;
       const externalSessionId = record.externalSessionId ?? record.sessionId;
@@ -460,13 +446,17 @@ export const createLoadAgentSessions = ({
           }),
           { persist: false },
         );
-        warmPersistedSession(
-          record.sessionId,
-          runtimeKind,
-          runtimeConnection,
-          externalSessionId,
-          record.role,
-        );
+        if (shouldHydrateRequestedSession && record.sessionId === requestedSessionId) {
+          const requestedSession = sessionsRef.current[record.sessionId];
+          warmPersistedSession(
+            record.sessionId,
+            runtimeKind,
+            runtimeConnection,
+            externalSessionId,
+            record.role,
+            !requestedSession?.modelCatalog && !requestedSession?.isLoadingModelCatalog,
+          );
+        }
         return;
       }
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentSessionRecord,
   RepoPromptOverrides,
   RunSummary,
   RuntimeInstanceSummary,
@@ -164,16 +165,52 @@ export const createLoadAgentSessions = ({
       return;
     }
 
-    const recordsToHydrate = persisted.filter((record) => {
-      if (shouldHydrateRequestedSession && record.sessionId !== requestedSessionId) {
-        return false;
-      }
-      if (!shouldHydrateRequestedSession) {
-        return false;
-      }
+    const shouldRefreshRuntimeConnection = (record: AgentSessionRecord): boolean => {
       const existingSession = sessionsRef.current[record.sessionId];
-      return !existingSession || existingSession.messages.length === 0;
-    });
+      if (!existingSession) {
+        return true;
+      }
+
+      const recordRuntimeKind =
+        record.runtimeKind ?? record.selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND;
+      const existingRuntimeKind =
+        existingSession.runtimeKind ??
+        existingSession.selectedModel?.runtimeKind ??
+        DEFAULT_RUNTIME_KIND;
+
+      return (
+        existingSession.runtimeEndpoint.trim().length === 0 ||
+        existingSession.workingDirectory !== record.workingDirectory ||
+        existingRuntimeKind !== recordRuntimeKind
+      );
+    };
+
+    const runtimeAttachmentSessionIds = new Set(
+      persisted
+        .filter((record) => shouldRefreshRuntimeConnection(record))
+        .map((record) => record.sessionId),
+    );
+
+    const historyHydrationSessionIds = new Set(
+      persisted
+        .filter((record) => {
+          if (shouldHydrateRequestedSession && record.sessionId !== requestedSessionId) {
+            return false;
+          }
+          if (!shouldHydrateRequestedSession) {
+            return false;
+          }
+          const existingSession = sessionsRef.current[record.sessionId];
+          return !existingSession || existingSession.messages.length === 0;
+        })
+        .map((record) => record.sessionId),
+    );
+
+    const recordsToHydrate = persisted.filter(
+      (record) =>
+        runtimeAttachmentSessionIds.has(record.sessionId) ||
+        historyHydrationSessionIds.has(record.sessionId),
+    );
 
     if (recordsToHydrate.length === 0) {
       if (!shouldHydrateRequestedSession) {
@@ -398,6 +435,7 @@ export const createLoadAgentSessions = ({
         return;
       }
 
+      const shouldHydrateHistory = historyHydrationSessionIds.has(record.sessionId);
       const existingSession = sessionsRef.current[record.sessionId];
       const workingDirectory = record.workingDirectory;
       const runtimeResolution = await resolveHydrationRuntime(record);
@@ -407,7 +445,7 @@ export const createLoadAgentSessions = ({
       const { runtimeKind, runtimeConnection, runtimeEndpoint } = runtimeResolution;
       const externalSessionId = record.externalSessionId ?? record.sessionId;
       const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
-      if (existingSession && existingSession.messages.length > 0) {
+      if (!shouldHydrateHistory) {
         if (isStaleRepoOperation()) {
           return;
         }


### PR DESCRIPTION
## Summary
- reattach live runtime connections for persisted agent sessions before fork/resume paths use them
- fix the AI PR draft flow so it captures the correct assistant baseline and accepts settled fork states
- refresh Kanban task/run data when build completion events arrive so stale Running badges clear

## Testing
- bun test apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
- bun test apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
- bun test apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
- bun run --filter @openducktor/desktop typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure task data refreshes when run completion events arrive.
  * Improve reliability of AI-assisted pull request creation when forked replies already exist.
  * Prevent stale runtime/session states by tightening readiness and timeout handling.

* **Improvements**
  * More robust and targeted session history hydration and runtime resolution to stabilize AI workflows.
  * Active repo task data is invalidated and refreshed on relevant run events.

* **Tests**
  * Expanded tests covering approval flows, run events, session hydration, and AI PR scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->