### PR TITLE
refactor: first desloppify cleanup batch

### DIFF
--- a/apps/desktop/src-tauri/src/commands/git/command_handlers.rs
+++ b/apps/desktop/src-tauri/src/commands/git/command_handlers.rs
@@ -24,10 +24,7 @@ fn authorize_git_scope(
     repo_path: &str,
     working_dir: Option<&str>,
 ) -> Result<AuthorizedGitScope, String> {
-    let repo_path = state
-        .service
-        .resolve_authorized_repo_path(repo_path)
-        .map_err(|error| error.to_string())?;
+    let repo_path = as_error(state.service.resolve_authorized_repo_path(repo_path))?;
     let effective_working_dir = resolve_working_dir(repo_path.as_str(), working_dir)?;
 
     Ok(AuthorizedGitScope {

--- a/apps/desktop/src-tauri/src/commands/git/command_handlers.rs
+++ b/apps/desktop/src-tauri/src/commands/git/command_handlers.rs
@@ -14,6 +14,28 @@ use super::{
     },
 };
 
+struct AuthorizedGitScope {
+    repo_path: String,
+    effective_working_dir: String,
+}
+
+fn authorize_git_scope(
+    state: &State<'_, AppState>,
+    repo_path: &str,
+    working_dir: Option<&str>,
+) -> Result<AuthorizedGitScope, String> {
+    let repo_path = state
+        .service
+        .resolve_authorized_repo_path(repo_path)
+        .map_err(|error| error.to_string())?;
+    let effective_working_dir = resolve_working_dir(repo_path.as_str(), working_dir)?;
+
+    Ok(AuthorizedGitScope {
+        repo_path,
+        effective_working_dir,
+    })
+}
+
 pub(crate) fn parse_diff_scope(
     diff_scope: Option<&str>,
 ) -> Result<host_domain::GitDiffScope, String> {
@@ -39,9 +61,10 @@ pub async fn git_get_branches(
     state: State<'_, AppState>,
     repo_path: String,
 ) -> Result<Vec<host_domain::GitBranch>, String> {
+    let scope = authorize_git_scope(&state, &repo_path, None)?;
     let service = state.service.clone();
     let result = run_service_blocking("git_get_branches", move || {
-        service.git_get_branches(&repo_path)
+        service.git_get_branches(&scope.repo_path)
     })
     .await;
     as_error(result)
@@ -53,14 +76,12 @@ pub async fn git_get_current_branch(
     repo_path: String,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitCurrentBranch, String> {
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     let service = state.service.clone();
     let result = run_service_blocking("git_get_current_branch", move || {
-        service.git_port().get_current_branch(Path::new(&effective))
+        service
+            .git_port()
+            .get_current_branch(Path::new(&scope.effective_working_dir))
     })
     .await;
     as_error(result)
@@ -73,10 +94,11 @@ pub async fn git_switch_branch(
     branch: String,
     create: Option<bool>,
 ) -> Result<host_domain::GitCurrentBranch, String> {
+    let scope = authorize_git_scope(&state, &repo_path, None)?;
     let service = state.service.clone();
     let create = create.unwrap_or(false);
     let result = run_service_blocking("git_switch_branch", move || {
-        service.git_switch_branch(&repo_path, &branch, create)
+        service.git_switch_branch(&scope.repo_path, &branch, create)
     })
     .await;
     as_error(result)
@@ -90,9 +112,10 @@ pub async fn git_create_worktree(
     branch: String,
     create_branch: Option<bool>,
 ) -> Result<host_domain::GitWorktreeSummary, String> {
+    let scope = authorize_git_scope(&state, &repo_path, None)?;
     let service = state.service.clone();
     let create_branch = create_branch.unwrap_or(false);
-    let repo_path_for_worker = repo_path.clone();
+    let repo_path_for_worker = scope.repo_path.clone();
     let result = run_service_blocking("git_create_worktree", move || {
         service.git_create_worktree(
             &repo_path_for_worker,
@@ -103,7 +126,7 @@ pub async fn git_create_worktree(
     })
     .await;
     let summary = as_error(result)?;
-    invalidate_worktree_resolution_cache_for_repo(&repo_path)?;
+    invalidate_worktree_resolution_cache_for_repo(&scope.repo_path)?;
     Ok(summary)
 }
 
@@ -114,15 +137,16 @@ pub async fn git_remove_worktree(
     worktree_path: String,
     force: Option<bool>,
 ) -> Result<serde_json::Value, String> {
+    let scope = authorize_git_scope(&state, &repo_path, None)?;
     let service = state.service.clone();
     let force = force.unwrap_or(false);
-    let repo_path_for_worker = repo_path.clone();
+    let repo_path_for_worker = scope.repo_path.clone();
     let result = run_service_blocking("git_remove_worktree", move || {
         service.git_remove_worktree(&repo_path_for_worker, &worktree_path, force)
     })
     .await;
     let removed = as_error(result)?;
-    invalidate_worktree_resolution_cache_for_repo(&repo_path)?;
+    invalidate_worktree_resolution_cache_for_repo(&scope.repo_path)?;
     Ok(serde_json::json!({ "ok": removed }))
 }
 
@@ -136,19 +160,14 @@ pub async fn git_push_branch(
     set_upstream: Option<bool>,
     force_with_lease: Option<bool>,
 ) -> Result<host_domain::GitPushResult, String> {
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     let service = state.service.clone();
     let set_upstream = set_upstream.unwrap_or(false);
     let force_with_lease = force_with_lease.unwrap_or(false);
     let result = run_service_blocking("git_push_branch", move || {
         service.git_push_branch(
-            &repo_path,
-            Some(effective.as_str()),
+            &scope.repo_path,
+            Some(scope.effective_working_dir.as_str()),
             remote.as_deref(),
             &branch,
             set_upstream,
@@ -165,14 +184,12 @@ pub async fn git_get_status(
     repo_path: String,
     working_dir: Option<String>,
 ) -> Result<Vec<host_domain::GitFileStatus>, String> {
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     let service = state.service.clone();
     let result = run_service_blocking("git_get_status", move || {
-        service.git_port().get_status(Path::new(&effective))
+        service
+            .git_port()
+            .get_status(Path::new(&scope.effective_working_dir))
     })
     .await;
     as_error(result)
@@ -185,16 +202,12 @@ pub async fn git_get_diff(
     target_branch: Option<String>,
     working_dir: Option<String>,
 ) -> Result<Vec<host_domain::GitFileDiff>, String> {
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     let service = state.service.clone();
     let result = run_service_blocking("git_get_diff", move || {
         service
             .git_port()
-            .get_diff(Path::new(&effective), target_branch.as_deref())
+            .get_diff(Path::new(&scope.effective_working_dir), target_branch.as_deref())
     })
     .await;
     as_error(result)
@@ -207,16 +220,12 @@ pub async fn git_commits_ahead_behind(
     target_branch: String,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitAheadBehind, String> {
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     let service = state.service.clone();
     let result = run_service_blocking("git_commits_ahead_behind", move || {
         service
             .git_port()
-            .commits_ahead_behind(Path::new(&effective), &target_branch)
+            .commits_ahead_behind(Path::new(&scope.effective_working_dir), &target_branch)
     })
     .await;
     as_error(result)
@@ -230,16 +239,11 @@ pub async fn git_get_worktree_status(
     diff_scope: Option<String>,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitWorktreeStatus, String> {
+    let git_scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     let trimmed_target = require_target_branch(&target_branch)?.to_string();
     let scope = parse_diff_scope(diff_scope.as_deref())?;
-
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
     let service = state.service.clone();
-    let effective_for_worker = effective.clone();
+    let effective_for_worker = git_scope.effective_working_dir.clone();
     let trimmed_target_for_worker = trimmed_target.clone();
     let scope_for_worker = scope.clone();
     let worktree_status = as_error(
@@ -267,7 +271,7 @@ pub async fn git_get_worktree_status(
     Ok(build_worktree_status_with_snapshot(
         worktree_status,
         WorktreeSnapshotMetadata {
-            effective_working_dir: effective,
+            effective_working_dir: git_scope.effective_working_dir,
             target_branch: trimmed_target,
             diff_scope: scope,
             observed_at_ms,
@@ -286,16 +290,11 @@ pub async fn git_get_worktree_status_summary(
     diff_scope: Option<String>,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitWorktreeStatusSummary, String> {
+    let git_scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     let trimmed_target = require_target_branch(&target_branch)?.to_string();
     let scope = parse_diff_scope(diff_scope.as_deref())?;
-
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
     let service = state.service.clone();
-    let effective_for_worker = effective.clone();
+    let effective_for_worker = git_scope.effective_working_dir.clone();
     let trimmed_target_for_worker = trimmed_target.clone();
     let scope_for_worker = scope.clone();
     let worktree_status = as_error(
@@ -331,7 +330,7 @@ pub async fn git_get_worktree_status_summary(
         worktree_status.target_ahead_behind,
         worktree_status.upstream_ahead_behind,
         WorktreeSnapshotMetadata {
-            effective_working_dir: effective,
+            effective_working_dir: git_scope.effective_working_dir,
             target_branch: trimmed_target,
             diff_scope: scope,
             observed_at_ms,
@@ -349,23 +348,18 @@ pub async fn git_commit_all(
     message: String,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitCommitAllResult, String> {
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     if message.trim().is_empty() {
         return Err("message is required".to_string());
     }
 
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-
     let request = host_domain::GitCommitAllRequest {
-        working_dir: Some(effective),
+        working_dir: Some(scope.effective_working_dir),
         message: message.trim().to_string(),
     };
     let service = state.service.clone();
     let result = run_service_blocking("git_commit_all", move || {
-        service.git_commit_all(&repo_path, request)
+        service.git_commit_all(&scope.repo_path, request)
     })
     .await;
     as_error(result)
@@ -377,18 +371,14 @@ pub async fn git_pull_branch(
     repo_path: String,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitPullResult, String> {
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
 
     let request = host_domain::GitPullRequest {
-        working_dir: Some(effective),
+        working_dir: Some(scope.effective_working_dir),
     };
     let service = state.service.clone();
     let result = run_service_blocking("git_pull_branch", move || {
-        service.git_pull_branch(&repo_path, request)
+        service.git_pull_branch(&scope.repo_path, request)
     })
     .await;
     as_error(result)
@@ -401,23 +391,18 @@ pub async fn git_rebase_branch(
     target_branch: String,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitRebaseBranchResult, String> {
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     if target_branch.trim().is_empty() {
         return Err("targetBranch is required".to_string());
     }
 
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
-
     let request = host_domain::GitRebaseBranchRequest {
-        working_dir: Some(effective),
+        working_dir: Some(scope.effective_working_dir),
         target_branch: target_branch.trim().to_string(),
     };
     let service = state.service.clone();
     let result = run_service_blocking("git_rebase_branch", move || {
-        service.git_rebase_branch(&repo_path, request)
+        service.git_rebase_branch(&scope.repo_path, request)
     })
     .await;
     as_error(result)
@@ -429,18 +414,14 @@ pub async fn git_rebase_abort(
     repo_path: String,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitRebaseAbortResult, String> {
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
 
     let request = host_domain::GitRebaseAbortRequest {
-        working_dir: Some(effective),
+        working_dir: Some(scope.effective_working_dir),
     };
     let service = state.service.clone();
     let result = run_service_blocking("git_rebase_abort", move || {
-        service.git_rebase_abort(&repo_path, request)
+        service.git_rebase_abort(&scope.repo_path, request)
     })
     .await;
     as_error(result)
@@ -453,19 +434,15 @@ pub async fn git_abort_conflict(
     operation: host_domain::GitConflictOperation,
     working_dir: Option<String>,
 ) -> Result<host_domain::GitConflictAbortResult, String> {
-    let _ = state
-        .service
-        .resolve_authorized_repo_path(&repo_path)
-        .map_err(|e| e.to_string())?;
-    let effective = resolve_working_dir(&repo_path, working_dir.as_deref())?;
+    let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
 
     let request = host_domain::GitConflictAbortRequest {
         operation,
-        working_dir: Some(effective),
+        working_dir: Some(scope.effective_working_dir),
     };
     let service = state.service.clone();
     let result = run_service_blocking("git_abort_conflict", move || {
-        service.git_abort_conflict(&repo_path, request)
+        service.git_abort_conflict(&scope.repo_path, request)
     })
     .await;
     as_error(result)

--- a/apps/desktop/src/components/layout/sidebar/branch-switcher.test.tsx
+++ b/apps/desktop/src/components/layout/sidebar/branch-switcher.test.tsx
@@ -1,10 +1,16 @@
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { ReactElement } from "react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import TestRenderer, { act, type ReactTestRenderer } from "react-test-renderer";
 
 let branchSyncDegraded = false;
 let isSwitchingWorkspace = false;
+let isSwitchingBranch = false;
 let activeBranchName = "main";
+let latestOnValueChange: ((value: string) => void) | undefined;
+
+const switchBranch = mock(async (_branchName: string) => {});
 
 mock.module("@/state", () => ({
   useWorkspaceState: () => ({
@@ -22,22 +28,61 @@ mock.module("@/state", () => ({
     },
     isSwitchingWorkspace,
     isLoadingBranches: false,
-    isSwitchingBranch: false,
+    isSwitchingBranch,
     branchSyncDegraded,
-    switchBranch: async () => {},
+    switchBranch,
   }),
 }));
 
 mock.module("@/components/features/repository/branch-selector", () => ({
-  BranchSelector: ({ value, disabled }: { value: string; disabled?: boolean }) => (
-    <div data-branch-value={value} data-disabled={disabled ? "true" : "false"} />
-  ),
+  BranchSelector: ({
+    value,
+    disabled,
+    onValueChange,
+  }: {
+    value: string;
+    disabled?: boolean;
+    onValueChange?: (value: string) => void;
+  }) => {
+    latestOnValueChange = onValueChange;
+    return <div data-branch-value={value} data-disabled={disabled ? "true" : "false"} />;
+  },
 }));
 
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+};
+
 describe("BranchSwitcher", () => {
+  beforeEach(() => {
+    branchSyncDegraded = false;
+    isSwitchingWorkspace = false;
+    isSwitchingBranch = false;
+    activeBranchName = "main";
+    latestOnValueChange = undefined;
+    switchBranch.mockReset();
+    switchBranch.mockImplementation(async () => {});
+  });
+
   test("shows degraded sync status when branch probe failures are active", async () => {
     branchSyncDegraded = true;
-    isSwitchingWorkspace = false;
     const { BranchSwitcher } = await import("./branch-switcher");
     const html = renderToStaticMarkup(createElement(BranchSwitcher));
 
@@ -45,8 +90,6 @@ describe("BranchSwitcher", () => {
   });
 
   test("hides degraded sync status when branch probe health is restored", async () => {
-    branchSyncDegraded = false;
-    isSwitchingWorkspace = false;
     const { BranchSwitcher } = await import("./branch-switcher");
     const html = renderToStaticMarkup(createElement(BranchSwitcher));
 
@@ -54,7 +97,6 @@ describe("BranchSwitcher", () => {
   });
 
   test("disables branch selection while switching repositories", async () => {
-    branchSyncDegraded = false;
     isSwitchingWorkspace = true;
     activeBranchName = "main";
     const { BranchSwitcher } = await import("./branch-switcher");
@@ -64,12 +106,68 @@ describe("BranchSwitcher", () => {
   });
 
   test("uses the active branch name on the first render", async () => {
-    branchSyncDegraded = false;
-    isSwitchingWorkspace = false;
     activeBranchName = "feature/desloppify";
     const { BranchSwitcher } = await import("./branch-switcher");
     const html = renderToStaticMarkup(createElement(BranchSwitcher));
 
     expect(html).toContain('data-branch-value="feature/desloppify"');
+  });
+
+  test("clears pending branch state after a successful switch completes", async () => {
+    const deferred = createDeferred<void>();
+    switchBranch.mockImplementation(() => deferred.promise);
+    const { BranchSwitcher } = await import("./branch-switcher");
+
+    let renderer: ReactTestRenderer | null = null;
+    const render = (): ReactElement => createElement(BranchSwitcher);
+
+    await act(async () => {
+      renderer = TestRenderer.create(render());
+    });
+
+    if (!renderer) {
+      throw new Error("Expected branch switcher renderer to mount");
+    }
+    const mountedRenderer: ReactTestRenderer = renderer;
+
+    expect(latestOnValueChange).toBeDefined();
+
+    await act(async () => {
+      latestOnValueChange?.("feature/desloppify");
+    });
+
+    isSwitchingBranch = true;
+    await act(async () => {
+      mountedRenderer.update(render());
+    });
+
+    expect(
+      mountedRenderer.root.findByProps({
+        "data-branch-value": "feature/desloppify",
+      }).props["data-branch-value"],
+    ).toBe("feature/desloppify");
+
+    activeBranchName = "feature/desloppify";
+    isSwitchingBranch = false;
+    await act(async () => {
+      deferred.resolve();
+      await flush();
+    });
+
+    activeBranchName = "release";
+    isSwitchingBranch = true;
+    await act(async () => {
+      mountedRenderer.update(render());
+    });
+
+    expect(
+      mountedRenderer.root.findByProps({
+        "data-branch-value": "release",
+      }).props["data-branch-value"],
+    ).toBe("release");
+
+    await act(async () => {
+      mountedRenderer.unmount();
+    });
   });
 });

--- a/apps/desktop/src/components/layout/sidebar/branch-switcher.test.tsx
+++ b/apps/desktop/src/components/layout/sidebar/branch-switcher.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 let branchSyncDegraded = false;
 let isSwitchingWorkspace = false;
+let activeBranchName = "main";
 
 mock.module("@/state", () => ({
   useWorkspaceState: () => ({
@@ -16,7 +17,7 @@ mock.module("@/state", () => ({
       },
     ],
     activeBranch: {
-      name: "main",
+      name: activeBranchName,
       detached: false,
     },
     isSwitchingWorkspace,
@@ -25,6 +26,12 @@ mock.module("@/state", () => ({
     branchSyncDegraded,
     switchBranch: async () => {},
   }),
+}));
+
+mock.module("@/components/features/repository/branch-selector", () => ({
+  BranchSelector: ({ value, disabled }: { value: string; disabled?: boolean }) => (
+    <div data-branch-value={value} data-disabled={disabled ? "true" : "false"} />
+  ),
 }));
 
 describe("BranchSwitcher", () => {
@@ -49,9 +56,20 @@ describe("BranchSwitcher", () => {
   test("disables branch selection while switching repositories", async () => {
     branchSyncDegraded = false;
     isSwitchingWorkspace = true;
+    activeBranchName = "main";
     const { BranchSwitcher } = await import("./branch-switcher");
     const html = renderToStaticMarkup(createElement(BranchSwitcher));
 
-    expect(html).toContain('disabled=""');
+    expect(html).toContain('data-disabled="true"');
+  });
+
+  test("uses the active branch name on the first render", async () => {
+    branchSyncDegraded = false;
+    isSwitchingWorkspace = false;
+    activeBranchName = "feature/desloppify";
+    const { BranchSwitcher } = await import("./branch-switcher");
+    const html = renderToStaticMarkup(createElement(BranchSwitcher));
+
+    expect(html).toContain('data-branch-value="feature/desloppify"');
   });
 });

--- a/apps/desktop/src/components/layout/sidebar/branch-switcher.test.tsx
+++ b/apps/desktop/src/components/layout/sidebar/branch-switcher.test.tsx
@@ -98,7 +98,6 @@ describe("BranchSwitcher", () => {
 
   test("disables branch selection while switching repositories", async () => {
     isSwitchingWorkspace = true;
-    activeBranchName = "main";
     const { BranchSwitcher } = await import("./branch-switcher");
     const html = renderToStaticMarkup(createElement(BranchSwitcher));
 
@@ -144,8 +143,8 @@ describe("BranchSwitcher", () => {
     expect(
       mountedRenderer.root.findByProps({
         "data-branch-value": "feature/desloppify",
-      }).props["data-branch-value"],
-    ).toBe("feature/desloppify");
+      }),
+    ).toBeTruthy();
 
     activeBranchName = "feature/desloppify";
     isSwitchingBranch = false;
@@ -163,8 +162,8 @@ describe("BranchSwitcher", () => {
     expect(
       mountedRenderer.root.findByProps({
         "data-branch-value": "release",
-      }).props["data-branch-value"],
-    ).toBe("release");
+      }),
+    ).toBeTruthy();
 
     await act(async () => {
       mountedRenderer.unmount();

--- a/apps/desktop/src/components/layout/sidebar/branch-switcher.tsx
+++ b/apps/desktop/src/components/layout/sidebar/branch-switcher.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useMemo, useState } from "react";
+import { type ReactElement, useMemo, useState } from "react";
 import { BranchSelector } from "@/components/features/repository/branch-selector";
 import { toBranchSelectorOptions } from "@/components/features/repository/branch-selector-model";
 import { useWorkspaceState } from "@/state";
@@ -14,13 +14,11 @@ export function BranchSwitcher(): ReactElement | null {
     branchSyncDegraded,
     switchBranch,
   } = useWorkspaceState();
-  const [selectedBranchValue, setSelectedBranchValue] = useState("");
+  const [pendingBranchValue, setPendingBranchValue] = useState<string | null>(null);
+  const activeBranchValue = activeBranch?.name ?? "";
 
   const branchOptions = useMemo(() => toBranchSelectorOptions(branches), [branches]);
-
-  useEffect(() => {
-    setSelectedBranchValue(activeBranch?.name ?? "");
-  }, [activeBranch?.name]);
+  const selectedBranchValue = isSwitchingBranch ? pendingBranchValue ?? activeBranchValue : activeBranchValue;
 
   if (!activeRepo) {
     return null;
@@ -46,15 +44,15 @@ export function BranchSwitcher(): ReactElement | null {
         placeholder={branchPlaceholder}
         popoverClassName="w-[min(28rem,calc(100vw-2rem))] p-0"
         onValueChange={(nextBranch) => {
-          const previousBranch = activeBranch?.name ?? "";
+          const previousBranch = activeBranchValue;
 
           if (!nextBranch || nextBranch === previousBranch) {
             return;
           }
 
-          setSelectedBranchValue(nextBranch);
+          setPendingBranchValue(nextBranch);
           void switchBranch(nextBranch).catch(() => {
-            setSelectedBranchValue(previousBranch);
+            setPendingBranchValue(null);
           });
         }}
       />

--- a/apps/desktop/src/components/layout/sidebar/branch-switcher.tsx
+++ b/apps/desktop/src/components/layout/sidebar/branch-switcher.tsx
@@ -53,7 +53,7 @@ export function BranchSwitcher(): ReactElement | null {
           }
 
           setPendingBranchValue(nextBranch);
-          void switchBranch(nextBranch).catch(() => {
+          void switchBranch(nextBranch).finally(() => {
             setPendingBranchValue(null);
           });
         }}

--- a/apps/desktop/src/components/layout/sidebar/branch-switcher.tsx
+++ b/apps/desktop/src/components/layout/sidebar/branch-switcher.tsx
@@ -18,7 +18,9 @@ export function BranchSwitcher(): ReactElement | null {
   const activeBranchValue = activeBranch?.name ?? "";
 
   const branchOptions = useMemo(() => toBranchSelectorOptions(branches), [branches]);
-  const selectedBranchValue = isSwitchingBranch ? pendingBranchValue ?? activeBranchValue : activeBranchValue;
+  const selectedBranchValue = isSwitchingBranch
+    ? (pendingBranchValue ?? activeBranchValue)
+    : activeBranchValue;
 
   if (!activeRepo) {
     return null;

--- a/apps/desktop/src/components/layout/theme-provider.tsx
+++ b/apps/desktop/src/components/layout/theme-provider.tsx
@@ -1,7 +1,7 @@
 import type { SettingsSnapshot, Theme } from "@openducktor/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createContext, useContext, useEffect, useLayoutEffect, useMemo, useState } from "react";
-import { createHostClient } from "@/lib/host-client";
+import { hostBridge } from "@/lib/host-client";
 import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
 import { applyThemeToDocument, readDocumentTheme } from "./theme-dom";
 
@@ -21,8 +21,6 @@ const initialState: ThemeProviderState = {
 };
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
-
-const hostClient = createHostClient();
 
 export function ThemeProvider({ children, defaultTheme = "light", ...props }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<Theme>(() => readDocumentTheme(defaultTheme));
@@ -64,7 +62,7 @@ export function ThemeProvider({ children, defaultTheme = "light", ...props }: Th
             };
           },
         );
-        void hostClient.setTheme(newTheme).catch((error) => {
+        void hostBridge.client.setTheme(newTheme).catch((error) => {
           console.error("Failed to persist theme change.", error);
           setThemeState(previousTheme);
           if (previousSnapshot) {

--- a/apps/desktop/src/features/git-conflict-resolution/git-conflict-resolution-modal.test.tsx
+++ b/apps/desktop/src/features/git-conflict-resolution/git-conflict-resolution-modal.test.tsx
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { ReactElement } from "react";
+import { createElement } from "react";
+import TestRenderer, { act, type ReactTestRenderer } from "react-test-renderer";
+import type { GitConflict } from "@/features/agent-studio-git";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import {
+  type PendingGitConflictResolutionRequest,
+  useGitConflictResolutionModalState,
+} from "./index";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+
+const builderSession = (sessionId: string): AgentSessionState => ({
+  sessionId,
+  externalSessionId: `external-${sessionId}`,
+  taskId: "task-1",
+  runtimeKind: "opencode",
+  role: "build",
+  scenario: "build_implementation_start",
+  status: "idle",
+  startedAt: "2026-03-18T10:00:00.000Z",
+  runtimeId: null,
+  runId: null,
+  runtimeEndpoint: "http://127.0.0.1:4444",
+  workingDirectory: "/tmp/repo",
+  messages: [],
+  draftAssistantText: "",
+  draftAssistantMessageId: null,
+  draftReasoningText: "",
+  draftReasoningMessageId: null,
+  pendingPermissions: [],
+  pendingQuestions: [],
+  todos: [],
+  modelCatalog: null,
+  selectedModel: null,
+  isLoadingModelCatalog: false,
+});
+
+const conflictFixture: GitConflict = {
+  operation: "rebase",
+  currentBranch: "feature/test",
+  targetBranch: "main",
+  conflictedFiles: ["src/example.ts"],
+  output: "CONFLICT",
+  workingDir: "/tmp/repo/worktree",
+};
+
+const createRequest = (
+  overrides: Partial<PendingGitConflictResolutionRequest> = {},
+): PendingGitConflictResolutionRequest => ({
+  requestId: "request-1",
+  conflict: conflictFixture,
+  currentWorktreePath: "/tmp/repo/worktree",
+  currentViewSessionId: "session-1",
+  defaultMode: "existing",
+  defaultSessionId: "session-1",
+  builderSessions: [builderSession("session-1"), builderSession("session-2")],
+  ...overrides,
+});
+
+let latestState: ReturnType<typeof useGitConflictResolutionModalState> | undefined;
+
+const HookHarness = ({
+  request,
+}: {
+  request: PendingGitConflictResolutionRequest;
+}): ReactElement => {
+  latestState = useGitConflictResolutionModalState(request);
+  return createElement("div");
+};
+
+describe("git-conflict-resolution-modal", () => {
+  beforeEach(() => {
+    latestState = undefined;
+  });
+
+  test("disables confirm when the selected existing session is no longer available", async () => {
+    const request = createRequest({
+      defaultSessionId: " missing-session ",
+    });
+
+    let renderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(HookHarness, { request }));
+    });
+
+    if (!renderer || !latestState) {
+      throw new Error("Expected conflict-resolution modal harness to mount");
+    }
+
+    expect(latestState.confirmDisabled).toBe(true);
+
+    await act(async () => {
+      renderer?.unmount();
+    });
+  });
+
+  test("reconciles state against the latest request before applying updates", async () => {
+    const firstRequest = createRequest();
+    const secondRequest = createRequest({
+      requestId: "request-2",
+      defaultMode: "new",
+      defaultSessionId: "",
+      builderSessions: [builderSession("session-3")],
+    });
+
+    let renderer: ReactTestRenderer | null = null;
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(HookHarness, { request: firstRequest }));
+    });
+
+    if (!renderer || !latestState) {
+      throw new Error("Expected conflict-resolution modal harness to mount");
+    }
+
+    await act(async () => {
+      renderer?.update(createElement(HookHarness, { request: secondRequest }));
+    });
+
+    await act(async () => {
+      latestState?.setSelectedSessionId("session-3");
+      renderer?.update(createElement(HookHarness, { request: secondRequest }));
+    });
+
+    if (!latestState) {
+      throw new Error("Expected latest conflict-resolution modal state");
+    }
+
+    expect(latestState.mode).toBe("new");
+    expect(latestState.selectedSessionId).toBe("session-3");
+    expect(latestState.confirmDisabled).toBe(false);
+
+    await act(async () => {
+      renderer?.unmount();
+    });
+  });
+});

--- a/apps/desktop/src/features/git-conflict-resolution/git-conflict-resolution-modal.tsx
+++ b/apps/desktop/src/features/git-conflict-resolution/git-conflict-resolution-modal.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useState } from "react";
+import { type ReactElement, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -37,26 +37,52 @@ const formatConflictResolutionSessionMeta = (session: AgentSessionState): string
   return `${startedAtLabel} · ${session.status} · ${session.sessionId.slice(0, 8)}`;
 };
 
+type GitConflictResolutionModalState = {
+  requestKey: string;
+  mode: "existing" | "new";
+  selectedSessionId: string;
+};
+
+const getRequestKey = (request: PendingGitConflictResolutionRequest): string =>
+  `${request.requestId}:${request.defaultMode}:${request.defaultSessionId ?? ""}`;
+
+const createModalState = (
+  request: PendingGitConflictResolutionRequest,
+): GitConflictResolutionModalState => ({
+  requestKey: getRequestKey(request),
+  mode: request.defaultMode,
+  selectedSessionId: request.defaultSessionId ?? "",
+});
+
 export function useGitConflictResolutionModalState(
   request: PendingGitConflictResolutionRequest,
 ): UseGitConflictResolutionModalStateResult {
-  const [mode, setMode] = useState<"existing" | "new">(request.defaultMode);
-  const [selectedSessionId, setSelectedSessionId] = useState(request.defaultSessionId ?? "");
+  const requestKey = getRequestKey(request);
+  const [state, setState] = useState<GitConflictResolutionModalState>(() => createModalState(request));
+  const currentState = state.requestKey === requestKey ? state : createModalState(request);
   const hasExistingSessions = request.builderSessions.length > 0;
-  const confirmDisabled = mode === "existing" && selectedSessionId.trim().length === 0;
-
-  useEffect(() => {
-    setMode(request.defaultMode);
-    setSelectedSessionId(request.defaultSessionId ?? "");
-  }, [request]);
+  const confirmDisabled =
+    currentState.mode === "existing" && currentState.selectedSessionId.trim().length === 0;
 
   return {
-    mode,
-    selectedSessionId,
+    mode: currentState.mode,
+    selectedSessionId: currentState.selectedSessionId,
     hasExistingSessions,
     confirmDisabled,
-    setMode,
-    setSelectedSessionId,
+    setMode: (mode) => {
+      setState((previousState) => {
+        const baseState =
+          previousState.requestKey === requestKey ? previousState : createModalState(request);
+        return { ...baseState, mode };
+      });
+    },
+    setSelectedSessionId: (selectedSessionId) => {
+      setState((previousState) => {
+        const baseState =
+          previousState.requestKey === requestKey ? previousState : createModalState(request);
+        return { ...baseState, selectedSessionId };
+      });
+    },
   };
 }
 

--- a/apps/desktop/src/features/git-conflict-resolution/git-conflict-resolution-modal.tsx
+++ b/apps/desktop/src/features/git-conflict-resolution/git-conflict-resolution-modal.tsx
@@ -54,6 +54,13 @@ const createModalState = (
   selectedSessionId: request.defaultSessionId ?? "",
 });
 
+const reconcileModalState = (
+  previousState: GitConflictResolutionModalState,
+  requestKey: string,
+  request: PendingGitConflictResolutionRequest,
+): GitConflictResolutionModalState =>
+  previousState.requestKey === requestKey ? previousState : createModalState(request);
+
 export function useGitConflictResolutionModalState(
   request: PendingGitConflictResolutionRequest,
 ): UseGitConflictResolutionModalStateResult {
@@ -61,10 +68,14 @@ export function useGitConflictResolutionModalState(
   const [state, setState] = useState<GitConflictResolutionModalState>(() =>
     createModalState(request),
   );
-  const currentState = state.requestKey === requestKey ? state : createModalState(request);
+  const currentState = reconcileModalState(state, requestKey, request);
   const hasExistingSessions = request.builderSessions.length > 0;
-  const confirmDisabled =
-    currentState.mode === "existing" && currentState.selectedSessionId.trim().length === 0;
+  const trimmedSelectedSessionId = currentState.selectedSessionId.trim();
+  const canConfirmExistingSession =
+    currentState.mode === "existing" &&
+    trimmedSelectedSessionId.length > 0 &&
+    request.builderSessions.some((session) => session.sessionId === trimmedSelectedSessionId);
+  const confirmDisabled = currentState.mode === "existing" && !canConfirmExistingSession;
 
   return {
     mode: currentState.mode,
@@ -73,15 +84,13 @@ export function useGitConflictResolutionModalState(
     confirmDisabled,
     setMode: (mode) => {
       setState((previousState) => {
-        const baseState =
-          previousState.requestKey === requestKey ? previousState : createModalState(request);
+        const baseState = reconcileModalState(previousState, requestKey, request);
         return { ...baseState, mode };
       });
     },
     setSelectedSessionId: (selectedSessionId) => {
       setState((previousState) => {
-        const baseState =
-          previousState.requestKey === requestKey ? previousState : createModalState(request);
+        const baseState = reconcileModalState(previousState, requestKey, request);
         return { ...baseState, selectedSessionId };
       });
     },
@@ -100,6 +109,11 @@ export function GitConflictResolutionModal({
     setMode,
     setSelectedSessionId,
   } = useGitConflictResolutionModalState(request);
+  const trimmedSelectedSessionId = selectedSessionId.trim();
+  const canConfirmExistingSession =
+    mode === "existing" &&
+    trimmedSelectedSessionId.length > 0 &&
+    request.builderSessions.some((session) => session.sessionId === trimmedSelectedSessionId);
 
   return (
     <Dialog
@@ -197,8 +211,11 @@ export function GitConflictResolutionModal({
             type="button"
             disabled={confirmDisabled}
             onClick={() => {
-              if (mode === "existing" && selectedSessionId.trim().length > 0) {
-                onResolve({ mode: "existing", sessionId: selectedSessionId });
+              if (mode === "existing") {
+                if (!canConfirmExistingSession) {
+                  return;
+                }
+                onResolve({ mode: "existing", sessionId: trimmedSelectedSessionId });
                 return;
               }
               onResolve({ mode: "new" });

--- a/apps/desktop/src/features/git-conflict-resolution/git-conflict-resolution-modal.tsx
+++ b/apps/desktop/src/features/git-conflict-resolution/git-conflict-resolution-modal.tsx
@@ -58,7 +58,9 @@ export function useGitConflictResolutionModalState(
   request: PendingGitConflictResolutionRequest,
 ): UseGitConflictResolutionModalStateResult {
   const requestKey = getRequestKey(request);
-  const [state, setState] = useState<GitConflictResolutionModalState>(() => createModalState(request));
+  const [state, setState] = useState<GitConflictResolutionModalState>(() =>
+    createModalState(request),
+  );
   const currentState = state.requestKey === requestKey ? state : createModalState(request);
   const hasExistingSessions = request.builderSessions.length > 0;
   const confirmDisabled =

--- a/apps/desktop/src/lib/errors.test.ts
+++ b/apps/desktop/src/lib/errors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { errorMessage } from "./errors";
+
+describe("errorMessage", () => {
+  test("returns a fallback string when JSON serialization yields undefined", () => {
+    expect(errorMessage(undefined)).toBe("Non-Error thrown: undefined");
+    expect(errorMessage(Symbol("branch"))).toBe("Non-Error thrown: Symbol(branch)");
+    expect(errorMessage(() => {})).toBe("Non-Error thrown: () => {}");
+  });
+
+  test("returns a fallback string when JSON serialization throws", () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    expect(errorMessage(circular)).toContain("Non-Error thrown:");
+  });
+});

--- a/apps/desktop/src/lib/errors.test.ts
+++ b/apps/desktop/src/lib/errors.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, test } from "bun:test";
+import { NON_ERROR_THROWN_PREFIX } from "@/types/constants";
 import { errorMessage } from "./errors";
 
 describe("errorMessage", () => {
   test("returns a fallback string when JSON serialization yields undefined", () => {
-    expect(errorMessage(undefined)).toBe("Non-Error thrown: undefined");
-    expect(errorMessage(Symbol("branch"))).toBe("Non-Error thrown: Symbol(branch)");
-    expect(errorMessage(() => {})).toBe("Non-Error thrown: () => {}");
+    expect(errorMessage(undefined)).toBe(`${NON_ERROR_THROWN_PREFIX} undefined`);
+    expect(errorMessage(Symbol("branch"))).toBe(`${NON_ERROR_THROWN_PREFIX} Symbol(branch)`);
+    expect(errorMessage(() => {})).toBe(`${NON_ERROR_THROWN_PREFIX} () => {}`);
   });
 
   test("returns a fallback string when JSON serialization throws", () => {
     const circular: { self?: unknown } = {};
     circular.self = circular;
 
-    expect(errorMessage(circular)).toContain("Non-Error thrown:");
+    expect(errorMessage(circular)).toContain(NON_ERROR_THROWN_PREFIX);
   });
 });

--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -1,3 +1,5 @@
+import { NON_ERROR_THROWN_PREFIX } from "@/types/constants";
+
 export const errorMessage = (error: unknown): string => {
   if (error instanceof Error) {
     return error.message;
@@ -7,7 +9,7 @@ export const errorMessage = (error: unknown): string => {
     return error;
   }
 
-  const fallbackMessage = `Non-Error thrown: ${String(error)}`;
+  const fallbackMessage = `${NON_ERROR_THROWN_PREFIX} ${String(error)}`;
 
   try {
     const serialized = JSON.stringify(error);

--- a/apps/desktop/src/lib/errors.ts
+++ b/apps/desktop/src/lib/errors.ts
@@ -7,9 +7,12 @@ export const errorMessage = (error: unknown): string => {
     return error;
   }
 
+  const fallbackMessage = `Non-Error thrown: ${String(error)}`;
+
   try {
-    return JSON.stringify(error);
+    const serialized = JSON.stringify(error);
+    return typeof serialized === "string" ? serialized : fallbackMessage;
   } catch {
-    return "Unknown error";
+    return fallbackMessage;
   }
 };

--- a/apps/desktop/src/lib/host-client.test.ts
+++ b/apps/desktop/src/lib/host-client.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let browserAppMode = false;
+let tauriRuntime = false;
+
+mock.module("@openducktor/adapters-tauri-host", () => ({
+  createTauriHostClient: () => ({}) as object,
+}));
+
+mock.module("@/lib/browser-live-client", () => ({
+  createBrowserLiveHostClient: () => ({}) as object,
+  subscribeBrowserLiveRunEvents: async () => () => {},
+}));
+
+mock.module("@/lib/browser-mode", () => ({
+  isBrowserAppMode: () => browserAppMode,
+}));
+
+mock.module("@/lib/runtime", () => ({
+  isTauriRuntime: () => tauriRuntime,
+}));
+
+describe("host-client", () => {
+  beforeEach(() => {
+    browserAppMode = false;
+    tauriRuntime = false;
+  });
+
+  test("warns when run-event subscriptions are unavailable in the current runtime", async () => {
+    const warnCalls: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnCalls.push(args);
+    };
+
+    try {
+      const { createHostBridge } = await import("./host-client");
+      const unsubscribe = await createHostBridge().subscribeRunEvents(() => {});
+
+      expect(typeof unsubscribe).toBe("function");
+      expect(warnCalls).toEqual([
+        ["run-event subscriptions not available in this runtime, returning no-op"],
+      ]);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/apps/desktop/src/lib/host-client.ts
+++ b/apps/desktop/src/lib/host-client.ts
@@ -7,7 +7,6 @@ import { isBrowserAppMode } from "@/lib/browser-mode";
 import { isTauriRuntime } from "@/lib/runtime";
 
 export type RunEventListener = (payload: unknown) => void;
-export type RunEventSubscription = () => Promise<() => void>;
 export type HostBridge = {
   client: TauriHostClient;
   subscribeRunEvents: (listener: RunEventListener) => Promise<() => void>;
@@ -62,7 +61,7 @@ export const createHostBridge = (): HostBridge => ({
 
 export const hostBridge = createHostBridge();
 
-export const createHostClient = (): TauriHostClient => createHostBridge().client;
+export const createHostClient = (): TauriHostClient => createHostCommands();
 
 export const hostClient = hostBridge.client;
 

--- a/apps/desktop/src/lib/host-client.ts
+++ b/apps/desktop/src/lib/host-client.ts
@@ -6,6 +6,13 @@ import {
 import { isBrowserAppMode } from "@/lib/browser-mode";
 import { isTauriRuntime } from "@/lib/runtime";
 
+export type RunEventListener = (payload: unknown) => void;
+export type RunEventSubscription = () => Promise<() => void>;
+export type HostBridge = {
+  client: TauriHostClient;
+  subscribeRunEvents: (listener: RunEventListener) => Promise<() => void>;
+};
+
 let tauriCoreModulePromise: Promise<typeof import("@tauri-apps/api/core")> | null = null;
 
 const getTauriCoreModule = (): Promise<typeof import("@tauri-apps/api/core")> => {
@@ -19,7 +26,7 @@ const notAvailable = async <T>(): Promise<T> => {
   throw new Error("Tauri runtime not available. Run inside the desktop shell.");
 };
 
-export const createHostClient = (): TauriHostClient => {
+const createHostCommands = (): TauriHostClient => {
   if (!isTauriRuntime()) {
     if (isBrowserAppMode()) {
       return createBrowserLiveHostClient();
@@ -33,11 +40,7 @@ export const createHostClient = (): TauriHostClient => {
   });
 };
 
-export const hostClient = createHostClient();
-
-export const subscribeRunEvents = async (
-  listener: (payload: unknown) => void,
-): Promise<() => void> => {
+const createRunEventSubscription = (): HostBridge["subscribeRunEvents"] => async (listener) => {
   if (isBrowserAppMode()) {
     return subscribeBrowserLiveRunEvents(listener);
   }
@@ -51,3 +54,16 @@ export const subscribeRunEvents = async (
     listener(event.payload);
   });
 };
+
+export const createHostBridge = (): HostBridge => ({
+  client: createHostCommands(),
+  subscribeRunEvents: createRunEventSubscription(),
+});
+
+export const hostBridge = createHostBridge();
+
+export const createHostClient = (): TauriHostClient => createHostBridge().client;
+
+export const hostClient = hostBridge.client;
+
+export const subscribeRunEvents = hostBridge.subscribeRunEvents;

--- a/apps/desktop/src/lib/host-client.ts
+++ b/apps/desktop/src/lib/host-client.ts
@@ -12,6 +12,9 @@ export type HostBridge = {
   subscribeRunEvents: (listener: RunEventListener) => Promise<() => void>;
 };
 
+const RUN_EVENT_SUBSCRIPTIONS_UNAVAILABLE_WARNING =
+  "run-event subscriptions not available in this runtime, returning no-op";
+
 let tauriCoreModulePromise: Promise<typeof import("@tauri-apps/api/core")> | null = null;
 
 const getTauriCoreModule = (): Promise<typeof import("@tauri-apps/api/core")> => {
@@ -45,6 +48,7 @@ const createRunEventSubscription = (): HostBridge["subscribeRunEvents"] => async
   }
 
   if (!isTauriRuntime()) {
+    console.warn(RUN_EVENT_SUBSCRIPTIONS_UNAVAILABLE_WARNING);
     return () => {};
   }
 

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -12,10 +12,32 @@ const toastSuccess = mock((_message: string, _options?: { description?: string }
 const toastDismiss = mock((_toastId?: string | number) => {});
 
 mock.module("@/lib/host-client", () => ({
+  createHostBridge: () => ({
+    client: createTauriHostClient(async () => {
+      throw new Error("Tauri runtime not available. Run inside the desktop shell.");
+    }),
+    subscribeRunEvents: async (listener: (payload: unknown) => void) => {
+      subscribedRunListener = listener;
+      return () => {
+        subscribedRunListener = null;
+      };
+    },
+  }),
   createHostClient: () =>
     createTauriHostClient(async () => {
       throw new Error("Tauri runtime not available. Run inside the desktop shell.");
     }),
+  hostBridge: {
+    client: createTauriHostClient(async () => {
+      throw new Error("Tauri runtime not available. Run inside the desktop shell.");
+    }),
+    subscribeRunEvents: async (listener: (payload: unknown) => void) => {
+      subscribedRunListener = listener;
+      return () => {
+        subscribedRunListener = null;
+      };
+    },
+  },
   hostClient: createTauriHostClient(async () => {
     throw new Error("Tauri runtime not available. Run inside the desktop shell.");
   }),
@@ -62,6 +84,7 @@ const createDeferred = <T,>() => {
 };
 
 beforeEach(() => {
+  subscribedRunListener = null;
   toastError.mockClear();
   toastLoading.mockClear();
   toastSuccess.mockClear();

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -2,7 +2,7 @@ import { type RunEvent, type RuntimeKind, runEventSchema } from "@openducktor/co
 import { type Dispatch, type SetStateAction, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
-import { subscribeRunEvents } from "@/lib/host-client";
+import { hostBridge } from "@/lib/host-client";
 import { summarizeTaskLoadError } from "@/state/tasks/task-load-errors";
 import type { RepoRuntimeHealthMap } from "@/types/diagnostics";
 import { prependRunEvent, shouldLoadChecks } from "./app-lifecycle-model";
@@ -90,29 +90,30 @@ export function useAppLifecycle({
     );
 
     let unsubscribe: (() => void) | null = null;
-    subscribeRunEvents((payload) => {
-      const parsed = runEventSchema.safeParse(payload);
-      if (!parsed.success) {
-        return;
-      }
-
-      setEvents((current) => prependRunEvent(current, parsed.data));
-      if (
-        parsed.data.type === "run_finished" ||
-        parsed.data.type === "ready_for_manual_done_confirmation" ||
-        parsed.data.type === "error"
-      ) {
-        setRunCompletionSignal(parsed.data.runId, parsed.data.type);
-        const repoPath = activeRepoRef.current;
-        if (repoPath) {
-          void refreshTaskDataRef.current(repoPath).catch((error: unknown) => {
-            toast.error("Failed to refresh tasks", {
-              description: summarizeTaskLoadError(error),
-            });
-          });
+    hostBridge
+      .subscribeRunEvents((payload) => {
+        const parsed = runEventSchema.safeParse(payload);
+        if (!parsed.success) {
+          return;
         }
-      }
-    })
+
+        setEvents((current) => prependRunEvent(current, parsed.data));
+        if (
+          parsed.data.type === "run_finished" ||
+          parsed.data.type === "ready_for_manual_done_confirmation" ||
+          parsed.data.type === "error"
+        ) {
+          setRunCompletionSignal(parsed.data.runId, parsed.data.type);
+          const repoPath = activeRepoRef.current;
+          if (repoPath) {
+            void refreshTaskDataRef.current(repoPath).catch((error: unknown) => {
+              toast.error("Failed to refresh tasks", {
+                description: summarizeTaskLoadError(error),
+              });
+            });
+          }
+        }
+      })
       .then((cleanup) => {
         unsubscribe = cleanup;
       })

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-helpers.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-helpers.ts
@@ -12,13 +12,6 @@ import type {
 } from "./session-event-types";
 
 const DRAFT_FLUSH_DELAY_MS = 32;
-
-export const inferToolPartStatus = (
-  part: Extract<SessionPart, { kind: "tool" }>,
-): Extract<SessionPart, { kind: "tool" }>["status"] => {
-  return part.status;
-};
-
 export const clearDraftBuffers = (
   context: Pick<SessionLifecycleEventContext, "drafts" | "store">,
 ): void => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
@@ -21,7 +21,6 @@ import type {
 import {
   eventTimestampMs,
   hasMeaningfulToolInput,
-  inferToolPartStatus,
   refreshTodosFromSessionRef,
 } from "./session-helpers";
 
@@ -211,7 +210,7 @@ export const handleToolPart = (
   const input = normalizeToolInput(part.input);
   const output = normalizeToolText(part.output);
   const error = normalizeToolText(part.error);
-  const resolvedStatus = inferToolPartStatus(part);
+  const resolvedStatus = part.status;
   const observedEventTimestampMs = eventTimestampMs(event.timestamp);
   const todoUpdateFromTool = resolveTodoUpdateFromTool(part, input, output);
   let shouldRefreshTaskData = false;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -890,4 +890,95 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       adapter.sendUserMessage = originalSendUserMessage;
     }
   });
+
+  test("forkAgentSession fails fast when no runtime kind is available", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    let forkCalls = 0;
+    let attachCalls = 0;
+    let persistCalls = 0;
+    let setCalls = 0;
+
+    const originalForkSession = adapter.forkSession;
+    adapter.forkSession = async () => {
+      forkCalls += 1;
+      return {
+        sessionId: "session-2",
+        externalSessionId: "external-2",
+        startedAt: "2026-02-22T09:00:00.000Z",
+        runtimeKind: "opencode",
+        role: "build",
+        scenario: "build_implementation_start",
+        status: "idle",
+      };
+    };
+
+    const sessionWithoutRuntimeKind = buildSession({
+      status: "idle",
+    });
+    delete sessionWithoutRuntimeKind.runtimeKind;
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": sessionWithoutRuntimeKind,
+      },
+    };
+    const task = createTaskCardFixture({
+      id: "task-1",
+      issueType: "feature",
+      aiReviewEnabled: true,
+      status: "in_progress",
+    });
+
+    const actions = createAgentSessionActions({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: (updater) => {
+        setCalls += 1;
+        sessionsRef.current =
+          typeof updater === "function" ? updater(sessionsRef.current) : updater;
+      },
+      sessionsRef,
+      taskRef: { current: [task] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      unsubscribersRef: { current: new Map() },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession: () => {},
+      attachSessionListener: () => {
+        attachCalls += 1;
+      },
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: null,
+        runId: "run-1",
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo/worktree",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadAgentSessions: async () => {},
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+      persistSessionSnapshot: async () => {
+        persistCalls += 1;
+      },
+    });
+
+    try {
+      await expect(
+        actions.forkAgentSession({
+          parentSessionId: "session-1",
+        }),
+      ).rejects.toThrow("Runtime kind is required to fork session 'session-1'.");
+      expect(forkCalls).toBe(0);
+      expect(attachCalls).toBe(0);
+      expect(persistCalls).toBe(0);
+      expect(setCalls).toBe(0);
+    } finally {
+      adapter.forkSession = originalForkSession;
+    }
+  });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -386,21 +386,27 @@ export const createAgentSessionActions = ({
     }));
     attachSessionListener(repoPath, summary.sessionId);
     void persistSessionSnapshot(nextSession);
-    warmSessionData({
-      operationPrefix: "fork-session-warm-session",
-      repoPath,
-      sessionId: summary.sessionId,
-      taskId: nextSession.taskId,
-      role: nextSession.role,
-      runtimeKind: nextSession.runtimeKind ?? DEFAULT_RUNTIME_KIND,
-      runtimeConnection: {
-        endpoint: nextSession.runtimeEndpoint,
-        workingDirectory: nextSession.workingDirectory,
+    warmSessionData(
+      {
+        repoPath,
+        sessionId: summary.sessionId,
+        taskId: nextSession.taskId,
+        role: nextSession.role,
+        runtimeKind: nextSession.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+        runtimeConnection: {
+          endpoint: nextSession.runtimeEndpoint,
+          workingDirectory: nextSession.workingDirectory,
+        },
+        externalSessionId: summary.externalSessionId,
       },
-      externalSessionId: summary.externalSessionId,
-      loadSessionTodos,
-      loadSessionModelCatalog,
-    });
+      {
+        loadSessionTodos,
+        loadSessionModelCatalog,
+      },
+      {
+        operationPrefix: "fork-session-warm-session",
+      },
+    );
     return summary.sessionId;
   };
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -5,7 +5,6 @@ import type {
   AgentRole,
   AgentRuntimeConnection,
 } from "@openducktor/core";
-import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import { errorMessage } from "@/lib/errors";
 import { isRoleAvailableForTask, unavailableRoleErrorMessage } from "@/lib/task-agent-workflows";
 import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
@@ -324,12 +323,14 @@ export const createAgentSessionActions = ({
       parentSession.selectedModel ??
       (await loadRepoDefaultModel(repoPath, parentSession.role));
     throwIfRepoStale(isStaleRepoOperation, STALE_FORK_ERROR);
+    const runtimeKind = parentSession.runtimeKind ?? modelSelection?.runtimeKind;
+    if (!runtimeKind) {
+      throw new Error(`Runtime kind is required to fork session '${parentSessionId}'.`);
+    }
     const { promptOverrides, systemPrompt } = promptContext;
     const summary = await adapter.forkSession({
       repoPath,
-      runtimeKind: (parentSession.runtimeKind ??
-        modelSelection?.runtimeKind ??
-        DEFAULT_RUNTIME_KIND) as string,
+      runtimeKind,
       runtimeConnection: {
         endpoint: parentSession.runtimeEndpoint,
         workingDirectory: parentSession.workingDirectory,
@@ -349,7 +350,7 @@ export const createAgentSessionActions = ({
       sessionId: summary.sessionId,
       externalSessionId: summary.externalSessionId,
       taskId: parentSession.taskId,
-      runtimeKind: parentSession.runtimeKind ?? modelSelection?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+      runtimeKind,
       role: parentSession.role,
       scenario: parentSession.scenario,
       status: "idle",
@@ -392,7 +393,7 @@ export const createAgentSessionActions = ({
         sessionId: summary.sessionId,
         taskId: nextSession.taskId,
         role: nextSession.role,
-        runtimeKind: nextSession.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+        runtimeKind,
         runtimeConnection: {
           endpoint: nextSession.runtimeEndpoint,
           workingDirectory: nextSession.workingDirectory,

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -515,18 +515,24 @@ const warmStartedSession = ({
     throw new Error(`Runtime kind is required to warm session '${startedCtx.summary.sessionId}'.`);
   }
 
-  warmSessionData({
-    operationPrefix: "start-session-warm-session",
-    repoPath: startedCtx.repoPath,
-    sessionId: startedCtx.summary.sessionId,
-    taskId: startedCtx.taskId,
-    role: startedCtx.role,
-    runtimeKind,
-    runtimeConnection,
-    externalSessionId: startedCtx.summary.externalSessionId,
-    loadSessionTodos: model.loadSessionTodos,
-    loadSessionModelCatalog: model.loadSessionModelCatalog,
-  });
+  warmSessionData(
+    {
+      repoPath: startedCtx.repoPath,
+      sessionId: startedCtx.summary.sessionId,
+      taskId: startedCtx.taskId,
+      role: startedCtx.role,
+      runtimeKind,
+      runtimeConnection,
+      externalSessionId: startedCtx.summary.externalSessionId,
+    },
+    {
+      loadSessionTodos: model.loadSessionTodos,
+      loadSessionModelCatalog: model.loadSessionModelCatalog,
+    },
+    {
+      operationPrefix: "start-session-warm-session",
+    },
+  );
 };
 
 const applyResolvedModelSelection = ({

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
@@ -8,6 +8,7 @@ import type {
 } from "@openducktor/core";
 import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
+import type { SessionWarmupDependencies } from "../support/session-warmup";
 
 export type StartAgentSessionInput = {
   taskId: string;
@@ -55,20 +56,9 @@ export type TaskDependencies = {
   sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
 };
 
-export type ModelDependencies = {
+export type ModelDependencies = SessionWarmupDependencies & {
   loadRepoDefaultModel: (repoPath: string, role: AgentRole) => Promise<AgentModelSelection | null>;
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
-  loadSessionTodos: (
-    sessionId: string,
-    runtimeKind: RuntimeKind,
-    runtimeConnection: AgentRuntimeConnection,
-    externalSessionId: string,
-  ) => Promise<void>;
-  loadSessionModelCatalog: (
-    sessionId: string,
-    runtimeKind: RuntimeKind,
-    runtimeConnection: AgentRuntimeConnection,
-  ) => Promise<void>;
 };
 
 export type RepoDependencies = {

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
@@ -1,9 +1,8 @@
-import type { RepoPromptOverrides, RuntimeKind, TaskCard } from "@openducktor/contracts";
+import type { RepoPromptOverrides, TaskCard } from "@openducktor/contracts";
 import type {
   AgentEnginePort,
   AgentModelSelection,
   AgentRole,
-  AgentRuntimeConnection,
   AgentScenario,
 } from "@openducktor/core";
 import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -196,28 +196,30 @@ export const createEnsureSessionReady = ({
 
     const activeSession = sessionsRef.current[sessionId];
     const runtimeConnection = resolveRuntimeConnection(runtime);
-    const warmPreparedSession = (targetSession: AgentSessionState): void => {
-      const targetRuntimeKind =
-        targetSession.runtimeKind ?? targetSession.selectedModel?.runtimeKind;
-      if (!targetRuntimeKind) {
+    if (activeSession) {
+      const runtimeKind = activeSession.runtimeKind ?? activeSession.selectedModel?.runtimeKind;
+      if (!runtimeKind) {
         throw new Error(`Runtime kind is required to warm session '${sessionId}'.`);
       }
-      warmSessionData({
-        operationPrefix: "ensure-ready-warm-session",
-        repoPath,
-        sessionId,
-        taskId: targetSession.taskId,
-        role: targetSession.role,
-        runtimeKind: targetRuntimeKind,
-        runtimeConnection,
-        externalSessionId: targetSession.externalSessionId,
-        loadSessionTodos,
-        loadSessionModelCatalog,
-        shouldLoadModelCatalog: !targetSession.modelCatalog && !targetSession.isLoadingModelCatalog,
-      });
-    };
-    if (activeSession) {
-      warmPreparedSession(activeSession);
+      warmSessionData(
+        {
+          repoPath,
+          sessionId,
+          taskId: activeSession.taskId,
+          role: activeSession.role,
+          runtimeKind,
+          runtimeConnection,
+          externalSessionId: activeSession.externalSessionId,
+        },
+        {
+          loadSessionTodos,
+          loadSessionModelCatalog,
+        },
+        {
+          operationPrefix: "ensure-ready-warm-session",
+          shouldLoadModelCatalog: !activeSession.modelCatalog && !activeSession.isLoadingModelCatalog,
+        },
+      );
     }
   };
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -217,7 +217,8 @@ export const createEnsureSessionReady = ({
         },
         {
           operationPrefix: "ensure-ready-warm-session",
-          shouldLoadModelCatalog: !activeSession.modelCatalog && !activeSession.isLoadingModelCatalog,
+          shouldLoadModelCatalog:
+            !activeSession.modelCatalog && !activeSession.isLoadingModelCatalog,
         },
       );
     }

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -118,19 +118,25 @@ export const createLoadAgentSessions = ({
       role: AgentSessionState["role"],
       shouldLoadModelCatalog = true,
     ): void => {
-      warmSessionData({
-        operationPrefix: "load-sessions-warm-session",
-        repoPath,
-        sessionId: targetSessionId,
-        taskId,
-        role,
-        runtimeKind,
-        runtimeConnection,
-        externalSessionId,
-        loadSessionTodos,
-        loadSessionModelCatalog,
-        shouldLoadModelCatalog,
-      });
+      warmSessionData(
+        {
+          repoPath,
+          sessionId: targetSessionId,
+          taskId,
+          role,
+          runtimeKind,
+          runtimeConnection,
+          externalSessionId,
+        },
+        {
+          loadSessionTodos,
+          loadSessionModelCatalog,
+        },
+        {
+          operationPrefix: "load-sessions-warm-session",
+          shouldLoadModelCatalog,
+        },
+      );
     };
 
     const [persisted, repoPromptOverrides] = await Promise.all([

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/session-warmup.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/session-warmup.ts
@@ -33,24 +33,11 @@ export type SessionWarmupOptions = {
 
 export const warmSessionData = (
   context: SessionOrchestrationContext,
-  {
-    loadSessionTodos,
-    loadSessionModelCatalog,
-  }: SessionWarmupDependencies,
-  {
-    operationPrefix,
-    shouldLoadModelCatalog = true,
-  }: SessionWarmupOptions,
+  { loadSessionTodos, loadSessionModelCatalog }: SessionWarmupDependencies,
+  { operationPrefix, shouldLoadModelCatalog = true }: SessionWarmupOptions,
 ): void => {
-  const {
-    repoPath,
-    sessionId,
-    taskId,
-  role,
-    runtimeKind,
-    runtimeConnection,
-    externalSessionId,
-  } = context;
+  const { repoPath, sessionId, taskId, role, runtimeKind, runtimeConnection, externalSessionId } =
+    context;
   const baseTags = {
     repoPath,
     sessionId,

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/session-warmup.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/session-warmup.ts
@@ -2,8 +2,7 @@ import type { RuntimeKind } from "@openducktor/contracts";
 import type { AgentRole, AgentRuntimeConnection } from "@openducktor/core";
 import { runOrchestratorSideEffect } from "./async-side-effects";
 
-export type SessionWarmupInput = {
-  operationPrefix: string;
+export type SessionOrchestrationContext = {
   repoPath: string;
   sessionId: string;
   taskId: string;
@@ -11,6 +10,9 @@ export type SessionWarmupInput = {
   runtimeKind: RuntimeKind;
   runtimeConnection: AgentRuntimeConnection;
   externalSessionId: string;
+};
+
+export type SessionWarmupDependencies = {
   loadSessionTodos: (
     sessionId: string,
     runtimeKind: RuntimeKind,
@@ -22,22 +24,33 @@ export type SessionWarmupInput = {
     runtimeKind: RuntimeKind,
     runtimeConnection: AgentRuntimeConnection,
   ) => Promise<void>;
+};
+
+export type SessionWarmupOptions = {
+  operationPrefix: string;
   shouldLoadModelCatalog?: boolean;
 };
 
-export const warmSessionData = ({
-  operationPrefix,
-  repoPath,
-  sessionId,
-  taskId,
+export const warmSessionData = (
+  context: SessionOrchestrationContext,
+  {
+    loadSessionTodos,
+    loadSessionModelCatalog,
+  }: SessionWarmupDependencies,
+  {
+    operationPrefix,
+    shouldLoadModelCatalog = true,
+  }: SessionWarmupOptions,
+): void => {
+  const {
+    repoPath,
+    sessionId,
+    taskId,
   role,
-  runtimeKind,
-  runtimeConnection,
-  externalSessionId,
-  loadSessionTodos,
-  loadSessionModelCatalog,
-  shouldLoadModelCatalog = true,
-}: SessionWarmupInput): void => {
+    runtimeKind,
+    runtimeConnection,
+    externalSessionId,
+  } = context;
   const baseTags = {
     repoPath,
     sessionId,

--- a/apps/desktop/src/state/operations/use-workspace-operations.ts
+++ b/apps/desktop/src/state/operations/use-workspace-operations.ts
@@ -282,7 +282,6 @@ export function useWorkspaceOperations({
         toast.error("Failed to switch branch", {
           description: errorMessage(error),
         });
-        throw error;
       } finally {
         if (branchRequestVersionRef.current === requestVersion) {
           setIsSwitchingBranch(false);

--- a/apps/desktop/src/state/operations/workspace-operations-model.ts
+++ b/apps/desktop/src/state/operations/workspace-operations-model.ts
@@ -1,4 +1,5 @@
 import type { GitCurrentBranch } from "@openducktor/contracts";
+import { errorMessage } from "@/lib/errors";
 
 type ProbeBranchChangeParams = {
   activeRepo: string | null;
@@ -80,22 +81,6 @@ export const shouldSkipBranchSwitch = (
   branchName: string,
 ): boolean => activeBranch?.name === branchName && !activeBranch.detached;
 
-const toErrorMessage = (error: unknown): string => {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === "string") {
-    return error;
-  }
-
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return "Unknown error";
-  }
-};
-
 const toOptionalString = (value: unknown): string | null =>
   typeof value === "string" && value.trim().length > 0 ? value : null;
 
@@ -156,7 +141,7 @@ export const classifyBranchProbeError = (
   error: unknown,
   stage: BranchProbeStage,
 ): BranchProbeError => {
-  const message = toErrorMessage(error);
+  const message = errorMessage(error);
   const structuredHint = extractStructuredErrorHint(error);
 
   return {

--- a/apps/desktop/src/types/constants.ts
+++ b/apps/desktop/src/types/constants.ts
@@ -1,0 +1,1 @@
+export const NON_ERROR_THROWN_PREFIX = "Non-Error thrown:";

--- a/apps/desktop/src/types/index.ts
+++ b/apps/desktop/src/types/index.ts
@@ -1,1 +1,2 @@
 export { AGENT_ROLE_LABELS } from "./agent-role-labels";
+export { NON_ERROR_THROWN_PREFIX } from "./constants";

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -33,27 +33,27 @@ export type BuildRespondInput =
   | { action: "approve" }
   | { action: "deny" }
   | { action: "message"; message: string };
-export const systemCheck = async (invokeFn: InvokeFn, repoPath: string): Promise<SystemCheck> => {
+const systemCheck = async (invokeFn: InvokeFn, repoPath: string): Promise<SystemCheck> => {
   const payload = await invokeFn("system_check", { repoPath });
   return systemCheckSchema.parse(payload);
 };
 
-export const runtimeCheck = async (invokeFn: InvokeFn, force = false): Promise<RuntimeCheck> => {
+const runtimeCheck = async (invokeFn: InvokeFn, force = false): Promise<RuntimeCheck> => {
   const payload = await invokeFn("runtime_check", { force });
   return runtimeCheckSchema.parse(payload);
 };
 
-export const beadsCheck = async (invokeFn: InvokeFn, repoPath: string): Promise<BeadsCheck> => {
+const beadsCheck = async (invokeFn: InvokeFn, repoPath: string): Promise<BeadsCheck> => {
   const payload = await invokeFn("beads_check", { repoPath });
   return beadsCheckSchema.parse(payload);
 };
 
-export const runsList = async (invokeFn: InvokeFn, repoPath?: string): Promise<RunSummary[]> => {
+const runsList = async (invokeFn: InvokeFn, repoPath?: string): Promise<RunSummary[]> => {
   const payload = await invokeFn("runs_list", { repoPath });
   return parseArray(runSummarySchema, payload, "runs_list");
 };
 
-export const runtimeList = async (
+const runtimeList = async (
   invokeFn: InvokeFn,
   repoPath: string | undefined,
   runtimeKind: RuntimeKind,
@@ -62,12 +62,12 @@ export const runtimeList = async (
   return parseArray(runtimeInstanceSummarySchema, payload, "runtime_list");
 };
 
-export const runtimeDefinitionsList = async (invokeFn: InvokeFn): Promise<RuntimeDescriptor[]> => {
+const runtimeDefinitionsList = async (invokeFn: InvokeFn): Promise<RuntimeDescriptor[]> => {
   const payload = await invokeFn("runtime_definitions_list", {});
   return parseArray(runtimeDescriptorSchema, payload, "runtime_definitions_list");
 };
 
-export const buildContinuationTargetGet = async (
+const buildContinuationTargetGet = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -79,17 +79,14 @@ export const buildContinuationTargetGet = async (
   return buildContinuationTargetSchema.parse(payload);
 };
 
-export const runtimeStop = async (
-  invokeFn: InvokeFn,
-  runtimeId: string,
-): Promise<{ ok: boolean }> => {
+const runtimeStop = async (invokeFn: InvokeFn, runtimeId: string): Promise<{ ok: boolean }> => {
   const payload = await invokeFn("runtime_stop", {
     runtimeId,
   });
   return parseOkResult(payload, "runtime_stop");
 };
 
-export const runtimeEnsure = async (
+const runtimeEnsure = async (
   invokeFn: InvokeFn,
   repoPath: string,
   runtimeKind: RuntimeKind,
@@ -101,7 +98,7 @@ export const runtimeEnsure = async (
   return runtimeInstanceSummarySchema.parse(payload);
 };
 
-export const buildStart = async (
+const buildStart = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -111,7 +108,7 @@ export const buildStart = async (
   return runSummarySchema.parse(payload);
 };
 
-export const buildBlocked = async (
+const buildBlocked = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -125,7 +122,7 @@ export const buildBlocked = async (
   return taskCardSchema.parse(payload);
 };
 
-export const buildResumed = async (
+const buildResumed = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -137,7 +134,7 @@ export const buildResumed = async (
   return taskCardSchema.parse(payload);
 };
 
-export const buildCompleted = async (
+const buildCompleted = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -151,7 +148,7 @@ export const buildCompleted = async (
   return taskCardSchema.parse(payload);
 };
 
-export const humanRequestChanges = async (
+const humanRequestChanges = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -165,7 +162,7 @@ export const humanRequestChanges = async (
   return taskCardSchema.parse(payload);
 };
 
-export const humanApprove = async (
+const humanApprove = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -177,11 +174,7 @@ export const humanApprove = async (
   return taskCardSchema.parse(payload);
 };
 
-export const taskApprovalContextGet = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-) => {
+const taskApprovalContextGet = async (invokeFn: InvokeFn, repoPath: string, taskId: string) => {
   const payload = await invokeFn("task_approval_context_get", {
     repoPath,
     taskId,
@@ -189,7 +182,7 @@ export const taskApprovalContextGet = async (
   return taskApprovalContextSchema.parse(payload);
 };
 
-export const taskDirectMerge = async (
+const taskDirectMerge = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -204,7 +197,7 @@ export const taskDirectMerge = async (
   return taskDirectMergeResultSchema.parse(payload);
 };
 
-export const taskDirectMergeComplete = async (
+const taskDirectMergeComplete = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -216,7 +209,7 @@ export const taskDirectMergeComplete = async (
   return taskCardSchema.parse(payload);
 };
 
-export const taskPullRequestUpsert = async (
+const taskPullRequestUpsert = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -231,7 +224,7 @@ export const taskPullRequestUpsert = async (
   return pullRequestSchema.parse(payload);
 };
 
-export const taskPullRequestUnlink = async (
+const taskPullRequestUnlink = async (
   invokeFn: InvokeFn,
   repoPath: string,
   taskId: string,
@@ -240,16 +233,12 @@ export const taskPullRequestUnlink = async (
   return parseOkResult(payload, "task_pull_request_unlink");
 };
 
-export const taskPullRequestDetect = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-  taskId: string,
-) => {
+const taskPullRequestDetect = async (invokeFn: InvokeFn, repoPath: string, taskId: string) => {
   const payload = await invokeFn("task_pull_request_detect", { repoPath, taskId });
   return taskPullRequestDetectResultSchema.parse(payload);
 };
 
-export const repoPullRequestSync = async (
+const repoPullRequestSync = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<{ ok: boolean }> => {
@@ -257,7 +246,7 @@ export const repoPullRequestSync = async (
   return parseOkResult(payload, "repo_pull_request_sync");
 };
 
-export const buildRespond = async (
+const buildRespond = async (
   invokeFn: InvokeFn,
   runId: string,
   input: BuildRespondInput,
@@ -270,12 +259,12 @@ export const buildRespond = async (
   return parseOkResult(response, "build_respond");
 };
 
-export const buildStop = async (invokeFn: InvokeFn, runId: string): Promise<{ ok: boolean }> => {
+const buildStop = async (invokeFn: InvokeFn, runId: string): Promise<{ ok: boolean }> => {
   const payload = await invokeFn("build_stop", { runId });
   return parseOkResult(payload, "build_stop");
 };
 
-export const buildCleanup = async (
+const buildCleanup = async (
   invokeFn: InvokeFn,
   runId: string,
   mode: BuildCleanupMode,

--- a/packages/adapters-tauri-host/src/git-client.ts
+++ b/packages/adapters-tauri-host/src/git-client.ts
@@ -38,15 +38,12 @@ import {
 import type { InvokeFn } from "./invoke-utils";
 import { parseArray, parseOkResult } from "./invoke-utils";
 
-export const gitGetBranches = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-): Promise<GitBranch[]> => {
+const gitGetBranches = async (invokeFn: InvokeFn, repoPath: string): Promise<GitBranch[]> => {
   const payload = await invokeFn("git_get_branches", { repoPath });
   return parseArray(gitBranchSchema, payload, "git_get_branches");
 };
 
-export const gitGetCurrentBranch = async (
+const gitGetCurrentBranch = async (
   invokeFn: InvokeFn,
   repoPath: string,
   workingDir?: string,
@@ -58,7 +55,7 @@ export const gitGetCurrentBranch = async (
   return gitCurrentBranchSchema.parse(payload);
 };
 
-export const gitSwitchBranch = async (
+const gitSwitchBranch = async (
   invokeFn: InvokeFn,
   repoPath: string,
   branch: string,
@@ -72,7 +69,7 @@ export const gitSwitchBranch = async (
   return gitCurrentBranchSchema.parse(payload);
 };
 
-export const gitCreateWorktree = async (
+const gitCreateWorktree = async (
   invokeFn: InvokeFn,
   repoPath: string,
   worktreePath: string,
@@ -88,7 +85,7 @@ export const gitCreateWorktree = async (
   return gitWorktreeSummarySchema.parse(payload);
 };
 
-export const gitRemoveWorktree = async (
+const gitRemoveWorktree = async (
   invokeFn: InvokeFn,
   repoPath: string,
   worktreePath: string,
@@ -102,7 +99,7 @@ export const gitRemoveWorktree = async (
   return parseOkResult(payload, "git_remove_worktree");
 };
 
-export const gitPushBranch = async (
+const gitPushBranch = async (
   invokeFn: InvokeFn,
   repoPath: string,
   branch: string,
@@ -124,7 +121,7 @@ export const gitPushBranch = async (
   return gitPushBranchResultSchema.parse(payload);
 };
 
-export const gitPullBranch = async (
+const gitPullBranch = async (
   invokeFn: InvokeFn,
   repoPath: string,
   workingDir?: string,
@@ -140,7 +137,7 @@ export const gitPullBranch = async (
   return gitPullBranchResultSchema.parse(payload);
 };
 
-export const gitGetStatus = async (
+const gitGetStatus = async (
   invokeFn: InvokeFn,
   repoPath: string,
   workingDir?: string,
@@ -152,7 +149,7 @@ export const gitGetStatus = async (
   return parseArray(fileStatusSchema, payload, "git_get_status");
 };
 
-export const gitGetDiff = async (
+const gitGetDiff = async (
   invokeFn: InvokeFn,
   repoPath: string,
   targetBranch?: string,
@@ -166,7 +163,7 @@ export const gitGetDiff = async (
   return parseArray(fileDiffSchema, payload, "git_get_diff");
 };
 
-export const gitCommitsAheadBehind = async (
+const gitCommitsAheadBehind = async (
   invokeFn: InvokeFn,
   repoPath: string,
   targetBranch: string,
@@ -180,7 +177,7 @@ export const gitCommitsAheadBehind = async (
   return commitsAheadBehindSchema.parse(payload);
 };
 
-export const gitGetWorktreeStatus = async (
+const gitGetWorktreeStatus = async (
   invokeFn: InvokeFn,
   repoPath: string,
   targetBranch: string,
@@ -196,7 +193,7 @@ export const gitGetWorktreeStatus = async (
   return gitWorktreeStatusSchema.parse(payload);
 };
 
-export const gitGetWorktreeStatusSummary = async (
+const gitGetWorktreeStatusSummary = async (
   invokeFn: InvokeFn,
   repoPath: string,
   targetBranch: string,
@@ -212,7 +209,7 @@ export const gitGetWorktreeStatusSummary = async (
   return gitWorktreeStatusSummarySchema.parse(payload);
 };
 
-export const gitCommitAll = async (
+const gitCommitAll = async (
   invokeFn: InvokeFn,
   repoPath: string,
   message: string,
@@ -231,7 +228,7 @@ export const gitCommitAll = async (
   return gitCommitAllResultSchema.parse(payload);
 };
 
-export const gitRebaseBranch = async (
+const gitRebaseBranch = async (
   invokeFn: InvokeFn,
   repoPath: string,
   targetBranch: string,
@@ -250,7 +247,7 @@ export const gitRebaseBranch = async (
   return gitRebaseBranchResultSchema.parse(payload);
 };
 
-export const gitRebaseAbort = async (
+const gitRebaseAbort = async (
   invokeFn: InvokeFn,
   repoPath: string,
   workingDir?: string,
@@ -266,7 +263,7 @@ export const gitRebaseAbort = async (
   return gitRebaseAbortResultSchema.parse(payload);
 };
 
-export const gitAbortConflict = async (
+const gitAbortConflict = async (
   invokeFn: InvokeFn,
   repoPath: string,
   operation: GitConflictOperation,

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -78,6 +78,12 @@ const createClient = (resolver: (command: string, args?: Record<string, unknown>
 const assertClientType = (client: TauriHostClientType): TauriHostClientType => client;
 
 describe("TauriHostClient", () => {
+  test("does not export a redundant runtime constructor alias", async () => {
+    const module = await import("./index");
+
+    expect(module).not.toHaveProperty("TauriHostClient");
+  });
+
   test("exports a value and type-compatible host client", async () => {
     const { client } = createClient((command) => {
       if (command === "set_spec") {

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -162,6 +162,3 @@ const createTauriHostClientApi = (invokeFn: InvokeFn): TauriHostClientApi => {
 export function createTauriHostClient(invokeFn: InvokeFn): TauriHostClient {
   return createTauriHostClientApi(invokeFn);
 }
-
-export const TauriHostClient = (invokeFn: InvokeFn): TauriHostClient =>
-  createTauriHostClient(invokeFn);

--- a/packages/adapters-tauri-host/src/workspace-client.ts
+++ b/packages/adapters-tauri-host/src/workspace-client.ts
@@ -100,28 +100,22 @@ const parseTrustedHooksChallenge = (payload: unknown): TrustedHooksChallenge => 
   };
 };
 
-export const workspaceList = async (invokeFn: InvokeFn): Promise<WorkspaceRecord[]> => {
+const workspaceList = async (invokeFn: InvokeFn): Promise<WorkspaceRecord[]> => {
   const payload = await invokeFn("workspace_list");
   return parseArray(workspaceRecordSchema, payload, "workspace_list");
 };
 
-export const workspaceAdd = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-): Promise<WorkspaceRecord> => {
+const workspaceAdd = async (invokeFn: InvokeFn, repoPath: string): Promise<WorkspaceRecord> => {
   const payload = await invokeFn("workspace_add", { repoPath });
   return workspaceRecordSchema.parse(payload);
 };
 
-export const workspaceSelect = async (
-  invokeFn: InvokeFn,
-  repoPath: string,
-): Promise<WorkspaceRecord> => {
+const workspaceSelect = async (invokeFn: InvokeFn, repoPath: string): Promise<WorkspaceRecord> => {
   const payload = await invokeFn("workspace_select", { repoPath });
   return workspaceRecordSchema.parse(payload);
 };
 
-export const workspaceUpdateRepoConfig = async (
+const workspaceUpdateRepoConfig = async (
   invokeFn: InvokeFn,
   repoPath: string,
   config: WorkspaceRepoConfigInput,
@@ -133,7 +127,7 @@ export const workspaceUpdateRepoConfig = async (
   return workspaceRecordSchema.parse(payload);
 };
 
-export const workspaceSaveRepoSettings = async (
+const workspaceSaveRepoSettings = async (
   invokeFn: InvokeFn,
   repoPath: string,
   settings: WorkspaceRepoSettingsInput,
@@ -145,7 +139,7 @@ export const workspaceSaveRepoSettings = async (
   return workspaceRecordSchema.parse(payload);
 };
 
-export const workspaceUpdateRepoHooks = async (
+const workspaceUpdateRepoHooks = async (
   invokeFn: InvokeFn,
   repoPath: string,
   hooks: WorkspaceRepoHooksInput,
@@ -157,7 +151,7 @@ export const workspaceUpdateRepoHooks = async (
   return workspaceRecordSchema.parse(payload);
 };
 
-export const workspaceGetRepoConfig = async (
+const workspaceGetRepoConfig = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<RepoConfig> => {
@@ -165,14 +159,12 @@ export const workspaceGetRepoConfig = async (
   return repoConfigSchema.parse(payload);
 };
 
-export const workspaceGetSettingsSnapshot = async (
-  invokeFn: InvokeFn,
-): Promise<SettingsSnapshot> => {
+const workspaceGetSettingsSnapshot = async (invokeFn: InvokeFn): Promise<SettingsSnapshot> => {
   const payload = await invokeFn("workspace_get_settings_snapshot");
   return settingsSnapshotSchema.parse(payload);
 };
 
-export const workspaceSaveSettingsSnapshot = async (
+const workspaceSaveSettingsSnapshot = async (
   invokeFn: InvokeFn,
   snapshot: SettingsSnapshot,
 ): Promise<WorkspaceRecord[]> => {
@@ -180,14 +172,14 @@ export const workspaceSaveSettingsSnapshot = async (
   return parseArray(workspaceRecordSchema, payload, "workspace_save_settings_snapshot");
 };
 
-export const workspaceUpdateGlobalGitConfig = async (
+const workspaceUpdateGlobalGitConfig = async (
   invokeFn: InvokeFn,
   git: GlobalGitConfig,
 ): Promise<void> => {
   await invokeFn("workspace_update_global_git_config", { git });
 };
 
-export const workspaceDetectGithubRepository = async (
+const workspaceDetectGithubRepository = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<GitProviderRepository | null> => {
@@ -195,7 +187,7 @@ export const workspaceDetectGithubRepository = async (
   return payload === null ? null : gitProviderRepositorySchema.parse(payload);
 };
 
-export const workspaceSetTrustedHooks = async (
+const workspaceSetTrustedHooks = async (
   invokeFn: InvokeFn,
   repoPath: string,
   trusted: boolean,
@@ -214,7 +206,7 @@ export const workspaceSetTrustedHooks = async (
   return workspaceRecordSchema.parse(payload);
 };
 
-export const workspacePrepareTrustedHooksChallenge = async (
+const workspacePrepareTrustedHooksChallenge = async (
   invokeFn: InvokeFn,
   repoPath: string,
 ): Promise<TrustedHooksChallenge> => {
@@ -224,7 +216,7 @@ export const workspacePrepareTrustedHooksChallenge = async (
   return parseTrustedHooksChallenge(payload);
 };
 
-export const setTheme = async (invokeFn: InvokeFn, theme: string): Promise<void> => {
+const setTheme = async (invokeFn: InvokeFn, theme: string): Promise<void> => {
   await invokeFn("set_theme", { theme });
 };
 


### PR DESCRIPTION
## Summary
This PR is the first `desloppify` cleanup batch for the desktop app and Tauri host.

It includes:
- removal of prop-to-state sync effects in desktop UI flows
- consolidation of duplicated desktop/orchestrator helper logic
- a unified desktop host bridge surface for commands and run-event subscription
- a narrower public API surface for the Tauri host adapter
- one shared auth/working-dir preflight path across repo-scoped git IPC handlers

## Checks
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`

## Notes
- Local `desloppify` artifacts such as `.agents/skills/desloppify/` and `scorecard.png` are intentionally not included.
- Follow-up subjective review items remain and will be handled in later batches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Refactoring**
  * Centralized git repository authorization and working-directory handling for more consistent git operations
  * Improved branch-switching and conflict-resolution state management for smoother UI behavior
  * Streamlined session/startup orchestration for more predictable session initialization

* **Bug Fixes**
  * Safer error formatting to provide clearer error messages in failure scenarios

* **Chores**
  * Reduced exported helper surface by consolidating internals behind class-style clients

* **Tests**
  * Added/expanded tests covering branch switching and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->