### PR TITLE
fix: keep workflow documents from disappearing after updates

### DIFF
--- a/apps/desktop/src/components/features/task-details/task-document-state.ts
+++ b/apps/desktop/src/components/features/task-details/task-document-state.ts
@@ -1,0 +1,50 @@
+export type TaskDocumentPayload = {
+  markdown: string;
+  updatedAt: string | null;
+};
+
+type TaskDocumentStateLike = {
+  markdown: string;
+  updatedAt: string | null;
+  isLoading: boolean;
+  error: string | null;
+  loaded: boolean;
+};
+
+const parseUpdatedAtTimestamp = (updatedAt: string | null): number | null => {
+  if (!updatedAt) {
+    return null;
+  }
+
+  const timestamp = Date.parse(updatedAt);
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
+
+export const resolveLoadedDocumentState = <TState extends TaskDocumentStateLike>(
+  current: TState,
+  incoming: TaskDocumentPayload,
+): TState => {
+  const currentTimestamp = parseUpdatedAtTimestamp(current.updatedAt);
+  const incomingTimestamp = parseUpdatedAtTimestamp(incoming.updatedAt);
+  const shouldPreserveCurrentDocument =
+    currentTimestamp !== null &&
+    (incomingTimestamp === null || incomingTimestamp < currentTimestamp);
+
+  if (shouldPreserveCurrentDocument) {
+    return {
+      ...current,
+      isLoading: false,
+      error: null,
+      loaded: true,
+    };
+  }
+
+  return {
+    ...current,
+    markdown: incoming.markdown,
+    updatedAt: incoming.updatedAt,
+    isLoading: false,
+    error: null,
+    loaded: true,
+  };
+};

--- a/apps/desktop/src/components/features/task-details/task-document-state.ts
+++ b/apps/desktop/src/components/features/task-details/task-document-state.ts
@@ -1,7 +1,4 @@
-export type TaskDocumentPayload = {
-  markdown: string;
-  updatedAt: string | null;
-};
+import type { TaskDocumentPayload } from "@/types/task-documents";
 
 type TaskDocumentStateLike = {
   markdown: string;
@@ -27,8 +24,7 @@ export const resolveLoadedDocumentState = <TState extends TaskDocumentStateLike>
   const currentTimestamp = parseUpdatedAtTimestamp(current.updatedAt);
   const incomingTimestamp = parseUpdatedAtTimestamp(incoming.updatedAt);
   const shouldPreserveCurrentDocument =
-    currentTimestamp !== null &&
-    (incomingTimestamp === null || incomingTimestamp < currentTimestamp);
+    currentTimestamp !== null && incomingTimestamp !== null && incomingTimestamp < currentTimestamp;
 
   if (shouldPreserveCurrentDocument) {
     return {

--- a/apps/desktop/src/components/features/task-details/use-task-documents.test.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { resolveLoadedDocumentState, type TaskDocumentPayload } from "./task-document-state";
+import type { TaskDocumentPayload } from "@/types/task-documents";
+import { resolveLoadedDocumentState } from "./task-document-state";
 import type { TaskDocumentState } from "./use-task-documents";
 
 const createDocumentState = (overrides: Partial<TaskDocumentState> = {}): TaskDocumentState => ({
@@ -20,7 +21,7 @@ const createDocumentPayload = (
 });
 
 describe("resolveLoadedDocumentState", () => {
-  test("preserves the current document when an older payload resolves", () => {
+  test("applies the incoming payload when the incoming document has no timestamp", () => {
     const current = createDocumentState({
       markdown: "# Updated spec",
       updatedAt: "2026-02-22T09:00:00.000Z",
@@ -29,7 +30,39 @@ describe("resolveLoadedDocumentState", () => {
       loaded: true,
     });
 
-    const resolved = resolveLoadedDocumentState(current, createDocumentPayload());
+    const resolved = resolveLoadedDocumentState(
+      current,
+      createDocumentPayload({
+        markdown: "# Server spec without timestamp",
+        updatedAt: null,
+      }),
+    );
+
+    expect(resolved).toEqual({
+      markdown: "# Server spec without timestamp",
+      updatedAt: null,
+      isLoading: false,
+      error: null,
+      loaded: true,
+    });
+  });
+
+  test("preserves the current document when the incoming timestamp is older", () => {
+    const current = createDocumentState({
+      markdown: "# Updated spec",
+      updatedAt: "2026-02-22T09:00:00.000Z",
+      isLoading: true,
+      error: "temporary",
+      loaded: true,
+    });
+
+    const resolved = resolveLoadedDocumentState(
+      current,
+      createDocumentPayload({
+        markdown: "# Older server spec",
+        updatedAt: "2026-02-22T08:45:00.000Z",
+      }),
+    );
 
     expect(resolved).toEqual({
       markdown: "# Updated spec",
@@ -59,6 +92,28 @@ describe("resolveLoadedDocumentState", () => {
     expect(resolved).toEqual({
       markdown: "# Server spec",
       updatedAt: "2026-02-22T09:15:00.000Z",
+      isLoading: false,
+      error: null,
+      loaded: true,
+    });
+  });
+
+  test("applies the incoming payload when neither document has a timestamp", () => {
+    const current = createDocumentState({
+      markdown: "# Loaded spec",
+      updatedAt: null,
+      isLoading: true,
+      loaded: true,
+    });
+
+    const resolved = resolveLoadedDocumentState(
+      current,
+      createDocumentPayload({ markdown: "# Incoming spec" }),
+    );
+
+    expect(resolved).toEqual({
+      markdown: "# Incoming spec",
+      updatedAt: null,
       isLoading: false,
       error: null,
       loaded: true,

--- a/apps/desktop/src/components/features/task-details/use-task-documents.test.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { resolveLoadedDocumentState, type TaskDocumentPayload } from "./task-document-state";
+import type { TaskDocumentState } from "./use-task-documents";
+
+const createDocumentState = (overrides: Partial<TaskDocumentState> = {}): TaskDocumentState => ({
+  markdown: "",
+  updatedAt: null,
+  isLoading: true,
+  error: "stale error",
+  loaded: false,
+  ...overrides,
+});
+
+const createDocumentPayload = (
+  overrides: Partial<TaskDocumentPayload> = {},
+): TaskDocumentPayload => ({
+  markdown: "",
+  updatedAt: null,
+  ...overrides,
+});
+
+describe("resolveLoadedDocumentState", () => {
+  test("preserves the current document when an older payload resolves", () => {
+    const current = createDocumentState({
+      markdown: "# Updated spec",
+      updatedAt: "2026-02-22T09:00:00.000Z",
+      isLoading: true,
+      error: "temporary",
+      loaded: true,
+    });
+
+    const resolved = resolveLoadedDocumentState(current, createDocumentPayload());
+
+    expect(resolved).toEqual({
+      markdown: "# Updated spec",
+      updatedAt: "2026-02-22T09:00:00.000Z",
+      isLoading: false,
+      error: null,
+      loaded: true,
+    });
+  });
+
+  test("applies the incoming payload when it is newer than the current document", () => {
+    const current = createDocumentState({
+      markdown: "# Old spec",
+      updatedAt: "2026-02-22T09:00:00.000Z",
+      isLoading: true,
+      loaded: true,
+    });
+
+    const resolved = resolveLoadedDocumentState(
+      current,
+      createDocumentPayload({
+        markdown: "# Server spec",
+        updatedAt: "2026-02-22T09:15:00.000Z",
+      }),
+    );
+
+    expect(resolved).toEqual({
+      markdown: "# Server spec",
+      updatedAt: "2026-02-22T09:15:00.000Z",
+      isLoading: false,
+      error: null,
+      loaded: true,
+    });
+  });
+});

--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSpecState } from "@/state";
+import type { TaskDocumentPayload } from "@/types/task-documents";
 import {
   createTaskDocumentLoadController,
   requestTaskDocumentLoad,
@@ -8,7 +9,7 @@ import {
   supersedeTaskDocumentLoad,
   type TaskDocumentSectionKey,
 } from "./task-document-load-controller";
-import { resolveLoadedDocumentState, type TaskDocumentPayload } from "./task-document-state";
+import { resolveLoadedDocumentState } from "./task-document-state";
 
 export type DocumentSectionKey = TaskDocumentSectionKey;
 

--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -8,6 +8,7 @@ import {
   supersedeTaskDocumentLoad,
   type TaskDocumentSectionKey,
 } from "./task-document-load-controller";
+import { resolveLoadedDocumentState, type TaskDocumentPayload } from "./task-document-state";
 
 export type DocumentSectionKey = TaskDocumentSectionKey;
 
@@ -20,11 +21,6 @@ export type TaskDocumentState = {
 };
 
 type TaskDocumentsState = Record<DocumentSectionKey, TaskDocumentState>;
-
-type TaskDocumentPayload = {
-  markdown: string;
-  updatedAt: string | null;
-};
 
 type TaskDocumentLoaders = {
   loadSpecDocument: (taskId: string) => Promise<TaskDocumentPayload>;
@@ -172,13 +168,7 @@ export function useTaskDocuments(
 
           const successSnapshot: TaskDocumentsState = {
             ...documentsRef.current,
-            [section]: {
-              markdown: result.markdown,
-              updatedAt: result.updatedAt,
-              isLoading: false,
-              error: null,
-              loaded: true,
-            },
+            [section]: resolveLoadedDocumentState(documentsRef.current[section], result),
           };
           updateDocumentsSnapshot(successSnapshot);
           replayPendingForcedReload(settlement.shouldReplay);

--- a/apps/desktop/src/types/index.ts
+++ b/apps/desktop/src/types/index.ts
@@ -1,2 +1,3 @@
 export { AGENT_ROLE_LABELS } from "./agent-role-labels";
 export { NON_ERROR_THROWN_PREFIX } from "./constants";
+export type { TaskDocumentPayload } from "./task-documents";

--- a/apps/desktop/src/types/task-documents.ts
+++ b/apps/desktop/src/types/task-documents.ts
@@ -1,0 +1,4 @@
+export type TaskDocumentPayload = {
+  markdown: string;
+  updatedAt: string | null;
+};


### PR DESCRIPTION
## Summary
- prevent stale task document reloads from overwriting newer workflow document content in the document panel
- extract the document-resolution logic into a small pure helper so the hook keeps the race handling explicit and easy to test
- add regression tests for older and newer payload ordering, then verify the workspace lint, typecheck, test, and build commands all pass

## Testing
- bun run lint
- bun run typecheck
- bun run test
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized document state resolution to consistently decide whether to preserve or replace task document content based on timestamps.

* **Tests**
  * Added tests verifying resolution behavior across timestamp scenarios and ensuring loading/error flags are set correctly.

* **Chores**
  * Exported a shared TaskDocument payload type for consistent typing across document handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->