### PR TITLE
fix(beads): repair centralized store startup handling

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
@@ -57,6 +57,9 @@ impl BeadsTaskStore {
         )?;
 
         if !stdout.trim().is_empty() {
+            // Treat malformed JSON as a hard failure: the CLI contract for
+            // `bd where --json` is broken in that case, so attempting repair
+            // would mask an unexpected protocol error.
             let payload: Value = serde_json::from_str(&stdout)
                 .context("Failed to parse `bd where --json` output")?;
             if payload.get("path").and_then(Value::as_str).is_some() {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Context, Result};
-#[cfg(test)]
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -44,7 +43,6 @@ impl BeadsTaskStore {
         Ok(())
     }
 
-    #[cfg(test)]
     pub(crate) fn verify_repo_initialized(
         &self,
         repo_path: &Path,
@@ -58,6 +56,19 @@ impl BeadsTaskStore {
             &[("BEADS_DIR", beads_dir_env.as_str())],
         )?;
 
+        if !stdout.trim().is_empty() {
+            let payload: Value = serde_json::from_str(&stdout)
+                .context("Failed to parse `bd where --json` output")?;
+            if payload.get("path").and_then(Value::as_str).is_some() {
+                return Ok((true, String::new()));
+            }
+            if let Some(error) = payload.get("error").and_then(Value::as_str) {
+                return Ok((false, error.trim().to_string()));
+            }
+
+            return Ok((false, "bd where returned malformed payload".to_string()));
+        }
+
         if !ok {
             let error = if stderr.trim().is_empty() {
                 "bd where failed".to_string()
@@ -67,13 +78,13 @@ impl BeadsTaskStore {
             return Ok((false, error));
         }
 
-        let payload: Value =
-            serde_json::from_str(&stdout).context("Failed to parse `bd where --json` output")?;
-        if payload.get("path").and_then(Value::as_str).is_some() {
-            return Ok((true, String::new()));
-        }
+        Ok((false, "bd where returned empty payload".to_string()))
+    }
 
-        Ok((false, "bd where returned malformed payload".to_string()))
+    pub(crate) fn repair_repo_store(&self, repo_path: &Path) -> Result<()> {
+        self.run_bd(repo_path, &["doctor", "--fix", "--yes"])
+            .with_context(|| format!("Failed to repair Beads store for {}", repo_path.display()))?;
+        Ok(())
     }
 
     pub(crate) fn ensure_custom_statuses(&self, repo_path: &Path) -> Result<()> {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -29,27 +29,56 @@ impl BeadsTaskStore {
             return Ok(());
         }
 
-        if !store_exists {
-            let slug = compute_repo_slug(repo_path);
-            let beads_dir_env = beads_dir.to_string_lossy().to_string();
-            let (ok, _stdout, stderr) = self.command_runner.run_allow_failure_with_env(
-                "bd",
-                &["init", "--quiet", "--skip-hooks", "--prefix", slug.as_str()],
-                Some(repo_path),
-                &[("BEADS_DIR", beads_dir_env.as_str())],
-            )?;
+        let (is_ready, reason) = if store_exists {
+            self.verify_repo_initialized(repo_path, &beads_dir)?
+        } else {
+            (false, format!("bd init failed for {}", beads_dir.display()))
+        };
 
-            if !ok {
-                let details = if stderr.trim().is_empty() {
-                    format!("bd init failed for {}", beads_dir.display())
-                } else {
-                    stderr.trim().to_string()
-                };
-                return Err(anyhow!(
-                    "Failed to initialize Beads at {}: {}",
-                    beads_dir.display(),
-                    details
-                ));
+        if !is_ready {
+            if store_exists {
+                self.repair_repo_store(repo_path)?;
+                let (is_ready_after_repair, reason_after_repair) =
+                    self.verify_repo_initialized(repo_path, &beads_dir)?;
+                if !is_ready_after_repair {
+                    return Err(anyhow!(
+                        "Failed to repair existing Beads store at {}: {}",
+                        beads_dir.display(),
+                        reason_after_repair
+                    ));
+                }
+            } else {
+                let slug = compute_repo_slug(repo_path);
+                let beads_dir_env = beads_dir.to_string_lossy().to_string();
+                let (ok, _stdout, stderr) = self.command_runner.run_allow_failure_with_env(
+                    "bd",
+                    &["init", "--quiet", "--skip-hooks", "--prefix", slug.as_str()],
+                    Some(repo_path),
+                    &[("BEADS_DIR", beads_dir_env.as_str())],
+                )?;
+
+                if !ok {
+                    let details = if stderr.trim().is_empty() {
+                        reason
+                    } else {
+                        stderr.trim().to_string()
+                    };
+                    return Err(anyhow!(
+                        "Failed to initialize Beads at {}: {}",
+                        beads_dir.display(),
+                        details
+                    ));
+                }
+
+                let (is_ready_after_init, reason_after_init) =
+                    self.verify_repo_initialized(repo_path, &beads_dir)?;
+                if !is_ready_after_init {
+                    return Err(anyhow!(
+                        "Beads init completed but store is not ready at {}: {}",
+                        beads_dir.display(),
+                        reason_after_init
+                    ));
+                }
             }
         }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -16,6 +16,61 @@ impl BeadsTaskStore {
         )
     }
 
+    fn ensure_existing_store_is_ready(&self, repo_path: &Path, beads_dir: &Path) -> Result<()> {
+        self.repair_repo_store(repo_path)?;
+        let (is_ready_after_repair, reason_after_repair) =
+            self.verify_repo_initialized(repo_path, beads_dir)?;
+        if !is_ready_after_repair {
+            return Err(anyhow!(
+                "Failed to repair existing Beads store at {}: {}",
+                beads_dir.display(),
+                reason_after_repair
+            ));
+        }
+        Ok(())
+    }
+
+    fn ensure_new_store_is_ready(
+        &self,
+        repo_path: &Path,
+        beads_dir: &Path,
+        init_failure_reason: &str,
+    ) -> Result<()> {
+        let slug = compute_repo_slug(repo_path);
+        let beads_dir_env = beads_dir.to_string_lossy().to_string();
+        let (ok, _stdout, stderr) = self.command_runner.run_allow_failure_with_env(
+            "bd",
+            &["init", "--quiet", "--skip-hooks", "--prefix", slug.as_str()],
+            Some(repo_path),
+            &[("BEADS_DIR", beads_dir_env.as_str())],
+        )?;
+
+        if !ok {
+            let details = if stderr.trim().is_empty() {
+                init_failure_reason.to_string()
+            } else {
+                stderr.trim().to_string()
+            };
+            return Err(anyhow!(
+                "Failed to initialize Beads at {}: {}",
+                beads_dir.display(),
+                details
+            ));
+        }
+
+        let (is_ready_after_init, reason_after_init) =
+            self.verify_repo_initialized(repo_path, beads_dir)?;
+        if !is_ready_after_init {
+            return Err(anyhow!(
+                "Beads init completed but store is not ready at {}: {}",
+                beads_dir.display(),
+                reason_after_init
+            ));
+        }
+
+        Ok(())
+    }
+
     pub(super) fn ensure_repo_initialized_impl(&self, repo_path: &Path) -> Result<()> {
         let repo_key = Self::repo_key(repo_path);
         let lock = self.repo_lock(&repo_key)?;
@@ -32,53 +87,14 @@ impl BeadsTaskStore {
         let (is_ready, reason) = if store_exists {
             self.verify_repo_initialized(repo_path, &beads_dir)?
         } else {
-            (false, format!("bd init failed for {}", beads_dir.display()))
+            (false, "bd init failed".to_string())
         };
 
         if !is_ready {
             if store_exists {
-                self.repair_repo_store(repo_path)?;
-                let (is_ready_after_repair, reason_after_repair) =
-                    self.verify_repo_initialized(repo_path, &beads_dir)?;
-                if !is_ready_after_repair {
-                    return Err(anyhow!(
-                        "Failed to repair existing Beads store at {}: {}",
-                        beads_dir.display(),
-                        reason_after_repair
-                    ));
-                }
+                self.ensure_existing_store_is_ready(repo_path, &beads_dir)?;
             } else {
-                let slug = compute_repo_slug(repo_path);
-                let beads_dir_env = beads_dir.to_string_lossy().to_string();
-                let (ok, _stdout, stderr) = self.command_runner.run_allow_failure_with_env(
-                    "bd",
-                    &["init", "--quiet", "--skip-hooks", "--prefix", slug.as_str()],
-                    Some(repo_path),
-                    &[("BEADS_DIR", beads_dir_env.as_str())],
-                )?;
-
-                if !ok {
-                    let details = if stderr.trim().is_empty() {
-                        reason
-                    } else {
-                        stderr.trim().to_string()
-                    };
-                    return Err(anyhow!(
-                        "Failed to initialize Beads at {}: {}",
-                        beads_dir.display(),
-                        details
-                    ));
-                }
-
-                let (is_ready_after_init, reason_after_init) =
-                    self.verify_repo_initialized(repo_path, &beads_dir)?;
-                if !is_ready_after_init {
-                    return Err(anyhow!(
-                        "Beads init completed but store is not ready at {}: {}",
-                        beads_dir.display(),
-                        reason_after_init
-                    ));
-                }
+                self.ensure_new_store_is_ready(repo_path, &beads_dir, &reason)?;
             }
         }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -350,6 +350,26 @@ fn verify_repo_initialized_parse_errors_do_not_include_raw_output() -> Result<()
 }
 
 #[test]
+fn verify_repo_initialized_reads_json_errors_from_nonzero_exit() -> Result<()> {
+    let repo = RepoFixture::new("where-json-error");
+    let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
+        false,
+        json!({
+            "error": "database \"beads\" not found"
+        })
+        .to_string(),
+        String::new(),
+    )))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+    let beads_dir = resolve_central_beads_dir(repo.path())?;
+
+    let (is_ready, reason) = store.verify_repo_initialized(repo.path(), &beads_dir)?;
+    assert!(!is_ready);
+    assert_eq!(reason, "database \"beads\" not found");
+    Ok(())
+}
+
+#[test]
 fn show_task_uses_id_flag_when_loading_issue() -> Result<()> {
     let repo = RepoFixture::new("show-with-id-flag");
     let issue = issue_value("task-1", "open", "task", None, json!([]), None);
@@ -591,26 +611,45 @@ fn metadata_parsing_benchmark_scaffold() {
 fn ensure_repo_initialized_skips_init_when_store_is_ready() -> Result<()> {
     let repo = RepoFixture::new("init-ready");
     let beads_dir = resolve_central_beads_dir(repo.path())?;
-    fs::create_dir_all(beads_dir.join("dolt")).expect("dolt directory should be writable");
-    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(
-        "Dolt server started".to_string()
-    ))]);
+    fs::create_dir_all(&beads_dir).expect("beads dir should be writable");
+    fs::write(beads_dir.join("beads.db"), "ready").expect("beads.db should be writable");
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+        MockStep::WithEnv(Ok("Dolt server started".to_string())),
+    ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     store.ensure_repo_initialized(repo.path())?;
     assert_eq!(runner.remaining_steps(), 0);
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].kind, CallKind::WithEnv);
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
     assert_eq!(
         calls[0].args,
-        vec!["dolt", "start"]
+        vec!["where", "--json"]
             .into_iter()
             .map(str::to_string)
             .collect::<Vec<_>>()
     );
     assert_beads_env(&calls[0]);
+    assert_eq!(calls[1].kind, CallKind::WithEnv);
+    assert_eq!(
+        calls[1].args,
+        vec!["dolt", "start"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    );
+    assert_beads_env(&calls[1]);
     Ok(())
 }
 
@@ -619,6 +658,15 @@ fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Resu
     let repo = RepoFixture::new("init-path");
     let runner = MockCommandRunner::with_steps(vec![
         MockStep::AllowFailureWithEnv(Ok((true, String::new(), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": "/tmp/central/.beads",
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
         MockStep::WithEnv(Ok("Dolt server started".to_string())),
     ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
@@ -632,7 +680,7 @@ fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Resu
     assert_eq!(runner.remaining_steps(), 0);
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 2);
+    assert_eq!(calls.len(), 3);
     let expected_slug = compute_repo_slug(repo.path());
     assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
     assert_eq!(
@@ -649,41 +697,96 @@ fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Resu
         .collect::<Vec<_>>()
     );
     assert_beads_env(&calls[0]);
-    assert_eq!(calls[1].kind, CallKind::WithEnv);
+    assert_eq!(calls[1].kind, CallKind::AllowFailureWithEnv);
     assert_eq!(
         calls[1].args,
-        vec!["dolt", "start"]
+        vec!["where", "--json"]
             .into_iter()
             .map(str::to_string)
             .collect::<Vec<_>>()
     );
     assert_beads_env(&calls[1]);
+    assert_eq!(calls[2].kind, CallKind::WithEnv);
+    assert_eq!(
+        calls[2].args,
+        vec!["dolt", "start"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    );
+    assert_beads_env(&calls[2]);
     Ok(())
 }
 
 #[test]
-fn ensure_repo_initialized_skips_reinit_after_restart_when_dolt_store_exists() -> Result<()> {
-    let repo = RepoFixture::new("init-restart-dolt");
+fn ensure_repo_initialized_repairs_unready_store_footprint() -> Result<()> {
+    let repo = RepoFixture::new("init-repair-footprint");
     let beads_dir = resolve_central_beads_dir(repo.path())?;
-    fs::create_dir_all(beads_dir.join("dolt")).expect("dolt directory should be writable");
-    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(
-        "Dolt server started".to_string()
-    ))]);
+    fs::create_dir_all(&beads_dir).expect("beads dir should be writable");
+    fs::write(beads_dir.join("beads.db"), "stale").expect("beads.db should be writable");
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((
+            false,
+            json!({
+                "error": "failed to open database: database \"beads\" not found"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+        MockStep::WithEnv(Ok("doctor fixed".to_string())),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+        MockStep::WithEnv(Ok("Dolt server started".to_string())),
+    ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     store.ensure_repo_initialized(repo.path())?;
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].kind, CallKind::WithEnv);
+    assert_eq!(calls.len(), 4);
+    assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
     assert_eq!(
         calls[0].args,
+        vec!["where", "--json"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(calls[1].kind, CallKind::WithEnv);
+    assert_eq!(
+        calls[1].args,
+        vec!["doctor", "--fix", "--yes"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(calls[2].kind, CallKind::AllowFailureWithEnv);
+    assert_eq!(
+        calls[2].args,
+        vec!["where", "--json"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(calls[3].kind, CallKind::WithEnv);
+    assert_eq!(
+        calls[3].args,
         vec!["dolt", "start"]
             .into_iter()
             .map(str::to_string)
             .collect::<Vec<_>>()
     );
     assert_beads_env(&calls[0]);
+    assert_beads_env(&calls[1]);
+    assert_beads_env(&calls[2]);
+    assert_beads_env(&calls[3]);
     Ok(())
 }
 
@@ -708,16 +811,47 @@ fn ensure_repo_initialized_returns_error_when_init_fails() {
 fn ensure_repo_initialized_returns_error_when_dolt_start_fails() {
     let repo = RepoFixture::new("dolt-start-fails");
     let beads_dir = resolve_central_beads_dir(repo.path()).expect("expected beads dir");
-    fs::create_dir_all(beads_dir.join("dolt")).expect("dolt directory should be writable");
-    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Err(
-        "port already in use".to_string()
-    ))]);
+    fs::create_dir_all(&beads_dir).expect("beads dir should be writable");
+    fs::write(beads_dir.join("beads.db"), "ready").expect("beads.db should be writable");
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+        MockStep::WithEnv(Err("port already in use".to_string())),
+    ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner);
 
     let error = store
         .ensure_repo_initialized(repo.path())
         .expect_err("dolt start should fail");
     assert!(error.to_string().contains("Failed to start Dolt server"));
+}
+
+#[test]
+fn ensure_repo_initialized_errors_when_verification_is_still_not_ready() {
+    let repo = RepoFixture::new("init-malformed");
+    let beads_dir = resolve_central_beads_dir(repo.path()).expect("expected beads dir");
+    fs::create_dir_all(&beads_dir).expect("beads dir should be writable");
+    fs::write(beads_dir.join("beads.db"), "stale").expect("beads.db should be writable");
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((false, String::new(), "bd where failed".to_string()))),
+        MockStep::WithEnv(Ok("doctor fixed".to_string())),
+        MockStep::AllowFailureWithEnv(Ok((true, "{}".to_string(), String::new()))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let error = store
+        .ensure_repo_initialized(repo.path())
+        .expect_err("init should fail when store remains unready");
+    assert!(error
+        .to_string()
+        .contains("Failed to repair existing Beads store"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- parse `bd where --json` error payloads even when Beads exits nonzero
- repair existing centralized Beads stores instead of incorrectly re-running `bd init`
- add regression coverage for broken-store repair and nonzero-exit JSON diagnostics

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic repository repair flow to attempt fixing unready stores.

* **Bug Fixes**
  * Improved repository readiness verification with clearer error detection and messaging (including malformed/empty payloads and JSON error handling).
  * More robust initialization fallback paths and clearer failure reasons.

* **Tests**
  * Expanded tests covering readiness checks, repair flow, and updated command sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->