### PR TITLE
fix(desktop): enforce authoritative agent stop lifecycle

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -142,3 +142,74 @@ fn extract_http_response_body(response: &str) -> String {
         .map(|(_, body)| body.trim().to_string())
         .unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        has_live_opencode_session_status, load_opencode_session_statuses, OpencodeSessionStatus,
+    };
+    use host_domain::AgentRuntimeKind;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn load_opencode_session_statuses_sends_directory_query_and_parses_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener should bind");
+        let port = listener
+            .local_addr()
+            .expect("listener should expose addr")
+            .port();
+        let request_line = Arc::new(Mutex::new(None::<String>));
+        let request_line_for_thread = Arc::clone(&request_line);
+
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("server should accept request");
+            let mut request_buffer = [0_u8; 4096];
+            let bytes_read = stream
+                .read(&mut request_buffer)
+                .expect("server should read request");
+            let request_text = String::from_utf8_lossy(&request_buffer[..bytes_read]);
+            let first_line = request_text.lines().next().unwrap_or_default().to_string();
+            *request_line_for_thread
+                .lock()
+                .expect("request line lock poisoned") = Some(first_line);
+
+            let body = r#"{"external-session":{"type":"busy"}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("server should write response");
+            stream.flush().expect("server should flush response");
+        });
+
+        let runtime_route = AgentRuntimeKind::Opencode.route_for_port(port);
+
+        let statuses = load_opencode_session_statuses(&runtime_route, "/tmp/repo path")
+            .expect("status request should succeed");
+        assert!(matches!(
+            statuses.get("external-session"),
+            Some(OpencodeSessionStatus::Busy)
+        ));
+        assert!(has_live_opencode_session_status(
+            &statuses,
+            "external-session"
+        ));
+
+        server.join().expect("server thread should finish");
+        let captured_request = request_line
+            .lock()
+            .expect("request line lock poisoned")
+            .clone()
+            .expect("request line should be captured");
+        assert!(
+            captured_request
+                .starts_with("GET /session/status?directory=%2Ftmp%2Frepo+path HTTP/1.1"),
+            "unexpected request line: {captured_request}"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -8,8 +8,9 @@ use crate::app_service::{
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
-    AgentSessionDocument, CreateTaskInput, GitWorktreeSummary, QaWorkflowVerdict, RunState,
-    RuntimeRole, TaskCard, TaskMetadata, TaskStatus, UpdateTaskPatch, DEFAULT_BRANCH_PREFIX,
+    AgentRuntimeKind, AgentSessionDocument, CreateTaskInput, GitWorktreeSummary, QaWorkflowVerdict,
+    RunState, RuntimeRole, RuntimeRoute, TaskCard, TaskMetadata, TaskStatus, UpdateTaskPatch,
+    DEFAULT_BRANCH_PREFIX,
 };
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -81,9 +82,16 @@ impl AppService {
             collect_task_delete_targets(&context.repo.tasks, task_id, delete_subtasks);
         let target_task_ids = target_tasks
             .iter()
-            .map(|task| task.id.as_str())
+            .map(|task| task.id.clone())
             .collect::<Vec<_>>();
-        self.ensure_no_active_task_delete_runs(context.repo.repo_path.as_str(), &target_task_ids)?;
+        let target_task_id_refs = target_task_ids
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        self.ensure_no_active_task_delete_runs(
+            context.repo.repo_path.as_str(),
+            &target_task_id_refs,
+        )?;
         let normalized_repo = normalize_path_for_comparison(context.repo.repo_path.as_str());
         let branch_prefix = self
             .config_store
@@ -122,7 +130,11 @@ impl AppService {
             .filter(|branch| !branch.is_remote)
             .filter(|branch| {
                 target_task_ids.iter().any(|task_id| {
-                    is_related_task_branch(branch.name.as_str(), branch_prefix.as_str(), task_id)
+                    is_related_task_branch(
+                        branch.name.as_str(),
+                        branch_prefix.as_str(),
+                        task_id.as_str(),
+                    )
                 })
             })
             .map(|branch| branch.name)
@@ -151,6 +163,12 @@ impl AppService {
         self.task_store
             .delete_task(context.repo_dir(), task_id, delete_subtasks)
             .with_context(|| format!("Failed to delete task {task_id}"))?;
+        for target_task_id in &target_task_ids {
+            self.clear_task_runs(context.repo.repo_path.as_str(), target_task_id)
+                .with_context(|| {
+                    format!("Failed to clear run state for deleted task {target_task_id}")
+                })?;
+        }
         Ok(())
     }
 
@@ -306,26 +324,18 @@ impl AppService {
     }
 
     fn ensure_no_active_task_delete_runs(&self, repo_path: &str, task_ids: &[&str]) -> Result<()> {
-        let normalized_repo = normalize_path_for_comparison(repo_path);
-        let runs = self
-            .runs
-            .lock()
-            .map_err(|_| anyhow!("Run state lock poisoned"))?;
-        let active_task_ids = runs
-            .values()
-            .filter(|run| normalize_path_for_comparison(run.repo_path.as_str()) == normalized_repo)
-            .filter(|run| task_ids.iter().any(|task_id| *task_id == run.task_id))
-            .filter(|run| {
-                matches!(
-                    run.summary.state,
-                    RunState::Starting
-                        | RunState::Running
-                        | RunState::Blocked
-                        | RunState::AwaitingDoneConfirmation
-                )
-            })
-            .map(|run| run.task_id.clone())
-            .collect::<HashSet<_>>();
+        let mut active_task_ids = HashSet::new();
+        for task_id in task_ids {
+            let sessions = self.agent_sessions_list(repo_path, task_id)?;
+            let evidence = self
+                .collect_active_task_work_evidence(repo_path, task_id, &sessions)
+                .with_context(|| {
+                    format!("Failed checking active task work before deleting {task_id}")
+                })?;
+            if evidence.has_any_activity() {
+                active_task_ids.insert((*task_id).to_string());
+            }
+        }
 
         if active_task_ids.is_empty() {
             return Ok(());
@@ -343,6 +353,34 @@ impl AppService {
         task_id: &str,
         sessions: &[AgentSessionDocument],
     ) -> Result<()> {
+        let evidence = self
+            .collect_active_task_work_evidence(repo_path, task_id, sessions)
+            .with_context(|| {
+                format!("Failed checking live runtime state before resetting {task_id}")
+            })?;
+
+        if evidence.has_active_run {
+            return Err(anyhow!(
+                "Cannot reset implementation while builder work is active for task {task_id}. Stop the active run first."
+            ));
+        }
+
+        if evidence.active_session_roles.is_empty() {
+            return Ok(());
+        }
+
+        Err(anyhow!(
+            "Cannot reset implementation while active {} session(s) exist for task {task_id}. Stop the active session(s) first.",
+            evidence.active_session_roles.join("/")
+        ))
+    }
+
+    fn collect_active_task_work_evidence(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+        sessions: &[AgentSessionDocument],
+    ) -> Result<TaskActiveWorkEvidence> {
         let normalized_repo = normalize_path_for_comparison(repo_path);
         let runs = self
             .runs
@@ -379,23 +417,7 @@ impl AppService {
             break;
         }
         drop(runs);
-
-        if has_active_run {
-            return Err(anyhow!(
-                "Cannot reset implementation while builder work is active for task {task_id}. Stop the active run first."
-            ));
-        }
-
-        let active_runtime_roles = collect_active_runtime_roles_for_task(self, repo_path, task_id)
-            .with_context(|| {
-                format!("Failed checking live runtime state before resetting {task_id}")
-            })?;
-        if !active_runtime_roles.is_empty() {
-            return Err(anyhow!(
-                "Cannot reset implementation while active {} session(s) exist for task {task_id}. Stop the active session(s) first.",
-                active_runtime_roles.join("/")
-            ));
-        }
+        let repo_runtime_routes_by_kind = self.collect_repo_runtime_routes_by_kind(repo_path)?;
 
         let mut active_roles = HashSet::new();
         for session in sessions
@@ -411,13 +433,14 @@ impl AppService {
                 continue;
             };
 
-            if session.role.as_str() != "build" {
-                continue;
-            }
-
             let worktree_key = normalize_path_key(session.working_directory.as_str());
-            let Some(runtime_route) = runtime_routes_by_worktree.get(worktree_key.as_str()) else {
-                active_roles.insert(session.role.as_str());
+            let fallback_runtime_kind = parse_runtime_kind(session.runtime_kind.as_str());
+            let runtime_route = runtime_routes_by_worktree
+                .get(worktree_key.as_str())
+                .or_else(|| {
+                    fallback_runtime_kind.and_then(|kind| repo_runtime_routes_by_kind.get(&kind))
+                });
+            let Some(runtime_route) = runtime_route else {
                 continue;
             };
             if !runtime_statuses_by_directory.contains_key(worktree_key.as_str()) {
@@ -444,16 +467,46 @@ impl AppService {
                 active_roles.insert(session.role.as_str());
             }
         }
-        if active_roles.is_empty() {
-            return Ok(());
+        let mut active_session_roles = active_roles
+            .into_iter()
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        active_session_roles.sort_unstable();
+
+        Ok(TaskActiveWorkEvidence {
+            has_active_run,
+            active_session_roles,
+        })
+    }
+
+    fn collect_repo_runtime_routes_by_kind(
+        &self,
+        repo_path: &str,
+    ) -> Result<HashMap<AgentRuntimeKind, RuntimeRoute>> {
+        let normalized_repo = normalize_path_for_comparison(repo_path);
+        let runtimes = self
+            .agent_runtimes
+            .lock()
+            .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
+        let mut routes_by_kind = HashMap::new();
+
+        for runtime in runtimes.values() {
+            if normalize_path_for_comparison(runtime.summary.repo_path.as_str()) != normalized_repo
+            {
+                continue;
+            }
+
+            if runtime.summary.role == RuntimeRole::Workspace {
+                routes_by_kind.insert(runtime.summary.kind, runtime.summary.runtime_route.clone());
+                continue;
+            }
+
+            routes_by_kind
+                .entry(runtime.summary.kind)
+                .or_insert_with(|| runtime.summary.runtime_route.clone());
         }
 
-        let mut roles = active_roles.into_iter().collect::<Vec<_>>();
-        roles.sort_unstable();
-        Err(anyhow!(
-            "Cannot reset implementation while active {} session(s) exist for task {task_id}. Stop the active session(s) first.",
-            roles.join("/")
-        ))
+        Ok(routes_by_kind)
     }
 
     pub fn task_transition(
@@ -625,6 +678,25 @@ impl AppService {
         self.task_store
             .get_task_metadata(std::path::Path::new(&repo_path), task_id)
             .with_context(|| format!("Failed to load task metadata for {task_id}"))
+    }
+}
+
+#[derive(Default)]
+struct TaskActiveWorkEvidence {
+    has_active_run: bool,
+    active_session_roles: Vec<String>,
+}
+
+impl TaskActiveWorkEvidence {
+    fn has_any_activity(&self) -> bool {
+        self.has_active_run || !self.active_session_roles.is_empty()
+    }
+}
+
+fn parse_runtime_kind(value: &str) -> Option<AgentRuntimeKind> {
+    match value.trim() {
+        "opencode" => Some(AgentRuntimeKind::Opencode),
+        _ => None,
     }
 }
 
@@ -910,49 +982,6 @@ fn with_reset_cleanup_progress(
 
     progress.push("Retry reset to finish cleanup safely.".to_string());
     error.context(progress.join("\n"))
-}
-
-fn collect_active_runtime_roles_for_task(
-    service: &AppService,
-    repo_path: &str,
-    task_id: &str,
-) -> Result<Vec<&'static str>> {
-    let normalized_repo = normalize_path_for_comparison(repo_path);
-    let mut runtimes = service
-        .agent_runtimes
-        .lock()
-        .map_err(|_| anyhow!("Agent runtime state lock poisoned"))?;
-    let mut active_roles = HashSet::new();
-
-    for runtime in runtimes.values_mut() {
-        if normalize_path_for_comparison(runtime.summary.repo_path.as_str()) != normalized_repo {
-            continue;
-        }
-        if runtime.summary.task_id.as_deref() != Some(task_id) {
-            continue;
-        }
-        match runtime.summary.role {
-            RuntimeRole::Build | RuntimeRole::Qa => {}
-            _ => continue,
-        }
-
-        match runtime.child.try_wait() {
-            Ok(Some(_)) => continue,
-            Ok(None) => {
-                active_roles.insert(runtime.summary.role.as_str());
-            }
-            Err(error) => {
-                return Err(anyhow!(
-                    "Failed checking runtime {} for task {task_id}: {error}",
-                    runtime.summary.runtime_id
-                ));
-            }
-        }
-    }
-
-    let mut roles = active_roles.into_iter().collect::<Vec<_>>();
-    roles.sort_unstable();
-    Ok(roles)
 }
 
 fn is_live_build_run_for_task_reset(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -435,16 +435,15 @@ impl AppService {
 
             let worktree_key = normalize_path_key(session.working_directory.as_str());
             let fallback_runtime_kind = parse_runtime_kind(session.runtime_kind.as_str());
-            let runtime_route = runtime_routes_by_worktree
-                .get(worktree_key.as_str())
-                .or_else(|| {
-                    fallback_runtime_kind.and_then(|kind| repo_runtime_routes_by_kind.get(&kind))
-                });
+            let worktree_runtime_route = runtime_routes_by_worktree.get(worktree_key.as_str());
+            let repo_runtime_route =
+                fallback_runtime_kind.and_then(|kind| repo_runtime_routes_by_kind.get(&kind));
+            let runtime_route = worktree_runtime_route.or(repo_runtime_route);
             let Some(runtime_route) = runtime_route else {
                 continue;
             };
             if !runtime_statuses_by_directory.contains_key(worktree_key.as_str()) {
-                let statuses = load_opencode_session_statuses(
+                let mut statuses = load_opencode_session_statuses(
                     runtime_route,
                     session.working_directory.as_str(),
                 )
@@ -455,7 +454,35 @@ impl AppService {
                         Err(error)
                     }
                 })?;
-                runtime_statuses_by_directory.insert(worktree_key.clone(), statuses);
+
+                if statuses.is_empty() {
+                    if let (Some(primary_route), Some(fallback_route)) =
+                        (worktree_runtime_route, repo_runtime_route)
+                    {
+                        let primary_endpoint = runtime_route_endpoint(primary_route);
+                        let fallback_endpoint = runtime_route_endpoint(fallback_route);
+                        if primary_endpoint != fallback_endpoint {
+                            let fallback_statuses = load_opencode_session_statuses(
+                                fallback_route,
+                                session.working_directory.as_str(),
+                            )
+                            .or_else(|error| {
+                                if is_unreachable_opencode_session_status_error(&error) {
+                                    Ok(OpencodeSessionStatusMap::new())
+                                } else {
+                                    Err(error)
+                                }
+                            })?;
+                            if !fallback_statuses.is_empty() {
+                                statuses = fallback_statuses;
+                            }
+                        }
+                    }
+                }
+
+                if !statuses.is_empty() {
+                    runtime_statuses_by_directory.insert(worktree_key.clone(), statuses);
+                }
             }
 
             if runtime_statuses_by_directory
@@ -697,6 +724,12 @@ fn parse_runtime_kind(value: &str) -> Option<AgentRuntimeKind> {
     match value.trim() {
         "opencode" => Some(AgentRuntimeKind::Opencode),
         _ => None,
+    }
+}
+
+fn runtime_route_endpoint(route: &RuntimeRoute) -> &str {
+    match route {
+        RuntimeRoute::LocalHttp { endpoint } => endpoint.as_str(),
     }
 }
 
@@ -1026,6 +1059,9 @@ fn is_live_build_run_for_task_reset(
                 }
             })?,
         };
+        if statuses.is_empty() {
+            return Ok(false);
+        }
         runtime_statuses_by_directory.insert(directory_key.clone(), statuses);
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -40,7 +40,7 @@ use std::ffi::OsString;
 use std::fs;
 #[cfg(unix)]
 use std::fs::Permissions;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -1245,6 +1245,27 @@ pub(crate) fn init_git_repo(path: &Path) -> Result<()> {
         .stderr(Stdio::null())
         .status();
     Ok(())
+}
+
+pub(crate) fn spawn_opencode_session_status_server(
+    response_body: &'static str,
+) -> Result<(u16, std::thread::JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        response_body.len(),
+        response_body
+    );
+    let handle = std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut request_buffer = [0_u8; 4096];
+            let _ = stream.read(&mut request_buffer);
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    Ok((port, handle))
 }
 
 pub(crate) fn create_fake_opencode(path: &Path) -> Result<()> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -1251,6 +1251,7 @@ pub(crate) fn spawn_opencode_session_status_server(
     response_body: &'static str,
 ) -> Result<(u16, std::thread::JoinHandle<()>)> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
+    listener.set_nonblocking(true)?;
     let port = listener.local_addr()?.port();
     let response = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -1258,11 +1259,24 @@ pub(crate) fn spawn_opencode_session_status_server(
         response_body
     );
     let handle = std::thread::spawn(move || {
-        if let Ok((mut stream, _)) = listener.accept() {
-            let mut request_buffer = [0_u8; 4096];
-            let _ = stream.read(&mut request_buffer);
-            let _ = stream.write_all(response.as_bytes());
-            let _ = stream.flush();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    let mut request_buffer = [0_u8; 4096];
+                    let _ = stream.read(&mut request_buffer);
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.flush();
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => break,
+            }
         }
     });
     Ok((port, handle))

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -10,7 +10,6 @@ use host_domain::{
 use host_infra_system::{AppConfigStore, GlobalConfig, HookSet, RepoConfig};
 use serde_json::Value;
 use std::fs;
-use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -22,9 +21,9 @@ use crate::app_service::test_support::{
     build_service_with_git_state, build_service_with_store, create_failing_opencode,
     create_fake_bd, create_fake_opencode, create_orphanable_opencode, empty_patch, init_git_repo,
     lock_env, make_emitter, make_session, make_task, prepend_path, process_is_alive,
-    remove_env_var, set_env_var, spawn_sleep_process, unique_temp_path,
-    wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
-    write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+    remove_env_var, set_env_var, spawn_opencode_session_status_server, spawn_sleep_process,
+    unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
+    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
 };
 use crate::app_service::{
     build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
@@ -616,18 +615,21 @@ fn task_delete_rejects_active_builder_runs() {
         .lock()
         .expect("task lock poisoned")
         .agent_sessions = vec![build_session];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)
+            .expect("status server should start");
     service.runs.lock().expect("run lock poisoned").insert(
         "run-1".to_string(),
         RunProcess {
             summary: RunSummary {
                 run_id: "run-1".to_string(),
                 runtime_kind: AgentRuntimeKind::Opencode,
-                runtime_route: AgentRuntimeKind::Opencode.route_for_port(4444),
+                runtime_route: AgentRuntimeKind::Opencode.route_for_port(port),
                 repo_path: repo_path.to_string(),
                 task_id: "parent-1".to_string(),
                 branch: "obp/parent-1-cleanup".to_string(),
                 worktree_path: worktree_path.to_string(),
-                port: 4444,
+                port,
                 state: RunState::Running,
                 last_message: None,
                 started_at: "2026-02-20T12:00:00Z".to_string(),
@@ -664,6 +666,9 @@ fn task_delete_rejects_active_builder_runs() {
     assert!(
         format!("{error:#}").contains("Cannot delete tasks with active builder work in progress")
     );
+    server_handle
+        .join()
+        .expect("status server thread should finish");
     let task_state = task_state.lock().expect("task lock poisoned");
     assert!(task_state.delete_calls.is_empty());
     drop(task_state);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -1002,6 +1002,100 @@ fn task_delete_rejects_live_build_session_status_with_repo_runtime_without_run()
 }
 
 #[test]
+fn task_delete_rejects_live_build_session_status_with_stale_run_route_and_repo_runtime_fallback(
+) -> Result<()> {
+    let repo_path = unique_temp_path("delete-task-live-shared-runtime-fallback-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    service.workspace_update_repo_config(
+        &repo_path.to_string_lossy(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            ..Default::default()
+        },
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "opencode".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+
+    let stale_route_port = {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        listener.local_addr()?.port()
+    };
+    service
+        .runs
+        .lock()
+        .expect("run state lock poisoned")
+        .insert(
+            "run-stale".to_string(),
+            crate::app_service::RunProcess {
+                summary: serde_json::from_value(json!({
+                    "runId": "run-stale",
+                    "runtimeKind": "opencode",
+                    "runtimeRoute": {
+                        "type": "local_http",
+                        "endpoint": format!("http://127.0.0.1:{stale_route_port}"),
+                    },
+                    "repoPath": repo_path.to_string_lossy().to_string(),
+                    "taskId": "task-1",
+                    "branch": "odt/task-1",
+                    "worktreePath": repo_path.to_string_lossy().to_string(),
+                    "port": stale_route_port,
+                    "state": "running",
+                    "lastMessage": null,
+                    "startedAt": "2026-03-17T11:00:00Z",
+                }))?,
+                child: None,
+                _opencode_process_guard: None,
+                repo_path: repo_path.to_string_lossy().to_string(),
+                task_id: "task-1".to_string(),
+                worktree_path: repo_path.to_string_lossy().to_string(),
+                repo_config: host_infra_system::RepoConfig {
+                    branch_prefix: "odt".to_string(),
+                    ..Default::default()
+                },
+            },
+        );
+
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
+    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+
+    let error = service
+        .task_delete(&repo_path.to_string_lossy(), "task-1", false)
+        .expect_err("live shared-runtime session should block delete");
+    assert!(error
+        .to_string()
+        .contains("Cannot delete tasks with active builder work in progress"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
+    Ok(())
+}
+
+#[test]
 fn task_delete_clears_stale_runs_after_successful_delete() -> Result<()> {
     let repo_path = unique_temp_path("delete-task-clears-stale-runs-repo");
     fs::create_dir_all(&repo_path)?;
@@ -1167,6 +1261,100 @@ fn task_reset_implementation_rejects_live_build_session_status() -> Result<()> {
     assert!(error
         .to_string()
         .contains("Cannot reset implementation while"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
+    Ok(())
+}
+
+#[test]
+fn task_reset_implementation_rejects_live_build_session_status_with_stale_run_route_and_repo_runtime_fallback(
+) -> Result<()> {
+    let repo_path = unique_temp_path("reset-implementation-live-shared-runtime-fallback-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    service.workspace_update_repo_config(
+        &repo_path.to_string_lossy(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            ..Default::default()
+        },
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "opencode".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+
+    let stale_route_port = {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        listener.local_addr()?.port()
+    };
+    service
+        .runs
+        .lock()
+        .expect("run state lock poisoned")
+        .insert(
+            "run-stale".to_string(),
+            crate::app_service::RunProcess {
+                summary: serde_json::from_value(json!({
+                    "runId": "run-stale",
+                    "runtimeKind": "opencode",
+                    "runtimeRoute": {
+                        "type": "local_http",
+                        "endpoint": format!("http://127.0.0.1:{stale_route_port}"),
+                    },
+                    "repoPath": repo_path.to_string_lossy().to_string(),
+                    "taskId": "task-1",
+                    "branch": "odt/task-1",
+                    "worktreePath": repo_path.to_string_lossy().to_string(),
+                    "port": stale_route_port,
+                    "state": "running",
+                    "lastMessage": null,
+                    "startedAt": "2026-03-17T11:00:00Z",
+                }))?,
+                child: None,
+                _opencode_process_guard: None,
+                repo_path: repo_path.to_string_lossy().to_string(),
+                task_id: "task-1".to_string(),
+                worktree_path: repo_path.to_string_lossy().to_string(),
+                repo_config: host_infra_system::RepoConfig {
+                    branch_prefix: "odt".to_string(),
+                    ..Default::default()
+                },
+            },
+        );
+
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
+    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+
+    let error = service
+        .task_reset_implementation(&repo_path.to_string_lossy(), "task-1")
+        .expect_err("live shared-runtime session should block reset");
+    assert!(error
+        .to_string()
+        .contains("Cannot reset implementation while active build session(s) exist"));
     server_handle
         .join()
         .expect("status server thread should finish");

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -1,15 +1,14 @@
 use anyhow::{Context, Result};
 use host_domain::{
-    AgentSessionDocument, CreateTaskInput, GitBranch, IssueType, PlanSubtaskInput,
-    PullRequestRecord, QaWorkflowVerdict, RuntimeRole, TaskAction, TaskStatus, TaskStore,
-    UpdateTaskPatch,
+    AgentRuntimeKind, AgentSessionDocument, CreateTaskInput, GitBranch, IssueType,
+    PlanSubtaskInput, PullRequestRecord, QaWorkflowVerdict, RuntimeInstanceSummary, RuntimeRole,
+    TaskAction, TaskStatus, TaskStore, UpdateTaskPatch,
 };
 use host_infra_system::{
     AppConfigStore, OpencodeStartupReadinessConfig, RuntimeConfig, RuntimeConfigStore,
 };
 use serde_json::json;
 use std::fs;
-use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -17,8 +16,9 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::app_service::test_support::{
-    build_service_with_git_state, make_task, spawn_sleep_process, spawn_sleep_process_group,
-    unique_temp_path, wait_for_process_exit, write_private_file, FakeTaskStore, TaskStoreState,
+    build_service_with_git_state, make_task, spawn_opencode_session_status_server,
+    spawn_sleep_process, spawn_sleep_process_group, unique_temp_path, wait_for_process_exit,
+    write_private_file, FakeTaskStore, TaskStoreState,
 };
 use crate::app_service::{
     allows_transition, build_opencode_startup_event_payload, can_set_plan,
@@ -28,7 +28,7 @@ use crate::app_service::{
     validate_plan_subtask_rules, validate_transition, wait_for_local_server,
     wait_for_local_server_with_process, AgentRuntimeProcess, AppService, DevServerGroupRuntime,
     OpencodeStartupMetricsSnapshot, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
-    RuntimeCleanupTarget, StartupEventContext, StartupEventCorrelation, StartupEventPayload,
+    StartupEventContext, StartupEventCorrelation, StartupEventPayload,
 };
 use host_domain::{DevServerGroupState, DevServerScriptState, DevServerScriptStatus};
 
@@ -47,25 +47,32 @@ fn init_git_repo(path: &std::path::Path) -> Result<()> {
     ))
 }
 
-fn spawn_opencode_session_status_server(
-    response_body: &'static str,
-) -> Result<(u16, std::thread::JoinHandle<()>)> {
-    let listener = TcpListener::bind("127.0.0.1:0")?;
-    let port = listener.local_addr()?.port();
-    let response = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-        response_body.len(),
-        response_body
-    );
-    let handle = std::thread::spawn(move || {
-        if let Ok((mut stream, _)) = listener.accept() {
-            let mut request_buffer = [0_u8; 4096];
-            let _ = stream.read(&mut request_buffer);
-            let _ = stream.write_all(response.as_bytes());
-            let _ = stream.flush();
-        }
-    });
-    Ok((port, handle))
+fn insert_workspace_runtime(service: &AppService, repo_path: &str, port: u16) -> Result<()> {
+    let summary = RuntimeInstanceSummary {
+        kind: AgentRuntimeKind::Opencode,
+        runtime_id: "runtime-workspace".to_string(),
+        repo_path: repo_path.to_string(),
+        task_id: None,
+        role: RuntimeRole::Workspace,
+        working_directory: repo_path.to_string(),
+        runtime_route: AgentRuntimeKind::Opencode.route_for_port(port),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        descriptor: AgentRuntimeKind::Opencode.descriptor(),
+    };
+    service
+        .agent_runtimes
+        .lock()
+        .expect("runtime lock poisoned")
+        .insert(
+            "runtime-workspace".to_string(),
+            AgentRuntimeProcess {
+                summary,
+                child: spawn_sleep_process(30),
+                _opencode_process_guard: None,
+                cleanup_target: None,
+            },
+        );
+    Ok(())
 }
 
 #[test]
@@ -678,7 +685,8 @@ fn task_reset_implementation_uses_document_presence_for_rollback_target() -> Res
 }
 
 #[test]
-fn task_reset_implementation_rejects_active_builder_or_qa_sessions() -> Result<()> {
+fn task_reset_implementation_ignores_stale_persisted_build_session_without_live_runtime(
+) -> Result<()> {
     let repo_path = unique_temp_path("reset-implementation-active-session-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -713,12 +721,8 @@ fn task_reset_implementation_rejects_active_builder_or_qa_sessions() -> Result<(
         selected_model: None,
     }];
 
-    let error = service
-        .task_reset_implementation(&repo_path.to_string_lossy(), "task-1")
-        .expect_err("active session should block reset");
-    assert!(error
-        .to_string()
-        .contains("Stop the active session(s) first"));
+    let reset = service.task_reset_implementation(&repo_path.to_string_lossy(), "task-1")?;
+    assert_eq!(reset.status, TaskStatus::Open);
     Ok(())
 }
 
@@ -765,8 +769,326 @@ fn task_reset_implementation_ignores_stale_qa_sessions_with_persisted_external_i
 }
 
 #[test]
-fn task_reset_implementation_rejects_live_runtime_even_without_persisted_session_status(
+fn task_reset_implementation_rejects_live_qa_session_status_with_repo_runtime_without_run(
 ) -> Result<()> {
+    let repo_path = unique_temp_path("reset-implementation-live-qa-shared-runtime-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    service.workspace_update_repo_config(
+        &repo_path.to_string_lossy(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            ..Default::default()
+        },
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "qa-session".to_string(),
+        external_session_id: Some("external-qa-session".to_string()),
+        role: "qa".to_string(),
+        scenario: "qa_review".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "opencode".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-qa-session":{"type":"busy"}}"#)?;
+    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+
+    let error = service
+        .task_reset_implementation(&repo_path.to_string_lossy(), "task-1")
+        .expect_err("live QA session should block reset");
+    assert!(error
+        .to_string()
+        .contains("Cannot reset implementation while active qa session(s) exist"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
+    Ok(())
+}
+
+#[test]
+fn task_delete_ignores_stale_persisted_build_session_without_live_runtime() -> Result<()> {
+    let repo_path = unique_temp_path("delete-task-stale-build-session-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    let repo_config = host_infra_system::RepoConfig {
+        branch_prefix: "odt".to_string(),
+        ..Default::default()
+    };
+    service.workspace_update_repo_config(&repo_path.to_string_lossy(), repo_config)?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "opencode".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+
+    service.task_delete(&repo_path.to_string_lossy(), "task-1", false)?;
+    Ok(())
+}
+
+#[test]
+fn task_delete_rejects_live_build_session_status() -> Result<()> {
+    let repo_path = unique_temp_path("delete-task-live-runtime-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    service.workspace_update_repo_config(
+        &repo_path.to_string_lossy(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            ..Default::default()
+        },
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "opencode".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
+    service
+        .runs
+        .lock()
+        .expect("run state lock poisoned")
+        .insert(
+            "run-1".to_string(),
+            crate::app_service::RunProcess {
+                summary: serde_json::from_value(json!({
+                    "runId": "run-1",
+                    "runtimeKind": "opencode",
+                    "runtimeRoute": {
+                        "type": "local_http",
+                        "endpoint": format!("http://127.0.0.1:{port}"),
+                    },
+                    "repoPath": repo_path.to_string_lossy().to_string(),
+                    "taskId": "task-1",
+                    "branch": "odt/task-1",
+                    "worktreePath": repo_path.to_string_lossy().to_string(),
+                    "port": port,
+                    "state": "running",
+                    "lastMessage": null,
+                    "startedAt": "2026-03-17T11:00:00Z",
+                }))?,
+                child: None,
+                _opencode_process_guard: None,
+                repo_path: repo_path.to_string_lossy().to_string(),
+                task_id: "task-1".to_string(),
+                worktree_path: repo_path.to_string_lossy().to_string(),
+                repo_config: host_infra_system::RepoConfig {
+                    branch_prefix: "odt".to_string(),
+                    ..Default::default()
+                },
+            },
+        );
+
+    let error = service
+        .task_delete(&repo_path.to_string_lossy(), "task-1", false)
+        .expect_err("live runtime should block delete");
+    assert!(error
+        .to_string()
+        .contains("Cannot delete tasks with active builder work in progress"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
+    Ok(())
+}
+
+#[test]
+fn task_delete_rejects_live_build_session_status_with_repo_runtime_without_run() -> Result<()> {
+    let repo_path = unique_temp_path("delete-task-live-shared-runtime-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    service.workspace_update_repo_config(
+        &repo_path.to_string_lossy(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            ..Default::default()
+        },
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "opencode".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
+    insert_workspace_runtime(&service, &repo_path.to_string_lossy(), port)?;
+
+    let error = service
+        .task_delete(&repo_path.to_string_lossy(), "task-1", false)
+        .expect_err("live shared-runtime session should block delete");
+    assert!(error
+        .to_string()
+        .contains("Cannot delete tasks with active builder work in progress"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
+    Ok(())
+}
+
+#[test]
+fn task_delete_clears_stale_runs_after_successful_delete() -> Result<()> {
+    let repo_path = unique_temp_path("delete-task-clears-stale-runs-repo");
+    fs::create_dir_all(&repo_path)?;
+    init_git_repo(&repo_path)?;
+
+    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task],
+        Vec::new(),
+        host_domain::GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    let _ = service.workspace_add(&repo_path.to_string_lossy())?;
+    service.workspace_update_repo_config(
+        &repo_path.to_string_lossy(),
+        host_infra_system::RepoConfig {
+            branch_prefix: "odt".to_string(),
+            ..Default::default()
+        },
+    )?;
+    task_state
+        .lock()
+        .expect("task store lock poisoned")
+        .agent_sessions = vec![AgentSessionDocument {
+        session_id: "build-session".to_string(),
+        external_session_id: Some("external-build-session".to_string()),
+        role: "build".to_string(),
+        scenario: "build_implementation_start".to_string(),
+        started_at: "2026-03-17T11:00:00Z".to_string(),
+        runtime_kind: "opencode".to_string(),
+        working_directory: repo_path.to_string_lossy().to_string(),
+        selected_model: None,
+    }];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"idle"}}"#)?;
+    service
+        .runs
+        .lock()
+        .expect("run state lock poisoned")
+        .insert(
+            "run-1".to_string(),
+            crate::app_service::RunProcess {
+                summary: serde_json::from_value(json!({
+                    "runId": "run-1",
+                    "runtimeKind": "opencode",
+                    "runtimeRoute": {
+                        "type": "local_http",
+                        "endpoint": format!("http://127.0.0.1:{port}"),
+                    },
+                    "repoPath": repo_path.to_string_lossy().to_string(),
+                    "taskId": "task-1",
+                    "branch": "odt/task-1",
+                    "worktreePath": repo_path.to_string_lossy().to_string(),
+                    "port": port,
+                    "state": "running",
+                    "lastMessage": null,
+                    "startedAt": "2026-03-17T11:00:00Z",
+                }))?,
+                child: None,
+                _opencode_process_guard: None,
+                repo_path: repo_path.to_string_lossy().to_string(),
+                task_id: "task-1".to_string(),
+                worktree_path: repo_path.to_string_lossy().to_string(),
+                repo_config: host_infra_system::RepoConfig {
+                    branch_prefix: "odt".to_string(),
+                    ..Default::default()
+                },
+            },
+        );
+
+    service.task_delete(&repo_path.to_string_lossy(), "task-1", false)?;
+    server_handle
+        .join()
+        .expect("status server thread should finish");
+    assert!(service
+        .runs
+        .lock()
+        .expect("run state lock poisoned")
+        .is_empty());
+    Ok(())
+}
+
+#[test]
+fn task_reset_implementation_rejects_live_build_session_status() -> Result<()> {
     let repo_path = unique_temp_path("reset-implementation-live-runtime-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -794,7 +1116,7 @@ fn task_reset_implementation_rejects_live_runtime_even_without_persisted_session
         .expect("task store lock poisoned")
         .agent_sessions = vec![AgentSessionDocument {
         session_id: "build-session".to_string(),
-        external_session_id: None,
+        external_session_id: Some("external-build-session".to_string()),
         role: "build".to_string(),
         scenario: "build_implementation_start".to_string(),
         started_at: "2026-03-17T11:00:00Z".to_string(),
@@ -802,33 +1124,40 @@ fn task_reset_implementation_rejects_live_runtime_even_without_persisted_session
         working_directory: repo_path.to_string_lossy().to_string(),
         selected_model: None,
     }];
+    let (port, server_handle) =
+        spawn_opencode_session_status_server(r#"{"external-build-session":{"type":"busy"}}"#)?;
     service
-        .agent_runtimes
+        .runs
         .lock()
-        .expect("runtime lock poisoned")
+        .expect("run state lock poisoned")
         .insert(
-            "runtime-build".to_string(),
-            AgentRuntimeProcess {
+            "run-1".to_string(),
+            crate::app_service::RunProcess {
                 summary: serde_json::from_value(json!({
-                    "kind": "opencode",
-                    "runtimeId": "runtime-build",
-                    "repoPath": repo_path.to_string_lossy().to_string(),
-                    "taskId": "task-1",
-                    "role": "build",
-                    "workingDirectory": repo_path.to_string_lossy().to_string(),
+                    "runId": "run-1",
+                    "runtimeKind": "opencode",
                     "runtimeRoute": {
                         "type": "local_http",
-                        "endpoint": "http://127.0.0.1:3456"
+                        "endpoint": format!("http://127.0.0.1:{port}"),
                     },
-                    "startedAt": "2026-03-17T11:30:00Z",
-                    "descriptor": host_domain::AgentRuntimeKind::Opencode.descriptor(),
+                    "repoPath": repo_path.to_string_lossy().to_string(),
+                    "taskId": "task-1",
+                    "branch": "odt/task-1",
+                    "worktreePath": repo_path.to_string_lossy().to_string(),
+                    "port": port,
+                    "state": "running",
+                    "lastMessage": null,
+                    "startedAt": "2026-03-17T11:00:00Z",
                 }))?,
-                child: spawn_sleep_process(20),
+                child: None,
                 _opencode_process_guard: None,
-                cleanup_target: Some(RuntimeCleanupTarget {
-                    repo_path: repo_path.to_string_lossy().to_string(),
-                    worktree_path: repo_path.to_string_lossy().to_string(),
-                }),
+                repo_path: repo_path.to_string_lossy().to_string(),
+                task_id: "task-1".to_string(),
+                worktree_path: repo_path.to_string_lossy().to_string(),
+                repo_config: host_infra_system::RepoConfig {
+                    branch_prefix: "odt".to_string(),
+                    ..Default::default()
+                },
             },
         );
 
@@ -837,8 +1166,10 @@ fn task_reset_implementation_rejects_live_runtime_even_without_persisted_session
         .expect_err("live runtime should block reset");
     assert!(error
         .to_string()
-        .contains("Stop the active session(s) first"));
-    service.shutdown()?;
+        .contains("Cannot reset implementation while"));
+    server_handle
+        .join()
+        .expect("status server thread should finish");
     Ok(())
 }
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/public-operations.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/public-operations.test.ts
@@ -230,6 +230,43 @@ describe("agent-orchestrator-public-operations", () => {
     }
   });
 
+  test("shows toast and rethrows stop errors", async () => {
+    const originalToastError = toast.error;
+    const toastError = mock(() => "");
+    toast.error = toastError;
+
+    const operations = createOrchestratorPublicOperations({
+      sessionsById: {},
+      bootstrapTaskSessions: async () => {},
+      hydrateRequestedTaskSessionHistory: async () => {},
+      reconcileLiveTaskSessions: async () => {},
+      loadAgentSessions: async () => {},
+      readSessionModelCatalog: async () => ({
+        providers: [],
+        models: [],
+        variants: [],
+        profiles: [],
+        defaultModelsByProvider: {},
+      }),
+      readSessionTodos: async () => [],
+      removeAgentSessions: () => {},
+      sessionActions: createSessionActions({
+        stopAgentSession: async () => {
+          throw new Error("stop failed");
+        },
+      }),
+    });
+
+    try {
+      await expect(operations.stopAgentSession("session-1")).rejects.toThrow("stop failed");
+      expect(toastError).toHaveBeenCalledWith("Failed to stop agent session", {
+        description: "stop failed",
+      });
+    } finally {
+      toast.error = originalToastError;
+    }
+  });
+
   test("forwards explicit session removals without toast wrapping", () => {
     const removeAgentSessions = mock(() => {});
     const operations = createOrchestratorPublicOperations({

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/public-operations.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/public-operations.ts
@@ -154,7 +154,10 @@ export const createOrchestratorPublicOperations = ({
     withErrorToast("Failed to send message", () =>
       sessionActions.sendAgentMessage(sessionId, content),
     ),
-  stopAgentSession: sessionActions.stopAgentSession,
+  stopAgentSession: (sessionId: string): Promise<void> =>
+    withErrorToast("Failed to stop agent session", () =>
+      sessionActions.stopAgentSession(sessionId),
+    ),
   updateAgentSessionModel: sessionActions.updateAgentSessionModel,
   replyAgentPermission: sessionActions.replyAgentPermission,
   answerAgentQuestion: sessionActions.answerAgentQuestion,

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -320,6 +320,12 @@ describe("agent-orchestrator/handlers/session-actions", () => {
   test("keeps session active when authoritative build stop fails", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalHasSession = adapter.hasSession;
+    const originalStopSession = adapter.stopSession;
+    let localStopCalls = 0;
+    adapter.hasSession = () => true;
+    adapter.stopSession = async () => {
+      localStopCalls += 1;
+    };
     let clearCalls = 0;
     let unsubscribeCalls = 0;
 
@@ -401,12 +407,14 @@ describe("agent-orchestrator/handlers/session-actions", () => {
         "Failed to stop build session 'session-1': build stop failed",
       );
       expect(clearCalls).toBe(0);
+      expect(localStopCalls).toBe(0);
       expect(unsubscribeCalls).toBe(0);
       expect(sessionsRef.current["session-1"]?.status).toBe("running");
       expect(sessionsRef.current["session-1"]?.pendingPermissions).toHaveLength(1);
       expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(1);
     } finally {
       adapter.hasSession = originalHasSession;
+      adapter.stopSession = originalStopSession;
     }
   });
 
@@ -414,8 +422,10 @@ describe("agent-orchestrator/handlers/session-actions", () => {
     const adapter = new OpencodeSdkAdapter();
     const originalHasSession = adapter.hasSession;
     const originalStopSession = adapter.stopSession;
+    const callOrder: string[] = [];
     adapter.hasSession = () => true;
     adapter.stopSession = async () => {
+      callOrder.push("local-stop");
       throw new Error("local stop failed");
     };
 
@@ -474,7 +484,9 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       },
       refreshTaskData: async () => {},
       persistSessionSnapshot: async () => {},
-      stopBuildRun: async () => {},
+      stopBuildRun: async () => {
+        callOrder.push("host-stop");
+      },
     });
 
     const originalWarn = console.warn;
@@ -482,6 +494,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
 
     try {
       await expect(actions.stopAgentSession("session-1")).resolves.toBeUndefined();
+      expect(callOrder).toEqual(["host-stop", "local-stop"]);
       expect(clearCalls).toBe(1);
       expect(unsubscribeCalls).toBe(1);
       expect(sessionsRef.current["session-1"]?.status).toBe("stopped");

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -410,11 +410,17 @@ describe("agent-orchestrator/handlers/session-actions", () => {
     }
   });
 
-  test("stops runtime-backed qa sessions via runtime stop", async () => {
+  test("does not stop shared runtime when build/qa session lacks runId", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalHasSession = adapter.hasSession;
-    adapter.hasSession = () => false;
-    let runtimeStopCalls = 0;
+    const originalStopSession = adapter.stopSession;
+    adapter.hasSession = () => true;
+    let buildStopCalls = 0;
+    let localStopCalls = 0;
+
+    adapter.stopSession = async () => {
+      localStopCalls += 1;
+    };
 
     const sessionsRef: { current: Record<string, AgentSessionState> } = {
       current: {
@@ -459,16 +465,119 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       clearTurnDuration: () => {},
       refreshTaskData: async () => {},
       persistSessionSnapshot: async () => {},
-      stopRuntime: async (runtimeId) => {
-        runtimeStopCalls += 1;
-        expect(runtimeId).toBe("runtime-1");
+      stopBuildRun: async () => {
+        buildStopCalls += 1;
       },
     });
 
     try {
       await actions.stopAgentSession("session-1");
-      expect(runtimeStopCalls).toBe(1);
+      expect(buildStopCalls).toBe(0);
+      expect(localStopCalls).toBe(1);
       expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
+    } finally {
+      adapter.hasSession = originalHasSession;
+      adapter.stopSession = originalStopSession;
+    }
+  });
+
+  test("persists stopped snapshot before reloading host sessions", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalHasSession = adapter.hasSession;
+    adapter.hasSession = () => false;
+
+    const persistDeferred = createDeferred<void>();
+    const callOrder: string[] = [];
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          runId: "run-1",
+          pendingPermissions: [{ requestId: "perm-1", permission: "read", patterns: ["*"] }],
+          pendingQuestions: [
+            {
+              requestId: "question-1",
+              questions: [
+                {
+                  header: "Proceed",
+                  question: "Proceed?",
+                  options: [],
+                  multiple: false,
+                  custom: false,
+                },
+              ],
+            },
+          ],
+        }),
+      },
+    };
+
+    const actions = createAgentSessionActions({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef,
+      taskRef: { current: [] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      unsubscribersRef: { current: new Map() },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession: (sessionId, updater) => {
+        const current = sessionsRef.current[sessionId];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current[sessionId] = updater(current);
+      },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: null,
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {
+        callOrder.push("load-agent-sessions");
+      },
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {
+        callOrder.push("refresh-task-data");
+      },
+      persistSessionSnapshot: async () => {
+        callOrder.push("persist-start");
+        await persistDeferred.promise;
+        callOrder.push("persist-end");
+      },
+      stopBuildRun: async () => {
+        callOrder.push("stop-build-run");
+      },
+      invalidateSessionStopQueries: async () => {
+        callOrder.push("invalidate-stop-queries");
+      },
+    });
+
+    try {
+      const stopPromise = actions.stopAgentSession("session-1");
+      await Promise.resolve();
+
+      expect(callOrder).toEqual(["stop-build-run", "persist-start"]);
+
+      persistDeferred.resolve();
+      await stopPromise;
+
+      const persistEndIndex = callOrder.indexOf("persist-end");
+      expect(persistEndIndex).toBeGreaterThan(-1);
+      expect(callOrder.indexOf("invalidate-stop-queries")).toBeGreaterThan(persistEndIndex);
+      expect(callOrder.indexOf("refresh-task-data")).toBeGreaterThan(persistEndIndex);
+      expect(callOrder.indexOf("load-agent-sessions")).toBeGreaterThan(persistEndIndex);
+      expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
+      expect(sessionsRef.current["session-1"]?.pendingPermissions).toHaveLength(0);
+      expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(0);
     } finally {
       adapter.hasSession = originalHasSession;
     }

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -410,6 +410,88 @@ describe("agent-orchestrator/handlers/session-actions", () => {
     }
   });
 
+  test("continues cleanup when local adapter stop fails after host stop", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalHasSession = adapter.hasSession;
+    const originalStopSession = adapter.stopSession;
+    adapter.hasSession = () => true;
+    adapter.stopSession = async () => {
+      throw new Error("local stop failed");
+    };
+
+    let clearCalls = 0;
+    let unsubscribeCalls = 0;
+
+    const unsubscribersRef = {
+      current: new Map<string, () => void>([
+        [
+          "session-1",
+          () => {
+            unsubscribeCalls += 1;
+          },
+        ],
+      ]),
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession(),
+      },
+    };
+
+    const actions = createAgentSessionActions({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef,
+      taskRef: { current: [] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      unsubscribersRef,
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession: (sessionId, updater) => {
+        const current = sessionsRef.current[sessionId];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current[sessionId] = updater(current);
+      },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: null,
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {},
+      clearTurnDuration: () => {
+        clearCalls += 1;
+      },
+      refreshTaskData: async () => {},
+      persistSessionSnapshot: async () => {},
+      stopBuildRun: async () => {},
+    });
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+
+    try {
+      await expect(actions.stopAgentSession("session-1")).resolves.toBeUndefined();
+      expect(clearCalls).toBe(1);
+      expect(unsubscribeCalls).toBe(1);
+      expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
+    } finally {
+      adapter.hasSession = originalHasSession;
+      adapter.stopSession = originalStopSession;
+      console.warn = originalWarn;
+    }
+  });
+
   test("does not stop shared runtime when build/qa session lacks runId", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalHasSession = adapter.hasSession;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -250,6 +250,9 @@ describe("agent-orchestrator/handlers/session-actions", () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = {
       current: {
         "session-1": buildSession({
+          role: "planner",
+          runId: null,
+          runtimeId: null,
           pendingPermissions: [{ requestId: "perm-1", permission: "read", patterns: ["*"] }],
           pendingQuestions: [
             {
@@ -314,16 +317,11 @@ describe("agent-orchestrator/handlers/session-actions", () => {
     }
   });
 
-  test("keeps local stop cleanup even when remote stop throws", async () => {
+  test("keeps session active when authoritative build stop fails", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalHasSession = adapter.hasSession;
-    const originalStopSession = adapter.stopSession;
     let clearCalls = 0;
-
-    adapter.hasSession = () => true;
-    adapter.stopSession = async () => {
-      throw new Error("remote stop failed");
-    };
+    let unsubscribeCalls = 0;
 
     const sessionsRef: { current: Record<string, AgentSessionState> } = {
       current: {
@@ -343,6 +341,87 @@ describe("agent-orchestrator/handlers/session-actions", () => {
               ],
             },
           ],
+        }),
+      },
+    };
+
+    const stopBuildRun = async () => {
+      throw new Error("build stop failed");
+    };
+
+    const actions = createAgentSessionActions({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef,
+      taskRef: { current: [] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      unsubscribersRef: {
+        current: new Map([
+          [
+            "session-1",
+            () => {
+              unsubscribeCalls += 1;
+            },
+          ],
+        ]),
+      },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession: (sessionId, updater) => {
+        const current = sessionsRef.current[sessionId];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current[sessionId] = updater(current);
+      },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: null,
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {},
+      clearTurnDuration: () => {
+        clearCalls += 1;
+      },
+      refreshTaskData: async () => {},
+      persistSessionSnapshot: async () => {},
+      stopBuildRun,
+    });
+
+    try {
+      await expect(actions.stopAgentSession("session-1")).rejects.toThrow(
+        "Failed to stop build session 'session-1': build stop failed",
+      );
+      expect(clearCalls).toBe(0);
+      expect(unsubscribeCalls).toBe(0);
+      expect(sessionsRef.current["session-1"]?.status).toBe("running");
+      expect(sessionsRef.current["session-1"]?.pendingPermissions).toHaveLength(1);
+      expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(1);
+    } finally {
+      adapter.hasSession = originalHasSession;
+    }
+  });
+
+  test("stops runtime-backed qa sessions via runtime stop", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalHasSession = adapter.hasSession;
+    adapter.hasSession = () => false;
+    let runtimeStopCalls = 0;
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          role: "qa",
+          runId: null,
+          runtimeId: "runtime-1",
         }),
       },
     };
@@ -377,19 +456,102 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       loadRepoDefaultModel: async () => null,
       loadRepoPromptOverrides: async () => ({}),
       loadAgentSessions: async () => {},
-      clearTurnDuration: () => {
-        clearCalls += 1;
-      },
+      clearTurnDuration: () => {},
       refreshTaskData: async () => {},
       persistSessionSnapshot: async () => {},
+      stopRuntime: async (runtimeId) => {
+        runtimeStopCalls += 1;
+        expect(runtimeId).toBe("runtime-1");
+      },
     });
 
     try {
       await actions.stopAgentSession("session-1");
-      expect(clearCalls).toBe(1);
+      expect(runtimeStopCalls).toBe(1);
       expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
-      expect(sessionsRef.current["session-1"]?.pendingPermissions).toHaveLength(0);
-      expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(0);
+    } finally {
+      adapter.hasSession = originalHasSession;
+    }
+  });
+
+  test("refreshes backend-owned state after successful host stop", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalHasSession = adapter.hasSession;
+    const originalStopSession = adapter.stopSession;
+    adapter.hasSession = () => true;
+    let refreshTaskDataCalls = 0;
+    let loadAgentSessionsCalls = 0;
+    let localStopCalls = 0;
+    const invalidationCalls: Array<{ repoPath: string; taskId: string; runtimeKind?: string }> = [];
+
+    adapter.stopSession = async () => {
+      localStopCalls += 1;
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          runtimeKind: "opencode",
+          runId: "run-1",
+        }),
+      },
+    };
+
+    const actions = createAgentSessionActions({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef,
+      taskRef: { current: [] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      unsubscribersRef: { current: new Map() },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession: (sessionId, updater) => {
+        const current = sessionsRef.current[sessionId];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current[sessionId] = updater(current);
+      },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: null,
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {
+        loadAgentSessionsCalls += 1;
+      },
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {
+        refreshTaskDataCalls += 1;
+      },
+      persistSessionSnapshot: async () => {},
+      stopBuildRun: async () => {},
+      invalidateSessionStopQueries: async (input) => {
+        invalidationCalls.push(input);
+      },
+    });
+
+    try {
+      await actions.stopAgentSession("session-1");
+      expect(localStopCalls).toBe(1);
+      expect(refreshTaskDataCalls).toBe(1);
+      expect(loadAgentSessionsCalls).toBe(1);
+      expect(invalidationCalls).toEqual([
+        {
+          repoPath: "/tmp/repo",
+          taskId: "task-1",
+          runtimeKind: "opencode",
+        },
+      ]);
     } finally {
       adapter.hasSession = originalHasSession;
       adapter.stopSession = originalStopSession;
@@ -1006,13 +1168,9 @@ describe("agent-orchestrator/handlers/session-actions", () => {
   test("allows stopping a running session even when role is unavailable", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalHasSession = adapter.hasSession;
-    const originalStopSession = adapter.stopSession;
     let stopCalls = 0;
 
-    adapter.hasSession = () => true;
-    adapter.stopSession = async () => {
-      stopCalls += 1;
-    };
+    adapter.hasSession = () => false;
 
     const sessionsRef: { current: Record<string, AgentSessionState> } = {
       current: {
@@ -1066,6 +1224,9 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       clearTurnDuration: () => {},
       refreshTaskData: async () => {},
       persistSessionSnapshot: async () => {},
+      stopBuildRun: async () => {
+        stopCalls += 1;
+      },
     });
 
     try {
@@ -1074,7 +1235,6 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
     } finally {
       adapter.hasSession = originalHasSession;
-      adapter.stopSession = originalStopSession;
     }
   });
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -397,18 +397,27 @@ export const createAgentSessionActions = ({
 
     const roleRequiresHostStop = session.role === "build" || session.role === "qa";
     const hasLocalRuntimeSession = adapter.hasSession(sessionId);
+
     try {
       if (roleRequiresHostStop && session.runId) {
         await stopBuildRun(session.runId);
-      }
-
-      if (hasLocalRuntimeSession) {
-        await adapter.stopSession(sessionId);
       }
     } catch (error) {
       throw new Error(
         `Failed to stop ${session.role} session '${sessionId}': ${errorMessage(error)}`,
       );
+    }
+
+    if (hasLocalRuntimeSession) {
+      try {
+        await adapter.stopSession(sessionId);
+      } catch (error) {
+        console.warn(
+          "[agent-orchestrator] local session stop failed after host stop",
+          sessionId,
+          errorMessage(error),
+        );
+      }
     }
 
     const unsubscribe = unsubscribersRef.current.get(sessionId);

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -44,7 +44,6 @@ type SessionActionsDependencies = {
   refreshTaskData: (repoPath: string) => Promise<void>;
   persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;
   stopBuildRun?: (runId: string) => Promise<void>;
-  stopRuntime?: (runtimeId: string) => Promise<void>;
   invalidateSessionStopQueries?: (input: {
     repoPath: string;
     taskId: string;
@@ -133,9 +132,6 @@ export const createAgentSessionActions = ({
   persistSessionSnapshot,
   stopBuildRun = async () => {
     throw new Error("Build stop operation is unavailable.");
-  },
-  stopRuntime = async () => {
-    throw new Error("Runtime stop operation is unavailable.");
   },
   invalidateSessionStopQueries,
 }: SessionActionsDependencies) => {
@@ -404,8 +400,6 @@ export const createAgentSessionActions = ({
     try {
       if (roleRequiresHostStop && session.runId) {
         await stopBuildRun(session.runId);
-      } else if (roleRequiresHostStop && session.runtimeId) {
-        await stopRuntime(session.runtimeId);
       }
 
       if (hasLocalRuntimeSession) {
@@ -425,9 +419,9 @@ export const createAgentSessionActions = ({
       delete turnModelBySessionRef.current[sessionId];
     }
 
-    updateSession(
-      sessionId,
-      (current) => ({
+    let stoppedSessionSnapshot: AgentSessionState | null = null;
+    updateSession(sessionId, (current) => {
+      const nextSession: AgentSessionState = {
         ...current,
         status: "stopped",
         draftAssistantText: "",
@@ -436,9 +430,14 @@ export const createAgentSessionActions = ({
         draftReasoningMessageId: null,
         pendingPermissions: [],
         pendingQuestions: [],
-      }),
-      { persist: true },
-    );
+      };
+      stoppedSessionSnapshot = nextSession;
+      return nextSession;
+    });
+
+    if (stoppedSessionSnapshot) {
+      await persistSessionSnapshot(stoppedSessionSnapshot);
+    }
 
     if (activeRepo) {
       await Promise.all([

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -1,4 +1,4 @@
-import type { RepoPromptOverrides, TaskCard } from "@openducktor/contracts";
+import type { RepoPromptOverrides, RuntimeKind, TaskCard } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentModelSelection, AgentRole } from "@openducktor/core";
 import { isAgentSessionWaitingInput } from "@/lib/agent-session-waiting-input";
 import { errorMessage } from "@/lib/errors";
@@ -43,6 +43,13 @@ type SessionActionsDependencies = {
   clearTurnDuration: (sessionId: string) => void;
   refreshTaskData: (repoPath: string) => Promise<void>;
   persistSessionSnapshot: (session: AgentSessionState) => Promise<void>;
+  stopBuildRun?: (runId: string) => Promise<void>;
+  stopRuntime?: (runtimeId: string) => Promise<void>;
+  invalidateSessionStopQueries?: (input: {
+    repoPath: string;
+    taskId: string;
+    runtimeKind?: RuntimeKind;
+  }) => Promise<void>;
 };
 
 export type ForkAgentSessionActionInput = {
@@ -124,6 +131,13 @@ export const createAgentSessionActions = ({
   clearTurnDuration,
   refreshTaskData,
   persistSessionSnapshot,
+  stopBuildRun = async () => {
+    throw new Error("Build stop operation is unavailable.");
+  },
+  stopRuntime = async () => {
+    throw new Error("Runtime stop operation is unavailable.");
+  },
+  invalidateSessionStopQueries,
 }: SessionActionsDependencies) => {
   const ensureSessionReady = createEnsureSessionReady({
     activeRepo,
@@ -385,35 +399,57 @@ export const createAgentSessionActions = ({
       return;
     }
 
+    const roleRequiresHostStop = session.role === "build" || session.role === "qa";
+    const hasLocalRuntimeSession = adapter.hasSession(sessionId);
+    try {
+      if (roleRequiresHostStop && session.runId) {
+        await stopBuildRun(session.runId);
+      } else if (roleRequiresHostStop && session.runtimeId) {
+        await stopRuntime(session.runtimeId);
+      }
+
+      if (hasLocalRuntimeSession) {
+        await adapter.stopSession(sessionId);
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to stop ${session.role} session '${sessionId}': ${errorMessage(error)}`,
+      );
+    }
+
     const unsubscribe = unsubscribersRef.current.get(sessionId);
     unsubscribe?.();
     unsubscribersRef.current.delete(sessionId);
+    clearTurnDuration(sessionId);
+    if (turnModelBySessionRef) {
+      delete turnModelBySessionRef.current[sessionId];
+    }
 
-    try {
-      if (adapter.hasSession(sessionId)) {
-        await adapter.stopSession(sessionId);
-      }
-    } catch {
-    } finally {
-      clearTurnDuration(sessionId);
-      if (turnModelBySessionRef) {
-        delete turnModelBySessionRef.current[sessionId];
-      }
+    updateSession(
+      sessionId,
+      (current) => ({
+        ...current,
+        status: "stopped",
+        draftAssistantText: "",
+        draftAssistantMessageId: null,
+        draftReasoningText: "",
+        draftReasoningMessageId: null,
+        pendingPermissions: [],
+        pendingQuestions: [],
+      }),
+      { persist: true },
+    );
 
-      updateSession(
-        sessionId,
-        (current) => ({
-          ...current,
-          status: "stopped",
-          draftAssistantText: "",
-          draftAssistantMessageId: null,
-          draftReasoningText: "",
-          draftReasoningMessageId: null,
-          pendingPermissions: [],
-          pendingQuestions: [],
+    if (activeRepo) {
+      await Promise.all([
+        invalidateSessionStopQueries?.({
+          repoPath: activeRepo,
+          taskId: session.taskId,
+          ...(session.runtimeKind ? { runtimeKind: session.runtimeKind } : {}),
         }),
-        { persist: true },
-      );
+        refreshTaskData(activeRepo),
+        loadAgentSessions(session.taskId),
+      ]);
     }
   };
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AgentSessionRecord,
+  OPENCODE_RUNTIME_DESCRIPTOR,
+  type RunSummary,
+  type RuntimeInstanceSummary,
+  type RuntimeKind,
+} from "@openducktor/contracts";
+import type { AgentRuntimeConnection } from "@openducktor/core";
+import { createHydrationRuntimeResolver } from "./hydration-runtime-resolution";
+import { runtimeWorkingDirectoryKey } from "./live-agent-session-cache";
+
+const createRecord = (
+  role: AgentSessionRecord["role"],
+  workingDirectory: string,
+): AgentSessionRecord => ({
+  runtimeKind: "opencode",
+  sessionId: "session-1",
+  externalSessionId: "external-1",
+  taskId: "task-1",
+  role,
+  scenario: role === "qa" ? "qa_review" : "build_implementation_start",
+  status: "running",
+  startedAt: "2026-03-01T10:00:00.000Z",
+  updatedAt: "2026-03-01T10:00:00.000Z",
+  workingDirectory,
+});
+
+const createRun = (workingDirectory: string): RunSummary => ({
+  runId: "run-1",
+  runtimeKind: "opencode",
+  runtimeRoute: {
+    type: "local_http",
+    endpoint: "http://127.0.0.1:4444",
+  },
+  repoPath: "/tmp/repo",
+  taskId: "task-1",
+  branch: "obp/task-1",
+  worktreePath: workingDirectory,
+  port: 4444,
+  state: "running",
+  lastMessage: null,
+  startedAt: "2026-03-01T10:00:00.000Z",
+});
+
+const createRuntime = (workingDirectory: string): RuntimeInstanceSummary => ({
+  kind: "opencode",
+  runtimeId: "runtime-1",
+  repoPath: "/tmp/repo",
+  taskId: null,
+  role: "workspace",
+  workingDirectory,
+  runtimeRoute: {
+    type: "local_http",
+    endpoint: "http://127.0.0.1:4555",
+  },
+  startedAt: "2026-03-01T10:00:00.000Z",
+  descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+});
+
+describe("createHydrationRuntimeResolver", () => {
+  test("prefers live run resolution over preloaded runtime connections", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
+      [
+        runtimeWorkingDirectoryKey("opencode", workingDirectory),
+        {
+          endpoint: "http://127.0.0.1:9999",
+          workingDirectory,
+        },
+      ],
+    ]);
+
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      liveRuns: [createRun(workingDirectory)],
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      preloadedRuntimeConnectionsByKey,
+      ensureWorkspaceRuntime: async () => null,
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("build", workingDirectory));
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runId).toBe("run-1");
+    expect(result.runtimeId).toBeNull();
+    expect(result.runtimeEndpoint).toBe("http://127.0.0.1:4444");
+  });
+
+  test("prefers live runtime resolution over preloaded runtime connections", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
+      [
+        runtimeWorkingDirectoryKey("opencode", workingDirectory),
+        {
+          endpoint: "http://127.0.0.1:9999",
+          workingDirectory,
+        },
+      ],
+    ]);
+
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      liveRuns: [],
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+        ["opencode", [createRuntime(workingDirectory)]],
+      ]),
+      preloadedRuntimeConnectionsByKey,
+      ensureWorkspaceRuntime: async () => null,
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("qa", workingDirectory));
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runtimeId).toBe("runtime-1");
+    expect(result.runId).toBeNull();
+    expect(result.runtimeEndpoint).toBe("http://127.0.0.1:4555");
+  });
+
+  test("falls back to preloaded runtime connection when no run or runtime exists", async () => {
+    const workingDirectory = "/tmp/repo";
+    const preloadedRuntimeConnectionsByKey = new Map<string, AgentRuntimeConnection>([
+      [
+        runtimeWorkingDirectoryKey("opencode", workingDirectory),
+        {
+          endpoint: "http://127.0.0.1:9999",
+          workingDirectory,
+        },
+      ],
+    ]);
+    let ensureCalls = 0;
+
+    const resolveHydrationRuntime = createHydrationRuntimeResolver({
+      repoPath: "/tmp/repo",
+      liveRuns: [],
+      runtimesByKind: new Map<RuntimeKind, RuntimeInstanceSummary[]>([["opencode", []]]),
+      preloadedRuntimeConnectionsByKey,
+      ensureWorkspaceRuntime: async () => {
+        ensureCalls += 1;
+        return null;
+      },
+    });
+
+    const result = await resolveHydrationRuntime(createRecord("planner", workingDirectory));
+    if (!result.ok) {
+      throw new Error("Expected runtime resolution to succeed");
+    }
+
+    expect(result.runtimeId).toBeNull();
+    expect(result.runId).toBeNull();
+    expect(result.runtimeEndpoint).toBe("http://127.0.0.1:9999");
+    expect(ensureCalls).toBe(0);
+  });
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
@@ -17,13 +17,11 @@ const createRecord = (
   runtimeKind: "opencode",
   sessionId: "session-1",
   externalSessionId: "external-1",
-  taskId: "task-1",
   role,
   scenario: role === "qa" ? "qa_review" : "build_implementation_start",
-  status: "running",
   startedAt: "2026-03-01T10:00:00.000Z",
-  updatedAt: "2026-03-01T10:00:00.000Z",
   workingDirectory,
+  selectedModel: null,
 });
 
 const createRun = (workingDirectory: string): RunSummary => ({

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.ts
@@ -90,19 +90,6 @@ export const createHydrationRuntimeResolver = ({
   return async (record: AgentSessionRecord): Promise<ResolvedHydrationRuntime> => {
     const runtimeKind = readPersistedRuntimeKind(record);
     const workingDirectory = record.workingDirectory;
-    const preloadedRuntimeConnection = preloadedRuntimeConnectionsByKey?.get(
-      runtimeWorkingDirectoryKey(runtimeKind, workingDirectory),
-    );
-    if (preloadedRuntimeConnection) {
-      return {
-        ok: true,
-        runtimeKind,
-        runtimeId: null,
-        runId: null,
-        runtimeEndpoint: preloadedRuntimeConnection.endpoint ?? "",
-        runtimeConnection: preloadedRuntimeConnection,
-      };
-    }
 
     if (record.role === "build" || record.role === "qa") {
       const run = findRunByWorkingDirectory(runtimeKind, workingDirectory);
@@ -135,6 +122,20 @@ export const createHydrationRuntimeResolver = ({
         runId: null,
         runtimeEndpoint,
         runtimeConnection,
+      };
+    }
+
+    const preloadedRuntimeConnection = preloadedRuntimeConnectionsByKey?.get(
+      runtimeWorkingDirectoryKey(runtimeKind, workingDirectory),
+    );
+    if (preloadedRuntimeConnection) {
+      return {
+        ok: true,
+        runtimeKind,
+        runtimeId: null,
+        runId: null,
+        runtimeEndpoint: preloadedRuntimeConnection.endpoint ?? "",
+        runtimeConnection: preloadedRuntimeConnection,
       };
     }
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -128,6 +128,21 @@ describe("agent-orchestrator-load-sessions", () => {
       sessionsRef.current = state;
     };
 
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
       adapter: createAdapter(),
@@ -137,7 +152,7 @@ describe("agent-orchestrator-load-sessions", () => {
       sessionsRef,
       setSessionsById,
       taskRef: { current: [taskFixture] },
-      updateSession: () => {},
+      updateSession,
       loadRepoPromptOverrides: async () => ({}),
     });
 
@@ -233,6 +248,21 @@ describe("agent-orchestrator-load-sessions", () => {
       sessionsRef.current = state;
     };
 
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
       adapter: createAdapter(),
@@ -242,7 +272,7 @@ describe("agent-orchestrator-load-sessions", () => {
       sessionsRef,
       setSessionsById,
       taskRef: { current: [taskFixture] },
-      updateSession: () => {},
+      updateSession,
       loadRepoPromptOverrides: async () => ({}),
     });
 
@@ -1026,6 +1056,21 @@ describe("agent-orchestrator-load-sessions", () => {
       sessionsRef.current = state;
     };
 
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
     const loadAgentSessions = createLoadAgentSessions({
       activeRepo: "/tmp/repo",
       adapter: createAdapter({
@@ -1040,7 +1085,7 @@ describe("agent-orchestrator-load-sessions", () => {
       sessionsRef,
       setSessionsById,
       taskRef: { current: [taskFixture] },
-      updateSession: () => {},
+      updateSession,
       loadRepoPromptOverrides: async () => ({}),
     });
 
@@ -1127,6 +1172,8 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(ensuredRuntimeKinds).toEqual([]);
     expect(observedRuntimeEndpoint).toBe("http://127.0.0.1:4555");
     expect(state["session-1"]?.runtimeKind).toBe("claude-code");
+    expect(state["session-1"]?.runtimeId).toBe("runtime-1");
+    expect(state["session-1"]?.runId).toBeNull();
   });
 
   test("rejects requested-session warmup when persisted runtime metadata is missing", async () => {
@@ -1751,6 +1798,8 @@ describe("agent-orchestrator-load-sessions", () => {
       throw new Error("Expected QA hydration to resolve a live runtime endpoint");
     }
     expect(String(observedRuntimeEndpoint)).toBe("http://127.0.0.1:4444");
+    expect(state["session-qa-1"]?.runId).toBe("run-1");
+    expect(state["session-qa-1"]?.runtimeId).toBeNull();
     expect(state["session-qa-1"]?.messages[0]?.id).toBe("history:session-start:session-qa-1");
   });
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -549,17 +549,17 @@ export const createLoadAgentSessions = ({
         );
         return;
       }
-
+      const { runtimeKind, runtimeId, runId, runtimeEndpoint } = runtimeResolution;
       const externalSessionId = record.externalSessionId ?? record.sessionId;
       if (!shouldHydrateHistory) {
         updateSession(
           record.sessionId,
           (current) => ({
             ...current,
-            runtimeKind: runtimeResolution.runtimeKind,
-            runtimeId: runtimeResolution.runtimeId,
-            runId: runtimeResolution.runId,
-            runtimeEndpoint: runtimeResolution.runtimeEndpoint,
+            runtimeKind,
+            runtimeId,
+            runId,
+            runtimeEndpoint,
             workingDirectory,
             promptOverrides: current.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
           }),
@@ -595,10 +595,10 @@ export const createLoadAgentSessions = ({
         (current) => {
           return {
             ...current,
-            runtimeKind: runtimeResolution.runtimeKind,
-            runtimeId: runtimeResolution.runtimeId,
-            runId: runtimeResolution.runId,
-            runtimeEndpoint: runtimeResolution.runtimeEndpoint,
+            runtimeKind,
+            runtimeId,
+            runId,
+            runtimeEndpoint,
             status: liveSessionStatus ?? current.status,
             workingDirectory,
             promptOverrides,

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -504,9 +504,6 @@ export function useAgentOrchestratorOperations({
         stopBuildRun: async (runId) => {
           await host.buildStop(runId);
         },
-        stopRuntime: async (runtimeId) => {
-          await host.runtimeStop(runtimeId);
-        },
         invalidateSessionStopQueries,
       }),
     [

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -14,6 +14,9 @@ import type {
 } from "@openducktor/core";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { appQueryClient } from "@/lib/query-client";
+import { agentSessionQueryKeys } from "@/state/queries/agent-sessions";
+import { runtimeQueryKeys } from "@/state/queries/runtime";
+import { invalidateRepoTaskQueries } from "@/state/queries/tasks";
 import type {
   AgentChatMessage,
   AgentSessionLoadOptions,
@@ -440,6 +443,37 @@ export function useAgentOrchestratorOperations({
     [refBridges, refreshTaskData],
   );
 
+  const invalidateSessionStopQueries = useCallback(
+    async ({
+      repoPath,
+      taskId,
+      runtimeKind,
+    }: {
+      repoPath: string;
+      taskId: string;
+      runtimeKind?: RuntimeKind;
+    }): Promise<void> => {
+      await Promise.all([
+        invalidateRepoTaskQueries(appQueryClient, repoPath),
+        appQueryClient.invalidateQueries({
+          queryKey: agentSessionQueryKeys.list(repoPath, taskId),
+          exact: true,
+          refetchType: "none",
+        }),
+        ...(runtimeKind
+          ? [
+              appQueryClient.invalidateQueries({
+                queryKey: runtimeQueryKeys.list(runtimeKind, repoPath),
+                exact: true,
+                refetchType: "none",
+              }),
+            ]
+          : []),
+      ]);
+    },
+    [],
+  );
+
   const sessionActions = useMemo(
     () =>
       createAgentSessionActions({
@@ -467,6 +501,13 @@ export function useAgentOrchestratorOperations({
         clearTurnDuration,
         refreshTaskData,
         persistSessionSnapshot,
+        stopBuildRun: async (runId) => {
+          await host.buildStop(runId);
+        },
+        stopRuntime: async (runtimeId) => {
+          await host.runtimeStop(runtimeId);
+        },
+        invalidateSessionStopQueries,
       }),
     [
       activeRepo,
@@ -476,6 +517,7 @@ export function useAgentOrchestratorOperations({
       commitSessions,
       ensureRuntime,
       loadAgentSessions,
+      invalidateSessionStopQueries,
       persistSessionSnapshot,
       refBridges,
       refreshTaskData,


### PR DESCRIPTION
## Summary
- Make agent session stop host-authoritative for build/qa flows, then clean local adapter session state only after successful host stop.
- Preserve `runId` and `runtimeId` during hydration by preferring live run/runtime resolution before preloaded connection fallback.
- Invalidate/refetch backend-owned session data after successful stop and add regression coverage for stop failures and hydration targeting.

## Verification
- bun test apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts apps/desktop/src/state/operations/agent-orchestrator/handlers/public-operations.test.ts apps/desktop/src/state/operations/agent-orchestrator/lifecycle/hydration-runtime-resolution.test.ts
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stop actions now display error toasts with failure details and trigger session-stop related cache invalidation.

* **Bug Fixes**
  * More robust stop flow across host and local runtimes with clearer failure reporting, reliable session-state persistence, and corrected post-stop refresh ordering.
  * Hydration now prefers live run/runtime resolution before falling back to preloaded connections.

* **Tests**
  * Expanded coverage for stop failure modes, cleanup sequencing, runtime/hydration resolution, and related integration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->