### PR TITLE
fix: change default branch prefix from 'obp' to 'odt'

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -5,8 +5,8 @@ use crate::app_service::workflow_rules::{
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentSessionDocument, CreateTaskInput, QaWorkflowVerdict, RunState, RuntimeRole, TaskCard,
-    TaskMetadata, TaskStatus, UpdateTaskPatch,
+    AgentSessionDocument, CreateTaskInput, DEFAULT_BRANCH_PREFIX, QaWorkflowVerdict, RunState,
+    RuntimeRole, TaskCard, TaskMetadata, TaskStatus, UpdateTaskPatch,
 };
 use std::collections::HashSet;
 use std::fs;
@@ -706,7 +706,7 @@ fn is_managed_task_worktree_session(
 
 fn is_related_task_branch(branch_name: &str, branch_prefix: &str, task_id: &str) -> bool {
     let clean_prefix = if branch_prefix.trim().is_empty() {
-        "obp"
+        DEFAULT_BRANCH_PREFIX
     } else {
         branch_prefix.trim()
     };

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -34,6 +34,7 @@ pub use task::{
 };
 
 pub const TASK_METADATA_NAMESPACE: &str = "openducktor";
+pub const DEFAULT_BRANCH_PREFIX: &str = "odt";
 
 pub fn now_rfc3339() -> String {
     chrono::Utc::now().to_rfc3339()

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
@@ -1,5 +1,6 @@
 use super::{lock_env, EnvVarGuard, RepoConfig, TestStoreHarness};
 use crate::GitTargetBranch;
+use host_domain::DEFAULT_BRANCH_PREFIX;
 use serde_json::json;
 use std::fs;
 #[cfg(unix)]
@@ -224,7 +225,7 @@ fn load_normalizes_legacy_blank_repo_config_values() {
         .repo_config(workspaces[0].path.as_str())
         .expect("repo config");
     assert!(repo_config.worktree_base_path.is_none());
-    assert_eq!(repo_config.branch_prefix, "obp");
+    assert_eq!(repo_config.branch_prefix, DEFAULT_BRANCH_PREFIX);
     assert_eq!(repo_config.default_target_branch.canonical(), "origin/main");
     assert_eq!(repo_config.hooks.pre_start, vec!["echo pre".to_string()]);
     assert_eq!(

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -1,3 +1,4 @@
+use host_domain::DEFAULT_BRANCH_PREFIX;
 use serde::{Deserialize, Deserializer, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -254,7 +255,7 @@ pub struct RepoConfig {
 }
 
 pub(super) fn default_branch_prefix() -> String {
-    "obp".to_string()
+    DEFAULT_BRANCH_PREFIX.to_string()
 }
 
 pub(super) fn default_runtime_kind() -> String {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use host_domain::DEFAULT_BRANCH_PREFIX;
 use std::net::TcpListener;
 use std::path::Path;
 use std::process::Command;
@@ -16,7 +17,7 @@ pub fn slugify_title(value: &str) -> String {
 }
 
 pub fn build_branch_name(prefix: &str, task_id: &str, title: &str) -> String {
-    let clean_prefix = if prefix.is_empty() { "obp" } else { prefix };
+    let clean_prefix = if prefix.is_empty() { DEFAULT_BRANCH_PREFIX } else { prefix };
     let slug = slugify_title(title);
     if slug.is_empty() {
         format!("{}/{}", clean_prefix, task_id)
@@ -54,6 +55,7 @@ pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{build_branch_name, pick_free_port, remove_worktree, slugify_title};
+    use host_domain::DEFAULT_BRANCH_PREFIX;
     use std::fs;
     use std::net::TcpListener;
     use std::path::{Path, PathBuf};
@@ -120,7 +122,7 @@ mod tests {
     #[test]
     fn build_branch_name_applies_defaults() {
         let branch = build_branch_name("", "task-123", "Implement feature");
-        assert!(branch.starts_with("obp/"));
+        assert!(branch.starts_with(&format!("{}/", DEFAULT_BRANCH_PREFIX)));
         assert!(branch.contains("task-123-implement-feature"));
     }
 

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
@@ -147,7 +147,7 @@ describe("settings-modal-normalization", () => {
     const normalized = normalizeRepoConfigForSave(createRepoConfig());
 
     expect(normalized.defaultRuntimeKind).toBe("opencode");
-    expect(normalized.branchPrefix).toBe("obp");
+    expect(normalized.branchPrefix).toBe("odt");
     expect(normalized.defaultTargetBranch).toEqual({ remote: "origin", branch: "main" });
     expect(normalized.worktreeBasePath).toBe("/tmp/worktrees");
     expect(normalized.hooks).toEqual({

--- a/apps/desktop/src/components/features/settings/settings-model.ts
+++ b/apps/desktop/src/components/features/settings/settings-model.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_BRANCH_PREFIX = "obp";
+export const DEFAULT_BRANCH_PREFIX = "odt";
 
 export const parseHookLines = (value: string): string[] =>
   value

--- a/apps/desktop/src/components/features/settings/settings-model.ts
+++ b/apps/desktop/src/components/features/settings/settings-model.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_BRANCH_PREFIX = "odt";
+export { DEFAULT_BRANCH_PREFIX } from "@openducktor/contracts";
 
 export const parseHookLines = (value: string): string[] =>
   value

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -3,6 +3,8 @@ import { runtimeKindSchema } from "./agent-runtime-schemas";
 import { gitTargetBranchSchema, globalGitConfigSchema, repoGitConfigSchema } from "./git-schemas";
 import { repoPromptOverridesSchema } from "./prompt-schemas";
 
+export const DEFAULT_BRANCH_PREFIX = "odt";
+
 const DEFAULT_SOFT_GUARDRAILS = {
   cpuHighWatermarkPercent: 85,
   minFreeMemoryMb: 2048,
@@ -55,7 +57,7 @@ export type RepoAgentDefaults = z.infer<typeof repoAgentDefaultsSchema>;
 export const repoConfigSchema = z.object({
   defaultRuntimeKind: runtimeKindSchema.default("opencode"),
   worktreeBasePath: nullableToOptional(z.string().min(1)),
-  branchPrefix: z.string().min(1).default("odt"),
+  branchPrefix: z.string().min(1).default(DEFAULT_BRANCH_PREFIX),
   defaultTargetBranch: gitTargetBranchSchema.default({ remote: "origin", branch: "main" }),
   git: repoGitConfigSchema.default({ providers: {} }),
   trustedHooks: z.boolean().default(false),

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -55,7 +55,7 @@ export type RepoAgentDefaults = z.infer<typeof repoAgentDefaultsSchema>;
 export const repoConfigSchema = z.object({
   defaultRuntimeKind: runtimeKindSchema.default("opencode"),
   worktreeBasePath: nullableToOptional(z.string().min(1)),
-  branchPrefix: z.string().min(1).default("obp"),
+  branchPrefix: z.string().min(1).default("odt"),
   defaultTargetBranch: gitTargetBranchSchema.default({ remote: "origin", branch: "main" }),
   git: repoGitConfigSchema.default({ providers: {} }),
   trustedHooks: z.boolean().default(false),

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -106,6 +106,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "parseAgentSessionTodoPayloadList",
   "beadsCheckSchema",
   "chatSettingsSchema",
+  "DEFAULT_BRANCH_PREFIX",
   "gitCommitAllRequestSchema",
   "gitCommitAllResultSchema",
   "gitConflictAbortRequestSchema",


### PR DESCRIPTION
## Summary

The default branch prefix was still set to "obp" (the old application name) instead of "odt" (the current application name) across multiple configuration layers. This fix centralizes the `DEFAULT_BRANCH_PREFIX` constant in the `host-domain` crate and updates all locations that use it.

## Changes

### TypeScript Contracts Layer
- `packages/contracts/src/config-schemas.ts` - Changed Zod schema default from "obp" to "odt"

### Frontend Settings Layer
- `apps/desktop/src/components/features/settings/settings-model.ts` - Changed `DEFAULT_BRANCH_PREFIX` constant from "obp" to "odt"

### Rust Domain Layer
- `apps/desktop/src-tauri/crates/host-domain/src/lib.rs` - Added centralized `DEFAULT_BRANCH_PREFIX` constant set to "odt"
- `apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs` - Updated fallback logic to use the centralized constant
- `apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs` - Updated `default_branch_prefix()` to use the centralized constant
- `apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs` - Updated branch cleanup logic to use the centralized constant

## Test Updates
- Updated `settings-modal-normalization.test.ts` to expect "odt" instead of "obp"
- Updated `normalization.rs` and `worktree.rs` tests to use the constant instead of hardcoded strings

## Verification
- All TypeScript type checks pass
- All linting passes
- All 1082 Bun tests pass
- All 478 Rust tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default repository branch prefix from "obp" to "odt" across the application configuration and centralized the constant for consistent usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->