### PR TITLE
feat(kanban): sort tasks with active sessions to top of lanes

### DIFF
--- a/apps/desktop/src/pages/kanban/use-kanban-board-model.test.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-board-model.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import type { RunSummary } from "@openducktor/contracts";
+import type { RunSummary, TaskCard } from "@openducktor/contracts";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { buildActiveSessionsByTaskId, buildRunStateByTaskId } from "./use-kanban-board-model";
+import {
+  buildActiveSessionsByTaskId,
+  buildRunStateByTaskId,
+  sortTasksByActiveSession,
+} from "./use-kanban-board-model";
 
 const createRun = (overrides: Partial<RunSummary> = {}): RunSummary => ({
   runId: "run-1",
@@ -18,6 +22,37 @@ const createRun = (overrides: Partial<RunSummary> = {}): RunSummary => ({
   state: "running",
   lastMessage: null,
   startedAt: "2026-03-17T10:00:00.000Z",
+  ...overrides,
+});
+
+const createTaskCard = (overrides: Partial<TaskCard> = {}): TaskCard => ({
+  id: "task-1",
+  title: "Test Task",
+  description: "",
+  notes: "",
+  status: "in_progress",
+  priority: 2,
+  issueType: "task",
+  aiReviewEnabled: true,
+  availableActions: [],
+  labels: [],
+  assignee: undefined,
+  parentId: undefined,
+  subtaskIds: [],
+  pullRequest: undefined,
+  documentSummary: {
+    spec: { has: false },
+    plan: { has: false },
+    qaReport: { has: false, verdict: "not_reviewed" },
+  },
+  agentWorkflows: {
+    spec: { required: false, canSkip: true, available: false, completed: false },
+    planner: { required: false, canSkip: true, available: false, completed: false },
+    builder: { required: true, canSkip: false, available: false, completed: false },
+    qa: { required: false, canSkip: true, available: false, completed: false },
+  },
+  updatedAt: "2026-03-17T10:00:00.000Z",
+  createdAt: "2026-03-17T10:00:00.000Z",
   ...overrides,
 });
 
@@ -102,5 +137,64 @@ describe("use-kanban-board-model helpers", () => {
       "session-running-older",
       "session-starting",
     ]);
+  });
+
+  test("sortTasksByActiveSession puts active tasks above inactive tasks", () => {
+    const tasks = [
+      createTaskCard({ id: "task-no-session" }),
+      createTaskCard({ id: "task-with-session" }),
+      createTaskCard({ id: "task-another-no-session" }),
+    ];
+    const activeSessionsByTaskId = new Map<string, AgentSessionState[]>([
+      ["task-with-session", [createSession({ taskId: "task-with-session" })]],
+    ]);
+
+    const sorted = sortTasksByActiveSession(tasks, activeSessionsByTaskId);
+
+    expect(sorted.map((t) => t.id)).toEqual([
+      "task-with-session",
+      "task-no-session",
+      "task-another-no-session",
+    ]);
+  });
+
+  test("sortTasksByActiveSession preserves relative order within groups (stable sort)", () => {
+    const tasks = [
+      createTaskCard({ id: "task-1-no-session" }),
+      createTaskCard({ id: "task-2-with-session" }),
+      createTaskCard({ id: "task-3-no-session" }),
+      createTaskCard({ id: "task-4-with-session" }),
+    ];
+    const activeSessionsByTaskId = new Map<string, AgentSessionState[]>([
+      ["task-2-with-session", [createSession({ taskId: "task-2-with-session" })]],
+      ["task-4-with-session", [createSession({ taskId: "task-4-with-session" })]],
+    ]);
+
+    const sorted = sortTasksByActiveSession(tasks, activeSessionsByTaskId);
+
+    expect(sorted.map((t) => t.id)).toEqual([
+      "task-2-with-session",
+      "task-4-with-session",
+      "task-1-no-session",
+      "task-3-no-session",
+    ]);
+  });
+
+  test("sortTasksByActiveSession handles empty columns gracefully", () => {
+    const tasks: TaskCard[] = [];
+    const activeSessionsByTaskId = new Map<string, AgentSessionState[]>();
+
+    const sorted = sortTasksByActiveSession(tasks, activeSessionsByTaskId);
+
+    expect(sorted).toEqual([]);
+  });
+
+  test("sortTasksByActiveSession handles no active sessions gracefully", () => {
+    const tasks = [createTaskCard({ id: "task-1" }), createTaskCard({ id: "task-2" })];
+    const activeSessionsByTaskId = new Map<string, AgentSessionState[]>();
+
+    const sorted = sortTasksByActiveSession(tasks, activeSessionsByTaskId);
+
+    expect(sorted.map((t) => t.id)).toEqual(["task-1", "task-2"]);
   });
 });

--- a/apps/desktop/src/pages/kanban/use-kanban-board-model.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-board-model.ts
@@ -44,6 +44,14 @@ export const buildRunStateByTaskId = (runs: RunSummary[]): Map<string, RunSummar
   );
 };
 
+export const sortTasksByActiveSession = (
+  tasks: TaskCard[],
+  activeSessionsByTaskId: Map<string, AgentSessionState[]>,
+): TaskCard[] => {
+  const hasActive = (task: TaskCard) => activeSessionsByTaskId.has(task.id);
+  return [...tasks].sort((a, b) => Number(hasActive(b)) - Number(hasActive(a)));
+};
+
 export const buildActiveSessionsByTaskId = (
   sessions: AgentSessionState[],
 ): Map<string, AgentSessionState[]> => {
@@ -107,10 +115,19 @@ export function useKanbanBoardModel({
 
   const activeSessionsByTaskId = useMemo(() => buildActiveSessionsByTaskId(sessions), [sessions]);
 
+  const columnsWithSortedTasks = useMemo(
+    () =>
+      columns.map((col) => ({
+        ...col,
+        tasks: sortTasksByActiveSession(col.tasks, activeSessionsByTaskId),
+      })),
+    [columns, activeSessionsByTaskId],
+  );
+
   return {
     isLoadingTasks,
     isSwitchingWorkspace,
-    columns,
+    columns: columnsWithSortedTasks,
     runStateByTaskId,
     activeSessionsByTaskId,
     onOpenDetails,

--- a/apps/desktop/src/pages/kanban/use-kanban-board-model.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-board-model.ts
@@ -44,12 +44,25 @@ export const buildRunStateByTaskId = (runs: RunSummary[]): Map<string, RunSummar
   );
 };
 
+/**
+ * Partitions tasks so that those with active sessions appear first, followed by those without.
+ * Uses O(N) single-pass partitioning instead of O(N log N) sorting.
+ * Relative order within each partition is preserved.
+ */
 export const sortTasksByActiveSession = (
   tasks: TaskCard[],
   activeSessionsByTaskId: Map<string, AgentSessionState[]>,
 ): TaskCard[] => {
-  const hasActive = (task: TaskCard) => activeSessionsByTaskId.has(task.id);
-  return [...tasks].sort((a, b) => Number(hasActive(b)) - Number(hasActive(a)));
+  const activeTasks: TaskCard[] = [];
+  const inactiveTasks: TaskCard[] = [];
+  for (const task of tasks) {
+    if (activeSessionsByTaskId.has(task.id)) {
+      activeTasks.push(task);
+    } else {
+      inactiveTasks.push(task);
+    }
+  }
+  return [...activeTasks, ...inactiveTasks];
 };
 
 export const buildActiveSessionsByTaskId = (


### PR DESCRIPTION
Sorts tasks within each kanban lane so that tasks with active agent sessions (`starting` or `running`) automatically appear at the top of their lane, before tasks without active sessions. This helps users quickly identify which tasks are being actively worked on, especially on boards with many tasks.

### Changes

`apps/desktop/src/pages/kanban/use-kanban-board-model.ts`
- Added `sortTasksByActiveSession` helper that uses `Map.has()` for O(1) active-session lookups
- Applied stable sort in `useKanbanBoardModel` hook via `columnsWithSortedTasks` memo
- Tasks with active sessions sort above inactive ones; relative order within groups is preserved

`apps/desktop/src/pages/kanban/use-kanban-board-model.test.ts`
- Added `createTaskCard` test factory
- Added 4 unit tests covering active/inactive sorting, stable sort preservation, and edge cases (empty columns, no active sessions)

### Verification

- All 6 tests pass
- `bun run typecheck` passes
- `bun run lint` passes

### Non-changes

- No changes to `KanbanColumn` or `KanbanTaskCard` rendering logic
- No changes to `buildActiveSessionsByTaskId` (already existed)
- Visual treatment of task cards remains unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Kanban board columns now prioritize tasks with active sessions, showing active tasks first and inactive tasks after, while preserving original ordering within each group.
* **Tests**
  * Added tests validating active-session sorting behavior, stability of ordering, handling of empty columns, and preserving order when no active sessions exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->