### PR TITLE
feat(desktop): compact agent studio chat header controls

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
@@ -216,6 +216,7 @@ describe("AgentStudioHeader", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Session history/i }));
 
+    expect(screen.getByPlaceholderText(/Search sessions/i)).toBeTruthy();
     expect(screen.getByText("Spec sessions")).toBeTruthy();
     expect(screen.getByText("Build sessions")).toBeTruthy();
 
@@ -255,22 +256,6 @@ describe("AgentStudioHeader", () => {
     );
     expect(html).toMatch(
       /<button[^>]*(aria-label="Create session"[^>]*disabled=""|disabled=""[^>]*aria-label="Create session")/,
-    );
-  });
-
-  test("disables session history trigger when studio is not ready", () => {
-    const html = renderToStaticMarkup(
-      createElement(AgentStudioHeader, {
-        model: {
-          ...buildModel(),
-          agentStudioReady: false,
-        },
-      }),
-    );
-
-    expect(html).toMatch(/aria-label="Session history[^"]*"/);
-    expect(html).toMatch(
-      /<button[^>]*(aria-label="Session history[^"]*"[^>]*disabled=""|disabled=""[^>]*aria-label="Session history[^"]*")/,
     );
   });
 

--- a/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { TEST_ROLE_OPTIONS } from "./agent-chat/agent-chat-test-fixtures";
 import { AgentStudioHeader } from "./agent-studio-header";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 const roleIcon = (index: number) => {
   const option = TEST_ROLE_OPTIONS[index];
@@ -119,8 +126,15 @@ describe("AgentStudioHeader", () => {
     expect(html).toContain("Rework Agent Studio UI");
     expect(html).toContain("fairnest-97f");
     expect(html).toContain('aria-label="Open task details"');
+    expect(html).toMatch(/aria-label="Session history[^"]*"/);
     expect(html).toContain(">Open<");
     expect(html).toContain("Create session");
+    expect(html).not.toMatch(/flex-wrap/);
+    expect(html).toContain("mt-1 flex items-center gap-1.5");
+    const taskIdIndex = html.indexOf("fairnest-97f");
+    const openButtonIndex = html.indexOf('aria-label="Open task details"');
+    expect(taskIdIndex).toBeGreaterThan(-1);
+    expect(openButtonIndex).toBeGreaterThan(taskIdIndex);
     expect(html).not.toContain("Viewing Session");
     expect(html).not.toContain("Sessions:");
     expect(html).not.toContain("Messages:");
@@ -141,6 +155,75 @@ describe("AgentStudioHeader", () => {
     );
 
     expect(html).toContain("Agent Studio");
+  });
+
+  test("adds full task title as hover affordance on truncated heading", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioHeader, {
+        model: buildModel(),
+      }),
+    );
+
+    expect(html).toContain('title="Rework Agent Studio UI"');
+  });
+
+  test("shows selected session label in history trigger title", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioHeader, {
+        model: buildModel(),
+      }),
+    );
+
+    expect(html).toContain('title="Session history · Spec Revision · Spec"');
+  });
+
+  test("opens session history menu with grouped options and selects session", () => {
+    const onValueChange = mock(() => {});
+    const { unmount } = render(
+      createElement(AgentStudioHeader, {
+        model: {
+          ...buildModel(),
+          sessionSelector: {
+            value: "spec-session",
+            groups: [
+              {
+                label: "Spec sessions",
+                options: [
+                  {
+                    value: "spec-session",
+                    label: "Spec Revision · Spec",
+                    description: "Today · idle",
+                  },
+                ],
+              },
+              {
+                label: "Build sessions",
+                options: [
+                  {
+                    value: "build-session",
+                    label: "Builder Draft · Build",
+                    description: "Today · running",
+                  },
+                ],
+              },
+            ],
+            disabled: false,
+            onValueChange,
+          },
+        },
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Session history/i }));
+
+    expect(screen.getByText("Spec sessions")).toBeTruthy();
+    expect(screen.getByText("Build sessions")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Builder Draft · Build"));
+
+    expect(onValueChange).toHaveBeenCalledWith("build-session");
+
+    unmount();
   });
 
   test("hides the task details button when no task is selected", () => {
@@ -167,7 +250,47 @@ describe("AgentStudioHeader", () => {
       }),
     );
 
-    expect(html).toContain("disabled");
+    expect(html).toMatch(
+      /<button[^>]*(aria-label="Session history[^"]*"[^>]*disabled=""|disabled=""[^>]*aria-label="Session history[^"]*")/,
+    );
+    expect(html).toMatch(
+      /<button[^>]*(aria-label="Create session"[^>]*disabled=""|disabled=""[^>]*aria-label="Create session")/,
+    );
+  });
+
+  test("disables session history trigger when studio is not ready", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioHeader, {
+        model: {
+          ...buildModel(),
+          agentStudioReady: false,
+        },
+      }),
+    );
+
+    expect(html).toMatch(/aria-label="Session history[^"]*"/);
+    expect(html).toMatch(
+      /<button[^>]*(aria-label="Session history[^"]*"[^>]*disabled=""|disabled=""[^>]*aria-label="Session history[^"]*")/,
+    );
+  });
+
+  test("disables session history trigger when selector is disabled", () => {
+    const model = buildModel();
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioHeader, {
+        model: {
+          ...model,
+          sessionSelector: {
+            ...model.sessionSelector,
+            disabled: true,
+          },
+        },
+      }),
+    );
+
+    expect(html).toMatch(
+      /<button[^>]*(aria-label="Session history[^"]*"[^>]*disabled=""|disabled=""[^>]*aria-label="Session history[^"]*")/,
+    );
   });
 
   test("disables create session while a session is starting without showing a loader", () => {

--- a/apps/desktop/src/components/features/agents/agent-studio-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.tsx
@@ -21,6 +21,7 @@ import {
   Command,
   CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
@@ -277,6 +278,7 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
             </PopoverTrigger>
             <PopoverContent align="end" className="w-80 p-0">
               <Command>
+                <CommandInput placeholder="Search sessions…" className="h-8 text-sm" />
                 <CommandList>
                   <CommandEmpty>No sessions available.</CommandEmpty>
                   {sessionGroupsWithOptions.map((group) => (

--- a/apps/desktop/src/components/features/agents/agent-studio-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.tsx
@@ -7,6 +7,7 @@ import {
   Circle,
   CircleDashed,
   CircleDotDashed,
+  History,
   LoaderCircle,
   Plus,
   Sparkles,
@@ -15,7 +16,7 @@ import { type ReactElement, useMemo, useState } from "react";
 import { TaskIdBadge } from "@/components/features/tasks/task-id-badge";
 import { Button } from "@/components/ui/button";
 import { CardHeader, CardTitle } from "@/components/ui/card";
-import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
+import type { ComboboxGroup } from "@/components/ui/combobox";
 import {
   Command,
   CommandEmpty,
@@ -186,13 +187,25 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
   } = model;
 
   const [isCreateSessionMenuOpen, setIsCreateSessionMenuOpen] = useState(false);
+  const [isSessionMenuOpen, setIsSessionMenuOpen] = useState(false);
 
   const normalizedTaskTitle = taskTitle?.trim() ?? "";
   const hasTaskTitle = normalizedTaskTitle.length > 0;
   const normalizedTaskId = taskId?.trim() ?? "";
   const hasTaskId = normalizedTaskId.length > 0;
   const canOpenTaskDetails = hasTaskId && Boolean(model.onOpenTaskDetails);
-  const sessionSelectorOptions = sessionSelector.groups.flatMap((group) => group.options);
+  const sessionGroupsWithOptions = useMemo(
+    () => sessionSelector.groups.filter((group) => group.options.length > 0),
+    [sessionSelector.groups],
+  );
+  const sessionSelectorOptions = useMemo(
+    () => sessionGroupsWithOptions.flatMap((group) => group.options),
+    [sessionGroupsWithOptions],
+  );
+  const selectedSessionOption = useMemo(
+    () => sessionSelectorOptions.find((option) => option.value === sessionSelector.value) ?? null,
+    [sessionSelector.value, sessionSelectorOptions],
+  );
   const createOptionsByRole = useMemo(
     () =>
       sessionCreateOptions.reduce(
@@ -209,40 +222,95 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
   );
 
   return (
-    <CardHeader className="space-y-2 border-b border-border bg-card pb-4">
-      <div className="flex flex-wrap items-start justify-between gap-2">
-        <div className="min-w-0">
-          <div className="flex items-center gap-1.5">
-            <CardTitle className="max-w-160 truncate text-xl">
+    <CardHeader className="border-b border-border bg-card pb-4">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <CardTitle
+              className="truncate text-xl"
+              title={hasTaskTitle ? normalizedTaskTitle : undefined}
+            >
               {hasTaskTitle ? normalizedTaskTitle : "Agent Studio"}
             </CardTitle>
-            {canOpenTaskDetails ? (
+          </div>
+          {hasTaskId ? (
+            <div className="mt-1 flex items-center gap-1.5">
+              <TaskIdBadge taskId={normalizedTaskId} />
+              {canOpenTaskDetails ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="h-auto shrink-0 gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] font-normal text-muted-foreground transition hover:border-border hover:bg-muted hover:text-muted-foreground"
+                  title="Open task details"
+                  aria-label="Open task details"
+                  onClick={() => model.onOpenTaskDetails?.()}
+                >
+                  <ArrowUpRightFromSquare className="size-3" />
+                  Open
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-stretch gap-2">
+          <Popover open={isSessionMenuOpen} onOpenChange={setIsSessionMenuOpen}>
+            <PopoverTrigger asChild>
               <Button
                 type="button"
-                variant="ghost"
-                className="h-auto shrink-0 gap-1 rounded-md border border-transparent px-1.5 py-0.5 text-[11px] font-normal text-muted-foreground transition hover:border-border hover:bg-muted hover:text-muted-foreground"
-                title="Open task details"
-                aria-label="Open task details"
-                onClick={() => model.onOpenTaskDetails?.()}
+                variant="outline"
+                size="icon"
+                className="h-9 w-9 rounded-md"
+                disabled={sessionSelector.disabled || !agentStudioReady}
+                title={
+                  selectedSessionOption
+                    ? `Session history · ${selectedSessionOption.label}`
+                    : "Session history"
+                }
+                aria-label={
+                  selectedSessionOption
+                    ? `Session history, selected ${selectedSessionOption.label}`
+                    : "Session history"
+                }
               >
-                <ArrowUpRightFromSquare className="size-3" />
-                Open
+                <History className="size-4" />
               </Button>
-            ) : null}
-          </div>
-          {hasTaskId ? <TaskIdBadge taskId={normalizedTaskId} /> : null}
-        </div>
-        <div className="flex min-w-56 max-w-full items-stretch gap-2 sm:min-w-[18rem]">
-          <div className="min-w-0 flex-1">
-            <Combobox
-              value={sessionSelector.value}
-              options={sessionSelectorOptions}
-              groups={sessionSelector.groups}
-              placeholder="Select session"
-              disabled={sessionSelector.disabled || !agentStudioReady}
-              onValueChange={sessionSelector.onValueChange}
-            />
-          </div>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-80 p-0">
+              <Command>
+                <CommandList>
+                  <CommandEmpty>No sessions available.</CommandEmpty>
+                  {sessionGroupsWithOptions.map((group) => (
+                    <CommandGroup key={group.label} heading={group.label}>
+                      {group.options.map((option) => (
+                        <CommandItem
+                          key={option.value}
+                          value={`${group.label} ${option.label} ${option.description ?? ""}`}
+                          onSelect={() => {
+                            sessionSelector.onValueChange(option.value);
+                            setIsSessionMenuOpen(false);
+                          }}
+                        >
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium text-foreground">
+                              {option.label}
+                            </p>
+                            {option.description ? (
+                              <p className="truncate text-[11px] text-muted-foreground">
+                                {option.description}
+                              </p>
+                            ) : null}
+                          </div>
+                          {sessionSelector.value === option.value ? (
+                            <Check className="ml-auto size-3.5 shrink-0 text-muted-foreground" />
+                          ) : null}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  ))}
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
           <Popover open={isCreateSessionMenuOpen} onOpenChange={setIsCreateSessionMenuOpen}>
             <PopoverTrigger asChild>
               <Button


### PR DESCRIPTION
## Summary
- keep the agent studio chat header top row stable on a single line while truncating long task titles with full-title hover affordance
- replace the wide session selector trigger with a compact History icon popover that preserves grouped session selection behavior and disabled/accessibility states
- move the task details Open action to the second row beside the task id and expand header tests (including interaction coverage)

## Verification
- bun run --filter @openducktor/desktop test agent-studio-header.test.ts
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned session selector as an icon-triggered, grouped session menu with visual checkmarks and empty-state messaging
  * Header layout adjusted for improved title, badge, and control placement; truncated task titles expose full title via tooltip
* **Accessibility**
  * Improved ARIA/labeling and keyboard-friendly session history interaction
* **Tests**
  * Expanded tests covering session menu interactions, ordering, titles, and disabled states
<!-- end of auto-generated comment: release notes by coderabbit.ai -->