### PR TITLE
refactor(agents): unify role/session selection authority

### DIFF
--- a/apps/desktop/src/pages/agents/agents-page-constants.ts
+++ b/apps/desktop/src/pages/agents/agents-page-constants.ts
@@ -22,6 +22,8 @@ export const ROLE_OPTIONS: Array<{
   { role: "qa", label: AGENT_ROLE_LABELS.qa, icon: ShieldCheck },
 ];
 
+export const AGENT_ROLE_ORDER: AgentRole[] = ROLE_OPTIONS.map((option) => option.role);
+
 const AGENT_ROLE_SET = new Set<string>(agentRoleValues);
 
 export const isRole = (value: string | null): value is AgentRole =>

--- a/apps/desktop/src/pages/agents/agents-page-selection.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-selection.test.ts
@@ -7,14 +7,29 @@ import {
   extractCompletionTimestamp,
   isSameSelection,
   pickDefaultVisibleSelectionForCatalog,
-  resolveAgentStudioActiveSession,
   resolveAgentStudioBuilderSessionForTask,
   resolveAgentStudioBuilderSessionsForTask,
+  resolveAgentStudioDefaultRoleForTask,
+  resolveAgentStudioSessionSelection,
   resolveAgentStudioTaskId,
   toContextStorageKey,
   toRightPanelStorageKey,
   toTabsStorageKey,
 } from "./agents-page-selection";
+
+const resolveAgentStudioActiveSession = (args: {
+  sessionsForTask: Parameters<typeof resolveAgentStudioSessionSelection>[0]["sessionsForTask"];
+  sessionParam: string | null;
+  hasExplicitRoleParam: boolean;
+  roleFromQuery: Parameters<typeof resolveAgentStudioSessionSelection>[0]["roleFromQuery"];
+  selectedTask: Parameters<typeof resolveAgentStudioSessionSelection>[0]["selectedTask"];
+}) => {
+  return resolveAgentStudioSessionSelection({
+    ...args,
+    fallbackRole: args.roleFromQuery,
+    scenarioFromQuery: null,
+  }).activeSession;
+};
 
 const catalogFixture: AgentModelCatalog = {
   models: [
@@ -164,6 +179,21 @@ describe("agents-page-selection", () => {
         selectedSessionById: session,
       }),
     ).toBe("task-from-session");
+  });
+
+  test("resolves default role for open tasks from first required available workflow", () => {
+    const task = createTaskCardFixture({
+      id: "task-1",
+      status: "open",
+      agentWorkflows: {
+        spec: { required: false, canSkip: true, available: true, completed: false },
+        planner: { required: false, canSkip: true, available: true, completed: false },
+        builder: { required: true, canSkip: false, available: true, completed: false },
+        qa: { required: false, canSkip: true, available: false, completed: false },
+      },
+    });
+
+    expect(resolveAgentStudioDefaultRoleForTask(task)).toBe("build");
   });
 
   test("keeps active session unresolved when explicit session param does not belong to active task", () => {
@@ -464,6 +494,45 @@ describe("agents-page-selection", () => {
     });
 
     expect(resolved).toBeNull();
+  });
+
+  test("resolves role from workflow default even when no session exists", () => {
+    const selection = resolveAgentStudioSessionSelection({
+      sessionsForTask: [],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "spec",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "human_review" }),
+      fallbackRole: "spec",
+    });
+
+    expect(selection.activeSession).toBeNull();
+    expect(selection.role).toBe("build");
+    expect(selection.scenario).toBe("build_implementation_start");
+  });
+
+  test("keeps explicit session authority over task-status defaults", () => {
+    const qaSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "qa-1",
+      taskId: "task-1",
+      role: "qa",
+      scenario: "qa_review",
+      startedAt: "2026-02-22T12:00:00.000Z",
+    });
+
+    const selection = resolveAgentStudioSessionSelection({
+      sessionsForTask: [qaSession],
+      sessionParam: "qa-1",
+      hasExplicitRoleParam: false,
+      roleFromQuery: "build",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "human_review" }),
+      fallbackRole: "build",
+    });
+
+    expect(selection.activeSession?.sessionId).toBe("qa-1");
+    expect(selection.role).toBe("qa");
+    expect(selection.scenario).toBe("qa_review");
   });
 
   test("prefers the current build session when resolving conflict reuse", () => {

--- a/apps/desktop/src/pages/agents/agents-page-selection.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-selection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentModelCatalog } from "@openducktor/core";
-import { createAgentSessionFixture } from "./agent-studio-test-utils";
+import { createAgentSessionFixture, createTaskCardFixture } from "./agent-studio-test-utils";
 import {
   coerceVisibleSelectionToCatalog,
   emptyDraftSelections,
@@ -185,6 +185,7 @@ describe("agents-page-selection", () => {
       sessionParam: "session-from-other-task",
       hasExplicitRoleParam: true,
       roleFromQuery: "planner",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
     });
 
     expect(resolved).toBeNull();
@@ -209,9 +210,260 @@ describe("agents-page-selection", () => {
       sessionParam: null,
       hasExplicitRoleParam: true,
       roleFromQuery: "planner",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
     });
 
     expect(resolved?.sessionId).toBe("planner-1");
+  });
+
+  test("prioritizes active running session over status defaults", () => {
+    const olderBuildSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "build-older",
+      taskId: "task-1",
+      role: "build",
+      status: "idle",
+      startedAt: "2026-02-22T10:00:00.000Z",
+    });
+    const runningSpecSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "spec-running",
+      taskId: "task-1",
+      role: "spec",
+      status: "running",
+      startedAt: "2026-02-22T09:00:00.000Z",
+    });
+
+    const resolved = resolveAgentStudioActiveSession({
+      sessionsForTask: [olderBuildSession, runningSpecSession],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "build",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
+    });
+
+    expect(resolved?.sessionId).toBe("spec-running");
+  });
+
+  test("selects required+available role for open tasks", () => {
+    const specSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "spec-1",
+      taskId: "task-1",
+      role: "spec",
+      startedAt: "2026-02-22T11:00:00.000Z",
+    });
+    const buildSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "build-1",
+      taskId: "task-1",
+      role: "build",
+      startedAt: "2026-02-22T10:00:00.000Z",
+    });
+
+    const resolved = resolveAgentStudioActiveSession({
+      sessionsForTask: [buildSession, specSession],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "spec",
+      selectedTask: createTaskCardFixture({
+        id: "task-1",
+        status: "open",
+        agentWorkflows: {
+          spec: { required: true, canSkip: false, available: true, completed: false },
+          planner: { required: false, canSkip: true, available: true, completed: false },
+          builder: { required: true, canSkip: false, available: true, completed: false },
+          qa: { required: false, canSkip: true, available: false, completed: false },
+        },
+      }),
+    });
+
+    expect(resolved?.sessionId).toBe("spec-1");
+  });
+
+  test("returns null for open tasks when no required+available role exists", () => {
+    const buildSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "build-1",
+      taskId: "task-1",
+      role: "build",
+    });
+
+    const resolved = resolveAgentStudioActiveSession({
+      sessionsForTask: [buildSession],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "build",
+      selectedTask: createTaskCardFixture({
+        id: "task-1",
+        status: "open",
+        agentWorkflows: {
+          spec: { required: true, canSkip: false, available: false, completed: false },
+          planner: { required: true, canSkip: false, available: false, completed: false },
+          builder: { required: true, canSkip: false, available: false, completed: false },
+          qa: { required: false, canSkip: true, available: false, completed: false },
+        },
+      }),
+    });
+
+    expect(resolved).toBeNull();
+  });
+
+  test("selects latest spec session for spec_ready tasks", () => {
+    const olderSpecSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "spec-older",
+      taskId: "task-1",
+      role: "spec",
+      startedAt: "2026-02-22T09:00:00.000Z",
+    });
+    const latestSpecSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "spec-latest",
+      taskId: "task-1",
+      role: "spec",
+      startedAt: "2026-02-22T11:00:00.000Z",
+    });
+
+    const resolved = resolveAgentStudioActiveSession({
+      sessionsForTask: [olderSpecSession, latestSpecSession],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "planner",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "spec_ready" }),
+    });
+
+    expect(resolved?.sessionId).toBe("spec-latest");
+  });
+
+  test("selects latest planner session for ready_for_dev tasks and falls back to spec", () => {
+    const latestSpecSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "spec-latest",
+      taskId: "task-1",
+      role: "spec",
+      startedAt: "2026-02-22T11:00:00.000Z",
+    });
+    const latestPlannerSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "planner-latest",
+      taskId: "task-1",
+      role: "planner",
+      startedAt: "2026-02-22T12:00:00.000Z",
+    });
+
+    const resolvedWithPlanner = resolveAgentStudioActiveSession({
+      sessionsForTask: [latestSpecSession, latestPlannerSession],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "build",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "ready_for_dev" }),
+    });
+
+    const resolvedWithFallback = resolveAgentStudioActiveSession({
+      sessionsForTask: [latestSpecSession],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "build",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "ready_for_dev" }),
+    });
+
+    expect(resolvedWithPlanner?.sessionId).toBe("planner-latest");
+    expect(resolvedWithFallback?.sessionId).toBe("spec-latest");
+  });
+
+  test("selects latest build session for in_progress, ai_review, and human_review tasks", () => {
+    const olderBuildSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "build-older",
+      taskId: "task-1",
+      role: "build",
+      startedAt: "2026-02-22T08:00:00.000Z",
+    });
+    const latestBuildSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "build-latest",
+      taskId: "task-1",
+      role: "build",
+      startedAt: "2026-02-22T12:00:00.000Z",
+    });
+
+    const statuses: Array<"in_progress" | "ai_review" | "human_review"> = [
+      "in_progress",
+      "ai_review",
+      "human_review",
+    ];
+
+    for (const status of statuses) {
+      const resolved = resolveAgentStudioActiveSession({
+        sessionsForTask: [olderBuildSession, latestBuildSession],
+        sessionParam: null,
+        hasExplicitRoleParam: false,
+        roleFromQuery: "spec",
+        selectedTask: createTaskCardFixture({ id: "task-1", status }),
+      });
+
+      expect(resolved?.sessionId).toBe("build-latest");
+    }
+  });
+
+  test("selects latest build session for blocked/deferred/closed and falls back to latest overall", () => {
+    const latestSpecSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "spec-latest",
+      taskId: "task-1",
+      role: "spec",
+      startedAt: "2026-02-22T13:00:00.000Z",
+    });
+    const latestBuildSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "build-latest",
+      taskId: "task-1",
+      role: "build",
+      startedAt: "2026-02-22T12:00:00.000Z",
+    });
+
+    const statuses: Array<"blocked" | "deferred" | "closed"> = ["blocked", "deferred", "closed"];
+
+    for (const status of statuses) {
+      const resolvedWithBuild = resolveAgentStudioActiveSession({
+        sessionsForTask: [latestSpecSession, latestBuildSession],
+        sessionParam: null,
+        hasExplicitRoleParam: false,
+        roleFromQuery: "qa",
+        selectedTask: createTaskCardFixture({ id: "task-1", status }),
+      });
+
+      const resolvedFallback = resolveAgentStudioActiveSession({
+        sessionsForTask: [latestSpecSession],
+        sessionParam: null,
+        hasExplicitRoleParam: false,
+        roleFromQuery: "qa",
+        selectedTask: createTaskCardFixture({ id: "task-1", status }),
+      });
+
+      expect(resolvedWithBuild?.sessionId).toBe("build-latest");
+      expect(resolvedFallback?.sessionId).toBe("spec-latest");
+    }
+  });
+
+  test("returns null when no selected task is available", () => {
+    const buildSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "build-1",
+      taskId: "task-1",
+      role: "build",
+    });
+
+    const resolved = resolveAgentStudioActiveSession({
+      sessionsForTask: [buildSession],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "build",
+      selectedTask: null,
+    });
+
+    expect(resolved).toBeNull();
   });
 
   test("prefers the current build session when resolving conflict reuse", () => {

--- a/apps/desktop/src/pages/agents/agents-page-selection.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-selection.test.ts
@@ -275,6 +275,35 @@ describe("agents-page-selection", () => {
     expect(resolved?.sessionId).toBe("spec-running");
   });
 
+  test("chooses the most recent running/starting session when multiple active sessions exist", () => {
+    const olderRunningSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "planner-running-older",
+      taskId: "task-1",
+      role: "planner",
+      status: "running",
+      startedAt: "2026-02-22T09:00:00.000Z",
+    });
+    const newerStartingSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "qa-starting-newer",
+      taskId: "task-1",
+      role: "qa",
+      status: "starting",
+      startedAt: "2026-02-22T12:00:00.000Z",
+    });
+
+    const resolved = resolveAgentStudioActiveSession({
+      sessionsForTask: [olderRunningSession, newerStartingSession],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "build",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "human_review" }),
+    });
+
+    expect(resolved?.sessionId).toBe("qa-starting-newer");
+  });
+
   test("selects required+available role for open tasks", () => {
     const specSession = createAgentSessionFixture({
       runtimeKind: "opencode",

--- a/apps/desktop/src/pages/agents/agents-page-selection.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-selection.test.ts
@@ -535,6 +535,62 @@ describe("agents-page-selection", () => {
     expect(selection.scenario).toBe("qa_review");
   });
 
+  test("prioritizes explicit scenario for explicit role selection", () => {
+    const buildSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "build-1",
+      taskId: "task-1",
+      role: "build",
+      scenario: "build_implementation_start",
+      startedAt: "2026-02-22T12:00:00.000Z",
+    });
+
+    const selection = resolveAgentStudioSessionSelection({
+      sessionsForTask: [buildSession],
+      sessionParam: null,
+      hasExplicitRoleParam: true,
+      roleFromQuery: "build",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "in_progress" }),
+      fallbackRole: "build",
+      scenarioFromQuery: "build_after_qa_rejected",
+    });
+
+    expect(selection.activeSession?.sessionId).toBe("build-1");
+    expect(selection.role).toBe("build");
+    expect(selection.scenario).toBe("build_after_qa_rejected");
+  });
+
+  test("uses most recent overall session for blocked fallback even with unsorted input", () => {
+    const olderSpecSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "spec-older",
+      taskId: "task-1",
+      role: "spec",
+      startedAt: "2026-02-22T09:00:00.000Z",
+    });
+    const newerQaSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "qa-newer",
+      taskId: "task-1",
+      role: "qa",
+      startedAt: "2026-02-22T13:00:00.000Z",
+    });
+
+    const selection = resolveAgentStudioSessionSelection({
+      sessionsForTask: [olderSpecSession, newerQaSession],
+      sessionParam: null,
+      hasExplicitRoleParam: false,
+      roleFromQuery: "spec",
+      selectedTask: createTaskCardFixture({ id: "task-1", status: "blocked" }),
+      fallbackRole: "spec",
+      scenarioFromQuery: null,
+    });
+
+    expect(selection.activeSession?.sessionId).toBe("qa-newer");
+    expect(selection.role).toBe("qa");
+    expect(selection.scenario).toBe("qa_review");
+  });
+
   test("prefers the current build session when resolving conflict reuse", () => {
     const activeBuildSession = createAgentSessionFixture({
       runtimeKind: "opencode",

--- a/apps/desktop/src/pages/agents/agents-page-selection.ts
+++ b/apps/desktop/src/pages/agents/agents-page-selection.ts
@@ -120,9 +120,10 @@ export const resolveAgentStudioSessionSelection = ({
   fallbackRole: AgentRole;
   scenarioFromQuery?: AgentScenario | null;
 }): { activeSession: AgentSessionState | null; role: AgentRole; scenario: AgentScenario } => {
-  const runningSession = sessionsForTask.find(
-    (session) => session.status === "running" || session.status === "starting",
-  );
+  const runningSession =
+    [...sessionsForTask]
+      .filter((session) => session.status === "running" || session.status === "starting")
+      .sort(compareAgentSessionRecency)[0] ?? null;
 
   const latestSessionByRole = (role: AgentRole): AgentSessionState | null => {
     const roleSessions = sessionsForTask

--- a/apps/desktop/src/pages/agents/agents-page-selection.ts
+++ b/apps/desktop/src/pages/agents/agents-page-selection.ts
@@ -4,7 +4,10 @@ export {
   pickDefaultVisibleSelectionForCatalog,
 } from "@/features/session-start";
 
+import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
+import { compareAgentSessionRecency } from "@/lib/agent-session-options";
+import { buildRoleWorkflowMapForTask } from "@/lib/task-agent-workflows";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 
 export {
@@ -66,19 +69,73 @@ export const resolveAgentStudioActiveSession = ({
   sessionParam,
   hasExplicitRoleParam,
   roleFromQuery,
+  selectedTask,
 }: {
   sessionsForTask: AgentSessionState[];
   sessionParam: string | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
+  selectedTask: TaskCard | null;
 }): AgentSessionState | null => {
+  const activeSession = sessionsForTask.find(
+    (session) => session.status === "running" || session.status === "starting",
+  );
+
+  const latestSessionByRole = (role: AgentRole): AgentSessionState | null => {
+    const roleSessions = sessionsForTask
+      .filter((session) => session.role === role)
+      .sort(compareAgentSessionRecency);
+    return roleSessions[0] ?? null;
+  };
+
+  const resolveDefaultRoleForOpenTask = (task: TaskCard): AgentRole | null => {
+    const roleWorkflowMap = buildRoleWorkflowMapForTask(task);
+    const orderedRoles: AgentRole[] = ["spec", "planner", "build", "qa"];
+    for (const role of orderedRoles) {
+      const workflow = roleWorkflowMap[role];
+      if (workflow.required && workflow.available) {
+        return role;
+      }
+    }
+    return null;
+  };
+
   if (sessionParam) {
     return sessionsForTask.find((entry) => entry.sessionId === sessionParam) ?? null;
   }
+
   if (hasExplicitRoleParam) {
     return sessionsForTask.find((entry) => entry.role === roleFromQuery) ?? null;
   }
-  return sessionsForTask[0] ?? null;
+
+  if (activeSession) {
+    return activeSession;
+  }
+
+  if (!selectedTask) {
+    return null;
+  }
+
+  switch (selectedTask.status) {
+    case "open": {
+      const defaultRole = resolveDefaultRoleForOpenTask(selectedTask);
+      return defaultRole ? latestSessionByRole(defaultRole) : null;
+    }
+    case "spec_ready":
+      return latestSessionByRole("spec");
+    case "ready_for_dev":
+      return latestSessionByRole("planner") ?? latestSessionByRole("spec");
+    case "in_progress":
+    case "ai_review":
+    case "human_review":
+      return latestSessionByRole("build");
+    case "blocked":
+    case "deferred":
+    case "closed":
+      return latestSessionByRole("build") ?? sessionsForTask[0] ?? null;
+    default:
+      return null;
+  }
 };
 
 export const resolveAgentStudioBuilderSessionsForTask = ({

--- a/apps/desktop/src/pages/agents/agents-page-selection.ts
+++ b/apps/desktop/src/pages/agents/agents-page-selection.ts
@@ -5,10 +5,11 @@ export {
 } from "@/features/session-start";
 
 import type { TaskCard } from "@openducktor/contracts";
-import type { AgentModelSelection, AgentRole } from "@openducktor/core";
+import type { AgentModelSelection, AgentRole, AgentScenario } from "@openducktor/core";
 import { compareAgentSessionRecency } from "@/lib/agent-session-options";
 import { buildRoleWorkflowMapForTask } from "@/lib/task-agent-workflows";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { firstScenario, SCENARIOS_BY_ROLE } from "./agents-page-constants";
 
 export {
   toContextStorageKey,
@@ -64,19 +65,62 @@ export const resolveAgentStudioTaskId = ({
   return taskIdParam || selectedSessionById?.taskId || "";
 };
 
-export const resolveAgentStudioActiveSession = ({
+export const resolveAgentStudioDefaultRoleForTask = (task: TaskCard | null): AgentRole | null => {
+  if (!task) {
+    return null;
+  }
+
+  if (task.status === "open") {
+    const roleWorkflowMap = buildRoleWorkflowMapForTask(task);
+    const orderedRoles: AgentRole[] = ["spec", "planner", "build", "qa"];
+    for (const role of orderedRoles) {
+      const workflow = roleWorkflowMap[role];
+      if (workflow.required && workflow.available) {
+        return role;
+      }
+    }
+    return null;
+  }
+
+  if (task.status === "spec_ready") {
+    return "spec";
+  }
+
+  if (task.status === "ready_for_dev") {
+    return "planner";
+  }
+
+  if (
+    task.status === "in_progress" ||
+    task.status === "ai_review" ||
+    task.status === "human_review" ||
+    task.status === "blocked" ||
+    task.status === "deferred" ||
+    task.status === "closed"
+  ) {
+    return "build";
+  }
+
+  return null;
+};
+
+export const resolveAgentStudioSessionSelection = ({
   sessionsForTask,
   sessionParam,
   hasExplicitRoleParam,
   roleFromQuery,
   selectedTask,
+  fallbackRole,
+  scenarioFromQuery,
 }: {
   sessionsForTask: AgentSessionState[];
   sessionParam: string | null;
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
   selectedTask: TaskCard | null;
-}): AgentSessionState | null => {
+  fallbackRole: AgentRole;
+  scenarioFromQuery?: AgentScenario | null;
+}): { activeSession: AgentSessionState | null; role: AgentRole; scenario: AgentScenario } => {
   const activeSession = sessionsForTask.find(
     (session) => session.status === "running" || session.status === "starting",
   );
@@ -88,53 +132,69 @@ export const resolveAgentStudioActiveSession = ({
     return roleSessions[0] ?? null;
   };
 
-  const resolveDefaultRoleForOpenTask = (task: TaskCard): AgentRole | null => {
-    const roleWorkflowMap = buildRoleWorkflowMapForTask(task);
-    const orderedRoles: AgentRole[] = ["spec", "planner", "build", "qa"];
-    for (const role of orderedRoles) {
-      const workflow = roleWorkflowMap[role];
-      if (workflow.required && workflow.available) {
-        return role;
-      }
-    }
-    return null;
+  const toSelection = (role: AgentRole, session: AgentSessionState | null) => {
+    const roleScenarios = SCENARIOS_BY_ROLE[role];
+    const explicitScenarioForRole =
+      hasExplicitRoleParam && scenarioFromQuery && roleScenarios.includes(scenarioFromQuery)
+        ? scenarioFromQuery
+        : null;
+
+    const scenario =
+      session?.scenario && roleScenarios.includes(session.scenario)
+        ? session.scenario
+        : (explicitScenarioForRole ?? firstScenario(role));
+
+    return {
+      activeSession: session,
+      role,
+      scenario,
+    };
   };
 
   if (sessionParam) {
-    return sessionsForTask.find((entry) => entry.sessionId === sessionParam) ?? null;
+    const explicitSession =
+      sessionsForTask.find((entry) => entry.sessionId === sessionParam) ?? null;
+    if (explicitSession) {
+      return toSelection(explicitSession.role, explicitSession);
+    }
+    return toSelection(fallbackRole, null);
   }
 
   if (hasExplicitRoleParam) {
-    return sessionsForTask.find((entry) => entry.role === roleFromQuery) ?? null;
+    return toSelection(roleFromQuery, latestSessionByRole(roleFromQuery));
   }
 
   if (activeSession) {
-    return activeSession;
+    return toSelection(activeSession.role, activeSession);
   }
 
   if (!selectedTask) {
-    return null;
+    return toSelection(fallbackRole, null);
   }
+
+  const defaultRole = resolveAgentStudioDefaultRoleForTask(selectedTask);
+
+  const withRoleFallback = (session: AgentSessionState | null) =>
+    toSelection(session?.role ?? defaultRole ?? fallbackRole, session);
 
   switch (selectedTask.status) {
     case "open": {
-      const defaultRole = resolveDefaultRoleForOpenTask(selectedTask);
-      return defaultRole ? latestSessionByRole(defaultRole) : null;
+      return withRoleFallback(defaultRole ? latestSessionByRole(defaultRole) : null);
     }
     case "spec_ready":
-      return latestSessionByRole("spec");
+      return withRoleFallback(latestSessionByRole("spec"));
     case "ready_for_dev":
-      return latestSessionByRole("planner") ?? latestSessionByRole("spec");
+      return withRoleFallback(latestSessionByRole("planner") ?? latestSessionByRole("spec"));
     case "in_progress":
     case "ai_review":
     case "human_review":
-      return latestSessionByRole("build");
+      return withRoleFallback(latestSessionByRole("build"));
     case "blocked":
     case "deferred":
     case "closed":
-      return latestSessionByRole("build") ?? sessionsForTask[0] ?? null;
+      return withRoleFallback(latestSessionByRole("build") ?? sessionsForTask[0] ?? null);
     default:
-      return null;
+      return toSelection(defaultRole ?? fallbackRole, null);
   }
 };
 

--- a/apps/desktop/src/pages/agents/agents-page-selection.ts
+++ b/apps/desktop/src/pages/agents/agents-page-selection.ts
@@ -9,7 +9,7 @@ import type { AgentModelSelection, AgentRole, AgentScenario } from "@openducktor
 import { compareAgentSessionRecency } from "@/lib/agent-session-options";
 import { buildRoleWorkflowMapForTask } from "@/lib/task-agent-workflows";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { firstScenario, SCENARIOS_BY_ROLE } from "./agents-page-constants";
+import { AGENT_ROLE_ORDER, firstScenario, SCENARIOS_BY_ROLE } from "./agents-page-constants";
 
 export {
   toContextStorageKey,
@@ -72,8 +72,7 @@ export const resolveAgentStudioDefaultRoleForTask = (task: TaskCard | null): Age
 
   if (task.status === "open") {
     const roleWorkflowMap = buildRoleWorkflowMapForTask(task);
-    const orderedRoles: AgentRole[] = ["spec", "planner", "build", "qa"];
-    for (const role of orderedRoles) {
+    for (const role of AGENT_ROLE_ORDER) {
       const workflow = roleWorkflowMap[role];
       if (workflow.required && workflow.available) {
         return role;
@@ -121,7 +120,7 @@ export const resolveAgentStudioSessionSelection = ({
   fallbackRole: AgentRole;
   scenarioFromQuery?: AgentScenario | null;
 }): { activeSession: AgentSessionState | null; role: AgentRole; scenario: AgentScenario } => {
-  const activeSession = sessionsForTask.find(
+  const runningSession = sessionsForTask.find(
     (session) => session.status === "running" || session.status === "starting",
   );
 
@@ -140,9 +139,10 @@ export const resolveAgentStudioSessionSelection = ({
         : null;
 
     const scenario =
-      session?.scenario && roleScenarios.includes(session.scenario)
+      explicitScenarioForRole ??
+      (session?.scenario && roleScenarios.includes(session.scenario)
         ? session.scenario
-        : (explicitScenarioForRole ?? firstScenario(role));
+        : firstScenario(role));
 
     return {
       activeSession: session,
@@ -164,8 +164,8 @@ export const resolveAgentStudioSessionSelection = ({
     return toSelection(roleFromQuery, latestSessionByRole(roleFromQuery));
   }
 
-  if (activeSession) {
-    return toSelection(activeSession.role, activeSession);
+  if (runningSession) {
+    return toSelection(runningSession.role, runningSession);
   }
 
   if (!selectedTask) {
@@ -173,6 +173,7 @@ export const resolveAgentStudioSessionSelection = ({
   }
 
   const defaultRole = resolveAgentStudioDefaultRoleForTask(selectedTask);
+  const mostRecentSession = [...sessionsForTask].sort(compareAgentSessionRecency)[0] ?? null;
 
   const withRoleFallback = (session: AgentSessionState | null) =>
     toSelection(session?.role ?? defaultRole ?? fallbackRole, session);
@@ -192,7 +193,7 @@ export const resolveAgentStudioSessionSelection = ({
     case "blocked":
     case "deferred":
     case "closed":
-      return withRoleFallback(latestSessionByRole("build") ?? sessionsForTask[0] ?? null);
+      return withRoleFallback(latestSessionByRole("build") ?? mostRecentSession);
     default:
       return toSelection(defaultRole ?? fallbackRole, null);
   }

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
@@ -184,11 +184,13 @@ describe("useAgentStudioSelectionController", () => {
       role: "planner",
       scenario: "planner_initial",
       startedAt: "2026-02-22T12:00:00.000Z",
+      status: "running",
     });
     const sessionTaskTwo = createSession("task-2", "session-2", {
       role: "qa",
       scenario: "qa_review",
       startedAt: "2026-02-22T13:00:00.000Z",
+      status: "running",
     });
 
     const harness = createHookHarness(

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
@@ -148,7 +148,7 @@ describe("useAgentStudioSelectionController", () => {
     }
   });
 
-  test("uses detached tab context instead of query role selection", async () => {
+  test("uses detached tab workflow default role instead of query role selection", async () => {
     const updateQuery = mock(() => {});
     const clearComposerInput = mock(() => {});
     const harness = createHookHarness(
@@ -170,10 +170,17 @@ describe("useAgentStudioSelectionController", () => {
 
       const latest = harness.getLatest();
       expect(latest.viewTaskId).toBe("task-2");
-      expect(latest.viewRole).toBe("spec");
-      expect(latest.viewScenario).toBe("spec_initial");
+      expect(latest.viewRole).toBe("build");
+      expect(latest.viewScenario).toBe("build_implementation_start");
       expect(clearComposerInput).toHaveBeenCalledTimes(1);
       expect(updateQuery).toHaveBeenCalledTimes(1);
+      expect(updateQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: "task-2",
+          session: undefined,
+          agent: undefined,
+        }),
+      );
     } finally {
       await harness.unmount();
     }
@@ -274,6 +281,155 @@ describe("useAgentStudioSelectionController", () => {
       const latest = harness.getLatest();
       const task1Tab = latest.taskTabs.find((tab) => tab.taskId === "task-1");
       expect(task1Tab?.status).toBe("idle");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("defaults to build role for open task even when only optional-role session exists", async () => {
+    const specSession = createSession("task-1", "session-spec", {
+      role: "spec",
+      scenario: "spec_initial",
+      startedAt: "2026-02-22T11:00:00.000Z",
+      status: "idle",
+    });
+
+    const openTask = createTaskCardFixture({
+      id: "task-1",
+      title: "task-1",
+      status: "open",
+      issueType: "task",
+      agentWorkflows: {
+        spec: { required: false, canSkip: true, available: true, completed: false },
+        planner: { required: false, canSkip: true, available: true, completed: false },
+        builder: { required: true, canSkip: false, available: true, completed: false },
+        qa: { required: false, canSkip: true, available: false, completed: false },
+      },
+    });
+
+    const harness = createHookHarness(
+      createBaseArgs({
+        tasks: [openTask, createTask("task-2")],
+        sessions: [specSession],
+        taskIdParam: "task-1",
+        hasExplicitRoleParam: false,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      const latest = harness.getLatest();
+
+      expect(latest.viewActiveSession).toBeNull();
+      expect(latest.viewRole).toBe("build");
+      expect(latest.viewScenario).toBe("build_implementation_start");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("keeps human_review task pinned to build session when newer qa session appears", async () => {
+    const humanReviewTask = createTaskCardFixture({
+      id: "task-1",
+      title: "task-1",
+      status: "human_review",
+    });
+    const initialBuildSession = createSession("task-1", "session-build", {
+      role: "build",
+      scenario: "build_implementation_start",
+      startedAt: "2026-02-22T10:00:00.000Z",
+      status: "idle",
+    });
+    const newerQaSession = createSession("task-1", "session-qa", {
+      role: "qa",
+      scenario: "qa_review",
+      startedAt: "2026-02-22T11:00:00.000Z",
+      status: "idle",
+    });
+
+    const harness = createHookHarness(
+      createBaseArgs({
+        tasks: [humanReviewTask, createTask("task-2")],
+        sessions: [initialBuildSession],
+        taskIdParam: "task-1",
+        sessionParam: null,
+        hasExplicitRoleParam: false,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(harness.getLatest().viewActiveSession?.sessionId).toBe("session-build");
+      expect(harness.getLatest().viewRole).toBe("build");
+
+      await harness.update(
+        createBaseArgs({
+          tasks: [humanReviewTask, createTask("task-2")],
+          sessions: [newerQaSession, initialBuildSession],
+          taskIdParam: "task-1",
+          sessionParam: null,
+          hasExplicitRoleParam: false,
+        }),
+      );
+
+      expect(harness.getLatest().viewActiveSession?.sessionId).toBe("session-build");
+      expect(harness.getLatest().viewRole).toBe("build");
+      expect(harness.getLatest().viewScenario).toBe("build_implementation_start");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("keeps human_review view stable on query role changes when session is not explicit", async () => {
+    const humanReviewTask = createTaskCardFixture({
+      id: "task-1",
+      title: "task-1",
+      status: "human_review",
+    });
+    const buildSession = createSession("task-1", "session-build", {
+      role: "build",
+      scenario: "build_implementation_start",
+      startedAt: "2026-02-22T10:00:00.000Z",
+      status: "idle",
+    });
+    const qaSession = createSession("task-1", "session-qa", {
+      role: "qa",
+      scenario: "qa_review",
+      startedAt: "2026-02-22T11:00:00.000Z",
+      status: "idle",
+    });
+
+    const harness = createHookHarness(
+      createBaseArgs({
+        tasks: [humanReviewTask, createTask("task-2")],
+        sessions: [qaSession, buildSession],
+        taskIdParam: "task-1",
+        sessionParam: null,
+        hasExplicitRoleParam: false,
+        roleFromQuery: "build",
+      }),
+    );
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().viewActiveSession?.sessionId).toBe("session-build");
+      expect(harness.getLatest().viewRole).toBe("build");
+
+      await harness.update(
+        createBaseArgs({
+          tasks: [humanReviewTask, createTask("task-2")],
+          sessions: [qaSession, buildSession],
+          taskIdParam: "task-1",
+          sessionParam: null,
+          hasExplicitRoleParam: false,
+          roleFromQuery: "qa",
+        }),
+      );
+
+      expect(harness.getLatest().viewActiveSession?.sessionId).toBe("session-build");
+      expect(harness.getLatest().viewRole).toBe("build");
+      expect(harness.getLatest().viewScenario).toBe("build_implementation_start");
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -204,8 +204,9 @@ export function useAgentStudioSelectionController({
       sessionParam,
       hasExplicitRoleParam,
       roleFromQuery,
+      selectedTask,
     });
-  }, [hasExplicitRoleParam, roleFromQuery, sessionParam, sessionsForTask]);
+  }, [hasExplicitRoleParam, roleFromQuery, selectedTask, sessionParam, sessionsForTask]);
   const hydratedActiveSession = useAgentStudioActiveSessionRuntimeData({
     session: activeSession,
     readSessionModelCatalog,
@@ -290,8 +291,15 @@ export function useAgentStudioSelectionController({
       sessionParam: viewSessionParam,
       hasExplicitRoleParam: hasViewRoleSelection,
       roleFromQuery,
+      selectedTask: viewSelectedTask,
     });
-  }, [hasViewRoleSelection, roleFromQuery, viewSessionParam, viewSessionsForTask]);
+  }, [
+    hasViewRoleSelection,
+    roleFromQuery,
+    viewSelectedTask,
+    viewSessionParam,
+    viewSessionsForTask,
+  ]);
   const hydratedViewActiveSession = useAgentStudioActiveSessionRuntimeData({
     session: viewActiveSession,
     readSessionModelCatalog,

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -9,8 +9,10 @@ import type {
 import { useMemo, useRef } from "react";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentStudioQueryUpdate as QueryUpdate } from "./agent-studio-navigation";
-import { firstScenario, SCENARIOS_BY_ROLE } from "./agents-page-constants";
-import { resolveAgentStudioActiveSession, resolveAgentStudioTaskId } from "./agents-page-selection";
+import {
+  resolveAgentStudioSessionSelection,
+  resolveAgentStudioTaskId,
+} from "./agents-page-selection";
 import { useAgentStudioActiveSessionRuntimeData } from "./use-agent-studio-active-session-runtime-data";
 import { useAgentStudioTaskHydration } from "./use-agent-studio-task-hydration";
 import { useAgentStudioTaskTabs } from "./use-agent-studio-task-tabs";
@@ -199,14 +201,23 @@ export function useAgentStudioSelectionController({
   }, [sessionsByTaskId, taskId]);
 
   const activeSession = useMemo(() => {
-    return resolveAgentStudioActiveSession({
+    return resolveAgentStudioSessionSelection({
       sessionsForTask,
       sessionParam,
       hasExplicitRoleParam,
       roleFromQuery,
       selectedTask,
-    });
-  }, [hasExplicitRoleParam, roleFromQuery, selectedTask, sessionParam, sessionsForTask]);
+      fallbackRole: roleFromQuery,
+      scenarioFromQuery,
+    }).activeSession;
+  }, [
+    hasExplicitRoleParam,
+    roleFromQuery,
+    scenarioFromQuery,
+    selectedTask,
+    sessionParam,
+    sessionsForTask,
+  ]);
   const hydratedActiveSession = useAgentStudioActiveSessionRuntimeData({
     session: activeSession,
     readSessionModelCatalog,
@@ -285,43 +296,33 @@ export function useAgentStudioSelectionController({
   const isViewTaskDetachedFromQuery = Boolean(viewTaskId && taskId && viewTaskId !== taskId);
   const hasViewRoleSelection = hasExplicitRoleParam && !isViewTaskDetachedFromQuery;
 
-  const viewActiveSession = useMemo(() => {
-    return resolveAgentStudioActiveSession({
+  const viewSelection = useMemo(() => {
+    return resolveAgentStudioSessionSelection({
       sessionsForTask: viewSessionsForTask,
       sessionParam: viewSessionParam,
       hasExplicitRoleParam: hasViewRoleSelection,
       roleFromQuery,
       selectedTask: viewSelectedTask,
+      fallbackRole: isViewTaskDetachedFromQuery ? "spec" : roleFromQuery,
+      scenarioFromQuery,
     });
   }, [
     hasViewRoleSelection,
+    isViewTaskDetachedFromQuery,
     roleFromQuery,
+    scenarioFromQuery,
     viewSelectedTask,
     viewSessionParam,
     viewSessionsForTask,
   ]);
+  const viewActiveSession = viewSelection.activeSession;
   const hydratedViewActiveSession = useAgentStudioActiveSessionRuntimeData({
     session: viewActiveSession,
     readSessionModelCatalog,
     readSessionTodos,
   });
-
-  const viewRole: AgentRole = hasViewRoleSelection
-    ? roleFromQuery
-    : (viewActiveSession?.role ??
-      viewSessionsForTask[0]?.role ??
-      (isViewTaskDetachedFromQuery ? "spec" : roleFromQuery));
-
-  const viewScenarios = SCENARIOS_BY_ROLE[viewRole];
-  const explicitViewScenario =
-    hasViewRoleSelection && scenarioFromQuery && viewScenarios.includes(scenarioFromQuery)
-      ? scenarioFromQuery
-      : null;
-
-  const viewScenario: AgentScenario =
-    viewActiveSession?.scenario && viewScenarios.includes(viewActiveSession.scenario)
-      ? viewActiveSession.scenario
-      : (explicitViewScenario ?? firstScenario(viewRole));
+  const viewRole = viewSelection.role;
+  const viewScenario = viewSelection.scenario;
 
   const {
     isActiveTaskHydrated,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -127,7 +127,7 @@ describe("useAgentStudioTaskTabs", () => {
     }
   });
 
-  test("selecting a tab routes to latest session when available", async () => {
+  test("selecting a tab routes as task intent and clears explicit session/role", async () => {
     const memoryStorage = createMemoryStorage();
     const originalStorage = globalThis.localStorage;
     Object.defineProperty(globalThis, "localStorage", {
@@ -164,8 +164,8 @@ describe("useAgentStudioTaskTabs", () => {
       const lastUpdate = updateCalls[updateCalls.length - 1];
       expect(lastUpdate).toEqual({
         task: "task-2",
-        session: "session-2",
-        agent: "spec",
+        session: undefined,
+        agent: undefined,
         scenario: undefined,
         autostart: undefined,
         start: undefined,
@@ -272,8 +272,8 @@ describe("useAgentStudioTaskTabs", () => {
       const lastUpdate = updateCalls[updateCalls.length - 1];
       expect(lastUpdate).toEqual({
         task: "task-1",
-        session: "session-1",
-        agent: "spec",
+        session: undefined,
+        agent: undefined,
         scenario: undefined,
         autostart: undefined,
         start: undefined,
@@ -327,8 +327,8 @@ describe("useAgentStudioTaskTabs", () => {
       expect(updateCalls).toHaveLength(1);
       expect(updateCalls[0]).toEqual({
         task: "task-2",
-        session: "session-2",
-        agent: "spec",
+        session: undefined,
+        agent: undefined,
         scenario: undefined,
         autostart: undefined,
         start: undefined,
@@ -467,8 +467,8 @@ describe("useAgentStudioTaskTabs", () => {
 
       expect(updateCalls[0]).toEqual({
         task: "task-b",
-        session: "session-b",
-        agent: "spec",
+        session: undefined,
+        agent: undefined,
         scenario: undefined,
         autostart: undefined,
         start: undefined,
@@ -551,8 +551,8 @@ describe("useAgentStudioTaskTabs", () => {
       expect(harness.getLatest().activeTaskTabId).toBe("task-1");
       expect(updateCalls[0]).toEqual({
         task: "task-1",
-        session: "session-1",
-        agent: "spec",
+        session: undefined,
+        agent: undefined,
         scenario: undefined,
         autostart: undefined,
         start: undefined,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
@@ -1,5 +1,4 @@
 import type { TaskCard } from "@openducktor/contracts";
-import type { AgentRole } from "@openducktor/core";
 import { startTransition, useCallback, useMemo, useState } from "react";
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
@@ -7,57 +6,16 @@ import {
   AGENT_STUDIO_QUERY_KEYS,
   type AgentStudioQueryUpdate as QueryUpdate,
 } from "./agent-studio-navigation";
-import {
-  buildRoleEnabledMapForTask,
-  buildTaskTabs,
-  getAvailableTabTasks,
-} from "./agents-page-session-tabs";
+import { buildTaskTabs, getAvailableTabTasks } from "./agents-page-session-tabs";
 import { useTaskTabActions } from "./use-agent-studio-task-tabs-actions";
 import { useTaskTabPersistence } from "./use-agent-studio-task-tabs-persistence";
 import { useTaskTabSelection } from "./use-agent-studio-task-tabs-selection";
 
-type TaskByIdMap = ReadonlyMap<string, TaskCard>;
-
-const resolveDefaultRoleForTask = (task: TaskCard | null): AgentRole => {
-  const roleEnabledByTask = buildRoleEnabledMapForTask(task);
-  if (roleEnabledByTask.spec) {
-    return "spec";
-  }
-  if (roleEnabledByTask.planner) {
-    return "planner";
-  }
-  if (roleEnabledByTask.build) {
-    return "build";
-  }
-  if (roleEnabledByTask.qa) {
-    return "qa";
-  }
-  return "spec";
-};
-
-const toTaskQueryUpdate = (params: {
-  taskId: string;
-  latestSessionByTaskId: ReadonlyMap<string, AgentSessionState>;
-  taskById: TaskByIdMap;
-}): QueryUpdate => {
-  const sessionForTask = params.latestSessionByTaskId.get(params.taskId);
-  if (sessionForTask) {
-    return {
-      [AGENT_STUDIO_QUERY_KEYS.task]: sessionForTask.taskId,
-      [AGENT_STUDIO_QUERY_KEYS.session]: sessionForTask.sessionId,
-      [AGENT_STUDIO_QUERY_KEYS.agent]: sessionForTask.role,
-      [AGENT_STUDIO_QUERY_KEYS.scenario]: undefined,
-      [AGENT_STUDIO_QUERY_KEYS.autostart]: undefined,
-      [AGENT_STUDIO_QUERY_KEYS.start]: undefined,
-    };
-  }
-
-  const nextTask = params.taskById.get(params.taskId) ?? null;
-  const nextRole = resolveDefaultRoleForTask(nextTask);
+const toTaskQueryUpdate = (taskId: string): QueryUpdate => {
   return {
-    [AGENT_STUDIO_QUERY_KEYS.task]: params.taskId,
+    [AGENT_STUDIO_QUERY_KEYS.task]: taskId,
     [AGENT_STUDIO_QUERY_KEYS.session]: undefined,
-    [AGENT_STUDIO_QUERY_KEYS.agent]: nextRole,
+    [AGENT_STUDIO_QUERY_KEYS.agent]: undefined,
     [AGENT_STUDIO_QUERY_KEYS.scenario]: undefined,
     [AGENT_STUDIO_QUERY_KEYS.autostart]: undefined,
     [AGENT_STUDIO_QUERY_KEYS.start]: undefined,
@@ -121,10 +79,6 @@ export function useAgentStudioTaskTabs(args: {
     [updateQuery],
   );
 
-  const taskById = useMemo<TaskByIdMap>(
-    () => new Map(tasks.map((task): [string, TaskCard] => [task.id, task])),
-    [tasks],
-  );
   const selectableTaskIds = useMemo(
     () => new Set(tasks.filter((task) => task.status !== "closed").map((task) => task.id)),
     [tasks],
@@ -136,15 +90,9 @@ export function useAgentStudioTaskTabs(args: {
 
   const navigateToTask = useCallback(
     (nextTaskId: string) => {
-      deferQueryUpdate(
-        toTaskQueryUpdate({
-          taskId: nextTaskId,
-          latestSessionByTaskId,
-          taskById,
-        }),
-      );
+      deferQueryUpdate(toTaskQueryUpdate(nextTaskId));
     },
-    [deferQueryUpdate, latestSessionByTaskId, taskById],
+    [deferQueryUpdate],
   );
 
   const clearTaskSelection = useCallback((): void => {


### PR DESCRIPTION
## Summary
- Centralize Agent Studio selection in a canonical resolver that returns active session, role, and scenario with one precedence contract.
- Make task-tab navigation task-intent only by clearing explicit `session/agent/scenario` on task navigation to prevent overlapping URL-driven selection.
- Add regressions for human_review stability and explicit-session precedence, including no transient Builder→QA switching without explicit session selection.

## Verification
- `bun run --filter @openducktor/desktop test src/pages/agents/agents-page-selection.test.ts src/pages/agents/use-agent-studio-selection-controller.test.tsx src/pages/agents/use-agent-studio-task-tabs.test.tsx src/pages/agents/use-agent-studio-query-session-sync.test.tsx`
- `bun run --filter @openducktor/desktop test src/pages/agents`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now returns a structured selection (role, scenario, active session) and an explicit ordered role list for consistent role preference.

* **Improvements**
  * Task tab routing clears explicit session/agent query params when switching tasks.
  * Selection now prefers running/starting sessions and preserves pinned view sessions across updates.
  * View defaults better reflect task status and available workflows.

* **Tests**
  * Expanded coverage for selection, role/scenario defaults, fallbacks and stability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->