### PR TITLE
fix(desktop): sync agent studio url updates deterministically

### DIFF
--- a/apps/desktop/src/pages/agents/agents-page.tsx
+++ b/apps/desktop/src/pages/agents/agents-page.tsx
@@ -1,5 +1,5 @@
 import { type ReactElement, startTransition, useCallback, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useNavigationType, useSearchParams } from "react-router-dom";
 import {
   TaskDetailsSheetController,
   type TaskDetailsSheetControllerHandle,
@@ -55,6 +55,7 @@ export function AgentsPage(): ReactElement {
   } = useAgentState();
 
   const [searchParams, setSearchParams] = useSearchParams();
+  const navigationType = useNavigationType();
   const [input, setInput] = useState("");
   const [contextSwitchVersion, setContextSwitchVersion] = useState(0);
   const taskDetailsSheetRef = useRef<TaskDetailsSheetControllerHandle | null>(null);
@@ -72,6 +73,7 @@ export function AgentsPage(): ReactElement {
     updateQuery,
   } = useAgentStudioQuerySync({
     activeRepo,
+    navigationType,
     searchParams,
     setSearchParams,
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
@@ -48,6 +48,7 @@ describe("useAgentStudioQuerySync", () => {
 
     const harness = createHookHarness({
       activeRepo: null,
+      navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=build"),
       setSearchParams,
     });
@@ -88,6 +89,7 @@ describe("useAgentStudioQuerySync", () => {
 
     const harness = createHookHarness({
       activeRepo: null,
+      navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=spec"),
       setSearchParams,
     });
@@ -99,6 +101,7 @@ describe("useAgentStudioQuerySync", () => {
 
     await harness.update({
       activeRepo: null,
+      navigationType: "POP",
       searchParams: new URLSearchParams("task=task-2&session=session-2&agent=planner"),
       setSearchParams,
     });
@@ -139,6 +142,7 @@ describe("useAgentStudioQuerySync", () => {
 
       const harness = createHookHarness({
         activeRepo: "/repo",
+        navigationType: "REPLACE",
         searchParams: new URLSearchParams(""),
         setSearchParams,
       });
@@ -173,6 +177,7 @@ describe("useAgentStudioQuerySync", () => {
 
       const harness = createHookHarness({
         activeRepo: "/repo",
+        navigationType: "REPLACE",
         searchParams: new URLSearchParams(""),
         setSearchParams: () => {},
       });
@@ -232,6 +237,7 @@ describe("useAgentStudioQuerySync", () => {
 
       const harness = createHookHarness({
         activeRepo: "/repo",
+        navigationType: "REPLACE",
         searchParams: new URLSearchParams("task=task-from-url&session=session-from-url&agent=spec"),
         setSearchParams: () => {},
       });
@@ -262,6 +268,7 @@ describe("useAgentStudioQuerySync", () => {
     try {
       const harness = createHookHarness({
         activeRepo: "/repo",
+        navigationType: "REPLACE",
         searchParams: new URLSearchParams("agent=spec"),
         setSearchParams: () => {},
       });

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-sync.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-sync.ts
@@ -6,12 +6,14 @@ import { useRepoNavigationPersistence } from "./use-repo-navigation-persistence"
 
 type UseAgentStudioQuerySyncArgs = {
   activeRepo: string | null;
+  navigationType: "POP" | "PUSH" | "REPLACE";
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
 };
 
 export function useAgentStudioQuerySync({
   activeRepo,
+  navigationType,
   searchParams,
   setSearchParams,
 }: UseAgentStudioQuerySyncArgs): {
@@ -24,6 +26,7 @@ export function useAgentStudioQuerySync({
   updateQuery: (updates: AgentStudioQueryUpdate) => void;
 } {
   const { navigation, setNavigation, updateQuery } = useNavigationUrlSync({
+    navigationType,
     searchParams,
     setSearchParams,
   });

--- a/apps/desktop/src/pages/agents/use-navigation-url-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-navigation-url-sync.test.tsx
@@ -90,4 +90,58 @@ describe("useNavigationUrlSync", () => {
 
     await harness.unmount();
   });
+
+  test("ignores stale self-authored URL echoes while newer local navigation is pending", async () => {
+    const calls: SearchParamsCall[] = [];
+    const setSearchParams: SetURLSearchParams = (nextInit, navigateOptions) => {
+      calls.push([nextInit, navigateOptions]);
+    };
+
+    const harness = createHookHarness({
+      searchParams: new URLSearchParams("task=task-1&agent=build&autostart=1&start=now"),
+      setSearchParams,
+    });
+
+    await harness.mount();
+    await harness.run((latest) => {
+      latest.updateQuery({ session: "session-1" });
+    });
+
+    const [firstCall, secondCall] = calls;
+    if (!firstCall || !secondCall) {
+      throw new Error("Expected two setSearchParams calls");
+    }
+
+    const [firstNext] = firstCall;
+    const [secondNext] = secondCall;
+    if (!(firstNext instanceof URLSearchParams) || !(secondNext instanceof URLSearchParams)) {
+      throw new Error("Expected URLSearchParams");
+    }
+
+    await harness.update({
+      searchParams: firstNext,
+      setSearchParams,
+    });
+
+    expect(harness.getLatest().navigation).toMatchObject({
+      taskId: "task-1",
+      sessionId: "session-1",
+      role: "build",
+    });
+    expect(calls).toHaveLength(2);
+
+    await harness.update({
+      searchParams: secondNext,
+      setSearchParams,
+    });
+
+    expect(harness.getLatest().navigation).toMatchObject({
+      taskId: "task-1",
+      sessionId: "session-1",
+      role: "build",
+    });
+    expect(calls).toHaveLength(2);
+
+    await harness.unmount();
+  });
 });

--- a/apps/desktop/src/pages/agents/use-navigation-url-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-navigation-url-sync.test.tsx
@@ -22,6 +22,7 @@ describe("useNavigationUrlSync", () => {
     };
 
     const harness = createHookHarness({
+      navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=build&autostart=1&start=now"),
       setSearchParams,
     });
@@ -64,6 +65,7 @@ describe("useNavigationUrlSync", () => {
     };
 
     const harness = createHookHarness({
+      navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=spec"),
       setSearchParams,
     });
@@ -77,6 +79,7 @@ describe("useNavigationUrlSync", () => {
     expect(calls).toHaveLength(0);
 
     await harness.update({
+      navigationType: "POP",
       searchParams: new URLSearchParams("task=task-2&session=session-2&agent=planner"),
       setSearchParams,
     });
@@ -98,27 +101,34 @@ describe("useNavigationUrlSync", () => {
     };
 
     const harness = createHookHarness({
+      navigationType: "REPLACE",
       searchParams: new URLSearchParams("task=task-1&agent=build&autostart=1&start=now"),
       setSearchParams,
     });
 
     await harness.mount();
+    const mountCleanupCall = calls[0];
+    if (!mountCleanupCall) {
+      throw new Error("Expected mount cleanup to normalize one-time URL params");
+    }
+
     await harness.run((latest) => {
       latest.updateQuery({ session: "session-1" });
     });
 
-    const [firstCall, secondCall] = calls;
-    if (!firstCall || !secondCall) {
-      throw new Error("Expected two setSearchParams calls");
+    const sessionWriteCall = calls[1];
+    if (!sessionWriteCall) {
+      throw new Error("Expected a second setSearchParams call after the session update");
     }
 
-    const [firstNext] = firstCall;
-    const [secondNext] = secondCall;
+    const [firstNext] = mountCleanupCall;
+    const [secondNext] = sessionWriteCall;
     if (!(firstNext instanceof URLSearchParams) || !(secondNext instanceof URLSearchParams)) {
       throw new Error("Expected URLSearchParams");
     }
 
     await harness.update({
+      navigationType: "REPLACE",
       searchParams: firstNext,
       setSearchParams,
     });
@@ -131,6 +141,7 @@ describe("useNavigationUrlSync", () => {
     expect(calls).toHaveLength(2);
 
     await harness.update({
+      navigationType: "REPLACE",
       searchParams: secondNext,
       setSearchParams,
     });
@@ -138,6 +149,49 @@ describe("useNavigationUrlSync", () => {
     expect(harness.getLatest().navigation).toMatchObject({
       taskId: "task-1",
       sessionId: "session-1",
+      role: "build",
+    });
+    expect(calls).toHaveLength(2);
+
+    await harness.unmount();
+  });
+
+  test("treats matching browser back navigations as external URL changes", async () => {
+    const calls: SearchParamsCall[] = [];
+    const setSearchParams: SetURLSearchParams = (nextInit, navigateOptions) => {
+      calls.push([nextInit, navigateOptions]);
+    };
+
+    const harness = createHookHarness({
+      navigationType: "REPLACE",
+      searchParams: new URLSearchParams("task=task-1&agent=build&autostart=1&start=now"),
+      setSearchParams,
+    });
+
+    await harness.mount();
+    await harness.run((latest) => {
+      latest.updateQuery({ session: "session-1" });
+    });
+
+    const mountCleanupCall = calls[0];
+    if (!mountCleanupCall) {
+      throw new Error("Expected mount cleanup to normalize one-time URL params");
+    }
+
+    const [previousUrl] = mountCleanupCall;
+    if (!(previousUrl instanceof URLSearchParams)) {
+      throw new Error("Expected URLSearchParams");
+    }
+
+    await harness.update({
+      navigationType: "POP",
+      searchParams: previousUrl,
+      setSearchParams,
+    });
+
+    expect(harness.getLatest().navigation).toMatchObject({
+      taskId: "task-1",
+      sessionId: null,
       role: "build",
     });
     expect(calls).toHaveLength(2);

--- a/apps/desktop/src/pages/agents/use-navigation-url-sync.ts
+++ b/apps/desktop/src/pages/agents/use-navigation-url-sync.ts
@@ -26,7 +26,8 @@ export function useNavigationUrlSync({
   setSearchParams,
 }: UseNavigationUrlSyncArgs): UseNavigationUrlSyncResult {
   const syncingFromSearchParamsRef = useRef(false);
-  const lastSetSearchParamsAtRef = useRef<number>(0);
+  const latestSearchParamsRef = useRef<URLSearchParams>(new URLSearchParams(searchParams));
+  const pendingSearchParamWritesRef = useRef<string[]>([]);
   const [navigation, setNavigation] = useState<AgentStudioNavigationState>(() =>
     parseNavigationStateFromSearchParams(searchParams),
   );
@@ -36,6 +37,21 @@ export function useNavigationUrlSync({
   }, []);
 
   useEffect(() => {
+    const currentSearchParams = searchParams.toString();
+    const pendingWriteIndex = pendingSearchParamWritesRef.current.indexOf(currentSearchParams);
+    if (pendingWriteIndex !== -1) {
+      pendingSearchParamWritesRef.current =
+        pendingSearchParamWritesRef.current.slice(pendingWriteIndex + 1);
+
+      if (pendingSearchParamWritesRef.current.length === 0) {
+        latestSearchParamsRef.current = new URLSearchParams(searchParams);
+      }
+      return;
+    }
+
+    pendingSearchParamWritesRef.current = [];
+    latestSearchParamsRef.current = new URLSearchParams(searchParams);
+
     const parsed = parseNavigationStateFromSearchParams(searchParams);
     setNavigation((current) => {
       if (isSameNavigationState(current, parsed)) {
@@ -52,19 +68,22 @@ export function useNavigationUrlSync({
       return;
     }
 
-    const now = Date.now();
-    if (now - lastSetSearchParamsAtRef.current < 100) {
+    const currentSearchParams = latestSearchParamsRef.current.toString();
+    const next = buildSearchParamsFromNavigationState(latestSearchParamsRef.current, navigation);
+    const nextSearchParams = next.toString();
+    if (nextSearchParams === currentSearchParams) {
       return;
     }
 
-    const next = buildSearchParamsFromNavigationState(searchParams, navigation);
-    if (next.toString() === searchParams.toString()) {
-      return;
+    latestSearchParamsRef.current = new URLSearchParams(next);
+    if (pendingSearchParamWritesRef.current.at(-1) !== nextSearchParams) {
+      pendingSearchParamWritesRef.current = [
+        ...pendingSearchParamWritesRef.current,
+        nextSearchParams,
+      ];
     }
-
-    lastSetSearchParamsAtRef.current = now;
     setSearchParams(next, { replace: true });
-  }, [navigation, searchParams, setSearchParams]);
+  }, [navigation, setSearchParams]);
 
   return {
     navigation,

--- a/apps/desktop/src/pages/agents/use-navigation-url-sync.ts
+++ b/apps/desktop/src/pages/agents/use-navigation-url-sync.ts
@@ -40,8 +40,9 @@ export function useNavigationUrlSync({
     const currentSearchParams = searchParams.toString();
     const pendingWriteIndex = pendingSearchParamWritesRef.current.indexOf(currentSearchParams);
     if (pendingWriteIndex !== -1) {
-      pendingSearchParamWritesRef.current =
-        pendingSearchParamWritesRef.current.slice(pendingWriteIndex + 1);
+      pendingSearchParamWritesRef.current = pendingSearchParamWritesRef.current.slice(
+        pendingWriteIndex + 1,
+      );
 
       if (pendingSearchParamWritesRef.current.length === 0) {
         latestSearchParamsRef.current = new URLSearchParams(searchParams);

--- a/apps/desktop/src/pages/agents/use-navigation-url-sync.ts
+++ b/apps/desktop/src/pages/agents/use-navigation-url-sync.ts
@@ -11,6 +11,7 @@ import {
 } from "./agent-studio-navigation";
 
 type UseNavigationUrlSyncArgs = {
+  navigationType: "POP" | "PUSH" | "REPLACE";
   searchParams: URLSearchParams;
   setSearchParams: SetURLSearchParams;
 };
@@ -22,6 +23,7 @@ type UseNavigationUrlSyncResult = {
 };
 
 export function useNavigationUrlSync({
+  navigationType,
   searchParams,
   setSearchParams,
 }: UseNavigationUrlSyncArgs): UseNavigationUrlSyncResult {
@@ -37,12 +39,13 @@ export function useNavigationUrlSync({
   }, []);
 
   useEffect(() => {
-    const currentSearchParams = searchParams.toString();
-    const pendingWriteIndex = pendingSearchParamWritesRef.current.indexOf(currentSearchParams);
+    const currentSearchParamsKey = toCanonicalSearchParamsKey(searchParams);
+    const pendingWriteIndex =
+      navigationType === "POP"
+        ? -1
+        : pendingSearchParamWritesRef.current.indexOf(currentSearchParamsKey);
     if (pendingWriteIndex !== -1) {
-      pendingSearchParamWritesRef.current = pendingSearchParamWritesRef.current.slice(
-        pendingWriteIndex + 1,
-      );
+      pendingSearchParamWritesRef.current.splice(pendingWriteIndex, 1);
 
       if (pendingSearchParamWritesRef.current.length === 0) {
         latestSearchParamsRef.current = new URLSearchParams(searchParams);
@@ -61,7 +64,7 @@ export function useNavigationUrlSync({
       syncingFromSearchParamsRef.current = true;
       return parsed;
     });
-  }, [searchParams]);
+  }, [navigationType, searchParams]);
 
   useEffect(() => {
     if (syncingFromSearchParamsRef.current) {
@@ -69,20 +72,19 @@ export function useNavigationUrlSync({
       return;
     }
 
-    const currentSearchParams = latestSearchParamsRef.current.toString();
+    const currentSearchParams = toCanonicalSearchParamsKey(latestSearchParamsRef.current);
     const next = buildSearchParamsFromNavigationState(latestSearchParamsRef.current, navigation);
-    const nextSearchParams = next.toString();
+    const nextSearchParams = toCanonicalSearchParamsKey(next);
     if (nextSearchParams === currentSearchParams) {
       return;
     }
 
-    latestSearchParamsRef.current = new URLSearchParams(next);
-    if (pendingSearchParamWritesRef.current.at(-1) !== nextSearchParams) {
-      pendingSearchParamWritesRef.current = [
-        ...pendingSearchParamWritesRef.current,
-        nextSearchParams,
-      ];
+    if (pendingSearchParamWritesRef.current.at(-1) === nextSearchParams) {
+      return;
     }
+
+    latestSearchParamsRef.current = new URLSearchParams(next);
+    pendingSearchParamWritesRef.current.push(nextSearchParams);
     setSearchParams(next, { replace: true });
   }, [navigation, setSearchParams]);
 
@@ -92,3 +94,14 @@ export function useNavigationUrlSync({
     updateQuery,
   };
 }
+
+const toCanonicalSearchParamsKey = (searchParams: URLSearchParams): string => {
+  const sortedEntries = Array.from(searchParams.entries()).sort((left, right) => {
+    if (left[0] === right[0]) {
+      return left[1].localeCompare(right[1]);
+    }
+    return left[0].localeCompare(right[0]);
+  });
+
+  return new URLSearchParams(sortedEntries).toString();
+};


### PR DESCRIPTION
## Summary
- replace the time-based URL sync suppression in agent studio navigation with explicit tracking of self-authored search param writes
- preserve local navigation updates while stale router echoes are still catching up
- add a regression test covering back-to-back local URL writes

## Testing
- bun run --filter @openducktor/desktop test -- use-navigation-url-sync
- bun run --filter @openducktor/desktop typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced URL query synchronization to better handle navigation state transitions, including improved support for browser back button navigation and prevention of stale URL echoes during active navigation flows.
  * Refined navigation behavior tracking to ensure consistent state management across agent studio page navigation.

* **Tests**
  * Added test coverage for back button navigation and stale URL echo scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->