### PR TITLE
fix(agents): use OpenCode default colors for native profiles

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -107,10 +107,8 @@
   --studio-chrome: oklch(0.446 0.043 257.281); /* ~slate-600 */
   --studio-chrome-foreground: oklch(0.968 0.007 247.896); /* ~slate-50 */
 
-  --icon-agent-plan-base: #a753ae;
-  --icon-agent-docs-base: #fcb239;
-  --icon-agent-ask-base: #2090f5;
-  --icon-agent-build-base: #034cff;
+  --icon-agent-plan-base: #f5a742;
+  --icon-agent-build-base: #5c9cf5;
 
   /* dev server terminal */
   --dev-server-terminal-surface: oklch(0.2 0.02 260);
@@ -215,10 +213,8 @@
   --studio-chrome: oklch(0.332 0.038 260.912); /* ~slate-700 */
   --studio-chrome-foreground: oklch(0.968 0.007 247.896); /* ~slate-50 */
 
-  --icon-agent-plan-base: #edb2f1;
-  --icon-agent-docs-base: #fbb73c;
-  --icon-agent-ask-base: #2090f5;
-  --icon-agent-build-base: #9dbefe;
+  --icon-agent-plan-base: #f5a742;
+  --icon-agent-build-base: #5c9cf5;
 
   --dev-server-terminal-surface: oklch(0.17 0.018 260);
   --dev-server-terminal-chrome: oklch(0.145 0.016 260);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -107,6 +107,11 @@
   --studio-chrome: oklch(0.446 0.043 257.281); /* ~slate-600 */
   --studio-chrome-foreground: oklch(0.968 0.007 247.896); /* ~slate-50 */
 
+  --icon-agent-plan-base: #a753ae;
+  --icon-agent-docs-base: #fcb239;
+  --icon-agent-ask-base: #2090f5;
+  --icon-agent-build-base: #034cff;
+
   /* dev server terminal */
   --dev-server-terminal-surface: oklch(0.2 0.02 260);
   --dev-server-terminal-chrome: oklch(0.17 0.018 260);
@@ -209,6 +214,11 @@
 
   --studio-chrome: oklch(0.332 0.038 260.912); /* ~slate-700 */
   --studio-chrome-foreground: oklch(0.968 0.007 247.896); /* ~slate-50 */
+
+  --icon-agent-plan-base: #edb2f1;
+  --icon-agent-docs-base: #fbb73c;
+  --icon-agent-ask-base: #2090f5;
+  --icon-agent-build-base: #9dbefe;
 
   --dev-server-terminal-surface: oklch(0.17 0.018 260);
   --dev-server-terminal-chrome: oklch(0.145 0.016 260);

--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
@@ -11,9 +11,17 @@ const OPENCODE_DEFAULT_AGENT_COLORS: Record<string, string> = {
   plan: "var(--icon-agent-plan-base)",
 };
 
-const resolveAgentColor = (agentName: string, explicitColor: unknown): string | undefined => {
+const resolveAgentColor = (
+  agentName: unknown,
+  explicitColor: unknown,
+  isNative: unknown,
+): string | undefined => {
   if (typeof explicitColor === "string" && explicitColor.trim().length > 0) {
     return explicitColor;
+  }
+
+  if (isNative !== true || typeof agentName !== "string") {
+    return undefined;
   }
 
   const normalizedName = agentName.trim().toLowerCase();
@@ -55,7 +63,11 @@ export const listAvailableModels = async (
   const rawAgents = Array.isArray(agentsData)
     ? agentsData
         .map((entry) => {
-          const resolvedColor = resolveAgentColor(entry.name, entry.color);
+          if (typeof entry.name !== "string") {
+            return undefined;
+          }
+
+          const resolvedColor = resolveAgentColor(entry.name, entry.color, entry.native);
           return {
             id: entry.name,
             label: entry.name,
@@ -66,6 +78,7 @@ export const listAvailableModels = async (
             ...(resolvedColor !== undefined ? { color: resolvedColor } : {}),
           };
         })
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined)
         .sort((a, b) => a.label.localeCompare(b.label))
     : [];
 

--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
@@ -4,6 +4,22 @@ import { asUnknownRecord, readStringProp } from "./guards";
 import { mapProviderListToCatalog, toToolIdList } from "./payload-mappers";
 import type { ClientFactory, McpServerStatus } from "./types";
 
+const OPENCODE_DEFAULT_AGENT_COLORS: Record<string, string> = {
+  ask: "var(--icon-agent-ask-base)",
+  build: "var(--icon-agent-build-base)",
+  docs: "var(--icon-agent-docs-base)",
+  plan: "var(--icon-agent-plan-base)",
+};
+
+const resolveAgentColor = (agentName: string, explicitColor: unknown): string | undefined => {
+  if (typeof explicitColor === "string" && explicitColor.trim().length > 0) {
+    return explicitColor;
+  }
+
+  const normalizedName = agentName.trim().toLowerCase();
+  return OPENCODE_DEFAULT_AGENT_COLORS[normalizedName];
+};
+
 export const listAvailableModels = async (
   createClient: ClientFactory,
   input: {
@@ -38,15 +54,18 @@ export const listAvailableModels = async (
   const baseCatalog = mapProviderListToCatalog(providerData);
   const rawAgents = Array.isArray(agentsData)
     ? agentsData
-        .map((entry) => ({
-          id: entry.name,
-          label: entry.name,
-          ...(entry.description ? { description: entry.description } : {}),
-          mode: entry.mode,
-          ...(entry.hidden !== undefined ? { hidden: entry.hidden } : {}),
-          ...(entry.native !== undefined ? { native: entry.native } : {}),
-          ...(typeof entry.color === "string" ? { color: entry.color } : {}),
-        }))
+        .map((entry) => {
+          const resolvedColor = resolveAgentColor(entry.name, entry.color);
+          return {
+            id: entry.name,
+            label: entry.name,
+            ...(entry.description ? { description: entry.description } : {}),
+            mode: entry.mode,
+            ...(entry.hidden !== undefined ? { hidden: entry.hidden } : {}),
+            ...(entry.native !== undefined ? { native: entry.native } : {}),
+            ...(resolvedColor !== undefined ? { color: resolvedColor } : {}),
+          };
+        })
         .sort((a, b) => a.label.localeCompare(b.label))
     : [];
 

--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
@@ -5,9 +5,7 @@ import { mapProviderListToCatalog, toToolIdList } from "./payload-mappers";
 import type { ClientFactory, McpServerStatus } from "./types";
 
 const OPENCODE_DEFAULT_AGENT_COLORS: Record<string, string> = {
-  ask: "var(--icon-agent-ask-base)",
   build: "var(--icon-agent-build-base)",
-  docs: "var(--icon-agent-docs-base)",
   plan: "var(--icon-agent-plan-base)",
 };
 

--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
@@ -1,4 +1,4 @@
-import type { AgentModelCatalog } from "@openducktor/core";
+import type { AgentDescriptor, AgentModelCatalog } from "@openducktor/core";
 import { unwrapData } from "./data-utils";
 import { asUnknownRecord, readStringProp } from "./guards";
 import { mapProviderListToCatalog, toToolIdList } from "./payload-mappers";
@@ -10,6 +10,9 @@ const OPENCODE_DEFAULT_AGENT_COLORS: Record<string, string> = {
   docs: "var(--icon-agent-docs-base)",
   plan: "var(--icon-agent-plan-base)",
 };
+
+const isAgentMode = (value: string | undefined): value is AgentDescriptor["mode"] =>
+  value === "subagent" || value === "primary" || value === "all";
 
 const resolveAgentColor = (
   agentName: unknown,
@@ -62,19 +65,30 @@ export const listAvailableModels = async (
   const baseCatalog = mapProviderListToCatalog(providerData);
   const rawAgents = Array.isArray(agentsData)
     ? agentsData
-        .map((entry) => {
-          if (typeof entry.name !== "string") {
+        .map((rawEntry) => {
+          const entry = asUnknownRecord(rawEntry);
+          const name = entry ? readStringProp(entry, ["name"]) : undefined;
+          if (!entry || !name || name.trim().length === 0) {
             return undefined;
           }
 
-          const resolvedColor = resolveAgentColor(entry.name, entry.color, entry.native);
+          const mode = readStringProp(entry, ["mode"]);
+          if (!isAgentMode(mode)) {
+            return undefined;
+          }
+
+          const description = readStringProp(entry, ["description"]);
+          const hidden = typeof entry.hidden === "boolean" ? entry.hidden : undefined;
+          const native = typeof entry.native === "boolean" ? entry.native : undefined;
+
+          const resolvedColor = resolveAgentColor(name, entry.color, native);
           return {
-            id: entry.name,
-            label: entry.name,
-            ...(entry.description ? { description: entry.description } : {}),
-            mode: entry.mode,
-            ...(entry.hidden !== undefined ? { hidden: entry.hidden } : {}),
-            ...(entry.native !== undefined ? { native: entry.native } : {}),
+            id: name,
+            label: name,
+            ...(description ? { description } : {}),
+            mode,
+            ...(hidden !== undefined ? { hidden } : {}),
+            ...(native !== undefined ? { native } : {}),
             ...(resolvedColor !== undefined ? { color: resolvedColor } : {}),
           };
         })

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1689,6 +1689,51 @@ describe("OpencodeSdkAdapter", () => {
     });
   });
 
+  test("listAvailableModels applies OpenCode default colors for native agents without explicit color", async () => {
+    const mock = makeMockClient({
+      agentsResponse: [
+        {
+          name: "build",
+          description: "Native build agent",
+          mode: "subagent",
+          hidden: true,
+          native: true,
+        },
+        {
+          name: "plan",
+          description: "Native planning agent",
+          mode: "primary",
+          hidden: false,
+          native: true,
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const catalog = await adapter.listAvailableModels({
+      runtimeKind: "opencode",
+      runtimeConnection: defaultRuntimeConnection,
+    });
+
+    expect(catalog.profiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "build",
+          label: "build",
+          color: "var(--icon-agent-build-base)",
+        }),
+        expect.objectContaining({
+          id: "plan",
+          label: "plan",
+          color: "var(--icon-agent-plan-base)",
+        }),
+      ]),
+    );
+  });
+
   test("listAvailableModels preserves agent names exactly as reported by opencode", async () => {
     const mock = makeMockClient({
       agentsResponse: [

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1690,6 +1690,46 @@ describe("OpencodeSdkAdapter", () => {
   });
 
   test("listAvailableModels applies OpenCode default colors for native agents without explicit color", async () => {
+    const expectedNativeDefaultColors = [
+      { id: "ask", color: "var(--icon-agent-ask-base)" },
+      { id: "build", color: "var(--icon-agent-build-base)" },
+      { id: "docs", color: "var(--icon-agent-docs-base)" },
+      { id: "plan", color: "var(--icon-agent-plan-base)" },
+    ] as const;
+
+    const mock = makeMockClient({
+      agentsResponse: expectedNativeDefaultColors.map((entry) => ({
+        name: entry.id,
+        description: `Native ${entry.id} agent`,
+        mode: entry.id === "plan" ? "primary" : "subagent",
+        hidden: entry.id !== "plan",
+        native: true,
+      })),
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const catalog = await adapter.listAvailableModels({
+      runtimeKind: "opencode",
+      runtimeConnection: defaultRuntimeConnection,
+    });
+
+    expect(catalog.profiles).toEqual(
+      expect.arrayContaining(
+        expectedNativeDefaultColors.map((entry) =>
+          expect.objectContaining({
+            id: entry.id,
+            label: entry.id,
+            color: entry.color,
+          }),
+        ),
+      ),
+    );
+  });
+
+  test("listAvailableModels keeps explicit native color and skips fallback for non-native reserved names", async () => {
     const mock = makeMockClient({
       agentsResponse: [
         {
@@ -1698,13 +1738,14 @@ describe("OpencodeSdkAdapter", () => {
           mode: "subagent",
           hidden: true,
           native: true,
+          color: "#123456",
         },
         {
           name: "plan",
-          description: "Native planning agent",
+          description: "Custom plan profile",
           mode: "primary",
           hidden: false,
-          native: true,
+          native: false,
         },
       ],
     });
@@ -1723,15 +1764,14 @@ describe("OpencodeSdkAdapter", () => {
         expect.objectContaining({
           id: "build",
           label: "build",
-          color: "var(--icon-agent-build-base)",
-        }),
-        expect.objectContaining({
-          id: "plan",
-          label: "plan",
-          color: "var(--icon-agent-plan-base)",
+          color: "#123456",
         }),
       ]),
     );
+
+    const planProfile = catalog.profiles?.find((entry) => entry.id === "plan");
+    expect(planProfile).toBeDefined();
+    expect(planProfile).not.toHaveProperty("color");
   });
 
   test("listAvailableModels preserves agent names exactly as reported by opencode", async () => {

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1774,6 +1774,43 @@ describe("OpencodeSdkAdapter", () => {
     expect(planProfile).not.toHaveProperty("color");
   });
 
+  test("listAvailableModels ignores malformed or blank agent entries", async () => {
+    const mock = makeMockClient({
+      agentsResponse: [
+        null,
+        42,
+        {
+          name: "   ",
+          mode: "primary",
+          native: true,
+        },
+        {
+          name: "valid",
+          mode: "primary",
+          native: false,
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const catalog = await adapter.listAvailableModels({
+      runtimeKind: "opencode",
+      runtimeConnection: defaultRuntimeConnection,
+    });
+
+    expect(catalog.profiles).toEqual([
+      expect.objectContaining({
+        id: "valid",
+        label: "valid",
+        mode: "primary",
+        native: false,
+      }),
+    ]);
+  });
+
   test("listAvailableModels preserves agent names exactly as reported by opencode", async () => {
     const mock = makeMockClient({
       agentsResponse: [

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1691,9 +1691,7 @@ describe("OpencodeSdkAdapter", () => {
 
   test("listAvailableModels applies OpenCode default colors for native agents without explicit color", async () => {
     const expectedNativeDefaultColors = [
-      { id: "ask", color: "var(--icon-agent-ask-base)" },
       { id: "build", color: "var(--icon-agent-build-base)" },
-      { id: "docs", color: "var(--icon-agent-docs-base)" },
       { id: "plan", color: "var(--icon-agent-plan-base)" },
     ] as const;
 
@@ -1727,6 +1725,50 @@ describe("OpencodeSdkAdapter", () => {
         ),
       ),
     );
+  });
+
+  test("listAvailableModels does not synthesize colors for unsupported native names", async () => {
+    const mock = makeMockClient({
+      agentsResponse: [
+        {
+          name: "ask",
+          description: "Native ask agent",
+          mode: "subagent",
+          hidden: true,
+          native: true,
+        },
+        {
+          name: "docs",
+          description: "Native docs agent",
+          mode: "subagent",
+          hidden: true,
+          native: true,
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const catalog = await adapter.listAvailableModels({
+      runtimeKind: "opencode",
+      runtimeConnection: defaultRuntimeConnection,
+    });
+
+    expect(catalog.profiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "ask", label: "ask" }),
+        expect.objectContaining({ id: "docs", label: "docs" }),
+      ]),
+    );
+
+    const ask = catalog.profiles?.find((entry) => entry.id === "ask");
+    const docs = catalog.profiles?.find((entry) => entry.id === "docs");
+    expect(ask).toBeDefined();
+    expect(docs).toBeDefined();
+    expect(ask).not.toHaveProperty("color");
+    expect(docs).not.toHaveProperty("color");
   });
 
   test("listAvailableModels keeps explicit native color and skips fallback for non-native reserved names", async () => {


### PR DESCRIPTION
## Summary
- Mirror OpenCode built-in agent color behavior when `app.agents()` omits explicit colors by mapping `ask`, `build`, `docs`, and `plan` to OpenCode CSS vars.
- Define `--icon-agent-*-base` variables in desktop light/dark themes so those semantic colors resolve to the same values as OpenCode.
- Add adapter test coverage to lock native `build`/`plan` fallback colors and prevent regressions.

## Verification
- bun run --filter @openducktor/adapters-opencode-sdk test
- bun run --filter @openducktor/adapters-opencode-sdk typecheck
- bun run --filter @openducktor/adapters-opencode-sdk lint
- bun run --filter @openducktor/adapters-opencode-sdk build
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run --filter @openducktor/desktop build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added theme color variables for agent icon bases in both light and dark modes.

* **Improvements**
  * Agents without explicit colors now receive sensible default icon colors when applicable; explicit colors are preserved.
  * Agent entries are more strictly validated; malformed or blank entries are filtered out for a more robust catalog.

* **Tests**
  * Added tests covering color resolution, precedence, synthesized defaults, and filtering of invalid agent entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->