### PR TITLE
fix(desktop): exclude waiting-for-input sessions from active session count

### DIFF
--- a/apps/desktop/src/components/layout/sidebar/agent-activity-model.test.ts
+++ b/apps/desktop/src/components/layout/sidebar/agent-activity-model.test.ts
@@ -100,7 +100,7 @@ describe("summarizeAgentActivity", () => {
       ],
     });
 
-    expect(summary.activeSessionCount).toBe(1);
+    expect(summary.activeSessionCount).toBe(0);
     expect(summary.waitingForInputCount).toBe(2);
     expect(summary.waitingForInputSessions).toHaveLength(2);
     expect(summary.waitingForInputSessions[0]?.sessionId).toBe("session-2");

--- a/apps/desktop/src/components/layout/sidebar/agent-activity-model.ts
+++ b/apps/desktop/src/components/layout/sidebar/agent-activity-model.ts
@@ -56,10 +56,12 @@ export const summarizeAgentActivity = ({
       startedAt: session.startedAt,
     };
 
-    if (ACTIVE_SESSION_STATUS.has(session.status)) {
+    const isWaiting = session.pendingPermissions.length > 0 || session.pendingQuestions.length > 0;
+
+    if (ACTIVE_SESSION_STATUS.has(session.status) && !isWaiting) {
       activeSessions.push(sessionItem);
     }
-    if (session.pendingPermissions.length > 0 || session.pendingQuestions.length > 0) {
+    if (isWaiting) {
       waitingForInputSessions.push(sessionItem);
     }
   }

--- a/apps/desktop/src/components/layout/sidebar/agent-activity-model.ts
+++ b/apps/desktop/src/components/layout/sidebar/agent-activity-model.ts
@@ -58,11 +58,10 @@ export const summarizeAgentActivity = ({
 
     const isWaiting = session.pendingPermissions.length > 0 || session.pendingQuestions.length > 0;
 
-    if (ACTIVE_SESSION_STATUS.has(session.status) && !isWaiting) {
-      activeSessions.push(sessionItem);
-    }
     if (isWaiting) {
       waitingForInputSessions.push(sessionItem);
+    } else if (ACTIVE_SESSION_STATUS.has(session.status)) {
+      activeSessions.push(sessionItem);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix sidebar session counting bug where sessions waiting for input appeared in both active and waiting counts
- Sessions with `pendingPermissions` or `pendingQuestions` are now only counted in `waitingForInputSessions`
- Updated test assertion to reflect correct behavior

## Testing
- `bun test --filter @openducktor/desktop -- agent-activity-model` passes
- Typecheck and lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected session classification so sessions awaiting user input (pending permissions or questions) are treated as waiting rather than active.
  * Adjusted active session counts to reflect the above, preventing double-counting of the same session.
  * Preserved waiting-for-input ordering and total waiting count so UI lists and counters remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->