### PR TITLE
fix(kanban): harden done visibility settings flow

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1326,6 +1326,7 @@ name = "host-infra-beads"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "host-domain",
  "host-infra-system",
  "serde",

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -75,7 +75,7 @@ pub(crate) use workflow_rules::{
 };
 pub use workspace_policy::{
     HookTrustConfirmationPort, HookTrustConfirmationRequest, PreparedHookTrustChallenge,
-    RepoConfigUpdate, RepoSettingsUpdate,
+    RepoConfigUpdate, RepoSettingsUpdate, WorkspaceSettingsSnapshotUpdate,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -290,7 +290,9 @@ impl AppService {
         config.theme = theme;
         config.git = git;
         config.chat = chat;
-        config.kanban = kanban;
+        config.kanban = KanbanSettings {
+            done_visible_days: kanban.done_visible_days.max(0),
+        };
         config.global_prompt_overrides = global_prompt_overrides;
         for (repo_path, repo_config) in repos {
             config.repos.insert(repo_path, repo_config);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -11,7 +11,7 @@ use host_domain::{
 use host_infra_system::{
     command_exists, copy_configured_worktree_files, remove_worktree, repo_script_fingerprint,
     resolve_central_beads_dir, run_command, run_command_allow_failure_with_env, version_command,
-    ChatSettings, GlobalGitConfig, HookSet, PromptOverrides, RepoConfig,
+    ChatSettings, GlobalGitConfig, HookSet, KanbanSettings, PromptOverrides, RepoConfig,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -25,6 +25,7 @@ type SettingsSnapshotTuple = (
     String,
     GlobalGitConfig,
     ChatSettings,
+    KanbanSettings,
     HashMap<String, RepoConfig>,
     PromptOverrides,
 );
@@ -258,6 +259,7 @@ impl AppService {
             config.theme,
             config.git,
             config.chat,
+            config.kanban,
             config.repos,
             config.global_prompt_overrides,
         ))
@@ -272,6 +274,7 @@ impl AppService {
         theme: String,
         git: GlobalGitConfig,
         chat: ChatSettings,
+        kanban: KanbanSettings,
         repos: HashMap<String, RepoConfig>,
         global_prompt_overrides: PromptOverrides,
     ) -> Result<()> {
@@ -287,6 +290,7 @@ impl AppService {
         config.theme = theme;
         config.git = git;
         config.chat = chat;
+        config.kanban = kanban;
         config.global_prompt_overrides = global_prompt_overrides;
         for (repo_path, repo_config) in repos {
             config.repos.insert(repo_path, repo_config);
@@ -911,12 +915,13 @@ mod tests {
     fn workspace_get_settings_snapshot_returns_defaulted_chat_settings() {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
 
-        let (_theme, _git, chat, repos, global_prompt_overrides) = service
+        let (_theme, _git, chat, kanban, repos, global_prompt_overrides) = service
             .workspace_get_settings_snapshot()
             .expect("settings snapshot should load");
 
         assert_eq!(chat, ChatSettings::default());
         assert!(!chat.show_thinking_messages);
+        assert_eq!(kanban.done_visible_days, 1);
         assert!(repos.is_empty());
         assert!(global_prompt_overrides.is_empty());
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_context.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_context.rs
@@ -54,6 +54,18 @@ impl AppService {
         self.load_task_repo_context_from_resolved(repo_path)
     }
 
+    pub(super) fn load_task_repo_context_for_kanban(
+        &self,
+        repo_path: &str,
+        done_visible_days: i32,
+    ) -> Result<TaskRepoContext> {
+        let repo_path = self.resolve_task_repo_path(repo_path)?;
+        let tasks = self
+            .task_store
+            .list_tasks_for_kanban(Path::new(&repo_path), done_visible_days)?;
+        Ok(TaskRepoContext { repo_path, tasks })
+    }
+
     pub(super) fn load_task_context_from_resolved(
         &self,
         repo_path: String,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -18,6 +18,15 @@ impl AppService {
         Ok(self.enrich_tasks(context.tasks))
     }
 
+    pub fn tasks_list_for_kanban(
+        &self,
+        repo_path: &str,
+        done_visible_days: i32,
+    ) -> Result<Vec<TaskCard>> {
+        let context = self.load_task_repo_context_for_kanban(repo_path, done_visible_days)?;
+        Ok(self.enrich_tasks(context.tasks))
+    }
+
     pub fn task_create(&self, repo_path: &str, mut input: CreateTaskInput) -> Result<TaskCard> {
         let mut context = self.load_task_repo_context(repo_path)?;
         if input.ai_review_enabled.is_none() {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -43,6 +43,16 @@ pub struct RepoSettingsUpdate {
 }
 
 #[derive(Debug, Clone)]
+pub struct WorkspaceSettingsSnapshotUpdate {
+    pub theme: String,
+    pub git: host_infra_system::GlobalGitConfig,
+    pub chat: ChatSettings,
+    pub kanban: KanbanSettings,
+    pub repos: HashMap<String, RepoConfig>,
+    pub global_prompt_overrides: PromptOverrides,
+}
+
+#[derive(Debug, Clone)]
 pub struct HookTrustConfirmationRequest {
     pub repo_path: String,
     pub hooks: HookSet,
@@ -243,15 +253,10 @@ impl AppService {
 
     pub fn workspace_save_settings_snapshot<P: HookTrustConfirmationPort + ?Sized>(
         &self,
-        theme: String,
-        git: host_infra_system::GlobalGitConfig,
-        chat: ChatSettings,
-        kanban: KanbanSettings,
-        mut repos: HashMap<String, RepoConfig>,
-        global_prompt_overrides: PromptOverrides,
+        mut update: WorkspaceSettingsSnapshotUpdate,
         confirmation_port: &P,
     ) -> Result<Vec<WorkspaceRecord>> {
-        for (repo_path, repo_config) in repos.iter_mut() {
+        for (repo_path, repo_config) in update.repos.iter_mut() {
             let existing = self
                 .workspace_get_repo_config_optional(repo_path)?
                 .unwrap_or_default();
@@ -272,12 +277,12 @@ impl AppService {
         }
 
         self.workspace_persist_settings_snapshot(
-            theme,
-            git,
-            chat,
-            kanban,
-            repos,
-            global_prompt_overrides,
+            update.theme,
+            update.git,
+            update.chat,
+            update.kanban,
+            update.repos,
+            update.global_prompt_overrides,
         )?;
         self.workspace_list()
     }
@@ -441,7 +446,7 @@ fn validate_trust_challenge_entry(
 mod tests {
     use super::{
         canonical_repo_key, normalize_hook_set, validate_trust_challenge_entry, AppService,
-        HookTrustChallenge, RepoConfigUpdate, RepoSettingsUpdate,
+        HookTrustChallenge, RepoConfigUpdate, RepoSettingsUpdate, WorkspaceSettingsSnapshotUpdate,
     };
     use crate::app_service::test_support::{
         lock_env, set_env_var, unique_temp_path, EnvVarGuard, FakeTaskStore, TaskStoreState,
@@ -903,12 +908,14 @@ mod tests {
         repo_config.trusted_hooks_fingerprint = None;
 
         fixture.service.workspace_save_settings_snapshot(
-            theme,
-            git,
-            chat,
-            kanban,
-            repos,
-            global_prompt_overrides,
+            WorkspaceSettingsSnapshotUpdate {
+                theme,
+                git,
+                chat,
+                kanban,
+                repos,
+                global_prompt_overrides,
+            },
             &confirmation,
         )?;
 
@@ -941,12 +948,14 @@ mod tests {
         chat.show_thinking_messages = true;
 
         fixture.service.workspace_save_settings_snapshot(
-            theme,
-            git,
-            chat,
-            kanban,
-            repos,
-            global_prompt_overrides,
+            WorkspaceSettingsSnapshotUpdate {
+                theme,
+                git,
+                chat,
+                kanban,
+                repos,
+                global_prompt_overrides,
+            },
             &confirmation,
         )?;
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -4,8 +4,8 @@ use chrono::{DateTime, Utc};
 use host_domain::WorkspaceRecord;
 use host_infra_system::{
     normalize_hook_set, normalize_repo_dev_servers, repo_script_fingerprint, AgentDefaults,
-    ChatSettings, GitTargetBranch, HookSet, PromptOverrides, RepoConfig, RepoDevServerScript,
-    RepoGitConfig,
+    ChatSettings, GitTargetBranch, HookSet, KanbanSettings, PromptOverrides, RepoConfig,
+    RepoDevServerScript, RepoGitConfig,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -246,6 +246,7 @@ impl AppService {
         theme: String,
         git: host_infra_system::GlobalGitConfig,
         chat: ChatSettings,
+        kanban: KanbanSettings,
         mut repos: HashMap<String, RepoConfig>,
         global_prompt_overrides: PromptOverrides,
         confirmation_port: &P,
@@ -270,7 +271,14 @@ impl AppService {
             repo_config.trusted_hooks_fingerprint = trusted_hooks_fingerprint;
         }
 
-        self.workspace_persist_settings_snapshot(theme, git, chat, repos, global_prompt_overrides)?;
+        self.workspace_persist_settings_snapshot(
+            theme,
+            git,
+            chat,
+            kanban,
+            repos,
+            global_prompt_overrides,
+        )?;
         self.workspace_list()
     }
 
@@ -872,7 +880,7 @@ mod tests {
         );
         let confirmation = RecordingHookTrustConfirmationPort::default();
 
-        let (theme, git, mut chat, mut repos, mut global_prompt_overrides) =
+        let (theme, git, mut chat, kanban, mut repos, mut global_prompt_overrides) =
             fixture.service.workspace_get_settings_snapshot()?;
         chat.show_thinking_messages = true;
         global_prompt_overrides.insert(
@@ -898,6 +906,7 @@ mod tests {
             theme,
             git,
             chat,
+            kanban,
             repos,
             global_prompt_overrides,
             &confirmation,
@@ -926,7 +935,7 @@ mod tests {
         let fixture = setup_fixture("snapshot-chat-roundtrip", HookSet::default());
         let confirmation = RecordingHookTrustConfirmationPort::default();
 
-        let (theme, git, mut chat, repos, global_prompt_overrides) =
+        let (theme, git, mut chat, kanban, repos, global_prompt_overrides) =
             fixture.service.workspace_get_settings_snapshot()?;
         assert_eq!(chat, ChatSettings::default());
         chat.show_thinking_messages = true;
@@ -935,6 +944,7 @@ mod tests {
             theme,
             git,
             chat,
+            kanban,
             repos,
             global_prompt_overrides,
             &confirmation,
@@ -944,6 +954,7 @@ mod tests {
             _persisted_theme,
             _persisted_git,
             persisted_chat,
+            _persisted_kanban,
             _persisted_repos,
             _persisted_global_prompt_overrides,
         ) = fixture.service.workspace_get_settings_snapshot()?;

--- a/apps/desktop/src-tauri/crates/host-application/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/lib.rs
@@ -4,4 +4,5 @@ pub use app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
 pub use app_service::{
     AppService, DevServerEmitter, HookTrustConfirmationPort, HookTrustConfirmationRequest,
     PreparedHookTrustChallenge, RepoConfigUpdate, RepoSettingsUpdate, RunEmitter,
+    WorkspaceSettingsSnapshotUpdate,
 };

--- a/apps/desktop/src-tauri/crates/host-domain/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/store.rs
@@ -9,6 +9,13 @@ use std::path::Path;
 pub trait TaskStore: Send + Sync {
     fn ensure_repo_initialized(&self, repo_path: &Path) -> Result<()>;
     fn list_tasks(&self, repo_path: &Path) -> Result<Vec<TaskCard>>;
+    fn list_tasks_for_kanban(
+        &self,
+        repo_path: &Path,
+        _done_visible_days: i32,
+    ) -> Result<Vec<TaskCard>> {
+        self.list_tasks(repo_path)
+    }
     fn create_task(&self, repo_path: &Path, input: CreateTaskInput) -> Result<TaskCard>;
     fn update_task(
         &self,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 host-domain = { path = "../host-domain" }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -29,7 +29,7 @@ mod namespace;
 mod session_ops;
 mod task_ops;
 
-use cache::TaskListCacheState;
+use cache::{KanbanTaskListCacheState, TaskListCacheState};
 
 pub struct BeadsTaskStore {
     pub(crate) command_runner: Arc<dyn CommandRunner>,
@@ -37,6 +37,7 @@ pub struct BeadsTaskStore {
     pub(crate) init_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
     pub(crate) initialized_repos: Mutex<HashSet<String>>,
     task_list_cache: Mutex<HashMap<String, TaskListCacheState>>,
+    kanban_task_list_cache: Mutex<HashMap<String, KanbanTaskListCacheState>>,
 }
 
 impl fmt::Debug for BeadsTaskStore {
@@ -75,6 +76,7 @@ impl BeadsTaskStore {
             init_locks: Mutex::new(HashMap::new()),
             initialized_repos: Mutex::new(HashSet::new()),
             task_list_cache: Mutex::new(HashMap::new()),
+            kanban_task_list_cache: Mutex::new(HashMap::new()),
         }
     }
 
@@ -94,6 +96,14 @@ impl TaskStore for BeadsTaskStore {
 
     fn list_tasks(&self, repo_path: &Path) -> Result<Vec<TaskCard>> {
         self.list_tasks_impl(repo_path)
+    }
+
+    fn list_tasks_for_kanban(
+        &self,
+        repo_path: &Path,
+        done_visible_days: i32,
+    ) -> Result<Vec<TaskCard>> {
+        self.list_tasks_for_kanban_impl(repo_path, done_visible_days)
     }
 
     fn create_task(&self, repo_path: &Path, input: CreateTaskInput) -> Result<TaskCard> {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/cache.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/cache.rs
@@ -13,6 +13,21 @@ pub(super) struct TaskListCacheState {
     pub(super) entry: Option<TaskListCacheEntry>,
 }
 
+#[derive(Clone)]
+pub(super) struct KanbanTaskListCacheEntry {
+    pub(super) tasks: Vec<TaskCard>,
+    pub(super) metadata_by_task_id: HashMap<String, TaskMetadata>,
+    pub(super) cached_at: Instant,
+    pub(super) metadata_namespace: String,
+    pub(super) done_visible_days: i32,
+}
+
+#[derive(Default)]
+pub(super) struct KanbanTaskListCacheState {
+    pub(super) generation: u64,
+    pub(super) entry: Option<KanbanTaskListCacheEntry>,
+}
+
 impl BeadsTaskStore {
     fn task_list_cache_ttl() -> Duration {
         Duration::from_millis(TASK_LIST_CACHE_TTL_MS)
@@ -66,13 +81,119 @@ impl BeadsTaskStore {
         Ok(())
     }
 
+    pub(super) fn cached_kanban_task_list_and_generation(
+        &self,
+        repo_key: &str,
+        metadata_namespace: &str,
+        done_visible_days: i32,
+    ) -> Result<(Option<Vec<TaskCard>>, u64)> {
+        let mut cache = self
+            .kanban_task_list_cache
+            .lock()
+            .map_err(|_| anyhow!("Beads kanban task-list cache lock poisoned"))?;
+        let state = cache.entry(repo_key.to_string()).or_default();
+        let generation = state.generation;
+
+        if let Some(entry) = state.entry.as_ref() {
+            let is_fresh = entry.cached_at.elapsed() <= Self::task_list_cache_ttl();
+            let namespace_matches = entry.metadata_namespace == metadata_namespace;
+            let days_match = entry.done_visible_days == done_visible_days;
+            if is_fresh && namespace_matches && days_match {
+                return Ok((Some(entry.tasks.clone()), generation));
+            }
+        }
+
+        state.entry = None;
+        Ok((None, generation))
+    }
+
+    pub(super) fn cache_kanban_task_list_if_generation(
+        &self,
+        repo_key: &str,
+        metadata_namespace: &str,
+        done_visible_days: i32,
+        generation: u64,
+        tasks: &[TaskCard],
+        metadata_by_task_id: &HashMap<String, TaskMetadata>,
+    ) -> Result<()> {
+        let mut cache = self
+            .kanban_task_list_cache
+            .lock()
+            .map_err(|_| anyhow!("Beads kanban task-list cache lock poisoned"))?;
+        let state = cache.entry(repo_key.to_string()).or_default();
+        if state.generation != generation {
+            return Ok(());
+        }
+
+        state.entry = Some(KanbanTaskListCacheEntry {
+            tasks: tasks.to_vec(),
+            metadata_by_task_id: metadata_by_task_id.clone(),
+            cached_at: Instant::now(),
+            metadata_namespace: metadata_namespace.to_string(),
+            done_visible_days,
+        });
+        Ok(())
+    }
+
+    pub(super) fn cached_task_metadata(
+        &self,
+        repo_key: &str,
+        metadata_namespace: &str,
+        task_id: &str,
+    ) -> Result<Option<TaskMetadata>> {
+        {
+            let mut cache = self
+                .task_list_cache
+                .lock()
+                .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
+            let state = cache.entry(repo_key.to_string()).or_default();
+
+            if let Some(entry) = state.entry.as_ref() {
+                let is_fresh = entry.cached_at.elapsed() <= Self::task_list_cache_ttl();
+                let namespace_matches = entry.metadata_namespace == metadata_namespace;
+                if is_fresh && namespace_matches {
+                    if let Some(metadata) = entry.metadata_by_task_id.get(task_id) {
+                        return Ok(Some(metadata.clone()));
+                    }
+                } else {
+                    state.entry = None;
+                }
+            }
+        }
+
+        let mut kanban_cache = self
+            .kanban_task_list_cache
+            .lock()
+            .map_err(|_| anyhow!("Beads kanban task-list cache lock poisoned"))?;
+        let state = kanban_cache.entry(repo_key.to_string()).or_default();
+        let Some(entry) = state.entry.as_ref() else {
+            return Ok(None);
+        };
+        let is_fresh = entry.cached_at.elapsed() <= Self::task_list_cache_ttl();
+        let namespace_matches = entry.metadata_namespace == metadata_namespace;
+        if !is_fresh || !namespace_matches {
+            state.entry = None;
+            return Ok(None);
+        }
+
+        Ok(entry.metadata_by_task_id.get(task_id).cloned())
+    }
     pub(crate) fn invalidate_task_list_cache(&self, repo_path: &Path) -> Result<()> {
         let repo_key = Self::repo_key(repo_path);
-        let mut cache = self
-            .task_list_cache
+        {
+            let mut cache = self
+                .task_list_cache
+                .lock()
+                .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
+            let state = cache.entry(repo_key.clone()).or_default();
+            state.generation = state.generation.saturating_add(1);
+            state.entry = None;
+        }
+        let mut kanban_cache = self
+            .kanban_task_list_cache
             .lock()
-            .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
-        let state = cache.entry(repo_key).or_default();
+            .map_err(|_| anyhow!("Beads kanban task-list cache lock poisoned"))?;
+        let state = kanban_cache.entry(repo_key).or_default();
         state.generation = state.generation.saturating_add(1);
         state.entry = None;
         Ok(())

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/cache.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/cache.rs
@@ -16,7 +16,6 @@ pub(super) struct TaskListCacheState {
 #[derive(Clone)]
 pub(super) struct KanbanTaskListCacheEntry {
     pub(super) tasks: Vec<TaskCard>,
-    pub(super) metadata_by_task_id: HashMap<String, TaskMetadata>,
     pub(super) cached_at: Instant,
     pub(super) metadata_namespace: String,
     pub(super) done_visible_days: i32,
@@ -114,7 +113,6 @@ impl BeadsTaskStore {
         done_visible_days: i32,
         generation: u64,
         tasks: &[TaskCard],
-        metadata_by_task_id: &HashMap<String, TaskMetadata>,
     ) -> Result<()> {
         let mut cache = self
             .kanban_task_list_cache
@@ -127,56 +125,11 @@ impl BeadsTaskStore {
 
         state.entry = Some(KanbanTaskListCacheEntry {
             tasks: tasks.to_vec(),
-            metadata_by_task_id: metadata_by_task_id.clone(),
             cached_at: Instant::now(),
             metadata_namespace: metadata_namespace.to_string(),
             done_visible_days,
         });
         Ok(())
-    }
-
-    pub(super) fn cached_task_metadata(
-        &self,
-        repo_key: &str,
-        metadata_namespace: &str,
-        task_id: &str,
-    ) -> Result<Option<TaskMetadata>> {
-        {
-            let mut cache = self
-                .task_list_cache
-                .lock()
-                .map_err(|_| anyhow!("Beads task-list cache lock poisoned"))?;
-            let state = cache.entry(repo_key.to_string()).or_default();
-
-            if let Some(entry) = state.entry.as_ref() {
-                let is_fresh = entry.cached_at.elapsed() <= Self::task_list_cache_ttl();
-                let namespace_matches = entry.metadata_namespace == metadata_namespace;
-                if is_fresh && namespace_matches {
-                    if let Some(metadata) = entry.metadata_by_task_id.get(task_id) {
-                        return Ok(Some(metadata.clone()));
-                    }
-                } else {
-                    state.entry = None;
-                }
-            }
-        }
-
-        let mut kanban_cache = self
-            .kanban_task_list_cache
-            .lock()
-            .map_err(|_| anyhow!("Beads kanban task-list cache lock poisoned"))?;
-        let state = kanban_cache.entry(repo_key.to_string()).or_default();
-        let Some(entry) = state.entry.as_ref() else {
-            return Ok(None);
-        };
-        let is_fresh = entry.cached_at.elapsed() <= Self::task_list_cache_ttl();
-        let namespace_matches = entry.metadata_namespace == metadata_namespace;
-        if !is_fresh || !namespace_matches {
-            state.entry = None;
-            return Ok(None);
-        }
-
-        Ok(entry.metadata_by_task_id.get(task_id).cloned())
     }
     pub(crate) fn invalidate_task_list_cache(&self, repo_path: &Path) -> Result<()> {
         let repo_key = Self::repo_key(repo_path);

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -216,7 +216,9 @@ impl BeadsTaskStore {
         )?;
 
         if done_visible_days > 0 {
-            let cutoff = (Utc::now() - ChronoDuration::days(i64::from(done_visible_days)))
+            let cutoff = Utc::now()
+                .checked_sub_signed(ChronoDuration::days(i64::from(done_visible_days)))
+                .ok_or_else(|| anyhow!("done_visible_days causes datetime underflow"))?
                 .format("%Y-%m-%d")
                 .to_string();
             self.append_raw_issue_list(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -9,7 +9,6 @@ impl BeadsTaskStore {
         metadata_namespace: &str,
         seen_task_ids: &mut HashSet<String>,
         tasks: &mut Vec<TaskCard>,
-        metadata_by_task_id: &mut HashMap<String, TaskMetadata>,
     ) -> Result<()> {
         for entry in value
             .as_array()
@@ -21,14 +20,11 @@ impl BeadsTaskStore {
                 continue;
             }
 
-            let task_id = issue.id.clone();
-            if !seen_task_ids.insert(task_id.clone()) {
+            if !seen_task_ids.insert(issue.id.clone()) {
                 continue;
             }
 
-            let metadata = self.parse_task_metadata_from_issue(&issue);
             tasks.push(self.parse_task_card(issue, metadata_namespace)?);
-            metadata_by_task_id.insert(task_id, metadata);
         }
 
         Ok(())
@@ -175,14 +171,7 @@ impl BeadsTaskStore {
 
         let mut tasks = Vec::new();
         let mut seen_task_ids = HashSet::new();
-        let mut metadata_by_task_id = HashMap::new();
-        self.append_raw_issue_list(
-            value,
-            &metadata_namespace,
-            &mut seen_task_ids,
-            &mut tasks,
-            &mut metadata_by_task_id,
-        )?;
+        self.append_raw_issue_list(value, &metadata_namespace, &mut seen_task_ids, &mut tasks)?;
         Self::finalize_task_cards(&mut tasks);
 
         self.cache_task_list_if_generation(
@@ -218,14 +207,12 @@ impl BeadsTaskStore {
 
         let mut tasks = Vec::new();
         let mut seen_task_ids = HashSet::new();
-        let mut metadata_by_task_id = HashMap::new();
 
         self.append_raw_issue_list(
             self.run_bd_json(repo_path, &["list", "--limit", "0"])?,
             &metadata_namespace,
             &mut seen_task_ids,
             &mut tasks,
-            &mut metadata_by_task_id,
         )?;
 
         if done_visible_days > 0 {
@@ -248,7 +235,6 @@ impl BeadsTaskStore {
                 &metadata_namespace,
                 &mut seen_task_ids,
                 &mut tasks,
-                &mut metadata_by_task_id,
             )?;
         }
 
@@ -259,7 +245,6 @@ impl BeadsTaskStore {
             done_visible_days,
             cache_generation,
             &tasks,
-            &metadata_by_task_id,
         )?;
         Ok(tasks)
     }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -1,7 +1,57 @@
 use super::*;
+use chrono::{Duration as ChronoDuration, Utc};
 use serde::Deserialize;
 
 impl BeadsTaskStore {
+    fn append_raw_issue_list(
+        &self,
+        value: serde_json::Value,
+        metadata_namespace: &str,
+        seen_task_ids: &mut HashSet<String>,
+        tasks: &mut Vec<TaskCard>,
+        metadata_by_task_id: &mut HashMap<String, TaskMetadata>,
+    ) -> Result<()> {
+        for entry in value
+            .as_array()
+            .ok_or_else(|| anyhow!("bd list did not return an array"))?
+        {
+            let issue: RawIssue =
+                RawIssue::deserialize(entry).context("Failed to decode task from bd list")?;
+            if issue.issue_type == "event" || issue.issue_type == "gate" {
+                continue;
+            }
+
+            let task_id = issue.id.clone();
+            if !seen_task_ids.insert(task_id.clone()) {
+                continue;
+            }
+
+            let metadata = self.parse_task_metadata_from_issue(&issue);
+            tasks.push(self.parse_task_card(issue, metadata_namespace)?);
+            metadata_by_task_id.insert(task_id, metadata);
+        }
+
+        Ok(())
+    }
+
+    fn finalize_task_cards(tasks: &mut [TaskCard]) {
+        let mut subtasks_by_parent: HashMap<String, Vec<String>> = HashMap::new();
+        for task in tasks.iter() {
+            if let Some(parent_id) = &task.parent_id {
+                subtasks_by_parent
+                    .entry(parent_id.clone())
+                    .or_default()
+                    .push(task.id.clone());
+            }
+        }
+
+        for task in tasks.iter_mut() {
+            let mut subtasks = subtasks_by_parent.remove(&task.id).unwrap_or_default();
+            subtasks.sort();
+            task.subtask_ids = subtasks;
+        }
+    }
+
     fn beads_store_footprint_exists(beads_dir: &Path) -> bool {
         beads_dir.join("dolt").exists() || beads_dir.join("beads.db").exists()
     }
@@ -124,39 +174,92 @@ impl BeadsTaskStore {
         let value = self.run_bd_json(repo_path, &["list", "--all", "--limit", "0"])?;
 
         let mut tasks = Vec::new();
-        for entry in value
-            .as_array()
-            .ok_or_else(|| anyhow!("bd list did not return an array"))?
-        {
-            let issue: RawIssue =
-                RawIssue::deserialize(entry).context("Failed to decode task from bd list")?;
-            if issue.issue_type == "event" || issue.issue_type == "gate" {
-                continue;
-            }
-            tasks.push(self.parse_task_card(issue, &metadata_namespace)?);
-        }
-
-        let mut subtasks_by_parent: HashMap<String, Vec<String>> = HashMap::new();
-        for task in &tasks {
-            if let Some(parent_id) = &task.parent_id {
-                subtasks_by_parent
-                    .entry(parent_id.clone())
-                    .or_default()
-                    .push(task.id.clone());
-            }
-        }
-
-        for task in &mut tasks {
-            let mut subtasks = subtasks_by_parent.remove(&task.id).unwrap_or_default();
-            subtasks.sort();
-            task.subtask_ids = subtasks;
-        }
+        let mut seen_task_ids = HashSet::new();
+        let mut metadata_by_task_id = HashMap::new();
+        self.append_raw_issue_list(
+            value,
+            &metadata_namespace,
+            &mut seen_task_ids,
+            &mut tasks,
+            &mut metadata_by_task_id,
+        )?;
+        Self::finalize_task_cards(&mut tasks);
 
         self.cache_task_list_if_generation(
             &repo_key,
             &metadata_namespace,
             cache_generation,
             &tasks,
+        )?;
+        Ok(tasks)
+    }
+
+    pub(super) fn list_tasks_for_kanban_impl(
+        &self,
+        repo_path: &Path,
+        done_visible_days: i32,
+    ) -> Result<Vec<TaskCard>> {
+        if done_visible_days < 0 {
+            return Err(anyhow!(
+                "done_visible_days must be greater than or equal to 0"
+            ));
+        }
+
+        let metadata_namespace = self.current_metadata_namespace();
+        let repo_key = Self::repo_key(repo_path);
+        let (cached_tasks, cache_generation) = self.cached_kanban_task_list_and_generation(
+            &repo_key,
+            &metadata_namespace,
+            done_visible_days,
+        )?;
+        if let Some(tasks) = cached_tasks {
+            return Ok(tasks);
+        }
+
+        let mut tasks = Vec::new();
+        let mut seen_task_ids = HashSet::new();
+        let mut metadata_by_task_id = HashMap::new();
+
+        self.append_raw_issue_list(
+            self.run_bd_json(repo_path, &["list", "--limit", "0"])?,
+            &metadata_namespace,
+            &mut seen_task_ids,
+            &mut tasks,
+            &mut metadata_by_task_id,
+        )?;
+
+        if done_visible_days > 0 {
+            let cutoff = (Utc::now() - ChronoDuration::days(i64::from(done_visible_days)))
+                .format("%Y-%m-%d")
+                .to_string();
+            self.append_raw_issue_list(
+                self.run_bd_json(
+                    repo_path,
+                    &[
+                        "list",
+                        "--status",
+                        "closed",
+                        "--closed-after",
+                        cutoff.as_str(),
+                        "--limit",
+                        "0",
+                    ],
+                )?,
+                &metadata_namespace,
+                &mut seen_task_ids,
+                &mut tasks,
+                &mut metadata_by_task_id,
+            )?;
+        }
+
+        Self::finalize_task_cards(&mut tasks);
+        self.cache_kanban_task_list_if_generation(
+            &repo_key,
+            &metadata_namespace,
+            done_visible_days,
+            cache_generation,
+            &tasks,
+            &metadata_by_task_id,
         )?;
         Ok(tasks)
     }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -5,6 +5,7 @@ use super::{
     ProcessCommandRunner, CUSTOM_STATUS_VALUES, TASK_LIST_CACHE_TTL_MS,
 };
 use anyhow::{anyhow, Result};
+use chrono::{Duration as ChronoDuration, Utc};
 use host_domain::{
     AgentSessionDocument, CreateTaskInput, IssueType, QaVerdict, TaskStatus, TaskStore,
     UpdateTaskPatch,
@@ -1345,7 +1346,101 @@ fn get_task_metadata_ignores_cached_task_list_metadata() -> Result<()> {
     assert_eq!(calls.len(), 2);
     assert_eq!(calls[0].args[0], "list");
     assert_eq!(calls[1].args[0], "show");
+    Ok(())
+}
 
+#[test]
+fn list_tasks_for_kanban_requests_recent_closed_tasks() -> Result<()> {
+    let repo = RepoFixture::new("kanban-list-recent-closed");
+    let open_tasks = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let recent_closed = json!([issue_value(
+        "task-2",
+        "closed",
+        "task",
+        None,
+        json!([]),
+        None
+    )]);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(open_tasks.to_string())),
+        MockStep::WithEnv(Ok(recent_closed.to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let tasks = store.list_tasks_for_kanban(repo.path(), 1)?;
+    assert_eq!(tasks.len(), 2);
+    assert!(tasks.iter().any(|task| task.id == "task-1"));
+    assert!(tasks.iter().any(|task| task.id == "task-2"));
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 2);
+    assert_eq!(calls[0].args[0], "list");
+    assert_eq!(calls[0].args[1], "--limit");
+    assert_eq!(calls[0].args[2], "0");
+    assert_eq!(calls[1].args[0], "list");
+    assert!(calls[1]
+        .args
+        .windows(2)
+        .any(|pair| pair == ["--status", "closed"]));
+    let expected_cutoff = (Utc::now() - ChronoDuration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    assert!(calls[1]
+        .args
+        .windows(2)
+        .any(|pair| pair[0] == "--closed-after" && pair[1] == expected_cutoff));
+    Ok(())
+}
+
+#[test]
+fn list_tasks_for_kanban_skips_closed_fetch_for_zero_days() -> Result<()> {
+    let repo = RepoFixture::new("kanban-list-zero-days");
+    let open_tasks = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(open_tasks.to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let tasks = store.list_tasks_for_kanban(repo.path(), 0)?;
+    assert_eq!(tasks.len(), 1);
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].args[0], "list");
+    Ok(())
+}
+
+#[test]
+fn list_tasks_for_kanban_cache_key_includes_done_visible_days() -> Result<()> {
+    let repo = RepoFixture::new("kanban-list-cache-key");
+    let open_tasks = json!([issue_value("task-1", "open", "task", None, json!([]), None)]);
+    let closed_tasks = json!([issue_value(
+        "task-2",
+        "closed",
+        "task",
+        None,
+        json!([]),
+        None
+    )]);
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::WithEnv(Ok(open_tasks.to_string())),
+        MockStep::WithEnv(Ok(closed_tasks.to_string())),
+        MockStep::WithEnv(Ok(open_tasks.to_string())),
+        MockStep::WithEnv(Ok(closed_tasks.to_string())),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let first = store.list_tasks_for_kanban(repo.path(), 1)?;
+    let second = store.list_tasks_for_kanban(repo.path(), 1)?;
+    let third = store.list_tasks_for_kanban(repo.path(), 7)?;
+    assert_eq!(first.len(), 2);
+    assert_eq!(second.len(), 2);
+    assert_eq!(third.len(), 2);
+
+    let calls = runner.take_calls();
+    let list_calls = calls
+        .iter()
+        .filter(|call| call.args.first().map(String::as_str) == Some("list"))
+        .count();
+    assert_eq!(list_calls, 4);
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1367,7 +1367,13 @@ fn list_tasks_for_kanban_requests_recent_closed_tasks() -> Result<()> {
     ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
+    let earliest_cutoff = (Utc::now() - ChronoDuration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
     let tasks = store.list_tasks_for_kanban(repo.path(), 1)?;
+    let latest_cutoff = (Utc::now() - ChronoDuration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
     assert_eq!(tasks.len(), 2);
     assert!(tasks.iter().any(|task| task.id == "task-1"));
     assert!(tasks.iter().any(|task| task.id == "task-2"));
@@ -1382,13 +1388,15 @@ fn list_tasks_for_kanban_requests_recent_closed_tasks() -> Result<()> {
         .args
         .windows(2)
         .any(|pair| pair == ["--status", "closed"]));
-    let expected_cutoff = (Utc::now() - ChronoDuration::days(1))
-        .format("%Y-%m-%d")
-        .to_string();
-    assert!(calls[1]
+    let actual_cutoff = calls[1]
         .args
         .windows(2)
-        .any(|pair| pair[0] == "--closed-after" && pair[1] == expected_cutoff));
+        .find_map(|pair| (pair[0] == "--closed-after").then(|| pair[1].clone()))
+        .expect("expected --closed-after argument");
+    assert!(
+        actual_cutoff >= earliest_cutoff && actual_cutoff <= latest_cutoff,
+        "unexpected cutoff: {actual_cutoff}"
+    );
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -11,8 +11,9 @@ pub use store::{AppConfigStore, RuntimeConfigStore};
 pub use types::{
     hook_set_fingerprint, repo_script_fingerprint, AgentDefaults, AgentModelDefault, ChatSettings,
     GitMergeMethod, GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig,
-    GlobalGitConfig, HookSet, OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides,
-    RepoConfig, RepoDevServerScript, RepoGitConfig, RuntimeConfig, SchedulerConfig, SoftGuardrails,
+    GlobalGitConfig, HookSet, KanbanSettings, OpencodeStartupReadinessConfig, PromptOverride,
+    PromptOverrides, RepoConfig, RepoDevServerScript, RepoGitConfig, RuntimeConfig,
+    SchedulerConfig, SoftGuardrails,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
@@ -1,8 +1,8 @@
 use super::types::{
     default_branch_prefix, normalize_git_target_branch_value, repo_script_fingerprint,
     AgentModelDefault, GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig,
-    HookSet, OpencodeStartupReadinessConfig, PromptOverrides, RepoConfig, RepoDevServerScript,
-    RuntimeConfig,
+    HookSet, KanbanSettings, OpencodeStartupReadinessConfig, PromptOverrides, RepoConfig,
+    RepoDevServerScript, RuntimeConfig,
 };
 use anyhow::{anyhow, Result};
 use std::collections::HashSet;
@@ -190,7 +190,12 @@ pub(super) fn normalize_opencode_startup_readiness_config(
     }
 }
 
+fn normalize_kanban_settings(config: &mut KanbanSettings) {
+    config.done_visible_days = config.done_visible_days.max(0);
+}
+
 pub(super) fn normalize_global_config(config: &mut GlobalConfig) -> Result<()> {
+    normalize_kanban_settings(&mut config.kanban);
     normalize_prompt_overrides(&mut config.global_prompt_overrides);
     for repo in config.repos.values_mut() {
         normalize_repo_config(repo)?;

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
@@ -18,6 +18,37 @@ fn load_missing_returns_default_config() {
 }
 
 #[test]
+fn load_clamps_negative_kanban_done_visible_days() {
+    let harness = TestStoreHarness::new("normalize-negative-kanban");
+    let store = harness.store();
+
+    fs::create_dir_all(store.path().parent().expect("config parent")).expect("create config dir");
+    let payload = json!({
+        "version": 1,
+        "kanban": {
+            "doneVisibleDays": -5
+        },
+        "recentRepos": []
+    });
+    fs::write(
+        store.path(),
+        serde_json::to_string_pretty(&payload).expect("serialize payload"),
+    )
+    .expect("write config");
+    #[cfg(unix)]
+    {
+        let parent = store.path().parent().expect("config parent");
+        fs::set_permissions(parent, Permissions::from_mode(0o700))
+            .expect("config directory should be private");
+        fs::set_permissions(store.path(), Permissions::from_mode(0o600))
+            .expect("config file should be private");
+    }
+
+    let config = store.load().expect("load normalized config");
+    assert_eq!(config.kanban.done_visible_days, 0);
+}
+
+#[test]
 fn update_repo_config_normalizes_blank_worktree_path() {
     let _env_lock = lock_env();
     let harness = TestStoreHarness::new("normalize-worktree");

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/normalization.rs
@@ -13,6 +13,7 @@ fn load_missing_returns_default_config() {
     let config = store.load().expect("load default");
     assert_eq!(config.version, 1);
     assert!(!config.chat.show_thinking_messages);
+    assert_eq!(config.kanban.done_visible_days, 1);
     assert!(config.repos.is_empty());
 }
 
@@ -261,6 +262,7 @@ fn load_normalizes_legacy_blank_repo_config_values() {
 
     let config = store.load().expect("legacy config should load");
     assert!(!config.chat.show_thinking_messages);
+    assert_eq!(config.kanban.done_visible_days, 1);
 
     let repo_config = store
         .repo_config(workspaces[0].path.as_str())

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -156,6 +156,25 @@ pub struct ChatSettings {
     pub show_thinking_messages: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct KanbanSettings {
+    #[serde(default = "default_done_visible_days")]
+    pub done_visible_days: i32,
+}
+
+const fn default_done_visible_days() -> i32 {
+    1
+}
+
+impl Default for KanbanSettings {
+    fn default() -> Self {
+        Self {
+            done_visible_days: default_done_visible_days(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct HookSet {
@@ -408,6 +427,8 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub chat: ChatSettings,
     #[serde(default)]
+    pub kanban: KanbanSettings,
+    #[serde(default)]
     pub global_prompt_overrides: PromptOverrides,
     #[serde(default)]
     pub repos: HashMap<String, RepoConfig>,
@@ -423,6 +444,7 @@ impl Default for GlobalConfig {
             theme: default_theme(),
             git: GlobalGitConfig::default(),
             chat: ChatSettings::default(),
+            kanban: KanbanSettings::default(),
             global_prompt_overrides: PromptOverrides::default(),
             repos: HashMap::new(),
             recent_repos: Vec::new(),

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -13,9 +13,9 @@ pub use config::{
     hook_set_fingerprint, normalize_hook_set, normalize_repo_dev_servers, repo_script_fingerprint,
     AgentDefaults, AgentModelDefault, AppConfigStore, ChatSettings, GitMergeMethod,
     GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig, GlobalGitConfig,
-    HookSet, OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides, RepoConfig,
-    RepoDevServerScript, RepoGitConfig, RuntimeConfig, RuntimeConfigStore, SchedulerConfig,
-    SoftGuardrails,
+    HookSet, KanbanSettings, OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides,
+    RepoConfig, RepoDevServerScript, RepoGitConfig, RuntimeConfig, RuntimeConfigStore,
+    SchedulerConfig, SoftGuardrails,
 };
 pub use git::GitCliPort;
 pub use process::{

--- a/apps/desktop/src-tauri/src/commands/tasks.rs
+++ b/apps/desktop/src-tauri/src/commands/tasks.rs
@@ -39,9 +39,16 @@ pub(crate) fn map_task_update_payload(patch: TaskUpdatePayload) -> Result<Update
 pub async fn tasks_list(
     state: State<'_, AppState>,
     repo_path: String,
+    done_visible_days: Option<i32>,
 ) -> Result<Vec<TaskCard>, String> {
     let service = state.service.clone();
-    let result = run_service_blocking("tasks_list", move || service.tasks_list(&repo_path)).await;
+    let result = match done_visible_days {
+        Some(days) => {
+            run_service_blocking("tasks_list", move || service.tasks_list_for_kanban(&repo_path, days))
+                .await
+        }
+        None => run_service_blocking("tasks_list", move || service.tasks_list(&repo_path)).await,
+    };
     as_error(result)
 }
 

--- a/apps/desktop/src-tauri/src/commands/tasks.rs
+++ b/apps/desktop/src-tauri/src/commands/tasks.rs
@@ -41,6 +41,12 @@ pub async fn tasks_list(
     repo_path: String,
     done_visible_days: Option<i32>,
 ) -> Result<Vec<TaskCard>, String> {
+    if let Some(days) = done_visible_days {
+        if days < 0 {
+            return Err("doneVisibleDays must be greater than or equal to 0".to_string());
+        }
+    }
+
     let service = state.service.clone();
     let result = match done_visible_days {
         Some(days) => {

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -133,12 +133,13 @@ pub async fn workspace_detect_github_repository(
 pub async fn workspace_get_settings_snapshot(
     state: State<'_, AppState>,
 ) -> Result<SettingsSnapshotResponsePayload, String> {
-    let (theme, git, chat, repos, global_prompt_overrides) =
+    let (theme, git, chat, kanban, repos, global_prompt_overrides) =
         as_error(state.service.workspace_get_settings_snapshot())?;
     Ok(SettingsSnapshotResponsePayload {
         theme,
         git,
         chat,
+        kanban,
         repos,
         global_prompt_overrides,
     })
@@ -169,6 +170,7 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
         theme,
         git,
         chat,
+        kanban,
         repos,
         global_prompt_overrides,
     } = snapshot;
@@ -181,6 +183,7 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
                 theme,
                 git,
                 chat,
+                kanban,
                 repos,
                 global_prompt_overrides,
                 &confirmation_port,
@@ -744,7 +747,7 @@ mod tests {
             Some(false),
         );
 
-        let (theme, git, chat, repos, global_prompt_overrides) = fixture
+        let (theme, git, chat, kanban, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -752,6 +755,7 @@ mod tests {
             theme,
             git,
             chat,
+            kanban,
             repos,
             global_prompt_overrides,
         };
@@ -794,7 +798,7 @@ mod tests {
             Some(true),
         );
 
-        let (theme, git, chat, repos, global_prompt_overrides) = fixture
+        let (theme, git, chat, kanban, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -802,6 +806,7 @@ mod tests {
             theme,
             git,
             chat,
+            kanban,
             repos,
             global_prompt_overrides,
         };
@@ -926,7 +931,7 @@ mod tests {
         let fixture =
             setup_workspace_command_fixture("snapshot-ipc-shared-prompts", HookSet::default());
 
-        let (theme, git, chat, repos, global_prompt_overrides) = fixture
+        let (theme, git, chat, kanban, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -934,6 +939,7 @@ mod tests {
             theme,
             git,
             chat,
+            kanban,
             repos,
             global_prompt_overrides,
         };
@@ -983,6 +989,7 @@ mod tests {
                 "theme": snapshot.theme,
                 "git": snapshot.git,
                 "chat": snapshot.chat,
+                "kanban": snapshot.kanban,
                 "repos": snapshot.repos,
                 "globalPromptOverrides": snapshot.global_prompt_overrides,
             }
@@ -998,11 +1005,17 @@ mod tests {
             "snapshot save response should include workspace records"
         );
 
-        let (_persisted_theme, _persisted_git, persisted_chat, persisted_repos, persisted_global) =
-            fixture
-                .service
-                .workspace_get_settings_snapshot()
-                .map_err(|error| error.to_string())?;
+        let (
+            _persisted_theme,
+            _persisted_git,
+            persisted_chat,
+            _persisted_kanban,
+            persisted_repos,
+            persisted_global,
+        ) = fixture
+            .service
+            .workspace_get_settings_snapshot()
+            .map_err(|error| error.to_string())?;
         let persisted_repo = persisted_repos
             .get(repo_key.as_str())
             .ok_or_else(|| "persisted repo config missing".to_string())?;
@@ -1042,13 +1055,14 @@ mod tests {
     fn workspace_get_settings_snapshot_returns_defaulted_chat_settings() -> Result<(), String> {
         let fixture = setup_workspace_command_fixture("snapshot-default-chat", HookSet::default());
 
-        let (_theme, _git, chat, _repos, _global_prompt_overrides) = fixture
+        let (_theme, _git, chat, kanban, _repos, _global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
 
         assert_eq!(chat, ChatSettings::default());
         assert!(!chat.show_thinking_messages);
+        assert_eq!(kanban.done_visible_days, 1);
         Ok(())
     }
 
@@ -1057,7 +1071,7 @@ mod tests {
         let fixture =
             setup_workspace_command_fixture("snapshot-chat-roundtrip", HookSet::default());
 
-        let (theme, git, _chat, repos, global_prompt_overrides) = fixture
+        let (theme, git, _chat, kanban, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -1066,6 +1080,7 @@ mod tests {
             "snapshot": {
                 "theme": theme.clone(),
                 "git": git.clone(),
+                "kanban": kanban.clone(),
                 "repos": repos.clone(),
                 "globalPromptOverrides": global_prompt_overrides.clone(),
             }
@@ -1084,6 +1099,7 @@ mod tests {
                 "chat": {
                     "showThinkingMessages": true
                 },
+                "kanban": kanban,
                 "repos": repos,
                 "globalPromptOverrides": global_prompt_overrides,
             }
@@ -1091,11 +1107,17 @@ mod tests {
         invoke_workspace_save_settings_snapshot_ipc(&fixture, payload_with_chat)
             .expect("IPC snapshot save should persist chat settings");
 
-        let (_reloaded_theme, _reloaded_git, reloaded_chat, _reloaded_repos, _reloaded_global) =
-            fixture
-                .service
-                .workspace_get_settings_snapshot()
-                .map_err(|error| error.to_string())?;
+        let (
+            _reloaded_theme,
+            _reloaded_git,
+            reloaded_chat,
+            _reloaded_kanban,
+            _reloaded_repos,
+            _reloaded_global,
+        ) = fixture
+            .service
+            .workspace_get_settings_snapshot()
+            .map_err(|error| error.to_string())?;
         assert!(reloaded_chat.show_thinking_messages);
         Ok(())
     }

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use host_application::{
     HookTrustConfirmationPort, HookTrustConfirmationRequest, PreparedHookTrustChallenge,
-    RepoConfigUpdate, RepoSettingsUpdate,
+    RepoConfigUpdate, RepoSettingsUpdate, WorkspaceSettingsSnapshotUpdate,
 };
 use host_infra_system::HookSet;
 #[cfg(test)]
@@ -180,12 +180,14 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
     as_error(
         run_service_blocking("workspace_save_settings_snapshot", move || {
             service.workspace_save_settings_snapshot(
-                theme,
-                git,
-                chat,
-                kanban,
-                repos,
-                global_prompt_overrides,
+                WorkspaceSettingsSnapshotUpdate {
+                    theme,
+                    git,
+                    chat,
+                    kanban,
+                    repos,
+                    global_prompt_overrides,
+                },
                 &confirmation_port,
             )
         })

--- a/apps/desktop/src-tauri/src/headless.rs
+++ b/apps/desktop/src-tauri/src/headless.rs
@@ -23,6 +23,7 @@ use axum::{Json, Router};
 use host_application::{
     AppService, BuildResponseAction, CleanupMode, DevServerEmitter, HookTrustConfirmationPort,
     HookTrustConfirmationRequest, RepoConfigUpdate, RepoSettingsUpdate, RunEmitter,
+    WorkspaceSettingsSnapshotUpdate,
 };
 use host_domain::AgentRuntimeKind;
 use serde::de::DeserializeOwned;
@@ -1235,12 +1236,14 @@ async fn handle_workspace_save_settings_snapshot(
     serialize_value(
         run_service_blocking_tokio("workspace_save_settings_snapshot", move || {
             service.workspace_save_settings_snapshot(
-                theme,
-                git,
-                chat,
-                kanban,
-                repos,
-                global_prompt_overrides,
+                WorkspaceSettingsSnapshotUpdate {
+                    theme,
+                    git,
+                    chat,
+                    kanban,
+                    repos,
+                    global_prompt_overrides,
+                },
                 &confirmation_port,
             )
         })

--- a/apps/desktop/src-tauri/src/headless.rs
+++ b/apps/desktop/src-tauri/src/headless.rs
@@ -365,6 +365,13 @@ struct TaskCreateArgs {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct TaskListArgs {
+    repo_path: String,
+    done_visible_days: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct TaskUpdateArgs {
     repo_path: String,
     task_id: String,
@@ -895,12 +902,7 @@ async fn dispatch_task_command(
     args: Value,
 ) -> Option<CommandResult> {
     match command {
-        "tasks_list" => Some(
-            handle_repo_path_operation_blocking(state, args, "tasks_list", |service, repo_path| {
-                service.tasks_list(&repo_path)
-            })
-            .await,
-        ),
+        "tasks_list" => Some(handle_tasks_list(state, args).await),
         "task_create" => Some(handle_task_create(state, args).await),
         "task_update" => Some(handle_task_update(state, args).await),
         "task_delete" => Some(handle_task_delete(state, args).await),
@@ -990,6 +992,21 @@ where
     serialize_value(
         run_headless_blocking(operation_name, move || operation(service, repo_path)).await?,
     )
+}
+
+async fn handle_tasks_list(state: &HeadlessState, args: Value) -> CommandResult {
+    let TaskListArgs {
+        repo_path,
+        done_visible_days,
+    } = deserialize_args(args)?;
+    let service = state.service.clone();
+    let tasks = run_service_blocking_tokio("tasks_list", move || match done_visible_days {
+        Some(days) => service.tasks_list_for_kanban(&repo_path, days),
+        None => service.tasks_list(&repo_path),
+    })
+    .await
+    .map_err(service_error)?;
+    serialize_value(tasks)
 }
 
 fn handle_repo_task_operation<T, F>(args: Value, operation: F) -> CommandResult
@@ -1172,7 +1189,7 @@ fn handle_workspace_update_repo_hooks(state: &HeadlessState, args: Value) -> Com
 }
 
 fn handle_workspace_get_settings_snapshot(state: &HeadlessState) -> CommandResult {
-    let (theme, git, chat, repos, global_prompt_overrides) = state
+    let (theme, git, chat, kanban, repos, global_prompt_overrides) = state
         .service
         .workspace_get_settings_snapshot()
         .map_err(service_error)?;
@@ -1180,6 +1197,7 @@ fn handle_workspace_get_settings_snapshot(state: &HeadlessState) -> CommandResul
         theme,
         git,
         chat,
+        kanban,
         repos,
         global_prompt_overrides,
     })
@@ -1210,6 +1228,7 @@ async fn handle_workspace_save_settings_snapshot(
         theme,
         git,
         chat,
+        kanban,
         repos,
         global_prompt_overrides,
     } = snapshot;
@@ -1219,6 +1238,7 @@ async fn handle_workspace_save_settings_snapshot(
                 theme,
                 git,
                 chat,
+                kanban,
                 repos,
                 global_prompt_overrides,
                 &confirmation_port,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -156,6 +156,7 @@ pub(crate) struct SettingsSnapshotPayload {
     theme: String,
     git: host_infra_system::GlobalGitConfig,
     chat: host_infra_system::ChatSettings,
+    kanban: host_infra_system::KanbanSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
     global_prompt_overrides: host_infra_system::PromptOverrides,
 }
@@ -166,6 +167,7 @@ pub(crate) struct SettingsSnapshotResponsePayload {
     theme: String,
     git: host_infra_system::GlobalGitConfig,
     chat: host_infra_system::ChatSettings,
+    kanban: host_infra_system::KanbanSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
     global_prompt_overrides: host_infra_system::PromptOverrides,
 }

--- a/apps/desktop/src/components/features/settings/settings-kanban-section.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-kanban-section.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import type { KanbanSettings } from "@openducktor/contracts";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SettingsKanbanSection } from "./settings-kanban-section";
+
+describe("settings kanban section", () => {
+  test("renders the done-task visibility setting", () => {
+    const kanban: KanbanSettings = { doneVisibleDays: 3 };
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsKanbanSection, {
+        kanban,
+        disabled: false,
+        onUpdateKanban: () => kanban,
+      }),
+    );
+
+    expect(html).toContain("Kanban Settings");
+    expect(html).toContain("Done tasks visible for");
+    expect(html).toContain('value="3"');
+  });
+});

--- a/apps/desktop/src/components/features/settings/settings-kanban-section.tsx
+++ b/apps/desktop/src/components/features/settings/settings-kanban-section.tsx
@@ -1,0 +1,52 @@
+import type { KanbanSettings } from "@openducktor/contracts";
+import type { ReactElement } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type SettingsKanbanSectionProps = {
+  kanban: KanbanSettings;
+  disabled: boolean;
+  onUpdateKanban: (updater: (current: KanbanSettings) => KanbanSettings) => void;
+};
+
+export function SettingsKanbanSection({
+  kanban,
+  disabled,
+  onUpdateKanban,
+}: SettingsKanbanSectionProps): ReactElement {
+  return (
+    <div className="grid gap-4 p-4">
+      <div className="space-y-2">
+        <h3 className="text-sm font-semibold text-foreground">Kanban Settings</h3>
+        <p className="text-xs text-muted-foreground">
+          Control how long completed tasks stay visible on the board.
+        </p>
+      </div>
+
+      <div className="grid gap-3 rounded-md border border-border bg-card p-4">
+        <div className="grid gap-2">
+          <Label htmlFor="kanban-done-visible-days">Done tasks visible for</Label>
+          <Input
+            id="kanban-done-visible-days"
+            type="number"
+            min={0}
+            step={1}
+            inputMode="numeric"
+            value={kanban.doneVisibleDays}
+            disabled={disabled}
+            onChange={(event) => {
+              const parsed = Number.parseInt(event.currentTarget.value, 10);
+              onUpdateKanban((current) => ({
+                ...current,
+                doneVisibleDays: Number.isNaN(parsed) ? 0 : Math.max(0, parsed),
+              }));
+            }}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Set to `0` to hide Done tasks by default. Changes take effect after you save settings.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/features/settings/settings-modal-constants.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-constants.ts
@@ -3,13 +3,14 @@ import { agentPromptTemplateIdValues } from "@openducktor/contracts";
 import { listBuiltinAgentPromptTemplates } from "@openducktor/core";
 import {
   FolderGit2,
+  LayoutGrid,
   type LucideIcon,
   MessageSquare,
   MessageSquareText,
   SlidersHorizontal,
 } from "lucide-react";
 
-export type SettingsSectionId = "general" | "git" | "repositories" | "prompts" | "chat";
+export type SettingsSectionId = "general" | "git" | "repositories" | "prompts" | "chat" | "kanban";
 export type RepositorySectionId = "configuration" | "git" | "agents" | "prompts";
 export type PromptRoleTabId = "shared" | "spec" | "planner" | "build" | "qa";
 
@@ -25,6 +26,7 @@ export const SETTINGS_SECTIONS: ReadonlyArray<{
   { id: "repositories", label: "Repositories", icon: FolderGit2 },
   { id: "prompts", label: "Prompts", icon: MessageSquareText },
   { id: "chat", label: "Chat", icon: MessageSquare },
+  { id: "kanban", label: "Kanban", icon: LayoutGrid },
 ];
 
 export const REPOSITORY_SECTIONS: ReadonlyArray<{

--- a/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
@@ -8,6 +8,7 @@ const createMockSnapshot = (overrides: Partial<SettingsSnapshot> = {}): Settings
   theme: "light",
   git: { defaultMergeMethod: "merge_commit" },
   chat: { showThinkingMessages: false },
+  kanban: { doneVisibleDays: 1 },
   repos: {},
   globalPromptOverrides: {},
   ...overrides,
@@ -54,7 +55,14 @@ const createMockController = (snapshot: SettingsSnapshot) => ({
   selectedRepoPromptValidationErrorCount: 0,
   globalPromptRoleTabErrorCounts: { shared: 0, spec: 0, planner: 0, build: 0, qa: 0 },
   selectedRepoPromptRoleTabErrorCounts: { shared: 0, spec: 0, planner: 0, build: 0, qa: 0 },
-  settingsSectionErrorCountById: { general: 0, git: 0, repositories: 0, prompts: 0, chat: 0 },
+  settingsSectionErrorCountById: {
+    general: 0,
+    git: 0,
+    repositories: 0,
+    prompts: 0,
+    chat: 0,
+    kanban: 0,
+  },
   setSelectedRepoPath: () => {},
   markRepoScriptSaveAttempt: () => {},
   retrySelectedRepoBranchesLoad: () => {},
@@ -62,6 +70,7 @@ const createMockController = (snapshot: SettingsSnapshot) => ({
   updateSelectedRepoConfig: () => {},
   updateGlobalGitConfig: () => {},
   updateGlobalChatSettings: () => {},
+  updateGlobalKanbanSettings: () => {},
   updateGlobalPromptOverrides: () => {},
   updateRepoPromptOverrides: () => {},
   updateSelectedRepoAgentDefault: () => {},
@@ -91,6 +100,28 @@ describe("settings modal content", () => {
 
     expect(html).toContain("Chat Settings");
     expect(html).toContain("Show Thinking Messages");
+  });
+
+  test("renders kanban section when section is kanban", () => {
+    const snapshot = createMockSnapshot({ kanban: { doneVisibleDays: 7 } });
+    const controller = createMockController(snapshot);
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsModalContent, {
+        section: "kanban",
+        repositorySection: "configuration",
+        globalPromptRoleTab: "shared",
+        repoPromptRoleTab: "shared",
+        isInteractionDisabled: false,
+        controller,
+        onRepositorySectionChange: () => {},
+        onGlobalPromptRoleTabChange: () => {},
+        onRepoPromptRoleTabChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Kanban Settings");
+    expect(html).toContain("Done tasks visible for");
   });
 
   test("renders general section when section is general", () => {

--- a/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
@@ -122,6 +122,7 @@ describe("settings modal content", () => {
 
     expect(html).toContain("Kanban Settings");
     expect(html).toContain("Done tasks visible for");
+    expect(html).toContain('value="7"');
   });
 
   test("renders general section when section is general", () => {

--- a/apps/desktop/src/components/features/settings/settings-modal-content.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-content.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from "react";
 import { SettingsChatSection } from "./settings-chat-section";
 import { GeneralSettingsSection } from "./settings-general-section";
 import { SettingsGitSection } from "./settings-git-section";
+import { SettingsKanbanSection } from "./settings-kanban-section";
 import type {
   PromptRoleTabId,
   RepositorySectionId,
@@ -70,6 +71,7 @@ export function SettingsModalContent({
     updateSelectedRepoConfig,
     updateGlobalGitConfig,
     updateGlobalChatSettings,
+    updateGlobalKanbanSettings,
     updateGlobalPromptOverrides,
     updateRepoPromptOverrides,
     updateSelectedRepoAgentDefault,
@@ -138,6 +140,16 @@ export function SettingsModalContent({
         chat={snapshotDraft.chat}
         disabled={isInteractionDisabled}
         onUpdateChat={updateGlobalChatSettings}
+      />
+    );
+  }
+
+  if (section === "kanban") {
+    return (
+      <SettingsKanbanSection
+        kanban={snapshotDraft.kanban}
+        disabled={isInteractionDisabled}
+        onUpdateKanban={updateGlobalKanbanSettings}
       />
     );
   }

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
@@ -277,6 +277,9 @@ describe("settings-modal-normalization", () => {
       chat: {
         showThinkingMessages: true,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {
         "/repo-a": createRepoConfig(),
       },
@@ -298,6 +301,7 @@ describe("settings-modal-normalization", () => {
       },
     ]);
     expect(snapshot.chat.showThinkingMessages).toBe(true);
+    expect(snapshot.kanban.doneVisibleDays).toBe(1);
     expect(snapshot.globalPromptOverrides).toEqual({
       "kickoff.spec_initial": {
         template: "global",
@@ -317,6 +321,9 @@ describe("settings-modal-normalization", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {
         "/repo-b": createRepoConfig(),
         "/repo-a": createRepoConfig(),
@@ -335,6 +342,9 @@ describe("settings-modal-normalization", () => {
           },
           chat: {
             showThinkingMessages: false,
+          },
+          kanban: {
+            doneVisibleDays: 1,
           },
           repos: {},
           globalPromptOverrides: {},

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
@@ -116,6 +116,7 @@ export const normalizeSnapshotForSave = (snapshot: SettingsSnapshot): SettingsSn
     theme: snapshot.theme,
     git: normalizeGlobalGitConfigForSave(snapshot.git),
     chat: snapshot.chat,
+    kanban: snapshot.kanban,
     repos,
     globalPromptOverrides: normalizePromptOverridesForSave(snapshot.globalPromptOverrides),
   };

--- a/apps/desktop/src/components/features/settings/settings-modal-sidebars.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-sidebars.test.tsx
@@ -11,6 +11,7 @@ describe("settings modal sidebars", () => {
       repositories: 0,
       prompts: 0,
       chat: 0,
+      kanban: 0,
     };
 
     const html = renderToStaticMarkup(
@@ -36,6 +37,7 @@ describe("settings modal sidebars", () => {
       repositories: 0,
       prompts: 0,
       chat: 0,
+      kanban: 0,
     };
 
     const html = renderToStaticMarkup(
@@ -57,6 +59,7 @@ describe("settings modal sidebars", () => {
       repositories: 0,
       prompts: 0,
       chat: 0,
+      kanban: 0,
     };
 
     const html = renderToStaticMarkup(
@@ -78,6 +81,7 @@ describe("settings modal sidebars", () => {
       repositories: 0,
       prompts: 0,
       chat: 2,
+      kanban: 0,
     };
 
     const html = renderToStaticMarkup(

--- a/apps/desktop/src/components/features/settings/settings-modal-sidebars.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-sidebars.test.tsx
@@ -28,6 +28,7 @@ describe("settings modal sidebars", () => {
     expect(html).toContain("Repositories");
     expect(html).toContain("Prompts");
     expect(html).toContain("Chat");
+    expect(html).toContain("Kanban");
   });
 
   test("renders chat section as active when selected", () => {
@@ -50,6 +51,7 @@ describe("settings modal sidebars", () => {
     );
 
     expect(html).toContain("Chat");
+    expect(html).toContain("Kanban");
   });
 
   test("disables all buttons when disabled prop is true", () => {
@@ -72,6 +74,7 @@ describe("settings modal sidebars", () => {
     );
 
     expect(html).toContain("disabled");
+    expect(html).toContain("Kanban");
   });
 
   test("displays error count for chat section when errors exist", () => {
@@ -94,6 +97,7 @@ describe("settings modal sidebars", () => {
     );
 
     expect(html).toContain("Chat");
+    expect(html).toContain("Kanban");
     expect(html).toContain("2");
   });
 });

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
@@ -16,6 +16,9 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
   chat: {
     showThinkingMessages: false,
   },
+  kanban: {
+    doneVisibleDays: 1,
+  },
   repos: {
     "/repo": {
       defaultRuntimeKind: "opencode",

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
@@ -36,6 +36,7 @@ import { useSettingsModalSnapshotState } from "./use-settings-modal-snapshot-sta
 type DirtySections = {
   chat: boolean;
   globalGit: boolean;
+  kanban: boolean;
   globalPromptOverrides: boolean;
   repoSettings: boolean;
 };
@@ -43,6 +44,7 @@ type DirtySections = {
 const EMPTY_DIRTY_SECTIONS: DirtySections = {
   chat: false,
   globalGit: false,
+  kanban: false,
   globalPromptOverrides: false,
   repoSettings: false,
 };
@@ -92,6 +94,9 @@ export type SettingsModalController = {
   ) => void;
   updateGlobalChatSettings: (
     updater: (current: SettingsSnapshot["chat"]) => SettingsSnapshot["chat"],
+  ) => void;
+  updateGlobalKanbanSettings: (
+    updater: (current: SettingsSnapshot["kanban"]) => SettingsSnapshot["kanban"],
   ) => void;
   updateGlobalPromptOverrides: (
     updater: (current: RepoPromptOverrides) => RepoPromptOverrides,
@@ -191,6 +196,7 @@ export const useSettingsModalController = ({
     updateSelectedRepoConfig: applySelectedRepoConfigUpdate,
     updateGlobalGitConfig: applyGlobalGitConfigUpdate,
     updateGlobalChatSettings: applyGlobalChatSettingsUpdate,
+    updateGlobalKanbanSettings: applyGlobalKanbanSettingsUpdate,
     updateGlobalPromptOverrides: applyGlobalPromptOverridesUpdate,
     updateRepoPromptOverrides: applyRepoPromptOverridesUpdate,
     updateSelectedRepoAgentDefault: applySelectedRepoAgentDefaultUpdate,
@@ -295,6 +301,14 @@ export const useSettingsModalController = ({
       applyGlobalChatSettingsUpdate(updater);
     },
     [applyGlobalChatSettingsUpdate, markDirty],
+  );
+
+  const updateGlobalKanbanSettings = useCallback(
+    (updater: (current: SettingsSnapshot["kanban"]) => SettingsSnapshot["kanban"]): void => {
+      markDirty("kanban");
+      applyGlobalKanbanSettingsUpdate(updater);
+    },
+    [applyGlobalKanbanSettingsUpdate, markDirty],
   );
 
   const updateGlobalPromptOverrides = useCallback(
@@ -452,6 +466,7 @@ export const useSettingsModalController = ({
       if (
         !dirtySections.chat &&
         !dirtySections.globalGit &&
+        !dirtySections.kanban &&
         !dirtySections.globalPromptOverrides &&
         !dirtySections.repoSettings
       ) {
@@ -461,6 +476,7 @@ export const useSettingsModalController = ({
       const shouldUseGlobalGitSave =
         dirtySections.globalGit &&
         !dirtySections.chat &&
+        !dirtySections.kanban &&
         !dirtySections.globalPromptOverrides &&
         !dirtySections.repoSettings;
 
@@ -493,6 +509,7 @@ export const useSettingsModalController = ({
   }, [
     dirtySections.chat,
     dirtySections.globalGit,
+    dirtySections.kanban,
     dirtySections.globalPromptOverrides,
     dirtySections.repoSettings,
     hasPromptValidationErrors,
@@ -549,6 +566,7 @@ export const useSettingsModalController = ({
     updateSelectedRepoConfig,
     updateGlobalGitConfig,
     updateGlobalChatSettings,
+    updateGlobalKanbanSettings,
     updateGlobalPromptOverrides,
     updateRepoPromptOverrides,
     updateSelectedRepoAgentDefault,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
@@ -22,6 +22,9 @@ const createInitialSnapshot = (): SettingsSnapshot => ({
   chat: {
     showThinkingMessages: false,
   },
+  kanban: {
+    doneVisibleDays: 1,
+  },
   globalPromptOverrides: {},
   repos: {
     "/repo-a": {
@@ -118,6 +121,27 @@ describe("useSettingsModalDraftActions", () => {
     expect(snapshot?.chat.showThinkingMessages).toBe(true);
     expect(snapshot?.git.defaultMergeMethod).toBe("merge_commit");
     expect(snapshot?.repos["/repo-a"]?.branchPrefix).toBe("obp");
+
+    await harness.unmount();
+  });
+
+  test("updates global kanban settings without touching unrelated sections", async () => {
+    const harness = createHookHarness({
+      selectedRepoPath: "/repo-a",
+      initialSnapshot: createInitialSnapshot(),
+    });
+    await harness.mount();
+
+    await harness.run((state) => {
+      state.updateGlobalKanbanSettings((kanban) => ({
+        ...kanban,
+        doneVisibleDays: 7,
+      }));
+    });
+
+    const snapshot = harness.getLatest().snapshotDraft;
+    expect(snapshot?.kanban.doneVisibleDays).toBe(7);
+    expect(snapshot?.chat.showThinkingMessages).toBe(false);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.ts
@@ -19,6 +19,9 @@ type SettingsModalDraftActions = {
   updateGlobalChatSettings: (
     updater: (current: SettingsSnapshot["chat"]) => SettingsSnapshot["chat"],
   ) => void;
+  updateGlobalKanbanSettings: (
+    updater: (current: SettingsSnapshot["kanban"]) => SettingsSnapshot["kanban"],
+  ) => void;
   updateGlobalPromptOverrides: (
     updater: (current: RepoPromptOverrides) => RepoPromptOverrides,
   ) => void;
@@ -109,6 +112,22 @@ export const useSettingsModalDraftActions = ({
     [setSnapshotDraft],
   );
 
+  const updateGlobalKanbanSettings = useCallback(
+    (updater: (current: SettingsSnapshot["kanban"]) => SettingsSnapshot["kanban"]): void => {
+      setSnapshotDraft((current) => {
+        if (!current) {
+          return current;
+        }
+
+        return {
+          ...current,
+          kanban: updater(current.kanban),
+        };
+      });
+    },
+    [setSnapshotDraft],
+  );
+
   const updateRepoPromptOverrides = useCallback(
     (updater: (current: RepoPromptOverrides) => RepoPromptOverrides): void => {
       updateSelectedRepoConfig((repoConfig) => ({
@@ -156,6 +175,7 @@ export const useSettingsModalDraftActions = ({
     updateSelectedRepoConfig,
     updateGlobalGitConfig,
     updateGlobalChatSettings,
+    updateGlobalKanbanSettings,
     updateGlobalPromptOverrides,
     updateRepoPromptOverrides,
     updateSelectedRepoAgentDefault,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
@@ -21,6 +21,9 @@ const createSnapshot = (): SettingsSnapshot => ({
   chat: {
     showThinkingMessages: false,
   },
+  kanban: {
+    doneVisibleDays: 1,
+  },
   globalPromptOverrides: {
     "system.scenario.spec_initial": {
       template: "invalid {{task.bad}}",
@@ -86,6 +89,7 @@ describe("useSettingsModalPromptValidation", () => {
       repositories: 0,
       prompts: 0,
       chat: 0,
+      kanban: 0,
     });
 
     await harness.unmount();
@@ -112,6 +116,7 @@ describe("useSettingsModalPromptValidation", () => {
       repositories: 1,
       prompts: 1,
       chat: 0,
+      kanban: 0,
     });
     expect(latest.selectedRepoPromptValidationErrors["kickoff.build_implementation_start"]).toBe(
       "Unsupported placeholder: {{unknown.value}}.",

--- a/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.ts
@@ -92,6 +92,7 @@ export const useSettingsModalPromptValidation = ({
     repositories: promptValidationState.repoTotalErrorCount,
     prompts: promptValidationState.globalErrorCount,
     chat: 0,
+    kanban: 0,
   };
 
   return {

--- a/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
@@ -15,6 +15,9 @@ const hostMock = {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {},
       globalPromptOverrides: {},
     }),
@@ -39,6 +42,9 @@ const createSettingsSnapshot = (
     theme: "light",
     git: {
       defaultMergeMethod: "merge_commit",
+    },
+    kanban: {
+      doneVisibleDays: 1,
     },
     ...(includeChat ? { chat: { showThinkingMessages } } : {}),
     repos: {},

--- a/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
@@ -99,6 +99,9 @@ beforeEach(() => {
     chat: {
       showThinkingMessages: false,
     },
+    kanban: {
+      doneVisibleDays: 1,
+    },
     repos: {},
     globalPromptOverrides: {},
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -193,6 +193,9 @@ describe("useAgentStudioSessionActions", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {},
       globalPromptOverrides: {},
     });

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -251,6 +251,9 @@ describe("useAgentStudioSessionStartFlow", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {},
       globalPromptOverrides: {},
     });

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -55,6 +55,9 @@ const workspaceGetSettingsSnapshotMock = mock(async () => ({
   chat: {
     showThinkingMessages: false,
   },
+  kanban: {
+    doneVisibleDays: 1,
+  },
   repos: {},
   globalPromptOverrides: {} as RepoPromptOverrides,
 }));
@@ -511,6 +514,9 @@ describe("KanbanPage session start modal flow", () => {
       },
       chat: {
         showThinkingMessages: false,
+      },
+      kanban: {
+        doneVisibleDays: 1,
       },
       repos: {},
       globalPromptOverrides: {},

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -23,6 +23,7 @@ enableReactActEnvironment();
 const originalConsoleError = console.error;
 const originalWorkspaceGetRepoConfig = host.workspaceGetRepoConfig;
 const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
+const originalTasksList = host.tasksList;
 const originalBuildContinuationTargetGet = host.buildContinuationTargetGet;
 
 const startAgentSessionMock = mock(async () => "session-1");
@@ -61,6 +62,7 @@ const workspaceGetSettingsSnapshotMock = mock(async () => ({
   repos: {},
   globalPromptOverrides: {} as RepoPromptOverrides,
 }));
+const tasksListMock = mock(async () => [currentTaskFixture]);
 const buildContinuationTargetGetMock = mock(async () => ({
   workingDirectory: "/repo/worktrees/task-1",
   source: "builder_session" as const,
@@ -100,6 +102,7 @@ const loadRepoRuntimeCatalogMock = mock(
 );
 
 let latestKanbanColumnProps: Record<string, unknown> | null = null;
+let latestKanbanColumnPropsList: Record<string, unknown>[] = [];
 let latestHumanReviewFeedbackModalModel: Record<string, unknown> | null = null;
 let latestSessionStartModalModel: Record<string, unknown> | null = null;
 let latestResetImplementationModalModel: Record<string, unknown> | null = null;
@@ -229,7 +232,7 @@ const createRepoConfigFixture = (promptOverrides: RepoPromptOverrides = {}): Rep
   },
 });
 
-const renderPage = async (): Promise<RenderResult> => {
+const renderPage = async (options?: { waitForKanbanReady?: boolean }): Promise<RenderResult> => {
   const { KanbanPage } = await import("./kanban-page");
   const LocationProbe = (): ReactElement | null => {
     const location = useLocation();
@@ -237,7 +240,7 @@ const renderPage = async (): Promise<RenderResult> => {
     return null;
   };
 
-  return render(
+  const renderer = render(
     <QueryProvider useIsolatedClient>
       <MemoryRouter initialEntries={["/"]}>
         <LocationProbe />
@@ -245,6 +248,21 @@ const renderPage = async (): Promise<RenderResult> => {
       </MemoryRouter>
     </QueryProvider>,
   );
+
+  if (options?.waitForKanbanReady !== false) {
+    await waitFor(
+      () => {
+        const totalTaskCount = latestKanbanColumnPropsList.reduce((count, props) => {
+          const column = props.column as { tasks: unknown[] };
+          return count + column.tasks.length;
+        }, 0);
+        expect(totalTaskCount).toBeGreaterThan(0);
+      },
+      { timeout: 1000 },
+    );
+  }
+
+  return renderer;
 };
 
 const waitForMockCall = async (
@@ -336,6 +354,7 @@ describe("KanbanPage session start modal flow", () => {
     mock.module("@/components/features/kanban/kanban-column", () => ({
       KanbanColumn: (props: Record<string, unknown>): ReactElement | null => {
         latestKanbanColumnProps = props;
+        latestKanbanColumnPropsList.push(props);
         return null;
       },
     }));
@@ -438,6 +457,7 @@ describe("KanbanPage session start modal flow", () => {
     host.workspaceGetRepoConfig = workspaceGetRepoConfigMock as typeof host.workspaceGetRepoConfig;
     host.workspaceGetSettingsSnapshot =
       workspaceGetSettingsSnapshotMock as typeof host.workspaceGetSettingsSnapshot;
+    host.tasksList = tasksListMock as typeof host.tasksList;
     host.buildContinuationTargetGet =
       buildContinuationTargetGetMock as typeof host.buildContinuationTargetGet;
     currentTaskFixture = createTaskCardFixture({ id: "TASK-123", status: "open" });
@@ -480,6 +500,7 @@ describe("KanbanPage session start modal flow", () => {
       },
     ];
     latestKanbanColumnProps = null;
+    latestKanbanColumnPropsList = [];
     latestHumanReviewFeedbackModalModel = null;
     latestSessionStartModalModel = null;
     latestResetImplementationModalModel = null;
@@ -504,6 +525,7 @@ describe("KanbanPage session start modal flow", () => {
     toastErrorMock.mockClear();
     workspaceGetRepoConfigMock.mockClear();
     workspaceGetSettingsSnapshotMock.mockClear();
+    tasksListMock.mockClear();
     buildContinuationTargetGetMock.mockClear();
     loadRepoRuntimeCatalogMock.mockClear();
     workspaceGetRepoConfigMock.mockImplementation(async () => createRepoConfigFixture());
@@ -521,11 +543,13 @@ describe("KanbanPage session start modal flow", () => {
       repos: {},
       globalPromptOverrides: {},
     }));
+    tasksListMock.mockImplementation(async () => [currentTaskFixture]);
   });
 
   afterEach(() => {
     host.workspaceGetRepoConfig = originalWorkspaceGetRepoConfig;
     host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
+    host.tasksList = originalTasksList;
     host.buildContinuationTargetGet = originalBuildContinuationTargetGet;
     mock.restore();
   });
@@ -535,7 +559,7 @@ describe("KanbanPage session start modal flow", () => {
   });
 
   test("delegate action opens modal and foreground confirm navigates to Agent Studio", async () => {
-    const renderer = await renderPage();
+    const renderer = await renderPage({ waitForKanbanReady: false });
 
     expect(latestKanbanColumnProps).toBeTruthy();
 
@@ -563,6 +587,56 @@ describe("KanbanPage session start modal flow", () => {
     );
     expect(updateAgentSessionModelMock).not.toHaveBeenCalled();
     expect(latestLocation).toContain("/agents?task=TASK-123");
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("settings load failure reports an error and leaves the Kanban board empty", async () => {
+    workspaceGetSettingsSnapshotMock.mockImplementationOnce(async () => {
+      throw new Error("settings unavailable");
+    });
+
+    const renderer = await renderPage({ waitForKanbanReady: false });
+
+    await waitForMockCall(toastErrorMock);
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Failed to load Kanban settings", {
+      description: "settings unavailable",
+    });
+    expect(tasksListMock).not.toHaveBeenCalled();
+    expect(
+      latestKanbanColumnPropsList.reduce((count, props) => {
+        const column = props.column as { tasks: unknown[] };
+        return count + column.tasks.length;
+      }, 0),
+    ).toBe(0);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  test("kanban task load failure reports an error and does not reuse shared task state", async () => {
+    tasksListMock.mockImplementationOnce(async () => {
+      throw new Error("tasks unavailable");
+    });
+
+    const renderer = await renderPage({ waitForKanbanReady: false });
+
+    await waitForMockCall(toastErrorMock);
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Failed to load Kanban tasks", {
+      description: "tasks unavailable",
+    });
+    expect(tasksListMock).toHaveBeenCalledWith("/repo", 1);
+    expect(
+      latestKanbanColumnPropsList.reduce((count, props) => {
+        const column = props.column as { tasks: unknown[] };
+        return count + column.tasks.length;
+      }, 0),
+    ).toBe(0);
 
     await act(async () => {
       renderer.unmount();

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
@@ -1,8 +1,13 @@
-import { useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 import type { GitConflict } from "@/features/agent-studio-git";
 import { useGitConflictResolution } from "@/features/git-conflict-resolution";
+import { errorMessage } from "@/lib/errors";
 import { useAgentState, useTasksState, useWorkspaceState } from "@/state";
+import { kanbanTaskListQueryOptions } from "@/state/queries/tasks";
+import { settingsSnapshotQueryOptions } from "@/state/queries/workspace";
 import { useAgentStudioRepoSettings } from "../agents/use-agent-studio-repo-settings";
 import type { KanbanPageModels } from "./kanban-page-model-types";
 import { useKanbanBoardModel } from "./use-kanban-board-model";
@@ -32,7 +37,6 @@ export function useKanbanPageModels({
     sendAgentMessage,
   } = useAgentState();
   const {
-    tasks,
     runs,
     refreshTasks,
     syncPullRequests,
@@ -50,12 +54,61 @@ export function useKanbanPageModels({
     resumeDeferredTask,
     humanRequestChangesTask,
   } = useTasksState();
+  const reportedSettingsErrorRef = useRef<string | null>(null);
+  const reportedKanbanTasksErrorRef = useRef<string | null>(null);
+  const settingsSnapshotQuery = useQuery(settingsSnapshotQueryOptions());
+  const doneVisibleDays = settingsSnapshotQuery.data?.kanban.doneVisibleDays;
+  const kanbanTaskListQuery = useQuery({
+    ...kanbanTaskListQueryOptions(activeRepo ?? "__disabled__", doneVisibleDays ?? 0),
+    enabled: activeRepo !== null && doneVisibleDays !== undefined,
+  });
+  useEffect(() => {
+    if (!settingsSnapshotQuery.isError) {
+      reportedSettingsErrorRef.current = null;
+      return;
+    }
+
+    const description = errorMessage(settingsSnapshotQuery.error);
+    if (reportedSettingsErrorRef.current === description) {
+      return;
+    }
+
+    reportedSettingsErrorRef.current = description;
+    toast.error("Failed to load Kanban settings", {
+      description,
+    });
+  }, [settingsSnapshotQuery.error, settingsSnapshotQuery.isError]);
+
+  useEffect(() => {
+    if (!kanbanTaskListQuery.isError) {
+      reportedKanbanTasksErrorRef.current = null;
+      return;
+    }
+
+    const description = errorMessage(kanbanTaskListQuery.error);
+    if (reportedKanbanTasksErrorRef.current === description) {
+      return;
+    }
+
+    reportedKanbanTasksErrorRef.current = description;
+    toast.error("Failed to load Kanban tasks", {
+      description,
+    });
+  }, [kanbanTaskListQuery.error, kanbanTaskListQuery.isError]);
+
+  const kanbanTasks = activeRepo ? (kanbanTaskListQuery.data ?? []) : [];
+  const isLoadingKanbanTasks =
+    isLoadingTasks ||
+    (activeRepo !== null &&
+      (settingsSnapshotQuery.isPending ||
+        (doneVisibleDays !== undefined &&
+          (kanbanTaskListQuery.isPending || kanbanTaskListQuery.isFetching))));
   const navigate = useNavigate();
 
   const sessionStartFlow = useKanbanSessionStartFlow({
     activeRepo,
     repoSettings,
-    tasks,
+    tasks: kanbanTasks,
     sessions,
     navigate,
     loadRepoSettings,
@@ -112,7 +165,7 @@ export function useKanbanPageModels({
   });
   const handleResolveKanbanGitConflict = useCallback(
     (conflict: GitConflict, taskId: string) => {
-      const task = tasks.find((entry) => entry.id === taskId) ?? null;
+      const task = kanbanTasks.find((entry) => entry.id === taskId) ?? null;
       const builderSessions = sessions.filter(
         (entry) => entry.role === "build" && entry.taskId === taskId,
       );
@@ -131,11 +184,11 @@ export function useKanbanPageModels({
         },
       });
     },
-    [handleResolveGitConflict, navigate, sessions, tasks],
+    [handleResolveGitConflict, kanbanTasks, navigate, sessions],
   );
   const { taskApprovalModal, taskGitConflictDialog, openTaskApproval } = useTaskApprovalFlow({
     activeRepo,
-    tasks,
+    tasks: kanbanTasks,
     requestPullRequestGeneration: onPullRequestGenerate,
     refreshTasks,
     onResolveGitConflict: handleResolveKanbanGitConflict,
@@ -149,7 +202,7 @@ export function useKanbanPageModels({
   );
 
   const { resetImplementationModal, openResetImplementation } = useTaskResetFlow({
-    tasks,
+    tasks: kanbanTasks,
     sessions,
     loadAgentSessions,
     removeAgentSessions,
@@ -158,13 +211,13 @@ export function useKanbanPageModels({
   });
 
   const taskDialogs = useKanbanTaskDialogs({
-    tasks,
+    tasks: kanbanTasks,
   });
 
   const content = useKanbanBoardModel({
-    isLoadingTasks,
+    isLoadingTasks: isLoadingKanbanTasks,
     isSwitchingWorkspace,
-    tasks,
+    tasks: kanbanTasks,
     runs,
     sessions,
     onOpenDetails,
@@ -181,7 +234,7 @@ export function useKanbanPageModels({
 
   return {
     header: {
-      isLoadingTasks,
+      isLoadingTasks: isLoadingKanbanTasks,
       isSwitchingWorkspace,
       onCreateTask: taskDialogs.onCreateTask,
       onRefreshTasks,
@@ -190,7 +243,7 @@ export function useKanbanPageModels({
     taskComposer: taskDialogs.taskComposer,
     taskDetailsController: {
       activeRepo,
-      allTasks: tasks,
+      allTasks: kanbanTasks,
       runs,
       taskSessionsByTaskId: content.taskSessionsByTaskId,
       activeTaskSessionContextByTaskId: content.activeTaskSessionContextByTaskId,

--- a/apps/desktop/src/state/app-state-context-values.test.ts
+++ b/apps/desktop/src/state/app-state-context-values.test.ts
@@ -69,6 +69,9 @@ describe("app-state-context-values", () => {
         chat: {
           showThinkingMessages: false,
         },
+        kanban: {
+          doneVisibleDays: 1,
+        },
         repos: {},
         globalPromptOverrides: {},
       }),

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -464,6 +464,9 @@ describe("agent-orchestrator-runtime", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {},
       globalPromptOverrides: {
         "kickoff.spec_initial": {
@@ -534,6 +537,9 @@ describe("agent-orchestrator-runtime", () => {
       },
       chat: {
         showThinkingMessages: false,
+      },
+      kanban: {
+        doneVisibleDays: 1,
       },
       repos: {},
       globalPromptOverrides,

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -283,6 +283,9 @@ describe("use-agent-orchestrator-operations", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {},
       globalPromptOverrides: {},
     });

--- a/apps/desktop/src/state/operations/shared/prompt-overrides.test.ts
+++ b/apps/desktop/src/state/operations/shared/prompt-overrides.test.ts
@@ -33,6 +33,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
   },
   repos: {},
   chat: { showThinkingMessages: false },
+  kanban: { doneVisibleDays: 1 },
   globalPromptOverrides: {
     "kickoff.spec_initial": {
       template: "global kickoff {{task.id}}",

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
@@ -267,6 +267,10 @@ describe("use-spec-operations", () => {
       tasks: [],
       runs: [],
     });
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a", 7), {
+      tasks: [],
+      runs: [],
+    });
 
     try {
       await harness.mount();
@@ -300,6 +304,9 @@ describe("use-spec-operations", () => {
         queryClient.getQueryState(["task-documents", "plan", "", "task-1"])?.isInvalidated,
       ).toBe(true);
       expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 1))?.isInvalidated).toBe(
+        true,
+      );
+      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 7))?.isInvalidated).toBe(
         true,
       );
     } finally {
@@ -352,6 +359,10 @@ describe("use-spec-operations", () => {
       tasks: [],
       runs: [],
     });
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a", 7), {
+      tasks: [],
+      runs: [],
+    });
 
     try {
       await harness.mount();
@@ -374,6 +385,9 @@ describe("use-spec-operations", () => {
         queryClient.getQueryState(["task-documents", "spec", "", "task-1"])?.isInvalidated,
       ).toBe(true);
       expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 1))?.isInvalidated).toBe(
+        true,
+      );
+      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 7))?.isInvalidated).toBe(
         true,
       );
     } finally {

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
@@ -263,7 +263,7 @@ describe("use-spec-operations", () => {
       markdown: "# Old plan (empty scope key)",
       updatedAt: "2026-02-22T10:00:00.000Z",
     });
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a"), {
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a", 1), {
       tasks: [],
       runs: [],
     });
@@ -299,7 +299,7 @@ describe("use-spec-operations", () => {
       expect(
         queryClient.getQueryState(["task-documents", "plan", "", "task-1"])?.isInvalidated,
       ).toBe(true);
-      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a"))?.isInvalidated).toBe(
+      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 1))?.isInvalidated).toBe(
         true,
       );
     } finally {
@@ -348,7 +348,7 @@ describe("use-spec-operations", () => {
       markdown: "# Old spec (empty scope key)",
       updatedAt: "2026-02-22T10:00:00.000Z",
     });
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a"), {
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a", 1), {
       tasks: [],
       runs: [],
     });
@@ -373,7 +373,7 @@ describe("use-spec-operations", () => {
       expect(
         queryClient.getQueryState(["task-documents", "spec", "", "task-1"])?.isInvalidated,
       ).toBe(true);
-      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a"))?.isInvalidated).toBe(
+      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 1))?.isInvalidated).toBe(
         true,
       );
     } finally {

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
@@ -263,11 +263,15 @@ describe("use-spec-operations", () => {
       markdown: "# Old plan (empty scope key)",
       updatedAt: "2026-02-22T10:00:00.000Z",
     });
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a", 1), {
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a"), {
       tasks: [],
       runs: [],
     });
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a", 7), {
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 1), {
+      tasks: [],
+      runs: [],
+    });
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 7), {
       tasks: [],
       runs: [],
     });
@@ -303,10 +307,13 @@ describe("use-spec-operations", () => {
       expect(
         queryClient.getQueryState(["task-documents", "plan", "", "task-1"])?.isInvalidated,
       ).toBe(true);
-      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 1))?.isInvalidated).toBe(
+      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a"))?.isInvalidated).toBe(
         true,
       );
-      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 7))?.isInvalidated).toBe(
+      expect(queryClient.getQueryState(taskQueryKeys.kanbanData("/repo-a", 1))?.isInvalidated).toBe(
+        true,
+      );
+      expect(queryClient.getQueryState(taskQueryKeys.kanbanData("/repo-a", 7))?.isInvalidated).toBe(
         true,
       );
     } finally {
@@ -355,11 +362,15 @@ describe("use-spec-operations", () => {
       markdown: "# Old spec (empty scope key)",
       updatedAt: "2026-02-22T10:00:00.000Z",
     });
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a", 1), {
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a"), {
       tasks: [],
       runs: [],
     });
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo-a", 7), {
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 1), {
+      tasks: [],
+      runs: [],
+    });
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 7), {
       tasks: [],
       runs: [],
     });
@@ -384,10 +395,13 @@ describe("use-spec-operations", () => {
       expect(
         queryClient.getQueryState(["task-documents", "spec", "", "task-1"])?.isInvalidated,
       ).toBe(true);
-      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 1))?.isInvalidated).toBe(
+      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a"))?.isInvalidated).toBe(
         true,
       );
-      expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a", 7))?.isInvalidated).toBe(
+      expect(queryClient.getQueryState(taskQueryKeys.kanbanData("/repo-a", 1))?.isInvalidated).toBe(
+        true,
+      );
+      expect(queryClient.getQueryState(taskQueryKeys.kanbanData("/repo-a", 7))?.isInvalidated).toBe(
         true,
       );
     } finally {

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
@@ -1,4 +1,8 @@
-import { defaultSpecTemplateMarkdown, validateSpecMarkdown } from "@openducktor/contracts";
+import {
+  DEFAULT_KANBAN_SETTINGS,
+  defaultSpecTemplateMarkdown,
+  validateSpecMarkdown,
+} from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import type { TaskDocumentPayload } from "../../../types/task-documents";
@@ -91,7 +95,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
         queryKey: documentQueryKeys.all,
       });
       await queryClient.invalidateQueries({
-        queryKey: taskQueryKeys.repoData(repo),
+        queryKey: taskQueryKeys.repoData(repo, DEFAULT_KANBAN_SETTINGS.doneVisibleDays),
         exact: true,
       });
       return saved;
@@ -115,7 +119,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
         queryKey: documentQueryKeys.all,
       });
       await queryClient.invalidateQueries({
-        queryKey: taskQueryKeys.repoData(repo),
+        queryKey: taskQueryKeys.repoData(repo, DEFAULT_KANBAN_SETTINGS.doneVisibleDays),
         exact: true,
       });
       return saved;
@@ -139,7 +143,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
         queryKey: documentQueryKeys.all,
       });
       await queryClient.invalidateQueries({
-        queryKey: taskQueryKeys.repoData(repo),
+        queryKey: taskQueryKeys.repoData(repo, DEFAULT_KANBAN_SETTINGS.doneVisibleDays),
         exact: true,
       });
       return saved;

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
@@ -1,8 +1,4 @@
-import {
-  DEFAULT_KANBAN_SETTINGS,
-  defaultSpecTemplateMarkdown,
-  validateSpecMarkdown,
-} from "@openducktor/contracts";
+import { defaultSpecTemplateMarkdown, validateSpecMarkdown } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import type { TaskDocumentPayload } from "../../../types/task-documents";
@@ -13,7 +9,7 @@ import {
   loadQaReportDocumentFromQuery,
   loadSpecDocumentFromQuery,
 } from "../../queries/documents";
-import { taskQueryKeys } from "../../queries/tasks";
+import { invalidateRepoTaskDataQueries } from "../../queries/tasks";
 import { host } from "../shared/host";
 import { requireActiveRepo } from "./task-operations-model";
 
@@ -94,10 +90,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await queryClient.invalidateQueries({
-        queryKey: taskQueryKeys.repoData(repo, DEFAULT_KANBAN_SETTINGS.doneVisibleDays),
-        exact: true,
-      });
+      await invalidateRepoTaskDataQueries(queryClient, repo);
       return saved;
     },
     [activeRepo, queryClient],
@@ -118,10 +111,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await queryClient.invalidateQueries({
-        queryKey: taskQueryKeys.repoData(repo, DEFAULT_KANBAN_SETTINGS.doneVisibleDays),
-        exact: true,
-      });
+      await invalidateRepoTaskDataQueries(queryClient, repo);
       return saved;
     },
     [activeRepo, queryClient],
@@ -142,10 +132,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await queryClient.invalidateQueries({
-        queryKey: taskQueryKeys.repoData(repo, DEFAULT_KANBAN_SETTINGS.doneVisibleDays),
-        exact: true,
-      });
+      await invalidateRepoTaskDataQueries(queryClient, repo);
       return saved;
     },
     [activeRepo, queryClient],

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
@@ -9,7 +9,7 @@ import {
   loadQaReportDocumentFromQuery,
   loadSpecDocumentFromQuery,
 } from "../../queries/documents";
-import { invalidateRepoTaskDataQueries } from "../../queries/tasks";
+import { invalidateRepoTaskListQueries } from "../../queries/tasks";
 import { host } from "../shared/host";
 import { requireActiveRepo } from "./task-operations-model";
 
@@ -90,7 +90,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await invalidateRepoTaskDataQueries(queryClient, repo);
+      await invalidateRepoTaskListQueries(queryClient, repo);
       return saved;
     },
     [activeRepo, queryClient],
@@ -111,7 +111,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await invalidateRepoTaskDataQueries(queryClient, repo);
+      await invalidateRepoTaskListQueries(queryClient, repo);
       return saved;
     },
     [activeRepo, queryClient],
@@ -132,7 +132,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await invalidateRepoTaskDataQueries(queryClient, repo);
+      await invalidateRepoTaskListQueries(queryClient, repo);
       return saved;
     },
     [activeRepo, queryClient],

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { BeadsCheck, RunSummary, TaskCard, TaskCreateInput } from "@openducktor/contracts";
+import type {
+  BeadsCheck,
+  RunSummary,
+  SettingsSnapshot,
+  TaskCard,
+  TaskCreateInput,
+} from "@openducktor/contracts";
 import type { PropsWithChildren, ReactElement } from "react";
 import { toast } from "sonner";
 import { clearAppQueryClient } from "@/lib/query-client";
@@ -17,6 +23,22 @@ const TASK_REFRESH_WARNING = "Pull request sync failed during task refresh";
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 const originalToastSuccess = toast.success;
+const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
+
+const DEFAULT_SETTINGS_SNAPSHOT: SettingsSnapshot = {
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  kanban: {
+    doneVisibleDays: 1,
+  },
+  repos: {},
+  globalPromptOverrides: {},
+};
 
 const createDeferred = <T,>() => {
   let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
@@ -114,6 +136,7 @@ const createHookHarness = (initialArgs: HookArgs) => {
 describe("use-task-operations", () => {
   beforeEach(async () => {
     await clearAppQueryClient();
+    host.workspaceGetSettingsSnapshot = mock(async () => DEFAULT_SETTINGS_SNAPSHOT);
     console.error = (...args: Parameters<typeof console.error>): void => {
       const [firstArg] = args;
       if (typeof firstArg === "string" && firstArg.startsWith(TASK_REFRESH_WARNING)) {
@@ -137,6 +160,7 @@ describe("use-task-operations", () => {
     console.error = originalConsoleError;
     console.warn = originalConsoleWarn;
     toast.success = originalToastSuccess;
+    host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
   });
 
   test("refreshTaskData filters deferred tasks and loads runs", async () => {
@@ -180,6 +204,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.status === "open");
       await harness.run(async (value) => {
         await value.refreshTaskData("/repo");
       });
@@ -444,6 +469,56 @@ describe("use-task-operations", () => {
     }
   });
 
+  test("surfaces settings load failures instead of silently using default Kanban visibility", async () => {
+    const settingsError = new Error("settings snapshot failed");
+    const workspaceGetSettingsSnapshot = mock(async () => {
+      throw settingsError;
+    });
+    const tasksList = mock(async () => [makeTask("A", "open")]);
+    const toastError = mock(() => {});
+
+    const original = {
+      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
+      tasksList: host.tasksList,
+      toastError: toast.error,
+    };
+    host.workspaceGetSettingsSnapshot = workspaceGetSettingsSnapshot;
+    host.tasksList = tasksList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        () =>
+          workspaceGetSettingsSnapshot.mock.calls.length > 0 && toastError.mock.calls.length > 0,
+      );
+
+      expect(tasksList).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith("Failed to load Kanban settings", {
+        description: "settings snapshot failed",
+      });
+      await expect(
+        harness.run(async (value) => {
+          await value.refreshTaskData("/repo");
+        }),
+      ).rejects.toThrow("settings snapshot failed");
+    } finally {
+      await harness.unmount();
+      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
+      host.tasksList = original.tasksList;
+      toast.error = original.toastError;
+    }
+  });
+
   test("syncPullRequests links a detected pull request for the task", async () => {
     const taskPullRequestDetect = mock(async () => ({
       outcome: "linked" as const,
@@ -502,6 +577,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => value.tasks.length === 1);
       tasksList.mockClear();
       runsList.mockClear();
       await harness.run(async (value) => {
@@ -563,6 +639,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => !value.isLoadingTasks);
 
       let syncPromise: Promise<void> | null = null;
       await harness.run((value) => {
@@ -652,6 +729,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => value.tasks.length === 1);
       tasksList.mockClear();
       runsList.mockClear();
       await harness.run(async (value) => {
@@ -729,6 +807,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => value.tasks.length === 1);
       tasksList.mockClear();
       runsList.mockClear();
       await harness.run(async (value) => {
@@ -829,6 +908,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => value.tasks.length === 1);
       tasksList.mockClear();
       runsList.mockClear();
       await harness.run(async (value) => {
@@ -880,6 +960,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => value.tasks.length === 1);
       tasksList.mockClear();
       runsList.mockClear();
       await harness.run(async (value) => {
@@ -966,6 +1047,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => value.tasks.length === 1);
       tasksList.mockClear();
       runsList.mockClear();
       await harness.run(async (value) => {
@@ -1063,6 +1145,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => !value.isLoadingTasks);
 
       let unlinkPromise: Promise<void> | null = null;
       await harness.run((value) => {
@@ -1211,6 +1294,7 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
+      await harness.waitFor((value) => value.tasks.length === 1);
       tasksList.mockClear();
       runsList.mockClear();
       await harness.run(async (value) => {

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -1,11 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type {
-  BeadsCheck,
-  RunSummary,
-  SettingsSnapshot,
-  TaskCard,
-  TaskCreateInput,
-} from "@openducktor/contracts";
+import type { BeadsCheck, RunSummary, TaskCard, TaskCreateInput } from "@openducktor/contracts";
 import type { PropsWithChildren, ReactElement } from "react";
 import { toast } from "sonner";
 import { clearAppQueryClient } from "@/lib/query-client";
@@ -23,22 +17,6 @@ const TASK_REFRESH_WARNING = "Pull request sync failed during task refresh";
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 const originalToastSuccess = toast.success;
-const originalWorkspaceGetSettingsSnapshot = host.workspaceGetSettingsSnapshot;
-
-const DEFAULT_SETTINGS_SNAPSHOT: SettingsSnapshot = {
-  theme: "light",
-  git: {
-    defaultMergeMethod: "merge_commit",
-  },
-  chat: {
-    showThinkingMessages: false,
-  },
-  kanban: {
-    doneVisibleDays: 1,
-  },
-  repos: {},
-  globalPromptOverrides: {},
-};
 
 const createDeferred = <T,>() => {
   let resolve: ((value: T | PromiseLike<T>) => void) | null = null;
@@ -136,7 +114,6 @@ const createHookHarness = (initialArgs: HookArgs) => {
 describe("use-task-operations", () => {
   beforeEach(async () => {
     await clearAppQueryClient();
-    host.workspaceGetSettingsSnapshot = mock(async () => DEFAULT_SETTINGS_SNAPSHOT);
     console.error = (...args: Parameters<typeof console.error>): void => {
       const [firstArg] = args;
       if (typeof firstArg === "string" && firstArg.startsWith(TASK_REFRESH_WARNING)) {
@@ -160,7 +137,6 @@ describe("use-task-operations", () => {
     console.error = originalConsoleError;
     console.warn = originalConsoleWarn;
     toast.success = originalToastSuccess;
-    host.workspaceGetSettingsSnapshot = originalWorkspaceGetSettingsSnapshot;
   });
 
   test("refreshTaskData filters deferred tasks and loads runs", async () => {
@@ -212,7 +188,7 @@ describe("use-task-operations", () => {
 
       expect(harness.getLatest().tasks.map((task) => task.id)).toEqual(["A"]);
       expect(harness.getLatest().runs).toHaveLength(1);
-      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
+      expect(tasksList).toHaveBeenCalledWith("/repo");
       expect(runsList).toHaveBeenCalledWith("/repo");
     } finally {
       await harness.unmount();
@@ -459,63 +435,13 @@ describe("use-task-operations", () => {
       });
 
       expect(repoPullRequestSync).toHaveBeenCalledWith("/repo");
-      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
+      expect(tasksList).toHaveBeenCalledWith("/repo");
       expect(harness.getLatest().tasks.map((task) => task.id)).toEqual(["A"]);
     } finally {
       await harness.unmount();
       host.repoPullRequestSync = original.repoPullRequestSync;
       host.tasksList = original.tasksList;
       host.runsList = original.runsList;
-    }
-  });
-
-  test("surfaces settings load failures instead of silently using default Kanban visibility", async () => {
-    const settingsError = new Error("settings snapshot failed");
-    const workspaceGetSettingsSnapshot = mock(async () => {
-      throw settingsError;
-    });
-    const tasksList = mock(async () => [makeTask("A", "open")]);
-    const toastError = mock(() => {});
-
-    const original = {
-      workspaceGetSettingsSnapshot: host.workspaceGetSettingsSnapshot,
-      tasksList: host.tasksList,
-      toastError: toast.error,
-    };
-    host.workspaceGetSettingsSnapshot = workspaceGetSettingsSnapshot;
-    host.tasksList = tasksList;
-    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
-
-    const harness = createHookHarness({
-      activeRepo: "/repo",
-      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
-        beadsOk: true,
-        beadsPath: "/repo/.beads",
-        beadsError: null,
-      }),
-    });
-
-    try {
-      await harness.mount();
-      await harness.waitFor(
-        () =>
-          workspaceGetSettingsSnapshot.mock.calls.length > 0 && toastError.mock.calls.length > 0,
-      );
-
-      expect(tasksList).not.toHaveBeenCalled();
-      expect(toastError).toHaveBeenCalledWith("Failed to load Kanban settings", {
-        description: "settings snapshot failed",
-      });
-      await expect(
-        harness.run(async (value) => {
-          await value.refreshTaskData("/repo");
-        }),
-      ).rejects.toThrow("settings snapshot failed");
-    } finally {
-      await harness.unmount();
-      host.workspaceGetSettingsSnapshot = original.workspaceGetSettingsSnapshot;
-      host.tasksList = original.tasksList;
-      toast.error = original.toastError;
     }
   });
 
@@ -585,7 +511,7 @@ describe("use-task-operations", () => {
       });
 
       expect(taskPullRequestDetect).toHaveBeenCalledWith("/repo", "A");
-      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
+      expect(tasksList).toHaveBeenCalledWith("/repo");
       expect(runsList).toHaveBeenCalledWith("/repo");
       expect(harness.getLatest().tasks[0]?.pullRequest?.number).toBe(17);
       expect(toastSuccess).toHaveBeenCalledWith("Pull request linked", {
@@ -828,7 +754,7 @@ describe("use-task-operations", () => {
         mergedAt: "2026-02-20T10:00:00Z",
         closedAt: "2026-02-20T10:00:00Z",
       });
-      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
+      expect(tasksList).toHaveBeenCalledWith("/repo");
       expect(runsList).toHaveBeenCalledWith("/repo");
       expect(harness.getLatest().pendingMergedPullRequest).toBeNull();
       expect(harness.getLatest().linkingMergedPullRequestTaskId).toBeNull();
@@ -1104,7 +1030,7 @@ describe("use-task-operations", () => {
       });
 
       expect(taskPullRequestUnlink).toHaveBeenCalledWith("/repo", "A");
-      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
+      expect(tasksList).toHaveBeenCalledWith("/repo");
       expect(runsList).toHaveBeenCalledWith("/repo");
       expect(harness.getLatest().tasks[0]?.pullRequest).toBeUndefined();
       expect(toastSuccess).toHaveBeenCalledWith("Pull request unlinked", {

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -187,7 +187,7 @@ describe("use-task-operations", () => {
 
       expect(harness.getLatest().tasks.map((task) => task.id)).toEqual(["A"]);
       expect(harness.getLatest().runs).toHaveLength(1);
-      expect(tasksList).toHaveBeenCalledWith("/repo");
+      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
       expect(runsList).toHaveBeenCalledWith("/repo");
     } finally {
       await harness.unmount();
@@ -434,7 +434,7 @@ describe("use-task-operations", () => {
       });
 
       expect(repoPullRequestSync).toHaveBeenCalledWith("/repo");
-      expect(tasksList).toHaveBeenCalledWith("/repo");
+      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
       expect(harness.getLatest().tasks.map((task) => task.id)).toEqual(["A"]);
     } finally {
       await harness.unmount();
@@ -509,7 +509,7 @@ describe("use-task-operations", () => {
       });
 
       expect(taskPullRequestDetect).toHaveBeenCalledWith("/repo", "A");
-      expect(tasksList).toHaveBeenCalledWith("/repo");
+      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
       expect(runsList).toHaveBeenCalledWith("/repo");
       expect(harness.getLatest().tasks[0]?.pullRequest?.number).toBe(17);
       expect(toastSuccess).toHaveBeenCalledWith("Pull request linked", {
@@ -749,7 +749,7 @@ describe("use-task-operations", () => {
         mergedAt: "2026-02-20T10:00:00Z",
         closedAt: "2026-02-20T10:00:00Z",
       });
-      expect(tasksList).toHaveBeenCalledWith("/repo");
+      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
       expect(runsList).toHaveBeenCalledWith("/repo");
       expect(harness.getLatest().pendingMergedPullRequest).toBeNull();
       expect(harness.getLatest().linkingMergedPullRequestTaskId).toBeNull();
@@ -1022,7 +1022,7 @@ describe("use-task-operations", () => {
       });
 
       expect(taskPullRequestUnlink).toHaveBeenCalledWith("/repo", "A");
-      expect(tasksList).toHaveBeenCalledWith("/repo");
+      expect(tasksList).toHaveBeenCalledWith("/repo", 1);
       expect(runsList).toHaveBeenCalledWith("/repo");
       expect(harness.getLatest().tasks[0]?.pullRequest).toBeUndefined();
       expect(toastSuccess).toHaveBeenCalledWith("Pull request unlinked", {

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -1,11 +1,12 @@
-import type {
-  BeadsCheck,
-  PullRequest,
-  RunSummary,
-  TaskCard,
-  TaskCreateInput,
-  TaskStatus,
-  TaskUpdatePatch,
+import {
+  type BeadsCheck,
+  DEFAULT_KANBAN_SETTINGS,
+  type PullRequest,
+  type RunSummary,
+  type TaskCard,
+  type TaskCreateInput,
+  type TaskStatus,
+  type TaskUpdatePatch,
 } from "@openducktor/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -19,6 +20,7 @@ import {
   loadRepoTaskDataFromQuery,
   repoTaskDataQueryOptions,
 } from "../../queries/tasks";
+import { settingsSnapshotQueryOptions } from "../../queries/workspace";
 import { host } from "../shared/host";
 import {
   DEFERRED_BY_USER_REASON,
@@ -75,8 +77,11 @@ export function useTaskOperations({
     pullRequest: PullRequest;
   } | null>(null);
   const activeRepoRef = useRef(activeRepo);
+  const settingsSnapshotQuery = useQuery(settingsSnapshotQueryOptions());
+  const doneVisibleDays =
+    settingsSnapshotQuery.data?.kanban.doneVisibleDays ?? DEFAULT_KANBAN_SETTINGS.doneVisibleDays;
   const repoTaskDataQuery = useQuery({
-    ...repoTaskDataQueryOptions(activeRepo ?? "__disabled__"),
+    ...repoTaskDataQueryOptions(activeRepo ?? "__disabled__", doneVisibleDays),
     enabled: activeRepo !== null,
   });
 
@@ -95,9 +100,9 @@ export function useTaskOperations({
   const refreshTaskData = useCallback(
     async (repoPath: string): Promise<void> => {
       await invalidateRepoTaskQueries(queryClient, repoPath);
-      await loadRepoTaskDataFromQuery(queryClient, repoPath);
+      await loadRepoTaskDataFromQuery(queryClient, repoPath, doneVisibleDays);
     },
-    [queryClient],
+    [doneVisibleDays, queryClient],
   );
 
   const runTaskMutation = useCallback(

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -19,10 +19,6 @@ import {
   loadRepoTaskDataFromQuery,
   repoTaskDataQueryOptions,
 } from "../../queries/tasks";
-import {
-  loadSettingsSnapshotFromQuery,
-  settingsSnapshotQueryOptions,
-} from "../../queries/workspace";
 import { host } from "../shared/host";
 import {
   DEFERRED_BY_USER_REASON,
@@ -79,12 +75,9 @@ export function useTaskOperations({
     pullRequest: PullRequest;
   } | null>(null);
   const activeRepoRef = useRef(activeRepo);
-  const reportedSettingsErrorRef = useRef<string | null>(null);
-  const settingsSnapshotQuery = useQuery(settingsSnapshotQueryOptions());
-  const doneVisibleDays = settingsSnapshotQuery.data?.kanban.doneVisibleDays;
   const repoTaskDataQuery = useQuery({
-    ...repoTaskDataQueryOptions(activeRepo ?? "__disabled__", doneVisibleDays ?? 0),
-    enabled: activeRepo !== null && doneVisibleDays !== undefined,
+    ...repoTaskDataQueryOptions(activeRepo ?? "__disabled__"),
+    enabled: activeRepo !== null,
   });
 
   useEffect(() => {
@@ -99,32 +92,10 @@ export function useTaskOperations({
     }
   }, [activeRepo]);
 
-  useEffect(() => {
-    if (!settingsSnapshotQuery.isError) {
-      reportedSettingsErrorRef.current = null;
-      return;
-    }
-
-    const description = errorMessage(settingsSnapshotQuery.error);
-    if (reportedSettingsErrorRef.current === description) {
-      return;
-    }
-
-    reportedSettingsErrorRef.current = description;
-    toast.error("Failed to load Kanban settings", {
-      description,
-    });
-  }, [settingsSnapshotQuery.error, settingsSnapshotQuery.isError]);
-
   const refreshTaskData = useCallback(
     async (repoPath: string): Promise<void> => {
-      const settingsSnapshot = await loadSettingsSnapshotFromQuery(queryClient);
       await invalidateRepoTaskQueries(queryClient, repoPath);
-      await loadRepoTaskDataFromQuery(
-        queryClient,
-        repoPath,
-        settingsSnapshot.kanban.doneVisibleDays,
-      );
+      await loadRepoTaskDataFromQuery(queryClient, repoPath);
     },
     [queryClient],
   );
@@ -453,10 +424,7 @@ export function useTaskOperations({
   const runs = activeRepo ? (repoTaskDataQuery.data?.runs ?? []) : [];
   const isLoadingTasks =
     isManualLoadingTasks ||
-    (activeRepo !== null &&
-      (settingsSnapshotQuery.isPending ||
-        (doneVisibleDays !== undefined &&
-          (repoTaskDataQuery.isPending || repoTaskDataQuery.isFetching))));
+    (activeRepo !== null && (repoTaskDataQuery.isPending || repoTaskDataQuery.isFetching));
 
   return {
     tasks,

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -1,12 +1,11 @@
-import {
-  type BeadsCheck,
-  DEFAULT_KANBAN_SETTINGS,
-  type PullRequest,
-  type RunSummary,
-  type TaskCard,
-  type TaskCreateInput,
-  type TaskStatus,
-  type TaskUpdatePatch,
+import type {
+  BeadsCheck,
+  PullRequest,
+  RunSummary,
+  TaskCard,
+  TaskCreateInput,
+  TaskStatus,
+  TaskUpdatePatch,
 } from "@openducktor/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -20,7 +19,10 @@ import {
   loadRepoTaskDataFromQuery,
   repoTaskDataQueryOptions,
 } from "../../queries/tasks";
-import { settingsSnapshotQueryOptions } from "../../queries/workspace";
+import {
+  loadSettingsSnapshotFromQuery,
+  settingsSnapshotQueryOptions,
+} from "../../queries/workspace";
 import { host } from "../shared/host";
 import {
   DEFERRED_BY_USER_REASON,
@@ -77,12 +79,12 @@ export function useTaskOperations({
     pullRequest: PullRequest;
   } | null>(null);
   const activeRepoRef = useRef(activeRepo);
+  const reportedSettingsErrorRef = useRef<string | null>(null);
   const settingsSnapshotQuery = useQuery(settingsSnapshotQueryOptions());
-  const doneVisibleDays =
-    settingsSnapshotQuery.data?.kanban.doneVisibleDays ?? DEFAULT_KANBAN_SETTINGS.doneVisibleDays;
+  const doneVisibleDays = settingsSnapshotQuery.data?.kanban.doneVisibleDays;
   const repoTaskDataQuery = useQuery({
-    ...repoTaskDataQueryOptions(activeRepo ?? "__disabled__", doneVisibleDays),
-    enabled: activeRepo !== null,
+    ...repoTaskDataQueryOptions(activeRepo ?? "__disabled__", doneVisibleDays ?? 0),
+    enabled: activeRepo !== null && doneVisibleDays !== undefined,
   });
 
   useEffect(() => {
@@ -97,12 +99,34 @@ export function useTaskOperations({
     }
   }, [activeRepo]);
 
+  useEffect(() => {
+    if (!settingsSnapshotQuery.isError) {
+      reportedSettingsErrorRef.current = null;
+      return;
+    }
+
+    const description = errorMessage(settingsSnapshotQuery.error);
+    if (reportedSettingsErrorRef.current === description) {
+      return;
+    }
+
+    reportedSettingsErrorRef.current = description;
+    toast.error("Failed to load Kanban settings", {
+      description,
+    });
+  }, [settingsSnapshotQuery.error, settingsSnapshotQuery.isError]);
+
   const refreshTaskData = useCallback(
     async (repoPath: string): Promise<void> => {
+      const settingsSnapshot = await loadSettingsSnapshotFromQuery(queryClient);
       await invalidateRepoTaskQueries(queryClient, repoPath);
-      await loadRepoTaskDataFromQuery(queryClient, repoPath, doneVisibleDays);
+      await loadRepoTaskDataFromQuery(
+        queryClient,
+        repoPath,
+        settingsSnapshot.kanban.doneVisibleDays,
+      );
     },
-    [doneVisibleDays, queryClient],
+    [queryClient],
   );
 
   const runTaskMutation = useCallback(
@@ -429,7 +453,10 @@ export function useTaskOperations({
   const runs = activeRepo ? (repoTaskDataQuery.data?.runs ?? []) : [];
   const isLoadingTasks =
     isManualLoadingTasks ||
-    (activeRepo !== null && (repoTaskDataQuery.isPending || repoTaskDataQuery.isFetching));
+    (activeRepo !== null &&
+      (settingsSnapshotQuery.isPending ||
+        (doneVisibleDays !== undefined &&
+          (repoTaskDataQuery.isPending || repoTaskDataQuery.isFetching))));
 
   return {
     tasks,

--- a/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -104,6 +104,9 @@ describe("use-repo-settings-operations", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {},
       globalPromptOverrides: {},
     }));
@@ -129,6 +132,9 @@ describe("use-repo-settings-operations", () => {
         chat: {
           showThinkingMessages: false,
         },
+        kanban: {
+          doneVisibleDays: 1,
+        },
         repos: {},
         globalPromptOverrides: {},
       });
@@ -139,6 +145,9 @@ describe("use-repo-settings-operations", () => {
         },
         chat: {
           showThinkingMessages: false,
+        },
+        kanban: {
+          doneVisibleDays: 1,
         },
         repos: {},
         globalPromptOverrides: {},
@@ -349,6 +358,9 @@ describe("use-repo-settings-operations", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {},
       globalPromptOverrides: {},
     }));
@@ -519,6 +531,9 @@ describe("use-repo-settings-operations", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {},
       globalPromptOverrides: {},
     }));
@@ -544,6 +559,9 @@ describe("use-repo-settings-operations", () => {
         chat: {
           showThinkingMessages: false,
         },
+        kanban: {
+          doneVisibleDays: 1,
+        },
         repos: {},
         globalPromptOverrides: {},
       });
@@ -568,6 +586,9 @@ describe("use-repo-settings-operations", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {},
       globalPromptOverrides: {},
     }));
@@ -591,6 +612,9 @@ describe("use-repo-settings-operations", () => {
       },
       chat: {
         showThinkingMessages: false,
+      },
+      kanban: {
+        doneVisibleDays: 1,
       },
       repos: {},
       globalPromptOverrides: {},
@@ -657,6 +681,9 @@ describe("use-repo-settings-operations", () => {
       },
       chat: {
         showThinkingMessages: false,
+      },
+      kanban: {
+        doneVisibleDays: 1,
       },
       repos: {
         "/repo-a": {

--- a/apps/desktop/src/state/queries/tasks.test.ts
+++ b/apps/desktop/src/state/queries/tasks.test.ts
@@ -46,24 +46,31 @@ const sessionFixture: AgentSessionRecord = {
 describe("tasks query cache helpers", () => {
   test("upsertAgentSessionInRepoTaskData inserts a persisted session into the repo task cache", () => {
     const queryClient = new QueryClient();
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS), {
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo"), {
       tasks: [taskFixture],
       runs: [] satisfies RunSummary[],
     });
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo", DONE_VISIBLE_DAYS), [
+      taskFixture,
+    ] satisfies TaskCard[]);
 
     upsertAgentSessionInRepoTaskData(queryClient, "/repo", "task-1", sessionFixture);
 
     const repoTaskData = queryClient.getQueryData<{
       tasks: TaskCard[];
       runs: RunSummary[];
-    }>(taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS));
+    }>(taskQueryKeys.repoData("/repo"));
+    const kanbanTasks = queryClient.getQueryData<TaskCard[]>(
+      taskQueryKeys.kanbanData("/repo", DONE_VISIBLE_DAYS),
+    );
 
     expect(repoTaskData?.tasks[0]?.agentSessions).toEqual([sessionFixture]);
+    expect(kanbanTasks?.[0]?.agentSessions).toEqual([sessionFixture]);
   });
 
   test("upsertAgentSessionInRepoTaskData replaces the existing persisted session for the same id", () => {
     const queryClient = new QueryClient();
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS), {
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo"), {
       tasks: [
         {
           ...taskFixture,
@@ -72,6 +79,12 @@ describe("tasks query cache helpers", () => {
       ],
       runs: [] satisfies RunSummary[],
     });
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo", DONE_VISIBLE_DAYS), [
+      {
+        ...taskFixture,
+        agentSessions: [sessionFixture],
+      },
+    ] satisfies TaskCard[]);
 
     const updatedSession: AgentSessionRecord = {
       ...sessionFixture,
@@ -83,8 +96,12 @@ describe("tasks query cache helpers", () => {
     const repoTaskData = queryClient.getQueryData<{
       tasks: TaskCard[];
       runs: RunSummary[];
-    }>(taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS));
+    }>(taskQueryKeys.repoData("/repo"));
+    const kanbanTasks = queryClient.getQueryData<TaskCard[]>(
+      taskQueryKeys.kanbanData("/repo", DONE_VISIBLE_DAYS),
+    );
 
     expect(repoTaskData?.tasks[0]?.agentSessions).toEqual([updatedSession]);
+    expect(kanbanTasks?.[0]?.agentSessions).toEqual([updatedSession]);
   });
 });

--- a/apps/desktop/src/state/queries/tasks.test.ts
+++ b/apps/desktop/src/state/queries/tasks.test.ts
@@ -3,6 +3,8 @@ import type { AgentSessionRecord, RunSummary, TaskCard } from "@openducktor/cont
 import { QueryClient } from "@tanstack/react-query";
 import { taskQueryKeys, upsertAgentSessionInRepoTaskData } from "./tasks";
 
+const DONE_VISIBLE_DAYS = 1;
+
 const taskFixture: TaskCard = {
   id: "task-1",
   title: "Task",
@@ -44,7 +46,7 @@ const sessionFixture: AgentSessionRecord = {
 describe("tasks query cache helpers", () => {
   test("upsertAgentSessionInRepoTaskData inserts a persisted session into the repo task cache", () => {
     const queryClient = new QueryClient();
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo"), {
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS), {
       tasks: [taskFixture],
       runs: [] satisfies RunSummary[],
     });
@@ -54,14 +56,14 @@ describe("tasks query cache helpers", () => {
     const repoTaskData = queryClient.getQueryData<{
       tasks: TaskCard[];
       runs: RunSummary[];
-    }>(taskQueryKeys.repoData("/repo"));
+    }>(taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS));
 
     expect(repoTaskData?.tasks[0]?.agentSessions).toEqual([sessionFixture]);
   });
 
   test("upsertAgentSessionInRepoTaskData replaces the existing persisted session for the same id", () => {
     const queryClient = new QueryClient();
-    queryClient.setQueryData(taskQueryKeys.repoData("/repo"), {
+    queryClient.setQueryData(taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS), {
       tasks: [
         {
           ...taskFixture,
@@ -81,7 +83,7 @@ describe("tasks query cache helpers", () => {
     const repoTaskData = queryClient.getQueryData<{
       tasks: TaskCard[];
       runs: RunSummary[];
-    }>(taskQueryKeys.repoData("/repo"));
+    }>(taskQueryKeys.repoData("/repo", DONE_VISIBLE_DAYS));
 
     expect(repoTaskData?.tasks[0]?.agentSessions).toEqual([updatedSession]);
   });

--- a/apps/desktop/src/state/queries/tasks.ts
+++ b/apps/desktop/src/state/queries/tasks.ts
@@ -13,16 +13,18 @@ type RepoTaskData = {
 
 export const taskQueryKeys = {
   all: ["tasks"] as const,
-  repoData: (repoPath: string) => [...taskQueryKeys.all, "repo-data", repoPath] as const,
+  repoDataPrefix: (repoPath: string) => [...taskQueryKeys.all, "repo-data", repoPath] as const,
+  repoData: (repoPath: string, doneVisibleDays: number) =>
+    [...taskQueryKeys.repoDataPrefix(repoPath), doneVisibleDays] as const,
   runs: (repoPath: string) => [...taskQueryKeys.all, "runs", repoPath] as const,
 };
 
-export const repoTaskDataQueryOptions = (repoPath: string) =>
+export const repoTaskDataQueryOptions = (repoPath: string, doneVisibleDays: number) =>
   queryOptions({
-    queryKey: taskQueryKeys.repoData(repoPath),
+    queryKey: taskQueryKeys.repoData(repoPath, doneVisibleDays),
     queryFn: async (): Promise<RepoTaskData> => {
       const [taskList, runList] = await Promise.all([
-        host.tasksList(repoPath),
+        host.tasksList(repoPath, doneVisibleDays),
         host.runsList(repoPath),
       ]);
 
@@ -44,12 +46,13 @@ const repoRunsQueryOptions = (repoPath: string) =>
 export const loadRepoTaskDataFromQuery = (
   queryClient: QueryClient,
   repoPath: string,
+  doneVisibleDays: number,
 ): Promise<RepoTaskData> =>
   queryClient.fetchQuery({
-    ...repoTaskDataQueryOptions(repoPath),
+    ...repoTaskDataQueryOptions(repoPath, doneVisibleDays),
     queryFn: async (): Promise<RepoTaskData> => {
       const [taskList, runList] = await Promise.all([
-        host.tasksList(repoPath),
+        host.tasksList(repoPath, doneVisibleDays),
         host.runsList(repoPath),
       ]);
       const repoTaskData = {
@@ -72,8 +75,8 @@ export const invalidateRepoTaskQueries = (
 ): Promise<unknown[]> => {
   return Promise.all([
     queryClient.invalidateQueries({
-      queryKey: taskQueryKeys.repoData(repoPath),
-      exact: true,
+      queryKey: taskQueryKeys.repoDataPrefix(repoPath),
+      exact: false,
       refetchType: "none",
     }),
     queryClient.invalidateQueries({
@@ -90,8 +93,11 @@ export const upsertAgentSessionInRepoTaskData = (
   taskId: string,
   session: AgentSessionRecord,
 ): void => {
-  queryClient.setQueryData<RepoTaskData | undefined>(
-    taskQueryKeys.repoData(repoPath),
+  queryClient.setQueriesData<RepoTaskData | undefined>(
+    {
+      queryKey: taskQueryKeys.repoDataPrefix(repoPath),
+      exact: false,
+    },
     (current): RepoTaskData | undefined => {
       if (!current) {
         return current;

--- a/apps/desktop/src/state/queries/tasks.ts
+++ b/apps/desktop/src/state/queries/tasks.ts
@@ -69,16 +69,26 @@ export const loadRepoRunsFromQuery = (
   repoPath: string,
 ): Promise<RunSummary[]> => queryClient.fetchQuery(repoRunsQueryOptions(repoPath));
 
+export const invalidateRepoTaskDataQueries = (
+  queryClient: QueryClient,
+  repoPath: string,
+  options?: {
+    refetchType?: "active" | "inactive" | "all" | "none";
+  },
+) => {
+  return queryClient.invalidateQueries({
+    queryKey: taskQueryKeys.repoDataPrefix(repoPath),
+    exact: false,
+    ...(options?.refetchType ? { refetchType: options.refetchType } : {}),
+  });
+};
+
 export const invalidateRepoTaskQueries = (
   queryClient: QueryClient,
   repoPath: string,
 ): Promise<unknown[]> => {
   return Promise.all([
-    queryClient.invalidateQueries({
-      queryKey: taskQueryKeys.repoDataPrefix(repoPath),
-      exact: false,
-      refetchType: "none",
-    }),
+    invalidateRepoTaskDataQueries(queryClient, repoPath, { refetchType: "none" }),
     queryClient.invalidateQueries({
       queryKey: taskQueryKeys.runs(repoPath),
       exact: true,

--- a/apps/desktop/src/state/queries/tasks.ts
+++ b/apps/desktop/src/state/queries/tasks.ts
@@ -13,18 +13,19 @@ type RepoTaskData = {
 
 export const taskQueryKeys = {
   all: ["tasks"] as const,
-  repoDataPrefix: (repoPath: string) => [...taskQueryKeys.all, "repo-data", repoPath] as const,
-  repoData: (repoPath: string, doneVisibleDays: number) =>
-    [...taskQueryKeys.repoDataPrefix(repoPath), doneVisibleDays] as const,
+  repoData: (repoPath: string) => [...taskQueryKeys.all, "repo-data", repoPath] as const,
+  kanbanDataPrefix: (repoPath: string) => [...taskQueryKeys.all, "kanban-data", repoPath] as const,
+  kanbanData: (repoPath: string, doneVisibleDays: number) =>
+    [...taskQueryKeys.kanbanDataPrefix(repoPath), doneVisibleDays] as const,
   runs: (repoPath: string) => [...taskQueryKeys.all, "runs", repoPath] as const,
 };
 
-export const repoTaskDataQueryOptions = (repoPath: string, doneVisibleDays: number) =>
+export const repoTaskDataQueryOptions = (repoPath: string) =>
   queryOptions({
-    queryKey: taskQueryKeys.repoData(repoPath, doneVisibleDays),
+    queryKey: taskQueryKeys.repoData(repoPath),
     queryFn: async (): Promise<RepoTaskData> => {
       const [taskList, runList] = await Promise.all([
-        host.tasksList(repoPath, doneVisibleDays),
+        host.tasksList(repoPath),
         host.runsList(repoPath),
       ]);
 
@@ -32,6 +33,16 @@ export const repoTaskDataQueryOptions = (repoPath: string, doneVisibleDays: numb
         tasks: toVisibleTasks(taskList),
         runs: runList,
       };
+    },
+    staleTime: TASK_DATA_STALE_TIME_MS,
+  });
+
+export const kanbanTaskListQueryOptions = (repoPath: string, doneVisibleDays: number) =>
+  queryOptions({
+    queryKey: taskQueryKeys.kanbanData(repoPath, doneVisibleDays),
+    queryFn: async (): Promise<TaskCard[]> => {
+      const taskList = await host.tasksList(repoPath, doneVisibleDays);
+      return toVisibleTasks(taskList);
     },
     staleTime: TASK_DATA_STALE_TIME_MS,
   });
@@ -46,13 +57,12 @@ const repoRunsQueryOptions = (repoPath: string) =>
 export const loadRepoTaskDataFromQuery = (
   queryClient: QueryClient,
   repoPath: string,
-  doneVisibleDays: number,
 ): Promise<RepoTaskData> =>
   queryClient.fetchQuery({
-    ...repoTaskDataQueryOptions(repoPath, doneVisibleDays),
+    ...repoTaskDataQueryOptions(repoPath),
     queryFn: async (): Promise<RepoTaskData> => {
       const [taskList, runList] = await Promise.all([
-        host.tasksList(repoPath, doneVisibleDays),
+        host.tasksList(repoPath),
         host.runsList(repoPath),
       ]);
       const repoTaskData = {
@@ -77,10 +87,37 @@ export const invalidateRepoTaskDataQueries = (
   },
 ) => {
   return queryClient.invalidateQueries({
-    queryKey: taskQueryKeys.repoDataPrefix(repoPath),
+    queryKey: taskQueryKeys.repoData(repoPath),
+    exact: true,
+    ...(options?.refetchType ? { refetchType: options.refetchType } : {}),
+  });
+};
+
+export const invalidateKanbanTaskQueries = (
+  queryClient: QueryClient,
+  repoPath: string,
+  options?: {
+    refetchType?: "active" | "inactive" | "all" | "none";
+  },
+) => {
+  return queryClient.invalidateQueries({
+    queryKey: taskQueryKeys.kanbanDataPrefix(repoPath),
     exact: false,
     ...(options?.refetchType ? { refetchType: options.refetchType } : {}),
   });
+};
+
+export const invalidateRepoTaskListQueries = (
+  queryClient: QueryClient,
+  repoPath: string,
+  options?: {
+    refetchType?: "active" | "inactive" | "all" | "none";
+  },
+) => {
+  return Promise.all([
+    invalidateRepoTaskDataQueries(queryClient, repoPath, options),
+    invalidateKanbanTaskQueries(queryClient, repoPath, options),
+  ]);
 };
 
 export const invalidateRepoTaskQueries = (
@@ -88,7 +125,7 @@ export const invalidateRepoTaskQueries = (
   repoPath: string,
 ): Promise<unknown[]> => {
   return Promise.all([
-    invalidateRepoTaskDataQueries(queryClient, repoPath, { refetchType: "none" }),
+    invalidateRepoTaskListQueries(queryClient, repoPath, { refetchType: "none" }),
     queryClient.invalidateQueries({
       queryKey: taskQueryKeys.runs(repoPath),
       exact: true,
@@ -103,18 +140,58 @@ export const upsertAgentSessionInRepoTaskData = (
   taskId: string,
   session: AgentSessionRecord,
 ): void => {
-  queryClient.setQueriesData<RepoTaskData | undefined>(
+  const updateRepoTaskData = (current: RepoTaskData | undefined): RepoTaskData | undefined => {
+    if (!current) {
+      return current;
+    }
+
+    let didChange = false;
+    const nextTasks = current.tasks.map((task) => {
+      if (task.id !== taskId) {
+        return task;
+      }
+
+      const currentAgentSessions = task.agentSessions ?? [];
+      const existingIndex = currentAgentSessions.findIndex(
+        (entry) => entry.sessionId === session.sessionId,
+      );
+      const existingSession =
+        existingIndex === -1 ? null : (currentAgentSessions[existingIndex] ?? null);
+      if (existingSession === session) {
+        return task;
+      }
+
+      const nextAgentSessions =
+        existingIndex === -1
+          ? [...currentAgentSessions, session]
+          : currentAgentSessions.map((entry, index) => (index === existingIndex ? session : entry));
+
+      didChange = true;
+      return {
+        ...task,
+        agentSessions: nextAgentSessions,
+      };
+    });
+
+    return didChange ? { ...current, tasks: nextTasks } : current;
+  };
+
+  queryClient.setQueryData<RepoTaskData | undefined>(
+    taskQueryKeys.repoData(repoPath),
+    updateRepoTaskData,
+  );
+  queryClient.setQueriesData<TaskCard[] | undefined>(
     {
-      queryKey: taskQueryKeys.repoDataPrefix(repoPath),
+      queryKey: taskQueryKeys.kanbanDataPrefix(repoPath),
       exact: false,
     },
-    (current): RepoTaskData | undefined => {
+    (current): TaskCard[] | undefined => {
       if (!current) {
         return current;
       }
 
       let didChange = false;
-      const nextTasks = current.tasks.map((task) => {
+      const nextTasks = current.map((task) => {
         if (task.id !== taskId) {
           return task;
         }
@@ -143,7 +220,7 @@ export const upsertAgentSessionInRepoTaskData = (
         };
       });
 
-      return didChange ? { ...current, tasks: nextTasks } : current;
+      return didChange ? nextTasks : current;
     },
   );
 };

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -455,6 +455,9 @@ describe("TauriHostClient", () => {
           chat: {
             showThinkingMessages: false,
           },
+          kanban: {
+            doneVisibleDays: 1,
+          },
           repos: {
             "/repo": {
               defaultRuntimeKind: "opencode",
@@ -513,6 +516,9 @@ describe("TauriHostClient", () => {
       chat: {
         showThinkingMessages: false,
       },
+      kanban: {
+        doneVisibleDays: 1,
+      },
       repos: {
         "/repo": {
           defaultRuntimeKind: "opencode",
@@ -543,6 +549,9 @@ describe("TauriHostClient", () => {
             },
             chat: {
               showThinkingMessages: false,
+            },
+            kanban: {
+              doneVisibleDays: 1,
             },
             repos: {
               "/repo": {

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -62,8 +62,11 @@ export class TauriTaskClient {
     return repoPath;
   }
 
-  async tasksList(repoPath: string): Promise<TaskCard[]> {
-    const payload = await this.invokeFn("tasks_list", { repoPath });
+  async tasksList(repoPath: string, doneVisibleDays?: number): Promise<TaskCard[]> {
+    const payload = await this.invokeFn("tasks_list", {
+      repoPath,
+      doneVisibleDays: doneVisibleDays ?? undefined,
+    });
     return parseArray(taskCardSchema, payload, "tasks_list");
   }
 

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -65,7 +65,7 @@ export class TauriTaskClient {
   async tasksList(repoPath: string, doneVisibleDays?: number): Promise<TaskCard[]> {
     const payload = await this.invokeFn("tasks_list", {
       repoPath,
-      doneVisibleDays: doneVisibleDays ?? undefined,
+      doneVisibleDays,
     });
     return parseArray(taskCardSchema, payload, "tasks_list");
   }

--- a/packages/contracts/src/config-schemas.test.ts
+++ b/packages/contracts/src/config-schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { repoConfigSchema } from "./config-schemas";
+import { repoConfigSchema, settingsSnapshotSchema } from "./config-schemas";
 
 describe("config-schemas", () => {
   test("defaults dev servers to an empty array", () => {
@@ -56,5 +56,16 @@ describe("config-schemas", () => {
         devServers: [{ id: "frontend", name: "Frontend", command: "   " }],
       }),
     ).toThrow("Dev server command cannot be blank.");
+  });
+
+  test("defaults kanban done visibility to one day", () => {
+    const parsed = settingsSnapshotSchema.parse({
+      theme: "light",
+      git: { defaultMergeMethod: "merge_commit" },
+      repos: {},
+      globalPromptOverrides: {},
+    });
+
+    expect(parsed.kanban.doneVisibleDays).toBe(1);
   });
 });

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -14,6 +14,9 @@ const DEFAULT_SOFT_GUARDRAILS = {
 const DEFAULT_CHAT_SETTINGS = {
   showThinkingMessages: false,
 } as const;
+export const DEFAULT_KANBAN_SETTINGS = {
+  doneVisibleDays: 1,
+} as const;
 const DEFAULT_THEME = "light" as const;
 
 const nullableToOptional = <T extends z.ZodTypeAny>(schema: T) =>
@@ -108,6 +111,11 @@ export const chatSettingsSchema = z.object({
 });
 export type ChatSettings = z.infer<typeof chatSettingsSchema>;
 
+export const kanbanSettingsSchema = z.object({
+  doneVisibleDays: z.number().int().min(0).default(DEFAULT_KANBAN_SETTINGS.doneVisibleDays),
+});
+export type KanbanSettings = z.infer<typeof kanbanSettingsSchema>;
+
 const themeValueSchema = z.enum(["light", "dark"]);
 
 export const themeSchema = themeValueSchema.default(DEFAULT_THEME);
@@ -119,6 +127,7 @@ export const globalConfigSchema = z.object({
   theme: themeSchema,
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
   chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
+  kanban: kanbanSettingsSchema.default(DEFAULT_KANBAN_SETTINGS),
   repos: z.record(z.string(), repoConfigSchema).default({}),
   globalPromptOverrides: repoPromptOverridesSchema.default({}),
   recentRepos: z.array(z.string()).default([]),
@@ -129,6 +138,7 @@ export const settingsSnapshotSchema = z.object({
   theme: themeValueSchema,
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
   chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
+  kanban: kanbanSettingsSchema.default(DEFAULT_KANBAN_SETTINGS),
   repos: z.record(z.string(), repoConfigSchema).default({}),
   globalPromptOverrides: repoPromptOverridesSchema.default({}),
 });

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -46,6 +46,7 @@ import type {
   GitWorktreeSummary,
   GlobalConfig,
   IssueType,
+  KanbanSettings,
   PlanSubtaskInput,
   PlanSubtaskIssueType,
   PlanSubtaskPriority,
@@ -118,6 +119,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "parseAgentSessionTodoPayloadList",
   "beadsCheckSchema",
   "chatSettingsSchema",
+  "DEFAULT_KANBAN_SETTINGS",
   "devServerEventSchema",
   "devServerGroupStateSchema",
   "devServerLogLineSchema",
@@ -165,6 +167,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "gitWorktreeStatusSummarySchema",
   "gitWorktreeStatusSnapshotSchema",
   "gitWorktreeSummarySchema",
+  "kanbanSettingsSchema",
   "globalConfigSchema",
   "globalGitConfigSchema",
   "issueTypeSchema",
@@ -290,6 +293,7 @@ type ExportedTypeContract = {
   GitWorktreeStatusSnapshot: GitWorktreeStatusSnapshot;
   GitWorktreeSummary: GitWorktreeSummary;
   GlobalConfig: GlobalConfig;
+  KanbanSettings: KanbanSettings;
   IssueType: IssueType;
   PlanSubtaskInput: PlanSubtaskInput;
   PlanSubtaskIssueType: PlanSubtaskIssueType;
@@ -346,6 +350,7 @@ describe("contracts exports contract", () => {
     });
 
     expect(parsedSnapshot.chat.showThinkingMessages).toBe(false);
+    expect(parsedSnapshot.kanban.doneVisibleDays).toBe(1);
   });
 
   test("rejects settings snapshots without a theme", () => {


### PR DESCRIPTION
## Summary
- invalidate all repo task cache variants after spec and plan saves so non-default done visibility settings refresh correctly
- stop masking Kanban settings load failures in task operations and use the validated settings snapshot for refreshes
- clamp invalid negative persisted `doneVisibleDays` values in host config normalization and add regression coverage

## Testing
- bun test src/state/operations/tasks/use-task-operations.test.tsx src/state/operations/tasks/use-spec-operations.test.tsx src/state/queries/tasks.test.ts
- cd apps/desktop/src-tauri && cargo test -p host-infra-system config::tests::normalization
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kanban settings section to configure "Done tasks visible for" (defaults to 1 day).
  * Kanban board now supports loading recent completed tasks based on that setting and exposes a UI control to adjust it.

* **Bug Fixes / Reliability**
  * Negative values are clamped to 0 to prevent invalid visibility windows.
  * Kanban task loading uses caching and shows helpful error toasts on load failures.

* **Tests**
  * Added tests covering Kanban listing, caching, and settings normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->