### PR TITLE
fix(desktop): copy configured files into new worktrees

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -7,8 +7,8 @@ use super::super::{
 use anyhow::{anyhow, Context, Result};
 use host_domain::{TaskStatus, TASK_METADATA_NAMESPACE};
 use host_infra_system::{
-    build_branch_name, pick_free_port, remove_worktree, resolve_effective_worktree_base_dir,
-    RepoConfig,
+    build_branch_name, copy_configured_worktree_files, pick_free_port, remove_worktree,
+    resolve_effective_worktree_base_dir, RepoConfig,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -179,6 +179,30 @@ impl AppService {
             ],
             Some(repo_path_ref),
         )?;
+
+        if let Err(error) = copy_configured_worktree_files(
+            repo_path_ref,
+            worktree_dir.as_path(),
+            prerequisites.repo_config.worktree_file_copies.as_slice(),
+        ) {
+            let _ = self.task_transition(
+                prerequisites.repo_path.as_str(),
+                task_id,
+                TaskStatus::Blocked,
+                Some("Configured worktree file copy failed"),
+            );
+            let cleanup_error = remove_worktree(repo_path_ref, worktree_dir.as_path())
+                .err()
+                .map(|cleanup_error| cleanup_error.to_string());
+            return Err(anyhow!(
+                "Configured worktree file copy failed: {error}{}",
+                cleanup_error
+                    .map(|cleanup_error| {
+                        format!("\nAlso failed to remove worktree: {cleanup_error}")
+                    })
+                    .unwrap_or_default()
+            ));
+        }
 
         self.run_pre_start_hooks(
             prerequisites,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use host_domain::{TaskStatus, TASK_METADATA_NAMESPACE};
 use host_infra_system::{
     build_branch_name, copy_configured_worktree_files, pick_free_port, remove_worktree,
-    resolve_effective_worktree_base_dir, RepoConfig,
+    resolve_effective_worktree_base_dir, run_command, RepoConfig,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -185,22 +185,14 @@ impl AppService {
             worktree_dir.as_path(),
             prerequisites.repo_config.worktree_file_copies.as_slice(),
         ) {
-            let _ = self.task_transition(
-                prerequisites.repo_path.as_str(),
-                task_id,
-                TaskStatus::Blocked,
-                Some("Configured worktree file copy failed"),
+            let cleanup_error = self.rollback_failed_build_worktree(
+                repo_path_ref,
+                worktree_dir.as_path(),
+                prerequisites.branch.as_str(),
             );
-            let cleanup_error = remove_worktree(repo_path_ref, worktree_dir.as_path())
-                .err()
-                .map(|cleanup_error| cleanup_error.to_string());
             return Err(anyhow!(
                 "Configured worktree file copy failed: {error}{}",
                 cleanup_error
-                    .map(|cleanup_error| {
-                        format!("\nAlso failed to remove worktree: {cleanup_error}")
-                    })
-                    .unwrap_or_default()
             ));
         }
 
@@ -219,29 +211,58 @@ impl AppService {
         prerequisites: &BuildPrerequisites,
         repo_path_ref: &Path,
         worktree_dir: &Path,
-        task_id: &str,
+        _task_id: &str,
     ) -> Result<()> {
         for hook in &prerequisites.repo_config.hooks.pre_start {
             let (ok, _stdout, stderr) = run_parsed_hook_command_allow_failure(hook, worktree_dir);
             if !ok {
-                let _ = self.task_transition(
-                    prerequisites.repo_path.as_str(),
-                    task_id,
-                    TaskStatus::Blocked,
-                    Some("Worktree setup script failed"),
+                let cleanup_error = self.rollback_failed_build_worktree(
+                    repo_path_ref,
+                    worktree_dir,
+                    prerequisites.branch.as_str(),
                 );
-                let cleanup_error = remove_worktree(repo_path_ref, worktree_dir)
-                    .err()
-                    .map(|error| error.to_string());
                 return Err(anyhow!(
                     "Worktree setup script command failed: {hook}\n{stderr}{}",
                     cleanup_error
-                        .map(|error| format!("\nAlso failed to remove worktree: {error}"))
-                        .unwrap_or_default()
                 ));
             }
         }
         Ok(())
+    }
+
+    fn rollback_failed_build_worktree(
+        &self,
+        repo_path_ref: &Path,
+        worktree_dir: &Path,
+        branch: &str,
+    ) -> String {
+        let mut cleanup_errors = Vec::new();
+
+        if let Err(error) = remove_worktree(repo_path_ref, worktree_dir) {
+            cleanup_errors.push(format!("Also failed to remove worktree: {error}"));
+        }
+        if let Err(error) = run_command(
+            "git",
+            &["worktree", "prune", "--expire", "now"],
+            Some(repo_path_ref),
+        ) {
+            cleanup_errors.push(format!("Also failed to prune worktree metadata: {error}"));
+        }
+        if let Err(error) = run_command(
+            "git",
+            &["branch", "-D", "--end-of-options", branch],
+            Some(repo_path_ref),
+        ) {
+            cleanup_errors.push(format!(
+                "Also failed to delete created branch {branch}: {error}"
+            ));
+        }
+
+        if cleanup_errors.is_empty() {
+            String::new()
+        } else {
+            format!("\n{}", cleanup_errors.join("\n"))
+        }
     }
 
     pub(super) fn spawn_and_wait_for_agent(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -9,9 +9,9 @@ use host_domain::{
     WorkspaceRecord,
 };
 use host_infra_system::{
-    command_exists, repo_script_fingerprint, resolve_central_beads_dir,
-    run_command_allow_failure_with_env, version_command, ChatSettings, GlobalGitConfig, HookSet,
-    PromptOverrides, RepoConfig,
+    command_exists, copy_configured_worktree_files, remove_worktree, repo_script_fingerprint,
+    resolve_central_beads_dir, run_command_allow_failure_with_env, version_command, ChatSettings,
+    GlobalGitConfig, HookSet, PromptOverrides, RepoConfig,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -370,6 +370,25 @@ impl AppService {
             branch,
             create_branch,
         )?;
+
+        let repo_config = self.config_store.repo_config(repo_path.as_str())?;
+        if let Err(error) = copy_configured_worktree_files(
+            Path::new(&repo_path),
+            Path::new(worktree),
+            repo_config.worktree_file_copies.as_slice(),
+        ) {
+            let cleanup_error = remove_worktree(Path::new(&repo_path), Path::new(worktree))
+                .err()
+                .map(|cleanup_error| cleanup_error.to_string());
+            return Err(anyhow!(
+                "Configured worktree file copy failed: {error}{}",
+                cleanup_error
+                    .map(|cleanup_error| {
+                        format!("\nAlso failed to remove worktree: {cleanup_error}")
+                    })
+                    .unwrap_or_default()
+            ));
+        }
 
         Ok(GitWorktreeSummary {
             branch: branch.trim().to_string(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -10,8 +10,8 @@ use host_domain::{
 };
 use host_infra_system::{
     command_exists, copy_configured_worktree_files, remove_worktree, repo_script_fingerprint,
-    resolve_central_beads_dir, run_command_allow_failure_with_env, version_command, ChatSettings,
-    GlobalGitConfig, HookSet, PromptOverrides, RepoConfig,
+    resolve_central_beads_dir, run_command, run_command_allow_failure_with_env, version_command,
+    ChatSettings, GlobalGitConfig, HookSet, PromptOverrides, RepoConfig,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -359,6 +359,7 @@ impl AppService {
         create_branch: bool,
     ) -> Result<GitWorktreeSummary> {
         let repo_path = self.resolve_authorized_repo_path(repo_path)?;
+        let repo_config = self.config_store.repo_config(repo_path.as_str())?;
         let worktree = worktree_path.trim();
         if worktree.is_empty() {
             return Err(anyhow!("worktree path cannot be empty"));
@@ -371,22 +372,20 @@ impl AppService {
             create_branch,
         )?;
 
-        let repo_config = self.config_store.repo_config(repo_path.as_str())?;
         if let Err(error) = copy_configured_worktree_files(
             Path::new(&repo_path),
             Path::new(worktree),
             repo_config.worktree_file_copies.as_slice(),
         ) {
-            let cleanup_error = remove_worktree(Path::new(&repo_path), Path::new(worktree))
-                .err()
-                .map(|cleanup_error| cleanup_error.to_string());
+            let cleanup_error = self.cleanup_failed_created_worktree(
+                Path::new(&repo_path),
+                Path::new(worktree),
+                branch,
+                create_branch,
+            );
             return Err(anyhow!(
                 "Configured worktree file copy failed: {error}{}",
                 cleanup_error
-                    .map(|cleanup_error| {
-                        format!("\nAlso failed to remove worktree: {cleanup_error}")
-                    })
-                    .unwrap_or_default()
             ));
         }
 
@@ -394,6 +393,40 @@ impl AppService {
             branch: branch.trim().to_string(),
             worktree_path: worktree.to_string(),
         })
+    }
+
+    fn cleanup_failed_created_worktree(
+        &self,
+        repo_path: &Path,
+        worktree_path: &Path,
+        branch: &str,
+        delete_branch: bool,
+    ) -> String {
+        let mut cleanup_errors = Vec::new();
+
+        if let Err(error) = remove_worktree(repo_path, worktree_path) {
+            cleanup_errors.push(format!("Also failed to remove worktree: {error}"));
+        }
+        if let Err(error) = run_command(
+            "git",
+            &["worktree", "prune", "--expire", "now"],
+            Some(repo_path),
+        ) {
+            cleanup_errors.push(format!("Also failed to prune worktree metadata: {error}"));
+        }
+        if delete_branch {
+            if let Err(error) = self.git_port.delete_local_branch(repo_path, branch, true) {
+                cleanup_errors.push(format!(
+                    "Also failed to delete created branch {branch}: {error}"
+                ));
+            }
+        }
+
+        if cleanup_errors.is_empty() {
+            String::new()
+        } else {
+            format!("\n{}", cleanup_errors.join("\n"))
+        }
     }
 
     pub fn git_remove_worktree(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -359,11 +359,11 @@ impl AppService {
         create_branch: bool,
     ) -> Result<GitWorktreeSummary> {
         let repo_path = self.resolve_authorized_repo_path(repo_path)?;
-        let repo_config = self.config_store.repo_config(repo_path.as_str())?;
         let worktree = worktree_path.trim();
         if worktree.is_empty() {
             return Err(anyhow!("worktree path cannot be empty"));
         }
+        let repo_config = self.config_store.repo_config(repo_path.as_str())?;
 
         self.git_port.create_worktree(
             Path::new(&repo_path),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -286,6 +286,70 @@ fn build_start_bases_worktree_on_configured_target_branch() -> Result<()> {
 }
 
 #[test]
+fn build_start_copies_configured_worktree_files_into_new_worktree() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("build-copy-configured-files");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    write_private_file(repo.join(".env").as_path(), "API_KEY=builder-secret\n")?;
+    let fake_opencode = root.join("opencode");
+    create_fake_opencode(&fake_opencode)?;
+    let _opencode_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        fake_opencode.to_string_lossy().as_ref(),
+    );
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let repo_path = repo.to_string_lossy().to_string();
+    let worktree_base = root.join("builder-worktrees");
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "bug", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            default_runtime_kind: "opencode".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: Some("origin".to_string()),
+                branch: "main".to_string(),
+            },
+            git: Default::default(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            dev_servers: Vec::new(),
+            worktree_file_copies: vec![".env".to_string()],
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    let emitter = make_emitter(Arc::new(Mutex::new(Vec::new())));
+    let run = service.build_start(repo_path.as_str(), "task-1", "opencode", emitter.clone())?;
+    let worktree_path = Path::new(run.worktree_path.as_str());
+    assert_eq!(
+        fs::read_to_string(worktree_path.join(".env"))?,
+        "API_KEY=builder-secret\n"
+    );
+
+    assert!(service.build_stop(run.run_id.as_str(), emitter.clone())?);
+    assert!(service.build_cleanup(run.run_id.as_str(), CleanupMode::Failure, emitter)?);
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn build_stop_respond_and_cleanup_failure_paths() -> Result<()> {
     let root = unique_temp_path("build-failure");
     let repo = root.join("repo");
@@ -366,10 +430,13 @@ fn build_stop_respond_and_cleanup_failure_paths() -> Result<()> {
     assert!(service.runs_list(Some(repo_path.as_str()))?.is_empty());
 
     let state = task_state.lock().expect("task lock poisoned");
-    assert!(state
-        .updated_patches
-        .iter()
-        .any(|(_, patch)| patch.status == Some(TaskStatus::Blocked)));
+    assert!(
+        state
+            .updated_patches
+            .iter()
+            .all(|(_, patch)| patch.status.is_none()),
+        "worktree copy failure should happen before task status changes"
+    );
     drop(state);
 
     let _ = fs::remove_dir_all(root);
@@ -482,10 +549,13 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
     assert!(invalid_mode.to_string().contains("Run not found"));
 
     let state = task_state.lock().expect("task lock poisoned");
-    assert!(state
-        .updated_patches
-        .iter()
-        .any(|(_, patch)| patch.status == Some(TaskStatus::Blocked)));
+    assert!(
+        state
+            .updated_patches
+            .iter()
+            .all(|(_, patch)| patch.status.is_none()),
+        "worktree copy failure should happen before task status changes"
+    );
     drop(state);
 
     let emitted = events.lock().expect("events lock poisoned");
@@ -508,6 +578,84 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
         "post-hook-started event should be emitted before post-hook-failed"
     );
     drop(emitted);
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn build_start_blocks_and_cleans_up_when_configured_worktree_file_copy_fails() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("build-copy-configured-files-failure");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    let fake_opencode = root.join("opencode");
+    create_fake_opencode(&fake_opencode)?;
+    let _opencode_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        fake_opencode.to_string_lossy().as_ref(),
+    );
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let repo_path = repo.to_string_lossy().to_string();
+    let worktree_base = root.join("builder-worktrees");
+    let (service, task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "bug", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            default_runtime_kind: "opencode".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: Some("origin".to_string()),
+                branch: "main".to_string(),
+            },
+            git: Default::default(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            dev_servers: Vec::new(),
+            worktree_file_copies: vec![".env".to_string()],
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    let error = service
+        .build_start(
+            repo_path.as_str(),
+            "task-1",
+            "opencode",
+            make_emitter(Arc::new(Mutex::new(Vec::new()))),
+        )
+        .expect_err("missing configured worktree file should fail build startup");
+    let message = error.to_string();
+    assert!(message.contains("Configured worktree file copy failed"));
+    assert!(message.contains(".env"));
+    assert!(
+        !worktree_base.join("task-1").exists(),
+        "failed worktree setup should clean up the created worktree"
+    );
+
+    let state = task_state.lock().expect("task lock poisoned");
+    assert!(
+        state
+            .updated_patches
+            .iter()
+            .all(|(_, patch)| patch.status.is_none()),
+        "worktree copy failure should happen before task status changes"
+    );
+    drop(state);
 
     let _ = fs::remove_dir_all(root);
     Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -66,6 +66,26 @@ fn run_command_in(current_dir: &Path, program: &str, args: &[&str]) -> Result<()
     ))
 }
 
+fn assert_branch_missing(repo_path: &Path, branch: &str) -> Result<()> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["branch", "--list", branch])
+        .output()
+        .with_context(|| format!("failed listing branch {branch} in {}", repo_path.display()))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git branch --list failed for {branch} in {}",
+            repo_path.display()
+        ));
+    }
+
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "branch {branch} should have been removed"
+    );
+    Ok(())
+}
+
 #[test]
 fn build_start_respond_and_cleanup_success_flow() -> Result<()> {
     let _env_lock = lock_env();
@@ -431,11 +451,10 @@ fn build_stop_respond_and_cleanup_failure_paths() -> Result<()> {
 
     let state = task_state.lock().expect("task lock poisoned");
     assert!(
-        state
-            .updated_patches
-            .iter()
-            .all(|(_, patch)| patch.status.is_none()),
-        "worktree copy failure should happen before task status changes"
+        state.updated_patches.iter().any(
+            |(task_id, patch)| task_id == "task-1" && patch.status == Some(TaskStatus::Blocked)
+        ),
+        "run failure should block the active task"
     );
     drop(state);
 
@@ -553,10 +572,25 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
         state
             .updated_patches
             .iter()
-            .all(|(_, patch)| patch.status.is_none()),
-        "worktree copy failure should happen before task status changes"
+            .all(|(task_id, _)| task_id != "task-1"),
+        "pre-start hook failure should not update task status before the build starts"
+    );
+    assert!(
+        state.updated_patches.iter().any(|(task_id, patch)| {
+            task_id == "task-2" && patch.status == Some(TaskStatus::InProgress)
+        }),
+        "successful build start should move task-2 into progress"
+    );
+    assert!(
+        state.updated_patches.iter().any(
+            |(task_id, patch)| task_id == "task-2" && patch.status == Some(TaskStatus::Blocked)
+        ),
+        "post-complete hook failure should block task-2"
     );
     drop(state);
+
+    let failed_branch = host_infra_system::build_branch_name("odt", "task-1", "Task task-1");
+    assert_branch_missing(repo.as_path(), failed_branch.as_str())?;
 
     let emitted = events.lock().expect("events lock poisoned");
     assert!(emitted
@@ -584,7 +618,7 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
 }
 
 #[test]
-fn build_start_blocks_and_cleans_up_when_configured_worktree_file_copy_fails() -> Result<()> {
+fn build_start_cleans_up_when_configured_worktree_file_copy_fails() -> Result<()> {
     let _env_lock = lock_env();
     let root = unique_temp_path("build-copy-configured-files-failure");
     let repo = root.join("repo");
@@ -652,10 +686,13 @@ fn build_start_blocks_and_cleans_up_when_configured_worktree_file_copy_fails() -
         state
             .updated_patches
             .iter()
-            .all(|(_, patch)| patch.status.is_none()),
-        "worktree copy failure should happen before task status changes"
+            .all(|(task_id, _)| task_id != "task-1"),
+        "configured file copy failure should not change task status before build start"
     );
     drop(state);
+
+    let failed_branch = host_infra_system::build_branch_name("odt", "task-1", "Task task-1");
+    assert_branch_missing(repo.as_path(), failed_branch.as_str())?;
 
     let _ = fs::remove_dir_all(root);
     Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
@@ -39,6 +39,26 @@ use crate::app_service::{
     OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 
+fn assert_branch_missing(repo_path: &Path, branch: &str) -> Result<()> {
+    let output = Command::new("git")
+        .current_dir(repo_path)
+        .args(["branch", "--list", branch])
+        .output()
+        .with_context(|| format!("failed listing branch {branch} in {}", repo_path.display()))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "git branch --list failed for {branch} in {}",
+            repo_path.display()
+        ));
+    }
+
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "branch {branch} should have been removed"
+    );
+    Ok(())
+}
+
 #[test]
 fn git_get_branches_returns_git_data_without_task_store_initialization() -> Result<()> {
     let repo_path = "/tmp/odt-repo";
@@ -303,6 +323,61 @@ fn git_create_worktree_copies_configured_files() -> Result<()> {
         worktree.to_string_lossy().as_ref(),
         true,
     )?;
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn git_create_worktree_cleans_up_when_configured_file_copy_fails() -> Result<()> {
+    let root = unique_temp_path("git-create-worktree-copy-failure");
+    let repo = root.join("repo");
+    let worktree = root.join("worktree");
+    init_git_repo(&repo)?;
+
+    let task_state = Arc::new(Mutex::new(TaskStoreState::default()));
+    let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore { state: task_state });
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let service = AppService::new(task_store, config_store);
+    let repo_path = repo.to_string_lossy().to_string();
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            default_runtime_kind: "opencode".to_string(),
+            worktree_base_path: Some(root.join("worktrees").to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: Some("origin".to_string()),
+                branch: "main".to_string(),
+            },
+            git: Default::default(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            dev_servers: Vec::new(),
+            worktree_file_copies: vec![".env".to_string()],
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    let error = service
+        .git_create_worktree(
+            repo_path.as_str(),
+            worktree.to_string_lossy().as_ref(),
+            "feature/manual-copy-failure",
+            true,
+        )
+        .expect_err("missing configured copy source should fail");
+    assert!(error
+        .to_string()
+        .contains("Configured worktree file copy failed"));
+    assert!(
+        !worktree.exists(),
+        "manual worktree creation should remove the failed worktree"
+    );
+    assert_branch_missing(repo.as_path(), "feature/manual-copy-failure")?;
+
     let _ = fs::remove_dir_all(root);
     Ok(())
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/git_and_task.rs
@@ -27,15 +27,16 @@ use crate::app_service::test_support::{
     lock_env, make_emitter, make_session, make_task, prepend_path, process_is_alive,
     remove_env_var, set_env_var, spawn_sleep_process, unique_temp_path,
     wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
-    write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+    write_executable_script, write_private_file, FakeTaskStore, GitCall, TaskStoreState,
 };
 use crate::app_service::{
     build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
     parse_mcp_command_json, read_opencode_process_registry, read_opencode_version,
     resolve_mcp_command, resolve_opencode_binary_path, terminate_child_process,
     terminate_process_by_pid, validate_parent_relationships_for_update,
-    with_locked_opencode_process_registry, AgentRuntimeProcess, OpencodeProcessRegistryInstance,
-    RunProcess, TrackedOpencodeProcessGuard, OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
+    with_locked_opencode_process_registry, AgentRuntimeProcess, AppService,
+    OpencodeProcessRegistryInstance, RunProcess, TrackedOpencodeProcessGuard,
+    OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 
 #[test]
@@ -248,6 +249,62 @@ fn git_remove_worktree_rejects_repository_root() {
         .calls
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
+}
+
+#[test]
+fn git_create_worktree_copies_configured_files() -> Result<()> {
+    let root = unique_temp_path("git-create-worktree-copies-files");
+    let repo = root.join("repo");
+    let worktree = root.join("worktree");
+    init_git_repo(&repo)?;
+    write_private_file(repo.join(".env").as_path(), "API_KEY=manual-copy\n")?;
+
+    let task_state = Arc::new(Mutex::new(TaskStoreState::default()));
+    let task_store: Arc<dyn TaskStore> = Arc::new(FakeTaskStore { state: task_state });
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let service = AppService::new(task_store, config_store);
+    let repo_path = repo.to_string_lossy().to_string();
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            default_runtime_kind: "opencode".to_string(),
+            worktree_base_path: Some(root.join("worktrees").to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: Some("origin".to_string()),
+                branch: "main".to_string(),
+            },
+            git: Default::default(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            dev_servers: Vec::new(),
+            worktree_file_copies: vec![".env".to_string()],
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    service.git_create_worktree(
+        repo_path.as_str(),
+        worktree.to_string_lossy().as_ref(),
+        "feature/manual-copy",
+        true,
+    )?;
+
+    assert_eq!(
+        fs::read_to_string(worktree.join(".env"))?,
+        "API_KEY=manual-copy\n"
+    );
+
+    service.git_remove_worktree(
+        repo_path.as_str(),
+        worktree.to_string_lossy().as_ref(),
+        true,
+    )?;
+    let _ = fs::remove_dir_all(root);
+    Ok(())
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -163,7 +163,8 @@ fn shutdown_terminates_pending_opencode_processes() -> Result<()> {
     let root = unique_temp_path("shutdown-pending-opencode");
     let orphanable_opencode = root.join("opencode");
     create_orphanable_opencode(&orphanable_opencode)?;
-    let mut pending_child = Command::new(orphanable_opencode.as_path())
+    let mut pending_child = Command::new("/bin/sh")
+        .arg(orphanable_opencode.as_path())
         .arg("serve")
         .arg("--hostname")
         .arg("127.0.0.1")

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -22,4 +22,7 @@ pub use process::{
     run_command_allow_failure, run_command_allow_failure_with_env, run_command_with_env,
     subprocess_path_env, version_command,
 };
-pub use worktree::{build_branch_name, pick_free_port, remove_worktree, slugify_title};
+pub use worktree::{
+    build_branch_name, copy_configured_worktree_files, pick_free_port, remove_worktree,
+    slugify_title,
+};

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::DEFAULT_BRANCH_PREFIX;
 use std::fs;
+use std::io::ErrorKind;
 use std::net::TcpListener;
 use std::path::{Component, Path};
 use std::process::Command;
@@ -44,11 +45,29 @@ pub fn copy_configured_worktree_files(
     worktree_path: &Path,
     configured_files: &[String],
 ) -> Result<()> {
+    let repo_root = repo_path
+        .canonicalize()
+        .with_context(|| format!("Failed resolving repository path: {}", repo_path.display()))?;
+    let worktree_root = worktree_path.canonicalize().with_context(|| {
+        format!(
+            "Failed resolving worktree path before copying configured files: {}",
+            worktree_path.display()
+        )
+    })?;
+
     for configured_file in configured_files {
         let relative_path = Path::new(configured_file);
         validate_worktree_copy_path(relative_path, configured_file)?;
+        reject_symlinked_components(repo_path, relative_path, configured_file, "source")?;
 
         let source_path = repo_path.join(relative_path);
+        let canonical_source = source_path.canonicalize().with_context(|| {
+            format!(
+                "Configured worktree copy source is unavailable: {}",
+                source_path.display()
+            )
+        })?;
+        ensure_path_within_root(&repo_root, &canonical_source, configured_file, "source")?;
         let source_metadata = fs::metadata(&source_path).with_context(|| {
             format!(
                 "Configured worktree copy source is unavailable: {}",
@@ -64,12 +83,31 @@ pub fn copy_configured_worktree_files(
 
         let destination_path = worktree_path.join(relative_path);
         if let Some(parent) = destination_path.parent() {
+            let relative_parent = relative_path.parent().unwrap_or_else(|| Path::new(""));
+            reject_symlinked_components(
+                worktree_path,
+                relative_parent,
+                configured_file,
+                "destination",
+            )?;
             fs::create_dir_all(parent).with_context(|| {
                 format!(
                     "Failed creating configured worktree copy directory: {}",
                     parent.display()
                 )
             })?;
+            let canonical_parent = parent.canonicalize().with_context(|| {
+                format!(
+                    "Failed resolving configured worktree copy directory: {}",
+                    parent.display()
+                )
+            })?;
+            ensure_path_within_root(
+                &worktree_root,
+                &canonical_parent,
+                configured_file,
+                "destination",
+            )?;
         }
 
         fs::copy(&source_path, &destination_path).with_context(|| {
@@ -113,6 +151,56 @@ fn validate_worktree_copy_path(path: &Path, original: &str) -> Result<()> {
     Ok(())
 }
 
+fn reject_symlinked_components(
+    root_path: &Path,
+    relative_path: &Path,
+    original: &str,
+    path_role: &str,
+) -> Result<()> {
+    let mut current = root_path.to_path_buf();
+    for component in relative_path.components() {
+        let Component::Normal(segment) = component else {
+            continue;
+        };
+        current.push(segment);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) => {
+                if metadata.file_type().is_symlink() {
+                    return Err(anyhow!(
+                        "Configured worktree copy {path_role} cannot use symlinked path components: {original}"
+                    ));
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed inspecting configured worktree copy {path_role} path: {}",
+                        current.display()
+                    )
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn ensure_path_within_root(
+    root_path: &Path,
+    candidate_path: &Path,
+    original: &str,
+    path_role: &str,
+) -> Result<()> {
+    if candidate_path.starts_with(root_path) {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "Configured worktree copy {path_role} escapes its root via symlinked path components: {original}"
+    ))
+}
+
 pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
     let status = Command::new("git")
         .arg("worktree")
@@ -141,6 +229,8 @@ mod tests {
     use host_domain::DEFAULT_BRANCH_PREFIX;
     use std::fs;
     use std::net::TcpListener;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -273,6 +363,58 @@ mod tests {
             error
                 .to_string()
                 .contains("cannot traverse outside the repository"),
+            "unexpected copy error: {error}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_configured_worktree_files_rejects_symlinked_source_components() {
+        let root = unique_temp_path("copy-configured-source-symlink");
+        let repo = root.join("repo");
+        let worktree = root.join("worktree");
+        let outside = root.join("outside");
+        fs::create_dir_all(&repo).expect("repo directory should exist");
+        fs::create_dir_all(&worktree).expect("worktree directory should exist");
+        fs::create_dir_all(&outside).expect("outside directory should exist");
+        fs::write(outside.join("secret.env"), "TOKEN=secret\n").expect("outside file should write");
+        symlink(&outside, repo.join("config")).expect("repo config symlink should exist");
+
+        let error =
+            copy_configured_worktree_files(&repo, &worktree, &["config/secret.env".to_string()])
+                .expect_err("symlinked source component should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("source cannot use symlinked path components"),
+            "unexpected copy error: {error}"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_configured_worktree_files_rejects_symlinked_destination_components() {
+        let root = unique_temp_path("copy-configured-destination-symlink");
+        let repo = root.join("repo");
+        let worktree = root.join("worktree");
+        let outside = root.join("outside");
+        fs::create_dir_all(repo.join("config")).expect("repo config directory should exist");
+        fs::create_dir_all(&worktree).expect("worktree directory should exist");
+        fs::create_dir_all(&outside).expect("outside directory should exist");
+        fs::write(repo.join("config").join("local.json"), "{}\n").expect("repo file should write");
+        symlink(&outside, worktree.join("config")).expect("worktree config symlink should exist");
+
+        let error =
+            copy_configured_worktree_files(&repo, &worktree, &["config/local.json".to_string()])
+                .expect_err("symlinked destination component should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("destination cannot use symlinked path components"),
             "unexpected copy error: {error}"
         );
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
@@ -228,7 +228,6 @@ mod tests {
     };
     use host_domain::DEFAULT_BRANCH_PREFIX;
     use std::fs;
-    use std::net::TcpListener;
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
     use std::path::{Path, PathBuf};
@@ -312,10 +311,9 @@ mod tests {
     }
 
     #[test]
-    fn pick_free_port_returns_bindable_localhost_port() {
+    fn pick_free_port_returns_nonzero_port() {
         let port = pick_free_port().expect("free port should resolve");
-        let listener = TcpListener::bind(("127.0.0.1", port)).expect("port should be bindable");
-        drop(listener);
+        assert!(port > 0, "picked port should be nonzero");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/worktree.rs
@@ -1,7 +1,8 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use host_domain::DEFAULT_BRANCH_PREFIX;
+use std::fs;
 use std::net::TcpListener;
-use std::path::Path;
+use std::path::{Component, Path};
 use std::process::Command;
 
 pub fn slugify_title(value: &str) -> String {
@@ -38,6 +39,80 @@ pub fn pick_free_port() -> Result<u16> {
     Ok(port)
 }
 
+pub fn copy_configured_worktree_files(
+    repo_path: &Path,
+    worktree_path: &Path,
+    configured_files: &[String],
+) -> Result<()> {
+    for configured_file in configured_files {
+        let relative_path = Path::new(configured_file);
+        validate_worktree_copy_path(relative_path, configured_file)?;
+
+        let source_path = repo_path.join(relative_path);
+        let source_metadata = fs::metadata(&source_path).with_context(|| {
+            format!(
+                "Configured worktree copy source is unavailable: {}",
+                source_path.display()
+            )
+        })?;
+        if !source_metadata.is_file() {
+            return Err(anyhow!(
+                "Configured worktree copy source is not a file: {}",
+                source_path.display()
+            ));
+        }
+
+        let destination_path = worktree_path.join(relative_path);
+        if let Some(parent) = destination_path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "Failed creating configured worktree copy directory: {}",
+                    parent.display()
+                )
+            })?;
+        }
+
+        fs::copy(&source_path, &destination_path).with_context(|| {
+            format!(
+                "Failed copying configured worktree file {} to {}",
+                source_path.display(),
+                destination_path.display()
+            )
+        })?;
+    }
+
+    Ok(())
+}
+
+fn validate_worktree_copy_path(path: &Path, original: &str) -> Result<()> {
+    if original.trim().is_empty() {
+        return Err(anyhow!("Configured worktree copy path cannot be empty"));
+    }
+    if path.is_absolute() {
+        return Err(anyhow!(
+            "Configured worktree copy path must be relative: {original}"
+        ));
+    }
+
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                return Err(anyhow!(
+                    "Configured worktree copy path cannot traverse outside the repository: {original}"
+                ));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(anyhow!(
+                    "Configured worktree copy path must be relative: {original}"
+                ));
+            }
+            Component::CurDir | Component::Normal(_) => {}
+        }
+    }
+
+    Ok(())
+}
+
 pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
     let status = Command::new("git")
         .arg("worktree")
@@ -59,7 +134,10 @@ pub fn remove_worktree(repo_path: &Path, worktree_path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_branch_name, pick_free_port, remove_worktree, slugify_title};
+    use super::{
+        build_branch_name, copy_configured_worktree_files, pick_free_port, remove_worktree,
+        slugify_title,
+    };
     use host_domain::DEFAULT_BRANCH_PREFIX;
     use std::fs;
     use std::net::TcpListener;
@@ -148,6 +226,57 @@ mod tests {
         let port = pick_free_port().expect("free port should resolve");
         let listener = TcpListener::bind(("127.0.0.1", port)).expect("port should be bindable");
         drop(listener);
+    }
+
+    #[test]
+    fn copy_configured_worktree_files_copies_hidden_and_nested_files() {
+        let root = unique_temp_path("copy-configured-files");
+        let repo = root.join("repo");
+        let worktree = root.join("worktree");
+        fs::create_dir_all(repo.join("config")).expect("repo config directory should exist");
+        fs::create_dir_all(&worktree).expect("worktree directory should exist");
+        fs::write(repo.join(".env"), "TOKEN=secret\n").expect("hidden file should write");
+        fs::write(repo.join("config").join("local.json"), "{}\n")
+            .expect("nested file should write");
+
+        copy_configured_worktree_files(
+            &repo,
+            &worktree,
+            &[".env".to_string(), "config/local.json".to_string()],
+        )
+        .expect("configured files should copy");
+
+        assert_eq!(
+            fs::read_to_string(worktree.join(".env")).expect("copied hidden file should exist"),
+            "TOKEN=secret\n"
+        );
+        assert_eq!(
+            fs::read_to_string(worktree.join("config").join("local.json"))
+                .expect("copied nested file should exist"),
+            "{}\n"
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn copy_configured_worktree_files_rejects_parent_traversal() {
+        let root = unique_temp_path("copy-configured-parent");
+        let repo = root.join("repo");
+        let worktree = root.join("worktree");
+        fs::create_dir_all(&repo).expect("repo directory should exist");
+        fs::create_dir_all(&worktree).expect("worktree directory should exist");
+
+        let error = copy_configured_worktree_files(&repo, &worktree, &["../.env".to_string()])
+            .expect_err("parent traversal should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("cannot traverse outside the repository"),
+            "unexpected copy error: {error}"
+        );
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/git/tests/fixtures/git_port.rs
+++ b/apps/desktop/src-tauri/src/commands/git/tests/fixtures/git_port.rs
@@ -1,4 +1,5 @@
 use std::{
+    fs,
     path::Path,
     sync::{Arc, Mutex},
 };
@@ -149,6 +150,7 @@ impl GitPort for CommandGitPort {
             branch: branch.to_string(),
             create_branch,
         });
+        fs::create_dir_all(worktree_path)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- copy repo-configured files such as `.env` into newly created manual and build worktrees
- fail fast on invalid or missing configured copy paths and remove partially created worktrees
- add Rust coverage for helper behavior plus manual and build worktree copy flows

## Testing
- `rtk cargo fmt --all --check`
- `rtk cargo test -p host-application build_start_blocks_and_cleans_up_when_configured_worktree_file_copy_fails`
- `rtk cargo test -p host-application git_create_worktree_copies_configured_files`
- `rtk cargo test -p host-application build_start_copies_configured_worktree_files_into_new_worktree`
- `rtk cargo test -p host-infra-system copy_configured_worktree_files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New worktree file-copying ensures configured repo files are placed into newly created worktrees, with safety checks to prevent unsafe paths or symlink issues.
* **Bug Fixes / Reliability**
  * Expanded rollback on failures: attempts worktree removal, metadata pruning, branch deletion, and surfaces aggregated cleanup details on errors.
* **Tests**
  * Added integration tests for successful copies and failure/cleanup paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->