### PR TITLE
feat(chat): add scroll-to-bottom button to Agent Studio chat

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, LoaderCircle, RefreshCcw, Sparkles } from "lucide-react";
-import { type ReactElement, useMemo, useRef } from "react";
+import { type ReactElement, useCallback, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
@@ -9,7 +9,9 @@ import type { AgentChatVirtualRow } from "./agent-chat-thread-virtualization";
 import { AgentSessionPermissionCard } from "./agent-session-permission-card";
 import { AgentSessionQuestionCard } from "./agent-session-question-card";
 import { AgentSessionTodoPanel } from "./agent-session-todo-panel";
+import { ScrollToBottomButton } from "./scroll-to-bottom-button";
 import { useAgentChatAutoScroll } from "./use-agent-chat-auto-scroll";
+import { isNearBottom, scrollMessagesContainerToBottom } from "./use-agent-chat-layout";
 import { useAgentChatLoadingOverlay } from "./use-agent-chat-loading-overlay";
 import { useAgentChatRowMotion } from "./use-agent-chat-row-motion";
 import { useAgentChatVirtualization } from "./use-agent-chat-virtualization";
@@ -88,6 +90,21 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     onMessagesTouchMove,
     onMessagesWheel,
   } = model;
+
+  const [isUserNearBottom, setIsUserNearBottom] = useState(true);
+
+  const handleMessagesScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const container = event.currentTarget;
+      setIsUserNearBottom(isNearBottom(container));
+      onMessagesScroll(event);
+    },
+    [onMessagesScroll],
+  );
+
+  const handleScrollToBottom = useCallback(() => {
+    scrollMessagesContainerToBottom(messagesContainerRef.current);
+  }, [messagesContainerRef]);
 
   const {
     activeSessionId,
@@ -195,7 +212,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
         ref={messagesContainerRef}
         className="relative min-h-0 flex-1 space-y-1 overflow-y-auto p-4 pb-6"
         onPointerDown={onMessagesPointerDown}
-        onScroll={onMessagesScroll}
+        onScroll={handleMessagesScroll}
         onTouchMove={onMessagesTouchMove}
         onWheel={onMessagesWheel}
       >
@@ -316,6 +333,10 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
             Preparing chat...
           </div>
         </div>
+      ) : null}
+
+      {session ? (
+        <ScrollToBottomButton visible={!isUserNearBottom} onClick={handleScrollToBottom} />
       ) : null}
 
       {session ? (

--- a/apps/desktop/src/components/features/agents/agent-chat/scroll-to-bottom-button.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/scroll-to-bottom-button.tsx
@@ -1,0 +1,35 @@
+import { ArrowDown } from "lucide-react";
+import type { ReactElement } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type ScrollToBottomButtonProps = {
+  onClick: () => void;
+  visible: boolean;
+};
+
+export function ScrollToBottomButton({
+  onClick,
+  visible,
+}: ScrollToBottomButtonProps): ReactElement {
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute bottom-6 left-1/2 z-20 -translate-x-1/2 transition-opacity duration-200",
+        visible && "pointer-events-auto opacity-100",
+        !visible && "opacity-0",
+      )}
+    >
+      <Button
+        type="button"
+        size="icon"
+        variant="outline"
+        className="size-9 rounded-full border-border bg-card text-muted-foreground shadow-md hover:bg-accent hover:text-foreground"
+        onClick={onClick}
+        aria-label="Scroll to bottom"
+      >
+        <ArrowDown className="size-4" />
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Add a floating scroll-to-bottom button in the Agent Studio chat interface that appears when the user has scrolled away from the bottom of the conversation, allowing quick one-click navigation to the latest messages.

- **Problem solved**: In long chat sessions, users scrolling up to review earlier messages had no quick way to return to the bottom where new messages appear
- **Out of scope**: Custom scroll animations beyond existing utilities, badge indicators for new messages, keyboard shortcuts

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [ ] `bun run check:rust`
- [ ] `bun run test:rust`
- [x] Not applicable (frontend-only change)

## Checklist

- [ ] I updated docs when behavior, workflows, runtime contracts, or setup changed
- [ ] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [x] I linked related issues or context below

## Related Issues

Part of: openducktor-ojn

## Breaking Changes

- [x] No breaking changes

## Additional Context

**Files changed:**
- `apps/desktop/src/components/features/agents/agent-chat/scroll-to-bottom-button.tsx` (new)
- `apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx` (modified)

**Implementation notes:**
- Reuses existing `isNearBottom()` and `scrollMessagesContainerToBottom()` utilities from `use-agent-chat-layout.ts`
- Uses 48px threshold (same as auto-scroll) for showing/hiding button
- Theme-aware using shadcn semantic tokens
- Button positioned at `bottom-6`, horizontally centered
- Smooth 200ms opacity transition on visibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scroll-to-bottom button to the agent chat interface. When you scroll up from the bottom of the conversation, the button appears, allowing you to quickly jump back to the latest messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->