### PR TITLE
fix(settings): streamline worktree script trust

### DIFF
--- a/apps/desktop/src/components/features/settings/index.ts
+++ b/apps/desktop/src/components/features/settings/index.ts
@@ -11,4 +11,8 @@ export {
   toRoleVariantOptions,
   updatePromptOverrideTemplate,
 } from "./settings-modal-model";
-export { hasConfiguredHookCommands, parseHookLines } from "./settings-model";
+export {
+  hasConfiguredHookCommands,
+  normalizeHooksWithTrust,
+  parseHookLines,
+} from "./settings-model";

--- a/apps/desktop/src/components/features/settings/index.ts
+++ b/apps/desktop/src/components/features/settings/index.ts
@@ -11,4 +11,4 @@ export {
   toRoleVariantOptions,
   updatePromptOverrideTemplate,
 } from "./settings-modal-model";
-export { parseHookLines } from "./settings-model";
+export { hasConfiguredHookCommands, parseHookLines } from "./settings-model";

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
@@ -176,6 +176,45 @@ describe("settings-modal-normalization", () => {
         profileId: "spec",
       },
     });
+    expect(normalized.trustedHooks).toBe(true);
+    expect(normalized.trustedHooksFingerprint).toBe("fingerprint");
+  });
+
+  test("disables trusted hooks when no hook commands remain after normalization", () => {
+    const normalized = normalizeRepoConfigForSave({
+      ...createRepoConfig(),
+      trustedHooks: true,
+      trustedHooksFingerprint: "fingerprint",
+      hooks: {
+        preStart: ["   "],
+        postComplete: [""],
+      },
+    });
+
+    expect(normalized.hooks).toEqual({
+      preStart: [],
+      postComplete: [],
+    });
+    expect(normalized.trustedHooks).toBe(false);
+    expect(normalized.trustedHooksFingerprint).toBeUndefined();
+  });
+
+  test("preserves explicit untrusted hooks when normalized hook commands exist", () => {
+    const normalized = normalizeRepoConfigForSave({
+      ...createRepoConfig(),
+      trustedHooks: false,
+      trustedHooksFingerprint: undefined,
+      hooks: {
+        preStart: [" bun install "],
+        postComplete: [],
+      },
+    });
+
+    expect(normalized.hooks).toEqual({
+      preStart: ["bun install"],
+      postComplete: [],
+    });
+    expect(normalized.trustedHooks).toBe(false);
   });
 
   test("normalizes snapshot repo map and global prompt overrides", () => {

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
@@ -5,7 +5,10 @@ import type {
   RepoPromptOverrides,
   SettingsSnapshot,
 } from "@openducktor/contracts";
-import { DEFAULT_BRANCH_PREFIX } from "@/components/features/settings/settings-model";
+import {
+  DEFAULT_BRANCH_PREFIX,
+  hasConfiguredHookCommands,
+} from "@/components/features/settings/settings-model";
 import { normalizeTargetBranch } from "@/lib/target-branch";
 import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 
@@ -68,6 +71,11 @@ export const normalizeRepoConfigForSave = (repo: RepoConfig): RepoConfig => {
   const planner = normalizeAgentDefaultForSave(repo.agentDefaults.planner);
   const build = normalizeAgentDefaultForSave(repo.agentDefaults.build);
   const qa = normalizeAgentDefaultForSave(repo.agentDefaults.qa);
+  const hooks = {
+    preStart: repo.hooks.preStart.map((entry) => entry.trim()).filter(Boolean),
+    postComplete: repo.hooks.postComplete.map((entry) => entry.trim()).filter(Boolean),
+  };
+  const trustedHooks = hasConfiguredHookCommands(hooks) ? repo.trustedHooks : false;
 
   return {
     defaultRuntimeKind: repo.defaultRuntimeKind ?? DEFAULT_RUNTIME_KIND,
@@ -75,12 +83,9 @@ export const normalizeRepoConfigForSave = (repo: RepoConfig): RepoConfig => {
     branchPrefix: trimNonEmpty(repo.branchPrefix) ?? DEFAULT_BRANCH_PREFIX,
     defaultTargetBranch: normalizeTargetBranch(repo.defaultTargetBranch),
     git: repo.git,
-    trustedHooks: repo.trustedHooks,
-    trustedHooksFingerprint: repo.trustedHooksFingerprint,
-    hooks: {
-      preStart: repo.hooks.preStart.map((entry) => entry.trim()).filter(Boolean),
-      postComplete: repo.hooks.postComplete.map((entry) => entry.trim()).filter(Boolean),
-    },
+    trustedHooks,
+    trustedHooksFingerprint: trustedHooks ? repo.trustedHooksFingerprint : undefined,
+    hooks,
     worktreeFileCopies: repo.worktreeFileCopies.map((entry) => entry.trim()).filter(Boolean),
     promptOverrides: normalizePromptOverridesForSave(repo.promptOverrides),
     agentDefaults: {

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
@@ -7,7 +7,7 @@ import type {
 } from "@openducktor/contracts";
 import {
   DEFAULT_BRANCH_PREFIX,
-  hasConfiguredHookCommands,
+  normalizeHooksWithTrust,
 } from "@/components/features/settings/settings-model";
 import { normalizeTargetBranch } from "@/lib/target-branch";
 import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
@@ -71,11 +71,7 @@ export const normalizeRepoConfigForSave = (repo: RepoConfig): RepoConfig => {
   const planner = normalizeAgentDefaultForSave(repo.agentDefaults.planner);
   const build = normalizeAgentDefaultForSave(repo.agentDefaults.build);
   const qa = normalizeAgentDefaultForSave(repo.agentDefaults.qa);
-  const hooks = {
-    preStart: repo.hooks.preStart.map((entry) => entry.trim()).filter(Boolean),
-    postComplete: repo.hooks.postComplete.map((entry) => entry.trim()).filter(Boolean),
-  };
-  const trustedHooks = hasConfiguredHookCommands(hooks) ? repo.trustedHooks : false;
+  const { hooks, trustedHooks } = normalizeHooksWithTrust(repo.hooks, repo.trustedHooks);
 
   return {
     defaultRuntimeKind: repo.defaultRuntimeKind ?? DEFAULT_RUNTIME_KIND,

--- a/apps/desktop/src/components/features/settings/settings-model.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-model.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { hasConfiguredHookCommands, parseHookLines } from "./settings-model";
+
+describe("settings-model", () => {
+  test("parseHookLines preserves blank lines while trimming entered commands", () => {
+    expect(parseHookLines(" bun install \n\n npm test \n")).toEqual([
+      "bun install",
+      "",
+      "npm test",
+      "",
+    ]);
+  });
+
+  test("hasConfiguredHookCommands ignores blank draft rows", () => {
+    expect(
+      hasConfiguredHookCommands({
+        preStart: ["", ""],
+        postComplete: [""],
+      }),
+    ).toBe(false);
+
+    expect(
+      hasConfiguredHookCommands({
+        preStart: ["bun install", ""],
+        postComplete: [],
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/components/features/settings/settings-model.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-model.test.ts
@@ -6,11 +6,11 @@ import {
 } from "./settings-model";
 
 describe("settings-model", () => {
-  test("parseHookLines preserves blank lines while trimming entered commands", () => {
+  test("parseHookLines preserves blank lines and raw spacing while editing", () => {
     expect(parseHookLines(" bun install \n\n npm test \n")).toEqual([
-      "bun install",
+      " bun install ",
       "",
-      "npm test",
+      " npm test ",
       "",
     ]);
   });

--- a/apps/desktop/src/components/features/settings/settings-model.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-model.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { hasConfiguredHookCommands, parseHookLines } from "./settings-model";
+import {
+  hasConfiguredHookCommands,
+  normalizeHooksWithTrust,
+  parseHookLines,
+} from "./settings-model";
 
 describe("settings-model", () => {
   test("parseHookLines preserves blank lines while trimming entered commands", () => {
@@ -25,5 +29,46 @@ describe("settings-model", () => {
         postComplete: [],
       }),
     ).toBe(true);
+
+    expect(
+      hasConfiguredHookCommands({
+        preStart: ["   "],
+        postComplete: [],
+      }),
+    ).toBe(false);
+  });
+
+  test("normalizeHooksWithTrust trims commands and disables trust when commands are empty", () => {
+    expect(
+      normalizeHooksWithTrust(
+        {
+          preStart: [" bun install ", " "],
+          postComplete: ["npm test"],
+        },
+        true,
+      ),
+    ).toEqual({
+      hooks: {
+        preStart: ["bun install"],
+        postComplete: ["npm test"],
+      },
+      trustedHooks: true,
+    });
+
+    expect(
+      normalizeHooksWithTrust(
+        {
+          preStart: [" "],
+          postComplete: [""],
+        },
+        true,
+      ),
+    ).toEqual({
+      hooks: {
+        preStart: [],
+        postComplete: [],
+      },
+      trustedHooks: false,
+    });
   });
 });

--- a/apps/desktop/src/components/features/settings/settings-model.ts
+++ b/apps/desktop/src/components/features/settings/settings-model.ts
@@ -1,11 +1,33 @@
 export { DEFAULT_BRANCH_PREFIX } from "@openducktor/contracts";
 
+type HookDraftInput = {
+  preStart: string[];
+  postComplete: string[];
+};
+
+// Preserve blank draft rows so controlled multi-line inputs do not collapse trailing newlines
+// while the user is still editing. Save-time normalization removes blank commands.
 export const parseHookLines = (value: string): string[] =>
   value.split("\n").map((entry) => entry.trim());
 
-export const hasConfiguredHookCommands = (hooks: {
-  preStart: string[];
-  postComplete: string[];
-}): boolean =>
-  hooks.preStart.some((entry) => entry.length > 0) ||
-  hooks.postComplete.some((entry) => entry.length > 0);
+const normalizeHookCommands = (commands: string[]): string[] =>
+  commands.map((entry) => entry.trim()).filter(Boolean);
+
+export const hasConfiguredHookCommands = (hooks: HookDraftInput): boolean =>
+  hooks.preStart.some((entry) => entry.trim().length > 0) ||
+  hooks.postComplete.some((entry) => entry.trim().length > 0);
+
+export const normalizeHooksWithTrust = (
+  hooks: HookDraftInput,
+  trustedHooks: boolean,
+): { hooks: HookDraftInput; trustedHooks: boolean } => {
+  const normalizedHooks = {
+    preStart: normalizeHookCommands(hooks.preStart),
+    postComplete: normalizeHookCommands(hooks.postComplete),
+  };
+
+  return {
+    hooks: normalizedHooks,
+    trustedHooks: hasConfiguredHookCommands(normalizedHooks) ? trustedHooks : false,
+  };
+};

--- a/apps/desktop/src/components/features/settings/settings-model.ts
+++ b/apps/desktop/src/components/features/settings/settings-model.ts
@@ -5,10 +5,10 @@ type HookDraftInput = {
   postComplete: string[];
 };
 
-// Preserve blank draft rows so controlled multi-line inputs do not collapse trailing newlines
-// while the user is still editing. Save-time normalization removes blank commands.
-export const parseHookLines = (value: string): string[] =>
-  value.split("\n").map((entry) => entry.trim());
+// Preserve blank draft rows and raw spacing so controlled multi-line inputs do not collapse
+// trailing newlines or strip characters while the user is still editing. Save-time
+// normalization removes blank commands and trims persisted values.
+export const parseHookLines = (value: string): string[] => value.split("\n");
 
 const normalizeHookCommands = (commands: string[]): string[] =>
   commands.map((entry) => entry.trim()).filter(Boolean);

--- a/apps/desktop/src/components/features/settings/settings-model.ts
+++ b/apps/desktop/src/components/features/settings/settings-model.ts
@@ -1,7 +1,11 @@
 export { DEFAULT_BRANCH_PREFIX } from "@openducktor/contracts";
 
 export const parseHookLines = (value: string): string[] =>
-  value
-    .split("\n")
-    .map((entry) => entry.trim())
-    .filter(Boolean);
+  value.split("\n").map((entry) => entry.trim());
+
+export const hasConfiguredHookCommands = (hooks: {
+  preStart: string[];
+  postComplete: string[];
+}): boolean =>
+  hooks.preStart.some((entry) => entry.length > 0) ||
+  hooks.postComplete.some((entry) => entry.length > 0);

--- a/apps/desktop/src/components/features/settings/settings-repository-configuration-section.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-repository-configuration-section.test.tsx
@@ -97,6 +97,7 @@ describe("RepositoryConfigurationSection", () => {
       {
         ...baseRepoConfig,
         trustedHooks: true,
+        trustedHooksFingerprint: "fingerprint",
         hooks: {
           preStart: ["bun install"],
           postComplete: [],
@@ -125,6 +126,7 @@ describe("RepositoryConfigurationSection", () => {
         updater({
           ...baseRepoConfig,
           trustedHooks: true,
+          trustedHooksFingerprint: "fingerprint",
           hooks: {
             preStart: ["bun install"],
             postComplete: [],
@@ -133,6 +135,7 @@ describe("RepositoryConfigurationSection", () => {
       ).toEqual({
         ...baseRepoConfig,
         trustedHooks: false,
+        trustedHooksFingerprint: undefined,
         hooks: {
           preStart: [""],
           postComplete: [],

--- a/apps/desktop/src/components/features/settings/settings-repository-configuration-section.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-repository-configuration-section.test.tsx
@@ -1,0 +1,145 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { GitBranch, RepoConfig } from "@openducktor/contracts";
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+import { RepositoryConfigurationSection } from "./settings-repository-configuration-section";
+
+enableReactActEnvironment();
+
+const baseRepoConfig: RepoConfig = {
+  defaultRuntimeKind: "opencode",
+  worktreeBasePath: undefined,
+  branchPrefix: "odt",
+  defaultTargetBranch: { remote: "origin", branch: "main" },
+  git: { providers: {} },
+  trustedHooks: false,
+  trustedHooksFingerprint: undefined,
+  hooks: {
+    preStart: [],
+    postComplete: [],
+  },
+  worktreeFileCopies: [],
+  promptOverrides: {},
+  agentDefaults: {},
+};
+
+const renderSection = (
+  selectedRepoConfig: RepoConfig,
+  onUpdateSelectedRepoConfig: (updater: (current: RepoConfig) => RepoConfig) => void,
+): ReturnType<typeof create> => {
+  let renderer!: ReturnType<typeof create>;
+
+  act(() => {
+    renderer = create(
+      createElement(RepositoryConfigurationSection, {
+        selectedRepoConfig,
+        selectedRepoEffectiveWorktreeBasePath: null,
+        selectedRepoBranches: [] as GitBranch[],
+        selectedRepoBranchesError: null,
+        isLoadingSettings: false,
+        isSaving: false,
+        isPickingWorktreeBasePath: false,
+        isLoadingSelectedRepoBranches: false,
+        onRetrySelectedRepoBranchesLoad: () => {},
+        onPickWorktreeBasePath: async () => {},
+        onUpdateSelectedRepoConfig,
+      }),
+    );
+  });
+
+  return renderer;
+};
+
+describe("RepositoryConfigurationSection", () => {
+  test("marks scripts as trusted when a script command is entered", () => {
+    const updaters: Array<(current: RepoConfig) => RepoConfig> = [];
+    const onUpdateSelectedRepoConfig = mock((updater: (current: RepoConfig) => RepoConfig) => {
+      updaters.push(updater);
+    });
+    const renderer = renderSection(baseRepoConfig, onUpdateSelectedRepoConfig);
+
+    try {
+      const preStartTextarea = renderer.root.findByProps({ id: "repo-pre-start-hooks" });
+
+      act(() => {
+        preStartTextarea.props.onChange({
+          currentTarget: {
+            value: "bun install\n",
+          },
+        });
+      });
+
+      const updater = updaters[0];
+      if (!updater) {
+        throw new Error("Expected repo config updater");
+      }
+
+      expect(updater(baseRepoConfig)).toEqual({
+        ...baseRepoConfig,
+        trustedHooks: true,
+        hooks: {
+          preStart: ["bun install", ""],
+          postComplete: [],
+        },
+      });
+    } finally {
+      renderer.unmount();
+    }
+  });
+
+  test("clears trust when both script fields become empty", () => {
+    const updaters: Array<(current: RepoConfig) => RepoConfig> = [];
+    const onUpdateSelectedRepoConfig = mock((updater: (current: RepoConfig) => RepoConfig) => {
+      updaters.push(updater);
+    });
+    const renderer = renderSection(
+      {
+        ...baseRepoConfig,
+        trustedHooks: true,
+        hooks: {
+          preStart: ["bun install"],
+          postComplete: [],
+        },
+      },
+      onUpdateSelectedRepoConfig,
+    );
+
+    try {
+      const preStartTextarea = renderer.root.findByProps({ id: "repo-pre-start-hooks" });
+
+      act(() => {
+        preStartTextarea.props.onChange({
+          currentTarget: {
+            value: "",
+          },
+        });
+      });
+
+      const updater = updaters[0];
+      if (!updater) {
+        throw new Error("Expected repo config updater");
+      }
+
+      expect(
+        updater({
+          ...baseRepoConfig,
+          trustedHooks: true,
+          hooks: {
+            preStart: ["bun install"],
+            postComplete: [],
+          },
+        }),
+      ).toEqual({
+        ...baseRepoConfig,
+        trustedHooks: false,
+        hooks: {
+          preStart: [""],
+          postComplete: [],
+        },
+      });
+    } finally {
+      renderer.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/components/features/settings/settings-repository-configuration-section.tsx
+++ b/apps/desktop/src/components/features/settings/settings-repository-configuration-section.tsx
@@ -3,11 +3,10 @@ import { FolderOpen } from "lucide-react";
 import type { ReactElement } from "react";
 import { BranchSelector } from "@/components/features/repository/branch-selector";
 import { toBranchSelectorOptions } from "@/components/features/repository/branch-selector-model";
-import { parseHookLines } from "@/components/features/settings";
+import { hasConfiguredHookCommands, parseHookLines } from "@/components/features/settings";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { canonicalTargetBranch, targetBranchFromSelection } from "@/lib/target-branch";
 
@@ -169,24 +168,6 @@ export function RepositoryConfigurationSection({
         </div>
       </div>
 
-      <Label
-        htmlFor="repo-trusted-hooks"
-        className="flex items-center gap-2 text-sm text-foreground"
-      >
-        <Switch
-          id="repo-trusted-hooks"
-          checked={selectedRepoConfig.trustedHooks}
-          disabled={isLoadingSettings || isSaving}
-          onCheckedChange={(checked) =>
-            onUpdateSelectedRepoConfig((repoConfig) => ({
-              ...repoConfig,
-              trustedHooks: checked,
-            }))
-          }
-        />
-        Trust scripts for this repository
-      </Label>
-
       <div className="grid gap-3 md:grid-cols-2">
         <div className="grid gap-2">
           <Label htmlFor="repo-pre-start-hooks">Worktree setup script (one command per line)</Label>
@@ -197,15 +178,25 @@ export function RepositoryConfigurationSection({
             disabled={isLoadingSettings || isSaving}
             onChange={(event) => {
               const preStartHooksInput = event.currentTarget.value;
-              onUpdateSelectedRepoConfig((repoConfig) => ({
-                ...repoConfig,
-                hooks: {
+              const preStart = parseHookLines(preStartHooksInput);
+              onUpdateSelectedRepoConfig((repoConfig) => {
+                const hooks = {
                   ...repoConfig.hooks,
-                  preStart: parseHookLines(preStartHooksInput),
-                },
-              }));
+                  preStart,
+                };
+
+                return {
+                  ...repoConfig,
+                  trustedHooks: hasConfiguredHookCommands(hooks),
+                  hooks,
+                };
+              });
             }}
           />
+          <p className="text-xs text-muted-foreground">
+            Saving configured scripts asks for confirmation automatically. Clear both script fields
+            to disable scripts for this repository.
+          </p>
         </div>
 
         <div className="grid gap-2">
@@ -219,13 +210,19 @@ export function RepositoryConfigurationSection({
             disabled={isLoadingSettings || isSaving}
             onChange={(event) => {
               const postCompleteHooksInput = event.currentTarget.value;
-              onUpdateSelectedRepoConfig((repoConfig) => ({
-                ...repoConfig,
-                hooks: {
+              const postComplete = parseHookLines(postCompleteHooksInput);
+              onUpdateSelectedRepoConfig((repoConfig) => {
+                const hooks = {
                   ...repoConfig.hooks,
-                  postComplete: parseHookLines(postCompleteHooksInput),
-                },
-              }));
+                  postComplete,
+                };
+
+                return {
+                  ...repoConfig,
+                  trustedHooks: hasConfiguredHookCommands(hooks),
+                  hooks,
+                };
+              });
             }}
           />
         </div>

--- a/apps/desktop/src/components/features/settings/settings-repository-configuration-section.tsx
+++ b/apps/desktop/src/components/features/settings/settings-repository-configuration-section.tsx
@@ -73,6 +73,23 @@ export function RepositoryConfigurationSection({
     : selectedRepoBranchesError
       ? "Branches unavailable"
       : "Select branch...";
+  const updateHookDraft = (key: "preStart" | "postComplete", value: string): void => {
+    const nextHookLines = parseHookLines(value);
+    onUpdateSelectedRepoConfig((repoConfig) => {
+      const hooks = {
+        ...repoConfig.hooks,
+        [key]: nextHookLines,
+      };
+      const trustedHooks = hasConfiguredHookCommands(hooks);
+
+      return {
+        ...repoConfig,
+        trustedHooks,
+        trustedHooksFingerprint: trustedHooks ? repoConfig.trustedHooksFingerprint : undefined,
+        hooks,
+      };
+    });
+  };
 
   return (
     <div className="grid gap-4 p-4">
@@ -176,22 +193,7 @@ export function RepositoryConfigurationSection({
             rows={4}
             value={selectedRepoConfig.hooks.preStart.join("\n")}
             disabled={isLoadingSettings || isSaving}
-            onChange={(event) => {
-              const preStartHooksInput = event.currentTarget.value;
-              const preStart = parseHookLines(preStartHooksInput);
-              onUpdateSelectedRepoConfig((repoConfig) => {
-                const hooks = {
-                  ...repoConfig.hooks,
-                  preStart,
-                };
-
-                return {
-                  ...repoConfig,
-                  trustedHooks: hasConfiguredHookCommands(hooks),
-                  hooks,
-                };
-              });
-            }}
+            onChange={(event) => updateHookDraft("preStart", event.currentTarget.value)}
           />
           <p className="text-xs text-muted-foreground">
             Saving configured scripts asks for confirmation automatically. Clear both script fields
@@ -208,22 +210,7 @@ export function RepositoryConfigurationSection({
             rows={4}
             value={selectedRepoConfig.hooks.postComplete.join("\n")}
             disabled={isLoadingSettings || isSaving}
-            onChange={(event) => {
-              const postCompleteHooksInput = event.currentTarget.value;
-              const postComplete = parseHookLines(postCompleteHooksInput);
-              onUpdateSelectedRepoConfig((repoConfig) => {
-                const hooks = {
-                  ...repoConfig.hooks,
-                  postComplete,
-                };
-
-                return {
-                  ...repoConfig,
-                  trustedHooks: hasConfiguredHookCommands(hooks),
-                  hooks,
-                };
-              });
-            }}
+            onChange={(event) => updateHookDraft("postComplete", event.currentTarget.value)}
           />
         </div>
       </div>

--- a/apps/desktop/src/components/features/settings/settings-repository-configuration-section.tsx
+++ b/apps/desktop/src/components/features/settings/settings-repository-configuration-section.tsx
@@ -1,5 +1,5 @@
 import type { GitBranch, RepoConfig } from "@openducktor/contracts";
-import { FolderOpen } from "lucide-react";
+import { CircleAlert, FolderOpen } from "lucide-react";
 import type { ReactElement } from "react";
 import { BranchSelector } from "@/components/features/repository/branch-selector";
 import { toBranchSelectorOptions } from "@/components/features/repository/branch-selector-model";
@@ -211,10 +211,15 @@ export function RepositoryConfigurationSection({
         </div>
       </div>
 
-      <p className="text-xs text-muted-foreground">
-        Saving configured scripts asks for confirmation automatically. Clear both script fields to
-        disable scripts for this repository.
-      </p>
+      <div className="flex items-center gap-3 rounded-md border border-info-border bg-info-surface p-3 text-sm text-info-surface-foreground">
+        <CircleAlert className="mt-0.5 size-4 shrink-0 text-info-muted" aria-hidden="true" />
+        <p className="leading-6">
+          OpenDucktor saves a fingerprint of the exact script commands you approve. This is a
+          security check: if something changes those scripts later without your consent, the
+          fingerprint no longer matches and OpenDucktor will ask you to confirm the scripts again
+          before they can run. Clear both script fields to disable scripts for this repository.
+        </p>
+      </div>
 
       <div className="grid gap-2">
         <Label htmlFor="repo-worktree-file-copies">Worktree file copies (one path per line)</Label>

--- a/apps/desktop/src/components/features/settings/settings-repository-configuration-section.tsx
+++ b/apps/desktop/src/components/features/settings/settings-repository-configuration-section.tsx
@@ -195,10 +195,6 @@ export function RepositoryConfigurationSection({
             disabled={isLoadingSettings || isSaving}
             onChange={(event) => updateHookDraft("preStart", event.currentTarget.value)}
           />
-          <p className="text-xs text-muted-foreground">
-            Saving configured scripts asks for confirmation automatically. Clear both script fields
-            to disable scripts for this repository.
-          </p>
         </div>
 
         <div className="grid gap-2">
@@ -214,6 +210,11 @@ export function RepositoryConfigurationSection({
           />
         </div>
       </div>
+
+      <p className="text-xs text-muted-foreground">
+        Saving configured scripts asks for confirmation automatically. Clear both script fields to
+        disable scripts for this repository.
+      </p>
 
       <div className="grid gap-2">
         <Label htmlFor="repo-worktree-file-copies">Worktree file copies (one path per line)</Label>

--- a/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -341,6 +341,61 @@ describe("use-repo-settings-operations", () => {
     }
   });
 
+  test("saveRepoSettings preserves explicit untrusted hook settings", async () => {
+    const applyWorkspaceRecords = mock(() => {});
+    const applyWorkspaceRecord = mock(() => {});
+    const workspaceSaveRepoSettings = mock(async () => createWorkspaceRecord());
+
+    const original = {
+      workspaceSaveRepoSettings: host.workspaceSaveRepoSettings,
+    };
+    host.workspaceSaveRepoSettings = workspaceSaveRepoSettings;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      applyWorkspaceRecords,
+      applyWorkspaceRecord,
+    });
+
+    try {
+      await harness.mount();
+      await harness.getLatest().saveRepoSettings({
+        ...inputFixture,
+        trustedHooks: false,
+      });
+
+      expect(workspaceSaveRepoSettings).toHaveBeenCalledWith("/repo-a", {
+        defaultRuntimeKind: "opencode" as const,
+        worktreeBasePath: "/tmp/worktrees",
+        branchPrefix: "codex/",
+        defaultTargetBranch: { remote: "origin", branch: "develop" },
+        trustedHooks: false,
+        hooks: {
+          preStart: ["echo pre"],
+          postComplete: ["echo post"],
+        },
+        worktreeFileCopies: [".env", ".env.local"],
+        agentDefaults: {
+          spec: {
+            runtimeKind: "opencode",
+            providerId: "openai",
+            modelId: "gpt-5",
+            variant: "mini",
+            profileId: "spec",
+          },
+          qa: {
+            runtimeKind: "opencode",
+            providerId: "anthropic",
+            modelId: "claude-4",
+          },
+        },
+      });
+    } finally {
+      await harness.unmount();
+      host.workspaceSaveRepoSettings = original.workspaceSaveRepoSettings;
+    }
+  });
+
   test("supports retry after update failure and preserves refresh invariant", async () => {
     const applyWorkspaceRecords = mock(() => {});
     const applyWorkspaceRecord = mock(() => {});

--- a/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.ts
+++ b/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.ts
@@ -6,7 +6,7 @@ import type {
 } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { hasConfiguredHookCommands } from "@/components/features/settings";
+import { normalizeHooksWithTrust } from "@/components/features/settings";
 import { normalizeTargetBranch } from "@/lib/target-branch";
 import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 import type { RepoAgentDefaultInput, RepoSettingsInput } from "@/types/state-slices";
@@ -89,10 +89,13 @@ export function useRepoSettingsOperations({
       const normalizedWorktreeBasePath = input.worktreeBasePath.trim();
       const normalizedBranchPrefix = input.branchPrefix.trim();
       const normalizedTargetBranch = normalizeTargetBranch(input.defaultTargetBranch);
-      const hooks = {
-        preStart: input.preStartHooks.map((entry) => entry.trim()).filter(Boolean),
-        postComplete: input.postCompleteHooks.map((entry) => entry.trim()).filter(Boolean),
-      };
+      const { hooks, trustedHooks } = normalizeHooksWithTrust(
+        {
+          preStart: input.preStartHooks,
+          postComplete: input.postCompleteHooks,
+        },
+        input.trustedHooks,
+      );
       const agentDefaults = {
         ...(specDefault ? { spec: specDefault } : {}),
         ...(plannerDefault ? { planner: plannerDefault } : {}),
@@ -105,7 +108,7 @@ export function useRepoSettingsOperations({
         worktreeBasePath: normalizedWorktreeBasePath,
         branchPrefix: normalizedBranchPrefix,
         defaultTargetBranch: normalizedTargetBranch,
-        trustedHooks: hasConfiguredHookCommands(hooks) ? input.trustedHooks : false,
+        trustedHooks,
         hooks,
         worktreeFileCopies: input.worktreeFileCopies.map((f) => f.trim()).filter(Boolean),
         agentDefaults,

--- a/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.ts
+++ b/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.ts
@@ -6,6 +6,7 @@ import type {
 } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import { hasConfiguredHookCommands } from "@/components/features/settings";
 import { normalizeTargetBranch } from "@/lib/target-branch";
 import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 import type { RepoAgentDefaultInput, RepoSettingsInput } from "@/types/state-slices";
@@ -88,6 +89,10 @@ export function useRepoSettingsOperations({
       const normalizedWorktreeBasePath = input.worktreeBasePath.trim();
       const normalizedBranchPrefix = input.branchPrefix.trim();
       const normalizedTargetBranch = normalizeTargetBranch(input.defaultTargetBranch);
+      const hooks = {
+        preStart: input.preStartHooks.map((entry) => entry.trim()).filter(Boolean),
+        postComplete: input.postCompleteHooks.map((entry) => entry.trim()).filter(Boolean),
+      };
       const agentDefaults = {
         ...(specDefault ? { spec: specDefault } : {}),
         ...(plannerDefault ? { planner: plannerDefault } : {}),
@@ -100,11 +105,8 @@ export function useRepoSettingsOperations({
         worktreeBasePath: normalizedWorktreeBasePath,
         branchPrefix: normalizedBranchPrefix,
         defaultTargetBranch: normalizedTargetBranch,
-        trustedHooks: input.trustedHooks,
-        hooks: {
-          preStart: input.preStartHooks,
-          postComplete: input.postCompleteHooks,
-        },
+        trustedHooks: hasConfiguredHookCommands(hooks) ? input.trustedHooks : false,
+        hooks,
         worktreeFileCopies: input.worktreeFileCopies.map((f) => f.trim()).filter(Boolean),
         agentDefaults,
       });


### PR DESCRIPTION
## Summary

- remove the manual worktree script trust switch from repository settings and derive draft trust from active script edits
- preserve explicit untrusted hook configs during snapshot/workspace normalization so unrelated saves do not trigger trust confirmation, especially in browser mode
- fix multiline script editing by preserving blank draft rows until save-time normalization
- out of scope: adding a dedicated "confirm existing untrusted scripts" affordance for repos that already have scripts saved with `trustedHooks=false`

## Testing

- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] `bun run test`
- [ ] `bun run build`
- [ ] `bun run check:rust`
- [ ] `bun run test:rust`
- [ ] Not applicable

Focused checks run:
- `bun run --filter @openducktor/desktop test src/components/features/settings/settings-model.test.ts src/components/features/settings/settings-modal-normalization.test.ts src/components/features/settings/settings-repository-configuration-section.test.tsx src/components/features/settings/use-settings-modal-controller.test.tsx src/state/operations/workspace/use-repo-settings-operations.test.tsx`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`

## Checklist

- [ ] I updated docs when behavior, workflows, runtime contracts, or setup changed
- [x] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [ ] I linked related issues or context below

## Related Issues

Closes #

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes are described below

## Additional Context

- Browser/headless mode still cannot approve trusted scripts because it cannot open the native confirmation dialog. This PR only removes the regression where unrelated snapshot saves would start requiring that approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook scripts now auto-toggle trust based on configured commands; clearing both script fields disables trust. Parsing preserves blank lines in hook editors, and commands are trimmed/normalized on save. Repository-level trust switch removed; informational alert added explaining fingerprint/confirmation behavior.
* **Bug Fixes**
  * Stored trust state and fingerprint now reflect normalized hook commands and are cleared when scripts are unconfigured.
* **Tests**
  * Added coverage for parsing, normalization, trust logic, UI updates, and saving repo settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->