### PR TITLE
feat(task-details): add floating copy actions for task documents

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-workspace-sidebar.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-workspace-sidebar.test.tsx
@@ -33,6 +33,7 @@ describe("AgentStudioWorkspaceSidebar", () => {
     expect(html).toContain("Specification");
     expect(html).toContain("Current specification document for this task.");
     expect(html).toContain("Spec");
+    expect(html).toContain('data-testid="copy-agent-studio-document-content"');
     expect(html).toMatch(/Feb 21(?:, \d{1,2}:\d{2}\s?[AP]M| at)/u);
   });
 
@@ -54,6 +55,7 @@ describe("AgentStudioWorkspaceSidebar", () => {
 
     expect(html).toContain("No QA report yet.");
     expect(html).toContain("Not set");
+    expect(html).not.toContain('data-testid="copy-agent-studio-document-content"');
   });
 
   test("renders empty sidebar for Builder role documents", () => {

--- a/apps/desktop/src/components/features/agents/agent-studio-workspace-sidebar.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-workspace-sidebar.tsx
@@ -1,6 +1,10 @@
-import type { ReactElement } from "react";
+import { Check, Copy } from "lucide-react";
+import { type MouseEvent, type ReactElement, useCallback } from "react";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
+import { Button } from "@/components/ui/button";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 
 export type AgentStudioWorkspaceDocument = {
   title: string;
@@ -38,15 +42,70 @@ type DocumentSectionProps = {
   document: TaskDocumentState;
 };
 
+const DOCUMENT_COPY_PREVIEW_LENGTH = 50;
+
+function buildCopyPreview(markdown: string): string {
+  if (markdown.length <= DOCUMENT_COPY_PREVIEW_LENGTH) {
+    return markdown;
+  }
+  return `${markdown.slice(0, DOCUMENT_COPY_PREVIEW_LENGTH)}...`;
+}
+
+function AgentStudioDocumentCopyButton({ markdown }: { markdown: string }): ReactElement {
+  const { copied, copyToClipboard } = useCopyToClipboard({
+    getSuccessDescription: buildCopyPreview,
+    errorLogContext: "AgentStudioWorkspaceSidebar",
+  });
+
+  const handleCopy = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      void copyToClipboard(markdown);
+    },
+    [copyToClipboard, markdown],
+  );
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="absolute top-2 right-2 z-10 size-7 text-muted-foreground hover:bg-accent hover:text-foreground"
+            aria-label="Copy document content"
+            data-testid="copy-agent-studio-document-content"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
+            ) : (
+              <Copy className="size-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          <p>Copy</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 function DocumentSection({ emptyState, document }: DocumentSectionProps): ReactElement {
   return (
-    <div className="p-4">
+    <div className="relative p-4">
       {document.markdown.trim().length > 0 ? (
-        <MarkdownRenderer
-          markdown={document.markdown}
-          variant="document"
-          premiumCodeBlocks={hasLabeledCodeFence(document.markdown)}
-        />
+        <>
+          <MarkdownRenderer
+            markdown={document.markdown}
+            variant="document"
+            premiumCodeBlocks={hasLabeledCodeFence(document.markdown)}
+          />
+          <AgentStudioDocumentCopyButton markdown={document.markdown} />
+        </>
       ) : (
         <p className="text-sm text-muted-foreground">{emptyState}</p>
       )}

--- a/apps/desktop/src/components/features/task-composer/task-document-editor.tsx
+++ b/apps/desktop/src/components/features/task-composer/task-document-editor.tsx
@@ -1,9 +1,17 @@
-import { Eye, FilePenLine, LayoutPanelLeft } from "lucide-react";
-import { type ReactElement, type ReactNode, useDeferredValue } from "react";
+import { Check, Copy, Eye, FilePenLine, LayoutPanelLeft } from "lucide-react";
+import {
+  type MouseEvent,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useDeferredValue,
+} from "react";
 import { Button } from "@/components/ui/button";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { humanDate } from "@/lib/task-display";
+import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
 import type { DocumentEditorView } from "@/types/task-composer";
 
@@ -38,6 +46,57 @@ const hasLabeledCodeFence = (value: string): boolean =>
 
 const PANEL_MIN_HEIGHT_CLASS = "min-h-[52vh]";
 const PANEL_SCROLL_VIEWPORT_CLASS = "max-h-[52vh] overflow-y-auto";
+const PREVIEW_COPY_LENGTH = 50;
+
+function buildPreviewCopyDescription(markdown: string): string {
+  if (markdown.length <= PREVIEW_COPY_LENGTH) {
+    return markdown;
+  }
+  return `${markdown.slice(0, PREVIEW_COPY_LENGTH)}...`;
+}
+
+function TaskDocumentPreviewCopyButton({ markdown }: { markdown: string }): ReactElement {
+  const { copied, copyToClipboard } = useCopyToClipboard({
+    getSuccessDescription: buildPreviewCopyDescription,
+    errorLogContext: "TaskDocumentEditor",
+  });
+
+  const handleCopy = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      void copyToClipboard(markdown);
+    },
+    [copyToClipboard, markdown],
+  );
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="absolute top-2 right-2 z-10 size-7 text-muted-foreground hover:bg-accent hover:text-foreground"
+            aria-label="Copy document preview content"
+            data-testid="copy-task-document-preview-content"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
+            ) : (
+              <Copy className="size-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          <p>Copy</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 type PaneProps = {
   label: string;
@@ -178,17 +237,21 @@ export function TaskDocumentEditor({
             <Pane label="Preview" hiddenOnMobile={view === "split"}>
               <div
                 className={cn(
+                  "relative",
                   PANEL_MIN_HEIGHT_CLASS,
                   PANEL_SCROLL_VIEWPORT_CLASS,
                   "rounded-md border border-border bg-card p-3",
                 )}
               >
                 {deferredMarkdown.trim().length > 0 ? (
-                  <MarkdownRenderer
-                    markdown={deferredMarkdown}
-                    variant="document"
-                    premiumCodeBlocks={hasLabeledCodeFence(deferredMarkdown)}
-                  />
+                  <>
+                    <MarkdownRenderer
+                      markdown={deferredMarkdown}
+                      variant="document"
+                      premiumCodeBlocks={hasLabeledCodeFence(deferredMarkdown)}
+                    />
+                    <TaskDocumentPreviewCopyButton markdown={deferredMarkdown} />
+                  </>
                 ) : (
                   <p className="text-sm text-muted-foreground">Nothing to preview yet.</p>
                 )}

--- a/apps/desktop/src/components/features/task-details/task-details-async-document-section.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-async-document-section.tsx
@@ -91,6 +91,7 @@ export const TaskDetailsAsyncDocumentSection = memo(function TaskDetailsAsyncDoc
               active={isExpanded}
               markdown={document.markdown}
               empty={empty}
+              copyableMarkdown={document.markdown}
             />
           </Suspense>
         );

--- a/apps/desktop/src/components/features/task-details/task-details-document-section.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-document-section.tsx
@@ -57,7 +57,12 @@ export const TaskDetailsDocumentSection = memo(
               </div>
             }
           >
-            <TaskDetailsMarkdownContent active={isExpanded} markdown={markdown} empty={empty} />
+            <TaskDetailsMarkdownContent
+              active={isExpanded}
+              markdown={markdown}
+              empty={empty}
+              copyableMarkdown={markdown}
+            />
           </Suspense>
         )}
       </TaskDetailsCollapsibleCard>

--- a/apps/desktop/src/components/features/task-details/task-details-markdown-content.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-markdown-content.test.tsx
@@ -144,41 +144,34 @@ describe("TaskDetailsMarkdownContent", () => {
   });
 
   test("shows check icon for two seconds after successful copy", async () => {
-    const originalSetTimeout = globalThis.setTimeout;
-    const acceleratedSetTimeout = ((
-      handler: TimerHandler,
-      _timeout?: number,
-      ...args: unknown[]
-    ): number => {
-      return originalSetTimeout(handler, 1, ...args);
-    }) as typeof globalThis.setTimeout;
-    globalThis.setTimeout = acceleratedSetTimeout;
-
     const rendered = render(
       createElement(TaskDetailsMarkdownContent, {
         markdown: "# Spec",
         empty: "No doc",
         active: true,
         copyableMarkdown: "# Spec",
+        copyResetDelayMs: 5,
       }),
     );
 
-    const button = rendered.getByTestId("copy-document-content");
-    expect(button.querySelector(".lucide-copy")).not.toBeNull();
-
-    fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(button.querySelector(".lucide-check")).not.toBeNull();
-    });
-
     try {
+      const button = rendered.getByTestId("copy-document-content");
+      expect(button.querySelector(".lucide-copy")).not.toBeNull();
+
+      fireEvent.click(button);
+
       await waitFor(() => {
-        expect(button.querySelector(".lucide-copy")).not.toBeNull();
+        expect(button.querySelector(".lucide-check")).not.toBeNull();
       });
-      rendered.unmount();
+
+      await waitFor(
+        () => {
+          expect(button.querySelector(".lucide-copy")).not.toBeNull();
+        },
+        { timeout: 200 },
+      );
     } finally {
-      globalThis.setTimeout = originalSetTimeout;
+      rendered.unmount();
     }
   });
 });

--- a/apps/desktop/src/components/features/task-details/task-details-markdown-content.test.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-markdown-content.test.tsx
@@ -1,0 +1,184 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { enableReactActEnvironment } from "@/pages/agents/agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+const toastSuccessMock = mock(() => {});
+const toastErrorMock = mock(() => {});
+const writeClipboardMock = mock(async (_value: string) => {});
+
+type TaskDetailsMarkdownContentComponent =
+  typeof import("./task-details-markdown-content").TaskDetailsMarkdownContent;
+let TaskDetailsMarkdownContent: TaskDetailsMarkdownContentComponent;
+
+describe("TaskDetailsMarkdownContent", () => {
+  beforeAll(async () => {
+    mock.module("sonner", () => ({
+      toast: {
+        success: toastSuccessMock,
+        error: toastErrorMock,
+        loading: () => "",
+        dismiss: () => {},
+      },
+    }));
+
+    ({ TaskDetailsMarkdownContent } = await import("./task-details-markdown-content"));
+  });
+
+  beforeEach(() => {
+    toastSuccessMock.mockClear();
+    toastErrorMock.mockClear();
+    writeClipboardMock.mockClear();
+    writeClipboardMock.mockImplementation(async () => {});
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: writeClipboardMock,
+      },
+    });
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("renders floating copy button when copyable markdown is provided", () => {
+    const rendered = render(
+      createElement(TaskDetailsMarkdownContent, {
+        markdown: "# Spec\n\nDetails",
+        empty: "No spec",
+        active: true,
+        copyableMarkdown: "# Spec\n\nDetails",
+      }),
+    );
+
+    const button = rendered.getByTestId("copy-document-content");
+    expect(button.className).toContain("absolute");
+    expect(button.className).toContain("top-2");
+    expect(button.className).toContain("right-2");
+    rendered.unmount();
+  });
+
+  test("does not render copy button when copyable markdown is missing", () => {
+    const rendered = render(
+      createElement(TaskDetailsMarkdownContent, {
+        markdown: "# Plan\n\nText",
+        empty: "No plan",
+        active: true,
+      }),
+    );
+
+    expect(rendered.queryByTestId("copy-document-content")).toBeNull();
+    rendered.unmount();
+  });
+
+  test("copies markdown and shows success toast", async () => {
+    const markdown = "12345678901234567890123456789012345678901234567890tail";
+    const rendered = render(
+      createElement(TaskDetailsMarkdownContent, {
+        markdown,
+        empty: "No doc",
+        active: true,
+        copyableMarkdown: markdown,
+      }),
+    );
+
+    fireEvent.click(rendered.getByTestId("copy-document-content"));
+
+    await waitFor(() => {
+      expect(writeClipboardMock).toHaveBeenCalledWith(markdown);
+      expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
+        description: `${markdown.slice(0, 50)}...`,
+      });
+    });
+    rendered.unmount();
+  });
+
+  test("uses full markdown as success preview when text is short", async () => {
+    const markdown = "short text";
+    const rendered = render(
+      createElement(TaskDetailsMarkdownContent, {
+        markdown,
+        empty: "No doc",
+        active: true,
+        copyableMarkdown: markdown,
+      }),
+    );
+
+    fireEvent.click(rendered.getByTestId("copy-document-content"));
+
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith("Copied!", {
+        description: markdown,
+      });
+    });
+    rendered.unmount();
+  });
+
+  test("shows error toast when clipboard copy fails", async () => {
+    const error = new DOMException("blocked by browser", "NotAllowedError");
+    writeClipboardMock.mockImplementation(async () => {
+      throw error;
+    });
+
+    const rendered = render(
+      createElement(TaskDetailsMarkdownContent, {
+        markdown: "# QA\n\nfailed",
+        empty: "No QA",
+        active: true,
+        copyableMarkdown: "# QA\n\nfailed",
+      }),
+    );
+
+    fireEvent.click(rendered.getByTestId("copy-document-content"));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "Permission denied: clipboard access not allowed",
+      );
+    });
+    rendered.unmount();
+  });
+
+  test("shows check icon for two seconds after successful copy", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const acceleratedSetTimeout = ((
+      handler: TimerHandler,
+      _timeout?: number,
+      ...args: unknown[]
+    ): number => {
+      return originalSetTimeout(handler, 1, ...args);
+    }) as typeof globalThis.setTimeout;
+    globalThis.setTimeout = acceleratedSetTimeout;
+
+    const rendered = render(
+      createElement(TaskDetailsMarkdownContent, {
+        markdown: "# Spec",
+        empty: "No doc",
+        active: true,
+        copyableMarkdown: "# Spec",
+      }),
+    );
+
+    const button = rendered.getByTestId("copy-document-content");
+    expect(button.querySelector(".lucide-copy")).not.toBeNull();
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(button.querySelector(".lucide-check")).not.toBeNull();
+    });
+
+    try {
+      await waitFor(() => {
+        expect(button.querySelector(".lucide-copy")).not.toBeNull();
+      });
+      rendered.unmount();
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+});

--- a/apps/desktop/src/components/features/task-details/task-details-markdown-content.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-markdown-content.tsx
@@ -1,14 +1,28 @@
-import { memo, type ReactElement, startTransition, useEffect, useState } from "react";
+import { Check, Copy } from "lucide-react";
+import {
+  type MouseEvent,
+  memo,
+  type ReactElement,
+  startTransition,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
+import { Button } from "@/components/ui/button";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 
 type TaskDetailsMarkdownContentProps = {
   markdown: string;
   empty: string;
   active: boolean;
+  copyableMarkdown?: string;
 };
 
 const LARGE_MARKDOWN_DEFER_THRESHOLD = 2000;
 const LABELED_CODE_FENCE_PATTERN = /^[ \t]{0,3}(?:```|~~~)[ \t]*[^\s`~]/im;
+const MARKDOWN_COPY_PREVIEW_LENGTH = 50;
 
 type TaskDetailsRenderedMarkdownProps = {
   markdown: string;
@@ -35,12 +49,18 @@ function TaskDetailsRenderedMarkdown({
 
 type DeferredTaskDetailsMarkdownProps = TaskDetailsRenderedMarkdownProps & {
   active: boolean;
+  copyableMarkdown: string | undefined;
+  copied: boolean;
+  onCopy: (e: MouseEvent<HTMLButtonElement>) => void;
 };
 
 function DeferredTaskDetailsMarkdown({
   active,
   markdown,
   hasLabeledCodeFence,
+  copyableMarkdown,
+  copied,
+  onCopy,
 }: DeferredTaskDetailsMarkdownProps): ReactElement {
   const [isMarkdownReady, setIsMarkdownReady] = useState(false);
 
@@ -71,20 +91,80 @@ function DeferredTaskDetailsMarkdown({
   }
 
   return (
-    <div className="max-h-84 overflow-y-auto">
+    <div className="relative max-h-84 overflow-y-auto">
       <TaskDetailsRenderedMarkdown markdown={markdown} hasLabeledCodeFence={hasLabeledCodeFence} />
+      {copyableMarkdown ? <TaskDetailsCopyButton copied={copied} onClick={onCopy} /> : null}
     </div>
   );
+}
+
+function TaskDetailsCopyButton({
+  copied,
+  onClick,
+}: {
+  copied: boolean;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+}): ReactElement {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="absolute top-2 right-2 size-7 text-muted-foreground hover:bg-accent hover:text-foreground"
+            aria-label="Copy document content"
+            data-testid="copy-document-content"
+            onClick={onClick}
+          >
+            {copied ? (
+              <Check className="size-3.5 text-emerald-500 dark:text-emerald-400" />
+            ) : (
+              <Copy className="size-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="left">
+          <p>Copy</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function buildCopyPreview(markdown: string): string {
+  if (markdown.length <= MARKDOWN_COPY_PREVIEW_LENGTH) {
+    return markdown;
+  }
+  return `${markdown.slice(0, MARKDOWN_COPY_PREVIEW_LENGTH)}...`;
 }
 
 export const TaskDetailsMarkdownContent = memo(function TaskDetailsMarkdownContent({
   markdown,
   empty,
   active,
+  copyableMarkdown,
 }: TaskDetailsMarkdownContentProps): ReactElement {
+  const { copied, copyToClipboard } = useCopyToClipboard({
+    getSuccessDescription: buildCopyPreview,
+    errorLogContext: "TaskDetailsMarkdownContent",
+  });
   const hasContent = /\S/.test(markdown);
   const hasLabeledCodeFence = LABELED_CODE_FENCE_PATTERN.test(markdown);
   const shouldDeferMarkdown = hasContent && markdown.length >= LARGE_MARKDOWN_DEFER_THRESHOLD;
+
+  const handleCopy = useCallback(
+    (e: MouseEvent<HTMLButtonElement>): void => {
+      e.stopPropagation();
+      e.preventDefault();
+      if (!copyableMarkdown) {
+        return;
+      }
+      void copyToClipboard(copyableMarkdown);
+    },
+    [copyToClipboard, copyableMarkdown],
+  );
 
   if (!hasContent) {
     return (
@@ -101,13 +181,17 @@ export const TaskDetailsMarkdownContent = memo(function TaskDetailsMarkdownConte
         active={active}
         markdown={markdown}
         hasLabeledCodeFence={hasLabeledCodeFence}
+        copyableMarkdown={copyableMarkdown}
+        copied={copied}
+        onCopy={handleCopy}
       />
     );
   }
 
   return (
-    <div className="max-h-84 overflow-y-auto">
+    <div className="relative max-h-84 overflow-y-auto">
       <TaskDetailsRenderedMarkdown markdown={markdown} hasLabeledCodeFence={hasLabeledCodeFence} />
+      {copyableMarkdown ? <TaskDetailsCopyButton copied={copied} onClick={handleCopy} /> : null}
     </div>
   );
 });

--- a/apps/desktop/src/components/features/task-details/task-details-markdown-content.tsx
+++ b/apps/desktop/src/components/features/task-details/task-details-markdown-content.tsx
@@ -18,6 +18,7 @@ type TaskDetailsMarkdownContentProps = {
   empty: string;
   active: boolean;
   copyableMarkdown?: string;
+  copyResetDelayMs?: number;
 };
 
 const LARGE_MARKDOWN_DEFER_THRESHOLD = 2000;
@@ -91,8 +92,13 @@ function DeferredTaskDetailsMarkdown({
   }
 
   return (
-    <div className="relative max-h-84 overflow-y-auto">
-      <TaskDetailsRenderedMarkdown markdown={markdown} hasLabeledCodeFence={hasLabeledCodeFence} />
+    <div className="relative">
+      <div className="max-h-84 overflow-y-auto">
+        <TaskDetailsRenderedMarkdown
+          markdown={markdown}
+          hasLabeledCodeFence={hasLabeledCodeFence}
+        />
+      </div>
       {copyableMarkdown ? <TaskDetailsCopyButton copied={copied} onClick={onCopy} /> : null}
     </div>
   );
@@ -113,7 +119,7 @@ function TaskDetailsCopyButton({
             type="button"
             variant="outline"
             size="icon"
-            className="absolute top-2 right-2 size-7 text-muted-foreground hover:bg-accent hover:text-foreground"
+            className="absolute top-2 right-2 z-10 size-7 text-muted-foreground hover:bg-accent hover:text-foreground"
             aria-label="Copy document content"
             data-testid="copy-document-content"
             onClick={onClick}
@@ -145,9 +151,11 @@ export const TaskDetailsMarkdownContent = memo(function TaskDetailsMarkdownConte
   empty,
   active,
   copyableMarkdown,
+  copyResetDelayMs,
 }: TaskDetailsMarkdownContentProps): ReactElement {
   const { copied, copyToClipboard } = useCopyToClipboard({
     getSuccessDescription: buildCopyPreview,
+    ...(copyResetDelayMs === undefined ? {} : { resetDelayMs: copyResetDelayMs }),
     errorLogContext: "TaskDetailsMarkdownContent",
   });
   const hasContent = /\S/.test(markdown);
@@ -189,8 +197,13 @@ export const TaskDetailsMarkdownContent = memo(function TaskDetailsMarkdownConte
   }
 
   return (
-    <div className="relative max-h-84 overflow-y-auto">
-      <TaskDetailsRenderedMarkdown markdown={markdown} hasLabeledCodeFence={hasLabeledCodeFence} />
+    <div className="relative">
+      <div className="max-h-84 overflow-y-auto">
+        <TaskDetailsRenderedMarkdown
+          markdown={markdown}
+          hasLabeledCodeFence={hasLabeledCodeFence}
+        />
+      </div>
       {copyableMarkdown ? <TaskDetailsCopyButton copied={copied} onClick={handleCopy} /> : null}
     </div>
   );

--- a/apps/desktop/src/components/features/tasks/task-id-badge.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.tsx
@@ -1,7 +1,8 @@
 import { Check, Copy } from "lucide-react";
-import { memo, type ReactElement, useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
+import { memo, type ReactElement, useCallback } from "react";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCopyToClipboard } from "@/lib/use-copy-to-clipboard";
 import { cn } from "@/lib/utils";
 
 type TaskIdBadgeProps = {
@@ -15,70 +16,52 @@ function TaskIdBadgeComponent({
   className,
   iconSize = 12,
 }: TaskIdBadgeProps): ReactElement {
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) return;
-    const timeoutId = setTimeout(() => setCopied(false), 2000);
-    return () => clearTimeout(timeoutId);
-  }, [copied]);
+  const { copied, copyToClipboard } = useCopyToClipboard({
+    getSuccessDescription: (value) => value,
+    errorLogContext: "TaskIdBadge",
+  });
 
   const handleCopy = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
       e.preventDefault();
-      navigator.clipboard
-        .writeText(taskId)
-        .then(() => {
-          setCopied(true);
-          toast.success("Copied!", { description: taskId });
-        })
-        .catch((err) => {
-          console.error("[TaskIdBadge] Clipboard write failed:", err);
-          const message =
-            err instanceof DOMException ? getClipboardErrorMessage(err) : "Copy failed";
-          toast.error(message);
-        });
+      void copyToClipboard(taskId);
     },
-    [taskId],
+    [copyToClipboard, taskId],
   );
 
   return (
     <div className={cn("inline-flex items-center gap-1", className)}>
       <span className="min-w-0 truncate font-mono text-xs text-muted-foreground">{taskId}</span>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-6 text-muted-foreground hover:bg-muted hover:text-foreground"
-        onClick={handleCopy}
-        data-testid="copy-task-id"
-        aria-label="Copy task ID"
-      >
-        {copied ? (
-          <Check
-            className="text-emerald-500 dark:text-emerald-400"
-            style={{ width: iconSize, height: iconSize }}
-          />
-        ) : (
-          <Copy style={{ width: iconSize, height: iconSize }} />
-        )}
-      </Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-6 text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={handleCopy}
+              data-testid="copy-task-id"
+              aria-label="Copy task ID"
+            >
+              {copied ? (
+                <Check
+                  className="text-emerald-500 dark:text-emerald-400"
+                  style={{ width: iconSize, height: iconSize }}
+                />
+              ) : (
+                <Copy style={{ width: iconSize, height: iconSize }} />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            <p>Copy</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </div>
   );
-}
-
-function getClipboardErrorMessage(error: DOMException): string {
-  switch (error.name) {
-    case "NotAllowedError":
-      return "Permission denied: clipboard access not allowed";
-    case "NotFoundError":
-      return "No clipboard available in this environment";
-    case "AbortError":
-      return "Copy operation was cancelled";
-    default:
-      return `Copy failed: ${error.message}`;
-  }
 }
 
 export const TaskIdBadge = memo(TaskIdBadgeComponent);

--- a/apps/desktop/src/components/features/tasks/task-id-badge.tsx
+++ b/apps/desktop/src/components/features/tasks/task-id-badge.tsx
@@ -11,13 +11,15 @@ type TaskIdBadgeProps = {
   iconSize?: number;
 };
 
+const getTaskIdDescription = (value: string): string => value;
+
 function TaskIdBadgeComponent({
   taskId,
   className,
   iconSize = 12,
 }: TaskIdBadgeProps): ReactElement {
   const { copied, copyToClipboard } = useCopyToClipboard({
-    getSuccessDescription: (value) => value,
+    getSuccessDescription: getTaskIdDescription,
     errorLogContext: "TaskIdBadge",
   });
 

--- a/apps/desktop/src/lib/clipboard.ts
+++ b/apps/desktop/src/lib/clipboard.ts
@@ -1,0 +1,12 @@
+export function getClipboardErrorMessage(error: DOMException): string {
+  switch (error.name) {
+    case "NotAllowedError":
+      return "Permission denied: clipboard access not allowed";
+    case "NotFoundError":
+      return "No clipboard available in this environment";
+    case "AbortError":
+      return "Copy operation was cancelled";
+    default:
+      return `Copy failed: ${error.message}`;
+  }
+}

--- a/apps/desktop/src/lib/use-copy-to-clipboard.ts
+++ b/apps/desktop/src/lib/use-copy-to-clipboard.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { getClipboardErrorMessage } from "@/lib/clipboard";
+
+type UseCopyToClipboardOptions = {
+  successMessage?: string;
+  getSuccessDescription?: ((value: string) => string | undefined) | undefined;
+  copyFailedMessage?: string;
+  resetDelayMs?: number;
+  errorLogContext?: string;
+};
+
+type UseCopyToClipboardResult = {
+  copied: boolean;
+  copyToClipboard: (value: string) => Promise<boolean>;
+};
+
+const DEFAULT_SUCCESS_MESSAGE = "Copied!";
+const DEFAULT_COPY_FAILED_MESSAGE = "Copy failed";
+const DEFAULT_RESET_DELAY_MS = 2000;
+
+export function useCopyToClipboard({
+  successMessage = DEFAULT_SUCCESS_MESSAGE,
+  getSuccessDescription,
+  copyFailedMessage = DEFAULT_COPY_FAILED_MESSAGE,
+  resetDelayMs = DEFAULT_RESET_DELAY_MS,
+  errorLogContext,
+}: UseCopyToClipboardOptions = {}): UseCopyToClipboardResult {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const timeoutId = setTimeout(() => {
+      setCopied(false);
+    }, resetDelayMs);
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [copied, resetDelayMs]);
+
+  const copyToClipboard = useCallback(
+    async (value: string): Promise<boolean> => {
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        const description = getSuccessDescription?.(value);
+        if (description) {
+          toast.success(successMessage, { description });
+        } else {
+          toast.success(successMessage);
+        }
+        return true;
+      } catch (error) {
+        if (errorLogContext) {
+          console.error(`[${errorLogContext}] Clipboard write failed:`, error);
+        }
+        const message =
+          error instanceof DOMException ? getClipboardErrorMessage(error) : copyFailedMessage;
+        toast.error(message);
+        return false;
+      }
+    },
+    [copyFailedMessage, errorLogContext, getSuccessDescription, successMessage],
+  );
+
+  return {
+    copied,
+    copyToClipboard,
+  };
+}

--- a/apps/desktop/src/lib/use-copy-to-clipboard.ts
+++ b/apps/desktop/src/lib/use-copy-to-clipboard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getClipboardErrorMessage } from "@/lib/clipboard";
 
@@ -27,24 +27,29 @@ export function useCopyToClipboard({
   errorLogContext,
 }: UseCopyToClipboardOptions = {}): UseCopyToClipboardResult {
   const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (!copied) {
-      return;
-    }
-    const timeoutId = setTimeout(() => {
-      setCopied(false);
-    }, resetDelayMs);
     return () => {
-      clearTimeout(timeoutId);
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+        resetTimeoutRef.current = null;
+      }
     };
-  }, [copied, resetDelayMs]);
+  }, []);
 
   const copyToClipboard = useCallback(
     async (value: string): Promise<boolean> => {
       try {
         await navigator.clipboard.writeText(value);
+        if (resetTimeoutRef.current) {
+          clearTimeout(resetTimeoutRef.current);
+        }
         setCopied(true);
+        resetTimeoutRef.current = setTimeout(() => {
+          setCopied(false);
+          resetTimeoutRef.current = null;
+        }, resetDelayMs);
         const description = getSuccessDescription?.(value);
         if (description) {
           toast.success(successMessage, { description });
@@ -62,7 +67,7 @@ export function useCopyToClipboard({
         return false;
       }
     },
-    [copyFailedMessage, errorLogContext, getSuccessDescription, successMessage],
+    [copyFailedMessage, errorLogContext, getSuccessDescription, resetDelayMs, successMessage],
   );
 
   return {


### PR DESCRIPTION
## Summary
- add a floating top-right copy button to task document markdown containers (spec/plan/qa), keeping the button overlayed so it does not affect layout
- centralize clipboard interactions with a shared `useCopyToClipboard` hook and reuse clipboard error handling for both task-id and document copy actions
- add tooltip polish and extend tests for document copy behavior, including success/error toasts and short-vs-truncated copy preview formatting

## Verification
- bun run test
- bun run lint
- bun run typecheck
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global copy-to-clipboard UI added: overlay copy buttons in task details, document previews, agent studio, and composer preview with success/check feedback and truncated preview text in notifications.

* **Tests**
  * New tests validate copy button presence, clipboard success/failure flows, permission-denied handling, toast messages, and UI state transitions.

* **Refactor**
  * Shared clipboard hook and error-message helper implemented and adopted for consistent copy UX across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->