### PR TITLE
refactor: remove unnecessary react effects

### DIFF
--- a/apps/desktop/src/components/features/task-composer/use-task-document-editor-state.ts
+++ b/apps/desktop/src/components/features/task-composer/use-task-document-editor-state.ts
@@ -104,9 +104,7 @@ export function useTaskDocumentEditorState({
     plan: false,
   });
 
-  useEffect(() => {
-    documentsRef.current = documents;
-  }, [documents]);
+  documentsRef.current = documents;
 
   useEffect(() => {
     const contextChanged =

--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -89,9 +89,7 @@ export function useTaskDocuments(
     [taskCacheKey],
   );
 
-  useEffect(() => {
-    documentsRef.current = documents;
-  }, [documents]);
+  documentsRef.current = documents;
 
   useEffect(() => {
     const contextDidChange =

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
@@ -112,7 +112,8 @@ export function useSessionStartModalState({
   const loadCatalogForRepo = loadCatalog ?? loadRepoRuntimeCatalog;
   const [intent, setIntent] = useState<SessionStartModalIntent | null>(null);
   const [selection, setSelection] = useState<AgentModelSelection | null>(null);
-  const [requestedRuntimeKind, setRequestedRuntimeKind] = useState<RuntimeKind>(DEFAULT_RUNTIME_KIND);
+  const [requestedRuntimeKind, setRequestedRuntimeKind] =
+    useState<RuntimeKind>(DEFAULT_RUNTIME_KIND);
   const activeRole = intent?.role ?? null;
   const runtimeOptions = useMemo(
     () => toAgentRuntimeOptions(runtimeDefinitions),

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
@@ -112,26 +112,24 @@ export function useSessionStartModalState({
   const loadCatalogForRepo = loadCatalog ?? loadRepoRuntimeCatalog;
   const [intent, setIntent] = useState<SessionStartModalIntent | null>(null);
   const [selection, setSelection] = useState<AgentModelSelection | null>(null);
-  const [selectedRuntimeKind, setSelectedRuntimeKind] = useState<RuntimeKind>(DEFAULT_RUNTIME_KIND);
+  const [requestedRuntimeKind, setRequestedRuntimeKind] = useState<RuntimeKind>(DEFAULT_RUNTIME_KIND);
   const activeRole = intent?.role ?? null;
   const runtimeOptions = useMemo(
     () => toAgentRuntimeOptions(runtimeDefinitions),
     [runtimeDefinitions],
   );
+  const selectedRuntimeKind = useMemo(
+    () =>
+      resolveRuntimeKindSelection({
+        runtimeDefinitions,
+        requestedRuntimeKind,
+      }),
+    [requestedRuntimeKind, runtimeDefinitions],
+  );
   const selectedRuntimeDescriptor = useMemo(
     () => findRuntimeDefinition(runtimeDefinitions, selectedRuntimeKind),
     [runtimeDefinitions, selectedRuntimeKind],
   );
-
-  useEffect(() => {
-    const nextRuntimeKind = resolveRuntimeKindSelection({
-      runtimeDefinitions,
-      requestedRuntimeKind: selectedRuntimeKind,
-    });
-    if (nextRuntimeKind !== selectedRuntimeKind) {
-      setSelectedRuntimeKind(nextRuntimeKind);
-    }
-  }, [runtimeDefinitions, selectedRuntimeKind]);
 
   const catalogQuery = useQuery({
     ...repoRuntimeCatalogQueryOptions(activeRepo ?? "", selectedRuntimeKind, loadCatalogForRepo),
@@ -165,7 +163,7 @@ export function useSessionStartModalState({
           repoSettings?.defaultRuntimeKind ??
           DEFAULT_RUNTIME_KIND,
       });
-      setSelectedRuntimeKind(initialRuntimeKind);
+      setRequestedRuntimeKind(initialRuntimeKind);
       setIntent(nextIntent);
       setSelection(
         resolveInitialSelection(
@@ -205,7 +203,7 @@ export function useSessionStartModalState({
         runtimeDefinitions,
         requestedRuntimeKind: runtimeKindValue,
       });
-      setSelectedRuntimeKind(runtimeKind);
+      setRequestedRuntimeKind(runtimeKind);
       setSelection((current) => {
         if (!activeRole) {
           return current ? { ...current, runtimeKind } : current;

--- a/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-human-review-feedback-flow.ts
@@ -86,13 +86,8 @@ export function useAgentStudioHumanReviewFeedbackFlow({
     useState<HumanReviewFeedbackState | null>(null);
   const [isSubmittingHumanReviewFeedback, setIsSubmittingHumanReviewFeedback] = useState(false);
 
-  useEffect(() => {
-    sessionsForTaskRef.current = sessionsForTask;
-  }, [sessionsForTask]);
-
-  useEffect(() => {
-    selectedTaskRef.current = selectedTask;
-  }, [selectedTask]);
+  sessionsForTaskRef.current = sessionsForTask;
+  selectedTaskRef.current = selectedTask;
 
   useEffect(() => {
     if (!pendingHumanReviewHydration) {

--- a/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
@@ -134,34 +134,20 @@ export function useKanbanSessionStartFlow({
     repoSettings,
   });
 
-  useEffect(() => {
-    tasksRef.current = tasks;
-  }, [tasks]);
-
-  useEffect(() => {
-    sessionsRef.current = sessions;
-  }, [sessions]);
-
-  useEffect(() => {
-    sessionStartIntentRef.current = sessionStartIntent
-      ? {
-          taskId: sessionStartIntent.taskId,
-          role: sessionStartIntent.role,
-          scenario: sessionStartIntent.scenario,
-          startMode: sessionStartIntent.startMode,
-          postStartAction: sessionStartIntent.postStartAction,
-          ...(sessionStartIntent.message ? { message: sessionStartIntent.message } : {}),
-        }
-      : null;
-  }, [sessionStartIntent]);
-
-  useEffect(() => {
-    sessionStartSelectionRef.current = sessionStartSelection;
-  }, [sessionStartSelection]);
-
-  useEffect(() => {
-    sessionStartBeforeActionRef.current = sessionStartBeforeAction;
-  }, [sessionStartBeforeAction]);
+  tasksRef.current = tasks;
+  sessionsRef.current = sessions;
+  sessionStartIntentRef.current = sessionStartIntent
+    ? {
+        taskId: sessionStartIntent.taskId,
+        role: sessionStartIntent.role,
+        scenario: sessionStartIntent.scenario,
+        startMode: sessionStartIntent.startMode,
+        postStartAction: sessionStartIntent.postStartAction,
+        ...(sessionStartIntent.message ? { message: sessionStartIntent.message } : {}),
+      }
+    : null;
+  sessionStartSelectionRef.current = sessionStartSelection;
+  sessionStartBeforeActionRef.current = sessionStartBeforeAction;
 
   useEffect(() => {
     if (!pendingHumanReviewHydration) {

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -1,7 +1,7 @@
 import type { TaskApprovalContext, TaskCard } from "@openducktor/contracts";
 import { buildAgentMessagePrompt } from "@openducktor/core";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { openExternalUrl } from "@/lib/open-external-url";
@@ -91,9 +91,7 @@ export function useTaskApprovalFlow({
   const sessionsRef = useRef(sessions);
   const approvalRequestVersionRef = useRef(0);
 
-  useEffect(() => {
-    sessionsRef.current = sessions;
-  }, [sessions]);
+  sessionsRef.current = sessions;
 
   const reset = useCallback(() => {
     approvalRequestVersionRef.current += 1;

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -67,10 +67,8 @@ export function useAppLifecycle({
   const activeRepoRef = useRef(activeRepo);
   const refreshTaskDataRef = useRef(refreshTaskData);
 
-  useEffect(() => {
-    activeRepoRef.current = activeRepo;
-    refreshTaskDataRef.current = refreshTaskData;
-  }, [activeRepo, refreshTaskData]);
+  activeRepoRef.current = activeRepo;
+  refreshTaskDataRef.current = refreshTaskData;
 
   useEffect(() => {
     Promise.allSettled([refreshWorkspaces(), refreshRuntimeCheck(false)]).then(

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -67,8 +67,10 @@ export function useAppLifecycle({
   const activeRepoRef = useRef(activeRepo);
   const refreshTaskDataRef = useRef(refreshTaskData);
 
-  activeRepoRef.current = activeRepo;
-  refreshTaskDataRef.current = refreshTaskData;
+  useEffect(() => {
+    activeRepoRef.current = activeRepo;
+    refreshTaskDataRef.current = refreshTaskData;
+  }, [activeRepo, refreshTaskData]);
 
   useEffect(() => {
     Promise.allSettled([refreshWorkspaces(), refreshRuntimeCheck(false)]).then(


### PR DESCRIPTION
## Summary
- remove effect-only ref mirroring in desktop hooks where render-time ref writes are sufficient
- derive the session start runtime kind from the requested runtime instead of correcting it in a follow-up effect
- keep effects only where they still synchronize with external systems, async hydration, or cleanup

## Verification
- bun test apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx apps/desktop/src/components/features/task-composer/use-task-document-editor-state.test.tsx
- bun run --filter @openducktor/desktop typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal state synchronization was simplified across several components: refs are now updated during render rather than via post-render effects. This streamlines lifecycle handling for task composition, documents, session modals, review flows, Kanban flows, and app lifecycle hooks. Public interfaces remain unchanged; users should see no functional changes, with modest improvements to responsiveness and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->