### PR TITLE
fix(desktop): refresh settings snapshot after workspace changes

### DIFF
--- a/apps/desktop/src/state/operations/workspace/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-workspace-operations.test.tsx
@@ -1,14 +1,14 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SettingsSnapshot, WorkspaceRecord } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
-import { QueryClientProvider } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { render, waitFor } from "@testing-library/react";
 import { act, createElement, type PropsWithChildren, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { clearAppQueryClient, createQueryClient } from "@/lib/query-client";
+import { clearAppQueryClient } from "@/lib/query-client";
 import { QueryProvider } from "@/lib/query-provider";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
-import { loadSettingsSnapshotFromQuery } from "../../queries/workspace";
+import { settingsSnapshotQueryOptions } from "../../queries/workspace";
 import { useWorkspaceOperations } from "./use-workspace-operations";
 
 const reactActEnvironment = globalThis as typeof globalThis & {
@@ -469,8 +469,12 @@ describe("use-workspace-operations", () => {
     hostClient.workspaceList = mock(
       async (): Promise<WorkspaceRecord[]> => [workspace("/repo-new", true)],
     );
-    const queryClient = createQueryClient();
     let latest: ReturnType<typeof useWorkspaceOperations> | null = null;
+
+    const SettingsSnapshotProbe = () => {
+      useQuery(settingsSnapshotQueryOptions(hostClient));
+      return null;
+    };
 
     const Harness = () => {
       latest = useWorkspaceOperations({
@@ -480,19 +484,19 @@ describe("use-workspace-operations", () => {
         clearActiveBeadsCheck: () => {},
         hostClient,
       });
-      return null;
+      return createElement(SettingsSnapshotProbe);
     };
 
     const rendered = render(createElement(Harness), {
       wrapper: ({ children }: PropsWithChildren) => (
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        <QueryProvider useIsolatedClient>{children}</QueryProvider>
       ),
     });
 
     try {
-      const firstSnapshot = await loadSettingsSnapshotFromQuery(queryClient, hostClient);
-      expect(Object.keys(firstSnapshot.repos)).toEqual(["/repo-old"]);
-      expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(1);
+      });
 
       workspaceGetSettingsSnapshot.mockImplementationOnce(async () =>
         settingsSnapshot(["/repo-old", "/repo-new"]),
@@ -506,13 +510,11 @@ describe("use-workspace-operations", () => {
         await latest?.addWorkspace("/repo-new");
       });
 
-      const refreshedSnapshot = await loadSettingsSnapshotFromQuery(queryClient, hostClient);
-      expect(Object.keys(refreshedSnapshot.repos).sort()).toEqual(["/repo-new", "/repo-old"]);
-      expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(2);
+      await waitFor(() => {
+        expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(2);
+      });
     } finally {
       rendered.unmount();
-      await queryClient.cancelQueries();
-      queryClient.clear();
     }
   });
 
@@ -666,8 +668,12 @@ describe("use-workspace-operations", () => {
       startedAt: "2026-02-22T08:00:00.000Z",
       descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
     }));
-    const queryClient = createQueryClient();
     let latest: ReturnType<typeof useWorkspaceOperations> | null = null;
+
+    const SettingsSnapshotProbe = () => {
+      useQuery(settingsSnapshotQueryOptions(hostClient));
+      return null;
+    };
 
     const Harness = () => {
       latest = useWorkspaceOperations({
@@ -677,19 +683,19 @@ describe("use-workspace-operations", () => {
         clearActiveBeadsCheck,
         hostClient,
       });
-      return null;
+      return createElement(SettingsSnapshotProbe);
     };
 
     const rendered = render(createElement(Harness), {
       wrapper: ({ children }: PropsWithChildren) => (
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        <QueryProvider useIsolatedClient>{children}</QueryProvider>
       ),
     });
 
     try {
-      const firstSnapshot = await loadSettingsSnapshotFromQuery(queryClient, hostClient);
-      expect(Object.keys(firstSnapshot.repos)).toEqual(["/repo-old"]);
-      expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(1);
+      });
 
       workspaceGetSettingsSnapshot.mockImplementationOnce(async () =>
         settingsSnapshot(["/repo-old", "/repo-a"]),
@@ -703,13 +709,11 @@ describe("use-workspace-operations", () => {
         await latest?.selectWorkspace("/repo-a");
       });
 
-      const refreshedSnapshot = await loadSettingsSnapshotFromQuery(queryClient, hostClient);
-      expect(Object.keys(refreshedSnapshot.repos).sort()).toEqual(["/repo-a", "/repo-old"]);
-      expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(2);
+      await waitFor(() => {
+        expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(2);
+      });
     } finally {
       rendered.unmount();
-      await queryClient.cancelQueries();
-      queryClient.clear();
     }
   });
 

--- a/apps/desktop/src/state/operations/workspace/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-workspace-operations.test.tsx
@@ -1,12 +1,14 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { WorkspaceRecord } from "@openducktor/contracts";
+import type { SettingsSnapshot, WorkspaceRecord } from "@openducktor/contracts";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { render, waitFor } from "@testing-library/react";
 import { act, createElement, type PropsWithChildren, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { clearAppQueryClient } from "@/lib/query-client";
+import { clearAppQueryClient, createQueryClient } from "@/lib/query-client";
 import { QueryProvider } from "@/lib/query-provider";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
+import { loadSettingsSnapshotFromQuery } from "../../queries/workspace";
 import { useWorkspaceOperations } from "./use-workspace-operations";
 
 const reactActEnvironment = globalThis as typeof globalThis & {
@@ -237,6 +239,42 @@ const workspace = (path: string, isActive = false): WorkspaceRecord => ({
   effectiveWorktreeBasePath: "/tmp/default-worktrees",
 });
 
+const settingsSnapshot = (repoPaths: string[]): SettingsSnapshot => ({
+  theme: "light",
+  git: {
+    defaultMergeMethod: "merge_commit",
+  },
+  chat: {
+    showThinkingMessages: false,
+  },
+  kanban: {
+    doneVisibleDays: 1,
+  },
+  repos: Object.fromEntries(
+    repoPaths.map((repoPath) => [
+      repoPath,
+      {
+        defaultRuntimeKind: "opencode" as const,
+        branchPrefix: "odt",
+        defaultTargetBranch: { remote: "origin", branch: "main" },
+        git: {
+          providers: {},
+        },
+        trustedHooks: false,
+        hooks: {
+          preStart: [],
+          postComplete: [],
+        },
+        devServers: [],
+        worktreeFileCopies: [],
+        promptOverrides: {},
+        agentDefaults: {},
+      },
+    ]),
+  ),
+  globalPromptOverrides: {},
+});
+
 describe("use-workspace-operations", () => {
   test("hydrates branches when startup activates the persisted repository", async () => {
     const setActiveRepo = mock(() => {});
@@ -420,6 +458,64 @@ describe("use-workspace-operations", () => {
     }
   });
 
+  test("addWorkspace clears cached settings snapshot for next read", async () => {
+    const setActiveRepo = mock(() => {});
+    const workspaceGetSettingsSnapshot = mock(async () => settingsSnapshot(["/repo-old"]));
+    const hostClient = createWorkspaceHostClient();
+    hostClient.workspaceGetSettingsSnapshot = workspaceGetSettingsSnapshot;
+    hostClient.workspaceAdd = mock(
+      async (): Promise<WorkspaceRecord> => workspace("/repo-new", true),
+    );
+    hostClient.workspaceList = mock(
+      async (): Promise<WorkspaceRecord[]> => [workspace("/repo-new", true)],
+    );
+    const queryClient = createQueryClient();
+    let latest: ReturnType<typeof useWorkspaceOperations> | null = null;
+
+    const Harness = () => {
+      latest = useWorkspaceOperations({
+        activeRepo: null,
+        setActiveRepo,
+        clearTaskData: () => {},
+        clearActiveBeadsCheck: () => {},
+        hostClient,
+      });
+      return null;
+    };
+
+    const rendered = render(createElement(Harness), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    try {
+      const firstSnapshot = await loadSettingsSnapshotFromQuery(queryClient, hostClient);
+      expect(Object.keys(firstSnapshot.repos)).toEqual(["/repo-old"]);
+      expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(1);
+
+      workspaceGetSettingsSnapshot.mockImplementationOnce(async () =>
+        settingsSnapshot(["/repo-old", "/repo-new"]),
+      );
+
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      await act(async () => {
+        await latest?.addWorkspace("/repo-new");
+      });
+
+      const refreshedSnapshot = await loadSettingsSnapshotFromQuery(queryClient, hostClient);
+      expect(Object.keys(refreshedSnapshot.repos).sort()).toEqual(["/repo-new", "/repo-old"]);
+      expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(2);
+    } finally {
+      rendered.unmount();
+      await queryClient.cancelQueries();
+      queryClient.clear();
+    }
+  });
+
   test("selectWorkspace clears state and triggers runtime ensure", async () => {
     const setActiveRepo = mock(() => {});
     const clearTaskData = mock(() => {});
@@ -523,6 +619,97 @@ describe("use-workspace-operations", () => {
       workspaceHost.runtimeEnsure = original.runtimeEnsure;
       workspaceHost.workspaceGetRepoConfig = original.workspaceGetRepoConfig;
       workspaceHost.workspaceList = original.workspaceList;
+    }
+  });
+
+  test("selectWorkspace clears cached settings snapshot for next read", async () => {
+    const setActiveRepo = mock(() => {});
+    const clearTaskData = mock(() => {});
+    const clearActiveBeadsCheck = mock(() => {});
+    const workspaceGetSettingsSnapshot = mock(async () => settingsSnapshot(["/repo-old"]));
+    const hostClient = createWorkspaceHostClient();
+    hostClient.workspaceGetSettingsSnapshot = workspaceGetSettingsSnapshot;
+    hostClient.workspaceSelect = mock(
+      async (): Promise<WorkspaceRecord> => workspace("/repo-a", true),
+    );
+    hostClient.workspaceList = mock(
+      async (): Promise<WorkspaceRecord[]> => [workspace("/repo-a", true)],
+    );
+    hostClient.workspaceGetRepoConfig = mock(async () => ({
+      defaultRuntimeKind: "opencode" as const,
+      branchPrefix: "obp",
+      defaultTargetBranch: { remote: "origin", branch: "main" },
+      git: {
+        providers: {},
+      },
+      trustedHooks: false,
+      hooks: {
+        preStart: [],
+        postComplete: [],
+      },
+      devServers: [],
+      worktreeFileCopies: [],
+      promptOverrides: {},
+      agentDefaults: {},
+    }));
+    hostClient.runtimeEnsure = mock(async () => ({
+      kind: "opencode",
+      runtimeId: "runtime-1",
+      repoPath: "/repo-a",
+      taskId: null,
+      role: "workspace" as const,
+      workingDirectory: "/tmp/repo-a",
+      runtimeRoute: {
+        type: "local_http" as const,
+        endpoint: "http://127.0.0.1:3030",
+      },
+      startedAt: "2026-02-22T08:00:00.000Z",
+      descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+    }));
+    const queryClient = createQueryClient();
+    let latest: ReturnType<typeof useWorkspaceOperations> | null = null;
+
+    const Harness = () => {
+      latest = useWorkspaceOperations({
+        activeRepo: null,
+        setActiveRepo,
+        clearTaskData,
+        clearActiveBeadsCheck,
+        hostClient,
+      });
+      return null;
+    };
+
+    const rendered = render(createElement(Harness), {
+      wrapper: ({ children }: PropsWithChildren) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    });
+
+    try {
+      const firstSnapshot = await loadSettingsSnapshotFromQuery(queryClient, hostClient);
+      expect(Object.keys(firstSnapshot.repos)).toEqual(["/repo-old"]);
+      expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(1);
+
+      workspaceGetSettingsSnapshot.mockImplementationOnce(async () =>
+        settingsSnapshot(["/repo-old", "/repo-a"]),
+      );
+
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+
+      await act(async () => {
+        await latest?.selectWorkspace("/repo-a");
+      });
+
+      const refreshedSnapshot = await loadSettingsSnapshotFromQuery(queryClient, hostClient);
+      expect(Object.keys(refreshedSnapshot.repos).sort()).toEqual(["/repo-a", "/repo-old"]);
+      expect(workspaceGetSettingsSnapshot).toHaveBeenCalledTimes(2);
+    } finally {
+      rendered.unmount();
+      await queryClient.cancelQueries();
+      queryClient.clear();
     }
   });
 

--- a/apps/desktop/src/state/operations/workspace/use-workspace-operations.ts
+++ b/apps/desktop/src/state/operations/workspace/use-workspace-operations.ts
@@ -444,6 +444,16 @@ export function useWorkspaceOperations({
     applyWorkspaceRecords(data);
   }, [applyWorkspaceRecords, hostClient, queryClient]);
 
+  const refreshWorkspaceCachesAfterMutation = useCallback(async (): Promise<void> => {
+    await queryClient.invalidateQueries({
+      queryKey: workspaceQueryKeys.list(),
+    });
+    queryClient.removeQueries({
+      queryKey: workspaceQueryKeys.settingsSnapshot(),
+      exact: true,
+    });
+  }, [queryClient]);
+
   const addWorkspace = useCallback(
     async (repoPath: string): Promise<void> => {
       const normalizedRepoPath = normalizeRepoPath(repoPath);
@@ -452,15 +462,13 @@ export function useWorkspaceOperations({
       }
 
       const workspace = await hostClient.workspaceAdd(normalizedRepoPath);
-      await queryClient.invalidateQueries({
-        queryKey: workspaceQueryKeys.list(),
-      });
+      await refreshWorkspaceCachesAfterMutation();
       await refreshWorkspaces();
       toast.success("Repository added", {
         description: workspace.path,
       });
     },
-    [hostClient, queryClient, refreshWorkspaces],
+    [hostClient, refreshWorkspaceCachesAfterMutation, refreshWorkspaces],
   );
 
   const selectWorkspace = useCallback(
@@ -472,9 +480,7 @@ export function useWorkspaceOperations({
 
       try {
         await hostClient.workspaceSelect(repoPath);
-        await queryClient.invalidateQueries({
-          queryKey: workspaceQueryKeys.list(),
-        });
+        await refreshWorkspaceCachesAfterMutation();
         if (workspaceSwitchVersionRef.current !== switchVersion) {
           return;
         }
@@ -541,6 +547,7 @@ export function useWorkspaceOperations({
       hostClient,
       markWorkspaceActiveLocally,
       queryClient,
+      refreshWorkspaceCachesAfterMutation,
       refreshWorkspaces,
       setActiveRepo,
     ],


### PR DESCRIPTION
## Summary
- ensure workspace mutations clear stale settings snapshot cache so first-opened repositories appear in settings immediately
- extract shared workspace cache refresh logic used by both `addWorkspace` and `selectWorkspace`
- add regression tests that simulate stale cached settings snapshots and verify subsequent settings reads include the newly opened repository

## Verification
- bun run test
- bun run lint
- bun run typecheck
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace settings are now properly refreshed when adding or selecting a workspace, ensuring data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->