### PR TITLE
feat(desktop): display app version in sidebar and normalize package versions

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openducktor/desktop",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./gen/schemas/desktop-schema.json",
   "productName": "OpenDucktor",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "identifier": "dev.openducktor.desktop",
   "build": {
     "beforeDevCommand": "cd .. && bun run dev",

--- a/apps/desktop/src/components/layout/sidebar/app-brand.tsx
+++ b/apps/desktop/src/components/layout/sidebar/app-brand.tsx
@@ -2,9 +2,9 @@ import { Bot } from "lucide-react";
 import type { ReactElement } from "react";
 import { getAppVersion } from "@/lib/app-version";
 
-export function AppBrand(): ReactElement {
-  const version = getAppVersion();
+const APP_VERSION = getAppVersion();
 
+export function AppBrand(): ReactElement {
   return (
     <div className="flex items-center gap-3">
       <div className="rounded-xl bg-sidebar-accent p-2 text-sidebar-accent-foreground shadow-md">
@@ -12,7 +12,7 @@ export function AppBrand(): ReactElement {
       </div>
       <div>
         <p className="text-lg font-semibold tracking-tight">OpenDucktor</p>
-        {version && <p className="text-xs text-sidebar-muted-foreground">{version}</p>}
+        {APP_VERSION && <p className="text-xs text-sidebar-muted-foreground">{APP_VERSION}</p>}
       </div>
     </div>
   );

--- a/apps/desktop/src/components/layout/sidebar/app-brand.tsx
+++ b/apps/desktop/src/components/layout/sidebar/app-brand.tsx
@@ -1,7 +1,10 @@
 import { Bot } from "lucide-react";
 import type { ReactElement } from "react";
+import { getAppVersion } from "@/lib/app-version";
 
 export function AppBrand(): ReactElement {
+  const version = getAppVersion();
+
   return (
     <div className="flex items-center gap-3">
       <div className="rounded-xl bg-sidebar-accent p-2 text-sidebar-accent-foreground shadow-md">
@@ -9,7 +12,7 @@ export function AppBrand(): ReactElement {
       </div>
       <div>
         <p className="text-lg font-semibold tracking-tight">OpenDucktor</p>
-        <p className="text-xs text-sidebar-muted-foreground">Agent Orchestration</p>
+        {version && <p className="text-xs text-sidebar-muted-foreground">{version}</p>}
       </div>
     </div>
   );

--- a/apps/desktop/src/lib/app-version.test.ts
+++ b/apps/desktop/src/lib/app-version.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { getAppVersion } from "./app-version";
+
+describe("getAppVersion", () => {
+  test("returns a string or null", () => {
+    const version = getAppVersion();
+    expect(version === null || typeof version === "string").toBe(true);
+  });
+
+  test("returns null when Vite define is absent", () => {
+    expect(getAppVersion()).toBeNull();
+  });
+});

--- a/apps/desktop/src/lib/app-version.test.ts
+++ b/apps/desktop/src/lib/app-version.test.ts
@@ -1,13 +1,27 @@
-import { describe, expect, test } from "bun:test";
-import { getAppVersion } from "./app-version";
+import { afterEach, describe, expect, test } from "bun:test";
 
 describe("getAppVersion", () => {
-  test("returns a string or null", () => {
-    const version = getAppVersion();
-    expect(version === null || typeof version === "string").toBe(true);
+  const originalValue = import.meta.env.VITE_ODT_APP_VERSION;
+
+  afterEach(() => {
+    import.meta.env.VITE_ODT_APP_VERSION = originalValue;
   });
 
-  test("returns null when Vite define is absent", () => {
+  test("returns version when VITE_ODT_APP_VERSION is set", async () => {
+    import.meta.env.VITE_ODT_APP_VERSION = "1.2.3";
+    const { getAppVersion } = await import("./app-version");
+    expect(getAppVersion()).toBe("1.2.3");
+  });
+
+  test("returns null when VITE_ODT_APP_VERSION is empty", async () => {
+    import.meta.env.VITE_ODT_APP_VERSION = "";
+    const { getAppVersion } = await import("./app-version");
+    expect(getAppVersion()).toBeNull();
+  });
+
+  test("returns null when VITE_ODT_APP_VERSION is absent", async () => {
+    import.meta.env.VITE_ODT_APP_VERSION = "";
+    const { getAppVersion } = await import("./app-version");
     expect(getAppVersion()).toBeNull();
   });
 });

--- a/apps/desktop/src/lib/app-version.ts
+++ b/apps/desktop/src/lib/app-version.ts
@@ -1,0 +1,3 @@
+export function getAppVersion(): string | null {
+  return (import.meta.env.VITE_ODT_APP_VERSION as string) ?? null;
+}

--- a/apps/desktop/src/lib/app-version.ts
+++ b/apps/desktop/src/lib/app-version.ts
@@ -1,3 +1,3 @@
 export function getAppVersion(): string | null {
-  return (import.meta.env.VITE_ODT_APP_VERSION as string) ?? null;
+  return import.meta.env.VITE_ODT_APP_VERSION || null;
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
@@ -6,6 +7,17 @@ import { defineConfig } from "vite";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+function getAppVersion(): string | null {
+  try {
+    const conf = JSON.parse(
+      readFileSync(path.resolve(__dirname, "src-tauri/tauri.conf.json"), "utf-8"),
+    );
+    return conf.version ?? null;
+  } catch {
+    return null;
+  }
+}
 
 const REACT_VENDOR_PACKAGES = new Set([
   "@remix-run/router",
@@ -142,6 +154,11 @@ function getVendorChunkName(id: string): string | undefined {
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    "import.meta.env.VITE_ODT_APP_VERSION": JSON.stringify(
+      process.env.ODT_APP_VERSION ?? getAppVersion(),
+    ),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -14,7 +14,8 @@ function getAppVersion(): string | null {
       readFileSync(path.resolve(__dirname, "src-tauri/tauri.conf.json"), "utf-8"),
     );
     return conf.version ?? null;
-  } catch {
+  } catch (error) {
+    console.warn("Could not read app version from tauri.conf.json:", error);
     return null;
   }
 }
@@ -156,7 +157,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
     "import.meta.env.VITE_ODT_APP_VERSION": JSON.stringify(
-      process.env.ODT_APP_VERSION ?? getAppVersion(),
+      process.env.ODT_APP_VERSION ?? getAppVersion() ?? "",
     ),
   },
   resolve: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openducktor",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.0.1",
   "packageManager": "bun@1.3.5",
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {

--- a/packages/adapters-opencode-sdk/package.json
+++ b/packages/adapters-opencode-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openducktor/adapters-opencode-sdk",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/adapters-tauri-host/package.json
+++ b/packages/adapters-tauri-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openducktor/adapters-tauri-host",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openducktor/contracts",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openducktor/core",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/openducktor-mcp/package.json
+++ b/packages/openducktor-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openducktor/mcp",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Replace "Agent Orchestration" subtitle with the app version number in the sidebar
- Version is read from `tauri.conf.json` at Vite build time via `define`, available in both Tauri and browser modes
- All workspace package versions normalized to `0.0.1`

## Files changed

- `apps/desktop/src/lib/app-version.ts` — new `getAppVersion()` function
- `apps/desktop/src/lib/app-version.test.ts` — tests
- `apps/desktop/src/components/layout/sidebar/app-brand.tsx` — uses `getAppVersion()`
- `apps/desktop/vite.config.ts` — reads version from `tauri.conf.json` and injects via `define`
- 8× `package.json` + `tauri.conf.json` — version `0.1.0` → `0.0.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar now displays the app version dynamically when available.

* **Chores**
  * Application version set to 0.0.1 across workspace manifests and desktop app configuration.

* **Tests**
  * Added tests covering app version detection and fallback behavior when version info is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->