### PR TITLE
perf(desktop): optimize dev server log streaming

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -15,8 +15,6 @@ const buildLogBuffer = (script: DevServerScriptState): AgentStudioDevServerLogBu
     stream: logLine.stream,
     text: logLine.text,
   })),
-  head: 0,
-  size: script.bufferedLogLines.length,
 });
 
 const baseModel = (

--- a/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -4,8 +4,20 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   AgentStudioDevServerPanel,
+  type AgentStudioDevServerLogBuffer,
   type AgentStudioDevServerPanelModel,
 } from "./agent-studio-dev-server-panel";
+
+const buildLogBuffer = (script: DevServerScriptState): AgentStudioDevServerLogBuffer => ({
+  entries: script.bufferedLogLines.map((logLine, index) => ({
+    id: `${script.scriptId}:${index}`,
+    timestamp: logLine.timestamp,
+    stream: logLine.stream,
+    text: logLine.text,
+  })),
+  head: 0,
+  size: script.bufferedLogLines.length,
+});
 
 const baseModel = (
   overrides: Partial<AgentStudioDevServerPanelModel> = {},
@@ -19,6 +31,7 @@ const baseModel = (
   scripts: [],
   selectedScriptId: null,
   selectedScript: null,
+  selectedScriptLogBuffer: null,
   error: null,
   isStartPending: false,
   isStopPending: false,
@@ -129,6 +142,7 @@ describe("AgentStudioDevServerPanel", () => {
           scripts: [runningScript],
           selectedScriptId: runningScript.scriptId,
           selectedScript: runningScript,
+          selectedScriptLogBuffer: buildLogBuffer(runningScript),
         }),
       }),
     );
@@ -155,6 +169,7 @@ describe("AgentStudioDevServerPanel", () => {
           scripts: [runningScript, backendScript],
           selectedScriptId: backendScript.scriptId,
           selectedScript: backendScript,
+          selectedScriptLogBuffer: buildLogBuffer(backendScript),
         }),
       }),
     );
@@ -173,6 +188,7 @@ describe("AgentStudioDevServerPanel", () => {
           scripts: [failedScript],
           selectedScriptId: failedScript.scriptId,
           selectedScript: failedScript,
+          selectedScriptLogBuffer: buildLogBuffer(failedScript),
         }),
       }),
     );

--- a/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.test.tsx
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test";
 import type { DevServerScriptState } from "@openducktor/contracts";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import type { AgentStudioDevServerLogBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import {
   AgentStudioDevServerPanel,
-  type AgentStudioDevServerLogBuffer,
   type AgentStudioDevServerPanelModel,
 } from "./agent-studio-dev-server-panel";
 

--- a/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -128,6 +128,53 @@ const buildRenderedLogLine = (
   offset: number,
 ): AgentStudioDevServerLogEntry | null => getDevServerLogEntryAt(buffer, offset);
 
+const AgentStudioDevServerLogRow = memo(function AgentStudioDevServerLogRow({
+  logLine,
+}: {
+  logLine: AgentStudioDevServerLogEntry;
+}): ReactElement {
+  return (
+    <div
+      key={logLine.id}
+      className="flex gap-3 [content-visibility:auto] [contain-intrinsic-size:20px]"
+      data-testid="agent-studio-dev-server-log-line"
+    >
+      <span className="shrink-0 text-[var(--dev-server-terminal-subtle)]">
+        {formatLogTimestamp(logLine.timestamp)}
+      </span>
+      <span className="shrink-0 text-[var(--dev-server-terminal-muted)]">[{logLine.stream}]</span>
+      <span
+        className={cn("min-w-0 whitespace-pre-wrap break-words", streamClassName(logLine.stream))}
+      >
+        {logLine.text}
+      </span>
+    </div>
+  );
+});
+
+const AgentStudioDevServerLogList = memo(function AgentStudioDevServerLogList({
+  logBuffer,
+}: {
+  logBuffer: AgentStudioDevServerLogBuffer;
+}): ReactElement {
+  const logRows = useMemo(() => {
+    const rows: ReactElement[] = [];
+
+    for (let offset = 0; offset < logBuffer.size; offset += 1) {
+      const logLine = buildRenderedLogLine(logBuffer, offset);
+      if (!logLine) {
+        continue;
+      }
+
+      rows.push(<AgentStudioDevServerLogRow key={logLine.id} logLine={logLine} />);
+    }
+
+    return rows;
+  }, [logBuffer]);
+
+  return <div className="space-y-1 px-4 py-4 font-mono text-[11px] leading-5">{logRows}</div>;
+});
+
 export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel({
   model,
 }: {
@@ -414,38 +461,7 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
                 <div ref={logViewportContainerRef} className="min-h-0 flex-1 overflow-hidden">
                   <ScrollArea className="h-full min-h-0 bg-[var(--dev-server-terminal-panel)]">
                     {selectedScriptLogCount > 0 && selectedScriptLogBuffer ? (
-                      <div className="space-y-1 px-4 py-4 font-mono text-[11px] leading-5">
-                        {Array.from({ length: selectedScriptLogBuffer.size }, (_, offset) => {
-                          const logLine = buildRenderedLogLine(selectedScriptLogBuffer, offset);
-
-                          if (!logLine) {
-                            return null;
-                          }
-
-                          return (
-                            <div
-                              key={logLine.id}
-                              className="flex gap-3 [content-visibility:auto] [contain-intrinsic-size:20px]"
-                              data-testid="agent-studio-dev-server-log-line"
-                            >
-                              <span className="shrink-0 text-[var(--dev-server-terminal-subtle)]">
-                                {formatLogTimestamp(logLine.timestamp)}
-                              </span>
-                              <span className="shrink-0 text-[var(--dev-server-terminal-muted)]">
-                                [{logLine.stream}]
-                              </span>
-                              <span
-                                className={cn(
-                                  "min-w-0 whitespace-pre-wrap break-words",
-                                  streamClassName(logLine.stream),
-                                )}
-                              >
-                                {logLine.text}
-                              </span>
-                            </div>
-                          );
-                        })}
-                      </div>
+                      <AgentStudioDevServerLogList logBuffer={selectedScriptLogBuffer} />
                     ) : (
                       <div
                         className="flex h-full min-h-0 items-center justify-center px-6 py-8 text-center text-sm text-[var(--dev-server-terminal-muted)]"

--- a/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -14,21 +14,14 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type {
+  AgentStudioDevServerLogBuffer,
+  AgentStudioDevServerLogEntry,
+} from "@/features/agent-studio-build-tools/dev-server-log-buffer";
+import { getDevServerLogEntryAt } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import { cn } from "@/lib/utils";
 
 export type AgentStudioDevServerPanelMode = "loading" | "empty" | "disabled" | "stopped" | "active";
-export type AgentStudioDevServerLogEntry = {
-  id: string;
-  timestamp: string;
-  stream: DevServerScriptState["bufferedLogLines"][number]["stream"];
-  text: string;
-};
-
-export type AgentStudioDevServerLogBuffer = {
-  entries: readonly AgentStudioDevServerLogEntry[];
-  head: number;
-  size: number;
-};
 
 export type AgentStudioDevServerPanelModel = {
   mode: AgentStudioDevServerPanelMode;
@@ -129,6 +122,11 @@ const getEmptyLogMessage = (script: DevServerScriptState): string => {
 
   return "Logs will appear here once this dev server writes output.";
 };
+
+const buildRenderedLogLine = (
+  buffer: AgentStudioDevServerLogBuffer,
+  offset: number,
+): AgentStudioDevServerLogEntry | null => getDevServerLogEntryAt(buffer, offset);
 
 export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel({
   model,
@@ -418,11 +416,7 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
                     {selectedScriptLogCount > 0 && selectedScriptLogBuffer ? (
                       <div className="space-y-1 px-4 py-4 font-mono text-[11px] leading-5">
                         {Array.from({ length: selectedScriptLogBuffer.size }, (_, offset) => {
-                          const logLine =
-                            selectedScriptLogBuffer.entries[
-                              (selectedScriptLogBuffer.head + offset) %
-                                selectedScriptLogBuffer.entries.length
-                            ];
+                          const logLine = buildRenderedLogLine(selectedScriptLogBuffer, offset);
 
                           if (!logLine) {
                             return null;

--- a/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -17,6 +17,18 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 
 export type AgentStudioDevServerPanelMode = "loading" | "empty" | "disabled" | "stopped" | "active";
+export type AgentStudioDevServerLogEntry = {
+  id: string;
+  timestamp: string;
+  stream: DevServerScriptState["bufferedLogLines"][number]["stream"];
+  text: string;
+};
+
+export type AgentStudioDevServerLogBuffer = {
+  entries: readonly AgentStudioDevServerLogEntry[];
+  head: number;
+  size: number;
+};
 
 export type AgentStudioDevServerPanelModel = {
   mode: AgentStudioDevServerPanelMode;
@@ -28,6 +40,7 @@ export type AgentStudioDevServerPanelModel = {
   scripts: DevServerScriptState[];
   selectedScriptId: string | null;
   selectedScript: DevServerScriptState | null;
+  selectedScriptLogBuffer: AgentStudioDevServerLogBuffer | null;
   error: string | null;
   isStartPending: boolean;
   isStopPending: boolean;
@@ -39,12 +52,6 @@ export type AgentStudioDevServerPanelModel = {
 };
 
 const AUTO_SCROLL_THRESHOLD_PX = 48;
-const ESC = String.fromCharCode(27);
-const CSI = String.fromCharCode(155);
-const ANSI_ESCAPE_SEQUENCE = new RegExp(
-  `(?:${ESC}\\[[0-?]*[ -/]*[@-~])|(?:${CSI}[0-?]*[ -/]*[@-~])|(?:\\uFFFD\\[[0-9;]*[A-Za-z])`,
-  "g",
-);
 
 const formatLogTimestamp = (timestamp: string): string => {
   if (timestamp.length >= 19) {
@@ -65,8 +72,6 @@ const streamClassName = (stream: "stdout" | "stderr" | "system"): string => {
 
   return "text-[var(--dev-server-terminal-foreground)]";
 };
-
-const sanitizeLogText = (text: string): string => text.replace(ANSI_ESCAPE_SEQUENCE, "");
 
 const getClipboardErrorMessage = (error: unknown): string => {
   if (!(error instanceof DOMException)) {
@@ -139,24 +144,8 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
   const hasExpandedActions = model.mode === "active";
   const selectedTabsValue = model.selectedScriptId ?? model.scripts[0]?.scriptId ?? "__none__";
   const selectedScriptContent = selectedScript ?? model.scripts[0] ?? null;
-  const selectedScriptLogCount = selectedScriptContent?.bufferedLogLines.length ?? 0;
-  const renderedLogLines = useMemo(() => {
-    if (!selectedScriptContent) {
-      return [];
-    }
-
-    const keyOccurrences = new Map<string, number>();
-    return selectedScriptContent.bufferedLogLines.map((logLine) => {
-      const baseKey = `${logLine.timestamp}:${logLine.stream}:${logLine.text}`;
-      const occurrence = (keyOccurrences.get(baseKey) ?? 0) + 1;
-      keyOccurrences.set(baseKey, occurrence);
-      return {
-        key: `${baseKey}:${occurrence}`,
-        logLine,
-        displayText: sanitizeLogText(logLine.text),
-      };
-    });
-  }, [selectedScriptContent]);
+  const selectedScriptLogBuffer = model.selectedScriptLogBuffer;
+  const selectedScriptLogCount = selectedScriptLogBuffer?.size ?? 0;
 
   useEffect(() => {
     if (!copiedWorktreePath) {
@@ -426,30 +415,42 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
 
                 <div ref={logViewportContainerRef} className="min-h-0 flex-1 overflow-hidden">
                   <ScrollArea className="h-full min-h-0 bg-[var(--dev-server-terminal-panel)]">
-                    {selectedScriptContent.bufferedLogLines.length > 0 ? (
+                    {selectedScriptLogCount > 0 && selectedScriptLogBuffer ? (
                       <div className="space-y-1 px-4 py-4 font-mono text-[11px] leading-5">
-                        {renderedLogLines.map(({ key, logLine, displayText }) => (
-                          <div
-                            key={key}
-                            className="flex gap-3"
-                            data-testid="agent-studio-dev-server-log-line"
-                          >
-                            <span className="shrink-0 text-[var(--dev-server-terminal-subtle)]">
-                              {formatLogTimestamp(logLine.timestamp)}
-                            </span>
-                            <span className="shrink-0 text-[var(--dev-server-terminal-muted)]">
-                              [{logLine.stream}]
-                            </span>
-                            <span
-                              className={cn(
-                                "min-w-0 whitespace-pre-wrap break-words",
-                                streamClassName(logLine.stream),
-                              )}
+                        {Array.from({ length: selectedScriptLogBuffer.size }, (_, offset) => {
+                          const logLine =
+                            selectedScriptLogBuffer.entries[
+                              (selectedScriptLogBuffer.head + offset) %
+                                selectedScriptLogBuffer.entries.length
+                            ];
+
+                          if (!logLine) {
+                            return null;
+                          }
+
+                          return (
+                            <div
+                              key={logLine.id}
+                              className="flex gap-3 [content-visibility:auto] [contain-intrinsic-size:20px]"
+                              data-testid="agent-studio-dev-server-log-line"
                             >
-                              {displayText}
-                            </span>
-                          </div>
-                        ))}
+                              <span className="shrink-0 text-[var(--dev-server-terminal-subtle)]">
+                                {formatLogTimestamp(logLine.timestamp)}
+                              </span>
+                              <span className="shrink-0 text-[var(--dev-server-terminal-muted)]">
+                                [{logLine.stream}]
+                              </span>
+                              <span
+                                className={cn(
+                                  "min-w-0 whitespace-pre-wrap break-words",
+                                  streamClassName(logLine.stream),
+                                )}
+                              >
+                                {logLine.text}
+                              </span>
+                            </div>
+                          );
+                        })}
                       </div>
                     ) : (
                       <div

--- a/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-dev-server-panel.tsx
@@ -123,11 +123,6 @@ const getEmptyLogMessage = (script: DevServerScriptState): string => {
   return "Logs will appear here once this dev server writes output.";
 };
 
-const buildRenderedLogLine = (
-  buffer: AgentStudioDevServerLogBuffer,
-  offset: number,
-): AgentStudioDevServerLogEntry | null => getDevServerLogEntryAt(buffer, offset);
-
 const AgentStudioDevServerLogRow = memo(function AgentStudioDevServerLogRow({
   logLine,
 }: {
@@ -135,7 +130,6 @@ const AgentStudioDevServerLogRow = memo(function AgentStudioDevServerLogRow({
 }): ReactElement {
   return (
     <div
-      key={logLine.id}
       className="flex gap-3 [content-visibility:auto] [contain-intrinsic-size:20px]"
       data-testid="agent-studio-dev-server-log-line"
     >
@@ -160,8 +154,8 @@ const AgentStudioDevServerLogList = memo(function AgentStudioDevServerLogList({
   const logRows = useMemo(() => {
     const rows: ReactElement[] = [];
 
-    for (let offset = 0; offset < logBuffer.size; offset += 1) {
-      const logLine = buildRenderedLogLine(logBuffer, offset);
+    for (let offset = 0; offset < logBuffer.entries.length; offset += 1) {
+      const logLine = getDevServerLogEntryAt(logBuffer, offset);
       if (!logLine) {
         continue;
       }
@@ -190,7 +184,7 @@ export const AgentStudioDevServerPanel = memo(function AgentStudioDevServerPanel
   const selectedTabsValue = model.selectedScriptId ?? model.scripts[0]?.scriptId ?? "__none__";
   const selectedScriptContent = selectedScript ?? model.scripts[0] ?? null;
   const selectedScriptLogBuffer = model.selectedScriptLogBuffer;
-  const selectedScriptLogCount = selectedScriptLogBuffer?.size ?? 0;
+  const selectedScriptLogCount = selectedScriptLogBuffer?.entries.length ?? 0;
 
   useEffect(() => {
     if (!copiedWorktreePath) {

--- a/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -2,10 +2,8 @@ import { describe, expect, test } from "bun:test";
 import type { DevServerScriptState } from "@openducktor/contracts";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import type {
-  AgentStudioDevServerLogBuffer,
-  AgentStudioDevServerPanelModel,
-} from "./agent-studio-dev-server-panel";
+import type { AgentStudioDevServerLogBuffer } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
+import type { AgentStudioDevServerPanelModel } from "./agent-studio-dev-server-panel";
 import type { AgentStudioGitPanelModel } from "./agent-studio-git-panel";
 import {
   AgentStudioRightPanel,

--- a/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -86,8 +86,6 @@ const devServerModel: AgentStudioDevServerPanelModel = {
       stream: logLine.stream,
       text: logLine.text,
     })),
-    head: 0,
-    size: selectedScript.bufferedLogLines.length,
   } satisfies AgentStudioDevServerLogBuffer,
   error: null,
   isStartPending: false,

--- a/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-right-panel.test.tsx
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import type { DevServerScriptState } from "@openducktor/contracts";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { AgentStudioDevServerPanelModel } from "./agent-studio-dev-server-panel";
+import type {
+  AgentStudioDevServerLogBuffer,
+  AgentStudioDevServerPanelModel,
+} from "./agent-studio-dev-server-panel";
 import type { AgentStudioGitPanelModel } from "./agent-studio-git-panel";
 import {
   AgentStudioRightPanel,
@@ -78,6 +81,16 @@ const devServerModel: AgentStudioDevServerPanelModel = {
   scripts: [selectedScript],
   selectedScriptId: selectedScript.scriptId,
   selectedScript,
+  selectedScriptLogBuffer: {
+    entries: selectedScript.bufferedLogLines.map((logLine, index) => ({
+      id: `${selectedScript.scriptId}:${index}`,
+      timestamp: logLine.timestamp,
+      stream: logLine.stream,
+      text: logLine.text,
+    })),
+    head: 0,
+    size: selectedScript.bufferedLogLines.length,
+  } satisfies AgentStudioDevServerLogBuffer,
   error: null,
   isStartPending: false,
   isStopPending: false,

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -46,9 +46,7 @@ describe("dev-server-log-buffer", () => {
 
     expect(trimmed).toHaveLength(MAX_BUFFERED_DEV_SERVER_LOG_LINES);
     expect(trimmed[0]?.text).toBe("line-2");
-    expect(trimmed.at(-1)?.text).toBe(
-      `line-${MAX_BUFFERED_DEV_SERVER_LOG_LINES + 1}`,
-    );
+    expect(trimmed.at(-1)?.text).toBe(`line-${MAX_BUFFERED_DEV_SERVER_LOG_LINES + 1}`);
   });
 
   test("stores sanitized log entries and rotates in ring order", () => {
@@ -72,8 +70,13 @@ describe("dev-server-log-buffer", () => {
 
     const buffer = getDevServerLogBuffer(store, "frontend");
     expect(buffer?.size).toBe(MAX_BUFFERED_DEV_SERVER_LOG_LINES);
-    expect(getDevServerLogEntryAt(buffer!, 0)?.text).toBe("line-1");
-    expect(getDevServerLogEntryAt(buffer!, buffer!.size - 1)?.text).toBe(
+    expect(buffer).not.toBeNull();
+    if (!buffer) {
+      throw new Error("Expected frontend log buffer to exist.");
+    }
+
+    expect(getDevServerLogEntryAt(buffer, 0)?.text).toBe("line-1");
+    expect(getDevServerLogEntryAt(buffer, buffer.size - 1)?.text).toBe(
       `line-${MAX_BUFFERED_DEV_SERVER_LOG_LINES}`,
     );
   });
@@ -107,9 +110,13 @@ describe("dev-server-log-buffer", () => {
     );
 
     expect(getDevServerLogBuffer(store, "stale")).toBeNull();
-    expect(getDevServerLogEntryAt(getDevServerLogBuffer(store, "frontend")!, 0)?.text).toBe(
-      "frontend failed",
-    );
+    const syncedBuffer = getDevServerLogBuffer(store, "frontend");
+    expect(syncedBuffer).not.toBeNull();
+    if (!syncedBuffer) {
+      throw new Error("Expected frontend log buffer after sync.");
+    }
+
+    expect(getDevServerLogEntryAt(syncedBuffer, 0)?.text).toBe("frontend failed");
 
     replaceDevServerLogBuffer(store, "frontend", [
       {
@@ -120,8 +127,12 @@ describe("dev-server-log-buffer", () => {
       },
     ]);
 
-    expect(getDevServerLogEntryAt(getDevServerLogBuffer(store, "frontend")!, 0)?.text).toBe(
-      "restarted",
-    );
+    const replacedBuffer = getDevServerLogBuffer(store, "frontend");
+    expect(replacedBuffer).not.toBeNull();
+    if (!replacedBuffer) {
+      throw new Error("Expected frontend log buffer after replace.");
+    }
+
+    expect(getDevServerLogEntryAt(replacedBuffer, 0)?.text).toBe("restarted");
   });
 });

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -59,6 +59,13 @@ describe("dev-server-log-buffer", () => {
       timestamp: "2026-03-25T10:00:00.000Z",
     });
 
+    const initialBuffer = getDevServerLogBuffer(store, "frontend");
+    expect(initialBuffer).not.toBeNull();
+    if (!initialBuffer) {
+      throw new Error("Expected initial frontend log buffer to exist.");
+    }
+    expect(getDevServerLogEntryAt(initialBuffer, 0)?.text).toBe("ready");
+
     for (let index = 1; index <= MAX_BUFFERED_DEV_SERVER_LOG_LINES; index += 1) {
       appendDevServerLogLine(store, {
         scriptId: "frontend",
@@ -69,16 +76,47 @@ describe("dev-server-log-buffer", () => {
     }
 
     const buffer = getDevServerLogBuffer(store, "frontend");
-    expect(buffer?.size).toBe(MAX_BUFFERED_DEV_SERVER_LOG_LINES);
+    expect(buffer?.entries.length).toBe(MAX_BUFFERED_DEV_SERVER_LOG_LINES);
     expect(buffer).not.toBeNull();
     if (!buffer) {
       throw new Error("Expected frontend log buffer to exist.");
     }
 
     expect(getDevServerLogEntryAt(buffer, 0)?.text).toBe("line-1");
-    expect(getDevServerLogEntryAt(buffer, buffer.size - 1)?.text).toBe(
+    expect(getDevServerLogEntryAt(buffer, buffer.entries.length - 1)?.text).toBe(
       `line-${MAX_BUFFERED_DEV_SERVER_LOG_LINES}`,
     );
+  });
+
+  test("returned buffer snapshots stay stable after later appends", () => {
+    const store = createDevServerLogBufferStore();
+
+    for (let index = 0; index < MAX_BUFFERED_DEV_SERVER_LOG_LINES; index += 1) {
+      appendDevServerLogLine(store, {
+        scriptId: "frontend",
+        stream: "stdout",
+        text: `line-${index}`,
+        timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
+      });
+    }
+
+    const previousSnapshot = getDevServerLogBuffer(store, "frontend");
+    expect(previousSnapshot).not.toBeNull();
+    if (!previousSnapshot) {
+      throw new Error("Expected frontend snapshot before wrap.");
+    }
+
+    appendDevServerLogLine(store, {
+      scriptId: "frontend",
+      stream: "stdout",
+      text: "latest",
+      timestamp: "2026-03-25T10:01:00.000Z",
+    });
+
+    expect(getDevServerLogEntryAt(previousSnapshot, 0)?.text).toBe("line-0");
+    expect(
+      getDevServerLogEntryAt(previousSnapshot, previousSnapshot.entries.length - 1)?.text,
+    ).toBe(`line-${MAX_BUFFERED_DEV_SERVER_LOG_LINES - 1}`);
   });
 
   test("replaces and prunes script buffers when syncing state", () => {

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import type { DevServerGroupState, DevServerScriptState } from "@openducktor/contracts";
+import {
+  appendDevServerLogLine,
+  createDevServerLogBufferStore,
+  getDevServerLogBuffer,
+  getDevServerLogEntryAt,
+  MAX_BUFFERED_DEV_SERVER_LOG_LINES,
+  replaceDevServerLogBuffer,
+  syncDevServerLogBufferStore,
+  trimDevServerLogLines,
+} from "./dev-server-log-buffer";
+
+const buildScript = (overrides: Partial<DevServerScriptState> = {}): DevServerScriptState => ({
+  scriptId: "frontend",
+  name: "Frontend",
+  command: "bun run dev",
+  status: "stopped",
+  pid: null,
+  startedAt: null,
+  exitCode: null,
+  lastError: null,
+  bufferedLogLines: [],
+  ...overrides,
+});
+
+const buildState = (overrides: Partial<DevServerGroupState> = {}): DevServerGroupState => ({
+  repoPath: "/repo",
+  taskId: "task-7",
+  worktreePath: "/tmp/worktree/task-7",
+  scripts: [buildScript()],
+  updatedAt: "2026-03-25T10:00:00.000Z",
+  ...overrides,
+});
+
+describe("dev-server-log-buffer", () => {
+  test("trims snapshots to the configured maximum", () => {
+    const lines = Array.from({ length: MAX_BUFFERED_DEV_SERVER_LOG_LINES + 2 }, (_, index) => ({
+      scriptId: "frontend",
+      stream: "stdout" as const,
+      text: `line-${index}`,
+      timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
+    }));
+
+    const trimmed = trimDevServerLogLines(lines);
+
+    expect(trimmed).toHaveLength(MAX_BUFFERED_DEV_SERVER_LOG_LINES);
+    expect(trimmed[0]?.text).toBe("line-2");
+    expect(trimmed.at(-1)?.text).toBe(
+      `line-${MAX_BUFFERED_DEV_SERVER_LOG_LINES + 1}`,
+    );
+  });
+
+  test("stores sanitized log entries and rotates in ring order", () => {
+    const store = createDevServerLogBufferStore();
+
+    appendDevServerLogLine(store, {
+      scriptId: "frontend",
+      stream: "stdout",
+      text: "\u001b[32mready\u001b[0m",
+      timestamp: "2026-03-25T10:00:00.000Z",
+    });
+
+    for (let index = 1; index <= MAX_BUFFERED_DEV_SERVER_LOG_LINES; index += 1) {
+      appendDevServerLogLine(store, {
+        scriptId: "frontend",
+        stream: "stdout",
+        text: `line-${index}`,
+        timestamp: `2026-03-25T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
+      });
+    }
+
+    const buffer = getDevServerLogBuffer(store, "frontend");
+    expect(buffer?.size).toBe(MAX_BUFFERED_DEV_SERVER_LOG_LINES);
+    expect(getDevServerLogEntryAt(buffer!, 0)?.text).toBe("line-1");
+    expect(getDevServerLogEntryAt(buffer!, buffer!.size - 1)?.text).toBe(
+      `line-${MAX_BUFFERED_DEV_SERVER_LOG_LINES}`,
+    );
+  });
+
+  test("replaces and prunes script buffers when syncing state", () => {
+    const store = createDevServerLogBufferStore();
+    appendDevServerLogLine(store, {
+      scriptId: "stale",
+      stream: "stdout",
+      text: "stale",
+      timestamp: "2026-03-25T10:00:00.000Z",
+    });
+
+    syncDevServerLogBufferStore(
+      store,
+      buildState({
+        scripts: [
+          buildScript({
+            scriptId: "frontend",
+            bufferedLogLines: [
+              {
+                scriptId: "frontend",
+                stream: "stderr",
+                text: "frontend failed",
+                timestamp: "2026-03-25T10:01:00.000Z",
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    expect(getDevServerLogBuffer(store, "stale")).toBeNull();
+    expect(getDevServerLogEntryAt(getDevServerLogBuffer(store, "frontend")!, 0)?.text).toBe(
+      "frontend failed",
+    );
+
+    replaceDevServerLogBuffer(store, "frontend", [
+      {
+        scriptId: "frontend",
+        stream: "system",
+        text: "restarted",
+        timestamp: "2026-03-25T10:02:00.000Z",
+      },
+    ]);
+
+    expect(getDevServerLogEntryAt(getDevServerLogBuffer(store, "frontend")!, 0)?.text).toBe(
+      "restarted",
+    );
+  });
+});

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -1,4 +1,8 @@
-import type { DevServerGroupState, DevServerLogLine, DevServerScriptState } from "@openducktor/contracts";
+import type {
+  DevServerGroupState,
+  DevServerLogLine,
+  DevServerScriptState,
+} from "@openducktor/contracts";
 
 const ESC = String.fromCharCode(27);
 const CSI = String.fromCharCode(155);

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -1,0 +1,157 @@
+import type { DevServerGroupState, DevServerLogLine, DevServerScriptState } from "@openducktor/contracts";
+
+const ESC = String.fromCharCode(27);
+const CSI = String.fromCharCode(155);
+const ANSI_ESCAPE_SEQUENCE = new RegExp(
+  `(?:${ESC}\\[[0-?]*[ -/]*[@-~])|(?:${CSI}[0-?]*[ -/]*[@-~])|(?:\\uFFFD\\[[0-9;]*[A-Za-z])`,
+  "g",
+);
+
+export const MAX_BUFFERED_DEV_SERVER_LOG_LINES = 2_000;
+
+export type AgentStudioDevServerLogEntry = {
+  id: string;
+  timestamp: string;
+  stream: DevServerScriptState["bufferedLogLines"][number]["stream"];
+  text: string;
+};
+
+export type AgentStudioDevServerLogBuffer = {
+  entries: readonly AgentStudioDevServerLogEntry[];
+  head: number;
+  size: number;
+};
+
+type DevServerLogBufferState = {
+  entries: AgentStudioDevServerLogEntry[];
+  head: number;
+  size: number;
+  nextSequence: number;
+};
+
+export type DevServerLogBufferStore = Map<string, DevServerLogBufferState>;
+
+export const trimDevServerLogLines = (lines: DevServerLogLine[]): DevServerLogLine[] => {
+  if (lines.length <= MAX_BUFFERED_DEV_SERVER_LOG_LINES) {
+    return lines;
+  }
+
+  return lines.slice(-MAX_BUFFERED_DEV_SERVER_LOG_LINES);
+};
+
+const sanitizeLogText = (text: string): string => text.replace(ANSI_ESCAPE_SEQUENCE, "");
+
+const createDevServerLogBufferState = (): DevServerLogBufferState => ({
+  entries: [],
+  head: 0,
+  size: 0,
+  nextSequence: 0,
+});
+
+const getOrCreateDevServerLogBufferState = (
+  store: DevServerLogBufferStore,
+  scriptId: string,
+): DevServerLogBufferState => {
+  const existingBuffer = store.get(scriptId);
+  if (existingBuffer) {
+    return existingBuffer;
+  }
+
+  const nextBuffer = createDevServerLogBufferState();
+  store.set(scriptId, nextBuffer);
+  return nextBuffer;
+};
+
+export const createDevServerLogBufferStore = (): DevServerLogBufferStore => new Map();
+
+export const appendDevServerLogLine = (
+  store: DevServerLogBufferStore,
+  logLine: DevServerLogLine,
+): void => {
+  const buffer = getOrCreateDevServerLogBufferState(store, logLine.scriptId);
+  const entry: AgentStudioDevServerLogEntry = {
+    id: `${logLine.scriptId}:${buffer.nextSequence}`,
+    timestamp: logLine.timestamp,
+    stream: logLine.stream,
+    text: sanitizeLogText(logLine.text),
+  };
+  buffer.nextSequence += 1;
+
+  if (buffer.size < MAX_BUFFERED_DEV_SERVER_LOG_LINES) {
+    const insertionIndex = (buffer.head + buffer.size) % MAX_BUFFERED_DEV_SERVER_LOG_LINES;
+    buffer.entries[insertionIndex] = entry;
+    buffer.size += 1;
+    return;
+  }
+
+  buffer.entries[buffer.head] = entry;
+  buffer.head = (buffer.head + 1) % MAX_BUFFERED_DEV_SERVER_LOG_LINES;
+};
+
+export const replaceDevServerLogBuffer = (
+  store: DevServerLogBufferStore,
+  scriptId: string,
+  logLines: DevServerLogLine[],
+): void => {
+  const buffer = getOrCreateDevServerLogBufferState(store, scriptId);
+  buffer.entries.length = 0;
+  buffer.head = 0;
+  buffer.size = 0;
+  buffer.nextSequence = 0;
+
+  for (const logLine of trimDevServerLogLines(logLines)) {
+    appendDevServerLogLine(store, logLine);
+  }
+};
+
+export const syncDevServerLogBufferStore = (
+  store: DevServerLogBufferStore,
+  state: DevServerGroupState | null,
+): void => {
+  if (!state) {
+    store.clear();
+    return;
+  }
+
+  const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
+  for (const scriptId of store.keys()) {
+    if (!nextScriptIds.has(scriptId)) {
+      store.delete(scriptId);
+    }
+  }
+
+  for (const script of state.scripts) {
+    replaceDevServerLogBuffer(store, script.scriptId, script.bufferedLogLines);
+  }
+};
+
+export const getDevServerLogBuffer = (
+  store: DevServerLogBufferStore,
+  scriptId: string | null,
+): AgentStudioDevServerLogBuffer | null => {
+  if (!scriptId) {
+    return null;
+  }
+
+  const buffer = store.get(scriptId);
+  if (!buffer) {
+    return null;
+  }
+
+  return {
+    entries: buffer.entries,
+    head: buffer.head,
+    size: buffer.size,
+  };
+};
+
+export const getDevServerLogEntryAt = (
+  buffer: AgentStudioDevServerLogBuffer,
+  offset: number,
+): AgentStudioDevServerLogEntry | null => {
+  if (offset < 0 || offset >= buffer.size || buffer.entries.length === 0) {
+    return null;
+  }
+
+  return buffer.entries[(buffer.head + offset) % buffer.entries.length] ?? null;
+};

--- a/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
+++ b/apps/desktop/src/features/agent-studio-build-tools/dev-server-log-buffer.ts
@@ -22,8 +22,6 @@ export type AgentStudioDevServerLogEntry = {
 
 export type AgentStudioDevServerLogBuffer = {
   entries: readonly AgentStudioDevServerLogEntry[];
-  head: number;
-  size: number;
 };
 
 type DevServerLogBufferState = {
@@ -143,9 +141,14 @@ export const getDevServerLogBuffer = (
   }
 
   return {
-    entries: buffer.entries,
-    head: buffer.head,
-    size: buffer.size,
+    entries: Array.from({ length: buffer.size }, (_, offset) => {
+      const entry = buffer.entries[(buffer.head + offset) % MAX_BUFFERED_DEV_SERVER_LOG_LINES];
+      if (!entry) {
+        throw new Error(`Missing dev server log entry at logical offset ${offset}.`);
+      }
+
+      return entry;
+    }),
   };
 };
 
@@ -153,9 +156,9 @@ export const getDevServerLogEntryAt = (
   buffer: AgentStudioDevServerLogBuffer,
   offset: number,
 ): AgentStudioDevServerLogEntry | null => {
-  if (offset < 0 || offset >= buffer.size || buffer.entries.length === 0) {
+  if (offset < 0 || offset >= buffer.entries.length) {
     return null;
   }
 
-  return buffer.entries[(buffer.head + offset) % buffer.entries.length] ?? null;
+  return buffer.entries[offset] ?? null;
 };

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { DevServerGroupState, DevServerScriptState } from "@openducktor/contracts";
 import { act, render, waitFor } from "@testing-library/react";
+import { getDevServerLogEntryAt } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import { QueryProvider } from "@/lib/query-provider";
 import type { RepoSettingsInput } from "@/types/state-slices";
 
@@ -283,6 +284,14 @@ describe("useAgentStudioDevServerPanel", () => {
       }
       return latest;
     };
+    const getSelectedLogText = (): string | undefined => {
+      const selectedLogBuffer = getLatest().selectedScriptLogBuffer;
+      if (!selectedLogBuffer) {
+        return undefined;
+      }
+
+      return getDevServerLogEntryAt(selectedLogBuffer, 0)?.text;
+    };
 
     const Harness = ({ args }: { args: HookArgs }) => {
       latest = useAgentStudioDevServerPanel(args);
@@ -322,10 +331,98 @@ describe("useAgentStudioDevServerPanel", () => {
       });
 
       await waitFor(() => {
-        expect(getLatest().selectedScriptLogBuffer?.size).toBe(1);
+        expect(getLatest().selectedScriptLogBuffer?.entries.length).toBe(1);
       });
       expect(getLatest().selectedScript?.bufferedLogLines).toHaveLength(0);
-      expect(getLatest().selectedScriptLogBuffer?.entries[0]?.text).toBe("ready");
+      expect(getSelectedLogText()).toBe("ready");
+    } finally {
+      view.unmount();
+    }
+  });
+
+  test("preserves newer streamed log lines when mutation state syncs stale query data", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    const runningState = buildState({
+      scripts: [
+        buildScript({
+          status: "running",
+          pid: 4242,
+          startedAt: "2026-03-19T15:30:00.000Z",
+        }),
+      ],
+    });
+
+    devServerGetState = async () => runningState;
+    devServerRestart = async () => runningState;
+
+    let latest: HookResult | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+    const getSelectedLogText = (): string | undefined => {
+      const selectedLogBuffer = getLatest().selectedScriptLogBuffer;
+      if (!selectedLogBuffer) {
+        return undefined;
+      }
+
+      return getDevServerLogEntryAt(selectedLogBuffer, 0)?.text;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getLatest().mode).toBe("active");
+      });
+
+      await act(async () => {
+        devServerEventListener?.({
+          type: "log_line",
+          repoPath: "/repo",
+          taskId: "task-7",
+          logLine: {
+            scriptId: "frontend",
+            stream: "stdout",
+            text: "fresh-line",
+            timestamp: "2026-03-19T15:30:01.000Z",
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(getSelectedLogText()).toBe("fresh-line");
+      });
+
+      await act(async () => {
+        getLatest().onRestart();
+      });
+
+      await waitFor(() => {
+        expect(getLatest().isRestartPending).toBe(false);
+      });
+      expect(getSelectedLogText()).toBe("fresh-line");
     } finally {
       view.unmount();
     }

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.hook.test.tsx
@@ -260,6 +260,77 @@ describe("useAgentStudioDevServerPanel", () => {
     }
   });
 
+  test("stores sanitized log lines in the selected script buffer without rewriting script state", async () => {
+    const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
+    type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];
+    type HookResult = ReturnType<typeof useAgentStudioDevServerPanel>;
+
+    devServerGetState = async () =>
+      buildState({
+        scripts: [
+          buildScript({
+            status: "running",
+            pid: 4242,
+            startedAt: "2026-03-19T15:30:00.000Z",
+          }),
+        ],
+      });
+
+    let latest: HookResult | null = null;
+    const getLatest = (): HookResult => {
+      if (latest === null) {
+        throw new Error("Hook result not ready");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useAgentStudioDevServerPanel(args);
+      return null;
+    };
+
+    const view = render(
+      <QueryProvider useIsolatedClient>
+        <Harness
+          args={{
+            repoPath: "/repo",
+            taskId: "task-7",
+            repoSettings,
+            enabled: true,
+          }}
+        />
+      </QueryProvider>,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(getLatest().mode).toBe("active");
+      });
+
+      await act(async () => {
+        devServerEventListener?.({
+          type: "log_line",
+          repoPath: "/repo",
+          taskId: "task-7",
+          logLine: {
+            scriptId: "frontend",
+            stream: "stdout",
+            text: "\u001b[32mready\u001b[0m",
+            timestamp: "2026-03-19T15:30:01.000Z",
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(getLatest().selectedScriptLogBuffer?.size).toBe(1);
+      });
+      expect(getLatest().selectedScript?.bufferedLogLines).toHaveLength(0);
+      expect(getLatest().selectedScriptLogBuffer?.entries[0]?.text).toBe("ready");
+    } finally {
+      view.unmount();
+    }
+  });
+
   test("reopens in loading mode until a fresh dev-server refetch completes", async () => {
     const { useAgentStudioDevServerPanel } = await import("./use-agent-studio-dev-server-panel");
     type HookArgs = Parameters<typeof useAgentStudioDevServerPanel>[0];

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.test.ts
@@ -33,7 +33,7 @@ const buildState = (overrides: Partial<DevServerGroupState> = {}): DevServerGrou
 });
 
 describe("useAgentStudioDevServerPanel helpers", () => {
-  test("applies log line events and preserves the latest 2000 lines", () => {
+  test("applies log line events without cloning script log buffers into state", () => {
     const initialLogs = Array.from({ length: 2_000 }, (_, index) => ({
       scriptId: "frontend",
       stream: "stdout" as const,
@@ -57,9 +57,9 @@ describe("useAgentStudioDevServerPanel helpers", () => {
 
     const nextState = applyDevServerEventToState(state, event);
 
-    expect(nextState?.scripts[0]?.bufferedLogLines).toHaveLength(2_000);
-    expect(nextState?.scripts[0]?.bufferedLogLines[0]?.text).toBe("line-1");
-    expect(nextState?.scripts[0]?.bufferedLogLines.at(-1)?.text).toBe("latest-line");
+    expect(nextState?.scripts).toBe(state.scripts);
+    expect(nextState?.scripts[0]?.bufferedLogLines).toBe(initialLogs);
+    expect(nextState?.updatedAt).toBe("2026-03-19T15:31:00.000Z");
   });
 
   test("selects the remembered tab when it still exists", () => {

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -8,6 +8,8 @@ import { devServerEventSchema } from "@openducktor/contracts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
+  AgentStudioDevServerLogBuffer,
+  AgentStudioDevServerLogEntry,
   AgentStudioDevServerPanelMode,
   AgentStudioDevServerPanelModel,
 } from "@/components/features/agents/agent-studio-dev-server-panel";
@@ -26,14 +28,126 @@ type UseAgentStudioDevServerPanelArgs = {
 };
 
 type SelectedScriptMemory = Map<string, string>;
+type ScriptLogBuffer = {
+  entries: AgentStudioDevServerLogEntry[];
+  head: number;
+  size: number;
+  nextSequence: number;
+};
+type ScriptLogBufferStore = Map<string, ScriptLogBuffer>;
 
 const buildTaskMemoryKey = (repoPath: string, taskId: string): string => `${repoPath}::${taskId}`;
+const ESC = String.fromCharCode(27);
+const CSI = String.fromCharCode(155);
+const ANSI_ESCAPE_SEQUENCE = new RegExp(
+  `(?:${ESC}\\[[0-?]*[ -/]*[@-~])|(?:${CSI}[0-?]*[ -/]*[@-~])|(?:\\uFFFD\\[[0-9;]*[A-Za-z])`,
+  "g",
+);
 
 const trimDevServerLogLines = (lines: DevServerLogLine[]): DevServerLogLine[] => {
   if (lines.length <= MAX_BUFFERED_LOG_LINES) {
     return lines;
   }
   return lines.slice(-MAX_BUFFERED_LOG_LINES);
+};
+
+const sanitizeLogText = (text: string): string => text.replace(ANSI_ESCAPE_SEQUENCE, "");
+
+const createScriptLogBuffer = (): ScriptLogBuffer => ({
+  entries: [],
+  head: 0,
+  size: 0,
+  nextSequence: 0,
+});
+
+const getOrCreateScriptLogBuffer = (
+  buffers: ScriptLogBufferStore,
+  scriptId: string,
+): ScriptLogBuffer => {
+  const existingBuffer = buffers.get(scriptId);
+  if (existingBuffer) {
+    return existingBuffer;
+  }
+
+  const nextBuffer = createScriptLogBuffer();
+  buffers.set(scriptId, nextBuffer);
+  return nextBuffer;
+};
+
+const appendScriptLogLine = (
+  buffers: ScriptLogBufferStore,
+  logLine: DevServerLogLine,
+): ScriptLogBuffer => {
+  const buffer = getOrCreateScriptLogBuffer(buffers, logLine.scriptId);
+  const entry: AgentStudioDevServerLogEntry = {
+    id: `${logLine.scriptId}:${buffer.nextSequence}`,
+    timestamp: logLine.timestamp,
+    stream: logLine.stream,
+    text: sanitizeLogText(logLine.text),
+  };
+  buffer.nextSequence += 1;
+
+  if (buffer.size < MAX_BUFFERED_LOG_LINES) {
+    const insertionIndex = (buffer.head + buffer.size) % MAX_BUFFERED_LOG_LINES;
+    buffer.entries[insertionIndex] = entry;
+    buffer.size += 1;
+    return buffer;
+  }
+
+  buffer.entries[buffer.head] = entry;
+  buffer.head = (buffer.head + 1) % MAX_BUFFERED_LOG_LINES;
+  return buffer;
+};
+
+const resetScriptLogBuffer = (
+  buffers: ScriptLogBufferStore,
+  scriptId: string,
+  logLines: DevServerLogLine[],
+): ScriptLogBuffer => {
+  const buffer = getOrCreateScriptLogBuffer(buffers, scriptId);
+  buffer.entries.length = 0;
+  buffer.head = 0;
+  buffer.size = 0;
+  buffer.nextSequence = 0;
+
+  for (const logLine of trimDevServerLogLines(logLines)) {
+    appendScriptLogLine(buffers, logLine);
+  }
+
+  return buffer;
+};
+
+const syncScriptLogBuffers = (
+  buffers: ScriptLogBufferStore,
+  state: DevServerGroupState | null,
+): void => {
+  if (!state) {
+    buffers.clear();
+    return;
+  }
+
+  const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
+  for (const scriptId of buffers.keys()) {
+    if (!nextScriptIds.has(scriptId)) {
+      buffers.delete(scriptId);
+    }
+  }
+
+  for (const script of state.scripts) {
+    resetScriptLogBuffer(buffers, script.scriptId, script.bufferedLogLines);
+  }
+};
+
+const toLogBufferView = (buffer: ScriptLogBuffer | null): AgentStudioDevServerLogBuffer | null => {
+  if (!buffer) {
+    return null;
+  }
+
+  return {
+    entries: buffer.entries,
+    head: buffer.head,
+    size: buffer.size,
+  };
 };
 
 const replaceScript = (
@@ -74,16 +188,7 @@ export const applyDevServerEventToState = (
   return {
     ...state,
     updatedAt: event.logLine.timestamp,
-    scripts: state.scripts.map((script) => {
-      if (script.scriptId !== event.logLine.scriptId) {
-        return script;
-      }
-
-      return {
-        ...script,
-        bufferedLogLines: trimDevServerLogLines([...script.bufferedLogLines, event.logLine]),
-      };
-    }),
+    scripts: state.scripts,
   };
 };
 
@@ -145,9 +250,12 @@ export function useAgentStudioDevServerPanel({
 }: UseAgentStudioDevServerPanelArgs): AgentStudioDevServerPanelModel {
   const queryClient = useQueryClient();
   const selectionMemoryRef = useRef<SelectedScriptMemory>(new Map());
+  const logBuffersRef = useRef<ScriptLogBufferStore>(new Map());
   const previousTaskMemoryKeyRef = useRef<string | null | undefined>(undefined);
+  const selectedScriptIdRef = useRef<string | null>(null);
   const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
   const [liveState, setLiveState] = useState<DevServerGroupState | null>(null);
+  const [selectedScriptLogRevision, setSelectedScriptLogRevision] = useState(0);
   const [actionError, setActionError] = useState<string | null>(null);
   const [subscriptionError, setSubscriptionError] = useState<string | null>(null);
 
@@ -211,17 +319,42 @@ export function useAgentStudioDevServerPanel({
         return;
       }
 
-      const queryKey = devServerQueryKeys.state(repoPath, taskId);
-      const cachedState = queryClient.getQueryData<DevServerGroupState>(queryKey) ?? null;
-      setLiveState((current) => {
-        const scopedCurrent =
-          current && current.repoPath === repoPath && current.taskId === taskId ? current : null;
-        const nextState = applyDevServerEventToState(cachedState ?? scopedCurrent, event);
-        if (nextState) {
-          queryClient.setQueryData(queryKey, nextState);
-        }
-        return nextState;
-      });
+      if (event.type === "snapshot") {
+        syncScriptLogBuffers(logBuffersRef.current, event.state);
+      } else if (event.type === "script_status_changed") {
+        resetScriptLogBuffer(
+          logBuffersRef.current,
+          event.script.scriptId,
+          event.script.bufferedLogLines,
+        );
+      } else {
+        appendScriptLogLine(logBuffersRef.current, event.logLine);
+      }
+
+      if (event.type !== "log_line") {
+        const queryKey = devServerQueryKeys.state(repoPath, taskId);
+        const cachedState = queryClient.getQueryData<DevServerGroupState>(queryKey) ?? null;
+        setLiveState((current) => {
+          const scopedCurrent =
+            current && current.repoPath === repoPath && current.taskId === taskId ? current : null;
+          const nextState = applyDevServerEventToState(cachedState ?? scopedCurrent, event);
+          if (nextState) {
+            queryClient.setQueryData(queryKey, nextState);
+          }
+          return nextState;
+        });
+      }
+
+      const selectedId = selectedScriptIdRef.current;
+      const touchedScriptId =
+        event.type === "snapshot"
+          ? selectedId
+          : event.type === "script_status_changed"
+            ? event.script.scriptId
+            : event.logLine.scriptId;
+      if (selectedId && touchedScriptId === selectedId) {
+        setSelectedScriptLogRevision((revision) => revision + 1);
+      }
     },
     [queryClient, repoPath, taskId],
   );
@@ -231,17 +364,21 @@ export function useAgentStudioDevServerPanel({
     previousTaskMemoryKeyRef.current = taskMemoryKey;
 
     if (scopeChanged) {
+      logBuffersRef.current.clear();
       setLiveState(null);
       setSelectedScriptId(null);
+      setSelectedScriptLogRevision(0);
       setActionError(null);
       setSubscriptionError(null);
     }
 
     if (!queryEnabled) {
+      logBuffersRef.current.clear();
       setLiveState(null);
       setActionError(null);
       setSubscriptionError(null);
       setSelectedScriptId(null);
+      setSelectedScriptLogRevision(0);
       return;
     }
 
@@ -250,7 +387,9 @@ export function useAgentStudioDevServerPanel({
       stateQuery.data &&
       stateQuery.dataUpdatedAt >= queryActivationState.since
     ) {
+      syncScriptLogBuffers(logBuffersRef.current, stateQuery.data);
       setLiveState(stateQuery.data);
+      setSelectedScriptLogRevision((revision) => revision + 1);
     }
   }, [
     queryActivationState.enabled,
@@ -267,8 +406,10 @@ export function useAgentStudioDevServerPanel({
         return;
       }
 
+      syncScriptLogBuffers(logBuffersRef.current, nextState);
       queryClient.setQueryData(devServerQueryKeys.state(repoPath, taskId), nextState);
       setLiveState(nextState);
+      setSelectedScriptLogRevision((revision) => revision + 1);
     },
     [queryClient, repoPath, taskId],
   );
@@ -382,6 +523,10 @@ export function useAgentStudioDevServerPanel({
   );
 
   useEffect(() => {
+    selectedScriptIdRef.current = effectiveSelectedScriptId;
+  }, [effectiveSelectedScriptId]);
+
+  useEffect(() => {
     if (!shouldSubscribeToEvents || repoPath === null || taskId === null) {
       return;
     }
@@ -462,6 +607,13 @@ export function useAgentStudioDevServerPanel({
 
   const selectedScript =
     effectiveState?.scripts.find((script) => script.scriptId === effectiveSelectedScriptId) ?? null;
+  const selectedScriptLogBuffer = useMemo(
+    () =>
+      effectiveSelectedScriptId
+        ? toLogBufferView(logBuffersRef.current.get(effectiveSelectedScriptId) ?? null)
+        : null,
+    [effectiveSelectedScriptId, selectedScriptLogRevision],
+  );
   const isExpanded = isDevServerPanelExpanded(
     effectiveState?.scripts ?? [],
     startMutation.isPending || restartMutation.isPending,
@@ -513,6 +665,7 @@ export function useAgentStudioDevServerPanel({
     scripts: effectiveState?.scripts ?? [],
     selectedScriptId: effectiveSelectedScriptId,
     selectedScript,
+    selectedScriptLogBuffer,
     error,
     isStartPending: startMutation.isPending,
     isStopPending: stopMutation.isPending,

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -204,6 +204,14 @@ export function useAgentStudioDevServerPanel({
     setSelectedScriptLogBuffer(getDevServerLogBuffer(logBuffersRef.current, scriptId));
   }, []);
 
+  const hydrateLogBuffersFromState = useCallback((state: DevServerGroupState | null): void => {
+    if (logBuffersRef.current.size > 0) {
+      return;
+    }
+
+    syncDevServerLogBufferStore(logBuffersRef.current, state);
+  }, []);
+
   const syncStateFromEvent = useCallback(
     (event: DevServerEvent): void => {
       if (!repoPath || !taskId) {
@@ -278,11 +286,12 @@ export function useAgentStudioDevServerPanel({
       stateQuery.data &&
       stateQuery.dataUpdatedAt >= queryActivationState.since
     ) {
-      syncDevServerLogBufferStore(logBuffersRef.current, stateQuery.data);
+      hydrateLogBuffersFromState(stateQuery.data);
       setLiveState(stateQuery.data);
       syncSelectedScriptLogBuffer(selectedScriptIdRef.current);
     }
   }, [
+    hydrateLogBuffersFromState,
     queryActivationState.enabled,
     queryActivationState.since,
     queryEnabled,
@@ -298,12 +307,12 @@ export function useAgentStudioDevServerPanel({
         return;
       }
 
-      syncDevServerLogBufferStore(logBuffersRef.current, nextState);
+      hydrateLogBuffersFromState(nextState);
       queryClient.setQueryData(devServerQueryKeys.state(repoPath, taskId), nextState);
       setLiveState(nextState);
       syncSelectedScriptLogBuffer(selectedScriptIdRef.current);
     },
-    [queryClient, repoPath, syncSelectedScriptLogBuffer, taskId],
+    [hydrateLogBuffersFromState, queryClient, repoPath, syncSelectedScriptLogBuffer, taskId],
   );
 
   const invalidateState = useCallback((): void => {

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -5,7 +5,7 @@ import type {
 } from "@openducktor/contracts";
 import { devServerEventSchema } from "@openducktor/contracts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
   AgentStudioDevServerPanelMode,
   AgentStudioDevServerPanelModel,
@@ -423,7 +423,7 @@ export function useAgentStudioDevServerPanel({
     [effectiveState?.scripts, rememberedScriptId, selectedScriptId],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     selectedScriptIdRef.current = effectiveSelectedScriptId;
     syncSelectedScriptLogBuffer(effectiveSelectedScriptId);
   }, [effectiveSelectedScriptId, syncSelectedScriptLogBuffer]);

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -6,19 +6,20 @@ import type {
 import { devServerEventSchema } from "@openducktor/contracts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { DevServerLogBufferStore } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
+import type {
+  AgentStudioDevServerPanelMode,
+  AgentStudioDevServerPanelModel,
+} from "@/components/features/agents/agent-studio-dev-server-panel";
 import {
+  type AgentStudioDevServerLogBuffer,
   appendDevServerLogLine,
   createDevServerLogBufferStore,
+  type DevServerLogBufferStore,
   getDevServerLogBuffer,
   replaceDevServerLogBuffer,
   syncDevServerLogBufferStore,
   trimDevServerLogLines,
 } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
-import type {
-  AgentStudioDevServerPanelMode,
-  AgentStudioDevServerPanelModel,
-} from "@/components/features/agents/agent-studio-dev-server-panel";
 import { errorMessage } from "@/lib/errors";
 import { hostClient, subscribeDevServerEvents } from "@/lib/host-client";
 import { devServerGroupStateQueryOptions, devServerQueryKeys } from "@/state/queries/dev-servers";
@@ -140,7 +141,8 @@ export function useAgentStudioDevServerPanel({
   const selectedScriptIdRef = useRef<string | null>(null);
   const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
   const [liveState, setLiveState] = useState<DevServerGroupState | null>(null);
-  const [selectedScriptLogRevision, setSelectedScriptLogRevision] = useState(0);
+  const [selectedScriptLogBuffer, setSelectedScriptLogBuffer] =
+    useState<AgentStudioDevServerLogBuffer | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [subscriptionError, setSubscriptionError] = useState<string | null>(null);
 
@@ -198,6 +200,10 @@ export function useAgentStudioDevServerPanel({
     taskId,
   ]);
 
+  const syncSelectedScriptLogBuffer = useCallback((scriptId: string | null): void => {
+    setSelectedScriptLogBuffer(getDevServerLogBuffer(logBuffersRef.current, scriptId));
+  }, []);
+
   const syncStateFromEvent = useCallback(
     (event: DevServerEvent): void => {
       if (!repoPath || !taskId) {
@@ -238,10 +244,10 @@ export function useAgentStudioDevServerPanel({
             ? event.script.scriptId
             : event.logLine.scriptId;
       if (selectedId && touchedScriptId === selectedId) {
-        setSelectedScriptLogRevision((revision) => revision + 1);
+        syncSelectedScriptLogBuffer(selectedId);
       }
     },
-    [queryClient, repoPath, taskId],
+    [queryClient, repoPath, syncSelectedScriptLogBuffer, taskId],
   );
 
   useEffect(() => {
@@ -252,7 +258,7 @@ export function useAgentStudioDevServerPanel({
       logBuffersRef.current.clear();
       setLiveState(null);
       setSelectedScriptId(null);
-      setSelectedScriptLogRevision(0);
+      setSelectedScriptLogBuffer(null);
       setActionError(null);
       setSubscriptionError(null);
     }
@@ -263,7 +269,7 @@ export function useAgentStudioDevServerPanel({
       setActionError(null);
       setSubscriptionError(null);
       setSelectedScriptId(null);
-      setSelectedScriptLogRevision(0);
+      setSelectedScriptLogBuffer(null);
       return;
     }
 
@@ -274,12 +280,13 @@ export function useAgentStudioDevServerPanel({
     ) {
       syncDevServerLogBufferStore(logBuffersRef.current, stateQuery.data);
       setLiveState(stateQuery.data);
-      setSelectedScriptLogRevision((revision) => revision + 1);
+      syncSelectedScriptLogBuffer(selectedScriptIdRef.current);
     }
   }, [
     queryActivationState.enabled,
     queryActivationState.since,
     queryEnabled,
+    syncSelectedScriptLogBuffer,
     stateQuery.data,
     stateQuery.dataUpdatedAt,
     taskMemoryKey,
@@ -294,9 +301,9 @@ export function useAgentStudioDevServerPanel({
       syncDevServerLogBufferStore(logBuffersRef.current, nextState);
       queryClient.setQueryData(devServerQueryKeys.state(repoPath, taskId), nextState);
       setLiveState(nextState);
-      setSelectedScriptLogRevision((revision) => revision + 1);
+      syncSelectedScriptLogBuffer(selectedScriptIdRef.current);
     },
-    [queryClient, repoPath, taskId],
+    [queryClient, repoPath, syncSelectedScriptLogBuffer, taskId],
   );
 
   const invalidateState = useCallback((): void => {
@@ -409,7 +416,8 @@ export function useAgentStudioDevServerPanel({
 
   useEffect(() => {
     selectedScriptIdRef.current = effectiveSelectedScriptId;
-  }, [effectiveSelectedScriptId]);
+    syncSelectedScriptLogBuffer(effectiveSelectedScriptId);
+  }, [effectiveSelectedScriptId, syncSelectedScriptLogBuffer]);
 
   useEffect(() => {
     if (!shouldSubscribeToEvents || repoPath === null || taskId === null) {
@@ -492,10 +500,6 @@ export function useAgentStudioDevServerPanel({
 
   const selectedScript =
     effectiveState?.scripts.find((script) => script.scriptId === effectiveSelectedScriptId) ?? null;
-  const selectedScriptLogBuffer = useMemo(
-    () => getDevServerLogBuffer(logBuffersRef.current, effectiveSelectedScriptId),
-    [effectiveSelectedScriptId, selectedScriptLogRevision],
-  );
   const isExpanded = isDevServerPanelExpanded(
     effectiveState?.scripts ?? [],
     startMutation.isPending || restartMutation.isPending,

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel.ts
@@ -1,15 +1,21 @@
 import type {
   DevServerEvent,
   DevServerGroupState,
-  DevServerLogLine,
   DevServerScriptState,
 } from "@openducktor/contracts";
 import { devServerEventSchema } from "@openducktor/contracts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { DevServerLogBufferStore } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
+import {
+  appendDevServerLogLine,
+  createDevServerLogBufferStore,
+  getDevServerLogBuffer,
+  replaceDevServerLogBuffer,
+  syncDevServerLogBufferStore,
+  trimDevServerLogLines,
+} from "@/features/agent-studio-build-tools/dev-server-log-buffer";
 import type {
-  AgentStudioDevServerLogBuffer,
-  AgentStudioDevServerLogEntry,
   AgentStudioDevServerPanelMode,
   AgentStudioDevServerPanelModel,
 } from "@/components/features/agents/agent-studio-dev-server-panel";
@@ -17,8 +23,6 @@ import { errorMessage } from "@/lib/errors";
 import { hostClient, subscribeDevServerEvents } from "@/lib/host-client";
 import { devServerGroupStateQueryOptions, devServerQueryKeys } from "@/state/queries/dev-servers";
 import type { RepoSettingsInput } from "@/types/state-slices";
-
-const MAX_BUFFERED_LOG_LINES = 2_000;
 
 type UseAgentStudioDevServerPanelArgs = {
   repoPath: string | null;
@@ -28,127 +32,8 @@ type UseAgentStudioDevServerPanelArgs = {
 };
 
 type SelectedScriptMemory = Map<string, string>;
-type ScriptLogBuffer = {
-  entries: AgentStudioDevServerLogEntry[];
-  head: number;
-  size: number;
-  nextSequence: number;
-};
-type ScriptLogBufferStore = Map<string, ScriptLogBuffer>;
 
 const buildTaskMemoryKey = (repoPath: string, taskId: string): string => `${repoPath}::${taskId}`;
-const ESC = String.fromCharCode(27);
-const CSI = String.fromCharCode(155);
-const ANSI_ESCAPE_SEQUENCE = new RegExp(
-  `(?:${ESC}\\[[0-?]*[ -/]*[@-~])|(?:${CSI}[0-?]*[ -/]*[@-~])|(?:\\uFFFD\\[[0-9;]*[A-Za-z])`,
-  "g",
-);
-
-const trimDevServerLogLines = (lines: DevServerLogLine[]): DevServerLogLine[] => {
-  if (lines.length <= MAX_BUFFERED_LOG_LINES) {
-    return lines;
-  }
-  return lines.slice(-MAX_BUFFERED_LOG_LINES);
-};
-
-const sanitizeLogText = (text: string): string => text.replace(ANSI_ESCAPE_SEQUENCE, "");
-
-const createScriptLogBuffer = (): ScriptLogBuffer => ({
-  entries: [],
-  head: 0,
-  size: 0,
-  nextSequence: 0,
-});
-
-const getOrCreateScriptLogBuffer = (
-  buffers: ScriptLogBufferStore,
-  scriptId: string,
-): ScriptLogBuffer => {
-  const existingBuffer = buffers.get(scriptId);
-  if (existingBuffer) {
-    return existingBuffer;
-  }
-
-  const nextBuffer = createScriptLogBuffer();
-  buffers.set(scriptId, nextBuffer);
-  return nextBuffer;
-};
-
-const appendScriptLogLine = (
-  buffers: ScriptLogBufferStore,
-  logLine: DevServerLogLine,
-): ScriptLogBuffer => {
-  const buffer = getOrCreateScriptLogBuffer(buffers, logLine.scriptId);
-  const entry: AgentStudioDevServerLogEntry = {
-    id: `${logLine.scriptId}:${buffer.nextSequence}`,
-    timestamp: logLine.timestamp,
-    stream: logLine.stream,
-    text: sanitizeLogText(logLine.text),
-  };
-  buffer.nextSequence += 1;
-
-  if (buffer.size < MAX_BUFFERED_LOG_LINES) {
-    const insertionIndex = (buffer.head + buffer.size) % MAX_BUFFERED_LOG_LINES;
-    buffer.entries[insertionIndex] = entry;
-    buffer.size += 1;
-    return buffer;
-  }
-
-  buffer.entries[buffer.head] = entry;
-  buffer.head = (buffer.head + 1) % MAX_BUFFERED_LOG_LINES;
-  return buffer;
-};
-
-const resetScriptLogBuffer = (
-  buffers: ScriptLogBufferStore,
-  scriptId: string,
-  logLines: DevServerLogLine[],
-): ScriptLogBuffer => {
-  const buffer = getOrCreateScriptLogBuffer(buffers, scriptId);
-  buffer.entries.length = 0;
-  buffer.head = 0;
-  buffer.size = 0;
-  buffer.nextSequence = 0;
-
-  for (const logLine of trimDevServerLogLines(logLines)) {
-    appendScriptLogLine(buffers, logLine);
-  }
-
-  return buffer;
-};
-
-const syncScriptLogBuffers = (
-  buffers: ScriptLogBufferStore,
-  state: DevServerGroupState | null,
-): void => {
-  if (!state) {
-    buffers.clear();
-    return;
-  }
-
-  const nextScriptIds = new Set(state.scripts.map((script) => script.scriptId));
-  for (const scriptId of buffers.keys()) {
-    if (!nextScriptIds.has(scriptId)) {
-      buffers.delete(scriptId);
-    }
-  }
-
-  for (const script of state.scripts) {
-    resetScriptLogBuffer(buffers, script.scriptId, script.bufferedLogLines);
-  }
-};
-
-const toLogBufferView = (buffer: ScriptLogBuffer | null): AgentStudioDevServerLogBuffer | null => {
-  if (!buffer) {
-    return null;
-  }
-
-  return {
-    entries: buffer.entries,
-    head: buffer.head,
-    size: buffer.size,
-  };
-};
 
 const replaceScript = (
   scripts: DevServerScriptState[],
@@ -250,7 +135,7 @@ export function useAgentStudioDevServerPanel({
 }: UseAgentStudioDevServerPanelArgs): AgentStudioDevServerPanelModel {
   const queryClient = useQueryClient();
   const selectionMemoryRef = useRef<SelectedScriptMemory>(new Map());
-  const logBuffersRef = useRef<ScriptLogBufferStore>(new Map());
+  const logBuffersRef = useRef<DevServerLogBufferStore>(createDevServerLogBufferStore());
   const previousTaskMemoryKeyRef = useRef<string | null | undefined>(undefined);
   const selectedScriptIdRef = useRef<string | null>(null);
   const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
@@ -320,15 +205,15 @@ export function useAgentStudioDevServerPanel({
       }
 
       if (event.type === "snapshot") {
-        syncScriptLogBuffers(logBuffersRef.current, event.state);
+        syncDevServerLogBufferStore(logBuffersRef.current, event.state);
       } else if (event.type === "script_status_changed") {
-        resetScriptLogBuffer(
+        replaceDevServerLogBuffer(
           logBuffersRef.current,
           event.script.scriptId,
           event.script.bufferedLogLines,
         );
       } else {
-        appendScriptLogLine(logBuffersRef.current, event.logLine);
+        appendDevServerLogLine(logBuffersRef.current, event.logLine);
       }
 
       if (event.type !== "log_line") {
@@ -387,7 +272,7 @@ export function useAgentStudioDevServerPanel({
       stateQuery.data &&
       stateQuery.dataUpdatedAt >= queryActivationState.since
     ) {
-      syncScriptLogBuffers(logBuffersRef.current, stateQuery.data);
+      syncDevServerLogBufferStore(logBuffersRef.current, stateQuery.data);
       setLiveState(stateQuery.data);
       setSelectedScriptLogRevision((revision) => revision + 1);
     }
@@ -406,7 +291,7 @@ export function useAgentStudioDevServerPanel({
         return;
       }
 
-      syncScriptLogBuffers(logBuffersRef.current, nextState);
+      syncDevServerLogBufferStore(logBuffersRef.current, nextState);
       queryClient.setQueryData(devServerQueryKeys.state(repoPath, taskId), nextState);
       setLiveState(nextState);
       setSelectedScriptLogRevision((revision) => revision + 1);
@@ -608,10 +493,7 @@ export function useAgentStudioDevServerPanel({
   const selectedScript =
     effectiveState?.scripts.find((script) => script.scriptId === effectiveSelectedScriptId) ?? null;
   const selectedScriptLogBuffer = useMemo(
-    () =>
-      effectiveSelectedScriptId
-        ? toLogBufferView(logBuffersRef.current.get(effectiveSelectedScriptId) ?? null)
-        : null,
+    () => getDevServerLogBuffer(logBuffersRef.current, effectiveSelectedScriptId),
     [effectiveSelectedScriptId, selectedScriptLogRevision],
   );
   const isExpanded = isDevServerPanelExpanded(

--- a/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-right-panel.test.tsx
@@ -104,6 +104,7 @@ const devServerModel: AgentStudioDevServerPanelModel = {
   scripts: [],
   selectedScriptId: null,
   selectedScript: null,
+  selectedScriptLogBuffer: null,
   error: null,
   isStartPending: false,
   isStopPending: false,


### PR DESCRIPTION
## Summary
- replace O(n) dev-server log appends with a per-script ring buffer and pre-sanitized log entries
- extract the dev-server log buffer/store into a dedicated feature utility with direct tests
- stabilize selected log state in React and isolate the selected log viewport rendering path

## What Changed
- moved live dev-server log ingestion off the old `bufferedLogLines` clone-on-append path in the Agent Studio right panel hook
- added a dedicated `dev-server-log-buffer` utility to own trimming, sanitization, ring-buffer rotation, store sync, and indexed log access
- updated the dev-server panel to consume the extracted buffer utility instead of re-sanitizing and re-keying log rows during render
- removed the hidden selected-log revision coupling by storing the selected script log buffer explicitly in React state
- added focused tests for the extracted buffer utility and updated the existing panel/right-panel tests to match the new log model
- completed the review follow-up by making the desktop lint suite clean again

## Verification
- `bun run lint`
- `bun run test`
- `bun run typecheck`
- `bun run build`
- `bun run check:rust`
- `bun run test:rust`

## Notes
- Bun workspace checks and Cargo workspace checks are green on this branch.
- The desktop build still reports Vite chunk-size warnings, but the build completes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev server panel now streams and displays a bounded, efficient log buffer for the selected script, improving responsiveness and memory usage.
  * Selected-script log output and failure styling are now reflected consistently in the right-hand panel.

* **Bug Fixes**
  * Centralized log sanitization for consistent, readable log text (removes stray ANSI/control sequences).

* **Tests**
  * Added thorough tests for log buffering, sync, and UI integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->