### PR TITLE
fix(agents): scroll chat to bottom when user sends message

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
@@ -45,6 +45,7 @@ const buildModel = () => ({
   composerFormRef: createRef<HTMLFormElement>(),
   composerTextareaRef: createRef<HTMLTextAreaElement>(),
   onComposerTextareaInput: () => {},
+  scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
 });
 
 describe("AgentChatComposer", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -42,6 +42,7 @@ const baseModel = {
   onToggleTodoPanel: () => {},
   todoPanelBottomOffset: 120,
   messagesContainerRef: createRef<HTMLDivElement>(),
+  scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
 } as const;
 
 const flush = async (): Promise<void> => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle, LoaderCircle, RefreshCcw, Sparkles } from "lucide-react";
-import { type ReactElement, useMemo, useRef } from "react";
+import { type ReactElement, useLayoutEffect, useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
@@ -71,6 +71,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     onToggleTodoPanel,
     todoPanelBottomOffset,
     messagesContainerRef,
+    scrollToBottomOnSendRef,
   } = model;
 
   const rows = useMemo(() => {
@@ -92,6 +93,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     bottomSentinelRef,
     scrollToBottom,
     scrollToTop,
+    scrollToBottomOnSend,
   } = useAgentChatWindow({
     rows,
     activeSessionId,
@@ -99,6 +101,11 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     messagesContainerRef,
     messagesContentRef,
   });
+
+  useLayoutEffect(() => {
+    scrollToBottomOnSendRef.current = scrollToBottomOnSend;
+  }, [scrollToBottomOnSend, scrollToBottomOnSendRef]);
+
   const showLoadingOverlay = useAgentChatLoadingOverlay({
     sessionId: activeSessionId,
     isSessionViewLoading,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -33,6 +33,7 @@ const buildModel = () => ({
     onToggleTodoPanel: () => {},
     todoPanelBottomOffset: 120,
     messagesContainerRef: createRef<HTMLDivElement>(),
+    scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
   },
   composer: {
     taskId: "task-1",
@@ -67,6 +68,7 @@ const buildModel = () => ({
     composerFormRef: createRef<HTMLFormElement>(),
     composerTextareaRef: createRef<HTMLTextAreaElement>(),
     onComposerTextareaInput: () => {},
+    scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
   },
 });
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -1,6 +1,6 @@
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
 import type { LucideIcon } from "lucide-react";
-import type { RefObject } from "react";
+import type { MutableRefObject, RefObject } from "react";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 
@@ -36,6 +36,7 @@ export type AgentChatThreadModel = {
   onToggleTodoPanel: () => void;
   todoPanelBottomOffset: number;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
+  scrollToBottomOnSendRef: MutableRefObject<(() => void) | null>;
 };
 
 export type AgentChatComposerModel = {
@@ -72,6 +73,7 @@ export type AgentChatComposerModel = {
   composerFormRef: RefObject<HTMLFormElement | null>;
   composerTextareaRef: RefObject<HTMLTextAreaElement | null>;
   onComposerTextareaInput: () => void;
+  scrollToBottomOnSendRef: MutableRefObject<(() => void) | null>;
 };
 
 export type AgentChatModel = {

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -268,14 +268,20 @@ export function useAgentChatScrollController({
     setIsNearTop(true);
   }, []);
 
+  /**
+   * Immediately scrolls the messages container to the bottom when the user sends a message.
+   * Cancels any in-flight auto-follow animation to prevent the animation from overriding
+   * the instant scroll position.
+   */
   const scrollToBottomOnSend = useCallback(() => {
     const container = messagesContainerRef.current;
     if (!container) return;
+    cancelScrollAnimation(true);
     container.scrollTo({
       top: container.scrollHeight,
       behavior: "instant",
     });
-  }, [messagesContainerRef]);
+  }, [cancelScrollAnimation, messagesContainerRef]);
 
   // Intentionally runs after every render so a pending anchor captured in refs
   // is applied on the next commit regardless of which state update caused it.

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -21,6 +21,7 @@ type UseAgentChatScrollControllerResult = {
   hasPendingScrollRequest: () => boolean;
   captureScrollAnchor: (rowKey: string) => void;
   syncBottomIfPinned: () => void;
+  scrollToBottomOnSend: () => void;
   requestWindowScroll: (request: PendingScrollRequest) => void;
   applyPendingScrollRequest: () => void;
   setBottomAnchoredState: (windowStart: number) => void;
@@ -267,6 +268,15 @@ export function useAgentChatScrollController({
     setIsNearTop(true);
   }, []);
 
+  const scrollToBottomOnSend = useCallback(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    container.scrollTo({
+      top: container.scrollHeight,
+      behavior: "instant",
+    });
+  }, [messagesContainerRef]);
+
   // Intentionally runs after every render so a pending anchor captured in refs
   // is applied on the next commit regardless of which state update caused it.
   useLayoutEffect(() => {
@@ -339,6 +349,7 @@ export function useAgentChatScrollController({
     hasPendingScrollRequest: () => pendingScrollRequestRef.current !== null,
     captureScrollAnchor,
     syncBottomIfPinned,
+    scrollToBottomOnSend,
     requestWindowScroll,
     applyPendingScrollRequest,
     setBottomAnchoredState,

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
@@ -26,6 +26,7 @@ type UseAgentChatWindowResult = {
   bottomSentinelRef: RefCallback<HTMLDivElement>;
   scrollToBottom: () => void;
   scrollToTop: () => void;
+  scrollToBottomOnSend: () => void;
 };
 
 export function useAgentChatWindow({
@@ -47,6 +48,7 @@ export function useAgentChatWindow({
     hasPendingScrollRequest,
     captureScrollAnchor,
     syncBottomIfPinned,
+    scrollToBottomOnSend,
     requestWindowScroll,
     applyPendingScrollRequest,
     setBottomAnchoredState,
@@ -110,5 +112,6 @@ export function useAgentChatWindow({
     bottomSentinelRef,
     scrollToBottom,
     scrollToTop,
+    scrollToBottomOnSend,
   };
 }

--- a/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
@@ -294,6 +294,7 @@ describe("agents-page-view-model", () => {
       onToggleTodoPanel,
       todoPanelBottomOffset: 12,
       messagesContainerRef: { current: null },
+      scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
       input: "message",
       isReadOnly: false,
       readOnlyReason: null,

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -129,6 +129,7 @@ type AgentChatThreadModelArgs = {
   onToggleTodoPanel: () => void;
   todoPanelBottomOffset: number;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
+  scrollToBottomOnSendRef: React.MutableRefObject<(() => void) | null>;
 };
 
 type AgentChatComposerModelArgs = {
@@ -161,6 +162,7 @@ type AgentChatComposerModelArgs = {
   composerFormRef: RefObject<HTMLFormElement | null>;
   composerTextareaRef: RefObject<HTMLTextAreaElement | null>;
   onComposerTextareaInput: () => void;
+  scrollToBottomOnSendRef: AgentChatModel["composer"]["scrollToBottomOnSendRef"];
 };
 
 export const buildAgentChatThreadModel = (
@@ -190,6 +192,7 @@ export const buildAgentChatThreadModel = (
   onToggleTodoPanel: args.onToggleTodoPanel,
   todoPanelBottomOffset: args.todoPanelBottomOffset,
   messagesContainerRef: args.messagesContainerRef,
+  scrollToBottomOnSendRef: args.scrollToBottomOnSendRef,
 });
 
 export const buildAgentChatComposerModel = (
@@ -224,6 +227,7 @@ export const buildAgentChatComposerModel = (
   composerFormRef: args.composerFormRef,
   composerTextareaRef: args.composerTextareaRef,
   onComposerTextareaInput: args.onComposerTextareaInput,
+  scrollToBottomOnSendRef: args.scrollToBottomOnSendRef,
 });
 
 export const buildAgentChatModel = (

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -1,6 +1,6 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { AgentChatModel } from "@/components/features/agents/agent-chat/agent-chat.types";
 import { useAgentChatLayout } from "@/components/features/agents/agent-chat/use-agent-chat-layout";
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents/agent-studio-task-tabs";
@@ -154,6 +154,8 @@ export function useAgentStudioPageModels({
     activeSessionId: threadSession?.sessionId ?? null,
   });
 
+  const scrollToBottomOnSendRef = useRef<(() => void) | null>(null);
+
   const agentStudioTaskTabsModel = useMemo(
     () =>
       buildAgentStudioTaskTabsModel({
@@ -292,6 +294,7 @@ export function useAgentStudioPageModels({
     onToggleTodoPanel: handleToggleTodoPanel,
     todoPanelBottomOffset,
     messagesContainerRef,
+    scrollToBottomOnSendRef,
   });
 
   const agentChatComposerModel = useAgentStudioComposerModel({
@@ -323,6 +326,7 @@ export function useAgentStudioPageModels({
     composerFormRef,
     composerTextareaRef,
     resizeComposerTextarea,
+    scrollToBottomOnSendRef,
   });
 
   const agentChatModel = useMemo(

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
@@ -35,6 +35,7 @@ const createHookArgs = (showThinkingMessages = false): HookArgs => ({
   onToggleTodoPanel: () => {},
   todoPanelBottomOffset: 0,
   messagesContainerRef: createRef<HTMLDivElement>(),
+  scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
 });
 
 const createHookHarness = (initialProps: HookArgs) =>

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -114,6 +114,7 @@ type UseAgentStudioThreadModelArgs = {
   onToggleTodoPanel: () => void;
   todoPanelBottomOffset: number;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
+  scrollToBottomOnSendRef: React.MutableRefObject<(() => void) | null>;
 };
 
 export const useAgentStudioThreadModel = ({
@@ -141,6 +142,7 @@ export const useAgentStudioThreadModel = ({
   onToggleTodoPanel,
   todoPanelBottomOffset,
   messagesContainerRef,
+  scrollToBottomOnSendRef,
 }: UseAgentStudioThreadModelArgs): ReturnType<typeof buildAgentChatThreadModel> => {
   const handleRefreshChecks = useCallback((): void => {
     void refreshChecks();
@@ -184,6 +186,7 @@ export const useAgentStudioThreadModel = ({
         onToggleTodoPanel,
         todoPanelBottomOffset,
         messagesContainerRef,
+        scrollToBottomOnSendRef,
       }),
     [
       activeSessionAgentColors,
@@ -203,6 +206,7 @@ export const useAgentStudioThreadModel = ({
       messagesContainerRef,
       onSubmitQuestionAnswers,
       permissionReplyErrorByRequestId,
+      scrollToBottomOnSendRef,
       selectedRoleAvailable,
       showThinkingMessages,
       taskId,
@@ -243,6 +247,7 @@ type UseAgentStudioComposerModelArgs = {
   composerFormRef: RefObject<HTMLFormElement | null>;
   composerTextareaRef: RefObject<HTMLTextAreaElement | null>;
   resizeComposerTextarea: () => void;
+  scrollToBottomOnSendRef: AgentChatModel["composer"]["scrollToBottomOnSendRef"];
 };
 
 export const useAgentStudioComposerModel = ({
@@ -274,6 +279,7 @@ export const useAgentStudioComposerModel = ({
   composerFormRef,
   composerTextareaRef,
   resizeComposerTextarea,
+  scrollToBottomOnSendRef,
 }: UseAgentStudioComposerModelArgs): ReturnType<typeof buildAgentChatComposerModel> => {
   const isModelSelectionPending = Boolean(
     activeSession?.isLoadingModelCatalog && !activeSession?.selectedModel,
@@ -285,7 +291,8 @@ export const useAgentStudioComposerModel = ({
 
   const handleSend = useCallback((): void => {
     void onSend();
-  }, [onSend]);
+    scrollToBottomOnSendRef.current?.();
+  }, [onSend, scrollToBottomOnSendRef]);
 
   const handleStopSession = useCallback((): void => {
     if (!activeSessionId) {
@@ -326,6 +333,7 @@ export const useAgentStudioComposerModel = ({
         composerFormRef,
         composerTextareaRef,
         onComposerTextareaInput: resizeComposerTextarea,
+        scrollToBottomOnSendRef,
       }),
     [
       activeSessionAgentColors,
@@ -351,6 +359,7 @@ export const useAgentStudioComposerModel = ({
       onSelectModel,
       onSelectVariant,
       resizeComposerTextarea,
+      scrollToBottomOnSendRef,
       selectedModelSelection,
       selectedRoleAvailable,
       selectedRoleReadOnlyReason,


### PR DESCRIPTION
## Summary
- Add `scrollToBottomOnSend` function to `useAgentChatScrollController` that instantly scrolls to bottom regardless of pinned state
- Expose via `useAgentChatWindow` and wire through `AgentChatThreadModel` and `AgentChatComposerModel` using a MutableRef
- `AgentChatThread` populates ref via `useLayoutEffect`; composer calls it after send

## Test Plan
- All 1377 desktop tests pass
- Typecheck and lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent chat exposes a "scroll to bottom on send" action so the view reliably jumps to the latest message after sending.

* **Tests**
  * Updated test fixtures and harnesses across agent chat to include and validate the new scroll-on-send ref.

* **Chores**
  * Wiring added so thread and composer share a coordinated scroll-on-send reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->