### PR TITLE
fix: isolate backend path resolution for parallel config dirs

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context, Result};
-use host_infra_system::{resolve_central_beads_dir, resolve_command_path};
+use host_infra_system::{parse_user_path, resolve_central_beads_dir, resolve_command_path};
 use serde_json::json;
 use std::path::{Path, PathBuf};
 
@@ -48,10 +48,10 @@ pub(crate) fn find_openducktor_workspace_root(start: &Path) -> Result<PathBuf> {
 pub(crate) fn default_mcp_workspace_root() -> Result<String> {
     let from_env = std::env::var("OPENDUCKTOR_WORKSPACE_ROOT")
         .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
+        .map(|value| parse_user_path(value.as_str()))
+        .transpose()?;
     if let Some(root) = from_env {
-        return Ok(root);
+        return Ok(root.to_string_lossy().to_string());
     }
 
     let compiled_path = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
@@ -46,12 +46,12 @@ pub(crate) fn find_openducktor_workspace_root(start: &Path) -> Result<PathBuf> {
 }
 
 pub(crate) fn default_mcp_workspace_root() -> Result<String> {
-    let from_env = std::env::var("OPENDUCKTOR_WORKSPACE_ROOT")
-        .ok()
-        .map(|value| parse_user_path(value.as_str()))
-        .transpose()?;
-    if let Some(root) = from_env {
-        return Ok(root.to_string_lossy().to_string());
+    if let Ok(value) = std::env::var("OPENDUCKTOR_WORKSPACE_ROOT") {
+        if !value.trim().is_empty() {
+            let root = parse_user_path(value.as_str())
+                .with_context(|| format!("Invalid OPENDUCKTOR_WORKSPACE_ROOT: {:?}", value))?;
+            return Ok(root.to_string_lossy().to_string());
+        }
     }
 
     let compiled_path = Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/process_lifecycle.rs
@@ -1,5 +1,7 @@
 use anyhow::{anyhow, Context, Result};
-use host_infra_system::{bundled_command, resolve_command_path, subprocess_path_env};
+use host_infra_system::{
+    bundled_command, parse_user_path, resolve_command_path, subprocess_path_env,
+};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
@@ -45,9 +47,8 @@ pub(crate) fn read_opencode_version(binary: &str) -> Option<String> {
 
 pub(crate) fn resolve_opencode_binary_path() -> Option<String> {
     if let Ok(override_binary) = std::env::var("OPENDUCKTOR_OPENCODE_BINARY") {
-        let trimmed = override_binary.trim();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_string());
+        if let Ok(path) = parse_user_path(override_binary.as_str()) {
+            return Some(path.to_string_lossy().to_string());
         }
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/process_registry.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/process_registry.rs
@@ -349,3 +349,45 @@ impl AppService {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_service::test_support::{lock_env, set_env_var, unique_temp_path};
+    use host_infra_system::AppConfigStore;
+    use host_test_support::EnvVarGuard;
+    use std::path::PathBuf;
+
+    #[test]
+    fn opencode_process_registry_path_uses_expanded_config_dir_override() {
+        let _env_lock = lock_env();
+        let home = unique_temp_path("process-registry-home");
+        let _home_guard = set_env_var("HOME", home.to_string_lossy().as_ref());
+        let _config_dir_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "~/.openducktor-local");
+
+        let config_store = AppConfigStore::new().expect("config store should resolve");
+        let registry_path = AppService::opencode_process_registry_path(&config_store);
+
+        let base_dir = home.join(".openducktor-local");
+        let expected = base_dir.join(PathBuf::from(OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH));
+        assert_eq!(config_store.path(), base_dir.join("config.json"));
+        assert_eq!(registry_path, expected);
+    }
+
+    #[test]
+    fn opencode_process_registry_path_uses_expanded_quoted_config_dir_override() {
+        let _env_lock = lock_env();
+        let home = unique_temp_path("process-registry-quoted-home");
+        let _home_guard = set_env_var("HOME", home.to_string_lossy().as_ref());
+        let _config_dir_guard =
+            EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "\"~/.openducktor-local\"");
+
+        let config_store = AppConfigStore::new().expect("config store should resolve");
+        let registry_path = AppService::opencode_process_registry_path(&config_store);
+
+        let expected = home
+            .join(".openducktor-local")
+            .join(PathBuf::from(OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH));
+        assert_eq!(registry_path, expected);
+    }
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -601,6 +601,29 @@ fn helper_functions_cover_mcp_and_opencode_resolution_paths() -> Result<()> {
 }
 
 #[test]
+fn resolve_opencode_binary_path_supports_home_shorthand_override() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("opencode-tilde-override");
+    let home = root.join("home");
+    let override_dir = home.join("custom-bin");
+    fs::create_dir_all(&override_dir)?;
+    let override_binary = override_dir.join("opencode");
+    create_fake_opencode(&override_binary)?;
+
+    let _home_guard = set_env_var("HOME", home.to_string_lossy().as_ref());
+    let _override_guard = set_env_var("OPENDUCKTOR_OPENCODE_BINARY", "~/custom-bin/opencode");
+
+    let resolved = resolve_opencode_binary_path();
+    assert_eq!(
+        resolved.as_deref(),
+        Some(override_binary.to_string_lossy().as_ref())
+    );
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn resolve_opencode_binary_path_uses_home_fallback_when_override_and_path_missing() -> Result<()> {
     let _env_lock = lock_env();
     let root = unique_temp_path("opencode-home-fallback");
@@ -828,6 +851,26 @@ fn resolve_mcp_command_supports_cli_and_bun_fallback_modes() -> Result<()> {
             ]
         );
     }
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn default_mcp_workspace_root_supports_home_shorthand_override() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("mcp-workspace-root-tilde");
+    let home = root.join("home");
+    let workspace = home.join("workspace-root");
+    fs::create_dir_all(&workspace)?;
+
+    let _home_guard = set_env_var("HOME", home.to_string_lossy().as_ref());
+    let _workspace_guard = set_env_var("OPENDUCKTOR_WORKSPACE_ROOT", "~/workspace-root");
+
+    assert_eq!(
+        default_mcp_workspace_root()?,
+        workspace.to_string_lossy().to_string()
+    );
 
     let _ = fs::remove_dir_all(root);
     Ok(())

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -877,6 +877,15 @@ fn default_mcp_workspace_root_supports_home_shorthand_override() -> Result<()> {
 }
 
 #[test]
+fn default_mcp_workspace_root_ignores_empty_override() -> Result<()> {
+    let _env_lock = lock_env();
+    let _workspace_guard = set_env_var("OPENDUCKTOR_WORKSPACE_ROOT", "   ");
+    let resolved = default_mcp_workspace_root()?;
+    assert!(!resolved.trim().is_empty());
+    Ok(())
+}
+
+#[test]
 fn parse_mcp_command_json_accepts_non_empty_string_array() {
     let parsed = parse_mcp_command_json(r#"["openducktor-mcp","--repo","/tmp/repo"]"#)
         .expect("command should parse");

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -4,7 +4,9 @@ use host_domain::{
     QaReportDocument, QaVerdict, SpecDocument, TaskCard, TaskMetadata, TaskStatus, TaskStore,
     UpdateTaskPatch,
 };
-use host_infra_system::{compute_repo_slug, resolve_central_beads_dir};
+use host_infra_system::{
+    compute_beads_database_name, compute_repo_slug, resolve_central_beads_dir,
+};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fmt;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -37,10 +37,19 @@ impl BeadsTaskStore {
         init_failure_reason: &str,
     ) -> Result<()> {
         let slug = compute_repo_slug(repo_path);
+        let database_name = compute_beads_database_name(repo_path, beads_dir)?;
         let beads_dir_env = beads_dir.to_string_lossy().to_string();
         let (ok, _stdout, stderr) = self.command_runner.run_allow_failure_with_env(
             "bd",
-            &["init", "--quiet", "--skip-hooks", "--prefix", slug.as_str()],
+            &[
+                "init",
+                "--quiet",
+                "--skip-hooks",
+                "--prefix",
+                slug.as_str(),
+                "--database",
+                database_name.as_str(),
+            ],
             Some(repo_path),
             &[("BEADS_DIR", beads_dir_env.as_str())],
         )?;

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -9,7 +9,9 @@ use host_domain::{
     AgentSessionDocument, CreateTaskInput, IssueType, QaVerdict, TaskStatus, TaskStore,
     UpdateTaskPatch,
 };
-use host_infra_system::{compute_repo_slug, resolve_central_beads_dir};
+use host_infra_system::{
+    compute_beads_database_name, compute_repo_slug, resolve_central_beads_dir,
+};
 use serde_json::{json, Value};
 use std::collections::VecDeque;
 use std::fs;
@@ -221,6 +223,24 @@ fn assert_beads_env(call: &RecordedCall) {
     assert!(
         !beads_dir_entry.1.trim().is_empty(),
         "BEADS_DIR must be set"
+    );
+}
+
+fn assert_init_args(call: &RecordedCall, repo_path: &Path, beads_dir: &Path) {
+    let expected_slug = compute_repo_slug(repo_path);
+    let expected_database =
+        compute_beads_database_name(repo_path, beads_dir).expect("expected database name");
+    assert_eq!(
+        call.args,
+        vec![
+            "init".to_string(),
+            "--quiet".to_string(),
+            "--skip-hooks".to_string(),
+            "--prefix".to_string(),
+            expected_slug,
+            "--database".to_string(),
+            expected_database,
+        ]
     );
 }
 
@@ -679,21 +699,9 @@ fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Resu
 
     let calls = runner.take_calls();
     assert_eq!(calls.len(), 3);
-    let expected_slug = compute_repo_slug(repo.path());
     assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
-    assert_eq!(
-        calls[0].args,
-        vec![
-            "init",
-            "--quiet",
-            "--skip-hooks",
-            "--prefix",
-            expected_slug.as_str()
-        ]
-        .into_iter()
-        .map(str::to_string)
-        .collect::<Vec<_>>()
-    );
+    let beads_dir = resolve_central_beads_dir(repo.path())?;
+    assert_init_args(&calls[0], repo.path(), &beads_dir);
     assert_beads_env(&calls[0]);
     assert_eq!(calls[1].kind, CallKind::AllowFailureWithEnv);
     assert_eq!(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -700,7 +700,6 @@ fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Resu
     let calls = runner.take_calls();
     assert_eq!(calls.len(), 3);
     assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
-    let beads_dir = resolve_central_beads_dir(repo.path())?;
     assert_init_args(&calls[0], repo.path(), &beads_dir);
     assert_beads_env(&calls[0]);
     assert_eq!(calls[1].kind, CallKind::AllowFailureWithEnv);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -29,7 +29,8 @@ pub fn compute_repo_id(repo_path: &Path) -> Result<String> {
 
 pub fn compute_beads_database_name(repo_path: &Path, beads_dir: &Path) -> Result<String> {
     let slug = sanitize_database_identifier(&compute_repo_slug(repo_path));
-    let resolved_beads_dir = canonical_or_absolute(beads_dir)?;
+    let resolved_repo_path = canonical_or_absolute(repo_path)?;
+    let resolved_beads_dir = canonical_or_absolute_from(beads_dir, &resolved_repo_path)?;
     let digest = Sha256::digest(resolved_beads_dir.to_string_lossy().as_bytes());
     let short_hash = format!("{digest:x}");
     let hash_suffix = &short_hash[..12];
@@ -68,12 +69,17 @@ fn resolve_repo_scoped_openducktor_dir(repo_path: &Path, namespace: &str) -> Res
 }
 
 fn canonical_or_absolute(repo_path: &Path) -> Result<PathBuf> {
-    let absolute = if repo_path.is_absolute() {
-        repo_path.to_path_buf()
+    canonical_or_absolute_from(
+        repo_path,
+        &env::current_dir().context("Unable to resolve current working directory")?,
+    )
+}
+
+fn canonical_or_absolute_from(path: &Path, base_dir: &Path) -> Result<PathBuf> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
     } else {
-        env::current_dir()
-            .context("Unable to resolve current working directory")?
-            .join(repo_path)
+        base_dir.join(path)
     };
 
     Ok(fs::canonicalize(&absolute).unwrap_or(absolute))
@@ -192,6 +198,20 @@ mod tests {
         .expect("second database name");
 
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn beads_database_name_resolves_relative_store_path_from_repo_path() {
+        let repo_path = Path::new("/tmp/example-project");
+        let relative = compute_beads_database_name(repo_path, Path::new("relative/.beads"))
+            .expect("relative database name");
+        let absolute = compute_beads_database_name(
+            repo_path,
+            Path::new("/tmp/example-project/relative/.beads"),
+        )
+        .expect("absolute database name");
+
+        assert_eq!(relative, absolute);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::config::resolve_openducktor_base_dir;
+use crate::{config::resolve_openducktor_base_dir, parse_user_path};
 
 pub fn compute_repo_slug(repo_path: &Path) -> String {
     let candidate = repo_path
@@ -27,6 +27,22 @@ pub fn compute_repo_id(repo_path: &Path) -> Result<String> {
     Ok(format!("{slug}-{short_hash}"))
 }
 
+pub fn compute_beads_database_name(repo_path: &Path, beads_dir: &Path) -> Result<String> {
+    let slug = sanitize_database_identifier(&compute_repo_slug(repo_path));
+    let resolved_beads_dir = canonical_or_absolute(beads_dir)?;
+    let digest = Sha256::digest(resolved_beads_dir.to_string_lossy().as_bytes());
+    let short_hash = format!("{digest:x}");
+    let hash_suffix = &short_hash[..12];
+    let max_slug_len = 64usize.saturating_sub("odt__".len() + hash_suffix.len());
+    let truncated_slug = if slug.len() > max_slug_len {
+        &slug[..max_slug_len]
+    } else {
+        slug.as_str()
+    };
+
+    Ok(format!("odt_{truncated_slug}_{hash_suffix}"))
+}
+
 pub fn resolve_central_beads_dir(repo_path: &Path) -> Result<PathBuf> {
     Ok(resolve_repo_scoped_openducktor_dir(repo_path, "beads")?.join(".beads"))
 }
@@ -40,7 +56,7 @@ pub fn resolve_effective_worktree_base_dir(
     configured_worktree_base_path: Option<&str>,
 ) -> Result<PathBuf> {
     match configured_worktree_base_path {
-        Some(configured_path) => Ok(PathBuf::from(configured_path)),
+        Some(configured_path) => parse_user_path(configured_path),
         None => resolve_default_worktree_base_dir(repo_path),
     }
 }
@@ -95,10 +111,24 @@ fn sanitize_slug(input: &str) -> String {
     }
 }
 
+fn sanitize_database_identifier(input: &str) -> String {
+    let sanitized = input
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    sanitized.trim_matches('_').to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_repo_id, compute_repo_slug, resolve_central_beads_dir,
+        compute_beads_database_name, compute_repo_id, compute_repo_slug, resolve_central_beads_dir,
         resolve_default_worktree_base_dir, resolve_effective_worktree_base_dir,
     };
     use host_test_support::{lock_env, EnvVarGuard};
@@ -129,6 +159,38 @@ mod tests {
     fn repo_id_differs_for_different_paths_with_same_basename() {
         let first = compute_repo_id(Path::new("/tmp/a/project")).expect("first id");
         let second = compute_repo_id(Path::new("/tmp/b/project")).expect("second id");
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn beads_database_name_is_stable_for_same_repo_and_store() {
+        let repo_path = Path::new("/tmp/example-project");
+        let beads_dir = Path::new("/tmp/.openducktor/beads/example-project/.beads");
+
+        let first = compute_beads_database_name(repo_path, beads_dir).expect("first database name");
+        let second =
+            compute_beads_database_name(repo_path, beads_dir).expect("second database name");
+
+        assert_eq!(first, second);
+        assert!(first.starts_with("odt_example_project_"));
+        assert!(first.len() <= 64);
+        assert!(!first.contains('-'));
+    }
+
+    #[test]
+    fn beads_database_name_differs_for_distinct_store_paths() {
+        let repo_path = Path::new("/tmp/example-project");
+        let first = compute_beads_database_name(
+            repo_path,
+            Path::new("/tmp/.openducktor/beads/example-project/.beads"),
+        )
+        .expect("first database name");
+        let second = compute_beads_database_name(
+            repo_path,
+            Path::new("/tmp/.openducktor-local/beads/example-project/.beads"),
+        )
+        .expect("second database name");
+
         assert_ne!(first, second);
     }
 
@@ -225,5 +287,20 @@ mod tests {
         let expected = resolve_default_worktree_base_dir(Path::new("/tmp/openducktor-test/repo"))
             .expect("default worktree base dir");
         assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn effective_worktree_base_dir_expands_home_shorthand_override() {
+        let _env_lock = lock_env();
+        let home = std::env::temp_dir().join("odt-worktree-home");
+        let _home_guard = EnvVarGuard::set("HOME", home.to_string_lossy().as_ref());
+
+        let resolved = resolve_effective_worktree_base_dir(
+            Path::new("/tmp/openducktor-test/repo"),
+            Some("~/custom-worktrees"),
+        )
+        .expect("effective worktree base dir");
+
+        assert_eq!(resolved, home.join("custom-worktrees"));
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/persistence.rs
@@ -29,10 +29,16 @@ pub fn resolve_openducktor_base_dir() -> Result<PathBuf> {
                 "OPENDUCKTOR_CONFIG_DIR is set but empty; provide a valid directory path"
             ));
         }
-        return Ok(PathBuf::from(env_dir));
+        return normalize_env_directory_override(&env_dir);
     }
     let home = dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
     Ok(home.join(DEFAULT_CONFIG_DIR_NAME))
+}
+
+fn normalize_env_directory_override(env_dir: &std::ffi::OsStr) -> Result<PathBuf> {
+    crate::parse_user_path_os(env_dir).map_err(|error| {
+        anyhow!("Invalid OPENDUCKTOR_CONFIG_DIR value: {error}. Provide a valid directory path")
+    })
 }
 
 pub(super) fn resolve_default_path(file_name: &str) -> Result<PathBuf> {
@@ -202,6 +208,7 @@ fn create_temporary_config_path(path: &Path, attempt: u8) -> Result<PathBuf> {
 mod tests {
     use super::resolve_openducktor_base_dir;
     use host_test_support::{lock_env, EnvVarGuard};
+    use std::path::PathBuf;
 
     #[test]
     fn resolve_openducktor_base_dir_rejects_empty_env_override() {
@@ -215,5 +222,54 @@ mod tests {
                 .contains("OPENDUCKTOR_CONFIG_DIR is set but empty"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn resolve_openducktor_base_dir_expands_tilde_prefix() {
+        let _env_lock = lock_env();
+        let home = dirs::home_dir().expect("home directory should resolve");
+        let _override_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "~/.openducktor-local");
+
+        let resolved =
+            resolve_openducktor_base_dir().expect("tilde-prefixed override should resolve");
+
+        assert_eq!(resolved, home.join(".openducktor-local"));
+    }
+
+    #[test]
+    fn resolve_openducktor_base_dir_preserves_non_tilde_relative_override() {
+        let _env_lock = lock_env();
+        let _override_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "./.openducktor-local");
+
+        let resolved =
+            resolve_openducktor_base_dir().expect("relative override should resolve as-is");
+
+        assert_eq!(resolved, PathBuf::from("./.openducktor-local"));
+    }
+
+    #[test]
+    fn resolve_openducktor_base_dir_expands_quoted_tilde_prefix() {
+        let _env_lock = lock_env();
+        let home = dirs::home_dir().expect("home directory should resolve");
+        let _override_guard =
+            EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "\"~/.openducktor-local\"");
+
+        let resolved =
+            resolve_openducktor_base_dir().expect("quoted tilde-prefixed override should resolve");
+
+        assert_eq!(resolved, home.join(".openducktor-local"));
+    }
+
+    #[test]
+    fn resolve_openducktor_base_dir_trims_whitespace_around_override() {
+        let _env_lock = lock_env();
+        let home = dirs::home_dir().expect("home directory should resolve");
+        let _override_guard =
+            EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "  ~/.openducktor-local  ");
+
+        let resolved = resolve_openducktor_base_dir()
+            .expect("whitespace-padded tilde-prefixed override should resolve");
+
+        assert_eq!(resolved, home.join(".openducktor-local"));
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/store.rs
@@ -5,7 +5,7 @@ use super::persistence::{
     should_enforce_private_parent_permissions,
 };
 use super::types::{repo_script_fingerprint, GlobalConfig, HookSet, RepoConfig, RuntimeConfig};
-use crate::resolve_default_worktree_base_dir;
+use crate::{parse_user_path, resolve_default_worktree_base_dir};
 use anyhow::{anyhow, Context, Result};
 use host_domain::WorkspaceRecord;
 use std::path::{Path, PathBuf};
@@ -30,7 +30,10 @@ fn default_worktree_base_path(repo_path: &str) -> Result<String> {
 
 fn effective_worktree_base_path(repo_path: &str, repo: &RepoConfig) -> Result<String> {
     match repo.worktree_base_path.as_ref() {
-        Some(configured_path) => Ok(configured_path.clone()),
+        Some(configured_path) => path_buf_to_utf8(
+            parse_user_path(configured_path)?,
+            &format!("Failed converting configured worktree base path to UTF-8 for {repo_path}"),
+        ),
         None => default_worktree_base_path(repo_path),
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/workspace_config.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/workspace_config.rs
@@ -209,3 +209,37 @@ fn explicit_worktree_override_does_not_require_home_for_workspace_records() {
         Some(override_path.as_str())
     );
 }
+
+#[test]
+fn explicit_worktree_override_expands_home_shorthand_for_effective_path() {
+    let _env_lock = lock_env();
+
+    let harness = TestStoreHarness::new("workspace-explicit-override-home-shorthand");
+    let store = harness.store();
+    let root = harness.root();
+    let repo = root.join("repo");
+    fs::create_dir_all(repo.join(".git")).expect("repo");
+    let repo_str = repo.to_string_lossy().to_string();
+
+    let _home_guard = EnvVarGuard::set("HOME", root.to_string_lossy().as_ref());
+    store.add_workspace(&repo_str).expect("add workspace");
+
+    let updated = store
+        .update_repo_config(
+            &repo_str,
+            RepoConfig {
+                worktree_base_path: Some("~/custom-worktrees".to_string()),
+                ..RepoConfig::default()
+            },
+        )
+        .expect("explicit override should resolve");
+
+    assert_eq!(
+        updated.configured_worktree_base_path.as_deref(),
+        Some("~/custom-worktrees")
+    );
+    assert_eq!(
+        updated.effective_worktree_base_path.as_deref(),
+        Some(root.join("custom-worktrees").to_string_lossy().as_ref())
+    );
+}

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -2,10 +2,11 @@ mod beads;
 mod config;
 mod git;
 mod process;
+mod user_paths;
 mod worktree;
 
 pub use beads::{
-    compute_repo_id, compute_repo_slug, resolve_central_beads_dir,
+    compute_beads_database_name, compute_repo_id, compute_repo_slug, resolve_central_beads_dir,
     resolve_default_worktree_base_dir, resolve_effective_worktree_base_dir,
 };
 pub use config::{
@@ -22,6 +23,7 @@ pub use process::{
     run_command_allow_failure, run_command_allow_failure_with_env, run_command_with_env,
     subprocess_path_env, version_command,
 };
+pub use user_paths::{normalize_user_path, parse_user_path, parse_user_path_os};
 pub use worktree::{
     build_branch_name, copy_configured_worktree_files, pick_free_port, remove_worktree,
     slugify_title,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -1,3 +1,4 @@
+use crate::parse_user_path_os;
 use anyhow::{anyhow, Context, Result};
 use std::env;
 use std::ffi::OsString;
@@ -61,9 +62,11 @@ fn command_env_override_name(program: &str) -> String {
 
 fn explicit_command_override(program: &str) -> Result<Option<String>> {
     let override_name = command_env_override_name(program);
-    let Some(explicit_path) = env::var_os(&override_name).map(PathBuf::from) else {
+    let Some(raw_path) = env::var_os(&override_name) else {
         return Ok(None);
     };
+    let explicit_path = parse_user_path_os(&raw_path)
+        .with_context(|| format!("Invalid {override_name} path override"))?;
 
     if explicit_path.is_file() {
         return Ok(Some(explicit_path.to_string_lossy().to_string()));
@@ -240,7 +243,7 @@ fn explicit_command_override_directories() -> Vec<PathBuf> {
                 return None;
             }
 
-            let path = PathBuf::from(value);
+            let path = parse_user_path_os(&value).ok()?;
             if !path.is_file() {
                 return None;
             }
@@ -787,10 +790,30 @@ mod tests {
 
         let env_name = command_env_override_name(program.as_str());
         let _override_guard = EnvVarGuard::set(&env_name, script.to_string_lossy().as_ref());
-        let output =
-            run_command(program.as_str(), &[], None).expect("override command should execute");
+        let output = run_command(&program, &[], None).expect("override command should execute");
 
         assert_eq!(output, "override-ok");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_command_prefers_tilde_expanded_env_override_for_command_lookup() {
+        let _env_lock = lock_env();
+        let root = unique_temp_path("odt-command-override-home");
+        let home = root.join("home");
+        let script_dir = home.join("bin");
+        fs::create_dir_all(&script_dir).expect("script dir should be created");
+        let program = "bd-override-home";
+        let script = script_dir.join(format!("fake-{program}"));
+        write_executable(&script, "#!/bin/sh\nprintf 'override-home-ok'");
+
+        let env_name = command_env_override_name(program);
+        let _home_guard = EnvVarGuard::set("HOME", home.to_string_lossy().as_ref());
+        let _override_guard = EnvVarGuard::set(&env_name, format!("~/bin/fake-{program}").as_str());
+        let output = run_command(program, &[], None).expect("override command should execute");
+
+        assert_eq!(output, "override-home-ok");
         let _ = fs::remove_dir_all(root);
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/user_paths.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/user_paths.rs
@@ -9,7 +9,7 @@ pub fn normalize_user_path(path: &Path) -> Result<PathBuf> {
     if raw == "~" {
         return dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"));
     }
-    if let Some(suffix) = raw.strip_prefix("~/") {
+    if let Some(suffix) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\")) {
         let home =
             dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
         return Ok(home.join(suffix));
@@ -102,5 +102,17 @@ mod tests {
         let resolved = normalize_user_path(Path::new("./relative/path"))
             .expect("relative path should resolve");
         assert_eq!(resolved, PathBuf::from("./relative/path"));
+    }
+
+    #[test]
+    fn normalize_user_path_supports_windows_style_home_shorthand() {
+        let _env_lock = lock_env();
+        let home = std::env::temp_dir().join("odt-user-paths-windows-home");
+        let _home_guard = EnvVarGuard::set("HOME", home.to_string_lossy().as_ref());
+
+        let resolved = normalize_user_path(Path::new("~\\workspace"))
+            .expect("windows-style path should resolve");
+
+        assert_eq!(resolved, home.join("workspace"));
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/user_paths.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/user_paths.rs
@@ -1,0 +1,106 @@
+use anyhow::{anyhow, Result};
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+pub fn normalize_user_path(path: &Path) -> Result<PathBuf> {
+    let Some(raw) = path.to_str() else {
+        return Ok(path.to_path_buf());
+    };
+    if raw == "~" {
+        return dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"));
+    }
+    if let Some(suffix) = raw.strip_prefix("~/") {
+        let home =
+            dirs::home_dir().ok_or_else(|| anyhow!("Unable to resolve user home directory"))?;
+        return Ok(home.join(suffix));
+    }
+    Ok(path.to_path_buf())
+}
+
+pub fn parse_user_path(raw: &str) -> Result<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("Path is empty; provide a valid path"));
+    }
+    let unquoted = strip_matching_quotes(trimmed);
+    if unquoted.is_empty() {
+        return Err(anyhow!("Path is empty; provide a valid path"));
+    }
+    normalize_user_path(Path::new(unquoted))
+}
+
+pub fn parse_user_path_os(raw: &OsStr) -> Result<PathBuf> {
+    if raw.is_empty() {
+        return Err(anyhow!("Path is empty; provide a valid path"));
+    }
+    let Some(raw_str) = raw.to_str() else {
+        return normalize_user_path(Path::new(raw));
+    };
+    parse_user_path(raw_str)
+}
+
+fn strip_matching_quotes(value: &str) -> &str {
+    if value.len() >= 2 {
+        let first = value.as_bytes()[0];
+        let last = value.as_bytes()[value.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_user_path, parse_user_path, parse_user_path_os};
+    use host_test_support::{lock_env, EnvVarGuard};
+    use std::ffi::OsStr;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn normalize_user_path_expands_home_shorthand() {
+        let _env_lock = lock_env();
+        let home = std::env::temp_dir().join("odt-user-paths-home");
+        let _home_guard = EnvVarGuard::set("HOME", home.to_string_lossy().as_ref());
+
+        let resolved = normalize_user_path(Path::new("~/workspace")).expect("path should resolve");
+
+        assert_eq!(resolved, home.join("workspace"));
+    }
+
+    #[test]
+    fn parse_user_path_trims_and_unquotes() {
+        let _env_lock = lock_env();
+        let home = std::env::temp_dir().join("odt-user-paths-quoted-home");
+        let _home_guard = EnvVarGuard::set("HOME", home.to_string_lossy().as_ref());
+
+        let resolved =
+            parse_user_path("  \"~/.openducktor-local\"  ").expect("quoted path should resolve");
+
+        assert_eq!(resolved, home.join(".openducktor-local"));
+    }
+
+    #[test]
+    fn parse_user_path_os_supports_utf8_values() {
+        let _env_lock = lock_env();
+        let home = std::env::temp_dir().join("odt-user-paths-os-home");
+        let _home_guard = EnvVarGuard::set("HOME", home.to_string_lossy().as_ref());
+
+        let resolved = parse_user_path_os(OsStr::new("~/.config")).expect("os path should resolve");
+
+        assert_eq!(resolved, home.join(".config"));
+    }
+
+    #[test]
+    fn parse_user_path_rejects_empty_input() {
+        let error = parse_user_path("   ").expect_err("empty path should fail");
+        assert!(error.to_string().contains("Path is empty"));
+    }
+
+    #[test]
+    fn normalize_user_path_preserves_non_tilde_relative_paths() {
+        let resolved = normalize_user_path(Path::new("./relative/path"))
+            .expect("relative path should resolve");
+        assert_eq!(resolved, PathBuf::from("./relative/path"));
+    }
+}

--- a/packages/openducktor-mcp/src/beads-runtime-client.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BeadsRuntimeClient } from "./beads-runtime-client";
+import { computeBeadsDatabaseName } from "./beads-runtime";
 
 type ProcessCall = {
   command: string;
@@ -28,6 +29,7 @@ afterEach(() => {
 describe("BeadsRuntimeClient", () => {
   test("ensureInitialized initializes missing stores and starts dolt", async () => {
     const beadsDir = makeTempBeadsDir();
+    const databaseName = await computeBeadsDatabaseName("/repo/fairnest", beadsDir);
     const calls: ProcessCall[] = [];
     const client = new BeadsRuntimeClient("/repo/fairnest", beadsDir, {
       runProcess: async (command, args, cwd, env) => {
@@ -39,7 +41,7 @@ describe("BeadsRuntimeClient", () => {
     await client.ensureInitialized();
 
     expect(calls.map((call) => call.args)).toEqual([
-      ["init", "--quiet", "--skip-hooks", "--prefix", "fairnest"],
+      ["init", "--quiet", "--skip-hooks", "--prefix", "fairnest", "--database", databaseName],
       ["dolt", "start"],
     ]);
     expect(calls.every((call) => call.command === "bd")).toBe(true);

--- a/packages/openducktor-mcp/src/beads-runtime-client.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.test.ts
@@ -2,8 +2,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { BeadsRuntimeClient } from "./beads-runtime-client";
 import { computeBeadsDatabaseName } from "./beads-runtime";
+import { BeadsRuntimeClient } from "./beads-runtime-client";
 
 type ProcessCall = {
   command: string;

--- a/packages/openducktor-mcp/src/beads-runtime-client.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { basename, join } from "node:path";
 import {
   type BeadsDirResolver,
+  computeBeadsDatabaseName,
   CUSTOM_STATUS_VALUES,
   type ProcessRunner,
   resolveCentralBeadsDir,
@@ -100,7 +101,16 @@ export class BeadsRuntimeClient {
       const beadsDir = await this.ensureBeadsDir();
       if (!this.beadsStoreFootprintExists(beadsDir)) {
         const slug = sanitizeSlug(basename(this.repoPath));
-        await this.runBd(["init", "--quiet", "--skip-hooks", "--prefix", slug]);
+        const databaseName = await computeBeadsDatabaseName(this.repoPath, beadsDir);
+        await this.runBd([
+          "init",
+          "--quiet",
+          "--skip-hooks",
+          "--prefix",
+          slug,
+          "--database",
+          databaseName,
+        ]);
       }
 
       await this.runBd(["dolt", "start"]);

--- a/packages/openducktor-mcp/src/beads-runtime-client.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.ts
@@ -2,8 +2,8 @@ import { existsSync } from "node:fs";
 import { basename, join } from "node:path";
 import {
   type BeadsDirResolver,
-  computeBeadsDatabaseName,
   CUSTOM_STATUS_VALUES,
+  computeBeadsDatabaseName,
   type ProcessRunner,
   resolveCentralBeadsDir,
   runProcess,

--- a/packages/openducktor-mcp/src/beads-runtime.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   bundledCommandCandidates,
   commandEnvOverrideName,
+  computeBeadsDatabaseName,
   resolveBundledCommandPath,
   resolveCommandExecutable,
 } from "./beads-runtime";
@@ -109,5 +110,21 @@ describe("beads runtime command resolution", () => {
     setExecPath(fakeExecPath);
 
     expect(resolveCommandExecutable("bd")).toBe("bd");
+  });
+
+  test("computeBeadsDatabaseName is stable and scoped to the beads directory", async () => {
+    const first = await computeBeadsDatabaseName(
+      "/repo/fairnest",
+      "/tmp/.openducktor/beads/fairnest/.beads",
+    );
+    const second = await computeBeadsDatabaseName(
+      "/repo/fairnest",
+      "/tmp/.openducktor-local/beads/fairnest/.beads",
+    );
+
+    expect(first).toMatch(/^odt_fairnest_[a-f0-9]{12}$/);
+    expect(second).toMatch(/^odt_fairnest_[a-f0-9]{12}$/);
+    expect(first).not.toBe(second);
+    expect(first.length).toBeLessThanOrEqual(64);
   });
 });

--- a/packages/openducktor-mcp/src/beads-runtime.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   bundledCommandCandidates,
@@ -12,6 +12,8 @@ import {
 } from "./beads-runtime";
 
 const originalExecPath = process.execPath;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
 const tempDirs: string[] = [];
 
 const setExecPath = (value: string): void => {
@@ -24,6 +26,16 @@ const setExecPath = (value: string): void => {
 
 afterEach(() => {
   setExecPath(originalExecPath);
+  if (typeof originalHome === "string") {
+    process.env.HOME = originalHome;
+  } else {
+    delete process.env.HOME;
+  }
+  if (typeof originalUserProfile === "string") {
+    process.env.USERPROFILE = originalUserProfile;
+  } else {
+    delete process.env.USERPROFILE;
+  }
   delete process.env[commandEnvOverrideName("bd")];
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
@@ -70,6 +82,19 @@ describe("beads runtime command resolution", () => {
     writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n");
     chmodSync(binaryPath, 0o755);
     process.env[commandEnvOverrideName("bd")] = binaryPath;
+
+    expect(resolveCommandExecutable("bd")).toBe(binaryPath);
+  });
+
+  test("resolveCommandExecutable expands home shorthand in explicit override", () => {
+    const subdirName = `.odt-mcp-home-override-${Date.now()}`;
+    const root = join(homedir(), subdirName);
+    tempDirs.push(root);
+    mkdirSync(root, { recursive: true });
+    const binaryPath = join(root, "bd-override");
+    writeFileSync(binaryPath, "#!/bin/sh\nexit 0\n");
+    chmodSync(binaryPath, 0o755);
+    process.env[commandEnvOverrideName("bd")] = `~/${subdirName}/bd-override`;
 
     expect(resolveCommandExecutable("bd")).toBe(binaryPath);
   });

--- a/packages/openducktor-mcp/src/beads-runtime.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   computeBeadsDatabaseName,
   resolveBundledCommandPath,
   resolveCommandExecutable,
+  sanitizeSlug,
 } from "./beads-runtime";
 
 const originalExecPath = process.execPath;
@@ -112,8 +113,17 @@ describe("beads runtime command resolution", () => {
     expect(resolveCommandExecutable("bd")).toBe("bd");
   });
 
+  test("sanitizeSlug matches the Rust ASCII-only behavior", () => {
+    expect(sanitizeSlug("İstanbul")).toBe("stanbul");
+    expect(sanitizeSlug("___My Repo___")).toBe("my-repo");
+  });
+
   test("computeBeadsDatabaseName is stable and scoped to the beads directory", async () => {
     const first = await computeBeadsDatabaseName(
+      "/repo/fairnest",
+      "/tmp/.openducktor/beads/fairnest/.beads",
+    );
+    const firstAgain = await computeBeadsDatabaseName(
       "/repo/fairnest",
       "/tmp/.openducktor/beads/fairnest/.beads",
     );
@@ -122,9 +132,20 @@ describe("beads runtime command resolution", () => {
       "/tmp/.openducktor-local/beads/fairnest/.beads",
     );
 
+    expect(firstAgain).toBe(first);
     expect(first).toMatch(/^odt_fairnest_[a-f0-9]{12}$/);
     expect(second).toMatch(/^odt_fairnest_[a-f0-9]{12}$/);
     expect(first).not.toBe(second);
     expect(first.length).toBeLessThanOrEqual(64);
+  });
+
+  test("computeBeadsDatabaseName resolves relative store paths from the repo path", async () => {
+    const relative = await computeBeadsDatabaseName("/repo/fairnest", "relative/.beads");
+    const absolute = await computeBeadsDatabaseName(
+      "/repo/fairnest",
+      "/repo/fairnest/relative/.beads",
+    );
+
+    expect(relative).toBe(absolute);
   });
 });

--- a/packages/openducktor-mcp/src/beads-runtime.ts
+++ b/packages/openducktor-mcp/src/beads-runtime.ts
@@ -25,6 +25,33 @@ export const normalizeOptionalInput = (value: string | undefined): string | unde
   return trimmed;
 };
 
+const stripMatchingQuotes = (value: string): string => {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' || first === "'") && first === last) {
+      return value.slice(1, -1).trim();
+    }
+  }
+  return value;
+};
+
+const normalizeOptionalPathInput = (value: string | undefined): string | undefined => {
+  const normalized = normalizeOptionalInput(value);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const unquoted = stripMatchingQuotes(normalized);
+  if (unquoted === "~") {
+    return homedir();
+  }
+  if (unquoted.startsWith("~/") || unquoted.startsWith("~\\")) {
+    return resolve(homedir(), unquoted.slice(2));
+  }
+  return unquoted;
+};
+
 export const sanitizeSlug = (input: string): string => {
   let slug = "";
   let lastDash = false;
@@ -120,7 +147,7 @@ export const resolveCommandExecutable = (command: string): string => {
   }
 
   const overrideName = commandEnvOverrideName(command);
-  const explicit = normalizeOptionalInput(process.env[overrideName]);
+  const explicit = normalizeOptionalPathInput(process.env[overrideName]);
   if (explicit) {
     if (!existsSync(explicit) || !statSync(explicit).isFile()) {
       throw new Error(

--- a/packages/openducktor-mcp/src/beads-runtime.ts
+++ b/packages/openducktor-mcp/src/beads-runtime.ts
@@ -31,7 +31,7 @@ export const sanitizeSlug = (input: string): string => {
 
   for (const char of input) {
     const lower = char.toLowerCase();
-    if (/^[a-z0-9]$/.test(lower)) {
+    if (/^[\x30-\x39\x61-\x7a]$/.test(lower)) {
       slug += lower;
       lastDash = false;
       continue;
@@ -192,7 +192,17 @@ export const computeRepoId = async (repoPath: string): Promise<string> => {
 };
 
 const sanitizeDatabaseIdentifier = (input: string): string => {
-  const sanitized = input.replace(/[^a-z0-9]+/gi, "_").replace(/^_+|_+$/g, "").toLowerCase();
+  const sanitized = input
+    .split("")
+    .map((char) => {
+      const lower = char.toLowerCase();
+      if (/^[\x30-\x39\x61-\x7a]$/.test(lower)) {
+        return lower;
+      }
+      return "_";
+    })
+    .join("")
+    .replace(/^_+|_+$/g, "");
   return sanitized.length > 0 ? sanitized : "repo";
 };
 
@@ -201,7 +211,8 @@ export const computeBeadsDatabaseName = async (
   beadsDir: string,
 ): Promise<string> => {
   const slug = sanitizeDatabaseIdentifier(sanitizeSlug(basename(repoPath)));
-  const canonicalBeadsDir = await resolveCanonicalPath(beadsDir);
+  const canonicalRepoPath = await resolveCanonicalPath(repoPath);
+  const canonicalBeadsDir = await resolveCanonicalPath(resolve(canonicalRepoPath, beadsDir));
   const hashSuffix = createHash("sha256").update(canonicalBeadsDir).digest("hex").slice(0, 12);
   const maxSlugLength = 64 - "odt__".length - hashSuffix.length;
   const truncatedSlug = slug.slice(0, maxSlugLength);

--- a/packages/openducktor-mcp/src/beads-runtime.ts
+++ b/packages/openducktor-mcp/src/beads-runtime.ts
@@ -191,6 +191,23 @@ export const computeRepoId = async (repoPath: string): Promise<string> => {
   return `${slug}-${digest}`;
 };
 
+const sanitizeDatabaseIdentifier = (input: string): string => {
+  const sanitized = input.replace(/[^a-z0-9]+/gi, "_").replace(/^_+|_+$/g, "").toLowerCase();
+  return sanitized.length > 0 ? sanitized : "repo";
+};
+
+export const computeBeadsDatabaseName = async (
+  repoPath: string,
+  beadsDir: string,
+): Promise<string> => {
+  const slug = sanitizeDatabaseIdentifier(sanitizeSlug(basename(repoPath)));
+  const canonicalBeadsDir = await resolveCanonicalPath(beadsDir);
+  const hashSuffix = createHash("sha256").update(canonicalBeadsDir).digest("hex").slice(0, 12);
+  const maxSlugLength = 64 - "odt__".length - hashSuffix.length;
+  const truncatedSlug = slug.slice(0, maxSlugLength);
+  return `odt_${truncatedSlug}_${hashSuffix}`;
+};
+
 export const resolveCentralBeadsDir = async (repoPath: string): Promise<string> => {
   const repoId = await computeRepoId(repoPath);
   const root = resolve(homedir(), ".openducktor", "beads", repoId);


### PR DESCRIPTION
## Summary
- isolate Beads/Dolt database initialization per backend store so parallel OpenDucktor instances do not collide
- introduce a shared backend user-path normalization utility and reuse it for config dir, worktree base path, command overrides, OpenCode binary override, and MCP workspace root
- add regression coverage for config-dir expansion, process registry paths, path override expansion, and MCP/runtime path resolution

## Verification
- cargo test -p host-infra-system
- cargo test -p host-infra-beads
- cargo test -p host-application opencode_process_registry_path_uses_ -- --nocapture
- cargo test -p host-application resolve_opencode_binary_path_supports_home_shorthand_override -- --nocapture
- cargo test -p host-application default_mcp_workspace_root_supports_home_shorthand_override -- --nocapture
- bun test packages/openducktor-mcp/src/beads-runtime.test.ts packages/openducktor-mcp/src/beads-runtime-client.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home-directory shorthand (~) is now supported in config and env path overrides
  * Beads stores get deterministic database names; initialization now selects the computed database

* **Bug Fixes**
  * Better handling of quoted and whitespace-padded env values
  * Improved path parsing, normalization and validation for config and command overrides

* **Tests**
  * Added tests covering home-shorthand expansion, beads database naming, and related path-parsing scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->