### PR TITLE
fix(desktop): enable stop button when agent session is actively working

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
@@ -76,6 +76,22 @@ describe("AgentChatComposer", () => {
     expect(html).not.toContain("22.5%");
   });
 
+  test("stop button is enabled when session is working even if agentStudioReady is false", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatComposer, {
+        model: {
+          ...buildModel(),
+          agentStudioReady: false,
+          canStopSession: true,
+          isSessionWorking: true,
+        },
+      }),
+    );
+
+    expect(html).toContain("Stop session");
+    expect(html).not.toContain('aria-label="Stop session" disabled');
+  });
+
   test("disables send when input is blank", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatComposer, {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -192,7 +192,6 @@ export function AgentChatComposer({ model }: { model: AgentChatComposerModel }):
                     type="button"
                     size="icon"
                     className="size-8 rounded-full border-0 bg-red-500 text-white shadow-sm hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700"
-                    disabled={!agentStudioReady}
                     aria-label="Stop session"
                     onClick={onStopSession}
                   >


### PR DESCRIPTION
## Summary
- Fix stop button being disabled in AgentChatComposer when `agentStudioReady` is false (e.g., runtime health check failures), even while an agent session is actively running
- Removed the `!agentStudioReady` condition since `canStopSession` already guarantees an active working session exists
- Added test to verify stop button is enabled when `canStopSession=true` even if `agentStudioReady=false`

## Testing
- All 9 composer tests pass
- Typecheck and lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stop session button availability fixed — it now correctly depends on session state and user permissions, and is no longer inappropriately disabled by unrelated conditions.

* **Tests**
  * Added test coverage verifying stop session button behavior across session states and permission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->