### PR TITLE
fix(desktop): keep task documents consistent across modal and MCP updates

### DIFF
--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/cache.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/cache.rs
@@ -3,7 +3,6 @@ use super::*;
 #[derive(Clone)]
 pub(super) struct TaskListCacheEntry {
     pub(super) tasks: Vec<TaskCard>,
-    pub(super) metadata_by_task_id: HashMap<String, TaskMetadata>,
     pub(super) cached_at: Instant,
     pub(super) metadata_namespace: String,
 }
@@ -49,7 +48,6 @@ impl BeadsTaskStore {
         metadata_namespace: &str,
         generation: u64,
         tasks: &[TaskCard],
-        metadata_by_task_id: &HashMap<String, TaskMetadata>,
     ) -> Result<()> {
         let mut cache = self
             .task_list_cache
@@ -62,36 +60,10 @@ impl BeadsTaskStore {
 
         state.entry = Some(TaskListCacheEntry {
             tasks: tasks.to_vec(),
-            metadata_by_task_id: metadata_by_task_id.clone(),
             cached_at: Instant::now(),
             metadata_namespace: metadata_namespace.to_string(),
         });
         Ok(())
-    }
-
-    pub(super) fn cached_task_metadata(
-        &self,
-        repo_key: &str,
-        metadata_namespace: &str,
-        task_id: &str,
-    ) -> Result<Option<TaskMetadata>> {
-        let mut cache = self
-            .task_list_cache
-            .lock()
-            .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
-        let state = cache.entry(repo_key.to_string()).or_default();
-
-        let Some(entry) = state.entry.as_ref() else {
-            return Ok(None);
-        };
-        let is_fresh = entry.cached_at.elapsed() <= Self::task_list_cache_ttl();
-        let namespace_matches = entry.metadata_namespace == metadata_namespace;
-        if !is_fresh || !namespace_matches {
-            state.entry = None;
-            return Ok(None);
-        }
-
-        Ok(entry.metadata_by_task_id.get(task_id).cloned())
     }
 
     pub(crate) fn invalidate_task_list_cache(&self, repo_path: &Path) -> Result<()> {
@@ -126,13 +98,7 @@ impl BeadsTaskStore {
         tasks: &[TaskCard],
     ) -> Result<()> {
         let repo_key = Self::repo_key(repo_path);
-        self.cache_task_list_if_generation(
-            &repo_key,
-            metadata_namespace,
-            generation,
-            tasks,
-            &HashMap::new(),
-        )?;
+        self.cache_task_list_if_generation(&repo_key, metadata_namespace, generation, tasks)?;
         Ok(())
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/session_ops.rs
@@ -311,14 +311,6 @@ impl BeadsTaskStore {
         repo_path: &Path,
         task_id: &str,
     ) -> Result<TaskMetadata> {
-        let metadata_namespace = self.current_metadata_namespace();
-        let repo_key = Self::repo_key(repo_path);
-        if let Some(metadata) =
-            self.cached_task_metadata(&repo_key, &metadata_namespace, task_id)?
-        {
-            return Ok(metadata);
-        }
-
         let issue = self.show_raw_issue(repo_path, task_id)?;
         Ok(self.parse_task_metadata_from_issue(&issue))
     }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -124,7 +124,6 @@ impl BeadsTaskStore {
         let value = self.run_bd_json(repo_path, &["list", "--all", "--limit", "0"])?;
 
         let mut tasks = Vec::new();
-        let mut metadata_by_task_id = HashMap::new();
         for entry in value
             .as_array()
             .ok_or_else(|| anyhow!("bd list did not return an array"))?
@@ -134,10 +133,7 @@ impl BeadsTaskStore {
             if issue.issue_type == "event" || issue.issue_type == "gate" {
                 continue;
             }
-            let task_id = issue.id.clone();
-            let metadata = self.parse_task_metadata_from_issue(&issue);
             tasks.push(self.parse_task_card(issue, &metadata_namespace)?);
-            metadata_by_task_id.insert(task_id, metadata);
         }
 
         let mut subtasks_by_parent: HashMap<String, Vec<String>> = HashMap::new();
@@ -161,7 +157,6 @@ impl BeadsTaskStore {
             &metadata_namespace,
             cache_generation,
             &tasks,
-            &metadata_by_task_id,
         )?;
         Ok(tasks)
     }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1336,7 +1336,10 @@ fn get_task_metadata_ignores_cached_task_list_metadata() -> Result<()> {
     let metadata = store.get_task_metadata(repo.path(), "task-1")?;
 
     assert_eq!(metadata.spec.markdown, "# Fresh spec");
-    assert_eq!(metadata.spec.revision, 2);
+    assert_eq!(
+        metadata.spec.updated_at.as_deref(),
+        Some("2026-02-20T11:00:00Z")
+    );
 
     let calls = runner.take_calls();
     assert_eq!(calls.len(), 2);

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1280,6 +1280,73 @@ fn stale_generation_cache_writes_are_ignored() -> Result<()> {
 }
 
 #[test]
+fn get_task_metadata_ignores_cached_task_list_metadata() -> Result<()> {
+    let repo = RepoFixture::new("metadata-read-bypasses-task-list-cache");
+    let stale = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "documents": {
+                    "spec": [
+                        {
+                            "markdown": "# Stale spec",
+                            "updatedAt": "2026-02-20T10:00:00Z",
+                            "updatedBy": "planner-agent",
+                            "sourceTool": "set_spec",
+                            "revision": 1
+                        }
+                    ]
+                }
+            }
+        })),
+    );
+    let fresh = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "documents": {
+                    "spec": [
+                        {
+                            "markdown": "# Fresh spec",
+                            "updatedAt": "2026-02-20T11:00:00Z",
+                            "updatedBy": "planner-agent",
+                            "sourceTool": "set_spec",
+                            "revision": 2
+                        }
+                    ]
+                }
+            }
+        })),
+    );
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(json!([stale]).to_string())),
+        MockStep::WithEnv(Ok(json!([fresh]).to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let _ = store.list_tasks(repo.path())?;
+    let metadata = store.get_task_metadata(repo.path(), "task-1")?;
+
+    assert_eq!(metadata.spec.markdown, "# Fresh spec");
+    assert_eq!(metadata.spec.revision, 2);
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].args[0], "list");
+    assert_eq!(calls[1].args[0], "show");
+
+    Ok(())
+}
+
+#[test]
 fn create_task_normalizes_payload_and_persists_qa_flag() -> Result<()> {
     let repo = RepoFixture::new("create-task");
     let created = issue_value("task-1", "open", "feature", None, json!([]), None);

--- a/apps/desktop/src/components/features/task-details/task-details-sheet-controller.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-controller.test.tsx
@@ -12,6 +12,7 @@ enableReactActEnvironment();
 
 const taskDetailsSheetRenderMock = mock(
   (_props: {
+    activeRepo?: string | null;
     task: TaskCard | null;
     allTasks: TaskCard[];
     runs: unknown[];
@@ -46,6 +47,7 @@ describe("TaskDetailsSheetController", () => {
       parentRenderCount += 1;
       return createElement(TaskDetailsSheetController, {
         ref: controllerRef,
+        activeRepo: "/repo-a",
         allTasks: [task],
         runs: [],
         workflowActionsEnabled: false,
@@ -58,6 +60,7 @@ describe("TaskDetailsSheetController", () => {
     expect(taskDetailsSheetRenderMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         task: null,
+        activeRepo: "/repo-a",
         allTasks: [task],
         runs: [],
         open: false,
@@ -73,6 +76,7 @@ describe("TaskDetailsSheetController", () => {
     expect(taskDetailsSheetRenderMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         task,
+        activeRepo: "/repo-a",
         allTasks: [task],
         runs: [],
         open: true,
@@ -96,6 +100,7 @@ describe("TaskDetailsSheetController", () => {
     const rendered = render(
       createElement(TaskDetailsSheetController, {
         ref: controllerRef,
+        activeRepo: "/repo-a",
         allTasks: [task],
         runs: [],
         workflowActionsEnabled: false,
@@ -113,6 +118,7 @@ describe("TaskDetailsSheetController", () => {
     expect(taskDetailsSheetRenderMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         task,
+        activeRepo: "/repo-a",
         open: true,
         runs: [],
         onDetectPullRequest,

--- a/apps/desktop/src/components/features/task-details/task-details-sheet-controller.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-controller.tsx
@@ -27,6 +27,7 @@ export const TaskDetailsSheetController = forwardRef<
   TaskDetailsSheetControllerProps
 >(function TaskDetailsSheetController(
   {
+    activeRepo = null,
     allTasks,
     runs,
     workflowActionsEnabled,
@@ -78,6 +79,7 @@ export const TaskDetailsSheetController = forwardRef<
 
   return (
     <TaskDetailsSheet
+      activeRepo={activeRepo}
       task={task}
       allTasks={allTasks}
       runs={runs}

--- a/apps/desktop/src/components/features/task-details/task-details-sheet-types.ts
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet-types.ts
@@ -1,6 +1,7 @@
 import type { RunSummary, TaskCard } from "@openducktor/contracts";
 
 export type TaskDetailsSheetProps = {
+  activeRepo?: string | null;
   task: TaskCard | null;
   allTasks: TaskCard[];
   runs: RunSummary[];

--- a/apps/desktop/src/components/features/task-details/task-details-sheet.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet.test.tsx
@@ -34,11 +34,42 @@ const viewModelMock = {
   confirmDelete: () => {},
 };
 
+const useTaskDetailsSheetViewModelMock = mock(() => viewModelMock);
+
 mock.module("./use-task-details-sheet-view-model", () => ({
-  useTaskDetailsSheetViewModel: () => viewModelMock,
+  useTaskDetailsSheetViewModel: useTaskDetailsSheetViewModelMock,
 }));
 
 describe("TaskDetailsSheet", () => {
+  test("passes activeRepo into task details view model", async () => {
+    const { TaskDetailsSheet } = await import("./task-details-sheet");
+
+    const task = createTaskCardFixture({
+      id: "TASK-1",
+      title: "Task 1",
+      documentSummary: {
+        spec: { has: false, updatedAt: undefined },
+        plan: { has: false, updatedAt: undefined },
+        qaReport: { has: false, updatedAt: undefined, verdict: "not_reviewed" },
+      },
+    });
+
+    renderToStaticMarkup(
+      createElement(TaskDetailsSheet, {
+        activeRepo: "/repo-a",
+        task,
+        allTasks: [task],
+        runs: [],
+        open: true,
+        onOpenChange: () => {},
+      }),
+    );
+
+    expect(useTaskDetailsSheetViewModelMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ activeRepo: "/repo-a" }),
+    );
+  });
+
   test("renders without the top-right close control", async () => {
     const { TaskDetailsSheet } = await import("./task-details-sheet");
 
@@ -54,6 +85,7 @@ describe("TaskDetailsSheet", () => {
 
     const html = renderToStaticMarkup(
       createElement(TaskDetailsSheet, {
+        activeRepo: "/repo-a",
         task,
         allTasks: [task],
         runs: [],

--- a/apps/desktop/src/components/features/task-details/task-details-sheet.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-sheet.tsx
@@ -30,6 +30,7 @@ const DETAIL_ACTIONS: readonly TaskWorkflowAction[] = [
 ];
 
 export function TaskDetailsSheet({
+  activeRepo = null,
   task,
   allTasks,
   runs,
@@ -54,6 +55,7 @@ export function TaskDetailsSheet({
   onDelete,
 }: TaskDetailsSheetProps): ReactElement {
   const viewModel = useTaskDetailsSheetViewModel({
+    activeRepo,
     task,
     allTasks,
     open,

--- a/apps/desktop/src/components/features/task-details/use-task-details-sheet-view-model.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-details-sheet-view-model.ts
@@ -49,6 +49,7 @@ type TaskDetailsSheetViewModel = {
 };
 
 type UseTaskDetailsSheetViewModelOptions = {
+  activeRepo?: string | null;
   task: TaskDetailsSheetProps["task"];
   allTasks: TaskDetailsSheetProps["allTasks"];
   open: TaskDetailsSheetProps["open"];
@@ -67,6 +68,7 @@ type UseTaskDetailsSheetViewModelOptions = {
 };
 
 export function useTaskDetailsSheetViewModel({
+  activeRepo = null,
   task,
   allTasks,
   open,
@@ -84,7 +86,11 @@ export function useTaskDetailsSheetViewModel({
   onDelete,
 }: UseTaskDetailsSheetViewModelOptions): TaskDetailsSheetViewModel {
   const taskId = task?.id ?? null;
-  const { specDoc, planDoc, qaDoc, ensureDocumentLoaded } = useTaskDocuments(taskId, open);
+  const { specDoc, planDoc, qaDoc, ensureDocumentLoaded } = useTaskDocuments(
+    taskId,
+    open,
+    activeRepo ?? "",
+  );
 
   const taskById = useMemo(() => new Map(allTasks.map((entry) => [entry.id, entry])), [allTasks]);
   const deleteImpactTaskIds = useMemo(

--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -1,6 +1,7 @@
 import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { host } from "@/state/operations/host";
+import { resolveLatestDocumentPayload } from "@/state/queries/document-utils";
 import type { TaskDocumentPayload } from "@/types/task-documents";
 
 export type DocumentSectionKey = "spec" | "plan" | "qa";
@@ -56,37 +57,6 @@ const createHostDocumentLoader = <TResult extends { markdown: string; updatedAt:
       updatedAt: document.updatedAt,
     };
   };
-};
-
-const toUpdatedAtTimestamp = (updatedAt: string | null): number | null => {
-  if (!updatedAt) {
-    return null;
-  }
-
-  const timestamp = Date.parse(updatedAt);
-  return Number.isNaN(timestamp) ? null : timestamp;
-};
-
-const resolveLatestDocumentPayload = (
-  current: TaskDocumentPayload | undefined,
-  incoming: TaskDocumentPayload,
-): TaskDocumentPayload => {
-  if (!current) {
-    return incoming;
-  }
-
-  const currentTimestamp = toUpdatedAtTimestamp(current.updatedAt);
-  const incomingTimestamp = toUpdatedAtTimestamp(incoming.updatedAt);
-
-  if (currentTimestamp !== null && incomingTimestamp !== null) {
-    return incomingTimestamp >= currentTimestamp ? incoming : current;
-  }
-
-  if (currentTimestamp !== null && incomingTimestamp === null) {
-    return incoming.markdown !== current.markdown ? incoming : current;
-  }
-
-  return incoming;
 };
 
 const createDocumentQueryKey = (cacheScope: string, taskId: string, section: DocumentSectionKey) =>

--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -83,7 +83,7 @@ const resolveLatestDocumentPayload = (
   }
 
   if (currentTimestamp !== null && incomingTimestamp === null) {
-    return current;
+    return incoming.markdown !== current.markdown ? incoming : current;
   }
 
   return incoming;
@@ -93,40 +93,52 @@ const createDocumentQueryKey = (cacheScope: string, taskId: string, section: Doc
   ["task-documents", section, cacheScope, taskId] as const;
 
 const createDocumentQueryOptions = ({
+  queryClient,
   cacheScope,
   taskId,
   section,
   loader,
 }: {
+  queryClient: ReturnType<typeof useQueryClient>;
   cacheScope: string;
   taskId: string;
   section: DocumentSectionKey;
   loader: (taskId: string) => Promise<TaskDocumentPayload>;
-}) =>
-  queryOptions({
-    queryKey: createDocumentQueryKey(cacheScope, taskId, section),
-    queryFn: (): Promise<TaskDocumentPayload> => loader(taskId),
+}) => {
+  const queryKey = createDocumentQueryKey(cacheScope, taskId, section);
+  return queryOptions({
+    queryKey,
+    queryFn: async (): Promise<TaskDocumentPayload> => {
+      const incoming = await loader(taskId);
+      const current = queryClient.getQueryData<TaskDocumentPayload>(queryKey);
+      return resolveLatestDocumentPayload(current, incoming);
+    },
     staleTime: TASK_DOCUMENT_STALE_TIME_MS,
   });
+};
 
 const createQueryOptionsBySection = (
+  queryClient: ReturnType<typeof useQueryClient>,
   cacheScope: string,
   taskId: string,
   loaders: SectionLoaders,
 ) => ({
   spec: createDocumentQueryOptions({
+    queryClient,
     cacheScope,
     taskId,
     section: "spec",
     loader: loaders.spec,
   }),
   plan: createDocumentQueryOptions({
+    queryClient,
     cacheScope,
     taskId,
     section: "plan",
     loader: loaders.plan,
   }),
   qa: createDocumentQueryOptions({
+    queryClient,
     cacheScope,
     taskId,
     section: "qa",
@@ -194,8 +206,8 @@ export function useTaskDocuments(
   const enabled = open && taskId !== null;
   const activeTaskId = taskId ?? DISABLED_TASK_ID;
   const queryOptionsBySection = useMemo(
-    () => createQueryOptionsBySection(cacheScope, activeTaskId, sectionLoaders),
-    [activeTaskId, cacheScope, sectionLoaders],
+    () => createQueryOptionsBySection(queryClient, cacheScope, activeTaskId, sectionLoaders),
+    [activeTaskId, cacheScope, queryClient, sectionLoaders],
   );
 
   const specQuery = useQuery({

--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -1,6 +1,6 @@
 import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
-import { useSpecState } from "@/state";
+import { host } from "@/state/operations/host";
 import type { TaskDocumentPayload } from "@/types/task-documents";
 
 export type DocumentSectionKey = "spec" | "plan" | "qa";
@@ -19,7 +19,10 @@ type TaskDocumentLoaders = {
   loadQaReportDocument: (taskId: string) => Promise<TaskDocumentPayload>;
 };
 
+type SectionLoaders = Record<DocumentSectionKey, (taskId: string) => Promise<TaskDocumentPayload>>;
+
 const TASK_DOCUMENT_STALE_TIME_MS = 60_000;
+const DISABLED_TASK_ID = "__disabled__";
 
 const createTaskDocumentState = (input?: {
   markdown?: string;
@@ -37,6 +40,54 @@ const createTaskDocumentState = (input?: {
 
 const toErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : "Unable to load document.";
+
+const createHostDocumentLoader = <TResult extends { markdown: string; updatedAt: string | null }>(
+  cacheScope: string,
+  readDocument: (repoPath: string, taskId: string) => Promise<TResult>,
+): ((taskId: string) => Promise<TaskDocumentPayload>) => {
+  return async (nextTaskId: string): Promise<TaskDocumentPayload> => {
+    if (!cacheScope) {
+      throw new Error("Select a repository before loading task documents.");
+    }
+
+    const document = await readDocument(cacheScope, nextTaskId);
+    return {
+      markdown: document.markdown,
+      updatedAt: document.updatedAt,
+    };
+  };
+};
+
+const toUpdatedAtTimestamp = (updatedAt: string | null): number | null => {
+  if (!updatedAt) {
+    return null;
+  }
+
+  const timestamp = Date.parse(updatedAt);
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
+
+const resolveLatestDocumentPayload = (
+  current: TaskDocumentPayload | undefined,
+  incoming: TaskDocumentPayload,
+): TaskDocumentPayload => {
+  if (!current) {
+    return incoming;
+  }
+
+  const currentTimestamp = toUpdatedAtTimestamp(current.updatedAt);
+  const incomingTimestamp = toUpdatedAtTimestamp(incoming.updatedAt);
+
+  if (currentTimestamp !== null && incomingTimestamp !== null) {
+    return incomingTimestamp >= currentTimestamp ? incoming : current;
+  }
+
+  if (currentTimestamp !== null && incomingTimestamp === null) {
+    return current;
+  }
+
+  return incoming;
+};
 
 const createDocumentQueryKey = (cacheScope: string, taskId: string, section: DocumentSectionKey) =>
   ["task-documents", section, cacheScope, taskId] as const;
@@ -57,6 +108,31 @@ const createDocumentQueryOptions = ({
     queryFn: (): Promise<TaskDocumentPayload> => loader(taskId),
     staleTime: TASK_DOCUMENT_STALE_TIME_MS,
   });
+
+const createQueryOptionsBySection = (
+  cacheScope: string,
+  taskId: string,
+  loaders: SectionLoaders,
+) => ({
+  spec: createDocumentQueryOptions({
+    cacheScope,
+    taskId,
+    section: "spec",
+    loader: loaders.spec,
+  }),
+  plan: createDocumentQueryOptions({
+    cacheScope,
+    taskId,
+    section: "plan",
+    loader: loaders.plan,
+  }),
+  qa: createDocumentQueryOptions({
+    cacheScope,
+    taskId,
+    section: "qa",
+    loader: loaders.qa,
+  }),
+});
 
 const toTaskDocumentState = (
   query: ReturnType<typeof useQuery<TaskDocumentPayload>>,
@@ -85,129 +161,106 @@ export function useTaskDocuments(
   reloadDocument: (section: DocumentSectionKey) => boolean;
   applyDocumentUpdate: (section: DocumentSectionKey, payload: TaskDocumentPayload) => void;
 } {
-  const specState = useSpecState();
-  const { loadSpecDocument, loadPlanDocument, loadQaReportDocument } = loadersOverride ?? specState;
+  const loadSpecDocumentFromHost = useMemo(
+    () => createHostDocumentLoader(cacheScope, host.specGet),
+    [cacheScope],
+  );
+  const loadPlanDocumentFromHost = useMemo(
+    () => createHostDocumentLoader(cacheScope, host.planGet),
+    [cacheScope],
+  );
+  const loadQaReportDocumentFromHost = useMemo(
+    () => createHostDocumentLoader(cacheScope, host.qaGetReport),
+    [cacheScope],
+  );
+
+  const sectionLoaders = useMemo<SectionLoaders>(() => {
+    return {
+      spec: loadersOverride?.loadSpecDocument ?? loadSpecDocumentFromHost,
+      plan: loadersOverride?.loadPlanDocument ?? loadPlanDocumentFromHost,
+      qa: loadersOverride?.loadQaReportDocument ?? loadQaReportDocumentFromHost,
+    };
+  }, [
+    loadersOverride?.loadPlanDocument,
+    loadersOverride?.loadQaReportDocument,
+    loadersOverride?.loadSpecDocument,
+    loadPlanDocumentFromHost,
+    loadQaReportDocumentFromHost,
+    loadSpecDocumentFromHost,
+  ]);
+
   const queryClient = useQueryClient();
 
   const enabled = open && taskId !== null;
+  const activeTaskId = taskId ?? DISABLED_TASK_ID;
+  const queryOptionsBySection = useMemo(
+    () => createQueryOptionsBySection(cacheScope, activeTaskId, sectionLoaders),
+    [activeTaskId, cacheScope, sectionLoaders],
+  );
+
   const specQuery = useQuery({
-    ...(taskId
-      ? createDocumentQueryOptions({
-          cacheScope,
-          taskId,
-          section: "spec",
-          loader: loadSpecDocument,
-        })
-      : createDocumentQueryOptions({
-          cacheScope,
-          taskId: "__disabled__",
-          section: "spec",
-          loader: loadSpecDocument,
-        })),
+    ...queryOptionsBySection.spec,
     enabled,
   });
   const planQuery = useQuery({
-    ...(taskId
-      ? createDocumentQueryOptions({
-          cacheScope,
-          taskId,
-          section: "plan",
-          loader: loadPlanDocument,
-        })
-      : createDocumentQueryOptions({
-          cacheScope,
-          taskId: "__disabled__",
-          section: "plan",
-          loader: loadPlanDocument,
-        })),
+    ...queryOptionsBySection.plan,
     enabled,
   });
   const qaQuery = useQuery({
-    ...(taskId
-      ? createDocumentQueryOptions({
-          cacheScope,
-          taskId,
-          section: "qa",
-          loader: loadQaReportDocument,
-        })
-      : createDocumentQueryOptions({
-          cacheScope,
-          taskId: "__disabled__",
-          section: "qa",
-          loader: loadQaReportDocument,
-        })),
+    ...queryOptionsBySection.qa,
     enabled,
   });
 
-  const queryOptionsBySection = useMemo(
-    () =>
-      taskId
-        ? {
-            spec: createDocumentQueryOptions({
-              cacheScope,
-              taskId,
-              section: "spec",
-              loader: loadSpecDocument,
-            }),
-            plan: createDocumentQueryOptions({
-              cacheScope,
-              taskId,
-              section: "plan",
-              loader: loadPlanDocument,
-            }),
-            qa: createDocumentQueryOptions({
-              cacheScope,
-              taskId,
-              section: "qa",
-              loader: loadQaReportDocument,
-            }),
-          }
-        : null,
-    [cacheScope, loadPlanDocument, loadQaReportDocument, loadSpecDocument, taskId],
-  );
-
   const ensureDocumentLoaded = useCallback(
     (section: DocumentSectionKey): boolean => {
-      if (!open || !queryOptionsBySection) {
+      if (!enabled) {
         return false;
       }
 
       void queryClient.ensureQueryData(queryOptionsBySection[section]).catch(() => undefined);
       return true;
     },
-    [open, queryClient, queryOptionsBySection],
+    [enabled, queryClient, queryOptionsBySection],
   );
 
   const reloadDocument = useCallback(
     (section: DocumentSectionKey): boolean => {
-      if (!open || !queryOptionsBySection) {
+      if (!enabled || !taskId) {
         return false;
       }
 
       const options = queryOptionsBySection[section];
+      const loadDocument = sectionLoaders[section];
       void queryClient.cancelQueries({ queryKey: options.queryKey, exact: true });
       void queryClient
         .fetchQuery({
           ...options,
+          queryFn: async (): Promise<TaskDocumentPayload> => {
+            const incoming = await loadDocument(taskId);
+            const current = queryClient.getQueryData<TaskDocumentPayload>(options.queryKey);
+            return resolveLatestDocumentPayload(current, incoming);
+          },
           staleTime: 0,
         })
         .catch(() => undefined);
       return true;
     },
-    [open, queryClient, queryOptionsBySection],
+    [enabled, queryClient, queryOptionsBySection, sectionLoaders, taskId],
   );
 
   const applyDocumentUpdate = useCallback(
     (section: DocumentSectionKey, payload: TaskDocumentPayload): void => {
-      if (!queryOptionsBySection) {
+      if (!taskId) {
         return;
       }
 
       const queryKey = queryOptionsBySection[section].queryKey;
       void queryClient.cancelQueries({ queryKey, exact: true });
-      queryClient.setQueryData<TaskDocumentPayload>(queryKey, payload);
+      queryClient.setQueryData<TaskDocumentPayload>(queryKey, (current) =>
+        resolveLatestDocumentPayload(current, payload),
+      );
     },
-    [queryClient, queryOptionsBySection],
+    [queryClient, queryOptionsBySection, taskId],
   );
 
   return {

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -298,6 +298,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
   const taskDetailsSheet = (
     <TaskDetailsSheetController
       ref={taskDetailsSheetRef}
+      activeRepo={activeRepo}
       allTasks={tasks}
       runs={runs}
       workflowActionsEnabled={false}

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -355,7 +355,7 @@ describe("useAgentStudioDocuments", () => {
       expect(applyDocumentUpdateMock).toHaveBeenCalledTimes(1);
       expect(applyDocumentUpdateMock).toHaveBeenCalledWith("plan", {
         markdown: "# Saved plan",
-        updatedAt: expect.any(String),
+        updatedAt: null,
       });
       expect(reloadDocumentMock).not.toHaveBeenCalled();
     } finally {

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
@@ -12,6 +12,47 @@ type UseAgentStudioDocumentsArgs = {
   selectedTask: TaskCard | null;
 };
 
+type WorkflowDocumentTarget = {
+  section: "spec" | "plan" | "qa";
+  state: ReturnType<typeof useTaskDocuments>["specDoc"];
+  inputKey: "markdown" | "reportMarkdown";
+};
+
+const resolveWorkflowDocumentTarget = (
+  normalizedTool: string | null,
+  docs: {
+    specDoc: ReturnType<typeof useTaskDocuments>["specDoc"];
+    planDoc: ReturnType<typeof useTaskDocuments>["planDoc"];
+    qaDoc: ReturnType<typeof useTaskDocuments>["qaDoc"];
+  },
+): WorkflowDocumentTarget | null => {
+  if (normalizedTool === "odt_set_spec") {
+    return {
+      section: "spec",
+      state: docs.specDoc,
+      inputKey: "markdown",
+    };
+  }
+
+  if (normalizedTool === "odt_set_plan") {
+    return {
+      section: "plan",
+      state: docs.planDoc,
+      inputKey: "markdown",
+    };
+  }
+
+  if (normalizedTool === "odt_qa_approved" || normalizedTool === "odt_qa_rejected") {
+    return {
+      section: "qa",
+      state: docs.qaDoc,
+      inputKey: "reportMarkdown",
+    };
+  }
+
+  return null;
+};
+
 export function useAgentStudioDocuments({
   activeRepo = null,
   taskId,
@@ -90,14 +131,11 @@ export function useAgentStudioDocuments({
         continue;
       }
       const normalizedTool = normalizeOdtWorkflowToolName(meta.tool);
-      const target =
-        normalizedTool === "odt_set_spec"
-          ? { section: "spec" as const, state: specDoc, inputKey: "markdown" as const }
-          : normalizedTool === "odt_set_plan"
-            ? { section: "plan" as const, state: planDoc, inputKey: "markdown" as const }
-            : normalizedTool === "odt_qa_approved" || normalizedTool === "odt_qa_rejected"
-              ? { section: "qa" as const, state: qaDoc, inputKey: "reportMarkdown" as const }
-              : null;
+      const target = resolveWorkflowDocumentTarget(normalizedTool, {
+        specDoc,
+        planDoc,
+        qaDoc,
+      });
       if (!target) {
         continue;
       }
@@ -111,7 +149,9 @@ export function useAgentStudioDocuments({
       const inputMarkdown = toolInput?.[target.inputKey];
       const hasInputMarkdown = typeof inputMarkdown === "string" && inputMarkdown.trim().length > 0;
 
-      let effectiveUpdatedAtTimestamp = parseTimestamp(target.state.updatedAt);
+      let effectiveUpdatedAtTimestamp = target.state.updatedAt
+        ? parseTimestamp(target.state.updatedAt)
+        : null;
       if (hasInputMarkdown) {
         const shouldApplyOptimisticDocument =
           target.state.markdown.trim() !== inputMarkdown.trim() ||
@@ -121,7 +161,7 @@ export function useAgentStudioDocuments({
         if (shouldApplyOptimisticDocument) {
           applyDocumentUpdate(target.section, {
             markdown: inputMarkdown,
-            updatedAt: completionInfo?.raw ?? target.state.updatedAt ?? new Date().toISOString(),
+            updatedAt: completionInfo?.raw ?? target.state.updatedAt ?? null,
           });
           effectiveUpdatedAtTimestamp = completionInfo?.timestamp ?? effectiveUpdatedAtTimestamp;
         }

--- a/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
+++ b/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
@@ -108,6 +108,7 @@ export type KanbanPageTaskComposerModel = {
 };
 
 export type KanbanPageTaskDetailsControllerModel = {
+  activeRepo: string | null;
   allTasks: TaskCard[];
   runs: RunSummary[];
   onPlan: (taskId: string, action: "set_spec" | "set_plan") => void;

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
@@ -187,6 +187,7 @@ export function useKanbanPageModels({
     content,
     taskComposer: taskDialogs.taskComposer,
     taskDetailsController: {
+      activeRepo,
       allTasks: tasks,
       runs,
       onPlan,

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
@@ -1,7 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
 import { defaultSpecTemplateMarkdown } from "@openducktor/contracts";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { PropsWithChildren, ReactElement } from "react";
 import { QueryProvider } from "@/lib/query-provider";
+import { documentQueryKeys } from "@/state/queries/documents";
+import { taskQueryKeys } from "@/state/queries/tasks";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
 import { host } from "../shared/host";
 import { useSpecOperations } from "./use-spec-operations";
@@ -208,6 +211,102 @@ describe("use-spec-operations", () => {
       host.qaGetReport = original.qaGetReport;
       host.saveSpecDocument = original.saveSpecDocument;
       host.savePlanDocument = original.savePlanDocument;
+    }
+  });
+
+  test("invalidates all task-document caches and task list cache after document saves", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    let latest: HookResult | null = null;
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useSpecOperations(args);
+      return null;
+    };
+
+    const harness = createSharedHookHarness(
+      Harness,
+      { args: { activeRepo: "/repo-a" } },
+      { wrapper },
+    );
+
+    const saveSpecDocument = mock(async () => ({ updatedAt: "2026-02-22T10:03:00.000Z" }));
+    const savePlanDocument = mock(async () => ({ updatedAt: "2026-02-22T10:04:00.000Z" }));
+    const original = {
+      saveSpecDocument: host.saveSpecDocument,
+      savePlanDocument: host.savePlanDocument,
+    };
+    host.saveSpecDocument = saveSpecDocument;
+    host.savePlanDocument = savePlanDocument;
+
+    queryClient.setQueryData(documentQueryKeys.spec("/repo-a", "task-1"), {
+      markdown: "# Old spec",
+      updatedAt: "2026-02-22T10:00:00.000Z",
+    });
+    queryClient.setQueryData(["task-documents", "spec", "", "task-1"], {
+      markdown: "# Old spec (empty scope key)",
+      updatedAt: "2026-02-22T10:00:00.000Z",
+    });
+    queryClient.setQueryData(documentQueryKeys.plan("/repo-a", "task-1"), {
+      markdown: "# Old plan",
+      updatedAt: "2026-02-22T10:00:00.000Z",
+    });
+    queryClient.setQueryData(["task-documents", "plan", "", "task-1"], {
+      markdown: "# Old plan (empty scope key)",
+      updatedAt: "2026-02-22T10:00:00.000Z",
+    });
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a"), {
+      tasks: [],
+      runs: [],
+    });
+
+    try {
+      await harness.mount();
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      await harness.run(async () => {
+        await latest?.saveSpecDocument("task-1", "# New spec");
+        await latest?.savePlanDocument("task-1", "# New plan");
+      });
+
+      const cachedSpec = queryClient.getQueryData<{
+        markdown: string;
+        updatedAt: string | null;
+      }>(documentQueryKeys.spec("/repo-a", "task-1"));
+      const cachedPlan = queryClient.getQueryData<{
+        markdown: string;
+        updatedAt: string | null;
+      }>(documentQueryKeys.plan("/repo-a", "task-1"));
+
+      expect(cachedSpec?.markdown).toBe("# New spec");
+      expect(cachedSpec?.updatedAt).toBe("2026-02-22T10:03:00.000Z");
+      expect(cachedPlan?.markdown).toBe("# New plan");
+      expect(cachedPlan?.updatedAt).toBe("2026-02-22T10:04:00.000Z");
+
+      expect(
+        queryClient.getQueryState(["task-documents", "spec", "", "task-1"])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        queryClient.getQueryState(["task-documents", "plan", "", "task-1"])?.isInvalidated,
+      ).toBe(true);
+      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a"))?.isInvalidated).toBe(
+        true,
+      );
+    } finally {
+      await harness.unmount();
+      host.saveSpecDocument = original.saveSpecDocument;
+      host.savePlanDocument = original.savePlanDocument;
+      queryClient.clear();
     }
   });
 });

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
@@ -309,4 +309,155 @@ describe("use-spec-operations", () => {
       queryClient.clear();
     }
   });
+
+  test("saveSpec updates spec cache and invalidates shared document/task caches", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    let latest: HookResult | null = null;
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useSpecOperations(args);
+      return null;
+    };
+
+    const harness = createSharedHookHarness(
+      Harness,
+      { args: { activeRepo: "/repo-a" } },
+      { wrapper },
+    );
+
+    const setSpec = mock(async () => ({ updatedAt: "2026-02-22T10:06:00.000Z" }));
+    const original = {
+      setSpec: host.setSpec,
+    };
+    host.setSpec = setSpec;
+
+    queryClient.setQueryData(documentQueryKeys.spec("/repo-a", "task-1"), {
+      markdown: "# Old spec",
+      updatedAt: "2026-02-22T10:00:00.000Z",
+    });
+    queryClient.setQueryData(["task-documents", "spec", "", "task-1"], {
+      markdown: "# Old spec (empty scope key)",
+      updatedAt: "2026-02-22T10:00:00.000Z",
+    });
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a"), {
+      tasks: [],
+      runs: [],
+    });
+
+    try {
+      await harness.mount();
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      await harness.run(async () => {
+        await latest?.saveSpec("task-1", defaultSpecTemplateMarkdown);
+      });
+
+      const cachedSpec = queryClient.getQueryData<{
+        markdown: string;
+        updatedAt: string | null;
+      }>(documentQueryKeys.spec("/repo-a", "task-1"));
+
+      expect(cachedSpec?.markdown).toBe(defaultSpecTemplateMarkdown);
+      expect(cachedSpec?.updatedAt).toBe("2026-02-22T10:06:00.000Z");
+      expect(
+        queryClient.getQueryState(["task-documents", "spec", "", "task-1"])?.isInvalidated,
+      ).toBe(true);
+      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a"))?.isInvalidated).toBe(
+        true,
+      );
+    } finally {
+      await harness.unmount();
+      host.setSpec = original.setSpec;
+      queryClient.clear();
+    }
+  });
+
+  test("preserves newer cached payloads when save responses arrive out of order", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    let latest: HookResult | null = null;
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useSpecOperations(args);
+      return null;
+    };
+
+    const harness = createSharedHookHarness(
+      Harness,
+      { args: { activeRepo: "/repo-a" } },
+      { wrapper },
+    );
+
+    const saveSpecDocument = mock(async () => ({ updatedAt: "2026-02-22T10:01:00.000Z" }));
+    const savePlanDocument = mock(async () => ({ updatedAt: "2026-02-22T10:01:00.000Z" }));
+    const original = {
+      saveSpecDocument: host.saveSpecDocument,
+      savePlanDocument: host.savePlanDocument,
+    };
+    host.saveSpecDocument = saveSpecDocument;
+    host.savePlanDocument = savePlanDocument;
+
+    queryClient.setQueryData(documentQueryKeys.spec("/repo-a", "task-1"), {
+      markdown: "# Newer spec",
+      updatedAt: "2026-02-22T10:05:00.000Z",
+    });
+    queryClient.setQueryData(documentQueryKeys.plan("/repo-a", "task-1"), {
+      markdown: "# Newer plan",
+      updatedAt: "2026-02-22T10:05:00.000Z",
+    });
+
+    try {
+      await harness.mount();
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      await harness.run(async () => {
+        await latest?.saveSpecDocument("task-1", "# Older spec response");
+        await latest?.savePlanDocument("task-1", "# Older plan response");
+      });
+
+      const cachedSpec = queryClient.getQueryData<{
+        markdown: string;
+        updatedAt: string | null;
+      }>(documentQueryKeys.spec("/repo-a", "task-1"));
+      const cachedPlan = queryClient.getQueryData<{
+        markdown: string;
+        updatedAt: string | null;
+      }>(documentQueryKeys.plan("/repo-a", "task-1"));
+
+      expect(cachedSpec).toEqual({
+        markdown: "# Newer spec",
+        updatedAt: "2026-02-22T10:05:00.000Z",
+      });
+      expect(cachedPlan).toEqual({
+        markdown: "# Newer plan",
+        updatedAt: "2026-02-22T10:05:00.000Z",
+      });
+    } finally {
+      await harness.unmount();
+      host.saveSpecDocument = original.saveSpecDocument;
+      host.savePlanDocument = original.savePlanDocument;
+      queryClient.clear();
+    }
+  });
 });

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
@@ -7,6 +7,7 @@ import {
   loadQaReportDocumentFromQuery,
   loadSpecDocumentFromQuery,
 } from "../../queries/documents";
+import { taskQueryKeys } from "../../queries/tasks";
 import { host } from "../shared/host";
 import { requireActiveRepo } from "./task-operations-model";
 
@@ -85,8 +86,16 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
         taskId,
         markdown,
       });
+      queryClient.setQueryData(documentQueryKeys.spec(repo, taskId), {
+        markdown,
+        updatedAt: saved.updatedAt,
+      });
       await queryClient.invalidateQueries({
-        queryKey: documentQueryKeys.spec(repo, taskId),
+        queryKey: documentQueryKeys.all,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: taskQueryKeys.repoData(repo),
+        exact: true,
       });
       return saved;
     },
@@ -101,8 +110,16 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
         taskId,
         markdown,
       });
+      queryClient.setQueryData(documentQueryKeys.plan(repo, taskId), {
+        markdown,
+        updatedAt: saved.updatedAt,
+      });
       await queryClient.invalidateQueries({
-        queryKey: documentQueryKeys.plan(repo, taskId),
+        queryKey: documentQueryKeys.all,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: taskQueryKeys.repoData(repo),
+        exact: true,
       });
       return saved;
     },

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
@@ -1,6 +1,8 @@
 import { defaultSpecTemplateMarkdown, validateSpecMarkdown } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import type { TaskDocumentPayload } from "../../../types/task-documents";
+import { resolveLatestDocumentPayload } from "../../queries/document-utils";
 import {
   documentQueryKeys,
   loadPlanDocumentFromQuery,
@@ -23,42 +25,6 @@ type UseSpecOperationsResult = {
   saveSpec: (taskId: string, markdown: string) => Promise<{ updatedAt: string }>;
   saveSpecDocument: (taskId: string, markdown: string) => Promise<{ updatedAt: string }>;
   savePlanDocument: (taskId: string, markdown: string) => Promise<{ updatedAt: string }>;
-};
-
-type TaskDocumentPayload = {
-  markdown: string;
-  updatedAt: string | null;
-};
-
-const toUpdatedAtTimestamp = (updatedAt: string | null): number | null => {
-  if (!updatedAt) {
-    return null;
-  }
-
-  const parsed = Date.parse(updatedAt);
-  return Number.isNaN(parsed) ? null : parsed;
-};
-
-const resolveLatestDocumentPayload = (
-  current: TaskDocumentPayload | undefined,
-  incoming: TaskDocumentPayload,
-): TaskDocumentPayload => {
-  if (!current) {
-    return incoming;
-  }
-
-  const currentTimestamp = toUpdatedAtTimestamp(current.updatedAt);
-  const incomingTimestamp = toUpdatedAtTimestamp(incoming.updatedAt);
-
-  if (currentTimestamp !== null && incomingTimestamp !== null) {
-    return incomingTimestamp >= currentTimestamp ? incoming : current;
-  }
-
-  if (currentTimestamp !== null && incomingTimestamp === null) {
-    return current;
-  }
-
-  return incoming;
 };
 
 const setLatestDocumentPayload = (

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
@@ -25,6 +25,53 @@ type UseSpecOperationsResult = {
   savePlanDocument: (taskId: string, markdown: string) => Promise<{ updatedAt: string }>;
 };
 
+type TaskDocumentPayload = {
+  markdown: string;
+  updatedAt: string | null;
+};
+
+const toUpdatedAtTimestamp = (updatedAt: string | null): number | null => {
+  if (!updatedAt) {
+    return null;
+  }
+
+  const parsed = Date.parse(updatedAt);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+const resolveLatestDocumentPayload = (
+  current: TaskDocumentPayload | undefined,
+  incoming: TaskDocumentPayload,
+): TaskDocumentPayload => {
+  if (!current) {
+    return incoming;
+  }
+
+  const currentTimestamp = toUpdatedAtTimestamp(current.updatedAt);
+  const incomingTimestamp = toUpdatedAtTimestamp(incoming.updatedAt);
+
+  if (currentTimestamp !== null && incomingTimestamp !== null) {
+    return incomingTimestamp >= currentTimestamp ? incoming : current;
+  }
+
+  if (currentTimestamp !== null && incomingTimestamp === null) {
+    return current;
+  }
+
+  return incoming;
+};
+
+const setLatestDocumentPayload = (
+  current: TaskDocumentPayload | undefined,
+  markdown: string,
+  updatedAt: string,
+): TaskDocumentPayload => {
+  return resolveLatestDocumentPayload(current, {
+    markdown,
+    updatedAt,
+  });
+};
+
 export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpecOperationsResult {
   const queryClient = useQueryClient();
 
@@ -70,8 +117,16 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       }
 
       const saved = await host.setSpec({ repoPath: repo, taskId, markdown });
+      queryClient.setQueryData<TaskDocumentPayload>(
+        documentQueryKeys.spec(repo, taskId),
+        (current) => setLatestDocumentPayload(current, markdown, saved.updatedAt),
+      );
       await queryClient.invalidateQueries({
-        queryKey: documentQueryKeys.spec(repo, taskId),
+        queryKey: documentQueryKeys.all,
+      });
+      await queryClient.invalidateQueries({
+        queryKey: taskQueryKeys.repoData(repo),
+        exact: true,
       });
       return saved;
     },
@@ -86,10 +141,10 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
         taskId,
         markdown,
       });
-      queryClient.setQueryData(documentQueryKeys.spec(repo, taskId), {
-        markdown,
-        updatedAt: saved.updatedAt,
-      });
+      queryClient.setQueryData<TaskDocumentPayload>(
+        documentQueryKeys.spec(repo, taskId),
+        (current) => setLatestDocumentPayload(current, markdown, saved.updatedAt),
+      );
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
@@ -110,10 +165,10 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
         taskId,
         markdown,
       });
-      queryClient.setQueryData(documentQueryKeys.plan(repo, taskId), {
-        markdown,
-        updatedAt: saved.updatedAt,
-      });
+      queryClient.setQueryData<TaskDocumentPayload>(
+        documentQueryKeys.plan(repo, taskId),
+        (current) => setLatestDocumentPayload(current, markdown, saved.updatedAt),
+      );
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });

--- a/apps/desktop/src/state/queries/document-utils.test.ts
+++ b/apps/desktop/src/state/queries/document-utils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import type { TaskDocumentPayload } from "@/types/task-documents";
+import { resolveLatestDocumentPayload, toUpdatedAtTimestamp } from "./document-utils";
+
+const payload = (overrides: Partial<TaskDocumentPayload>): TaskDocumentPayload => ({
+  markdown: "",
+  updatedAt: null,
+  ...overrides,
+});
+
+describe("document-utils", () => {
+  test("toUpdatedAtTimestamp returns null for invalid values", () => {
+    expect(toUpdatedAtTimestamp(null)).toBeNull();
+    expect(toUpdatedAtTimestamp("not-a-date")).toBeNull();
+  });
+
+  test("resolveLatestDocumentPayload keeps newer timestamped payload", () => {
+    const current = payload({ markdown: "# Current", updatedAt: "2026-03-26T20:00:00.000Z" });
+    const incoming = payload({ markdown: "# Incoming old", updatedAt: "2026-03-26T19:59:00.000Z" });
+
+    expect(resolveLatestDocumentPayload(current, incoming)).toEqual(current);
+  });
+
+  test("resolveLatestDocumentPayload applies incoming null timestamp when content changed", () => {
+    const current = payload({ markdown: "# Existing", updatedAt: "2026-03-26T20:00:00.000Z" });
+    const incoming = payload({ markdown: "", updatedAt: null });
+
+    expect(resolveLatestDocumentPayload(current, incoming)).toEqual(incoming);
+  });
+
+  test("resolveLatestDocumentPayload keeps current null-timestamp incoming when content unchanged", () => {
+    const current = payload({ markdown: "# Existing", updatedAt: "2026-03-26T20:00:00.000Z" });
+    const incoming = payload({ markdown: "# Existing", updatedAt: null });
+
+    expect(resolveLatestDocumentPayload(current, incoming)).toEqual(current);
+  });
+});

--- a/apps/desktop/src/state/queries/document-utils.ts
+++ b/apps/desktop/src/state/queries/document-utils.ts
@@ -1,0 +1,32 @@
+import type { TaskDocumentPayload } from "@/types/task-documents";
+
+export const toUpdatedAtTimestamp = (updatedAt: string | null): number | null => {
+  if (!updatedAt) {
+    return null;
+  }
+
+  const parsed = Date.parse(updatedAt);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+export const resolveLatestDocumentPayload = (
+  current: TaskDocumentPayload | undefined,
+  incoming: TaskDocumentPayload,
+): TaskDocumentPayload => {
+  if (!current) {
+    return incoming;
+  }
+
+  const currentTimestamp = toUpdatedAtTimestamp(current.updatedAt);
+  const incomingTimestamp = toUpdatedAtTimestamp(incoming.updatedAt);
+
+  if (currentTimestamp !== null && incomingTimestamp !== null) {
+    return incomingTimestamp >= currentTimestamp ? incoming : current;
+  }
+
+  if (currentTimestamp !== null && incomingTimestamp === null) {
+    return incoming.markdown !== current.markdown ? incoming : current;
+  }
+
+  return incoming;
+};


### PR DESCRIPTION
## Summary
- synchronize task document cache updates so Task Details and Task Edit views immediately reflect spec/plan saves, including active-repo scoped keys
- remove backend task-metadata cache coupling by serving `task_metadata_get` from fresh issue reads and keeping task-list cache limited to task cards
- refactor `useTaskDocuments` and Agent Studio document handling for clearer control flow and timestamp-safe optimistic MCP document updates

## Verification
- `bun run --filter @openducktor/desktop test`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop build`
- `bun run check:rust`
- `bun run test:rust`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed stale per-task metadata caching so task metadata is fetched fresh.

* **Improvements**
  * Task details now respect an active repository context for more accurate document and UI state.
  * Document loading, merge and timestamp logic improved to prefer the latest content and avoid regressions.
  * Query cache updates and invalidation refined for more consistent spec/plan and task-list state.

* **Tests**
  * Added tests covering metadata fetch behavior, document-resolution logic, and cache/invalidation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->