### PR TITLE
fix(deps): upgrade hono to remediate prototype pollution advisory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -109,7 +109,7 @@
   "overrides": {
     "@hono/node-server": "^1.19.11",
     "express-rate-limit": "^8.2.2",
-    "hono": "^4.12.5",
+    "hono": "^4.12.7",
     "rollup": "^4.59.0",
   },
   "packages": {
@@ -673,7 +673,7 @@
 
     "highlightjs-vue": ["highlightjs-vue@1.0.0", "", {}, "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="],
 
-    "hono": ["hono@4.12.5", "", {}, "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg=="],
+    "hono": ["hono@4.12.9", "", {}, "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 

--- a/docs/dependency-hygiene.md
+++ b/docs/dependency-hygiene.md
@@ -75,7 +75,7 @@ Implementation notes:
 
 - Command: `bun run deps:audit:hono`
 - Backed by: `bun audit --json`
-- Scope: blocks GHSA-`xh87-mx6m-69f3` reintroduction (`hono` must resolve to `>=4.12.2`)
+- Scope: blocks GHSA-`xh87-mx6m-69f3` and GHSA-`v8w9-8mx6-g223` reintroduction (`hono` must resolve to `>=4.12.7`)
 
 Implementation notes:
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "overrides": {
     "@hono/node-server": "^1.19.11",
     "express-rate-limit": "^8.2.2",
-    "hono": "^4.12.5",
+    "hono": "^4.12.7",
     "rollup": "^4.59.0"
   },
   "devDependencies": {

--- a/scripts/audit-hono-guard.ts
+++ b/scripts/audit-hono-guard.ts
@@ -7,7 +7,11 @@ const { parsed, exitCode } = runBunAuditJson("[deps:audit:hono]");
 
 const honoAdvisories = Array.isArray(parsed.hono) ? parsed.hono : [];
 const detectedAdvisoryIds = HONO_ADVISORY_IDS.filter((advisoryId) => {
-  return honoAdvisories.some((advisory) => advisory.url?.includes(advisoryId));
+  const advisoryIdLower = advisoryId.toLowerCase();
+  return honoAdvisories.some((advisory) => {
+    const advisoryUrl = advisory.url?.trim().toLowerCase() ?? "";
+    return advisoryUrl.includes(advisoryIdLower);
+  });
 });
 
 if (detectedAdvisoryIds.length > 0) {

--- a/scripts/audit-hono-guard.ts
+++ b/scripts/audit-hono-guard.ts
@@ -1,18 +1,20 @@
 import { runBunAuditJson } from "./audit-utils";
 
-const HONO_ADVISORY_ID = "GHSA-xh87-mx6m-69f3";
-const HONO_MIN_SAFE_VERSION = "4.12.2";
+const HONO_ADVISORY_IDS = ["GHSA-xh87-mx6m-69f3", "GHSA-v8w9-8mx6-g223"] as const;
+const HONO_MIN_SAFE_VERSION = "4.12.7";
 
 const { parsed, exitCode } = runBunAuditJson("[deps:audit:hono]");
 
 const honoAdvisories = Array.isArray(parsed.hono) ? parsed.hono : [];
-const hasVulnerableHono = honoAdvisories.some((advisory) => {
-  return advisory.url?.includes(HONO_ADVISORY_ID);
+const detectedAdvisoryIds = HONO_ADVISORY_IDS.filter((advisoryId) => {
+  return honoAdvisories.some((advisory) => advisory.url?.includes(advisoryId));
 });
 
-if (hasVulnerableHono) {
+if (detectedAdvisoryIds.length > 0) {
   console.error(
-    `[deps:audit:hono] ${HONO_ADVISORY_ID} detected for hono. Lockfile must resolve hono >=${HONO_MIN_SAFE_VERSION}.`,
+    `[deps:audit:hono] Advisory detected for hono: ${detectedAdvisoryIds.join(
+      ", ",
+    )}. Lockfile must resolve hono >=${HONO_MIN_SAFE_VERSION}.`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- upgrade `hono` override from `^4.12.5` to `^4.12.7`
- regenerate lockfile so transitive resolution uses safe `hono@4.12.9`
- extend `deps:audit:hono` guard to fail on both `GHSA-xh87-mx6m-69f3` and `GHSA-v8w9-8mx6-g223`

## Validation
- `bun run deps:audit:hono`
- `bun audit --json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated hono dependency constraint to `^4.12.7`
  * Enhanced dependency audit to detect and report multiple vulnerability advisories and raised the minimum safe hono version to 4.12.7

* **Documentation**
  * Updated dependency hygiene guidance to reflect blocking of multiple advisories and the new minimum hono version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->