### PR TITLE
fix(desktop): restore agent CLI tool discovery

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "fs2",
  "host-domain",
  "host-infra-system",
+ "host-test-support",
  "libc",
  "serde",
  "serde_json",
@@ -1336,6 +1337,7 @@ dependencies = [
  "chrono",
  "dirs",
  "host-domain",
+ "host-test-support",
  "libc",
  "rayon",
  "serde",
@@ -1343,6 +1345,10 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "host-test-support"
+version = "0.1.0"
 
 [[package]]
 name = "html5ever"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "crates/host-domain",
   "crates/host-infra-beads",
   "crates/host-infra-system",
+  "crates/host-test-support",
 ]
 resolver = "2"
 

--- a/apps/desktop/src-tauri/crates/host-application/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-application/Cargo.toml
@@ -18,3 +18,6 @@ shell-words = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+host-test-support = { path = "../host-test-support" }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context, Result};
-use host_infra_system::{bundled_command, resolve_command_path};
+use host_infra_system::{bundled_command, resolve_command_path, subprocess_path_env};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -12,6 +12,9 @@ pub(crate) fn read_opencode_version(binary: &str) -> Option<String> {
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
+    if let Some(path_value) = subprocess_path_env() {
+        command.env("PATH", path_value);
+    }
     configure_process_group(&mut command);
 
     let mut child = command.spawn().ok()?;
@@ -285,6 +288,9 @@ fn spawn_opencode_server_with_binary(
         .current_dir(working_directory)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    if let Some(path_value) = subprocess_path_env() {
+        command.env("PATH", path_value);
+    }
     configure_process_group(&mut command);
     let child = command.spawn().with_context(|| {
         format!(
@@ -306,9 +312,11 @@ fn spawn_opencode_server_with_binary(
 mod tests {
     use super::terminate_child_process;
     use anyhow::{Context, Result};
+    use std::ffi::OsString;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, MutexGuard, OnceLock};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     fn temp_test_dir(prefix: &str) -> Result<PathBuf> {
@@ -335,6 +343,52 @@ mod tests {
             "timed out waiting for complete capture in {}",
             path.display()
         ))
+    }
+
+    fn wait_for_marker(path: &Path, marker: &str) -> Result<String> {
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            if let Ok(contents) = fs::read_to_string(path) {
+                if contents.contains(marker) {
+                    return Ok(contents);
+                }
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        Err(anyhow::anyhow!(
+            "timed out waiting for marker {marker} in {}",
+            path.display()
+        ))
+    }
+
+    fn lock_env() -> MutexGuard<'static, ()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should not be poisoned")
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
     }
 
     #[test]
@@ -379,6 +433,57 @@ sleep 5
             "captured output: {captured}"
         );
         assert!(captured.contains("args=serve --hostname 127.0.0.1 --port 43123"));
+
+        terminate_child_process(&mut child);
+        fs::remove_dir_all(&sandbox).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn spawn_with_config_augments_path_for_common_user_toolchains() -> Result<()> {
+        let _env_lock = lock_env();
+        let sandbox = temp_test_dir("spawn-with-config-path")?;
+        let home = sandbox.join("home");
+        fs::create_dir_all(home.join(".bun").join("bin"))?;
+        fs::create_dir_all(home.join(".cargo").join("bin"))?;
+
+        let output_path = sandbox.join("captured-path.txt");
+        let script_path = sandbox.join("fake-opencode.sh");
+        let script = format!(
+            r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "opencode-fake 0.0.1"
+  exit 0
+fi
+echo "path=$PATH" > "{}"
+sleep 5
+"#,
+            output_path.display()
+        );
+        fs::write(&script_path, script)
+            .with_context(|| format!("failed writing {}", script_path.display()))?;
+        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("failed chmod {}", script_path.display()))?;
+
+        let _home_guard = EnvVarGuard::set("HOME", home.to_string_lossy().as_ref());
+        let _path_guard = EnvVarGuard::set("PATH", "/usr/bin:/bin");
+
+        let mut child = super::spawn_opencode_server_with_binary(
+            script_path.to_string_lossy().as_ref(),
+            sandbox.as_path(),
+            r#"{"logLevel":"INFO"}"#,
+            43124,
+        )?;
+
+        let captured = wait_for_marker(output_path.as_path(), "path=")?;
+        assert!(
+            captured.contains(home.join(".bun").join("bin").to_string_lossy().as_ref()),
+            "captured PATH: {captured}"
+        );
+        assert!(
+            captured.contains(home.join(".cargo").join("bin").to_string_lossy().as_ref()),
+            "captured PATH: {captured}"
+        );
 
         terminate_child_process(&mut child);
         fs::remove_dir_all(&sandbox).ok();

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
@@ -311,12 +311,11 @@ fn spawn_opencode_server_with_binary(
 #[cfg(unix)]
 mod tests {
     use super::terminate_child_process;
+    use crate::app_service::test_support::{lock_env, set_env_var};
     use anyhow::{Context, Result};
-    use std::ffi::OsString;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
-    use std::sync::{Mutex, MutexGuard, OnceLock};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     fn temp_test_dir(prefix: &str) -> Result<PathBuf> {
@@ -361,38 +360,9 @@ mod tests {
         ))
     }
 
-    fn lock_env() -> MutexGuard<'static, ()> {
-        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        ENV_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .expect("env lock should not be poisoned")
-    }
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-
     #[test]
     fn spawn_with_config_injects_config_content_and_args() -> Result<()> {
+        let _env_lock = lock_env();
         let sandbox = temp_test_dir("spawn-with-config")?;
         let output_path = sandbox.join("captured.txt");
         let script_path = sandbox.join("fake-opencode.sh");
@@ -465,8 +435,8 @@ sleep 5
         fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))
             .with_context(|| format!("failed chmod {}", script_path.display()))?;
 
-        let _home_guard = EnvVarGuard::set("HOME", home.to_string_lossy().as_ref());
-        let _path_guard = EnvVarGuard::set("PATH", "/usr/bin:/bin");
+        let _home_guard = set_env_var("HOME", home.to_string_lossy().as_ref());
+        let _path_guard = set_env_var("PATH", "/usr/bin:/bin");
 
         let mut child = super::spawn_opencode_server_with_binary(
             script_path.to_string_lossy().as_ref(),
@@ -484,6 +454,8 @@ sleep 5
             captured.contains(home.join(".cargo").join("bin").to_string_lossy().as_ref()),
             "captured PATH: {captured}"
         );
+        assert!(captured.contains("/usr/bin"), "captured PATH: {captured}");
+        assert!(captured.contains("/bin"), "captured PATH: {captured}");
 
         terminate_child_process(&mut child);
         fs::remove_dir_all(&sandbox).ok();

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -31,6 +31,7 @@ use host_domain::{
 use host_infra_system::{
     AppConfigStore, GlobalConfig, HookSet, OpencodeStartupReadinessConfig, RepoConfig,
 };
+pub(crate) use host_test_support::{lock_env, EnvVarGuard};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -1118,12 +1119,7 @@ pub(crate) fn make_session(task_id: &str, session_id: &str) -> AgentSessionDocum
     }
 }
 
-pub(crate) static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 pub(crate) static UNIQUE_TEMP_PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-pub(crate) fn lock_env<'a>() -> std::sync::MutexGuard<'a, ()> {
-    ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
-}
 
 pub(crate) fn unique_temp_path(name: &str) -> PathBuf {
     let nonce = UNIQUE_TEMP_PATH_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -1349,51 +1345,16 @@ echo "bd-fake"
     write_executable_script(path, script)
 }
 
-pub(crate) struct EnvVarGuard {
-    pub(crate) key: String,
-    pub(crate) previous: Option<OsString>,
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(previous) = self.previous.clone() {
-            std::env::set_var(self.key.as_str(), previous);
-        } else {
-            std::env::remove_var(self.key.as_str());
-        }
-    }
-}
-
 pub(crate) fn set_env_var(key: &str, value: &str) -> EnvVarGuard {
-    let previous = std::env::var_os(key);
-    std::env::set_var(key, value);
-    EnvVarGuard {
-        key: key.to_string(),
-        previous,
-    }
+    EnvVarGuard::set(key, value)
 }
 
 pub(crate) fn remove_env_var(key: &str) -> EnvVarGuard {
-    let previous = std::env::var_os(key);
-    std::env::remove_var(key);
-    EnvVarGuard {
-        key: key.to_string(),
-        previous,
-    }
+    EnvVarGuard::remove(key)
 }
 
 pub(crate) fn prepend_path(path_prefix: &Path) -> EnvVarGuard {
-    let previous = std::env::var_os("PATH");
-    let mut parts = vec![path_prefix.to_string_lossy().to_string()];
-    if let Some(current) = previous.as_ref() {
-        parts.push(current.to_string_lossy().to_string());
-    }
-    let value = parts.join(":");
-    std::env::set_var("PATH", value);
-    EnvVarGuard {
-        key: "PATH".to_string(),
-        previous,
-    }
+    EnvVarGuard::prepend_path(path_prefix)
 }
 
 pub(crate) fn wait_for_path_exists(path: &Path, timeout: Duration) -> bool {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -29,7 +29,7 @@ use crate::app_service::test_support::{
     lock_env, make_emitter, make_session, make_task, prepend_path, process_is_alive, set_env_var,
     spawn_sleep_process, unique_temp_path, wait_for_orphaned_opencode_process,
     wait_for_path_exists, wait_for_process_exit, write_executable_script, write_private_file,
-    FakeTaskStore, GitCall, TaskStoreState,
+    EnvVarGuard, FakeTaskStore, GitCall, TaskStoreState,
 };
 use crate::app_service::{
     build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
@@ -64,32 +64,6 @@ fn run_command_in(current_dir: &Path, program: &str, args: &[&str]) -> Result<()
         current_dir.display(),
         status
     ))
-}
-
-#[cfg(unix)]
-struct EnvVarGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-#[cfg(unix)]
-impl EnvVarGuard {
-    fn set_os(key: &'static str, value: OsString) -> Self {
-        let previous = std::env::var_os(key);
-        std::env::set_var(key, &value);
-        Self { key, previous }
-    }
-}
-
-#[cfg(unix)]
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(previous) = self.previous.clone() {
-            std::env::set_var(self.key, previous);
-        } else {
-            std::env::remove_var(self.key);
-        }
-    }
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
@@ -138,7 +138,9 @@ pub(crate) fn parse_agent_sessions(value: &Value) -> Option<Vec<AgentSessionDocu
     let entries = value
         .as_array()?
         .iter()
-        .filter_map(|entry| AgentSessionDocument::deserialize(normalize_agent_session_entry(entry)).ok())
+        .filter_map(|entry| {
+            AgentSessionDocument::deserialize(normalize_agent_session_entry(entry)).ok()
+        })
         .collect::<Vec<_>>();
     Some(entries)
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
@@ -14,3 +14,6 @@ sha2 = "0.10"
 rayon = "1"
 libc = "0.2"
 host-domain = { path = "../host-domain" }
+
+[dev-dependencies]
+host-test-support = { path = "../host-test-support" }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/mod.rs
@@ -2,10 +2,9 @@ use super::{
     hook_set_fingerprint, touch_recent, AppConfigStore, GlobalConfig, HookSet,
     OpencodeStartupReadinessConfig, RepoConfig, RuntimeConfig, RuntimeConfigStore,
 };
-use std::ffi::OsString;
+pub(super) use host_test_support::{lock_env, EnvVarGuard};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 mod constructors_and_io;
@@ -92,42 +91,4 @@ pub(super) fn unique_temp_path(name: &str) -> PathBuf {
 
 pub(super) fn fake_git_workspace(path: &Path) {
     fs::create_dir_all(path.join(".git")).expect("git directory should be created");
-}
-
-pub(super) fn lock_env() -> MutexGuard<'static, ()> {
-    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    ENV_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-}
-
-pub(super) struct EnvVarGuard {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl EnvVarGuard {
-    pub(super) fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var_os(key);
-        std::env::set_var(key, value);
-        Self { key, previous }
-    }
-
-    #[cfg(unix)]
-    pub(super) fn set_os(key: &'static str, value: OsString) -> Self {
-        let previous = std::env::var_os(key);
-        std::env::set_var(key, &value);
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        if let Some(previous) = self.previous.clone() {
-            std::env::set_var(self.key, previous);
-        } else {
-            std::env::remove_var(self.key);
-        }
-    }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/git/status.rs
@@ -11,8 +11,7 @@ use super::GitCliPort;
 
 const UPSTREAM_TARGET_BRANCH: &str = "@{upstream}";
 const EMPTY_TREE_SHA1: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-const EMPTY_TREE_SHA256: &str =
-    "6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321";
+const EMPTY_TREE_SHA256: &str = "6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321";
 
 fn resolve_effective_target_branch(
     requested_target_branch: &str,
@@ -96,13 +95,9 @@ impl GitCliPort {
                             GitDiffScope::Target => self
                                 .load_branch_changes_diff_payload_unchecked(
                                     repo_path,
-                                    effective_target_branch
-                                        .as_deref()
-                                        .ok_or_else(|| {
-                                            anyhow!(
-                                                "target scope requires an effective target branch"
-                                            )
-                                        })?,
+                                    effective_target_branch.as_deref().ok_or_else(|| {
+                                        anyhow!("target scope requires an effective target branch")
+                                    })?,
                                 )
                                 .map(Some),
                             GitDiffScope::Uncommitted => self

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -19,6 +19,6 @@ pub use git::GitCliPort;
 pub use process::{
     bundled_command, command_exists, command_path, resolve_command_path, run_command,
     run_command_allow_failure, run_command_allow_failure_with_env, run_command_with_env,
-    version_command,
+    subprocess_path_env, version_command,
 };
 pub use worktree::{build_branch_name, pick_free_port, remove_worktree, slugify_title};

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -283,23 +283,62 @@ fn command_path_from_environment_path(
     command_path_from_directories(program, &directories)
 }
 
-fn augmented_process_path(path_override: Option<&str>) -> Option<OsString> {
+fn explicit_command_override_directories() -> Vec<PathBuf> {
+    let directories = env::vars_os()
+        .filter_map(|(key, value)| {
+            let key = key.to_string_lossy();
+            if !key.starts_with("OPENDUCKTOR_") || !key.ends_with("_PATH") {
+                return None;
+            }
+
+            let path = PathBuf::from(value);
+            if !path.is_file() {
+                return None;
+            }
+
+            path.parent().map(Path::to_path_buf)
+        })
+        .collect::<Vec<_>>();
+    unique_path_entries(directories)
+}
+
+fn process_path_with_order(
+    path_override: Option<&str>,
+    bundled_dir_first: bool,
+) -> Option<OsString> {
     let bundled_dir = env::current_exe()
         .ok()
         .and_then(|path| path.parent().map(Path::to_path_buf));
+    let explicit_override_directories = explicit_command_override_directories();
     let inherited = path_entries_from_value(
         path_override
             .map(OsString::from)
             .or_else(|| env::var_os("PATH")),
     );
+    let standard = standard_search_directories();
 
-    let entries = unique_path_entries(
-        bundled_dir
-            .into_iter()
-            .chain(inherited)
-            .chain(standard_search_directories()),
-    );
+    let entries = if bundled_dir_first {
+        unique_path_entries(
+            bundled_dir
+                .into_iter()
+                .chain(explicit_override_directories)
+                .chain(inherited)
+                .chain(standard),
+        )
+    } else {
+        unique_path_entries(
+            explicit_override_directories
+                .into_iter()
+                .chain(inherited)
+                .chain(standard)
+                .chain(bundled_dir),
+        )
+    };
     path_value_from_entries(&entries)
+}
+
+fn augmented_process_path(path_override: Option<&str>) -> Option<OsString> {
+    process_path_with_order(path_override, true)
 }
 
 fn resolve_command_path_with_path_override(
@@ -328,7 +367,7 @@ pub fn resolve_command_path(program: &str) -> Result<Option<String>> {
 }
 
 pub fn subprocess_path_env() -> Option<OsString> {
-    augmented_process_path(None)
+    process_path_with_order(None, false)
 }
 
 fn configured_command(
@@ -460,44 +499,13 @@ mod tests {
         bundled_command_path_from_executable, command_env_override_name, command_exists,
         command_path, explicit_command_override, resolve_command_path, run_command,
         run_command_allow_failure, run_command_allow_failure_with_env, run_command_with_env,
-        version_command,
+        subprocess_path_env, version_command,
     };
+    use host_test_support::{lock_env, EnvVarGuard};
     use std::{
-        ffi::OsString,
         fs,
-        sync::{Mutex, MutexGuard, OnceLock},
         time::{SystemTime, UNIX_EPOCH},
     };
-
-    fn lock_env() -> MutexGuard<'static, ()> {
-        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        ENV_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .expect("env lock should not be poisoned")
-    }
-
-    struct EnvVarGuard {
-        key: &'static str,
-        previous: Option<OsString>,
-    }
-
-    impl EnvVarGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let previous = std::env::var_os(key);
-            std::env::set_var(key, value);
-            Self { key, previous }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
 
     #[test]
     fn run_command_returns_stdout() {
@@ -710,6 +718,64 @@ mod tests {
 
         assert_eq!(output, "home-search-ok");
         let _ = fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn subprocess_path_env_prioritizes_override_and_inherited_directories() {
+        let _env_lock = lock_env();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("odt-subprocess-path-{nonce}"));
+        let override_dir = root.join("override-bin");
+        let inherited_a = root.join("inherited-a");
+        let inherited_b = root.join("inherited-b");
+        fs::create_dir_all(&override_dir).expect("override dir should exist");
+        fs::create_dir_all(&inherited_a).expect("inherited dir should exist");
+        fs::create_dir_all(&inherited_b).expect("inherited dir should exist");
+
+        let override_file = override_dir.join("custom-bun");
+        fs::write(&override_file, "").expect("override file should exist");
+
+        let inherited_path = std::env::join_paths([inherited_a.as_path(), inherited_b.as_path()])
+            .expect("inherited path should join");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_BUN_PATH",
+            override_file.to_string_lossy().as_ref(),
+        );
+        let _path_guard = EnvVarGuard::set("PATH", inherited_path.to_string_lossy().as_ref());
+
+        let path = subprocess_path_env().expect("subprocess PATH should be assembled");
+        let entries = std::env::split_paths(&path).collect::<Vec<_>>();
+        let bundled_dir = std::env::current_exe()
+            .expect("current executable should resolve")
+            .parent()
+            .expect("current executable should have parent")
+            .to_path_buf();
+
+        let override_index = entries
+            .iter()
+            .position(|entry| entry == &override_dir)
+            .expect("override parent should be included");
+        let inherited_a_index = entries
+            .iter()
+            .position(|entry| entry == &inherited_a)
+            .expect("first inherited path should be included");
+        let inherited_b_index = entries
+            .iter()
+            .position(|entry| entry == &inherited_b)
+            .expect("second inherited path should be included");
+        let bundled_index = entries
+            .iter()
+            .position(|entry| entry == &bundled_dir)
+            .expect("bundled directory should be included");
+
+        assert!(override_index < bundled_index);
+        assert!(inherited_a_index < bundled_index);
+        assert!(inherited_b_index < bundled_index);
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -4,6 +4,9 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
+#[cfg(windows)]
+const DEFAULT_WINDOWS_EXECUTABLE_EXTENSIONS: [&str; 4] = [".exe", ".cmd", ".bat", ".com"];
+
 fn command_env_override_name(program: &str) -> String {
     let sanitized = program
         .chars()
@@ -56,15 +59,106 @@ pub fn bundled_command(program: &str) -> Option<String> {
     bundled_command_path(program)
 }
 
-fn command_file_name(program: &str) -> OsString {
+#[cfg(windows)]
+fn command_file_names(program: &str) -> Vec<OsString> {
+    if Path::new(program).extension().is_some() {
+        return vec![OsString::from(program)];
+    }
+
+    let configured_extensions = env::var_os("PATHEXT")
+        .map(|value| value.to_string_lossy().to_string())
+        .map(|value| {
+            value
+                .split(';')
+                .map(str::trim)
+                .filter(|extension| !extension.is_empty())
+                .map(|extension| {
+                    let normalized = if extension.starts_with('.') {
+                        extension.to_ascii_lowercase()
+                    } else {
+                        format!(".{extension}").to_ascii_lowercase()
+                    };
+                    OsString::from(format!("{program}{normalized}"))
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|extensions| !extensions.is_empty())
+        .unwrap_or_else(|| {
+            DEFAULT_WINDOWS_EXECUTABLE_EXTENSIONS
+                .iter()
+                .map(|extension| OsString::from(format!("{program}{extension}")))
+                .collect()
+        });
+
+    let mut file_names = vec![OsString::from(program)];
+    for candidate in configured_extensions {
+        if file_names.iter().any(|existing| existing == &candidate) {
+            continue;
+        }
+        file_names.push(candidate);
+    }
+
+    file_names
+}
+
+#[cfg(not(windows))]
+fn command_file_names(program: &str) -> Vec<OsString> {
+    vec![OsString::from(program)]
+}
+
+fn home_directory() -> Option<PathBuf> {
     #[cfg(windows)]
     {
-        OsString::from(format!("{program}.exe"))
+        env::var_os("USERPROFILE")
+            .or_else(|| env::var_os("HOME"))
+            .map(PathBuf::from)
     }
     #[cfg(not(windows))]
     {
-        OsString::from(program)
+        env::var_os("HOME").map(PathBuf::from)
     }
+}
+
+fn common_user_search_directories() -> Vec<PathBuf> {
+    let mut directories = Vec::new();
+
+    if let Some(home) = home_directory() {
+        directories.push(home.join(".cargo").join("bin"));
+        directories.push(home.join(".bun").join("bin"));
+        directories.push(home.join(".local").join("bin"));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(local_app_data) = env::var_os("LOCALAPPDATA") {
+            let local_app_data = PathBuf::from(local_app_data);
+            directories.push(
+                local_app_data
+                    .join("Microsoft")
+                    .join("WinGet")
+                    .join("Links"),
+            );
+            directories.push(local_app_data.join("Programs").join("GitHub CLI"));
+            directories.push(
+                local_app_data
+                    .join("Programs")
+                    .join("GitHub CLI")
+                    .join("bin"),
+            );
+        }
+        if let Some(program_files) = env::var_os("ProgramFiles") {
+            let program_files = PathBuf::from(program_files);
+            directories.push(program_files.join("GitHub CLI"));
+            directories.push(program_files.join("GitHub CLI").join("bin"));
+        }
+        if let Some(program_files_x86) = env::var_os("ProgramFiles(x86)") {
+            let program_files_x86 = PathBuf::from(program_files_x86);
+            directories.push(program_files_x86.join("GitHub CLI"));
+            directories.push(program_files_x86.join("GitHub CLI").join("bin"));
+        }
+    }
+
+    unique_path_entries(directories)
 }
 
 fn existing_file_path(path: PathBuf) -> Option<String> {
@@ -104,7 +198,7 @@ fn unique_path_entries(entries: impl IntoIterator<Item = PathBuf>) -> Vec<PathBu
 }
 
 fn standard_search_directories() -> Vec<PathBuf> {
-    let mut directories = Vec::new();
+    let mut directories = common_user_search_directories();
 
     #[cfg(target_os = "macos")]
     {
@@ -170,11 +264,15 @@ fn standard_command_directories(program: &str) -> Vec<PathBuf> {
 }
 
 fn command_path_from_directories(program: &str, directories: &[PathBuf]) -> Option<String> {
-    let file_name = command_file_name(program);
+    let file_names = command_file_names(program);
     directories
         .iter()
         .filter(|directory| !directory.as_os_str().is_empty())
-        .find_map(|directory| existing_file_path(directory.join(&file_name)))
+        .find_map(|directory| {
+            file_names
+                .iter()
+                .find_map(|file_name| existing_file_path(directory.join(file_name)))
+        })
 }
 
 fn command_path_from_environment_path(
@@ -227,6 +325,10 @@ fn resolve_command_path_with_path_override(
 
 pub fn resolve_command_path(program: &str) -> Result<Option<String>> {
     resolve_command_path_with_path_override(program, None)
+}
+
+pub fn subprocess_path_env() -> Option<OsString> {
+    augmented_process_path(None)
 }
 
 fn configured_command(
@@ -332,10 +434,7 @@ pub fn run_command_allow_failure_with_env(
     ))
 }
 
-/// Resolves a command name using the active shell's PATH lookup.
-///
-/// The lookup script is static and `program` is passed as a positional shell
-/// argument (`$1`) to avoid shell interpolation of untrusted input.
+/// Resolves a command name using the same augmented PATH used for subprocesses.
 pub fn command_path(program: &str) -> Option<String> {
     command_path_from_environment_path(program, augmented_process_path(None))
 }
@@ -359,14 +458,46 @@ pub fn version_command(program: &str, args: &[&str]) -> Option<String> {
 mod tests {
     use super::{
         bundled_command_path_from_executable, command_env_override_name, command_exists,
-        command_file_name, command_path, explicit_command_override, resolve_command_path,
-        run_command, run_command_allow_failure, run_command_allow_failure_with_env,
-        run_command_with_env, version_command,
+        command_path, explicit_command_override, resolve_command_path, run_command,
+        run_command_allow_failure, run_command_allow_failure_with_env, run_command_with_env,
+        version_command,
     };
     use std::{
+        ffi::OsString,
         fs,
+        sync::{Mutex, MutexGuard, OnceLock},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    fn lock_env() -> MutexGuard<'static, ()> {
+        static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should not be poisoned")
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 
     #[test]
     fn run_command_returns_stdout() {
@@ -461,7 +592,10 @@ mod tests {
         let executable_dir = root.join("MacOS");
         fs::create_dir_all(&executable_dir).expect("temp executable dir should be created");
         let fake_executable = executable_dir.join("openducktor-desktop");
-        let fake_bd = executable_dir.join(command_file_name("bd"));
+        #[cfg(windows)]
+        let fake_bd = executable_dir.join("bd.exe");
+        #[cfg(not(windows))]
+        let fake_bd = executable_dir.join("bd");
         fs::write(&fake_executable, "").expect("fake executable should be writable");
         fs::write(&fake_bd, "").expect("fake bundled command should be writable");
 
@@ -540,6 +674,42 @@ mod tests {
 
         assert_eq!(output, "path-override-ok");
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_command_searches_common_user_toolchain_directories() {
+        let _env_lock = lock_env();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let program = format!("bd-home-{nonce}");
+        let home = std::env::temp_dir().join(format!("odt-home-search-{nonce}"));
+        let cargo_bin = home.join(".cargo").join("bin");
+        fs::create_dir_all(&cargo_bin).expect("toolchain bin dir should be created");
+
+        let script = cargo_bin.join(program.as_str());
+        fs::write(&script, "#!/bin/sh\nprintf 'home-search-ok'")
+            .expect("script should be writable");
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = fs::metadata(&script)
+                .expect("script metadata should exist")
+                .permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&script, permissions).expect("script should be executable");
+        }
+
+        let _home_guard = EnvVarGuard::set("HOME", home.to_string_lossy().as_ref());
+        let _path_guard = EnvVarGuard::set("PATH", "/usr/bin:/bin");
+
+        let output = run_command(program.as_str(), &[], None)
+            .expect("command in common user toolchain dir should execute");
+
+        assert_eq!(output, "home-search-ok");
+        let _ = fs::remove_dir_all(home);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-test-support/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-test-support/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "host-test-support"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/apps/desktop/src-tauri/crates/host-test-support/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-test-support/src/lib.rs
@@ -1,0 +1,130 @@
+use std::env;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex, MutexGuard};
+
+pub static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+pub fn lock_env<'a>() -> MutexGuard<'a, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
+}
+
+pub struct EnvVarGuard {
+    key: String,
+    previous: Option<OsString>,
+}
+
+impl EnvVarGuard {
+    pub fn set(key: &str, value: &str) -> Self {
+        let previous = env::var_os(key);
+        env::set_var(key, value);
+        Self {
+            key: key.to_string(),
+            previous,
+        }
+    }
+
+    pub fn set_os(key: &str, value: OsString) -> Self {
+        let previous = env::var_os(key);
+        env::set_var(key, &value);
+        Self {
+            key: key.to_string(),
+            previous,
+        }
+    }
+
+    pub fn remove(key: &str) -> Self {
+        let previous = env::var_os(key);
+        env::remove_var(key);
+        Self {
+            key: key.to_string(),
+            previous,
+        }
+    }
+
+    pub fn prepend_path(path_prefix: &Path) -> Self {
+        let previous = env::var_os("PATH");
+        let joined = joined_path_with_prefix(path_prefix, previous.as_ref());
+        env::set_var("PATH", &joined);
+        Self {
+            key: "PATH".to_string(),
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.previous.as_ref() {
+            Some(previous) => env::set_var(self.key.as_str(), previous),
+            None => env::remove_var(self.key.as_str()),
+        }
+    }
+}
+
+fn joined_path_with_prefix(path_prefix: &Path, previous: Option<&OsString>) -> OsString {
+    let entries = std::iter::once(path_prefix.to_path_buf())
+        .chain(previous.into_iter().flat_map(env::split_paths))
+        .collect::<Vec<PathBuf>>();
+    env::join_paths(entries).expect("PATH entries should join successfully")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{lock_env, EnvVarGuard};
+    use std::ffi::OsString;
+    use std::path::Path;
+
+    #[test]
+    fn env_var_guard_restores_previous_value() {
+        let _env_lock = lock_env();
+        std::env::set_var("ODT_TEST_GUARD", "before");
+
+        {
+            let _guard = EnvVarGuard::set("ODT_TEST_GUARD", "after");
+            assert_eq!(std::env::var("ODT_TEST_GUARD").as_deref(), Ok("after"));
+        }
+
+        assert_eq!(std::env::var("ODT_TEST_GUARD").as_deref(), Ok("before"));
+        std::env::remove_var("ODT_TEST_GUARD");
+    }
+
+    #[test]
+    fn prepend_path_keeps_existing_entries() {
+        let _env_lock = lock_env();
+        std::env::set_var("PATH", "/usr/bin:/bin");
+
+        {
+            let _guard = EnvVarGuard::prepend_path(Path::new("/tmp/tool"));
+            let path = std::env::var_os("PATH").expect("PATH should be set");
+            let entries = std::env::split_paths(&path).collect::<Vec<_>>();
+            assert_eq!(entries[0], Path::new("/tmp/tool"));
+            assert!(entries.iter().any(|entry| entry == Path::new("/usr/bin")));
+            assert!(entries.iter().any(|entry| entry == Path::new("/bin")));
+        }
+
+        assert_eq!(std::env::var("PATH").as_deref(), Ok("/usr/bin:/bin"));
+    }
+
+    #[test]
+    fn remove_and_set_os_round_trip() {
+        let _env_lock = lock_env();
+        std::env::remove_var("ODT_TEST_OS");
+
+        {
+            let _guard = EnvVarGuard::set_os("ODT_TEST_OS", OsString::from("value"));
+            assert_eq!(std::env::var("ODT_TEST_OS").as_deref(), Ok("value"));
+        }
+
+        assert!(std::env::var_os("ODT_TEST_OS").is_none());
+
+        std::env::set_var("ODT_TEST_OS", "value");
+        {
+            let _guard = EnvVarGuard::remove("ODT_TEST_OS");
+            assert!(std::env::var_os("ODT_TEST_OS").is_none());
+        }
+
+        assert_eq!(std::env::var("ODT_TEST_OS").as_deref(), Ok("value"));
+        std::env::remove_var("ODT_TEST_OS");
+    }
+}

--- a/apps/desktop/src/features/git-conflict-resolution/git-conflict-strip.tsx
+++ b/apps/desktop/src/features/git-conflict-resolution/git-conflict-strip.tsx
@@ -30,10 +30,10 @@ export const GitConflictStrip = memo(function GitConflictStrip({
 }: GitConflictStripProps): ReactElement {
   return (
     <div
-      className="border-b border-border bg-muted/40 px-4 py-4"
+      className="border-b border-border bg-muted/40 p-2"
       data-testid={GIT_CONFLICT_TEST_IDS.strip}
     >
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+      <div className="flex flex-col gap-2">
         <div className="flex min-w-0 items-start gap-3">
           <div className="rounded-full border border-warning-border bg-warning-surface p-2.5 text-warning-muted">
             <AlertTriangle className="size-4" />
@@ -56,7 +56,7 @@ export const GitConflictStrip = memo(function GitConflictStrip({
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2 xl:justify-end">
+        <div className="flex flex-wrap items-center gap-2 justify-between">
           <Button
             type="button"
             variant="outline"


### PR DESCRIPTION
## Summary
- restore the augmented PATH for OpenCode child processes so agent sessions can find user-installed CLI tools like `bun`, `cargo`, and `gh` again
- expand command discovery for common user toolchain locations and Windows executable resolution, with regression coverage around runtime PATH propagation
- include the conflict resolution strip spacing/layout polish from the desktop UI refresh

## Checks
- cargo test -p host-infra-system -p host-application
- bun run check:rust
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted layout and padding of the git conflict resolution UI component.

* **Refactor**
  * Enhanced subprocess launch behavior to propagate an augmented PATH and better locate common user toolchains.

* **Tests**
  * Expanded cross-platform tests for subprocess configuration and PATH ordering; serialized environment mutations via shared test helpers.

* **Chores**
  * Added a test-support crate and wired it into the workspace and dev-dependencies for shared testing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->