### PR TITLE
fix(desktop): stabilize chat composer resize and autoscroll

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
@@ -58,6 +58,7 @@ describe("use-agent-chat-layout helpers", () => {
       getBoundingClientRect: () => ({ height: 40 }),
       scrollHeight: 40,
       style: styleState,
+      value: "draft",
     } as unknown as HTMLTextAreaElement;
 
     resizeComposerTextareaElement(textarea);
@@ -75,6 +76,25 @@ describe("use-agent-chat-layout helpers", () => {
       getBoundingClientRect: () => ({ height: 120 }),
       scrollHeight: 40,
       style: styleState,
+      value: "draft",
+    } as unknown as HTMLTextAreaElement;
+
+    resizeComposerTextareaElement(textarea);
+
+    expect(styleState.height).toBe("44px");
+    expect(styleState.overflowY).toBe("hidden");
+  });
+
+  test("resizeComposerTextareaElement clamps empty drafts to minimum height", () => {
+    const styleState = {
+      height: "220px",
+      overflowY: "auto" as "auto" | "hidden",
+    };
+    const textarea = {
+      getBoundingClientRect: () => ({ height: 220 }),
+      scrollHeight: 220,
+      style: styleState,
+      value: "",
     } as unknown as HTMLTextAreaElement;
 
     resizeComposerTextareaElement(textarea);
@@ -106,6 +126,109 @@ describe("use-agent-chat-layout helpers", () => {
     const updatedState = harness.getLatest() as LayoutHookState;
 
     expect(updatedState.todoPanelBottomOffset).toBe(12);
+
+    await harness.unmount();
+  });
+
+  test("resizes only when controlled input value changes", async () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    const queuedFrameCallbacks: FrameRequestCallback[] = [];
+
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      queuedFrameCallbacks.push(callback);
+      return queuedFrameCallbacks.length;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((_id: number) => undefined) as typeof cancelAnimationFrame;
+
+    const harness = createSharedHookHarness(
+      ({ activeSessionId, input }: { activeSessionId: string | null; input: string }) => {
+        return useAgentChatLayout({ activeSessionId, input });
+      },
+      { activeSessionId: "session-1", input: "" },
+    );
+
+    await harness.mount();
+
+    const state = harness.getLatest() as LayoutHookState;
+    const styleState = {
+      height: "44px",
+      overflowY: "hidden" as const,
+    };
+    const textarea = {
+      getBoundingClientRect: () => ({ height: 44 }),
+      scrollHeight: 120,
+      style: styleState,
+      value: "",
+    } as unknown as HTMLTextAreaElement;
+    state.composerTextareaRef.current = textarea;
+
+    const pendingInitFrames = queuedFrameCallbacks.splice(0);
+    for (const callback of pendingInitFrames) {
+      callback(0);
+    }
+
+    queuedFrameCallbacks.length = 0;
+    textarea.value = "line one\nline two";
+    await harness.update({ activeSessionId: "session-1", input: "line one\nline two" });
+
+    expect(queuedFrameCallbacks).toHaveLength(1);
+    const firstFrame = queuedFrameCallbacks.shift();
+    if (!firstFrame) {
+      throw new Error("Expected queued frame callback");
+    }
+    firstFrame(0);
+    expect(styleState.height).toBe("120px");
+
+    queuedFrameCallbacks.length = 0;
+    await harness.update({ activeSessionId: "session-1", input: "line one\nline two" });
+    expect(queuedFrameCallbacks).toHaveLength(0);
+
+    Object.assign(textarea, {
+      value: "",
+      scrollHeight: 20,
+    });
+    await harness.update({ activeSessionId: "session-1", input: "" });
+    expect(queuedFrameCallbacks).toHaveLength(1);
+
+    const secondFrame = queuedFrameCallbacks.shift();
+    if (!secondFrame) {
+      throw new Error("Expected queued frame callback");
+    }
+    secondFrame(16);
+    expect(styleState.height).toBe("44px");
+
+    await harness.unmount();
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  test("initializes textarea height when ref becomes available after first mount", async () => {
+    const harness = createSharedHookHarness(
+      ({ activeSessionId, input }: { activeSessionId: string | null; input: string }) => {
+        return useAgentChatLayout({ activeSessionId, input });
+      },
+      { activeSessionId: "session-1", input: "" },
+    );
+
+    await harness.mount();
+
+    const state = harness.getLatest() as LayoutHookState;
+    const styleState = {
+      height: "220px",
+      overflowY: "hidden" as const,
+    };
+    const textarea = {
+      getBoundingClientRect: () => ({ height: 220 }),
+      scrollHeight: 44,
+      style: styleState,
+      value: "",
+    } as unknown as HTMLTextAreaElement;
+
+    state.composerTextareaRef.current = textarea;
+    await harness.update({ activeSessionId: "session-1", input: "" });
+
+    expect(styleState.height).toBe("44px");
 
     await harness.unmount();
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -34,6 +34,20 @@ export const resizeComposerTextareaElement = (
   overflowY: "auto" | "hidden";
 } => {
   const currentHeight = readComposerTextareaHeight(textarea);
+  const isEmptyDraft = textarea.value.length === 0;
+  if (isEmptyDraft) {
+    const nextHeight = COMPOSER_TEXTAREA_MIN_HEIGHT_PX;
+    const didHeightChange = Math.abs(currentHeight - nextHeight) > 0.5;
+    textarea.style.height = `${nextHeight}px`;
+    if (textarea.style.overflowY !== "hidden") {
+      textarea.style.overflowY = "hidden";
+    }
+    return {
+      didHeightChange,
+      overflowY: "hidden",
+    };
+  }
+
   textarea.style.height = "auto";
   const layout = computeComposerTextareaLayout(textarea.scrollHeight);
   const didHeightChange = Math.abs(currentHeight - layout.heightPx) > 0.5;
@@ -66,14 +80,17 @@ type UseAgentChatLayoutResult = {
 
 export const useAgentChatLayout = ({
   input,
-  activeSessionId: _activeSessionId,
+  activeSessionId,
 }: UseAgentChatLayoutInput): UseAgentChatLayoutResult => {
   const messagesContainerRef = useRef<HTMLDivElement | null>(null);
   const composerFormRef = useRef<HTMLFormElement | null>(null);
   const composerTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const resizeFrameIdRef = useRef<number | null>(null);
+  const previousInputRef = useRef(input);
+  const didInitializeTextareaForSessionRef = useRef(false);
   const [composerFormHeight, setComposerFormHeight] = useState(0);
 
-  const resizeComposerTextarea = useCallback((): void => {
+  const flushComposerTextareaResize = useCallback((): void => {
     const textarea = composerTextareaRef.current;
     if (!textarea) {
       return;
@@ -82,10 +99,71 @@ export const useAgentChatLayout = ({
     resizeComposerTextareaElement(textarea);
   }, []);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Input string is an explicit resize trigger.
+  const resizeComposerTextarea = useCallback((): void => {
+    const requestAnimationFrameFn = globalThis.requestAnimationFrame;
+    if (typeof requestAnimationFrameFn !== "function") {
+      flushComposerTextareaResize();
+      return;
+    }
+
+    if (resizeFrameIdRef.current !== null) {
+      return;
+    }
+
+    resizeFrameIdRef.current = requestAnimationFrameFn(() => {
+      resizeFrameIdRef.current = null;
+      flushComposerTextareaResize();
+    });
+  }, [flushComposerTextareaResize]);
+
   useLayoutEffect(() => {
+    didInitializeTextareaForSessionRef.current = false;
+    const hasActiveSession = activeSessionId !== null;
+    if (hasActiveSession && resizeFrameIdRef.current !== null) {
+      const cancelAnimationFrameFn = globalThis.cancelAnimationFrame;
+      if (typeof cancelAnimationFrameFn === "function") {
+        cancelAnimationFrameFn(resizeFrameIdRef.current);
+      }
+      resizeFrameIdRef.current = null;
+    }
+
+    flushComposerTextareaResize();
+    resizeComposerTextarea();
+  }, [activeSessionId, flushComposerTextareaResize, resizeComposerTextarea]);
+
+  useLayoutEffect(() => {
+    if (didInitializeTextareaForSessionRef.current) {
+      return;
+    }
+    if (!composerTextareaRef.current) {
+      return;
+    }
+
+    didInitializeTextareaForSessionRef.current = true;
+    flushComposerTextareaResize();
+    resizeComposerTextarea();
+  });
+
+  useEffect(() => {
+    if (previousInputRef.current === input) {
+      return;
+    }
+    previousInputRef.current = input;
     resizeComposerTextarea();
   }, [input, resizeComposerTextarea]);
+
+  useEffect(() => {
+    return () => {
+      if (resizeFrameIdRef.current === null) {
+        return;
+      }
+      const cancelAnimationFrameFn = globalThis.cancelAnimationFrame;
+      if (typeof cancelAnimationFrameFn === "function") {
+        cancelAnimationFrameFn(resizeFrameIdRef.current);
+      }
+      resizeFrameIdRef.current = null;
+    };
+  }, []);
 
   useEffect(() => {
     const form = composerFormRef.current;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-resize-sync.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-resize-sync.ts
@@ -13,8 +13,10 @@ export function useAgentChatResizeSync({
   syncBottomIfPinned,
 }: UseAgentChatResizeSyncInput): void {
   const contentResizeFrameRef = useRef<number | null>(null);
+  const contentSettleFrameRef = useRef<number | null>(null);
   const observedContentHeightRef = useRef<number | null>(null);
   const containerResizeFrameRef = useRef<number | null>(null);
+  const containerSettleFrameRef = useRef<number | null>(null);
   const observedContainerHeightRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -30,8 +32,8 @@ export function useAgentChatResizeSync({
       return;
     }
 
-    const syncAfterResize = () => {
-      contentResizeFrameRef.current = null;
+    const runContentSyncAfterSettle = () => {
+      contentSettleFrameRef.current = null;
       const nextContent = messagesContentRef.current;
       if (!nextContent) {
         return;
@@ -47,12 +49,36 @@ export function useAgentChatResizeSync({
       syncBottomIfPinned();
     };
 
+    const syncAfterResize = () => {
+      contentResizeFrameRef.current = null;
+      const requestAnimationFrameFn = globalThis.requestAnimationFrame;
+      if (typeof requestAnimationFrameFn !== "function") {
+        runContentSyncAfterSettle();
+        return;
+      }
+      if (contentSettleFrameRef.current !== null) {
+        return;
+      }
+
+      contentSettleFrameRef.current = requestAnimationFrameFn(() => {
+        runContentSyncAfterSettle();
+      });
+    };
+
     const scheduleResizeSync = () => {
       if (contentResizeFrameRef.current !== null) {
         return;
       }
 
-      contentResizeFrameRef.current = globalThis.requestAnimationFrame(syncAfterResize);
+      const requestAnimationFrameFn = globalThis.requestAnimationFrame;
+      if (typeof requestAnimationFrameFn !== "function") {
+        syncAfterResize();
+        return;
+      }
+
+      contentResizeFrameRef.current = requestAnimationFrameFn(() => {
+        syncAfterResize();
+      });
     };
 
     const observer = new ResizeObserver(() => {
@@ -65,6 +91,10 @@ export function useAgentChatResizeSync({
       if (contentResizeFrameRef.current !== null) {
         globalThis.cancelAnimationFrame(contentResizeFrameRef.current);
         contentResizeFrameRef.current = null;
+      }
+      if (contentSettleFrameRef.current !== null) {
+        globalThis.cancelAnimationFrame(contentSettleFrameRef.current);
+        contentSettleFrameRef.current = null;
       }
     };
   }, [messagesContainerRef, messagesContentRef, syncBottomIfPinned]);
@@ -81,8 +111,8 @@ export function useAgentChatResizeSync({
       return;
     }
 
-    const syncAfterResize = () => {
-      containerResizeFrameRef.current = null;
+    const runContainerSyncAfterSettle = () => {
+      containerSettleFrameRef.current = null;
       const nextContainer = messagesContainerRef.current;
       if (!nextContainer) {
         return;
@@ -98,12 +128,36 @@ export function useAgentChatResizeSync({
       syncBottomIfPinned();
     };
 
+    const syncAfterResize = () => {
+      containerResizeFrameRef.current = null;
+      const requestAnimationFrameFn = globalThis.requestAnimationFrame;
+      if (typeof requestAnimationFrameFn !== "function") {
+        runContainerSyncAfterSettle();
+        return;
+      }
+      if (containerSettleFrameRef.current !== null) {
+        return;
+      }
+
+      containerSettleFrameRef.current = requestAnimationFrameFn(() => {
+        runContainerSyncAfterSettle();
+      });
+    };
+
     const scheduleResizeSync = () => {
       if (containerResizeFrameRef.current !== null) {
         return;
       }
 
-      containerResizeFrameRef.current = globalThis.requestAnimationFrame(syncAfterResize);
+      const requestAnimationFrameFn = globalThis.requestAnimationFrame;
+      if (typeof requestAnimationFrameFn !== "function") {
+        syncAfterResize();
+        return;
+      }
+
+      containerResizeFrameRef.current = requestAnimationFrameFn(() => {
+        syncAfterResize();
+      });
     };
 
     const observer = new ResizeObserver(() => {
@@ -116,6 +170,10 @@ export function useAgentChatResizeSync({
       if (containerResizeFrameRef.current !== null) {
         globalThis.cancelAnimationFrame(containerResizeFrameRef.current);
         containerResizeFrameRef.current = null;
+      }
+      if (containerSettleFrameRef.current !== null) {
+        globalThis.cancelAnimationFrame(containerSettleFrameRef.current);
+        containerSettleFrameRef.current = null;
       }
     };
   }, [messagesContainerRef, syncBottomIfPinned]);

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -197,8 +197,8 @@ export function useAgentChatScrollController({
 
     const distanceFromBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight;
-    const isNearBottom = distanceFromBottom <= CHAT_SCROLL_EDGE_THRESHOLD_PX;
-    if (!isPinnedToBottomRef.current && !isNearBottom) {
+    const isWithinBottomThreshold = distanceFromBottom <= CHAT_SCROLL_EDGE_THRESHOLD_PX;
+    if (!isPinnedToBottomRef.current && !isWithinBottomThreshold) {
       return;
     }
 

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -195,7 +195,10 @@ export function useAgentChatScrollController({
       return;
     }
 
-    if (!isPinnedToBottomRef.current) {
+    const distanceFromBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    const isNearBottom = distanceFromBottom <= CHAT_SCROLL_EDGE_THRESHOLD_PX;
+    if (!isPinnedToBottomRef.current && !isNearBottom) {
       return;
     }
 
@@ -203,6 +206,7 @@ export function useAgentChatScrollController({
       top: container.scrollHeight,
       behavior: "auto",
     });
+    isPinnedToBottomRef.current = true;
     setIsNearBottom(true);
     setIsNearTop(false);
   }, [messagesContainerRef]);

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -705,6 +705,50 @@ describe("useAgentChatWindow", () => {
     await harness.unmount();
   });
 
+  test("does not auto-scroll to bottom when container height changes while not near bottom", async () => {
+    const harness = await mountHarness(
+      {
+        rows: createRows(80),
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+      },
+      { attachContainer: true },
+    );
+
+    const container = harness.messagesContainerRef.current as
+      | (MockMessagesContainer & { clientHeight: number })
+      | null;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+
+    const latestScrollListenerCall = container.addEventListener.mock.calls
+      .filter(([eventName]) => eventName === "scroll")
+      .at(-1);
+    const latestScrollListener = latestScrollListenerCall?.[1];
+    if (typeof latestScrollListener !== "function") {
+      throw new Error("Expected scroll listener");
+    }
+
+    container.scrollTop = 500;
+    await act(async () => {
+      latestScrollListener(new Event("scroll"));
+      await flush();
+    });
+
+    container.scrollTo.mockClear();
+    Object.assign(container, { clientHeight: 220 });
+
+    await act(async () => {
+      triggerResizeObservers();
+      await flush();
+    });
+
+    expect(container.scrollTo).not.toHaveBeenCalled();
+
+    await harness.unmount();
+  });
+
   test("mock resize observers only unobserve the requested target", () => {
     const callback = mock(
       (_entries: ResizeObserverEntry[], _observer: ResizeObserver) => undefined,


### PR DESCRIPTION
## Summary
- fix startup composer height flashes by clamping empty drafts to the minimum textarea height and ensuring reliable initialization timing
- stabilize multiline add/remove autoscroll with settle-frame resize syncing and improved sticky-bottom follow checks
- add and update targeted chat layout/scroll regressions to lock in the behavior

## Verification
- bun test apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
- bun test apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for textarea resizing (empty vs filled drafts), initialization after ref becomes available, controlled-input change behavior, and scroll behavior when container height changes while away from bottom.

* **Bug Fixes**
  * Enforced minimum textarea height for empty drafts and hidden overflow.
  * Throttled/coalesced textarea resize scheduling and added synchronous flush/cleanup.
  * Improved bottom-scroll detection to consider proximity to the edge and update pinned state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->