### PR TITLE
feat: allow parallel OpenDucktor instances via OPENDUCKTOR_CONFIG_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,15 @@ bun run test:rust
 
 ### Local Data And Config
 
-OpenDucktor stores local config at:
+OpenDucktor resolves its base directory to `~/.openducktor` by default. You can override this with the `OPENDUCKTOR_CONFIG_DIR` environment variable.
 
-- `~/.openducktor/config.json`
+Local config is stored at:
+
+- `$OPENDUCKTOR_CONFIG_DIR/config.json` (or `~/.openducktor/config.json`)
 
 Beads storage is managed centrally per repository in:
 
-- `~/.openducktor/beads/`
+- `$OPENDUCKTOR_CONFIG_DIR/beads/` (or `~/.openducktor/beads/`)
 
 The app initializes and uses a central Beads directory for each repository. Existing repo-local `.beads` folders are not the V1 source of truth.
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -4,6 +4,8 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::config::resolve_openducktor_base_dir;
+
 pub fn compute_repo_slug(repo_path: &Path) -> String {
     let candidate = repo_path
         .file_name()
@@ -44,9 +46,9 @@ pub fn resolve_effective_worktree_base_dir(
 }
 
 fn resolve_repo_scoped_openducktor_dir(repo_path: &Path, namespace: &str) -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
+    let base_dir = resolve_openducktor_base_dir()?;
     let repo_id = compute_repo_id(repo_path)?;
-    Ok(home.join(".openducktor").join(namespace).join(repo_id))
+    Ok(base_dir.join(namespace).join(repo_id))
 }
 
 fn canonical_or_absolute(repo_path: &Path) -> Result<PathBuf> {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
@@ -101,7 +101,7 @@ mod tests {
         compute_repo_id, compute_repo_slug, resolve_central_beads_dir,
         resolve_default_worktree_base_dir, resolve_effective_worktree_base_dir,
     };
-    use host_test_support::lock_env;
+    use host_test_support::{lock_env, EnvVarGuard};
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -135,6 +135,7 @@ mod tests {
     #[test]
     fn central_beads_dir_uses_expected_layout_suffix() {
         let _env_lock = lock_env();
+        let _override_guard = EnvVarGuard::remove("OPENDUCKTOR_CONFIG_DIR");
         let resolved =
             resolve_central_beads_dir(Path::new("/tmp/openducktor-test/repo")).expect("beads dir");
         let as_string = resolved.to_string_lossy();
@@ -145,6 +146,7 @@ mod tests {
     #[test]
     fn central_beads_dir_resolution_does_not_create_directories() {
         let _env_lock = lock_env();
+        let _override_guard = EnvVarGuard::remove("OPENDUCKTOR_CONFIG_DIR");
         let home = dirs::home_dir().expect("home directory should resolve");
 
         for attempt in 0..64 {
@@ -178,11 +180,29 @@ mod tests {
     #[test]
     fn default_worktree_base_dir_uses_expected_layout() {
         let _env_lock = lock_env();
+        let _override_guard = EnvVarGuard::remove("OPENDUCKTOR_CONFIG_DIR");
         let resolved = resolve_default_worktree_base_dir(Path::new("/tmp/openducktor-test/repo"))
             .expect("worktree base dir");
         let as_string = resolved.to_string_lossy();
         assert!(as_string.contains(".openducktor/worktrees/"));
         assert!(!as_string.ends_with("/.beads"));
+    }
+
+    #[test]
+    fn central_beads_dir_uses_env_override_when_set() {
+        let _env_lock = lock_env();
+        let override_base = "/tmp/odt-custom-config-dir";
+        let _override_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", override_base);
+
+        let repo_path = Path::new("/tmp/openducktor-test/repo");
+        let repo_id = compute_repo_id(repo_path).expect("repo id should resolve");
+        let resolved = resolve_central_beads_dir(repo_path).expect("beads dir should resolve");
+        let expected = PathBuf::from(override_base)
+            .join("beads")
+            .join(repo_id)
+            .join(".beads");
+
+        assert_eq!(resolved, expected);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -6,6 +6,7 @@ mod store;
 mod types;
 
 pub use normalize::{normalize_hook_set, normalize_repo_dev_servers};
+pub use persistence::resolve_openducktor_base_dir;
 pub use store::{AppConfigStore, RuntimeConfigStore};
 pub use types::{
     hook_set_fingerprint, repo_script_fingerprint, AgentDefaults, AgentModelDefault, ChatSettings,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
@@ -3,6 +3,7 @@ use super::security::CONFIG_FILE_MODE;
 use super::security::{enforce_directory_permissions, validate_config_access};
 use anyhow::{anyhow, Context, Result};
 use serde::{de::DeserializeOwned, Serialize};
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 #[cfg(unix)]
@@ -14,9 +15,24 @@ use std::{
 #[cfg(unix)]
 const MAX_TEMP_FILE_ATTEMPTS: u8 = 8;
 
-pub(super) fn resolve_default_path(file_name: &str) -> Result<PathBuf> {
+const OPENDUCKTOR_CONFIG_DIR_ENV: &str = "OPENDUCKTOR_CONFIG_DIR";
+const DEFAULT_CONFIG_DIR_NAME: &str = ".openducktor";
+
+/// Resolves the effective OpenDucktor base directory.
+///
+/// If `OPENDUCKTOR_CONFIG_DIR` is set, returns that path.
+/// Otherwise returns `~/.openducktor`.
+pub fn resolve_openducktor_base_dir() -> Result<PathBuf> {
+    if let Some(env_dir) = env::var_os(OPENDUCKTOR_CONFIG_DIR_ENV) {
+        return Ok(PathBuf::from(env_dir));
+    }
     let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
-    Ok(home.join(".openducktor").join(file_name))
+    Ok(home.join(DEFAULT_CONFIG_DIR_NAME))
+}
+
+pub(super) fn resolve_default_path(file_name: &str) -> Result<PathBuf> {
+    let base_dir = resolve_openducktor_base_dir()?;
+    Ok(base_dir.join(file_name))
 }
 
 pub(super) fn should_enforce_private_parent_permissions(path: &Path, file_name: &str) -> bool {

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
@@ -24,6 +24,11 @@ const DEFAULT_CONFIG_DIR_NAME: &str = ".openducktor";
 /// Otherwise returns `~/.openducktor`.
 pub fn resolve_openducktor_base_dir() -> Result<PathBuf> {
     if let Some(env_dir) = env::var_os(OPENDUCKTOR_CONFIG_DIR_ENV) {
+        if env_dir.is_empty() {
+            return Err(anyhow!(
+                "OPENDUCKTOR_CONFIG_DIR is set but empty; provide a valid directory path"
+            ));
+        }
         return Ok(PathBuf::from(env_dir));
     }
     let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
@@ -191,4 +196,24 @@ fn create_temporary_config_path(path: &Path, attempt: u8) -> Result<PathBuf> {
     temp_name.push(file_name);
     temp_name.push(format!(".tmp-{}-{nanos}-{attempt}", std::process::id()));
     Ok(parent.join(temp_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_openducktor_base_dir;
+    use host_test_support::{lock_env, EnvVarGuard};
+
+    #[test]
+    fn resolve_openducktor_base_dir_rejects_empty_env_override() {
+        let _env_lock = lock_env();
+        let _override_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "");
+
+        let error = resolve_openducktor_base_dir().expect_err("empty override should be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("OPENDUCKTOR_CONFIG_DIR is set but empty"),
+            "unexpected error: {error}"
+        );
+    }
 }

--- a/scripts/browser-dev.ts
+++ b/scripts/browser-dev.ts
@@ -4,13 +4,18 @@ const repoRoot = resolve(import.meta.dir, "..");
 const backendPort = process.env.ODT_BROWSER_BACKEND_PORT ?? "14327";
 const backendUrl = `http://127.0.0.1:${backendPort}`;
 
+const backendEnv: Record<string, string> = {
+  ...process.env,
+  ODT_BROWSER_BACKEND_PORT: backendPort,
+};
+if (process.env.OPENDUCKTOR_CONFIG_DIR) {
+  backendEnv.OPENDUCKTOR_CONFIG_DIR = process.env.OPENDUCKTOR_CONFIG_DIR;
+}
+
 const backendProcess = Bun.spawn({
   cmd: ["cargo", "run", "--bin", "browser_backend"],
   cwd: `${repoRoot}/apps/desktop/src-tauri`,
-  env: {
-    ...process.env,
-    ODT_BROWSER_BACKEND_PORT: backendPort,
-  },
+  env: backendEnv,
   stdout: "inherit",
   stderr: "inherit",
 });

--- a/scripts/browser-dev.ts
+++ b/scripts/browser-dev.ts
@@ -8,9 +8,6 @@ const backendEnv: Record<string, string> = {
   ...process.env,
   ODT_BROWSER_BACKEND_PORT: backendPort,
 };
-if (process.env.OPENDUCKTOR_CONFIG_DIR) {
-  backendEnv.OPENDUCKTOR_CONFIG_DIR = process.env.OPENDUCKTOR_CONFIG_DIR;
-}
 
 const backendProcess = Bun.spawn({
   cmd: ["cargo", "run", "--bin", "browser_backend"],


### PR DESCRIPTION
## Summary
- Add `OPENDUCKTOR_CONFIG_DIR` support in host infra path resolution through a shared `resolve_openducktor_base_dir()` helper.
- Update config and repo-scoped storage path builders to derive from the configured base dir instead of hardcoded `~/.openducktor`.
- Forward `OPENDUCKTOR_CONFIG_DIR` in `scripts/browser-dev.ts` and document the override behavior in `README.md`.

## Validation
- `bun run check:rust`
- `bun run test:rust`
- `cargo test -p host-domain -p host-infra-system`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration and beads storage base directories can be customized via the OPENDUCKTOR_CONFIG_DIR environment variable, falling back to ~/.openducktor.

* **Bug Fixes**
  * Rejects empty OPENDUCKTOR_CONFIG_DIR to prevent invalid configuration paths.

* **Documentation**
  * README updated to reflect the new configurable base directory and storage locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->