### PR TITLE
fix(desktop): reduce reset button size in git panel file row

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx
@@ -119,7 +119,7 @@ function FileDiffEntry({
                 type="button"
                 variant="ghost"
                 size="icon"
-                className="size-7 shrink-0"
+                className="size-6 shrink-0"
                 aria-label="Reset file"
                 title="Reset file"
                 data-testid="agent-studio-git-reset-file-button"


### PR DESCRIPTION
## Summary
- Reduce reset button size from `size-7` (28px) to `size-6` (24px) in git panel file row to minimize height impact on file rows