### PR TITLE
fix: QA rejection summary propagation and add approved mapping coverage

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
@@ -55,9 +55,15 @@ pub(crate) fn qa_document_presence(entries: Option<Vec<QaEntry>>) -> TaskQaDocum
         return TaskQaDocumentPresence::default();
     };
 
+    let has_content = !latest.markdown.trim().is_empty();
+
     TaskQaDocumentPresence {
-        has: true,
-        updated_at: Some(latest.updated_at.clone()),
+        has: has_content,
+        updated_at: if has_content {
+            Some(latest.updated_at.clone())
+        } else {
+            None
+        },
         verdict: qa_workflow_verdict_from_entry(&latest.verdict),
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/metadata.rs
@@ -56,7 +56,7 @@ pub(crate) fn qa_document_presence(entries: Option<Vec<QaEntry>>) -> TaskQaDocum
     };
 
     TaskQaDocumentPresence {
-        has: !latest.markdown.trim().is_empty(),
+        has: true,
         updated_at: Some(latest.updated_at.clone()),
         verdict: qa_workflow_verdict_from_entry(&latest.verdict),
     }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -991,7 +991,8 @@ fn list_tasks_filters_events_and_populates_subtask_ids() -> Result<()> {
 }
 
 #[test]
-fn list_tasks_marks_qa_report_present_when_latest_markdown_is_empty() -> Result<()> {
+fn list_tasks_keeps_qa_verdict_but_marks_missing_content_when_latest_markdown_is_empty(
+) -> Result<()> {
     let repo = RepoFixture::new("list-qa-empty-markdown");
     let payload = json!([issue_value(
         "task-qa-empty",
@@ -1033,11 +1034,8 @@ fn list_tasks_marks_qa_report_present_when_latest_markdown_is_empty() -> Result<
     assert_eq!(tasks.len(), 1);
 
     let task = &tasks[0];
-    assert!(task.document_summary.qa_report.has);
-    assert_eq!(
-        task.document_summary.qa_report.updated_at.as_deref(),
-        Some("2026-02-20T10:00:00Z")
-    );
+    assert!(!task.document_summary.qa_report.has);
+    assert!(task.document_summary.qa_report.updated_at.is_none());
     assert_eq!(
         task.document_summary.qa_report.verdict,
         host_domain::QaWorkflowVerdict::Rejected

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -991,6 +991,62 @@ fn list_tasks_filters_events_and_populates_subtask_ids() -> Result<()> {
 }
 
 #[test]
+fn list_tasks_marks_qa_report_present_when_latest_markdown_is_empty() -> Result<()> {
+    let repo = RepoFixture::new("list-qa-empty-markdown");
+    let payload = json!([issue_value(
+        "task-qa-empty",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "qaRequired": true,
+                "documents": {
+                    "qaReports": [
+                        {
+                            "markdown": "previous qa",
+                            "verdict": "approved",
+                            "updatedAt": "2026-02-20T09:00:00Z",
+                            "updatedBy": "qa-agent",
+                            "sourceTool": "qa_approved",
+                            "revision": 1
+                        },
+                        {
+                            "markdown": "   ",
+                            "verdict": "rejected",
+                            "updatedAt": "2026-02-20T10:00:00Z",
+                            "updatedBy": "qa-agent",
+                            "sourceTool": "qa_rejected",
+                            "revision": 2
+                        }
+                    ]
+                }
+            }
+        })),
+    )]);
+
+    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(payload.to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let tasks = store.list_tasks(repo.path())?;
+    assert_eq!(tasks.len(), 1);
+
+    let task = &tasks[0];
+    assert!(task.document_summary.qa_report.has);
+    assert_eq!(
+        task.document_summary.qa_report.updated_at.as_deref(),
+        Some("2026-02-20T10:00:00Z")
+    );
+    assert_eq!(
+        task.document_summary.qa_report.verdict,
+        host_domain::QaWorkflowVerdict::Rejected
+    );
+
+    Ok(())
+}
+
+#[test]
 fn list_tasks_uses_short_lived_repo_cache() -> Result<()> {
     let repo = RepoFixture::new("list-cache-hit");
     let payload = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);

--- a/packages/openducktor-mcp/src/beads-persistence.test.ts
+++ b/packages/openducktor-mcp/src/beads-persistence.test.ts
@@ -153,6 +153,11 @@ describe("BeadsPersistence", () => {
         status: "in_progress",
         issueType: "feature",
         aiReviewEnabled: false,
+        documentSummary: {
+          spec: { has: false },
+          plan: { has: false },
+          qaReport: { has: false, verdict: "not_reviewed" },
+        },
       },
     ]);
     expect(state.calls).toEqual([["list", "--all", "--limit", "0"]]);
@@ -271,6 +276,11 @@ describe("BeadsPersistence", () => {
         status: "open",
         issueType: "task",
         aiReviewEnabled: true,
+        documentSummary: {
+          spec: { has: false },
+          plan: { has: false },
+          qaReport: { has: false, verdict: "not_reviewed" },
+        },
       },
     ]);
   });

--- a/packages/openducktor-mcp/src/contracts.ts
+++ b/packages/openducktor-mcp/src/contracts.ts
@@ -10,7 +10,7 @@ export type { IssueType, PlanSubtaskInput, QaReportVerdict, TaskStatus };
 
 export type TaskCard = Pick<
   CanonicalTaskCard,
-  "id" | "title" | "status" | "issueType" | "aiReviewEnabled"
+  "id" | "title" | "status" | "issueType" | "aiReviewEnabled" | "documentSummary"
 > & {
   description?: CanonicalTaskCard["description"];
   parentId?: string;

--- a/packages/openducktor-mcp/src/task-mapping.test.ts
+++ b/packages/openducktor-mcp/src/task-mapping.test.ts
@@ -123,6 +123,56 @@ describe("task mapping entry parsers", () => {
     });
   });
 
+  test("issueToTaskCard maps document summary with latest QA approved verdict", () => {
+    const issue: RawIssue = {
+      id: "task-qa-approved",
+      title: "Carry QA approved summary",
+      status: "ai_review",
+      issue_type: "task",
+      metadata: {
+        openducktor: {
+          documents: {
+            qaReports: [
+              {
+                markdown: "Needs fixes first",
+                verdict: "rejected",
+                updatedAt: "2026-02-28T04:00:00Z",
+                updatedBy: "qa",
+                sourceTool: "odt_qa_rejected",
+                revision: 1,
+              },
+              {
+                markdown: "Looks good now",
+                verdict: "approved",
+                updatedAt: "2026-02-28T05:00:00Z",
+                updatedBy: "qa",
+                sourceTool: "odt_qa_approved",
+                revision: 2,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(issueToTaskCard(issue, "openducktor")).toMatchObject({
+      id: "task-qa-approved",
+      documentSummary: {
+        spec: {
+          has: false,
+        },
+        plan: {
+          has: false,
+        },
+        qaReport: {
+          has: true,
+          updatedAt: "2026-02-28T05:00:00Z",
+          verdict: "approved",
+        },
+      },
+    });
+  });
+
   test("issueToTaskCard defaults QA summary to not_reviewed when no QA metadata exists", () => {
     const issue: RawIssue = {
       id: "task-qa-missing",

--- a/packages/openducktor-mcp/src/task-mapping.test.ts
+++ b/packages/openducktor-mcp/src/task-mapping.test.ts
@@ -53,6 +53,117 @@ describe("task mapping entry parsers", () => {
     });
   });
 
+  test("issueToTaskCard maps document summary with latest QA rejected verdict", () => {
+    const issue: RawIssue = {
+      id: "task-qa-rejected",
+      title: "Carry QA summary",
+      status: "ai_review",
+      issue_type: "task",
+      metadata: {
+        openducktor: {
+          documents: {
+            spec: [
+              {
+                markdown: "# Spec",
+                updatedAt: "2026-02-28T00:00:00Z",
+                updatedBy: "planner",
+                sourceTool: "odt_set_spec",
+                revision: 1,
+              },
+            ],
+            implementationPlan: [
+              {
+                markdown: "# Plan",
+                updatedAt: "2026-02-28T01:00:00Z",
+                updatedBy: "planner",
+                sourceTool: "odt_set_plan",
+                revision: 1,
+              },
+            ],
+            qaReports: [
+              {
+                markdown: "",
+                verdict: "approved",
+                updatedAt: "2026-02-28T02:00:00Z",
+                updatedBy: "qa",
+                sourceTool: "odt_qa_approved",
+                revision: 1,
+              },
+              {
+                markdown: "Needs changes",
+                verdict: "rejected",
+                updatedAt: "2026-02-28T03:00:00Z",
+                updatedBy: "qa",
+                sourceTool: "odt_qa_rejected",
+                revision: 2,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(issueToTaskCard(issue, "openducktor")).toMatchObject({
+      id: "task-qa-rejected",
+      documentSummary: {
+        spec: {
+          has: true,
+          updatedAt: "2026-02-28T00:00:00Z",
+        },
+        plan: {
+          has: true,
+          updatedAt: "2026-02-28T01:00:00Z",
+        },
+        qaReport: {
+          has: true,
+          updatedAt: "2026-02-28T03:00:00Z",
+          verdict: "rejected",
+        },
+      },
+    });
+  });
+
+  test("issueToTaskCard defaults QA summary to not_reviewed when no QA metadata exists", () => {
+    const issue: RawIssue = {
+      id: "task-qa-missing",
+      title: "No QA yet",
+      status: "ready_for_dev",
+      issue_type: "task",
+      metadata: {
+        openducktor: {
+          documents: {
+            spec: [
+              {
+                markdown: "",
+                updatedAt: "2026-02-28T00:00:00Z",
+                updatedBy: "planner",
+                sourceTool: "odt_set_spec",
+                revision: 1,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(issueToTaskCard(issue, "openducktor")).toMatchObject({
+      id: "task-qa-missing",
+      documentSummary: {
+        spec: {
+          has: false,
+          updatedAt: "2026-02-28T00:00:00Z",
+        },
+        plan: {
+          has: false,
+        },
+        qaReport: {
+          has: false,
+          verdict: "not_reviewed",
+        },
+      },
+    });
+  });
+
   test("issueToPublicTask rejects invalid Beads created_at timestamps", () => {
     const issue: RawIssue = {
       id: "task-11",

--- a/packages/openducktor-mcp/src/task-mapping.test.ts
+++ b/packages/openducktor-mcp/src/task-mapping.test.ts
@@ -173,6 +173,55 @@ describe("task mapping entry parsers", () => {
     });
   });
 
+  test("issueToTaskCard keeps latest QA verdict when latest QA markdown is empty", () => {
+    const issue: RawIssue = {
+      id: "task-qa-empty-latest",
+      title: "Carry QA verdict without content",
+      status: "ai_review",
+      issue_type: "task",
+      metadata: {
+        openducktor: {
+          documents: {
+            qaReports: [
+              {
+                markdown: "Has content",
+                verdict: "approved",
+                updatedAt: "2026-02-28T06:00:00Z",
+                updatedBy: "qa",
+                sourceTool: "odt_qa_approved",
+                revision: 1,
+              },
+              {
+                markdown: "   ",
+                verdict: "rejected",
+                updatedAt: "2026-02-28T07:00:00Z",
+                updatedBy: "qa",
+                sourceTool: "odt_qa_rejected",
+                revision: 2,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(issueToTaskCard(issue, "openducktor")).toMatchObject({
+      id: "task-qa-empty-latest",
+      documentSummary: {
+        spec: {
+          has: false,
+        },
+        plan: {
+          has: false,
+        },
+        qaReport: {
+          has: false,
+          verdict: "rejected",
+        },
+      },
+    });
+  });
+
   test("issueToTaskCard defaults QA summary to not_reviewed when no QA metadata exists", () => {
     const issue: RawIssue = {
       id: "task-qa-missing",
@@ -201,7 +250,6 @@ describe("task mapping entry parsers", () => {
       documentSummary: {
         spec: {
           has: false,
-          updatedAt: "2026-02-28T00:00:00Z",
         },
         plan: {
           has: false,

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -149,6 +149,31 @@ export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): Tas
   const issueType = parseBeadsIssueType(issue.id, issue.issue_type);
   const root = parseMetadataRoot(issue.metadata);
   const namespace = ensureObject(root[metadataNamespace]);
+  const documents = ensureObject(namespace.documents);
+  const specEntries = parseMarkdownEntries(documents.spec);
+  const planEntries = parseMarkdownEntries(documents.implementationPlan);
+  const qaEntries = parseQaEntries(documents.qaReports);
+
+  const latestSpec = specEntries.length > 0 ? specEntries[specEntries.length - 1] : undefined;
+  const latestPlan = planEntries.length > 0 ? planEntries[planEntries.length - 1] : undefined;
+  const latestQa = qaEntries.length > 0 ? qaEntries[qaEntries.length - 1] : undefined;
+
+  const documentSummary: TaskCard["documentSummary"] = {
+    spec: {
+      has: typeof latestSpec === "object" && latestSpec.markdown.trim().length > 0,
+      ...(latestSpec ? { updatedAt: latestSpec.updatedAt } : {}),
+    },
+    plan: {
+      has: typeof latestPlan === "object" && latestPlan.markdown.trim().length > 0,
+      ...(latestPlan ? { updatedAt: latestPlan.updatedAt } : {}),
+    },
+    qaReport: {
+      has: typeof latestQa === "object",
+      ...(latestQa ? { updatedAt: latestQa.updatedAt } : {}),
+      verdict: latestQa?.verdict ?? "not_reviewed",
+    },
+  };
+
   const qaRequired =
     typeof namespace.qaRequired === "boolean"
       ? namespace.qaRequired
@@ -163,6 +188,7 @@ export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): Tas
     status: parseBeadsTaskStatus(issue.id, issue.status),
     issueType,
     aiReviewEnabled: qaRequired,
+    documentSummary,
     ...(parentId ? { parentId } : {}),
   };
 };

--- a/packages/openducktor-mcp/src/task-mapping.ts
+++ b/packages/openducktor-mcp/src/task-mapping.ts
@@ -157,19 +157,22 @@ export const issueToTaskCard = (issue: RawIssue, metadataNamespace: string): Tas
   const latestSpec = specEntries.length > 0 ? specEntries[specEntries.length - 1] : undefined;
   const latestPlan = planEntries.length > 0 ? planEntries[planEntries.length - 1] : undefined;
   const latestQa = qaEntries.length > 0 ? qaEntries[qaEntries.length - 1] : undefined;
+  const specHasContent = typeof latestSpec === "object" && latestSpec.markdown.trim().length > 0;
+  const planHasContent = typeof latestPlan === "object" && latestPlan.markdown.trim().length > 0;
+  const qaHasContent = typeof latestQa === "object" && latestQa.markdown.trim().length > 0;
 
   const documentSummary: TaskCard["documentSummary"] = {
     spec: {
-      has: typeof latestSpec === "object" && latestSpec.markdown.trim().length > 0,
-      ...(latestSpec ? { updatedAt: latestSpec.updatedAt } : {}),
+      has: specHasContent,
+      ...(specHasContent ? { updatedAt: latestSpec.updatedAt } : {}),
     },
     plan: {
-      has: typeof latestPlan === "object" && latestPlan.markdown.trim().length > 0,
-      ...(latestPlan ? { updatedAt: latestPlan.updatedAt } : {}),
+      has: planHasContent,
+      ...(planHasContent ? { updatedAt: latestPlan.updatedAt } : {}),
     },
     qaReport: {
-      has: typeof latestQa === "object",
-      ...(latestQa ? { updatedAt: latestQa.updatedAt } : {}),
+      has: qaHasContent,
+      ...(qaHasContent ? { updatedAt: latestQa.updatedAt } : {}),
       verdict: latestQa?.verdict ?? "not_reviewed",
     },
   };

--- a/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
+++ b/packages/openducktor-mcp/src/task-workflow-runtime.test.ts
@@ -26,6 +26,11 @@ const createTaskCard = (input: TaskCardFixtureInput) => ({
   status: input.status,
   issueType: input.issueType,
   aiReviewEnabled: input.aiReviewEnabled,
+  documentSummary: {
+    spec: { has: false },
+    plan: { has: false },
+    qaReport: { has: false, verdict: "not_reviewed" as const },
+  },
 });
 
 const makeIssue = (input: { id?: string; status?: string; metadata?: unknown }) => ({


### PR DESCRIPTION
## Summary
- propagate `documentSummary` through MCP task-card mapping and preserve latest QA verdict, including default `not_reviewed` handling
- align host Beads metadata summary semantics so QA report presence reflects entry existence and latest verdict consistently
- add regression tests for rejected/default/approved verdict mapping paths across MCP and host-infra-beads surfaces

## Verification
- bun run --filter @openducktor/mcp test ./src/task-mapping.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task cards now include document summary information (specification, implementation plan, and QA reports) with presence indicators and metadata.

* **Bug Fixes**
  * Fixed QA report presence detection to correctly show as present when a latest QA report exists, regardless of content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->