### PR TITLE
feat: customize squash direct merge messages

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_service.rs
@@ -52,6 +52,7 @@ impl AppService {
                 uncommitted_file_count: 0,
                 pull_request: metadata.pull_request,
                 direct_merge: Some(direct_merge),
+                suggested_squash_commit_message: None,
                 providers: vec![github_provider_availability(
                     Path::new(&context.repo.repo_path),
                     &repo_config,
@@ -75,6 +76,11 @@ impl AppService {
         let source_branch = current_branch
             .name
             .ok_or_else(|| anyhow!("Human approval requires a builder branch name."))?;
+        let suggested_squash_commit_message = self.git_port.suggested_squash_commit_message(
+            Path::new(&context.repo.repo_path),
+            source_branch.as_str(),
+            target_branch.canonical().as_str(),
+        )?;
         let worktree_status = self.git_port.get_worktree_status_summary(
             Path::new(&working_directory),
             target_branch.canonical().as_str(),
@@ -93,6 +99,7 @@ impl AppService {
             uncommitted_file_count: worktree_status.file_status_counts.total,
             pull_request: metadata.pull_request,
             direct_merge: None,
+            suggested_squash_commit_message,
             providers: vec![github_provider_availability(
                 Path::new(&context.repo.repo_path),
                 &repo_config,
@@ -105,6 +112,7 @@ impl AppService {
         repo_path: &str,
         task_id: &str,
         method: GitMergeMethod,
+        squash_commit_message: Option<String>,
     ) -> Result<TaskDirectMergeResult> {
         let approval = self.task_approval_context_get(repo_path, task_id)?;
         if approval.direct_merge.is_some() {
@@ -113,6 +121,7 @@ impl AppService {
             ));
         }
         ensure_clean_builder_worktree(&approval)?;
+        let force_delete_source_branch = matches!(method, GitMergeMethod::Squash);
         let repo_path = self.resolve_task_repo_path(repo_path)?;
         match self.git_port.merge_branch(
             Path::new(&repo_path),
@@ -121,6 +130,7 @@ impl AppService {
                 target_branch: approval.target_branch.canonical(),
                 source_working_directory: approval.working_directory.clone(),
                 method: method.clone(),
+                squash_commit_message,
             },
         )? {
             GitMergeBranchResult::Merged { .. } | GitMergeBranchResult::UpToDate { .. } => {}
@@ -182,6 +192,7 @@ impl AppService {
             repo_path.as_str(),
             task_id,
             approval.source_branch.as_str(),
+            force_delete_source_branch,
         )?;
         Ok(TaskDirectMergeResult::Completed {
             task: Box::new(task),
@@ -214,6 +225,7 @@ impl AppService {
             repo_path.as_str(),
             task_id,
             direct_merge.source_branch.as_str(),
+            matches!(direct_merge.method, GitMergeMethod::Squash),
         )?;
         Ok(task)
     }
@@ -464,6 +476,7 @@ impl AppService {
                     repo_path.as_str(),
                     task.id.as_str(),
                     updated.source_branch.as_str(),
+                    false,
                 )?;
             }
         }
@@ -513,14 +526,19 @@ impl AppService {
         Ok(detected.map(|repository| to_config_repository(&repository)))
     }
 
-    fn cleanup_builder_branch(&self, repo_path: &str, source_branch: &str) -> Result<()> {
+    fn cleanup_builder_branch(
+        &self,
+        repo_path: &str,
+        source_branch: &str,
+        force_delete: bool,
+    ) -> Result<()> {
         let branch_exists = self
             .git_port
             .get_branches(Path::new(repo_path))?
             .into_iter()
             .any(|branch| !branch.is_remote && branch.name == source_branch);
         if branch_exists {
-            let _ = self.git_delete_local_branch(repo_path, source_branch, false)?;
+            let _ = self.git_delete_local_branch(repo_path, source_branch, force_delete)?;
         }
 
         Ok(())
@@ -531,6 +549,7 @@ impl AppService {
         repo_path: &str,
         task_id: &str,
         source_branch: &str,
+        force_delete_source_branch: bool,
     ) -> Result<()> {
         if let Some(cleanup_target) =
             latest_builder_cleanup_target(self, repo_path, task_id, Some(source_branch))?
@@ -552,7 +571,7 @@ impl AppService {
             }
         }
 
-        self.cleanup_builder_branch(repo_path, source_branch)
+        self.cleanup_builder_branch(repo_path, source_branch, force_delete_source_branch)
     }
 
     fn github_pull_request_repository(&self, repo_path: &str) -> Result<GitProviderRepository> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_service.rs
@@ -60,51 +60,13 @@ impl AppService {
             });
         }
 
-        let target_branch = normalize_approval_target_branch(&repo_config.default_target_branch)?;
-        let publish_target = publish_target_branch(&repo_config.default_target_branch)?;
-        let working_directory = self
-            .build_continuation_target_get(context.repo.repo_path.as_str(), task_id)?
-            .working_directory;
-        let current_branch = self
-            .git_port
-            .get_current_branch(Path::new(&working_directory))?;
-        if current_branch.detached {
-            return Err(anyhow!(
-                "Human approval requires a builder branch, but the latest builder workspace is detached."
-            ));
-        }
-        let source_branch = current_branch
-            .name
-            .ok_or_else(|| anyhow!("Human approval requires a builder branch name."))?;
-        let suggested_squash_commit_message = self.git_port.suggested_squash_commit_message(
+        let mut approval = self.load_open_task_approval_context(repo_path, task_id)?;
+        approval.suggested_squash_commit_message = self.git_port.suggested_squash_commit_message(
             Path::new(&context.repo.repo_path),
-            source_branch.as_str(),
-            target_branch.canonical().as_str(),
+            approval.source_branch.as_str(),
+            approval.target_branch.canonical().as_str(),
         )?;
-        let worktree_status = self.git_port.get_worktree_status_summary(
-            Path::new(&working_directory),
-            target_branch.canonical().as_str(),
-            GitDiffScope::Uncommitted,
-        )?;
-
-        Ok(TaskApprovalContext {
-            task_id: task_id.to_string(),
-            task_status: context.task.status.as_cli_value().to_string(),
-            working_directory: Some(working_directory),
-            source_branch,
-            target_branch,
-            publish_target,
-            default_merge_method: to_domain_merge_method(config.git.default_merge_method),
-            has_uncommitted_changes: worktree_status.file_status_counts.total > 0,
-            uncommitted_file_count: worktree_status.file_status_counts.total,
-            pull_request: metadata.pull_request,
-            direct_merge: None,
-            suggested_squash_commit_message,
-            providers: vec![github_provider_availability(
-                Path::new(&context.repo.repo_path),
-                &repo_config,
-            )],
-        })
+        Ok(approval)
     }
 
     pub fn task_direct_merge(
@@ -114,16 +76,16 @@ impl AppService {
         method: GitMergeMethod,
         squash_commit_message: Option<String>,
     ) -> Result<TaskDirectMergeResult> {
-        let approval = self.task_approval_context_get(repo_path, task_id)?;
-        if approval.direct_merge.is_some() {
+        let metadata = self.task_metadata_get(repo_path, task_id)?;
+        if metadata.direct_merge.is_some() {
             return Err(anyhow!(
                 "A local direct merge is already recorded for task {task_id}. Finish the direct merge workflow before trying again."
             ));
         }
+        let approval = self.load_open_task_approval_context(repo_path, task_id)?;
         ensure_clean_builder_worktree(&approval)?;
-        let force_delete_source_branch = matches!(method, GitMergeMethod::Squash);
         let repo_path = self.resolve_task_repo_path(repo_path)?;
-        match self.git_port.merge_branch(
+        let squash_created_commit = match self.git_port.merge_branch(
             Path::new(&repo_path),
             GitMergeBranchRequest {
                 source_branch: approval.source_branch.clone(),
@@ -133,7 +95,8 @@ impl AppService {
                 squash_commit_message,
             },
         )? {
-            GitMergeBranchResult::Merged { .. } | GitMergeBranchResult::UpToDate { .. } => {}
+            GitMergeBranchResult::Merged { .. } => matches!(method, GitMergeMethod::Squash),
+            GitMergeBranchResult::UpToDate { .. } => false,
             GitMergeBranchResult::Conflicts {
                 conflicted_files,
                 output,
@@ -148,7 +111,7 @@ impl AppService {
                     ),
                 });
             }
-        }
+        };
 
         self.task_store
             .set_pull_request(Path::new(&repo_path), task_id, None)?;
@@ -192,7 +155,7 @@ impl AppService {
             repo_path.as_str(),
             task_id,
             approval.source_branch.as_str(),
-            force_delete_source_branch,
+            squash_created_commit,
         )?;
         Ok(TaskDirectMergeResult::Completed {
             task: Box::new(task),
@@ -220,12 +183,14 @@ impl AppService {
                 Some("Human approved via direct merge"),
             )?
         };
+        let force_delete_source_branch =
+            self.should_force_delete_source_branch(repo_path.as_str(), &direct_merge)?;
 
         self.finalize_direct_merge_cleanup(
             repo_path.as_str(),
             task_id,
             direct_merge.source_branch.as_str(),
-            matches!(direct_merge.method, GitMergeMethod::Squash),
+            force_delete_source_branch,
         )?;
         Ok(task)
     }
@@ -280,12 +245,13 @@ impl AppService {
         title: &str,
         body: &str,
     ) -> Result<PullRequestRecord> {
-        let approval = self.task_approval_context_get(repo_path, task_id)?;
-        if approval.direct_merge.is_some() {
+        let metadata = self.task_metadata_get(repo_path, task_id)?;
+        if metadata.direct_merge.is_some() {
             return Err(anyhow!(
                 "A local direct merge is already recorded for task {task_id}. Finish or discard that direct merge workflow before opening a pull request."
             ));
         }
+        let approval = self.load_open_task_approval_context(repo_path, task_id)?;
         ensure_clean_builder_worktree(&approval)?;
         let repo_path = self.resolve_task_repo_path(repo_path)?;
         let provider = github_provider();
@@ -349,6 +315,75 @@ impl AppService {
         }
 
         Ok(pull_request.record)
+    }
+
+    fn load_open_task_approval_context(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+    ) -> Result<TaskApprovalContext> {
+        let context = self.load_task_context(repo_path, task_id)?;
+        ensure_human_approval_status(&context.task.status)?;
+        let repo_config = self.workspace_get_repo_config(context.repo.repo_path.as_str())?;
+        let metadata = self.task_metadata_get(context.repo.repo_path.as_str(), task_id)?;
+        let config = self.config_store.load()?;
+        let target_branch = normalize_approval_target_branch(&repo_config.default_target_branch)?;
+        let publish_target = publish_target_branch(&repo_config.default_target_branch)?;
+        let working_directory = self
+            .build_continuation_target_get(context.repo.repo_path.as_str(), task_id)?
+            .working_directory;
+        let current_branch = self
+            .git_port
+            .get_current_branch(Path::new(&working_directory))?;
+        if current_branch.detached {
+            return Err(anyhow!(
+                "Human approval requires a builder branch, but the latest builder workspace is detached."
+            ));
+        }
+        let source_branch = current_branch
+            .name
+            .ok_or_else(|| anyhow!("Human approval requires a builder branch name."))?;
+        let worktree_status = self.git_port.get_worktree_status_summary(
+            Path::new(&working_directory),
+            target_branch.canonical().as_str(),
+            GitDiffScope::Uncommitted,
+        )?;
+
+        Ok(TaskApprovalContext {
+            task_id: task_id.to_string(),
+            task_status: context.task.status.as_cli_value().to_string(),
+            working_directory: Some(working_directory),
+            source_branch,
+            target_branch,
+            publish_target,
+            default_merge_method: to_domain_merge_method(config.git.default_merge_method),
+            has_uncommitted_changes: worktree_status.file_status_counts.total > 0,
+            uncommitted_file_count: worktree_status.file_status_counts.total,
+            pull_request: metadata.pull_request,
+            direct_merge: None,
+            suggested_squash_commit_message: None,
+            providers: vec![github_provider_availability(
+                Path::new(&context.repo.repo_path),
+                &repo_config,
+            )],
+        })
+    }
+
+    fn should_force_delete_source_branch(
+        &self,
+        repo_path: &str,
+        direct_merge: &DirectMergeRecord,
+    ) -> Result<bool> {
+        if !matches!(direct_merge.method, GitMergeMethod::Squash) {
+            return Ok(false);
+        }
+
+        let target_branch = direct_merge.target_branch.checkout_branch();
+        Ok(!self.git_port.is_ancestor(
+            Path::new(repo_path),
+            direct_merge.source_branch.as_str(),
+            target_branch.as_str(),
+        )?)
     }
 
     pub fn task_pull_request_unlink(&self, repo_path: &str, task_id: &str) -> Result<bool> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_service.rs
@@ -378,6 +378,15 @@ impl AppService {
             return Ok(false);
         }
 
+        let source_branch_exists = self
+            .git_port
+            .get_branches(Path::new(repo_path))?
+            .into_iter()
+            .any(|branch| !branch.is_remote && branch.name == direct_merge.source_branch);
+        if !source_branch_exists {
+            return Ok(false);
+        }
+
         let target_branch = direct_merge.target_branch.checkout_branch();
         Ok(!self.git_port.is_ancestor(
             Path::new(repo_path),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -518,6 +518,11 @@ pub(crate) enum GitCall {
         source_branch: String,
         target_branch: String,
     },
+    IsAncestor {
+        repo_path: String,
+        ancestor_ref: String,
+        descendant_ref: String,
+    },
     GetWorktreeStatus {
         repo_path: String,
         target_branch: String,
@@ -552,6 +557,7 @@ pub(crate) struct GitState {
     pub(crate) conflict_abort_result: GitConflictAbortResult,
     pub(crate) merge_branch_result: GitMergeBranchResult,
     pub(crate) suggested_squash_commit_message_result: Option<String>,
+    pub(crate) is_ancestor_result: bool,
     pub(crate) commits_ahead_behind_result: GitAheadBehind,
 }
 
@@ -762,6 +768,21 @@ impl GitPort for FakeGitPort {
             target_branch: target_branch.to_string(),
         });
         Ok(state.suggested_squash_commit_message_result.clone())
+    }
+
+    fn is_ancestor(
+        &self,
+        repo_path: &Path,
+        ancestor_ref: &str,
+        descendant_ref: &str,
+    ) -> Result<bool> {
+        let mut state = self.state.lock().expect("git state lock poisoned");
+        state.calls.push(GitCall::IsAncestor {
+            repo_path: repo_path.to_string_lossy().to_string(),
+            ancestor_ref: ancestor_ref.to_string(),
+            descendant_ref: descendant_ref.to_string(),
+        });
+        Ok(state.is_ancestor_result)
     }
 
     fn get_status(&self, _repo_path: &Path) -> Result<Vec<GitFileStatus>> {
@@ -983,6 +1004,7 @@ pub(crate) fn build_service_with_git_state_enforced(
             output: "merge completed".to_string(),
         },
         suggested_squash_commit_message_result: Some("feat: builder change".to_string()),
+        is_ancestor_result: false,
         commits_ahead_behind_result: GitAheadBehind {
             ahead: 0,
             behind: 0,
@@ -1062,6 +1084,7 @@ pub(crate) fn build_service_with_git_state(
             output: "merge completed".to_string(),
         },
         suggested_squash_commit_message_result: Some("feat: builder change".to_string()),
+        is_ancestor_result: false,
         commits_ahead_behind_result: GitAheadBehind {
             ahead: 0,
             behind: 0,
@@ -1492,6 +1515,7 @@ pub(crate) fn build_service_with_store(
             output: "merge completed".to_string(),
         },
         suggested_squash_commit_message_result: Some("feat: builder change".to_string()),
+        is_ancestor_result: false,
         commits_ahead_behind_result: GitAheadBehind {
             ahead: 0,
             behind: 0,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -511,6 +511,12 @@ pub(crate) enum GitCall {
         source_branch: String,
         target_branch: String,
         method: GitMergeMethod,
+        squash_commit_message: Option<String>,
+    },
+    SuggestedSquashCommitMessage {
+        repo_path: String,
+        source_branch: String,
+        target_branch: String,
     },
     GetWorktreeStatus {
         repo_path: String,
@@ -545,6 +551,7 @@ pub(crate) struct GitState {
     pub(crate) rebase_abort_result: GitRebaseAbortResult,
     pub(crate) conflict_abort_result: GitConflictAbortResult,
     pub(crate) merge_branch_result: GitMergeBranchResult,
+    pub(crate) suggested_squash_commit_message_result: Option<String>,
     pub(crate) commits_ahead_behind_result: GitAheadBehind,
 }
 
@@ -737,8 +744,24 @@ impl GitPort for FakeGitPort {
             source_branch: request.source_branch,
             target_branch: request.target_branch,
             method: request.method,
+            squash_commit_message: request.squash_commit_message,
         });
         Ok(state.merge_branch_result.clone())
+    }
+
+    fn suggested_squash_commit_message(
+        &self,
+        repo_path: &Path,
+        source_branch: &str,
+        target_branch: &str,
+    ) -> Result<Option<String>> {
+        let mut state = self.state.lock().expect("git state lock poisoned");
+        state.calls.push(GitCall::SuggestedSquashCommitMessage {
+            repo_path: repo_path.to_string_lossy().to_string(),
+            source_branch: source_branch.to_string(),
+            target_branch: target_branch.to_string(),
+        });
+        Ok(state.suggested_squash_commit_message_result.clone())
     }
 
     fn get_status(&self, _repo_path: &Path) -> Result<Vec<GitFileStatus>> {
@@ -959,6 +982,7 @@ pub(crate) fn build_service_with_git_state_enforced(
         merge_branch_result: GitMergeBranchResult::Merged {
             output: "merge completed".to_string(),
         },
+        suggested_squash_commit_message_result: Some("feat: builder change".to_string()),
         commits_ahead_behind_result: GitAheadBehind {
             ahead: 0,
             behind: 0,
@@ -1037,6 +1061,7 @@ pub(crate) fn build_service_with_git_state(
         merge_branch_result: GitMergeBranchResult::Merged {
             output: "merge completed".to_string(),
         },
+        suggested_squash_commit_message_result: Some("feat: builder change".to_string()),
         commits_ahead_behind_result: GitAheadBehind {
             ahead: 0,
             behind: 0,
@@ -1466,6 +1491,7 @@ pub(crate) fn build_service_with_store(
         merge_branch_result: GitMergeBranchResult::Merged {
             output: "merge completed".to_string(),
         },
+        suggested_squash_commit_message_result: Some("feat: builder change".to_string()),
         commits_ahead_behind_result: GitAheadBehind {
             ahead: 0,
             behind: 0,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
@@ -554,6 +554,86 @@ fn task_direct_merge_complete_uses_safe_branch_delete_when_squash_branch_is_alre
 }
 
 #[test]
+fn task_direct_merge_complete_skips_ancestry_probe_when_squash_source_branch_is_missing(
+) -> Result<()> {
+    let root = unique_temp_path("approval-direct-merge-complete-squash-missing-branch");
+    let repo = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    let worktree_path = worktree_base.join("task-1");
+    init_git_repo(&repo)?;
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, task_state, git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    let repo_path = repo.to_string_lossy().to_string();
+    configure_builder_session(
+        repo_path.as_str(),
+        &worktree_path,
+        "odt/task-1",
+        &service,
+        &task_state,
+        &git_state,
+    )?;
+    service.workspace_update_repo_config(repo_path.as_str(), base_repo_config(&worktree_base))?;
+
+    task_state
+        .lock()
+        .expect("task state lock poisoned")
+        .direct_merge_records
+        .insert(
+            "task-1".to_string(),
+            host_domain::DirectMergeRecord {
+                method: GitMergeMethod::Squash,
+                source_branch: "odt/task-1".to_string(),
+                target_branch: host_domain::GitTargetBranch {
+                    remote: Some("origin".to_string()),
+                    branch: "main".to_string(),
+                },
+                merged_at: "2026-03-18T12:00:00Z".to_string(),
+            },
+        );
+    {
+        let mut git = git_state.lock().expect("git state lock poisoned");
+        git.commits_ahead_behind_result = host_domain::GitAheadBehind {
+            ahead: 0,
+            behind: 0,
+        };
+        git.branches = vec![host_domain::GitBranch {
+            name: "main".to_string(),
+            is_current: true,
+            is_remote: false,
+        }];
+    }
+
+    let completed = service.task_direct_merge_complete(repo_path.as_str(), "task-1")?;
+    assert_eq!(completed.status, TaskStatus::Closed);
+
+    let git = git_state.lock().expect("git state lock poisoned");
+    assert!(git
+        .calls
+        .iter()
+        .any(|call| matches!(call, GitCall::GetBranches { .. })));
+    assert!(!git
+        .calls
+        .iter()
+        .any(|call| matches!(call, GitCall::IsAncestor { .. })));
+    assert!(!git.calls.iter().any(
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
+    ));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn task_approval_context_uses_pending_direct_merge_metadata_without_builder_worktree() -> Result<()>
 {
     let root = unique_temp_path("approval-direct-merge-reopen");

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
@@ -259,7 +259,8 @@ fn task_direct_merge_with_publish_target_stays_resumable_until_completion() -> R
     )?;
     service.workspace_update_repo_config(repo_path.as_str(), base_repo_config(&worktree_base))?;
 
-    let task = service.task_direct_merge(repo_path.as_str(), "task-1", GitMergeMethod::Rebase)?;
+    let task =
+        service.task_direct_merge(repo_path.as_str(), "task-1", GitMergeMethod::Rebase, None)?;
     let host_domain::TaskDirectMergeResult::Completed { task } = task else {
         panic!("expected completed direct merge result");
     };
@@ -371,9 +372,14 @@ fn task_direct_merge_with_publish_target_stays_resumable_until_completion() -> R
         GitCall::RemoveWorktree { worktree_path, .. }
             if worktree_path == unrelated_cleanup_worktree.as_str()
     )));
-    assert!(git.calls.iter().any(
-        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
-    ));
+    assert!(git.calls.iter().any(|call| matches!(
+        call,
+        GitCall::DeleteLocalBranch {
+            branch,
+            force: false,
+            ..
+        } if branch == "odt/task-1"
+    )));
 
     let _ = fs::remove_dir_all(root);
     Ok(())
@@ -416,7 +422,12 @@ fn task_direct_merge_local_only_closes_task_records_metadata_and_cleans_builder_
     };
     service.workspace_update_repo_config(repo_path.as_str(), repo_config)?;
 
-    let task = service.task_direct_merge(repo_path.as_str(), "task-1", GitMergeMethod::Squash)?;
+    let task = service.task_direct_merge(
+        repo_path.as_str(),
+        "task-1",
+        GitMergeMethod::Squash,
+        Some("feat: release work".to_string()),
+    )?;
     let host_domain::TaskDirectMergeResult::Completed { task } = task else {
         panic!("expected completed direct merge result");
     };
@@ -427,9 +438,27 @@ fn task_direct_merge_local_only_closes_task_records_metadata_and_cleans_builder_
         .calls
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
-    assert!(git.calls.iter().any(
-        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
-    ));
+    assert!(git.calls.iter().any(|call| matches!(
+        call,
+        GitCall::DeleteLocalBranch {
+            branch,
+            force: true,
+            ..
+        } if branch == "odt/task-1"
+    )));
+    assert!(git.calls.iter().any(|call| matches!(
+        call,
+        GitCall::MergeBranch {
+            source_branch,
+            target_branch,
+            method,
+            squash_commit_message,
+            ..
+        } if source_branch == "odt/task-1"
+            && target_branch == "release/2026.03"
+            && *method == GitMergeMethod::Squash
+            && squash_commit_message.as_deref() == Some("feat: release work")
+    )));
 
     let _ = fs::remove_dir_all(root);
     Ok(())
@@ -570,6 +599,10 @@ fn task_approval_context_reports_global_merge_default_and_dirty_worktree() -> Re
     assert_eq!(approval.default_merge_method, GitMergeMethod::Rebase);
     assert!(approval.has_uncommitted_changes);
     assert_eq!(approval.uncommitted_file_count, 1);
+    assert_eq!(
+        approval.suggested_squash_commit_message.as_deref(),
+        Some("feat: builder change")
+    );
     Ok(())
 }
 
@@ -639,7 +672,12 @@ fn approval_actions_reject_dirty_builder_worktree() -> Result<()> {
     }
 
     let merge_error = service
-        .task_direct_merge(repo_path.as_str(), "task-1", GitMergeMethod::MergeCommit)
+        .task_direct_merge(
+            repo_path.as_str(),
+            "task-1",
+            GitMergeMethod::MergeCommit,
+            None,
+        )
         .expect_err("direct merge should be blocked");
     assert!(merge_error.to_string().contains("uncommitted"));
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
@@ -322,6 +322,10 @@ fn task_direct_merge_with_publish_target_stays_resumable_until_completion() -> R
         .calls
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
+    assert!(!git
+        .calls
+        .iter()
+        .any(|call| matches!(call, GitCall::SuggestedSquashCommitMessage { .. })));
     assert!(!git.calls.iter().any(
         |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
     ));
@@ -458,6 +462,91 @@ fn task_direct_merge_local_only_closes_task_records_metadata_and_cleans_builder_
             && target_branch == "release/2026.03"
             && *method == GitMergeMethod::Squash
             && squash_commit_message.as_deref() == Some("feat: release work")
+    )));
+    assert!(!git
+        .calls
+        .iter()
+        .any(|call| matches!(call, GitCall::SuggestedSquashCommitMessage { .. })));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn task_direct_merge_complete_uses_safe_branch_delete_when_squash_branch_is_already_merged(
+) -> Result<()> {
+    let root = unique_temp_path("approval-direct-merge-complete-squash-up-to-date");
+    let repo = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    let worktree_path = worktree_base.join("task-1");
+    init_git_repo(&repo)?;
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, task_state, git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    let repo_path = repo.to_string_lossy().to_string();
+    configure_builder_session(
+        repo_path.as_str(),
+        &worktree_path,
+        "odt/task-1",
+        &service,
+        &task_state,
+        &git_state,
+    )?;
+    service.workspace_update_repo_config(repo_path.as_str(), base_repo_config(&worktree_base))?;
+
+    task_state
+        .lock()
+        .expect("task state lock poisoned")
+        .direct_merge_records
+        .insert(
+            "task-1".to_string(),
+            host_domain::DirectMergeRecord {
+                method: GitMergeMethod::Squash,
+                source_branch: "odt/task-1".to_string(),
+                target_branch: host_domain::GitTargetBranch {
+                    remote: Some("origin".to_string()),
+                    branch: "main".to_string(),
+                },
+                merged_at: "2026-03-18T12:00:00Z".to_string(),
+            },
+        );
+    {
+        let mut git = git_state.lock().expect("git state lock poisoned");
+        git.commits_ahead_behind_result = host_domain::GitAheadBehind {
+            ahead: 0,
+            behind: 0,
+        };
+        git.is_ancestor_result = true;
+    }
+
+    let completed = service.task_direct_merge_complete(repo_path.as_str(), "task-1")?;
+    assert_eq!(completed.status, TaskStatus::Closed);
+
+    let git = git_state.lock().expect("git state lock poisoned");
+    assert!(git.calls.iter().any(|call| matches!(
+        call,
+        GitCall::IsAncestor {
+            ancestor_ref,
+            descendant_ref,
+            ..
+        } if ancestor_ref == "odt/task-1" && descendant_ref == "main"
+    )));
+    assert!(git.calls.iter().any(|call| matches!(
+        call,
+        GitCall::DeleteLocalBranch {
+            branch,
+            force: false,
+            ..
+        } if branch == "odt/task-1"
     )));
 
     let _ = fs::remove_dir_all(root);

--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -444,6 +444,12 @@ pub trait GitPort: Send + Sync {
         source_branch: &str,
         target_branch: &str,
     ) -> Result<Option<String>>;
+    fn is_ancestor(
+        &self,
+        repo_path: &Path,
+        ancestor_ref: &str,
+        descendant_ref: &str,
+    ) -> Result<bool>;
     fn commits_ahead_behind(&self, repo_path: &Path, target_branch: &str)
         -> Result<GitAheadBehind>;
     fn commit_all(

--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -148,6 +148,7 @@ pub struct TaskApprovalContext {
     pub uncommitted_file_count: u32,
     pub pull_request: Option<PullRequestRecord>,
     pub direct_merge: Option<DirectMergeRecord>,
+    pub suggested_squash_commit_message: Option<String>,
     pub providers: Vec<GitProviderAvailability>,
 }
 
@@ -376,6 +377,7 @@ pub struct GitMergeBranchRequest {
     pub target_branch: String,
     pub source_working_directory: Option<String>,
     pub method: GitMergeMethod,
+    pub squash_commit_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -436,6 +438,12 @@ pub trait GitPort: Send + Sync {
         diff_scope: GitDiffScope,
     ) -> Result<GitWorktreeStatusSummaryData>;
     fn resolve_upstream_target(&self, repo_path: &Path) -> Result<Option<String>>;
+    fn suggested_squash_commit_message(
+        &self,
+        repo_path: &Path,
+        source_branch: &str,
+        target_branch: &str,
+    ) -> Result<Option<String>>;
     fn commits_ahead_behind(&self, repo_path: &Path, target_branch: &str)
         -> Result<GitAheadBehind>;
     fn commit_all(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/merge.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/merge.rs
@@ -153,6 +153,38 @@ impl GitCliPort {
         Ok(Some(trimmed.to_string()))
     }
 
+    pub(super) fn is_ancestor_impl(
+        &self,
+        repo_path: &Path,
+        ancestor_ref: &str,
+        descendant_ref: &str,
+    ) -> Result<bool> {
+        self.ensure_repository(repo_path)?;
+
+        let ancestor_ref = normalize_non_empty(ancestor_ref, "ancestor ref")?;
+        let descendant_ref = normalize_non_empty(descendant_ref, "descendant ref")?;
+        let (ok, _, stderr) = self.run_git_allow_failure(
+            repo_path,
+            &[
+                "merge-base",
+                "--is-ancestor",
+                &ancestor_ref,
+                &descendant_ref,
+            ],
+        )?;
+        if ok {
+            return Ok(true);
+        }
+        if stderr.trim().is_empty() {
+            return Ok(false);
+        }
+
+        Err(anyhow!(
+            "git merge-base --is-ancestor failed: {}",
+            stderr.trim()
+        ))
+    }
+
     fn merge_with_rebase(
         &self,
         repo_path: &Path,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/merge.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/merge.rs
@@ -41,9 +41,12 @@ impl GitCliPort {
             GitMergeMethod::MergeCommit => {
                 self.merge_with_commit(repo_path, source_branch.as_str(), before_head.as_str())
             }
-            GitMergeMethod::Squash => {
-                self.merge_with_squash(repo_path, source_branch.as_str(), before_head.as_str())
-            }
+            GitMergeMethod::Squash => self.merge_with_squash(
+                repo_path,
+                source_branch.as_str(),
+                before_head.as_str(),
+                request.squash_commit_message.as_deref(),
+            ),
             GitMergeMethod::Rebase => self.merge_with_rebase(
                 repo_path,
                 request.source_working_directory.as_deref(),
@@ -75,6 +78,7 @@ impl GitCliPort {
         repo_path: &Path,
         source_branch: &str,
         before_head: &str,
+        squash_commit_message: Option<&str>,
     ) -> Result<GitMergeBranchResult> {
         let args = ["merge", "--squash", source_branch];
         let (ok, stdout, stderr) = self.run_git_allow_failure(repo_path, &args)?;
@@ -89,7 +93,10 @@ impl GitCliPort {
             return Ok(GitMergeBranchResult::UpToDate { output });
         }
 
-        let commit_message = format!("Squash merge branch '{source_branch}'");
+        let commit_message = normalize_non_empty(
+            squash_commit_message.unwrap_or_default(),
+            "squash commit message",
+        )?;
         let (commit_ok, commit_stdout, commit_stderr) =
             self.run_git_allow_failure(repo_path, &["commit", "-m", commit_message.as_str()])?;
         let commit_output = combine_output(commit_stdout, commit_stderr);
@@ -109,6 +116,41 @@ impl GitCliPort {
         };
 
         self.finish_merge_result(repo_path, before_head, merged_output)
+    }
+
+    pub(super) fn suggested_squash_commit_message_impl(
+        &self,
+        repo_path: &Path,
+        source_branch: &str,
+        target_branch: &str,
+    ) -> Result<Option<String>> {
+        self.ensure_repository(repo_path)?;
+
+        let source_branch = normalize_non_empty(source_branch, "source branch")?;
+        let target_branch = normalize_non_empty(target_branch, "target branch")?;
+        let oldest_commit = self.run_git(
+            repo_path,
+            &[
+                "rev-list",
+                "--reverse",
+                &format!("{target_branch}..{source_branch}"),
+            ],
+        )?;
+        let oldest_commit = oldest_commit
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty());
+        let Some(oldest_commit) = oldest_commit else {
+            return Ok(None);
+        };
+
+        let output = self.run_git(repo_path, &["show", "-s", "--format=%B", oldest_commit])?;
+        let trimmed = output.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(trimmed.to_string()))
     }
 
     fn merge_with_rebase(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/merge.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/merge.rs
@@ -80,6 +80,10 @@ impl GitCliPort {
         before_head: &str,
         squash_commit_message: Option<&str>,
     ) -> Result<GitMergeBranchResult> {
+        let commit_message = normalize_non_empty(
+            squash_commit_message.unwrap_or_default(),
+            "squash commit message",
+        )?;
         let args = ["merge", "--squash", source_branch];
         let (ok, stdout, stderr) = self.run_git_allow_failure(repo_path, &args)?;
         let output = combine_output(stdout, stderr);
@@ -93,10 +97,6 @@ impl GitCliPort {
             return Ok(GitMergeBranchResult::UpToDate { output });
         }
 
-        let commit_message = normalize_non_empty(
-            squash_commit_message.unwrap_or_default(),
-            "squash commit message",
-        )?;
         let (commit_ok, commit_stdout, commit_stderr) =
             self.run_git_allow_failure(repo_path, &["commit", "-m", commit_message.as_str()])?;
         let commit_output = combine_output(commit_stdout, commit_stderr);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
@@ -141,6 +141,15 @@ impl GitPort for GitCliPort {
         self.resolve_upstream_target_impl(repo_path)
     }
 
+    fn suggested_squash_commit_message(
+        &self,
+        repo_path: &Path,
+        source_branch: &str,
+        target_branch: &str,
+    ) -> Result<Option<String>> {
+        self.suggested_squash_commit_message_impl(repo_path, source_branch, target_branch)
+    }
+
     fn commits_ahead_behind(
         &self,
         repo_path: &Path,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/mod.rs
@@ -150,6 +150,15 @@ impl GitPort for GitCliPort {
         self.suggested_squash_commit_message_impl(repo_path, source_branch, target_branch)
     }
 
+    fn is_ancestor(
+        &self,
+        repo_path: &Path,
+        ancestor_ref: &str,
+        descendant_ref: &str,
+    ) -> Result<bool> {
+        self.is_ancestor_impl(repo_path, ancestor_ref, descendant_ref)
+    }
+
     fn commits_ahead_behind(
         &self,
         repo_path: &Path,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/merge_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/merge_tests.rs
@@ -37,6 +37,7 @@ fn merge_branch_accepts_canonical_remote_target_branch() {
                 target_branch: "origin/main".to_string(),
                 source_working_directory: None,
                 method: GitMergeMethod::MergeCommit,
+                squash_commit_message: None,
             },
         )
         .expect("merge with canonical remote target should succeed");
@@ -90,6 +91,7 @@ fn merge_branch_accepts_non_origin_remote_target_branch() {
                 target_branch: "upstream/release".to_string(),
                 source_working_directory: None,
                 method: GitMergeMethod::MergeCommit,
+                squash_commit_message: None,
             },
         )
         .expect("merge with non-origin remote target should succeed");
@@ -159,6 +161,7 @@ fn rebase_merge_succeeds_when_source_branch_is_checked_out_in_linked_worktree() 
                         .to_string(),
                 ),
                 method: GitMergeMethod::Rebase,
+                squash_commit_message: None,
             },
         )
         .expect(
@@ -177,4 +180,103 @@ fn rebase_merge_succeeds_when_source_branch_is_checked_out_in_linked_worktree() 
     let feature_contents = fs::read_to_string(repo.path.join("feature.txt"))
         .expect("rebased feature file should exist");
     assert_eq!(feature_contents, "feature\n");
+}
+
+#[test]
+fn squash_merge_uses_explicit_commit_message() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("merge-squash-message");
+    let git = GitCliPort::new();
+
+    run_git_ok(&repo.path, &["branch", "feature/squash-message"]);
+    git.switch_branch(&repo.path, "feature/squash-message", false)
+        .expect("feature branch should be selected");
+    fs::write(repo.path.join("feature.txt"), "feature\n").expect("feature file should write");
+    run_git_ok(&repo.path, &["add", "feature.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "feat: add login"]);
+
+    let result = git
+        .merge_branch(
+            &repo.path,
+            GitMergeBranchRequest {
+                source_branch: "feature/squash-message".to_string(),
+                target_branch: "main".to_string(),
+                source_working_directory: None,
+                method: GitMergeMethod::Squash,
+                squash_commit_message: Some("feat: add login".to_string()),
+            },
+        )
+        .expect("squash merge should succeed");
+
+    match result {
+        GitMergeBranchResult::Merged { .. } | GitMergeBranchResult::UpToDate { .. } => {}
+        other => panic!("expected merged/up-to-date result, got {other:?}"),
+    }
+
+    let commit_subject = run_git_ok(&repo.path, &["log", "-1", "--format=%s"]);
+    assert_eq!(commit_subject.trim(), "feat: add login");
+}
+
+#[test]
+fn squash_merge_requires_a_commit_message_when_it_creates_a_commit() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("merge-squash-message-required");
+    let git = GitCliPort::new();
+
+    run_git_ok(&repo.path, &["branch", "feature/squash-message-required"]);
+    git.switch_branch(&repo.path, "feature/squash-message-required", false)
+        .expect("feature branch should be selected");
+    fs::write(repo.path.join("feature.txt"), "feature\n").expect("feature file should write");
+    run_git_ok(&repo.path, &["add", "feature.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "feat: add login"]);
+
+    let error = git
+        .merge_branch(
+            &repo.path,
+            GitMergeBranchRequest {
+                source_branch: "feature/squash-message-required".to_string(),
+                target_branch: "main".to_string(),
+                source_working_directory: None,
+                method: GitMergeMethod::Squash,
+                squash_commit_message: None,
+            },
+        )
+        .expect_err("squash merge without a commit message should fail");
+
+    assert!(error.to_string().contains("squash commit message"));
+}
+
+#[test]
+fn suggested_squash_commit_message_uses_oldest_unique_commit_message() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("merge-suggested-squash-message");
+    let git = GitCliPort::new();
+
+    run_git_ok(&repo.path, &["branch", "feature/suggested-squash-message"]);
+    git.switch_branch(&repo.path, "feature/suggested-squash-message", false)
+        .expect("feature branch should be selected");
+
+    fs::write(repo.path.join("feature-a.txt"), "first\n").expect("first feature file should write");
+    run_git_ok(&repo.path, &["add", "feature-a.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "feat: first builder commit"]);
+
+    fs::write(repo.path.join("feature-b.txt"), "second\n")
+        .expect("second feature file should write");
+    run_git_ok(&repo.path, &["add", "feature-b.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "fix: latest builder commit"]);
+
+    let suggested = git
+        .suggested_squash_commit_message(&repo.path, "feature/suggested-squash-message", "main")
+        .expect("suggested squash commit message should resolve");
+
+    assert_eq!(suggested.as_deref(), Some("feat: first builder commit"));
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/merge_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/merge_tests.rs
@@ -250,6 +250,14 @@ fn squash_merge_requires_a_commit_message_when_it_creates_a_commit() {
         .expect_err("squash merge without a commit message should fail");
 
     assert!(error.to_string().contains("squash commit message"));
+    assert_eq!(
+        run_git_ok(&repo.path, &["diff", "--cached", "--name-only"]).trim(),
+        ""
+    );
+    assert!(
+        !repo.path.join("feature.txt").exists(),
+        "blank squash message should fail before staging merge changes"
+    );
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/commands/build.rs
+++ b/apps/desktop/src-tauri/src/commands/build.rs
@@ -128,12 +128,17 @@ pub async fn task_direct_merge(
     task_id: String,
     input: TaskDirectMergePayload,
 ) -> Result<TaskDirectMergeResult, String> {
-    as_error(state.service.task_direct_merge(
-        &repo_path,
-        &task_id,
-        input.merge_method,
-        input.squash_commit_message,
-    ))
+    let service = state.service.clone();
+    let result = run_service_blocking("task_direct_merge", move || {
+        service.task_direct_merge(
+            &repo_path,
+            &task_id,
+            input.merge_method,
+            input.squash_commit_message,
+        )
+    })
+    .await;
+    as_error(result)
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/build.rs
+++ b/apps/desktop/src-tauri/src/commands/build.rs
@@ -1,10 +1,10 @@
 use crate::{
     as_error, run_emitter, run_service_blocking, AppState, BuildCompletePayload,
-    PullRequestContentPayload,
+    PullRequestContentPayload, TaskDirectMergePayload,
 };
 use host_application::{BuildResponseAction, CleanupMode};
 use host_domain::{
-    AgentRuntimeKind, GitMergeMethod, PullRequestRecord, RunSummary, TaskApprovalContext, TaskCard,
+    AgentRuntimeKind, PullRequestRecord, RunSummary, TaskApprovalContext, TaskCard,
     TaskDirectMergeResult, TaskPullRequestDetectResult,
 };
 use tauri::{AppHandle, State};
@@ -126,13 +126,14 @@ pub async fn task_direct_merge(
     state: State<'_, AppState>,
     repo_path: String,
     task_id: String,
-    merge_method: GitMergeMethod,
+    input: TaskDirectMergePayload,
 ) -> Result<TaskDirectMergeResult, String> {
-    as_error(
-        state
-            .service
-            .task_direct_merge(&repo_path, &task_id, merge_method),
-    )
+    as_error(state.service.task_direct_merge(
+        &repo_path,
+        &task_id,
+        input.merge_method,
+        input.squash_commit_message,
+    ))
 }
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/git/tests/fixtures/git_port.rs
+++ b/apps/desktop/src-tauri/src/commands/git/tests/fixtures/git_port.rs
@@ -262,6 +262,15 @@ impl GitPort for CommandGitPort {
         panic!("unexpected call: resolve_upstream_target");
     }
 
+    fn suggested_squash_commit_message(
+        &self,
+        _repo_path: &Path,
+        _source_branch: &str,
+        _target_branch: &str,
+    ) -> anyhow::Result<Option<String>> {
+        panic!("unexpected call: suggested_squash_commit_message");
+    }
+
     fn commits_ahead_behind(
         &self,
         _repo_path: &Path,

--- a/apps/desktop/src-tauri/src/commands/git/tests/fixtures/git_port.rs
+++ b/apps/desktop/src-tauri/src/commands/git/tests/fixtures/git_port.rs
@@ -271,6 +271,15 @@ impl GitPort for CommandGitPort {
         panic!("unexpected call: suggested_squash_commit_message");
     }
 
+    fn is_ancestor(
+        &self,
+        _repo_path: &Path,
+        _ancestor_ref: &str,
+        _descendant_ref: &str,
+    ) -> anyhow::Result<bool> {
+        panic!("unexpected call: is_ancestor");
+    }
+
     fn commits_ahead_behind(
         &self,
         _repo_path: &Path,

--- a/apps/desktop/src-tauri/src/headless.rs
+++ b/apps/desktop/src-tauri/src/headless.rs
@@ -10,7 +10,7 @@ use crate::{
     run_service_blocking_tokio, startup_phase_service_bootstrap, startup_phase_shutdown_hooks,
     startup_phase_tracing, BuildCompletePayload, MarkdownPayload, PlanPayload,
     PullRequestContentPayload, RepoConfigPayload, RepoSettingsPayload, SettingsSnapshotPayload,
-    SettingsSnapshotResponsePayload, TaskCreatePayload, TaskUpdatePayload,
+    SettingsSnapshotResponsePayload, TaskCreatePayload, TaskDirectMergePayload, TaskUpdatePayload,
 };
 use anyhow::{anyhow, Context};
 use axum::extract::{Path, State};
@@ -24,7 +24,7 @@ use host_application::{
     AppService, BuildResponseAction, CleanupMode, HookTrustConfirmationPort,
     HookTrustConfirmationRequest, RepoConfigUpdate, RepoSettingsUpdate, RunEmitter,
 };
-use host_domain::{AgentRuntimeKind, GitMergeMethod};
+use host_domain::AgentRuntimeKind;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -450,7 +450,7 @@ struct BuildCompletedArgs {
 struct TaskDirectMergeArgs {
     repo_path: String,
     task_id: String,
-    merge_method: GitMergeMethod,
+    input: TaskDirectMergePayload,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1807,12 +1807,17 @@ fn handle_task_direct_merge(state: &HeadlessState, args: Value) -> CommandResult
     let TaskDirectMergeArgs {
         repo_path,
         task_id,
-        merge_method,
+        input,
     } = deserialize_args(args)?;
     serialize_value(
         state
             .service
-            .task_direct_merge(&repo_path, &task_id, merge_method)
+            .task_direct_merge(
+                &repo_path,
+                &task_id,
+                input.merge_method,
+                input.squash_commit_message,
+            )
             .map_err(service_error)?,
     )
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -115,6 +115,13 @@ pub(crate) struct PullRequestContentPayload {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct TaskDirectMergePayload {
+    merge_method: host_domain::GitMergeMethod,
+    squash_commit_message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct RepoConfigPayload {
     default_runtime_kind: Option<String>,
     worktree_base_path: Option<String>,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -619,6 +619,40 @@ mod tests {
     }
 
     #[test]
+    fn task_direct_merge_payload_deserializes_camel_case_fields() {
+        let payload = json!({
+            "mergeMethod": "squash",
+            "squashCommitMessage": "feat: add Microsoft login"
+        });
+        let parsed = serde_json::from_value::<TaskDirectMergePayload>(payload)
+            .expect("direct merge payload should deserialize");
+
+        assert!(matches!(
+            parsed.merge_method,
+            host_domain::GitMergeMethod::Squash
+        ));
+        assert_eq!(
+            parsed.squash_commit_message.as_deref(),
+            Some("feat: add Microsoft login")
+        );
+    }
+
+    #[test]
+    fn task_direct_merge_payload_allows_missing_squash_commit_message() {
+        let payload = json!({
+            "mergeMethod": "merge_commit"
+        });
+        let parsed = serde_json::from_value::<TaskDirectMergePayload>(payload)
+            .expect("direct merge payload without squash message should deserialize");
+
+        assert!(matches!(
+            parsed.merge_method,
+            host_domain::GitMergeMethod::MergeCommit
+        ));
+        assert_eq!(parsed.squash_commit_message, None);
+    }
+
+    #[test]
     fn task_status_deserialization_rejects_unknown_status() {
         let error = serde_json::from_value::<TaskStatus>(json!("backlog"))
             .expect_err("unknown status should fail deserialization");

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -930,7 +930,8 @@ describe("AgentStudioGitPanel", () => {
     expect(findByTestId(root, "agent-studio-git-conflict-strip")).toBeTruthy();
     const conflictCountBadge = findByTestId(root, "agent-studio-git-conflict-count-badge");
     expect(getNodeText(conflictCountBadge)).toContain("2 conflicted files");
-    expect(String(conflictCountBadge.props.className)).toContain("amber");
+    expect(String(conflictCountBadge.props.className)).toContain("bg-warning-surface");
+    expect(String(conflictCountBadge.props.className)).toContain("border-warning-border");
     expect(findByTestId(root, "agent-studio-git-view-conflict-details-button")).toBeTruthy();
     expect(findByTestId(root, "agent-studio-git-abort-conflict-strip-button")).toBeTruthy();
     expect(findByTestId(root, "agent-studio-git-ask-builder-conflict-strip-button")).toBeTruthy();

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -928,9 +928,9 @@ describe("AgentStudioGitPanel", () => {
     const root = getRoot(renderer);
     expect(countByTestId(root, "agent-studio-git-lock-reason")).toBe(0);
     expect(findByTestId(root, "agent-studio-git-conflict-strip")).toBeTruthy();
-    expect(getNodeText(findByTestId(root, "agent-studio-git-conflict-count-badge"))).toContain(
-      "2 conflicted files",
-    );
+    const conflictCountBadge = findByTestId(root, "agent-studio-git-conflict-count-badge");
+    expect(getNodeText(conflictCountBadge)).toContain("2 conflicted files");
+    expect(String(conflictCountBadge.props.className)).toContain("amber");
     expect(findByTestId(root, "agent-studio-git-view-conflict-details-button")).toBeTruthy();
     expect(findByTestId(root, "agent-studio-git-abort-conflict-strip-button")).toBeTruthy();
     expect(findByTestId(root, "agent-studio-git-ask-builder-conflict-strip-button")).toBeTruthy();

--- a/apps/desktop/src/features/git-conflict-resolution/git-conflict-strip.tsx
+++ b/apps/desktop/src/features/git-conflict-resolution/git-conflict-strip.tsx
@@ -35,7 +35,7 @@ export const GitConflictStrip = memo(function GitConflictStrip({
     >
       <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
         <div className="flex min-w-0 items-start gap-3">
-          <div className="rounded-full bg-amber-500/12 p-2.5 text-amber-600 dark:text-amber-300">
+          <div className="rounded-full border border-warning-border bg-warning-surface p-2.5 text-warning-muted">
             <AlertTriangle className="size-4" />
           </div>
           <div className="min-w-0 flex-1 space-y-1.5">
@@ -44,7 +44,7 @@ export const GitConflictStrip = memo(function GitConflictStrip({
                 {getGitConflictCopy(conflict.operation).inProgressLabel}
               </p>
               <span
-                className="inline-flex max-w-full shrink-0 items-center rounded-full border border-amber-500/20 bg-amber-500/12 px-2.5 py-1 text-xs font-semibold leading-none text-amber-700 dark:text-amber-300"
+                className="inline-flex max-w-full shrink-0 items-center rounded-full border border-warning-border bg-warning-surface px-2.5 py-1 text-xs font-semibold leading-none text-warning-muted"
                 data-testid={GIT_CONFLICT_TEST_IDS.conflictCountBadge}
               >
                 {`${conflict.conflictedFiles.length} conflicted file${conflict.conflictedFiles.length === 1 ? "" : "s"}`}

--- a/apps/desktop/src/features/git-conflict-resolution/git-conflict-strip.tsx
+++ b/apps/desktop/src/features/git-conflict-resolution/git-conflict-strip.tsx
@@ -30,31 +30,33 @@ export const GitConflictStrip = memo(function GitConflictStrip({
 }: GitConflictStripProps): ReactElement {
   return (
     <div
-      className="border-b border-border bg-muted px-3 py-3"
+      className="border-b border-border bg-muted/40 px-4 py-4"
       data-testid={GIT_CONFLICT_TEST_IDS.strip}
     >
-      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
         <div className="flex min-w-0 items-start gap-3">
-          <div className="rounded-full bg-destructive/10 p-2 text-destructive">
+          <div className="rounded-full bg-amber-500/12 p-2.5 text-amber-600 dark:text-amber-300">
             <AlertTriangle className="size-4" />
           </div>
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <p className="text-sm font-medium text-foreground">
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-sm font-semibold text-foreground">
                 {getGitConflictCopy(conflict.operation).inProgressLabel}
               </p>
               <span
-                className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive"
+                className="inline-flex max-w-full shrink-0 items-center rounded-full border border-amber-500/20 bg-amber-500/12 px-2.5 py-1 text-xs font-semibold leading-none text-amber-700 dark:text-amber-300"
                 data-testid={GIT_CONFLICT_TEST_IDS.conflictCountBadge}
               >
                 {`${conflict.conflictedFiles.length} conflicted file${conflict.conflictedFiles.length === 1 ? "" : "s"}`}
               </span>
             </div>
-            <p className="mt-1 text-sm text-muted-foreground">{toConflictDescription(conflict)}</p>
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+              {toConflictDescription(conflict)}
+            </p>
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 xl:justify-end">
           <Button
             type="button"
             variant="outline"

--- a/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
+++ b/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
@@ -41,6 +41,8 @@ export type TaskApprovalModalModel = {
   title: string;
   body: string;
   squashCommitMessage: string;
+  squashCommitMessageTouched: boolean;
+  hasSuggestedSquashCommitMessage: boolean;
   targetBranch: GitTargetBranch | null;
   publishTarget: GitTargetBranch | null;
   isSubmitting: boolean;

--- a/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
+++ b/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
@@ -40,6 +40,7 @@ export type TaskApprovalModalModel = {
   pullRequestUrl: string | null;
   title: string;
   body: string;
+  squashCommitMessage: string;
   targetBranch: GitTargetBranch | null;
   publishTarget: GitTargetBranch | null;
   isSubmitting: boolean;
@@ -50,6 +51,7 @@ export type TaskApprovalModalModel = {
   onPullRequestDraftModeChange: (mode: PullRequestDraftMode) => void;
   onTitleChange: (value: string) => void;
   onBodyChange: (value: string) => void;
+  onSquashCommitMessageChange: (value: string) => void;
   onConfirm: () => void;
   onSkipDirectMergeCompletion: () => void;
   onCompleteDirectMerge: () => void;

--- a/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
@@ -35,6 +35,7 @@ const createModel = (overrides: Partial<TaskApprovalModalModel> = {}): TaskAppro
   pullRequestUrl: null,
   title: "Ship direct merge flow",
   body: "Task description",
+  squashCommitMessage: "feat: add Microsoft login",
   targetBranch: { remote: "origin", branch: "beta" },
   publishTarget: { remote: "origin", branch: "beta" },
   isSubmitting: false,
@@ -45,6 +46,7 @@ const createModel = (overrides: Partial<TaskApprovalModalModel> = {}): TaskAppro
   onPullRequestDraftModeChange: noop,
   onTitleChange: noop,
   onBodyChange: noop,
+  onSquashCommitMessageChange: noop,
   onConfirm: noop,
   onSkipDirectMergeCompletion: noop,
   onCompleteDirectMerge: noop,
@@ -91,6 +93,38 @@ describe("TaskApprovalModal", () => {
 
     expect(html).toContain("Merge Locally");
     expect(html).toContain("animate-spin");
+  });
+
+  test("renders the squash commit message editor when squash is selected", () => {
+    const html = renderToStaticMarkup(
+      createElement(TaskApprovalModal, {
+        model: createModel({
+          stage: "approval",
+          mergeMethod: "squash",
+          publishTarget: null,
+        }),
+      }),
+    );
+
+    expect(html).toContain("Squash Commit Message");
+    expect(html).toContain("feat: add Microsoft login");
+    expect(html).toContain("oldest commit unique to the builder branch");
+  });
+
+  test("disables direct merge confirmation when the squash commit message is empty", () => {
+    const html = renderToStaticMarkup(
+      createElement(TaskApprovalModal, {
+        model: createModel({
+          stage: "approval",
+          mergeMethod: "squash",
+          squashCommitMessage: "",
+          publishTarget: null,
+        }),
+      }),
+    );
+
+    expect(html).toContain("Enter the squash commit message before merging locally.");
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Merge Locally<\/button>/);
   });
 
   test("fails fast when direct-merge completion branch context is missing", () => {

--- a/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
@@ -36,6 +36,8 @@ const createModel = (overrides: Partial<TaskApprovalModalModel> = {}): TaskAppro
   title: "Ship direct merge flow",
   body: "Task description",
   squashCommitMessage: "feat: add Microsoft login",
+  squashCommitMessageTouched: false,
+  hasSuggestedSquashCommitMessage: true,
   targetBranch: { remote: "origin", branch: "beta" },
   publishTarget: { remote: "origin", branch: "beta" },
   isSubmitting: false,
@@ -125,6 +127,25 @@ describe("TaskApprovalModal", () => {
 
     expect(html).toContain("Enter the squash commit message before merging locally.");
     expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Merge Locally<\/button>/);
+  });
+
+  test("does not show a squash validation error before the user interacts when no suggestion exists", () => {
+    const html = renderToStaticMarkup(
+      createElement(TaskApprovalModal, {
+        model: createModel({
+          stage: "approval",
+          mergeMethod: "squash",
+          squashCommitMessage: "",
+          squashCommitMessageTouched: false,
+          hasSuggestedSquashCommitMessage: false,
+          publishTarget: null,
+        }),
+      }),
+    );
+
+    expect(html).toContain('placeholder="e.g. feat: add Microsoft login"');
+    expect(html).not.toContain("Enter the squash commit message before merging locally.");
+    expect(html).not.toMatch(/<button[^>]*disabled=""[^>]*>Merge Locally<\/button>/);
   });
 
   test("fails fast when direct-merge completion branch context is missing", () => {

--- a/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
@@ -145,7 +145,7 @@ describe("TaskApprovalModal", () => {
 
     expect(html).toContain('placeholder="e.g. feat: add Microsoft login"');
     expect(html).not.toContain("Enter the squash commit message before merging locally.");
-    expect(html).not.toMatch(/<button[^>]*disabled=""[^>]*>Merge Locally<\/button>/);
+    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>Merge Locally<\/button>/);
   });
 
   test("fails fast when direct-merge completion branch context is missing", () => {

--- a/apps/desktop/src/pages/kanban/task-approval-modal.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal.tsx
@@ -185,18 +185,20 @@ export function TaskApprovalModal({
     model.pullRequestAvailable &&
     model.pullRequestDraftMode === "manual" &&
     (model.title.trim().length === 0 || model.body.trim().length === 0);
-  const hasSquashCommitMessageValidationError =
+  const hasSquashCommitMessageSubmitError =
     model.stage === "approval" &&
     model.mode === "direct_merge" &&
     model.mergeMethod === "squash" &&
-    (model.hasSuggestedSquashCommitMessage || model.squashCommitMessageTouched) &&
     model.squashCommitMessage.trim().length === 0;
+  const showSquashCommitMessageValidationError =
+    hasSquashCommitMessageSubmitError &&
+    (model.hasSuggestedSquashCommitMessage || model.squashCommitMessageTouched);
   const confirmDisabled =
     model.isLoading ||
     model.isSubmitting ||
     model.hasUncommittedChanges ||
     hasManualPullRequestValidationError ||
-    hasSquashCommitMessageValidationError;
+    hasSquashCommitMessageSubmitError;
   const isCompletionStage = model.stage === "complete_direct_merge";
   const hasPublishTarget = model.publishTarget !== null;
   const hasCompletionBranchContext = model.targetBranch !== null;
@@ -356,7 +358,7 @@ export function TaskApprovalModal({
                           </span>
                           .
                         </p>
-                        {hasSquashCommitMessageValidationError ? (
+                        {showSquashCommitMessageValidationError ? (
                           <p className="text-sm text-destructive">
                             Enter the squash commit message before merging locally.
                           </p>

--- a/apps/desktop/src/pages/kanban/task-approval-modal.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal.tsx
@@ -185,11 +185,17 @@ export function TaskApprovalModal({
     model.pullRequestAvailable &&
     model.pullRequestDraftMode === "manual" &&
     (model.title.trim().length === 0 || model.body.trim().length === 0);
+  const hasSquashCommitMessageValidationError =
+    model.stage === "approval" &&
+    model.mode === "direct_merge" &&
+    model.mergeMethod === "squash" &&
+    model.squashCommitMessage.trim().length === 0;
   const confirmDisabled =
     model.isLoading ||
     model.isSubmitting ||
     model.hasUncommittedChanges ||
-    hasManualPullRequestValidationError;
+    hasManualPullRequestValidationError ||
+    hasSquashCommitMessageValidationError;
   const isCompletionStage = model.stage === "complete_direct_merge";
   const hasPublishTarget = model.publishTarget !== null;
   const hasCompletionBranchContext = model.targetBranch !== null;
@@ -280,16 +286,16 @@ export function TaskApprovalModal({
             ) : (
               <>
                 {model.hasUncommittedChanges ? (
-                  <div className="grid gap-1 rounded-2xl border border-border bg-muted p-4 text-foreground">
+                  <div className="grid gap-1 rounded-2xl border border-warning-border bg-warning-surface p-4 text-warning-surface-foreground">
                     <p className="text-sm font-semibold">Uncommitted changes detected</p>
                     <p className="text-sm">{dirtyWorktreeMessage}</p>
                   </div>
                 ) : null}
 
                 {model.errorMessage ? (
-                  <div className="grid gap-1 rounded-2xl border border-destructive/20 bg-destructive/10 p-4 text-destructive">
+                  <div className="grid gap-1 rounded-2xl border border-destructive-border bg-destructive-surface p-4 text-destructive-surface-foreground">
                     <p className="text-sm font-semibold">Approval failed</p>
-                    <p className="text-sm">{model.errorMessage}</p>
+                    <p className="text-sm text-destructive-muted">{model.errorMessage}</p>
                   </div>
                 ) : null}
 
@@ -325,6 +331,36 @@ export function TaskApprovalModal({
                         />
                       ))}
                     </div>
+
+                    {model.mergeMethod === "squash" ? (
+                      <div className="grid gap-2 rounded-2xl border border-border bg-card p-5">
+                        <Label htmlFor="task-approval-squash-commit-message">
+                          Squash Commit Message
+                        </Label>
+                        <Textarea
+                          id="task-approval-squash-commit-message"
+                          className="min-h-28"
+                          value={model.squashCommitMessage}
+                          disabled={model.isSubmitting}
+                          onChange={(event) =>
+                            model.onSquashCommitMessageChange(event.currentTarget.value)
+                          }
+                        />
+                        <p className="text-sm text-muted-foreground">
+                          OpenDucktor prefills this from the oldest commit unique to the builder
+                          branch. Edit it before creating the single squash commit on{" "}
+                          <span className="font-mono text-[13px] text-foreground">
+                            {model.targetBranch?.branch ?? "the target branch"}
+                          </span>
+                          .
+                        </p>
+                        {hasSquashCommitMessageValidationError ? (
+                          <p className="text-sm text-destructive">
+                            Enter the squash commit message before merging locally.
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : null}
                   </div>
                 ) : (
                   <div className="space-y-5">
@@ -396,9 +432,9 @@ export function TaskApprovalModal({
         {isCompletionStage ? (
           <div className="grid gap-4 px-6 py-6 sm:px-8">
             {completionErrorMessage ? (
-              <div className="grid gap-1 rounded-2xl border border-destructive/20 bg-destructive/10 p-4 text-destructive">
+              <div className="grid gap-1 rounded-2xl border border-destructive-border bg-destructive-surface p-4 text-destructive-surface-foreground">
                 <p className="text-sm font-semibold">Direct merge completion failed</p>
-                <p className="text-sm">{completionErrorMessage}</p>
+                <p className="text-sm text-destructive-muted">{completionErrorMessage}</p>
               </div>
             ) : null}
 

--- a/apps/desktop/src/pages/kanban/task-approval-modal.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal.tsx
@@ -189,6 +189,7 @@ export function TaskApprovalModal({
     model.stage === "approval" &&
     model.mode === "direct_merge" &&
     model.mergeMethod === "squash" &&
+    (model.hasSuggestedSquashCommitMessage || model.squashCommitMessageTouched) &&
     model.squashCommitMessage.trim().length === 0;
   const confirmDisabled =
     model.isLoading ||
@@ -340,6 +341,7 @@ export function TaskApprovalModal({
                         <Textarea
                           id="task-approval-squash-commit-message"
                           className="min-h-28"
+                          placeholder="e.g. feat: add Microsoft login"
                           value={model.squashCommitMessage}
                           disabled={model.isSubmitting}
                           onChange={(event) =>

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -151,12 +151,15 @@ let latestHarnessValue: {
     mode: "direct_merge" | "pull_request";
     mergeMethod: "merge_commit" | "squash" | "rebase";
     pullRequestDraftMode: "manual" | "generate_ai";
+    squashCommitMessage: string;
     hasUncommittedChanges: boolean;
     uncommittedFileCount: number;
     errorMessage: string | null;
     onOpenChange: (open: boolean) => void;
     onModeChange: (mode: "direct_merge" | "pull_request") => void;
+    onMergeMethodChange: (mergeMethod: "merge_commit" | "squash" | "rebase") => void;
     onPullRequestDraftModeChange: (mode: "manual" | "generate_ai") => void;
+    onSquashCommitMessageChange: (value: string) => void;
     onConfirm: () => void;
     onCompleteDirectMerge: () => void;
   } | null;
@@ -254,6 +257,7 @@ describe("useTaskApprovalFlow", () => {
       hasUncommittedChanges: true,
       uncommittedFileCount: 2,
       pullRequest: undefined,
+      suggestedSquashCommitMessage: "feat: builder change",
       providers: [],
     });
 
@@ -264,6 +268,7 @@ describe("useTaskApprovalFlow", () => {
 
     expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(false);
     expect(latestHarnessValue?.taskApprovalModal?.mergeMethod).toBe("squash");
+    expect(latestHarnessValue?.taskApprovalModal?.squashCommitMessage).toBe("feat: builder change");
     expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.uncommittedFileCount).toBe(2);
 
@@ -478,6 +483,12 @@ describe("useTaskApprovalFlow", () => {
     });
 
     await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onMergeMethodChange("squash");
+      latestHarnessValue?.taskApprovalModal?.onSquashCommitMessageChange("feat: merged task");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
       latestHarnessValue?.taskApprovalModal?.onConfirm();
       await Promise.resolve();
     });
@@ -489,7 +500,10 @@ describe("useTaskApprovalFlow", () => {
       await Promise.resolve();
     });
 
-    expect(taskDirectMergeMock).toHaveBeenCalledWith("/repo", "TASK-1", "merge_commit");
+    expect(taskDirectMergeMock).toHaveBeenCalledWith("/repo", "TASK-1", {
+      mergeMethod: "squash",
+      squashCommitMessage: "feat: merged task",
+    });
     expect(gitPushBranchMock).toHaveBeenCalledWith("/repo", "main", {
       remote: "upstream",
     });
@@ -550,7 +564,10 @@ describe("useTaskApprovalFlow", () => {
       await Promise.resolve();
     });
 
-    expect(taskDirectMergeMock).toHaveBeenCalledWith("/repo", "TASK-1", "merge_commit");
+    expect(taskDirectMergeMock).toHaveBeenCalledWith("/repo", "TASK-1", {
+      mergeMethod: "merge_commit",
+      squashCommitMessage: undefined,
+    });
     expect(gitPushBranchMock).not.toHaveBeenCalled();
     expect(refreshTasksMock).toHaveBeenCalledTimes(1);
     expect(latestHarnessValue?.taskApprovalModal).toBeNull();

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -152,6 +152,8 @@ let latestHarnessValue: {
     mergeMethod: "merge_commit" | "squash" | "rebase";
     pullRequestDraftMode: "manual" | "generate_ai";
     squashCommitMessage: string;
+    squashCommitMessageTouched: boolean;
+    hasSuggestedSquashCommitMessage: boolean;
     hasUncommittedChanges: boolean;
     uncommittedFileCount: number;
     errorMessage: string | null;

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -35,6 +35,7 @@ type ApprovalState = {
   title: string;
   body: string;
   squashCommitMessage: string;
+  squashCommitMessageTouched: boolean;
   isSubmitting: boolean;
   errorMessage: string | null;
   approvalContext: TaskApprovalContext | null;
@@ -167,6 +168,7 @@ export function useTaskApprovalFlow({
         title: task?.title ?? "",
         body: task?.description ?? "",
         squashCommitMessage: "",
+        squashCommitMessageTouched: false,
         isSubmitting: false,
         errorMessage: options?.errorMessage ?? null,
         approvalContext: null,
@@ -193,6 +195,7 @@ export function useTaskApprovalFlow({
             title: task?.title ?? "",
             body: task?.description ?? "",
             squashCommitMessage: approvalContext.suggestedSquashCommitMessage ?? "",
+            squashCommitMessageTouched: false,
             isSubmitting: false,
             errorMessage: options?.errorMessage ?? null,
             approvalContext,
@@ -672,6 +675,8 @@ export function useTaskApprovalFlow({
       targetBranch: approvalContext?.targetBranch ?? null,
       publishTarget: approvalContext?.publishTarget ?? null,
       squashCommitMessage: state.squashCommitMessage,
+      squashCommitMessageTouched: state.squashCommitMessageTouched,
+      hasSuggestedSquashCommitMessage: approvalContext?.suggestedSquashCommitMessage != null,
       isSubmitting: state.isSubmitting,
       errorMessage: state.errorMessage,
       onOpenChange: (open) => {
@@ -695,7 +700,14 @@ export function useTaskApprovalFlow({
         setState((current) => (current ? { ...current, body, errorMessage: null } : current)),
       onSquashCommitMessageChange: (squashCommitMessage) =>
         setState((current) =>
-          current ? { ...current, squashCommitMessage, errorMessage: null } : current,
+          current
+            ? {
+                ...current,
+                squashCommitMessage,
+                squashCommitMessageTouched: true,
+                errorMessage: null,
+              }
+            : current,
         ),
       onConfirm: confirm,
       onSkipDirectMergeCompletion: reset,

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -34,6 +34,7 @@ type ApprovalState = {
   pullRequestDraftMode: "manual" | "generate_ai";
   title: string;
   body: string;
+  squashCommitMessage: string;
   isSubmitting: boolean;
   errorMessage: string | null;
   approvalContext: TaskApprovalContext | null;
@@ -165,6 +166,7 @@ export function useTaskApprovalFlow({
         pullRequestDraftMode: options?.pullRequestDraftMode ?? "manual",
         title: task?.title ?? "",
         body: task?.description ?? "",
+        squashCommitMessage: "",
         isSubmitting: false,
         errorMessage: options?.errorMessage ?? null,
         approvalContext: null,
@@ -190,6 +192,7 @@ export function useTaskApprovalFlow({
             pullRequestDraftMode: options?.pullRequestDraftMode ?? "manual",
             title: task?.title ?? "",
             body: task?.description ?? "",
+            squashCommitMessage: approvalContext.suggestedSquashCommitMessage ?? "",
             isSubmitting: false,
             errorMessage: options?.errorMessage ?? null,
             approvalContext,
@@ -353,11 +356,13 @@ export function useTaskApprovalFlow({
       setState((current) => (current ? { ...current, isSubmitting: true } : current));
       try {
         if (state.mode === "direct_merge") {
-          const directMergeResult = await host.taskDirectMerge(
-            activeRepo,
-            state.taskId,
-            state.mergeMethod,
-          );
+          const directMergeResult = await host.taskDirectMerge(activeRepo, state.taskId, {
+            mergeMethod: state.mergeMethod,
+            squashCommitMessage:
+              state.mergeMethod === "squash"
+                ? state.squashCommitMessage.trim() || undefined
+                : undefined,
+          });
           if (directMergeResult.outcome === "conflicts") {
             reset();
             setGitConflictState({
@@ -666,6 +671,7 @@ export function useTaskApprovalFlow({
       body: state.body,
       targetBranch: approvalContext?.targetBranch ?? null,
       publishTarget: approvalContext?.publishTarget ?? null,
+      squashCommitMessage: state.squashCommitMessage,
       isSubmitting: state.isSubmitting,
       errorMessage: state.errorMessage,
       onOpenChange: (open) => {
@@ -687,6 +693,10 @@ export function useTaskApprovalFlow({
         setState((current) => (current ? { ...current, title, errorMessage: null } : current)),
       onBodyChange: (body) =>
         setState((current) => (current ? { ...current, body, errorMessage: null } : current)),
+      onSquashCommitMessageChange: (squashCommitMessage) =>
+        setState((current) =>
+          current ? { ...current, squashCommitMessage, errorMessage: null } : current,
+        ),
       onConfirm: confirm,
       onSkipDirectMergeCompletion: reset,
       onCompleteDirectMerge: completeDirectMerge,

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -3,7 +3,6 @@ import {
   type BuildContinuationTarget,
   beadsCheckSchema,
   buildContinuationTargetSchema,
-  gitMergeMethodSchema,
   pullRequestSchema,
   type RunSummary,
   type RuntimeCheck,
@@ -17,9 +16,11 @@ import {
   type SystemCheck,
   systemCheckSchema,
   type TaskCard,
+  type TaskDirectMergeInput,
   type TaskDirectMergeResult,
   taskApprovalContextSchema,
   taskCardSchema,
+  taskDirectMergeInputSchema,
   taskDirectMergeResultSchema,
   taskPullRequestDetectResultSchema,
 } from "@openducktor/contracts";
@@ -192,12 +193,13 @@ export const taskDirectMerge = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
-  mergeMethod: string,
+  input: TaskDirectMergeInput,
 ): Promise<TaskDirectMergeResult> => {
+  const parsedInput = taskDirectMergeInputSchema.parse(input);
   const payload = await invokeFn("task_direct_merge", {
     repoPath,
     taskId,
-    mergeMethod: gitMergeMethodSchema.parse(mergeMethod),
+    input: parsedInput,
   });
   return taskDirectMergeResultSchema.parse(payload);
 };
@@ -365,9 +367,9 @@ export class TauriAgentClient {
   async taskDirectMerge(
     repoPath: string,
     taskId: string,
-    mergeMethod: string,
+    input: TaskDirectMergeInput,
   ): Promise<TaskDirectMergeResult> {
-    const result = await taskDirectMerge(this.invokeFn, repoPath, taskId, mergeMethod);
+    const result = await taskDirectMerge(this.invokeFn, repoPath, taskId, input);
     this.metadataCache?.invalidate(repoPath, taskId);
     return result;
   }

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1417,7 +1417,7 @@ describe("TauriHostClient", () => {
     });
 
     expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V1");
-    await client.taskDirectMerge("/repo", "task-1", "merge_commit");
+    await client.taskDirectMerge("/repo", "task-1", { mergeMethod: "merge_commit" });
     expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V2");
 
     await client.taskDirectMergeComplete("/repo", "task-1");
@@ -1476,7 +1476,9 @@ describe("TauriHostClient", () => {
     });
 
     expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V1");
-    await expect(client.taskDirectMerge("/repo", "task-1", "merge_commit")).resolves.toEqual({
+    await expect(
+      client.taskDirectMerge("/repo", "task-1", { mergeMethod: "merge_commit" }),
+    ).resolves.toEqual({
       outcome: "conflicts",
       conflict: {
         operation: "direct_merge_rebase",
@@ -1493,6 +1495,37 @@ describe("TauriHostClient", () => {
       "task_metadata_get",
       "task_direct_merge",
       "task_metadata_get",
+    ]);
+  });
+
+  test("taskDirectMerge sends structured squash input", async () => {
+    const { client, calls } = createClient((command) => {
+      if (command === "task_direct_merge") {
+        return {
+          outcome: "completed",
+          task: makeTaskCardPayload(),
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await client.taskDirectMerge("/repo", "task-1", {
+      mergeMethod: "squash",
+      squashCommitMessage: "feat: add Microsoft login",
+    });
+
+    expect(calls).toEqual([
+      {
+        command: "task_direct_merge",
+        args: {
+          repoPath: "/repo",
+          taskId: "task-1",
+          input: {
+            mergeMethod: "squash",
+            squashCommitMessage: "feat: add Microsoft login",
+          },
+        },
+      },
     ]);
   });
 

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -63,6 +63,7 @@ import type {
   TaskAction,
   TaskCard,
   TaskCreateInput,
+  TaskDirectMergeInput,
   TaskDirectMergeResult,
   TaskDocumentPresence,
   TaskDocumentSummary,
@@ -193,6 +194,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "taskApprovalContextSchema",
   "taskCardSchema",
   "taskCreateInputSchema",
+  "taskDirectMergeInputSchema",
   "taskDirectMergeResultSchema",
   "taskPullRequestDetectResultSchema",
   "taskMetadataDocumentSchema",
@@ -273,6 +275,7 @@ type ExportedTypeContract = {
   TaskAction: TaskAction;
   TaskCard: TaskCard;
   TaskCreateInput: TaskCreateInput;
+  TaskDirectMergeInput: TaskDirectMergeInput;
   TaskDirectMergeResult: TaskDirectMergeResult;
   TaskDocumentPresence: TaskDocumentPresence;
   TaskDocumentSummary: TaskDocumentSummary;

--- a/packages/contracts/src/git-schemas.ts
+++ b/packages/contracts/src/git-schemas.ts
@@ -162,6 +162,10 @@ export const taskApprovalContextSchema = z.object({
     (value) => (value === null ? undefined : value),
     directMergeRecordSchema.optional(),
   ),
+  suggestedSquashCommitMessage: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    z.string().trim().min(1).optional(),
+  ),
   providers: z.array(gitProviderAvailabilitySchema).default([]),
 });
 export type TaskApprovalContext = z.infer<typeof taskApprovalContextSchema>;

--- a/packages/contracts/src/task-schemas.ts
+++ b/packages/contracts/src/task-schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { gitConflictSchema, pullRequestSchema } from "./git-schemas";
+import { gitConflictSchema, gitMergeMethodSchema, pullRequestSchema } from "./git-schemas";
 
 export const taskStatusSchema = z.enum([
   "open",
@@ -179,6 +179,15 @@ export const taskCardSchema = z.object({
   createdAt: z.string(),
 });
 export type TaskCard = z.infer<typeof taskCardSchema>;
+
+export const taskDirectMergeInputSchema = z.object({
+  mergeMethod: gitMergeMethodSchema,
+  squashCommitMessage: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    z.string().trim().min(1).optional(),
+  ),
+});
+export type TaskDirectMergeInput = z.infer<typeof taskDirectMergeInputSchema>;
 
 export const taskDirectMergeResultSchema = z.discriminatedUnion("outcome", [
   z.object({


### PR DESCRIPTION
## Summary
- add explicit squash commit message support to the direct-merge approval flow and prefill it from the oldest commit unique to the builder branch
- replace the hardcoded squash commit subject in the git layer and fix squash cleanup so the source branch is force-deleted only when a completed squash merge makes `git branch -d` invalid
- restore the git conflict strip warning presentation in the builder panel and tighten the conflict layout so the badge/actions render cleanly again
- align the approval modal error and warning surfaces with the app's semantic warning/destructive tokens

## Testing
- bun run lint
- bun run typecheck
- bun run test
- bun run build
- cd apps/desktop/src-tauri && cargo fmt --all --check
- cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings
- cd apps/desktop/src-tauri && cargo test --workspace
- cd apps/desktop/src-tauri && cargo build --workspace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Specify a custom squash commit message when performing squash merges
  * Auto-suggest a squash commit message based on commits being squashed
  * Direct-merge now accepts and forwards an optional squash message

* **UI Improvements**
  * Squash commit message input added to the merge approval dialog with inline validation and prefill behavior
  * Updated conflict-resolution panel styling and layout

* **Bug Fixes**
  * Safer source-branch deletion and cleanup behavior for squash merge flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->