### PR TITLE
feat: publish external MCP task tools

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 env:
   BUN_VERSION: 1.3.5
@@ -40,5 +41,5 @@ jobs:
         working-directory: packages/openducktor-mcp
         env:
           NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
         run: bun publish --access public
-

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,44 @@
+name: Publish MCP Package
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "mcp-v*"
+
+permissions:
+  contents: read
+
+env:
+  BUN_VERSION: 1.3.5
+
+jobs:
+  publish-mcp:
+    name: Publish @openducktor/mcp
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify MCP package
+        run: |
+          bun run --filter @openducktor/mcp typecheck
+          bun run --filter @openducktor/mcp test
+          bun run --filter @openducktor/mcp build
+
+      - name: Publish package
+        working-directory: packages/openducktor-mcp
+        env:
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun publish --access public
+

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
@@ -95,7 +95,7 @@ pub(crate) fn resolve_mcp_command() -> Result<Vec<String>> {
         "--cwd".to_string(),
         workspace_root,
         "--filter".to_string(),
-        "@openducktor/openducktor-mcp".to_string(),
+        "@openducktor/mcp".to_string(),
         "start".to_string(),
     ])
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -745,7 +745,7 @@ fn resolve_mcp_command_supports_cli_and_bun_fallback_modes() -> Result<()> {
                 "--cwd".to_string(),
                 workspace_filter.to_string_lossy().to_string(),
                 "--filter".to_string(),
-                "@openducktor/openducktor-mcp".to_string(),
+                "@openducktor/mcp".to_string(),
                 "start".to_string(),
             ]
         );

--- a/bun.lock
+++ b/bun.lock
@@ -94,8 +94,11 @@
       },
     },
     "packages/openducktor-mcp": {
-      "name": "@openducktor/openducktor-mcp",
+      "name": "@openducktor/mcp",
       "version": "0.1.0",
+      "bin": {
+        "openducktor-mcp": "./dist/index.js",
+      },
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@openducktor/contracts": "workspace:*",
@@ -230,7 +233,7 @@
 
     "@openducktor/desktop": ["@openducktor/desktop@workspace:apps/desktop"],
 
-    "@openducktor/openducktor-mcp": ["@openducktor/openducktor-mcp@workspace:packages/openducktor-mcp"],
+    "@openducktor/mcp": ["@openducktor/mcp@workspace:packages/openducktor-mcp"],
 
     "@oxc-project/runtime": ["@oxc-project/runtime@0.115.0", "", {}, "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This folder contains the project documentation that explains how OpenDucktor is 
 - [agent-orchestrator-module-map.md](agent-orchestrator-module-map.md): maintainer map for the desktop agent orchestration modules.
 - [agent-runtime-implementation-plan.md](agent-runtime-implementation-plan.md): runtime abstraction plan and guardrails.
 - [agent-ui-library-evaluation.md](agent-ui-library-evaluation.md): reasoning behind the current agent UI approach.
+- [external-mcp.md](external-mcp.md): public MCP package usage, install config, and the external task tools.
 - [runtime-integration-guide.md](runtime-integration-guide.md): runtime vocabulary, capability model, integration checklist, and verification path.
 
 ## Security And Maintenance Docs

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -24,7 +24,7 @@ Current scope note:
 | Tauri command bridge (Rust) | `apps/desktop/src-tauri/src/lib.rs`, `apps/desktop/src-tauri/src/commands/*` | Typed command surface (`tauri::command`), argument mapping, command registration | Deep business policy (kept in `AppService`) |
 | Host application/domain (Rust) | `apps/desktop/src-tauri/crates/host-application/src/app_service/*`, `apps/desktop/src-tauri/crates/host-domain/src/*` | Workflow transition rules, task enrichment (`available_actions`, `agent_workflows`), runtime orchestration, `TaskStore` trait | UI concerns, view-level behavior |
 | Infrastructure/persistence (Rust) | `apps/desktop/src-tauri/crates/host-infra-beads/*`, `apps/desktop/src-tauri/crates/host-infra-system/*` | Beads-backed `TaskStore`, config/worktree/process integrations | UI workflow decisions |
-| MCP workflow service (TS) | `packages/openducktor-mcp/src/index.ts`, `packages/openducktor-mcp/src/lib.ts`, `packages/openducktor-mcp/src/odt-task-store.ts` | `odt_*` tool execution and validation against Beads metadata/status | Frontend rendering/state |
+| MCP workflow service (TS) | `packages/openducktor-mcp/src/index.ts`, `packages/openducktor-mcp/src/lib.ts`, `packages/openducktor-mcp/src/odt-task-store.ts` | public MCP task tools (`create_task`, `search_tasks`, `odt_read_task`) plus `odt_*` workflow execution and validation against Beads metadata/status | Frontend rendering/state |
 
 ## Runtime Data Flows
 
@@ -82,7 +82,7 @@ Agent-triggered path:
 | Task statuses, issue types, action IDs | `packages/contracts/src/task-schemas.ts` | `@openducktor/contracts`, consumed by adapters/frontend/host |
 | Role, scenario, ODT tool IDs | `packages/contracts/src/agent-workflow-schemas.ts` | `@openducktor/contracts` |
 | Role-to-tool allowlist | `AGENT_ROLE_TOOL_POLICY` in `packages/core/src/types/agent-orchestrator.ts` | `@openducktor/core` |
-| ODT tool schema validation | `ODT_TOOL_SCHEMAS` exported from `packages/openducktor-mcp/src/lib.ts` (defined in `src/tool-schemas.ts`) | `@openducktor/openducktor-mcp` |
+| ODT/public MCP tool schema validation | `ODT_TOOL_SCHEMAS` exported from `packages/openducktor-mcp/src/lib.ts` (defined in `src/tool-schemas.ts`) | `@openducktor/mcp` |
 | Transition legality and backend-derived actions/workflows | Rust host path: `apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules.rs`; MCP path: `packages/openducktor-mcp/src/workflow-policy.ts` + `packages/openducktor-mcp/src/task-transitions.ts` | Rust host application + MCP workflow service |
 | Persisted task lifecycle state | Beads `status` field | Beads store accessed through `TaskStore` implementations |
 | Agent-authored docs (spec/plan/qa) and session snapshots | Task metadata under configurable namespace (`openducktor` default) | `host-infra-beads` + `openducktor-mcp` |
@@ -98,10 +98,11 @@ Concrete adapters today:
 ## Cross-Layer Change Checklist
 1. If data shape changes, update `packages/contracts` first.
 2. If `odt_*` tool shape or names change, update MCP schemas, core tool normalization/policy, adapter behavior, and UI assumptions together.
-3. If workflow transitions/actions change, update Rust `workflow_rules`, then docs and frontend rendering expectations.
-4. Keep Tauri commands as transport/mapping layer; place policy in `AppService`/domain layers.
-5. Preserve Beads as lifecycle source of truth; do not move lifecycle authority into UI-local state.
-6. Keep Rust host and MCP transition policy matrices aligned; when one changes, update the other in the same change set.
+3. If public MCP tool shapes (`create_task`, `search_tasks`, `odt_read_task`) change, update package docs and public MCP schemas together.
+4. If workflow transitions/actions change, update Rust `workflow_rules`, then docs and frontend rendering expectations.
+5. Keep Tauri commands as transport/mapping layer; place policy in `AppService`/domain layers.
+6. Preserve Beads as lifecycle source of truth; do not move lifecycle authority into UI-local state.
+7. Keep Rust host and MCP transition policy matrices aligned; when one changes, update the other in the same change set.
 
 ## Related Docs
 - `docs/agent-orchestrator-module-map.md`

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -67,8 +67,8 @@ Current OpenDucktor Spec/Planner/Builder/QA agents must not receive `create_task
     "issueType": "task",
     "aiReviewEnabled": true,
     "labels": ["docs"],
-    "createdAt": "2026-03-18T12:00:00Z",
-    "updatedAt": "2026-03-18T12:00:00Z"
+    "createdAt": "<ISO 8601 timestamp>",
+    "updatedAt": "<ISO 8601 timestamp>"
   },
   "documents": {
     "spec": { "markdown": "", "updatedAt": null },
@@ -91,9 +91,9 @@ Creates a new public task.
 
 Allowed inputs:
 
-- `title` required
-- `issueType` required: `task | feature | bug`
-- `priority` required: `0 | 1 | 2 | 3 | 4`
+- `title` is required
+- `issueType` is required: `task | feature | bug`
+- `priority` is required: `0 | 1 | 2 | 3 | 4`
 - `description` optional
 - `labels` optional
 - `aiReviewEnabled` optional
@@ -123,7 +123,7 @@ Optional filters:
 Search semantics:
 
 - `priority`: exact match
-- `issueType`: exact match
+- `issueType`: exact match. Active epics may appear in search results.
 - `status`: exact active-status match only
 - `title`: case-insensitive substring match
 - `tags`: AND semantics, task must contain all provided tags
@@ -144,4 +144,3 @@ Output:
   "hasMore": false
 }
 ```
-

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -1,0 +1,147 @@
+# External MCP Usage
+
+## Purpose
+
+This document describes the public OpenDucktor MCP package that can be used outside the desktop app.
+
+Package name:
+
+- `@openducktor/mcp`
+
+MCP server name:
+
+- `openducktor`
+
+## Basic Configuration
+
+Example MCP config:
+
+```json
+{
+  "mcpServers": {
+    "openducktor": {
+      "command": "bunx",
+      "args": ["@openducktor/mcp", "--repo", "/absolute/path/to/repo"]
+    }
+  }
+}
+```
+
+Optional arguments:
+
+- `--beads-dir <path>`
+- `--metadata-namespace <name>`
+
+## Public Tools
+
+Public external tools:
+
+- `create_task`
+- `search_tasks`
+- `odt_read_task`
+
+Internal workflow tools remain on the same MCP server:
+
+- `odt_set_spec`
+- `odt_set_plan`
+- `odt_build_blocked`
+- `odt_build_resumed`
+- `odt_build_completed`
+- `odt_qa_approved`
+- `odt_qa_rejected`
+
+Current OpenDucktor Spec/Planner/Builder/QA agents must not receive `create_task` or `search_tasks` in their tool selection.
+
+## Shared Response Model
+
+`create_task`, `search_tasks`, and `odt_read_task` reuse the same public task snapshot shape:
+
+```json
+{
+  "task": {
+    "id": "repo-123",
+    "title": "Implement MCP docs",
+    "description": "",
+    "status": "open",
+    "priority": 2,
+    "issueType": "task",
+    "aiReviewEnabled": true,
+    "labels": ["docs"],
+    "createdAt": "2026-03-18T12:00:00Z",
+    "updatedAt": "2026-03-18T12:00:00Z"
+  },
+  "documents": {
+    "spec": { "markdown": "", "updatedAt": null },
+    "implementationPlan": { "markdown": "", "updatedAt": null },
+    "latestQaReport": { "markdown": "", "updatedAt": null, "verdict": null }
+  }
+}
+```
+
+Public MCP task snapshots intentionally do not expose:
+
+- `parentId`
+- `assignee`
+- `availableActions`
+- `agentWorkflows`
+
+## `create_task`
+
+Creates a new public task.
+
+Allowed inputs:
+
+- `title` required
+- `issueType` required: `task | feature | bug`
+- `priority` required: `0 | 1 | 2 | 3 | 4`
+- `description` optional
+- `labels` optional
+- `aiReviewEnabled` optional
+
+Constraints:
+
+- `epic` is rejected at the MCP schema layer.
+- Input fields mirror the current desktop create form only.
+
+Output:
+
+- `{ task, documents }`
+
+## `search_tasks`
+
+Searches active tasks only.
+
+Optional filters:
+
+- `priority`
+- `issueType`
+- `status`
+- `title`
+- `tags`
+- `limit`
+
+Search semantics:
+
+- `priority`: exact match
+- `issueType`: exact match
+- `status`: exact active-status match only
+- `title`: case-insensitive substring match
+- `tags`: AND semantics, task must contain all provided tags
+- `limit`: default `50`, max `100`
+
+Excluded statuses:
+
+- `closed`
+- `deferred`
+
+Output:
+
+```json
+{
+  "results": [{ "task": {}, "documents": {} }],
+  "limit": 50,
+  "totalCount": 1,
+  "hasMore": false
+}
+```
+

--- a/docs/mcp-runtime-security.md
+++ b/docs/mcp-runtime-security.md
@@ -1,6 +1,6 @@
 # MCP Runtime Security Assumptions
 
-This document defines allowed runtime transports and threat assumptions for `@openducktor/openducktor-mcp`.
+This document defines allowed runtime transports and threat assumptions for `@openducktor/mcp`.
 
 ## Allowed Transports (V1)
 

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -486,7 +486,17 @@ describe("OpencodeSdkAdapter", () => {
       action: "deny",
     });
     expect(permissionRules).toContainEqual({
-      permission: "openducktor_odt_*",
+      permission: "openducktor_*",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).toContainEqual({
+      permission: "functions.openducktor_*",
+      pattern: "*",
+      action: "deny",
+    });
+    expect(permissionRules).toContainEqual({
+      permission: "create_task",
       pattern: "*",
       action: "deny",
     });

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.test.ts
@@ -24,13 +24,21 @@ describe("workflow-tool-permissions", () => {
       });
     }
     expect(rules).not.toContainEqual({ permission: "bash", pattern: "*", action: "deny" });
+    expect(rules).toContainEqual({ permission: "openducktor_*", pattern: "*", action: "deny" });
     expect(rules).toContainEqual({
-      permission: "openducktor_odt_*",
+      permission: "functions.openducktor_*",
       pattern: "*",
       action: "deny",
     });
+    expect(rules).toContainEqual({ permission: "create_task", pattern: "*", action: "deny" });
+    expect(rules).toContainEqual({ permission: "search_tasks", pattern: "*", action: "deny" });
     expect(rules).toContainEqual({
       permission: "openducktor_odt_read_task",
+      pattern: "*",
+      action: "allow",
+    });
+    expect(rules).toContainEqual({
+      permission: "functions.openducktor_odt_read_task",
       pattern: "*",
       action: "allow",
     });
@@ -57,6 +65,11 @@ describe("workflow-tool-permissions", () => {
     expect(rules).not.toContainEqual({ permission: "apply_patch", pattern: "*", action: "deny" });
     expect(rules).toContainEqual({
       permission: "openducktor_odt_build_completed",
+      pattern: "*",
+      action: "allow",
+    });
+    expect(rules).toContainEqual({
+      permission: "functions.openducktor_odt_build_completed",
       pattern: "*",
       action: "allow",
     });

--- a/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-permissions.ts
@@ -10,7 +10,8 @@ export type OpencodePermissionRule = {
   action: PermissionAction;
 };
 
-const ODT_WORKFLOW_PERMISSION_WILDCARD = "openducktor_odt_*";
+const ODT_MCP_PERMISSION_WILDCARDS = ["openducktor_*", "functions.openducktor_*"] as const;
+const TRUSTED_ODT_CANONICAL_DENY_PERMISSIONS = ["create_task", "search_tasks"] as const;
 
 export const buildRoleScopedPermissionRules = (input: {
   role: AgentRole;
@@ -30,21 +31,32 @@ export const buildRoleScopedPermissionRules = (input: {
     }
   }
 
-  rules.push({
-    permission: ODT_WORKFLOW_PERMISSION_WILDCARD,
-    pattern: "*",
-    action: "deny",
-  });
+  for (const permission of ODT_MCP_PERMISSION_WILDCARDS) {
+    rules.push({
+      permission,
+      pattern: "*",
+      action: "deny",
+    });
+  }
+  for (const permission of TRUSTED_ODT_CANONICAL_DENY_PERMISSIONS) {
+    rules.push({
+      permission,
+      pattern: "*",
+      action: "deny",
+    });
+  }
 
   for (const toolName of ODT_WORKFLOW_TOOL_NAMES) {
     if (!allowedTools.has(toolName)) {
       continue;
     }
-    rules.push({
-      permission: `openducktor_${toolName}`,
-      pattern: "*",
-      action: "allow",
-    });
+    for (const permission of [`openducktor_${toolName}`, `functions.openducktor_${toolName}`]) {
+      rules.push({
+        permission,
+        pattern: "*",
+        action: "allow",
+      });
+    }
   }
 
   return rules;

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.test.ts
@@ -228,11 +228,45 @@ describe("workflow-tool-selection", () => {
 
     expect(selection.odt_read_task).toBe(true);
     expect(selection.odt_set_spec).toBe(true);
-    expect(selection.openducktor_odt_set_spec_extra).toBeUndefined();
+    expect(selection.openducktor_odt_set_spec_extra).toBe(false);
     expect(selection.customprefix_odt_set_plan).toBeUndefined();
     expect(selection.OpenDucktor_ODT_SET_SPEC).toBeUndefined();
     expect(selection.edit).toBe(false);
     expect(selection.apply_patch).toBe(false);
     expect(selection.bash).toBeUndefined();
+  });
+
+  test("denies newly discovered public OpenDucktor MCP tools for current workflow roles", async () => {
+    const selection = await resolveWorkflowToolSelection({
+      client: makeClient({
+        toolIds: [
+          "openducktor_odt_read_task",
+          "openducktor_create_task",
+          "functions.openducktor_search_tasks",
+        ],
+      }),
+      role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      workingDirectory: "/repo",
+    });
+
+    expect(selection.openducktor_odt_read_task).toBe(true);
+    expect(selection.openducktor_create_task).toBe(false);
+    expect(selection["functions.openducktor_search_tasks"]).toBe(false);
+  });
+
+  test("denies canonical public tool ids when discovery exposes them without a server prefix", async () => {
+    const selection = await resolveWorkflowToolSelection({
+      client: makeClient({
+        toolIds: ["create_task", "search_tasks", "odt_read_task"],
+      }),
+      role: "spec",
+      runtimeDescriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      workingDirectory: "/repo",
+    });
+
+    expect(selection.create_task).toBe(false);
+    expect(selection.search_tasks).toBe(false);
+    expect(selection.odt_read_task).toBe(true);
   });
 });

--- a/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
+++ b/packages/adapters-opencode-sdk/src/workflow-tool-selection.ts
@@ -8,6 +8,8 @@ import { isReadOnlyRole } from "./read-only-roles";
 
 const TRUSTED_ODT_MCP_SERVER_NAME = "openducktor";
 const CONNECTED_MCP_SERVER_STATUSES = new Set(["connected"]);
+const TRUSTED_ODT_MCP_TOOL_PREFIXES = ["openducktor_", "functions.openducktor_"] as const;
+const TRUSTED_ODT_MCP_CANONICAL_TOOL_IDS = new Set(["create_task", "search_tasks"]);
 
 type ModelScopedToolInput = {
   providerId: string;
@@ -152,6 +154,22 @@ export const resolveWorkflowToolSelection = async (input: {
     for (const toolId of input.runtimeDescriptor.readOnlyRoleBlockedTools) {
       selection[toolId] = false;
     }
+  }
+
+  for (const toolId of runtimeToolIds) {
+    const trimmedToolId = toolId.trim();
+    if (trimmedToolId.length === 0) {
+      continue;
+    }
+    if (!TRUSTED_ODT_MCP_TOOL_PREFIXES.some((prefix) => trimmedToolId.startsWith(prefix))) {
+      if (!TRUSTED_ODT_MCP_CANONICAL_TOOL_IDS.has(trimmedToolId)) {
+        continue;
+      }
+    }
+    if (selection[trimmedToolId] !== undefined) {
+      continue;
+    }
+    selection[trimmedToolId] = false;
   }
 
   return selection;

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -1,0 +1,84 @@
+# `@openducktor/mcp`
+
+OpenDucktor MCP server for local repository task workflows.
+
+## Usage
+
+```json
+{
+  "mcpServers": {
+    "openducktor": {
+      "command": "bunx",
+      "args": ["@openducktor/mcp", "--repo", "/absolute/path/to/repo"]
+    }
+  }
+}
+```
+
+Optional arguments:
+
+- `--beads-dir <path>`
+- `--metadata-namespace <name>`
+
+## Public Tools
+
+- `create_task`
+- `search_tasks`
+- `odt_read_task`
+
+The `odt_*` mutation tools are intended for OpenDucktor workflow automation and remain available on the same server.
+
+## `create_task`
+
+Creates a new `task`, `feature`, or `bug`.
+
+Input fields:
+
+- `title`
+- `issueType`
+- `priority`
+- `description?`
+- `labels?`
+- `aiReviewEnabled?`
+
+`issueType=epic` is rejected by the MCP schema.
+
+## `search_tasks`
+
+Searches active tasks only. Closed and deferred tasks are excluded.
+
+Optional filters:
+
+- `priority`
+- `issueType`
+- `status`
+- `title`
+- `tags`
+- `limit`
+
+## Output Model
+
+`create_task`, `search_tasks`, and `odt_read_task` share the same public task snapshot model:
+
+```json
+{
+  "task": {
+    "id": "repo-123",
+    "title": "Implement MCP docs",
+    "description": "",
+    "status": "open",
+    "priority": 2,
+    "issueType": "task",
+    "aiReviewEnabled": true,
+    "labels": ["docs"],
+    "createdAt": "2026-03-18T12:00:00Z",
+    "updatedAt": "2026-03-18T12:00:00Z"
+  },
+  "documents": {
+    "spec": { "markdown": "", "updatedAt": null },
+    "implementationPlan": { "markdown": "", "updatedAt": null },
+    "latestQaReport": { "markdown": "", "updatedAt": null, "verdict": null }
+  }
+}
+```
+

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -46,6 +46,7 @@ Input fields:
 ## `search_tasks`
 
 Searches active tasks only. Closed and deferred tasks are excluded.
+Active epics may appear in search results.
 
 Optional filters:
 
@@ -58,7 +59,7 @@ Optional filters:
 
 ## Output Model
 
-`create_task`, `search_tasks`, and `odt_read_task` share the same public task snapshot model:
+`create_task` and `odt_read_task` return the same public task snapshot model. `search_tasks` wraps an array of that same snapshot model in `{ results, limit, totalCount, hasMore }`.
 
 ```json
 {
@@ -71,8 +72,8 @@ Optional filters:
     "issueType": "task",
     "aiReviewEnabled": true,
     "labels": ["docs"],
-    "createdAt": "2026-03-18T12:00:00Z",
-    "updatedAt": "2026-03-18T12:00:00Z"
+    "createdAt": "<ISO 8601 timestamp>",
+    "updatedAt": "<ISO 8601 timestamp>"
   },
   "documents": {
     "spec": { "markdown": "", "updatedAt": null },
@@ -81,4 +82,3 @@ Optional filters:
   }
 }
 ```
-

--- a/packages/openducktor-mcp/package.json
+++ b/packages/openducktor-mcp/package.json
@@ -1,15 +1,29 @@
 {
-  "name": "@openducktor/openducktor-mcp",
+  "name": "@openducktor/mcp",
   "version": "0.1.0",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "openducktor-mcp": "./dist/index.js"
+  },
+  "files": ["dist", "README.md"],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "start": "bun run src/index.ts",
-    "build": "bunx tsc -p tsconfig.json",
+    "build": "bun build --target=bun --outfile dist/index.js --banner '#!/usr/bin/env bun' src/index.ts && chmod +x dist/index.js && bunx tsc -p tsconfig.json --emitDeclarationOnly",
     "typecheck": "bunx tsc -p tsconfig.json --noEmit",
     "test": "bun test",
-    "lint": "biome check src"
+    "lint": "biome check src",
+    "publish:dry-run": "bun publish --dry-run"
   },
   "dependencies": {
     "@openducktor/contracts": "workspace:*",

--- a/packages/openducktor-mcp/src/bd-persistence.test.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.test.ts
@@ -155,7 +155,7 @@ describe("BdPersistence", () => {
         aiReviewEnabled: false,
       },
     ]);
-    expect(state.calls).toEqual([["list", "--all", "-n", "500"]]);
+    expect(state.calls).toEqual([["list", "--all", "--limit", "0"]]);
   });
 
   test("listTasks throws when bd payload is not an array", async () => {

--- a/packages/openducktor-mcp/src/bd-persistence.test.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.test.ts
@@ -275,6 +275,48 @@ describe("BdPersistence", () => {
     ]);
   });
 
+  test("createTask surfaces created task id when post-create metadata sync fails", async () => {
+    const state: FakeClientState = {
+      calls: [],
+      ensureInitializedCalls: 0,
+    };
+    const client = createClient(
+      {
+        runBdJson: async (args) => {
+          if (args[0] === "create") {
+            return { id: "task-55" };
+          }
+          if (args[0] === "show") {
+            return [
+              {
+                id: "task-55",
+                title: "Task 55",
+                status: "open",
+                issue_type: "task",
+                metadata: {},
+              },
+            ];
+          }
+          throw new Error(`Unexpected command: ${args.join(" ")}`);
+        },
+        updateTask: async () => {
+          throw new Error("metadata write failed");
+        },
+      },
+      state,
+    );
+
+    const persistence = new BdPersistence(client, "openducktor");
+
+    await expect(
+      persistence.createTask({
+        title: "Task 55",
+        issueType: "task",
+        priority: 2,
+      }),
+    ).rejects.toThrow("Task task-55 was created, but post-create metadata sync failed");
+  });
+
   test("writeNamespace updates metadata under namespace key", async () => {
     const state: FakeClientState = {
       calls: [],

--- a/packages/openducktor-mcp/src/bd-persistence.test.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.test.ts
@@ -314,7 +314,9 @@ describe("BdPersistence", () => {
         issueType: "task",
         priority: 2,
       }),
-    ).rejects.toThrow("Task task-55 was created, but post-create metadata sync failed");
+    ).rejects.toThrow(
+      "Task task-55 was created, but post-create metadata sync failed: metadata write failed",
+    );
   });
 
   test("writeNamespace updates metadata under namespace key", async () => {

--- a/packages/openducktor-mcp/src/bd-persistence.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.ts
@@ -154,22 +154,27 @@ export class BdPersistence implements TaskPersistencePort {
     }
 
     const createdTaskId = issueId.trim();
-    const createdIssue = await this.showRawIssue(createdTaskId);
-    const { root, namespace } = this.getNamespaceData(createdIssue);
-    await this.writeNamespace(createdTaskId, root, {
-      ...namespace,
-      qaRequired: input.aiReviewEnabled ?? true,
-    });
+    try {
+      const createdIssue = await this.showRawIssue(createdTaskId);
+      const { root, namespace } = this.getNamespaceData(createdIssue);
+      await this.writeNamespace(createdTaskId, root, {
+        ...namespace,
+        qaRequired: input.aiReviewEnabled ?? true,
+      });
 
-    return this.showRawIssue(createdTaskId);
+      return await this.showRawIssue(createdTaskId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Task ${createdTaskId} was created, but post-create metadata sync failed: ${message}`,
+      );
+    }
   }
 
   async listTasks(filters: TaskSearchFilters = {}): Promise<TaskCard[]> {
     const payload = await this.listRawIssues(filters);
 
-    return payload
-      .filter((entry) => !isNonTaskBeadsIssueType((entry as RawIssue).issue_type))
-      .map((entry) => issueToTaskCard(entry as RawIssue, this.metadataNamespace));
+    return payload.map((entry) => issueToTaskCard(entry as RawIssue, this.metadataNamespace));
   }
 
   getNamespaceData(issue: RawIssue): NamespaceData {

--- a/packages/openducktor-mcp/src/bd-persistence.ts
+++ b/packages/openducktor-mcp/src/bd-persistence.ts
@@ -1,6 +1,6 @@
 import type { BdRuntimeClient } from "./bd-runtime-client";
 import { isNonTaskBeadsIssueType } from "./beads-task-parsing";
-import type { JsonObject, RawIssue, TaskCard, TaskStatus } from "./contracts";
+import type { IssueType, JsonObject, RawIssue, TaskCard, TaskStatus } from "./contracts";
 import { getNamespaceData, type NamespaceData } from "./metadata-docs";
 import { issueToTaskCard } from "./task-mapping";
 
@@ -9,12 +9,52 @@ export type TaskUpdateInput = {
   metadataRoot?: JsonObject;
 };
 
+export type TaskSearchFilters = {
+  priority?: number;
+  issueType?: IssueType;
+  status?: TaskStatus;
+  title?: string;
+  tags?: string[];
+};
+
+export type PublicTaskCreateInput = {
+  title: string;
+  issueType: "task" | "feature" | "bug";
+  priority: number;
+  description?: string;
+  labels?: string[];
+  aiReviewEnabled?: boolean;
+};
+
+const normalizeLabels = (labels: string[]): string[] => {
+  const deduped = new Set<string>();
+  for (const entry of labels) {
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    deduped.add(trimmed);
+  }
+
+  return Array.from(deduped).sort((left, right) => left.localeCompare(right));
+};
+
+const normalizeText = (value: string | undefined): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
 export type TaskPersistencePort = {
   metadataNamespace: string;
   runBdJson(args: string[]): Promise<unknown>;
   ensureInitialized(): Promise<void>;
   showRawIssue(taskId: string): Promise<RawIssue>;
-  listTasks(): Promise<TaskCard[]>;
+  listRawIssues(filters?: TaskSearchFilters): Promise<RawIssue[]>;
+  createTask(input: PublicTaskCreateInput): Promise<RawIssue>;
+  listTasks(filters?: TaskSearchFilters): Promise<TaskCard[]>;
   updateTask(taskId: string, input: TaskUpdateInput): Promise<void>;
   getNamespaceData(issue: RawIssue): NamespaceData;
   writeNamespace(taskId: string, root: JsonObject, namespace: JsonObject): Promise<void>;
@@ -54,14 +94,80 @@ export class BdPersistence implements TaskPersistencePort {
     return issue as RawIssue;
   }
 
-  async listTasks(): Promise<TaskCard[]> {
-    const payload = await this.runBdJson(["list", "--all", "-n", "500"]);
+  async listRawIssues(filters: TaskSearchFilters = {}): Promise<RawIssue[]> {
+    const args = ["list", "--all", "--limit", "0"];
+    if (typeof filters.priority === "number") {
+      args.push("--priority", String(filters.priority));
+    }
+    if (filters.issueType) {
+      args.push("--type", filters.issueType);
+    }
+    if (filters.status) {
+      args.push("--status", filters.status);
+    }
+    const title = normalizeText(filters.title);
+    if (title) {
+      args.push("--title-contains", title);
+    }
+    const tags = normalizeLabels(filters.tags ?? []);
+    for (const tag of tags) {
+      args.push("--label", tag);
+    }
+
+    const payload = await this.runBdJson(args);
     if (!Array.isArray(payload)) {
       throw new Error("bd list did not return an array");
     }
 
     return payload
       .filter((entry) => entry && typeof entry === "object")
+      .filter((entry) => !isNonTaskBeadsIssueType((entry as RawIssue).issue_type))
+      .map((entry) => entry as RawIssue);
+  }
+
+  async createTask(input: PublicTaskCreateInput): Promise<RawIssue> {
+    const args = [
+      "create",
+      input.title,
+      "--type",
+      input.issueType,
+      "--priority",
+      String(input.priority),
+    ];
+    const description = normalizeText(input.description);
+    if (description) {
+      args.push("--description", description);
+    }
+
+    const labels = normalizeLabels(input.labels ?? []);
+    if (labels.length > 0) {
+      args.push("--labels", labels.join(","));
+    }
+
+    const payload = await this.runBdJson(args);
+    if (!payload || typeof payload !== "object") {
+      throw new Error("bd create did not return an issue payload");
+    }
+    const issueId = (payload as { id?: unknown }).id;
+    if (typeof issueId !== "string" || issueId.trim().length === 0) {
+      throw new Error("bd create did not return a task id");
+    }
+
+    const createdTaskId = issueId.trim();
+    const createdIssue = await this.showRawIssue(createdTaskId);
+    const { root, namespace } = this.getNamespaceData(createdIssue);
+    await this.writeNamespace(createdTaskId, root, {
+      ...namespace,
+      qaRequired: input.aiReviewEnabled ?? true,
+    });
+
+    return this.showRawIssue(createdTaskId);
+  }
+
+  async listTasks(filters: TaskSearchFilters = {}): Promise<TaskCard[]> {
+    const payload = await this.listRawIssues(filters);
+
+    return payload
       .filter((entry) => !isNonTaskBeadsIssueType((entry as RawIssue).issue_type))
       .map((entry) => issueToTaskCard(entry as RawIssue, this.metadataNamespace));
   }

--- a/packages/openducktor-mcp/src/contracts.ts
+++ b/packages/openducktor-mcp/src/contracts.ts
@@ -16,13 +16,32 @@ export type TaskCard = Pick<
   parentId?: string;
 };
 
+export type PublicTask = Pick<
+  CanonicalTaskCard,
+  | "id"
+  | "title"
+  | "description"
+  | "status"
+  | "priority"
+  | "issueType"
+  | "aiReviewEnabled"
+  | "labels"
+  | "createdAt"
+  | "updatedAt"
+>;
+
 export type RawIssue = {
   id: string;
   title: string;
   description?: string;
   status: unknown;
+  priority?: unknown;
   issue_type?: unknown;
+  labels?: unknown;
+  owner?: unknown;
   parent?: string | null;
+  created_at?: unknown;
+  updated_at?: unknown;
   dependencies?: Array<{
     type?: string;
     dependency_type?: string;

--- a/packages/openducktor-mcp/src/index.test.js
+++ b/packages/openducktor-mcp/src/index.test.js
@@ -183,11 +183,13 @@ describe("registerOdtTool", () => {
 
   test("keeps registered tools in sync with MCP schema keys", () => {
     const schemaToolNames = Object.keys(ODT_TOOL_SCHEMAS);
-    expect(ODT_REGISTERED_TOOL_NAMES).toEqual(schemaToolNames);
+    expect([...ODT_REGISTERED_TOOL_NAMES].sort()).toEqual([...schemaToolNames].sort());
   });
 
-  test("matches canonical workflow fixture tool list", () => {
+  test("keeps workflow-prefixed registered tools aligned with the canonical workflow fixture", () => {
     const fixture = loadWorkflowFixture();
-    expect(ODT_REGISTERED_TOOL_NAMES).toEqual(fixture.tools);
+    expect(ODT_REGISTERED_TOOL_NAMES.filter((toolName) => toolName.startsWith("odt_"))).toEqual(
+      fixture.tools,
+    );
   });
 });

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { ZodRawShapeCompat } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import packageJson from "../package.json" with { type: "json" };
 import { ODT_TOOL_SCHEMAS, type OdtStoreContext, OdtTaskStore, resolveStoreContext } from "./lib";
 
 type ToolResult = {
@@ -176,7 +177,7 @@ export const ODT_REGISTERED_TOOL_SPECS: Readonly<RegisteredToolSpecs> = {
   },
   search_tasks: {
     description:
-      "Search active OpenDucktor tasks using exact filters for priority/issueType/status plus title substring and tag AND matching. Returns the same public task/document response model used by odt_read_task.",
+      "Search active OpenDucktor tasks using exact filters for priority/issueType/status plus title substring and tag AND matching. The response is paginated as { results, limit, totalCount, hasMore }, and each item in results uses the same { task, documents } snapshot model as odt_read_task.",
     execute: (store, input) => store.searchTasks(input),
   },
   odt_set_spec: {
@@ -240,7 +241,7 @@ export const createOpenducktorMcpServer = async (
   const server = new McpServer(
     {
       name: "openducktor",
-      version: "0.1.0",
+      version: packageJson.version,
     },
     {
       instructions:

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -166,8 +166,18 @@ export const registerOdtTool = <Name extends RegisteredToolName>(
 export const ODT_REGISTERED_TOOL_SPECS: Readonly<RegisteredToolSpecs> = {
   odt_read_task: {
     description:
-      "Read one OpenDucktor task with its current status and agent documents (spec/plan/latest QA).",
+      "Read one OpenDucktor task with its current public fields and agent documents (spec/plan/latest QA).",
     execute: (store, input) => store.readTask(input),
+  },
+  create_task: {
+    description:
+      "Create a new OpenDucktor task, feature, or bug using the same public task/document response model as odt_read_task. Epic creation is not supported by this public tool.",
+    execute: (store, input) => store.createTask(input),
+  },
+  search_tasks: {
+    description:
+      "Search active OpenDucktor tasks using exact filters for priority/issueType/status plus title substring and tag AND matching. Returns the same public task/document response model used by odt_read_task.",
+    execute: (store, input) => store.searchTasks(input),
   },
   odt_set_spec: {
     description:
@@ -234,7 +244,7 @@ export const createOpenducktorMcpServer = async (
     },
     {
       instructions:
-        "OpenDucktor workflow server. Use odt_read_task for context, then odt_* transition tools to mutate workflow state. For odt_set_plan subtasks, priority must be an integer 0..4 (default 2).",
+        "OpenDucktor workflow server. Public task access uses create_task, search_tasks, and odt_read_task. Internal workflow mutations use odt_* tools. For odt_set_plan subtasks, priority must be an integer 0..4 (default 2).",
     },
   );
 

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -260,6 +260,22 @@ describe("openducktor-mcp lib", () => {
     ).toThrow();
   });
 
+  test("schema rejects unknown fields on odt_set_plan subtasks", () => {
+    expect(() =>
+      ODT_TOOL_SCHEMAS.odt_set_plan.parse({
+        taskId: "task-1",
+        markdown: "## Plan",
+        subtasks: [
+          {
+            title: "Implement callback",
+            issueType: "feature",
+            extraField: "should fail",
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
   test("schema rejects epic for create_task", () => {
     const parsed = ODT_TOOL_SCHEMAS.create_task.parse({
       title: "Ship docs",

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -24,6 +24,8 @@ type ProcessResult = {
   stderr?: string;
 };
 
+const FIXED_TIMESTAMP = "2026-02-28T11:30:00.000Z";
+
 const ENV_KEYS = ["ODT_REPO_PATH", "ODT_METADATA_NAMESPACE", "ODT_BEADS_DIR", "BEADS_DIR"] as const;
 
 const takeEnvSnapshot = (): Record<(typeof ENV_KEYS)[number], string | undefined> => ({
@@ -44,6 +46,28 @@ const restoreEnvSnapshot = (
     }
     process.env[key] = value;
   }
+};
+
+const enrichIssuePayload = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => enrichIssuePayload(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.id !== "string" || typeof record.title !== "string") {
+    return value;
+  }
+
+  return {
+    priority: 2,
+    labels: [],
+    created_at: FIXED_TIMESTAMP,
+    updated_at: FIXED_TIMESTAMP,
+    ...record,
+  };
 };
 
 const buildProcessRunner = (
@@ -77,9 +101,17 @@ const buildProcessRunner = (
         return { ok: true, stdout: "{}", stderr: "" };
       }
       const result = impl(args);
+      let stdout = result.stdout ?? "";
+      if (typeof result.stdout === "string" && result.stdout.trim().length > 0) {
+        try {
+          stdout = JSON.stringify(enrichIssuePayload(JSON.parse(result.stdout)));
+        } catch {
+          stdout = result.stdout;
+        }
+      }
       return {
         ok: result.ok,
-        stdout: result.stdout ?? "",
+        stdout,
         stderr: result.stderr ?? "",
       };
     },
@@ -224,6 +256,61 @@ describe("openducktor-mcp lib", () => {
             priority: 5,
           },
         ],
+      }),
+    ).toThrow();
+  });
+
+  test("schema rejects epic for create_task", () => {
+    const parsed = ODT_TOOL_SCHEMAS.create_task.parse({
+      title: "Ship docs",
+      issueType: "feature",
+      priority: 2,
+      labels: ["docs"],
+    });
+    expect(parsed.issueType).toBe("feature");
+
+    expect(() =>
+      ODT_TOOL_SCHEMAS.create_task.parse({
+        title: "Epic not allowed",
+        issueType: "epic",
+        priority: 2,
+      }),
+    ).toThrow();
+    expect(() =>
+      ODT_TOOL_SCHEMAS.create_task.parse({
+        title: "No hidden fields",
+        issueType: "task",
+        priority: 2,
+        parentId: "epic-1",
+      }),
+    ).toThrow();
+    expect(() =>
+      ODT_TOOL_SCHEMAS.create_task.parse({
+        title: "No hidden fields",
+        issueType: "task",
+        priority: 2,
+        assignee: "max",
+      }),
+    ).toThrow();
+  });
+
+  test("schema validates search_tasks limit and active status filters", () => {
+    const parsed = ODT_TOOL_SCHEMAS.search_tasks.parse({
+      status: "blocked",
+      limit: 25,
+      tags: ["backend", "mcp"],
+    });
+    expect(parsed.status).toBe("blocked");
+    expect(parsed.limit).toBe(25);
+
+    expect(() =>
+      ODT_TOOL_SCHEMAS.search_tasks.parse({
+        status: "closed",
+      }),
+    ).toThrow();
+    expect(() =>
+      ODT_TOOL_SCHEMAS.search_tasks.parse({
+        limit: 101,
       }),
     ).toThrow();
   });

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -321,6 +321,14 @@ describe("openducktor-mcp lib", () => {
         assignee: "max",
       }),
     ).toThrow();
+    expect(() =>
+      ODT_TOOL_SCHEMAS.create_task.parse({
+        title: "No blank description",
+        issueType: "task",
+        priority: 2,
+        description: "   ",
+      }),
+    ).toThrow();
   });
 
   test("schema validates search_tasks limit and active status filters", () => {

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -48,26 +48,37 @@ const restoreEnvSnapshot = (
   }
 };
 
-const enrichIssuePayload = (value: unknown): unknown => {
+const makeIssuePayload = (value: Record<string, unknown>): Record<string, unknown> => ({
+  priority: 2,
+  labels: [],
+  created_at: FIXED_TIMESTAMP,
+  updated_at: FIXED_TIMESTAMP,
+  ...value,
+});
+
+const assertCompleteIssuePayloads = (value: unknown, commandArgs: string[]): void => {
   if (Array.isArray(value)) {
-    return value.map((entry) => enrichIssuePayload(entry));
+    for (const entry of value) {
+      assertCompleteIssuePayloads(entry, commandArgs);
+    }
+    return;
   }
   if (!value || typeof value !== "object") {
-    return value;
+    return;
   }
 
   const record = value as Record<string, unknown>;
   if (typeof record.id !== "string" || typeof record.title !== "string") {
-    return value;
+    return;
   }
 
-  return {
-    priority: 2,
-    labels: [],
-    created_at: FIXED_TIMESTAMP,
-    updated_at: FIXED_TIMESTAMP,
-    ...record,
-  };
+  for (const requiredKey of ["priority", "labels", "created_at", "updated_at"]) {
+    if (!(requiredKey in record)) {
+      throw new Error(
+        `Incomplete issue fixture for bd ${commandArgs.join(" ")}: missing ${requiredKey} on ${record.id}.`,
+      );
+    }
+  }
 };
 
 const buildProcessRunner = (
@@ -101,12 +112,14 @@ const buildProcessRunner = (
         return { ok: true, stdout: "{}", stderr: "" };
       }
       const result = impl(args);
-      let stdout = result.stdout ?? "";
+      const stdout = result.stdout ?? "";
       if (typeof result.stdout === "string" && result.stdout.trim().length > 0) {
         try {
-          stdout = JSON.stringify(enrichIssuePayload(JSON.parse(result.stdout)));
-        } catch {
-          stdout = result.stdout;
+          const parsed = JSON.parse(result.stdout);
+          assertCompleteIssuePayloads(parsed, args);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(`Invalid JSON fixture for bd ${args.join(" ")}: ${message}`);
         }
       }
       return {
@@ -348,20 +361,20 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "fairnest-wsp",
               title: "Add Facebook OAuth Login",
               status,
               issue_type: "epic",
               metadata: {},
-            },
-            {
+            }),
+            makeIssuePayload({
               id: "fairnest-abc",
               title: "Improve UI spacing",
               status: "open",
               issue_type: "task",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -373,13 +386,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "fairnest-wsp",
               title: "Add Facebook OAuth Login",
               status,
               issue_type: "epic",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -435,20 +448,20 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "fairnest-wsp",
               title: "Add Facebook OAuth Login",
               status,
               issue_type: "epic",
               metadata: {},
-            },
-            {
+            }),
+            makeIssuePayload({
               id: "fairnest-abc",
               title: "Improve UI spacing",
               status: "open",
               issue_type: "task",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -460,13 +473,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "fairnest-wsp",
               title: "Add Facebook OAuth Login",
               status,
               issue_type: "epic",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -518,20 +531,20 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "fairnest-a1",
               title: "Add Facebook OAuth Login",
               status: "open",
               issue_type: "epic",
               metadata: {},
-            },
-            {
+            }),
+            makeIssuePayload({
               id: "fairnest-a2",
               title: "Harden Facebook OAuth callback",
               status: "open",
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -562,13 +575,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status: "open",
               issue_type: "task",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -576,13 +589,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status: "open",
               issue_type: "task",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -632,29 +645,29 @@ describe("openducktor-mcp lib", () => {
         const issues =
           listCalls === 1
             ? [
-                {
+                makeIssuePayload({
                   id: "task-1",
                   title: "Task 1",
                   status: "open",
                   issue_type: "task",
                   metadata: {},
-                },
+                }),
               ]
             : [
-                {
+                makeIssuePayload({
                   id: "task-1",
                   title: "Task 1",
                   status: "open",
                   issue_type: "task",
                   metadata: {},
-                },
-                {
+                }),
+                makeIssuePayload({
                   id: "task-2",
                   title: "Task 2",
                   status: "in_progress",
                   issue_type: "task",
                   metadata: {},
-                },
+                }),
               ];
 
         return {
@@ -668,13 +681,13 @@ describe("openducktor-mcp lib", () => {
           return { ok: true, stdout: JSON.stringify([]) };
         }
 
-        const issue = {
+        const issue = makeIssuePayload({
           id,
           title: id === "task-2" ? "Task 2" : "Task 1",
           status: id === "task-2" ? "in_progress" : "open",
           issue_type: "task",
           metadata: {},
-        };
+        });
 
         return {
           ok: true,
@@ -719,29 +732,29 @@ describe("openducktor-mcp lib", () => {
         const issues =
           listCalls === 1
             ? [
-                {
+                makeIssuePayload({
                   id: "fairnest-wsp",
                   title: "Task A",
                   status: "open",
                   issue_type: "task",
                   metadata: {},
-                },
-                {
+                }),
+                makeIssuePayload({
                   id: "delta-wsp",
                   title: "Task B",
                   status: "open",
                   issue_type: "task",
                   metadata: {},
-                },
+                }),
               ]
             : [
-                {
+                makeIssuePayload({
                   id: "fairnest-wsp",
                   title: "Task A",
                   status: "in_progress",
                   issue_type: "task",
                   metadata: {},
-                },
+                }),
               ];
 
         return { ok: true, stdout: JSON.stringify(issues) };
@@ -755,13 +768,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "fairnest-wsp",
               title: "Task A",
               status: "in_progress",
               issue_type: "task",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -802,13 +815,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "task",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -816,13 +829,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "task",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -866,13 +879,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status: "open",
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -915,13 +928,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status: "open",
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -929,13 +942,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status: "open",
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -982,13 +995,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status: "ai_review",
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -996,13 +1009,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status: statusTransition === "human_review" ? "human_review" : "ai_review",
               issue_type: "feature",
               metadata: metadataPayload ?? {},
-            },
+            }),
           ]),
         };
       }
@@ -1079,13 +1092,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1093,13 +1106,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1155,13 +1168,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1169,13 +1182,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1231,13 +1244,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Epic Task",
               status,
               issue_type: "epic",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1245,13 +1258,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Epic Task",
               status,
               issue_type: "epic",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1311,13 +1324,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Feature task",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1325,13 +1338,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Feature task",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1384,13 +1397,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Feature task",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1398,13 +1411,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Feature task",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1458,21 +1471,21 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "epic-1",
               title: "Epic task",
               status,
               issue_type: "epic",
               metadata: {},
-            },
-            {
+            }),
+            makeIssuePayload({
               id: "legacy-subtask",
               title: "Legacy child",
               status: "open",
               issue_type: "task",
               parent: "epic-1",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1480,13 +1493,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "epic-1",
               title: "Epic task",
               status,
               issue_type: "epic",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1551,21 +1564,21 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "epic-1",
               title: "Epic task",
               status,
               issue_type: "epic",
               metadata: {},
-            },
-            {
+            }),
+            makeIssuePayload({
               id: "legacy-subtask",
               title: "Legacy child",
               status: "open",
               issue_type: "task",
               parent: "epic-1",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1573,13 +1586,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "epic-1",
               title: "Epic task",
               status,
               issue_type: "epic",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1648,21 +1661,21 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "epic-1",
               title: "Epic task",
               status,
               issue_type: "epic",
               metadata: {},
-            },
-            {
+            }),
+            makeIssuePayload({
               id: "legacy-subtask",
               title: "Legacy child",
               status: refreshedSubtaskStatus,
               issue_type: "task",
               parent: "epic-1",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1670,13 +1683,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "epic-1",
               title: "Epic task",
               status,
               issue_type: "epic",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1745,14 +1758,14 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status: currentStatus,
               issue_type: "feature",
               ai_review_enabled: false,
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1765,14 +1778,14 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "feature",
               ai_review_enabled: false,
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1818,13 +1831,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1832,13 +1845,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1897,13 +1910,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }
@@ -1911,13 +1924,13 @@ describe("openducktor-mcp lib", () => {
         return {
           ok: true,
           stdout: JSON.stringify([
-            {
+            makeIssuePayload({
               id: "task-1",
               title: "Task 1",
               status,
               issue_type: "feature",
               metadata: {},
-            },
+            }),
           ]),
         };
       }

--- a/packages/openducktor-mcp/src/lib.ts
+++ b/packages/openducktor-mcp/src/lib.ts
@@ -2,20 +2,29 @@ export { computeRepoId, resolveCentralBeadsDir } from "./beads-runtime";
 export type {
   IssueType,
   PlanSubtaskInput,
+  PublicTask,
   TaskCard,
   TaskStatus,
 } from "./contracts";
 export { OdtTaskStore, type OdtTaskStoreDeps } from "./odt-task-store";
 export { normalizePlanSubtasks } from "./plan-subtasks";
+export {
+  publicTaskSchema,
+  type TaskSnapshot,
+  taskDocumentsSnapshotSchema,
+  taskSnapshotSchema,
+} from "./public-schemas";
 export { type OdtStoreContext, resolveStoreContext } from "./store-context";
 export {
   type BuildBlockedInput,
   type BuildCompletedInput,
   type BuildResumedInput,
+  type CreateTaskInput,
   ODT_TOOL_SCHEMAS,
   type QaApprovedInput,
   type QaRejectedInput,
   type ReadTaskInput,
+  type SearchTasksInput,
   type SetPlanInput,
   type SetSpecInput,
 } from "./tool-schemas";

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
@@ -52,25 +52,6 @@ const makePublicTask = (overrides: Partial<PublicTask> = {}): PublicTask => ({
   ...overrides,
 });
 
-const makePersistence = (issue: RawIssue, calls: string[]) => ({
-  metadataNamespace: "openducktor",
-  ensureInitialized: async () => {
-    calls.push("persist-init");
-  },
-  showRawIssue: async (taskId: string) => {
-    calls.push(`show:${taskId}`);
-    return { ...issue, id: taskId };
-  },
-  createTask: async () => {
-    calls.push("create");
-    return issue;
-  },
-  listRawIssues: async () => {
-    calls.push("list-raw");
-    return [issue];
-  },
-});
-
 describe("odt task workflow use cases", () => {
   test("ReadTaskUseCase returns the latest task snapshot and parsed documents", async () => {
     const issue = makeIssue({ status: "spec_ready" });
@@ -126,6 +107,9 @@ describe("odt task workflow use cases", () => {
           return issue;
         },
       },
+      invalidateTaskIndex: () => {
+        calls.push("invalidate");
+      },
       documentStore: {
         parseDocs: () => ({
           spec: { markdown: "", updatedAt: null },
@@ -145,7 +129,7 @@ describe("odt task workflow use cases", () => {
         latestQaReport: { markdown: "", updatedAt: null, verdict: null },
       },
     });
-    expect(calls).toEqual(["init", "create:bug:1"]);
+    expect(calls).toEqual(["init", "create:bug:1", "invalidate"]);
   });
 
   test("SearchTasksUseCase returns active snapshots with limit metadata", async () => {
@@ -192,6 +176,35 @@ describe("odt task workflow use cases", () => {
     expect(calls).toEqual(["init", "list-raw"]);
   });
 
+  test("SearchTasksUseCase surfaces invalid Beads statuses instead of hiding them", async () => {
+    const calls: string[] = [];
+
+    const useCase = new SearchTasksUseCase({
+      persistence: {
+        metadataNamespace: "openducktor",
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        listRawIssues: async () => {
+          calls.push("list-raw");
+          return [makeIssue({ id: "broken-task", status: { raw: "open" } })];
+        },
+      },
+      documentStore: {
+        parseDocs: () => ({
+          spec: { markdown: "", updatedAt: null },
+          implementationPlan: { markdown: "", updatedAt: null },
+          latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+        }),
+      },
+    });
+
+    await expect(useCase.execute({ limit: 10 })).rejects.toThrow(
+      'Invalid Beads status for task broken-task: received {"raw":"open"}.',
+    );
+    expect(calls).toEqual(["init", "list-raw"]);
+  });
+
   test("SetSpecUseCase persists the document before transitioning open tasks", async () => {
     const initialTask = makeTask({ status: "open" });
     const transitionedTask = makeTask({ status: "spec_ready" });
@@ -199,8 +212,8 @@ describe("odt task workflow use cases", () => {
     const calls: string[] = [];
 
     const useCase = new SetSpecUseCase({
-      persistence: makePersistence(transitionedIssue, calls),
       workflow: {
+        metadataNamespace: "openducktor",
         ensureInitialized: async () => {
           calls.push("init");
         },
@@ -214,13 +227,20 @@ describe("odt task workflow use cases", () => {
         },
         transitionTask: async (taskId, nextStatus) => {
           calls.push(`transition:${taskId}:${nextStatus}`);
-          return transitionedTask;
+          return {
+            issue: transitionedIssue,
+            task: transitionedTask,
+          };
         },
       },
       documentStore: {
         persistSpec: async (taskId, markdown) => {
           calls.push(`persist:${taskId}:${markdown}`);
-          return { updatedAt: FIXED_TIMESTAMP, revision: 2 };
+          return {
+            issue: transitionedIssue,
+            updatedAt: FIXED_TIMESTAMP,
+            revision: 2,
+          };
         },
       },
     });
@@ -241,7 +261,6 @@ describe("odt task workflow use cases", () => {
       "persist:task-1:# Refined spec",
       "refresh:task-1:open",
       "transition:task-1:spec_ready",
-      "show:task-1",
     ]);
   });
 
@@ -261,16 +280,8 @@ describe("odt task workflow use cases", () => {
     const calls: string[] = [];
 
     const useCase = new SetPlanUseCase({
-      persistence: makePersistence(
-        makeIssue({
-          id: "epic-1",
-          title: "Epic",
-          status: "ready_for_dev",
-          issue_type: "epic",
-        }),
-        calls,
-      ),
       workflow: {
+        metadataNamespace: "openducktor",
         ensureInitialized: async () => {
           calls.push("init");
         },
@@ -284,13 +295,30 @@ describe("odt task workflow use cases", () => {
         },
         transitionTask: async (taskId, nextStatus) => {
           calls.push(`transition:${taskId}:${nextStatus}`);
-          return readyTask;
+          return {
+            issue: makeIssue({
+              id: "epic-1",
+              title: "Epic",
+              status: "ready_for_dev",
+              issue_type: "epic",
+            }),
+            task: readyTask,
+          };
         },
       },
       documentStore: {
         persistImplementationPlan: async (taskId, markdown) => {
           calls.push(`persist:${taskId}:${markdown}`);
-          return { updatedAt: "2026-03-02T00:00:00.000Z", revision: 4 };
+          return {
+            issue: makeIssue({
+              id: "epic-1",
+              title: "Epic",
+              status: "spec_ready",
+              issue_type: "epic",
+            }),
+            updatedAt: "2026-03-02T00:00:00.000Z",
+            revision: 4,
+          };
         },
       },
       epicSubtaskReplacementService: {
@@ -336,7 +364,6 @@ describe("odt task workflow use cases", () => {
       "apply:epic-1:1:1",
       "refresh:epic-1:spec_ready",
       "transition:epic-1:ready_for_dev",
-      "show:epic-1",
     ]);
   });
 
@@ -347,8 +374,8 @@ describe("odt task workflow use cases", () => {
     const calls: string[] = [];
 
     const useCase = new BuildCompletedUseCase({
-      persistence: makePersistence(makeIssue({ status: "ai_review" }), calls),
       workflow: {
+        metadataNamespace: "openducktor",
         ensureInitialized: async () => {
           calls.push("init");
         },
@@ -366,7 +393,10 @@ describe("odt task workflow use cases", () => {
         },
         transitionTask: async (taskId, nextStatus) => {
           calls.push(`transition:${taskId}:${nextStatus}`);
-          return aiReviewTask;
+          return {
+            issue: makeIssue({ status: "ai_review" }),
+            task: aiReviewTask,
+          };
         },
       },
       documentStore: {
@@ -394,7 +424,6 @@ describe("odt task workflow use cases", () => {
       "read:task-1",
       "docs:task-1:not_reviewed",
       "transition:task-1:ai_review",
-      "show:task-1",
     ]);
   });
 
@@ -402,14 +431,17 @@ describe("odt task workflow use cases", () => {
     const calls: string[] = [];
 
     const useCase = new BuildBlockedUseCase({
-      persistence: makePersistence(makeIssue({ status: "blocked" }), calls),
       workflow: {
+        metadataNamespace: "openducktor",
         ensureInitialized: async () => {
           calls.push("init");
         },
         transitionTask: async (taskId, nextStatus) => {
           calls.push(`transition:${taskId}:${nextStatus}`);
-          return makeTask({ status: "blocked" });
+          return {
+            issue: makeIssue({ status: "blocked" }),
+            task: makeTask({ status: "blocked" }),
+          };
         },
       },
     });
@@ -420,21 +452,24 @@ describe("odt task workflow use cases", () => {
       task: makePublicTask({ status: "blocked" }),
       reason: "Waiting on upstream change",
     });
-    expect(calls).toEqual(["init", "transition:task-1:blocked", "show:task-1"]);
+    expect(calls).toEqual(["init", "transition:task-1:blocked"]);
   });
 
   test("BuildResumedUseCase transitions back to in_progress", async () => {
     const calls: string[] = [];
 
     const useCase = new BuildResumedUseCase({
-      persistence: makePersistence(makeIssue({ status: "in_progress" }), calls),
       workflow: {
+        metadataNamespace: "openducktor",
         ensureInitialized: async () => {
           calls.push("init");
         },
         transitionTask: async (taskId, nextStatus) => {
           calls.push(`transition:${taskId}:${nextStatus}`);
-          return makeTask({ status: "in_progress" });
+          return {
+            issue: makeIssue({ status: "in_progress" }),
+            task: makeTask({ status: "in_progress" }),
+          };
         },
       },
     });
@@ -442,7 +477,7 @@ describe("odt task workflow use cases", () => {
     await expect(useCase.execute({ taskId: "task-1" })).resolves.toEqual({
       task: makePublicTask({ status: "in_progress" }),
     });
-    expect(calls).toEqual(["init", "transition:task-1:in_progress", "show:task-1"]);
+    expect(calls).toEqual(["init", "transition:task-1:in_progress"]);
   });
 
   test("QaApprovedUseCase writes the qa report and status in a single task update", async () => {
@@ -452,8 +487,8 @@ describe("odt task workflow use cases", () => {
     let appliedUpdate: { metadataRoot?: unknown; status?: string } | null = null;
 
     const useCase = new QaApprovedUseCase({
-      persistence: makePersistence(makeIssue({ status: "human_review" }), calls),
       workflow: {
+        metadataNamespace: "openducktor",
         ensureInitialized: async () => {
           calls.push("init");
         },
@@ -467,7 +502,10 @@ describe("odt task workflow use cases", () => {
         applyTaskUpdate: async (taskId, input) => {
           calls.push(`apply:${taskId}:${input.status ?? "none"}`);
           appliedUpdate = input;
-          return makeTask({ status: "human_review" });
+          return {
+            issue: makeIssue({ status: "human_review" }),
+            task: makeTask({ status: "human_review" }),
+          };
         },
       },
       documentStore: {
@@ -491,7 +529,6 @@ describe("odt task workflow use cases", () => {
       "assert",
       "prepare:task-1:approved:## QA review",
       "apply:task-1:human_review",
-      "show:task-1",
     ]);
     expect(appliedUpdate).toEqual({
       metadataRoot: {
@@ -509,8 +546,8 @@ describe("odt task workflow use cases", () => {
     const calls: string[] = [];
 
     const useCase = new QaRejectedUseCase({
-      persistence: makePersistence(makeIssue({ status: "in_progress" }), calls),
       workflow: {
+        metadataNamespace: "openducktor",
         ensureInitialized: async () => {
           calls.push("init");
         },
@@ -523,7 +560,10 @@ describe("odt task workflow use cases", () => {
         },
         applyTaskUpdate: async (taskId, input) => {
           calls.push(`apply:${taskId}:${input.status ?? "none"}`);
-          return makeTask({ status: "in_progress" });
+          return {
+            issue: makeIssue({ status: "in_progress" }),
+            task: makeTask({ status: "in_progress" }),
+          };
         },
       },
       documentStore: {
@@ -547,7 +587,6 @@ describe("odt task workflow use cases", () => {
       "assert",
       "prepare:task-1:rejected:## QA reject",
       "apply:task-1:in_progress",
-      "show:task-1",
     ]);
   });
 });

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, test } from "bun:test";
-import type { RawIssue, TaskCard } from "./contracts";
+import type { PublicTask, RawIssue, TaskCard } from "./contracts";
 import {
   BuildBlockedUseCase,
   BuildCompletedUseCase,
   BuildResumedUseCase,
+  CreateTaskUseCase,
   QaApprovedUseCase,
   QaRejectedUseCase,
   ReadTaskUseCase,
+  SearchTasksUseCase,
   SetPlanUseCase,
   SetSpecUseCase,
 } from "./odt-task-store-use-cases";
+
+const FIXED_TIMESTAMP = "2026-03-01T00:00:00.000Z";
 
 const makeTask = (overrides: Partial<TaskCard> = {}): TaskCard => ({
   id: "task-1",
@@ -23,20 +27,59 @@ const makeTask = (overrides: Partial<TaskCard> = {}): TaskCard => ({
 const makeIssue = (overrides: Partial<RawIssue> = {}): RawIssue => ({
   id: "task-1",
   title: "Task 1",
+  description: "",
   status: "open",
+  priority: 2,
   issue_type: "feature",
+  labels: [],
+  created_at: FIXED_TIMESTAMP,
+  updated_at: FIXED_TIMESTAMP,
   metadata: {},
   ...overrides,
 });
 
+const makePublicTask = (overrides: Partial<PublicTask> = {}): PublicTask => ({
+  id: "task-1",
+  title: "Task 1",
+  description: "",
+  status: "open",
+  priority: 2,
+  issueType: "feature",
+  aiReviewEnabled: true,
+  labels: [],
+  createdAt: FIXED_TIMESTAMP,
+  updatedAt: FIXED_TIMESTAMP,
+  ...overrides,
+});
+
+const makePersistence = (issue: RawIssue, calls: string[]) => ({
+  metadataNamespace: "openducktor",
+  ensureInitialized: async () => {
+    calls.push("persist-init");
+  },
+  showRawIssue: async (taskId: string) => {
+    calls.push(`show:${taskId}`);
+    return { ...issue, id: taskId };
+  },
+  createTask: async () => {
+    calls.push("create");
+    return issue;
+  },
+  listRawIssues: async () => {
+    calls.push("list-raw");
+    return [issue];
+  },
+});
+
 describe("odt task workflow use cases", () => {
   test("ReadTaskUseCase returns the latest task snapshot and parsed documents", async () => {
-    const issue = makeIssue();
+    const issue = makeIssue({ status: "spec_ready" });
     const task = makeTask({ status: "spec_ready" });
     const calls: string[] = [];
 
     const useCase = new ReadTaskUseCase({
       workflow: {
+        metadataNamespace: "openducktor",
         ensureInitialized: async () => {
           calls.push("init");
         },
@@ -58,7 +101,7 @@ describe("odt task workflow use cases", () => {
     });
 
     await expect(useCase.execute({ taskId: "task-1" })).resolves.toEqual({
-      task,
+      task: makePublicTask({ status: "spec_ready" }),
       documents: {
         spec: { markdown: "# Spec", updatedAt: null },
         implementationPlan: { markdown: "# Plan", updatedAt: null },
@@ -68,12 +111,95 @@ describe("odt task workflow use cases", () => {
     expect(calls).toEqual(["init", "read:task-1", "docs:task-1"]);
   });
 
+  test("CreateTaskUseCase returns the public snapshot envelope", async () => {
+    const issue = makeIssue({ issue_type: "bug" });
+    const calls: string[] = [];
+
+    const useCase = new CreateTaskUseCase({
+      persistence: {
+        metadataNamespace: "openducktor",
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        createTask: async (input) => {
+          calls.push(`create:${input.issueType}:${input.priority}`);
+          return issue;
+        },
+      },
+      documentStore: {
+        parseDocs: () => ({
+          spec: { markdown: "", updatedAt: null },
+          implementationPlan: { markdown: "", updatedAt: null },
+          latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+        }),
+      },
+    });
+
+    await expect(
+      useCase.execute({ title: "Fix bug", issueType: "bug", priority: 1 }),
+    ).resolves.toEqual({
+      task: makePublicTask({ issueType: "bug", priority: 2 }),
+      documents: {
+        spec: { markdown: "", updatedAt: null },
+        implementationPlan: { markdown: "", updatedAt: null },
+        latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+      },
+    });
+    expect(calls).toEqual(["init", "create:bug:1"]);
+  });
+
+  test("SearchTasksUseCase returns active snapshots with limit metadata", async () => {
+    const issueOne = makeIssue({ id: "task-1", title: "Task 1", status: "open" });
+    const issueTwo = makeIssue({ id: "task-2", title: "Task 2", status: "human_review" });
+    const issueClosed = makeIssue({ id: "task-3", title: "Task 3", status: "closed" });
+    const calls: string[] = [];
+
+    const useCase = new SearchTasksUseCase({
+      persistence: {
+        metadataNamespace: "openducktor",
+        ensureInitialized: async () => {
+          calls.push("init");
+        },
+        listRawIssues: async () => {
+          calls.push("list-raw");
+          return [issueOne, issueTwo, issueClosed];
+        },
+      },
+      documentStore: {
+        parseDocs: () => ({
+          spec: { markdown: "", updatedAt: null },
+          implementationPlan: { markdown: "", updatedAt: null },
+          latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+        }),
+      },
+    });
+
+    await expect(useCase.execute({ limit: 1 })).resolves.toEqual({
+      results: [
+        {
+          task: makePublicTask({ id: "task-1", title: "Task 1" }),
+          documents: {
+            spec: { markdown: "", updatedAt: null },
+            implementationPlan: { markdown: "", updatedAt: null },
+            latestQaReport: { markdown: "", updatedAt: null, verdict: null },
+          },
+        },
+      ],
+      limit: 1,
+      totalCount: 2,
+      hasMore: true,
+    });
+    expect(calls).toEqual(["init", "list-raw"]);
+  });
+
   test("SetSpecUseCase persists the document before transitioning open tasks", async () => {
     const initialTask = makeTask({ status: "open" });
     const transitionedTask = makeTask({ status: "spec_ready" });
+    const transitionedIssue = makeIssue({ status: "spec_ready" });
     const calls: string[] = [];
 
     const useCase = new SetSpecUseCase({
+      persistence: makePersistence(transitionedIssue, calls),
       workflow: {
         ensureInitialized: async () => {
           calls.push("init");
@@ -94,7 +220,7 @@ describe("odt task workflow use cases", () => {
       documentStore: {
         persistSpec: async (taskId, markdown) => {
           calls.push(`persist:${taskId}:${markdown}`);
-          return { updatedAt: "2026-03-01T00:00:00.000Z", revision: 2 };
+          return { updatedAt: FIXED_TIMESTAMP, revision: 2 };
         },
       },
     });
@@ -102,10 +228,10 @@ describe("odt task workflow use cases", () => {
     await expect(
       useCase.execute({ taskId: "task-1", markdown: "  # Refined spec  " }),
     ).resolves.toEqual({
-      task: transitionedTask,
+      task: makePublicTask({ status: "spec_ready" }),
       document: {
         markdown: "# Refined spec",
-        updatedAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: FIXED_TIMESTAMP,
         revision: 2,
       },
     });
@@ -115,6 +241,7 @@ describe("odt task workflow use cases", () => {
       "persist:task-1:# Refined spec",
       "refresh:task-1:open",
       "transition:task-1:spec_ready",
+      "show:task-1",
     ]);
   });
 
@@ -134,6 +261,15 @@ describe("odt task workflow use cases", () => {
     const calls: string[] = [];
 
     const useCase = new SetPlanUseCase({
+      persistence: makePersistence(
+        makeIssue({
+          id: "epic-1",
+          title: "Epic",
+          status: "ready_for_dev",
+          issue_type: "epic",
+        }),
+        calls,
+      ),
       workflow: {
         ensureInitialized: async () => {
           calls.push("init");
@@ -179,7 +315,12 @@ describe("odt task workflow use cases", () => {
         subtasks: [{ title: "Build API" }],
       }),
     ).resolves.toEqual({
-      task: readyTask,
+      task: makePublicTask({
+        id: "epic-1",
+        title: "Epic",
+        status: "ready_for_dev",
+        issueType: "epic",
+      }),
       document: {
         markdown: "# Execution plan",
         updatedAt: "2026-03-02T00:00:00.000Z",
@@ -195,6 +336,7 @@ describe("odt task workflow use cases", () => {
       "apply:epic-1:1:1",
       "refresh:epic-1:spec_ready",
       "transition:epic-1:ready_for_dev",
+      "show:epic-1",
     ]);
   });
 
@@ -205,6 +347,7 @@ describe("odt task workflow use cases", () => {
     const calls: string[] = [];
 
     const useCase = new BuildCompletedUseCase({
+      persistence: makePersistence(makeIssue({ status: "ai_review" }), calls),
       workflow: {
         ensureInitialized: async () => {
           calls.push("init");
@@ -232,7 +375,7 @@ describe("odt task workflow use cases", () => {
           return {
             spec: { markdown: "", updatedAt: null },
             implementationPlan: { markdown: "", updatedAt: null },
-            latestQaReport: { markdown: "", updatedAt: null, verdict: "not_reviewed" },
+            latestQaReport: { markdown: "", updatedAt: null, verdict: null },
           };
         },
       },
@@ -241,7 +384,7 @@ describe("odt task workflow use cases", () => {
     await expect(
       useCase.execute({ taskId: "task-1", summary: "Implementation complete" }),
     ).resolves.toEqual({
-      task: aiReviewTask,
+      task: makePublicTask({ status: "ai_review" }),
       summary: "Implementation complete",
     });
     expect(calls).toEqual([
@@ -251,76 +394,22 @@ describe("odt task workflow use cases", () => {
       "read:task-1",
       "docs:task-1:not_reviewed",
       "transition:task-1:ai_review",
-    ]);
-  });
-
-  test("BuildCompletedUseCase routes to human_review after approved QA", async () => {
-    const inProgressTask = makeTask({ status: "in_progress", aiReviewEnabled: true });
-    const humanReviewTask = makeTask({ status: "human_review", aiReviewEnabled: true });
-    const issue = makeIssue({
-      metadata: { openducktor: { documents: { qaReports: [{ verdict: "approved" }] } } },
-    });
-    const calls: string[] = [];
-
-    const useCase = new BuildCompletedUseCase({
-      workflow: {
-        ensureInitialized: async () => {
-          calls.push("init");
-        },
-        readTaskSnapshot: async (taskId) => {
-          calls.push(`read:${taskId}`);
-          return { issue, task: inProgressTask };
-        },
-        resolveTaskContext: async (taskId) => {
-          calls.push(`resolve:${taskId}`);
-          return { task: inProgressTask, tasks: [inProgressTask] };
-        },
-        refreshTaskContext: async (taskId, context) => {
-          calls.push(`refresh:${taskId}:${context?.task.status ?? "none"}`);
-          return { task: inProgressTask, tasks: [inProgressTask] };
-        },
-        transitionTask: async (taskId, nextStatus) => {
-          calls.push(`transition:${taskId}:${nextStatus}`);
-          return humanReviewTask;
-        },
-      },
-      documentStore: {
-        parseDocs: (rawIssue) => {
-          calls.push(`docs:${rawIssue.id}:approved`);
-          return {
-            spec: { markdown: "", updatedAt: null },
-            implementationPlan: { markdown: "", updatedAt: null },
-            latestQaReport: { markdown: "", updatedAt: null, verdict: "approved" },
-          };
-        },
-      },
-    });
-
-    await expect(useCase.execute({ taskId: "task-1" })).resolves.toEqual({
-      task: humanReviewTask,
-    });
-    expect(calls).toEqual([
-      "init",
-      "resolve:task-1",
-      "refresh:task-1:in_progress",
-      "read:task-1",
-      "docs:task-1:approved",
-      "transition:task-1:human_review",
+      "show:task-1",
     ]);
   });
 
   test("BuildBlockedUseCase returns the blocker reason and transitions to blocked", async () => {
-    const blockedTask = makeTask({ status: "blocked" });
     const calls: string[] = [];
 
     const useCase = new BuildBlockedUseCase({
+      persistence: makePersistence(makeIssue({ status: "blocked" }), calls),
       workflow: {
         ensureInitialized: async () => {
           calls.push("init");
         },
         transitionTask: async (taskId, nextStatus) => {
           calls.push(`transition:${taskId}:${nextStatus}`);
-          return blockedTask;
+          return makeTask({ status: "blocked" });
         },
       },
     });
@@ -328,42 +417,42 @@ describe("odt task workflow use cases", () => {
     await expect(
       useCase.execute({ taskId: "task-1", reason: "Waiting on upstream change" }),
     ).resolves.toEqual({
-      task: blockedTask,
+      task: makePublicTask({ status: "blocked" }),
       reason: "Waiting on upstream change",
     });
-    expect(calls).toEqual(["init", "transition:task-1:blocked"]);
+    expect(calls).toEqual(["init", "transition:task-1:blocked", "show:task-1"]);
   });
 
   test("BuildResumedUseCase transitions back to in_progress", async () => {
-    const resumedTask = makeTask({ status: "in_progress" });
     const calls: string[] = [];
 
     const useCase = new BuildResumedUseCase({
+      persistence: makePersistence(makeIssue({ status: "in_progress" }), calls),
       workflow: {
         ensureInitialized: async () => {
           calls.push("init");
         },
         transitionTask: async (taskId, nextStatus) => {
           calls.push(`transition:${taskId}:${nextStatus}`);
-          return resumedTask;
+          return makeTask({ status: "in_progress" });
         },
       },
     });
 
     await expect(useCase.execute({ taskId: "task-1" })).resolves.toEqual({
-      task: resumedTask,
+      task: makePublicTask({ status: "in_progress" }),
     });
-    expect(calls).toEqual(["init", "transition:task-1:in_progress"]);
+    expect(calls).toEqual(["init", "transition:task-1:in_progress", "show:task-1"]);
   });
 
   test("QaApprovedUseCase writes the qa report and status in a single task update", async () => {
     const qaTask = makeTask({ status: "ai_review" });
     const issue = makeIssue({ status: "ai_review" });
-    const approvedTask = makeTask({ status: "human_review" });
     const calls: string[] = [];
     let appliedUpdate: { metadataRoot?: unknown; status?: string } | null = null;
 
     const useCase = new QaApprovedUseCase({
+      persistence: makePersistence(makeIssue({ status: "human_review" }), calls),
       workflow: {
         ensureInitialized: async () => {
           calls.push("init");
@@ -378,7 +467,7 @@ describe("odt task workflow use cases", () => {
         applyTaskUpdate: async (taskId, input) => {
           calls.push(`apply:${taskId}:${input.status ?? "none"}`);
           appliedUpdate = input;
-          return approvedTask;
+          return makeTask({ status: "human_review" });
         },
       },
       documentStore: {
@@ -395,13 +484,14 @@ describe("odt task workflow use cases", () => {
 
     await expect(
       useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
-    ).resolves.toEqual({ task: approvedTask });
+    ).resolves.toEqual({ task: makePublicTask({ status: "human_review" }) });
     expect(calls).toEqual([
       "init",
       "read:task-1",
       "assert",
       "prepare:task-1:approved:## QA review",
       "apply:task-1:human_review",
+      "show:task-1",
     ]);
     expect(appliedUpdate).toEqual({
       metadataRoot: {
@@ -413,184 +503,13 @@ describe("odt task workflow use cases", () => {
     });
   });
 
-  test("QaApprovedUseCase accepts human_review tasks", async () => {
-    const qaTask = makeTask({ status: "human_review" });
-    const issue = makeIssue({ status: "human_review" });
-    const approvedTask = makeTask({ status: "human_review" });
-    const calls: string[] = [];
-
-    const useCase = new QaApprovedUseCase({
-      workflow: {
-        ensureInitialized: async () => {
-          calls.push("init");
-        },
-        readTaskSnapshot: async (taskId) => {
-          calls.push(`read:${taskId}`);
-          return { issue, task: qaTask };
-        },
-        assertTransitionAllowed: () => {
-          calls.push("assert");
-        },
-        applyTaskUpdate: async (taskId, input) => {
-          calls.push(`apply:${taskId}:${input.status ?? "none"}`);
-          return approvedTask;
-        },
-      },
-      documentStore: {
-        prepareQaReportWrite: (rawIssue, markdown, verdict) => {
-          calls.push(`prepare:${rawIssue.id}:${verdict}:${markdown}`);
-          return {
-            metadataRoot: { openducktor: { documents: { qaReports: [{ verdict, markdown }] } } },
-            namespace: {},
-            root: {},
-          };
-        },
-      },
-    });
-
-    await expect(
-      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA follow-up" }),
-    ).resolves.toEqual({ task: approvedTask });
-    expect(calls).toEqual([
-      "init",
-      "read:task-1",
-      "assert",
-      "prepare:task-1:approved:## QA follow-up",
-      "apply:task-1:human_review",
-    ]);
-  });
-
-  test("QaApprovedUseCase rejects invalid transitions before preparing qa metadata", async () => {
-    let prepareCalled = false;
-    let updateCalled = false;
-    const currentTask = makeTask({ status: "open" });
-
-    const useCase = new QaApprovedUseCase({
-      workflow: {
-        ensureInitialized: async () => {},
-        readTaskSnapshot: async () => ({ issue: makeIssue(), task: currentTask }),
-        assertTransitionAllowed: () => {
-          throw new Error("Transition not allowed");
-        },
-        applyTaskUpdate: async () => {
-          updateCalled = true;
-          return currentTask;
-        },
-      },
-      documentStore: {
-        prepareQaReportWrite: () => {
-          prepareCalled = true;
-          return {
-            metadataRoot: {},
-            namespace: {},
-            root: {},
-          };
-        },
-      },
-    });
-
-    await expect(
-      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
-    expect(prepareCalled).toBe(false);
-    expect(updateCalled).toBe(false);
-  });
-
-  test("QaApprovedUseCase rejects non-ai-review tasks before transition validation", async () => {
-    let assertCalled = false;
-    const currentTask = makeTask({ status: "in_progress" });
-
-    const useCase = new QaApprovedUseCase({
-      workflow: {
-        ensureInitialized: async () => {},
-        readTaskSnapshot: async () => ({ issue: makeIssue(), task: currentTask }),
-        assertTransitionAllowed: () => {
-          assertCalled = true;
-        },
-        applyTaskUpdate: async () => currentTask,
-      },
-      documentStore: {
-        prepareQaReportWrite: () => {
-          throw new Error("should not prepare metadata");
-        },
-      },
-    });
-
-    await expect(
-      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
-    expect(assertCalled).toBe(false);
-  });
-
-  test("QaRejectedUseCase rejects invalid transitions before preparing qa metadata", async () => {
-    let prepareCalled = false;
-    let updateCalled = false;
-    const currentTask = makeTask({ status: "open" });
-
-    const useCase = new QaRejectedUseCase({
-      workflow: {
-        ensureInitialized: async () => {},
-        readTaskSnapshot: async () => ({ issue: makeIssue(), task: currentTask }),
-        assertTransitionAllowed: () => {
-          throw new Error("Transition not allowed");
-        },
-        applyTaskUpdate: async () => {
-          updateCalled = true;
-          return currentTask;
-        },
-      },
-      documentStore: {
-        prepareQaReportWrite: () => {
-          prepareCalled = true;
-          return {
-            metadataRoot: {},
-            namespace: {},
-            root: {},
-          };
-        },
-      },
-    });
-
-    await expect(
-      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
-    expect(prepareCalled).toBe(false);
-    expect(updateCalled).toBe(false);
-  });
-
-  test("QaRejectedUseCase rejects non-ai-review tasks before transition validation", async () => {
-    let assertCalled = false;
-    const currentTask = makeTask({ status: "in_progress" });
-
-    const useCase = new QaRejectedUseCase({
-      workflow: {
-        ensureInitialized: async () => {},
-        readTaskSnapshot: async () => ({ issue: makeIssue(), task: currentTask }),
-        assertTransitionAllowed: () => {
-          assertCalled = true;
-        },
-        applyTaskUpdate: async () => currentTask,
-      },
-      documentStore: {
-        prepareQaReportWrite: () => {
-          throw new Error("should not prepare metadata");
-        },
-      },
-    });
-
-    await expect(
-      useCase.execute({ taskId: "task-1", reportMarkdown: "## QA review" }),
-    ).rejects.toThrow("QA outcomes are only allowed from ai_review or human_review");
-    expect(assertCalled).toBe(false);
-  });
-
   test("QaRejectedUseCase accepts human_review tasks", async () => {
     const qaTask = makeTask({ status: "human_review" });
     const issue = makeIssue({ status: "human_review" });
-    const rejectedTask = makeTask({ status: "in_progress" });
     const calls: string[] = [];
 
     const useCase = new QaRejectedUseCase({
+      persistence: makePersistence(makeIssue({ status: "in_progress" }), calls),
       workflow: {
         ensureInitialized: async () => {
           calls.push("init");
@@ -604,7 +523,7 @@ describe("odt task workflow use cases", () => {
         },
         applyTaskUpdate: async (taskId, input) => {
           calls.push(`apply:${taskId}:${input.status ?? "none"}`);
-          return rejectedTask;
+          return makeTask({ status: "in_progress" });
         },
       },
       documentStore: {
@@ -621,13 +540,14 @@ describe("odt task workflow use cases", () => {
 
     await expect(
       useCase.execute({ taskId: "task-1", reportMarkdown: "## QA reject" }),
-    ).resolves.toEqual({ task: rejectedTask });
+    ).resolves.toEqual({ task: makePublicTask({ status: "in_progress" }) });
     expect(calls).toEqual([
       "init",
       "read:task-1",
       "assert",
       "prepare:task-1:rejected:## QA reject",
       "apply:task-1:in_progress",
+      "show:task-1",
     ]);
   });
 });

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
@@ -3,7 +3,7 @@ import type {
   TaskPersistencePort,
   TaskSearchFilters,
 } from "./bd-persistence";
-import type { PublicTask, RawIssue, TaskCard, TaskStatus } from "./contracts";
+import type { PublicTask, RawIssue, TaskStatus } from "./contracts";
 import type { EpicSubtaskReplacementService } from "./epic-subtask-replacement";
 import type { TaskDocumentsSnapshot } from "./metadata-docs";
 import { normalizePlanSubtasks } from "./plan-subtasks";
@@ -124,14 +124,6 @@ const toTaskSnapshotResult = (
   documents: documentStore.parseDocs(issue),
 });
 
-const toPublicTaskFromWorkflow = async (
-  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">,
-  taskId: string,
-): Promise<PublicTask> => {
-  const issue = await persistence.showRawIssue(taskId);
-  return issueToPublicTask(issue, persistence.metadataNamespace);
-};
-
 type ReadTaskUseCaseDeps = {
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
@@ -159,15 +151,18 @@ export class ReadTaskUseCase implements OdtTaskStoreUseCase<ReadTaskInput, ReadT
 type CreateTaskUseCaseDeps = {
   persistence: Pick<TaskPersistencePort, "createTask" | "ensureInitialized" | "metadataNamespace">;
   documentStore: Pick<TaskDocumentPort, "parseDocs">;
+  invalidateTaskIndex(): void;
 };
 
 export class CreateTaskUseCase implements OdtTaskStoreUseCase<CreateTaskInput, CreateTaskResult> {
   private readonly persistence: CreateTaskUseCaseDeps["persistence"];
   private readonly documentStore: CreateTaskUseCaseDeps["documentStore"];
+  private readonly invalidateTaskIndex: CreateTaskUseCaseDeps["invalidateTaskIndex"];
 
   constructor(deps: CreateTaskUseCaseDeps) {
     this.persistence = deps.persistence;
     this.documentStore = deps.documentStore;
+    this.invalidateTaskIndex = deps.invalidateTaskIndex;
   }
 
   async execute(input: CreateTaskInput): Promise<CreateTaskResult> {
@@ -180,8 +175,12 @@ export class CreateTaskUseCase implements OdtTaskStoreUseCase<CreateTaskInput, C
       ...(input.labels !== undefined ? { labels: input.labels } : {}),
       ...(input.aiReviewEnabled !== undefined ? { aiReviewEnabled: input.aiReviewEnabled } : {}),
     };
-    const issue = await this.persistence.createTask(createInput);
-    return toTaskSnapshotResult(issue, this.persistence.metadataNamespace, this.documentStore);
+    try {
+      const issue = await this.persistence.createTask(createInput);
+      return toTaskSnapshotResult(issue, this.persistence.metadataNamespace, this.documentStore);
+    } finally {
+      this.invalidateTaskIndex();
+    }
   }
 }
 
@@ -214,15 +213,16 @@ export class SearchTasksUseCase
       ...(input.tags ? { tags: input.tags } : {}),
     };
     const issues = await this.persistence.listRawIssues(filters);
-    const activeIssues = issues.filter((issue) =>
-      ACTIVE_TASK_STATUSES.has(issue.status as TaskStatus),
-    );
+    const parsedTasks = issues.map((issue) => ({
+      issue,
+      task: issueToPublicTask(issue, this.persistence.metadataNamespace),
+    }));
+    const activeIssues = parsedTasks.filter(({ task }) => ACTIVE_TASK_STATUSES.has(task.status));
     const totalCount = activeIssues.length;
-    const results = activeIssues
-      .slice(0, input.limit)
-      .map((issue) =>
-        toTaskSnapshotResult(issue, this.persistence.metadataNamespace, this.documentStore),
-      );
+    const results = activeIssues.slice(0, input.limit).map(({ issue, task }) => ({
+      task,
+      documents: this.documentStore.parseDocs(issue),
+    }));
 
     return {
       results,
@@ -234,21 +234,22 @@ export class SearchTasksUseCase
 }
 
 type SetSpecUseCaseDeps = {
-  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
-    "ensureInitialized" | "resolveTaskContext" | "refreshTaskContext" | "transitionTask"
+    | "ensureInitialized"
+    | "metadataNamespace"
+    | "refreshTaskContext"
+    | "resolveTaskContext"
+    | "transitionTask"
   >;
   documentStore: Pick<TaskDocumentPort, "persistSpec">;
 };
 
 export class SetSpecUseCase implements OdtTaskStoreUseCase<SetSpecInput, SetSpecResult> {
-  private readonly persistence: SetSpecUseCaseDeps["persistence"];
   private readonly workflow: SetSpecUseCaseDeps["workflow"];
   private readonly documentStore: SetSpecUseCaseDeps["documentStore"];
 
   constructor(deps: SetSpecUseCaseDeps) {
-    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
   }
@@ -263,14 +264,19 @@ export class SetSpecUseCase implements OdtTaskStoreUseCase<SetSpecInput, SetSpec
 
     const persistedDocument = await this.documentStore.persistSpec(task.id, markdown);
 
-    let nextTask: TaskCard = task;
+    let nextIssue = persistedDocument.issue;
     if (task.status === "open") {
       const refreshedContext = await this.workflow.refreshTaskContext(task.id, context);
-      nextTask = await this.workflow.transitionTask(task.id, "spec_ready", refreshedContext);
+      const transitionedTask = await this.workflow.transitionTask(
+        task.id,
+        "spec_ready",
+        refreshedContext,
+      );
+      nextIssue = transitionedTask.issue;
     }
 
     return {
-      task: await toPublicTaskFromWorkflow(this.persistence, nextTask.id),
+      task: issueToPublicTask(nextIssue, this.workflow.metadataNamespace),
       document: {
         markdown,
         updatedAt: persistedDocument.updatedAt,
@@ -281,23 +287,24 @@ export class SetSpecUseCase implements OdtTaskStoreUseCase<SetSpecInput, SetSpec
 }
 
 type SetPlanUseCaseDeps = {
-  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
-    "ensureInitialized" | "resolveTaskContext" | "refreshTaskContext" | "transitionTask"
+    | "ensureInitialized"
+    | "metadataNamespace"
+    | "refreshTaskContext"
+    | "resolveTaskContext"
+    | "transitionTask"
   >;
   documentStore: Pick<TaskDocumentPort, "persistImplementationPlan">;
   epicSubtaskReplacementService: EpicSubtaskReplacementPort;
 };
 
 export class SetPlanUseCase implements OdtTaskStoreUseCase<SetPlanInput, SetPlanResult> {
-  private readonly persistence: SetPlanUseCaseDeps["persistence"];
   private readonly workflow: SetPlanUseCaseDeps["workflow"];
   private readonly documentStore: SetPlanUseCaseDeps["documentStore"];
   private readonly epicSubtaskReplacementService: SetPlanUseCaseDeps["epicSubtaskReplacementService"];
 
   constructor(deps: SetPlanUseCaseDeps) {
-    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
     this.epicSubtaskReplacementService = deps.epicSubtaskReplacementService;
@@ -311,7 +318,7 @@ export class SetPlanUseCase implements OdtTaskStoreUseCase<SetPlanInput, SetPlan
     const { task, tasks } = context;
 
     const normalizedSubtasks = normalizePlanSubtasks(input.subtasks ?? []);
-    let persistedDocument: { updatedAt: string; revision: number };
+    let persistedDocument: Awaited<ReturnType<TaskDocumentPort["persistImplementationPlan"]>>;
     let createdSubtaskIds: string[] = [];
     if (task.issueType === "epic") {
       const epicReplacement = await this.epicSubtaskReplacementService.prepareReplacement(
@@ -331,10 +338,14 @@ export class SetPlanUseCase implements OdtTaskStoreUseCase<SetPlanInput, SetPlan
     }
 
     const refreshedContext = await this.workflow.refreshTaskContext(task.id, context);
-    const nextTask = await this.workflow.transitionTask(task.id, "ready_for_dev", refreshedContext);
+    const transitionedTask = await this.workflow.transitionTask(
+      task.id,
+      "ready_for_dev",
+      refreshedContext,
+    );
 
     return {
-      task: await toPublicTaskFromWorkflow(this.persistence, nextTask.id),
+      task: issueToPublicTask(transitionedTask.issue, this.workflow.metadataNamespace),
       document: {
         markdown,
         updatedAt: persistedDocument.updatedAt,
@@ -346,26 +357,26 @@ export class SetPlanUseCase implements OdtTaskStoreUseCase<SetPlanInput, SetPlan
 }
 
 type TransitionTaskUseCaseDeps = {
-  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
-  workflow: Pick<OdtTaskWorkflowRuntimePort, "ensureInitialized" | "transitionTask">;
+  workflow: Pick<
+    OdtTaskWorkflowRuntimePort,
+    "ensureInitialized" | "metadataNamespace" | "transitionTask"
+  >;
 };
 
 export class BuildBlockedUseCase
   implements OdtTaskStoreUseCase<BuildBlockedInput, BuildBlockedResult>
 {
-  private readonly persistence: TransitionTaskUseCaseDeps["persistence"];
   private readonly workflow: TransitionTaskUseCaseDeps["workflow"];
 
   constructor(deps: TransitionTaskUseCaseDeps) {
-    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
   }
 
   async execute(input: BuildBlockedInput): Promise<BuildBlockedResult> {
     await this.workflow.ensureInitialized();
-    const task = await this.workflow.transitionTask(input.taskId, "blocked");
+    const nextTask = await this.workflow.transitionTask(input.taskId, "blocked");
     return {
-      task: await toPublicTaskFromWorkflow(this.persistence, task.id),
+      task: issueToPublicTask(nextTask.issue, this.workflow.metadataNamespace),
       reason: input.reason,
     };
   }
@@ -374,31 +385,29 @@ export class BuildBlockedUseCase
 export class BuildResumedUseCase
   implements OdtTaskStoreUseCase<BuildResumedInput, BuildResumedResult>
 {
-  private readonly persistence: TransitionTaskUseCaseDeps["persistence"];
   private readonly workflow: TransitionTaskUseCaseDeps["workflow"];
 
   constructor(deps: TransitionTaskUseCaseDeps) {
-    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
   }
 
   async execute(input: BuildResumedInput): Promise<BuildResumedResult> {
     await this.workflow.ensureInitialized();
-    const task = await this.workflow.transitionTask(input.taskId, "in_progress");
+    const nextTask = await this.workflow.transitionTask(input.taskId, "in_progress");
     return {
-      task: await toPublicTaskFromWorkflow(this.persistence, task.id),
+      task: issueToPublicTask(nextTask.issue, this.workflow.metadataNamespace),
     };
   }
 }
 
 type BuildCompletedUseCaseDeps = {
-  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
     | "ensureInitialized"
+    | "metadataNamespace"
     | "readTaskSnapshot"
-    | "resolveTaskContext"
     | "refreshTaskContext"
+    | "resolveTaskContext"
     | "transitionTask"
   >;
   documentStore: Pick<TaskDocumentPort, "parseDocs">;
@@ -407,12 +416,10 @@ type BuildCompletedUseCaseDeps = {
 export class BuildCompletedUseCase
   implements OdtTaskStoreUseCase<BuildCompletedInput, BuildCompletedResult>
 {
-  private readonly persistence: BuildCompletedUseCaseDeps["persistence"];
   private readonly workflow: BuildCompletedUseCaseDeps["workflow"];
   private readonly documentStore: BuildCompletedUseCaseDeps["documentStore"];
 
   constructor(deps: BuildCompletedUseCaseDeps) {
-    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
   }
@@ -422,8 +429,7 @@ export class BuildCompletedUseCase
 
     const context = await this.workflow.resolveTaskContext(input.taskId);
     const refreshedContext = await this.workflow.refreshTaskContext(context.task.id, context);
-    const { task } = refreshedContext;
-    const { issue } = await this.workflow.readTaskSnapshot(task.id);
+    const { issue, task } = await this.workflow.readTaskSnapshot(refreshedContext.task.id);
     const documents = this.documentStore.parseDocs(issue);
 
     const nextStatus =
@@ -432,28 +438,29 @@ export class BuildCompletedUseCase
         : "human_review";
     const updatedTask = await this.workflow.transitionTask(task.id, nextStatus, refreshedContext);
     return {
-      task: await toPublicTaskFromWorkflow(this.persistence, updatedTask.id),
+      task: issueToPublicTask(updatedTask.issue, this.workflow.metadataNamespace),
       ...(input.summary ? { summary: input.summary } : {}),
     };
   }
 }
 
 type QaUseCaseDeps = {
-  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
-    "applyTaskUpdate" | "assertTransitionAllowed" | "ensureInitialized" | "readTaskSnapshot"
+    | "applyTaskUpdate"
+    | "assertTransitionAllowed"
+    | "ensureInitialized"
+    | "metadataNamespace"
+    | "readTaskSnapshot"
   >;
   documentStore: Pick<TaskDocumentPort, "prepareQaReportWrite">;
 };
 
 export class QaApprovedUseCase implements OdtTaskStoreUseCase<QaApprovedInput, QaApprovedResult> {
-  private readonly persistence: QaUseCaseDeps["persistence"];
   private readonly workflow: QaUseCaseDeps["workflow"];
   private readonly documentStore: QaUseCaseDeps["documentStore"];
 
   constructor(deps: QaUseCaseDeps) {
-    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
   }
@@ -477,18 +484,16 @@ export class QaApprovedUseCase implements OdtTaskStoreUseCase<QaApprovedInput, Q
       status: "human_review",
     });
     return {
-      task: await toPublicTaskFromWorkflow(this.persistence, updatedTask.id),
+      task: issueToPublicTask(updatedTask.issue, this.workflow.metadataNamespace),
     };
   }
 }
 
 export class QaRejectedUseCase implements OdtTaskStoreUseCase<QaRejectedInput, QaRejectedResult> {
-  private readonly persistence: QaUseCaseDeps["persistence"];
   private readonly workflow: QaUseCaseDeps["workflow"];
   private readonly documentStore: QaUseCaseDeps["documentStore"];
 
   constructor(deps: QaUseCaseDeps) {
-    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
   }
@@ -512,7 +517,7 @@ export class QaRejectedUseCase implements OdtTaskStoreUseCase<QaRejectedInput, Q
       status: "in_progress",
     });
     return {
-      task: await toPublicTaskFromWorkflow(this.persistence, updatedTask.id),
+      task: issueToPublicTask(updatedTask.issue, this.workflow.metadataNamespace),
     };
   }
 }
@@ -522,6 +527,7 @@ export type CreateOdtTaskStoreUseCasesDeps = {
   workflow: OdtTaskWorkflowRuntimePort;
   documentStore: TaskDocumentPort;
   epicSubtaskReplacementService: EpicSubtaskReplacementPort;
+  invalidateTaskIndex(): void;
 };
 
 export const createOdtTaskStoreUseCases = (
@@ -534,42 +540,36 @@ export const createOdtTaskStoreUseCases = (
   createTask: new CreateTaskUseCase({
     persistence: deps.persistence,
     documentStore: deps.documentStore,
+    invalidateTaskIndex: deps.invalidateTaskIndex,
   }),
   searchTasks: new SearchTasksUseCase({
     persistence: deps.persistence,
     documentStore: deps.documentStore,
   }),
   setSpec: new SetSpecUseCase({
-    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
   }),
   setPlan: new SetPlanUseCase({
-    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
     epicSubtaskReplacementService: deps.epicSubtaskReplacementService,
   }),
   buildBlocked: new BuildBlockedUseCase({
-    persistence: deps.persistence,
     workflow: deps.workflow,
   }),
   buildResumed: new BuildResumedUseCase({
-    persistence: deps.persistence,
     workflow: deps.workflow,
   }),
   buildCompleted: new BuildCompletedUseCase({
-    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
   }),
   qaApproved: new QaApprovedUseCase({
-    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
   }),
   qaRejected: new QaRejectedUseCase({
-    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
   }),

--- a/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
+++ b/packages/openducktor-mcp/src/odt-task-store-use-cases.ts
@@ -1,16 +1,24 @@
-import type { TaskCard } from "./contracts";
+import type {
+  PublicTaskCreateInput,
+  TaskPersistencePort,
+  TaskSearchFilters,
+} from "./bd-persistence";
+import type { PublicTask, RawIssue, TaskCard, TaskStatus } from "./contracts";
 import type { EpicSubtaskReplacementService } from "./epic-subtask-replacement";
 import type { TaskDocumentsSnapshot } from "./metadata-docs";
 import { normalizePlanSubtasks } from "./plan-subtasks";
 import type { TaskDocumentPort } from "./task-document-store";
+import { issueToPublicTask } from "./task-mapping";
 import type { OdtTaskWorkflowRuntimePort } from "./task-workflow-runtime";
 import type {
   BuildBlockedInput,
   BuildCompletedInput,
   BuildResumedInput,
+  CreateTaskInput,
   QaApprovedInput,
   QaRejectedInput,
   ReadTaskInput,
+  SearchTasksInput,
   SetPlanInput,
   SetSpecInput,
 } from "./tool-schemas";
@@ -27,8 +35,15 @@ type PersistedDocumentResult = {
   revision: number;
 };
 
+export type TaskSnapshotResult = {
+  task: PublicTask;
+  documents: TaskDocumentsSnapshot;
+};
+
 export type OdtTaskStoreUseCases = {
   readTask: OdtTaskStoreUseCase<ReadTaskInput, ReadTaskResult>;
+  createTask: OdtTaskStoreUseCase<CreateTaskInput, CreateTaskResult>;
+  searchTasks: OdtTaskStoreUseCase<SearchTasksInput, SearchTasksResult>;
   setSpec: OdtTaskStoreUseCase<SetSpecInput, SetSpecResult>;
   setPlan: OdtTaskStoreUseCase<SetPlanInput, SetPlanResult>;
   buildBlocked: OdtTaskStoreUseCase<BuildBlockedInput, BuildBlockedResult>;
@@ -42,42 +57,47 @@ export type OdtTaskStoreUseCase<Input, Output> = {
   execute(input: Input): Promise<Output>;
 };
 
-export type ReadTaskResult = {
-  task: TaskCard;
-  documents: TaskDocumentsSnapshot;
+export type ReadTaskResult = TaskSnapshotResult;
+export type CreateTaskResult = TaskSnapshotResult;
+
+export type SearchTasksResult = {
+  results: TaskSnapshotResult[];
+  limit: number;
+  totalCount: number;
+  hasMore: boolean;
 };
 
 export type SetSpecResult = {
-  task: TaskCard;
+  task: PublicTask;
   document: PersistedDocumentResult;
 };
 
 export type SetPlanResult = {
-  task: TaskCard;
+  task: PublicTask;
   document: PersistedDocumentResult;
   createdSubtaskIds: string[];
 };
 
 export type BuildBlockedResult = {
-  task: TaskCard;
+  task: PublicTask;
   reason: string;
 };
 
 export type BuildResumedResult = {
-  task: TaskCard;
+  task: PublicTask;
 };
 
 export type BuildCompletedResult = {
-  task: TaskCard;
+  task: PublicTask;
   summary?: string;
 };
 
 export type QaApprovedResult = {
-  task: TaskCard;
+  task: PublicTask;
 };
 
 export type QaRejectedResult = {
-  task: TaskCard;
+  task: PublicTask;
 };
 
 type EpicSubtaskReplacementPort = Pick<
@@ -85,8 +105,38 @@ type EpicSubtaskReplacementPort = Pick<
   "prepareReplacement" | "applyReplacement"
 >;
 
+const ACTIVE_TASK_STATUSES = new Set<TaskStatus>([
+  "open",
+  "spec_ready",
+  "ready_for_dev",
+  "in_progress",
+  "blocked",
+  "ai_review",
+  "human_review",
+]);
+
+const toTaskSnapshotResult = (
+  issue: RawIssue,
+  metadataNamespace: string,
+  documentStore: Pick<TaskDocumentPort, "parseDocs">,
+): TaskSnapshotResult => ({
+  task: issueToPublicTask(issue, metadataNamespace),
+  documents: documentStore.parseDocs(issue),
+});
+
+const toPublicTaskFromWorkflow = async (
+  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">,
+  taskId: string,
+): Promise<PublicTask> => {
+  const issue = await persistence.showRawIssue(taskId);
+  return issueToPublicTask(issue, persistence.metadataNamespace);
+};
+
 type ReadTaskUseCaseDeps = {
-  workflow: Pick<OdtTaskWorkflowRuntimePort, "ensureInitialized" | "readTaskSnapshot">;
+  workflow: Pick<
+    OdtTaskWorkflowRuntimePort,
+    "ensureInitialized" | "readTaskSnapshot" | "metadataNamespace"
+  >;
   documentStore: Pick<TaskDocumentPort, "parseDocs">;
 };
 
@@ -101,16 +151,90 @@ export class ReadTaskUseCase implements OdtTaskStoreUseCase<ReadTaskInput, ReadT
 
   async execute(input: ReadTaskInput): Promise<ReadTaskResult> {
     await this.workflow.ensureInitialized();
-    const { issue, task } = await this.workflow.readTaskSnapshot(input.taskId);
+    const { issue } = await this.workflow.readTaskSnapshot(input.taskId);
+    return toTaskSnapshotResult(issue, this.workflow.metadataNamespace, this.documentStore);
+  }
+}
+
+type CreateTaskUseCaseDeps = {
+  persistence: Pick<TaskPersistencePort, "createTask" | "ensureInitialized" | "metadataNamespace">;
+  documentStore: Pick<TaskDocumentPort, "parseDocs">;
+};
+
+export class CreateTaskUseCase implements OdtTaskStoreUseCase<CreateTaskInput, CreateTaskResult> {
+  private readonly persistence: CreateTaskUseCaseDeps["persistence"];
+  private readonly documentStore: CreateTaskUseCaseDeps["documentStore"];
+
+  constructor(deps: CreateTaskUseCaseDeps) {
+    this.persistence = deps.persistence;
+    this.documentStore = deps.documentStore;
+  }
+
+  async execute(input: CreateTaskInput): Promise<CreateTaskResult> {
+    await this.persistence.ensureInitialized();
+    const createInput: PublicTaskCreateInput = {
+      title: input.title.trim(),
+      issueType: input.issueType,
+      priority: input.priority,
+      ...(input.description !== undefined ? { description: input.description } : {}),
+      ...(input.labels !== undefined ? { labels: input.labels } : {}),
+      ...(input.aiReviewEnabled !== undefined ? { aiReviewEnabled: input.aiReviewEnabled } : {}),
+    };
+    const issue = await this.persistence.createTask(createInput);
+    return toTaskSnapshotResult(issue, this.persistence.metadataNamespace, this.documentStore);
+  }
+}
+
+type SearchTasksUseCaseDeps = {
+  persistence: Pick<
+    TaskPersistencePort,
+    "ensureInitialized" | "listRawIssues" | "metadataNamespace"
+  >;
+  documentStore: Pick<TaskDocumentPort, "parseDocs">;
+};
+
+export class SearchTasksUseCase
+  implements OdtTaskStoreUseCase<SearchTasksInput, SearchTasksResult>
+{
+  private readonly persistence: SearchTasksUseCaseDeps["persistence"];
+  private readonly documentStore: SearchTasksUseCaseDeps["documentStore"];
+
+  constructor(deps: SearchTasksUseCaseDeps) {
+    this.persistence = deps.persistence;
+    this.documentStore = deps.documentStore;
+  }
+
+  async execute(input: SearchTasksInput): Promise<SearchTasksResult> {
+    await this.persistence.ensureInitialized();
+    const filters: TaskSearchFilters = {
+      ...(input.priority !== undefined ? { priority: input.priority } : {}),
+      ...(input.issueType ? { issueType: input.issueType } : {}),
+      ...(input.status ? { status: input.status } : {}),
+      ...(input.title ? { title: input.title } : {}),
+      ...(input.tags ? { tags: input.tags } : {}),
+    };
+    const issues = await this.persistence.listRawIssues(filters);
+    const activeIssues = issues.filter((issue) =>
+      ACTIVE_TASK_STATUSES.has(issue.status as TaskStatus),
+    );
+    const totalCount = activeIssues.length;
+    const results = activeIssues
+      .slice(0, input.limit)
+      .map((issue) =>
+        toTaskSnapshotResult(issue, this.persistence.metadataNamespace, this.documentStore),
+      );
 
     return {
-      task,
-      documents: this.documentStore.parseDocs(issue),
+      results,
+      limit: input.limit,
+      totalCount,
+      hasMore: totalCount > results.length,
     };
   }
 }
 
 type SetSpecUseCaseDeps = {
+  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
     "ensureInitialized" | "resolveTaskContext" | "refreshTaskContext" | "transitionTask"
@@ -119,10 +243,12 @@ type SetSpecUseCaseDeps = {
 };
 
 export class SetSpecUseCase implements OdtTaskStoreUseCase<SetSpecInput, SetSpecResult> {
+  private readonly persistence: SetSpecUseCaseDeps["persistence"];
   private readonly workflow: SetSpecUseCaseDeps["workflow"];
   private readonly documentStore: SetSpecUseCaseDeps["documentStore"];
 
   constructor(deps: SetSpecUseCaseDeps) {
+    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
   }
@@ -144,7 +270,7 @@ export class SetSpecUseCase implements OdtTaskStoreUseCase<SetSpecInput, SetSpec
     }
 
     return {
-      task: nextTask,
+      task: await toPublicTaskFromWorkflow(this.persistence, nextTask.id),
       document: {
         markdown,
         updatedAt: persistedDocument.updatedAt,
@@ -155,6 +281,7 @@ export class SetSpecUseCase implements OdtTaskStoreUseCase<SetSpecInput, SetSpec
 }
 
 type SetPlanUseCaseDeps = {
+  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
     "ensureInitialized" | "resolveTaskContext" | "refreshTaskContext" | "transitionTask"
@@ -164,11 +291,13 @@ type SetPlanUseCaseDeps = {
 };
 
 export class SetPlanUseCase implements OdtTaskStoreUseCase<SetPlanInput, SetPlanResult> {
+  private readonly persistence: SetPlanUseCaseDeps["persistence"];
   private readonly workflow: SetPlanUseCaseDeps["workflow"];
   private readonly documentStore: SetPlanUseCaseDeps["documentStore"];
   private readonly epicSubtaskReplacementService: SetPlanUseCaseDeps["epicSubtaskReplacementService"];
 
   constructor(deps: SetPlanUseCaseDeps) {
+    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
     this.epicSubtaskReplacementService = deps.epicSubtaskReplacementService;
@@ -185,7 +314,6 @@ export class SetPlanUseCase implements OdtTaskStoreUseCase<SetPlanInput, SetPlan
     let persistedDocument: { updatedAt: string; revision: number };
     let createdSubtaskIds: string[] = [];
     if (task.issueType === "epic") {
-      // Epic subtask replacement must validate against a fresh snapshot, not the initial context.
       const epicReplacement = await this.epicSubtaskReplacementService.prepareReplacement(
         task,
         normalizedSubtasks,
@@ -206,7 +334,7 @@ export class SetPlanUseCase implements OdtTaskStoreUseCase<SetPlanInput, SetPlan
     const nextTask = await this.workflow.transitionTask(task.id, "ready_for_dev", refreshedContext);
 
     return {
-      task: nextTask,
+      task: await toPublicTaskFromWorkflow(this.persistence, nextTask.id),
       document: {
         markdown,
         updatedAt: persistedDocument.updatedAt,
@@ -218,15 +346,18 @@ export class SetPlanUseCase implements OdtTaskStoreUseCase<SetPlanInput, SetPlan
 }
 
 type TransitionTaskUseCaseDeps = {
+  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
   workflow: Pick<OdtTaskWorkflowRuntimePort, "ensureInitialized" | "transitionTask">;
 };
 
 export class BuildBlockedUseCase
   implements OdtTaskStoreUseCase<BuildBlockedInput, BuildBlockedResult>
 {
+  private readonly persistence: TransitionTaskUseCaseDeps["persistence"];
   private readonly workflow: TransitionTaskUseCaseDeps["workflow"];
 
   constructor(deps: TransitionTaskUseCaseDeps) {
+    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
   }
 
@@ -234,7 +365,7 @@ export class BuildBlockedUseCase
     await this.workflow.ensureInitialized();
     const task = await this.workflow.transitionTask(input.taskId, "blocked");
     return {
-      task,
+      task: await toPublicTaskFromWorkflow(this.persistence, task.id),
       reason: input.reason,
     };
   }
@@ -243,20 +374,25 @@ export class BuildBlockedUseCase
 export class BuildResumedUseCase
   implements OdtTaskStoreUseCase<BuildResumedInput, BuildResumedResult>
 {
+  private readonly persistence: TransitionTaskUseCaseDeps["persistence"];
   private readonly workflow: TransitionTaskUseCaseDeps["workflow"];
 
   constructor(deps: TransitionTaskUseCaseDeps) {
+    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
   }
 
   async execute(input: BuildResumedInput): Promise<BuildResumedResult> {
     await this.workflow.ensureInitialized();
     const task = await this.workflow.transitionTask(input.taskId, "in_progress");
-    return { task };
+    return {
+      task: await toPublicTaskFromWorkflow(this.persistence, task.id),
+    };
   }
 }
 
 type BuildCompletedUseCaseDeps = {
+  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
     | "ensureInitialized"
@@ -271,10 +407,12 @@ type BuildCompletedUseCaseDeps = {
 export class BuildCompletedUseCase
   implements OdtTaskStoreUseCase<BuildCompletedInput, BuildCompletedResult>
 {
+  private readonly persistence: BuildCompletedUseCaseDeps["persistence"];
   private readonly workflow: BuildCompletedUseCaseDeps["workflow"];
   private readonly documentStore: BuildCompletedUseCaseDeps["documentStore"];
 
   constructor(deps: BuildCompletedUseCaseDeps) {
+    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
   }
@@ -294,13 +432,14 @@ export class BuildCompletedUseCase
         : "human_review";
     const updatedTask = await this.workflow.transitionTask(task.id, nextStatus, refreshedContext);
     return {
-      task: updatedTask,
+      task: await toPublicTaskFromWorkflow(this.persistence, updatedTask.id),
       ...(input.summary ? { summary: input.summary } : {}),
     };
   }
 }
 
 type QaUseCaseDeps = {
+  persistence: Pick<TaskPersistencePort, "metadataNamespace" | "showRawIssue">;
   workflow: Pick<
     OdtTaskWorkflowRuntimePort,
     "applyTaskUpdate" | "assertTransitionAllowed" | "ensureInitialized" | "readTaskSnapshot"
@@ -309,10 +448,12 @@ type QaUseCaseDeps = {
 };
 
 export class QaApprovedUseCase implements OdtTaskStoreUseCase<QaApprovedInput, QaApprovedResult> {
+  private readonly persistence: QaUseCaseDeps["persistence"];
   private readonly workflow: QaUseCaseDeps["workflow"];
   private readonly documentStore: QaUseCaseDeps["documentStore"];
 
   constructor(deps: QaUseCaseDeps) {
+    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
   }
@@ -335,15 +476,19 @@ export class QaApprovedUseCase implements OdtTaskStoreUseCase<QaApprovedInput, Q
       metadataRoot: preparedWrite.metadataRoot,
       status: "human_review",
     });
-    return { task: updatedTask };
+    return {
+      task: await toPublicTaskFromWorkflow(this.persistence, updatedTask.id),
+    };
   }
 }
 
 export class QaRejectedUseCase implements OdtTaskStoreUseCase<QaRejectedInput, QaRejectedResult> {
+  private readonly persistence: QaUseCaseDeps["persistence"];
   private readonly workflow: QaUseCaseDeps["workflow"];
   private readonly documentStore: QaUseCaseDeps["documentStore"];
 
   constructor(deps: QaUseCaseDeps) {
+    this.persistence = deps.persistence;
     this.workflow = deps.workflow;
     this.documentStore = deps.documentStore;
   }
@@ -366,11 +511,14 @@ export class QaRejectedUseCase implements OdtTaskStoreUseCase<QaRejectedInput, Q
       metadataRoot: preparedWrite.metadataRoot,
       status: "in_progress",
     });
-    return { task: updatedTask };
+    return {
+      task: await toPublicTaskFromWorkflow(this.persistence, updatedTask.id),
+    };
   }
 }
 
 export type CreateOdtTaskStoreUseCasesDeps = {
+  persistence: TaskPersistencePort;
   workflow: OdtTaskWorkflowRuntimePort;
   documentStore: TaskDocumentPort;
   epicSubtaskReplacementService: EpicSubtaskReplacementPort;
@@ -383,30 +531,45 @@ export const createOdtTaskStoreUseCases = (
     workflow: deps.workflow,
     documentStore: deps.documentStore,
   }),
+  createTask: new CreateTaskUseCase({
+    persistence: deps.persistence,
+    documentStore: deps.documentStore,
+  }),
+  searchTasks: new SearchTasksUseCase({
+    persistence: deps.persistence,
+    documentStore: deps.documentStore,
+  }),
   setSpec: new SetSpecUseCase({
+    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
   }),
   setPlan: new SetPlanUseCase({
+    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
     epicSubtaskReplacementService: deps.epicSubtaskReplacementService,
   }),
   buildBlocked: new BuildBlockedUseCase({
+    persistence: deps.persistence,
     workflow: deps.workflow,
   }),
   buildResumed: new BuildResumedUseCase({
+    persistence: deps.persistence,
     workflow: deps.workflow,
   }),
   buildCompleted: new BuildCompletedUseCase({
+    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
   }),
   qaApproved: new QaApprovedUseCase({
+    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
   }),
   qaRejected: new QaRejectedUseCase({
+    persistence: deps.persistence,
     workflow: deps.workflow,
     documentStore: deps.documentStore,
   }),

--- a/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
@@ -20,7 +20,11 @@ describe("OdtTaskStore composition", () => {
       title: "Task 1",
       description: "Read the task description from Beads.",
       status: "open",
+      priority: 2,
       issue_type: "feature",
+      labels: [],
+      created_at: "2026-03-01T00:00:00.000Z",
+      updated_at: "2026-03-01T00:00:00.000Z",
       metadata: {
         custom_ns: {
           qaRequired: false,
@@ -34,6 +38,10 @@ describe("OdtTaskStore composition", () => {
       runBdJson: async () => {
         throw new Error("runBdJson should not be called by readTask");
       },
+      createTask: async () => {
+        throw new Error("createTask should not be called by readTask");
+      },
+      listRawIssues: async () => [issue],
       listTasks: async () => [makeTask()],
       showRawIssue: async () => issue,
       getNamespaceData: () => {
@@ -82,6 +90,7 @@ describe("OdtTaskStore composition", () => {
 
     expect(result.task.aiReviewEnabled).toBe(false);
     expect(result.task.description).toBe("Read the task description from Beads.");
+    expect((result.task as unknown as { priority: number }).priority).toBe(2);
     expect(result.documents.spec.markdown).toBe("spec");
   });
 
@@ -90,7 +99,11 @@ describe("OdtTaskStore composition", () => {
       id: "task-1",
       title: "Task 1",
       status: "open",
+      priority: 2,
       issue_type: "decision",
+      labels: [],
+      created_at: "2026-03-01T00:00:00.000Z",
+      updated_at: "2026-03-01T00:00:00.000Z",
       metadata: {},
     };
 
@@ -100,6 +113,10 @@ describe("OdtTaskStore composition", () => {
       runBdJson: async () => {
         throw new Error("runBdJson should not be called by readTask");
       },
+      createTask: async () => {
+        throw new Error("createTask should not be called by readTask");
+      },
+      listRawIssues: async () => [issue],
       listTasks: async () => [makeTask()],
       showRawIssue: async () => issue,
       getNamespaceData: () => {
@@ -151,7 +168,11 @@ describe("OdtTaskStore composition", () => {
       id: "task-1",
       title: "Task 1",
       status: null,
+      priority: 2,
       issue_type: "feature",
+      labels: [],
+      created_at: "2026-03-01T00:00:00.000Z",
+      updated_at: "2026-03-01T00:00:00.000Z",
       metadata: {},
     };
 
@@ -161,6 +182,10 @@ describe("OdtTaskStore composition", () => {
       runBdJson: async () => {
         throw new Error("runBdJson should not be called by readTask");
       },
+      createTask: async () => {
+        throw new Error("createTask should not be called by readTask");
+      },
+      listRawIssues: async () => [issue],
       listTasks: async () => [makeTask()],
       showRawIssue: async () => issue,
       getNamespaceData: () => {

--- a/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
@@ -66,8 +66,8 @@ describe("OdtTaskStore composition", () => {
         namespace: {},
         root: {},
       }),
-      persistSpec: async () => ({ updatedAt: "", revision: 1 }),
-      persistImplementationPlan: async () => ({ updatedAt: "", revision: 1 }),
+      persistSpec: async () => ({ issue, updatedAt: "", revision: 1 }),
+      persistImplementationPlan: async () => ({ issue, updatedAt: "", revision: 1 }),
       appendQaReport: async () => {},
     };
 
@@ -141,8 +141,8 @@ describe("OdtTaskStore composition", () => {
         namespace: {},
         root: {},
       }),
-      persistSpec: async () => ({ updatedAt: "", revision: 1 }),
-      persistImplementationPlan: async () => ({ updatedAt: "", revision: 1 }),
+      persistSpec: async () => ({ issue, updatedAt: "", revision: 1 }),
+      persistImplementationPlan: async () => ({ issue, updatedAt: "", revision: 1 }),
       appendQaReport: async () => {},
     };
 
@@ -210,8 +210,8 @@ describe("OdtTaskStore composition", () => {
         namespace: {},
         root: {},
       }),
-      persistSpec: async () => ({ updatedAt: "", revision: 1 }),
-      persistImplementationPlan: async () => ({ updatedAt: "", revision: 1 }),
+      persistSpec: async () => ({ issue, updatedAt: "", revision: 1 }),
+      persistImplementationPlan: async () => ({ issue, updatedAt: "", revision: 1 }),
       appendQaReport: async () => {},
     };
 

--- a/packages/openducktor-mcp/src/odt-task-store.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.test.ts
@@ -19,6 +19,10 @@ type TestIssue = {
   title: string;
   status: string;
   issue_type: string;
+  priority: number;
+  labels: string[];
+  created_at: string;
+  updated_at: string;
   parent?: string;
   metadata?: unknown;
 };
@@ -53,6 +57,10 @@ const makeIssue = (input: {
     title: input.title,
     status: input.status,
     issue_type: input.issueType ?? "task",
+    priority: 2,
+    labels: [],
+    created_at: FIXED_NOW,
+    updated_at: FIXED_NOW,
   };
 
   if (input.parentId) {
@@ -279,11 +287,16 @@ describe("OdtTaskStore workflow mutation paths", () => {
     };
 
     expect(result.task).toEqual({
-      id: "alpha-wsp",
-      title: "Alpha workflow",
-      status: "in_progress",
-      issueType: "feature",
       aiReviewEnabled: true,
+      createdAt: FIXED_NOW,
+      description: "",
+      id: "alpha-wsp",
+      issueType: "feature",
+      labels: [],
+      priority: 2,
+      status: "in_progress",
+      title: "Alpha workflow",
+      updatedAt: FIXED_NOW,
     });
     expect(harness.getCommandCalls("list")).toHaveLength(2);
   });

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -71,6 +71,7 @@ export class OdtTaskStore {
       workflow,
       documentStore,
       epicSubtaskReplacementService,
+      invalidateTaskIndex: () => taskIndexCache.invalidate(),
     });
   }
 

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -12,9 +12,11 @@ import {
   BuildBlockedInputSchema,
   BuildCompletedInputSchema,
   BuildResumedInputSchema,
+  CreateTaskInputSchema,
   QaApprovedInputSchema,
   QaRejectedInputSchema,
   ReadTaskInputSchema,
+  SearchTasksInputSchema,
   SetPlanInputSchema,
   SetSpecInputSchema,
 } from "./tool-schemas";
@@ -65,6 +67,7 @@ export class OdtTaskStore {
       taskLookup: taskIndexCache,
     });
     this.useCases = createOdtTaskStoreUseCases({
+      persistence,
       workflow,
       documentStore,
       epicSubtaskReplacementService,
@@ -86,6 +89,18 @@ export class OdtTaskStore {
     rawInput: unknown,
   ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["readTask"]["execute"]>>> {
     return this.useCases.readTask.execute(ReadTaskInputSchema.parse(rawInput));
+  }
+
+  async createTask(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["createTask"]["execute"]>>> {
+    return this.useCases.createTask.execute(CreateTaskInputSchema.parse(rawInput));
+  }
+
+  async searchTasks(
+    rawInput: unknown,
+  ): Promise<Awaited<ReturnType<OdtTaskStoreUseCases["searchTasks"]["execute"]>>> {
+    return this.useCases.searchTasks.execute(SearchTasksInputSchema.parse(rawInput));
   }
 
   async setSpec(

--- a/packages/openducktor-mcp/src/public-schemas.ts
+++ b/packages/openducktor-mcp/src/public-schemas.ts
@@ -1,0 +1,43 @@
+import { issueTypeSchema, taskPrioritySchema, taskStatusSchema } from "@openducktor/contracts";
+import { z } from "zod";
+
+export const publicTaskSchema = z.object({
+  id: z.string().trim().min(1).describe("Canonical task identifier."),
+  title: z.string().describe("Task title."),
+  description: z.string().describe("Task description. Empty string when omitted."),
+  status: taskStatusSchema.describe("Current task status."),
+  priority: taskPrioritySchema.describe(
+    "Task priority. Valid values: 0 (P0 Critical), 1 (P1 High), 2 (P2 Normal), 3 (P3 Low), 4 (P4 Very low).",
+  ),
+  issueType: issueTypeSchema.describe("Task issue type."),
+  aiReviewEnabled: z
+    .boolean()
+    .describe("Whether OpenDucktor QA review is required before human review."),
+  labels: z.array(z.string()).describe("Task labels."),
+  createdAt: z.string().describe("Task creation timestamp."),
+  updatedAt: z.string().describe("Task last update timestamp."),
+});
+export type PublicTask = z.infer<typeof publicTaskSchema>;
+
+export const taskDocumentsSnapshotSchema = z.object({
+  spec: z.object({
+    markdown: z.string(),
+    updatedAt: z.string().nullable(),
+  }),
+  implementationPlan: z.object({
+    markdown: z.string(),
+    updatedAt: z.string().nullable(),
+  }),
+  latestQaReport: z.object({
+    markdown: z.string(),
+    updatedAt: z.string().nullable(),
+    verdict: z.enum(["approved", "rejected"]).nullable(),
+  }),
+});
+export type TaskDocumentsSnapshotOutput = z.infer<typeof taskDocumentsSnapshotSchema>;
+
+export const taskSnapshotSchema = z.object({
+  task: publicTaskSchema,
+  documents: taskDocumentsSnapshotSchema,
+});
+export type TaskSnapshot = z.infer<typeof taskSnapshotSchema>;

--- a/packages/openducktor-mcp/src/public-schemas.ts
+++ b/packages/openducktor-mcp/src/public-schemas.ts
@@ -1,43 +1,55 @@
 import { issueTypeSchema, taskPrioritySchema, taskStatusSchema } from "@openducktor/contracts";
 import { z } from "zod";
 
-export const publicTaskSchema = z.object({
-  id: z.string().trim().min(1).describe("Canonical task identifier."),
-  title: z.string().describe("Task title."),
-  description: z.string().describe("Task description. Empty string when omitted."),
-  status: taskStatusSchema.describe("Current task status."),
-  priority: taskPrioritySchema.describe(
-    "Task priority. Valid values: 0 (P0 Critical), 1 (P1 High), 2 (P2 Normal), 3 (P3 Low), 4 (P4 Very low).",
-  ),
-  issueType: issueTypeSchema.describe("Task issue type."),
-  aiReviewEnabled: z
-    .boolean()
-    .describe("Whether OpenDucktor QA review is required before human review."),
-  labels: z.array(z.string()).describe("Task labels."),
-  createdAt: z.string().describe("Task creation timestamp."),
-  updatedAt: z.string().describe("Task last update timestamp."),
-});
+export const publicTaskSchema = z
+  .object({
+    id: z.string().trim().min(1).describe("Canonical task identifier."),
+    title: z.string().describe("Task title."),
+    description: z.string().describe("Task description. Empty string when omitted."),
+    status: taskStatusSchema.describe("Current task status."),
+    priority: taskPrioritySchema.describe(
+      "Task priority. Valid values: 0 (P0 Critical), 1 (P1 High), 2 (P2 Normal), 3 (P3 Low), 4 (P4 Very low).",
+    ),
+    issueType: issueTypeSchema.describe("Task issue type."),
+    aiReviewEnabled: z
+      .boolean()
+      .describe("Whether OpenDucktor QA review is required before human review."),
+    labels: z.array(z.string()).describe("Task labels."),
+    createdAt: z.string().describe("Task creation timestamp."),
+    updatedAt: z.string().describe("Task last update timestamp."),
+  })
+  .strict();
 export type PublicTask = z.infer<typeof publicTaskSchema>;
 
-export const taskDocumentsSnapshotSchema = z.object({
-  spec: z.object({
-    markdown: z.string(),
-    updatedAt: z.string().nullable(),
-  }),
-  implementationPlan: z.object({
-    markdown: z.string(),
-    updatedAt: z.string().nullable(),
-  }),
-  latestQaReport: z.object({
-    markdown: z.string(),
-    updatedAt: z.string().nullable(),
-    verdict: z.enum(["approved", "rejected"]).nullable(),
-  }),
-});
+export const taskDocumentsSnapshotSchema = z
+  .object({
+    spec: z
+      .object({
+        markdown: z.string(),
+        updatedAt: z.string().nullable(),
+      })
+      .strict(),
+    implementationPlan: z
+      .object({
+        markdown: z.string(),
+        updatedAt: z.string().nullable(),
+      })
+      .strict(),
+    latestQaReport: z
+      .object({
+        markdown: z.string(),
+        updatedAt: z.string().nullable(),
+        verdict: z.enum(["approved", "rejected"]).nullable(),
+      })
+      .strict(),
+  })
+  .strict();
 export type TaskDocumentsSnapshotOutput = z.infer<typeof taskDocumentsSnapshotSchema>;
 
-export const taskSnapshotSchema = z.object({
-  task: publicTaskSchema,
-  documents: taskDocumentsSnapshotSchema,
-});
+export const taskSnapshotSchema = z
+  .object({
+    task: publicTaskSchema,
+    documents: taskDocumentsSnapshotSchema,
+  })
+  .strict();
 export type TaskSnapshot = z.infer<typeof taskSnapshotSchema>;

--- a/packages/openducktor-mcp/src/task-document-store.test.ts
+++ b/packages/openducktor-mcp/src/task-document-store.test.ts
@@ -183,6 +183,7 @@ describe("TaskDocumentStore", () => {
     const persisted = await documents.persistImplementationPlan("task-1", "# new plan");
 
     expect(persisted).toEqual({
+      issue: harness.getIssue(),
       updatedAt: FIXED_NOW,
       revision: 5,
     });
@@ -307,6 +308,7 @@ describe("TaskDocumentStore", () => {
     const persisted = await documents.persistSpec("task-1", "# new spec");
 
     expect(persisted).toEqual({
+      issue: harness.getIssue(),
       updatedAt: FIXED_NOW,
       revision: 2,
     });

--- a/packages/openducktor-mcp/src/task-document-store.ts
+++ b/packages/openducktor-mcp/src/task-document-store.ts
@@ -53,13 +53,16 @@ type PreparedNamespaceWrite = {
 
 export type PreparedQaReportWrite = PreparedNamespaceWrite;
 
+export type PersistedTaskDocumentResult = {
+  issue: RawIssue;
+  updatedAt: string;
+  revision: number;
+};
+
 export type TaskDocumentPort = {
   parseDocs(issue: RawIssue): TaskDocumentsSnapshot;
-  persistSpec(taskId: string, markdown: string): Promise<{ updatedAt: string; revision: number }>;
-  persistImplementationPlan(
-    taskId: string,
-    markdown: string,
-  ): Promise<{ updatedAt: string; revision: number }>;
+  persistSpec(taskId: string, markdown: string): Promise<PersistedTaskDocumentResult>;
+  persistImplementationPlan(taskId: string, markdown: string): Promise<PersistedTaskDocumentResult>;
   appendQaReport(taskId: string, markdown: string, verdict: QaReportVerdict): Promise<void>;
   prepareQaReportWrite(
     issue: RawIssue,
@@ -86,10 +89,7 @@ export class TaskDocumentStore implements TaskDocumentPort {
     return parseTaskDocuments(issue, this.persistence.metadataNamespace);
   }
 
-  async persistSpec(
-    taskId: string,
-    markdown: string,
-  ): Promise<{ updatedAt: string; revision: number }> {
+  async persistSpec(taskId: string, markdown: string): Promise<PersistedTaskDocumentResult> {
     const issue = await this.persistence.showRawIssue(taskId);
     return this.persistLatestMarkdown({
       issue,
@@ -101,7 +101,7 @@ export class TaskDocumentStore implements TaskDocumentPort {
   async persistImplementationPlan(
     taskId: string,
     markdown: string,
-  ): Promise<{ updatedAt: string; revision: number }> {
+  ): Promise<PersistedTaskDocumentResult> {
     const issue = await this.persistence.showRawIssue(taskId);
     return this.persistLatestMarkdown({
       issue,
@@ -155,7 +155,7 @@ export class TaskDocumentStore implements TaskDocumentPort {
 
   private async persistLatestMarkdown(
     input: PersistLatestMarkdownInput,
-  ): Promise<{ updatedAt: string; revision: number }> {
+  ): Promise<PersistedTaskDocumentResult> {
     const { root, namespace, documents } = this.persistence.getNamespaceData(input.issue);
     const source = MARKDOWN_DOCUMENT_SOURCES[input.documentKey];
     const nextRevision = getNextRevision(parseMarkdownEntries(documents[input.documentKey]));
@@ -180,7 +180,9 @@ export class TaskDocumentStore implements TaskDocumentPort {
     };
 
     await this.persistence.writeNamespace(input.issue.id, root, nextNamespace);
+    const refreshedIssue = await this.persistence.showRawIssue(input.issue.id);
     return {
+      issue: refreshedIssue,
       updatedAt,
       revision: nextRevision,
     };

--- a/packages/openducktor-mcp/src/task-mapping.test.ts
+++ b/packages/openducktor-mcp/src/task-mapping.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { RawIssue } from "./contracts";
-import { issueToTaskCard, parseMarkdownEntries, parseQaEntries } from "./task-mapping";
+import {
+  issueToPublicTask,
+  issueToTaskCard,
+  parseMarkdownEntries,
+  parseQaEntries,
+} from "./task-mapping";
 
 describe("task mapping entry parsers", () => {
   test("issueToTaskCard rejects invalid Beads issue types with task context", () => {
@@ -46,6 +51,42 @@ describe("task mapping entry parsers", () => {
       issueType: "task",
       aiReviewEnabled: true,
     });
+  });
+
+  test("issueToPublicTask rejects invalid Beads created_at timestamps", () => {
+    const issue: RawIssue = {
+      id: "task-11",
+      title: "Broken created_at",
+      status: "open",
+      issue_type: "task",
+      priority: 2,
+      labels: [],
+      created_at: "not-a-timestamp",
+      updated_at: "2026-02-28T00:00:00Z",
+      metadata: {},
+    };
+
+    expect(() => issueToPublicTask(issue, "openducktor")).toThrow(
+      "Invalid Beads created_at for task task-11: expected a valid ISO-8601 timestamp string.",
+    );
+  });
+
+  test("issueToPublicTask rejects invalid Beads updated_at timestamps", () => {
+    const issue: RawIssue = {
+      id: "task-12",
+      title: "Broken updated_at",
+      status: "open",
+      issue_type: "task",
+      priority: 2,
+      labels: [],
+      created_at: "2026-02-28T00:00:00Z",
+      updated_at: "2026-02-28",
+      metadata: {},
+    };
+
+    expect(() => issueToPublicTask(issue, "openducktor")).toThrow(
+      "Invalid Beads updated_at for task task-12: expected a valid ISO-8601 timestamp string.",
+    );
   });
 
   test("parseMarkdownEntries returns only valid markdown metadata entries", () => {

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -28,6 +28,7 @@ export const ensureObject = (value: unknown): JsonObject => {
 
 const RevisionSchema = z.number().int().positive();
 const UpdatedAtSchema = z.string().datetime({ offset: true });
+const BeadsTimestampSchema = z.string().datetime({ offset: true });
 
 const MarkdownEntrySchema = z.object({
   markdown: z.string(),
@@ -101,11 +102,16 @@ const parseTimestamp = (
   fieldName: "created_at" | "updated_at",
   value: unknown,
 ): string => {
-  if (typeof value === "string" && value.trim().length > 0) {
-    return value;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (BeadsTimestampSchema.safeParse(trimmed).success) {
+      return trimmed;
+    }
   }
 
-  throw new Error(`Invalid Beads ${fieldName} for task ${taskId}: expected a non-empty string.`);
+  throw new Error(
+    `Invalid Beads ${fieldName} for task ${taskId}: expected a valid ISO-8601 timestamp string.`,
+  );
 };
 
 const normalizeParentId = (issue: RawIssue): string | undefined => {

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -1,7 +1,14 @@
-import { qaReportVerdictSchema } from "@openducktor/contracts";
+import { qaReportVerdictSchema, taskPrioritySchema } from "@openducktor/contracts";
 import { z } from "zod";
 import { parseBeadsIssueType, parseBeadsTaskStatus } from "./beads-task-parsing";
-import type { JsonObject, MarkdownEntry, QaEntry, RawIssue, TaskCard } from "./contracts";
+import type {
+  JsonObject,
+  MarkdownEntry,
+  PublicTask,
+  QaEntry,
+  RawIssue,
+  TaskCard,
+} from "./contracts";
 
 const defaultQaRequiredForIssueType = (): boolean => true;
 
@@ -59,6 +66,48 @@ export const parseQaEntries = (value: unknown): QaEntry[] => {
   return parseTypedEntries(QaEntrySchema, value);
 };
 
+export const normalizeLabels = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const labels = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    labels.add(trimmed);
+  }
+
+  return Array.from(labels).sort((left, right) => left.localeCompare(right));
+};
+
+const parsePriority = (taskId: string, value: unknown): number => {
+  const parsed = taskPrioritySchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(
+      `Invalid Beads priority for task ${taskId}: received ${JSON.stringify(value)}. Expected an integer 0..4.`,
+    );
+  }
+  return parsed.data;
+};
+
+const parseTimestamp = (
+  taskId: string,
+  fieldName: "created_at" | "updated_at",
+  value: unknown,
+): string => {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+
+  throw new Error(`Invalid Beads ${fieldName} for task ${taskId}: expected a non-empty string.`);
+};
+
 const normalizeParentId = (issue: RawIssue): string | undefined => {
   if (typeof issue.parent === "string" && issue.parent.trim().length > 0) {
     return issue.parent;
@@ -109,5 +158,29 @@ export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): Tas
     issueType,
     aiReviewEnabled: qaRequired,
     ...(parentId ? { parentId } : {}),
+  };
+};
+
+export const issueToPublicTask = (issue: RawIssue, metadataNamespace: string): PublicTask => {
+  const issueType = parseBeadsIssueType(issue.id, issue.issue_type);
+  const status = parseBeadsTaskStatus(issue.id, issue.status);
+  const root = parseMetadataRoot(issue.metadata);
+  const namespace = ensureObject(root[metadataNamespace]);
+  const qaRequired =
+    typeof namespace.qaRequired === "boolean"
+      ? namespace.qaRequired
+      : defaultQaRequiredForIssueType();
+
+  return {
+    id: issue.id,
+    title: issue.title,
+    description: typeof issue.description === "string" ? issue.description : "",
+    status,
+    priority: parsePriority(issue.id, issue.priority),
+    issueType,
+    aiReviewEnabled: qaRequired,
+    labels: normalizeLabels(issue.labels),
+    createdAt: parseTimestamp(issue.id, "created_at", issue.created_at),
+    updatedAt: parseTimestamp(issue.id, "updated_at", issue.updated_at),
   };
 };

--- a/packages/openducktor-mcp/src/task-transitions.ts
+++ b/packages/openducktor-mcp/src/task-transitions.ts
@@ -8,6 +8,11 @@ export type TaskContext = {
   tasks: TaskCard[];
 };
 
+export type RefreshedTaskState = {
+  issue: RawIssue;
+  task: TaskCard;
+};
+
 export const resolveTaskContext = async (
   taskId: string,
   listTasks: () => Promise<TaskCard[]>,
@@ -56,14 +61,17 @@ export const applyTransition = async (input: {
   showRawIssue: (taskId: string) => Promise<RawIssue>;
   invalidateTaskIndex: () => void;
   metadataNamespace: string;
-}): Promise<TaskCard> => {
+}): Promise<RefreshedTaskState> => {
   if (input.task.status !== input.nextStatus) {
     await input.runBdJson(["update", input.task.id, "--status", input.nextStatus]);
   }
 
-  const refreshed = await input.showRawIssue(input.task.id);
+  const issue = await input.showRawIssue(input.task.id);
   input.invalidateTaskIndex();
-  return issueToTaskCard(refreshed, input.metadataNamespace);
+  return {
+    issue,
+    task: issueToTaskCard(issue, input.metadataNamespace),
+  };
 };
 
 export const transitionTask = async (input: {
@@ -75,7 +83,7 @@ export const transitionTask = async (input: {
   showRawIssue: (taskId: string) => Promise<RawIssue>;
   invalidateTaskIndex: () => void;
   metadataNamespace: string;
-}): Promise<TaskCard> => {
+}): Promise<RefreshedTaskState> => {
   const { task, tasks } =
     input.context ?? (await resolveTaskContext(input.taskId, input.listTasks));
   assertTransitionAllowed(task, tasks, input.nextStatus);

--- a/packages/openducktor-mcp/src/task-transitions.ts
+++ b/packages/openducktor-mcp/src/task-transitions.ts
@@ -62,12 +62,20 @@ export const applyTransition = async (input: {
   invalidateTaskIndex: () => void;
   metadataNamespace: string;
 }): Promise<RefreshedTaskState> => {
-  if (input.task.status !== input.nextStatus) {
+  const mutated = input.task.status !== input.nextStatus;
+  if (mutated) {
     await input.runBdJson(["update", input.task.id, "--status", input.nextStatus]);
   }
 
-  const issue = await input.showRawIssue(input.task.id);
-  input.invalidateTaskIndex();
+  let issue: RawIssue;
+  try {
+    issue = await input.showRawIssue(input.task.id);
+  } finally {
+    if (mutated) {
+      input.invalidateTaskIndex();
+    }
+  }
+
   return {
     issue,
     task: issueToTaskCard(issue, input.metadataNamespace),

--- a/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
@@ -165,6 +165,40 @@ describe("task workflow runtime", () => {
     expect(invalidateCalls).toBe(1);
   });
 
+  test("transitionTask invalidates lookup state even when refreshed issue loading fails", async () => {
+    let invalidateCalls = 0;
+    const currentTask = makeTask({ status: "spec_ready" });
+    const runtime = createOdtTaskWorkflowRuntime({
+      persistence: {
+        metadataNamespace: "openducktor",
+        ensureInitialized: async () => {},
+        runBdJson: async () => ({}),
+        listTasks: async () => [currentTask],
+        showRawIssue: async () => {
+          throw new Error("show failed");
+        },
+        updateTask: async () => {
+          throw new Error("updateTask should not be called");
+        },
+        getNamespaceData: () => {
+          throw new Error("getNamespaceData should not be called");
+        },
+        writeNamespace: async () => {
+          throw new Error("writeNamespace should not be called");
+        },
+      },
+      taskLookup: {
+        resolveTask: async () => currentTask,
+        invalidate: () => {
+          invalidateCalls += 1;
+        },
+      },
+    });
+
+    await expect(runtime.transitionTask("task-1", "ready_for_dev")).rejects.toThrow("show failed");
+    expect(invalidateCalls).toBe(1);
+  });
+
   test("applyTaskUpdate writes metadata and status together and invalidates lookup state", async () => {
     const updateCalls: Array<{ metadataRoot?: unknown; status?: string }> = [];
     let invalidateCalls = 0;
@@ -222,6 +256,45 @@ describe("task workflow runtime", () => {
         status: "human_review",
       },
     ]);
+    expect(invalidateCalls).toBe(1);
+  });
+
+  test("applyTaskUpdate invalidates lookup state even when refreshed issue loading fails", async () => {
+    let invalidateCalls = 0;
+
+    const runtime = createOdtTaskWorkflowRuntime({
+      persistence: {
+        metadataNamespace: "openducktor",
+        ensureInitialized: async () => {},
+        runBdJson: async () => {
+          throw new Error("runBdJson should not be called");
+        },
+        listTasks: async () => [],
+        showRawIssue: async () => {
+          throw new Error("show failed");
+        },
+        updateTask: async () => {},
+        getNamespaceData: () => {
+          throw new Error("getNamespaceData should not be called");
+        },
+        writeNamespace: async () => {
+          throw new Error("writeNamespace should not be called");
+        },
+      },
+      taskLookup: {
+        resolveTask: async () => makeTask(),
+        invalidate: () => {
+          invalidateCalls += 1;
+        },
+      },
+    });
+
+    await expect(
+      runtime.applyTaskUpdate("task-1", {
+        metadataRoot: { openducktor: { documents: { qaReports: [{ verdict: "approved" }] } } },
+        status: "human_review",
+      }),
+    ).rejects.toThrow("show failed");
     expect(invalidateCalls).toBe(1);
   });
 });

--- a/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
@@ -157,9 +157,10 @@ describe("task workflow runtime", () => {
       },
     });
 
-    await expect(runtime.transitionTask("task-1", "ready_for_dev")).resolves.toEqual(
-      makeTask({ status: "ready_for_dev" }),
-    );
+    await expect(runtime.transitionTask("task-1", "ready_for_dev")).resolves.toEqual({
+      issue: makeIssue({ status: "ready_for_dev" }),
+      task: makeTask({ status: "ready_for_dev" }),
+    });
     expect(runCalls).toEqual([["update", "task-1", "--status", "ready_for_dev"]]);
     expect(invalidateCalls).toBe(1);
   });
@@ -208,7 +209,13 @@ describe("task workflow runtime", () => {
         metadataRoot: { openducktor: { documents: { qaReports: [{ verdict: "approved" }] } } },
         status: "human_review",
       }),
-    ).resolves.toEqual(makeTask({ status: "human_review" }));
+    ).resolves.toEqual({
+      issue: makeIssue({
+        status: "human_review",
+        metadata: { openducktor: { documents: { qaReports: [{ verdict: "approved" }] } } },
+      }),
+      task: makeTask({ status: "human_review" }),
+    });
     expect(updateCalls).toEqual([
       {
         metadataRoot: { openducktor: { documents: { qaReports: [{ verdict: "approved" }] } } },

--- a/packages/openducktor-mcp/src/task-workflow-runtime.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.ts
@@ -51,8 +51,13 @@ class DefaultOdtTaskWorkflowRuntime implements OdtTaskWorkflowRuntimePort {
   async applyTaskUpdate(taskId: string, input: TaskUpdateInput): Promise<RefreshedTaskState> {
     await this.persistence.updateTask(taskId, input);
 
-    const issue = await this.persistence.showRawIssue(taskId);
-    this.taskLookup.invalidate();
+    let issue: RawIssue;
+    try {
+      issue = await this.persistence.showRawIssue(taskId);
+    } finally {
+      this.taskLookup.invalidate();
+    }
+
     return {
       issue,
       task: issueToTaskCard(issue, this.metadataNamespace),

--- a/packages/openducktor-mcp/src/task-workflow-runtime.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.ts
@@ -4,6 +4,7 @@ import type { TaskIndexCache } from "./task-index-cache";
 import { issueToTaskCard } from "./task-mapping";
 import {
   assertTransitionAllowed as assertTaskTransitionAllowed,
+  type RefreshedTaskState,
   refreshTaskContext,
   resolveTaskContext,
   type TaskContext,
@@ -13,12 +14,16 @@ import {
 export type OdtTaskWorkflowRuntimePort = {
   metadataNamespace: string;
   ensureInitialized(): Promise<void>;
-  applyTaskUpdate(taskId: string, input: TaskUpdateInput): Promise<TaskCard>;
+  applyTaskUpdate(taskId: string, input: TaskUpdateInput): Promise<RefreshedTaskState>;
   readTaskSnapshot(taskId: string): Promise<{ issue: RawIssue; task: TaskCard }>;
   resolveTaskContext(taskId: string): Promise<TaskContext>;
   refreshTaskContext(taskId: string, context?: TaskContext): Promise<TaskContext>;
   assertTransitionAllowed(task: TaskCard, tasks: TaskCard[], nextStatus: TaskStatus): void;
-  transitionTask(taskId: string, nextStatus: TaskStatus, context?: TaskContext): Promise<TaskCard>;
+  transitionTask(
+    taskId: string,
+    nextStatus: TaskStatus,
+    context?: TaskContext,
+  ): Promise<RefreshedTaskState>;
 };
 
 type TaskLookupPort = Pick<TaskIndexCache, "invalidate" | "resolveTask">;
@@ -43,12 +48,15 @@ class DefaultOdtTaskWorkflowRuntime implements OdtTaskWorkflowRuntimePort {
     await this.persistence.ensureInitialized();
   }
 
-  async applyTaskUpdate(taskId: string, input: TaskUpdateInput): Promise<TaskCard> {
+  async applyTaskUpdate(taskId: string, input: TaskUpdateInput): Promise<RefreshedTaskState> {
     await this.persistence.updateTask(taskId, input);
 
-    const refreshed = await this.persistence.showRawIssue(taskId);
+    const issue = await this.persistence.showRawIssue(taskId);
     this.taskLookup.invalidate();
-    return issueToTaskCard(refreshed, this.metadataNamespace);
+    return {
+      issue,
+      task: issueToTaskCard(issue, this.metadataNamespace),
+    };
   }
 
   async readTaskSnapshot(taskId: string): Promise<{ issue: RawIssue; task: TaskCard }> {
@@ -79,7 +87,7 @@ class DefaultOdtTaskWorkflowRuntime implements OdtTaskWorkflowRuntimePort {
     taskId: string,
     nextStatus: TaskStatus,
     context?: TaskContext,
-  ): Promise<TaskCard> {
+  ): Promise<RefreshedTaskState> {
     return transitionTask({
       taskId,
       nextStatus,

--- a/packages/openducktor-mcp/src/tool-schemas.ts
+++ b/packages/openducktor-mcp/src/tool-schemas.ts
@@ -1,44 +1,116 @@
-import { type AgentToolName, planSubtaskInputSchema } from "@openducktor/contracts";
+import {
+  type AgentToolName,
+  issueTypeSchema,
+  planSubtaskInputSchema,
+  taskPrioritySchema,
+} from "@openducktor/contracts";
 import { z } from "zod";
 
-export const ReadTaskInputSchema = z.object({
-  taskId: z.string().trim().min(1),
-});
+export const ReadTaskInputSchema = z
+  .object({
+    taskId: z.string().trim().min(1),
+  })
+  .strict();
 
-export const SetSpecInputSchema = z.object({
-  taskId: z.string().trim().min(1),
-  markdown: z.string().trim().min(1),
-});
+const publicIssueTypeSchema = z.enum(["task", "feature", "bug"]);
+const activeTaskStatusSchema = z.enum([
+  "open",
+  "spec_ready",
+  "ready_for_dev",
+  "in_progress",
+  "blocked",
+  "ai_review",
+  "human_review",
+]);
+const labelStringSchema = z.string().trim().min(1);
 
-export const SetPlanInputSchema = z.object({
-  taskId: z.string().trim().min(1),
-  markdown: z.string().trim().min(1),
-  subtasks: z.array(planSubtaskInputSchema).optional(),
-});
+export const SetSpecInputSchema = z
+  .object({
+    taskId: z.string().trim().min(1),
+    markdown: z.string().trim().min(1),
+  })
+  .strict();
 
-export const BuildBlockedInputSchema = z.object({
-  taskId: z.string().trim().min(1),
-  reason: z.string().trim().min(1),
-});
+export const SetPlanInputSchema = z
+  .object({
+    taskId: z.string().trim().min(1),
+    markdown: z.string().trim().min(1),
+    subtasks: z.array(planSubtaskInputSchema).optional(),
+  })
+  .strict();
 
-export const BuildResumedInputSchema = z.object({
-  taskId: z.string().trim().min(1),
-});
+export const BuildBlockedInputSchema = z
+  .object({
+    taskId: z.string().trim().min(1),
+    reason: z.string().trim().min(1),
+  })
+  .strict();
 
-export const BuildCompletedInputSchema = z.object({
-  taskId: z.string().trim().min(1),
-  summary: z.string().optional(),
-});
+export const BuildResumedInputSchema = z
+  .object({
+    taskId: z.string().trim().min(1),
+  })
+  .strict();
 
-export const QaApprovedInputSchema = z.object({
-  taskId: z.string().trim().min(1),
-  reportMarkdown: z.string().trim().min(1),
-});
+export const BuildCompletedInputSchema = z
+  .object({
+    taskId: z.string().trim().min(1),
+    summary: z.string().optional(),
+  })
+  .strict();
 
-export const QaRejectedInputSchema = z.object({
-  taskId: z.string().trim().min(1),
-  reportMarkdown: z.string().trim().min(1),
-});
+export const QaApprovedInputSchema = z
+  .object({
+    taskId: z.string().trim().min(1),
+    reportMarkdown: z.string().trim().min(1),
+  })
+  .strict();
+
+export const QaRejectedInputSchema = z
+  .object({
+    taskId: z.string().trim().min(1),
+    reportMarkdown: z.string().trim().min(1),
+  })
+  .strict();
+
+export const CreateTaskInputSchema = z
+  .object({
+    title: z.string().trim().min(1).describe("Task title."),
+    issueType: publicIssueTypeSchema.describe(
+      "Issue type. Allowed values: task, feature, bug. Epic is not supported by the public MCP create tool.",
+    ),
+    priority: taskPrioritySchema.describe(
+      "Task priority. Valid values: 0 (P0 Critical), 1 (P1 High), 2 (P2 Normal), 3 (P3 Low), 4 (P4 Very low).",
+    ),
+    description: z.string().optional().describe("Optional task description."),
+    labels: z.array(labelStringSchema).optional().describe("Optional task labels."),
+    aiReviewEnabled: z
+      .boolean()
+      .optional()
+      .describe("Optional override for whether OpenDucktor QA review is required."),
+  })
+  .strict();
+
+export const SearchTasksInputSchema = z
+  .object({
+    priority: taskPrioritySchema.optional().describe("Exact-match priority filter."),
+    issueType: issueTypeSchema.optional().describe("Exact-match issue type filter."),
+    status: activeTaskStatusSchema.optional().describe("Exact-match active status filter."),
+    title: z.string().trim().min(1).optional().describe("Case-insensitive title substring filter."),
+    tags: z
+      .array(labelStringSchema)
+      .min(1)
+      .optional()
+      .describe("Task labels filter. Matching tasks must contain all tags."),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(100)
+      .default(50)
+      .describe("Maximum number of results to return. Default 50, max 100."),
+  })
+  .strict();
 
 export type ReadTaskInput = z.infer<typeof ReadTaskInputSchema>;
 export type SetSpecInput = z.infer<typeof SetSpecInputSchema>;
@@ -48,8 +120,10 @@ export type BuildResumedInput = z.infer<typeof BuildResumedInputSchema>;
 export type BuildCompletedInput = z.infer<typeof BuildCompletedInputSchema>;
 export type QaApprovedInput = z.infer<typeof QaApprovedInputSchema>;
 export type QaRejectedInput = z.infer<typeof QaRejectedInputSchema>;
+export type CreateTaskInput = z.infer<typeof CreateTaskInputSchema>;
+export type SearchTasksInput = z.infer<typeof SearchTasksInputSchema>;
 
-export const ODT_TOOL_SCHEMAS = {
+const ODT_WORKFLOW_TOOL_SCHEMAS = {
   odt_read_task: ReadTaskInputSchema,
   odt_set_spec: SetSpecInputSchema,
   odt_set_plan: SetPlanInputSchema,
@@ -59,3 +133,9 @@ export const ODT_TOOL_SCHEMAS = {
   odt_qa_approved: QaApprovedInputSchema,
   odt_qa_rejected: QaRejectedInputSchema,
 } as const satisfies Record<AgentToolName, z.ZodTypeAny>;
+
+export const ODT_TOOL_SCHEMAS = {
+  ...ODT_WORKFLOW_TOOL_SCHEMAS,
+  create_task: CreateTaskInputSchema,
+  search_tasks: SearchTasksInputSchema,
+} as const;

--- a/packages/openducktor-mcp/src/tool-schemas.ts
+++ b/packages/openducktor-mcp/src/tool-schemas.ts
@@ -94,7 +94,9 @@ export const CreateTaskInputSchema = z
 export const SearchTasksInputSchema = z
   .object({
     priority: taskPrioritySchema.optional().describe("Exact-match priority filter."),
-    issueType: issueTypeSchema.optional().describe("Exact-match issue type filter."),
+    issueType: issueTypeSchema
+      .optional()
+      .describe("Exact-match issue type filter. Active epics may appear in search results."),
     status: activeTaskStatusSchema.optional().describe("Exact-match active status filter."),
     title: z.string().trim().min(1).optional().describe("Case-insensitive title substring filter."),
     tags: z

--- a/packages/openducktor-mcp/src/tool-schemas.ts
+++ b/packages/openducktor-mcp/src/tool-schemas.ts
@@ -82,7 +82,7 @@ export const CreateTaskInputSchema = z
     priority: taskPrioritySchema.describe(
       "Task priority. Valid values: 0 (P0 Critical), 1 (P1 High), 2 (P2 Normal), 3 (P3 Low), 4 (P4 Very low).",
     ),
-    description: z.string().optional().describe("Optional task description."),
+    description: z.string().trim().min(1).optional().describe("Optional task description."),
     labels: z.array(labelStringSchema).optional().describe("Optional task labels."),
     aiReviewEnabled: z
       .boolean()

--- a/packages/openducktor-mcp/src/tool-schemas.ts
+++ b/packages/openducktor-mcp/src/tool-schemas.ts
@@ -35,7 +35,7 @@ export const SetPlanInputSchema = z
   .object({
     taskId: z.string().trim().min(1),
     markdown: z.string().trim().min(1),
-    subtasks: z.array(planSubtaskInputSchema).optional(),
+    subtasks: z.array(planSubtaskInputSchema.strict()).optional(),
   })
   .strict();
 

--- a/packages/openducktor-mcp/tsconfig.json
+++ b/packages/openducktor-mcp/tsconfig.json
@@ -4,6 +4,8 @@
     "composite": true,
     "declaration": true,
     "emitDeclarationOnly": true,
+    "noEmit": false,
+    "rootDir": "src",
     "outDir": "dist",
     "lib": ["ES2022"]
   },

--- a/packages/openducktor-mcp/tsconfig.json
+++ b/packages/openducktor-mcp/tsconfig.json
@@ -7,7 +7,8 @@
     "noEmit": false,
     "rootDir": "src",
     "outDir": "dist",
-    "lib": ["ES2022"]
+    "lib": ["ES2022"],
+    "resolveJsonModule": true
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]


### PR DESCRIPTION
## Summary
- publish `packages/openducktor-mcp` as `@openducktor/mcp` for external `bunx @openducktor/mcp --repo <repo>` usage
- add public `create_task` and `search_tasks` MCP tools with shared public task/document response schemas and updated docs
- keep the new public tools unavailable to current internal agent roles by tightening OpenCode tool selection and permission gating

## Review fixes
- make public MCP input schemas strict so unsupported fields like `parentId` and `assignee` are rejected instead of silently stripped
- deny canonical `create_task` / `search_tasks` IDs in role gating in addition to prefixed MCP-discovered aliases
- filter non-task Beads issue types out of MCP search/list paths
- remove extra workflow re-read/list coupling in mutation responses by rebuilding public task payloads from `showRawIssue`
- restore declaration output for the publishable MCP package and cover the new behavior with tests

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`
- `cd apps/desktop/src-tauri && cargo fmt --all --check`
- `cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public MCP package: add create_task and search_tasks endpoints, richer public task snapshots (priority, labels, createdAt/updatedAt, aiReviewEnabled), and store methods to create/search tasks.

* **Documentation**
  * Added external MCP docs, package README, architecture and security notes with usage, schemas, examples, and public tool contracts.

* **Refactor**
  * Improved tool discovery and permission generation to recognize trusted prefixes/canonical IDs and emit broader deny/allow groups.

* **Chores**
  * Packaging/build metadata updated and CI workflow added to publish the MCP package.

* **Tests**
  * Expanded/updated tests to cover new public shapes, inputs, validation, and return formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->