### PR TITLE
feat(tasks): add TaskIdBadge with copy-to-clipboard button

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.tsx
@@ -12,6 +12,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import { type ReactElement, useMemo, useState } from "react";
+import { TaskIdBadge } from "@/components/features/tasks/task-id-badge";
 import { Button } from "@/components/ui/button";
 import { CardHeader, CardTitle } from "@/components/ui/card";
 import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
@@ -229,9 +230,7 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
               </Button>
             ) : null}
           </div>
-          {hasTaskId ? (
-            <p className="font-mono text-[11px] text-muted-foreground">{normalizedTaskId}</p>
-          ) : null}
+          {hasTaskId ? <TaskIdBadge taskId={normalizedTaskId} /> : null}
         </div>
         <div className="flex min-w-56 max-w-full items-stretch gap-2 sm:min-w-[18rem]">
           <div className="min-w-0 flex-1">

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
@@ -348,11 +348,19 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
       ) : null}
 
       <div className="kanban-active-session-content flex min-w-0 flex-col space-y-2.5 p-3.5">
-        <button
-          type="button"
+        {/* biome-ignore lint/a11y/useSemanticElements: TaskIdBadge contains a button element */}
+        <div
+          role="button"
+          tabIndex={0}
           aria-label={`Open details for ${task.title}`}
           className="flex w-full min-w-0 cursor-pointer items-start justify-between gap-2 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
           onClick={() => onOpenDetails(task.id)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              onOpenDetails(task.id);
+            }
+          }}
         >
           <div className="min-w-0 space-y-1">
             <p
@@ -367,14 +375,11 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
             <ExternalLink className="size-3" />
             Open
           </span>
-        </button>
-
+        </div>
         <TaskMeta task={task} runState={visibleRunState} />
-
         {hasActiveSessions ? (
           <ActiveSessionsLine taskId={task.id} activeSessions={activeSessions} />
         ) : null}
-
         <TaskActions
           task={task}
           onPlan={onPlan}

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
@@ -356,6 +356,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
           className="flex w-full min-w-0 cursor-pointer items-start justify-between gap-2 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
           onClick={() => onOpenDetails(task.id)}
           onKeyDown={(e) => {
+            if (e.target !== e.currentTarget) return;
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
               onOpenDetails(task.id);
@@ -369,7 +370,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
             >
               {task.title}
             </p>
-            <TaskIdBadge taskId={task.id} className="truncate" />
+            <TaskIdBadge taskId={task.id} />
           </div>
           <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] text-muted-foreground transition group-hover:border-border group-hover:bg-muted group-hover:text-muted-foreground">
             <ExternalLink className="size-3" />

--- a/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
+++ b/apps/desktop/src/components/features/kanban/kanban-task-card.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/features/kanban/kanban-task-workflow";
 import { TaskWorkflowActionGroup } from "@/components/features/kanban/task-workflow-action-group";
 import { TaskPullRequestLink } from "@/components/features/task-pull-request-link";
+import { TaskIdBadge } from "@/components/features/tasks/task-id-badge";
 import { Badge } from "@/components/ui/badge";
 import { BorderRay } from "@/components/ui/border-ray";
 import { cn } from "@/lib/utils";
@@ -360,7 +361,7 @@ export const KanbanTaskCard = memo(function KanbanTaskCard({
             >
               {task.title}
             </p>
-            <p className="truncate font-mono text-[11px] text-muted-foreground">{task.id}</p>
+            <TaskIdBadge taskId={task.id} className="truncate" />
           </div>
           <span className="inline-flex shrink-0 items-center gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] text-muted-foreground transition group-hover:border-border group-hover:bg-muted group-hover:text-muted-foreground">
             <ExternalLink className="size-3" />

--- a/apps/desktop/src/components/features/task-details/task-details-sheet-header.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-header.tsx
@@ -3,6 +3,7 @@ import { Link2, Sparkles, Unlink } from "lucide-react";
 import type { ReactElement } from "react";
 import { IssueTypeBadge, PriorityBadge } from "@/components/features/kanban/kanban-task-badges";
 import { TaskPullRequestLink } from "@/components/features/task-pull-request-link";
+import { TaskIdBadge } from "@/components/features/tasks/task-id-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { canUnlinkTaskPullRequest, statusBadgeClassName, statusLabel } from "@/lib/task-display";
@@ -57,7 +58,7 @@ export function TaskDetailsSheetHeader({
               {task.title}
             </span>
           </h2>
-          <p className="truncate font-mono text-xs text-muted-foreground">{task.id}</p>
+          <TaskIdBadge taskId={task.id} />
         </div>
         <Badge variant="outline" className={statusBadgeClassName(task.status)}>
           {statusLabel(task.status)}

--- a/apps/desktop/src/components/features/task-details/task-details-subtasks.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-subtasks.tsx
@@ -30,7 +30,7 @@ export const TaskDetailsSubtasks = memo(
                     <p className="truncate text-sm font-semibold text-foreground">
                       {subtask.title}
                     </p>
-                    <TaskIdBadge taskId={subtask.id} className="mt-1 truncate" />
+                    <TaskIdBadge taskId={subtask.id} className="mt-1" />
                   </div>
                   <Badge variant="outline" className={statusBadgeClassName(subtask.status)}>
                     {statusLabel(subtask.status)}

--- a/apps/desktop/src/components/features/task-details/task-details-subtasks.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-subtasks.tsx
@@ -2,6 +2,7 @@ import type { TaskCard } from "@openducktor/contracts";
 import { GitBranch } from "lucide-react";
 import { memo, type ReactElement } from "react";
 import { IssueTypeBadge, PriorityBadge } from "@/components/features/kanban/kanban-task-badges";
+import { TaskIdBadge } from "@/components/features/tasks/task-id-badge";
 import { Badge } from "@/components/ui/badge";
 import { statusBadgeClassName, statusLabel } from "@/lib/task-display";
 
@@ -29,9 +30,7 @@ export const TaskDetailsSubtasks = memo(
                     <p className="truncate text-sm font-semibold text-foreground">
                       {subtask.title}
                     </p>
-                    <p className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
-                      {subtask.id}
-                    </p>
+                    <TaskIdBadge taskId={subtask.id} className="mt-1 truncate" />
                   </div>
                   <Badge variant="outline" className={statusBadgeClassName(subtask.status)}>
                     {statusLabel(subtask.status)}

--- a/apps/desktop/src/components/features/tasks/task-id-badge.test.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.test.tsx
@@ -1,13 +1,6 @@
-import { describe, expect, mock, test } from "bun:test";
-import { createElement, type ReactNode } from "react";
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-
-mock.module("@/components/ui/tooltip", () => ({
-  TooltipProvider: ({ children }: { children: ReactNode }) => createElement("div", null, children),
-  Tooltip: ({ children }: { children: ReactNode }) => createElement("div", null, children),
-  TooltipTrigger: ({ children }: { children: ReactNode }) => createElement("div", null, children),
-  TooltipContent: ({ children }: { children: ReactNode }) => createElement("div", null, children),
-}));
 
 import { TaskIdBadge } from "./task-id-badge";
 

--- a/apps/desktop/src/components/features/tasks/task-id-badge.test.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.test.tsx
@@ -26,11 +26,11 @@ describe("TaskIdBadge", () => {
     expect(html).toContain("truncate");
   });
 
-  test("renders copy button to the left of task ID", () => {
+  test("renders copy button to the right of task ID", () => {
     const html = renderToStaticMarkup(createElement(TaskIdBadge, { taskId: "TASK-ABC" }));
 
     const copyIndex = html.indexOf('data-testid="copy-task-id"');
     const taskIdIndex = html.indexOf("TASK-ABC");
-    expect(copyIndex).toBeLessThan(taskIdIndex);
+    expect(copyIndex).toBeGreaterThan(taskIdIndex);
   });
 });

--- a/apps/desktop/src/components/features/tasks/task-id-badge.test.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: ReactNode }) => createElement("div", null, children),
+  Tooltip: ({ children }: { children: ReactNode }) => createElement("div", null, children),
+  TooltipTrigger: ({ children }: { children: ReactNode }) => createElement("div", null, children),
+  TooltipContent: ({ children }: { children: ReactNode }) => createElement("div", null, children),
+}));
+
+import { TaskIdBadge } from "./task-id-badge";
+
+describe("TaskIdBadge", () => {
+  test("renders task ID in monospace font", () => {
+    const html = renderToStaticMarkup(createElement(TaskIdBadge, { taskId: "TASK-123" }));
+
+    expect(html).toContain("TASK-123");
+    expect(html).toContain("font-mono");
+  });
+
+  test("renders copy button with Copy icon", () => {
+    const html = renderToStaticMarkup(createElement(TaskIdBadge, { taskId: "TASK-456" }));
+
+    expect(html).toContain('data-testid="copy-task-id"');
+  });
+
+  test("applies custom className", () => {
+    const html = renderToStaticMarkup(
+      createElement(TaskIdBadge, { taskId: "TASK-789", className: "truncate" }),
+    );
+
+    expect(html).toContain("truncate");
+  });
+
+  test("renders copy button to the left of task ID", () => {
+    const html = renderToStaticMarkup(createElement(TaskIdBadge, { taskId: "TASK-ABC" }));
+
+    const copyIndex = html.indexOf('data-testid="copy-task-id"');
+    const taskIdIndex = html.indexOf("TASK-ABC");
+    expect(copyIndex).toBeLessThan(taskIdIndex);
+  });
+});

--- a/apps/desktop/src/components/features/tasks/task-id-badge.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.tsx
@@ -2,6 +2,7 @@ import { Check, Copy } from "lucide-react";
 import { memo, type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 type TaskIdBadgeProps = {
   taskId: string;
@@ -31,14 +32,16 @@ function TaskIdBadgeComponent({
         setCopied(true);
         toast.success("Copied!", { description: taskId });
       })
-      .catch(() => {
-        toast.error("Copy failed");
+      .catch((err) => {
+        console.error("[TaskIdBadge] Clipboard write failed:", err);
+        const message = err instanceof DOMException ? getClipboardErrorMessage(err) : "Copy failed";
+        toast.error(message);
       });
   };
 
   return (
-    <div className={`inline-flex items-center gap-1 ${className ?? ""}`}>
-      <span className="font-mono text-xs text-muted-foreground">{taskId}</span>
+    <div className={cn("inline-flex items-center gap-1", className)}>
+      <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">{taskId}</span>
       <Button
         type="button"
         variant="ghost"
@@ -49,13 +52,29 @@ function TaskIdBadgeComponent({
         aria-label="Copy task ID"
       >
         {copied ? (
-          <Check className="text-emerald-500" style={{ width: iconSize, height: iconSize }} />
+          <Check
+            className="text-emerald-500 dark:text-emerald-400"
+            style={{ width: iconSize, height: iconSize }}
+          />
         ) : (
           <Copy style={{ width: iconSize, height: iconSize }} />
         )}
       </Button>
     </div>
   );
+}
+
+function getClipboardErrorMessage(error: DOMException): string {
+  switch (error.name) {
+    case "NotAllowedError":
+      return "Permission denied: clipboard access not allowed";
+    case "NotFoundError":
+      return "No clipboard available in this environment";
+    case "AbortError":
+      return "Copy operation was cancelled";
+    default:
+      return `Copy failed: ${error.message}`;
+  }
 }
 
 export const TaskIdBadge = memo(TaskIdBadgeComponent);

--- a/apps/desktop/src/components/features/tasks/task-id-badge.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.tsx
@@ -1,0 +1,57 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+type TaskIdBadgeProps = {
+  taskId: string;
+  className?: string;
+  iconSize?: number;
+};
+
+export function TaskIdBadge({
+  taskId,
+  className,
+  iconSize = 12,
+}: TaskIdBadgeProps): React.ReactElement {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(taskId);
+      setCopied(true);
+      toast.success("Copied!", { description: taskId });
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Copy failed");
+    }
+  };
+
+  return (
+    <div className={`inline-flex items-center gap-1 ${className ?? ""}`}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-6 text-muted-foreground hover:bg-muted hover:text-foreground"
+            onClick={handleCopy}
+            data-testid="copy-task-id"
+          >
+            {copied ? (
+              <Check className="text-emerald-500" style={{ width: iconSize, height: iconSize }} />
+            ) : (
+              <Copy style={{ width: iconSize, height: iconSize }} />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p>Copy task ID</p>
+        </TooltipContent>
+      </Tooltip>
+      <span className="font-mono text-xs text-muted-foreground">{taskId}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/features/tasks/task-id-badge.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { memo, type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -10,19 +10,24 @@ type TaskIdBadgeProps = {
   iconSize?: number;
 };
 
-export function TaskIdBadge({
+function TaskIdBadgeComponent({
   taskId,
   className,
   iconSize = 12,
-}: TaskIdBadgeProps): React.ReactElement {
+}: TaskIdBadgeProps): ReactElement {
   const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timeoutId = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(timeoutId);
+  }, [copied]);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(taskId);
       setCopied(true);
       toast.success("Copied!", { description: taskId });
-      setTimeout(() => setCopied(false), 2000);
     } catch {
       toast.error("Copy failed");
     }
@@ -55,3 +60,5 @@ export function TaskIdBadge({
     </div>
   );
 }
+
+export const TaskIdBadge = memo(TaskIdBadgeComponent);

--- a/apps/desktop/src/components/features/tasks/task-id-badge.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.tsx
@@ -22,18 +22,23 @@ function TaskIdBadgeComponent({
     return () => clearTimeout(timeoutId);
   }, [copied]);
 
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(taskId);
-      setCopied(true);
-      toast.success("Copied!", { description: taskId });
-    } catch {
-      toast.error("Copy failed");
-    }
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    navigator.clipboard
+      .writeText(taskId)
+      .then(() => {
+        setCopied(true);
+        toast.success("Copied!", { description: taskId });
+      })
+      .catch(() => {
+        toast.error("Copy failed");
+      });
   };
 
   return (
     <div className={`inline-flex items-center gap-1 ${className ?? ""}`}>
+      <span className="font-mono text-xs text-muted-foreground">{taskId}</span>
       <Button
         type="button"
         variant="ghost"
@@ -49,7 +54,6 @@ function TaskIdBadgeComponent({
           <Copy style={{ width: iconSize, height: iconSize }} />
         )}
       </Button>
-      <span className="font-mono text-xs text-muted-foreground">{taskId}</span>
     </div>
   );
 }

--- a/apps/desktop/src/components/features/tasks/task-id-badge.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy } from "lucide-react";
-import { memo, type ReactElement, useEffect, useState } from "react";
+import { memo, type ReactElement, useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -23,21 +23,25 @@ function TaskIdBadgeComponent({
     return () => clearTimeout(timeoutId);
   }, [copied]);
 
-  const handleCopy = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-    navigator.clipboard
-      .writeText(taskId)
-      .then(() => {
-        setCopied(true);
-        toast.success("Copied!", { description: taskId });
-      })
-      .catch((err) => {
-        console.error("[TaskIdBadge] Clipboard write failed:", err);
-        const message = err instanceof DOMException ? getClipboardErrorMessage(err) : "Copy failed";
-        toast.error(message);
-      });
-  };
+  const handleCopy = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      e.preventDefault();
+      navigator.clipboard
+        .writeText(taskId)
+        .then(() => {
+          setCopied(true);
+          toast.success("Copied!", { description: taskId });
+        })
+        .catch((err) => {
+          console.error("[TaskIdBadge] Clipboard write failed:", err);
+          const message =
+            err instanceof DOMException ? getClipboardErrorMessage(err) : "Copy failed";
+          toast.error(message);
+        });
+    },
+    [taskId],
+  );
 
   return (
     <div className={cn("inline-flex items-center gap-1", className)}>

--- a/apps/desktop/src/components/features/tasks/task-id-badge.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.tsx
@@ -2,7 +2,6 @@ import { Check, Copy } from "lucide-react";
 import { memo, type ReactElement, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 type TaskIdBadgeProps = {
   taskId: string;
@@ -35,27 +34,21 @@ function TaskIdBadgeComponent({
 
   return (
     <div className={`inline-flex items-center gap-1 ${className ?? ""}`}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="size-6 text-muted-foreground hover:bg-muted hover:text-foreground"
-            onClick={handleCopy}
-            data-testid="copy-task-id"
-          >
-            {copied ? (
-              <Check className="text-emerald-500" style={{ width: iconSize, height: iconSize }} />
-            ) : (
-              <Copy style={{ width: iconSize, height: iconSize }} />
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          <p>Copy task ID</p>
-        </TooltipContent>
-      </Tooltip>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-6 text-muted-foreground hover:bg-muted hover:text-foreground"
+        onClick={handleCopy}
+        data-testid="copy-task-id"
+        aria-label="Copy task ID"
+      >
+        {copied ? (
+          <Check className="text-emerald-500" style={{ width: iconSize, height: iconSize }} />
+        ) : (
+          <Copy style={{ width: iconSize, height: iconSize }} />
+        )}
+      </Button>
       <span className="font-mono text-xs text-muted-foreground">{taskId}</span>
     </div>
   );


### PR DESCRIPTION
## Summary

Added a reusable `TaskIdBadge` component that displays a task ID alongside a copy button. When clicked, the button copies the task ID to the clipboard and shows a toast confirmation. The button swaps to a checkmark icon for 2 seconds after a successful copy.

## Changes

### New Component: `TaskIdBadge`
- Created at `apps/desktop/src/components/features/tasks/task-id-badge.tsx`
- Props: `taskId` (required), `className` (optional), `iconSize` (default: 12)
- Uses `navigator.clipboard.writeText()` for clipboard operations
- Shows success toast with task ID on copy
- Shows error toast on failure
- Button uses `ghost` variant with `size="icon"`
- Icon switches to emerald checkmark on success
- Memoized to prevent unnecessary re-renders
- `stopPropagation` prevents click events from bubbling up

### Integration Locations
Replaced raw task ID displays with `TaskIdBadge` at:
- Kanban Task Card (`kanban-task-card.tsx`) - copy button on the right of task ID
- Task Details Sheet Header (`task-details-sheet-header.tsx`)
- Task Details Subtasks (`task-details-subtasks.tsx`)
- Agent Studio Header (`agent-studio-header.tsx`)

### Kanban Card Fix
Changed the outer "Open details" element from `<button>` to `<div role="button">` with proper keyboard handling. This allows `TaskIdBadge` (which contains a `<button>`) to be nested inside without violating HTML nesting rules.

## Files Changed
- `apps/desktop/src/components/features/tasks/task-id-badge.tsx` (new)
- `apps/desktop/src/components/features/tasks/task-id-badge.test.tsx` (new)
- `apps/desktop/src/components/features/kanban/kanban-task-card.tsx`
- `apps/desktop/src/components/features/task-details/task-details-sheet-header.tsx`
- `apps/desktop/src/components/features/task-details/task-details-subtasks.tsx`
- `apps/desktop/src/components/features/agents/agent-studio-header.tsx`

## Tests
- 4 unit tests covering: rendering, monospace styling, custom className, and button positioning
- All 1136 desktop tests pass
- Typecheck and lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task IDs now use a unified badge with an integrated copy-to-clipboard button and instant copied confirmation.
  * Improved keyboard interaction for opening task details (supports Enter/Space).

* **Refactor**
  * Unified task ID presentation across agent studio, kanban, task details, and subtasks for a consistent UI.

* **Tests**
  * Added tests covering the task ID badge rendering and copy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->