### PR TITLE
fix(desktop): add title tooltip to truncated task title in details sheet

### DIFF
--- a/apps/desktop/src/components/features/task-details/task-details-sheet-header.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-header.test.tsx
@@ -206,4 +206,23 @@ describe("TaskDetailsSheetHeader", () => {
     expect(html).not.toContain("Detect PR");
     expect(html).not.toContain("task-details-detect-pr-button");
   });
+
+  test("renders title attribute on truncated title span for hover tooltip", () => {
+    const longTitle =
+      "This is a very long task title that exceeds available width and should truncate";
+    const task = createTaskCardFixture({
+      id: "TASK-7",
+      title: longTitle,
+    });
+
+    const html = renderToStaticMarkup(
+      createElement(TaskDetailsSheetHeader, {
+        task,
+        subtasksCount: 0,
+        taskLabels: [],
+      }),
+    );
+
+    expect(html).toContain(`title="${longTitle}"`);
+  });
 });

--- a/apps/desktop/src/components/features/task-details/task-details-sheet-header.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-header.tsx
@@ -53,7 +53,9 @@ export function TaskDetailsSheetHeader({
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <h2 className="flex items-center gap-2 text-xl font-semibold text-foreground">
             <Sparkles className="size-5 shrink-0 text-primary" />
-            <span className="truncate">{task.title}</span>
+            <span className="truncate" title={task.title}>
+              {task.title}
+            </span>
           </h2>
           <p className="truncate font-mono text-xs text-muted-foreground">{task.id}</p>
         </div>


### PR DESCRIPTION
## Summary

Fixed an issue where long task titles in the task details sheet header were silently truncated without a way to view the full text on hover.

## Problem

The `TaskDetailsSheetHeader` component used `truncate` CSS class to limit title display, but this only clips the text visually without providing a native browser tooltip. Users with long task titles could not read the full content.

## Solution

Added the native `title` attribute to the truncated title span, enabling the browser's built-in tooltip to display the full title on hover. This mirrors the existing behavior in the kanban task card component.

## Changes

- **apps/desktop/src/components/features/task-details/task-details-sheet-header.tsx**: Added `title={task.title}` to the truncated title span
- **apps/desktop/src/components/features/task-details/task-details-sheet-header.test.tsx**: Added test case verifying the title attribute renders correctly

## Test Plan

- All existing tests pass (9 tests in the file)
- Added specific test for long titles to verify `title` attribute is rendered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Truncated task titles now show a hover tooltip with the full title, improving readability for long task names.

* **Tests**
  * Added a unit test to verify the tooltip/title attribute is present on truncated task titles to ensure consistent hover behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->