### PR TITLE
fix(agents): preserve rejected QA lane in ai_review

### DIFF
--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
@@ -493,6 +493,84 @@ describe("agents-page-session-tabs", () => {
     });
   });
 
+  test("keeps qa step rejected in ai_review when no new qa review session has started", () => {
+    const task = buildTask({
+      issueType: "feature",
+      status: "ai_review",
+      documentSummary: {
+        spec: { has: true, updatedAt: "2026-02-22T08:00:00.000Z" },
+        plan: { has: true, updatedAt: "2026-02-22T08:10:00.000Z" },
+        qaReport: { has: true, updatedAt: "2026-02-22T08:20:00.000Z", verdict: "rejected" },
+      },
+      agentWorkflows: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: true, completed: true },
+        builder: { required: true, canSkip: false, available: true, completed: true },
+        qa: { required: true, canSkip: false, available: true, completed: false },
+      },
+    });
+
+    const states = buildWorkflowStateByRole({
+      task,
+      roleWorkflowsByTask: {
+        spec: task.agentWorkflows.spec,
+        planner: task.agentWorkflows.planner,
+        build: task.agentWorkflows.builder,
+        qa: task.agentWorkflows.qa,
+      },
+      roleSessionByRole: buildRoleSessionSummaryMap([
+        buildSession({ role: "build", status: "stopped", scenario: "build_after_qa_rejected" }),
+        buildSession({ role: "qa", status: "idle", scenario: "qa_review" }),
+      ]),
+    });
+
+    expect(states.qa).toEqual({
+      tone: "rejected",
+      availability: "available",
+      completion: "rejected",
+      liveSession: "idle",
+    });
+  });
+
+  test("shows qa step as active in ai_review when a new qa review session is running", () => {
+    const task = buildTask({
+      issueType: "feature",
+      status: "ai_review",
+      documentSummary: {
+        spec: { has: true, updatedAt: "2026-02-22T08:00:00.000Z" },
+        plan: { has: true, updatedAt: "2026-02-22T08:10:00.000Z" },
+        qaReport: { has: true, updatedAt: "2026-02-22T08:20:00.000Z", verdict: "rejected" },
+      },
+      agentWorkflows: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: true, completed: true },
+        builder: { required: true, canSkip: false, available: true, completed: true },
+        qa: { required: true, canSkip: false, available: true, completed: false },
+      },
+    });
+
+    const states = buildWorkflowStateByRole({
+      task,
+      roleWorkflowsByTask: {
+        spec: task.agentWorkflows.spec,
+        planner: task.agentWorkflows.planner,
+        build: task.agentWorkflows.builder,
+        qa: task.agentWorkflows.qa,
+      },
+      roleSessionByRole: buildRoleSessionSummaryMap([
+        buildSession({ role: "build", status: "stopped", scenario: "build_after_qa_rejected" }),
+        buildSession({ role: "qa", status: "running", scenario: "qa_review" }),
+      ]),
+    });
+
+    expect(states.qa).toEqual({
+      tone: "in_progress",
+      availability: "available",
+      completion: "in_progress",
+      liveSession: "running",
+    });
+  });
+
   test("keeps builder done after completed qa-rework session even before task status catches up", () => {
     const task = buildTask({
       status: "in_progress",

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
@@ -532,7 +532,31 @@ describe("agents-page-session-tabs", () => {
     });
   });
 
-  test("shows qa step as active in ai_review when a new qa review session is running", () => {
+  test.each([
+    {
+      name: "running",
+      session: buildSession({ role: "qa", status: "running", scenario: "qa_review" }),
+      expected: { tone: "in_progress" as const, liveSession: "running" as const },
+    },
+    {
+      name: "waiting_input",
+      session: buildSession({
+        role: "qa",
+        status: "running",
+        scenario: "qa_review",
+        pendingQuestions: [{ requestId: "q-1", questions: [] }],
+      }),
+      expected: { tone: "waiting_input" as const, liveSession: "waiting_input" as const },
+    },
+    {
+      name: "error",
+      session: buildSession({ role: "qa", status: "error", scenario: "qa_review" }),
+      expected: { tone: "failed" as const, liveSession: "error" as const },
+    },
+  ])("shows qa step as active in ai_review when a new qa review session is $name", ({
+    session,
+    expected,
+  }) => {
     const task = buildTask({
       issueType: "feature",
       status: "ai_review",
@@ -559,15 +583,15 @@ describe("agents-page-session-tabs", () => {
       },
       roleSessionByRole: buildRoleSessionSummaryMap([
         buildSession({ role: "build", status: "stopped", scenario: "build_after_qa_rejected" }),
-        buildSession({ role: "qa", status: "running", scenario: "qa_review" }),
+        session,
       ]),
     });
 
     expect(states.qa).toEqual({
-      tone: "in_progress",
+      tone: expected.tone,
       availability: "available",
       completion: "in_progress",
-      liveSession: "running",
+      liveSession: expected.liveSession,
     });
   });
 

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -242,7 +242,8 @@ export const buildWorkflowStateByRole = (params: {
   };
   const qaRejected = isQaRejectedTask(params.task);
   const qaRejectedInAiReview =
-    params.task?.status === "ai_review" &&
+    params.task &&
+    params.task.status === "ai_review" &&
     params.task.documentSummary.qaReport.verdict === "rejected";
 
   for (const role of ALL_AGENT_ROLES) {
@@ -251,9 +252,8 @@ export const buildWorkflowStateByRole = (params: {
     const availability = deriveWorkflowAvailability(workflow);
     const latestRoleSession = sessionSummary.latestSession;
     const liveSession = sessionSummary.liveSession;
-    const hasActiveQaSession =
-      role === "qa" &&
-      (liveSession === "running" || liveSession === "waiting_input" || liveSession === "error");
+    const isLiveSessionActive =
+      liveSession === "running" || liveSession === "waiting_input" || liveSession === "error";
     let completion: AgentWorkflowStepState["completion"] = "not_started";
 
     if (role === "build" && qaRejected) {
@@ -266,14 +266,14 @@ export const buildWorkflowStateByRole = (params: {
       !qaRejected
     ) {
       completion = "done";
-    } else if (role === "qa" && (qaRejected || (qaRejectedInAiReview && !hasActiveQaSession))) {
+    } else if (role === "qa" && qaRejected) {
+      completion = "rejected";
+    } else if (role === "qa" && qaRejectedInAiReview && !isLiveSessionActive) {
       completion = "rejected";
     } else if (workflow.completed) {
       completion = "done";
     } else if (
-      liveSession === "waiting_input" ||
-      liveSession === "running" ||
-      liveSession === "error" ||
+      isLiveSessionActive ||
       (liveSession === "idle" && workflow.available) ||
       (role === "build" && liveSession === "stopped" && workflow.available)
     ) {

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -241,6 +241,9 @@ export const buildWorkflowStateByRole = (params: {
     },
   };
   const qaRejected = isQaRejectedTask(params.task);
+  const qaRejectedInAiReview =
+    params.task?.status === "ai_review" &&
+    params.task.documentSummary.qaReport.verdict === "rejected";
 
   for (const role of ALL_AGENT_ROLES) {
     const workflow = params.roleWorkflowsByTask[role];
@@ -248,6 +251,9 @@ export const buildWorkflowStateByRole = (params: {
     const availability = deriveWorkflowAvailability(workflow);
     const latestRoleSession = sessionSummary.latestSession;
     const liveSession = sessionSummary.liveSession;
+    const hasActiveQaSession =
+      role === "qa" &&
+      (liveSession === "running" || liveSession === "waiting_input" || liveSession === "error");
     let completion: AgentWorkflowStepState["completion"] = "not_started";
 
     if (role === "build" && qaRejected) {
@@ -260,7 +266,7 @@ export const buildWorkflowStateByRole = (params: {
       !qaRejected
     ) {
       completion = "done";
-    } else if (role === "qa" && qaRejected) {
+    } else if (role === "qa" && (qaRejected || (qaRejectedInAiReview && !hasActiveQaSession))) {
       completion = "rejected";
     } else if (workflow.completed) {
       completion = "done";


### PR DESCRIPTION
## Summary
- keep the QA lane in rejected (red) state when a task is in `ai_review` with a rejected verdict and no active QA rerun session
- allow the QA lane to switch to active/in-progress only when a fresh QA session is actually running/waiting/error
- add regression tests that cover both idle and running QA session scenarios in `ai_review`

## Validation
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QA workflow state handling to correctly reflect rejection status and session activity during the AI review phase.

* **Tests**
  * Added comprehensive test coverage for QA state transitions when reviews are rejected, including various session statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->