### PR TITLE
fix diagnostics readiness and decouple branch refresh from beads checks

### DIFF
--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -66,6 +66,44 @@ describe("buildDiagnosticsPanelModel", () => {
     expect(model.summaryState.label).toBe("Checking...");
   });
 
+  test("keeps summary in checking state while runtime health is still pending", () => {
+    const model = buildDiagnosticsPanelModel({
+      activeRepo: "/repo",
+      activeWorkspace: {
+        path: "/repo",
+        isActive: true,
+        hasConfig: true,
+        configuredWorktreeBasePath: "/worktrees",
+        defaultWorktreeBasePath: "/Users/dev/.openducktor/worktrees/repo",
+        effectiveWorktreeBasePath: "/worktrees",
+      },
+      runtimeDefinitions,
+      isLoadingRuntimeDefinitions: false,
+      runtimeDefinitionsError: null,
+      runtimeCheck: {
+        gitOk: true,
+        gitVersion: "git version 2.50.1",
+        ghOk: true,
+        ghVersion: "gh version 2.73.0",
+        ghAuthOk: true,
+        ghAuthLogin: "octocat",
+        ghAuthError: null,
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        errors: [],
+      },
+      beadsCheck: {
+        beadsOk: true,
+        beadsPath: "/Users/dev/.openducktor/beads/repo/.beads",
+        beadsError: null,
+      },
+      runtimeHealthByRuntime: {},
+      isLoadingChecks: false,
+    });
+
+    expect(model.isSummaryChecking).toBe(true);
+    expect(model.summaryState.label).toBe("Checking...");
+  });
+
   test("returns setup-needed summary when no effective worktree directory is available", () => {
     const model = buildDiagnosticsPanelModel({
       activeRepo: "/repo",

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
@@ -6,6 +6,7 @@ import type {
   WorkspaceRecord,
 } from "@openducktor/contracts";
 import { runtimeLabelFor } from "@/lib/agent-runtime";
+import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
 import type { RepoRuntimeHealthMap } from "@/types/diagnostics";
 import {
   buildDiagnosticsSummary,
@@ -70,14 +71,14 @@ export const buildDiagnosticsPanelModel = (
   const repoName = activeRepo?.split("/").filter(Boolean).at(-1) ?? "No repository";
   const effectiveWorktreeBasePath = activeWorkspace?.effectiveWorktreeBasePath ?? null;
   const worktreeAvailable = Boolean(effectiveWorktreeBasePath);
-  const hasRuntimeHealthData = runtimeDefinitions.some(
-    (definition) => runtimeHealthByRuntime[definition.kind] !== undefined,
-  );
   const runtimeEntries = runtimeDefinitions.map((definition) => ({
     definition,
     cliHealth: runtimeCheck?.runtimes.find((entry) => entry.kind === definition.kind) ?? null,
-    runtimeHealth: runtimeHealthByRuntime[definition.kind] ?? null,
+    runtimeHealth: runtimeHealthByRuntime[definition.kind],
   }));
+  const isRuntimeHealthPending = runtimeDefinitions.some(
+    (definition) => runtimeHealthByRuntime[definition.kind] === undefined,
+  );
 
   const criticalReasons: string[] = [];
   if (activeRepo) {
@@ -87,14 +88,12 @@ export const buildDiagnosticsPanelModel = (
     if (runtimeCheck && (!runtimeCheck.gitOk || runtimeCheck.runtimes.some((entry) => !entry.ok))) {
       criticalReasons.push("Runtime CLI checks failing");
     }
-    if (hasRuntimeHealthData) {
-      for (const { definition, runtimeHealth } of runtimeEntries) {
-        if (runtimeHealth?.runtimeOk === false) {
-          criticalReasons.push(`${definition.label} runtime unavailable`);
-        }
-        if (definition.capabilities.supportsMcpStatus && runtimeHealth?.mcpOk === false) {
-          criticalReasons.push(`${definition.label} OpenDucktor MCP unavailable`);
-        }
+    for (const { definition, runtimeHealth } of runtimeEntries) {
+      if (runtimeHealth?.runtimeOk === false) {
+        criticalReasons.push(`${definition.label} runtime unavailable`);
+      }
+      if (definition.capabilities.supportsMcpStatus && runtimeHealth?.mcpOk === false) {
+        criticalReasons.push(`${definition.label} OpenDucktor MCP unavailable`);
       }
     }
     if (beadsCheck?.beadsOk === false) {
@@ -112,7 +111,8 @@ export const buildDiagnosticsPanelModel = (
     (isLoadingRuntimeDefinitions ||
       isLoadingChecks ||
       runtimeCheck === null ||
-      beadsCheck === null);
+      beadsCheck === null ||
+      isRuntimeHealthPending);
 
   const repositorySection: DiagnosticsSectionModel = {
     key: "repository",
@@ -188,7 +188,7 @@ export const buildDiagnosticsPanelModel = (
       title: `${definition.label} Runtime`,
       badge: {
         label:
-          runtimeHealth === null ? "Checking" : runtimeHealth.runtimeOk ? "Running" : "Unavailable",
+          runtimeHealth == null ? "Checking" : runtimeHealth.runtimeOk ? "Running" : "Unavailable",
         variant: healthVariant(runtimeHealth?.runtimeOk ?? null),
       },
       rows: runtimeHealth?.runtime
@@ -215,7 +215,7 @@ export const buildDiagnosticsPanelModel = (
         : [],
       errors: runtimeHealth?.runtimeError ? [runtimeHealth.runtimeError] : [],
       ...(activeRepo
-        ? runtimeHealth === null
+        ? runtimeHealth == null
           ? { emptyMessage: "Runtime health is loading..." }
           : {}
         : { emptyMessage: "Select a repository first." }),
@@ -230,14 +230,14 @@ export const buildDiagnosticsPanelModel = (
       title: `${definition.label} MCP`,
       badge: {
         label:
-          runtimeHealth === null ? "Checking" : runtimeHealth.mcpOk ? "Connected" : "Unavailable",
+          runtimeHealth == null ? "Checking" : runtimeHealth.mcpOk ? "Connected" : "Unavailable",
         variant: healthVariant(runtimeHealth?.mcpOk ?? null),
       },
       rows: activeRepo
         ? [
             {
               label: "Server name",
-              value: runtimeHealth?.mcpServerName ?? "openducktor",
+              value: runtimeHealth?.mcpServerName ?? ODT_MCP_SERVER_NAME,
               mono: true,
             },
             {
@@ -260,7 +260,7 @@ export const buildDiagnosticsPanelModel = (
           ? [runtimeHealth.mcpServerError ?? runtimeHealth.mcpError ?? ""]
           : [],
       ...(activeRepo
-        ? runtimeHealth === null
+        ? runtimeHealth == null
           ? { emptyMessage: "MCP health is loading..." }
           : {}
         : { emptyMessage: "Select a repository first." }),

--- a/apps/desktop/src/lib/openducktor-mcp.ts
+++ b/apps/desktop/src/lib/openducktor-mcp.ts
@@ -1,0 +1,1 @@
+export const ODT_MCP_SERVER_NAME = "openducktor";

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -243,6 +243,74 @@ describe("useAppLifecycle", () => {
     }
   });
 
+  test("does not block repo diagnostics load on branch refresh completion", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const taskLoadDeferred = createDeferred<void>();
+    const runtimeRepoCheckDeferred = createDeferred<unknown>();
+    const branchesDeferred = createDeferred<void>();
+
+    let runtimeCheckCallCount = 0;
+    const refreshRuntimeCheck = mock(() => {
+      runtimeCheckCallCount += 1;
+      return runtimeCheckCallCount === 1
+        ? Promise.resolve({ runtimeOk: true })
+        : runtimeRepoCheckDeferred.promise;
+    });
+
+    const baseArgs: HookArgs = {
+      activeRepo: null,
+      setEvents: mock((_updater) => {}),
+      setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => branchesDeferred.promise),
+      refreshRuntimeCheck,
+      refreshBeadsCheckForRepo: mock(async () => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      })),
+      refreshTaskData: mock(async () => taskLoadDeferred.promise),
+      clearBranchData: mock(() => {}),
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+
+    const harness = createSharedHookHarness(Harness, { args: baseArgs });
+
+    try {
+      await harness.mount();
+      await harness.update({
+        args: {
+          ...baseArgs,
+          activeRepo: "/repo",
+        },
+      });
+
+      await harness.run(async () => {
+        taskLoadDeferred.resolve();
+        runtimeRepoCheckDeferred.resolve({ runtimeOk: true });
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(baseArgs.refreshTaskData).toHaveBeenCalledWith("/repo");
+      expect(refreshRuntimeCheck).toHaveBeenCalledTimes(2);
+      expect(baseArgs.refreshBranches).toHaveBeenCalledWith(false);
+    } finally {
+      taskLoadDeferred.resolve();
+      runtimeRepoCheckDeferred.resolve({ runtimeOk: true });
+      branchesDeferred.resolve();
+      await harness.unmount();
+    }
+  });
+
   test("shows Beads preparation toasts when repository initialization is slow", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = Parameters<typeof useAppLifecycle>[0];

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -311,6 +311,88 @@ describe("useAppLifecycle", () => {
     }
   });
 
+  test("suppresses late repo-load toasts after the repository is deselected", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const taskDeferred = createDeferred<void>();
+    const runtimeDeferred = createDeferred<unknown>();
+    const branchesDeferred = createDeferred<void>();
+
+    let runtimeCheckCallCount = 0;
+    const refreshRuntimeCheck = mock(() => {
+      runtimeCheckCallCount += 1;
+      return runtimeCheckCallCount === 1
+        ? Promise.resolve({ runtimeOk: true })
+        : runtimeDeferred.promise;
+    });
+
+    const baseArgs: HookArgs = {
+      activeRepo: null,
+      setEvents: mock((_updater) => {}),
+      setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => branchesDeferred.promise),
+      refreshRuntimeCheck,
+      refreshBeadsCheckForRepo: mock(async () => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      })),
+      refreshTaskData: mock(async () => taskDeferred.promise),
+      clearBranchData: mock(() => {}),
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+
+    const harness = createSharedHookHarness(Harness, { args: baseArgs });
+
+    try {
+      await harness.mount();
+      await harness.update({
+        args: {
+          ...baseArgs,
+          activeRepo: "/repo",
+        },
+      });
+
+      await harness.update({
+        args: {
+          ...baseArgs,
+          activeRepo: null,
+        },
+      });
+
+      await harness.run(async () => {
+        taskDeferred.reject(new Error("tasks failed after deselect"));
+        runtimeDeferred.reject(new Error("runtime failed after deselect"));
+        branchesDeferred.reject(new Error("branches failed after deselect"));
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(toastError).not.toHaveBeenCalledWith(
+        "Repository tasks unavailable",
+        expect.anything(),
+      );
+      expect(toastError).not.toHaveBeenCalledWith("Runtime checks unavailable", expect.anything());
+      expect(toastError).not.toHaveBeenCalledWith(
+        "Repository branches unavailable",
+        expect.anything(),
+      );
+    } finally {
+      taskDeferred.resolve();
+      runtimeDeferred.resolve({ runtimeOk: true });
+      branchesDeferred.resolve();
+      await harness.unmount();
+    }
+  });
+
   test("shows Beads preparation toasts when repository initialization is slow", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = Parameters<typeof useAppLifecycle>[0];

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -169,10 +169,17 @@ export function useAppLifecycle({
       }
     })();
     const runtimeCheckPromise = refreshRuntimeCheck(false);
-    const branchesPromise = refreshBranches(false);
+    void refreshBranches(false).catch((error: unknown) => {
+      if (repoLoadVersionRef.current !== loadVersion) {
+        return;
+      }
+      toast.error("Repository branches unavailable", {
+        description: errorMessage(error),
+      });
+    });
 
-    Promise.allSettled([taskLoadPromise, runtimeCheckPromise, branchesPromise])
-      .then(([tasksResult, runtimeResult, branchesResult]) => {
+    Promise.allSettled([taskLoadPromise, runtimeCheckPromise])
+      .then(([tasksResult, runtimeResult]) => {
         if (repoLoadVersionRef.current !== loadVersion) {
           return;
         }
@@ -186,12 +193,6 @@ export function useAppLifecycle({
         if (runtimeResult.status === "rejected") {
           toast.error("Runtime checks unavailable", {
             description: errorMessage(runtimeResult.reason),
-          });
-        }
-
-        if (branchesResult.status === "rejected") {
-          toast.error("Repository branches unavailable", {
-            description: errorMessage(branchesResult.reason),
           });
         }
       })

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -1,5 +1,5 @@
 import { type RunEvent, runEventSchema } from "@openducktor/contracts";
-import { type Dispatch, type SetStateAction, useEffect, useRef } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useLayoutEffect, useRef } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { hostBridge } from "@/lib/host-client";
@@ -43,7 +43,7 @@ export function useAppLifecycle({
   const activeRepoRef = useRef(activeRepo);
   const refreshTaskDataRef = useRef(refreshTaskData);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     activeRepoRef.current = activeRepo;
     refreshTaskDataRef.current = refreshTaskData;
   }, [activeRepo, refreshTaskData]);

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -169,8 +169,11 @@ export function useAppLifecycle({
       }
     })();
     const runtimeCheckPromise = refreshRuntimeCheck(false);
+    const isStaleRepoLoad = (): boolean =>
+      repoLoadVersionRef.current !== loadVersion || activeRepoRef.current !== activeRepo;
+
     void refreshBranches(false).catch((error: unknown) => {
-      if (repoLoadVersionRef.current !== loadVersion) {
+      if (isStaleRepoLoad()) {
         return;
       }
       toast.error("Repository branches unavailable", {
@@ -180,7 +183,7 @@ export function useAppLifecycle({
 
     Promise.allSettled([taskLoadPromise, runtimeCheckPromise])
       .then(([tasksResult, runtimeResult]) => {
-        if (repoLoadVersionRef.current !== loadVersion) {
+        if (isStaleRepoLoad()) {
           return;
         }
 

--- a/apps/desktop/src/state/operations/shared/runtime-catalog.ts
+++ b/apps/desktop/src/state/operations/shared/runtime-catalog.ts
@@ -7,6 +7,7 @@ import type {
 } from "@openducktor/contracts";
 import type { AgentEnginePort, AgentModelCatalog } from "@openducktor/core";
 import { errorMessage } from "@/lib/errors";
+import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
 import { appQueryClient } from "@/lib/query-client";
 import { ensureRuntimeListFromQuery } from "@/state/queries/runtime";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
@@ -74,7 +75,6 @@ type NormalizedMcpStatus = {
   mcpServerError: string | null;
 };
 
-const ODT_MCP_SERVER_NAME = "openducktor";
 const ACTIVE_RUN_STATES = new Set<RunSummary["state"]>([
   "starting",
   "running",

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -410,4 +410,49 @@ describe("use-checks", () => {
       await harness.unmount();
     }
   });
+
+  test("prefers runtime health query error state over stale successful data", async () => {
+    let shouldFailRefresh = false;
+    repoHealthHandler = async () => {
+      if (shouldFailRefresh) {
+        throw new Error("runtime health refresh failed");
+      }
+      return makeRepoHealth({ availableToolIds: ["healthy"] });
+    };
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => {
+        return value.activeRepoRuntimeHealthByRuntime.opencode?.runtimeOk === true;
+      });
+
+      shouldFailRefresh = true;
+
+      await harness.run(async (value) => {
+        await expect(value.refreshRepoRuntimeHealthForRepo("/repo-a", true)).rejects.toThrow(
+          "runtime health refresh failed",
+        );
+      });
+
+      await harness.waitFor((value) => {
+        const runtimeHealth = value.activeRepoRuntimeHealthByRuntime.opencode;
+        return runtimeHealth != null && runtimeHealth.runtimeOk === false;
+      });
+
+      expect(harness.getLatest().activeRepoRuntimeHealthByRuntime.opencode).toEqual(
+        expect.objectContaining({
+          runtimeOk: false,
+          mcpOk: false,
+          runtimeError: "runtime health refresh failed",
+        }),
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
 });

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -3,6 +3,7 @@ import {
   type BeadsCheck,
   OPENCODE_RUNTIME_DESCRIPTOR,
   type RuntimeCheck,
+  type RuntimeDescriptor,
   type RuntimeKind,
 } from "@openducktor/contracts";
 import type { PropsWithChildren, ReactElement } from "react";
@@ -53,6 +54,16 @@ const makeRepoHealth = (
   errors: [],
   ...overrides,
 });
+
+const MOCK_RUNTIME_DESCRIPTOR: RuntimeDescriptor = {
+  kind: "mock-runtime",
+  label: "Mock Runtime",
+  description: "Mock runtime descriptor for per-kind health tests.",
+  readOnlyRoleBlockedTools: [],
+  capabilities: {
+    ...OPENCODE_RUNTIME_DESCRIPTOR.capabilities,
+  },
+};
 
 const toastError = mock((_message: string, _options?: { description?: string }) => {});
 const toastSuccess = mock((_message: string, _options?: { description?: string }) => {});
@@ -389,9 +400,7 @@ describe("use-checks", () => {
       await harness.mount();
 
       await harness.run(async (value) => {
-        await expect(value.refreshRepoRuntimeHealthForRepo("/repo-a", true)).rejects.toThrow(
-          "runtime health unreachable",
-        );
+        await expect(value.refreshRepoRuntimeHealthForRepo("/repo-a", true)).resolves.toBeDefined();
       });
 
       await harness.waitFor((value) => {
@@ -434,9 +443,7 @@ describe("use-checks", () => {
       shouldFailRefresh = true;
 
       await harness.run(async (value) => {
-        await expect(value.refreshRepoRuntimeHealthForRepo("/repo-a", true)).rejects.toThrow(
-          "runtime health refresh failed",
-        );
+        await expect(value.refreshRepoRuntimeHealthForRepo("/repo-a", true)).resolves.toBeDefined();
       });
 
       await harness.waitFor((value) => {
@@ -449,6 +456,50 @@ describe("use-checks", () => {
           runtimeOk: false,
           mcpOk: false,
           runtimeError: "runtime health refresh failed",
+        }),
+      );
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("keeps healthy runtime kinds when one runtime health probe fails", async () => {
+    repoHealthHandler = async (_repoPath, runtimeKind) => {
+      if (runtimeKind === "mock-runtime") {
+        throw new Error("mock runtime probe failed");
+      }
+      return makeRepoHealth({ availableToolIds: [runtimeKind] });
+    };
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, MOCK_RUNTIME_DESCRIPTOR],
+    });
+
+    try {
+      await harness.mount();
+
+      await harness.run(async (value) => {
+        await expect(value.refreshRepoRuntimeHealthForRepo("/repo-a", true)).resolves.toBeDefined();
+      });
+
+      await harness.waitFor((value) => {
+        const opencodeHealth = value.activeRepoRuntimeHealthByRuntime.opencode;
+        const mockRuntimeHealth = value.activeRepoRuntimeHealthByRuntime["mock-runtime"];
+        return opencodeHealth != null && mockRuntimeHealth != null;
+      });
+
+      expect(harness.getLatest().activeRepoRuntimeHealthByRuntime.opencode).toEqual(
+        expect.objectContaining({
+          runtimeOk: true,
+          availableToolIds: ["opencode"],
+        }),
+      );
+      expect(harness.getLatest().activeRepoRuntimeHealthByRuntime["mock-runtime"]).toEqual(
+        expect.objectContaining({
+          runtimeOk: false,
+          mcpOk: false,
+          runtimeError: "mock runtime probe failed",
         }),
       );
     } finally {

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -259,7 +259,9 @@ describe("use-checks", () => {
       await harness.waitFor((value) => value.hasCachedRepoRuntimeHealth("/repo-b", ["opencode"]));
 
       expect(harness.getLatest().activeBeadsCheck?.beadsPath).toBe("/repo-a/.beads");
-      expect(harness.getLatest().activeRepoRuntimeHealthByRuntime.opencode).toBeNull();
+      expect(
+        harness.getLatest().activeRepoRuntimeHealthByRuntime.opencode?.availableToolIds,
+      ).toEqual(["/repo-a"]);
       expect(harness.getLatest().hasCachedBeadsCheck("/repo-b")).toBe(true);
       expect(harness.getLatest().hasCachedRepoRuntimeHealth("/repo-b", ["opencode"])).toBe(true);
       expect(beadsCheck).toHaveBeenCalledTimes(1);
@@ -370,6 +372,42 @@ describe("use-checks", () => {
     } finally {
       await harness.unmount();
       host.runtimeCheck = original.runtimeCheck;
+    }
+  });
+
+  test("projects runtime health query failures as unhealthy runtime state", async () => {
+    repoHealthHandler = async () => {
+      throw new Error("runtime health unreachable");
+    };
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    try {
+      await harness.mount();
+
+      await harness.run(async (value) => {
+        await expect(value.refreshRepoRuntimeHealthForRepo("/repo-a", true)).rejects.toThrow(
+          "runtime health unreachable",
+        );
+      });
+
+      await harness.waitFor((value) => {
+        const runtimeHealth = value.activeRepoRuntimeHealthByRuntime.opencode;
+        return runtimeHealth != null && runtimeHealth.runtimeOk === false;
+      });
+
+      expect(harness.getLatest().activeRepoRuntimeHealthByRuntime.opencode).toEqual(
+        expect.objectContaining({
+          runtimeOk: false,
+          mcpOk: false,
+          runtimeError: "runtime health unreachable",
+        }),
+      );
+    } finally {
+      await harness.unmount();
     }
   });
 });

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -5,9 +5,10 @@ import type {
   RuntimeKind,
 } from "@openducktor/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
+import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
 import type { RepoRuntimeHealthCheck, RepoRuntimeHealthMap } from "@/types/diagnostics";
 import {
   beadsCheckQueryOptions,
@@ -49,10 +50,30 @@ type UseChecksResult = {
   clearActiveRepoRuntimeHealth: () => void;
 };
 
-const buildEmptyRuntimeHealthMap = (
+const buildRuntimeHealthErrorMap = (
   runtimeDefinitions: RuntimeDescriptor[],
-): RepoRuntimeHealthMap =>
-  Object.fromEntries(runtimeDefinitions.map((definition) => [definition.kind, null]));
+  runtimeHealthError: string,
+  checkedAt: string,
+): RepoRuntimeHealthMap => {
+  return Object.fromEntries(
+    runtimeDefinitions.map((definition) => [
+      definition.kind,
+      {
+        runtimeOk: false,
+        runtimeError: runtimeHealthError,
+        runtime: null,
+        mcpOk: false,
+        mcpError: runtimeHealthError,
+        mcpServerName: ODT_MCP_SERVER_NAME,
+        mcpServerStatus: null,
+        mcpServerError: runtimeHealthError,
+        availableToolIds: [],
+        checkedAt,
+        errors: [runtimeHealthError],
+      },
+    ]),
+  ) as RepoRuntimeHealthMap;
+};
 
 export function useChecks({
   activeRepo,
@@ -72,7 +93,7 @@ export function useChecks({
       runtimeDefinitions,
       checkRepoRuntimeHealth,
     ),
-    enabled: false,
+    enabled: activeRepo !== null && runtimeDefinitions.length > 0,
   });
 
   const refreshRuntimeCheck = useCallback(
@@ -216,10 +237,32 @@ export function useChecks({
     setIsManualLoadingChecks(false);
   }, []);
 
-  const activeRepoRuntimeHealthByRuntime =
-    activeRepo === null
-      ? {}
-      : (runtimeHealthQuery.data ?? buildEmptyRuntimeHealthMap(runtimeDefinitions));
+  const activeRepoRuntimeHealthByRuntime = useMemo((): RepoRuntimeHealthMap => {
+    if (activeRepo === null) {
+      return {};
+    }
+
+    if (runtimeHealthQuery.data) {
+      return runtimeHealthQuery.data;
+    }
+
+    if (runtimeHealthQuery.error && runtimeDefinitions.length > 0) {
+      const runtimeHealthError = errorMessage(runtimeHealthQuery.error);
+      const checkedAt =
+        runtimeHealthQuery.errorUpdatedAt > 0
+          ? new Date(runtimeHealthQuery.errorUpdatedAt).toISOString()
+          : new Date().toISOString();
+      return buildRuntimeHealthErrorMap(runtimeDefinitions, runtimeHealthError, checkedAt);
+    }
+
+    return {};
+  }, [
+    activeRepo,
+    runtimeDefinitions,
+    runtimeHealthQuery.data,
+    runtimeHealthQuery.error,
+    runtimeHealthQuery.errorUpdatedAt,
+  ]);
   const isLoadingChecks =
     isManualLoadingChecks ||
     runtimeCheckQuery.isFetching ||

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -231,19 +231,32 @@ export function useChecks({
 
   const clearActiveBeadsCheck = useCallback(() => {
     setIsManualLoadingChecks(false);
-  }, []);
+    if (activeRepo === null) {
+      return;
+    }
+    queryClient.removeQueries({
+      queryKey: checksQueryKeys.beads(activeRepo),
+      exact: true,
+    });
+  }, [activeRepo, queryClient]);
 
   const clearActiveRepoRuntimeHealth = useCallback(() => {
     setIsManualLoadingChecks(false);
-  }, []);
+    if (activeRepo === null || runtimeDefinitions.length === 0) {
+      return;
+    }
+    queryClient.removeQueries({
+      queryKey: checksQueryKeys.runtimeHealth(
+        activeRepo,
+        runtimeDefinitions.map((definition) => definition.kind),
+      ),
+      exact: true,
+    });
+  }, [activeRepo, queryClient, runtimeDefinitions]);
 
   const activeRepoRuntimeHealthByRuntime = useMemo((): RepoRuntimeHealthMap => {
     if (activeRepo === null) {
       return {};
-    }
-
-    if (runtimeHealthQuery.data) {
-      return runtimeHealthQuery.data;
     }
 
     if (runtimeHealthQuery.error && runtimeDefinitions.length > 0) {
@@ -253,6 +266,10 @@ export function useChecks({
           ? new Date(runtimeHealthQuery.errorUpdatedAt).toISOString()
           : new Date().toISOString();
       return buildRuntimeHealthErrorMap(runtimeDefinitions, runtimeHealthError, checkedAt);
+    }
+
+    if (runtimeHealthQuery.data) {
+      return runtimeHealthQuery.data;
     }
 
     return {};

--- a/apps/desktop/src/state/queries/checks.ts
+++ b/apps/desktop/src/state/queries/checks.ts
@@ -5,12 +5,31 @@ import type {
   RuntimeKind,
 } from "@openducktor/contracts";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import { errorMessage } from "@/lib/errors";
+import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
 import type { RepoRuntimeHealthCheck, RepoRuntimeHealthMap } from "@/types/diagnostics";
 import { host } from "../operations/host";
 
 const RUNTIME_CHECK_STALE_TIME_MS = 5 * 60_000;
 const BEADS_CHECK_STALE_TIME_MS = 60_000;
 const RUNTIME_HEALTH_STALE_TIME_MS = 60_000;
+
+const buildRuntimeHealthErrorCheck = (
+  runtimeHealthError: string,
+  checkedAt: string,
+): RepoRuntimeHealthCheck => ({
+  runtimeOk: false,
+  runtimeError: runtimeHealthError,
+  runtime: null,
+  mcpOk: false,
+  mcpError: runtimeHealthError,
+  mcpServerName: ODT_MCP_SERVER_NAME,
+  mcpServerStatus: null,
+  mcpServerError: runtimeHealthError,
+  availableToolIds: [],
+  checkedAt,
+  errors: [runtimeHealthError],
+});
 
 const normalizeRuntimeKinds = (runtimeKinds: RuntimeKind[]): RuntimeKind[] =>
   [...runtimeKinds].sort();
@@ -58,7 +77,9 @@ export const repoRuntimeHealthQueryOptions = (
     queryFn: async (): Promise<RepoRuntimeHealthMap> => {
       const checks = await Promise.all(
         runtimeDefinitions.map(async (definition) => {
-          const check = await checkRepoRuntimeHealth(repoPath, definition.kind);
+          const check = await checkRepoRuntimeHealth(repoPath, definition.kind).catch((error) =>
+            buildRuntimeHealthErrorCheck(errorMessage(error), new Date().toISOString()),
+          );
           return [definition.kind, check] as const;
         }),
       );

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.8",
         "@types/node": "^25.5.0",
-        "knip": "^6.0.3",
+        "knip": "^6.0.5",
         "typescript": "^5.7.3",
       },
     },
@@ -721,7 +721,7 @@
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
-    "knip": ["knip@6.0.3", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "get-tsconfig": "4.13.7", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-parser": "^0.120.0", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-6Ai+Iv41dVpBYH6mReFejhniWq4eiaKrBw4kghqz2Ew5psQMYEqYxJtXLdj/7vRJ3nVaHpakhYUCKO8p3ftNsQ=="],
+    "knip": ["knip@6.0.5", "", { "dependencies": { "@nodelib/fs.walk": "^1.2.3", "fast-glob": "^3.3.3", "formatly": "^0.3.0", "get-tsconfig": "4.13.7", "jiti": "^2.6.0", "minimist": "^1.2.8", "oxc-parser": "^0.120.0", "oxc-resolver": "^11.19.1", "picocolors": "^1.1.1", "picomatch": "^4.0.1", "smol-toml": "^1.5.2", "strip-json-comments": "5.0.3", "unbash": "^2.2.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-+i9e/ZKuYlECB5iIK82NQwnYso4oNLBhzsTbXhSqCG1qfGi6D84GNtRENafmS3C0lABX8Wf3BKM434nPXi2AbQ=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -895,7 +895,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
@@ -1111,7 +1111,7 @@
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.8",
     "@types/node": "^25.5.0",
-    "knip": "^6.0.3",
+    "knip": "^6.0.5",
     "typescript": "^5.7.3"
   }
 }


### PR DESCRIPTION
## Summary
- keep diagnostics summary in checking state until runtime health resolves, so healthy is not shown prematurely
- surface runtime-health query failures as explicit unhealthy runtime diagnostics and add regression tests
- decouple sidebar branch refresh from beads/task readiness and centralize the OpenDucktor MCP server name constant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime health UI now reliably shows "Checking..." until all runtime data finishes loading; clearer distinction between pending and error states.
  * Avoids showing stale branch-error toasts when a repository load has moved on.
  * MCP server name is displayed consistently across the UI.

* **Tests**
  * Added coverage for diagnostics, lifecycle transitions, runtime-health refreshes, and related error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->