### PR TITLE
fix(runtime): stop synthetic idle flicker on kanban

### DIFF
--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -172,7 +172,7 @@ describe("event-stream", () => {
     expect(emitted.some((event) => event.type === "assistant_part")).toBe(true);
   });
 
-  test("emits session_idle for stop-finished assistant turns without visible text", async () => {
+  test("does not emit session_idle for stop-finished assistant turns without visible text", async () => {
     const emitted = await runEventStream([
       {
         type: "message.updated",
@@ -197,11 +197,11 @@ describe("event-stream", () => {
     ]);
 
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
-    expect(idleEvents).toHaveLength(1);
+    expect(idleEvents).toHaveLength(0);
     expect(emitted.some((event) => event.type === "assistant_message")).toBe(false);
   });
 
-  test("emits session_idle when assistant completion has completed time without finish stop", async () => {
+  test("does not emit session_idle when assistant completion has completed time without finish stop", async () => {
     const emitted = await runEventStream([
       {
         type: "message.updated",
@@ -229,11 +229,11 @@ describe("event-stream", () => {
     ]);
 
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
-    expect(idleEvents).toHaveLength(1);
+    expect(idleEvents).toHaveLength(0);
     expect(emitted.some((event) => event.type === "assistant_message")).toBe(true);
   });
 
-  test("deduplicates session_idle when a terminal assistant update is followed by session.idle", async () => {
+  test("emits only the upstream session.idle when a terminal assistant update is followed by session.idle", async () => {
     const emitted = await runEventStream([
       {
         type: "message.updated",
@@ -268,7 +268,7 @@ describe("event-stream", () => {
     expect(idleEvents).toHaveLength(1);
   });
 
-  test("deduplicates session_idle when session.idle arrives before a terminal assistant update", async () => {
+  test("preserves existing idle state when session.idle arrives before a terminal assistant update", async () => {
     const emitted = await runEventStream([
       {
         type: "session.idle",
@@ -303,7 +303,7 @@ describe("event-stream", () => {
     expect(idleEvents).toHaveLength(1);
   });
 
-  test("deduplicates session_idle across repeated terminal message updates", async () => {
+  test("does not emit session_idle across repeated terminal message updates", async () => {
     const terminalEvent = {
       type: "message.updated",
       properties: {
@@ -332,7 +332,7 @@ describe("event-stream", () => {
     const emitted = await runEventStream([terminalEvent, terminalEvent]);
 
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
-    expect(idleEvents).toHaveLength(1);
+    expect(idleEvents).toHaveLength(0);
   });
 
   test("deduplicates prompt-path idle against a later stream terminal update for the same message", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -20,12 +20,7 @@ import {
   readMessageCompletedAt,
 } from "./schemas";
 import type { EventStreamRuntime } from "./shared";
-import {
-  applyDeltaToPart,
-  emitSessionIdle,
-  isReasoningDeltaField,
-  markSessionActive,
-} from "./shared";
+import { applyDeltaToPart, isReasoningDeltaField, markSessionActive } from "./shared";
 
 const emitAssistantPart = (
   runtime: EventStreamRuntime,
@@ -134,11 +129,11 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
 
   const completedAt = infoRecord ? readMessageCompletedAt(infoRecord) : undefined;
   const finish = infoRecord ? readStringProp(infoRecord, ["finish"]) : undefined;
-  const shouldEmitIdle =
+  const isTerminalAssistantUpdate =
     messageId !== undefined &&
     role === "assistant" &&
     (completedAt !== undefined || finish === "stop");
-  const preserveIdleState = shouldEmitIdle && session?.hasIdleSinceActivity === true;
+  const preserveIdleState = isTerminalAssistantUpdate && session?.hasIdleSinceActivity === true;
 
   const normalizedParts: Part[] = [];
   const rawParts = readRawMessageParts(properties, infoRecord);
@@ -181,18 +176,12 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     normalizedParts.length > 0 &&
     (completedAt !== undefined || finish === "stop");
   if (!shouldEmitCompletedMessage || !messageId) {
-    if (shouldEmitIdle) {
-      emitSessionIdle(runtime, messageId);
-    }
     return true;
   }
 
   const text = readTextFromParts(normalizedParts);
   const visible = sanitizeAssistantMessage(text);
   if (visible.length === 0) {
-    if (shouldEmitIdle) {
-      emitSessionIdle(runtime, messageId);
-    }
     return true;
   }
 
@@ -200,9 +189,6 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
   const assistantModel = readMessageModelSelection(infoRecord);
   const emittedAssistantMessageIds = session?.emittedAssistantMessageIds;
   if (emittedAssistantMessageIds?.has(messageId)) {
-    if (shouldEmitIdle) {
-      emitSessionIdle(runtime, messageId);
-    }
     return true;
   }
 
@@ -216,9 +202,6 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     ...(assistantModel ? { model: assistantModel } : {}),
   });
   emittedAssistantMessageIds?.add(messageId);
-  if (shouldEmitIdle) {
-    emitSessionIdle(runtime, messageId);
-  }
   return true;
 };
 

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -693,7 +693,7 @@ describe("OpencodeSdkAdapter", () => {
       messageId: "assistant-1",
       totalTokens: 1_100,
     });
-    expect(events.some((event) => event.type === "session_idle")).toBe(true);
+    expect(events.some((event) => event.type === "session_idle")).toBe(false);
   });
 
   test("sendUserMessage falls back to part messageID when response info.id is absent", async () => {
@@ -1010,11 +1010,6 @@ describe("OpencodeSdkAdapter", () => {
 
     expect(partEvents.length).toBeGreaterThanOrEqual(2);
     expect(messageEvents).toHaveLength(1);
-    expect(events).toContainEqual({
-      type: "session_idle",
-      sessionId: "session-1",
-      timestamp: "2026-02-17T12:00:00Z",
-    });
     expect(messageEvents[0]).toMatchObject({
       type: "assistant_message",
       messageId: "assistant-1",

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -10,7 +10,7 @@ import type {
   SendAgentUserMessageInput,
 } from "@openducktor/core";
 import { unwrapData } from "./data-utils";
-import { emitIdleForSession, setSessionActive } from "./event-stream/shared";
+import { setSessionActive } from "./event-stream/shared";
 import {
   extractMessageTotalTokens,
   readMessageModelSelection,
@@ -355,16 +355,6 @@ export const sendUserMessage = async (input: {
     });
     input.session.emittedAssistantMessageIds.add(responseMessageId);
   }
-
-  emitIdleForSession(
-    input.session,
-    {
-      sessionId: input.session.summary.sessionId,
-      emit: (_sessionId, event) => input.emit(event),
-      now: input.now,
-    },
-    responseMessageId ?? undefined,
-  );
 };
 
 export const replyPermission = async (


### PR DESCRIPTION
## Summary
- remove locally synthesized `session_idle` emissions from the OpenCode adapter's stream and prompt paths so active sessions only go idle when upstream emits a real idle signal
- keep real upstream idle handling intact while updating adapter regression tests to cover the flicker and the original true-idle behavior
- verify the rebased branch with `bun run typecheck`, `bun run lint`, `bun run test`, and `bun run build`

## Root Cause
The Mar 23 runtime idle-normalization series started manufacturing local idle transitions from completed assistant messages and prompt responses. Those synthetic idle events briefly downgraded still-running sessions to `idle`, which made the kanban session chips and sidebar active-session count disappear until the next busy event restored them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal session idle event handling behavior to suppress idle emissions in certain assistant message terminal scenarios, except when upstream idle events are present.
  * Removed redundant idle emission calls from the message handling pipeline to simplify event flow logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->