### PR TITLE
feat(kanban): default approval mode based on git provider availability

### DIFF
--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -323,6 +323,7 @@ describe("useTaskApprovalFlow", () => {
 
     expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
+    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
 
     pendingApprovalContext.resolve({
       taskId: "TASK-1",

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -151,6 +151,8 @@ let latestHarnessValue: {
     mode: "direct_merge" | "pull_request";
     mergeMethod: "merge_commit" | "squash" | "rebase";
     pullRequestDraftMode: "manual" | "generate_ai";
+    pullRequestAvailable: boolean;
+    pullRequestUnavailableReason: string | null;
     squashCommitMessage: string;
     squashCommitMessageTouched: boolean;
     hasSuggestedSquashCommitMessage: boolean;
@@ -273,6 +275,158 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.squashCommitMessage).toBe("feat: builder change");
     expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.uncommittedFileCount).toBe(2);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("defaults to pull_request mode when GitHub provider is available", async () => {
+    const pendingApprovalContext = createDeferred<TaskApprovalContext>();
+    taskApprovalContextGetMock.mockImplementationOnce(
+      (async () => pendingApprovalContext.promise) as unknown as never,
+    );
+
+    const { useTaskApprovalFlow } = await import("./use-task-approval-flow");
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [
+          createTaskCardFixture({
+            id: "TASK-1",
+            title: "Ship approval flow",
+            description: "Task description",
+          }),
+        ],
+        sessions: [],
+        loadAgentSessions: async () => {},
+        forkAgentSession: async () => "forked-session",
+        sendAgentMessage: async () => {},
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <QueryProvider useIsolatedClient>
+          <Harness />
+        </QueryProvider>,
+      );
+    });
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
+    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
+
+    pendingApprovalContext.resolve({
+      taskId: "TASK-1",
+      taskStatus: "human_review",
+      workingDirectory: "/repo/.worktrees/task-1",
+      sourceBranch: "odt/TASK-1",
+      targetBranch: { remote: "origin", branch: "main" },
+      publishTarget: undefined,
+      defaultMergeMethod: "merge_commit",
+      hasUncommittedChanges: false,
+      uncommittedFileCount: 0,
+      pullRequest: undefined,
+      suggestedSquashCommitMessage: undefined,
+      providers: [
+        {
+          providerId: "github",
+          enabled: true,
+          available: true,
+          reason: undefined,
+        },
+      ],
+    });
+
+    await act(async () => {
+      await pendingApprovalContext.promise;
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(false);
+    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("pull_request");
+    expect(latestHarnessValue?.taskApprovalModal?.pullRequestAvailable).toBe(true);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("defaults to direct_merge mode when no git provider is available", async () => {
+    const pendingApprovalContext = createDeferred<TaskApprovalContext>();
+    taskApprovalContextGetMock.mockImplementationOnce(
+      (async () => pendingApprovalContext.promise) as unknown as never,
+    );
+
+    const { useTaskApprovalFlow } = await import("./use-task-approval-flow");
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [
+          createTaskCardFixture({
+            id: "TASK-1",
+            title: "Ship approval flow",
+            description: "Task description",
+          }),
+        ],
+        sessions: [],
+        loadAgentSessions: async () => {},
+        forkAgentSession: async () => "forked-session",
+        sendAgentMessage: async () => {},
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    let renderer!: ReactTestRenderer;
+    await act(async () => {
+      renderer = create(
+        <QueryProvider useIsolatedClient>
+          <Harness />
+        </QueryProvider>,
+      );
+    });
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
+    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
+    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
+
+    pendingApprovalContext.resolve({
+      taskId: "TASK-1",
+      taskStatus: "human_review",
+      workingDirectory: "/repo/.worktrees/task-1",
+      sourceBranch: "odt/TASK-1",
+      targetBranch: { remote: "origin", branch: "main" },
+      publishTarget: undefined,
+      defaultMergeMethod: "merge_commit",
+      hasUncommittedChanges: false,
+      uncommittedFileCount: 0,
+      pullRequest: undefined,
+      suggestedSquashCommitMessage: undefined,
+      providers: [],
+    });
+
+    await act(async () => {
+      await pendingApprovalContext.promise;
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(false);
+    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
+    expect(latestHarnessValue?.taskApprovalModal?.pullRequestAvailable).toBe(false);
 
     await act(async () => {
       renderer.unmount();

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -20,6 +20,7 @@ import {
 import {
   invalidateTaskApprovalContextQuery,
   loadTaskApprovalContextFromQuery,
+  taskApprovalQueryKeys,
 } from "@/state/queries/task-approval";
 import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import type { TaskApprovalModalModel } from "./kanban-page-model-types";
@@ -165,12 +166,22 @@ export function useTaskApprovalFlow({
 
       const task = tasks.find((entry) => entry.id === taskId);
       const requestVersion = ++approvalRequestVersionRef.current;
+
+      const cachedContext = queryClient.getQueryData(
+        taskApprovalQueryKeys.context(activeRepo, taskId),
+      ) as TaskApprovalContext | undefined;
+      const githubProvider = cachedContext?.providers.find(
+        (entry) => entry.providerId === "github",
+      );
+      const effectiveMode =
+        options?.mode ?? (githubProvider?.available ? "pull_request" : "direct_merge");
+
       setState({
         open: true,
         stage: "approval",
         taskId,
         isLoading: true,
-        mode: options?.mode ?? "direct_merge",
+        mode: effectiveMode,
         mergeMethod: "merge_commit",
         pullRequestDraftMode: options?.pullRequestDraftMode ?? "manual",
         title: task?.title ?? "",
@@ -192,12 +203,17 @@ export function useTaskApprovalFlow({
           if (approvalRequestVersionRef.current !== requestVersion) {
             return;
           }
+          const updatedGithubProvider = approvalContext?.providers.find(
+            (entry) => entry.providerId === "github",
+          );
+          const updatedEffectiveMode =
+            options?.mode ?? (updatedGithubProvider?.available ? "pull_request" : "direct_merge");
           setState({
             open: true,
             stage: resolveApprovalStage(approvalContext),
             taskId,
             isLoading: false,
-            mode: options?.mode ?? "direct_merge",
+            mode: updatedEffectiveMode,
             mergeMethod: approvalContext.defaultMergeMethod,
             pullRequestDraftMode: options?.pullRequestDraftMode ?? "manual",
             title: task?.title ?? "",

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -167,14 +167,17 @@ export function useTaskApprovalFlow({
       const task = tasks.find((entry) => entry.id === taskId);
       const requestVersion = ++approvalRequestVersionRef.current;
 
+      const determineDefaultMode = (
+        context: TaskApprovalContext | undefined,
+      ): "direct_merge" | "pull_request" => {
+        const githubProvider = context?.providers?.find((entry) => entry.providerId === "github");
+        return githubProvider?.available ? "pull_request" : "direct_merge";
+      };
+
       const cachedContext = queryClient.getQueryData(
         taskApprovalQueryKeys.context(activeRepo, taskId),
       ) as TaskApprovalContext | undefined;
-      const githubProvider = cachedContext?.providers.find(
-        (entry) => entry.providerId === "github",
-      );
-      const effectiveMode =
-        options?.mode ?? (githubProvider?.available ? "pull_request" : "direct_merge");
+      const effectiveMode = options?.mode ?? determineDefaultMode(cachedContext);
 
       setState({
         open: true,
@@ -203,11 +206,7 @@ export function useTaskApprovalFlow({
           if (approvalRequestVersionRef.current !== requestVersion) {
             return;
           }
-          const updatedGithubProvider = approvalContext?.providers.find(
-            (entry) => entry.providerId === "github",
-          );
-          const updatedEffectiveMode =
-            options?.mode ?? (updatedGithubProvider?.available ? "pull_request" : "direct_merge");
+          const updatedEffectiveMode = options?.mode ?? determineDefaultMode(approvalContext);
           setState({
             open: true,
             stage: resolveApprovalStage(approvalContext),

--- a/apps/desktop/src/state/queries/task-approval.ts
+++ b/apps/desktop/src/state/queries/task-approval.ts
@@ -2,7 +2,7 @@ import type { TaskApprovalContext } from "@openducktor/contracts";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { host } from "../operations/host";
 
-const taskApprovalQueryKeys = {
+export const taskApprovalQueryKeys = {
   all: ["task-approval"] as const,
   context: (repoPath: string, taskId: string) =>
     [...taskApprovalQueryKeys.all, "context", repoPath, taskId] as const,


### PR DESCRIPTION
## Summary
- When opening the Task Approval modal, the default selected tab now depends on whether a git provider (e.g., GitHub) is configured
- If a GitHub provider is available: default to Pull Request tab
- Otherwise: default to Direct Merge tab

## Changes
- **task-approval.ts**: Export `taskApprovalQueryKeys` for cache access
- **use-task-approval-flow.ts**: Modified `openTaskApproval` to check cached approval context and compute `effectiveMode` based on `githubProvider?.available`
- **use-task-approval-flow.test.tsx**: Added tests for both scenarios

## Testing
- All 1210 tests pass
- Added 2 new test cases covering the default mode behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test cases for task approval flow with GitHub provider availability detection.

* **Improvements**
  * Task approval flow now intelligently selects pull request mode when GitHub provider is available, otherwise defaults to direct merge.
  * Enhanced responsiveness by leveraging cached context data for faster mode determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->