### PR TITLE
fix(session): force reuse to keep previous agent/model/variant

### DIFF
--- a/apps/desktop/src/components/features/agents/session-start-modal.test.tsx
+++ b/apps/desktop/src/components/features/agents/session-start-modal.test.tsx
@@ -188,4 +188,26 @@ describe("SessionStartModal", () => {
 
     unmount();
   });
+
+  test("shows reuse helper text even when catalog is loading", () => {
+    const { unmount } = render(
+      createElement(SessionStartModal, {
+        model: createModel({
+          isSelectionCatalogLoading: true,
+          selectedModelSelection: null,
+          availableStartModes: ["fresh", "reuse"],
+          selectedStartMode: "reuse",
+          existingSessionOptions: [{ value: "session-1", label: "Session #1" }],
+          selectedSourceSessionId: "session-1",
+        }),
+      }),
+    );
+
+    expect(
+      screen.getByText("Reuse mode keeps the previous session agent/model/variant."),
+    ).toBeTruthy();
+    expect(screen.queryByText("Loading agents for the selected runtime.")).toBeNull();
+
+    unmount();
+  });
 });

--- a/apps/desktop/src/components/features/agents/session-start-modal.test.tsx
+++ b/apps/desktop/src/components/features/agents/session-start-modal.test.tsx
@@ -118,4 +118,74 @@ describe("SessionStartModal", () => {
 
     unmount();
   });
+
+  test("disables runtime and model selectors when reusing an existing session", () => {
+    const { container, unmount } = render(
+      createElement(SessionStartModal, {
+        model: createModel({
+          availableStartModes: ["fresh", "reuse"],
+          selectedStartMode: "reuse",
+          existingSessionOptions: [{ value: "session-1", label: "Session #1" }],
+          selectedSourceSessionId: "session-1",
+        }),
+      }),
+    );
+
+    const runtimeCombobox = container.querySelector("agent-runtime-combobox");
+    if (!runtimeCombobox) {
+      throw new Error("Expected runtime combobox element");
+    }
+    expect(runtimeCombobox.hasAttribute("disabled")).toBe(true);
+
+    const allComboboxes = container.querySelectorAll("mock-combobox");
+    expect(allComboboxes.length).toBeGreaterThanOrEqual(4);
+
+    const sourceCombobox = allComboboxes[0];
+    const agentCombobox = allComboboxes[1];
+    const modelCombobox = allComboboxes[2];
+    const variantCombobox = allComboboxes[3];
+
+    if (!sourceCombobox || !agentCombobox || !modelCombobox || !variantCombobox) {
+      throw new Error("Expected existing session + agent/model/variant comboboxes");
+    }
+
+    expect(sourceCombobox.hasAttribute("disabled")).toBe(false);
+    expect(agentCombobox.hasAttribute("disabled")).toBe(true);
+    expect(modelCombobox.hasAttribute("disabled")).toBe(true);
+    expect(variantCombobox.hasAttribute("disabled")).toBe(true);
+
+    unmount();
+  });
+
+  test("allows reuse confirm while catalog is loading", () => {
+    const onConfirm = mock(() => {});
+    const { container, unmount } = render(
+      createElement(SessionStartModal, {
+        model: createModel({
+          isSelectionCatalogLoading: true,
+          selectedModelSelection: null,
+          availableStartModes: ["fresh", "reuse"],
+          selectedStartMode: "reuse",
+          existingSessionOptions: [{ value: "session-1", label: "Session #1" }],
+          selectedSourceSessionId: "session-1",
+          onConfirm,
+        }),
+      }),
+    );
+
+    const form = container.querySelector("form");
+    if (!form) {
+      throw new Error("Expected form element");
+    }
+
+    fireEvent.submit(form);
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      runInBackground: false,
+      startMode: "reuse",
+      sourceSessionId: "session-1",
+    });
+
+    unmount();
+  });
 });

--- a/apps/desktop/src/components/features/agents/session-start-modal.tsx
+++ b/apps/desktop/src/components/features/agents/session-start-modal.tsx
@@ -127,10 +127,10 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
   };
 
   let agentHelperText: string | null = null;
-  if (isSelectionCatalogLoading) {
-    agentHelperText = "Loading agents for the selected runtime.";
-  } else if (isReuseMode) {
+  if (isReuseMode) {
     agentHelperText = "Reuse mode keeps the previous session agent/model/variant.";
+  } else if (isSelectionCatalogLoading) {
+    agentHelperText = "Loading agents for the selected runtime.";
   } else if (!supportsProfiles) {
     agentHelperText = "This runtime manages agent selection automatically.";
   } else if (agentOptions.length === 0) {

--- a/apps/desktop/src/components/features/agents/session-start-modal.tsx
+++ b/apps/desktop/src/components/features/agents/session-start-modal.tsx
@@ -96,17 +96,21 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
     : "";
   const selectedVariant = selectedModelSelection?.variant ?? "";
   const hasExistingSessionOptions = existingSessionOptions.length > 0;
+  const isReuseMode = selectedStartMode === "reuse";
   const requiresExistingSession = selectedStartMode === "reuse" || selectedStartMode === "fork";
   const hasExistingSessionSelection = existingSessionOptions.some(
     (option) => option.value === selectedSourceSessionId,
   );
   const confirmDisabled =
     isStarting ||
-    isSelectionCatalogLoading ||
-    !selectedModelSelection ||
+    (!isReuseMode && (isSelectionCatalogLoading || !selectedModelSelection)) ||
     (requiresExistingSession && !hasExistingSessionSelection);
-  const agentDisabled = isSelectionCatalogLoading || !supportsProfiles || agentOptions.length === 0;
+  const runtimeDisabled = isSelectionCatalogLoading || isReuseMode;
+  const agentDisabled =
+    isReuseMode || isSelectionCatalogLoading || !supportsProfiles || agentOptions.length === 0;
+  const modelDisabled = isReuseMode || isSelectionCatalogLoading;
   const variantDisabled =
+    isReuseMode ||
     isSelectionCatalogLoading ||
     !selectedModelSelection ||
     !supportsVariants ||
@@ -125,6 +129,8 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
   let agentHelperText: string | null = null;
   if (isSelectionCatalogLoading) {
     agentHelperText = "Loading agents for the selected runtime.";
+  } else if (isReuseMode) {
+    agentHelperText = "Reuse mode keeps the previous session agent/model/variant.";
   } else if (!supportsProfiles) {
     agentHelperText = "This runtime manages agent selection automatically.";
   } else if (agentOptions.length === 0) {
@@ -217,7 +223,7 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
                 <AgentRuntimeCombobox
                   value={selectedRuntimeKind}
                   runtimeOptions={runtimeOptions}
-                  disabled={isSelectionCatalogLoading}
+                  disabled={runtimeDisabled}
                   className="sm:min-w-[20rem]"
                   onValueChange={onSelectRuntime}
                 />
@@ -256,7 +262,7 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
                     options={modelOptions}
                     groups={modelGroups}
                     placeholder={isSelectionCatalogLoading ? "Loading models..." : "Select model"}
-                    disabled={isSelectionCatalogLoading}
+                    disabled={modelDisabled}
                     className="w-full"
                     onValueChange={onSelectModel}
                   />

--- a/apps/desktop/src/features/session-start/session-start-reuse-options.ts
+++ b/apps/desktop/src/features/session-start/session-start-reuse-options.ts
@@ -1,4 +1,5 @@
 import type { AgentRole } from "@openducktor/core";
+import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import {
   buildRoleSessionSequenceById,
   compareAgentSessionRecency,
@@ -29,6 +30,13 @@ export const buildReusableSessionOptions = ({
       roleLabelByRole: AGENT_ROLE_LABELS,
     }),
     description: formatAgentSessionOptionDescription(session),
+    selectedModel: session.selectedModel
+      ? {
+          ...session.selectedModel,
+          runtimeKind:
+            session.selectedModel.runtimeKind ?? session.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+        }
+      : null,
     ...(index === 0 ? { secondaryLabel: "Latest" } : {}),
   }));
 };

--- a/apps/desktop/src/features/session-start/session-start-types.ts
+++ b/apps/desktop/src/features/session-start/session-start-types.ts
@@ -10,6 +10,7 @@ export type SessionStartExistingSessionOption = {
   label: string;
   description: string;
   secondaryLabel?: string;
+  selectedModel?: AgentModelSelection | null;
 };
 
 export type SessionStartRequestReason =

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
@@ -388,4 +388,71 @@ describe("useSessionStartModalState", () => {
 
     await harness.unmount();
   });
+
+  test("locks selection to selected source session model in reuse mode", async () => {
+    const harness = createHookHarness(createBaseProps());
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-9",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        existingSessionOptions: [
+          {
+            value: "session-newer",
+            label: "Builder session 2",
+            description: "Latest builder session",
+            selectedModel: {
+              runtimeKind: "opencode",
+              providerId: "anthropic",
+              modelId: "claude-sonnet",
+              variant: "default",
+              profileId: "build-agent",
+            },
+          },
+          {
+            value: "session-older",
+            label: "Builder session 1",
+            description: "Older builder session",
+            selectedModel: {
+              runtimeKind: "opencode",
+              providerId: "openai",
+              modelId: "gpt-5",
+              variant: "high",
+              profileId: "spec-agent",
+            },
+          },
+        ],
+        initialSourceSessionId: "session-older",
+        postStartAction: "kickoff",
+        title: "Start Builder Session",
+      });
+    });
+
+    expect(harness.getLatest().selectedStartMode).toBe("reuse");
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    });
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectSourceSession("session-newer");
+    });
+
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      variant: "default",
+      profileId: "build-agent",
+    });
+
+    await harness.unmount();
+  });
 });

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
@@ -52,6 +52,12 @@ const CATALOG: AgentModelCatalog = {
   ],
 };
 
+const ALTERNATE_RUNTIME_DESCRIPTOR = {
+  ...OPENCODE_RUNTIME_DESCRIPTOR,
+  kind: "alternate-runtime",
+  label: "Alternate Runtime",
+} as const;
+
 const createRepoSettings = (
   overrides: Partial<RepoSettingsInput["agentDefaults"]> = {},
 ): RepoSettingsInput => ({
@@ -390,7 +396,11 @@ describe("useSessionStartModalState", () => {
   });
 
   test("locks selection to selected source session model in reuse mode", async () => {
-    const harness = createHookHarness(createBaseProps());
+    const harness = createHookHarness(
+      createBaseProps({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, ALTERNATE_RUNTIME_DESCRIPTOR],
+      }),
+    );
 
     await harness.mount();
 
@@ -406,7 +416,7 @@ describe("useSessionStartModalState", () => {
             label: "Builder session 2",
             description: "Latest builder session",
             selectedModel: {
-              runtimeKind: "opencode",
+              runtimeKind: "alternate-runtime",
               providerId: "anthropic",
               modelId: "claude-sonnet",
               variant: "default",
@@ -433,6 +443,7 @@ describe("useSessionStartModalState", () => {
     });
 
     expect(harness.getLatest().selectedStartMode).toBe("reuse");
+    expect(harness.getLatest().selectedRuntimeKind).toBe("opencode");
     expect(harness.getLatest().selection).toEqual({
       runtimeKind: "opencode",
       providerId: "openai",
@@ -445,13 +456,68 @@ describe("useSessionStartModalState", () => {
       harness.getLatest().handleSelectSourceSession("session-newer");
     });
 
+    expect(harness.getLatest().selectedRuntimeKind).toBe("alternate-runtime");
     expect(harness.getLatest().selection).toEqual({
-      runtimeKind: "opencode",
+      runtimeKind: "alternate-runtime",
       providerId: "anthropic",
       modelId: "claude-sonnet",
       variant: "default",
       profileId: "build-agent",
     });
+
+    await harness.unmount();
+  });
+
+  test("clears locked selection when reused source session has no model", async () => {
+    const harness = createHookHarness(createBaseProps());
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-10",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        existingSessionOptions: [
+          {
+            value: "session-with-model",
+            label: "Builder session with model",
+            description: "Session with persisted model",
+            selectedModel: {
+              runtimeKind: "opencode",
+              providerId: "openai",
+              modelId: "gpt-5",
+              variant: "high",
+              profileId: "spec-agent",
+            },
+          },
+          {
+            value: "session-without-model",
+            label: "Builder session without model",
+            description: "Session without persisted model",
+            selectedModel: null,
+          },
+        ],
+        initialSourceSessionId: "session-with-model",
+        postStartAction: "kickoff",
+        title: "Start Builder Session",
+      });
+    });
+
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    });
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectSourceSession("session-without-model");
+    });
+
+    expect(harness.getLatest().selection).toBeNull();
 
     await harness.unmount();
   });

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
@@ -123,6 +123,44 @@ const resolveSourceSelection = (
   return selectedOption?.selectedModel ?? null;
 };
 
+const applyReuseSourceSelection = ({
+  catalog,
+  options,
+  runtimeDefinitions,
+  sourceSessionId,
+  setRequestedRuntimeKind,
+  setSelection,
+}: {
+  catalog: AgentModelCatalog | null;
+  options: SessionStartExistingSessionOption[];
+  runtimeDefinitions: RuntimeDescriptor[];
+  sourceSessionId: string;
+  setRequestedRuntimeKind: (runtimeKind: RuntimeKind) => void;
+  setSelection: (selection: AgentModelSelection | null) => void;
+}): void => {
+  const sourceSelection = resolveSourceSelection(options, sourceSessionId);
+  const nextRuntimeKind = resolveRuntimeKindSelection({
+    runtimeDefinitions,
+    requestedRuntimeKind: sourceSelection?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+  });
+  setRequestedRuntimeKind(nextRuntimeKind);
+
+  if (!sourceSelection) {
+    setSelection(null);
+    return;
+  }
+
+  setSelection(
+    normalizeSelectionForCatalog(catalog, {
+      ...sourceSelection,
+      runtimeKind: nextRuntimeKind,
+    }) ?? {
+      ...sourceSelection,
+      runtimeKind: nextRuntimeKind,
+    },
+  );
+};
+
 export function useSessionStartModalState({
   activeRepo,
   repoSettings,
@@ -233,24 +271,14 @@ export function useSessionStartModalState({
         return;
       }
       setSelectedSourceSessionId(nextSourceSessionId);
-      const sourceSelection = resolveSourceSelection(existingSessionOptions, nextSourceSessionId);
-      if (!sourceSelection) {
-        return;
-      }
-      const nextRuntimeKind = resolveRuntimeKindSelection({
+      applyReuseSourceSelection({
+        catalog,
+        options: existingSessionOptions,
         runtimeDefinitions,
-        requestedRuntimeKind: sourceSelection.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+        sourceSessionId: nextSourceSessionId,
+        setRequestedRuntimeKind,
+        setSelection,
       });
-      setRequestedRuntimeKind(nextRuntimeKind);
-      setSelection(
-        normalizeSelectionForCatalog(catalog, {
-          ...sourceSelection,
-          runtimeKind: nextRuntimeKind,
-        }) ?? {
-          ...sourceSelection,
-          runtimeKind: nextRuntimeKind,
-        },
-      );
     },
     [catalog, existingSessionOptions, runtimeDefinitions, selectedSourceSessionId],
   );
@@ -261,30 +289,23 @@ export function useSessionStartModalState({
       if (selectedStartMode !== "reuse") {
         return;
       }
-      const sourceSelection = resolveSourceSelection(existingSessionOptions, sessionId);
-      if (!sourceSelection) {
-        return;
-      }
-      const nextRuntimeKind = resolveRuntimeKindSelection({
+      applyReuseSourceSelection({
+        catalog,
+        options: existingSessionOptions,
         runtimeDefinitions,
-        requestedRuntimeKind: sourceSelection.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+        sourceSessionId: sessionId,
+        setRequestedRuntimeKind,
+        setSelection,
       });
-      setRequestedRuntimeKind(nextRuntimeKind);
-      setSelection(
-        normalizeSelectionForCatalog(catalog, {
-          ...sourceSelection,
-          runtimeKind: nextRuntimeKind,
-        }) ?? {
-          ...sourceSelection,
-          runtimeKind: nextRuntimeKind,
-        },
-      );
     },
     [catalog, existingSessionOptions, runtimeDefinitions, selectedStartMode],
   );
 
   useEffect(() => {
     if (!activeRole) {
+      return;
+    }
+    if (selectedStartMode === "reuse") {
       return;
     }
 
@@ -300,22 +321,36 @@ export function useSessionStartModalState({
       const next = normalizedCurrent ?? fallback;
       return isSameSelection(current, next) ? current : next;
     });
-  }, [activeRole, catalog, intent?.selectedModel, repoSettings, selectedRuntimeKind]);
+  }, [
+    activeRole,
+    catalog,
+    intent?.selectedModel,
+    repoSettings,
+    selectedRuntimeKind,
+    selectedStartMode,
+  ]);
 
   useEffect(() => {
     if (selectedStartMode !== "reuse") {
       return;
     }
-    const sourceSelection = resolveSourceSelection(existingSessionOptions, selectedSourceSessionId);
-    if (!sourceSelection) {
+    if (!selectedSourceSessionId) {
       return;
     }
+    const sourceSelection = resolveSourceSelection(existingSessionOptions, selectedSourceSessionId);
     const nextRuntimeKind = resolveRuntimeKindSelection({
       runtimeDefinitions,
-      requestedRuntimeKind: sourceSelection.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+      requestedRuntimeKind: sourceSelection?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
     });
-    if (nextRuntimeKind !== requestedRuntimeKind) {
-      setRequestedRuntimeKind(nextRuntimeKind);
+    setRequestedRuntimeKind((current) => {
+      if (current === nextRuntimeKind) {
+        return current;
+      }
+      return nextRuntimeKind;
+    });
+    if (!sourceSelection) {
+      setSelection((current) => (current === null ? current : null));
+      return;
     }
     const nextSelection = normalizeSelectionForCatalog(catalog, {
       ...sourceSelection,
@@ -328,7 +363,6 @@ export function useSessionStartModalState({
   }, [
     catalog,
     existingSessionOptions,
-    requestedRuntimeKind,
     runtimeDefinitions,
     selectedSourceSessionId,
     selectedStartMode,

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
@@ -112,6 +112,17 @@ const resolveInitialSelection = (
   );
 };
 
+const resolveSourceSelection = (
+  options: SessionStartExistingSessionOption[],
+  sourceSessionId: string,
+): AgentModelSelection | null => {
+  if (!sourceSessionId) {
+    return null;
+  }
+  const selectedOption = options.find((option) => option.value === sourceSessionId);
+  return selectedOption?.selectedModel ?? null;
+};
+
 export function useSessionStartModalState({
   activeRepo,
   repoSettings,
@@ -214,13 +225,63 @@ export function useSessionStartModalState({
         return;
       }
       setSelectedStartMode(startMode);
+      if (startMode !== "reuse") {
+        return;
+      }
+      const nextSourceSessionId = selectedSourceSessionId || existingSessionOptions[0]?.value || "";
+      if (!nextSourceSessionId) {
+        return;
+      }
+      setSelectedSourceSessionId(nextSourceSessionId);
+      const sourceSelection = resolveSourceSelection(existingSessionOptions, nextSourceSessionId);
+      if (!sourceSelection) {
+        return;
+      }
+      const nextRuntimeKind = resolveRuntimeKindSelection({
+        runtimeDefinitions,
+        requestedRuntimeKind: sourceSelection.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+      });
+      setRequestedRuntimeKind(nextRuntimeKind);
+      setSelection(
+        normalizeSelectionForCatalog(catalog, {
+          ...sourceSelection,
+          runtimeKind: nextRuntimeKind,
+        }) ?? {
+          ...sourceSelection,
+          runtimeKind: nextRuntimeKind,
+        },
+      );
     },
-    [existingSessionOptions],
+    [catalog, existingSessionOptions, runtimeDefinitions, selectedSourceSessionId],
   );
 
-  const handleSelectSourceSession = useCallback((sessionId: string): void => {
-    setSelectedSourceSessionId(sessionId);
-  }, []);
+  const handleSelectSourceSession = useCallback(
+    (sessionId: string): void => {
+      setSelectedSourceSessionId(sessionId);
+      if (selectedStartMode !== "reuse") {
+        return;
+      }
+      const sourceSelection = resolveSourceSelection(existingSessionOptions, sessionId);
+      if (!sourceSelection) {
+        return;
+      }
+      const nextRuntimeKind = resolveRuntimeKindSelection({
+        runtimeDefinitions,
+        requestedRuntimeKind: sourceSelection.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+      });
+      setRequestedRuntimeKind(nextRuntimeKind);
+      setSelection(
+        normalizeSelectionForCatalog(catalog, {
+          ...sourceSelection,
+          runtimeKind: nextRuntimeKind,
+        }) ?? {
+          ...sourceSelection,
+          runtimeKind: nextRuntimeKind,
+        },
+      );
+    },
+    [catalog, existingSessionOptions, runtimeDefinitions, selectedStartMode],
+  );
 
   useEffect(() => {
     if (!activeRole) {
@@ -240,6 +301,38 @@ export function useSessionStartModalState({
       return isSameSelection(current, next) ? current : next;
     });
   }, [activeRole, catalog, intent?.selectedModel, repoSettings, selectedRuntimeKind]);
+
+  useEffect(() => {
+    if (selectedStartMode !== "reuse") {
+      return;
+    }
+    const sourceSelection = resolveSourceSelection(existingSessionOptions, selectedSourceSessionId);
+    if (!sourceSelection) {
+      return;
+    }
+    const nextRuntimeKind = resolveRuntimeKindSelection({
+      runtimeDefinitions,
+      requestedRuntimeKind: sourceSelection.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+    });
+    if (nextRuntimeKind !== requestedRuntimeKind) {
+      setRequestedRuntimeKind(nextRuntimeKind);
+    }
+    const nextSelection = normalizeSelectionForCatalog(catalog, {
+      ...sourceSelection,
+      runtimeKind: nextRuntimeKind,
+    }) ?? {
+      ...sourceSelection,
+      runtimeKind: nextRuntimeKind,
+    };
+    setSelection((current) => (isSameSelection(current, nextSelection) ? current : nextSelection));
+  }, [
+    catalog,
+    existingSessionOptions,
+    requestedRuntimeKind,
+    runtimeDefinitions,
+    selectedSourceSessionId,
+    selectedStartMode,
+  ]);
 
   useEffect(() => {
     if (selectedStartMode !== "reuse" && selectedStartMode !== "fork") {

--- a/apps/desktop/src/pages/agents/session-start/use-agent-studio-fresh-session-creation.ts
+++ b/apps/desktop/src/pages/agents/session-start/use-agent-studio-fresh-session-creation.ts
@@ -40,7 +40,6 @@ type UseAgentStudioFreshSessionCreationArgs = {
   isSessionWorking: boolean;
   startAgentSession: AgentStateContextValue["startAgentSession"];
   sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
-  updateAgentSessionModel: AgentStateContextValue["updateAgentSessionModel"];
   updateQuery: (updates: QueryUpdate) => void;
   onContextSwitchIntent?: () => void;
   setStartingActivityCountByContext: Dispatch<SetStateAction<Record<string, number>>>;
@@ -61,7 +60,6 @@ export function useAgentStudioFreshSessionCreation({
   isSessionWorking,
   startAgentSession,
   sendAgentMessage,
-  updateAgentSessionModel,
   updateQuery,
   onContextSwitchIntent,
   setStartingActivityCountByContext,
@@ -209,9 +207,6 @@ export function useAgentStudioFreshSessionCreation({
           return undefined;
         }
         if (decision.startMode === "reuse" && decision.sourceSessionId) {
-          if (decision.selectedModel) {
-            updateAgentSessionModel(decision.sourceSessionId, decision.selectedModel);
-          }
           if (
             shouldTriggerContextSwitchIntent({
               currentSessionId: activeSession?.sessionId ?? null,
@@ -275,7 +270,6 @@ export function useAgentStudioFreshSessionCreation({
       role,
       sendFreshSessionKickoff,
       startFreshSession,
-      updateAgentSessionModel,
     ],
   );
 

--- a/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-flow.ts
+++ b/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-flow.ts
@@ -265,7 +265,6 @@ export function useAgentStudioSessionStartFlow({
     isSessionWorking,
     startAgentSession,
     sendAgentMessage,
-    updateAgentSessionModel,
     updateQuery,
     ...(onContextSwitchIntent ? { onContextSwitchIntent } : {}),
     setStartingActivityCountByContext,

--- a/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-session.ts
+++ b/apps/desktop/src/pages/agents/session-start/use-agent-studio-session-start-session.ts
@@ -80,9 +80,6 @@ export function useAgentStudioSessionStartSession({
         }
         const selectedModel = decision.selectedModel;
         if (decision.startMode === "reuse" && decision.sourceSessionId) {
-          if (selectedModel) {
-            updateAgentSessionModel(decision.sourceSessionId, selectedModel);
-          }
           applyAgentStudioSelectionQuery(updateQuery, {
             taskId,
             sessionId: decision.sourceSessionId,
@@ -132,7 +129,7 @@ export function useAgentStudioSessionStartSession({
           ...(builderContext ? { builderContext } : {}),
         });
 
-        if (selectedModel) {
+        if (selectedModel && decision.startMode !== "reuse") {
           updateAgentSessionModel(sessionId, selectedModel);
         }
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
@@ -48,7 +48,6 @@ const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   isSessionWorking: false,
   startAgentSession: async () => "session-new",
   sendAgentMessage: async () => {},
-  updateAgentSessionModel: () => {},
   updateQuery: () => {},
   setStartingActivityCountByContext: createSetStartingActivityCountByContext(),
   startingSessionByTaskRef: {

--- a/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
@@ -186,4 +186,54 @@ describe("useAgentStudioFreshSessionCreation", () => {
 
     await harness.unmount();
   });
+
+  test("reuses an existing session without starting a fresh one", async () => {
+    const startAgentSession = mock(async () => "session-new");
+    const sendAgentMessage = mock(async () => {});
+    const harness = createHookHarness(
+      createBaseArgs({
+        role: "build",
+        activeSession: createAgentSessionFixture({
+          sessionId: "active-build",
+          role: "build",
+          scenario: "build_implementation_start",
+          taskId: "task-1",
+        }),
+        startAgentSession,
+        sendAgentMessage,
+        resolveRequestedDecision: async () => ({
+          selectedModel: {
+            runtimeKind: "opencode",
+            providerId: "openai",
+            modelId: "gpt-5",
+            variant: "high",
+            profileId: "Hephaestus",
+          },
+          startMode: "reuse",
+          sourceSessionId: "session-existing",
+        }),
+      }),
+    );
+
+    await harness.mount();
+    await harness.run((state) => {
+      state.handleCreateSession({
+        id: "build:build_implementation_start:reuse",
+        role: "build",
+        scenario: "build_implementation_start",
+        label: "Builder · Continue",
+        description: "Reuse latest builder session",
+        disabled: false,
+      });
+    });
+    await harness.waitFor(() => sendAgentMessage.mock.calls.length > 0);
+
+    expect(startAgentSession).not.toHaveBeenCalled();
+    expect(sendAgentMessage).toHaveBeenCalledWith(
+      "session-existing",
+      expect.stringContaining("task-1"),
+    );
+
+    await harness.unmount();
+  });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -731,6 +731,7 @@ describe("useAgentStudioSessionStartFlow", () => {
           label: "Start Implementation · Builder #1",
           description: "2/22/2026, 12:00:00 PM · idle · session-",
           secondaryLabel: "Latest",
+          selectedModel: null,
         },
       ],
       initialSourceSessionId: "session-build-latest",

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-session.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-session.test.tsx
@@ -165,4 +165,45 @@ describe("useAgentStudioSessionStartSession", () => {
 
     await harness.unmount();
   });
+
+  test("does not overwrite selected model when reusing an existing session", async () => {
+    const updateAgentSessionModel = mock(() => {});
+    const updateQuery = mock(() => {});
+    const startAgentSession = mock(async () => "session-new");
+    const harness = createHookHarness(
+      createBaseArgs({
+        startAgentSession,
+        updateAgentSessionModel,
+        updateQuery,
+        resolveRequestedDecision: async () => ({
+          selectedModel: {
+            runtimeKind: "opencode",
+            providerId: "openai",
+            modelId: "gpt-5",
+            variant: "high",
+            profileId: "Hephaestus",
+          },
+          startMode: "reuse",
+          sourceSessionId: "session-existing",
+        }),
+      }),
+    );
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await state.startSession("composer_send");
+    });
+
+    expect(startAgentSession).not.toHaveBeenCalled();
+    expect(updateAgentSessionModel).not.toHaveBeenCalled();
+    expect(updateQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "task-1",
+        session: "session-existing",
+        agent: "spec",
+      }),
+    );
+
+    await harness.unmount();
+  });
 });

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -537,6 +537,44 @@ describe("KanbanPage session start modal flow", () => {
     });
   });
 
+  test("reuse confirm does not overwrite the reused session model", async () => {
+    const renderer = await renderPage();
+
+    await act(async () => {
+      (latestKanbanColumnProps?.onDelegate as (taskId: string) => void)("TASK-123");
+    });
+
+    await act(async () => {
+      (
+        latestSessionStartModalModel?.onConfirm as (input: {
+          runInBackground?: boolean;
+          startMode?: "fresh" | "reuse" | "fork";
+          sourceSessionId?: string | null;
+        }) => void
+      )({
+        startMode: "reuse",
+        sourceSessionId: "session-existing",
+      });
+      await Promise.resolve();
+    });
+
+    expect(startAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: "TASK-123",
+        role: "build",
+        scenario: "build_implementation_start",
+        startMode: "reuse",
+        sourceSessionId: "session-existing",
+        selectedModel: null,
+      }),
+    );
+    expect(updateAgentSessionModelMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
   test("background kickoff pending does not keep modal in loading state on next open", async () => {
     let resolveKickoff: (() => void) | null = null;
     sendAgentMessageMock.mockImplementationOnce(

--- a/apps/desktop/src/pages/kanban/kanban-session-start-actions.ts
+++ b/apps/desktop/src/pages/kanban/kanban-session-start-actions.ts
@@ -64,7 +64,7 @@ export const startKanbanSessionFlow = async ({
     taskId: intent.taskId,
     role: intent.role,
     scenario: intent.scenario,
-    selectedModel: selection,
+    selectedModel: intent.startMode === "reuse" ? null : selection,
     sendKickoff: false,
     startMode: intent.startMode,
     ...(intent.sourceSessionId ? { sourceSessionId: intent.sourceSessionId } : {}),
@@ -73,7 +73,7 @@ export const startKanbanSessionFlow = async ({
     ...(builderContext ? { builderContext } : {}),
   });
 
-  if (selection) {
+  if (selection && intent.startMode !== "reuse") {
     updateAgentSessionModel(sessionId, selection);
   }
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -484,7 +484,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     }
   });
 
-  test("applies selected model immediately when reusing an in-memory session", async () => {
+  test("keeps existing selected model when reusing an in-memory session", async () => {
     const selectedModel: AgentModelSelection = {
       runtimeKind: "opencode",
       providerId: "openai",
@@ -493,6 +493,13 @@ describe("agent-orchestrator/handlers/start-session", () => {
       profileId: "Hephaestus",
     };
     let persistedSessions = 0;
+    const existingSelectedModel: AgentModelSelection = {
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "medium",
+      profileId: "Sisyphus",
+    };
     const sessionsRef: { current: Record<string, AgentSessionState> } = {
       current: {
         reused: {
@@ -517,7 +524,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
           pendingQuestions: [],
           todos: [],
           modelCatalog: null,
-          selectedModel: null,
+          selectedModel: existingSelectedModel,
           isLoadingModelCatalog: false,
         },
       },
@@ -572,14 +579,14 @@ describe("agent-orchestrator/handlers/start-session", () => {
           selectedModel,
         }),
       ).resolves.toBe("reused");
-      expect(sessionsRef.current.reused?.selectedModel).toEqual(selectedModel);
-      expect(persistedSessions).toBe(1);
+      expect(sessionsRef.current.reused?.selectedModel).toEqual(existingSelectedModel);
+      expect(persistedSessions).toBe(0);
     } finally {
       host.agentSessionsList = originalAgentSessionsList;
     }
   });
 
-  test("starts a fresh session instead of reusing when selected runtime differs in memory", async () => {
+  test("reuses in-memory session even when selected runtime differs", async () => {
     const selectedModel: AgentModelSelection = {
       runtimeKind: "claude-code",
       providerId: "anthropic",
@@ -650,6 +657,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       previousRepoRef: { current: "/tmp/repo" },
       inFlightStartsByRepoTaskRef: { current: new Map() },
       attachSessionListener: () => {},
+      resolveBuildContinuationTarget: async () => "/tmp/repo/worktree",
       ensureRuntime: async () => ({
         kind: "claude-code",
         runtimeId: "runtime-claude",
@@ -667,17 +675,23 @@ describe("agent-orchestrator/handlers/start-session", () => {
     });
 
     try {
-      await expect(start({ taskId: "task-1", role: "build", selectedModel })).resolves.toBe(
-        "fresh-runtime-session",
-      );
-      expect(startCalls).toBe(1);
+      await expect(
+        start({
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_after_human_request_changes",
+          startMode: "reuse",
+          selectedModel,
+        }),
+      ).resolves.toBe("reused");
+      expect(startCalls).toBe(0);
     } finally {
       adapter.startSession = originalStartSession;
       host.agentSessionsList = originalAgentSessionsList;
     }
   });
 
-  test("starts a fresh session instead of reusing when selected agent profile differs", async () => {
+  test("reuses in-memory session even when selected agent profile differs", async () => {
     const selectedModel: AgentModelSelection = {
       runtimeKind: "opencode",
       providerId: "openai",
@@ -750,6 +764,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       previousRepoRef: { current: "/tmp/repo" },
       inFlightStartsByRepoTaskRef: { current: new Map() },
       attachSessionListener: () => {},
+      resolveBuildContinuationTarget: async () => "/tmp/repo/worktree",
       ensureRuntime: async () => ({
         kind: "opencode",
         runtimeId: "runtime-2",
@@ -767,10 +782,16 @@ describe("agent-orchestrator/handlers/start-session", () => {
     });
 
     try {
-      await expect(start({ taskId: "task-1", role: "build", selectedModel })).resolves.toBe(
-        "fresh-profile-session",
-      );
-      expect(startCalls).toBe(1);
+      await expect(
+        start({
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_after_human_request_changes",
+          startMode: "reuse",
+          selectedModel,
+        }),
+      ).resolves.toBe("reused");
+      expect(startCalls).toBe(0);
     } finally {
       adapter.startSession = originalStartSession;
       host.agentSessionsList = originalAgentSessionsList;
@@ -1201,7 +1222,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
     }
   });
 
-  test("starts a fresh session instead of reusing persisted session when selected runtime differs", async () => {
+  test("reuses persisted session when selected runtime differs", async () => {
     const selectedModel: AgentModelSelection = {
       runtimeKind: "claude-code",
       providerId: "anthropic",
@@ -1263,6 +1284,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
       previousRepoRef: { current: "/tmp/repo" },
       inFlightStartsByRepoTaskRef: { current: new Map() },
       attachSessionListener: () => {},
+      resolveBuildContinuationTarget: async () => "/tmp/repo/worktree",
       ensureRuntime: async () => ({
         kind: "claude-code",
         runtimeId: "runtime-claude",
@@ -1276,10 +1298,10 @@ describe("agent-orchestrator/handlers/start-session", () => {
       loadAgentSessions: async () => {
         loadAgentSessionsCalls += 1;
         sessionsRef.current = {
-          "persisted-claude": {
-            runtimeKind: "claude-code",
-            sessionId: "persisted-claude",
-            externalSessionId: "external-claude",
+          "persisted-opencode": {
+            runtimeKind: "opencode",
+            sessionId: "persisted-opencode",
+            externalSessionId: "external-opencode",
             taskId: "task-1",
             role: "build",
             scenario: "build_after_human_request_changes",
@@ -1299,10 +1321,10 @@ describe("agent-orchestrator/handlers/start-session", () => {
             todos: [],
             modelCatalog: null,
             selectedModel: {
-              runtimeKind: "claude-code",
-              providerId: "anthropic",
-              modelId: "claude-3-7-sonnet",
-              profileId: "Hephaestus",
+              runtimeKind: "opencode",
+              providerId: "openai",
+              modelId: "gpt-5",
+              profileId: "Ares",
             },
             isLoadingModelCatalog: false,
           },
@@ -1314,11 +1336,17 @@ describe("agent-orchestrator/handlers/start-session", () => {
     });
 
     try {
-      await expect(start({ taskId: "task-1", role: "build", selectedModel })).resolves.toBe(
-        "fresh-runtime-session",
-      );
-      expect(loadAgentSessionsCalls).toBe(0);
-      expect(startCalls).toBe(1);
+      await expect(
+        start({
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_after_human_request_changes",
+          startMode: "reuse",
+          selectedModel,
+        }),
+      ).resolves.toBe("persisted-opencode");
+      expect(loadAgentSessionsCalls).toBe(1);
+      expect(startCalls).toBe(0);
     } finally {
       adapter.startSession = originalStartSession;
       host.agentSessionsList = originalAgentSessionsList;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -17,7 +17,6 @@ import { requireActiveRepo } from "../../tasks/task-operations-model";
 import { type RuntimeInfo, resolveRuntimeConnection } from "../runtime/runtime";
 import { runOrchestratorSideEffect, runOrchestratorTask } from "../support/async-side-effects";
 import { createRepoStaleGuard, normalizeWorkingDirectory, throwIfRepoStale } from "../support/core";
-import { normalizePersistedSelection } from "../support/models";
 import { inferScenario, kickoffPromptWithTaskContext } from "../support/scenario";
 import {
   buildSessionPreludeMessages,
@@ -230,110 +229,13 @@ const persistInitialSession = ({
   );
 };
 
-const canReuseSessionForSelectedModel = ({
-  sessionRuntimeKind,
-  sessionSelectedModel,
-  selectedModel,
-}: {
-  sessionRuntimeKind: AgentModelSelection["runtimeKind"] | undefined;
-  sessionSelectedModel: AgentModelSelection | null | undefined;
-  selectedModel: AgentModelSelection | null;
-}): boolean => {
-  const requestedRuntimeKind = selectedModel?.runtimeKind;
-  if (!requestedRuntimeKind) {
-    return true;
-  }
-
-  if ((sessionRuntimeKind ?? DEFAULT_RUNTIME_KIND) !== requestedRuntimeKind) {
-    return false;
-  }
-  if (!selectedModel) {
-    return true;
-  }
-  if (!sessionSelectedModel) {
-    return true;
-  }
-
-  return (
-    sessionSelectedModel.providerId === selectedModel.providerId &&
-    sessionSelectedModel.modelId === selectedModel.modelId &&
-    (selectedModel.variant ? sessionSelectedModel.variant === selectedModel.variant : true) &&
-    (selectedModel.profileId ? sessionSelectedModel.profileId === selectedModel.profileId : true)
-  );
-};
-
-const applySelectedModelToReusedSession = ({
-  repoPath,
-  sessionId,
-  selectedModel,
-  session,
-}: {
-  repoPath: string;
-  sessionId: string;
-  selectedModel: AgentModelSelection | null;
-  session: SessionDependencies;
-}): void => {
-  if (!selectedModel) {
-    return;
-  }
-
-  const currentSession = session.sessionsRef.current[sessionId];
-  if (!currentSession) {
-    return;
-  }
-  if (
-    currentSession.selectedModel?.runtimeKind === selectedModel.runtimeKind &&
-    currentSession.selectedModel?.providerId === selectedModel.providerId &&
-    currentSession.selectedModel?.modelId === selectedModel.modelId &&
-    currentSession.selectedModel?.variant === selectedModel.variant &&
-    currentSession.selectedModel?.profileId === selectedModel.profileId
-  ) {
-    return;
-  }
-
-  const nextSession: AgentSessionState = {
-    ...currentSession,
-    selectedModel,
-  };
-  const summary = {
-    sessionId: currentSession.sessionId,
-    externalSessionId: currentSession.externalSessionId,
-    role: currentSession.role,
-    scenario: currentSession.scenario,
-    startedAt: currentSession.startedAt,
-    status: currentSession.status,
-    ...(currentSession.runtimeKind ? { runtimeKind: currentSession.runtimeKind } : {}),
-  };
-  session.setSessionsById((current) => ({
-    ...current,
-    [sessionId]: nextSession,
-  }));
-  persistInitialSession({
-    initialSession: nextSession,
-    session,
-    tags: createSessionStartTags({
-      repoPath,
-      taskId: currentSession.taskId,
-      role: currentSession.role,
-      resolvedScenario: currentSession.scenario,
-      summary,
-      isStaleRepoOperation: () => false,
-    }),
-  });
-};
-
 const resolveReuseValidationError = ({
-  canReuseSession,
   matchesQaTarget,
   matchesBuildTarget,
 }: {
-  canReuseSession: boolean;
   matchesQaTarget: boolean;
   matchesBuildTarget: boolean;
 }): string | null => {
-  if (!canReuseSession) {
-    return "its runtime or model selection does not match the requested configuration";
-  }
   if (!matchesQaTarget) {
     return "it does not match the required builder worktree for this QA session";
   }
@@ -450,32 +352,18 @@ const createOrReuseSession = async ({
       ? existingSessionsForRole.find((entry) => entry.sessionId === explicitSourceSessionId)
       : pickLatestSession(existingSessionsForRole);
     if (existingSession) {
-      const canReuseExistingSession = canReuseSessionForSelectedModel({
-        sessionRuntimeKind:
-          existingSession.runtimeKind ??
-          existingSession.selectedModel?.runtimeKind ??
-          DEFAULT_RUNTIME_KIND,
-        sessionSelectedModel: existingSession.selectedModel,
-        selectedModel: input.selectedModel,
-      });
       const existingSessionMatchesQaTarget =
         ctx.role !== "qa" ||
-        (canReuseExistingSession &&
-          normalizeWorkingDirectory(existingSession.workingDirectory) ===
-            (await resolveExpectedQaWorkingDirectory()));
-      const existingSessionMatchesBuildTarget =
-        canReuseExistingSession &&
-        (await existingSessionMatchesExpectedBuildTarget(existingSession.workingDirectory));
+        normalizeWorkingDirectory(existingSession.workingDirectory) ===
+          (await resolveExpectedQaWorkingDirectory());
+      const existingSessionMatchesBuildTarget = await existingSessionMatchesExpectedBuildTarget(
+        existingSession.workingDirectory,
+      );
       const existingSessionReuseError = resolveReuseValidationError({
-        canReuseSession: canReuseExistingSession,
         matchesQaTarget: existingSessionMatchesQaTarget,
         matchesBuildTarget: existingSessionMatchesBuildTarget,
       });
-      if (
-        canReuseExistingSession &&
-        existingSessionMatchesQaTarget &&
-        existingSessionMatchesBuildTarget
-      ) {
+      if (existingSessionMatchesQaTarget && existingSessionMatchesBuildTarget) {
         if (input.scenario) {
           assertScenarioStartPolicy({
             role: ctx.role,
@@ -483,12 +371,6 @@ const createOrReuseSession = async ({
             startMode: input.startMode,
           });
         }
-        applySelectedModelToReusedSession({
-          repoPath: ctx.repoPath,
-          sessionId: existingSession.sessionId,
-          selectedModel: input.selectedModel,
-          session: deps.session,
-        });
         return {
           kind: "reused",
           sessionId: existingSession.sessionId,
@@ -509,40 +391,22 @@ const createOrReuseSession = async ({
     const persistedSession = explicitSourceSessionId
       ? persistedSessionsForRole.find((entry) => entry.sessionId === explicitSourceSessionId)
       : pickLatestSession(persistedSessionsForRole);
-    const canReusePersistedSession = persistedSession
-      ? canReuseSessionForSelectedModel({
-          sessionRuntimeKind:
-            persistedSession.runtimeKind ??
-            persistedSession.selectedModel?.runtimeKind ??
-            DEFAULT_RUNTIME_KIND,
-          sessionSelectedModel: normalizePersistedSelection(persistedSession.selectedModel),
-          selectedModel: input.selectedModel,
-        })
-      : false;
     const persistedSessionMatchesQaTarget =
       ctx.role !== "qa" ||
       (persistedSession !== undefined &&
-        canReusePersistedSession &&
         normalizeWorkingDirectory(persistedSession.workingDirectory) ===
           (await resolveExpectedQaWorkingDirectory()));
     const persistedSessionMatchesBuildTarget =
       persistedSession !== undefined &&
-      canReusePersistedSession &&
       (await existingSessionMatchesExpectedBuildTarget(persistedSession.workingDirectory));
     const persistedSessionReuseError =
       persistedSession == null
         ? null
         : resolveReuseValidationError({
-            canReuseSession: canReusePersistedSession,
             matchesQaTarget: persistedSessionMatchesQaTarget,
             matchesBuildTarget: persistedSessionMatchesBuildTarget,
           });
-    if (
-      persistedSession &&
-      canReusePersistedSession &&
-      persistedSessionMatchesQaTarget &&
-      persistedSessionMatchesBuildTarget
-    ) {
+    if (persistedSession && persistedSessionMatchesQaTarget && persistedSessionMatchesBuildTarget) {
       if (input.scenario) {
         assertScenarioStartPolicy({
           role: ctx.role,
@@ -561,12 +425,6 @@ const createOrReuseSession = async ({
       if (!deps.session.sessionsRef.current[persistedSession.sessionId]) {
         throw new Error(`Failed to hydrate session "${persistedSession.sessionId}" for reuse.`);
       }
-      applySelectedModelToReusedSession({
-        repoPath: ctx.repoPath,
-        sessionId: persistedSession.sessionId,
-        selectedModel: input.selectedModel,
-        session: deps.session,
-      });
       return {
         kind: "reused",
         sessionId: persistedSession.sessionId,


### PR DESCRIPTION
## Summary
- enforce reuse semantics across handler, Agent Studio, and Kanban flows so reused sessions keep their prior agent/model/variant and skip post-reuse model overwrites
- lock reuse-mode modal selection to the chosen source session model/runtime and propagate source-session model metadata through reuse options
- add regression coverage for reuse behaviors and patch the QA-rejected flow assertion to include `selectedModel: null`

## Validation
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing session model selections when reusing sessions; avoid overwriting or creating duplicate sessions.
  * Runtime, model, agent, and variant controls now disable/enable correctly in reuse vs. fresh modes.
* **Improvements**
  * Confirmation behavior refined to allow reuse flows while catalog data is loading and show reuse-specific helper text.
* **Tests**
  * Added behavioral and unit tests covering reuse modal, selection initialization, and reuse control flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->