### PR TITLE
fix(agents): use ListTodo icon for todo tool calls

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -371,6 +371,16 @@ describe("agent-chat-message-card-model", () => {
           "",
         ),
       ).toBe("2 todos");
+
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "  todoread  ",
+            output: JSON.stringify({ todos: [{ id: "1" }] }),
+          }),
+          "",
+        ),
+      ).toBe("1 todo");
     });
 
     test("builds todo status summaries when counts are unavailable", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
@@ -4,6 +4,7 @@ import {
   FileText,
   Folder,
   Globe,
+  ListTodo,
   LoaderCircle,
   Search,
   ShieldCheck,
@@ -13,6 +14,7 @@ import {
 } from "lucide-react";
 import type { ReactElement } from "react";
 import { cn } from "@/lib/utils";
+import { isTodoToolName } from "@/state/operations/agent-orchestrator/agent-tool-messages";
 import { AgentChatFileEditCard } from "./agent-chat-file-edit-card";
 import {
   buildToolSummary,
@@ -60,6 +62,9 @@ const toolIcon = (toolName: string): ReactElement => {
   }
   if (value.startsWith("web")) {
     return <Globe className="size-3.5" />;
+  }
+  if (isTodoToolName(value)) {
+    return <ListTodo className="size-3.5" />;
   }
   return <Wrench className="size-3.5" />;
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -102,103 +102,62 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).toContain("fairnest-97f");
   });
 
-  test("renders ListTodo icon for todowrite tool rows", () => {
+  test.each([
+    {
+      id: "tool-todowrite",
+      tool: "todowrite",
+      content: "Tool todowrite completed",
+      timestamp: "2026-02-22T10:20:31.000Z",
+      input: { todos: [] },
+      output: "ok",
+    },
+    {
+      id: "tool-namespaced-todowrite",
+      tool: "openducktor_odt_todowrite",
+      content: "Tool openducktor_odt_todowrite completed",
+      timestamp: "2026-02-22T10:20:32.000Z",
+      input: { todos: [] },
+      output: "ok",
+    },
+    {
+      id: "tool-todoread",
+      tool: "todoread",
+      content: "Tool todoread completed",
+      timestamp: "2026-02-22T10:20:33.000Z",
+      input: {},
+      output: "[]",
+    },
+    {
+      id: "tool-namespaced-todoread",
+      tool: "openducktor_odt_todoread",
+      content: "Tool openducktor_odt_todoread completed",
+      timestamp: "2026-02-22T10:20:34.000Z",
+      input: {},
+      output: "[]",
+    },
+  ])("renders ListTodo icon for $tool tool rows", ({
+    id,
+    tool,
+    content,
+    timestamp,
+    input,
+    output,
+  }) => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {
         message: {
-          id: "tool-todowrite",
+          id,
           role: "tool",
-          content: "Tool todowrite completed",
-          timestamp: "2026-02-22T10:20:31.000Z",
+          content,
+          timestamp,
           meta: {
             kind: "tool",
-            partId: "part-todowrite",
-            callId: "call-todowrite",
-            tool: "todowrite",
+            partId: `part-${id}`,
+            callId: `call-${id}`,
+            tool,
             status: "completed",
-            input: { todos: [] },
-            output: "ok",
-          },
-        },
-        sessionRole: "build",
-        sessionSelectedModel: null,
-        sessionAgentColors: {},
-      }),
-    );
-
-    expect(html).toContain("lucide-list-todo");
-  });
-
-  test("renders ListTodo icon for namespaced todo tool rows", () => {
-    const html = renderToStaticMarkup(
-      createElement(AgentChatMessageCard, {
-        message: {
-          id: "tool-namespaced-todowrite",
-          role: "tool",
-          content: "Tool openducktor_odt_todowrite completed",
-          timestamp: "2026-02-22T10:20:32.000Z",
-          meta: {
-            kind: "tool",
-            partId: "part-namespaced-todowrite",
-            callId: "call-namespaced-todowrite",
-            tool: "openducktor_odt_todowrite",
-            status: "completed",
-            input: { todos: [] },
-            output: "ok",
-          },
-        },
-        sessionRole: "build",
-        sessionSelectedModel: null,
-        sessionAgentColors: {},
-      }),
-    );
-
-    expect(html).toContain("lucide-list-todo");
-  });
-
-  test("renders ListTodo icon for todoread tool rows", () => {
-    const html = renderToStaticMarkup(
-      createElement(AgentChatMessageCard, {
-        message: {
-          id: "tool-todoread",
-          role: "tool",
-          content: "Tool todoread completed",
-          timestamp: "2026-02-22T10:20:33.000Z",
-          meta: {
-            kind: "tool",
-            partId: "part-todoread",
-            callId: "call-todoread",
-            tool: "todoread",
-            status: "completed",
-            input: {},
-            output: "[]",
-          },
-        },
-        sessionRole: "build",
-        sessionSelectedModel: null,
-        sessionAgentColors: {},
-      }),
-    );
-
-    expect(html).toContain("lucide-list-todo");
-  });
-
-  test("renders ListTodo icon for namespaced todoread tool rows", () => {
-    const html = renderToStaticMarkup(
-      createElement(AgentChatMessageCard, {
-        message: {
-          id: "tool-namespaced-todoread",
-          role: "tool",
-          content: "Tool openducktor_odt_todoread completed",
-          timestamp: "2026-02-22T10:20:34.000Z",
-          meta: {
-            kind: "tool",
-            partId: "part-namespaced-todoread",
-            callId: "call-namespaced-todoread",
-            tool: "openducktor_odt_todoread",
-            status: "completed",
-            input: {},
-            output: "[]",
+            input,
+            output,
           },
         },
         sessionRole: "build",

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -102,6 +102,114 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).toContain("fairnest-97f");
   });
 
+  test("renders ListTodo icon for todowrite tool rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-todowrite",
+          role: "tool",
+          content: "Tool todowrite completed",
+          timestamp: "2026-02-22T10:20:31.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-todowrite",
+            callId: "call-todowrite",
+            tool: "todowrite",
+            status: "completed",
+            input: { todos: [] },
+            output: "ok",
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("lucide-list-todo");
+  });
+
+  test("renders ListTodo icon for namespaced todo tool rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-namespaced-todowrite",
+          role: "tool",
+          content: "Tool openducktor_odt_todowrite completed",
+          timestamp: "2026-02-22T10:20:32.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-namespaced-todowrite",
+            callId: "call-namespaced-todowrite",
+            tool: "openducktor_odt_todowrite",
+            status: "completed",
+            input: { todos: [] },
+            output: "ok",
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("lucide-list-todo");
+  });
+
+  test("renders ListTodo icon for todoread tool rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-todoread",
+          role: "tool",
+          content: "Tool todoread completed",
+          timestamp: "2026-02-22T10:20:33.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-todoread",
+            callId: "call-todoread",
+            tool: "todoread",
+            status: "completed",
+            input: {},
+            output: "[]",
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("lucide-list-todo");
+  });
+
+  test("renders ListTodo icon for namespaced todoread tool rows", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-namespaced-todoread",
+          role: "tool",
+          content: "Tool openducktor_odt_todoread completed",
+          timestamp: "2026-02-22T10:20:34.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-namespaced-todoread",
+            callId: "call-namespaced-todoread",
+            tool: "openducktor_odt_todoread",
+            status: "completed",
+            input: {},
+            output: "[]",
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("lucide-list-todo");
+  });
+
   test("renders file tool summaries relative to the session working directory", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
@@ -1,3 +1,4 @@
+import { isTodoToolName } from "@/state/operations/agent-orchestrator/agent-tool-messages";
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 import { extractPathFromInput, readInputString } from "./tool-input-utils";
 import { getToolLifecyclePhase, hasNonEmptyText } from "./tool-lifecycle";
@@ -130,15 +131,6 @@ const parseStructuredOutputSummary = (output: string): string | null => {
   } catch {
     return null;
   }
-};
-
-const isTodoToolName = (tool: string): boolean => {
-  return (
-    tool === "todowrite" ||
-    tool === "todoread" ||
-    tool.endsWith("_todowrite") ||
-    tool.endsWith("_todoread")
-  );
 };
 
 const countTodosFromUnknown = (value: unknown): number | null => {


### PR DESCRIPTION
## Summary
- replace the generic fallback icon with `ListTodo` for todo tool calls in agent chat rows
- reuse `isTodoToolName` so plain and namespaced todo tools (runtime-agnostic) map consistently
- add targeted chat card tests for `todoread`/`todowrite` and namespaced variants to prevent regressions

## Validation
- bun run --filter @openducktor/desktop test src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Todo tools in agent chat now show a dedicated list icon for clearer visual distinction.

* **Tests**
  * Added tests validating the todo icon renders across namespaced and unprefixed tool identifiers and handles extra whitespace.

* **Refactor**
  * Todo-tool detection logic consolidated to rely on a single shared implementation for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->