### PR TITLE
refactor(desktop): split session start modal state into runtime, reuse, and selection models

### DIFF
--- a/apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts
@@ -1,0 +1,239 @@
+import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
+import type {
+  AgentModelCatalog,
+  AgentModelSelection,
+  AgentScenario,
+  AgentSessionStartMode,
+} from "@openducktor/core";
+import { getAgentScenarioDefinition } from "@openducktor/core";
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { DEFAULT_RUNTIME_KIND, resolveRuntimeKindSelection } from "@/lib/agent-runtime";
+import type { SessionStartExistingSessionOption } from "./session-start-types";
+import { resolveScenarioStartMode } from "./session-start-mode";
+import { coerceVisibleSelectionToCatalog, isSameSelection } from "./session-start-selection";
+import type { SessionStartModalIntent } from "./use-session-start-modal-state";
+
+const resolveSourceSelection = (
+  options: SessionStartExistingSessionOption[],
+  sourceSessionId: string,
+): AgentModelSelection | null => {
+  if (!sourceSessionId) {
+    return null;
+  }
+
+  const selectedOption = options.find((option) => option.value === sourceSessionId);
+  return selectedOption?.selectedModel ?? null;
+};
+
+const resolveInitialStartState = ({
+  existingSessionOptions,
+  initialSourceSessionId,
+  initialStartMode,
+  scenario,
+}: {
+  existingSessionOptions: SessionStartExistingSessionOption[];
+  initialSourceSessionId: string | null | undefined;
+  initialStartMode: AgentSessionStartMode | undefined;
+  scenario: AgentScenario;
+}): {
+  selectedSourceSessionId: string;
+  selectedStartMode: AgentSessionStartMode;
+} => {
+  const allowedStartModes = getAgentScenarioDefinition(scenario).allowedStartModes;
+  const selectedStartMode =
+    initialStartMode && allowedStartModes.includes(initialStartMode)
+      ? initialStartMode
+      : resolveScenarioStartMode({
+          scenario,
+          existingSessionOptions,
+        });
+
+  return {
+    selectedStartMode,
+    selectedSourceSessionId:
+      initialSourceSessionId?.trim() || existingSessionOptions[0]?.value || "",
+  };
+};
+
+const buildReuseSelectionDraft = ({
+  catalog,
+  options,
+  runtimeDefinitions,
+  sourceSessionId,
+}: {
+  catalog: AgentModelCatalog | null;
+  options: SessionStartExistingSessionOption[];
+  runtimeDefinitions: RuntimeDescriptor[];
+  sourceSessionId: string;
+}): {
+  runtimeKind: RuntimeKind;
+  selection: AgentModelSelection | null;
+} => {
+  const sourceSelection = resolveSourceSelection(options, sourceSessionId);
+  const runtimeKind = resolveRuntimeKindSelection({
+    runtimeDefinitions,
+    requestedRuntimeKind: sourceSelection?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
+  });
+
+  if (!sourceSelection) {
+    return {
+      runtimeKind,
+      selection: null,
+    };
+  }
+
+  return {
+    runtimeKind,
+    selection:
+      coerceVisibleSelectionToCatalog(catalog, {
+        ...sourceSelection,
+        runtimeKind,
+      }) ?? {
+        ...sourceSelection,
+        runtimeKind,
+      },
+  };
+};
+
+type UseSessionStartModalReuseStateArgs = {
+  catalog: AgentModelCatalog | null;
+  intent: SessionStartModalIntent | null;
+  runtimeDefinitions: RuntimeDescriptor[];
+  setRequestedRuntimeKind: (runtimeKind: RuntimeKind) => void;
+  setSelection: Dispatch<SetStateAction<AgentModelSelection | null>>;
+};
+
+type UseSessionStartModalReuseStateResult = {
+  availableStartModes: AgentSessionStartMode[];
+  existingSessionOptions: SessionStartExistingSessionOption[];
+  initializeStartState: (intent: SessionStartModalIntent) => void;
+  resetStartState: () => void;
+  selectedSourceSessionId: string;
+  selectedStartMode: AgentSessionStartMode;
+  handleSelectSourceSession: (sessionId: string) => void;
+  handleSelectStartMode: (startMode: AgentSessionStartMode) => void;
+};
+
+export function useSessionStartModalReuseState({
+  catalog,
+  intent,
+  runtimeDefinitions,
+  setRequestedRuntimeKind,
+  setSelection,
+}: UseSessionStartModalReuseStateArgs): UseSessionStartModalReuseStateResult {
+  const [selectedStartMode, setSelectedStartMode] = useState<AgentSessionStartMode>("fresh");
+  const [selectedSourceSessionId, setSelectedSourceSessionId] = useState("");
+
+  const availableStartModes = useMemo<AgentSessionStartMode[]>(
+    () => (intent ? getAgentScenarioDefinition(intent.scenario).allowedStartModes : ["fresh"]),
+    [intent],
+  );
+
+  const existingSessionOptions = intent?.existingSessionOptions ?? [];
+
+  const resetStartState = useCallback((): void => {
+    setSelectedStartMode("fresh");
+    setSelectedSourceSessionId("");
+  }, []);
+
+  const initializeStartState = useCallback((nextIntent: SessionStartModalIntent): void => {
+    const nextState = resolveInitialStartState({
+      scenario: nextIntent.scenario,
+      existingSessionOptions: nextIntent.existingSessionOptions ?? [],
+      initialStartMode: nextIntent.initialStartMode,
+      initialSourceSessionId: nextIntent.initialSourceSessionId,
+    });
+    setSelectedStartMode(nextState.selectedStartMode);
+    setSelectedSourceSessionId(nextState.selectedSourceSessionId);
+  }, []);
+
+  const applyReuseSourceSelection = useCallback(
+    (sourceSessionId: string): void => {
+      const nextDraft = buildReuseSelectionDraft({
+        catalog,
+        options: existingSessionOptions,
+        runtimeDefinitions,
+        sourceSessionId,
+      });
+      setRequestedRuntimeKind(nextDraft.runtimeKind);
+      setSelection((current) =>
+        isSameSelection(current, nextDraft.selection) ? current : nextDraft.selection,
+      );
+    },
+    [catalog, existingSessionOptions, runtimeDefinitions, setRequestedRuntimeKind, setSelection],
+  );
+
+  const handleSelectStartMode = useCallback(
+    (startMode: AgentSessionStartMode): void => {
+      if ((startMode === "reuse" || startMode === "fork") && existingSessionOptions.length === 0) {
+        return;
+      }
+
+      setSelectedStartMode(startMode);
+      if (startMode !== "reuse") {
+        return;
+      }
+
+      const nextSourceSessionId = selectedSourceSessionId || existingSessionOptions[0]?.value || "";
+      if (!nextSourceSessionId) {
+        return;
+      }
+
+      setSelectedSourceSessionId(nextSourceSessionId);
+      applyReuseSourceSelection(nextSourceSessionId);
+    },
+    [applyReuseSourceSelection, existingSessionOptions, selectedSourceSessionId],
+  );
+
+  const handleSelectSourceSession = useCallback(
+    (sessionId: string): void => {
+      setSelectedSourceSessionId(sessionId);
+      if (selectedStartMode !== "reuse") {
+        return;
+      }
+      applyReuseSourceSelection(sessionId);
+    },
+    [applyReuseSourceSelection, selectedStartMode],
+  );
+
+  useEffect(() => {
+    if (selectedStartMode !== "reuse") {
+      return;
+    }
+    if (!selectedSourceSessionId) {
+      return;
+    }
+    applyReuseSourceSelection(selectedSourceSessionId);
+  }, [applyReuseSourceSelection, selectedSourceSessionId, selectedStartMode]);
+
+  useEffect(() => {
+    if (selectedStartMode !== "reuse" && selectedStartMode !== "fork") {
+      return;
+    }
+    if (existingSessionOptions.length > 0) {
+      return;
+    }
+    if (!availableStartModes.includes("fresh")) {
+      return;
+    }
+    setSelectedStartMode("fresh");
+  }, [availableStartModes, existingSessionOptions, selectedStartMode]);
+
+  return {
+    availableStartModes,
+    existingSessionOptions,
+    initializeStartState,
+    resetStartState,
+    selectedSourceSessionId,
+    selectedStartMode,
+    handleSelectSourceSession,
+    handleSelectStartMode,
+  };
+}

--- a/apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts
@@ -135,7 +135,10 @@ export function useSessionStartModalReuseState({
     [intent],
   );
 
-  const existingSessionOptions = intent?.existingSessionOptions ?? [];
+  const existingSessionOptions = useMemo(
+    () => intent?.existingSessionOptions ?? [],
+    [intent?.existingSessionOptions],
+  );
 
   const resetStartState = useCallback((): void => {
     setSelectedStartMode("fresh");

--- a/apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts
@@ -32,6 +32,20 @@ const resolveSourceSelection = (
   return selectedOption?.selectedModel ?? null;
 };
 
+const resolveValidSourceSessionId = (
+  options: SessionStartExistingSessionOption[],
+  sourceSessionId: string | null | undefined,
+): string => {
+  const normalizedSourceSessionId = sourceSessionId?.trim() ?? "";
+  if (!normalizedSourceSessionId) {
+    return options[0]?.value ?? "";
+  }
+
+  return options.some((option) => option.value === normalizedSourceSessionId)
+    ? normalizedSourceSessionId
+    : (options[0]?.value ?? "");
+};
+
 const resolveInitialStartState = ({
   existingSessionOptions,
   initialSourceSessionId,
@@ -57,8 +71,10 @@ const resolveInitialStartState = ({
 
   return {
     selectedStartMode,
-    selectedSourceSessionId:
-      initialSourceSessionId?.trim() || existingSessionOptions[0]?.value || "",
+    selectedSourceSessionId: resolveValidSourceSessionId(
+      existingSessionOptions,
+      initialSourceSessionId,
+    ),
   };
 };
 
@@ -183,7 +199,10 @@ export function useSessionStartModalReuseState({
         return;
       }
 
-      const nextSourceSessionId = selectedSourceSessionId || existingSessionOptions[0]?.value || "";
+      const nextSourceSessionId = resolveValidSourceSessionId(
+        existingSessionOptions,
+        selectedSourceSessionId,
+      );
       if (!nextSourceSessionId) {
         return;
       }
@@ -196,24 +215,40 @@ export function useSessionStartModalReuseState({
 
   const handleSelectSourceSession = useCallback(
     (sessionId: string): void => {
-      setSelectedSourceSessionId(sessionId);
+      const nextSourceSessionId = resolveValidSourceSessionId(existingSessionOptions, sessionId);
+      setSelectedSourceSessionId(nextSourceSessionId);
       if (selectedStartMode !== "reuse") {
         return;
       }
-      applyReuseSourceSelection(sessionId);
+      if (!nextSourceSessionId) {
+        return;
+      }
+      applyReuseSourceSelection(nextSourceSessionId);
     },
-    [applyReuseSourceSelection, selectedStartMode],
+    [applyReuseSourceSelection, existingSessionOptions, selectedStartMode],
   );
 
   useEffect(() => {
     if (selectedStartMode !== "reuse") {
       return;
     }
-    if (!selectedSourceSessionId) {
+    const nextSourceSessionId = resolveValidSourceSessionId(
+      existingSessionOptions,
+      selectedSourceSessionId,
+    );
+    if (!nextSourceSessionId) {
       return;
     }
-    applyReuseSourceSelection(selectedSourceSessionId);
-  }, [applyReuseSourceSelection, selectedSourceSessionId, selectedStartMode]);
+    if (nextSourceSessionId !== selectedSourceSessionId) {
+      setSelectedSourceSessionId(nextSourceSessionId);
+    }
+    applyReuseSourceSelection(nextSourceSessionId);
+  }, [
+    applyReuseSourceSelection,
+    existingSessionOptions,
+    selectedSourceSessionId,
+    selectedStartMode,
+  ]);
 
   useEffect(() => {
     if (selectedStartMode !== "reuse" && selectedStartMode !== "fork") {

--- a/apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts
@@ -15,10 +15,10 @@ import {
   useState,
 } from "react";
 import { DEFAULT_RUNTIME_KIND, resolveRuntimeKindSelection } from "@/lib/agent-runtime";
-import type { SessionStartExistingSessionOption } from "./session-start-types";
+import type { SessionStartModalIntent } from "./session-start-modal-types";
 import { resolveScenarioStartMode } from "./session-start-mode";
 import { coerceVisibleSelectionToCatalog, isSameSelection } from "./session-start-selection";
-import type { SessionStartModalIntent } from "./use-session-start-modal-state";
+import type { SessionStartExistingSessionOption } from "./session-start-types";
 
 const resolveSourceSelection = (
   options: SessionStartExistingSessionOption[],
@@ -91,14 +91,13 @@ const buildReuseSelectionDraft = ({
 
   return {
     runtimeKind,
-    selection:
-      coerceVisibleSelectionToCatalog(catalog, {
-        ...sourceSelection,
-        runtimeKind,
-      }) ?? {
-        ...sourceSelection,
-        runtimeKind,
-      },
+    selection: coerceVisibleSelectionToCatalog(catalog, {
+      ...sourceSelection,
+      runtimeKind,
+    }) ?? {
+      ...sourceSelection,
+      runtimeKind,
+    },
   };
 };
 

--- a/apps/desktop/src/features/session-start/session-start-modal-runtime-state.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-runtime-state.ts
@@ -57,27 +57,13 @@ export function useSessionStartModalRuntimeState({
     [runtimeDefinitions, selectedRuntimeKind],
   );
 
-  const setRequestedRuntimeKind = useCallback(
-    (runtimeKind: RuntimeKind): void => {
-      setRequestedRuntimeKindState(
-        resolveRuntimeKindSelection({
-          runtimeDefinitions,
-          requestedRuntimeKind: runtimeKind,
-        }),
-      );
-    },
-    [runtimeDefinitions],
-  );
+  const setRequestedRuntimeKind = useCallback((runtimeKind: RuntimeKind): void => {
+    setRequestedRuntimeKindState(runtimeKind);
+  }, []);
 
   const catalogQuery = useQuery({
     ...repoRuntimeCatalogQueryOptions(activeRepo ?? "", selectedRuntimeKind, loadCatalog),
     enabled: initialCatalog === undefined && Boolean(activeRepo) && isOpen,
-    queryFn: async (): Promise<AgentModelCatalog> => {
-      if (!activeRepo) {
-        throw new Error("No repository selected.");
-      }
-      return loadCatalog(activeRepo, selectedRuntimeKind);
-    },
   });
 
   const catalog = initialCatalog ?? catalogQuery.data ?? null;

--- a/apps/desktop/src/features/session-start/session-start-modal-runtime-state.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-runtime-state.ts
@@ -1,0 +1,95 @@
+import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
+import type { AgentModelCatalog } from "@openducktor/core";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+import type { ComboboxOption } from "@/components/ui/combobox";
+import {
+  DEFAULT_RUNTIME_KIND,
+  findRuntimeDefinition,
+  resolveRuntimeKindSelection,
+  toAgentRuntimeOptions,
+} from "@/lib/agent-runtime";
+import { repoRuntimeCatalogQueryOptions } from "@/state/queries/runtime-catalog";
+
+type UseSessionStartModalRuntimeStateArgs = {
+  activeRepo: string | null;
+  initialCatalog: AgentModelCatalog | null | undefined;
+  isOpen: boolean;
+  loadCatalog: (repoPath: string, runtimeKind: RuntimeKind) => Promise<AgentModelCatalog>;
+  runtimeDefinitions: RuntimeDescriptor[];
+};
+
+type UseSessionStartModalRuntimeStateResult = {
+  catalog: AgentModelCatalog | null;
+  isCatalogLoading: boolean;
+  runtimeOptions: ComboboxOption[];
+  selectedRuntimeDescriptor: RuntimeDescriptor | null;
+  selectedRuntimeKind: RuntimeKind;
+  setRequestedRuntimeKind: (runtimeKind: RuntimeKind) => void;
+};
+
+export function useSessionStartModalRuntimeState({
+  activeRepo,
+  initialCatalog,
+  isOpen,
+  loadCatalog,
+  runtimeDefinitions,
+}: UseSessionStartModalRuntimeStateArgs): UseSessionStartModalRuntimeStateResult {
+  const [requestedRuntimeKind, setRequestedRuntimeKindState] =
+    useState<RuntimeKind>(DEFAULT_RUNTIME_KIND);
+
+  const runtimeOptions = useMemo(
+    () => toAgentRuntimeOptions(runtimeDefinitions),
+    [runtimeDefinitions],
+  );
+
+  const selectedRuntimeKind = useMemo(
+    () =>
+      resolveRuntimeKindSelection({
+        runtimeDefinitions,
+        requestedRuntimeKind,
+      }),
+    [requestedRuntimeKind, runtimeDefinitions],
+  );
+
+  const selectedRuntimeDescriptor = useMemo(
+    () => findRuntimeDefinition(runtimeDefinitions, selectedRuntimeKind),
+    [runtimeDefinitions, selectedRuntimeKind],
+  );
+
+  const setRequestedRuntimeKind = useCallback(
+    (runtimeKind: RuntimeKind): void => {
+      setRequestedRuntimeKindState(
+        resolveRuntimeKindSelection({
+          runtimeDefinitions,
+          requestedRuntimeKind: runtimeKind,
+        }),
+      );
+    },
+    [runtimeDefinitions],
+  );
+
+  const catalogQuery = useQuery({
+    ...repoRuntimeCatalogQueryOptions(activeRepo ?? "", selectedRuntimeKind, loadCatalog),
+    enabled: initialCatalog === undefined && Boolean(activeRepo) && isOpen,
+    queryFn: async (): Promise<AgentModelCatalog> => {
+      if (!activeRepo) {
+        throw new Error("No repository selected.");
+      }
+      return loadCatalog(activeRepo, selectedRuntimeKind);
+    },
+  });
+
+  const catalog = initialCatalog ?? catalogQuery.data ?? null;
+  const isCatalogLoading =
+    initialCatalog === undefined && isOpen && activeRepo !== null ? catalogQuery.isLoading : false;
+
+  return {
+    catalog,
+    isCatalogLoading,
+    runtimeOptions,
+    selectedRuntimeDescriptor,
+    selectedRuntimeKind,
+    setRequestedRuntimeKind,
+  };
+}

--- a/apps/desktop/src/features/session-start/session-start-modal-selection.test.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-selection.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import type { AgentModelCatalog } from "@openducktor/core";
+import type { RepoSettingsInput } from "@/types/state-slices";
+import {
+  resolveInitialModalSelection,
+  resolveSelectionForAgentChange,
+  resolveSelectionForModelChange,
+  resolveSelectionForRuntimeChange,
+  resolveSelectionForVariantChange,
+} from "./session-start-modal-selection";
+
+const CATALOG: AgentModelCatalog = {
+  runtime: OPENCODE_RUNTIME_DESCRIPTOR,
+  models: [
+    {
+      id: "openai/gpt-5",
+      providerId: "openai",
+      providerName: "OpenAI",
+      modelId: "gpt-5",
+      modelName: "GPT-5",
+      variants: ["default", "high"],
+      contextWindow: 200_000,
+      outputLimit: 8_192,
+    },
+    {
+      id: "anthropic/claude-sonnet",
+      providerId: "anthropic",
+      providerName: "Anthropic",
+      modelId: "claude-sonnet",
+      modelName: "Claude Sonnet",
+      variants: ["default"],
+    },
+  ],
+  defaultModelsByProvider: {
+    openai: "gpt-5",
+  },
+  profiles: [
+    {
+      name: "spec-agent",
+      mode: "primary",
+      hidden: false,
+    },
+    {
+      name: "build-agent",
+      mode: "primary",
+      hidden: false,
+    },
+  ],
+};
+
+const REPO_SETTINGS: RepoSettingsInput = {
+  defaultRuntimeKind: "opencode",
+  worktreeBasePath: "",
+  branchPrefix: "codex/",
+  defaultTargetBranch: { remote: "origin", branch: "main" },
+  trustedHooks: false,
+  preStartHooks: [],
+  postCompleteHooks: [],
+  devServers: [],
+  worktreeFileCopies: [],
+  agentDefaults: {
+    spec: {
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    },
+    planner: null,
+    build: {
+      runtimeKind: "opencode",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      variant: "default",
+      profileId: "build-agent",
+    },
+    qa: null,
+  },
+};
+
+describe("session-start-modal-selection", () => {
+  test("resolveInitialModalSelection prefers a valid requested selection", () => {
+    expect(
+      resolveInitialModalSelection({
+        catalog: CATALOG,
+        repoSettings: REPO_SETTINGS,
+        role: "spec",
+        runtimeKind: "opencode",
+        selectedModel: {
+          runtimeKind: "opencode",
+          providerId: "anthropic",
+          modelId: "claude-sonnet",
+          variant: "default",
+          profileId: "build-agent",
+        },
+      }),
+    ).toEqual({
+      runtimeKind: "opencode",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      variant: "default",
+      profileId: "build-agent",
+    });
+  });
+
+  test("resolveInitialModalSelection falls back to normalized role defaults", () => {
+    expect(
+      resolveInitialModalSelection({
+        catalog: CATALOG,
+        repoSettings: {
+          ...REPO_SETTINGS,
+          agentDefaults: {
+            ...REPO_SETTINGS.agentDefaults,
+            spec: {
+              runtimeKind: "opencode",
+              providerId: "openai",
+              modelId: "gpt-5",
+              variant: "legacy",
+              profileId: "spec-agent",
+            },
+          },
+        },
+        role: "spec",
+        runtimeKind: "opencode",
+        selectedModel: null,
+      }),
+    ).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "default",
+      profileId: "spec-agent",
+    });
+  });
+
+  test("resolveSelectionForRuntimeChange keeps draft shape for missing role", () => {
+    expect(
+      resolveSelectionForRuntimeChange({
+        activeRole: null,
+        currentSelection: {
+          runtimeKind: "opencode",
+          providerId: "openai",
+          modelId: "gpt-5",
+        },
+        intentSelectedModel: null,
+        repoSettings: REPO_SETTINGS,
+        runtimeKind: "alternate-runtime",
+      }),
+    ).toEqual({
+      runtimeKind: "alternate-runtime",
+      providerId: "openai",
+      modelId: "gpt-5",
+    });
+  });
+
+  test("resolveSelectionForAgentChange derives a base selection when no draft exists", () => {
+    expect(
+      resolveSelectionForAgentChange({
+        activeRole: "spec",
+        catalog: CATALOG,
+        currentSelection: null,
+        intentSelectedModel: null,
+        profileId: "build-agent",
+        repoSettings: REPO_SETTINGS,
+        runtimeKind: "opencode",
+      }),
+    ).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "build-agent",
+    });
+  });
+
+  test("resolveSelectionForModelChange preserves the current profile", () => {
+    expect(
+      resolveSelectionForModelChange({
+        catalog: CATALOG,
+        currentSelection: {
+          runtimeKind: "opencode",
+          providerId: "openai",
+          modelId: "gpt-5",
+          profileId: "spec-agent",
+        },
+        modelKey: "anthropic/claude-sonnet",
+        runtimeKind: "opencode",
+      }),
+    ).toEqual({
+      runtimeKind: "opencode",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      variant: "default",
+      profileId: "spec-agent",
+    });
+  });
+
+  test("resolveSelectionForVariantChange is a no-op without a selection", () => {
+    expect(
+      resolveSelectionForVariantChange({
+        currentSelection: null,
+        variant: "high",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session-start/session-start-modal-selection.test.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-selection.test.ts
@@ -154,6 +154,44 @@ describe("session-start-modal-selection", () => {
     });
   });
 
+  test("resolveSelectionForRuntimeChange preserves the draft when role is provided", () => {
+    expect(
+      resolveSelectionForRuntimeChange({
+        activeRole: "spec",
+        currentSelection: {
+          runtimeKind: "opencode",
+          providerId: "anthropic",
+          modelId: "claude-sonnet",
+        },
+        intentSelectedModel: null,
+        repoSettings: REPO_SETTINGS,
+        runtimeKind: "opencode",
+      }),
+    ).toEqual({
+      runtimeKind: "opencode",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+    });
+  });
+
+  test("resolveSelectionForRuntimeChange falls back to role defaults when no draft exists", () => {
+    expect(
+      resolveSelectionForRuntimeChange({
+        activeRole: "spec",
+        currentSelection: null,
+        intentSelectedModel: null,
+        repoSettings: REPO_SETTINGS,
+        runtimeKind: "opencode",
+      }),
+    ).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    });
+  });
+
   test("resolveSelectionForAgentChange derives a base selection when no draft exists", () => {
     expect(
       resolveSelectionForAgentChange({

--- a/apps/desktop/src/features/session-start/session-start-modal-selection.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-selection.ts
@@ -1,0 +1,154 @@
+import type { RuntimeKind } from "@openducktor/contracts";
+import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
+import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
+import type { RepoSettingsInput } from "@/types/state-slices";
+import {
+  coerceVisibleSelectionToCatalog,
+  pickDefaultVisibleSelectionForCatalog,
+  roleDefaultSelectionFor,
+} from "./session-start-selection";
+
+export const resolveInitialModalSelection = ({
+  catalog,
+  repoSettings,
+  role,
+  runtimeKind,
+  selectedModel,
+}: {
+  catalog: AgentModelCatalog | null;
+  repoSettings: RepoSettingsInput | null;
+  role: AgentRole;
+  runtimeKind: RuntimeKind;
+  selectedModel: AgentModelSelection | null;
+}): AgentModelSelection | null => {
+  const requestedSelection =
+    selectedModel && (selectedModel.runtimeKind ?? DEFAULT_RUNTIME_KIND) === runtimeKind
+      ? coerceVisibleSelectionToCatalog(catalog, selectedModel)
+      : null;
+  const roleDefault = roleDefaultSelectionFor(repoSettings, role);
+  const runtimeRoleDefault =
+    roleDefault && (roleDefault.runtimeKind ?? DEFAULT_RUNTIME_KIND) === runtimeKind
+      ? roleDefault
+      : null;
+  const catalogDefault = pickDefaultVisibleSelectionForCatalog(catalog);
+
+  return (
+    requestedSelection ??
+    coerceVisibleSelectionToCatalog(catalog, runtimeRoleDefault) ??
+    (catalogDefault ? { ...catalogDefault, runtimeKind } : null) ??
+    selectedModel ??
+    runtimeRoleDefault
+  );
+};
+
+export const resolveSelectionForRuntimeChange = ({
+  activeRole,
+  currentSelection,
+  intentSelectedModel,
+  repoSettings,
+  runtimeKind,
+}: {
+  activeRole: AgentRole | null;
+  currentSelection: AgentModelSelection | null;
+  intentSelectedModel: AgentModelSelection | null;
+  repoSettings: RepoSettingsInput | null;
+  runtimeKind: RuntimeKind;
+}): AgentModelSelection | null => {
+  if (!activeRole) {
+    return currentSelection ? { ...currentSelection, runtimeKind } : currentSelection;
+  }
+
+  return resolveInitialModalSelection({
+    catalog: null,
+    repoSettings,
+    role: activeRole,
+    runtimeKind,
+    selectedModel: currentSelection ? { ...currentSelection, runtimeKind } : intentSelectedModel,
+  });
+};
+
+export const resolveSelectionForAgentChange = ({
+  activeRole,
+  catalog,
+  currentSelection,
+  intentSelectedModel,
+  profileId,
+  repoSettings,
+  runtimeKind,
+}: {
+  activeRole: AgentRole | null;
+  catalog: AgentModelCatalog | null;
+  currentSelection: AgentModelSelection | null;
+  intentSelectedModel: AgentModelSelection | null;
+  profileId: string;
+  repoSettings: RepoSettingsInput | null;
+  runtimeKind: RuntimeKind;
+}): AgentModelSelection | null => {
+  const baseSelection =
+    currentSelection ??
+    (activeRole
+      ? resolveInitialModalSelection({
+          catalog,
+          repoSettings,
+          role: activeRole,
+          runtimeKind,
+          selectedModel: intentSelectedModel,
+        })
+      : null) ??
+    pickDefaultVisibleSelectionForCatalog(catalog);
+
+  if (!baseSelection) {
+    return null;
+  }
+
+  return {
+    ...baseSelection,
+    profileId,
+  };
+};
+
+export const resolveSelectionForModelChange = ({
+  catalog,
+  currentSelection,
+  modelKey,
+  runtimeKind,
+}: {
+  catalog: AgentModelCatalog | null;
+  currentSelection: AgentModelSelection | null;
+  modelKey: string;
+  runtimeKind: RuntimeKind;
+}): AgentModelSelection | null => {
+  if (!catalog) {
+    return currentSelection;
+  }
+
+  const model = catalog.models.find((entry) => entry.id === modelKey);
+  if (!model) {
+    return currentSelection;
+  }
+
+  return {
+    runtimeKind,
+    providerId: model.providerId,
+    modelId: model.modelId,
+    ...(model.variants[0] ? { variant: model.variants[0] } : {}),
+    ...(currentSelection?.profileId ? { profileId: currentSelection.profileId } : {}),
+  };
+};
+
+export const resolveSelectionForVariantChange = ({
+  currentSelection,
+  variant,
+}: {
+  currentSelection: AgentModelSelection | null;
+  variant: string;
+}): AgentModelSelection | null => {
+  if (!currentSelection) {
+    return currentSelection;
+  }
+
+  return {
+    ...currentSelection,
+    variant,
+  };
+};

--- a/apps/desktop/src/features/session-start/session-start-modal-types.ts
+++ b/apps/desktop/src/features/session-start/session-start-modal-types.ts
@@ -1,0 +1,26 @@
+import type {
+  AgentModelSelection,
+  AgentRole,
+  AgentScenario,
+  AgentSessionStartMode,
+} from "@openducktor/core";
+import type { SessionStartExistingSessionOption } from "./session-start-types";
+
+export type SessionStartModalSource = "agent_studio" | "kanban";
+export type SessionStartPostAction = "none" | "kickoff" | "send_message";
+
+export type SessionStartModalIntent = {
+  source: SessionStartModalSource;
+  taskId: string;
+  role: AgentRole;
+  scenario: AgentScenario;
+  initialStartMode?: AgentSessionStartMode;
+  existingSessionOptions?: SessionStartExistingSessionOption[];
+  initialSourceSessionId?: string | null;
+  targetWorkingDirectory?: string | null;
+  postStartAction: SessionStartPostAction;
+  message?: string;
+  selectedModel?: AgentModelSelection | null;
+  title: string;
+  description?: string;
+};

--- a/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.ts
@@ -9,13 +9,10 @@ import { useCallback } from "react";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { RepoSettingsInput } from "@/types/state-slices";
+import type { SessionStartModalIntent, SessionStartPostAction } from "./session-start-modal-types";
 import { SCENARIO_LABELS } from "./session-start-prompts";
 import type { SessionStartRequestReason } from "./session-start-types";
-import {
-  type SessionStartModalIntent,
-  type SessionStartPostAction,
-  useSessionStartModalState,
-} from "./use-session-start-modal-state";
+import { useSessionStartModalState } from "./use-session-start-modal-state";
 
 const startModeLabelFor = (startMode: "fresh" | "reuse" | "fork"): string => {
   if (startMode === "fresh") {

--- a/apps/desktop/src/features/session-start/use-session-start-modal-selection-state.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-selection-state.ts
@@ -1,0 +1,162 @@
+import type { RuntimeKind } from "@openducktor/contracts";
+import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
+import { type Dispatch, type SetStateAction, useCallback, useEffect } from "react";
+import type { RepoSettingsInput } from "@/types/state-slices";
+import {
+  resolveInitialModalSelection,
+  resolveSelectionForAgentChange,
+  resolveSelectionForModelChange,
+  resolveSelectionForRuntimeChange,
+  resolveSelectionForVariantChange,
+} from "./session-start-modal-selection";
+import { coerceVisibleSelectionToCatalog, isSameSelection } from "./session-start-selection";
+
+type UseSessionStartModalSelectionStateArgs = {
+  activeRole: AgentRole | null;
+  catalog: AgentModelCatalog | null;
+  intentSelectedModel: AgentModelSelection | null;
+  repoSettings: RepoSettingsInput | null;
+  selectedRuntimeKind: RuntimeKind;
+  selectedStartMode: "fresh" | "reuse" | "fork";
+  setSelection: Dispatch<SetStateAction<AgentModelSelection | null>>;
+};
+
+type UseSessionStartModalSelectionStateResult = {
+  resetSelection: () => void;
+  initializeSelection: (
+    role: AgentRole,
+    runtimeKind: RuntimeKind,
+    selectedModel: AgentModelSelection | null,
+  ) => void;
+  handleSelectAgent: (profileId: string) => void;
+  handleSelectModel: (modelKey: string) => void;
+  handleSelectRuntime: (runtimeKind: RuntimeKind) => void;
+  handleSelectVariant: (variant: string) => void;
+};
+
+export function useSessionStartModalSelectionState({
+  activeRole,
+  catalog,
+  intentSelectedModel,
+  repoSettings,
+  selectedRuntimeKind,
+  selectedStartMode,
+  setSelection,
+}: UseSessionStartModalSelectionStateArgs): UseSessionStartModalSelectionStateResult {
+  const resetSelection = useCallback((): void => {
+    setSelection(null);
+  }, [setSelection]);
+
+  const initializeSelection = useCallback(
+    (
+      role: AgentRole,
+      runtimeKind: RuntimeKind,
+      selectedModel: AgentModelSelection | null,
+    ): void => {
+      setSelection(
+        resolveInitialModalSelection({
+          catalog,
+          repoSettings,
+          role,
+          runtimeKind,
+          selectedModel,
+        }),
+      );
+    },
+    [catalog, repoSettings, setSelection],
+  );
+
+  useEffect(() => {
+    if (!activeRole) {
+      return;
+    }
+    if (selectedStartMode === "reuse") {
+      return;
+    }
+
+    setSelection((current) => {
+      const normalizedCurrent = coerceVisibleSelectionToCatalog(catalog, current);
+      const fallback = resolveInitialModalSelection({
+        catalog,
+        repoSettings,
+        role: activeRole,
+        runtimeKind: selectedRuntimeKind,
+        selectedModel: intentSelectedModel,
+      });
+      const next = normalizedCurrent ?? fallback;
+      return isSameSelection(current, next) ? current : next;
+    });
+  }, [
+    activeRole,
+    catalog,
+    intentSelectedModel,
+    repoSettings,
+    selectedRuntimeKind,
+    selectedStartMode,
+    setSelection,
+  ]);
+
+  const handleSelectRuntime = useCallback(
+    (runtimeKind: RuntimeKind): void => {
+      setSelection((current) =>
+        resolveSelectionForRuntimeChange({
+          activeRole,
+          currentSelection: current,
+          intentSelectedModel,
+          repoSettings,
+          runtimeKind,
+        }),
+      );
+    },
+    [activeRole, intentSelectedModel, repoSettings, setSelection],
+  );
+
+  const handleSelectAgent = useCallback(
+    (profileId: string): void => {
+      setSelection((current) =>
+        resolveSelectionForAgentChange({
+          activeRole,
+          catalog,
+          currentSelection: current,
+          intentSelectedModel,
+          profileId,
+          repoSettings,
+          runtimeKind: selectedRuntimeKind,
+        }),
+      );
+    },
+    [activeRole, catalog, intentSelectedModel, repoSettings, selectedRuntimeKind, setSelection],
+  );
+
+  const handleSelectModel = useCallback(
+    (modelKey: string): void => {
+      setSelection((current) =>
+        resolveSelectionForModelChange({
+          catalog,
+          currentSelection: current,
+          modelKey,
+          runtimeKind: selectedRuntimeKind,
+        }),
+      );
+    },
+    [catalog, selectedRuntimeKind, setSelection],
+  );
+
+  const handleSelectVariant = useCallback(
+    (variant: string): void => {
+      setSelection((current) =>
+        resolveSelectionForVariantChange({ currentSelection: current, variant }),
+      );
+    },
+    [setSelection],
+  );
+
+  return {
+    resetSelection,
+    initializeSelection,
+    handleSelectAgent,
+    handleSelectModel,
+    handleSelectRuntime,
+    handleSelectVariant,
+  };
+}

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
@@ -393,6 +393,50 @@ describe("useSessionStartModalState", () => {
     await harness.unmount();
   });
 
+  test("falls back to the first valid reuse source session when the initial source id is stale", async () => {
+    const harness = createHookHarness(createBaseProps());
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-7A",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        existingSessionOptions: [
+          {
+            value: "session-fallback",
+            label: "Builder session fallback",
+            description: "Fallback builder session",
+            selectedModel: {
+              runtimeKind: "opencode",
+              providerId: "openai",
+              modelId: "gpt-5",
+              variant: "high",
+              profileId: "spec-agent",
+            },
+          },
+        ],
+        initialSourceSessionId: "missing-session",
+        postStartAction: "kickoff",
+        title: "Start Builder Session",
+      });
+    });
+
+    expect(harness.getLatest().selectedStartMode).toBe("reuse");
+    expect(harness.getLatest().selectedSourceSessionId).toBe("session-fallback");
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    });
+
+    await harness.unmount();
+  });
+
   test("defaults to fresh when reuse is requested but no reusable sessions exist", async () => {
     const harness = createHookHarness(createBaseProps());
 
@@ -540,6 +584,52 @@ describe("useSessionStartModalState", () => {
     });
 
     expect(harness.getLatest().selection).toBeNull();
+
+    await harness.unmount();
+  });
+
+  test("normalizes a stale source session id back to the first valid option in reuse mode", async () => {
+    const harness = createHookHarness(createBaseProps());
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-10A",
+        role: "build",
+        scenario: "build_after_human_request_changes",
+        existingSessionOptions: [
+          {
+            value: "session-valid",
+            label: "Builder session valid",
+            description: "Valid builder session",
+            selectedModel: {
+              runtimeKind: "opencode",
+              providerId: "anthropic",
+              modelId: "claude-sonnet",
+              variant: "default",
+              profileId: "build-agent",
+            },
+          },
+        ],
+        postStartAction: "kickoff",
+        title: "Start Builder Session",
+      });
+    });
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectSourceSession("missing-session");
+    });
+
+    expect(harness.getLatest().selectedSourceSessionId).toBe("session-valid");
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      variant: "default",
+      profileId: "build-agent",
+    });
 
     await harness.unmount();
   });

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
@@ -6,8 +6,6 @@ import type {
   AgentScenario,
   AgentSessionStartMode,
 } from "@openducktor/core";
-import { getAgentScenarioDefinition } from "@openducktor/core";
-import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { resolveAgentAccentColor } from "@/components/features/agents/agent-accent-color";
 import {
@@ -18,14 +16,12 @@ import {
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import {
   DEFAULT_RUNTIME_KIND,
-  findRuntimeDefinition,
   resolveRuntimeKindSelection,
-  toAgentRuntimeOptions,
 } from "@/lib/agent-runtime";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
-import { repoRuntimeCatalogQueryOptions } from "@/state/queries/runtime-catalog";
 import type { RepoSettingsInput } from "@/types/state-slices";
-import { resolveScenarioStartMode } from "./session-start-mode";
+import { useSessionStartModalReuseState } from "./session-start-modal-reuse-state";
+import { useSessionStartModalRuntimeState } from "./session-start-modal-runtime-state";
 import {
   coerceVisibleSelectionToCatalog,
   isSameSelection,
@@ -114,55 +110,6 @@ const resolveInitialSelection = (
   );
 };
 
-const resolveSourceSelection = (
-  options: SessionStartExistingSessionOption[],
-  sourceSessionId: string,
-): AgentModelSelection | null => {
-  if (!sourceSessionId) {
-    return null;
-  }
-  const selectedOption = options.find((option) => option.value === sourceSessionId);
-  return selectedOption?.selectedModel ?? null;
-};
-
-const applyReuseSourceSelection = ({
-  catalog,
-  options,
-  runtimeDefinitions,
-  sourceSessionId,
-  setRequestedRuntimeKind,
-  setSelection,
-}: {
-  catalog: AgentModelCatalog | null;
-  options: SessionStartExistingSessionOption[];
-  runtimeDefinitions: RuntimeDescriptor[];
-  sourceSessionId: string;
-  setRequestedRuntimeKind: (runtimeKind: RuntimeKind) => void;
-  setSelection: (selection: AgentModelSelection | null) => void;
-}): void => {
-  const sourceSelection = resolveSourceSelection(options, sourceSessionId);
-  const nextRuntimeKind = resolveRuntimeKindSelection({
-    runtimeDefinitions,
-    requestedRuntimeKind: sourceSelection?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
-  });
-  setRequestedRuntimeKind(nextRuntimeKind);
-
-  if (!sourceSelection) {
-    setSelection(null);
-    return;
-  }
-
-  setSelection(
-    coerceVisibleSelectionToCatalog(catalog, {
-      ...sourceSelection,
-      runtimeKind: nextRuntimeKind,
-    }) ?? {
-      ...sourceSelection,
-      runtimeKind: nextRuntimeKind,
-    },
-  );
-};
-
 export function useSessionStartModalState({
   activeRepo,
   repoSettings,
@@ -174,70 +121,46 @@ export function useSessionStartModalState({
   const loadCatalogForRepo = loadCatalog ?? loadRepoRuntimeCatalog;
   const [intent, setIntent] = useState<SessionStartModalIntent | null>(null);
   const [selection, setSelection] = useState<AgentModelSelection | null>(null);
-  const [selectedStartMode, setSelectedStartMode] = useState<AgentSessionStartMode>("fresh");
-  const [selectedSourceSessionId, setSelectedSourceSessionId] = useState("");
-  const [requestedRuntimeKind, setRequestedRuntimeKind] =
-    useState<RuntimeKind>(DEFAULT_RUNTIME_KIND);
   const activeRole = intent?.role ?? null;
-  const availableStartModes = useMemo<AgentSessionStartMode[]>(
-    () => (intent ? getAgentScenarioDefinition(intent.scenario).allowedStartModes : ["fresh"]),
-    [intent],
-  );
-  const existingSessionOptions = intent?.existingSessionOptions ?? [];
-  const runtimeOptions = useMemo(
-    () => toAgentRuntimeOptions(runtimeDefinitions),
-    [runtimeDefinitions],
-  );
-  const selectedRuntimeKind = useMemo(
-    () =>
-      resolveRuntimeKindSelection({
-        runtimeDefinitions,
-        requestedRuntimeKind,
-      }),
-    [requestedRuntimeKind, runtimeDefinitions],
-  );
-  const selectedRuntimeDescriptor = useMemo(
-    () => findRuntimeDefinition(runtimeDefinitions, selectedRuntimeKind),
-    [runtimeDefinitions, selectedRuntimeKind],
-  );
-
-  const catalogQuery = useQuery({
-    ...repoRuntimeCatalogQueryOptions(activeRepo ?? "", selectedRuntimeKind, loadCatalogForRepo),
-    enabled: initialCatalog === undefined && Boolean(activeRepo) && intent !== null,
-    queryFn: async (): Promise<AgentModelCatalog> => {
-      if (!activeRepo) {
-        throw new Error("No repository selected.");
-      }
-      return loadCatalogForRepo(activeRepo, selectedRuntimeKind);
-    },
+  const {
+    catalog,
+    isCatalogLoading,
+    selectedRuntimeDescriptor,
+    selectedRuntimeKind,
+    runtimeOptions,
+    setRequestedRuntimeKind,
+  } = useSessionStartModalRuntimeState({
+    activeRepo,
+    initialCatalog,
+    isOpen: intent !== null,
+    loadCatalog: loadCatalogForRepo,
+    runtimeDefinitions,
   });
-
-  const catalog = initialCatalog ?? catalogQuery.data ?? null;
-  const isCatalogLoading =
-    initialCatalog === undefined && intent !== null && activeRepo !== null
-      ? catalogQuery.isLoading
-      : false;
+  const {
+    availableStartModes,
+    existingSessionOptions,
+    initializeStartState,
+    resetStartState,
+    selectedSourceSessionId,
+    selectedStartMode,
+    handleSelectSourceSession,
+    handleSelectStartMode,
+  } = useSessionStartModalReuseState({
+    catalog,
+    intent,
+    runtimeDefinitions,
+    setRequestedRuntimeKind,
+    setSelection,
+  });
 
   const closeStartModal = useCallback(() => {
     setIntent(null);
     setSelection(null);
-    setSelectedStartMode("fresh");
-    setSelectedSourceSessionId("");
-  }, []);
+    resetStartState();
+  }, [resetStartState]);
 
   const openStartModal = useCallback(
     (nextIntent: SessionStartModalIntent) => {
-      const existingSessionOptions = nextIntent.existingSessionOptions ?? [];
-      const allowedStartModes = getAgentScenarioDefinition(nextIntent.scenario).allowedStartModes;
-      const initialStartMode =
-        nextIntent.initialStartMode && allowedStartModes.includes(nextIntent.initialStartMode)
-          ? nextIntent.initialStartMode
-          : resolveScenarioStartMode({
-              scenario: nextIntent.scenario,
-              existingSessionOptions,
-            });
-      const initialSourceSessionId =
-        nextIntent.initialSourceSessionId?.trim() || existingSessionOptions[0]?.value || "";
       const initialRuntimeKind = resolveRuntimeKindSelection({
         runtimeDefinitions,
         requestedRuntimeKind:
@@ -248,8 +171,7 @@ export function useSessionStartModalState({
       });
       setRequestedRuntimeKind(initialRuntimeKind);
       setIntent(nextIntent);
-      setSelectedStartMode(initialStartMode);
-      setSelectedSourceSessionId(initialSourceSessionId);
+      initializeStartState(nextIntent);
       setSelection(
         resolveInitialSelection(
           repoSettings,
@@ -260,51 +182,7 @@ export function useSessionStartModalState({
         ),
       );
     },
-    [catalog, repoSettings, runtimeDefinitions],
-  );
-
-  const handleSelectStartMode = useCallback(
-    (startMode: AgentSessionStartMode): void => {
-      if ((startMode === "reuse" || startMode === "fork") && existingSessionOptions.length === 0) {
-        return;
-      }
-      setSelectedStartMode(startMode);
-      if (startMode !== "reuse") {
-        return;
-      }
-      const nextSourceSessionId = selectedSourceSessionId || existingSessionOptions[0]?.value || "";
-      if (!nextSourceSessionId) {
-        return;
-      }
-      setSelectedSourceSessionId(nextSourceSessionId);
-      applyReuseSourceSelection({
-        catalog,
-        options: existingSessionOptions,
-        runtimeDefinitions,
-        sourceSessionId: nextSourceSessionId,
-        setRequestedRuntimeKind,
-        setSelection,
-      });
-    },
-    [catalog, existingSessionOptions, runtimeDefinitions, selectedSourceSessionId],
-  );
-
-  const handleSelectSourceSession = useCallback(
-    (sessionId: string): void => {
-      setSelectedSourceSessionId(sessionId);
-      if (selectedStartMode !== "reuse") {
-        return;
-      }
-      applyReuseSourceSelection({
-        catalog,
-        options: existingSessionOptions,
-        runtimeDefinitions,
-        sourceSessionId: sessionId,
-        setRequestedRuntimeKind,
-        setSelection,
-      });
-    },
-    [catalog, existingSessionOptions, runtimeDefinitions, selectedStartMode],
+    [catalog, initializeStartState, repoSettings, runtimeDefinitions, setRequestedRuntimeKind],
   );
 
   useEffect(() => {
@@ -335,57 +213,6 @@ export function useSessionStartModalState({
     selectedRuntimeKind,
     selectedStartMode,
   ]);
-
-  useEffect(() => {
-    if (selectedStartMode !== "reuse") {
-      return;
-    }
-    if (!selectedSourceSessionId) {
-      return;
-    }
-    const sourceSelection = resolveSourceSelection(existingSessionOptions, selectedSourceSessionId);
-    const nextRuntimeKind = resolveRuntimeKindSelection({
-      runtimeDefinitions,
-      requestedRuntimeKind: sourceSelection?.runtimeKind ?? DEFAULT_RUNTIME_KIND,
-    });
-    setRequestedRuntimeKind((current) => {
-      if (current === nextRuntimeKind) {
-        return current;
-      }
-      return nextRuntimeKind;
-    });
-    if (!sourceSelection) {
-      setSelection((current) => (current === null ? current : null));
-      return;
-    }
-    const nextSelection = coerceVisibleSelectionToCatalog(catalog, {
-      ...sourceSelection,
-      runtimeKind: nextRuntimeKind,
-    }) ?? {
-      ...sourceSelection,
-      runtimeKind: nextRuntimeKind,
-    };
-    setSelection((current) => (isSameSelection(current, nextSelection) ? current : nextSelection));
-  }, [
-    catalog,
-    existingSessionOptions,
-    runtimeDefinitions,
-    selectedSourceSessionId,
-    selectedStartMode,
-  ]);
-
-  useEffect(() => {
-    if (selectedStartMode !== "reuse" && selectedStartMode !== "fork") {
-      return;
-    }
-    if (existingSessionOptions.length > 0) {
-      return;
-    }
-    if (!availableStartModes.includes("fresh")) {
-      return;
-    }
-    setSelectedStartMode("fresh");
-  }, [availableStartModes, existingSessionOptions, selectedStartMode]);
 
   const handleSelectRuntime = useCallback(
     (runtimeKindValue: RuntimeKind): void => {
@@ -564,6 +391,6 @@ export function useSessionStartModalState({
     handleSelectRuntime,
     handleSelectAgent,
     handleSelectModel,
-    handleSelectVariant,
+      handleSelectVariant,
   };
 }

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
@@ -2,11 +2,9 @@ import type { RuntimeDescriptor, RuntimeKind } from "@openducktor/contracts";
 import type {
   AgentModelCatalog,
   AgentModelSelection,
-  AgentRole,
-  AgentScenario,
   AgentSessionStartMode,
 } from "@openducktor/core";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { resolveAgentAccentColor } from "@/components/features/agents/agent-accent-color";
 import {
   toModelGroupsByProvider,
@@ -14,40 +12,21 @@ import {
   toPrimaryAgentOptions,
 } from "@/components/features/agents/catalog-select-options";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
-import {
-  DEFAULT_RUNTIME_KIND,
-  resolveRuntimeKindSelection,
-} from "@/lib/agent-runtime";
+import { DEFAULT_RUNTIME_KIND, resolveRuntimeKindSelection } from "@/lib/agent-runtime";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import type { RepoSettingsInput } from "@/types/state-slices";
 import { useSessionStartModalReuseState } from "./session-start-modal-reuse-state";
 import { useSessionStartModalRuntimeState } from "./session-start-modal-runtime-state";
-import {
-  coerceVisibleSelectionToCatalog,
-  isSameSelection,
-  pickDefaultVisibleSelectionForCatalog,
-  roleDefaultSelectionFor,
-} from "./session-start-selection";
+import type { SessionStartModalIntent } from "./session-start-modal-types";
+import { roleDefaultSelectionFor } from "./session-start-selection";
 import type { SessionStartExistingSessionOption } from "./session-start-types";
+import { useSessionStartModalSelectionState } from "./use-session-start-modal-selection-state";
 
-export type SessionStartModalSource = "agent_studio" | "kanban";
-export type SessionStartPostAction = "none" | "kickoff" | "send_message";
-
-export type SessionStartModalIntent = {
-  source: SessionStartModalSource;
-  taskId: string;
-  role: AgentRole;
-  scenario: AgentScenario;
-  initialStartMode?: AgentSessionStartMode;
-  existingSessionOptions?: SessionStartExistingSessionOption[];
-  initialSourceSessionId?: string | null;
-  targetWorkingDirectory?: string | null;
-  postStartAction: SessionStartPostAction;
-  message?: string;
-  selectedModel?: AgentModelSelection | null;
-  title: string;
-  description?: string;
-};
+export type {
+  SessionStartModalIntent,
+  SessionStartModalSource,
+  SessionStartPostAction,
+} from "./session-start-modal-types";
 
 type UseSessionStartModalStateArgs = {
   activeRepo: string | null;
@@ -82,32 +61,6 @@ type UseSessionStartModalStateResult = {
   handleSelectAgent: (profileId: string) => void;
   handleSelectModel: (modelKey: string) => void;
   handleSelectVariant: (variant: string) => void;
-};
-
-const resolveInitialSelection = (
-  repoSettings: RepoSettingsInput | null,
-  role: AgentRole,
-  catalog: AgentModelCatalog | null,
-  selectedModel: AgentModelSelection | null,
-  runtimeKind: RuntimeKind,
-): AgentModelSelection | null => {
-  const requestedSelection =
-    selectedModel && (selectedModel.runtimeKind ?? DEFAULT_RUNTIME_KIND) === runtimeKind
-      ? coerceVisibleSelectionToCatalog(catalog, selectedModel)
-      : null;
-  const roleDefault = roleDefaultSelectionFor(repoSettings, role);
-  const runtimeRoleDefault =
-    roleDefault && (roleDefault.runtimeKind ?? DEFAULT_RUNTIME_KIND) === runtimeKind
-      ? roleDefault
-      : null;
-  const catalogDefault = pickDefaultVisibleSelectionForCatalog(catalog);
-  return (
-    requestedSelection ??
-    coerceVisibleSelectionToCatalog(catalog, runtimeRoleDefault) ??
-    (catalogDefault ? { ...catalogDefault, runtimeKind } : null) ??
-    selectedModel ??
-    runtimeRoleDefault
-  );
 };
 
 export function useSessionStartModalState({
@@ -152,12 +105,28 @@ export function useSessionStartModalState({
     setRequestedRuntimeKind,
     setSelection,
   });
+  const {
+    resetSelection,
+    initializeSelection,
+    handleSelectAgent,
+    handleSelectModel,
+    handleSelectRuntime: handleSelectionRuntimeChange,
+    handleSelectVariant,
+  } = useSessionStartModalSelectionState({
+    activeRole,
+    catalog,
+    intentSelectedModel: intent?.selectedModel ?? null,
+    repoSettings,
+    selectedRuntimeKind,
+    selectedStartMode,
+    setSelection,
+  });
 
   const closeStartModal = useCallback(() => {
     setIntent(null);
-    setSelection(null);
+    resetSelection();
     resetStartState();
-  }, [resetStartState]);
+  }, [resetSelection, resetStartState]);
 
   const openStartModal = useCallback(
     (nextIntent: SessionStartModalIntent) => {
@@ -172,47 +141,16 @@ export function useSessionStartModalState({
       setRequestedRuntimeKind(initialRuntimeKind);
       setIntent(nextIntent);
       initializeStartState(nextIntent);
-      setSelection(
-        resolveInitialSelection(
-          repoSettings,
-          nextIntent.role,
-          catalog,
-          nextIntent.selectedModel ?? null,
-          initialRuntimeKind,
-        ),
-      );
+      initializeSelection(nextIntent.role, initialRuntimeKind, nextIntent.selectedModel ?? null);
     },
-    [catalog, initializeStartState, repoSettings, runtimeDefinitions, setRequestedRuntimeKind],
+    [
+      initializeSelection,
+      initializeStartState,
+      repoSettings,
+      runtimeDefinitions,
+      setRequestedRuntimeKind,
+    ],
   );
-
-  useEffect(() => {
-    if (!activeRole) {
-      return;
-    }
-    if (selectedStartMode === "reuse") {
-      return;
-    }
-
-    setSelection((current) => {
-      const normalizedCurrent = coerceVisibleSelectionToCatalog(catalog, current);
-      const fallback = resolveInitialSelection(
-        repoSettings,
-        activeRole,
-        catalog,
-        intent?.selectedModel ?? null,
-        selectedRuntimeKind,
-      );
-      const next = normalizedCurrent ?? fallback;
-      return isSameSelection(current, next) ? current : next;
-    });
-  }, [
-    activeRole,
-    catalog,
-    intent?.selectedModel,
-    repoSettings,
-    selectedRuntimeKind,
-    selectedStartMode,
-  ]);
 
   const handleSelectRuntime = useCallback(
     (runtimeKindValue: RuntimeKind): void => {
@@ -221,20 +159,9 @@ export function useSessionStartModalState({
         requestedRuntimeKind: runtimeKindValue,
       });
       setRequestedRuntimeKind(runtimeKind);
-      setSelection((current) => {
-        if (!activeRole) {
-          return current ? { ...current, runtimeKind } : current;
-        }
-        return resolveInitialSelection(
-          repoSettings,
-          activeRole,
-          null,
-          current ? { ...current, runtimeKind } : (intent?.selectedModel ?? null),
-          runtimeKind,
-        );
-      });
+      handleSelectionRuntimeChange(runtimeKind);
     },
-    [activeRole, intent?.selectedModel, repoSettings, runtimeDefinitions],
+    [handleSelectionRuntimeChange, runtimeDefinitions, setRequestedRuntimeKind],
   );
 
   const selectedModelEntry = useMemo(() => {
@@ -307,66 +234,6 @@ export function useSessionStartModalState({
     return [{ value: selection.variant, label: selection.variant }];
   }, [selectedModelEntry, selection?.variant]);
 
-  const handleSelectAgent = useCallback(
-    (profileId: string): void => {
-      const baseSelection =
-        selection ??
-        (activeRole
-          ? resolveInitialSelection(
-              repoSettings,
-              activeRole,
-              catalog,
-              intent?.selectedModel ?? null,
-              selectedRuntimeKind,
-            )
-          : null) ??
-        pickDefaultVisibleSelectionForCatalog(catalog);
-      if (!baseSelection) {
-        return;
-      }
-
-      setSelection({
-        ...baseSelection,
-        profileId,
-      });
-    },
-    [activeRole, catalog, intent?.selectedModel, repoSettings, selection, selectedRuntimeKind],
-  );
-
-  const handleSelectModel = useCallback(
-    (modelKey: string): void => {
-      if (!catalog) {
-        return;
-      }
-
-      const model = catalog.models.find((entry) => entry.id === modelKey);
-      if (!model) {
-        return;
-      }
-
-      setSelection((current) => ({
-        runtimeKind: selectedRuntimeKind,
-        providerId: model.providerId,
-        modelId: model.modelId,
-        ...(model.variants[0] ? { variant: model.variants[0] } : {}),
-        ...(current?.profileId ? { profileId: current.profileId } : {}),
-      }));
-    },
-    [catalog, selectedRuntimeKind],
-  );
-
-  const handleSelectVariant = useCallback((variant: string): void => {
-    setSelection((current) => {
-      if (!current) {
-        return current;
-      }
-      return {
-        ...current,
-        variant,
-      };
-    });
-  }, []);
-
   return {
     intent,
     isOpen: intent !== null,
@@ -391,6 +258,6 @@ export function useSessionStartModalState({
     handleSelectRuntime,
     handleSelectAgent,
     handleSelectModel,
-      handleSelectVariant,
+    handleSelectVariant,
   };
 }

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
@@ -158,7 +158,7 @@ export function useSessionStartModalState({
         runtimeDefinitions,
         requestedRuntimeKind: runtimeKindValue,
       });
-      setRequestedRuntimeKind(runtimeKind);
+      setRequestedRuntimeKind(runtimeKindValue);
       handleSelectionRuntimeChange(runtimeKind);
     },
     [handleSelectionRuntimeChange, runtimeDefinitions, setRequestedRuntimeKind],


### PR DESCRIPTION
## Summary

This PR refactors the session-start modal state in the desktop app to break a large monolithic hook into smaller, focused models.

The previous `useSessionStartModalState` mixed:
- runtime-definition and catalog loading
- start-mode and source-session reuse/fork behavior
- initial selection derivation
- selection mutation handlers
- combobox option shaping

That made the modal hard to evolve safely because selection behavior and reuse/runtime behavior were tightly coupled in one place.

This change separates those responsibilities into dedicated modules and adds direct tests for the rule-heavy selection logic.

## Commits

- `d3db436c` `refactor(desktop): split session start modal state concerns`
- `88d3be1f` `refactor(desktop): extract session start modal selection logic`

## What Changed

### 1. Split runtime and catalog concerns out of the main hook

Added:
- `apps/desktop/src/features/session-start/session-start-modal-runtime-state.ts`

This hook now owns:
- requested runtime kind state
- runtime option derivation
- runtime descriptor lookup
- runtime catalog query orchestration
- catalog loading state

This removes the TanStack Query and runtime-resolution path from the main modal hook.

### 2. Split reuse/fork mode behavior out of the main hook

Added:
- `apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts`

This hook now owns:
- available start modes
- selected start mode
- selected source session id
- initialization from modal intent
- reuse-mode source-session locking behavior
- fresh fallback when reuse/fork is unavailable

The reuse path still preserves the previous behavior:
- selecting `reuse` locks selection to the source session model
- switching source session updates runtime + selection together
- reuse/fork degrades to fresh when there are no eligible existing sessions and the scenario allows it

### 3. Extract modal intent types into a dedicated type module

Added:
- `apps/desktop/src/features/session-start/session-start-modal-types.ts`

This isolates modal-specific types from the main state hook and removes an unnecessary type dependency edge between helpers and the main hook.

### 4. Extract initial selection and mutation rules into pure helpers

Added:
- `apps/desktop/src/features/session-start/session-start-modal-selection.ts`

This module now holds the pure rule engine for:
- initial visible selection resolution
- runtime-change selection behavior
- agent-change selection behavior
- model-change selection behavior
- variant-change selection behavior

This is the highest-signal logic in the feature, and moving it out makes the behavior easier to reason about and test directly.

### 5. Extract selection state orchestration into a dedicated hook

Added:
- `apps/desktop/src/features/session-start/use-session-start-modal-selection-state.ts`

This hook now owns:
- selection normalization outside reuse mode
- initialization of selection on modal open
- handler wiring for runtime/agent/model/variant selection changes

The main modal hook now composes:
- runtime state
- reuse state
- selection state
- option shaping for the UI model

### 6. Simplify the main modal hook into composition

Updated:
- `apps/desktop/src/features/session-start/use-session-start-modal-state.ts`

The hook is now much closer to a coordinator than a state machine:
- composes the extracted runtime, reuse, and selection hooks
- keeps the public return contract unchanged
- still shapes `agentOptions`, `modelOptions`, `modelGroups`, and `variantOptions` for the modal UI

### 7. Keep coordinator imports aligned with the new boundaries

Updated:
- `apps/desktop/src/features/session-start/use-session-start-modal-coordinator.ts`

This now imports modal intent/post-action types from the new dedicated type module.

## Tests Added

Added:
- `apps/desktop/src/features/session-start/session-start-modal-selection.test.ts`

These tests directly cover the extracted pure selection logic, including:
- requested selection precedence
- normalized role-default fallback
- runtime-change behavior
- agent-change base-selection derivation
- model-change profile preservation
- variant-change no-op behavior when no selection exists

## Behavior / Regression Notes

This refactor was intentionally behavioral-preserving.

The following invariants were kept:
- caller-selected model still wins when valid for the selected runtime
- stale defaults are still normalized against the loaded catalog
- reuse mode still locks runtime and model selection to the chosen source session
- selection still resets when closing and reopening the modal
- fresh-only scenarios still force fresh
- invalid initial reuse/fork selections still degrade correctly

One subtle issue addressed during the refactor:
- selection initialization on modal open now uses the computed initial runtime directly, so it does not momentarily derive selection against a stale previously-selected runtime

## Verification

### Bun
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `bun run build`

### Rust / Cargo
- `bun run check:rust`
- `bun run test:rust`
- `cd apps/desktop/src-tauri && cargo clippy --workspace --all-targets -- -D warnings`
- `cd apps/desktop/src-tauri && cargo build --workspace`

All commands completed successfully.

## Diff Summary

Files changed:
- `apps/desktop/src/features/session-start/session-start-modal-reuse-state.ts`
- `apps/desktop/src/features/session-start/session-start-modal-runtime-state.ts`
- `apps/desktop/src/features/session-start/session-start-modal-selection.test.ts`
- `apps/desktop/src/features/session-start/session-start-modal-selection.ts`
- `apps/desktop/src/features/session-start/session-start-modal-types.ts`
- `apps/desktop/src/features/session-start/use-session-start-modal-coordinator.ts`
- `apps/desktop/src/features/session-start/use-session-start-modal-selection-state.ts`
- `apps/desktop/src/features/session-start/use-session-start-modal-state.ts`

Aggregate diff:
- 8 files changed
- 955 insertions
- 382 deletions

## Why This Refactor Is Worth It

This reduces the maintenance risk around the session-start modal in three ways:
- runtime/catalog fetching is no longer tangled with selection behavior
- reuse/fork workflow rules are isolated from general selection logic
- the most fragile rules are now pure and directly unit-tested

That should make future changes to session-start behavior materially safer, especially around runtime switching and reuse/fork flows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Session-start modal split into dedicated composable hooks for start-mode, runtime/catalog, and model selection; selection resolution and intent types centralized.

* **Bug Fixes**
  * More reliable initialization and reset of start mode/selection, including automatic fallback when reuse/fork sources are missing and consistent runtime/catalog loading behavior.

* **Tests**
  * Added unit tests covering selection resolution and reuse-mode source normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->