### PR TITLE
fix(runtime): resume live sessions from opencode

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -40,7 +40,8 @@ mod workspace_policy;
 pub(crate) use events::emit_event;
 pub(crate) use hook_security::{run_parsed_hook_command_allow_failure, validate_hook_trust};
 pub(crate) use opencode_session_status::{
-    has_live_opencode_session_status, load_opencode_session_statuses, OpencodeSessionStatusMap,
+    has_live_opencode_session_status, is_unreachable_opencode_session_status_error,
+    load_opencode_session_statuses, OpencodeSessionStatusMap,
 };
 pub(crate) use opencode_runtime::{
     opencode_server_parent_pid, process_exists, read_opencode_version,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -22,6 +22,7 @@ mod dev_server_manager;
 mod events;
 mod git_provider;
 mod hook_security;
+mod opencode_session_status;
 mod opencode_runtime;
 mod process_registry;
 mod repo_init;
@@ -38,6 +39,9 @@ mod workspace_policy;
 
 pub(crate) use events::emit_event;
 pub(crate) use hook_security::{run_parsed_hook_command_allow_failure, validate_hook_trust};
+pub(crate) use opencode_session_status::{
+    has_live_opencode_session_status, load_opencode_session_statuses, OpencodeSessionStatusMap,
+};
 pub(crate) use opencode_runtime::{
     opencode_server_parent_pid, process_exists, read_opencode_version,
     resolve_opencode_binary_path, spawn_opencode_server, terminate_child_process,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -1,0 +1,126 @@
+use anyhow::{anyhow, Context, Result};
+use host_domain::RuntimeRoute;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+use url::{form_urlencoded, Url};
+
+#[derive(serde::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum OpencodeSessionStatus {
+    Idle,
+    Retry {
+        #[allow(dead_code)]
+        attempt: u64,
+        #[allow(dead_code)]
+        message: String,
+        #[allow(dead_code)]
+        next: u64,
+    },
+    Busy,
+}
+
+pub(crate) type OpencodeSessionStatusMap = HashMap<String, OpencodeSessionStatus>;
+
+pub(crate) fn has_live_opencode_session_status(
+    statuses: &OpencodeSessionStatusMap,
+    external_session_id: &str,
+) -> bool {
+    matches!(
+        statuses.get(external_session_id),
+        Some(OpencodeSessionStatus::Busy | OpencodeSessionStatus::Retry { .. })
+    )
+}
+
+pub(crate) fn load_opencode_session_statuses(
+    runtime_route: &RuntimeRoute,
+    working_directory: &str,
+) -> Result<OpencodeSessionStatusMap> {
+    let endpoint = match runtime_route {
+        RuntimeRoute::LocalHttp { endpoint } => endpoint.as_str(),
+    };
+    let parsed_endpoint =
+        Url::parse(endpoint).with_context(|| format!("Invalid OpenCode runtime endpoint: {endpoint}"))?;
+    let host = parsed_endpoint
+        .host_str()
+        .ok_or_else(|| anyhow!("OpenCode runtime endpoint is missing a host: {endpoint}"))?;
+    let port = parsed_endpoint
+        .port()
+        .ok_or_else(|| anyhow!("OpenCode runtime route must expose a port: {endpoint}"))?;
+    let request_path = format!(
+        "/session/status?{}",
+        form_urlencoded::Serializer::new(String::new())
+            .append_pair("directory", working_directory)
+            .finish()
+    );
+    let mut stream = TcpStream::connect((host, port)).with_context(|| {
+        format!(
+            "Failed to connect to OpenCode runtime at {endpoint} to inspect session status for {working_directory}"
+        )
+    })?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .context("Failed configuring OpenCode session status read timeout")?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .context("Failed configuring OpenCode session status write timeout")?;
+
+    let request = format!(
+        "GET {request_path} HTTP/1.1\r\nHost: {host}:{port}\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(request.as_bytes()).with_context(|| {
+        format!("Failed sending OpenCode session status request for {working_directory}")
+    })?;
+    stream.flush().with_context(|| {
+        format!("Failed flushing OpenCode session status request for {working_directory}")
+    })?;
+
+    let mut reader = BufReader::new(stream);
+    let mut status_line = String::new();
+    reader.read_line(&mut status_line).with_context(|| {
+        format!("Failed reading OpenCode session status response for {working_directory}")
+    })?;
+    let status_code = parse_http_status_code(status_line.as_str())?;
+
+    let mut response = String::new();
+    reader.read_to_string(&mut response).with_context(|| {
+        format!("Failed reading OpenCode session status body for {working_directory}")
+    })?;
+
+    if !(200..300).contains(&status_code) {
+        let response_body = extract_http_response_body(response.as_str());
+        let detail_suffix = if response_body.is_empty() {
+            String::new()
+        } else {
+            format!(": {response_body}")
+        };
+        return Err(anyhow!(
+            "OpenCode runtime failed to load session status for {working_directory}: HTTP {status_code}{detail_suffix}"
+        ));
+    }
+
+    let body = extract_http_response_body(response.as_str());
+    serde_json::from_str::<OpencodeSessionStatusMap>(body.as_str()).with_context(|| {
+        format!("Failed parsing OpenCode session status response for {working_directory}")
+    })
+}
+
+fn parse_http_status_code(status_line: &str) -> Result<u16> {
+    let trimmed = status_line.trim();
+    let status_code = trimmed
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| anyhow!("OpenCode response missing HTTP status code"))?;
+    status_code
+        .parse::<u16>()
+        .with_context(|| format!("Invalid OpenCode HTTP status code: {status_code}"))
+}
+
+fn extract_http_response_body(response: &str) -> String {
+    response
+        .split_once("\r\n\r\n")
+        .or_else(|| response.split_once("\n\n"))
+        .map(|(_, body)| body.trim().to_string())
+        .unwrap_or_default()
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::RuntimeRoute;
 use std::collections::HashMap;
+use std::io::ErrorKind;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
 use std::time::Duration;
@@ -22,6 +23,24 @@ pub(crate) enum OpencodeSessionStatus {
 }
 
 pub(crate) type OpencodeSessionStatusMap = HashMap<String, OpencodeSessionStatus>;
+
+pub(crate) fn is_unreachable_opencode_session_status_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io_error| {
+                matches!(
+                    io_error.kind(),
+                    ErrorKind::ConnectionRefused
+                        | ErrorKind::ConnectionReset
+                        | ErrorKind::ConnectionAborted
+                        | ErrorKind::NotConnected
+                        | ErrorKind::TimedOut
+                        | ErrorKind::UnexpectedEof
+                )
+            })
+    })
+}
 
 pub(crate) fn has_live_opencode_session_status(
     statuses: &OpencodeSessionStatusMap,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -4,9 +4,9 @@ mod startup;
 use super::AppService;
 use anyhow::{anyhow, Result};
 use host_domain::{
-    AgentRuntimeKind, RunSummary, RuntimeDescriptor, RuntimeInstanceSummary, RuntimeRole,
+    AgentRuntimeKind, RunState, RunSummary, RuntimeDescriptor, RuntimeInstanceSummary, RuntimeRole,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::process::Child;
 use std::sync::Arc;
 
@@ -289,6 +289,8 @@ impl AppService {
             .runs
             .lock()
             .map_err(|_| anyhow!("Run state lock poisoned"))?;
+        let mut runtime_statuses_by_worktree = HashMap::new();
+        let mut sessions_by_repo_task = HashMap::new();
 
         let mut list = runs
             .values()
@@ -302,8 +304,18 @@ impl AppService {
                     true
                 }
             })
-            .map(|run| run.summary.clone())
-            .collect::<Vec<_>>();
+            .filter_map(|run| {
+                match self.should_expose_run(
+                    run,
+                    &mut runtime_statuses_by_worktree,
+                    &mut sessions_by_repo_task,
+                ) {
+                    Ok(true) => Some(Ok(run.summary.clone())),
+                    Ok(false) => None,
+                    Err(error) => Some(Err(error)),
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         list.sort_by(|a, b| b.started_at.cmp(&a.started_at));
         Ok(list)
@@ -392,15 +404,108 @@ impl AppService {
             other => Err(anyhow!("Unsupported agent runtime kind: {other}")),
         }
     }
+
+    fn should_expose_run(
+        &self,
+        run: &super::RunProcess,
+        runtime_statuses_by_worktree: &mut HashMap<String, super::OpencodeSessionStatusMap>,
+        sessions_by_repo_task: &mut HashMap<String, Vec<host_domain::AgentSessionDocument>>,
+    ) -> Result<bool> {
+        if !matches!(
+            run.summary.state,
+            RunState::Starting
+                | RunState::Running
+                | RunState::Blocked
+                | RunState::AwaitingDoneConfirmation
+        ) {
+            return Ok(true);
+        }
+
+        let session_cache_key = format!("{}::{}", run.repo_path, run.task_id);
+        if !sessions_by_repo_task.contains_key(session_cache_key.as_str()) {
+            let sessions = self.agent_sessions_list(run.repo_path.as_str(), run.task_id.as_str())?;
+            sessions_by_repo_task.insert(session_cache_key.clone(), sessions);
+        }
+        let sessions = sessions_by_repo_task
+            .get(session_cache_key.as_str())
+            .ok_or_else(|| anyhow!("Missing cached agent sessions for {}", session_cache_key))?;
+        let external_session_ids = sessions
+            .iter()
+            .filter(|session| session.role.trim() == "build")
+            .filter(|session| session.runtime_kind.trim() == run.summary.runtime_kind.as_str())
+            .filter(|session| {
+                super::task_workflow::normalize_path_for_comparison(session.working_directory.as_str())
+                    == super::task_workflow::normalize_path_for_comparison(
+                        run.worktree_path.as_str(),
+                    )
+            })
+            .filter_map(|session| {
+                session
+                    .external_session_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+            })
+            .collect::<Vec<_>>();
+
+        if external_session_ids.is_empty() {
+            return Ok(true);
+        }
+
+        let worktree_key = super::task_workflow::normalize_path_key(run.worktree_path.as_str());
+        if !runtime_statuses_by_worktree.contains_key(worktree_key.as_str()) {
+            let statuses = match run.summary.runtime_kind {
+                AgentRuntimeKind::Opencode => {
+                    super::load_opencode_session_statuses(
+                        &run.summary.runtime_route,
+                        run.worktree_path.as_str(),
+                    )?
+                }
+            };
+            runtime_statuses_by_worktree.insert(worktree_key.clone(), statuses);
+        }
+        let statuses = runtime_statuses_by_worktree
+            .get(worktree_key.as_str())
+            .ok_or_else(|| anyhow!("Missing cached OpenCode session statuses for {}", worktree_key))?;
+        Ok(external_session_ids
+            .iter()
+            .any(|external_session_id| super::has_live_opencode_session_status(statuses, external_session_id)))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{AppService, RuntimeEnsureFlightGuard};
-    use crate::app_service::test_support::build_service_with_state;
+    use crate::app_service::test_support::{build_service_with_state, make_task};
+    use crate::app_service::RunProcess;
     use anyhow::{anyhow, Result};
-    use host_domain::AgentRuntimeKind;
+    use host_domain::{AgentRuntimeKind, AgentSessionDocument, RunSummary, TaskStatus};
+    use host_infra_system::RepoConfig;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
     use std::thread;
+
+    fn spawn_opencode_session_status_server(
+        response_body: &'static str,
+    ) -> Result<(u16, std::thread::JoinHandle<()>)> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut request_buffer = [0_u8; 4096];
+                let _ = stream.read(&mut request_buffer);
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        Ok((port, handle))
+    }
 
     #[test]
     fn runtime_ensure_flight_guard_finishes_waiters_when_dropped_uncompleted() -> Result<()> {
@@ -478,6 +583,67 @@ mod tests {
             .expect("runs list should be available");
 
         assert!(runs.is_empty());
+    }
+
+    #[test]
+    fn module_runs_list_filters_stale_build_runs_without_live_runtime_session() -> Result<()> {
+        let (service, task_state, _git_state) =
+            build_service_with_state(vec![make_task("task-1", "task", TaskStatus::InProgress)]);
+        let (port, server_handle) =
+            spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"idle"}}"#)?;
+
+        task_state
+            .lock()
+            .expect("task store lock poisoned")
+            .agent_sessions = vec![AgentSessionDocument {
+            session_id: "build-session".to_string(),
+            external_session_id: Some("external-build-session".to_string()),
+            task_id: Some("task-1".to_string()),
+            role: "build".to_string(),
+            scenario: Some("build_implementation_start".to_string()),
+            status: Some("running".to_string()),
+            started_at: "2026-03-17T11:00:00Z".to_string(),
+            updated_at: None,
+            ended_at: None,
+            runtime_kind: "opencode".to_string(),
+            working_directory: "/tmp/repo/worktree".to_string(),
+            pending_permissions: Vec::new(),
+            pending_questions: Vec::new(),
+            selected_model: None,
+        }];
+
+        service.runs.lock().expect("run state lock poisoned").insert(
+            "run-1".to_string(),
+            RunProcess {
+                summary: RunSummary {
+                    run_id: "run-1".to_string(),
+                    runtime_kind: AgentRuntimeKind::Opencode,
+                    runtime_route: host_domain::RuntimeRoute::LocalHttp {
+                        endpoint: format!("http://127.0.0.1:{port}"),
+                    },
+                    repo_path: "/tmp/repo".to_string(),
+                    task_id: "task-1".to_string(),
+                    branch: "odt/task-1".to_string(),
+                    worktree_path: "/tmp/repo/worktree".to_string(),
+                    port,
+                    state: host_domain::RunState::Running,
+                    last_message: None,
+                    started_at: "2026-03-17T11:00:00Z".to_string(),
+                },
+                child: None,
+                _opencode_process_guard: None,
+                repo_path: "/tmp/repo".to_string(),
+                task_id: "task-1".to_string(),
+                worktree_path: "/tmp/repo/worktree".to_string(),
+                repo_config: RepoConfig::default(),
+            },
+        );
+
+        let runs = service.runs_list(Some("/tmp/repo"))?;
+        server_handle.join().expect("status server thread should finish");
+
+        assert!(runs.is_empty());
+        Ok(())
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -457,10 +457,18 @@ impl AppService {
         if !runtime_statuses_by_worktree.contains_key(worktree_key.as_str()) {
             let statuses = match run.summary.runtime_kind {
                 AgentRuntimeKind::Opencode => {
-                    super::load_opencode_session_statuses(
+                    match super::load_opencode_session_statuses(
                         &run.summary.runtime_route,
                         run.worktree_path.as_str(),
-                    )?
+                    ) {
+                        Ok(statuses) => statuses,
+                        Err(error)
+                            if super::is_unreachable_opencode_session_status_error(&error) =>
+                        {
+                            super::OpencodeSessionStatusMap::new()
+                        }
+                        Err(error) => return Err(error),
+                    }
                 }
             };
             runtime_statuses_by_worktree.insert(worktree_key.clone(), statuses);
@@ -641,6 +649,67 @@ mod tests {
 
         let runs = service.runs_list(Some("/tmp/repo"))?;
         server_handle.join().expect("status server thread should finish");
+
+        assert!(runs.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn module_runs_list_treats_unreachable_status_endpoint_as_stale_run() -> Result<()> {
+        let (service, task_state, _git_state) =
+            build_service_with_state(vec![make_task("task-1", "task", TaskStatus::InProgress)]);
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        drop(listener);
+
+        task_state
+            .lock()
+            .expect("task store lock poisoned")
+            .agent_sessions = vec![AgentSessionDocument {
+            session_id: "build-session".to_string(),
+            external_session_id: Some("external-build-session".to_string()),
+            task_id: Some("task-1".to_string()),
+            role: "build".to_string(),
+            scenario: Some("build_implementation_start".to_string()),
+            status: Some("running".to_string()),
+            started_at: "2026-03-17T11:00:00Z".to_string(),
+            updated_at: None,
+            ended_at: None,
+            runtime_kind: "opencode".to_string(),
+            working_directory: "/tmp/repo/worktree".to_string(),
+            pending_permissions: Vec::new(),
+            pending_questions: Vec::new(),
+            selected_model: None,
+        }];
+
+        service.runs.lock().expect("run state lock poisoned").insert(
+            "run-1".to_string(),
+            RunProcess {
+                summary: RunSummary {
+                    run_id: "run-1".to_string(),
+                    runtime_kind: AgentRuntimeKind::Opencode,
+                    runtime_route: host_domain::RuntimeRoute::LocalHttp {
+                        endpoint: format!("http://127.0.0.1:{port}"),
+                    },
+                    repo_path: "/tmp/repo".to_string(),
+                    task_id: "task-1".to_string(),
+                    branch: "odt/task-1".to_string(),
+                    worktree_path: "/tmp/repo/worktree".to_string(),
+                    port,
+                    state: host_domain::RunState::Running,
+                    last_message: None,
+                    started_at: "2026-03-17T11:00:00Z".to_string(),
+                },
+                child: None,
+                _opencode_process_guard: None,
+                repo_path: "/tmp/repo".to_string(),
+                task_id: "task-1".to_string(),
+                worktree_path: "/tmp/repo/worktree".to_string(),
+                repo_config: RepoConfig::default(),
+            },
+        );
+
+        let runs = service.runs_list(Some("/tmp/repo"))?;
 
         assert!(runs.is_empty());
         Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/mod.rs
@@ -4,3 +4,5 @@ mod qa_service;
 mod session_service;
 mod task_context;
 mod task_service;
+
+pub(crate) use task_service::{normalize_path_for_comparison, normalize_path_key};

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -1,4 +1,7 @@
-use crate::app_service::service_core::AppService;
+use crate::app_service::{
+    has_live_opencode_session_status, load_opencode_session_statuses, service_core::AppService,
+    OpencodeSessionStatusMap,
+};
 use crate::app_service::workflow_rules::{
     default_qa_required_for_issue_type, is_open_state, validate_parent_relationships_for_create,
     validate_parent_relationships_for_update, validate_transition,
@@ -8,7 +11,7 @@ use host_domain::{
     AgentSessionDocument, CreateTaskInput, QaWorkflowVerdict, RunState, RuntimeRole, TaskCard,
     TaskMetadata, TaskStatus, UpdateTaskPatch, DEFAULT_BRANCH_PREFIX,
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -317,17 +320,39 @@ impl AppService {
             .runs
             .lock()
             .map_err(|_| anyhow!("Run state lock poisoned"))?;
-        let has_active_run = runs.values().any(|run| {
-            normalize_path_for_comparison(run.repo_path.as_str()) == normalized_repo
-                && run.task_id == task_id
-                && matches!(
+        let mut runtime_statuses_by_directory = HashMap::<String, OpencodeSessionStatusMap>::new();
+        let mut runtime_routes_by_worktree = HashMap::new();
+        let mut has_active_run = false;
+        for run in runs.values() {
+            if normalize_path_for_comparison(run.repo_path.as_str()) != normalized_repo
+                || run.task_id != task_id
+                || !matches!(
                     run.summary.state,
                     RunState::Starting
                         | RunState::Running
                         | RunState::Blocked
                         | RunState::AwaitingDoneConfirmation
                 )
-        });
+            {
+                continue;
+            }
+
+            runtime_routes_by_worktree.insert(
+                normalize_path_key(run.worktree_path.as_str()),
+                run.summary.runtime_route.clone(),
+            );
+
+            if !is_live_build_run_for_task_reset(
+                run,
+                sessions,
+                &mut runtime_statuses_by_directory,
+            )? {
+                continue;
+            }
+
+            has_active_run = true;
+            break;
+        }
         drop(runs);
 
         if has_active_run {
@@ -347,17 +372,50 @@ impl AppService {
             ));
         }
 
-        let active_roles = sessions
+        let mut active_roles = HashSet::new();
+        for session in sessions
             .iter()
             .filter(|session| matches!(session.role.as_str(), "build" | "qa"))
-            .filter(|session| {
-                matches!(
-                    session.status.as_deref(),
-                    Some("starting") | Some("running")
-                )
-            })
-            .map(|session| session.role.as_str())
-            .collect::<HashSet<_>>();
+        {
+            if !matches!(session.status.as_deref(), Some("starting") | Some("running")) {
+                continue;
+            }
+
+            let external_session_id = session
+                .external_session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            let Some(external_session_id) = external_session_id else {
+                active_roles.insert(session.role.as_str());
+                continue;
+            };
+
+            if session.role.as_str() != "build" {
+                active_roles.insert(session.role.as_str());
+                continue;
+            }
+
+            let worktree_key = normalize_path_key(session.working_directory.as_str());
+            let Some(runtime_route) = runtime_routes_by_worktree.get(worktree_key.as_str()) else {
+                active_roles.insert(session.role.as_str());
+                continue;
+            };
+            if !runtime_statuses_by_directory.contains_key(worktree_key.as_str()) {
+                let statuses = load_opencode_session_statuses(
+                    runtime_route,
+                    session.working_directory.as_str(),
+                )?;
+                runtime_statuses_by_directory.insert(worktree_key.clone(), statuses);
+            }
+
+            if runtime_statuses_by_directory
+                .get(worktree_key.as_str())
+                .is_some_and(|statuses| has_live_opencode_session_status(statuses, external_session_id))
+            {
+                active_roles.insert(session.role.as_str());
+            }
+        }
         if active_roles.is_empty() {
             return Ok(());
         }
@@ -582,7 +640,7 @@ fn derive_reset_implementation_status(task: &TaskCard) -> TaskStatus {
     TaskStatus::Open
 }
 
-fn normalize_path_for_comparison(path: &str) -> PathBuf {
+pub(crate) fn normalize_path_for_comparison(path: &str) -> PathBuf {
     let trimmed = path.trim();
     if trimmed.is_empty() {
         return PathBuf::new();
@@ -598,7 +656,7 @@ fn normalize_path_for_comparison(path: &str) -> PathBuf {
     })
 }
 
-fn normalize_path_key(path: &str) -> String {
+pub(crate) fn normalize_path_key(path: &str) -> String {
     normalize_path_for_comparison(path)
         .to_string_lossy()
         .to_string()
@@ -852,4 +910,50 @@ fn collect_active_runtime_roles_for_task(
     let mut roles = active_roles.into_iter().collect::<Vec<_>>();
     roles.sort_unstable();
     Ok(roles)
+}
+
+fn is_live_build_run_for_task_reset(
+    run: &crate::app_service::RunProcess,
+    sessions: &[AgentSessionDocument],
+    runtime_statuses_by_directory: &mut HashMap<String, OpencodeSessionStatusMap>,
+) -> Result<bool> {
+    let normalized_worktree = normalize_path_for_comparison(run.worktree_path.as_str());
+    let external_session_ids = sessions
+        .iter()
+        .filter(|session| session.role.trim() == "build")
+        .filter(|session| session.runtime_kind.trim() == run.summary.runtime_kind.as_str())
+        .filter(|session| {
+            normalize_path_for_comparison(session.working_directory.as_str()) == normalized_worktree
+        })
+        .filter_map(|session| {
+            session
+                .external_session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+        })
+        .collect::<Vec<_>>();
+
+    if external_session_ids.is_empty() {
+        return Ok(true);
+    }
+
+    let directory_key = normalize_path_key(run.worktree_path.as_str());
+    if !runtime_statuses_by_directory.contains_key(directory_key.as_str()) {
+        let statuses = match run.summary.runtime_kind {
+            host_domain::AgentRuntimeKind::Opencode => load_opencode_session_statuses(
+                &run.summary.runtime_route,
+                run.worktree_path.as_str(),
+            )?,
+        };
+        runtime_statuses_by_directory.insert(directory_key.clone(), statuses);
+    }
+
+    let statuses = runtime_statuses_by_directory
+        .get(directory_key.as_str())
+        .ok_or_else(|| anyhow!("Missing cached OpenCode session statuses for {}", run.worktree_path))?;
+    Ok(external_session_ids
+        .iter()
+        .any(|external_session_id| has_live_opencode_session_status(statuses, external_session_id)))
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -1,6 +1,6 @@
 use crate::app_service::{
-    has_live_opencode_session_status, load_opencode_session_statuses, service_core::AppService,
-    OpencodeSessionStatusMap,
+    has_live_opencode_session_status, is_unreachable_opencode_session_status_error,
+    load_opencode_session_statuses, service_core::AppService, OpencodeSessionStatusMap,
 };
 use crate::app_service::workflow_rules::{
     default_qa_required_for_issue_type, is_open_state, validate_parent_relationships_for_create,
@@ -405,7 +405,14 @@ impl AppService {
                 let statuses = load_opencode_session_statuses(
                     runtime_route,
                     session.working_directory.as_str(),
-                )?;
+                )
+                .or_else(|error| {
+                    if is_unreachable_opencode_session_status_error(&error) {
+                        Ok(OpencodeSessionStatusMap::new())
+                    } else {
+                        Err(error)
+                    }
+                })?;
                 runtime_statuses_by_directory.insert(worktree_key.clone(), statuses);
             }
 
@@ -945,7 +952,14 @@ fn is_live_build_run_for_task_reset(
             host_domain::AgentRuntimeKind::Opencode => load_opencode_session_statuses(
                 &run.summary.runtime_route,
                 run.worktree_path.as_str(),
-            )?,
+            )
+            .or_else(|error| {
+                if is_unreachable_opencode_session_status_error(&error) {
+                    Ok(OpencodeSessionStatusMap::new())
+                } else {
+                    Err(error)
+                }
+            })?,
         };
         runtime_statuses_by_directory.insert(directory_key.clone(), statuses);
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -1292,6 +1292,7 @@ pid_file = os.environ.get("OPENDUCKTOR_TEST_PID_FILE", "")
 termination_file = os.environ.get("OPENDUCKTOR_TEST_TERM_FILE", "")
 aborts_file = os.environ.get("OPENDUCKTOR_TEST_ABORTS_FILE", "")
 abort_status = int(os.environ.get("OPENDUCKTOR_TEST_ABORT_STATUS", "200") or "200")
+session_status_body = os.environ.get("OPENDUCKTOR_TEST_SESSION_STATUS_BODY", "{}")
 
 if pid_file:
     try:
@@ -1338,7 +1339,17 @@ while True:
 
         request_text = request.decode("utf-8", "ignore")
         request_line = request_text.splitlines()[0] if request_text else ""
-        if request_line.startswith("POST /session/") and "/abort" in request_line:
+        if request_line.startswith("GET /session/status"):
+            body = session_status_body.encode("utf-8")
+            response = (
+                "HTTP/1.1 200 OK\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                "Content-Type: application/json\r\n"
+                "Connection: close\r\n"
+                "\r\n"
+            ).encode("utf-8")
+            conn.sendall(response + body)
+        elif request_line.startswith("POST /session/") and "/abort" in request_line:
             if aborts_file:
                 try:
                     with open(aborts_file, "a", encoding="utf-8") as file:

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -544,6 +544,10 @@ fn build_stop_propagates_abort_failures_without_marking_run_stopped() -> Result<
         aborts_file.to_string_lossy().as_ref(),
     );
     let _abort_status_guard = set_env_var("OPENDUCKTOR_TEST_ABORT_STATUS", "500");
+    let _session_status_guard = set_env_var(
+        "OPENDUCKTOR_TEST_SESSION_STATUS_BODY",
+        r#"{"external-build-session":{"type":"busy"}}"#,
+    );
 
     let config_store = AppConfigStore::from_path(root.join("config.json"));
     let repo_path = repo.to_string_lossy().to_string();

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -938,6 +938,117 @@ fn task_reset_implementation_ignores_stale_build_run_when_runtime_session_is_idl
 }
 
 #[test]
+fn task_reset_implementation_ignores_stale_build_run_when_status_endpoint_is_unreachable(
+) -> Result<()> {
+    let repo_path = unique_temp_path("reset-implementation-stale-build-run-unreachable-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+    let worktree_base = repo_path.join("worktrees");
+    let build_worktree = worktree_base.join("task-1");
+    fs::create_dir_all(&worktree_base)?;
+    fs::create_dir_all(&build_worktree)?;
+
+    let mut task = make_task("task-1", "task", TaskStatus::HumanReview);
+    task.document_summary.spec.has = true;
+    task.document_summary.plan.has = true;
+
+    let (service, task_state, git_state) = build_service_with_git_state(
+        vec![task],
+        vec![GitBranch {
+            name: "odt/task-1".to_string(),
+            is_current: false,
+            is_remote: false,
+        }],
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let workspace = service.workspace_add(&repo_path.to_string_lossy())?;
+    service.workspace_update_repo_config(
+        workspace.path.as_str(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            ..Default::default()
+        },
+    )?;
+    git_state
+        .lock()
+        .expect("git state lock poisoned")
+        .current_branches_by_path
+        .insert(
+            build_worktree.to_string_lossy().to_string(),
+            host_domain::GitCurrentBranch {
+                name: Some("odt/task-1".to_string()),
+                detached: false,
+                revision: None,
+            },
+        );
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        task_id: Some("task-1".to_string()),
+        role: "build".to_string(),
+        scenario: Some("build_implementation_start".to_string()),
+        status: Some("running".to_string()),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        updated_at: None,
+        ended_at: None,
+        runtime_kind: "opencode".to_string(),
+        working_directory: build_worktree.to_string_lossy().to_string(),
+        pending_permissions: Vec::new(),
+        pending_questions: Vec::new(),
+        selected_model: None,
+    }];
+
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+
+    service.runs.lock().expect("run state lock poisoned").insert(
+        "run-1".to_string(),
+        crate::app_service::RunProcess {
+            summary: serde_json::from_value(json!({
+                "runId": "run-1",
+                "runtimeKind": "opencode",
+                "runtimeRoute": {
+                    "type": "local_http",
+                    "endpoint": format!("http://127.0.0.1:{port}"),
+                },
+                "repoPath": workspace.path.clone(),
+                "taskId": "task-1",
+                "branch": "odt/task-1",
+                "worktreePath": build_worktree.to_string_lossy().to_string(),
+                "port": port,
+                "state": "running",
+                "lastMessage": null,
+                "startedAt": "2026-03-17T11:00:00Z",
+            }))?,
+            child: None,
+            _opencode_process_guard: None,
+            repo_path: workspace.path.clone(),
+            task_id: "task-1".to_string(),
+            worktree_path: build_worktree.to_string_lossy().to_string(),
+            repo_config: host_infra_system::RepoConfig {
+                branch_prefix: "odt".to_string(),
+                worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+                ..Default::default()
+            },
+        },
+    );
+
+    let updated = service.task_reset_implementation(workspace.path.as_str(), "task-1")?;
+
+    assert_eq!(updated.status, TaskStatus::ReadyForDev);
+    Ok(())
+}
+
+#[test]
 fn task_reset_implementation_only_removes_task_managed_worktrees() -> Result<()> {
     let repo_path = unique_temp_path("reset-implementation-owned-worktrees-repo");
     fs::create_dir_all(&repo_path)?;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -9,6 +9,7 @@ use host_infra_system::{
 };
 use serde_json::json;
 use std::fs;
+use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -44,6 +45,25 @@ fn init_git_repo(path: &std::path::Path) -> Result<()> {
         "failed to initialize git repo for test at {}",
         path.display()
     ))
+}
+
+fn spawn_opencode_session_status_server(response_body: &'static str) -> Result<(u16, std::thread::JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        response_body.len(),
+        response_body
+    );
+    let handle = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buffer = [0_u8; 4096];
+            let _ = stream.read(&mut request_buffer);
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    Ok((port, handle))
 }
 
 #[test]
@@ -805,6 +825,115 @@ fn task_reset_implementation_rejects_live_runtime_even_without_persisted_session
         .to_string()
         .contains("Stop the active session(s) first"));
     service.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn task_reset_implementation_ignores_stale_build_run_when_runtime_session_is_idle() -> Result<()> {
+    let repo_path = unique_temp_path("reset-implementation-stale-build-run-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+    let worktree_base = repo_path.join("worktrees");
+    let build_worktree = worktree_base.join("task-1");
+    fs::create_dir_all(&worktree_base)?;
+    fs::create_dir_all(&build_worktree)?;
+
+    let mut task = make_task("task-1", "task", TaskStatus::HumanReview);
+    task.document_summary.spec.has = true;
+    task.document_summary.plan.has = true;
+
+    let (service, task_state, git_state) = build_service_with_git_state(
+        vec![task],
+        vec![GitBranch {
+            name: "odt/task-1".to_string(),
+            is_current: false,
+            is_remote: false,
+        }],
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let workspace = service.workspace_add(&repo_path.to_string_lossy())?;
+    service.workspace_update_repo_config(
+        workspace.path.as_str(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            ..Default::default()
+        },
+    )?;
+    git_state
+        .lock()
+        .expect("git state lock poisoned")
+        .current_branches_by_path
+        .insert(
+            build_worktree.to_string_lossy().to_string(),
+            host_domain::GitCurrentBranch {
+                name: Some("odt/task-1".to_string()),
+                detached: false,
+                revision: None,
+            },
+        );
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        task_id: Some("task-1".to_string()),
+        role: "build".to_string(),
+        scenario: Some("build_implementation_start".to_string()),
+        status: Some("running".to_string()),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        updated_at: None,
+        ended_at: None,
+        runtime_kind: "opencode".to_string(),
+        working_directory: build_worktree.to_string_lossy().to_string(),
+        pending_permissions: Vec::new(),
+        pending_questions: Vec::new(),
+        selected_model: None,
+    }];
+
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"idle"}}"#)?;
+    service.runs.lock().expect("run state lock poisoned").insert(
+        "run-1".to_string(),
+        crate::app_service::RunProcess {
+            summary: serde_json::from_value(json!({
+                "runId": "run-1",
+                "runtimeKind": "opencode",
+                "runtimeRoute": {
+                    "type": "local_http",
+                    "endpoint": format!("http://127.0.0.1:{port}"),
+                },
+                "repoPath": workspace.path.clone(),
+                "taskId": "task-1",
+                "branch": "odt/task-1",
+                "worktreePath": build_worktree.to_string_lossy().to_string(),
+                "port": port,
+                "state": "running",
+                "lastMessage": null,
+                "startedAt": "2026-03-17T11:00:00Z",
+            }))?,
+            child: None,
+            _opencode_process_guard: None,
+            repo_path: workspace.path.clone(),
+            task_id: "task-1".to_string(),
+            worktree_path: build_worktree.to_string_lossy().to_string(),
+            repo_config: host_infra_system::RepoConfig {
+                branch_prefix: "odt".to_string(),
+                worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+                ..Default::default()
+            },
+        },
+    );
+
+    let updated = service.task_reset_implementation(workspace.path.as_str(), "task-1")?;
+    server_handle.join().expect("status server thread should finish");
+
+    assert_eq!(updated.status, TaskStatus::ReadyForDev);
     Ok(())
 }
 

--- a/apps/desktop/src/state/agent-runtime-registry.ts
+++ b/apps/desktop/src/state/agent-runtime-registry.ts
@@ -116,6 +116,12 @@ class RuntimeRegistryAgentEngine implements AgentEnginePort {
     ).listAvailableModels(input);
   }
 
+  listRuntimeSessions(input: Parameters<AgentEnginePort["listRuntimeSessions"]>[0]) {
+    return this.getAdapter(
+      this.requireInputRuntimeKind(input.runtimeKind, "runtime session discovery"),
+    ).listRuntimeSessions(input);
+  }
+
   hasSession(sessionId: string): boolean {
     return this.discoverSessionRuntimeKind(sessionId) !== null;
   }

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -9,18 +9,51 @@ import { createLoadAgentSessions } from "./load-sessions";
 
 const taskFixture = createTaskCardFixture({ title: "Task" });
 
+const createAdapter = (
+  overrides: Partial<Parameters<typeof createLoadAgentSessions>[0]["adapter"]> = {},
+): Parameters<typeof createLoadAgentSessions>[0]["adapter"] => ({
+  hasSession: () => false,
+  listRuntimeSessions: async () => [],
+  loadSessionHistory: async () => [],
+  resumeSession: async (input) => ({
+    sessionId: input.sessionId,
+    externalSessionId: input.externalSessionId,
+    role: input.role,
+    scenario: input.scenario,
+    startedAt: "2026-02-22T08:00:00.000Z",
+    status: "idle",
+    runtimeKind: input.runtimeKind,
+  }),
+  ...overrides,
+});
+
 describe("agent-orchestrator-load-sessions", () => {
   beforeEach(async () => {
     await clearAppQueryClient();
+    const hostModule = await import("../../shared/host");
+    hostModule.host.runtimeList = async () => [];
+    hostModule.host.runsList = async () => [];
+    hostModule.host.runtimeEnsure = async (repoPath) => ({
+      kind: "opencode",
+      runtimeId: "runtime-1",
+      repoPath,
+      taskId: null,
+      role: "workspace",
+      workingDirectory: repoPath,
+      runtimeRoute: {
+        type: "local_http",
+        endpoint: "http://127.0.0.1:4444",
+      },
+      startedAt: "2026-02-22T08:00:00.000Z",
+      descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+    });
   });
 
   test("no-ops when active repo is missing", async () => {
     let setCalled = false;
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: null,
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 0 },
       previousRepoRef: { current: null },
       sessionsRef: { current: {} },
@@ -43,9 +76,7 @@ describe("agent-orchestrator-load-sessions", () => {
     let setCalled = false;
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 0 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef: { current: {} },
@@ -78,9 +109,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -200,9 +229,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -300,12 +327,12 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
+      adapter: createAdapter({
         loadSessionHistory: async () => {
           historyLoads += 1;
           return [];
         },
-      },
+      }),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -368,12 +395,12 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
+      adapter: createAdapter({
         loadSessionHistory: async ({ runtimeConnection }) => {
           observedRuntimeEndpoint = runtimeConnection.endpoint ?? "";
           return [];
         },
-      },
+      }),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -506,9 +533,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -590,9 +615,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -712,12 +735,12 @@ describe("agent-orchestrator-load-sessions", () => {
     let historyLoads = 0;
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
+      adapter: createAdapter({
         loadSessionHistory: async () => {
           historyLoads += 1;
           return [];
         },
-      },
+      }),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -794,9 +817,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -867,9 +888,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -965,9 +984,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -1068,9 +1085,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -1098,7 +1113,6 @@ describe("agent-orchestrator-load-sessions", () => {
         taskId: "task-1",
         role: "planner",
         scenario: "planner_initial",
-        status: "running",
         startedAt: "2026-02-22T08:00:00.000Z",
         updatedAt: "2026-02-22T08:00:00.000Z",
         workingDirectory: "/tmp/repo",
@@ -1167,9 +1181,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,
@@ -1255,6 +1267,425 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(state["session-1"]?.messages[0]?.id).toBe("history:session-start:session-1");
   });
 
+  test("resumes live persisted sessions when runtime discovery finds them active", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    let resumeCalls = 0;
+    let attachedListeners = 0;
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        listRuntimeSessions: async () => [
+          {
+            externalSessionId: "external-1",
+            title: "PLANNER task-1",
+            workingDirectory: "/tmp/repo",
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+          },
+        ],
+        resumeSession: async (input) => {
+          resumeCalls += 1;
+          return {
+            sessionId: input.sessionId,
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            scenario: input.scenario,
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: "running",
+            runtimeKind: input.runtimeKind,
+          };
+        },
+      }),
+      repoEpochRef: { current: 2 },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      attachSessionListener: () => {
+        attachedListeners += 1;
+      },
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadRepoPromptOverrides: async () => ({}),
+      loadTaskDocuments: async () => ({
+        specMarkdown: "",
+        planMarkdown: "",
+        qaMarkdown: "",
+      }),
+    });
+
+    const hostModule = await import("../../shared/host");
+    const originalList = hostModule.host.agentSessionsList;
+    const originalRuntimeList = hostModule.host.runtimeList;
+    hostModule.host.agentSessionsList = async () => [
+      {
+        runtimeKind: "opencode",
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        taskId: "task-1",
+        role: "planner",
+        scenario: "planner_initial",
+        status: "running",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+        workingDirectory: "/tmp/repo",
+      },
+    ];
+    hostModule.host.runtimeList = async () => [
+      {
+        kind: "opencode",
+        runtimeId: "runtime-1",
+        repoPath: "/tmp/repo",
+        taskId: null,
+        role: "workspace",
+        workingDirectory: "/tmp/repo",
+        runtimeRoute: {
+          type: "local_http" as const,
+          endpoint: "http://127.0.0.1:4555",
+        },
+        startedAt: "2026-02-22T08:00:00.000Z",
+        descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      },
+    ];
+
+    try {
+      await loadAgentSessions("task-1", { reconcileLiveSessions: true });
+    } finally {
+      hostModule.host.agentSessionsList = originalList;
+      hostModule.host.runtimeList = originalRuntimeList;
+    }
+
+    expect(resumeCalls).toBe(1);
+    expect(attachedListeners).toBe(1);
+    expect(state["session-1"]?.status).toBe("running");
+    expect(state["session-1"]?.runtimeEndpoint).toBe("http://127.0.0.1:4555");
+  });
+
+  test("does not resume persisted sessions when the runtime does not report them live", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    let resumeCalls = 0;
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        listRuntimeSessions: async () => [],
+        resumeSession: async (input) => {
+          resumeCalls += 1;
+          return {
+            sessionId: input.sessionId,
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            scenario: input.scenario,
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: "running",
+            runtimeKind: input.runtimeKind,
+          };
+        },
+      }),
+      repoEpochRef: { current: 2 },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession: () => {},
+      attachSessionListener: () => {},
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadRepoPromptOverrides: async () => ({}),
+      loadTaskDocuments: async () => ({
+        specMarkdown: "",
+        planMarkdown: "",
+        qaMarkdown: "",
+      }),
+    });
+
+    const hostModule = await import("../../shared/host");
+    const originalList = hostModule.host.agentSessionsList;
+    const originalRuntimeList = hostModule.host.runtimeList;
+    hostModule.host.agentSessionsList = async () => [
+      {
+        runtimeKind: "opencode",
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        taskId: "task-1",
+        role: "planner",
+        scenario: "planner_initial",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+        workingDirectory: "/tmp/repo",
+      },
+    ];
+    hostModule.host.runtimeList = async () => [
+      {
+        kind: "opencode",
+        runtimeId: "runtime-1",
+        repoPath: "/tmp/repo",
+        taskId: null,
+        role: "workspace",
+        workingDirectory: "/tmp/repo",
+        runtimeRoute: {
+          type: "local_http" as const,
+          endpoint: "http://127.0.0.1:4555",
+        },
+        startedAt: "2026-02-22T08:00:00.000Z",
+        descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      },
+    ];
+
+    try {
+      await loadAgentSessions("task-1", { reconcileLiveSessions: true });
+    } finally {
+      hostModule.host.agentSessionsList = originalList;
+      hostModule.host.runtimeList = originalRuntimeList;
+    }
+
+    expect(resumeCalls).toBe(0);
+    expect(state["session-1"]?.status).toBe("stopped");
+  });
+
+  test("reattaches already attached live sessions when reconciling after a repo switch", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    let attachedListeners = 0;
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        hasSession: () => true,
+        listRuntimeSessions: async () => [
+          {
+            externalSessionId: "external-1",
+            title: "PLANNER task-1",
+            workingDirectory: "/tmp/repo",
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+          },
+        ],
+      }),
+      repoEpochRef: { current: 2 },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      attachSessionListener: () => {
+        attachedListeners += 1;
+      },
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadRepoPromptOverrides: async () => ({}),
+      loadTaskDocuments: async () => ({
+        specMarkdown: "",
+        planMarkdown: "",
+        qaMarkdown: "",
+      }),
+    });
+
+    const hostModule = await import("../../shared/host");
+    const originalList = hostModule.host.agentSessionsList;
+    const originalRuntimeList = hostModule.host.runtimeList;
+    hostModule.host.agentSessionsList = async () => [
+      {
+        runtimeKind: "opencode",
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        taskId: "task-1",
+        role: "planner",
+        scenario: "planner_initial",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+        workingDirectory: "/tmp/repo",
+      },
+    ];
+    hostModule.host.runtimeList = async () => [
+      {
+        kind: "opencode",
+        runtimeId: "runtime-1",
+        repoPath: "/tmp/repo",
+        taskId: null,
+        role: "workspace",
+        workingDirectory: "/tmp/repo",
+        runtimeRoute: {
+          type: "local_http" as const,
+          endpoint: "http://127.0.0.1:4555",
+        },
+        startedAt: "2026-02-22T08:00:00.000Z",
+        descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      },
+    ];
+
+    try {
+      await loadAgentSessions("task-1", { reconcileLiveSessions: true });
+    } finally {
+      hostModule.host.agentSessionsList = originalList;
+      hostModule.host.runtimeList = originalRuntimeList;
+    }
+
+    expect(attachedListeners).toBe(1);
+    expect(state["session-1"]?.status).toBe("running");
+    expect(state["session-1"]?.runtimeEndpoint).toBe("http://127.0.0.1:4555");
+  });
+
+  test("does not reattach adapter-held sessions when the runtime no longer reports them live", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    let attachedListeners = 0;
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        hasSession: () => true,
+        listRuntimeSessions: async () => [],
+      }),
+      repoEpochRef: { current: 2 },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      attachSessionListener: () => {
+        attachedListeners += 1;
+      },
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadRepoPromptOverrides: async () => ({}),
+      loadTaskDocuments: async () => ({
+        specMarkdown: "",
+        planMarkdown: "",
+        qaMarkdown: "",
+      }),
+    });
+
+    const hostModule = await import("../../shared/host");
+    const originalList = hostModule.host.agentSessionsList;
+    const originalRuntimeList = hostModule.host.runtimeList;
+    hostModule.host.agentSessionsList = async () => [
+      {
+        runtimeKind: "opencode",
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        taskId: "task-1",
+        role: "build",
+        scenario: "build_implementation_start",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+        workingDirectory: "/tmp/repo/worktree",
+      },
+    ];
+    hostModule.host.runtimeList = async () => [
+      {
+        kind: "opencode",
+        runtimeId: "runtime-1",
+        repoPath: "/tmp/repo",
+        taskId: null,
+        role: "workspace",
+        workingDirectory: "/tmp/repo/worktree",
+        runtimeRoute: {
+          type: "local_http" as const,
+          endpoint: "http://127.0.0.1:4555",
+        },
+        startedAt: "2026-02-22T08:00:00.000Z",
+        descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      },
+    ];
+
+    try {
+      await loadAgentSessions("task-1", { reconcileLiveSessions: true });
+    } finally {
+      hostModule.host.agentSessionsList = originalList;
+      hostModule.host.runtimeList = originalRuntimeList;
+    }
+
+    expect(attachedListeners).toBe(0);
+    expect(state["session-1"]?.status).toBe("stopped");
+    expect(state["session-1"]?.runtimeEndpoint).toBe("http://127.0.0.1:4555");
+  });
+
   test("skips hydration when repo epoch changes while loading persisted sessions", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     const repoEpochRef = { current: 2 };
@@ -1279,12 +1710,12 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
+      adapter: createAdapter({
         loadSessionHistory: async () => {
           historyLoads += 1;
           return [];
         },
-      },
+      }),
       repoEpochRef,
       previousRepoRef,
       sessionsRef,
@@ -1371,9 +1802,7 @@ describe("agent-orchestrator-load-sessions", () => {
 
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
-      adapter: {
-        loadSessionHistory: async () => [],
-      },
+      adapter: createAdapter(),
       repoEpochRef: { current: 2 },
       previousRepoRef: { current: "/tmp/repo" },
       sessionsRef,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -1388,6 +1388,130 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(state["session-1"]?.runtimeEndpoint).toBe("http://127.0.0.1:4555");
   });
 
+  test("does not attach resumed sessions when the repo changes while resume is in flight", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    const repoEpochRef = { current: 2 };
+    const previousRepoRef = { current: "/tmp/repo" as string | null };
+    const resumeDeferred = createDeferred<void>();
+    let attachedListeners = 0;
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        listRuntimeSessions: async () => [
+          {
+            externalSessionId: "external-1",
+            title: "PLANNER task-1",
+            workingDirectory: "/tmp/repo",
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+          },
+        ],
+        resumeSession: async (input) => {
+          await resumeDeferred.promise;
+          return {
+            sessionId: input.sessionId,
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            scenario: input.scenario,
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: "running",
+            runtimeKind: input.runtimeKind,
+          };
+        },
+      }),
+      repoEpochRef,
+      previousRepoRef,
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      attachSessionListener: () => {
+        attachedListeners += 1;
+      },
+      loadSessionTodos: async () => {},
+      loadSessionModelCatalog: async () => {},
+      loadRepoPromptOverrides: async () => ({}),
+      loadTaskDocuments: async () => ({
+        specMarkdown: "",
+        planMarkdown: "",
+        qaMarkdown: "",
+      }),
+    });
+
+    const hostModule = await import("../../shared/host");
+    const originalList = hostModule.host.agentSessionsList;
+    const originalRuntimeList = hostModule.host.runtimeList;
+    hostModule.host.agentSessionsList = async () => [
+      {
+        runtimeKind: "opencode",
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        taskId: "task-1",
+        role: "planner",
+        scenario: "planner_initial",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+        workingDirectory: "/tmp/repo",
+      },
+    ];
+    hostModule.host.runtimeList = async () => [
+      {
+        kind: "opencode",
+        runtimeId: "runtime-1",
+        repoPath: "/tmp/repo",
+        taskId: null,
+        role: "workspace",
+        workingDirectory: "/tmp/repo",
+        runtimeRoute: {
+          type: "local_http" as const,
+          endpoint: "http://127.0.0.1:4555",
+        },
+        startedAt: "2026-02-22T08:00:00.000Z",
+        descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+      },
+    ];
+
+    try {
+      const loadPromise = loadAgentSessions("task-1", { reconcileLiveSessions: true });
+      repoEpochRef.current = 3;
+      previousRepoRef.current = "/tmp/other-repo";
+      resumeDeferred.resolve(undefined);
+      await loadPromise;
+    } finally {
+      hostModule.host.agentSessionsList = originalList;
+      hostModule.host.runtimeList = originalRuntimeList;
+    }
+
+    expect(attachedListeners).toBe(0);
+    expect(state["session-1"]).toBeUndefined();
+  });
+
   test("does not resume persisted sessions when the runtime does not report them live", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentSessionRecord,
   RepoPromptOverrides,
   RunSummary,
   RuntimeInstanceSummary,
@@ -13,7 +14,11 @@ import { loadRuntimeListFromQuery, runtimeQueryKeys } from "@/state/queries/runt
 import { loadRepoRunsFromQuery } from "@/state/queries/tasks";
 import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
 import { host } from "../../shared/host";
-import { resolveRuntimeRouteConnection, toRuntimeConnection } from "../runtime/runtime";
+import {
+  resolveRuntimeRouteConnection,
+  type TaskDocuments,
+  toRuntimeConnection,
+} from "../runtime/runtime";
 import { createRepoStaleGuard, normalizeWorkingDirectory } from "../support/core";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
 import {
@@ -22,7 +27,11 @@ import {
   historyToChatMessages,
   recoverPendingQuestionsFromHistory,
 } from "../support/persistence";
-import { buildSessionPreludeMessages, buildSessionSystemPrompt } from "../support/session-prompt";
+import {
+  buildSessionPreludeMessages,
+  buildSessionSystemPrompt,
+  loadSessionPromptContext,
+} from "../support/session-prompt";
 import { warmSessionData } from "../support/session-warmup";
 
 type UpdateSession = (
@@ -31,15 +40,17 @@ type UpdateSession = (
   options?: { persist?: boolean },
 ) => void;
 
-type SessionHistoryAdapter = Pick<AgentEnginePort, "loadSessionHistory">;
+type SessionLifecycleAdapter = Pick<
+  AgentEnginePort,
+  "hasSession" | "listRuntimeSessions" | "loadSessionHistory" | "resumeSession"
+>;
 
 const INITIAL_SESSION_HISTORY_LIMIT = 600;
 const SESSION_HISTORY_HYDRATION_CONCURRENCY = 3;
-type PersistedSessionRecord = Awaited<ReturnType<typeof loadAgentSessionListFromQuery>>[number];
 
 const mergePersistedSessionRecord = (
   current: AgentSessionState,
-  record: PersistedSessionRecord,
+  record: AgentSessionRecord,
   taskId: string,
   promptOverrides: RepoPromptOverrides,
 ): AgentSessionState => {
@@ -64,7 +75,7 @@ const readPersistedRuntimeKind = ({
   sessionId,
   runtimeKind,
   selectedModel,
-}: Pick<PersistedSessionRecord, "sessionId" | "runtimeKind" | "selectedModel">): RuntimeKind => {
+}: Pick<AgentSessionRecord, "sessionId" | "runtimeKind" | "selectedModel">): RuntimeKind => {
   const resolvedRuntimeKind = runtimeKind ?? selectedModel?.runtimeKind;
   if (!resolvedRuntimeKind) {
     throw new Error(`Persisted session '${sessionId}' is missing runtime kind metadata.`);
@@ -72,15 +83,40 @@ const readPersistedRuntimeKind = ({
   return resolvedRuntimeKind;
 };
 
+const toLiveSessionState = (
+  status: Awaited<ReturnType<SessionLifecycleAdapter["listRuntimeSessions"]>>[number]["status"],
+): AgentSessionState["status"] => {
+  if (status.type === "busy" || status.type === "retry") {
+    return "running";
+  }
+  return "idle";
+};
+
+type ResolvedRuntime =
+  | {
+      ok: true;
+      runtimeKind: RuntimeKind;
+      runtimeId: string | null;
+      runId: string | null;
+      runtimeEndpoint: string;
+      runtimeConnection: AgentRuntimeConnection;
+    }
+  | {
+      ok: false;
+      runtimeKind: RuntimeKind;
+      reason: string;
+    };
+
 type CreateLoadAgentSessionsArgs = {
   activeRepo: string | null;
-  adapter: SessionHistoryAdapter;
+  adapter: SessionLifecycleAdapter;
   repoEpochRef: MutableRefObject<number>;
   previousRepoRef: MutableRefObject<string | null>;
   sessionsRef: MutableRefObject<Record<string, AgentSessionState>>;
   setSessionsById: Dispatch<SetStateAction<Record<string, AgentSessionState>>>;
   taskRef: MutableRefObject<TaskCard[]>;
   updateSession: UpdateSession;
+  attachSessionListener?: (repoPath: string, sessionId: string) => void;
   loadSessionTodos: (
     sessionId: string,
     runtimeKind: RuntimeKind,
@@ -93,6 +129,7 @@ type CreateLoadAgentSessionsArgs = {
     runtimeConnection: AgentRuntimeConnection,
   ) => Promise<void>;
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
+  loadTaskDocuments?: (repoPath: string, taskId: string) => Promise<TaskDocuments>;
 };
 
 export const createLoadAgentSessions = ({
@@ -104,9 +141,11 @@ export const createLoadAgentSessions = ({
   setSessionsById,
   taskRef,
   updateSession,
+  attachSessionListener,
   loadSessionTodos,
   loadSessionModelCatalog,
   loadRepoPromptOverrides,
+  loadTaskDocuments,
 }: CreateLoadAgentSessionsArgs): ((
   taskId: string,
   options?: AgentSessionLoadOptions,
@@ -156,7 +195,7 @@ export const createLoadAgentSessions = ({
     };
 
     const [persisted, repoPromptOverrides] = await Promise.all([
-      loadAgentSessionListFromQuery(appQueryClient, repoPath, taskId),
+      loadAgentSessionListFromQuery(appQueryClient, repoPath, taskId, { forceFresh: true }),
       loadRepoPromptOverrides(repoPath),
     ]);
     if (isStaleRepoOperation()) {
@@ -165,6 +204,8 @@ export const createLoadAgentSessions = ({
 
     const requestedSessionId = options?.hydrateHistoryForSessionId?.trim() || null;
     const shouldHydrateRequestedSession = requestedSessionId !== null;
+    const shouldReconcileLiveSessions = options?.reconcileLiveSessions === true;
+
     setSessionsById((current) => {
       if (isStaleRepoOperation()) {
         return current;
@@ -193,12 +234,17 @@ export const createLoadAgentSessions = ({
       return;
     }
 
+    if (!shouldHydrateRequestedSession && !shouldReconcileLiveSessions) {
+      return;
+    }
+
+    const recordsToHydrate = shouldHydrateRequestedSession
+      ? persisted.filter((record) => record.sessionId === requestedSessionId)
+      : persisted;
+
     const historyHydrationSessionIds = new Set(
-      persisted
+      recordsToHydrate
         .filter((record) => {
-          if (shouldHydrateRequestedSession && record.sessionId !== requestedSessionId) {
-            return false;
-          }
           if (!shouldHydrateRequestedSession) {
             return false;
           }
@@ -207,17 +253,8 @@ export const createLoadAgentSessions = ({
         })
         .map((record) => record.sessionId),
     );
-    if (!shouldHydrateRequestedSession) {
-      return;
-    }
-
-    const recordsToHydrate = persisted.filter((record) => record.sessionId === requestedSessionId);
 
     if (recordsToHydrate.length === 0) {
-      if (!shouldHydrateRequestedSession) {
-        return;
-      }
-
       const requestedSession = requestedSessionId
         ? sessionsRef.current[requestedSessionId]
         : undefined;
@@ -227,17 +264,18 @@ export const createLoadAgentSessions = ({
         requestedSession.runtimeEndpoint &&
         requestedSession.workingDirectory
       ) {
-        const requestedRecord =
-          requestedSessionId === null
-            ? undefined
-            : persisted.find((record) => record.sessionId === requestedSessionId);
+        const requestedRecord = requestedSessionId
+          ? persisted.find((record) => record.sessionId === requestedSessionId)
+          : undefined;
         const runtimeConnection = toRuntimeConnection(
           requestedSession.runtimeEndpoint,
           requestedSession.workingDirectory,
         );
-        const requestedRuntimeKind = requestedRecord
-          ? readPersistedRuntimeKind(requestedRecord)
-          : (requestedSession.runtimeKind ?? requestedSession.selectedModel?.runtimeKind);
+        const requestedRuntimeKind =
+          requestedRecord?.runtimeKind ??
+          requestedRecord?.selectedModel?.runtimeKind ??
+          requestedSession.runtimeKind ??
+          requestedSession.selectedModel?.runtimeKind;
         if (!requestedRuntimeKind) {
           throw new Error(`Session '${requestedSession.sessionId}' is missing runtime kind.`);
         }
@@ -253,20 +291,21 @@ export const createLoadAgentSessions = ({
       return;
     }
 
-    const runtimeKindsToHydrate = Array.from(
+    const runtimeKindsToInspect = Array.from(
       new Set(recordsToHydrate.map((record) => readPersistedRuntimeKind(record))),
     );
     const runtimeLists = await Promise.all(
-      runtimeKindsToHydrate.map(async (runtimeKind) => {
+      runtimeKindsToInspect.map(async (runtimeKind) => {
         const runtimes = await loadRuntimeListFromQuery(appQueryClient, runtimeKind, repoPath);
         return [runtimeKind, runtimes] as const;
       }),
     );
     const runtimesByKind = new Map(runtimeLists);
 
-    const liveRuns = recordsToHydrate.some(
+    const requiresRunInspection = recordsToHydrate.some(
       (record) => record.role === "build" || record.role === "qa",
-    )
+    );
+    const liveRuns = requiresRunInspection
       ? await loadRepoRunsFromQuery(appQueryClient, repoPath)
       : [];
     const ensuredWorkspaceRuntimes = new Map<RuntimeKind, RuntimeInstanceSummary | null>();
@@ -279,13 +318,11 @@ export const createLoadAgentSessions = ({
       }
       const runtime = await host.runtimeEnsure(repoPath, runtimeKind);
       ensuredWorkspaceRuntimes.set(runtimeKind, runtime);
-      if (runtime) {
-        await appQueryClient.invalidateQueries({
-          queryKey: runtimeQueryKeys.list(runtimeKind, repoPath),
-          exact: true,
-          refetchType: "none",
-        });
-      }
+      await appQueryClient.invalidateQueries({
+        queryKey: runtimeQueryKeys.list(runtimeKind, repoPath),
+        exact: true,
+        refetchType: "none",
+      });
       return runtime;
     };
 
@@ -294,11 +331,10 @@ export const createLoadAgentSessions = ({
       workingDirectory: string,
     ): RuntimeInstanceSummary | null => {
       const runtimes = runtimesByKind.get(runtimeKind) ?? [];
-      const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+      const normalizedDirectory = normalizeWorkingDirectory(workingDirectory);
       return (
         runtimes.find(
-          (runtime) =>
-            normalizeWorkingDirectory(runtime.workingDirectory) === normalizedWorkingDirectory,
+          (runtime) => normalizeWorkingDirectory(runtime.workingDirectory) === normalizedDirectory,
         ) ?? null
       );
     };
@@ -307,33 +343,22 @@ export const createLoadAgentSessions = ({
       runtimeKind: RuntimeKind,
       workingDirectory: string,
     ): RunSummary | null => {
-      const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+      const normalizedDirectory = normalizeWorkingDirectory(workingDirectory);
       return (
         liveRuns.find(
           (run) =>
             run.runtimeKind === runtimeKind &&
-            normalizeWorkingDirectory(run.worktreePath) === normalizedWorkingDirectory,
+            normalizeWorkingDirectory(run.worktreePath) === normalizedDirectory,
         ) ?? null
       );
     };
 
     const resolveHydrationRuntime = async (
-      record: PersistedSessionRecord,
-    ): Promise<
-      | {
-          ok: true;
-          runtimeKind: RuntimeKind;
-          runtimeEndpoint: string;
-          runtimeConnection: AgentRuntimeConnection;
-        }
-      | {
-          ok: false;
-          runtimeKind: RuntimeKind;
-          reason: string;
-        }
-    > => {
+      record: AgentSessionRecord,
+    ): Promise<ResolvedRuntime> => {
       const runtimeKind = readPersistedRuntimeKind(record);
       const workingDirectory = record.workingDirectory;
+
       if (record.role === "build" || record.role === "qa") {
         const run = findRunByWorkingDirectory(runtimeKind, workingDirectory);
         if (run) {
@@ -344,6 +369,8 @@ export const createLoadAgentSessions = ({
           return {
             ok: true,
             runtimeKind,
+            runtimeId: null,
+            runId: run.runId,
             runtimeEndpoint,
             runtimeConnection,
           };
@@ -359,41 +386,48 @@ export const createLoadAgentSessions = ({
         return {
           ok: true,
           runtimeKind,
+          runtimeId: runtime.runtimeId,
+          runId: null,
           runtimeEndpoint,
           runtimeConnection,
         };
       }
 
+      const normalizedWorkingDirectory = normalizeWorkingDirectory(workingDirectory);
+      const normalizedRepoPath = normalizeWorkingDirectory(repoPath);
       const shouldEnsureWorkspaceRuntime =
         record.role === "build" ||
-        (record.role === "qa" &&
-          normalizeWorkingDirectory(workingDirectory) !== normalizeWorkingDirectory(repoPath)) ||
-        ((record.role === "spec" || record.role === "planner") && workingDirectory === repoPath);
-      if (shouldEnsureWorkspaceRuntime) {
-        const workspaceRuntime = await ensureWorkspaceRuntime(runtimeKind);
-        if (!workspaceRuntime) {
-          return {
-            ok: false,
-            runtimeKind,
-            reason: `Runtime ${runtimeKind} is unavailable for session hydration.`,
-          };
-        }
-        const { runtimeEndpoint, runtimeConnection } = resolveRuntimeRouteConnection(
-          workspaceRuntime.runtimeRoute,
-          workingDirectory,
-        );
+        (record.role === "qa" && normalizedWorkingDirectory !== normalizedRepoPath) ||
+        ((record.role === "spec" || record.role === "planner") &&
+          normalizedWorkingDirectory === normalizedRepoPath);
+
+      if (!shouldEnsureWorkspaceRuntime) {
         return {
-          ok: true,
+          ok: false,
           runtimeKind,
-          runtimeEndpoint,
-          runtimeConnection,
+          reason: `No live runtime found for working directory ${workingDirectory}.`,
         };
       }
 
+      const workspaceRuntime = await ensureWorkspaceRuntime(runtimeKind);
+      if (!workspaceRuntime) {
+        return {
+          ok: false,
+          runtimeKind,
+          reason: `Runtime ${runtimeKind} is unavailable for session hydration.`,
+        };
+      }
+      const { runtimeEndpoint, runtimeConnection } = resolveRuntimeRouteConnection(
+        workspaceRuntime.runtimeRoute,
+        workingDirectory,
+      );
       return {
-        ok: false,
+        ok: true,
         runtimeKind,
-        reason: `No live runtime found for working directory ${workingDirectory}.`,
+        runtimeId: workspaceRuntime.runtimeId,
+        runId: null,
+        runtimeEndpoint,
+        runtimeConnection,
       };
     };
 
@@ -401,7 +435,7 @@ export const createLoadAgentSessions = ({
       record,
       resolvedScenario,
     }: {
-      record: PersistedSessionRecord;
+      record: AgentSessionRecord;
       resolvedScenario: AgentSessionState["scenario"];
     }): AgentSessionState["messages"] => {
       const task = taskRef.current.find((entry) => entry.id === taskId);
@@ -436,11 +470,135 @@ export const createLoadAgentSessions = ({
         startedAt: record.startedAt,
       });
     };
-    if (isStaleRepoOperation()) {
-      return;
+
+    const runtimeSessionsByKey = new Map<
+      string,
+      Awaited<ReturnType<SessionLifecycleAdapter["listRuntimeSessions"]>>
+    >();
+    const listLiveRuntimeSessions = async (
+      runtimeKind: RuntimeKind,
+      runtimeConnection: AgentRuntimeConnection,
+    ) => {
+      const key = `${runtimeKind}::${runtimeConnection.endpoint}::${runtimeConnection.workingDirectory}`;
+      if (runtimeSessionsByKey.has(key)) {
+        return runtimeSessionsByKey.get(key) ?? [];
+      }
+      const sessions = await adapter.listRuntimeSessions({
+        runtimeKind,
+        runtimeConnection,
+      });
+      runtimeSessionsByKey.set(key, sessions);
+      return sessions;
+    };
+
+    const maybeResumeLiveRecord = async (record: AgentSessionRecord): Promise<void> => {
+      if (typeof adapter.hasSession !== "function" || !attachSessionListener) {
+        return;
+      }
+
+      const runtimeResolution = await resolveHydrationRuntime(record);
+      if (!runtimeResolution.ok) {
+        return;
+      }
+
+      const externalSessionId = record.externalSessionId ?? record.sessionId;
+      const attachedExistingSession = adapter.hasSession(record.sessionId);
+      const runtimeSessions = await listLiveRuntimeSessions(
+        runtimeResolution.runtimeKind,
+        runtimeResolution.runtimeConnection,
+      );
+      const liveSession = runtimeSessions.find(
+        (session) => session.externalSessionId === externalSessionId,
+      );
+      if (!liveSession) {
+        return;
+      }
+      const nextStatus = toLiveSessionState(liveSession.status);
+
+      const selectedModel = normalizePersistedSelection(record.selectedModel);
+      if (!attachedExistingSession) {
+        if (typeof adapter.resumeSession !== "function" || !loadTaskDocuments) {
+          return;
+        }
+
+        const task = taskRef.current.find((entry) => entry.id === taskId);
+        if (!task) {
+          throw new Error(`Task not found: ${taskId}`);
+        }
+
+        const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
+        const promptContext = await loadSessionPromptContext({
+          repoPath,
+          taskId,
+          role: record.role,
+          scenario: resolvedScenario,
+          task,
+          loadTaskDocuments,
+          loadRepoPromptOverrides,
+        });
+        if (isStaleRepoOperation()) {
+          return;
+        }
+
+        await adapter.resumeSession({
+          sessionId: record.sessionId,
+          externalSessionId,
+          repoPath,
+          runtimeKind: runtimeResolution.runtimeKind,
+          runtimeConnection: runtimeResolution.runtimeConnection,
+          workingDirectory: runtimeResolution.runtimeConnection.workingDirectory,
+          taskId,
+          role: record.role,
+          scenario: resolvedScenario,
+          systemPrompt: promptContext.systemPrompt,
+          ...(selectedModel ? { model: selectedModel } : {}),
+        });
+      }
+
+      attachSessionListener(repoPath, record.sessionId);
+      updateSession(
+        record.sessionId,
+        (current) => ({
+          ...current,
+          runtimeKind: runtimeResolution.runtimeKind,
+          runtimeId: runtimeResolution.runtimeId,
+          runId: runtimeResolution.runId,
+          runtimeEndpoint: runtimeResolution.runtimeEndpoint,
+          workingDirectory: runtimeResolution.runtimeConnection.workingDirectory,
+          status: nextStatus,
+          promptOverrides: repoPromptOverrides,
+          selectedModel: mergeModelSelection(current.selectedModel, selectedModel ?? undefined),
+        }),
+        { persist: false },
+      );
+      warmPersistedSession(
+        record.sessionId,
+        runtimeResolution.runtimeKind,
+        runtimeResolution.runtimeConnection,
+        externalSessionId,
+        record.role,
+        true,
+      );
+    };
+
+    if (shouldReconcileLiveSessions) {
+      for (
+        let offset = 0;
+        offset < recordsToHydrate.length;
+        offset += SESSION_HISTORY_HYDRATION_CONCURRENCY
+      ) {
+        if (isStaleRepoOperation()) {
+          return;
+        }
+        const batch = recordsToHydrate.slice(
+          offset,
+          offset + SESSION_HISTORY_HYDRATION_CONCURRENCY,
+        );
+        await Promise.all(batch.map((record) => maybeResumeLiveRecord(record)));
+      }
     }
 
-    const hydrateRecord = async (record: PersistedSessionRecord): Promise<void> => {
+    const hydrateRecord = async (record: AgentSessionRecord): Promise<void> => {
       if (isStaleRepoOperation()) {
         return;
       }
@@ -457,6 +615,8 @@ export const createLoadAgentSessions = ({
           (current) => ({
             ...current,
             runtimeKind: readPersistedRuntimeKind(record),
+            runtimeId: null,
+            runId: null,
             runtimeEndpoint: "",
             workingDirectory,
             promptOverrides: repoPromptOverrides,
@@ -465,30 +625,30 @@ export const createLoadAgentSessions = ({
         );
         return;
       }
-      const { runtimeKind, runtimeConnection, runtimeEndpoint } = runtimeResolution;
+
       const externalSessionId = record.externalSessionId ?? record.sessionId;
       const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
       if (!shouldHydrateHistory) {
-        if (isStaleRepoOperation()) {
-          return;
-        }
         updateSession(
           record.sessionId,
           (current) => ({
             ...current,
-            runtimeKind,
-            runtimeEndpoint,
+            runtimeKind: runtimeResolution.runtimeKind,
+            runtimeId: runtimeResolution.runtimeId,
+            runId: runtimeResolution.runId,
+            runtimeEndpoint: runtimeResolution.runtimeEndpoint,
             workingDirectory,
             promptOverrides: repoPromptOverrides,
           }),
           { persist: false },
         );
-        if (shouldHydrateRequestedSession && record.sessionId === requestedSessionId) {
+
+        if (requestedSessionId && record.sessionId === requestedSessionId) {
           const requestedSession = sessionsRef.current[record.sessionId];
           warmPersistedSession(
             record.sessionId,
-            runtimeKind,
-            runtimeConnection,
+            runtimeResolution.runtimeKind,
+            runtimeResolution.runtimeConnection,
             externalSessionId,
             record.role,
             !requestedSession?.modelCatalog && !requestedSession?.isLoadingModelCatalog,
@@ -501,14 +661,9 @@ export const createLoadAgentSessions = ({
         record,
         resolvedScenario,
       });
-
-      if (isStaleRepoOperation()) {
-        return;
-      }
-
       const history = await adapter.loadSessionHistory({
-        runtimeKind,
-        runtimeConnection,
+        runtimeKind: runtimeResolution.runtimeKind,
+        runtimeConnection: runtimeResolution.runtimeConnection,
         externalSessionId,
         limit: INITIAL_SESSION_HISTORY_LIMIT,
       });
@@ -522,8 +677,10 @@ export const createLoadAgentSessions = ({
         record.sessionId,
         (current) => ({
           ...current,
-          runtimeKind,
-          runtimeEndpoint,
+          runtimeKind: runtimeResolution.runtimeKind,
+          runtimeId: runtimeResolution.runtimeId,
+          runId: runtimeResolution.runId,
+          runtimeEndpoint: runtimeResolution.runtimeEndpoint,
           workingDirectory,
           promptOverrides: repoPromptOverrides,
           pendingQuestions:
@@ -542,8 +699,8 @@ export const createLoadAgentSessions = ({
       );
       warmPersistedSession(
         record.sessionId,
-        runtimeKind,
-        runtimeConnection,
+        runtimeResolution.runtimeKind,
+        runtimeResolution.runtimeConnection,
         externalSessionId,
         record.role,
       );

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -553,6 +553,9 @@ export const createLoadAgentSessions = ({
           systemPrompt: promptContext.systemPrompt,
           ...(selectedModel ? { model: selectedModel } : {}),
         });
+        if (isStaleRepoOperation()) {
+          return;
+        }
       }
 
       attachSessionListener(repoPath, record.sessionId);

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -29,7 +29,7 @@ const recordFixture: AgentSessionRecord = {
 };
 
 describe("agent-orchestrator/support/persistence", () => {
-  test("normalizes persisted running status to stopped", () => {
+  test("hydrates persisted sessions as stopped until runtime reconciliation", () => {
     const hydrated = fromPersistedSessionRecord(recordFixture, "task-1");
     expect(hydrated.status).toBe("stopped");
     expect(hydrated.runtimeKind).toBe("opencode");
@@ -102,6 +102,7 @@ describe("agent-orchestrator/support/persistence", () => {
     const persisted = toPersistedSessionRecord(session);
     expect(persisted.scenario).toBe("build_implementation_start");
     expect(persisted.runtimeKind).toBe("opencode");
+    expect(persisted.status).toBeUndefined();
     expect(persisted.endedAt).toBeUndefined();
     expect(persisted.pendingPermissions).toEqual([]);
     expect(persisted.pendingQuestions).toEqual([]);

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -326,7 +326,6 @@ export const toPersistedSessionRecord = (session: AgentSessionState): AgentSessi
   taskId: session.taskId,
   role: session.role,
   scenario: session.scenario,
-  status: session.status,
   startedAt: session.startedAt,
   runtimeKind: session.runtimeKind ?? session.selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
   workingDirectory: session.workingDirectory,
@@ -361,16 +360,15 @@ export const fromPersistedSessionRecord = (
   session: AgentSessionRecord,
   fallbackTaskId: string,
 ): AgentSessionState => {
-  const persistedStatus = session.status ?? "stopped";
-  const normalizedStatus =
-    persistedStatus === "starting" || persistedStatus === "running" ? "stopped" : persistedStatus;
   return {
     sessionId: session.sessionId,
     externalSessionId: session.externalSessionId ?? session.sessionId,
     taskId: session.taskId ?? fallbackTaskId,
     role: session.role,
     scenario: session.scenario ?? defaultScenarioForRole(session.role),
-    status: normalizedStatus,
+    // Persisted Beads records are durable session metadata only.
+    // Live state must always be derived from the runtime on hydration/reconciliation.
+    status: "stopped",
     startedAt: session.startedAt,
     runtimeKind: session.runtimeKind ?? session.selectedModel?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
     runtimeId: null,

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -48,6 +48,12 @@ const taskFixture: TaskCard = {
   createdAt: "2026-02-22T08:00:00.000Z",
 };
 
+const taskFixture2: TaskCard = {
+  ...taskFixture,
+  id: "task-2",
+  title: "Task 2",
+};
+
 beforeEach(async () => {
   await clearAppQueryClient();
 });
@@ -59,7 +65,6 @@ const persistedSessionFixture: AgentSessionRecord = {
   taskId: "task-1",
   role: "build",
   scenario: "build_implementation_start",
-  status: "running",
   startedAt: "2026-02-22T08:00:00.000Z",
   updatedAt: "2026-02-22T08:00:00.000Z",
   workingDirectory: "/tmp/repo",
@@ -216,6 +221,10 @@ const createHookHarness = (args: {
 describe("use-agent-orchestrator-operations", () => {
   const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
   const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
+  const originalRuntimeList = host.runtimeList;
+  const originalRunsList = host.runsList;
+  const originalRuntimeEnsure = host.runtimeEnsure;
+  const originalListRuntimeSessions = OpencodeSdkAdapter.prototype.listRuntimeSessions;
 
   beforeEach(() => {
     host.workspaceGetRepoConfig = async () =>
@@ -233,11 +242,35 @@ describe("use-agent-orchestrator-operations", () => {
       repos: {},
       globalPromptOverrides: {},
     });
+    host.runtimeList = async () => [];
+    host.runsList = async () => [];
+    host.runtimeEnsure = async (repoPath, runtimeKind) => ({
+      kind: runtimeKind,
+      runtimeId: "runtime-1",
+      repoPath,
+      taskId: null,
+      role: "workspace",
+      workingDirectory: repoPath,
+      runtimeRoute: {
+        type: "local_http",
+        endpoint: "http://127.0.0.1:4444",
+      },
+      startedAt: "2026-02-22T08:00:00.000Z",
+      descriptor: {
+        ...OPENCODE_RUNTIME_DESCRIPTOR,
+        kind: runtimeKind,
+      },
+    });
+    OpencodeSdkAdapter.prototype.listRuntimeSessions = async () => [];
   });
 
   afterEach(() => {
     host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
+    host.runtimeList = originalRuntimeList;
+    host.runsList = originalRunsList;
+    host.runtimeEnsure = originalRuntimeEnsure;
+    OpencodeSdkAdapter.prototype.listRuntimeSessions = originalListRuntimeSessions;
   });
 
   test("reattaches listener before send when adapter session exists", async () => {
@@ -511,7 +544,7 @@ describe("use-agent-orchestrator-operations", () => {
         expect(firstSessionId).toBe("session-in-memory");
         expect(secondSessionId).toBe("session-in-memory");
         expect(startCalls).toBe(1);
-        expect(persistedListCalls).toBe(1);
+        expect(persistedListCalls).toBe(2);
       } finally {
         await harness.unmount();
 
@@ -628,7 +661,7 @@ describe("use-agent-orchestrator-operations", () => {
         expect(firstSessionId).toBe("session-concurrent");
         expect(secondSessionId).toBe("session-concurrent");
         expect(startCalls).toBe(1);
-        expect(persistedListCalls).toBe(1);
+        expect(persistedListCalls).toBe(2);
       } finally {
         await harness.unmount();
 
@@ -1441,6 +1474,241 @@ describe("use-agent-orchestrator-operations", () => {
       } finally {
         host.agentSessionsList = originalAgentSessionsList;
         await harness.unmount();
+      }
+    });
+  });
+
+  test("revisit to the same repo bootstraps task sessions again", async () => {
+    await withSuppressedRendererWarning(async () => {
+      const originalAgentSessionsList = host.agentSessionsList;
+      host.agentSessionsList = async () => [persistedSessionFixture];
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo-a",
+        tasks: [taskFixture],
+        runs: [],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+        await harness.updateArgs({
+          activeRepo: null,
+          tasks: [],
+          runs: [],
+        });
+        await harness.updateArgs({
+          activeRepo: "/tmp/repo-a",
+          tasks: [taskFixture],
+          runs: [],
+        });
+        const hydrated = await harness.waitFor((state) => state.sessions.length === 1);
+        expect(hydrated.sessions[0]?.sessionId).toBe("session-1");
+      } finally {
+        await harness.unmount();
+        host.agentSessionsList = originalAgentSessionsList;
+      }
+    });
+  });
+
+  test("reconciles live runtime sessions even when persisted records omit status", async () => {
+    await withSuppressedRendererWarning(async () => {
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+      const originalResumeSession = OpencodeSdkAdapter.prototype.resumeSession;
+      const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+      const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+      const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
+
+      host.agentSessionsList = async () => [persistedSessionFixture];
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+      host.runtimeList = async () => [
+        {
+          kind: "opencode",
+          runtimeId: "runtime-1",
+          repoPath: "/tmp/repo",
+          taskId: null,
+          role: "workspace",
+          workingDirectory: "/tmp/repo",
+          runtimeRoute: {
+            type: "local_http" as const,
+            endpoint: "http://127.0.0.1:4444",
+          },
+          startedAt: "2026-02-22T08:00:00.000Z",
+          descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+        },
+      ];
+      OpencodeSdkAdapter.prototype.listRuntimeSessions = async () => [
+        {
+          externalSessionId: "external-1",
+          title: "BUILD task-1",
+          workingDirectory: "/tmp/repo",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          status: { type: "busy" },
+        },
+      ];
+      OpencodeSdkAdapter.prototype.resumeSession = async (input) => ({
+        runtimeKind: input.runtimeKind,
+        sessionId: input.sessionId,
+        externalSessionId: input.externalSessionId,
+        startedAt: "2026-02-22T08:00:00.000Z",
+        role: input.role,
+        scenario: input.scenario,
+        status: "running",
+      });
+      OpencodeSdkAdapter.prototype.listAvailableModels = async () => ({
+        models: [],
+        defaultModelsByProvider: {},
+        profiles: [],
+      });
+      OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
+      OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture],
+        runs: [],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+        const resolved = await harness.waitFor((state) =>
+          state.sessions.some(
+            (session) => session.sessionId === "session-1" && session.status === "running",
+          ),
+        );
+        expect(resolved.sessions.find((session) => session.sessionId === "session-1")?.status).toBe(
+          "running",
+        );
+      } finally {
+        await harness.unmount();
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+        OpencodeSdkAdapter.prototype.resumeSession = originalResumeSession;
+        OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+        OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+        OpencodeSdkAdapter.prototype.loadSessionHistory = originalLoadSessionHistory;
+      }
+    });
+  });
+
+  test("reconciles live runtime sessions for tasks added after the first repo bootstrap", async () => {
+    await withSuppressedRendererWarning(async () => {
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+      const originalResumeSession = OpencodeSdkAdapter.prototype.resumeSession;
+      const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+      const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+      const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
+
+      host.agentSessionsList = async (_repoPath, taskId) => {
+        if (taskId === "task-1") {
+          return [persistedSessionFixture];
+        }
+        if (taskId === "task-2") {
+          return [
+            {
+              ...persistedSessionFixture,
+              sessionId: "session-2",
+              externalSessionId: "external-2",
+              taskId: "task-2",
+            },
+          ];
+        }
+        return [];
+      };
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+      host.runtimeList = async () => [
+        {
+          kind: "opencode",
+          runtimeId: "runtime-1",
+          repoPath: "/tmp/repo",
+          taskId: null,
+          role: "workspace",
+          workingDirectory: "/tmp/repo",
+          runtimeRoute: {
+            type: "local_http" as const,
+            endpoint: "http://127.0.0.1:4444",
+          },
+          startedAt: "2026-02-22T08:00:00.000Z",
+          descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+        },
+      ];
+      OpencodeSdkAdapter.prototype.listRuntimeSessions = async () => [
+        {
+          externalSessionId: "external-2",
+          title: "BUILD task-2",
+          workingDirectory: "/tmp/repo",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          status: { type: "busy" },
+        },
+      ];
+      OpencodeSdkAdapter.prototype.resumeSession = async (input) => ({
+        runtimeKind: input.runtimeKind,
+        sessionId: input.sessionId,
+        externalSessionId: input.externalSessionId,
+        startedAt: "2026-02-22T08:00:00.000Z",
+        role: input.role,
+        scenario: input.scenario,
+        status: "running",
+      });
+      OpencodeSdkAdapter.prototype.listAvailableModels = async () => ({
+        models: [],
+        defaultModelsByProvider: {},
+        profiles: [],
+      });
+      OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
+      OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture],
+        runs: [],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+        await harness.updateArgs({
+          activeRepo: "/tmp/repo",
+          tasks: [taskFixture, taskFixture2],
+          runs: [],
+        });
+        const resolved = await harness.waitFor((state) =>
+          state.sessions.some(
+            (session) => session.sessionId === "session-2" && session.status === "running",
+          ),
+        );
+        expect(resolved.sessions.find((session) => session.sessionId === "session-2")?.status).toBe(
+          "running",
+        );
+      } finally {
+        await harness.unmount();
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+        OpencodeSdkAdapter.prototype.resumeSession = originalResumeSession;
+        OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+        OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+        OpencodeSdkAdapter.prototype.loadSessionHistory = originalLoadSessionHistory;
       }
     });
   });

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -1602,6 +1602,146 @@ describe("use-agent-orchestrator-operations", () => {
     });
   });
 
+  test("reconciles idle live runtime sessions on repo bootstrap", async () => {
+    await withSuppressedRendererWarning(async () => {
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+      const originalResumeSession = OpencodeSdkAdapter.prototype.resumeSession;
+      const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+      const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+      const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
+
+      host.agentSessionsList = async () => [persistedSessionFixture];
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+      host.runtimeList = async () => [
+        {
+          kind: "opencode",
+          runtimeId: "runtime-1",
+          repoPath: "/tmp/repo",
+          taskId: null,
+          role: "workspace",
+          workingDirectory: "/tmp/repo",
+          runtimeRoute: {
+            type: "local_http" as const,
+            endpoint: "http://127.0.0.1:4444",
+          },
+          startedAt: "2026-02-22T08:00:00.000Z",
+          descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+        },
+      ];
+      OpencodeSdkAdapter.prototype.listRuntimeSessions = async () => [
+        {
+          externalSessionId: "external-1",
+          title: "BUILD task-1",
+          workingDirectory: "/tmp/repo",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          status: { type: "idle" },
+        },
+      ];
+      OpencodeSdkAdapter.prototype.resumeSession = async (input) => ({
+        runtimeKind: input.runtimeKind,
+        sessionId: input.sessionId,
+        externalSessionId: input.externalSessionId,
+        startedAt: "2026-02-22T08:00:00.000Z",
+        role: input.role,
+        scenario: input.scenario,
+        status: "idle",
+      });
+      OpencodeSdkAdapter.prototype.listAvailableModels = async () => ({
+        models: [],
+        defaultModelsByProvider: {},
+        profiles: [],
+      });
+      OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
+      OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture],
+        runs: [],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+        const resolved = await harness.waitFor((state) =>
+          state.sessions.some(
+            (session) => session.sessionId === "session-1" && session.status === "idle",
+          ),
+        );
+        expect(resolved.sessions.find((session) => session.sessionId === "session-1")?.status).toBe(
+          "idle",
+        );
+      } finally {
+        await harness.unmount();
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+        OpencodeSdkAdapter.prototype.resumeSession = originalResumeSession;
+        OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+        OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+        OpencodeSdkAdapter.prototype.loadSessionHistory = originalLoadSessionHistory;
+      }
+    });
+  });
+
+  test("retries background session bootstrap after a transient persisted-session load failure", async () => {
+    await withSuppressedRendererWarning(async () => {
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+
+      let listCalls = 0;
+      host.agentSessionsList = async () => {
+        listCalls += 1;
+        if (listCalls === 1) {
+          throw new Error("temporary session list failure");
+        }
+        return [persistedSessionFixture];
+      };
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture],
+        runs: [],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+        const resolved = await harness.waitFor(
+          (state) => state.sessions.some((session) => session.sessionId === "session-1"),
+          2_000,
+        );
+        expect(listCalls).toBeGreaterThanOrEqual(2);
+        expect(
+          resolved.sessions.find((session) => session.sessionId === "session-1"),
+        ).toBeDefined();
+      } finally {
+        await harness.unmount();
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+      }
+    });
+  });
+
   test("reconciles live runtime sessions for tasks added after the first repo bootstrap", async () => {
     await withSuppressedRendererWarning(async () => {
       const originalAgentSessionsList = host.agentSessionsList;

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -1693,6 +1693,118 @@ describe("use-agent-orchestrator-operations", () => {
     });
   });
 
+  test("scans each runtime endpoint only once during repo reconciliation", async () => {
+    await withSuppressedRendererWarning(async () => {
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+      const originalResumeSession = OpencodeSdkAdapter.prototype.resumeSession;
+      const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+      const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+      const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
+
+      let listRuntimeSessionsCalls = 0;
+      const scannedEndpoints: string[] = [];
+
+      host.agentSessionsList = async () => [persistedSessionFixture];
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+      host.runtimeList = async () =>
+        [
+          {
+            kind: "opencode",
+            runtimeId: "runtime-repo",
+            repoPath: "/tmp/repo",
+            taskId: null,
+            role: "workspace",
+            workingDirectory: "/tmp/repo",
+            runtimeRoute: {
+              type: "local_http" as const,
+              endpoint: "http://127.0.0.1:4444",
+            },
+            startedAt: "2026-02-22T08:00:00.000Z",
+            descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+          },
+          {
+            kind: "opencode",
+            runtimeId: "runtime-build",
+            repoPath: "/tmp/repo",
+            taskId: "task-1",
+            role: "build",
+            workingDirectory: "/tmp/repo/worktree",
+            runtimeRoute: {
+              type: "local_http" as const,
+              endpoint: "http://127.0.0.1:4444",
+            },
+            startedAt: "2026-02-22T08:00:00.000Z",
+            descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+          },
+        ] as Awaited<ReturnType<typeof host.runtimeList>>;
+      OpencodeSdkAdapter.prototype.listRuntimeSessions = async (input) => {
+        listRuntimeSessionsCalls += 1;
+        scannedEndpoints.push(input.runtimeConnection.endpoint ?? "");
+        return [
+          {
+            externalSessionId: "external-1",
+            title: "BUILD task-1",
+            workingDirectory: "/tmp/repo/worktree",
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+          },
+        ];
+      };
+      OpencodeSdkAdapter.prototype.resumeSession = async (input) => ({
+        runtimeKind: input.runtimeKind,
+        sessionId: input.sessionId,
+        externalSessionId: input.externalSessionId,
+        startedAt: "2026-02-22T08:00:00.000Z",
+        role: input.role,
+        scenario: input.scenario,
+        status: "running",
+      });
+      OpencodeSdkAdapter.prototype.listAvailableModels = async () => ({
+        models: [],
+        defaultModelsByProvider: {},
+        profiles: [],
+      });
+      OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
+      OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture],
+        runs: [runningRunFixture],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+        await harness.waitFor((state) =>
+          state.sessions.some(
+            (session) => session.sessionId === "session-1" && session.status === "running",
+          ),
+        );
+        expect(new Set(scannedEndpoints)).toEqual(new Set(["http://127.0.0.1:4444"]));
+        expect(listRuntimeSessionsCalls).toBeLessThan(3);
+      } finally {
+        await harness.unmount();
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+        OpencodeSdkAdapter.prototype.resumeSession = originalResumeSession;
+        OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+        OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+        OpencodeSdkAdapter.prototype.loadSessionHistory = originalLoadSessionHistory;
+      }
+    });
+  });
+
   test("retries background session bootstrap after a transient persisted-session load failure", async () => {
     await withSuppressedRendererWarning(async () => {
       const originalAgentSessionsList = host.agentSessionsList;

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -1854,6 +1854,234 @@ describe("use-agent-orchestrator-operations", () => {
     });
   });
 
+  test("reconciles unaffected tasks when one persisted session list load fails", async () => {
+    await withSuppressedRendererWarning(async () => {
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+      const originalResumeSession = OpencodeSdkAdapter.prototype.resumeSession;
+      const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+      const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+      const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
+
+      host.agentSessionsList = async (_repoPath, taskId) => {
+        if (taskId === "task-1") {
+          throw new Error("task-1 persisted sessions unavailable");
+        }
+        if (taskId === "task-2") {
+          return [
+            {
+              ...persistedSessionFixture,
+              sessionId: "session-2",
+              externalSessionId: "external-2",
+              taskId: "task-2",
+            },
+          ];
+        }
+        return [];
+      };
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+      host.runtimeList = async () => [
+        {
+          kind: "opencode",
+          runtimeId: "runtime-1",
+          repoPath: "/tmp/repo",
+          taskId: null,
+          role: "workspace",
+          workingDirectory: "/tmp/repo",
+          runtimeRoute: {
+            type: "local_http" as const,
+            endpoint: "http://127.0.0.1:4444",
+          },
+          startedAt: "2026-02-22T08:00:00.000Z",
+          descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+        },
+      ];
+      OpencodeSdkAdapter.prototype.listRuntimeSessions = async () => [
+        {
+          externalSessionId: "external-2",
+          title: "BUILD task-2",
+          workingDirectory: "/tmp/repo",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          status: { type: "busy" },
+        },
+      ];
+      OpencodeSdkAdapter.prototype.resumeSession = async (input) => ({
+        runtimeKind: input.runtimeKind,
+        sessionId: input.sessionId,
+        externalSessionId: input.externalSessionId,
+        startedAt: "2026-02-22T08:00:00.000Z",
+        role: input.role,
+        scenario: input.scenario,
+        status: "running",
+      });
+      OpencodeSdkAdapter.prototype.listAvailableModels = async () => ({
+        models: [],
+        defaultModelsByProvider: {},
+        profiles: [],
+      });
+      OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
+      OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture, taskFixture2],
+        runs: [],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+        const resolved = await harness.waitFor((state) =>
+          state.sessions.some(
+            (session) => session.sessionId === "session-2" && session.status === "running",
+          ),
+        );
+        expect(
+          resolved.sessions.some(
+            (session) => session.sessionId === "session-1" && session.status === "running",
+          ),
+        ).toBe(false);
+      } finally {
+        await harness.unmount();
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+        OpencodeSdkAdapter.prototype.resumeSession = originalResumeSession;
+        OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+        OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+        OpencodeSdkAdapter.prototype.loadSessionHistory = originalLoadSessionHistory;
+      }
+    });
+  });
+
+  test("reconciles unaffected tasks when one live-session resume fails", async () => {
+    await withSuppressedRendererWarning(async () => {
+      const originalAgentSessionsList = host.agentSessionsList;
+      const originalAgentSessionUpsert = host.agentSessionUpsert;
+      const originalSpecGet = host.specGet;
+      const originalPlanGet = host.planGet;
+      const originalQaGetReport = host.qaGetReport;
+      const originalResumeSession = OpencodeSdkAdapter.prototype.resumeSession;
+      const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
+      const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
+      const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
+
+      host.agentSessionsList = async (_repoPath, taskId) => {
+        if (taskId === "task-1") {
+          return [persistedSessionFixture];
+        }
+        if (taskId === "task-2") {
+          return [
+            {
+              ...persistedSessionFixture,
+              sessionId: "session-2",
+              externalSessionId: "external-2",
+              taskId: "task-2",
+            },
+          ];
+        }
+        return [];
+      };
+      host.agentSessionUpsert = async () => {};
+      host.specGet = async () => ({ markdown: "", updatedAt: null });
+      host.planGet = async () => ({ markdown: "", updatedAt: null });
+      host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
+      host.runtimeList = async () => [
+        {
+          kind: "opencode",
+          runtimeId: "runtime-1",
+          repoPath: "/tmp/repo",
+          taskId: null,
+          role: "workspace",
+          workingDirectory: "/tmp/repo",
+          runtimeRoute: {
+            type: "local_http" as const,
+            endpoint: "http://127.0.0.1:4444",
+          },
+          startedAt: "2026-02-22T08:00:00.000Z",
+          descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+        },
+      ];
+      OpencodeSdkAdapter.prototype.listRuntimeSessions = async () => [
+        {
+          externalSessionId: "external-1",
+          title: "BUILD task-1",
+          workingDirectory: "/tmp/repo",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          status: { type: "busy" },
+        },
+        {
+          externalSessionId: "external-2",
+          title: "BUILD task-2",
+          workingDirectory: "/tmp/repo",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          status: { type: "busy" },
+        },
+      ];
+      OpencodeSdkAdapter.prototype.resumeSession = async (input) => {
+        if (input.sessionId === "session-1") {
+          throw new Error("task-1 resume failed");
+        }
+        return {
+          runtimeKind: input.runtimeKind,
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          startedAt: "2026-02-22T08:00:00.000Z",
+          role: input.role,
+          scenario: input.scenario,
+          status: "running",
+        };
+      };
+      OpencodeSdkAdapter.prototype.listAvailableModels = async () => ({
+        models: [],
+        defaultModelsByProvider: {},
+        profiles: [],
+      });
+      OpencodeSdkAdapter.prototype.loadSessionTodos = async () => [];
+      OpencodeSdkAdapter.prototype.loadSessionHistory = async () => [];
+
+      const harness = createHookHarness({
+        activeRepo: "/tmp/repo",
+        tasks: [taskFixture, taskFixture2],
+        runs: [],
+        refreshTaskData: async () => {},
+      });
+
+      try {
+        await harness.mount();
+        const resolved = await harness.waitFor((state) =>
+          state.sessions.some(
+            (session) => session.sessionId === "session-2" && session.status === "running",
+          ),
+        );
+        expect(
+          resolved.sessions.some(
+            (session) => session.sessionId === "session-1" && session.status === "running",
+          ),
+        ).toBe(false);
+      } finally {
+        await harness.unmount();
+        host.agentSessionsList = originalAgentSessionsList;
+        host.agentSessionUpsert = originalAgentSessionUpsert;
+        host.specGet = originalSpecGet;
+        host.planGet = originalPlanGet;
+        host.qaGetReport = originalQaGetReport;
+        OpencodeSdkAdapter.prototype.resumeSession = originalResumeSession;
+        OpencodeSdkAdapter.prototype.listAvailableModels = originalListAvailableModels;
+        OpencodeSdkAdapter.prototype.loadSessionTodos = originalLoadSessionTodos;
+        OpencodeSdkAdapter.prototype.loadSessionHistory = originalLoadSessionHistory;
+      }
+    });
+  });
+
   test("reconciles live runtime sessions for tasks added after the first repo bootstrap", async () => {
     await withSuppressedRendererWarning(async () => {
       const originalAgentSessionsList = host.agentSessionsList;

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -73,6 +73,9 @@ const getOrCreateRepoTaskSet = (
 
 const nextSessionRetryDelayMs = (attempt: number): number => Math.min(5_000, 500 * 2 ** attempt);
 
+const getRuntimeSessionScanKey = (runtimeKind: string, endpoint: string): string =>
+  `${runtimeKind}::${endpoint}`;
+
 export function useAgentOrchestratorOperations({
   activeRepo,
   tasks,
@@ -500,15 +503,17 @@ export function useAgentOrchestratorOperations({
             return;
           }
           for (const runtime of runtimes) {
-            const { runtimeConnection } = resolveRuntimeRouteConnection(
+            const { runtimeEndpoint, runtimeConnection } = resolveRuntimeRouteConnection(
               runtime.runtimeRoute,
               runtime.workingDirectory,
             );
-            const key = `${runtimeKind}::${runtimeConnection.endpoint}::${runtimeConnection.workingDirectory}`;
-            runtimeConnections.set(key, {
-              runtimeKind,
-              runtimeConnection,
-            });
+            const key = getRuntimeSessionScanKey(runtimeKind, runtimeEndpoint);
+            if (!runtimeConnections.has(key)) {
+              runtimeConnections.set(key, {
+                runtimeKind,
+                runtimeConnection,
+              });
+            }
           }
         }
 
@@ -516,15 +521,17 @@ export function useAgentOrchestratorOperations({
           if (!activeRunStates.has(run.state)) {
             continue;
           }
-          const { runtimeConnection } = resolveRuntimeRouteConnection(
+          const { runtimeEndpoint, runtimeConnection } = resolveRuntimeRouteConnection(
             run.runtimeRoute,
             run.worktreePath,
           );
-          const key = `${run.runtimeKind}::${runtimeConnection.endpoint}::${runtimeConnection.workingDirectory}`;
-          runtimeConnections.set(key, {
-            runtimeKind: run.runtimeKind,
-            runtimeConnection,
-          });
+          const key = getRuntimeSessionScanKey(run.runtimeKind, runtimeEndpoint);
+          if (!runtimeConnections.has(key)) {
+            runtimeConnections.set(key, {
+              runtimeKind: run.runtimeKind,
+              runtimeConnection,
+            });
+          }
         }
 
         const taskIdsToReconcile = new Set<string>();

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -1,6 +1,6 @@
 import type { RunSummary, TaskCard } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentModelSelection } from "@openducktor/core";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { findRuntimeDefinition } from "@/lib/agent-runtime";
 import { appQueryClient } from "@/lib/query-client";
 import type {
@@ -71,6 +71,8 @@ const getOrCreateRepoTaskSet = (
   return created;
 };
 
+const nextSessionRetryDelayMs = (attempt: number): number => Math.min(5_000, 500 * 2 ** attempt);
+
 export function useAgentOrchestratorOperations({
   activeRepo,
   tasks,
@@ -86,6 +88,9 @@ export function useAgentOrchestratorOperations({
   const { sessionsRef, turnStartedAtBySessionRef, unsubscribersRef } = refBridges;
   const bootstrappedTasksByRepoRef = useRef<Record<string, Set<string>>>({});
   const reconciledLiveSessionTasksByRepoRef = useRef<Record<string, Set<string>>>({});
+  const retryAttemptsByKeyRef = useRef<Record<string, number>>({});
+  const retryTimeoutsByKeyRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const [sessionRetryTick, setSessionRetryTick] = useState(0);
   const runtimeDefinitions = useMemo(() => agentEngine.listRuntimeDefinitions(), [agentEngine]);
 
   const persistSessionSnapshot = useCallback(
@@ -314,6 +319,55 @@ export function useAgentOrchestratorOperations({
     ],
   );
 
+  const clearSessionRetry = useCallback(
+    (scope: "bootstrap" | "reconcile", repoPath: string, taskId: string) => {
+      const retryKey = `${scope}::${repoPath}::${taskId}`;
+      const timeout = retryTimeoutsByKeyRef.current[retryKey];
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+        delete retryTimeoutsByKeyRef.current[retryKey];
+      }
+      delete retryAttemptsByKeyRef.current[retryKey];
+    },
+    [],
+  );
+
+  const isCurrentActiveRepo = useCallback(
+    (repoPath: string): boolean => refBridges.previousRepoRef.current === repoPath,
+    [refBridges],
+  );
+
+  const scheduleSessionRetry = useCallback(
+    (scope: "bootstrap" | "reconcile", repoPath: string, taskId: string, error: unknown) => {
+      const retryKey = `${scope}::${repoPath}::${taskId}`;
+      if (retryTimeoutsByKeyRef.current[retryKey] !== undefined) {
+        return;
+      }
+      const attempt = retryAttemptsByKeyRef.current[retryKey] ?? 0;
+      retryAttemptsByKeyRef.current[retryKey] = attempt + 1;
+      const delayMs = nextSessionRetryDelayMs(attempt);
+      console.error(
+        `Failed to ${scope} agent sessions for task '${taskId}' in repo '${repoPath}'. Retrying in ${delayMs}ms.`,
+        error,
+      );
+      retryTimeoutsByKeyRef.current[retryKey] = setTimeout(() => {
+        delete retryTimeoutsByKeyRef.current[retryKey];
+        setSessionRetryTick((current) => current + 1);
+      }, delayMs);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    return () => {
+      for (const timeout of Object.values(retryTimeoutsByKeyRef.current)) {
+        clearTimeout(timeout);
+      }
+      retryTimeoutsByKeyRef.current = {};
+      retryAttemptsByKeyRef.current = {};
+    };
+  }, []);
+
   useEffect(() => {
     if (!activeRepo) {
       return;
@@ -326,6 +380,8 @@ export function useAgentOrchestratorOperations({
     if (!activeRepo) {
       return;
     }
+    // Explicitly reference the retry tick: this effect must rerun when a delayed retry fires.
+    void sessionRetryTick;
 
     const bootstrappedTasks = getOrCreateRepoTaskSet(
       bootstrappedTasksByRepoRef.current,
@@ -340,17 +396,35 @@ export function useAgentOrchestratorOperations({
 
     for (const taskId of pendingTaskIds) {
       bootstrappedTasks.add(taskId);
-      void loadAgentSessions(taskId).catch(() => {
-        const currentSet = bootstrappedTasksByRepoRef.current[activeRepo];
-        currentSet?.delete(taskId);
-      });
+      void loadAgentSessions(taskId)
+        .then(() => {
+          clearSessionRetry("bootstrap", activeRepo, taskId);
+        })
+        .catch((error) => {
+          if (!isCurrentActiveRepo(activeRepo)) {
+            return;
+          }
+          scheduleSessionRetry("bootstrap", activeRepo, taskId, error);
+          const currentSet = bootstrappedTasksByRepoRef.current[activeRepo];
+          currentSet?.delete(taskId);
+        });
     }
-  }, [activeRepo, loadAgentSessions, tasks]);
+  }, [
+    activeRepo,
+    clearSessionRetry,
+    isCurrentActiveRepo,
+    loadAgentSessions,
+    scheduleSessionRetry,
+    sessionRetryTick,
+    tasks,
+  ]);
 
   useEffect(() => {
     if (!activeRepo || tasks.length === 0) {
       return;
     }
+    // Explicitly reference the retry tick: this effect must rerun when a delayed retry fires.
+    void sessionRetryTick;
     const reconciledTaskIds = getOrCreateRepoTaskSet(
       reconciledLiveSessionTasksByRepoRef.current,
       activeRepo,
@@ -410,6 +484,7 @@ export function useAgentOrchestratorOperations({
             activeRepo,
           );
           for (const taskId of pendingTaskIds) {
+            clearSessionRetry("reconcile", activeRepo, taskId);
             currentSet.add(taskId);
           }
           return;
@@ -459,9 +534,6 @@ export function useAgentOrchestratorOperations({
             return;
           }
           for (const runtimeSession of runtimeSessions) {
-            if (runtimeSession.status.type !== "busy" && runtimeSession.status.type !== "retry") {
-              continue;
-            }
             const key = `${input.runtimeKind}::${runtimeSession.externalSessionId}`;
             const taskIds = persistedTaskIdsByLiveSessionKey.get(key);
             if (!taskIds) {
@@ -490,17 +562,33 @@ export function useAgentOrchestratorOperations({
           activeRepo,
         );
         for (const taskId of pendingTaskIds) {
+          clearSessionRetry("reconcile", activeRepo, taskId);
           currentSet.add(taskId);
         }
-      } catch {
-        // Leave pending tasks unreconciled so a later render can retry.
+      } catch (error) {
+        if (cancelled || !isCurrentActiveRepo(activeRepo)) {
+          return;
+        }
+        for (const taskId of pendingTaskIds) {
+          scheduleSessionRetry("reconcile", activeRepo, taskId, error);
+        }
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [activeRepo, agentEngine, loadAgentSessions, runs, tasks]);
+  }, [
+    activeRepo,
+    agentEngine,
+    clearSessionRetry,
+    isCurrentActiveRepo,
+    loadAgentSessions,
+    runs,
+    scheduleSessionRetry,
+    sessionRetryTick,
+    tasks,
+  ]);
 
   const ensureRuntime = useMemo(
     () =>

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -449,24 +449,38 @@ export function useAgentOrchestratorOperations({
 
     void (async () => {
       try {
-        const persistedByTask = await Promise.all(
-          pendingTaskIds.map(
-            async (taskId) =>
-              [
-                taskId,
-                await loadAgentSessionListFromQuery(appQueryClient, activeRepo, taskId, {
-                  forceFresh: true,
-                }),
-              ] as const,
-          ),
+        const persistedTaskResults = await Promise.allSettled(
+          pendingTaskIds.map(async (taskId) => ({
+            taskId,
+            records: await loadAgentSessionListFromQuery(appQueryClient, activeRepo, taskId, {
+              forceFresh: true,
+            }),
+          })),
         );
         if (cancelled) {
           return;
         }
 
+        const persistedByTask: Array<{
+          taskId: string;
+          records: Awaited<ReturnType<typeof loadAgentSessionListFromQuery>>;
+        }> = [];
+        const failedTaskErrors = new Map<string, unknown>();
+        for (const [index, result] of persistedTaskResults.entries()) {
+          const taskId = pendingTaskIds[index];
+          if (!taskId) {
+            continue;
+          }
+          if (result.status === "fulfilled") {
+            persistedByTask.push(result.value);
+            continue;
+          }
+          failedTaskErrors.set(taskId, result.reason);
+        }
+
         const persistedTaskIdsByLiveSessionKey = new Map<string, Set<string>>();
         const runtimeKinds = new Set<string>();
-        for (const [taskId, records] of persistedByTask) {
+        for (const { taskId, records } of persistedByTask) {
           for (const record of records) {
             const runtimeKind = record.runtimeKind ?? record.selectedModel?.runtimeKind;
             const externalSessionId = record.externalSessionId ?? record.sessionId;
@@ -486,9 +500,12 @@ export function useAgentOrchestratorOperations({
             reconciledLiveSessionTasksByRepoRef.current,
             activeRepo,
           );
-          for (const taskId of pendingTaskIds) {
+          for (const { taskId } of persistedByTask) {
             clearSessionRetry("reconcile", activeRepo, taskId);
             currentSet.add(taskId);
+          }
+          for (const [taskId, error] of failedTaskErrors) {
+            scheduleSessionRetry("reconcile", activeRepo, taskId, error);
           }
           return;
         }
@@ -556,21 +573,40 @@ export function useAgentOrchestratorOperations({
           return;
         }
 
-        await Promise.all(
-          Array.from(taskIdsToReconcile).map((taskId) =>
-            loadAgentSessions(taskId, { reconcileLiveSessions: true }),
-          ),
+        const reconcileResults = await Promise.allSettled(
+          Array.from(taskIdsToReconcile).map(async (taskId) => {
+            await loadAgentSessions(taskId, { reconcileLiveSessions: true });
+            return taskId;
+          }),
         );
         if (cancelled) {
           return;
         }
+
+        for (const [index, result] of reconcileResults.entries()) {
+          if (result.status === "fulfilled") {
+            continue;
+          }
+          const taskId = Array.from(taskIdsToReconcile)[index];
+          if (!taskId) {
+            continue;
+          }
+          failedTaskErrors.set(taskId, result.reason);
+        }
+
         const currentSet = getOrCreateRepoTaskSet(
           reconciledLiveSessionTasksByRepoRef.current,
           activeRepo,
         );
-        for (const taskId of pendingTaskIds) {
+        for (const { taskId } of persistedByTask) {
+          if (failedTaskErrors.has(taskId)) {
+            continue;
+          }
           clearSessionRetry("reconcile", activeRepo, taskId);
           currentSet.add(taskId);
+        }
+        for (const [taskId, error] of failedTaskErrors) {
+          scheduleSessionRetry("reconcile", activeRepo, taskId, error);
         }
       } catch (error) {
         if (cancelled || !isCurrentActiveRepo(activeRepo)) {

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -1,12 +1,15 @@
 import type { RunSummary, TaskCard } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentModelSelection } from "@openducktor/core";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { findRuntimeDefinition } from "@/lib/agent-runtime";
+import { appQueryClient } from "@/lib/query-client";
 import type {
   AgentChatMessage,
   AgentSessionLoadOptions,
   AgentSessionState,
 } from "@/types/agent-orchestrator";
+import { loadAgentSessionListFromQuery } from "../../queries/agent-sessions";
+import { loadRuntimeListFromQuery } from "../../queries/runtime";
 import { host } from "../shared/host";
 import {
   attachAgentSessionListener,
@@ -24,6 +27,7 @@ import { createOrchestratorPublicOperations } from "./handlers/public-operations
 import type { StartAgentSessionInput } from "./handlers/start-session";
 import { useOrchestratorSessionState } from "./hooks/use-orchestrator-session-state";
 import { createLoadSessionModelCatalog, createLoadSessionTodos } from "./lifecycle/session-loaders";
+import { resolveRuntimeRouteConnection } from "./runtime/runtime";
 
 type UseAgentOrchestratorOperationsArgs = {
   activeRepo: string | null;
@@ -54,6 +58,19 @@ type UseAgentOrchestratorOperationsResult = {
   answerAgentQuestion: (sessionId: string, requestId: string, answers: string[][]) => Promise<void>;
 };
 
+const getOrCreateRepoTaskSet = (
+  store: Record<string, Set<string>>,
+  repoPath: string,
+): Set<string> => {
+  const existing = store[repoPath];
+  if (existing) {
+    return existing;
+  }
+  const created = new Set<string>();
+  store[repoPath] = created;
+  return created;
+};
+
 export function useAgentOrchestratorOperations({
   activeRepo,
   tasks,
@@ -67,6 +84,8 @@ export function useAgentOrchestratorOperations({
     runs,
   });
   const { sessionsRef, turnStartedAtBySessionRef, unsubscribersRef } = refBridges;
+  const bootstrappedTasksByRepoRef = useRef<Record<string, Set<string>>>({});
+  const reconciledLiveSessionTasksByRepoRef = useRef<Record<string, Set<string>>>({});
   const runtimeDefinitions = useMemo(() => agentEngine.listRuntimeDefinitions(), [agentEngine]);
 
   const persistSessionSnapshot = useCallback(
@@ -186,32 +205,6 @@ export function useAgentOrchestratorOperations({
     [agentEngine, runtimeDefinitions, updateSession],
   );
 
-  const loadAgentSessions = useMemo(
-    () =>
-      createLoadAgentSessions({
-        activeRepo,
-        adapter: agentEngine,
-        repoEpochRef: refBridges.repoEpochRef,
-        previousRepoRef: refBridges.previousRepoRef,
-        sessionsRef: refBridges.sessionsRef,
-        setSessionsById: commitSessions,
-        taskRef: refBridges.taskRef,
-        updateSession,
-        loadSessionTodos,
-        loadSessionModelCatalog,
-        loadRepoPromptOverrides,
-      }),
-    [
-      activeRepo,
-      agentEngine,
-      commitSessions,
-      loadSessionModelCatalog,
-      loadSessionTodos,
-      refBridges,
-      updateSession,
-    ],
-  );
-
   const removeAgentSessions = useCallback(
     ({ taskId, roles }: { taskId: string; roles?: AgentSessionState["role"][] }): void => {
       const matchingRoles = roles ? new Set(roles) : null;
@@ -291,6 +284,223 @@ export function useAgentOrchestratorOperations({
       updateSession,
     ],
   );
+
+  const loadAgentSessions = useMemo(
+    () =>
+      createLoadAgentSessions({
+        activeRepo,
+        adapter: agentEngine,
+        repoEpochRef: refBridges.repoEpochRef,
+        previousRepoRef: refBridges.previousRepoRef,
+        sessionsRef: refBridges.sessionsRef,
+        setSessionsById: commitSessions,
+        taskRef: refBridges.taskRef,
+        updateSession,
+        attachSessionListener,
+        loadSessionTodos,
+        loadSessionModelCatalog,
+        loadRepoPromptOverrides,
+        loadTaskDocuments,
+      }),
+    [
+      activeRepo,
+      agentEngine,
+      attachSessionListener,
+      commitSessions,
+      loadSessionModelCatalog,
+      loadSessionTodos,
+      refBridges,
+      updateSession,
+    ],
+  );
+
+  useEffect(() => {
+    if (!activeRepo) {
+      return;
+    }
+    bootstrappedTasksByRepoRef.current[activeRepo] = new Set<string>();
+    reconciledLiveSessionTasksByRepoRef.current[activeRepo] = new Set<string>();
+  }, [activeRepo]);
+
+  useEffect(() => {
+    if (!activeRepo) {
+      return;
+    }
+
+    const bootstrappedTasks = getOrCreateRepoTaskSet(
+      bootstrappedTasksByRepoRef.current,
+      activeRepo,
+    );
+    const pendingTaskIds = tasks
+      .map((task) => task.id)
+      .filter((taskId) => !bootstrappedTasks.has(taskId));
+    if (pendingTaskIds.length === 0) {
+      return;
+    }
+
+    for (const taskId of pendingTaskIds) {
+      bootstrappedTasks.add(taskId);
+      void loadAgentSessions(taskId).catch(() => {
+        const currentSet = bootstrappedTasksByRepoRef.current[activeRepo];
+        currentSet?.delete(taskId);
+      });
+    }
+  }, [activeRepo, loadAgentSessions, tasks]);
+
+  useEffect(() => {
+    if (!activeRepo || tasks.length === 0) {
+      return;
+    }
+    const reconciledTaskIds = getOrCreateRepoTaskSet(
+      reconciledLiveSessionTasksByRepoRef.current,
+      activeRepo,
+    );
+    const pendingTaskIds = tasks
+      .map((task) => task.id)
+      .filter((taskId) => !reconciledTaskIds.has(taskId));
+    if (pendingTaskIds.length === 0) {
+      return;
+    }
+
+    let cancelled = false;
+    const activeRunStates = new Set<RunSummary["state"]>([
+      "starting",
+      "running",
+      "blocked",
+      "awaiting_done_confirmation",
+    ]);
+
+    void (async () => {
+      try {
+        const persistedByTask = await Promise.all(
+          pendingTaskIds.map(
+            async (taskId) =>
+              [
+                taskId,
+                await loadAgentSessionListFromQuery(appQueryClient, activeRepo, taskId, {
+                  forceFresh: true,
+                }),
+              ] as const,
+          ),
+        );
+        if (cancelled) {
+          return;
+        }
+
+        const persistedTaskIdsByLiveSessionKey = new Map<string, Set<string>>();
+        const runtimeKinds = new Set<string>();
+        for (const [taskId, records] of persistedByTask) {
+          for (const record of records) {
+            const runtimeKind = record.runtimeKind ?? record.selectedModel?.runtimeKind;
+            const externalSessionId = record.externalSessionId ?? record.sessionId;
+            if (!runtimeKind || !externalSessionId) {
+              continue;
+            }
+            runtimeKinds.add(runtimeKind);
+            const key = `${runtimeKind}::${externalSessionId}`;
+            const taskIds = persistedTaskIdsByLiveSessionKey.get(key) ?? new Set<string>();
+            taskIds.add(taskId);
+            persistedTaskIdsByLiveSessionKey.set(key, taskIds);
+          }
+        }
+
+        if (persistedTaskIdsByLiveSessionKey.size === 0) {
+          const currentSet = getOrCreateRepoTaskSet(
+            reconciledLiveSessionTasksByRepoRef.current,
+            activeRepo,
+          );
+          for (const taskId of pendingTaskIds) {
+            currentSet.add(taskId);
+          }
+          return;
+        }
+
+        const runtimeConnections = new Map<
+          string,
+          Parameters<AgentEnginePort["listRuntimeSessions"]>[0]
+        >();
+        for (const runtimeKind of runtimeKinds) {
+          const runtimes = await loadRuntimeListFromQuery(appQueryClient, runtimeKind, activeRepo);
+          if (cancelled) {
+            return;
+          }
+          for (const runtime of runtimes) {
+            const { runtimeConnection } = resolveRuntimeRouteConnection(
+              runtime.runtimeRoute,
+              runtime.workingDirectory,
+            );
+            const key = `${runtimeKind}::${runtimeConnection.endpoint}::${runtimeConnection.workingDirectory}`;
+            runtimeConnections.set(key, {
+              runtimeKind,
+              runtimeConnection,
+            });
+          }
+        }
+
+        for (const run of runs) {
+          if (!activeRunStates.has(run.state)) {
+            continue;
+          }
+          const { runtimeConnection } = resolveRuntimeRouteConnection(
+            run.runtimeRoute,
+            run.worktreePath,
+          );
+          const key = `${run.runtimeKind}::${runtimeConnection.endpoint}::${runtimeConnection.workingDirectory}`;
+          runtimeConnections.set(key, {
+            runtimeKind: run.runtimeKind,
+            runtimeConnection,
+          });
+        }
+
+        const taskIdsToReconcile = new Set<string>();
+        for (const input of runtimeConnections.values()) {
+          const runtimeSessions = await agentEngine.listRuntimeSessions(input);
+          if (cancelled) {
+            return;
+          }
+          for (const runtimeSession of runtimeSessions) {
+            if (runtimeSession.status.type !== "busy" && runtimeSession.status.type !== "retry") {
+              continue;
+            }
+            const key = `${input.runtimeKind}::${runtimeSession.externalSessionId}`;
+            const taskIds = persistedTaskIdsByLiveSessionKey.get(key);
+            if (!taskIds) {
+              continue;
+            }
+            for (const taskId of taskIds) {
+              taskIdsToReconcile.add(taskId);
+            }
+          }
+        }
+
+        if (cancelled) {
+          return;
+        }
+
+        await Promise.all(
+          Array.from(taskIdsToReconcile).map((taskId) =>
+            loadAgentSessions(taskId, { reconcileLiveSessions: true }),
+          ),
+        );
+        if (cancelled) {
+          return;
+        }
+        const currentSet = getOrCreateRepoTaskSet(
+          reconciledLiveSessionTasksByRepoRef.current,
+          activeRepo,
+        );
+        for (const taskId of pendingTaskIds) {
+          currentSet.add(taskId);
+        }
+      } catch {
+        // Leave pending tasks unreconciled so a later render can retry.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeRepo, agentEngine, loadAgentSessions, runs, tasks]);
 
   const ensureRuntime = useMemo(
     () =>

--- a/apps/desktop/src/state/queries/agent-sessions.ts
+++ b/apps/desktop/src/state/queries/agent-sessions.ts
@@ -21,5 +21,11 @@ export const loadAgentSessionListFromQuery = (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
+  options?: {
+    forceFresh?: boolean;
+  },
 ): Promise<AgentSessionRecord[]> =>
-  queryClient.fetchQuery(agentSessionListQueryOptions(repoPath, taskId));
+  queryClient.fetchQuery({
+    ...agentSessionListQueryOptions(repoPath, taskId),
+    ...(options?.forceFresh ? { staleTime: 0 } : {}),
+  });

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -128,4 +128,5 @@ export type AgentSessionState = {
 
 export type AgentSessionLoadOptions = {
   hydrateHistoryForSessionId?: string | null;
+  reconcileLiveSessions?: boolean;
 };

--- a/packages/adapters-opencode-sdk/src/client-factory.ts
+++ b/packages/adapters-opencode-sdk/src/client-factory.ts
@@ -7,6 +7,6 @@ export const buildDefaultFactory = (): ClientFactory => {
   return (input) =>
     createOpencodeClient({
       baseUrl: input.runtimeEndpoint,
-      directory: input.workingDirectory,
+      ...(input.workingDirectory ? { directory: input.workingDirectory } : {}),
     });
 };

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -290,4 +290,44 @@ describe("opencode-sdk-adapter", () => {
       },
     ]);
   });
+
+  test("listRuntimeSessions rejects sessions with invalid directories", async () => {
+    const mock = makeMockClient();
+    const malformedClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        list: async () => ({
+          data: [
+            {
+              id: "external-session-1",
+              projectID: "project-1",
+              directory: "   ",
+              title: "BUILD task-1",
+              time: {
+                created: Date.parse("2026-02-22T12:00:00.000Z"),
+              },
+            },
+          ],
+          error: undefined,
+        }),
+      },
+    } as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => malformedClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await expect(
+      adapter.listRuntimeSessions({
+        runtimeKind: "opencode",
+        runtimeConnection: {
+          endpoint: "http://127.0.0.1:12345",
+          workingDirectory: "/repo",
+        },
+      }),
+    ).rejects.toThrow(
+      "Malformed Opencode session payload for 'external-session-1': missing directory.",
+    );
+  });
 });

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -210,4 +210,32 @@ describe("opencode-sdk-adapter", () => {
       }),
     ).rejects.toThrow("Unsupported Opencode runtime session status type");
   });
+
+  test("listRuntimeSessions rejects non-object session status maps", async () => {
+    const mock = makeMockClient();
+    const malformedClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        status: async () => ({
+          data: ["bad-status-map"],
+          error: undefined,
+        }),
+      },
+    } as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => malformedClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await expect(
+      adapter.listRuntimeSessions({
+        runtimeKind: "opencode",
+        runtimeConnection: {
+          endpoint: "http://127.0.0.1:12345",
+          workingDirectory: "/repo",
+        },
+      }),
+    ).rejects.toThrow("Malformed Opencode session status response for directory '/repo'");
+  });
 });

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -238,4 +238,56 @@ describe("opencode-sdk-adapter", () => {
       }),
     ).rejects.toThrow("Malformed Opencode session status response for directory '/repo'");
   });
+
+  test("listRuntimeSessions normalizes directory keys for status lookups", async () => {
+    const mock = makeMockClient();
+    const whitespaceClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        list: async () => ({
+          data: [
+            {
+              id: "external-session-1",
+              projectID: "project-1",
+              directory: "  /repo  ",
+              title: "BUILD task-1",
+              time: {
+                created: Date.parse("2026-02-22T12:00:00.000Z"),
+              },
+            },
+          ],
+          error: undefined,
+        }),
+      },
+    } as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => whitespaceClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    const sessions = await adapter.listRuntimeSessions({
+      runtimeKind: "opencode",
+      runtimeConnection: {
+        endpoint: "http://127.0.0.1:12345",
+        workingDirectory: "/repo",
+      },
+    });
+
+    expect(mock.statusCalls).toEqual([{ directory: "/repo" }]);
+    expect(sessions).toEqual([
+      {
+        externalSessionId: "external-session-1",
+        title: "BUILD task-1",
+        workingDirectory: "/repo",
+        startedAt: "2026-02-22T12:00:00.000Z",
+        status: {
+          type: "retry",
+          attempt: 2,
+          message: "retrying",
+          nextEpochMs: 1234,
+        },
+      },
+    ]);
+  });
 });

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -7,9 +7,13 @@ const makeMockClient = (): {
   client: OpencodeClient;
   createCalls: unknown[];
   abortCalls: unknown[];
+  listCalls: unknown[];
+  statusCalls: unknown[];
 } => {
   const createCalls: unknown[] = [];
   const abortCalls: unknown[] = [];
+  const listCalls: unknown[] = [];
+  const statusCalls: unknown[] = [];
 
   const client = {
     session: {
@@ -20,6 +24,61 @@ const makeMockClient = (): {
       abort: async (input: unknown) => {
         abortCalls.push(input);
         return { data: true, error: undefined };
+      },
+      list: async (input?: unknown) => {
+        listCalls.push(input);
+        return {
+          data: [
+            {
+              id: "external-session-1",
+              projectID: "project-1",
+              directory: "/repo",
+              title: "BUILD task-1",
+              time: {
+                created: Date.parse("2026-02-22T12:00:00.000Z"),
+                updated: Date.parse("2026-02-22T12:00:00.000Z"),
+              },
+            },
+            {
+              id: "external-session-2",
+              projectID: "project-2",
+              directory: "/other",
+              title: "OTHER task",
+              time: {
+                created: Date.parse("2026-02-22T12:00:00.000Z"),
+                updated: Date.parse("2026-02-22T12:00:00.000Z"),
+              },
+            },
+          ],
+          error: undefined,
+        };
+      },
+      status: async (input?: unknown) => {
+        statusCalls.push(input);
+        const directory =
+          typeof input === "object" && input !== null && "directory" in input
+            ? (input as { directory?: string }).directory
+            : undefined;
+        return {
+          data:
+            directory === "/repo"
+              ? {
+                  "external-session-1": {
+                    type: "retry",
+                    attempt: 2,
+                    message: "retrying",
+                    next: 1234,
+                  },
+                }
+              : directory === "/other"
+                ? {
+                    "external-session-2": {
+                      type: "busy",
+                    },
+                  }
+                : {},
+          error: undefined,
+        };
       },
     },
     event: {
@@ -35,7 +94,7 @@ const makeMockClient = (): {
     },
   } as unknown as OpencodeClient;
 
-  return { client, createCalls, abortCalls };
+  return { client, createCalls, abortCalls, listCalls, statusCalls };
 };
 
 describe("opencode-sdk-adapter", () => {
@@ -76,5 +135,47 @@ describe("opencode-sdk-adapter", () => {
     expect(mock.abortCalls).toHaveLength(1);
     expect(adapter.hasSession("session-1")).toBe(false);
     expect(events.some((event) => event.type === "session_finished")).toBe(true);
+  });
+
+  test("listRuntimeSessions maps server sessions and statuses", async () => {
+    const mock = makeMockClient();
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    const sessions = await adapter.listRuntimeSessions({
+      runtimeKind: "opencode",
+      runtimeConnection: {
+        endpoint: "http://127.0.0.1:12345",
+        workingDirectory: "/repo",
+      },
+    });
+
+    expect(mock.listCalls).toHaveLength(1);
+    expect(mock.statusCalls).toEqual([{ directory: "/repo" }, { directory: "/other" }]);
+    expect(sessions).toEqual([
+      {
+        externalSessionId: "external-session-1",
+        title: "BUILD task-1",
+        workingDirectory: "/repo",
+        startedAt: "2026-02-22T12:00:00.000Z",
+        status: {
+          type: "retry",
+          attempt: 2,
+          message: "retrying",
+          nextEpochMs: 1234,
+        },
+      },
+      {
+        externalSessionId: "external-session-2",
+        title: "OTHER task",
+        workingDirectory: "/other",
+        startedAt: "2026-02-22T12:00:00.000Z",
+        status: {
+          type: "busy",
+        },
+      },
+    ]);
   });
 });

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.test.ts
@@ -178,4 +178,36 @@ describe("opencode-sdk-adapter", () => {
       },
     ]);
   });
+
+  test("listRuntimeSessions fails fast on malformed runtime statuses", async () => {
+    const mock = makeMockClient();
+    const malformedClient = {
+      ...mock.client,
+      session: {
+        ...mock.client.session,
+        status: async () => ({
+          data: {
+            "external-session-1": {
+              type: "unexpected",
+            },
+          },
+          error: undefined,
+        }),
+      },
+    } as OpencodeClient;
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => malformedClient,
+      now: () => "2026-02-22T12:00:00.000Z",
+    });
+
+    await expect(
+      adapter.listRuntimeSessions({
+        runtimeKind: "opencode",
+        runtimeConnection: {
+          endpoint: "http://127.0.0.1:12345",
+          workingDirectory: "/repo",
+        },
+      }),
+    ).rejects.toThrow("Unsupported Opencode runtime session status type");
+  });
 });

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -11,6 +11,7 @@ import {
   type EventUnsubscribe,
   type ForkAgentSessionInput,
   type ListAgentModelsInput,
+  type ListRuntimeSessionsInput,
   type LoadAgentFileStatusInput,
   type LoadAgentSessionDiffInput,
   type LoadAgentSessionHistoryInput,
@@ -18,6 +19,7 @@ import {
   type ReplyPermissionInput,
   type ReplyQuestionInput,
   type ResumeAgentSessionInput,
+  type RuntimeSessionSummary,
   type SendAgentUserMessageInput,
   type StartAgentSessionInput,
   toRuntimeClientInput,
@@ -66,6 +68,45 @@ import type {
 import { WORKFLOW_TOOL_CACHE_TTL_MS } from "./types";
 import { buildRoleScopedPermissionRules } from "./workflow-tool-permissions";
 import { resolveWorkflowToolSelection } from "./workflow-tool-selection";
+
+const toRuntimeSessionStatus = (status: unknown): RuntimeSessionSummary["status"] => {
+  if (typeof status !== "object" || status === null || !("type" in status)) {
+    return {
+      type: "idle",
+    };
+  }
+
+  const type = (status as { type?: unknown }).type;
+  if (type === "busy" || type === "idle") {
+    return {
+      type,
+    };
+  }
+
+  if (type === "retry") {
+    const retryStatus = status as {
+      attempt?: unknown;
+      message?: unknown;
+      next?: unknown;
+      nextEpochMs?: unknown;
+    };
+    return {
+      type: "retry",
+      attempt: typeof retryStatus.attempt === "number" ? retryStatus.attempt : 0,
+      message: typeof retryStatus.message === "string" ? retryStatus.message : "",
+      nextEpochMs:
+        typeof retryStatus.nextEpochMs === "number"
+          ? retryStatus.nextEpochMs
+          : typeof retryStatus.next === "number"
+            ? retryStatus.next
+            : 0,
+    };
+  }
+
+  return {
+    type: "idle",
+  };
+};
 
 export class OpencodeSdkAdapter
   implements AgentCatalogPort, AgentSessionPort, AgentWorkspaceInspectionPort
@@ -189,6 +230,40 @@ export class OpencodeSdkAdapter
       emit: this.emit.bind(this),
       ...(this.logEvent ? { logEvent: this.logEvent } : {}),
     });
+  }
+
+  async listRuntimeSessions(input: ListRuntimeSessionsInput): Promise<RuntimeSessionSummary[]> {
+    const runtimeClientInput = toRuntimeClientInput(
+      input.runtimeConnection,
+      "list runtime sessions",
+    );
+    const unscopedClient = this.createClient({
+      runtimeEndpoint: runtimeClientInput.runtimeEndpoint,
+    });
+    const sessionsPayload = await unscopedClient.session.list();
+    const sessions = unwrapData(sessionsPayload, "list sessions");
+    const sessionDirectories = Array.from(
+      new Set(
+        sessions
+          .map((session) => session.directory?.trim())
+          .filter((directory): directory is string => Boolean(directory)),
+      ),
+    );
+    const statusEntries = await Promise.all(
+      sessionDirectories.map(async (directory) => {
+        const statusPayload = await unscopedClient.session.status({ directory });
+        return [directory, unwrapData(statusPayload, "get session status")] as const;
+      }),
+    );
+    const statusesByDirectory = new Map(statusEntries);
+
+    return sessions.map((session) => ({
+      externalSessionId: session.id,
+      title: session.title,
+      workingDirectory: session.directory,
+      startedAt: toIsoFromEpoch(session.time?.created, this.now),
+      status: toRuntimeSessionStatus(statusesByDirectory.get(session.directory)?.[session.id]),
+    }));
   }
 
   hasSession(sessionId: string): boolean {

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -134,6 +134,14 @@ const normalizeSessionDirectory = (directory: unknown): string | undefined => {
   return normalized.length > 0 ? normalized : undefined;
 };
 
+const requireSessionDirectory = (directory: unknown, sessionId: string): string => {
+  const normalized = normalizeSessionDirectory(directory);
+  if (normalized !== undefined) {
+    return normalized;
+  }
+  throw new Error(`Malformed Opencode session payload for '${sessionId}': missing directory.`);
+};
+
 export class OpencodeSdkAdapter
   implements AgentCatalogPort, AgentSessionPort, AgentWorkspaceInspectionPort
 {
@@ -269,11 +277,7 @@ export class OpencodeSdkAdapter
     const sessionsPayload = await unscopedClient.session.list();
     const sessions = unwrapData(sessionsPayload, "list sessions");
     const sessionDirectories = Array.from(
-      new Set(
-        sessions
-          .map((session) => normalizeSessionDirectory(session.directory))
-          .filter((directory): directory is string => directory !== undefined),
-      ),
+      new Set(sessions.map((session) => requireSessionDirectory(session.directory, session.id))),
     );
     const statusEntries = await Promise.all(
       sessionDirectories.map(async (directory) => {
@@ -287,15 +291,12 @@ export class OpencodeSdkAdapter
     const statusesByDirectory = new Map(statusEntries);
 
     return sessions.map((session) => {
-      const normalizedDirectory = normalizeSessionDirectory(session.directory);
-      const directoryStatuses =
-        normalizedDirectory !== undefined
-          ? statusesByDirectory.get(normalizedDirectory)
-          : undefined;
+      const normalizedDirectory = requireSessionDirectory(session.directory, session.id);
+      const directoryStatuses = statusesByDirectory.get(normalizedDirectory);
       return {
         externalSessionId: session.id,
         title: session.title,
-        workingDirectory: normalizedDirectory ?? session.directory,
+        workingDirectory: normalizedDirectory,
         startedAt: toIsoFromEpoch(session.time?.created, this.now),
         status: toRuntimeSessionStatus(directoryStatuses?.[session.id]),
       };

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -70,10 +70,13 @@ import { buildRoleScopedPermissionRules } from "./workflow-tool-permissions";
 import { resolveWorkflowToolSelection } from "./workflow-tool-selection";
 
 const toRuntimeSessionStatus = (status: unknown): RuntimeSessionSummary["status"] => {
-  if (typeof status !== "object" || status === null || !("type" in status)) {
+  if (status === undefined || status === null) {
     return {
       type: "idle",
     };
+  }
+  if (typeof status !== "object" || !("type" in status)) {
+    throw new Error("Malformed runtime session status payload from Opencode.");
   }
 
   const type = (status as { type?: unknown }).type;
@@ -90,22 +93,28 @@ const toRuntimeSessionStatus = (status: unknown): RuntimeSessionSummary["status"
       next?: unknown;
       nextEpochMs?: unknown;
     };
+    const attempt = retryStatus.attempt;
+    const message = retryStatus.message;
+    const nextEpochMs =
+      typeof retryStatus.nextEpochMs === "number" ? retryStatus.nextEpochMs : retryStatus.next;
+    if (typeof attempt !== "number") {
+      throw new Error("Malformed Opencode retry status: missing numeric attempt.");
+    }
+    if (typeof message !== "string") {
+      throw new Error("Malformed Opencode retry status: missing message.");
+    }
+    if (typeof nextEpochMs !== "number") {
+      throw new Error("Malformed Opencode retry status: missing next epoch.");
+    }
     return {
       type: "retry",
-      attempt: typeof retryStatus.attempt === "number" ? retryStatus.attempt : 0,
-      message: typeof retryStatus.message === "string" ? retryStatus.message : "",
-      nextEpochMs:
-        typeof retryStatus.nextEpochMs === "number"
-          ? retryStatus.nextEpochMs
-          : typeof retryStatus.next === "number"
-            ? retryStatus.next
-            : 0,
+      attempt,
+      message,
+      nextEpochMs,
     };
   }
 
-  return {
-    type: "idle",
-  };
+  throw new Error(`Unsupported Opencode runtime session status type: ${String(type)}`);
 };
 
 export class OpencodeSdkAdapter

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -126,6 +126,14 @@ const toRuntimeStatusMap = (payload: unknown, directory: string): Record<string,
   return payload as Record<string, unknown>;
 };
 
+const normalizeSessionDirectory = (directory: unknown): string | undefined => {
+  if (typeof directory !== "string") {
+    return undefined;
+  }
+  const normalized = directory.trim();
+  return normalized.length > 0 ? normalized : undefined;
+};
+
 export class OpencodeSdkAdapter
   implements AgentCatalogPort, AgentSessionPort, AgentWorkspaceInspectionPort
 {
@@ -263,8 +271,8 @@ export class OpencodeSdkAdapter
     const sessionDirectories = Array.from(
       new Set(
         sessions
-          .map((session) => session.directory?.trim())
-          .filter((directory): directory is string => Boolean(directory)),
+          .map((session) => normalizeSessionDirectory(session.directory))
+          .filter((directory): directory is string => directory !== undefined),
       ),
     );
     const statusEntries = await Promise.all(
@@ -278,13 +286,20 @@ export class OpencodeSdkAdapter
     );
     const statusesByDirectory = new Map(statusEntries);
 
-    return sessions.map((session) => ({
-      externalSessionId: session.id,
-      title: session.title,
-      workingDirectory: session.directory,
-      startedAt: toIsoFromEpoch(session.time?.created, this.now),
-      status: toRuntimeSessionStatus(statusesByDirectory.get(session.directory)?.[session.id]),
-    }));
+    return sessions.map((session) => {
+      const normalizedDirectory = normalizeSessionDirectory(session.directory);
+      const directoryStatuses =
+        normalizedDirectory !== undefined
+          ? statusesByDirectory.get(normalizedDirectory)
+          : undefined;
+      return {
+        externalSessionId: session.id,
+        title: session.title,
+        workingDirectory: normalizedDirectory ?? session.directory,
+        startedAt: toIsoFromEpoch(session.time?.created, this.now),
+        status: toRuntimeSessionStatus(directoryStatuses?.[session.id]),
+      };
+    });
   }
 
   hasSession(sessionId: string): boolean {

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -117,6 +117,15 @@ const toRuntimeSessionStatus = (status: unknown): RuntimeSessionSummary["status"
   throw new Error(`Unsupported Opencode runtime session status type: ${String(type)}`);
 };
 
+const toRuntimeStatusMap = (payload: unknown, directory: string): Record<string, unknown> => {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    throw new Error(
+      `Malformed Opencode session status response for directory '${directory}': expected an object map.`,
+    );
+  }
+  return payload as Record<string, unknown>;
+};
+
 export class OpencodeSdkAdapter
   implements AgentCatalogPort, AgentSessionPort, AgentWorkspaceInspectionPort
 {
@@ -261,7 +270,10 @@ export class OpencodeSdkAdapter
     const statusEntries = await Promise.all(
       sessionDirectories.map(async (directory) => {
         const statusPayload = await unscopedClient.session.status({ directory });
-        return [directory, unwrapData(statusPayload, "get session status")] as const;
+        return [
+          directory,
+          toRuntimeStatusMap(unwrapData(statusPayload, "get session status"), directory),
+        ] as const;
       }),
     );
     const statusesByDirectory = new Map(statusEntries);

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -29,7 +29,7 @@ export type SessionRecord = {
 
 export type ClientFactory = (input: {
   runtimeEndpoint: string;
-  workingDirectory: string;
+  workingDirectory?: string;
 }) => OpencodeClient;
 
 export type OpencodeStreamEventLog = {

--- a/packages/core/src/ports/agent-engine.ts
+++ b/packages/core/src/ports/agent-engine.ts
@@ -56,6 +56,11 @@ export type ListAgentModelsInput = {
   runtimeConnection: AgentRuntimeConnection;
 };
 
+export type ListRuntimeSessionsInput = {
+  runtimeKind: RuntimeKind;
+  runtimeConnection: AgentRuntimeConnection;
+};
+
 export type LoadAgentSessionDiffInput = {
   runtimeKind: RuntimeKind;
   runtimeConnection: AgentRuntimeConnection;
@@ -76,6 +81,28 @@ export type AgentSessionHistoryMessage = {
   totalTokens?: number;
   model?: AgentModelSelection;
   parts: AgentStreamPart[];
+};
+
+export type RuntimeSessionStatus =
+  | {
+      type: "busy";
+    }
+  | {
+      type: "idle";
+    }
+  | {
+      type: "retry";
+      attempt: number;
+      message: string;
+      nextEpochMs: number;
+    };
+
+export type RuntimeSessionSummary = {
+  externalSessionId: string;
+  title: string;
+  workingDirectory: string;
+  startedAt: string;
+  status: RuntimeSessionStatus;
 };
 
 export type ReplyPermissionInput = {
@@ -115,6 +142,7 @@ export interface AgentSessionPort {
   startSession(input: StartAgentSessionInput): Promise<AgentSessionSummary>;
   resumeSession(input: ResumeAgentSessionInput): Promise<AgentSessionSummary>;
   forkSession(input: ForkAgentSessionInput): Promise<AgentSessionSummary>;
+  listRuntimeSessions(input: ListRuntimeSessionsInput): Promise<RuntimeSessionSummary[]>;
   hasSession(sessionId: string): boolean;
   loadSessionHistory(input: LoadAgentSessionHistoryInput): Promise<AgentSessionHistoryMessage[]>;
   loadSessionTodos(input: LoadAgentSessionTodosInput): Promise<AgentSessionTodoItem[]>;


### PR DESCRIPTION
## Summary
- add runtime-level live session discovery to the agent engine port and implement it in the Opencode SDK adapter
- resume matching live Opencode sessions on repo reopen/reload while keeping Beads session persistence limited to durable metadata only
- harden host-side stale run/reset checks against live OpenCode session status and keep runtime route handling aligned with the endpoint abstraction

## Review notes
- Persisted Beads session records no longer drive liveness. The frontend now treats them as durable metadata and derives live status from `listRuntimeSessions()`.
- The runtime abstraction stays at the port boundary: session discovery is exposed as `AgentEnginePort.listRuntimeSessions(...)`, while Opencode-specific HTTP/SDK details remain inside adapters.
- I found and fixed one follow-up gap during review: live-session reconciliation was tracked once per repo, which could miss tasks added later in the same app session. It is now tracked per task.
- I also tightened the host-side OpenCode status probe to use the actual `RuntimeRoute` endpoint instead of assuming `127.0.0.1`.

## Validation
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime session discovery API and per-runtime status checks to detect live external sessions.

* **Bug Fixes**
  * Filter out stale build runs when external sessions are not live or status endpoints are unreachable.
  * Persisted sessions now hydrate as stopped until live-state reconciliation completes.

* **Improvements**
  * Enhanced session reconciliation: resume/reattach behavior, retry/backoff for bootstrapping, working-directory normalization, and broader test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->