### PR TITLE
fix: disable rebase when uncommitted changes exist

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -1003,6 +1003,8 @@ describe("AgentStudioGitPanel", () => {
     const root = getRoot(renderer);
     const rebaseButton = findByTestId(root, "agent-studio-git-rebase-button");
     expect(Boolean(rebaseButton.props.disabled)).toBe(true);
+    expect(rebaseButton.props.className).toContain("disabled:pointer-events-auto");
+    expect(rebaseButton.props.className).toContain("disabled:cursor-not-allowed");
     expect(hasVisibleText(root, "Commit or stash changes before rebasing")).toBe(true);
 
     await act(async () => {

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -983,6 +983,34 @@ describe("AgentStudioGitPanel", () => {
     });
   });
 
+  test("disables rebase with uncommitted changes and explains why", async () => {
+    const rebaseOntoTarget = mock(async () => {});
+
+    let renderer: RenderResult | null = null;
+    await act(async () => {
+      renderer = render(
+        createElement(AgentStudioGitPanel, {
+          model: baseModel({
+            commitsAheadBehind: { ahead: 0, behind: 2 },
+            fileStatuses: [{ path: "src/dirty.ts", staged: false, status: "M" }],
+            rebaseOntoTarget,
+          }),
+        }),
+      );
+      await flush();
+    });
+
+    const root = getRoot(renderer);
+    const rebaseButton = findByTestId(root, "agent-studio-git-rebase-button");
+    expect(Boolean(rebaseButton.props.disabled)).toBe(true);
+    expect(hasVisibleText(root, "Commit or stash changes before rebasing")).toBe(true);
+
+    await act(async () => {
+      ensureRenderer(renderer).unmount();
+      await flush();
+    });
+  });
+
   test("hides the generic lock banner when the conflict strip is already visible", async () => {
     let renderer: RenderResult | null = null;
     await act(async () => {

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
@@ -476,6 +476,7 @@ export function GitInfoHeader({
     !isRepositoryMode &&
     !isDetachedHead &&
     hasTargetBranch &&
+    !hasUncommittedFiles &&
     !isAnyActionInFlight &&
     !isGitActionsLocked &&
     rebaseOntoTarget != null;
@@ -496,9 +497,11 @@ export function GitInfoHeader({
     ? "Rebasing"
     : isGitActionsLocked
       ? (gitActionsLockReason ?? "Git actions are disabled.")
-      : rebaseBehindCount != null && rebaseBehindCount > 0
-        ? `Rebase onto target (${rebaseBehindCount} behind)`
-        : "Rebase onto target";
+      : hasUncommittedFiles
+        ? "Commit or stash changes before rebasing"
+        : rebaseBehindCount != null && rebaseBehindCount > 0
+          ? `Rebase onto target (${rebaseBehindCount} behind)`
+          : "Rebase onto target";
   const pullTooltip = isRebasing
     ? "Pulling"
     : isGitActionsLocked

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/git-info-header.tsx
@@ -295,6 +295,7 @@ function GitActionRow({
                   }
                 : undefined
             }
+            wrapTrigger
           />
         )}
         <span className="inline-flex" data-testid="agent-studio-git-pull-tooltip-trigger">


### PR DESCRIPTION
## Summary
- Disable the Agent Studio rebase action when uncommitted files are present, matching pull safety behavior.
- Show a clear tooltip message: \"Commit or stash changes before rebasing\" when rebase is unavailable.
- Add regression coverage for the rebase-disabled-with-dirty-worktree state in `agent-studio-git-panel.test.tsx`.

## Verification
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rebase is now disabled when uncommitted, unstaged changes exist; users see "Commit or stash changes before rebasing" and cannot trigger rebase in that state.
  * Tooltip text/behavior updated so the uncommitted-files message takes precedence over other rebase messaging.

* **Tests**
  * Added a unit test to verify the Rebase button is disabled and displays the explanatory message with uncommitted changes.

* **Style**
  * Improved tooltip trigger wrapping for consistent UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->