### PR TITLE
fix(agent-studio): align git panel branch diffs

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -10,6 +10,9 @@ use super::util::{combine_output, normalize_non_empty};
 use super::GitCliPort;
 
 const UPSTREAM_TARGET_BRANCH: &str = "@{upstream}";
+const EMPTY_TREE_SHA1: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+const EMPTY_TREE_SHA256: &str =
+    "6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321";
 
 fn resolve_effective_target_branch(
     requested_target_branch: &str,
@@ -95,7 +98,11 @@ impl GitCliPort {
                                     repo_path,
                                     effective_target_branch
                                         .as_deref()
-                                        .expect("target scope requires an effective target branch"),
+                                        .ok_or_else(|| {
+                                            anyhow!(
+                                                "target scope requires an effective target branch"
+                                            )
+                                        })?,
                                 )
                                 .map(Some),
                             GitDiffScope::Uncommitted => self
@@ -313,11 +320,11 @@ impl GitCliPort {
         repo_path: &Path,
         target_branch: &str,
     ) -> Result<(String, String)> {
-        let merge_base = self.resolve_merge_base_unchecked(repo_path, target_branch)?;
-        self.load_diff_payload_unchecked(repo_path, Some(merge_base.as_str()))
+        let diff_base = self.resolve_branch_diff_base_unchecked(repo_path, target_branch)?;
+        self.load_diff_payload_unchecked(repo_path, Some(diff_base.as_str()))
     }
 
-    fn resolve_merge_base_unchecked(
+    fn resolve_branch_diff_base_unchecked(
         &self,
         repo_path: &Path,
         target_branch: &str,
@@ -329,8 +336,14 @@ impl GitCliPort {
         )?;
 
         if !ok {
+            if stdout.trim().is_empty() && stderr.trim().is_empty() {
+                return self.empty_tree_oid_unchecked(repo_path).with_context(|| {
+                    format!("Failed to resolve branch diff base for unrelated histories against {target}")
+                });
+            }
+
             return Err(anyhow!(
-                "git merge-base {target} HEAD failed: {}",
+                "git merge-base {target} HEAD failed for target branch '{target}': {}",
                 combine_output(stdout, stderr)
             ));
         }
@@ -342,6 +355,21 @@ impl GitCliPort {
             .ok_or_else(|| anyhow!("git merge-base {target} HEAD returned no merge base"))?;
 
         Ok(merge_base.to_string())
+    }
+
+    fn empty_tree_oid_unchecked(&self, repo_path: &Path) -> Result<String> {
+        let object_format = self
+            .run_git(repo_path, &["rev-parse", "--show-object-format"])
+            .context("Failed to read git object format for branch diff base")?;
+        let object_format = object_format.trim();
+
+        match object_format {
+            "sha1" => Ok(EMPTY_TREE_SHA1.to_string()),
+            "sha256" => Ok(EMPTY_TREE_SHA256.to_string()),
+            _ => Err(anyhow!(
+                "Unsupported git object format for empty tree branch diff base: {object_format}"
+            )),
+        }
     }
 
     pub(super) fn commits_ahead_behind_unchecked(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -90,7 +90,15 @@ impl GitCliPort {
                         || self.get_status_unchecked(repo_path),
                         || match diff_scope {
                             GitDiffScope::Target if effective_target_branch.is_none() => Ok(None),
-                            _ => self
+                            GitDiffScope::Target => self
+                                .load_branch_changes_diff_payload_unchecked(
+                                    repo_path,
+                                    effective_target_branch
+                                        .as_deref()
+                                        .expect("target scope requires an effective target branch"),
+                                )
+                                .map(Some),
+                            GitDiffScope::Uncommitted => self
                                 .load_diff_payload_unchecked(repo_path, diff_target)
                                 .map(Some),
                         },
@@ -298,6 +306,42 @@ impl GitCliPort {
         }
 
         Ok((numstat_stdout, diff_stdout))
+    }
+
+    fn load_branch_changes_diff_payload_unchecked(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+    ) -> Result<(String, String)> {
+        let merge_base = self.resolve_merge_base_unchecked(repo_path, target_branch)?;
+        self.load_diff_payload_unchecked(repo_path, Some(merge_base.as_str()))
+    }
+
+    fn resolve_merge_base_unchecked(
+        &self,
+        repo_path: &Path,
+        target_branch: &str,
+    ) -> Result<String> {
+        let target = normalize_non_empty(target_branch, "target branch")?;
+        let (ok, stdout, stderr) = self.run_git_allow_failure(
+            repo_path,
+            &["merge-base", "--end-of-options", &target, "HEAD"],
+        )?;
+
+        if !ok {
+            return Err(anyhow!(
+                "git merge-base {target} HEAD failed: {}",
+                combine_output(stdout, stderr)
+            ));
+        }
+
+        let merge_base = stdout
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty())
+            .ok_or_else(|| anyhow!("git merge-base {target} HEAD returned no merge base"))?;
+
+        Ok(merge_base.to_string())
     }
 
     pub(super) fn commits_ahead_behind_unchecked(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
@@ -344,6 +344,62 @@ fn get_worktree_status_honors_diff_scope_uncommitted_vs_target() {
 }
 
 #[test]
+fn get_worktree_status_target_scope_uses_branch_point_when_branch_is_ahead_and_behind() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-branch-point");
+    run_git_ok(&repo.path, &["switch", "-c", "feature/branch-point"]);
+
+    fs::write(repo.path.join("feature_only.txt"), "feature change\n")
+        .expect("feature file should write");
+    run_git_ok(&repo.path, &["add", "feature_only.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "feature commit"]);
+
+    run_git_ok(&repo.path, &["switch", "main"]);
+    fs::write(repo.path.join("main_only.txt"), "main change\n").expect("main file should write");
+    run_git_ok(&repo.path, &["add", "main_only.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "main commit"]);
+
+    run_git_ok(&repo.path, &["switch", "feature/branch-point"]);
+    fs::write(
+        repo.path.join("README.md"),
+        "# OpenDucktor\nbranch point dirty change\n",
+    )
+    .expect("dirty file should write");
+
+    let git = GitCliPort::new();
+    let status = git
+        .get_worktree_status(&repo.path, "main", GitDiffScope::Target)
+        .expect("target scope should resolve from branch point");
+
+    assert_eq!(status.target_ahead_behind.ahead, 1);
+    assert_eq!(status.target_ahead_behind.behind, 1);
+    assert!(
+        status
+            .file_diffs
+            .iter()
+            .any(|diff| diff.file == "feature_only.txt"),
+        "target scope should include feature commits after the merge base"
+    );
+    assert!(
+        status
+            .file_diffs
+            .iter()
+            .any(|diff| diff.file == "README.md"),
+        "target scope should keep uncommitted worktree changes on top of branch changes"
+    );
+    assert!(
+        !status
+            .file_diffs
+            .iter()
+            .any(|diff| diff.file == "main_only.txt"),
+        "target scope should exclude target-only commits after the merge base"
+    );
+}
+
+#[test]
 fn get_worktree_status_surfaces_non_fatal_upstream_count_error() {
     if !git_available() {
         return;

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/tests/status_tests.rs
@@ -400,6 +400,36 @@ fn get_worktree_status_target_scope_uses_branch_point_when_branch_is_ahead_and_b
 }
 
 #[test]
+fn get_worktree_status_target_scope_uses_empty_tree_when_histories_are_unrelated() {
+    if !git_available() {
+        return;
+    }
+
+    let repo = setup_repo("worktree-status-unrelated-histories");
+    run_git_ok(&repo.path, &["switch", "--orphan", "feature/unrelated"]);
+    run_git_ok(&repo.path, &["rm", "-rf", "--ignore-unmatch", "."]);
+
+    fs::write(repo.path.join("orphan.txt"), "orphan branch\n").expect("orphan file should write");
+    run_git_ok(&repo.path, &["add", "orphan.txt"]);
+    run_git_ok(&repo.path, &["commit", "-m", "orphan root"]);
+
+    let git = GitCliPort::new();
+    let status = git
+        .get_worktree_status(&repo.path, "main", GitDiffScope::Target)
+        .expect("target scope should resolve for unrelated histories");
+
+    assert!(
+        status.file_diffs.iter().any(|diff| {
+            diff.file == "orphan.txt"
+                && diff.diff_type == "added"
+                && diff.additions == 1
+                && diff.deletions == 0
+        }),
+        "target scope should diff against the empty tree when there is no merge base"
+    );
+}
+
+#[test]
 fn get_worktree_status_surfaces_non_fatal_upstream_count_error() {
     if !git_available() {
         return;

--- a/apps/desktop/src-tauri/src/commands/git/command_handlers.rs
+++ b/apps/desktop/src-tauri/src/commands/git/command_handlers.rs
@@ -202,9 +202,10 @@ pub async fn git_get_diff(
     let scope = authorize_git_scope(&state, &repo_path, working_dir.as_deref())?;
     let service = state.service.clone();
     let result = run_service_blocking("git_get_diff", move || {
-        service
-            .git_port()
-            .get_diff(Path::new(&scope.effective_working_dir), target_branch.as_deref())
+        service.git_port().get_diff(
+            Path::new(&scope.effective_working_dir),
+            target_branch.as_deref(),
+        )
     })
     .await;
     as_error(result)

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -244,7 +244,7 @@ describe("AgentStudioGitPanel", () => {
       findByTestId(root, "agent-studio-git-diff-scope-uncommitted").children.join(""),
     ).toContain("Uncommitted changes");
     expect(findByTestId(root, "agent-studio-git-diff-scope-target").children.join("")).toContain(
-      "Compare to target",
+      "Branch changes",
     );
     expect(hasVisibleText(root, "/tmp/worktree")).toBe(false);
 
@@ -418,7 +418,7 @@ describe("AgentStudioGitPanel", () => {
     expect(findByTestId(root, "agent-studio-git-push-button")).toBeTruthy();
     expect(findByTestId(root, "agent-studio-git-commit-message-input")).toBeTruthy();
     expect(findByTestId(root, "agent-studio-git-diff-scope-target").children.join("")).toContain(
-      "Compare to upstream",
+      "Branch changes",
     );
 
     await act(async () => {
@@ -450,7 +450,7 @@ describe("AgentStudioGitPanel", () => {
     expect(
       hasVisibleText(
         root,
-        "This branch is not tracking an upstream branch yet. Push it first to create one, then compare against it here.",
+        "This branch is not tracking an upstream branch yet. Push it first to create one, then its branch changes will appear here.",
       ),
     ).toBe(true);
     expect(Boolean(findByTestId(root, "agent-studio-git-pull-button").props.disabled)).toBe(true);

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/constants.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/constants.ts
@@ -25,7 +25,7 @@ export const DIFF_SCOPE_OPTIONS: Array<{
   },
   {
     scope: "target",
-    label: "Compare to target",
+    label: "Branch changes",
     testId: "agent-studio-git-diff-scope-target",
   },
 ];

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/empty-diff-state.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/empty-diff-state.tsx
@@ -16,14 +16,14 @@ export function EmptyDiffState({
   const title = (() => {
     if (isLoading) {
       return contextMode === "repository" && diffScope === "target"
-        ? "Checking upstream differences..."
+        ? "Checking branch changes..."
         : "Scanning for changes...";
     }
     if (contextMode === "repository" && diffScope === "target" && upstreamStatus === "untracked") {
       return "No upstream branch yet";
     }
     if (contextMode === "repository" && diffScope === "target") {
-      return "No upstream differences detected";
+      return "No branch changes detected";
     }
     if (contextMode === "repository") {
       return "No repository changes detected";
@@ -34,14 +34,14 @@ export function EmptyDiffState({
   const description = (() => {
     if (isLoading) {
       return contextMode === "repository" && diffScope === "target"
-        ? "Comparing this branch against its tracked upstream branch."
+        ? "Collecting changes in this branch since it diverged from its tracked upstream branch."
         : "Checking the working directory for file modifications.";
     }
     if (contextMode === "repository" && diffScope === "target" && upstreamStatus === "untracked") {
-      return "This branch is not tracking an upstream branch yet. Push it first to create one, then compare against it here.";
+      return "This branch is not tracking an upstream branch yet. Push it first to create one, then its branch changes will appear here.";
     }
     if (contextMode === "repository" && diffScope === "target") {
-      return "Differences against the tracked upstream branch will appear here.";
+      return "Changes in this branch since it diverged from the tracked upstream branch will appear here.";
     }
     if (contextMode === "repository") {
       return "Uncommitted changes in the repository branch will appear here.";

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
@@ -384,7 +384,7 @@ function GitDiffScopeTabs({
               )}
               data-testid={option.testId}
             >
-              {option.scope === "target" && isRepositoryMode ? "Compare to upstream" : option.label}
+              {option.label}
             </TabsTrigger>
           ))}
         </TabsList>

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
@@ -349,15 +349,10 @@ function GitActionRow({
 
 type GitDiffScopeTabsProps = {
   diffScope: DiffScope;
-  isRepositoryMode: boolean;
   onScopeChange: (scope: DiffScope) => void;
 };
 
-function GitDiffScopeTabs({
-  diffScope,
-  isRepositoryMode,
-  onScopeChange,
-}: GitDiffScopeTabsProps): ReactElement {
+function GitDiffScopeTabs({ diffScope, onScopeChange }: GitDiffScopeTabsProps): ReactElement {
   return (
     <div className="flex flex-col gap-1">
       <Tabs
@@ -569,11 +564,7 @@ export function GitInfoHeader({
         </div>
       ) : null}
 
-      <GitDiffScopeTabs
-        diffScope={diffScope}
-        isRepositoryMode={isRepositoryMode}
-        onScopeChange={handleScopeChange}
-      />
+      <GitDiffScopeTabs diffScope={diffScope} onScopeChange={handleScopeChange} />
       <GitInfoHeaderErrors pushError={pushError ?? null} rebaseError={rebaseError ?? null} />
     </div>
   );

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
@@ -101,7 +101,17 @@ export function useAgentStudioDiffController({
   const [controllerState, setControllerState] = useState<DiffControllerState>(
     createInitialControllerState,
   );
-  const [diffScope, setDiffScope] = useState<DiffScope>("target");
+  const [diffScope, setDiffScope] = useState<DiffScope>("uncommitted");
+
+  const versionByScopeAndModeRef = useRef(createVersionState());
+  // Keep this monotonic across context resets so stale completions cannot
+  // collide with a newer loading request after resetRequestTracking clears refs.
+  const requestSequenceRef = useRef(0);
+  const inFlightScopeRequestRef = useRef(createInFlightState());
+  const queuedFullReloadByScopeRef = useRef(createQueuedReloadState());
+  const queuedFullReloadForceByScopeRef = useRef(createQueuedReloadForceState());
+  const invalidatedFullReloadByScopeRef = useRef(createInvalidatedFullReloadState());
+  const latestLoadingRequestSequenceRef = useRef<number | null>(null);
   const requestContextKeyRef = useRef<string | null>(null);
   const {
     beginRequest,
@@ -144,6 +154,15 @@ export function useAgentStudioDiffController({
     resetRequestTracking();
     setControllerState(createInitialControllerState());
   }, [resetRequestTracking]);
+
+  const resetToDefaultScope = useCallback((): void => {
+    if (diffScopeRef.current === "uncommitted") {
+      return;
+    }
+
+    diffScopeRef.current = "uncommitted";
+    setDiffScope("uncommitted");
+  }, []);
 
   const hasLoadContextChanged = useCallback(
     (path: string, nextTargetBranch: string, nextWorkingDir: string | null): boolean =>
@@ -433,6 +452,7 @@ export function useAgentStudioDiffController({
 
     if (repoPath && !shouldBlockDiffLoading) {
       if (hasContextChanged) {
+        resetToDefaultScope();
         resetControllerState();
       }
 
@@ -440,7 +460,7 @@ export function useAgentStudioDiffController({
         repoPath,
         targetBranch,
         workingDir,
-        scope: diffScopeRef.current,
+        scope: hasContextChanged ? "uncommitted" : diffScopeRef.current,
         force: hasContextChanged,
       });
       return;
@@ -448,18 +468,21 @@ export function useAgentStudioDiffController({
 
     if (repoPath) {
       if (hasContextChanged) {
+        resetToDefaultScope();
         resetControllerState();
       }
       return;
     }
 
     requestContextKeyRef.current = null;
+    resetToDefaultScope();
     resetControllerState();
   }, [
     loadData,
     repoPath,
     requestContextKey,
     resetControllerState,
+    resetToDefaultScope,
     shouldBlockDiffLoading,
     targetBranch,
     workingDir,

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-controller.ts
@@ -102,16 +102,6 @@ export function useAgentStudioDiffController({
     createInitialControllerState,
   );
   const [diffScope, setDiffScope] = useState<DiffScope>("uncommitted");
-
-  const versionByScopeAndModeRef = useRef(createVersionState());
-  // Keep this monotonic across context resets so stale completions cannot
-  // collide with a newer loading request after resetRequestTracking clears refs.
-  const requestSequenceRef = useRef(0);
-  const inFlightScopeRequestRef = useRef(createInFlightState());
-  const queuedFullReloadByScopeRef = useRef(createQueuedReloadState());
-  const queuedFullReloadForceByScopeRef = useRef(createQueuedReloadForceState());
-  const invalidatedFullReloadByScopeRef = useRef(createInvalidatedFullReloadState());
-  const latestLoadingRequestSequenceRef = useRef<number | null>(null);
   const requestContextKeyRef = useRef<string | null>(null);
   const {
     beginRequest,

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
@@ -262,35 +262,28 @@ describe("useAgentStudioDiffData", () => {
       await harness.mount();
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
 
-      expect(harness.getLatest().diffScope).toBe("target");
+      expect(harness.getLatest().diffScope).toBe("uncommitted");
       expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
         1,
         "/repo",
         "origin/main",
-        "target",
+        "uncommitted",
         undefined,
       );
       expect(harness.getLatest().upstreamAheadBehind).toEqual({ ahead: 1, behind: 0 });
-      expect(harness.getLatest().fileDiffs.length).toBe(1);
+      expect(harness.getLatest().fileDiffs).toEqual([]);
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
+        state.setDiffScope("target");
       });
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
       expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
         2,
         "/repo",
         "origin/main",
-        "uncommitted",
+        "target",
         undefined,
       );
-      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
-      expect(harness.getLatest().fileDiffs).toEqual([]);
-
-      await harness.run((state) => {
-        state.setDiffScope("target");
-      });
-      await harness.waitFor(() => harness.getLatest().diffScope === "target");
       expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
       expect(harness.getLatest().fileDiffs.length).toBe(1);
 
@@ -298,6 +291,13 @@ describe("useAgentStudioDiffData", () => {
         state.setDiffScope("uncommitted");
       });
       await harness.waitFor(() => harness.getLatest().diffScope === "uncommitted");
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
+      expect(harness.getLatest().fileDiffs).toEqual([]);
+
+      await harness.run((state) => {
+        state.setDiffScope("target");
+      });
+      await harness.waitFor(() => harness.getLatest().diffScope === "target");
       expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
     } finally {
       await harness.unmount();
@@ -314,7 +314,7 @@ describe("useAgentStudioDiffData", () => {
       await firstHarness.unmount();
 
       await secondHarness.mount();
-      await secondHarness.waitFor((state) => state.fileDiffs.length === 1);
+      await secondHarness.waitFor((state) => state.diffScope === "uncommitted" && !state.isLoading);
 
       expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(1);
     } finally {
@@ -339,7 +339,7 @@ describe("useAgentStudioDiffData", () => {
         2,
         "/repo",
         "origin/main",
-        "target",
+        "uncommitted",
         undefined,
       );
     } finally {
@@ -355,7 +355,7 @@ describe("useAgentStudioDiffData", () => {
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
+        state.setDiffScope("target");
       });
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
 
@@ -438,13 +438,9 @@ describe("useAgentStudioDiffData", () => {
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
-      });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
-
-      await harness.run((state) => {
         state.setDiffScope("target");
       });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
       await harness.waitFor((state) => state.diffScope === "target");
 
       gitGetWorktreeStatusMock.mockImplementation(
@@ -552,6 +548,10 @@ describe("useAgentStudioDiffData", () => {
       });
 
       await harness.waitFor((state) => state.branch === "feature/switched");
+      await harness.run((state) => {
+        state.setDiffScope("target");
+      });
+      await harness.waitFor((state) => state.diffScope === "target");
       expect(harness.getLatest().fileDiffs[0]).toMatchObject({
         file: "src/switched.ts",
         additions: 5,
@@ -573,14 +573,9 @@ describe("useAgentStudioDiffData", () => {
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
-      });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
-
-      await harness.run((state) => {
         state.setDiffScope("target");
       });
-      await harness.waitFor((state) => state.diffScope === "target");
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
       expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
 
       gitGetWorktreeStatusMock.mockImplementation(
@@ -668,14 +663,10 @@ describe("useAgentStudioDiffData", () => {
       expect(harness.getLatest().upstreamStatus).toBe("tracking");
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
+        state.setDiffScope("target");
       });
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
       expect(harness.getLatest().upstreamStatus).toBe("tracking");
-
-      await harness.run((state) => {
-        state.setDiffScope("target");
-      });
       await harness.waitFor((state) => state.diffScope === "target");
 
       gitGetWorktreeStatusMock.mockImplementation(
@@ -766,13 +757,9 @@ describe("useAgentStudioDiffData", () => {
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
-      });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
-
-      await harness.run((state) => {
         state.setDiffScope("target");
       });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
       await harness.waitFor((state) => state.diffScope === "target");
 
       gitGetWorktreeStatusMock.mockImplementation(
@@ -932,20 +919,20 @@ describe("useAgentStudioDiffData", () => {
         1,
         "/repo",
         "origin/main",
-        "target",
+        "uncommitted",
         undefined,
       );
       expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(1);
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
+        state.setDiffScope("target");
       });
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
       expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
         2,
         "/repo",
         "origin/main",
-        "uncommitted",
+        "target",
         undefined,
       );
 
@@ -957,7 +944,7 @@ describe("useAgentStudioDiffData", () => {
         2,
         "/repo",
         "origin/main",
-        "uncommitted",
+        "target",
         undefined,
       );
       expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
@@ -1623,7 +1610,7 @@ describe("useAgentStudioDiffData", () => {
     });
     const clearIntervalMock = mock((_intervalId: number) => {});
 
-    let fullRequestCount = 0;
+    let targetFullRequestCount = 0;
     gitGetWorktreeStatusMock.mockImplementation(
       async (
         _repoPath: string,
@@ -1631,24 +1618,37 @@ describe("useAgentStudioDiffData", () => {
         diffScope?: "target" | "uncommitted",
         workingDir?: string,
       ): Promise<GitWorktreeStatus> => {
-        fullRequestCount += 1;
-
-        if (fullRequestCount === 1) {
+        if ((diffScope ?? "target") !== "target") {
           return withSnapshotHashes({
             currentBranch: { name: "feature/task-10", detached: false },
             fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
-            fileDiffs:
-              (diffScope ?? "target") === "target"
-                ? [
-                    {
-                      file: "src/main.ts",
-                      type: "modified",
-                      additions: 1,
-                      deletions: 1,
-                      diff: "@@ -1 +1 @@\n-old\n+draft\n",
-                    },
-                  ]
-                : [],
+            fileDiffs: [],
+            targetAheadBehind: { ahead: 1, behind: 0 },
+            upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
+            snapshot: {
+              effectiveWorkingDir: workingDir ?? "/repo",
+              targetBranch,
+              diffScope: diffScope ?? "target",
+              observedAtMs: 1731000000000,
+            },
+          });
+        }
+
+        targetFullRequestCount += 1;
+
+        if (targetFullRequestCount === 1) {
+          return withSnapshotHashes({
+            currentBranch: { name: "feature/task-10", detached: false },
+            fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
+            fileDiffs: [
+              {
+                file: "src/main.ts",
+                type: "modified",
+                additions: 1,
+                deletions: 1,
+                diff: "@@ -1 +1 @@\n-old\n+draft\n",
+              },
+            ],
             targetAheadBehind: { ahead: 1, behind: 0 },
             upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
             snapshot: {
@@ -1663,18 +1663,15 @@ describe("useAgentStudioDiffData", () => {
         return withSnapshotHashes({
           currentBranch: { name: "feature/task-10", detached: false },
           fileStatuses: [{ path: "src/main.ts", status: "M", staged: false }],
-          fileDiffs:
-            (diffScope ?? "target") === "target"
-              ? [
-                  {
-                    file: "src/main.ts",
-                    type: "modified",
-                    additions: 3,
-                    deletions: 1,
-                    diff: "@@ -1 +1,2 @@\n-old\n+new\n+line\n",
-                  },
-                ]
-              : [],
+          fileDiffs: [
+            {
+              file: "src/main.ts",
+              type: "modified",
+              additions: 3,
+              deletions: 1,
+              diff: "@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+            },
+          ],
           targetAheadBehind: { ahead: 1, behind: 0 },
           upstreamAheadBehind: { outcome: "tracking", ahead: 1, behind: 0 },
           snapshot: {
@@ -1739,13 +1736,17 @@ describe("useAgentStudioDiffData", () => {
     try {
       await harness.mount();
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+      await harness.run((state) => {
+        state.setDiffScope("target");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
       expect(harness.getLatest().fileDiffs[0]?.additions).toBe(1);
 
       await harness.run(() => {
         runTick();
       });
       await harness.waitFor(() => gitGetWorktreeStatusSummaryMock.mock.calls.length >= 1);
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 3);
 
       expect(harness.getLatest().fileDiffs[0]).toMatchObject({
         file: "src/main.ts",
@@ -1769,14 +1770,9 @@ describe("useAgentStudioDiffData", () => {
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
-      });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
-
-      await harness.run((state) => {
         state.setDiffScope("target");
       });
-      await harness.waitFor((state) => state.diffScope === "target");
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
       expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(2);
 
       await harness.update({
@@ -1856,7 +1852,7 @@ describe("useAgentStudioDiffData", () => {
         2,
         "/repo-b",
         "origin/main",
-        "target",
+        "uncommitted",
         undefined,
       );
 
@@ -1952,9 +1948,31 @@ describe("useAgentStudioDiffData", () => {
       await harness.waitFor((state) => state.isLoading);
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
+        state.setDiffScope("target");
       });
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+
+      uncommittedRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/uncommitted", detached: false },
+          fileStatuses: [{ path: "src/uncommitted.ts", status: "M", staged: false }],
+          fileDiffs: [],
+          targetAheadBehind: { ahead: 0, behind: 0 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch: "origin/main",
+            diffScope: "uncommitted",
+            observedAtMs: 1731000001000,
+          },
+        }),
+      );
+
+      await harness.run(async () => {
+        await Promise.resolve();
+      });
+
+      expect(harness.getLatest().isLoading).toBe(true);
 
       targetRequest.resolve(
         withSnapshotHashes({
@@ -1975,34 +1993,12 @@ describe("useAgentStudioDiffData", () => {
             effectiveWorkingDir: "/repo",
             targetBranch: "origin/main",
             diffScope: "target",
-            observedAtMs: 1731000001000,
-          },
-        }),
-      );
-
-      await harness.run(async () => {
-        await Promise.resolve();
-      });
-
-      expect(harness.getLatest().isLoading).toBe(true);
-
-      uncommittedRequest.resolve(
-        withSnapshotHashes({
-          currentBranch: { name: "feature/uncommitted", detached: false },
-          fileStatuses: [{ path: "src/uncommitted.ts", status: "M", staged: false }],
-          fileDiffs: [],
-          targetAheadBehind: { ahead: 0, behind: 0 },
-          upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
-          snapshot: {
-            effectiveWorkingDir: "/repo",
-            targetBranch: "origin/main",
-            diffScope: "uncommitted",
             observedAtMs: 1731000002000,
           },
         }),
       );
 
-      await harness.waitFor((state) => !state.isLoading && state.diffScope === "uncommitted");
+      await harness.waitFor((state) => !state.isLoading && state.diffScope === "target");
     } finally {
       await harness.unmount();
     }
@@ -2285,7 +2281,7 @@ describe("useAgentStudioDiffData", () => {
   test("keeps newer shared fields when older response resolves from another scope", async () => {
     const targetRequest = createDeferred<GitWorktreeStatus>();
     const uncommittedRequest = createDeferred<GitWorktreeStatus>();
-    const queue = [targetRequest, uncommittedRequest];
+    const queue = [uncommittedRequest, targetRequest];
 
     gitGetWorktreeStatusMock.mockImplementation(
       async (
@@ -2318,46 +2314,46 @@ describe("useAgentStudioDiffData", () => {
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
+        state.setDiffScope("target");
       });
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
 
-      uncommittedRequest.resolve(
+      targetRequest.resolve(
         withSnapshotHashes({
           currentBranch: { name: "feature/newer", detached: false },
           fileStatuses: [{ path: "src/newer.ts", status: "M", staged: false }],
-          fileDiffs: [],
-          targetAheadBehind: { ahead: 2, behind: 1 },
-          upstreamAheadBehind: { outcome: "tracking", ahead: 4, behind: 1 },
-          snapshot: {
-            effectiveWorkingDir: "/repo",
-            targetBranch: "origin/main",
-            diffScope: "uncommitted",
-            observedAtMs: 1731000004000,
-          },
-        }),
-      );
-      await harness.waitFor((state) => state.branch === "feature/newer");
-
-      targetRequest.resolve(
-        withSnapshotHashes({
-          currentBranch: { name: "feature/older", detached: false },
-          fileStatuses: [{ path: "src/older.ts", status: "M", staged: false }],
           fileDiffs: [
             {
-              file: "src/older.ts",
+              file: "src/newer.ts",
               type: "modified",
               additions: 1,
               deletions: 0,
               diff: "@@ -1 +1 @@",
             },
           ],
+          targetAheadBehind: { ahead: 2, behind: 1 },
+          upstreamAheadBehind: { outcome: "tracking", ahead: 4, behind: 1 },
+          snapshot: {
+            effectiveWorkingDir: "/repo",
+            targetBranch: "origin/main",
+            diffScope: "target",
+            observedAtMs: 1731000004000,
+          },
+        }),
+      );
+      await harness.waitFor((state) => state.branch === "feature/newer");
+
+      uncommittedRequest.resolve(
+        withSnapshotHashes({
+          currentBranch: { name: "feature/older", detached: false },
+          fileStatuses: [{ path: "src/older.ts", status: "M", staged: false }],
+          fileDiffs: [],
           targetAheadBehind: { ahead: 0, behind: 0 },
           upstreamAheadBehind: { outcome: "tracking", ahead: 0, behind: 0 },
           snapshot: {
             effectiveWorkingDir: "/repo",
             targetBranch: "origin/main",
-            diffScope: "target",
+            diffScope: "uncommitted",
             observedAtMs: 1731000003000,
           },
         }),
@@ -2368,7 +2364,7 @@ describe("useAgentStudioDiffData", () => {
       });
 
       const latest = harness.getLatest();
-      expect(latest.diffScope).toBe("uncommitted");
+      expect(latest.diffScope).toBe("target");
       expect(latest.branch).toBe("feature/newer");
       expect(latest.fileStatuses[0]?.path).toBe("src/newer.ts");
       expect(latest.commitsAheadBehind).toEqual({ ahead: 2, behind: 1 });
@@ -2462,7 +2458,7 @@ describe("useAgentStudioDiffData", () => {
         1,
         "/repo",
         "origin/main",
-        "target",
+        "uncommitted",
         "/repo/.worktrees/run-1",
       );
       expect(harness.getLatest().error).toBeNull();
@@ -2530,7 +2526,7 @@ describe("useAgentStudioDiffData", () => {
         1,
         "/repo",
         "origin/main",
-        "target",
+        "uncommitted",
         "/repo/.worktrees/run-1",
       );
       expect(harness.getLatest().error).toBeNull();
@@ -2576,7 +2572,7 @@ describe("useAgentStudioDiffData", () => {
         1,
         "/repo",
         "origin/main",
-        "target",
+        "uncommitted",
         "/repo/.worktrees/run-1",
       );
       expect(harness.getLatest().error).toBeNull();
@@ -2801,7 +2797,7 @@ describe("useAgentStudioDiffData", () => {
         1,
         "/repo",
         "origin/main",
-        "target",
+        "uncommitted",
         undefined,
       );
     } finally {

--- a/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
+++ b/apps/desktop/src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx
@@ -315,6 +315,8 @@ describe("useAgentStudioDiffData", () => {
 
       await secondHarness.mount();
       await secondHarness.waitFor((state) => state.diffScope === "uncommitted" && !state.isLoading);
+      expect(secondHarness.getLatest().fileStatuses[0]?.path).toBe("src/main.ts");
+      expect(secondHarness.getLatest().upstreamAheadBehind).toEqual({ ahead: 1, behind: 0 });
 
       expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(1);
     } finally {
@@ -390,6 +392,41 @@ describe("useAgentStudioDiffData", () => {
       });
 
       await harness.waitFor((state) => state.selectedFile === null);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("resets diff scope to uncommitted when repository context changes", async () => {
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      repoPath: "/repo-a",
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 1);
+
+      await harness.run((state) => {
+        state.setDiffScope("target");
+      });
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 2);
+      await harness.waitFor((state) => state.diffScope === "target");
+
+      await harness.update({
+        ...createBaseArgs(),
+        repoPath: "/repo-b",
+      });
+
+      await harness.waitFor((state) => state.diffScope === "uncommitted");
+      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 3);
+      expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
+        3,
+        "/repo-b",
+        "origin/main",
+        "uncommitted",
+        undefined,
+      );
     } finally {
       await harness.unmount();
     }
@@ -629,13 +666,8 @@ describe("useAgentStudioDiffData", () => {
       });
 
       await harness.waitFor((state) => state.branch === "feature/switched");
-      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(3);
-
-      await harness.run((state) => {
-        state.setDiffScope("uncommitted");
-      });
-      await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 4);
       await harness.waitFor((state) => state.diffScope === "uncommitted");
+      expect(gitGetWorktreeStatusMock.mock.calls.length).toBe(3);
 
       expect(harness.getLatest().fileDiffs).toEqual([
         {
@@ -1784,19 +1816,19 @@ describe("useAgentStudioDiffData", () => {
         3,
         "/repo-b",
         "origin/main",
-        "target",
+        "uncommitted",
         undefined,
       );
 
       await harness.run((state) => {
-        state.setDiffScope("uncommitted");
+        state.setDiffScope("target");
       });
       await harness.waitFor(() => gitGetWorktreeStatusMock.mock.calls.length >= 4);
       expect(gitGetWorktreeStatusMock).toHaveBeenNthCalledWith(
         4,
         "/repo-b",
         "origin/main",
-        "uncommitted",
+        "target",
         undefined,
       );
     } finally {


### PR DESCRIPTION
## Summary
- make Agent Studio default to `Uncommitted changes` in the git panel
- change target-scope diffs to use the merge base with the target branch so the panel shows source-branch changes instead of a misleading two-ref diff when the branch is both ahead and behind
- relabel the target-scope tab to `Branch changes` so the UI matches the new source-side diff semantics in both worktree and repository modes

## Testing
- `bun test src/components/features/agents/agent-studio-git-panel.test.tsx src/pages/agents/use-agent-studio-right-panel.test.tsx src/features/agent-studio-git/use-agent-studio-diff-data.test.tsx`
- `cd apps/desktop/src-tauri && cargo fmt --all --check`
- `cd apps/desktop/src-tauri && cargo test -p host-infra-system status_tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * Renamed "Compare to target/upstream" references to "Branch changes" throughout the interface for clarity
  * Updated empty state messaging to better describe branch divergence and change detection

* **Feature Changes**
  * Modified default git diff view to display uncommitted changes on initial load rather than branch changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->