### PR TITLE
fix: task and document sync between Agent Studio and Kanban

### DIFF
--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -2,6 +2,7 @@ import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { host } from "@/state/operations/host";
 import { resolveLatestDocumentPayload } from "@/state/queries/document-utils";
+import { documentQueryKeyForSection, TASK_DOCUMENT_STALE_TIME_MS } from "@/state/queries/documents";
 import type { TaskDocumentPayload } from "@/types/task-documents";
 
 export type DocumentSectionKey = "spec" | "plan" | "qa";
@@ -22,7 +23,6 @@ type TaskDocumentLoaders = {
 
 type SectionLoaders = Record<DocumentSectionKey, (taskId: string) => Promise<TaskDocumentPayload>>;
 
-const TASK_DOCUMENT_STALE_TIME_MS = 60_000;
 const DISABLED_TASK_ID = "__disabled__";
 
 const createTaskDocumentState = (input?: {
@@ -59,9 +59,6 @@ const createHostDocumentLoader = <TResult extends { markdown: string; updatedAt:
   };
 };
 
-const createDocumentQueryKey = (cacheScope: string, taskId: string, section: DocumentSectionKey) =>
-  ["task-documents", section, cacheScope, taskId] as const;
-
 const createDocumentQueryOptions = ({
   queryClient,
   cacheScope,
@@ -75,7 +72,7 @@ const createDocumentQueryOptions = ({
   section: DocumentSectionKey;
   loader: (taskId: string) => Promise<TaskDocumentPayload>;
 }) => {
-  const queryKey = createDocumentQueryKey(cacheScope, taskId, section);
+  const queryKey = documentQueryKeyForSection(cacheScope, taskId, section);
   return queryOptions({
     queryKey,
     queryFn: async (): Promise<TaskDocumentPayload> => {

--- a/apps/desktop/src/state/app-state-contexts.ts
+++ b/apps/desktop/src/state/app-state-contexts.ts
@@ -63,7 +63,7 @@ export type TaskDataContextValue = {
 };
 
 export type TaskControlContextValue = {
-  refreshTaskData: (repoPath: string) => Promise<void>;
+  refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
   clearTaskData: () => void;
   setIsLoadingTasks: (value: boolean) => void;
 };

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -22,7 +22,7 @@ type UseAppLifecycleArgs = {
     beadsOk: boolean;
     beadsError?: string | null;
   }>;
-  refreshTaskData: (repoPath: string) => Promise<void>;
+  refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
   clearBranchData: () => void;
   beadsPreparationToastDelayMs?: number;
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
@@ -40,7 +40,7 @@ export type AttachAgentSessionListenerParams = {
   updateSession: UpdateSession;
   resolveTurnDurationMs: ResolveTurnDuration;
   clearTurnDuration: (sessionId: string) => void;
-  refreshTaskData: (repoPath: string) => Promise<void>;
+  refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
 };
 
 export type SessionStoreContext = Pick<

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -185,6 +185,7 @@ describe("agent-orchestrator-session-events", () => {
     for (const scenario of scenarios) {
       const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
       let refreshTaskDataCalls = 0;
+      const refreshTaskDataArgs: Array<[string, string | undefined]> = [];
 
       const adapter: SessionEventAdapter = {
         subscribeEvents: (_sessionId, handler) => {
@@ -229,8 +230,9 @@ describe("agent-orchestrator-session-events", () => {
         updateSession,
         resolveTurnDurationMs: () => undefined,
         clearTurnDuration: () => {},
-        refreshTaskData: async () => {
+        refreshTaskData: async (repoPath, taskId) => {
           refreshTaskDataCalls += 1;
+          refreshTaskDataArgs.push([repoPath, taskId]);
         },
       });
 
@@ -274,6 +276,9 @@ describe("agent-orchestrator-session-events", () => {
       await Promise.resolve();
 
       expect(refreshTaskDataCalls).toBe(scenario.expectedRefreshTaskDataCalls);
+      if (scenario.expectedRefreshTaskDataCalls > 0) {
+        expect(refreshTaskDataArgs).toEqual([["/tmp/repo", "task-1"]]);
+      }
     }
   });
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-tool-parts.ts
@@ -208,6 +208,7 @@ export const handleToolPart = (
   const observedEventTimestampMs = eventTimestampMs(event.timestamp);
   const todoUpdateFromTool = resolveTodoUpdateFromTool(part, input, output);
   let shouldRefreshTaskData = false;
+  const taskId = context.store.sessionsRef.current[context.store.sessionId]?.taskId;
 
   context.store.updateSession(
     context.store.sessionId,
@@ -236,7 +237,7 @@ export const handleToolPart = (
   if (shouldRefreshTaskData) {
     runOrchestratorSideEffect(
       "session-events-refresh-task-data",
-      context.refresh.refreshTaskData(context.refresh.repoPath),
+      context.refresh.refreshTaskData(context.refresh.repoPath, taskId),
       {
         tags: {
           repoPath: context.refresh.repoPath,

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -50,7 +50,7 @@ type SessionActionsDependencies = {
   loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
   loadAgentSessions: (taskId: string, options?: AgentSessionLoadOptions) => Promise<void>;
   clearTurnDuration: (sessionId: string) => void;
-  refreshTaskData: (repoPath: string) => Promise<void>;
+  refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
   persistSessionRecord: (taskId: string, record: AgentSessionRecord) => Promise<void>;
   stopBuildRun?: (runId: string) => Promise<void>;
   invalidateSessionStopQueries?: (input: {

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.ts
@@ -124,7 +124,7 @@ const maybeSendKickoff = async ({
   throwIfRepoStale(startedCtx.isStaleRepoOperation, STALE_START_ERROR);
   runOrchestratorSideEffect(
     "start-session-refresh-task-data-after-kickoff",
-    task.refreshTaskData(startedCtx.repoPath),
+    task.refreshTaskData(startedCtx.repoPath, startedCtx.taskId),
     {
       tags: createSessionStartTags(startedCtx),
     },

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.types.ts
@@ -76,7 +76,7 @@ export type RuntimeDependencies = {
 export type TaskDependencies = {
   taskRef: { current: TaskCard[] };
   loadTaskDocuments: (repoPath: string, taskId: string) => Promise<TaskDocuments>;
-  refreshTaskData: (repoPath: string) => Promise<void>;
+  refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
   sendAgentMessage: (sessionId: string, content: string) => Promise<void>;
 };
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.ts
@@ -67,7 +67,7 @@ export type TaskDocuments = {
 
 type EnsureRuntimeDependencies = {
   runsRef: { current: RunSummary[] };
-  refreshTaskData: (repoPath: string) => Promise<void>;
+  refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
 };
 
 export const loadTaskDocuments = async (

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.ts
@@ -48,7 +48,7 @@ type UseAgentOrchestratorOperationsArgs = {
   activeRepo: string | null;
   tasks: TaskCard[];
   runs: RunSummary[];
-  refreshTaskData: (repoPath: string) => Promise<void>;
+  refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
   agentEngine: AgentEnginePort;
 };
 

--- a/apps/desktop/src/state/operations/tasks/use-delegation-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-delegation-operations.ts
@@ -6,7 +6,7 @@ import { requireActiveRepo } from "./task-operations-model";
 
 type UseDelegationOperationsArgs = {
   activeRepo: string | null;
-  refreshTaskData: (repoPath: string) => Promise<void>;
+  refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
 };
 
 type UseDelegationOperationsResult = {

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
@@ -107,12 +107,30 @@ describe("use-spec-operations", () => {
   });
 
   test("saveSpec rejects invalid markdown and allows retry with valid markdown", async () => {
-    const setSpec = mock(async () => ({ updatedAt: "2026-02-22T10:30:00.000Z" }));
+    let currentSpecMarkdown = "";
+    let currentSpecUpdatedAt: string | null = null;
+    const specGet = mock(async () => ({
+      markdown: currentSpecMarkdown,
+      updatedAt: currentSpecUpdatedAt,
+    }));
+    const setSpec = mock(async ({ markdown }: { markdown: string }) => {
+      currentSpecMarkdown = markdown;
+      currentSpecUpdatedAt = "2026-02-22T10:30:00.000Z";
+      return { updatedAt: "2026-02-22T10:30:00.000Z" };
+    });
+    const tasksList = mock(async () => []);
+    const runsList = mock(async () => []);
 
     const original = {
+      specGet: host.specGet,
       setSpec: host.setSpec,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
     };
+    host.specGet = specGet;
     host.setSpec = setSpec;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
 
     const harness = createHookHarness({ activeRepo: "/repo-a" });
 
@@ -132,25 +150,42 @@ describe("use-spec-operations", () => {
       });
     } finally {
       await harness.unmount();
+      host.specGet = original.specGet;
       host.setSpec = original.setSpec;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
     }
   });
 
   test("loads and saves document variants through host adapter", async () => {
+    let currentSpecMarkdown = "# Spec";
+    let currentSpecUpdatedAt: string | null = "2026-02-22T10:00:00.000Z";
+    let currentPlanMarkdown = "# Plan";
+    let currentPlanUpdatedAt: string | null = "2026-02-22T10:01:00.000Z";
     const specGet = mock(async () => ({
-      markdown: "# Spec",
-      updatedAt: "2026-02-22T10:00:00.000Z",
+      markdown: currentSpecMarkdown,
+      updatedAt: currentSpecUpdatedAt,
     }));
     const planGet = mock(async () => ({
-      markdown: "# Plan",
-      updatedAt: "2026-02-22T10:01:00.000Z",
+      markdown: currentPlanMarkdown,
+      updatedAt: currentPlanUpdatedAt,
     }));
     const qaGetReport = mock(async () => ({
       markdown: "# QA",
       updatedAt: "2026-02-22T10:02:00.000Z",
     }));
-    const saveSpecDocument = mock(async () => ({ updatedAt: "2026-02-22T10:03:00.000Z" }));
-    const savePlanDocument = mock(async () => ({ updatedAt: "2026-02-22T10:04:00.000Z" }));
+    const saveSpecDocument = mock(async ({ markdown }: { markdown: string }) => {
+      currentSpecMarkdown = markdown;
+      currentSpecUpdatedAt = "2026-02-22T10:03:00.000Z";
+      return { updatedAt: "2026-02-22T10:03:00.000Z" };
+    });
+    const savePlanDocument = mock(async ({ markdown }: { markdown: string }) => {
+      currentPlanMarkdown = markdown;
+      currentPlanUpdatedAt = "2026-02-22T10:04:00.000Z";
+      return { updatedAt: "2026-02-22T10:04:00.000Z" };
+    });
+    const tasksList = mock(async () => []);
+    const runsList = mock(async () => []);
 
     const original = {
       specGet: host.specGet,
@@ -158,12 +193,16 @@ describe("use-spec-operations", () => {
       qaGetReport: host.qaGetReport,
       saveSpecDocument: host.saveSpecDocument,
       savePlanDocument: host.savePlanDocument,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
     };
     host.specGet = specGet;
     host.planGet = planGet;
     host.qaGetReport = qaGetReport;
     host.saveSpecDocument = saveSpecDocument;
     host.savePlanDocument = savePlanDocument;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
 
     const harness = createHookHarness({ activeRepo: "/repo-a" });
 
@@ -211,6 +250,8 @@ describe("use-spec-operations", () => {
       host.qaGetReport = original.qaGetReport;
       host.saveSpecDocument = original.saveSpecDocument;
       host.savePlanDocument = original.savePlanDocument;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
     }
   });
 
@@ -238,14 +279,44 @@ describe("use-spec-operations", () => {
       { wrapper },
     );
 
-    const saveSpecDocument = mock(async () => ({ updatedAt: "2026-02-22T10:03:00.000Z" }));
-    const savePlanDocument = mock(async () => ({ updatedAt: "2026-02-22T10:04:00.000Z" }));
+    let currentSpecMarkdown = "# Old spec";
+    let currentSpecUpdatedAt: string | null = "2026-02-22T10:00:00.000Z";
+    let currentPlanMarkdown = "# Old plan";
+    let currentPlanUpdatedAt: string | null = "2026-02-22T10:00:00.000Z";
+    const specGet = mock(async () => ({
+      markdown: currentSpecMarkdown,
+      updatedAt: currentSpecUpdatedAt,
+    }));
+    const planGet = mock(async () => ({
+      markdown: currentPlanMarkdown,
+      updatedAt: currentPlanUpdatedAt,
+    }));
+    const saveSpecDocument = mock(async ({ markdown }: { markdown: string }) => {
+      currentSpecMarkdown = markdown;
+      currentSpecUpdatedAt = "2026-02-22T10:03:00.000Z";
+      return { updatedAt: "2026-02-22T10:03:00.000Z" };
+    });
+    const savePlanDocument = mock(async ({ markdown }: { markdown: string }) => {
+      currentPlanMarkdown = markdown;
+      currentPlanUpdatedAt = "2026-02-22T10:04:00.000Z";
+      return { updatedAt: "2026-02-22T10:04:00.000Z" };
+    });
+    const tasksList = mock(async () => []);
+    const runsList = mock(async () => []);
     const original = {
+      specGet: host.specGet,
+      planGet: host.planGet,
       saveSpecDocument: host.saveSpecDocument,
       savePlanDocument: host.savePlanDocument,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
     };
+    host.specGet = specGet;
+    host.planGet = planGet;
     host.saveSpecDocument = saveSpecDocument;
     host.savePlanDocument = savePlanDocument;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
 
     queryClient.setQueryData(documentQueryKeys.spec("/repo-a", "task-1"), {
       markdown: "# Old spec",
@@ -267,14 +338,8 @@ describe("use-spec-operations", () => {
       tasks: [],
       runs: [],
     });
-    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 1), {
-      tasks: [],
-      runs: [],
-    });
-    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 7), {
-      tasks: [],
-      runs: [],
-    });
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 1), []);
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 7), []);
 
     try {
       await harness.mount();
@@ -308,18 +373,22 @@ describe("use-spec-operations", () => {
         queryClient.getQueryState(["task-documents", "plan", "", "task-1"])?.isInvalidated,
       ).toBe(true);
       expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a"))?.isInvalidated).toBe(
-        true,
+        false,
       );
       expect(queryClient.getQueryState(taskQueryKeys.kanbanData("/repo-a", 1))?.isInvalidated).toBe(
-        true,
+        false,
       );
       expect(queryClient.getQueryState(taskQueryKeys.kanbanData("/repo-a", 7))?.isInvalidated).toBe(
-        true,
+        false,
       );
     } finally {
       await harness.unmount();
+      host.specGet = original.specGet;
+      host.planGet = original.planGet;
       host.saveSpecDocument = original.saveSpecDocument;
       host.savePlanDocument = original.savePlanDocument;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
       queryClient.clear();
     }
   });
@@ -348,11 +417,29 @@ describe("use-spec-operations", () => {
       { wrapper },
     );
 
-    const setSpec = mock(async () => ({ updatedAt: "2026-02-22T10:06:00.000Z" }));
+    let currentSpecMarkdown = "# Old spec";
+    let currentSpecUpdatedAt: string | null = "2026-02-22T10:00:00.000Z";
+    const specGet = mock(async () => ({
+      markdown: currentSpecMarkdown,
+      updatedAt: currentSpecUpdatedAt,
+    }));
+    const setSpec = mock(async ({ markdown }: { markdown: string }) => {
+      currentSpecMarkdown = markdown;
+      currentSpecUpdatedAt = "2026-02-22T10:06:00.000Z";
+      return { updatedAt: "2026-02-22T10:06:00.000Z" };
+    });
+    const tasksList = mock(async () => []);
+    const runsList = mock(async () => []);
     const original = {
+      specGet: host.specGet,
       setSpec: host.setSpec,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
     };
+    host.specGet = specGet;
     host.setSpec = setSpec;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
 
     queryClient.setQueryData(documentQueryKeys.spec("/repo-a", "task-1"), {
       markdown: "# Old spec",
@@ -366,14 +453,8 @@ describe("use-spec-operations", () => {
       tasks: [],
       runs: [],
     });
-    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 1), {
-      tasks: [],
-      runs: [],
-    });
-    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 7), {
-      tasks: [],
-      runs: [],
-    });
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 1), []);
+    queryClient.setQueryData(taskQueryKeys.kanbanData("/repo-a", 7), []);
 
     try {
       await harness.mount();
@@ -396,17 +477,20 @@ describe("use-spec-operations", () => {
         queryClient.getQueryState(["task-documents", "spec", "", "task-1"])?.isInvalidated,
       ).toBe(true);
       expect(queryClient.getQueryState(taskQueryKeys.repoData("/repo-a"))?.isInvalidated).toBe(
-        true,
+        false,
       );
       expect(queryClient.getQueryState(taskQueryKeys.kanbanData("/repo-a", 1))?.isInvalidated).toBe(
-        true,
+        false,
       );
       expect(queryClient.getQueryState(taskQueryKeys.kanbanData("/repo-a", 7))?.isInvalidated).toBe(
-        true,
+        false,
       );
     } finally {
       await harness.unmount();
+      host.specGet = original.specGet;
       host.setSpec = original.setSpec;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
       queryClient.clear();
     }
   });
@@ -435,14 +519,36 @@ describe("use-spec-operations", () => {
       { wrapper },
     );
 
+    const currentSpecMarkdown = "# Newer spec";
+    const currentSpecUpdatedAt: string | null = "2026-02-22T10:05:00.000Z";
+    const currentPlanMarkdown = "# Newer plan";
+    const currentPlanUpdatedAt: string | null = "2026-02-22T10:05:00.000Z";
+    const specGet = mock(async () => ({
+      markdown: currentSpecMarkdown,
+      updatedAt: currentSpecUpdatedAt,
+    }));
+    const planGet = mock(async () => ({
+      markdown: currentPlanMarkdown,
+      updatedAt: currentPlanUpdatedAt,
+    }));
     const saveSpecDocument = mock(async () => ({ updatedAt: "2026-02-22T10:01:00.000Z" }));
     const savePlanDocument = mock(async () => ({ updatedAt: "2026-02-22T10:01:00.000Z" }));
+    const tasksList = mock(async () => []);
+    const runsList = mock(async () => []);
     const original = {
+      specGet: host.specGet,
+      planGet: host.planGet,
       saveSpecDocument: host.saveSpecDocument,
       savePlanDocument: host.savePlanDocument,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
     };
+    host.specGet = specGet;
+    host.planGet = planGet;
     host.saveSpecDocument = saveSpecDocument;
     host.savePlanDocument = savePlanDocument;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
 
     queryClient.setQueryData(documentQueryKeys.spec("/repo-a", "task-1"), {
       markdown: "# Newer spec",
@@ -483,8 +589,12 @@ describe("use-spec-operations", () => {
       });
     } finally {
       await harness.unmount();
+      host.specGet = original.specGet;
+      host.planGet = original.planGet;
       host.saveSpecDocument = original.saveSpecDocument;
       host.savePlanDocument = original.savePlanDocument;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
       queryClient.clear();
     }
   });

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
@@ -90,7 +90,10 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await refreshRepoTaskViewsFromQuery(queryClient, repo, { taskId });
+      await refreshRepoTaskViewsFromQuery(queryClient, repo, {
+        taskDocumentStrategy: "refresh",
+        taskId,
+      });
       return saved;
     },
     [activeRepo, queryClient],
@@ -111,7 +114,10 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await refreshRepoTaskViewsFromQuery(queryClient, repo, { taskId });
+      await refreshRepoTaskViewsFromQuery(queryClient, repo, {
+        taskDocumentStrategy: "refresh",
+        taskId,
+      });
       return saved;
     },
     [activeRepo, queryClient],
@@ -132,7 +138,10 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await refreshRepoTaskViewsFromQuery(queryClient, repo, { taskId });
+      await refreshRepoTaskViewsFromQuery(queryClient, repo, {
+        taskDocumentStrategy: "refresh",
+        taskId,
+      });
       return saved;
     },
     [activeRepo, queryClient],

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.ts
@@ -9,7 +9,7 @@ import {
   loadQaReportDocumentFromQuery,
   loadSpecDocumentFromQuery,
 } from "../../queries/documents";
-import { invalidateRepoTaskListQueries } from "../../queries/tasks";
+import { refreshRepoTaskViewsFromQuery } from "../../queries/task-view-sync";
 import { host } from "../shared/host";
 import { requireActiveRepo } from "./task-operations-model";
 
@@ -90,7 +90,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await invalidateRepoTaskListQueries(queryClient, repo);
+      await refreshRepoTaskViewsFromQuery(queryClient, repo, { taskId });
       return saved;
     },
     [activeRepo, queryClient],
@@ -111,7 +111,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await invalidateRepoTaskListQueries(queryClient, repo);
+      await refreshRepoTaskViewsFromQuery(queryClient, repo, { taskId });
       return saved;
     },
     [activeRepo, queryClient],
@@ -132,7 +132,7 @@ export function useSpecOperations({ activeRepo }: UseSpecOperationsArgs): UseSpe
       await queryClient.invalidateQueries({
         queryKey: documentQueryKeys.all,
       });
-      await invalidateRepoTaskListQueries(queryClient, repo);
+      await refreshRepoTaskViewsFromQuery(queryClient, repo, { taskId });
       return saved;
     },
     [activeRepo, queryClient],

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -1,13 +1,13 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { BeadsCheck, RunSummary, TaskCard, TaskCreateInput } from "@openducktor/contracts";
-import { useQuery } from "@tanstack/react-query";
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import type { PropsWithChildren, ReactElement } from "react";
 import { toast } from "sonner";
-import { clearAppQueryClient } from "@/lib/query-client";
+import { clearAppQueryClient, createQueryClient } from "@/lib/query-client";
 import { QueryProvider } from "@/lib/query-provider";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { kanbanTaskListQueryOptions } from "../../queries/tasks";
+import { kanbanTaskListQueryOptions, taskQueryKeys } from "../../queries/tasks";
 import {
   attachAgentSessionListener,
   type SessionEventAdapter,
@@ -612,6 +612,94 @@ describe("use-task-operations", () => {
     } finally {
       await harness.unmount();
       host.repoPullRequestSync = original.repoPullRequestSync;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+    }
+  });
+
+  test("refreshTaskData updates inactive cached kanban queries after off-board task changes", async () => {
+    let currentStatus: TaskCard["status"] = "ready_for_dev";
+    const tasksList = mock(async () => [makeTask("A", currentStatus)]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+
+    const original = {
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+    };
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+
+    const queryClient = createQueryClient();
+    let latest: ReturnType<typeof useTaskOperations> | null = null;
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useTaskOperations(args);
+      return null;
+    };
+
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const harness = createSharedHookHarness(
+      Harness,
+      {
+        args: {
+          activeRepo: "/repo",
+          refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+            beadsOk: true,
+            beadsPath: "/repo/.beads",
+            beadsError: null,
+          }),
+        },
+      },
+      { wrapper },
+    );
+
+    try {
+      await queryClient.fetchQuery(kanbanTaskListQueryOptions("/repo", 1));
+      expect(
+        queryClient.getQueryData<TaskCard[]>(taskQueryKeys.kanbanData("/repo", 1))?.[0]?.status,
+      ).toBe("ready_for_dev");
+
+      await harness.mount();
+      await harness.waitFor(() => latest?.tasks[0]?.status === "ready_for_dev", 1000);
+
+      tasksList.mockClear();
+      runsList.mockClear();
+      currentStatus = "in_progress";
+
+      await harness.run(async () => {
+        if (!latest) {
+          throw new Error("Hook not mounted");
+        }
+
+        await latest.refreshTaskData("/repo");
+      });
+
+      await harness.waitFor(
+        () =>
+          latest?.tasks[0]?.status === "in_progress" &&
+          queryClient.getQueryData<TaskCard[]>(taskQueryKeys.kanbanData("/repo", 1))?.[0]
+            ?.status === "in_progress",
+        1000,
+      );
+
+      expect(
+        tasksList.mock.calls.some((call) => {
+          const args = call as unknown[];
+          return args[0] === "/repo" && args.length === 1;
+        }),
+      ).toBe(true);
+      expect(
+        tasksList.mock.calls.some((call) => {
+          const args = call as unknown[];
+          return args[0] === "/repo" && args[1] === 1;
+        }),
+      ).toBe(true);
+      expect(runsList).toHaveBeenCalledWith("/repo");
+    } finally {
+      await harness.unmount();
       host.tasksList = original.tasksList;
       host.runsList = original.runsList;
     }

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -828,6 +828,95 @@ describe("use-task-operations", () => {
     }
   });
 
+  test("deleteTask removes cached task documents for deleted tasks and subtasks", async () => {
+    let isDeleted = false;
+    const taskDelete = mock(async () => {
+      isDeleted = true;
+      return { ok: true };
+    });
+    const tasksList = mock(async () =>
+      isDeleted ? [] : [{ ...makeTask("A", "open"), subtaskIds: ["B"] }, makeTask("B", "open")],
+    );
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+
+    const original = {
+      taskDelete: host.taskDelete,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+    };
+    host.taskDelete = taskDelete;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+
+    const queryClient = createQueryClient();
+    let latest: ReturnType<typeof useTaskOperations> | null = null;
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      latest = useTaskOperations(args);
+      return null;
+    };
+
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const harness = createSharedHookHarness(
+      Harness,
+      {
+        args: {
+          activeRepo: "/repo",
+          refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+            beadsOk: true,
+            beadsPath: "/repo/.beads",
+            beadsError: null,
+          }),
+        },
+      },
+      { wrapper },
+    );
+
+    try {
+      queryClient.setQueryData(taskQueryKeys.repoData("/repo"), {
+        tasks: [{ ...makeTask("A", "open"), subtaskIds: ["B"] }, makeTask("B", "open")],
+        runs: [] satisfies RunSummary[],
+      });
+      queryClient.setQueryData(documentQueryKeys.spec("/repo", "A"), {
+        markdown: "# Parent spec",
+        updatedAt: "2026-03-28T00:00:00.000Z",
+      });
+      queryClient.setQueryData(documentQueryKeys.plan("/repo", "B"), {
+        markdown: "# Child plan",
+        updatedAt: "2026-03-28T00:00:00.000Z",
+      });
+
+      await harness.mount();
+      await harness.run(async () => {
+        if (!latest) {
+          throw new Error("Hook not mounted");
+        }
+
+        await latest.deleteTask("A", true);
+      });
+
+      await harness.waitFor(
+        () =>
+          queryClient.getQueryData<{ tasks: TaskCard[]; runs: RunSummary[] }>(
+            taskQueryKeys.repoData("/repo"),
+          )?.tasks.length === 0,
+        1000,
+      );
+
+      expect(taskDelete).toHaveBeenCalledWith("/repo", "A", true);
+      expect(queryClient.getQueryData(documentQueryKeys.spec("/repo", "A"))).toBeUndefined();
+      expect(queryClient.getQueryData(documentQueryKeys.plan("/repo", "B"))).toBeUndefined();
+    } finally {
+      await harness.unmount();
+      host.taskDelete = original.taskDelete;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+    }
+  });
+
   test("completed ODT tool events refresh an active kanban query through the session listener", async () => {
     let currentStatus: TaskCard["status"] = "human_review";
     const tasksList = mock(async () => [makeTask("A", currentStatus)]);

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -3,10 +3,12 @@ import type { BeadsCheck, RunSummary, TaskCard, TaskCreateInput } from "@openduc
 import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import type { PropsWithChildren, ReactElement } from "react";
 import { toast } from "sonner";
+import { useTaskDocuments } from "@/components/features/task-details/use-task-documents";
 import { clearAppQueryClient, createQueryClient } from "@/lib/query-client";
 import { QueryProvider } from "@/lib/query-provider";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { documentQueryKeys } from "../../queries/documents";
 import { kanbanTaskListQueryOptions, taskQueryKeys } from "../../queries/tasks";
 import {
   attachAgentSessionListener,
@@ -702,6 +704,127 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.tasksList = original.tasksList;
       host.runsList = original.runsList;
+    }
+  });
+
+  test("refreshTaskData refreshes cached task detail documents after off-board workflow updates", async () => {
+    let currentStatus: TaskCard["status"] = "ready_for_dev";
+    let currentPlanMarkdown = "";
+    let currentPlanUpdatedAt: string | null = null;
+    const tasksList = mock(async () => [makeTask("A", currentStatus)]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const specGet = mock(async () => ({ markdown: "", updatedAt: null }));
+    const planGet = mock(async () => ({
+      markdown: currentPlanMarkdown,
+      updatedAt: currentPlanUpdatedAt,
+    }));
+    const qaGetReport = mock(async () => ({ markdown: "", updatedAt: null }));
+
+    const original = {
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+      specGet: host.specGet,
+      planGet: host.planGet,
+      qaGetReport: host.qaGetReport,
+    };
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+    host.specGet = specGet;
+    host.planGet = planGet;
+    host.qaGetReport = qaGetReport;
+
+    const queryClient = createQueryClient();
+    let latest: {
+      operations: ReturnType<typeof useTaskOperations>;
+      planMarkdown: string;
+      planLoaded: boolean;
+    } | null = null;
+    const getLatestState = () => {
+      if (!latest) {
+        throw new Error("Hook not mounted");
+      }
+      return latest;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      const operations = useTaskOperations(args);
+      const { planDoc } = useTaskDocuments("A", true, args.activeRepo ?? "");
+      latest = {
+        operations,
+        planMarkdown: planDoc.markdown,
+        planLoaded: planDoc.loaded,
+      };
+      return null;
+    };
+
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const harness = createSharedHookHarness(
+      Harness,
+      {
+        args: {
+          activeRepo: "/repo",
+          refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+            beadsOk: true,
+            beadsPath: "/repo/.beads",
+            beadsError: null,
+          }),
+        },
+      },
+      { wrapper },
+    );
+
+    try {
+      queryClient.setQueryData(taskQueryKeys.repoData("/repo"), {
+        tasks: [makeTask("A", "ready_for_dev")],
+        runs: [] satisfies RunSummary[],
+      });
+      queryClient.setQueryData(documentQueryKeys.plan("/repo", "A"), {
+        markdown: "",
+        updatedAt: null,
+      });
+      await harness.mount();
+      expect(getLatestState().planMarkdown).toBe("");
+
+      tasksList.mockClear();
+      runsList.mockClear();
+      planGet.mockClear();
+      currentStatus = "in_progress";
+      currentPlanMarkdown = "# New plan";
+      currentPlanUpdatedAt = "2026-03-28T00:00:00.000Z";
+
+      await harness.run(async () => {
+        await getLatestState().operations.refreshTaskData("/repo", "A");
+      });
+
+      await harness.waitFor(
+        () =>
+          queryClient.getQueryData<{
+            tasks: TaskCard[];
+            runs: RunSummary[];
+          }>(taskQueryKeys.repoData("/repo"))?.tasks[0]?.status === "in_progress" &&
+          queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(
+            documentQueryKeys.plan("/repo", "A"),
+          )?.markdown === "# New plan",
+        3000,
+      );
+
+      expect(planGet).toHaveBeenCalledWith("/repo", "A");
+      expect(tasksList).toHaveBeenCalledWith("/repo");
+      expect(
+        queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(
+          documentQueryKeys.plan("/repo", "A"),
+        )?.markdown,
+      ).toBe("# New plan");
+    } finally {
+      await harness.unmount();
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+      host.specGet = original.specGet;
+      host.planGet = original.planGet;
+      host.qaGetReport = original.qaGetReport;
     }
   });
 

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -17,7 +17,7 @@ import { agentSessionQueryKeys } from "../../queries/agent-sessions";
 import {
   invalidateRepoTaskQueries,
   loadRepoTaskDataFromQuery,
-  refetchActiveKanbanQueries,
+  refreshCachedKanbanQueries,
   repoTaskDataQueryOptions,
 } from "../../queries/tasks";
 import { host } from "../shared/host";
@@ -98,7 +98,7 @@ export function useTaskOperations({
       await invalidateRepoTaskQueries(queryClient, repoPath);
       await Promise.all([
         loadRepoTaskDataFromQuery(queryClient, repoPath),
-        refetchActiveKanbanQueries(queryClient, repoPath),
+        refreshCachedKanbanQueries(queryClient, repoPath),
       ]);
     },
     [queryClient],

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -12,14 +12,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { documentQueryKeys } from "@/state/queries/documents";
+import { refreshRepoTaskViewsFromQuery } from "@/state/queries/task-view-sync";
 import { summarizeTaskLoadError } from "@/state/tasks/task-load-errors";
 import { agentSessionQueryKeys } from "../../queries/agent-sessions";
-import {
-  invalidateRepoTaskQueries,
-  loadRepoTaskDataFromQuery,
-  refreshCachedKanbanQueries,
-  repoTaskDataQueryOptions,
-} from "../../queries/tasks";
+import { repoTaskDataQueryOptions } from "../../queries/tasks";
 import { host } from "../shared/host";
 import {
   DEFERRED_BY_USER_REASON,
@@ -43,7 +39,7 @@ type UseTaskOperationsResult = {
   pendingMergedPullRequest: { taskId: string; pullRequest: PullRequest } | null;
   setIsLoadingTasks: (value: boolean) => void;
   clearTaskData: () => void;
-  refreshTaskData: (repoPath: string) => Promise<void>;
+  refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
   refreshTasks: () => Promise<void>;
   syncPullRequests: (taskId: string) => Promise<void>;
   linkMergedPullRequest: () => Promise<void>;
@@ -94,18 +90,15 @@ export function useTaskOperations({
   }, [activeRepo]);
 
   const refreshTaskData = useCallback(
-    async (repoPath: string): Promise<void> => {
-      await invalidateRepoTaskQueries(queryClient, repoPath);
-      await Promise.all([
-        loadRepoTaskDataFromQuery(queryClient, repoPath),
-        refreshCachedKanbanQueries(queryClient, repoPath),
-      ]);
+    async (repoPath: string, taskId?: string): Promise<void> => {
+      await refreshRepoTaskViewsFromQuery(queryClient, repoPath, taskId ? { taskId } : undefined);
     },
     [queryClient],
   );
 
   const runTaskMutation = useCallback(
     async (options: {
+      taskId?: string;
       run: (repoPath: string) => Promise<void>;
       successTitle?: string;
       successDescription: string;
@@ -114,7 +107,7 @@ export function useTaskOperations({
       try {
         const repoPath = requireActiveRepo(activeRepo);
         await options.run(repoPath);
-        await refreshTaskData(repoPath);
+        await refreshTaskData(repoPath, options.taskId);
         if (options.successTitle) {
           toast.success(options.successTitle, {
             description: options.successDescription,
@@ -166,7 +159,7 @@ export function useTaskOperations({
         const repoPath = requireActiveRepo(activeRepo);
         const result = await host.taskPullRequestDetect(repoPath, taskId);
         if (result.outcome === "linked") {
-          await refreshTaskData(repoPath);
+          await refreshTaskData(repoPath, taskId);
           toast.success("Pull request linked", {
             description: `PR #${result.pullRequest.number}`,
           });
@@ -216,7 +209,7 @@ export function useTaskOperations({
       const repoPath = requireActiveRepo(activeRepo);
       await host.taskPullRequestLinkMerged(repoPath, taskId, pullRequest);
       setPendingMergedPullRequest((current) => (current?.taskId === taskId ? null : current));
-      await refreshTaskData(repoPath);
+      await refreshTaskData(repoPath, taskId);
       toast.success("Merged pull request linked", {
         description: `PR #${pullRequest.number}; task moved to Done.`,
       });
@@ -236,6 +229,7 @@ export function useTaskOperations({
       setUnlinkingPullRequestTaskId(taskId);
       try {
         await runTaskMutation({
+          taskId,
           run: async (repoPath) => {
             await host.taskPullRequestUnlink(repoPath, taskId);
           },
@@ -281,6 +275,7 @@ export function useTaskOperations({
   const updateTask = useCallback(
     async (taskId: string, patch: TaskUpdatePatch): Promise<void> => {
       await runTaskMutation({
+        taskId,
         run: async (repoPath) => {
           await host.taskUpdate(repoPath, taskId, patch);
         },
@@ -333,7 +328,7 @@ export function useTaskOperations({
             refetchType: "none",
           }),
         ]);
-        await refreshTaskData(repoPath);
+        await refreshTaskData(repoPath, taskId);
         toast.success("Implementation reset", {
           description: taskId,
         });
@@ -350,6 +345,7 @@ export function useTaskOperations({
   const transitionTask = useCallback(
     async (taskId: string, status: TaskStatus, reason?: string): Promise<void> => {
       await runTaskMutation({
+        taskId,
         run: async (repoPath) => {
           await host.taskTransition(repoPath, taskId, status, reason);
         },
@@ -363,6 +359,7 @@ export function useTaskOperations({
   const deferTask = useCallback(
     async (taskId: string): Promise<void> => {
       await runTaskMutation({
+        taskId,
         run: async (repoPath) => {
           await host.taskDefer(repoPath, taskId, DEFERRED_BY_USER_REASON);
         },
@@ -377,6 +374,7 @@ export function useTaskOperations({
   const resumeDeferredTask = useCallback(
     async (taskId: string): Promise<void> => {
       await runTaskMutation({
+        taskId,
         run: async (repoPath) => {
           await host.taskResumeDeferred(repoPath, taskId);
         },
@@ -391,6 +389,7 @@ export function useTaskOperations({
   const humanApproveTask = useCallback(
     async (taskId: string): Promise<void> => {
       await runTaskMutation({
+        taskId,
         run: async (repoPath) => {
           await host.humanApprove(repoPath, taskId);
         },
@@ -405,6 +404,7 @@ export function useTaskOperations({
   const humanRequestChangesTask = useCallback(
     async (taskId: string, note?: string): Promise<void> => {
       await runTaskMutation({
+        taskId,
         run: async (repoPath) => {
           await host.humanRequestChanges(repoPath, taskId, note);
         },

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -56,6 +56,44 @@ type UseTaskOperationsResult = {
   humanRequestChangesTask: (taskId: string, note?: string) => Promise<void>;
 };
 
+type TaskMutationRefreshStrategy =
+  | { kind: "repo" }
+  | { kind: "task"; taskId: string }
+  | { kind: "remove-task"; taskIds: string[] };
+
+const collectTaskDeletionIds = (
+  tasks: TaskCard[],
+  taskId: string,
+  deleteSubtasks: boolean,
+): string[] => {
+  if (!deleteSubtasks) {
+    return [taskId];
+  }
+
+  const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const collectedIds: string[] = [];
+  const pendingIds = [taskId];
+  const seenIds = new Set<string>();
+
+  while (pendingIds.length > 0) {
+    const currentId = pendingIds.shift();
+    if (!currentId || seenIds.has(currentId)) {
+      continue;
+    }
+
+    seenIds.add(currentId);
+    collectedIds.push(currentId);
+
+    for (const subtaskId of taskById.get(currentId)?.subtaskIds ?? []) {
+      if (!seenIds.has(subtaskId)) {
+        pendingIds.push(subtaskId);
+      }
+    }
+  }
+
+  return collectedIds;
+};
+
 export function useTaskOperations({
   activeRepo,
   refreshBeadsCheckForRepo,
@@ -91,14 +129,41 @@ export function useTaskOperations({
 
   const refreshTaskData = useCallback(
     async (repoPath: string, taskId?: string): Promise<void> => {
-      await refreshRepoTaskViewsFromQuery(queryClient, repoPath, taskId ? { taskId } : undefined);
+      await refreshRepoTaskViewsFromQuery(
+        queryClient,
+        repoPath,
+        taskId ? { taskDocumentStrategy: "refresh", taskId } : undefined,
+      );
+    },
+    [queryClient],
+  );
+
+  const refreshTaskMutationViews = useCallback(
+    async (repoPath: string, strategy: TaskMutationRefreshStrategy): Promise<void> => {
+      if (strategy.kind === "task") {
+        await refreshRepoTaskViewsFromQuery(queryClient, repoPath, {
+          taskDocumentStrategy: "refresh",
+          taskId: strategy.taskId,
+        });
+        return;
+      }
+
+      if (strategy.kind === "remove-task") {
+        await refreshRepoTaskViewsFromQuery(queryClient, repoPath, {
+          taskDocumentStrategy: "remove",
+          taskIds: strategy.taskIds,
+        });
+        return;
+      }
+
+      await refreshRepoTaskViewsFromQuery(queryClient, repoPath);
     },
     [queryClient],
   );
 
   const runTaskMutation = useCallback(
     async (options: {
-      taskId?: string;
+      refreshStrategy: TaskMutationRefreshStrategy;
       run: (repoPath: string) => Promise<void>;
       successTitle?: string;
       successDescription: string;
@@ -107,7 +172,7 @@ export function useTaskOperations({
       try {
         const repoPath = requireActiveRepo(activeRepo);
         await options.run(repoPath);
-        await refreshTaskData(repoPath, options.taskId);
+        await refreshTaskMutationViews(repoPath, options.refreshStrategy);
         if (options.successTitle) {
           toast.success(options.successTitle, {
             description: options.successDescription,
@@ -120,7 +185,7 @@ export function useTaskOperations({
         throw error;
       }
     },
-    [activeRepo, refreshTaskData],
+    [activeRepo, refreshTaskMutationViews],
   );
 
   const refreshTasks = useCallback(async (): Promise<void> => {
@@ -229,7 +294,7 @@ export function useTaskOperations({
       setUnlinkingPullRequestTaskId(taskId);
       try {
         await runTaskMutation({
-          taskId,
+          refreshStrategy: { kind: "task", taskId },
           run: async (repoPath) => {
             await host.taskPullRequestUnlink(repoPath, taskId);
           },
@@ -258,6 +323,7 @@ export function useTaskOperations({
       }
 
       await runTaskMutation({
+        refreshStrategy: { kind: "repo" },
         run: async (repoPath) => {
           await host.taskCreate(repoPath, {
             ...input,
@@ -275,7 +341,7 @@ export function useTaskOperations({
   const updateTask = useCallback(
     async (taskId: string, patch: TaskUpdatePatch): Promise<void> => {
       await runTaskMutation({
-        taskId,
+        refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
           await host.taskUpdate(repoPath, taskId, patch);
         },
@@ -289,7 +355,13 @@ export function useTaskOperations({
 
   const deleteTask = useCallback(
     async (taskId: string, deleteSubtasks = false): Promise<void> => {
+      const taskIdsToRemove = collectTaskDeletionIds(
+        repoTaskDataQuery.data?.tasks ?? [],
+        taskId,
+        deleteSubtasks,
+      );
       await runTaskMutation({
+        refreshStrategy: { kind: "remove-task", taskIds: taskIdsToRemove },
         run: async (repoPath) => {
           await host.taskDelete(repoPath, taskId, deleteSubtasks);
         },
@@ -298,7 +370,7 @@ export function useTaskOperations({
         failureTitle: "Failed to delete task",
       });
     },
-    [runTaskMutation],
+    [repoTaskDataQuery.data?.tasks, runTaskMutation],
   );
 
   const resetTaskImplementation = useCallback(
@@ -345,7 +417,7 @@ export function useTaskOperations({
   const transitionTask = useCallback(
     async (taskId: string, status: TaskStatus, reason?: string): Promise<void> => {
       await runTaskMutation({
-        taskId,
+        refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
           await host.taskTransition(repoPath, taskId, status, reason);
         },
@@ -359,7 +431,7 @@ export function useTaskOperations({
   const deferTask = useCallback(
     async (taskId: string): Promise<void> => {
       await runTaskMutation({
-        taskId,
+        refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
           await host.taskDefer(repoPath, taskId, DEFERRED_BY_USER_REASON);
         },
@@ -374,7 +446,7 @@ export function useTaskOperations({
   const resumeDeferredTask = useCallback(
     async (taskId: string): Promise<void> => {
       await runTaskMutation({
-        taskId,
+        refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
           await host.taskResumeDeferred(repoPath, taskId);
         },
@@ -389,7 +461,7 @@ export function useTaskOperations({
   const humanApproveTask = useCallback(
     async (taskId: string): Promise<void> => {
       await runTaskMutation({
-        taskId,
+        refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
           await host.humanApprove(repoPath, taskId);
         },
@@ -404,7 +476,7 @@ export function useTaskOperations({
   const humanRequestChangesTask = useCallback(
     async (taskId: string, note?: string): Promise<void> => {
       await runTaskMutation({
-        taskId,
+        refreshStrategy: { kind: "task", taskId },
         run: async (repoPath) => {
           await host.humanRequestChanges(repoPath, taskId, note);
         },

--- a/apps/desktop/src/state/queries/documents.ts
+++ b/apps/desktop/src/state/queries/documents.ts
@@ -1,12 +1,14 @@
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { host } from "../operations/host";
 
-const TASK_DOCUMENT_STALE_TIME_MS = 60_000;
+export const TASK_DOCUMENT_STALE_TIME_MS = 60_000;
 
-type TaskDocument = {
+export type TaskDocument = {
   markdown: string;
   updatedAt: string | null;
 };
+
+export type TaskDocumentSection = "spec" | "plan" | "qa";
 
 export const documentQueryKeys = {
   all: ["task-documents"] as const,
@@ -16,6 +18,22 @@ export const documentQueryKeys = {
     [...documentQueryKeys.all, "plan", repoPath, taskId] as const,
   qaReport: (repoPath: string, taskId: string) =>
     [...documentQueryKeys.all, "qa-report", repoPath, taskId] as const,
+};
+
+export const documentQueryKeyForSection = (
+  repoPath: string,
+  taskId: string,
+  section: TaskDocumentSection,
+) => {
+  if (section === "spec") {
+    return documentQueryKeys.spec(repoPath, taskId);
+  }
+
+  if (section === "plan") {
+    return documentQueryKeys.plan(repoPath, taskId);
+  }
+
+  return documentQueryKeys.qaReport(repoPath, taskId);
 };
 
 const specDocumentQueryOptions = (repoPath: string, taskId: string) =>
@@ -56,6 +74,63 @@ const qaReportDocumentQueryOptions = (repoPath: string, taskId: string) =>
     },
     staleTime: TASK_DOCUMENT_STALE_TIME_MS,
   });
+
+const cachedTaskDocumentSections = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): TaskDocumentSection[] => {
+  const sections = new Set<TaskDocumentSection>();
+  for (const query of queryClient.getQueryCache().findAll({
+    queryKey: documentQueryKeys.all,
+    exact: false,
+  })) {
+    const [scope, section, cachedRepoPath, cachedTaskId] = query.queryKey;
+    if (
+      scope !== documentQueryKeys.all[0] ||
+      cachedRepoPath !== repoPath ||
+      cachedTaskId !== taskId
+    ) {
+      continue;
+    }
+    if (section === "spec" || section === "plan") {
+      sections.add(section);
+      continue;
+    }
+    if (section === "qa" || section === "qa-report") {
+      sections.add("qa");
+    }
+  }
+  return [...sections];
+};
+
+export const refreshCachedTaskDocumentQueries = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+): Promise<void> => {
+  const cachedSections = cachedTaskDocumentSections(queryClient, repoPath, taskId);
+  await Promise.all(
+    cachedSections.map((section) => {
+      if (section === "spec") {
+        return queryClient.fetchQuery({
+          ...specDocumentQueryOptions(repoPath, taskId),
+          staleTime: 0,
+        });
+      }
+      if (section === "plan") {
+        return queryClient.fetchQuery({
+          ...planDocumentQueryOptions(repoPath, taskId),
+          staleTime: 0,
+        });
+      }
+      return queryClient.fetchQuery({
+        ...qaReportDocumentQueryOptions(repoPath, taskId),
+        staleTime: 0,
+      });
+    }),
+  );
+};
 
 export const loadSpecDocumentFromQuery = (
   queryClient: QueryClient,

--- a/apps/desktop/src/state/queries/documents.ts
+++ b/apps/desktop/src/state/queries/documents.ts
@@ -97,11 +97,38 @@ const cachedTaskDocumentSections = (
       sections.add(section);
       continue;
     }
-    if (section === "qa" || section === "qa-report") {
+    if (section === "qa-report") {
       sections.add("qa");
     }
   }
   return [...sections];
+};
+
+export const removeCachedTaskDocumentQueries = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskIds: string[],
+): void => {
+  const taskIdSet = new Set(taskIds);
+  for (const query of queryClient.getQueryCache().findAll({
+    queryKey: documentQueryKeys.all,
+    exact: false,
+  })) {
+    const [scope, _section, cachedRepoPath, cachedTaskId] = query.queryKey;
+    if (
+      scope !== documentQueryKeys.all[0] ||
+      cachedRepoPath !== repoPath ||
+      typeof cachedTaskId !== "string" ||
+      !taskIdSet.has(cachedTaskId)
+    ) {
+      continue;
+    }
+
+    queryClient.removeQueries({
+      queryKey: query.queryKey,
+      exact: true,
+    });
+  }
 };
 
 export const refreshCachedTaskDocumentQueries = async (

--- a/apps/desktop/src/state/queries/task-view-sync.ts
+++ b/apps/desktop/src/state/queries/task-view-sync.ts
@@ -1,0 +1,24 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { refreshCachedTaskDocumentQueries } from "./documents";
+import {
+  invalidateRepoTaskQueries,
+  loadRepoTaskDataFromQuery,
+  refreshCachedKanbanQueries,
+} from "./tasks";
+
+export const refreshRepoTaskViewsFromQuery = async (
+  queryClient: QueryClient,
+  repoPath: string,
+  options?: {
+    taskId?: string;
+  },
+): Promise<void> => {
+  await invalidateRepoTaskQueries(queryClient, repoPath);
+  await Promise.all([
+    loadRepoTaskDataFromQuery(queryClient, repoPath),
+    refreshCachedKanbanQueries(queryClient, repoPath),
+    ...(options?.taskId
+      ? [refreshCachedTaskDocumentQueries(queryClient, repoPath, options.taskId)]
+      : []),
+  ]);
+};

--- a/apps/desktop/src/state/queries/task-view-sync.ts
+++ b/apps/desktop/src/state/queries/task-view-sync.ts
@@ -1,24 +1,42 @@
 import type { QueryClient } from "@tanstack/react-query";
-import { refreshCachedTaskDocumentQueries } from "./documents";
+import { refreshCachedTaskDocumentQueries, removeCachedTaskDocumentQueries } from "./documents";
 import {
   invalidateRepoTaskQueries,
   loadRepoTaskDataFromQuery,
   refreshCachedKanbanQueries,
 } from "./tasks";
 
+export type RepoTaskViewRefreshOptions =
+  | {
+      taskDocumentStrategy?: "none";
+    }
+  | {
+      taskDocumentStrategy: "refresh";
+      taskId: string;
+    }
+  | {
+      taskDocumentStrategy: "remove";
+      taskIds: string[];
+    };
+
 export const refreshRepoTaskViewsFromQuery = async (
   queryClient: QueryClient,
   repoPath: string,
-  options?: {
-    taskId?: string;
-  },
+  options?: RepoTaskViewRefreshOptions,
 ): Promise<void> => {
+  const taskDocumentRefresh =
+    options?.taskDocumentStrategy === "refresh"
+      ? refreshCachedTaskDocumentQueries(queryClient, repoPath, options.taskId)
+      : Promise.resolve();
+
+  if (options?.taskDocumentStrategy === "remove") {
+    removeCachedTaskDocumentQueries(queryClient, repoPath, options.taskIds);
+  }
+
   await invalidateRepoTaskQueries(queryClient, repoPath);
   await Promise.all([
     loadRepoTaskDataFromQuery(queryClient, repoPath),
     refreshCachedKanbanQueries(queryClient, repoPath),
-    ...(options?.taskId
-      ? [refreshCachedTaskDocumentQueries(queryClient, repoPath, options.taskId)]
-      : []),
+    taskDocumentRefresh,
   ]);
 };

--- a/apps/desktop/src/state/queries/tasks.test.ts
+++ b/apps/desktop/src/state/queries/tasks.test.ts
@@ -217,7 +217,7 @@ describe("tasks query cache helpers", () => {
     ).toBe(true);
   });
 
-  test("refreshCachedKanbanQueries refreshes inactive cached kanban queries for the repo", async () => {
+  test("refreshCachedKanbanQueries refreshes cached kanban queries even without prior invalidation", async () => {
     const queryClient = new QueryClient();
     let currentStatus: TaskCard["status"] = "ready_for_dev";
     const tasksList = mock(
@@ -246,7 +246,6 @@ describe("tasks query cache helpers", () => {
     await queryClient.fetchQuery(kanbanTaskListQueryOptions("/other", 1));
 
     currentStatus = "in_progress";
-    await invalidateRepoTaskQueries(queryClient, "/repo");
     tasksList.mockClear();
 
     await refreshCachedKanbanQueries(queryClient, "/repo");

--- a/apps/desktop/src/state/queries/tasks.test.ts
+++ b/apps/desktop/src/state/queries/tasks.test.ts
@@ -6,6 +6,7 @@ import {
   invalidateRepoTaskQueries,
   kanbanTaskListQueryOptions,
   refetchActiveKanbanQueries,
+  refreshCachedKanbanQueries,
   taskQueryKeys,
   upsertAgentSessionInRepoTaskData,
 } from "./tasks";
@@ -214,5 +215,53 @@ describe("tasks query cache helpers", () => {
       queryClient.getQueryState(taskQueryKeys.kanbanData("/repo", DONE_VISIBLE_DAYS))
         ?.isInvalidated,
     ).toBe(true);
+  });
+
+  test("refreshCachedKanbanQueries refreshes inactive cached kanban queries for the repo", async () => {
+    const queryClient = new QueryClient();
+    let currentStatus: TaskCard["status"] = "ready_for_dev";
+    const tasksList = mock(
+      async (repoPath: string, doneVisibleDays?: number): Promise<TaskCard[]> => {
+        if (repoPath === "/repo") {
+          return [
+            {
+              ...taskFixture,
+              status: currentStatus,
+              id: `repo-${doneVisibleDays}`,
+            },
+          ];
+        }
+
+        if (repoPath === "/other") {
+          return [{ ...taskFixture, id: "other-1", status: "open" }];
+        }
+
+        throw new Error(`Unexpected repo path: ${repoPath}`);
+      },
+    );
+    host.tasksList = tasksList;
+
+    await queryClient.fetchQuery(kanbanTaskListQueryOptions("/repo", 1));
+    await queryClient.fetchQuery(kanbanTaskListQueryOptions("/repo", 7));
+    await queryClient.fetchQuery(kanbanTaskListQueryOptions("/other", 1));
+
+    currentStatus = "in_progress";
+    await invalidateRepoTaskQueries(queryClient, "/repo");
+    tasksList.mockClear();
+
+    await refreshCachedKanbanQueries(queryClient, "/repo");
+
+    expect(tasksList).toHaveBeenCalledTimes(2);
+    expect(tasksList).toHaveBeenCalledWith("/repo", 1);
+    expect(tasksList).toHaveBeenCalledWith("/repo", 7);
+    expect(
+      queryClient.getQueryData<TaskCard[]>(taskQueryKeys.kanbanData("/repo", 1))?.[0]?.status,
+    ).toBe("in_progress");
+    expect(
+      queryClient.getQueryData<TaskCard[]>(taskQueryKeys.kanbanData("/repo", 7))?.[0]?.status,
+    ).toBe("in_progress");
+    expect(
+      queryClient.getQueryData<TaskCard[]>(taskQueryKeys.kanbanData("/other", 1))?.[0]?.status,
+    ).toBe("open");
   });
 });

--- a/apps/desktop/src/state/queries/tasks.ts
+++ b/apps/desktop/src/state/queries/tasks.ts
@@ -117,6 +117,37 @@ export const refetchActiveKanbanQueries = (
     type: "active",
   });
 
+const cachedKanbanQueryKeysForRepo = (
+  queryClient: QueryClient,
+  repoPath: string,
+): Array<ReturnType<typeof taskQueryKeys.kanbanData>> =>
+  queryClient
+    .getQueryCache()
+    .findAll({
+      queryKey: taskQueryKeys.kanbanDataPrefix(repoPath),
+      exact: false,
+    })
+    .map((query) => query.queryKey)
+    .filter(
+      (queryKey): queryKey is ReturnType<typeof taskQueryKeys.kanbanData> =>
+        queryKey[0] === taskQueryKeys.all[0] &&
+        queryKey[1] === "kanban-data" &&
+        queryKey[2] === repoPath &&
+        typeof queryKey[3] === "number",
+    );
+
+export const refreshCachedKanbanQueries = async (
+  queryClient: QueryClient,
+  repoPath: string,
+): Promise<void> => {
+  const cachedQueryKeys = cachedKanbanQueryKeysForRepo(queryClient, repoPath);
+  await Promise.all(
+    cachedQueryKeys.map(([, , , doneVisibleDays]) =>
+      queryClient.fetchQuery(kanbanTaskListQueryOptions(repoPath, doneVisibleDays)),
+    ),
+  );
+};
+
 export const invalidateRepoTaskListQueries = (
   queryClient: QueryClient,
   repoPath: string,

--- a/apps/desktop/src/state/queries/tasks.ts
+++ b/apps/desktop/src/state/queries/tasks.ts
@@ -143,7 +143,10 @@ export const refreshCachedKanbanQueries = async (
   const cachedQueryKeys = cachedKanbanQueryKeysForRepo(queryClient, repoPath);
   await Promise.all(
     cachedQueryKeys.map(([, , , doneVisibleDays]) =>
-      queryClient.fetchQuery(kanbanTaskListQueryOptions(repoPath, doneVisibleDays)),
+      queryClient.fetchQuery({
+        ...kanbanTaskListQueryOptions(repoPath, doneVisibleDays),
+        staleTime: 0,
+      }),
     ),
   );
 };


### PR DESCRIPTION
## Summary

- Fix stale task state and task-document state when workflow updates happen outside the Kanban page.
- Centralize refresh behavior so repo task lists, cached Kanban variants, and cached task documents stay in sync by design.
- Out of scope: introducing live push/event subscriptions for all task views; this PR hardens the existing query-driven sync model.

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run check:rust`
- [x] `bun run test:rust`
- [ ] Not applicable

## Checklist

- [ ] I updated docs when behavior, workflows, runtime contracts, or setup changed
- [x] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [x] I linked related issues or context below

## Related Issues

- OpenDucktor task: `openducktor-lxh`

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes are described below

## Additional Context

- The refresh path now supports explicit task-document refresh vs removal strategies so task deletion clears stale cached task details instead of leaving orphaned document entries behind.
- Review-follow-up changes also harden exported cache refresh helpers so they do not rely on hidden invalidation preconditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced task data refresh strategy to target specific tasks rather than refreshing all task data, improving performance and responsiveness when working with individual tasks.
  * Improved caching and synchronization of task documents (specifications, plans, and QA reports) for more efficient data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->