### PR TITLE
fix(agent-studio): reset stale composer busy state

### DIFF
--- a/apps/desktop/src/pages/agents/session-start/use-agent-studio-fresh-session-creation.ts
+++ b/apps/desktop/src/pages/agents/session-start/use-agent-studio-fresh-session-creation.ts
@@ -15,9 +15,12 @@ import { loadEffectivePromptOverrides } from "../../../state/operations/shared/p
 import { kickoffPromptForScenario } from "../agents-page-constants";
 import { buildRoleEnabledMapForTask, type SessionCreateOption } from "../agents-page-session-tabs";
 import {
+  buildAgentStudioAsyncActivityContextKey,
   buildAgentStudioSelectionQueryUpdate,
   buildCreateSessionStartKey,
   buildPreviousSelectionQueryUpdate,
+  decrementActivityCountRecord,
+  incrementActivityCountRecord,
   type QueryUpdate,
   shouldTriggerContextSwitchIntent,
 } from "../use-agent-studio-session-action-helpers";
@@ -35,7 +38,7 @@ type UseAgentStudioFreshSessionCreationArgs = {
   sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
   updateQuery: (updates: QueryUpdate) => void;
   onContextSwitchIntent?: () => void;
-  setStartingActivityCount: Dispatch<SetStateAction<number>>;
+  setStartingActivityCountByContext: Dispatch<SetStateAction<Record<string, number>>>;
   startingSessionByTaskRef: MutableRefObject<Map<string, Promise<string | undefined>>>;
   resolveRequestedSelection: (
     request: Omit<NewSessionStartRequest, "selectedModel">,
@@ -55,7 +58,7 @@ export function useAgentStudioFreshSessionCreation({
   sendAgentMessage,
   updateQuery,
   onContextSwitchIntent,
-  setStartingActivityCount,
+  setStartingActivityCountByContext,
   startingSessionByTaskRef,
   resolveRequestedSelection,
 }: UseAgentStudioFreshSessionCreationArgs): {
@@ -171,7 +174,15 @@ export function useAgentStudioFreshSessionCreation({
       nextScenario: AgentScenario;
       previousSelection: QueryUpdate;
     }): Promise<string | undefined> => {
-      setStartingActivityCount((current) => current + 1);
+      const startContextKey = buildAgentStudioAsyncActivityContextKey({
+        activeRepo,
+        taskId,
+        role: params.nextRole,
+        sessionId: null,
+      });
+      setStartingActivityCountByContext((current) =>
+        incrementActivityCountRecord(current, startContextKey),
+      );
       try {
         const selectedModel = await resolveRequestedSelection({
           taskId,
@@ -210,20 +221,23 @@ export function useAgentStudioFreshSessionCreation({
         sendFreshSessionKickoff(sessionId, params.nextRole, params.nextScenario);
         return sessionId;
       } finally {
-        setStartingActivityCount((current) => Math.max(0, current - 1));
+        setStartingActivityCountByContext((current) =>
+          decrementActivityCountRecord(current, startContextKey),
+        );
       }
     },
     [
       activeSession,
+      activeRepo,
       applyFreshSessionDraftQuery,
       applyFreshSessionSelectionQuery,
+      setStartingActivityCountByContext,
+      taskId,
       onContextSwitchIntent,
       resolveRequestedSelection,
       role,
       sendFreshSessionKickoff,
-      setStartingActivityCount,
       startFreshSession,
-      taskId,
     ],
   );
 

--- a/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-flow.ts
+++ b/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-flow.ts
@@ -18,6 +18,7 @@ import { kickoffPromptForScenario } from "../agents-page-constants";
 import type { SessionCreateOption } from "../agents-page-session-tabs";
 import { useAgentStudioHumanReviewFeedbackFlow } from "../use-agent-studio-human-review-feedback-flow";
 import {
+  buildAgentStudioAsyncActivityContextKey,
   canStartSessionForRole,
   type QueryUpdate,
 } from "../use-agent-studio-session-action-helpers";
@@ -74,13 +75,21 @@ export function useAgentStudioSessionStartFlow({
   handleCreateSession: (option: SessionCreateOption) => void;
 } {
   const queryClient = useQueryClient();
-  const [startingActivityCount, setStartingActivityCount] = useState(0);
-  const isStarting = startingActivityCount > 0;
+  const [startingActivityCountByContext, setStartingActivityCountByContext] = useState<
+    Record<string, number>
+  >({});
+  const isStarting =
+    (startingActivityCountByContext[
+      buildAgentStudioAsyncActivityContextKey({
+        activeRepo,
+        taskId,
+        role,
+        sessionId: activeSession?.sessionId ?? null,
+      })
+    ] ?? 0) > 0;
 
   const previousRepoForSessionRefs = useRef<string | null>(activeRepo);
   const startingSessionByTaskRef = useRef(new Map<string, Promise<string | undefined>>());
-  const sessionStartScopeKey = `${activeRepo ?? ""}:${taskId}:${role}`;
-  const previousSessionStartScopeKeyRef = useRef(sessionStartScopeKey);
 
   useEffect(() => {
     if (previousRepoForSessionRefs.current === activeRepo) {
@@ -90,15 +99,6 @@ export function useAgentStudioSessionStartFlow({
     previousRepoForSessionRefs.current = activeRepo;
     startingSessionByTaskRef.current.clear();
   }, [activeRepo]);
-
-  useEffect(() => {
-    if (previousSessionStartScopeKeyRef.current === sessionStartScopeKey) {
-      return;
-    }
-
-    previousSessionStartScopeKeyRef.current = sessionStartScopeKey;
-    setStartingActivityCount(0);
-  }, [sessionStartScopeKey]);
 
   const resolveRequestedSelection = useCallback(
     async (
@@ -132,7 +132,7 @@ export function useAgentStudioSessionStartFlow({
     isActiveTaskHydrated,
     startAgentSession,
     updateAgentSessionModel,
-    setStartingActivityCount,
+    setStartingActivityCountByContext,
     startingSessionByTaskRef,
     updateQuery,
     resolveRequestedSelection,
@@ -226,7 +226,7 @@ export function useAgentStudioSessionStartFlow({
     sendAgentMessage,
     updateQuery,
     ...(onContextSwitchIntent ? { onContextSwitchIntent } : {}),
-    setStartingActivityCount,
+    setStartingActivityCountByContext,
     startingSessionByTaskRef,
     resolveRequestedSelection,
   });

--- a/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-flow.ts
+++ b/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-flow.ts
@@ -79,6 +79,8 @@ export function useAgentStudioSessionStartFlow({
 
   const previousRepoForSessionRefs = useRef<string | null>(activeRepo);
   const startingSessionByTaskRef = useRef(new Map<string, Promise<string | undefined>>());
+  const sessionStartScopeKey = `${activeRepo ?? ""}:${taskId}:${role}`;
+  const previousSessionStartScopeKeyRef = useRef(sessionStartScopeKey);
 
   useEffect(() => {
     if (previousRepoForSessionRefs.current === activeRepo) {
@@ -88,6 +90,15 @@ export function useAgentStudioSessionStartFlow({
     previousRepoForSessionRefs.current = activeRepo;
     startingSessionByTaskRef.current.clear();
   }, [activeRepo]);
+
+  useEffect(() => {
+    if (previousSessionStartScopeKeyRef.current === sessionStartScopeKey) {
+      return;
+    }
+
+    previousSessionStartScopeKeyRef.current = sessionStartScopeKey;
+    setStartingActivityCount(0);
+  }, [sessionStartScopeKey]);
 
   const resolveRequestedSelection = useCallback(
     async (

--- a/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-session.ts
+++ b/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-session.ts
@@ -6,8 +6,11 @@ import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentStateContextValue } from "@/types/state-slices";
 import {
   applyAgentStudioSelectionQuery,
+  buildAgentStudioAsyncActivityContextKey,
   buildCreateSessionStartKey,
   canStartSessionForRole,
+  decrementActivityCountRecord,
+  incrementActivityCountRecord,
   type QueryUpdate,
   resolveReusableSessionForStart,
 } from "../use-agent-studio-session-action-helpers";
@@ -24,7 +27,7 @@ type UseAgentStudioSessionStartSessionArgs = {
   isActiveTaskHydrated: boolean;
   startAgentSession: AgentStateContextValue["startAgentSession"];
   updateAgentSessionModel: AgentStateContextValue["updateAgentSessionModel"];
-  setStartingActivityCount: Dispatch<SetStateAction<number>>;
+  setStartingActivityCountByContext: Dispatch<SetStateAction<Record<string, number>>>;
   startingSessionByTaskRef: MutableRefObject<Map<string, Promise<string | undefined>>>;
   updateQuery: (updates: QueryUpdate) => void;
   resolveRequestedSelection: (
@@ -44,7 +47,7 @@ export function useAgentStudioSessionStartSession({
   isActiveTaskHydrated,
   startAgentSession,
   updateAgentSessionModel,
-  setStartingActivityCount,
+  setStartingActivityCountByContext,
   startingSessionByTaskRef,
   updateQuery,
   resolveRequestedSelection,
@@ -56,7 +59,15 @@ export function useAgentStudioSessionStartSession({
       reason: SessionStartRequestReason;
       startMode: "fresh" | "reuse_latest";
     }): Promise<string | undefined> => {
-      setStartingActivityCount((current) => current + 1);
+      const startContextKey = buildAgentStudioAsyncActivityContextKey({
+        activeRepo,
+        taskId,
+        role,
+        sessionId: null,
+      });
+      setStartingActivityCountByContext((current) =>
+        incrementActivityCountRecord(current, startContextKey),
+      );
       try {
         const selectedModel = await resolveRequestedSelection({
           taskId,
@@ -105,15 +116,17 @@ export function useAgentStudioSessionStartSession({
         });
         return sessionId;
       } finally {
-        setStartingActivityCount((current) => Math.max(0, current - 1));
+        setStartingActivityCountByContext((current) =>
+          decrementActivityCountRecord(current, startContextKey),
+        );
       }
     },
     [
+      activeRepo,
       resolveRequestedSelection,
       role,
       scenario,
-      activeRepo,
-      setStartingActivityCount,
+      setStartingActivityCountByContext,
       startAgentSession,
       updateQuery,
       taskId,

--- a/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
@@ -26,8 +26,10 @@ type HookArgs = Parameters<UseAgentStudioFreshSessionCreationHook>[0];
 const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useAgentStudioFreshSessionCreation, initialProps);
 
-const createSetStartingActivityCount = (): Dispatch<SetStateAction<number>> => {
-  let current = 0;
+const createSetStartingActivityCountByContext = (): Dispatch<
+  SetStateAction<Record<string, number>>
+> => {
+  let current: Record<string, number> = {};
   return (update) => {
     current = typeof update === "function" ? update(current) : update;
   };
@@ -45,7 +47,7 @@ const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   startAgentSession: async () => "session-new",
   sendAgentMessage: async () => {},
   updateQuery: () => {},
-  setStartingActivityCount: createSetStartingActivityCount(),
+  setStartingActivityCountByContext: createSetStartingActivityCountByContext(),
   startingSessionByTaskRef: {
     current: new Map<string, Promise<string | undefined>>(),
   } satisfies MutableRefObject<Map<string, Promise<string | undefined>>>,

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-action-helpers.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-action-helpers.ts
@@ -19,6 +19,13 @@ type AgentStudioSessionSelectionQueryParams = {
   role: AgentRole;
 };
 
+type AgentStudioAsyncActivityContextKeyParams = {
+  activeRepo: string | null;
+  taskId: string;
+  role: AgentRole;
+  sessionId: string | null | undefined;
+};
+
 export const canStartSessionForRole = (task: TaskCard | null, role: AgentRole): boolean => {
   return !task || isRoleAvailableForTask(task, role);
 };
@@ -89,6 +96,44 @@ export const shouldTriggerContextSwitchIntent = (params: {
   nextRole: AgentRole;
 }): boolean => {
   return params.currentSessionId !== params.nextSessionId || params.currentRole !== params.nextRole;
+};
+
+export const buildAgentStudioAsyncActivityContextKey = (
+  params: AgentStudioAsyncActivityContextKeyParams,
+): string => {
+  const sessionId = params.sessionId ?? "__draft__";
+  return `${params.activeRepo ?? ""}:${params.taskId}:${params.role}:${sessionId}`;
+};
+
+export const incrementActivityCountRecord = (
+  current: Record<string, number>,
+  key: string,
+): Record<string, number> => {
+  return {
+    ...current,
+    [key]: (current[key] ?? 0) + 1,
+  };
+};
+
+export const decrementActivityCountRecord = (
+  current: Record<string, number>,
+  key: string,
+): Record<string, number> => {
+  const currentCount = current[key];
+  if (!currentCount) {
+    return current;
+  }
+
+  if (currentCount === 1) {
+    const next = { ...current };
+    delete next[key];
+    return next;
+  }
+
+  return {
+    ...current,
+    [key]: currentCount - 1,
+  };
 };
 
 export const buildCreateSessionStartKey = (params: {

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -208,6 +208,55 @@ describe("useAgentStudioSessionActions", () => {
     await harness.unmount();
   });
 
+  test("resets transient sending state when switching task context", async () => {
+    const sendDeferred = createDeferred<void>();
+    const sendAgentMessage = mock(() => sendDeferred.promise);
+    const taskOneSession = createSession({
+      taskId: "task-1",
+      sessionId: "session-task-1",
+      status: "stopped",
+    });
+    const taskTwoSession = createSession({
+      taskId: "task-2",
+      sessionId: "session-task-2",
+      status: "stopped",
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession: taskOneSession,
+      sessionsForTask: [taskOneSession],
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+
+    let sendPromise: Promise<void> | undefined;
+    await harness.run((state) => {
+      sendPromise = state.onSend();
+    });
+
+    await harness.waitFor((state) => state.isSending);
+    expect(harness.getLatest().isSessionWorking).toBe(true);
+
+    await harness.update({
+      ...createBaseArgs(),
+      taskId: "task-2",
+      activeSession: taskTwoSession,
+      sessionsForTask: [taskTwoSession],
+      sendAgentMessage,
+      input: "follow up",
+    });
+
+    const nextState = harness.getLatest();
+    expect(nextState.isSending).toBe(false);
+    expect(nextState.isSessionWorking).toBe(false);
+
+    sendDeferred.resolve();
+    await sendPromise;
+    await harness.unmount();
+  });
+
   test("onSend requests model selection before creating a new session", async () => {
     const requestedSelection = {
       runtimeKind: "opencode",

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -257,6 +257,116 @@ describe("useAgentStudioSessionActions", () => {
     await harness.unmount();
   });
 
+  test("keeps the latest send active after switching away and back", async () => {
+    const firstSendDeferred = createDeferred<void>();
+    const secondSendDeferred = createDeferred<void>();
+    const sendPromises = [firstSendDeferred.promise, secondSendDeferred.promise];
+    const sendAgentMessage = mock(() => {
+      const nextPromise = sendPromises.shift();
+      return nextPromise ?? Promise.resolve();
+    });
+    const taskOneSession = createSession({
+      taskId: "task-1",
+      sessionId: "session-task-1",
+      status: "stopped",
+    });
+    const taskTwoSession = createSession({
+      taskId: "task-2",
+      sessionId: "session-task-2",
+      status: "stopped",
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession: taskOneSession,
+      sessionsForTask: [taskOneSession],
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+
+    let firstSendPromise: Promise<void> | undefined;
+    await harness.run((state) => {
+      firstSendPromise = state.onSend();
+    });
+    await harness.waitFor((state) => state.isSending);
+
+    await harness.update({
+      ...createBaseArgs(),
+      taskId: "task-2",
+      activeSession: taskTwoSession,
+      sessionsForTask: [taskTwoSession],
+      sendAgentMessage,
+      input: "other task",
+    });
+    expect(harness.getLatest().isSending).toBe(false);
+
+    await harness.update({
+      ...createBaseArgs(),
+      activeSession: taskOneSession,
+      sessionsForTask: [taskOneSession],
+      sendAgentMessage,
+      input: "second send",
+    });
+
+    let secondSendPromise: Promise<void> | undefined;
+    await harness.run((state) => {
+      secondSendPromise = state.onSend();
+    });
+    await harness.waitFor((state) => state.isSending);
+
+    firstSendDeferred.resolve();
+    await firstSendPromise;
+    expect(harness.getLatest().isSending).toBe(true);
+
+    secondSendDeferred.resolve();
+    await secondSendPromise;
+    await harness.waitFor((state) => !state.isSending);
+    await harness.unmount();
+  });
+
+  test("keeps sending state while a newly created session becomes selected", async () => {
+    const sendDeferred = createDeferred<void>();
+    const sendAgentMessage = mock(() => sendDeferred.promise);
+    const startAgentSession = mock(async () => "session-new");
+    const nextSession = createSession({
+      taskId: "task-1",
+      sessionId: "session-new",
+      role: "spec",
+      status: "stopped",
+    });
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      startAgentSession,
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+
+    let sendPromise: Promise<void> | undefined;
+    await harness.run((state) => {
+      sendPromise = state.onSend();
+    });
+
+    await harness.waitFor((state) => state.isSending);
+
+    await harness.update({
+      ...createBaseArgs(),
+      activeSession: nextSession,
+      sessionsForTask: [nextSession],
+      startAgentSession,
+      sendAgentMessage,
+    });
+
+    expect(harness.getLatest().isSending).toBe(true);
+
+    sendDeferred.resolve();
+    await sendPromise;
+    await harness.waitFor((state) => !state.isSending);
+    await harness.unmount();
+  });
+
   test("onSend requests model selection before creating a new session", async () => {
     const requestedSelection = {
       runtimeKind: "opencode",
@@ -789,6 +899,26 @@ describe("useAgentStudioSessionActions", () => {
           description: "Create a new planner session from scratch",
           disabled: false,
         });
+      });
+
+      expect(harness.getLatest().isStarting).toBe(false);
+
+      await harness.update({
+        ...createBaseArgs(),
+        role: "planner",
+        scenario: "planner_initial",
+        activeSession: null,
+        selectedTask: createTask({
+          agentWorkflows: {
+            spec: { required: true, canSkip: false, available: true, completed: true },
+            planner: { required: true, canSkip: false, available: true, completed: false },
+            builder: { required: true, canSkip: false, available: true, completed: false },
+            qa: { required: true, canSkip: false, available: false, completed: false },
+          },
+        }),
+        startAgentSession,
+        sendAgentMessage,
+        updateQuery: () => {},
       });
 
       expect(harness.getLatest().isStarting).toBe(true);

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.ts
@@ -87,6 +87,8 @@ export function useAgentStudioSessionActions({
   const latestInputRef = useRef(input);
 
   const activeSessionId = activeSession?.sessionId ?? null;
+  const activeComposerContextKey = `${activeRepo ?? ""}:${taskId}:${role}:${activeSessionId ?? ""}`;
+  const previousComposerContextKeyRef = useRef(activeComposerContextKey);
   const isSessionWorking =
     Boolean(activeSession) &&
     ((activeSession?.status ?? "stopped") === "running" ||
@@ -124,6 +126,15 @@ export function useAgentStudioSessionActions({
   useEffect(() => {
     latestInputRef.current = input;
   }, [input]);
+
+  useEffect(() => {
+    if (previousComposerContextKeyRef.current === activeComposerContextKey) {
+      return;
+    }
+
+    previousComposerContextKeyRef.current = activeComposerContextKey;
+    setIsSending(false);
+  }, [activeComposerContextKey]);
 
   const onSend = useCallback(async (): Promise<void> => {
     if (isSending || isStarting || !agentStudioReady) {

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.ts
@@ -10,7 +10,10 @@ import { SCENARIO_LABELS } from "./agents-page-constants";
 import type { SessionCreateOption } from "./agents-page-session-tabs";
 import {
   applyAgentStudioSelectionQuery,
+  buildAgentStudioAsyncActivityContextKey,
   canStartSessionForRole,
+  decrementActivityCountRecord,
+  incrementActivityCountRecord,
   type QueryUpdate,
   shouldTriggerContextSwitchIntent,
 } from "./use-agent-studio-session-action-helpers";
@@ -80,15 +83,22 @@ export function useAgentStudioSessionActions({
   handleSessionSelectionChange: (nextValue: string) => void;
   handleCreateSession: (option: SessionCreateOption) => void;
 } {
-  const [isSending, setIsSending] = useState(false);
+  const [sendingActivityCountByContext, setSendingActivityCountByContext] = useState<
+    Record<string, number>
+  >({});
   const [isSubmittingQuestionByRequestId, setIsSubmittingQuestionByRequestId] = useState<
     Record<string, boolean>
   >({});
   const latestInputRef = useRef(input);
 
   const activeSessionId = activeSession?.sessionId ?? null;
-  const activeComposerContextKey = `${activeRepo ?? ""}:${taskId}:${role}:${activeSessionId ?? ""}`;
-  const previousComposerContextKeyRef = useRef(activeComposerContextKey);
+  const activeComposerContextKey = buildAgentStudioAsyncActivityContextKey({
+    activeRepo,
+    taskId,
+    role,
+    sessionId: activeSessionId,
+  });
+  const isSending = (sendingActivityCountByContext[activeComposerContextKey] ?? 0) > 0;
   const isSessionWorking =
     Boolean(activeSession) &&
     ((activeSession?.status ?? "stopped") === "running" ||
@@ -127,15 +137,6 @@ export function useAgentStudioSessionActions({
     latestInputRef.current = input;
   }, [input]);
 
-  useEffect(() => {
-    if (previousComposerContextKeyRef.current === activeComposerContextKey) {
-      return;
-    }
-
-    previousComposerContextKeyRef.current = activeComposerContextKey;
-    setIsSending(false);
-  }, [activeComposerContextKey]);
-
   const onSend = useCallback(async (): Promise<void> => {
     if (isSending || isStarting || !agentStudioReady) {
       return;
@@ -160,6 +161,7 @@ export function useAgentStudioSessionActions({
       }
       setInput(message);
     };
+    const sendContextKeys = new Set<string>();
 
     try {
       let targetSessionId = activeSession?.sessionId;
@@ -172,15 +174,40 @@ export function useAgentStudioSessionActions({
         return;
       }
 
-      setIsSending(true);
+      const targetComposerContextKey = buildAgentStudioAsyncActivityContextKey({
+        activeRepo,
+        taskId,
+        role,
+        sessionId: targetSessionId,
+      });
+      sendContextKeys.add(activeComposerContextKey);
+      sendContextKeys.add(targetComposerContextKey);
+
+      setSendingActivityCountByContext((current) => {
+        let next = current;
+        for (const contextKey of sendContextKeys) {
+          next = incrementActivityCountRecord(next, contextKey);
+        }
+        return next;
+      });
       await sendAgentMessage(targetSessionId, message);
     } catch (error) {
       restoreComposerInput();
       throw error;
     } finally {
-      setIsSending(false);
+      if (sendContextKeys.size > 0) {
+        setSendingActivityCountByContext((current) => {
+          let next = current;
+          for (const contextKey of sendContextKeys) {
+            next = decrementActivityCountRecord(next, contextKey);
+          }
+          return next;
+        });
+      }
     }
   }, [
+    activeRepo,
+    activeComposerContextKey,
     activeSession,
     agentStudioReady,
     input,

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -176,6 +176,39 @@ describe("useAgentStudioSessionStartFlow", () => {
     await harness.unmount();
   });
 
+  test("resets transient starting state when switching task context", async () => {
+    const selectionDeferred = createDeferred<{
+      selectedModel: HookArgs["selectionForNewSession"];
+    } | null>();
+    const requestNewSessionStart = mock(() => selectionDeferred.promise);
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      requestNewSessionStart,
+    });
+
+    await harness.mount();
+
+    let startPromise: Promise<string | undefined> | undefined;
+    await harness.run((state) => {
+      startPromise = state.startSession("composer_send");
+    });
+
+    await harness.waitFor((state) => state.isStarting);
+
+    await harness.update({
+      ...createBaseArgs(),
+      taskId: "task-2",
+      requestNewSessionStart,
+    });
+
+    expect(harness.getLatest().isStarting).toBe(false);
+
+    selectionDeferred.resolve(null);
+    await startPromise;
+    await harness.unmount();
+  });
+
   test("handleCreateSession for qa rejection starts a fresh builder session in the existing worktree", async () => {
     const startAgentSession = mock(async () => "session-build-rework");
     const sendAgentMessage = mock(async () => {});

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -209,6 +209,100 @@ describe("useAgentStudioSessionStartFlow", () => {
     await harness.unmount();
   });
 
+  test("restores starting state when returning to the original task context", async () => {
+    const selectionDeferred = createDeferred<{
+      selectedModel: HookArgs["selectionForNewSession"];
+    } | null>();
+    const requestNewSessionStart = mock(() => selectionDeferred.promise);
+    const startAgentSession = mock(async () => "session-new");
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      requestNewSessionStart,
+      startAgentSession,
+    });
+
+    await harness.mount();
+
+    let firstStartPromise: Promise<string | undefined> | undefined;
+    await harness.run((state) => {
+      firstStartPromise = state.startSession("composer_send");
+    });
+
+    await harness.waitFor((state) => state.isStarting);
+
+    await harness.update({
+      ...createBaseArgs(),
+      taskId: "task-2",
+      requestNewSessionStart,
+      startAgentSession,
+    });
+    expect(harness.getLatest().isStarting).toBe(false);
+
+    await harness.update({
+      ...createBaseArgs(),
+      requestNewSessionStart,
+      startAgentSession,
+    });
+    expect(harness.getLatest().isStarting).toBe(true);
+
+    let resumedStartPromise: Promise<string | undefined> | undefined;
+    await harness.run((state) => {
+      resumedStartPromise = state.startSession("composer_send");
+    });
+
+    expect(requestNewSessionStart).toHaveBeenCalledTimes(1);
+    expect(harness.getLatest().isStarting).toBe(true);
+
+    selectionDeferred.resolve(null);
+    await firstStartPromise;
+    await resumedStartPromise;
+    expect(startAgentSession).toHaveBeenCalledTimes(0);
+    await harness.waitFor((state) => !state.isStarting);
+    await harness.unmount();
+  });
+
+  test("keeps starting state while fresh session creation switches to the draft role", async () => {
+    const startDeferred = createDeferred<string>();
+    const startAgentSession = mock(() => startDeferred.promise);
+    const sendAgentMessage = mock(async () => {});
+
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      startAgentSession,
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.handleCreateSession({
+        id: "planner:planner_initial:fresh",
+        role: "planner",
+        scenario: "planner_initial",
+        label: "Planner · New Session",
+        description: "Create a fresh planner session",
+        disabled: false,
+      });
+    });
+
+    await harness.update({
+      ...createBaseArgs(),
+      role: "planner",
+      scenario: "planner_initial",
+      startAgentSession,
+      sendAgentMessage,
+      activeSession: null,
+    });
+
+    await harness.waitFor((state) => state.isStarting);
+    expect(harness.getLatest().isStarting).toBe(true);
+
+    startDeferred.resolve("session-planner");
+    await harness.waitFor((state) => !state.isStarting);
+    await harness.unmount();
+  });
+
   test("handleCreateSession for qa rejection starts a fresh builder session in the existing worktree", async () => {
     const startAgentSession = mock(async () => "session-build-rework");
     const sendAgentMessage = mock(async () => {});
@@ -288,7 +382,7 @@ describe("useAgentStudioSessionStartFlow", () => {
     await harness.unmount();
   });
 
-  test("keeps isStarting true until all parallel fresh-session starts finish", async () => {
+  test("tracks parallel fresh-session starts per visible draft role", async () => {
     const plannerStart = createDeferred<string>();
     const buildStart = createDeferred<string>();
     const startAgentSession = mock(async (params: { role: string }) =>
@@ -325,6 +419,16 @@ describe("useAgentStudioSessionStartFlow", () => {
     });
 
     expect(startAgentSession).toHaveBeenCalledTimes(2);
+    expect(harness.getLatest().isStarting).toBe(false);
+
+    await harness.update({
+      ...createBaseArgs(),
+      role: "planner",
+      scenario: "planner_initial",
+      activeSession: null,
+      startAgentSession,
+      sendAgentMessage,
+    });
     expect(harness.getLatest().isStarting).toBe(true);
 
     await harness.run(async () => {
@@ -333,6 +437,16 @@ describe("useAgentStudioSessionStartFlow", () => {
       await Promise.resolve();
     });
 
+    expect(harness.getLatest().isStarting).toBe(false);
+
+    await harness.update({
+      ...createBaseArgs(),
+      role: "build",
+      scenario: "build_implementation_start",
+      activeSession: null,
+      startAgentSession,
+      sendAgentMessage,
+    });
     expect(harness.getLatest().isStarting).toBe(true);
 
     await harness.run(async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-session.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-session.test.tsx
@@ -15,8 +15,10 @@ type HookArgs = Parameters<typeof useAgentStudioSessionStartSession>[0];
 const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useAgentStudioSessionStartSession, initialProps);
 
-const createSetStartingActivityCount = (): Dispatch<SetStateAction<number>> => {
-  let current = 0;
+const createSetStartingActivityCountByContext = (): Dispatch<
+  SetStateAction<Record<string, number>>
+> => {
+  let current: Record<string, number> = {};
   return (update) => {
     current = typeof update === "function" ? update(current) : update;
   };
@@ -34,7 +36,7 @@ const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   isActiveTaskHydrated: true,
   startAgentSession: async () => "session-new",
   updateAgentSessionModel: () => {},
-  setStartingActivityCount: createSetStartingActivityCount(),
+  setStartingActivityCountByContext: createSetStartingActivityCountByContext(),
   startingSessionByTaskRef: {
     current: new Map<string, Promise<string | undefined>>(),
   } satisfies MutableRefObject<Map<string, Promise<string | undefined>>>,


### PR DESCRIPTION
## Summary
- reset transient Agent Studio composer/session-start busy state when the active repo, task, role, or session context changes so tab switches do not leave the composer disabled in the wrong tab
- add regression tests covering task-context switches while send and session-start requests are still pending
- verify the change with full Bun and Cargo test, lint, typecheck/check, clippy, and build runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity indicators are now tracked per context, improving accuracy when multiple sessions/tasks/roles are active.

* **Bug Fixes**
  * Transient UI states (sending and starting indicators) correctly reset and reflect the active repository/task/role/session when contexts change.

* **Tests**
  * Added tests validating sending/starting state behavior across task, session, and role switches and concurrent flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->