### PR TITLE
fix(desktop): show builder as in_progress when session stopped without build_completed

### DIFF
--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
@@ -261,7 +261,53 @@ describe("agents-page-session-tabs", () => {
     expect(states.qa.availability).toBe("blocked");
   });
 
-  test("marks workflow role as in_progress when latest role session is started but not completed", () => {
+  test("does not mark builder as in_progress when stopped session exists but builder is not available", () => {
+    const roleSessionByRole = buildRoleSessionSummaryMap([
+      buildSession({ role: "build", status: "stopped", scenario: "build_implementation_start" }),
+    ]);
+    const states = buildWorkflowStateByRole({
+      task: null,
+      roleWorkflowsByTask: {
+        spec: { required: true, canSkip: false, available: false, completed: false },
+        planner: { required: true, canSkip: false, available: false, completed: false },
+        build: { required: true, canSkip: false, available: false, completed: false },
+        qa: { required: false, canSkip: true, available: false, completed: false },
+      },
+      roleSessionByRole,
+    });
+
+    expect(states.build).toEqual({
+      tone: "blocked",
+      availability: "blocked",
+      completion: "not_started",
+      liveSession: "stopped",
+    });
+  });
+
+  test("marks builder as in_progress when builder session exists but is stopped without build_completed", () => {
+    const roleSessionByRole = buildRoleSessionSummaryMap([
+      buildSession({ role: "build", status: "stopped", scenario: "build_implementation_start" }),
+    ]);
+    const states = buildWorkflowStateByRole({
+      task: null,
+      roleWorkflowsByTask: {
+        spec: { required: true, canSkip: false, available: false, completed: false },
+        planner: { required: true, canSkip: false, available: false, completed: false },
+        build: { required: true, canSkip: false, available: true, completed: false },
+        qa: { required: false, canSkip: true, available: false, completed: false },
+      },
+      roleSessionByRole,
+    });
+
+    expect(states.build).toEqual({
+      tone: "in_progress",
+      availability: "available",
+      completion: "in_progress",
+      liveSession: "stopped",
+    });
+  });
+
+  test("marks builder as in_progress when latest role session is started but not completed", () => {
     const roleSessionByRole = buildRoleSessionSummaryMap([
       buildSession({ role: "planner", status: "idle" }),
     ]);

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
@@ -307,7 +307,7 @@ describe("agents-page-session-tabs", () => {
     });
   });
 
-  test("marks builder as in_progress when latest role session is started but not completed", () => {
+  test("marks workflow role as in_progress when latest role session is started but not completed", () => {
     const roleSessionByRole = buildRoleSessionSummaryMap([
       buildSession({ role: "planner", status: "idle" }),
     ]);

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -97,9 +97,6 @@ const deriveWorkflowTone = (params: {
   if (liveSession === "error") {
     return "failed";
   }
-  if (liveSession === "stopped" && completion === "in_progress") {
-    return "in_progress";
-  }
   if (completion === "done") {
     return "done";
   }
@@ -271,7 +268,7 @@ export const buildWorkflowStateByRole = (params: {
       liveSession === "running" ||
       liveSession === "error" ||
       (liveSession === "idle" && workflow.available) ||
-      (liveSession === "stopped" && workflow.available)
+      (role === "build" && liveSession === "stopped" && workflow.available)
     ) {
       completion = "in_progress";
     }

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -97,6 +97,9 @@ const deriveWorkflowTone = (params: {
   if (liveSession === "error") {
     return "failed";
   }
+  if (liveSession === "stopped" && completion === "in_progress") {
+    return "in_progress";
+  }
   if (completion === "done") {
     return "done";
   }
@@ -267,7 +270,8 @@ export const buildWorkflowStateByRole = (params: {
       liveSession === "waiting_input" ||
       liveSession === "running" ||
       liveSession === "error" ||
-      (liveSession === "idle" && workflow.available)
+      (liveSession === "idle" && workflow.available) ||
+      (liveSession === "stopped" && workflow.available)
     ) {
       completion = "in_progress";
     }


### PR DESCRIPTION
## Summary

Fixed a bug where builders that stopped without calling `build_completed` appeared as "not started" in the agent lane instead of showing "in progress" (blue) without a loader icon.

## Changes

### Core Fix (`apps/desktop/src/pages/agents/agents-page-session-tabs.ts`)

1. **`buildWorkflowStateByRole`**: Added condition to set `completion: "in_progress"` when a builder session exists with `liveSession: "stopped"` and `workflow.available: true`.

2. **`deriveWorkflowTone`**: Added case to return `"in_progress"` tone when `liveSession === "stopped"` and `completion === "in_progress"`, ensuring the correct blue visual state without spinner.

### Tests (`apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts`)

Added two test cases:
- Verifies builder shows `tone: "in_progress"`, `completion: "in_progress"`, `liveSession: "stopped"` when session stopped without completing
- Verifies builder remains `blocked` when stopped session exists but builder is not available

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Builder started, stopped without `build_completed` | "not started" (neutral) | "in progress" (blue, static icon) |
| Builder completed | "done" (green) | "done" (green) |
| Builder running | "in progress" (blue, spinner) | "in progress" (blue, spinner) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected builder and workflow status logic to treat certain stopped but incomplete sessions as in-progress, and to keep builders blocked when appropriate.
* **Tests**
  * Added tests covering stopped-session scenarios to ensure availability and in-progress transitions behave correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->