### PR TITLE
feat(agents): allow reuse mode and stabilize hydrated sessions

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
@@ -114,7 +114,7 @@ describe("AgentChatComposer", () => {
     );
 
     expect(html).toContain("px-4 pb-4");
-    expect(html).toContain("relative border border-input bg-card shadow-md");
+    expect(html).toContain("relative border border-input border-l-0 bg-card shadow-md");
     expect(html).toContain("border-l-4");
     expect(html).toContain("focus-within:shadow-xl");
     expect(html).toContain("border-left-color:#d97706");

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -84,7 +84,7 @@ export function AgentChatComposer({ model }: { model: AgentChatComposerModel }):
           className={
             isWaitingInput
               ? "odt-waiting-input-card relative border border-warning-border bg-card shadow-md transition-[border-color,box-shadow,background-color] focus-within:shadow-xl"
-              : "relative border border-input bg-card shadow-md transition-[border-color,box-shadow,background-color] focus-within:shadow-xl"
+              : "relative border border-input border-l-0 bg-card shadow-md transition-[border-color,box-shadow,background-color] focus-within:shadow-xl"
           }
         >
           {isSessionWorking && !isWaitingInput ? (

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -22,6 +22,7 @@ const buildBaseModel = () => ({
   isSessionWorking: false,
   showThinkingMessages: false,
   isSessionViewLoading: false,
+  isSessionHistoryLoading: false,
   roleOptions: TEST_ROLE_OPTIONS,
   agentStudioReady: true,
   blockedReason: "",
@@ -487,7 +488,25 @@ describe("AgentChatThread", () => {
       }),
     );
 
-    expect(html).toContain("Preparing chat...");
+    expect(html).toContain("Loading session...");
+  });
+
+  test("hides transcript rows while session history is hydrating", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatThread, {
+        model: {
+          ...buildBaseModel(),
+          isSessionHistoryLoading: true,
+          session: buildSession({
+            sessionId: "session-hydrating",
+            messages: [buildMessage("assistant", "Old cached message", { id: "assistant-old-1" })],
+          }),
+        },
+      }),
+    );
+
+    expect(html).toContain("Loading session...");
+    expect(html).not.toContain("Old cached message");
   });
 
   test("renders native scroll controls for top and bottom navigation", async () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -56,6 +56,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     session,
     showThinkingMessages,
     isSessionViewLoading,
+    isSessionHistoryLoading,
     agentStudioReady,
     blockedReason,
     isLoadingChecks,
@@ -78,14 +79,16 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     messagesContainerRef,
     scrollToBottomOnSendRef,
   } = model;
+  const isTranscriptLoading = isSessionViewLoading || isSessionHistoryLoading;
+  const hideTranscriptWhileHydrating = isSessionHistoryLoading;
 
   const rows = useMemo(() => {
-    if (!session) {
+    if (!session || hideTranscriptWhileHydrating) {
       return [];
     }
 
     return buildAgentChatWindowRows(session, { showThinkingMessages });
-  }, [session, showThinkingMessages]);
+  }, [hideTranscriptWhileHydrating, session, showThinkingMessages]);
   const messagesContentRef = useRef<HTMLDivElement | null>(null);
   const activeSessionId = session?.sessionId ?? null;
   const {
@@ -102,7 +105,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   } = useAgentChatWindow({
     rows,
     activeSessionId,
-    isSessionViewLoading,
+    isSessionViewLoading: isTranscriptLoading,
     messagesContainerRef,
     messagesContentRef,
   });
@@ -113,7 +116,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
 
   const showLoadingOverlay = useAgentChatLoadingOverlay({
     sessionId: activeSessionId,
-    isSessionViewLoading,
+    isSessionViewLoading: isTranscriptLoading,
   });
   const sessionRole = session?.role ?? null;
   const sessionSelectedModel = session?.selectedModel ?? null;
@@ -211,32 +214,42 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
 
           {session ? (
             rows.length > 0 ? (
-              <>
-                {windowStart > 0 ? <div ref={topSentinelRef} className="h-px" /> : null}
+              hideTranscriptWhileHydrating ? null : (
+                <>
+                  {windowStart > 0 ? <div ref={topSentinelRef} className="h-px" /> : null}
 
-                {windowedRows.map((row) => (
-                  <AgentChatThreadMotionRow
-                    key={row.key}
-                    row={row}
-                    sessionRole={sessionRole}
-                    sessionSelectedModel={sessionSelectedModel}
-                    sessionAgentColors={sessionAgentColors}
-                    sessionWorkingDirectory={sessionWorkingDirectory}
-                    resolveRowRef={resolveRowRef}
-                  />
-                ))}
+                  {windowedRows.map((row) => (
+                    <AgentChatThreadMotionRow
+                      key={row.key}
+                      row={row}
+                      sessionRole={sessionRole}
+                      sessionSelectedModel={sessionSelectedModel}
+                      sessionAgentColors={sessionAgentColors}
+                      sessionWorkingDirectory={sessionWorkingDirectory}
+                      resolveRowRef={resolveRowRef}
+                    />
+                  ))}
 
-                {windowEnd < rows.length - 1 ? (
-                  <div ref={bottomSentinelRef} className="h-px" />
-                ) : null}
-              </>
-            ) : session.messages.length === 0 ? (
+                  {windowEnd < rows.length - 1 ? (
+                    <div ref={bottomSentinelRef} className="h-px" />
+                  ) : null}
+                </>
+              )
+            ) : session.messages.length === 0 && !hideTranscriptWhileHydrating ? (
               <div className="rounded-lg border border-dashed border-input bg-card p-4 text-sm text-muted-foreground">
                 Loading session history...
               </div>
             ) : null
           ) : null}
         </div>
+        {showLoadingOverlay ? (
+          <div className="absolute inset-0 z-30 flex items-center justify-center bg-muted">
+            <div className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm">
+              <LoaderCircle className="size-3.5 animate-spin" />
+              Loading session...
+            </div>
+          </div>
+        ) : null}
       </div>
 
       {hasBottomStack && session ? (
@@ -272,16 +285,6 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
           />
         </div>
       ) : null}
-
-      {showLoadingOverlay ? (
-        <div className="absolute inset-0 z-30 flex items-center justify-center bg-muted">
-          <div className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm">
-            <LoaderCircle className="size-3.5 animate-spin" />
-            Preparing chat...
-          </div>
-        </div>
-      ) : null}
-
       {session ? <ScrollToTopButton visible={!isNearTop} onClick={scrollToTop} /> : null}
       {session ? <ScrollToBottomButton visible={!isNearBottom} onClick={scrollToBottom} /> : null}
     </div>

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -18,6 +18,7 @@ const buildModel = () => ({
     isSessionWorking: true,
     showThinkingMessages: false,
     isSessionViewLoading: false,
+    isSessionHistoryLoading: false,
     roleOptions: TEST_ROLE_OPTIONS,
     agentStudioReady: true,
     blockedReason: "",

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -16,6 +16,7 @@ export type AgentChatThreadModel = {
   isSessionWorking: boolean;
   showThinkingMessages: boolean;
   isSessionViewLoading: boolean;
+  isSessionHistoryLoading: boolean;
   roleOptions: AgentRoleOption[];
   agentStudioReady: boolean;
   blockedReason: string | null;

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.tsx
@@ -74,13 +74,13 @@ export function AgentSessionTodoPanel({
   return (
     <section
       className={cn(
-        "w-full rounded-t-xl border border-input border-b-0 border-l-transparent bg-card",
+        "w-full border border-input border-b-0 border-l-0 bg-card",
         className,
       )}
       aria-label="Agent todo list"
     >
       <div
-        className={cn("rounded-t-xl border-l-4", !accentColor && "border-l-transparent")}
+        className={cn("border-l-4", !accentColor && "border-l-0")}
         style={accentColor ? { borderLeftColor: accentColor } : undefined}
       >
         <button

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.tsx
@@ -73,10 +73,7 @@ export function AgentSessionTodoPanel({
 
   return (
     <section
-      className={cn(
-        "w-full border border-input border-b-0 border-l-0 bg-card",
-        className,
-      )}
+      className={cn("w-full border border-input border-b-0 border-l-0 bg-card", className)}
       aria-label="Agent todo list"
     >
       <div

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -1016,6 +1016,40 @@ describe("useAgentChatWindow", () => {
     await harness.unmount();
   });
 
+  test("jumps to bottom without animation when session history loading settles", async () => {
+    const harness = await mountHarness(
+      {
+        rows: [],
+        activeSessionId: "session-1",
+        isSessionViewLoading: true,
+      },
+      { attachContainer: true, attachContent: true },
+    );
+
+    const container = harness.messagesContainerRef.current as MockMessagesContainer | null;
+    const content = harness.messagesContentRef.current as MockMessagesContent | null;
+    if (!container || !content) {
+      throw new Error("Expected messages container and content");
+    }
+
+    container.scrollTo.mockClear();
+    Object.assign(content, { scrollHeight: 1600 });
+    Object.assign(container, { scrollHeight: 1600 });
+
+    await harness.update({
+      rows: createRows(80),
+      activeSessionId: "session-1",
+      isSessionViewLoading: false,
+    });
+
+    expect(container.scrollTo).toHaveBeenCalledWith({
+      top: 1600,
+      behavior: "auto",
+    });
+
+    await harness.unmount();
+  });
+
   test("restores bottom pinning when downward shifts reach the latest rows", async () => {
     const harness = await mountHarness({
       rows: createRows(80),

--- a/apps/desktop/src/components/features/agents/session-start-modal.test.tsx
+++ b/apps/desktop/src/components/features/agents/session-start-modal.test.tsx
@@ -212,4 +212,47 @@ describe("SessionStartModal", () => {
 
     unmount();
   });
+
+  test("keeps existing-session selection visible and model controls enabled in fork mode", () => {
+    const { container, unmount } = render(
+      createElement(SessionStartModal, {
+        model: createModel({
+          availableStartModes: ["reuse", "fork"],
+          selectedStartMode: "fork",
+          existingSessionOptions: [{ value: "session-1", label: "Session #1" }],
+          selectedSourceSessionId: "session-1",
+        }),
+      }),
+    );
+
+    expect(screen.getByText("Session Mode")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /reuse existing/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /fork existing/i })).toBeTruthy();
+    expect(screen.getByText("Existing Session")).toBeTruthy();
+
+    const runtimeCombobox = container.querySelector("agent-runtime-combobox");
+    if (!runtimeCombobox) {
+      throw new Error("Expected runtime combobox element");
+    }
+    expect(runtimeCombobox.hasAttribute("disabled")).toBe(false);
+
+    const allComboboxes = container.querySelectorAll("mock-combobox");
+    expect(allComboboxes.length).toBeGreaterThanOrEqual(4);
+
+    const sourceCombobox = allComboboxes[0];
+    const agentCombobox = allComboboxes[1];
+    const modelCombobox = allComboboxes[2];
+    const variantCombobox = allComboboxes[3];
+
+    if (!sourceCombobox || !agentCombobox || !modelCombobox || !variantCombobox) {
+      throw new Error("Expected existing session + agent/model/variant comboboxes");
+    }
+
+    expect(sourceCombobox.hasAttribute("disabled")).toBe(false);
+    expect(agentCombobox.hasAttribute("disabled")).toBe(false);
+    expect(modelCombobox.hasAttribute("disabled")).toBe(false);
+    expect(variantCombobox.hasAttribute("disabled")).toBe(false);
+
+    unmount();
+  });
 });

--- a/apps/desktop/src/components/features/agents/session-start-modal.test.tsx
+++ b/apps/desktop/src/components/features/agents/session-start-modal.test.tsx
@@ -139,13 +139,18 @@ describe("SessionStartModal", () => {
     }
     expect(runtimeCombobox.hasAttribute("disabled")).toBe(true);
 
-    const allComboboxes = container.querySelectorAll("mock-combobox");
-    expect(allComboboxes.length).toBeGreaterThanOrEqual(4);
-
-    const sourceCombobox = allComboboxes[0];
-    const agentCombobox = allComboboxes[1];
-    const modelCombobox = allComboboxes[2];
-    const variantCombobox = allComboboxes[3];
+    const sourceCombobox = screen
+      .getByTestId("session-start-source-field")
+      .querySelector("mock-combobox");
+    const agentCombobox = screen
+      .getByTestId("session-start-agent-field")
+      .querySelector("mock-combobox");
+    const modelCombobox = screen
+      .getByTestId("session-start-model-field")
+      .querySelector("mock-combobox");
+    const variantCombobox = screen
+      .getByTestId("session-start-variant-field")
+      .querySelector("mock-combobox");
 
     if (!sourceCombobox || !agentCombobox || !modelCombobox || !variantCombobox) {
       throw new Error("Expected existing session + agent/model/variant comboboxes");
@@ -236,13 +241,18 @@ describe("SessionStartModal", () => {
     }
     expect(runtimeCombobox.hasAttribute("disabled")).toBe(false);
 
-    const allComboboxes = container.querySelectorAll("mock-combobox");
-    expect(allComboboxes.length).toBeGreaterThanOrEqual(4);
-
-    const sourceCombobox = allComboboxes[0];
-    const agentCombobox = allComboboxes[1];
-    const modelCombobox = allComboboxes[2];
-    const variantCombobox = allComboboxes[3];
+    const sourceCombobox = screen
+      .getByTestId("session-start-source-field")
+      .querySelector("mock-combobox");
+    const agentCombobox = screen
+      .getByTestId("session-start-agent-field")
+      .querySelector("mock-combobox");
+    const modelCombobox = screen
+      .getByTestId("session-start-model-field")
+      .querySelector("mock-combobox");
+    const variantCombobox = screen
+      .getByTestId("session-start-variant-field")
+      .querySelector("mock-combobox");
 
     if (!sourceCombobox || !agentCombobox || !modelCombobox || !variantCombobox) {
       throw new Error("Expected existing session + agent/model/variant comboboxes");

--- a/apps/desktop/src/components/features/agents/session-start-modal.tsx
+++ b/apps/desktop/src/components/features/agents/session-start-modal.tsx
@@ -14,6 +14,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { sessionStartModeButtonLabel } from "@/features/session-start/session-start-display";
 
 type SessionStartModalConfirmInput =
   | boolean
@@ -142,6 +143,10 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
     agentHelperText = "No agent profiles are available for this runtime.";
   }
 
+  const isStartModeDisabled = (startMode: AgentSessionStartMode): boolean => {
+    return (startMode === "reuse" || startMode === "fork") && !hasExistingSessionOptions;
+  };
+
   return (
     <Dialog
       open={open}
@@ -165,41 +170,23 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
                 <div className="grid gap-1.5">
                   <p className="text-sm font-medium text-foreground">Session Mode</p>
                   <div className="grid grid-cols-2 gap-2">
-                    {availableStartModes.includes("fresh") ? (
+                    {availableStartModes.map((startMode) => (
                       <Button
+                        key={startMode}
                         type="button"
-                        variant={selectedStartMode === "fresh" ? "default" : "outline"}
-                        onClick={() => onSelectStartMode("fresh")}
+                        variant={selectedStartMode === startMode ? "default" : "outline"}
+                        disabled={isStartModeDisabled(startMode)}
+                        onClick={() => onSelectStartMode(startMode)}
                       >
-                        Start fresh
+                        {sessionStartModeButtonLabel(startMode)}
                       </Button>
-                    ) : null}
-                    {availableStartModes.includes("reuse") ? (
-                      <Button
-                        type="button"
-                        variant={selectedStartMode === "reuse" ? "default" : "outline"}
-                        disabled={!hasExistingSessionOptions}
-                        onClick={() => onSelectStartMode("reuse")}
-                      >
-                        Reuse existing
-                      </Button>
-                    ) : null}
-                    {availableStartModes.includes("fork") ? (
-                      <Button
-                        type="button"
-                        variant={selectedStartMode === "fork" ? "default" : "outline"}
-                        disabled={!hasExistingSessionOptions}
-                        onClick={() => onSelectStartMode("fork")}
-                      >
-                        Fork existing
-                      </Button>
-                    ) : null}
+                    ))}
                   </div>
                 </div>
               ) : null}
 
               {requiresExistingSession ? (
-                <div className="grid gap-1.5">
+                <div className="grid gap-1.5" data-testid="session-start-source-field">
                   <label
                     className="text-sm font-medium text-foreground"
                     htmlFor="session-start-source"
@@ -218,7 +205,7 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
                 </div>
               ) : null}
 
-              <div className="grid gap-1.5">
+              <div className="grid gap-1.5" data-testid="session-start-runtime-field">
                 <label
                   className="text-sm font-medium text-foreground"
                   htmlFor="session-start-runtime"
@@ -234,7 +221,7 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
                 />
               </div>
 
-              <div className="grid gap-1.5">
+              <div className="grid gap-1.5" data-testid="session-start-agent-field">
                 <label
                   className="text-sm font-medium text-foreground"
                   htmlFor="session-start-agent"
@@ -255,7 +242,7 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
               </div>
 
               <div className="grid gap-4 sm:grid-cols-2">
-                <div className="grid gap-1.5">
+                <div className="grid gap-1.5" data-testid="session-start-model-field">
                   <label
                     className="text-sm font-medium text-foreground"
                     htmlFor="session-start-model"
@@ -273,7 +260,7 @@ export function SessionStartModal({ model }: { model: SessionStartModalModel }):
                   />
                 </div>
 
-                <div className="grid gap-1.5">
+                <div className="grid gap-1.5" data-testid="session-start-variant-field">
                   <label
                     className="text-sm font-medium text-foreground"
                     htmlFor="session-start-variant"

--- a/apps/desktop/src/features/session-start/session-start-display.ts
+++ b/apps/desktop/src/features/session-start/session-start-display.ts
@@ -1,0 +1,25 @@
+import type { AgentSessionStartMode } from "@openducktor/core";
+
+const START_MODE_DISPLAY_ORDER: Record<AgentSessionStartMode, number> = {
+  fresh: 0,
+  reuse: 1,
+  fork: 2,
+};
+
+export const orderStartModesForDisplay = (
+  startModes: readonly AgentSessionStartMode[],
+): AgentSessionStartMode[] => {
+  return [...startModes].sort(
+    (left, right) => START_MODE_DISPLAY_ORDER[left] - START_MODE_DISPLAY_ORDER[right],
+  );
+};
+
+export const sessionStartModeButtonLabel = (startMode: AgentSessionStartMode): string => {
+  if (startMode === "fresh") {
+    return "Start fresh";
+  }
+  if (startMode === "reuse") {
+    return "Reuse existing";
+  }
+  return "Fork existing";
+};

--- a/apps/desktop/src/features/session-start/session-start-mode.test.ts
+++ b/apps/desktop/src/features/session-start/session-start-mode.test.ts
@@ -35,12 +35,12 @@ describe("resolveScenarioStartMode", () => {
     ).toBe("fresh");
   });
 
-  test("keeps fork when the scenario only allows fork", () => {
+  test("keeps reuse as the default when the scenario allows reuse and fork", () => {
     expect(
       resolveScenarioStartMode({
         scenario: "build_pull_request_generation",
         existingSessionOptions: [],
       }),
-    ).toBe("fork");
+    ).toBe("reuse");
   });
 });

--- a/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.test.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { orderStartModesForDisplay } from "./session-start-display";
 import {
   buildSessionStartModalDescription,
   buildSessionStartModalTitle,
-  orderStartModesForDisplay,
   toSessionStartPostAction,
 } from "./use-session-start-modal-coordinator";
 

--- a/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.test.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.test.ts
@@ -25,6 +25,14 @@ describe("use-session-start-modal-coordinator", () => {
         scenario: "build_after_human_request_changes",
       }),
     ).toBe("Choose how to start fresh or reuse an existing session for Apply Human Changes.");
+
+    expect(
+      buildSessionStartModalDescription({
+        scenario: "build_pull_request_generation",
+      }),
+    ).toBe(
+      "Choose how to reuse an existing session or fork an existing session for Generate Pull Request.",
+    );
   });
 
   test("maps session-start reasons to post actions", () => {

--- a/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.test.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.test.ts
@@ -2,10 +2,20 @@ import { describe, expect, test } from "bun:test";
 import {
   buildSessionStartModalDescription,
   buildSessionStartModalTitle,
+  orderStartModesForDisplay,
   toSessionStartPostAction,
 } from "./use-session-start-modal-coordinator";
 
 describe("use-session-start-modal-coordinator", () => {
+  test("orders start modes for display consistently", () => {
+    expect(orderStartModesForDisplay(["fork", "reuse"])).toEqual(["reuse", "fork"]);
+    expect(orderStartModesForDisplay(["fork", "fresh", "reuse"])).toEqual([
+      "fresh",
+      "reuse",
+      "fork",
+    ]);
+  });
+
   test("builds role-specific session start titles", () => {
     expect(buildSessionStartModalTitle("spec")).toBe("Start Spec Session");
     expect(buildSessionStartModalTitle("planner")).toBe("Start Planner Session");

--- a/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.ts
@@ -14,6 +14,12 @@ import { SCENARIO_LABELS } from "./session-start-prompts";
 import type { SessionStartRequestReason } from "./session-start-types";
 import { useSessionStartModalState } from "./use-session-start-modal-state";
 
+const START_MODE_DISPLAY_ORDER: Record<"fresh" | "reuse" | "fork", number> = {
+  fresh: 0,
+  reuse: 1,
+  fork: 2,
+};
+
 const startModeLabelFor = (startMode: "fresh" | "reuse" | "fork"): string => {
   if (startMode === "fresh") {
     return "Start a fresh session";
@@ -29,13 +35,23 @@ export const buildSessionStartModalTitle = (role: AgentRole): string => {
   return `Start ${roleLabel} Session`;
 };
 
+export const orderStartModesForDisplay = (
+  startModes: readonly ("fresh" | "reuse" | "fork")[],
+): ("fresh" | "reuse" | "fork")[] => {
+  return [...startModes].sort(
+    (left, right) => START_MODE_DISPLAY_ORDER[left] - START_MODE_DISPLAY_ORDER[right],
+  );
+};
+
 export const buildSessionStartModalDescription = ({
   scenario,
 }: {
   scenario: AgentScenario;
 }): string => {
   const scenarioLabel = SCENARIO_LABELS[scenario] ?? scenario;
-  const allowedStartModes = getAgentScenarioDefinition(scenario).allowedStartModes;
+  const allowedStartModes = orderStartModesForDisplay(
+    getAgentScenarioDefinition(scenario).allowedStartModes,
+  );
   if (allowedStartModes.length > 1) {
     const allowedModeLabels = allowedStartModes.map((mode) => {
       if (mode === "fresh") {

--- a/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-coordinator.ts
@@ -9,16 +9,11 @@ import { useCallback } from "react";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { RepoSettingsInput } from "@/types/state-slices";
+import { orderStartModesForDisplay } from "./session-start-display";
 import type { SessionStartModalIntent, SessionStartPostAction } from "./session-start-modal-types";
 import { SCENARIO_LABELS } from "./session-start-prompts";
 import type { SessionStartRequestReason } from "./session-start-types";
 import { useSessionStartModalState } from "./use-session-start-modal-state";
-
-const START_MODE_DISPLAY_ORDER: Record<"fresh" | "reuse" | "fork", number> = {
-  fresh: 0,
-  reuse: 1,
-  fork: 2,
-};
 
 const startModeLabelFor = (startMode: "fresh" | "reuse" | "fork"): string => {
   if (startMode === "fresh") {
@@ -33,14 +28,6 @@ const startModeLabelFor = (startMode: "fresh" | "reuse" | "fork"): string => {
 export const buildSessionStartModalTitle = (role: AgentRole): string => {
   const roleLabel = AGENT_ROLE_LABELS[role] ?? role.toUpperCase();
   return `Start ${roleLabel} Session`;
-};
-
-export const orderStartModesForDisplay = (
-  startModes: readonly ("fresh" | "reuse" | "fork")[],
-): ("fresh" | "reuse" | "fork")[] => {
-  return [...startModes].sort(
-    (left, right) => START_MODE_DISPLAY_ORDER[left] - START_MODE_DISPLAY_ORDER[right],
-  );
 };
 
 export const buildSessionStartModalDescription = ({

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
@@ -534,6 +534,70 @@ describe("useSessionStartModalState", () => {
     await harness.unmount();
   });
 
+  test("supports mixed reuse and fork modes for pull request generation", async () => {
+    const harness = createHookHarness(createBaseProps());
+
+    await harness.mount();
+
+    await harness.run(() => {
+      harness.getLatest().openStartModal({
+        source: "kanban",
+        taskId: "TASK-PR",
+        role: "build",
+        scenario: "build_pull_request_generation",
+        existingSessionOptions: [
+          {
+            value: "session-pr-2",
+            label: "Builder session 2",
+            description: "Latest builder session",
+            selectedModel: {
+              runtimeKind: "opencode",
+              providerId: "anthropic",
+              modelId: "claude-sonnet",
+              variant: "default",
+              profileId: "build-agent",
+            },
+          },
+          {
+            value: "session-pr-1",
+            label: "Builder session 1",
+            description: "Older builder session",
+            selectedModel: {
+              runtimeKind: "opencode",
+              providerId: "openai",
+              modelId: "gpt-5",
+              variant: "high",
+              profileId: "spec-agent",
+            },
+          },
+        ],
+        initialSourceSessionId: "session-pr-1",
+        postStartAction: "kickoff",
+        title: "Start Builder Session",
+      });
+    });
+
+    expect(harness.getLatest().availableStartModes).toEqual(["reuse", "fork"]);
+    expect(harness.getLatest().selectedStartMode).toBe("reuse");
+    expect(harness.getLatest().selectedSourceSessionId).toBe("session-pr-1");
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    });
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectStartMode("fork");
+    });
+
+    expect(harness.getLatest().selectedStartMode).toBe("fork");
+    expect(harness.getLatest().selectedSourceSessionId).toBe("session-pr-1");
+
+    await harness.unmount();
+  });
+
   test("clears locked selection when reused source session has no model", async () => {
     const harness = createHookHarness(createBaseProps());
 

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.test.tsx
@@ -534,8 +534,12 @@ describe("useSessionStartModalState", () => {
     await harness.unmount();
   });
 
-  test("supports mixed reuse and fork modes for pull request generation", async () => {
-    const harness = createHookHarness(createBaseProps());
+  test("restores source-session model state when switching back to reuse for pull request generation", async () => {
+    const harness = createHookHarness(
+      createBaseProps({
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR, ALTERNATE_RUNTIME_DESCRIPTOR],
+      }),
+    );
 
     await harness.mount();
 
@@ -551,7 +555,7 @@ describe("useSessionStartModalState", () => {
             label: "Builder session 2",
             description: "Latest builder session",
             selectedModel: {
-              runtimeKind: "opencode",
+              runtimeKind: "alternate-runtime",
               providerId: "anthropic",
               modelId: "claude-sonnet",
               variant: "default",
@@ -594,6 +598,43 @@ describe("useSessionStartModalState", () => {
 
     expect(harness.getLatest().selectedStartMode).toBe("fork");
     expect(harness.getLatest().selectedSourceSessionId).toBe("session-pr-1");
+    expect(harness.getLatest().selectedRuntimeKind).toBe("opencode");
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    });
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectSourceSession("session-pr-2");
+    });
+
+    expect(harness.getLatest().selectedSourceSessionId).toBe("session-pr-2");
+    expect(harness.getLatest().selectedRuntimeKind).toBe("opencode");
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "spec-agent",
+    });
+
+    await harness.run(() => {
+      harness.getLatest().handleSelectStartMode("reuse");
+    });
+
+    expect(harness.getLatest().selectedStartMode).toBe("reuse");
+    expect(harness.getLatest().selectedSourceSessionId).toBe("session-pr-2");
+    expect(harness.getLatest().selectedRuntimeKind).toBe("alternate-runtime");
+    expect(harness.getLatest().selection).toEqual({
+      runtimeKind: "alternate-runtime",
+      providerId: "anthropic",
+      modelId: "claude-sonnet",
+      variant: "default",
+      profileId: "build-agent",
+    });
 
     await harness.unmount();
   });

--- a/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
+++ b/apps/desktop/src/features/session-start/use-session-start-modal-state.ts
@@ -15,6 +15,7 @@ import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import { DEFAULT_RUNTIME_KIND, resolveRuntimeKindSelection } from "@/lib/agent-runtime";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import type { RepoSettingsInput } from "@/types/state-slices";
+import { orderStartModesForDisplay } from "./session-start-display";
 import { useSessionStartModalReuseState } from "./session-start-modal-reuse-state";
 import { useSessionStartModalRuntimeState } from "./session-start-modal-runtime-state";
 import type { SessionStartModalIntent } from "./session-start-modal-types";
@@ -234,6 +235,10 @@ export function useSessionStartModalState({
     return [{ value: selection.variant, label: selection.variant }];
   }, [selectedModelEntry, selection?.variant]);
 
+  const orderedStartModes = useMemo<AgentSessionStartMode[]>(() => {
+    return orderStartModesForDisplay(availableStartModes);
+  }, [availableStartModes]);
+
   return {
     intent,
     isOpen: intent !== null,
@@ -247,7 +252,7 @@ export function useSessionStartModalState({
     modelOptions,
     modelGroups,
     variantOptions,
-    availableStartModes,
+    availableStartModes: orderedStartModes,
     selectedStartMode,
     existingSessionOptions,
     selectedSourceSessionId,

--- a/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
@@ -274,6 +274,7 @@ describe("agents-page-view-model", () => {
       isSessionWorking: true,
       showThinkingMessages: true,
       isSessionViewLoading: false,
+      isSessionHistoryLoading: false,
       roleOptions: [{ role: "spec", label: "Spec", icon: Sparkles }],
       agentStudioReady: true,
       agentStudioBlockedReason: "",

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -109,6 +109,7 @@ type AgentChatThreadModelArgs = {
   isSessionWorking: boolean;
   showThinkingMessages: boolean;
   isSessionViewLoading: boolean;
+  isSessionHistoryLoading: boolean;
   roleOptions: AgentRoleOption[];
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
@@ -172,6 +173,7 @@ export const buildAgentChatThreadModel = (
   isSessionWorking: args.isSessionWorking,
   showThinkingMessages: args.showThinkingMessages,
   isSessionViewLoading: args.isSessionViewLoading,
+  isSessionHistoryLoading: args.isSessionHistoryLoading,
   roleOptions: args.roleOptions,
   agentStudioReady: args.agentStudioReady,
   blockedReason: args.agentStudioBlockedReason,

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
@@ -253,6 +253,26 @@ describe("use-agent-studio-model-selection-model", () => {
     });
   });
 
+  test("derives live session context window from stored model identity without scanning messages", () => {
+    const lookup = toModelDescriptorByKey(CATALOG);
+
+    expect(
+      extractLatestContextUsage({
+        messages: null,
+        liveContextUsage: {
+          totalTokens: 44,
+          providerId: "openai",
+          modelId: "gpt-5",
+        },
+        modelDescriptorByKey: lookup,
+      }),
+    ).toEqual({
+      totalTokens: 44,
+      contextWindow: 200_000,
+      outputLimit: 8_192,
+    });
+  });
+
   test("falls back to an older assistant message when the latest tokenized one has no usable context window", () => {
     const lookup = toModelDescriptorByKey(CATALOG);
     const messages: AgentChatMessage[] = [

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -83,6 +83,21 @@ const toModelDescriptorKey = (providerId: string, modelId: string): string => {
   return `${providerId}::${modelId}`;
 };
 
+const resolveContextUsageDescriptor = ({
+  liveContextUsage,
+  modelDescriptorByKey,
+}: {
+  liveContextUsage: AgentSessionContextUsage;
+  modelDescriptorByKey: ReadonlyMap<string, CatalogModelDescriptor>;
+}): CatalogModelDescriptor | undefined => {
+  if (!liveContextUsage.providerId || !liveContextUsage.modelId) {
+    return undefined;
+  }
+  return modelDescriptorByKey.get(
+    toModelDescriptorKey(liveContextUsage.providerId, liveContextUsage.modelId),
+  );
+};
+
 export const toModelDescriptorByKey = (
   catalog: AgentModelCatalog | null,
 ): Map<string, CatalogModelDescriptor> => {
@@ -108,16 +123,22 @@ export const extractLatestContextUsage = ({
   fallbackContextWindow?: number;
 }): AgentStudioContextUsage => {
   if (liveContextUsage && liveContextUsage.totalTokens > 0) {
-    const contextWindow = liveContextUsage.contextWindow ?? fallbackContextWindow;
+    const modelDescriptor = resolveContextUsageDescriptor({
+      liveContextUsage,
+      modelDescriptorByKey,
+    });
+    const contextWindow =
+      liveContextUsage.contextWindow ?? modelDescriptor?.contextWindow ?? fallbackContextWindow;
     if (typeof contextWindow === "number" && contextWindow > 0) {
+      const resolvedOutputLimit = liveContextUsage.outputLimit ?? modelDescriptor?.outputLimit;
       return {
         totalTokens: liveContextUsage.totalTokens,
         contextWindow,
-        ...(typeof liveContextUsage.outputLimit === "number"
-          ? { outputLimit: liveContextUsage.outputLimit }
-          : {}),
+        ...(typeof resolvedOutputLimit === "number" ? { outputLimit: resolvedOutputLimit } : {}),
       };
     }
+
+    return null;
   }
 
   if (!messages) {

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -269,6 +269,7 @@ export function useAgentStudioPageModels({
     isSessionWorking: sessionActions.isSessionWorking,
     showThinkingMessages: chatSettings.showThinkingMessages,
     isContextSwitching,
+    isSessionHistoryLoading: core.isSessionHistoryHydrating,
     taskId: core.taskId,
     activeSessionAgentColors: modelSelection.activeSessionAgentColors,
     agentStudioReady: readiness.agentStudioReady,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
@@ -15,6 +15,7 @@ const createHookArgs = (showThinkingMessages = false): HookArgs => ({
   isSessionWorking: false,
   showThinkingMessages,
   isContextSwitching: false,
+  isSessionHistoryLoading: false,
   taskId: "task-1",
   activeSessionAgentColors: {},
   agentStudioReady: true,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -94,6 +94,7 @@ type UseAgentStudioThreadModelArgs = {
   isSessionWorking: boolean;
   showThinkingMessages: boolean;
   isContextSwitching: boolean;
+  isSessionHistoryLoading: boolean;
   taskId: string;
   activeSessionAgentColors: Record<string, string>;
   agentStudioReady: boolean;
@@ -122,6 +123,7 @@ export const useAgentStudioThreadModel = ({
   isSessionWorking,
   showThinkingMessages,
   isContextSwitching,
+  isSessionHistoryLoading,
   taskId,
   activeSessionAgentColors,
   agentStudioReady,
@@ -166,6 +168,7 @@ export const useAgentStudioThreadModel = ({
         isSessionWorking,
         showThinkingMessages,
         isSessionViewLoading: isContextSwitching,
+        isSessionHistoryLoading,
         roleOptions: ROLE_OPTIONS,
         agentStudioReady,
         agentStudioBlockedReason,
@@ -197,6 +200,7 @@ export const useAgentStudioThreadModel = ({
       handlePermissionReply,
       handleRefreshChecks,
       isContextSwitching,
+      isSessionHistoryLoading,
       isLoadingChecks,
       isSessionWorking,
       isSending,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -74,7 +74,14 @@ describe("useAgentStudioTaskHydration", () => {
 
     try {
       await harness.mount();
-      await harness.waitFor((state) => state.isActiveSessionHistoryHydrated);
+      await harness.waitFor(() => hydrateRequestedTaskSessionHistory.mock.calls.length === 1);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: createSession({ historyHydrationState: "hydrated" }),
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
 
       expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
       expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
@@ -84,7 +91,7 @@ describe("useAgentStudioTaskHydration", () => {
 
       await harness.update(
         createBaseArgs({
-          activeSession: createSession(),
+          activeSession: createSession({ historyHydrationState: "hydrated" }),
           hydrateRequestedTaskSessionHistory,
         }),
       );
@@ -132,6 +139,7 @@ describe("useAgentStudioTaskHydration", () => {
       createBaseArgs({
         activeSession: createSession({
           status: "running",
+          historyHydrationState: "hydrated",
           messages: [
             {
               id: "kickoff",
@@ -152,6 +160,64 @@ describe("useAgentStudioTaskHydration", () => {
       expect(harness.getLatest().isActiveSessionHistoryHydrated).toBe(true);
       expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(false);
       expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("still hydrates when a reused live session only has newly added local messages", async () => {
+    const hydrateRequestedTaskSessionHistory = mock(async (): Promise<void> => {});
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeSession: createSession({
+          status: "running",
+          historyHydrationState: "not_requested",
+          messages: [
+            {
+              id: "local-user-message",
+              role: "user",
+              content: "Generate the PR",
+              timestamp: "2026-02-22T08:00:05.000Z",
+            },
+          ],
+        }),
+        hydrateRequestedTaskSessionHistory,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor(() => hydrateRequestedTaskSessionHistory.mock.calls.length === 1);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: createSession({
+            status: "running",
+            historyHydrationState: "hydrated",
+            messages: [
+              {
+                id: "m-user",
+                role: "user",
+                content: "Earlier request",
+                timestamp: "2026-02-22T08:00:00.000Z",
+              },
+              {
+                id: "local-user-message",
+                role: "user",
+                content: "Generate the PR",
+                timestamp: "2026-02-22T08:00:05.000Z",
+              },
+            ],
+          }),
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
+        taskId: "task-1",
+        sessionId: "session-1",
+      });
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -74,6 +74,7 @@ describe("useAgentStudioTaskHydration", () => {
 
     try {
       await harness.mount();
+      expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(true);
       await harness.waitFor(() => hydrateRequestedTaskSessionHistory.mock.calls.length === 1);
 
       await harness.update(

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -84,6 +84,7 @@ export function useAgentStudioTaskHydration({
     requestState.sessionId === activeSessionId && requestState.status === "pending";
   const isRequestFailed =
     requestState.sessionId === activeSessionId && requestState.status === "failed";
+  const shouldShowPendingHydrationState = shouldHydrateSessionHistory && !isRequestFailed;
 
   return {
     isActiveTaskHydrated: Boolean(activeRepo && activeTaskId),
@@ -93,7 +94,7 @@ export function useAgentStudioTaskHydration({
       ? historyHydrationState === "failed" || isRequestFailed
       : false,
     isActiveSessionHistoryHydrating: activeSessionId
-      ? historyHydrationState === "hydrating" || isRequestPending
+      ? shouldShowPendingHydrationState || historyHydrationState === "hydrating" || isRequestPending
       : false,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -1,4 +1,8 @@
-import { queryOptions, useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import {
+  getAgentSessionHistoryHydrationState,
+  shouldAutoHydrateAgentSessionHistory,
+} from "@/state/operations/agent-orchestrator/support/history-hydration";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 
 type UseAgentStudioTaskHydrationParams = {
@@ -19,27 +23,6 @@ type UseAgentStudioTaskHydrationResult = {
   isActiveSessionHistoryHydrating: boolean;
 };
 
-const sessionHistoryHydrationQueryOptions = (
-  repoPath: string,
-  taskId: string,
-  sessionId: string,
-  hydrateRequestedTaskSessionHistory: (input: {
-    taskId: string;
-    sessionId: string;
-  }) => Promise<void>,
-) =>
-  queryOptions({
-    queryKey: ["agent-session-history-hydration", repoPath, taskId, sessionId] as const,
-    queryFn: (): Promise<null> =>
-      hydrateRequestedTaskSessionHistory({
-        taskId,
-        sessionId,
-      }).then(() => null),
-    staleTime: Number.POSITIVE_INFINITY,
-    gcTime: Number.POSITIVE_INFINITY,
-    retry: false,
-  });
-
 export function useAgentStudioTaskHydration({
   activeRepo,
   activeTaskId,
@@ -47,58 +30,70 @@ export function useAgentStudioTaskHydration({
   hydrateRequestedTaskSessionHistory,
 }: UseAgentStudioTaskHydrationParams): UseAgentStudioTaskHydrationResult {
   const activeSessionId = activeSession?.sessionId ?? null;
-  const activeRepoPath = activeRepo ?? "";
+  const [requestState, setRequestState] = useState<{
+    sessionId: string | null;
+    status: "idle" | "pending" | "failed";
+  }>({ sessionId: null, status: "idle" });
+  const historyHydrationState = getAgentSessionHistoryHydrationState(activeSession);
   const shouldHydrateSessionHistory =
     Boolean(activeRepo && activeTaskId && activeSessionId) &&
-    !(
-      activeSession &&
-      activeSession.status !== "stopped" &&
-      activeSession.runtimeEndpoint.trim().length > 0 &&
-      activeSession.messages.length > 0
-    );
-  const sessionHistoryHydrationQuery = useQuery({
-    queryKey:
-      shouldHydrateSessionHistory && activeSessionId
-        ? sessionHistoryHydrationQueryOptions(
-            activeRepoPath,
-            activeTaskId,
-            activeSessionId,
-            hydrateRequestedTaskSessionHistory,
-          ).queryKey
-        : (["agent-session-history-hydration", "", "", ""] as const),
-    queryFn: async (): Promise<null> => {
-      if (!activeRepo || !activeTaskId || !activeSessionId) {
-        return null;
-      }
-      await hydrateRequestedTaskSessionHistory({
-        taskId: activeTaskId,
-        sessionId: activeSessionId,
+    shouldAutoHydrateAgentSessionHistory(activeSession);
+
+  useEffect(() => {
+    if (!activeSessionId) {
+      setRequestState({ sessionId: null, status: "idle" });
+      return;
+    }
+
+    if (!shouldHydrateSessionHistory) {
+      setRequestState((current) =>
+        current.sessionId === activeSessionId && current.status !== "idle"
+          ? { sessionId: activeSessionId, status: "idle" }
+          : current,
+      );
+      return;
+    }
+
+    setRequestState({ sessionId: activeSessionId, status: "pending" });
+    void hydrateRequestedTaskSessionHistory({
+      taskId: activeTaskId,
+      sessionId: activeSessionId,
+    })
+      .then(() => {
+        setRequestState((current) =>
+          current.sessionId === activeSessionId
+            ? { sessionId: activeSessionId, status: "idle" }
+            : current,
+        );
+      })
+      .catch(() => {
+        setRequestState((current) =>
+          current.sessionId === activeSessionId
+            ? { sessionId: activeSessionId, status: "failed" }
+            : current,
+        );
       });
-      return null;
-    },
-    enabled: shouldHydrateSessionHistory,
-    staleTime: Number.POSITIVE_INFINITY,
-    gcTime: Number.POSITIVE_INFINITY,
-    retry: false,
-  });
+  }, [
+    activeSessionId,
+    activeTaskId,
+    hydrateRequestedTaskSessionHistory,
+    shouldHydrateSessionHistory,
+  ]);
+
+  const isRequestPending =
+    requestState.sessionId === activeSessionId && requestState.status === "pending";
+  const isRequestFailed =
+    requestState.sessionId === activeSessionId && requestState.status === "failed";
 
   return {
     isActiveTaskHydrated: Boolean(activeRepo && activeTaskId),
     isActiveTaskHydrationFailed: false,
-    isActiveSessionHistoryHydrated: activeSessionId
-      ? shouldHydrateSessionHistory
-        ? sessionHistoryHydrationQuery.isSuccess
-        : true
-      : false,
+    isActiveSessionHistoryHydrated: activeSessionId ? historyHydrationState === "hydrated" : false,
     isActiveSessionHistoryHydrationFailed: activeSessionId
-      ? shouldHydrateSessionHistory
-        ? sessionHistoryHydrationQuery.isError
-        : false
+      ? historyHydrationState === "failed" || isRequestFailed
       : false,
     isActiveSessionHistoryHydrating: activeSessionId
-      ? shouldHydrateSessionHistory
-        ? sessionHistoryHydrationQuery.isPending
-        : false
+      ? historyHydrationState === "hydrating" || isRequestPending
       : false,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-thread-context.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-thread-context.test.tsx
@@ -133,7 +133,7 @@ describe("useAgentStudioThreadContext", () => {
     await harness.unmount();
   });
 
-  test("clears context-switch intent after one animation frame when no hydration is active", async () => {
+  test("keeps the visible thread ready immediately when the selected session is already available", async () => {
     const session = createSession({
       runtimeKind: "opencode",
       sessionId: "session-a",
@@ -148,11 +148,6 @@ describe("useAgentStudioThreadContext", () => {
 
     await harness.mount();
     await harness.update(createHookArgs({ activeSession: session, contextSwitchVersion: 1 }));
-    expect(harness.getLatest().isContextSwitching).toBe(true);
-
-    await harness.run(() => {
-      flushRafFrames(1);
-    });
     expect(harness.getLatest().isContextSwitching).toBe(false);
     await harness.unmount();
   });
@@ -193,11 +188,28 @@ describe("useAgentStudioThreadContext", () => {
         isSessionHistoryHydrating: false,
       }),
     );
-    expect(harness.getLatest().isContextSwitching).toBe(true);
+    expect(harness.getLatest().isContextSwitching).toBe(false);
+    await harness.unmount();
+  });
 
-    await harness.run(() => {
-      flushRafFrames(1);
+  test("does not treat session history hydration as a full context switch once session is selected", async () => {
+    const session = createSession({
+      runtimeKind: "opencode",
+      sessionId: "session-a",
+      externalSessionId: "external-a",
+      role: "spec",
+      scenario: "spec_initial",
     });
+    const harness = createHookHarness(
+      useAgentStudioThreadContext,
+      createHookArgs({
+        activeSession: session,
+        isSessionHistoryHydrating: true,
+      }),
+    );
+
+    await harness.mount();
+    expect(harness.getLatest().threadSession?.sessionId).toBe("session-a");
     expect(harness.getLatest().isContextSwitching).toBe(false);
     await harness.unmount();
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-thread-context.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-thread-context.ts
@@ -17,7 +17,7 @@ type AgentStudioThreadContext = {
 export const useAgentStudioThreadContext = ({
   activeSession,
   isTaskHydrating,
-  isSessionHistoryHydrating,
+  isSessionHistoryHydrating: _isSessionHistoryHydrating,
   contextSwitchVersion,
 }: UseAgentStudioThreadContextArgs): AgentStudioThreadContext => {
   const [isContextSwitchIntentActive, setIsContextSwitchIntentActive] = useState(false);
@@ -43,7 +43,7 @@ export const useAgentStudioThreadContext = ({
       return;
     }
 
-    if (isTaskHydrating || isSessionHistoryHydrating) {
+    if (isTaskHydrating) {
       return;
     }
 
@@ -69,7 +69,7 @@ export const useAgentStudioThreadContext = ({
         clearIntentRafRef.current = null;
       }
     };
-  }, [isContextSwitchIntentActive, isSessionHistoryHydrating, isTaskHydrating]);
+  }, [isContextSwitchIntentActive, isTaskHydrating]);
 
   useEffect(() => {
     return () => {
@@ -82,6 +82,7 @@ export const useAgentStudioThreadContext = ({
   return {
     threadSession: activeSession,
     activeSessionId,
-    isContextSwitching: isTaskHydrating || isSessionHistoryHydrating || isContextSwitchIntentActive,
+    isContextSwitching:
+      isTaskHydrating || (isContextSwitchIntentActive && activeSessionId === null),
   };
 };

--- a/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.test.tsx
@@ -229,7 +229,7 @@ describe("useKanbanSessionStartFlow", () => {
     await harness.unmount();
   });
 
-  test("opens the shared session start modal for pull request generation as a fork-only builder flow", async () => {
+  test("opens the shared session start modal for pull request generation with reuse as the default builder flow", async () => {
     const harness = createHookHarness(createBaseArgs());
     let startPromise: Promise<string | undefined> | undefined;
 
@@ -241,9 +241,12 @@ describe("useKanbanSessionStartFlow", () => {
     const modal = harness.getLatest().sessionStartModal;
     expect(modal).not.toBeNull();
     expect(modal?.title).toBe("Start Builder Session");
-    expect(modal?.availableStartModes).toEqual(["fork"]);
-    expect(modal?.selectedStartMode).toBe("fork");
+    expect(modal?.availableStartModes).toEqual(["reuse", "fork"]);
+    expect(modal?.selectedStartMode).toBe("reuse");
     expect(modal?.selectedSourceSessionId).toBe("builder-session-2");
+    expect(modal?.description).toBe(
+      "Choose how to reuse an existing session or fork an existing session for Generate Pull Request.",
+    );
     expect(modal?.existingSessionOptions).toEqual([
       expect.objectContaining({
         value: "builder-session-2",
@@ -266,7 +269,7 @@ describe("useKanbanSessionStartFlow", () => {
     await harness.unmount();
   });
 
-  test("pull request generation resolves with the started builder session id", async () => {
+  test("pull request generation resolves with the started builder session id using reuse by default", async () => {
     const startAgentSession = mock(async () => "builder-session-pr");
     const args = createBaseArgs();
     args.repoSettings = createDefaultRepoSettings();
@@ -286,7 +289,7 @@ describe("useKanbanSessionStartFlow", () => {
     await harness.run(async (state) => {
       state.sessionStartModal?.onConfirm({
         runInBackground: false,
-        startMode: "fork",
+        startMode: "reuse",
         sourceSessionId: "builder-session-2",
       });
       await Promise.resolve();
@@ -299,7 +302,7 @@ describe("useKanbanSessionStartFlow", () => {
         taskId: "TASK-1",
         role: "build",
         scenario: "build_pull_request_generation",
-        startMode: "fork",
+        startMode: "reuse",
         sourceSessionId: "builder-session-2",
       }),
     );
@@ -332,7 +335,7 @@ describe("useKanbanSessionStartFlow", () => {
     await harness.unmount();
   });
 
-  test("pull request generation rejects when no builder session is available to fork", async () => {
+  test("pull request generation rejects when no builder session is available to fork or reuse", async () => {
     const args = createBaseArgs();
     args.sessions = [];
 
@@ -347,7 +350,7 @@ describe("useKanbanSessionStartFlow", () => {
     });
 
     await expect(startPromise).rejects.toThrow(
-      'No Builder session is available to fork for task "TASK-1".',
+      'No Builder session is available to fork or reuse for task "TASK-1".',
     );
     expect(harness.getLatest().sessionStartModal).toBeNull();
 

--- a/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-session-start-flow.ts
@@ -302,7 +302,7 @@ export function useKanbanSessionStartFlow({
     async (taskId: string): Promise<string | undefined> => {
       const builderSessions = findSessionsByRoleForTask(sessionsRef.current, taskId, "build");
       if (builderSessions.length === 0) {
-        throw new Error(`No Builder session is available to fork for task "${taskId}".`);
+        throw new Error(`No Builder session is available to fork or reuse for task "${taskId}".`);
       }
 
       return startSessionIntent({

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -1396,6 +1396,10 @@ describe("agent-orchestrator-session-events", () => {
       totalTokens: 35_022,
       contextWindow: 200_000,
       outputLimit: 8_192,
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "Hephaestus",
     });
   });
 
@@ -1515,6 +1519,10 @@ describe("agent-orchestrator-session-events", () => {
       totalTokens: 35_022,
       contextWindow: 200_000,
       outputLimit: 8_192,
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "Hephaestus",
     });
   });
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -282,6 +282,88 @@ describe("agent-orchestrator-session-events", () => {
     }
   });
 
+  test("writes canonical user_message events into the transcript", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession(),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      draftMessageIdBySessionRef: { current: {} },
+      draftFlushTimeoutBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "user_message",
+      sessionId: "session-1",
+      messageId: "user-message-1",
+      timestamp: "2026-02-22T08:00:01.000Z",
+      message: "Generate the pull request",
+      model: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        variant: "high",
+        profileId: "Hephaestus",
+      },
+    });
+
+    const userMessages = sessionsRef.current["session-1"]?.messages.filter(
+      (message) => message.role === "user",
+    );
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages?.[0]?.id).toBe("user-message-1");
+    expect(userMessages?.[0]?.content).toBe("Generate the pull request");
+    if (!userMessages?.[0]?.meta || userMessages[0].meta.kind !== "user") {
+      throw new Error("Expected canonical user message metadata");
+    }
+    expect(userMessages[0].meta.providerId).toBe("openai");
+    expect(userMessages[0].meta.modelId).toBe("gpt-5");
+    expect(userMessages[0].meta.variant).toBe("high");
+    expect(userMessages[0].meta.profileId).toBe("Hephaestus");
+  });
+
   test("auto-rejects mutating permissions for read-only roles", async () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const replyPermission = mock(

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -14,6 +14,7 @@ import {
   handleSessionStarted,
   handleSessionStatus,
   handleSessionTodosUpdated,
+  handleUserMessage,
 } from "./session-lifecycle";
 import { handleAssistantDelta, handleAssistantPart } from "./session-parts";
 
@@ -32,6 +33,9 @@ const handleSessionEvent = (context: SessionEventHandlerContext, event: SessionE
       return;
     case "assistant_message":
       handleAssistantMessage(context.lifecycle, event);
+      return;
+    case "user_message":
+      handleUserMessage(context.lifecycle, event);
       return;
     case "session_status":
       handleSessionStatus(context.lifecycle, event);
@@ -63,6 +67,7 @@ const handleSessionEvent = (context: SessionEventHandlerContext, event: SessionE
 const isImmediateSessionEvent = (event: SessionEvent): boolean => {
   switch (event.type) {
     case "assistant_message":
+    case "user_message":
     case "permission_required":
     case "question_required":
     case "session_error":

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -78,6 +78,20 @@ const findExistingAssistantMessageIndex = (
   return -1;
 };
 
+const toUserMessageMeta = (model: Extract<SessionEvent, { type: "user_message" }>["model"]) => {
+  if (!model) {
+    return undefined;
+  }
+
+  return {
+    kind: "user" as const,
+    ...(model.providerId ? { providerId: model.providerId } : {}),
+    ...(model.modelId ? { modelId: model.modelId } : {}),
+    ...(model.variant ? { variant: model.variant } : {}),
+    ...(model.profileId ? { profileId: model.profileId } : {}),
+  };
+};
+
 const shouldAutoRejectPermission = (
   role: AgentRole | undefined,
   event: PermissionRequiredEvent,
@@ -225,6 +239,29 @@ export const handleAssistantMessage = (
   });
   context.turn.clearTurnDuration(context.store.sessionId);
   clearTurnModelSnapshot(context);
+};
+
+export const handleUserMessage = (
+  context: Pick<SessionLifecycleEventContext, "store">,
+  event: Extract<SessionEvent, { type: "user_message" }>,
+): void => {
+  context.store.updateSession(
+    context.store.sessionId,
+    (current) => {
+      const userMessageMeta = toUserMessageMeta(event.model);
+      return {
+        ...current,
+        messages: upsertMessage(current.messages, {
+          id: event.messageId,
+          role: "user",
+          content: event.message,
+          timestamp: event.timestamp,
+          ...(userMessageMeta ? { meta: userMessageMeta } : {}),
+        }),
+      };
+    },
+    { persist: false },
+  );
 };
 
 export const handleSessionStatus = (

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -1131,6 +1131,92 @@ describe("agent-orchestrator/handlers/session-actions", () => {
     }
   });
 
+  test("does not send a free-form message if hydration reveals pending input", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalHasSession = adapter.hasSession;
+    const originalListLiveAgentSessionSnapshots = adapter.listLiveAgentSessionSnapshots;
+    const originalSendUserMessage = adapter.sendUserMessage;
+    let sendCalls = 0;
+
+    adapter.hasSession = () => true;
+    adapter.listLiveAgentSessionSnapshots = async () => [];
+    adapter.sendUserMessage = async () => {
+      sendCalls += 1;
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          status: "idle",
+          historyHydrationState: "not_requested",
+          messages: [],
+        }),
+      },
+    };
+
+    const actions = createAgentSessionActions({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef,
+      taskRef: { current: [] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      unsubscribersRef: { current: new Map([["session-1", () => {}]]) },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession: (sessionId, updater) => {
+        const current = sessionsRef.current[sessionId];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current[sessionId] = updater(current);
+      },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: null,
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {
+        const currentSession = sessionsRef.current["session-1"];
+        if (!currentSession) {
+          throw new Error("Expected session to hydrate");
+        }
+        sessionsRef.current["session-1"] = {
+          ...currentSession,
+          historyHydrationState: "hydrated",
+          pendingQuestions: [
+            {
+              requestId: "question-1",
+              questions: [{ header: "Confirm", question: "Confirm", options: [] }],
+            },
+          ],
+        };
+      },
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+      persistSessionRecord: async () => {},
+    });
+
+    try {
+      await actions.sendAgentMessage("session-1", "hello");
+
+      expect(sendCalls).toBe(0);
+      expect(sessionsRef.current["session-1"]?.status).toBe("idle");
+      expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(1);
+    } finally {
+      adapter.hasSession = originalHasSession;
+      adapter.listLiveAgentSessionSnapshots = originalListLiveAgentSessionSnapshots;
+      adapter.sendUserMessage = originalSendUserMessage;
+    }
+  });
+
   test("does not send free-form messages while waiting for pending input", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalHasSession = adapter.hasSession;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -966,7 +966,7 @@ describe("agent-orchestrator/handlers/session-actions", () => {
     }
   });
 
-  test("sends user message and appends optimistic user entry", async () => {
+  test("sends user message without mutating the transcript optimistically", async () => {
     const adapter = new OpencodeSdkAdapter();
     const originalHasSession = adapter.hasSession;
     const originalListLiveAgentSessionSnapshots = adapter.listLiveAgentSessionSnapshots;
@@ -1032,16 +1032,98 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       await actions.sendAgentMessage("session-1", " hello ");
       expect(sendCalls).toBe(1);
       expect(sessionsRef.current["session-1"]?.status).toBe("running");
-      const latest = sessionsRef.current["session-1"]?.messages.at(-1);
-      expect(latest?.role).toBe("user");
-      expect(latest?.content).toBe("hello");
-      if (!latest?.meta || latest.meta.kind !== "user") {
-        throw new Error("Expected user message metadata");
-      }
-      expect(latest.meta.providerId).toBe("openai");
-      expect(latest.meta.modelId).toBe("gpt-5.3-codex");
-      expect(latest.meta.variant).toBe("high");
-      expect(latest.meta.profileId).toBe("Hephaestus (Deep Agent)");
+      expect(sessionsRef.current["session-1"]?.messages).toHaveLength(0);
+    } finally {
+      adapter.hasSession = originalHasSession;
+      adapter.listLiveAgentSessionSnapshots = originalListLiveAgentSessionSnapshots;
+      adapter.sendUserMessage = originalSendUserMessage;
+    }
+  });
+
+  test("hydrates requested history before sending to an unhydrated reused session", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalHasSession = adapter.hasSession;
+    const originalListLiveAgentSessionSnapshots = adapter.listLiveAgentSessionSnapshots;
+    const originalSendUserMessage = adapter.sendUserMessage;
+    const callOrder: string[] = [];
+
+    adapter.hasSession = () => true;
+    adapter.listLiveAgentSessionSnapshots = async () => [];
+    adapter.sendUserMessage = async () => {
+      callOrder.push("send");
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          status: "idle",
+          historyHydrationState: "not_requested",
+          messages: [],
+        }),
+      },
+    };
+
+    const actions = createAgentSessionActions({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef,
+      taskRef: { current: [] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      unsubscribersRef: { current: new Map([["session-1", () => {}]]) },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession: (sessionId, updater) => {
+        const current = sessionsRef.current[sessionId];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current[sessionId] = updater(current);
+      },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: null,
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {
+        callOrder.push("hydrate");
+        const currentSession = sessionsRef.current["session-1"];
+        if (!currentSession) {
+          throw new Error("Expected session to hydrate");
+        }
+        sessionsRef.current["session-1"] = {
+          ...currentSession,
+          historyHydrationState: "hydrated",
+          messages: [
+            {
+              id: "m-user",
+              role: "user",
+              content: "Earlier request",
+              timestamp: "2026-02-22T08:00:00.000Z",
+            },
+          ],
+        };
+      },
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+      persistSessionRecord: async () => {},
+    });
+
+    try {
+      await actions.sendAgentMessage("session-1", "hello");
+
+      expect(callOrder).toEqual(["hydrate", "send"]);
+      expect(sessionsRef.current["session-1"]?.messages.map((message) => message.content)).toEqual([
+        "Earlier request",
+      ]);
+      expect(sessionsRef.current["session-1"]?.historyHydrationState).toBe("hydrated");
     } finally {
       adapter.hasSession = originalHasSession;
       adapter.listLiveAgentSessionSnapshots = originalListLiveAgentSessionSnapshots;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -13,6 +13,7 @@ import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-o
 import { createEnsureSessionReady } from "../lifecycle/ensure-ready";
 import type { RuntimeInfo, TaskDocuments } from "../runtime/runtime";
 import { now } from "../support/core";
+import { requiresHydratedAgentSessionHistory } from "../support/history-hydration";
 import { toPersistedSessionRecord } from "../support/persistence";
 import { annotateQuestionToolMessage } from "../support/question-messages";
 import { createStartAgentSession } from "./start-session";
@@ -169,16 +170,16 @@ export const createAgentSessionActions = ({
 
     await ensureSessionReady(sessionId);
 
+    const readySession = sessionsRef.current[sessionId];
+    if (readySession && requiresHydratedAgentSessionHistory(readySession)) {
+      await loadAgentSessions(readySession.taskId, {
+        mode: "requested_history",
+        targetSessionId: sessionId,
+        historyPolicy: "requested_only",
+      });
+    }
+
     const selectedModel = sessionsRef.current[sessionId]?.selectedModel ?? undefined;
-    const userMessageMeta = selectedModel?.profileId
-      ? {
-          kind: "user" as const,
-          ...(selectedModel.providerId ? { providerId: selectedModel.providerId } : {}),
-          ...(selectedModel.modelId ? { modelId: selectedModel.modelId } : {}),
-          ...(selectedModel.variant ? { variant: selectedModel.variant } : {}),
-          ...(selectedModel.profileId ? { profileId: selectedModel.profileId } : {}),
-        }
-      : undefined;
     turnStartedAtBySessionRef.current[sessionId] = Date.now();
     if (turnModelBySessionRef) {
       turnModelBySessionRef.current[sessionId] = selectedModel ?? null;
@@ -193,16 +194,6 @@ export const createAgentSessionActions = ({
         draftAssistantMessageId: null,
         draftReasoningText: "",
         draftReasoningMessageId: null,
-        messages: [
-          ...current.messages,
-          {
-            id: crypto.randomUUID(),
-            role: "user",
-            content: trimmed,
-            timestamp: now(),
-            ...(userMessageMeta ? { meta: userMessageMeta } : {}),
-          },
-        ],
       }),
       { persist: false },
     );

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -179,7 +179,12 @@ export const createAgentSessionActions = ({
       });
     }
 
-    const selectedModel = sessionsRef.current[sessionId]?.selectedModel ?? undefined;
+    const hydratedSession = sessionsRef.current[sessionId];
+    if (!hydratedSession || isAgentSessionWaitingInput(hydratedSession)) {
+      return;
+    }
+
+    const selectedModel = hydratedSession.selectedModel ?? undefined;
     turnStartedAtBySessionRef.current[sessionId] = Date.now();
     if (turnModelBySessionRef) {
       turnModelBySessionRef.current[sessionId] = selectedModel ?? null;

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-local-state.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-local-state.ts
@@ -38,6 +38,7 @@ export const buildInitialSession = ({
   runId: runtime.runId,
   runtimeEndpoint: runtime.runtimeEndpoint,
   workingDirectory: runtime.workingDirectory,
+  historyHydrationState: "hydrated",
   messages:
     initialMessages ??
     buildSessionHeaderMessages({

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-reuse-strategy.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session-reuse-strategy.ts
@@ -3,7 +3,7 @@ import { appQueryClient } from "@/lib/query-client";
 import { agentSessionListQueryOptions } from "@/state/queries/agent-sessions";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { normalizeWorkingDirectory, throwIfRepoStale } from "../support/core";
-import { hasOnlySessionHeaderMessages } from "../support/session-prompt";
+import { requiresHydratedAgentSessionHistory } from "../support/history-hydration";
 import type {
   StartSessionContext,
   StartSessionCreationInput,
@@ -155,11 +155,7 @@ export const resolveLoadedSourceSession = async ({
       entry.taskId === ctx.taskId && entry.role === ctx.role && entry.sessionId === sourceSessionId,
   );
   if (existingSourceSession) {
-    if (
-      existingSourceSession.messages.length === 0 ||
-      (existingSourceSession.status === "stopped" &&
-        hasOnlySessionHeaderMessages(existingSourceSession))
-    ) {
+    if (requiresHydratedAgentSessionHistory(existingSourceSession)) {
       return ensureSessionHydrated({
         ctx,
         deps,

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/start-session.test.ts
@@ -1701,13 +1701,13 @@ describe("agent-orchestrator/handlers/start-session", () => {
           timestamp: "2026-02-22T08:20:00.000Z",
         },
         {
-          id: "history:text:fork-user-1",
+          id: "fork-user-1",
           role: "user",
           content: "Generate the PR summary.",
           timestamp: "2026-02-22T08:21:00.000Z",
         },
         {
-          id: "history:text:fork-assistant-1",
+          id: "fork-assistant-1",
           role: "assistant",
           content: "I drafted the summary.",
           timestamp: "2026-02-22T08:22:00.000Z",
@@ -1863,7 +1863,7 @@ describe("agent-orchestrator/handlers/start-session", () => {
           timestamp: "2026-02-22T08:20:00.000Z",
         },
         {
-          id: "history:text:child-user-1",
+          id: "child-user-1",
           role: "user",
           content: "Hydrated child history",
           timestamp: "2026-02-22T08:21:00.000Z",

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/ensure-ready.ts
@@ -160,10 +160,49 @@ export const createEnsureSessionReady = ({
         attachSessionListener(repoPath, sessionId);
       }
       if (session.status !== "error") {
+        let attachedRuntimeKind = session.runtimeKind;
+        let attachedRuntimeId = session.runtimeId;
+        let attachedRunId = session.runId;
+        let attachedRuntimeEndpoint = session.runtimeEndpoint;
+        let attachedWorkingDirectory = session.workingDirectory;
+
+        if (!attachedRuntimeKind || attachedRuntimeEndpoint.trim().length === 0) {
+          const runtime = await ensureRuntime(repoPath, session.taskId, session.role, {
+            targetWorkingDirectory: session.workingDirectory,
+            ...(session.selectedModel?.runtimeKind
+              ? { runtimeKind: session.selectedModel.runtimeKind }
+              : {}),
+          });
+          assertNotStale();
+
+          attachedRuntimeKind =
+            runtime.runtimeKind ??
+            session.selectedModel?.runtimeKind ??
+            session.runtimeKind ??
+            DEFAULT_RUNTIME_KIND;
+          attachedRuntimeId = runtime.runtimeId;
+          attachedRunId = runtime.runId;
+          attachedRuntimeEndpoint = runtime.runtimeEndpoint;
+          attachedWorkingDirectory = runtime.workingDirectory;
+
+          updateSession(
+            sessionId,
+            (current) => ({
+              ...current,
+              runtimeId: attachedRuntimeId,
+              runId: attachedRunId,
+              runtimeEndpoint: attachedRuntimeEndpoint,
+              workingDirectory: attachedWorkingDirectory,
+              ...(attachedRuntimeKind ? { runtimeKind: attachedRuntimeKind } : {}),
+            }),
+            { persist: false },
+          );
+        }
+
         const liveSnapshot = await loadLiveSnapshot({
-          runtimeKind: session.runtimeKind,
-          runtimeEndpoint: session.runtimeEndpoint,
-          workingDirectory: session.workingDirectory,
+          runtimeKind: attachedRuntimeKind,
+          runtimeEndpoint: attachedRuntimeEndpoint,
+          workingDirectory: attachedWorkingDirectory,
           externalSessionId: session.externalSessionId,
         });
         assertNotStale();
@@ -174,8 +213,13 @@ export const createEnsureSessionReady = ({
           (current) => ({
             ...current,
             status: liveSnapshot ? toLiveSessionState(liveSnapshot.status) : current.status,
+            runtimeId: attachedRuntimeId,
+            runId: attachedRunId,
+            runtimeEndpoint: attachedRuntimeEndpoint,
+            workingDirectory: attachedWorkingDirectory,
             pendingPermissions,
             pendingQuestions,
+            ...(attachedRuntimeKind ? { runtimeKind: attachedRuntimeKind } : {}),
           }),
           { persist: false },
         );

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -3161,4 +3161,118 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(planCalls).toBe(0);
     expect(qaCalls).toBe(0);
   });
+
+  test("deduplicates concurrent requested-history hydration for the same session", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const historyDeferred =
+      createDeferred<Awaited<ReturnType<ReturnType<typeof createAdapter>["loadSessionHistory"]>>>();
+    let historyCalls = 0;
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        loadSessionHistory: async () => {
+          historyCalls += 1;
+          return historyDeferred.promise;
+        },
+      }),
+      repoEpochRef: { current: 1 },
+      activeRepoRef: { current: "/tmp/repo" },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    const persistedRecords = [
+      persistedSessionRecord({
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        role: "build",
+        scenario: "build_implementation_start",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        workingDirectory: "/tmp/repo",
+      }),
+    ];
+    const preloadedRuntimeLists = new Map([
+      [
+        "opencode",
+        [
+          {
+            kind: "opencode",
+            runtimeId: "runtime-1",
+            repoPath: "/tmp/repo",
+            taskId: null,
+            role: "workspace",
+            workingDirectory: "/tmp/repo",
+            runtimeRoute: { type: "local_http", endpoint: "http://127.0.0.1:4444" },
+            startedAt: "2026-02-22T08:00:00.000Z",
+            descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+          } satisfies RuntimeInstanceSummary,
+        ],
+      ],
+    ]);
+
+    const firstLoad = loadAgentSessions("task-1", {
+      mode: "requested_history",
+      targetSessionId: "session-1",
+      historyPolicy: "requested_only",
+      persistedRecords,
+      preloadedRuntimeLists,
+    });
+    const secondLoad = loadAgentSessions("task-1", {
+      mode: "requested_history",
+      targetSessionId: "session-1",
+      historyPolicy: "requested_only",
+      persistedRecords,
+      preloadedRuntimeLists,
+    });
+
+    while (historyCalls === 0) {
+      await Promise.resolve();
+    }
+    expect(historyCalls).toBe(1);
+    historyDeferred.resolve([
+      {
+        messageId: "history-user-1",
+        role: "user",
+        timestamp: "2026-02-22T08:00:01.000Z",
+        text: "Previous request",
+        parts: [],
+      },
+    ]);
+
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(historyCalls).toBe(1);
+    expect(state["session-1"]?.historyHydrationState).toBe("hydrated");
+    expect(
+      state["session-1"]?.messages.some((message) => message.content === "Previous request"),
+    ).toBe(true);
+  });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -3275,4 +3275,138 @@ describe("agent-orchestrator-load-sessions", () => {
       state["session-1"]?.messages.some((message) => message.content === "Previous request"),
     ).toBe(true);
   });
+
+  test("hydrates an already loaded requested session without reloading the full persisted session list", async () => {
+    const existingSession: AgentSessionState = {
+      sessionId: "session-1",
+      externalSessionId: "external-1",
+      taskId: "task-1",
+      role: "build",
+      scenario: "build_implementation_start",
+      status: "idle",
+      startedAt: "2026-02-22T08:00:00.000Z",
+      runtimeKind: "opencode",
+      runtimeId: "runtime-1",
+      runId: null,
+      runtimeEndpoint: "http://127.0.0.1:4444",
+      workingDirectory: "/tmp/repo",
+      historyHydrationState: "not_requested",
+      messages: [],
+      draftAssistantText: "",
+      draftAssistantMessageId: null,
+      draftReasoningText: "",
+      draftReasoningMessageId: null,
+      contextUsage: null,
+      pendingPermissions: [],
+      pendingQuestions: [],
+      todos: [],
+      modelCatalog: null,
+      selectedModel: {
+        runtimeKind: "opencode",
+        providerId: "openai",
+        modelId: "gpt-5",
+      },
+      isLoadingModelCatalog: false,
+      promptOverrides: {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: { "session-1": existingSession },
+    };
+    let state: Record<string, AgentSessionState> = sessionsRef.current;
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    let persistedListCalls = 0;
+    const originalList = (await import("../../shared/host")).host.agentSessionsList;
+    (await import("../../shared/host")).host.agentSessionsList = async () => {
+      persistedListCalls += 1;
+      return [];
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        loadSessionHistory: async () => [
+          {
+            messageId: "hydrated-assistant-1",
+            role: "assistant",
+            timestamp: "2026-02-22T08:00:02.000Z",
+            text: "Hydrated response",
+            totalTokens: 123,
+            model: {
+              providerId: "openai",
+              modelId: "gpt-5",
+            },
+            parts: [
+              {
+                kind: "step",
+                messageId: "hydrated-assistant-1",
+                partId: "hydrated-step-finish-1",
+                phase: "finish",
+                reason: "stop",
+              },
+            ],
+          },
+          {
+            messageId: "hydrated-user-1",
+            role: "user",
+            timestamp: "2026-02-22T08:00:01.000Z",
+            text: "Hydrated message",
+            parts: [],
+          },
+        ],
+      }),
+      repoEpochRef: { current: 2 },
+      activeRepoRef: { current: "/tmp/repo" },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    try {
+      await loadAgentSessions("task-1", {
+        mode: "requested_history",
+        targetSessionId: "session-1",
+        historyPolicy: "requested_only",
+      });
+    } finally {
+      (await import("../../shared/host")).host.agentSessionsList = originalList;
+    }
+
+    expect(persistedListCalls).toBe(0);
+    expect(state["session-1"]?.historyHydrationState).toBe("hydrated");
+    expect(state["session-1"]?.contextUsage).toEqual({
+      totalTokens: 123,
+      providerId: "openai",
+      modelId: "gpt-5",
+    });
+    expect(
+      state["session-1"]?.messages.some((message) => message.content === "Hydrated message"),
+    ).toBe(true);
+  });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -961,6 +961,269 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(historyLoads).toBe(1);
   });
 
+  test("uses the resolved working directory for requested-history live lookups and state updates", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": {
+          sessionId: "session-1",
+          externalSessionId: "external-1",
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_implementation_start",
+          status: "running",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          runtimeKind: "opencode",
+          runtimeId: "runtime-1",
+          runId: null,
+          runtimeEndpoint: "http://127.0.0.1:4555",
+          workingDirectory: "/tmp/repo/resolved-worktree",
+          messages: [],
+          draftAssistantText: "",
+          draftAssistantMessageId: null,
+          draftReasoningText: "",
+          draftReasoningMessageId: null,
+          contextUsage: null,
+          pendingPermissions: [],
+          pendingQuestions: [],
+          todos: [],
+          modelCatalog: null,
+          selectedModel: null,
+          isLoadingModelCatalog: false,
+          promptOverrides: {},
+        },
+      },
+    };
+    let state: Record<string, AgentSessionState> = sessionsRef.current;
+    let observedSnapshotDirectories: string[] = [];
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        loadSessionHistory: async () => [],
+        listLiveAgentSessionSnapshots: async ({ directories }) => {
+          observedSnapshotDirectories = directories ?? [];
+          return [
+            {
+              externalSessionId: "external-1",
+              title: "BUILD task-1",
+              workingDirectory: "/tmp/repo/resolved-worktree",
+              startedAt: "2026-02-22T08:00:00.000Z",
+              status: { type: "busy" },
+              pendingPermissions: [],
+              pendingQuestions: [],
+            },
+          ];
+        },
+      }),
+      repoEpochRef: { current: 2 },
+      activeRepoRef: { current: "/tmp/repo" },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    await loadAgentSessions("task-1", {
+      mode: "requested_history",
+      targetSessionId: "session-1",
+      historyPolicy: "requested_only",
+      persistedRecords: [
+        persistedSessionRecord({
+          runtimeKind: "opencode",
+          sessionId: "session-1",
+          externalSessionId: "external-1",
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_implementation_start",
+          status: "running",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          updatedAt: "2026-02-22T08:00:00.000Z",
+          workingDirectory: "/tmp/repo/stale-worktree",
+        }),
+      ],
+    });
+
+    expect(observedSnapshotDirectories).toEqual(["/tmp/repo/resolved-worktree"]);
+    expect(state["session-1"]?.workingDirectory).toBe("/tmp/repo/resolved-worktree");
+  });
+
+  test("preserves canonical live messages that arrive during requested-history hydration", async () => {
+    const historyDeferred =
+      createDeferred<Awaited<ReturnType<ReturnType<typeof createAdapter>["loadSessionHistory"]>>>();
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-live": {
+          sessionId: "session-live",
+          externalSessionId: "external-live",
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_implementation_start",
+          status: "running",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          runtimeKind: "opencode",
+          runtimeId: "runtime-live",
+          runId: null,
+          runtimeEndpoint: "http://127.0.0.1:4444",
+          workingDirectory: "/tmp/repo/worktree",
+          messages: [],
+          draftAssistantText: "",
+          draftAssistantMessageId: null,
+          draftReasoningText: "",
+          draftReasoningMessageId: null,
+          contextUsage: null,
+          pendingPermissions: [],
+          pendingQuestions: [],
+          todos: [],
+          modelCatalog: null,
+          selectedModel: null,
+          isLoadingModelCatalog: false,
+          promptOverrides: {},
+        },
+      },
+    };
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      sessionsRef.current = typeof updater === "function" ? updater(sessionsRef.current) : updater;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        loadSessionHistory: async () => historyDeferred.promise,
+        listLiveAgentSessionSnapshots: async () => [
+          {
+            externalSessionId: "external-live",
+            title: "BUILD task-1",
+            workingDirectory: "/tmp/repo/worktree",
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+            pendingPermissions: [],
+            pendingQuestions: [],
+          },
+        ],
+      }),
+      repoEpochRef: { current: 2 },
+      activeRepoRef: { current: "/tmp/repo" },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession: (sessionId, updater) => {
+        const current = sessionsRef.current[sessionId];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current = {
+          ...sessionsRef.current,
+          [sessionId]: updater(current),
+        };
+      },
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    const loadPromise = loadAgentSessions("task-1", {
+      mode: "requested_history",
+      targetSessionId: "session-live",
+      historyPolicy: "requested_only",
+      persistedRecords: [
+        persistedSessionRecord({
+          runtimeKind: "opencode",
+          sessionId: "session-live",
+          externalSessionId: "external-live",
+          taskId: "task-1",
+          role: "build",
+          scenario: "build_implementation_start",
+          status: "running",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          updatedAt: "2026-02-22T08:00:00.000Z",
+          workingDirectory: "/tmp/repo/worktree",
+          pendingPermissions: [],
+          pendingQuestions: [],
+        }),
+      ],
+    });
+
+    await Promise.resolve();
+    const currentSession = sessionsRef.current["session-live"];
+    if (!currentSession) {
+      throw new Error("Expected in-memory session before resolving hydration");
+    }
+    sessionsRef.current["session-live"] = {
+      ...currentSession,
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          content: "Live replacement",
+          timestamp: "2026-02-22T08:00:02.000Z",
+          meta: { kind: "assistant", agentRole: "build", isFinal: true },
+        },
+        {
+          id: "live-user-1",
+          role: "user",
+          content: "Live user message",
+          timestamp: "2026-02-22T08:00:03.000Z",
+        },
+      ],
+    };
+
+    historyDeferred.resolve([
+      {
+        messageId: "assistant-1",
+        parts: [
+          {
+            kind: "text",
+            messageId: "assistant-1",
+            partId: "assistant-part-1",
+            text: "Hydrated assistant message",
+            completed: true,
+          },
+        ],
+        role: "assistant",
+        timestamp: "2026-02-22T08:00:01.000Z",
+        text: "Hydrated assistant message",
+      },
+    ]);
+
+    await loadPromise;
+
+    const mergedMessages = sessionsRef.current["session-live"]?.messages ?? [];
+    expect(mergedMessages.some((message) => message.id === "live-user-1")).toBe(true);
+    expect(mergedMessages.find((message) => message.id === "assistant-1")?.content).toBe(
+      "Live replacement",
+    );
+  });
+
   test("does not eagerly hydrate session history or runtime connections without an explicit target session", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
     let state: Record<string, AgentSessionState> = {};

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -75,6 +75,7 @@ const mergePersistedSessionRecord = (
   promptOverrides: RepoPromptOverrides,
 ): AgentSessionState => {
   const persisted = fromPersistedSessionRecord(record, taskId);
+  const shouldPreserveCurrentWorkingDirectory = current.runtimeEndpoint.trim().length > 0;
 
   return {
     ...current,
@@ -83,7 +84,9 @@ const mergePersistedSessionRecord = (
     role: persisted.role,
     scenario: persisted.scenario,
     startedAt: persisted.startedAt,
-    workingDirectory: persisted.workingDirectory,
+    workingDirectory: shouldPreserveCurrentWorkingDirectory
+      ? current.workingDirectory
+      : persisted.workingDirectory,
     pendingPermissions: current.pendingPermissions,
     pendingQuestions: current.pendingQuestions,
     selectedModel: mergeModelSelection(current.selectedModel, persisted.selectedModel ?? undefined),
@@ -93,6 +96,26 @@ const mergePersistedSessionRecord = (
       DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE,
     promptOverrides,
   };
+};
+
+const mergeHydratedMessages = (
+  hydratedMessages: AgentSessionState["messages"],
+  currentMessages: AgentSessionState["messages"],
+): AgentSessionState["messages"] => {
+  const currentMessageById = new Map(currentMessages.map((message) => [message.id, message]));
+  const mergedMessages = hydratedMessages.map(
+    (message) => currentMessageById.get(message.id) ?? message,
+  );
+  const hydratedMessageIds = new Set(hydratedMessages.map((message) => message.id));
+
+  for (const message of currentMessages) {
+    if (hydratedMessageIds.has(message.id)) {
+      continue;
+    }
+    mergedMessages.push(message);
+  }
+
+  return mergedMessages;
 };
 
 const toRequestedHistoryRecordFromSession = (
@@ -338,12 +361,13 @@ export const createLoadAgentSessions = ({
         record: AgentSessionRecord,
         runtimeResolution: Extract<HydrationRuntimeResolution, { ok: true }>,
       ): Promise<LiveAgentSessionSnapshot | null> => {
+        const resolvedWorkingDirectory = runtimeResolution.runtimeConnection.workingDirectory;
         const externalSessionId = record.externalSessionId ?? record.sessionId;
         const storedSnapshot = liveAgentSessionStore?.readSnapshot({
           repoPath,
           runtimeKind: runtimeResolution.runtimeKind,
           runtimeEndpoint: runtimeResolution.runtimeEndpoint,
-          workingDirectory: record.workingDirectory,
+          workingDirectory: resolvedWorkingDirectory,
           externalSessionId,
         });
         if (storedSnapshot) {
@@ -354,7 +378,7 @@ export const createLoadAgentSessions = ({
           liveAgentSessionLookupKey(
             runtimeResolution.runtimeKind,
             runtimeResolution.runtimeEndpoint,
-            record.workingDirectory,
+            resolvedWorkingDirectory,
           ),
         );
         if (preloadedSnapshots) {
@@ -370,7 +394,7 @@ export const createLoadAgentSessions = ({
         const snapshots = await adapter.listLiveAgentSessionSnapshots({
           runtimeKind: runtimeResolution.runtimeKind,
           runtimeConnection: runtimeResolution.runtimeConnection,
-          directories: [record.workingDirectory],
+          directories: [resolvedWorkingDirectory],
         });
         return (
           snapshots.find((snapshot) => snapshot.externalSessionId === externalSessionId) ?? null
@@ -604,7 +628,6 @@ export const createLoadAgentSessions = ({
         }
 
         const shouldHydrateHistory = historyHydrationSessionIds.has(record.sessionId);
-        const workingDirectory = record.workingDirectory;
         const runtimeResolution =
           (shouldHydrateHistory ? readCurrentHydratedRuntimeResolution(record) : null) ??
           (await resolveHydrationRuntime(record));
@@ -635,7 +658,9 @@ export const createLoadAgentSessions = ({
           );
           return;
         }
-        const { runtimeKind, runtimeId, runId, runtimeEndpoint } = runtimeResolution;
+        const { runtimeKind, runtimeId, runId, runtimeEndpoint, runtimeConnection } =
+          runtimeResolution;
+        const workingDirectory = runtimeConnection.workingDirectory;
         const externalSessionId = record.externalSessionId ?? record.sessionId;
         if (!shouldHydrateHistory) {
           updateSession(
@@ -683,6 +708,13 @@ export const createLoadAgentSessions = ({
           record.sessionId,
           (current) => {
             const selectedModel = normalizePersistedSelection(record.selectedModel);
+            const hydratedMessages = [
+              ...preludeMessages,
+              ...historyToChatMessages(history, {
+                role: record.role,
+                selectedModel,
+              }),
+            ];
             return {
               ...current,
               runtimeKind,
@@ -696,13 +728,7 @@ export const createLoadAgentSessions = ({
               pendingPermissions: livePendingPermissions,
               pendingQuestions: livePendingQuestions,
               contextUsage: historyToSessionContextUsage(history, selectedModel),
-              messages: [
-                ...preludeMessages,
-                ...historyToChatMessages(history, {
-                  role: record.role,
-                  selectedModel,
-                }),
-              ],
+              messages: mergeHydratedMessages(hydratedMessages, current.messages),
             };
           },
           { persist: false },

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -19,6 +19,7 @@ import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-o
 import { host } from "../../shared/host";
 import type { TaskDocuments } from "../runtime/runtime";
 import { createRepoStaleGuard } from "../support/core";
+import { DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE } from "../support/history-hydration";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
 import {
   defaultScenarioForRole,
@@ -85,6 +86,10 @@ const mergePersistedSessionRecord = (
     pendingPermissions: current.pendingPermissions,
     pendingQuestions: current.pendingQuestions,
     selectedModel: mergeModelSelection(current.selectedModel, persisted.selectedModel ?? undefined),
+    historyHydrationState:
+      current.historyHydrationState ??
+      persisted.historyHydrationState ??
+      DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE,
     promptOverrides,
   };
 };
@@ -132,6 +137,11 @@ export const createLoadAgentSessions = ({
   taskId: string,
   options?: AgentSessionLoadOptions,
 ) => Promise<void>) => {
+  const inFlightRequestedHistoryLoads = new Map<string, Promise<void>>();
+
+  const buildRequestedHistoryKey = (repoPath: string, taskId: string, sessionId: string): string =>
+    `${repoPath}::${taskId}::${sessionId}`;
+
   return async (taskId: string, options?: AgentSessionLoadOptions): Promise<void> => {
     if (!activeRepo || taskId.trim().length === 0) {
       return;
@@ -148,330 +158,513 @@ export const createLoadAgentSessions = ({
       return;
     }
 
-    const persisted = await (options?.persistedRecords
-      ? Promise.resolve(options.persistedRecords)
-      : loadAgentSessionListFromQuery(appQueryClient, repoPath, taskId));
-    if (isStaleRepoOperation()) {
-      return;
-    }
-    let repoPromptOverridesPromise: Promise<RepoPromptOverrides> | null = null;
-    const getRepoPromptOverrides = (): Promise<RepoPromptOverrides> => {
-      if (repoPromptOverridesPromise === null) {
-        repoPromptOverridesPromise = loadRepoPromptOverrides(repoPath);
-      }
-      return repoPromptOverridesPromise;
-    };
-
     const mode = options?.mode ?? "bootstrap";
     const requestedSessionId = options?.targetSessionId?.trim() || null;
     const shouldHydrateRequestedSession =
       mode === "requested_history" && requestedSessionId !== null;
-    const shouldReconcileLiveSessions = mode === "reconcile_live";
-    const historyPolicy =
-      options?.historyPolicy ??
-      (shouldHydrateRequestedSession
-        ? "requested_only"
-        : shouldReconcileLiveSessions
-          ? "live_if_empty"
-          : "none");
+    const requestedHistoryKey = shouldHydrateRequestedSession
+      ? buildRequestedHistoryKey(repoPath, taskId, requestedSessionId)
+      : null;
+    if (requestedHistoryKey) {
+      const existingLoad = inFlightRequestedHistoryLoads.get(requestedHistoryKey);
+      if (existingLoad) {
+        await existingLoad;
+        return;
+      }
+    }
 
-    setSessionsById((current) => {
+    const executeLoad = async (): Promise<void> => {
+      const persisted = await (options?.persistedRecords
+        ? Promise.resolve(options.persistedRecords)
+        : loadAgentSessionListFromQuery(appQueryClient, repoPath, taskId));
       if (isStaleRepoOperation()) {
-        return current;
+        return;
       }
-      const next = { ...current };
-      for (const record of persisted) {
-        const existingSession = next[record.sessionId];
-        if (existingSession) {
-          next[record.sessionId] = mergePersistedSessionRecord(
-            existingSession,
-            record,
-            taskId,
-            existingSession.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
-          );
-          continue;
+      let repoPromptOverridesPromise: Promise<RepoPromptOverrides> | null = null;
+      const getRepoPromptOverrides = (): Promise<RepoPromptOverrides> => {
+        if (repoPromptOverridesPromise === null) {
+          repoPromptOverridesPromise = loadRepoPromptOverrides(repoPath);
         }
-        next[record.sessionId] = {
-          ...fromPersistedSessionRecord(record, taskId),
-          pendingPermissions: [],
-          pendingQuestions: [],
-          promptOverrides: EMPTY_PROMPT_OVERRIDES,
-        };
-      }
-      return next;
-    });
-
-    if (isStaleRepoOperation()) {
-      return;
-    }
-
-    if (!shouldHydrateRequestedSession && !shouldReconcileLiveSessions) {
-      return;
-    }
-
-    const recordsToHydrate = shouldHydrateRequestedSession
-      ? persisted.filter((record) => record.sessionId === requestedSessionId)
-      : persisted;
-
-    const historyHydrationSessionIds = new Set(
-      recordsToHydrate
-        .filter((record) => {
-          if (historyPolicy !== "requested_only") {
-            return false;
-          }
-          return requestedSessionId === null || record.sessionId === requestedSessionId;
-        })
-        .map((record) => record.sessionId),
-    );
-
-    if (recordsToHydrate.length === 0) {
-      return;
-    }
-
-    const readCurrentHydratedRuntimeResolution = (
-      record: AgentSessionRecord,
-    ): Extract<HydrationRuntimeResolution, { ok: true }> | null => {
-      const currentSession = sessionsRef.current[record.sessionId];
-      const runtimeKind = currentSession?.runtimeKind ?? null;
-      const runtimeEndpoint = currentSession?.runtimeEndpoint.trim() ?? "";
-      const workingDirectory =
-        currentSession?.workingDirectory.trim() || record.workingDirectory.trim();
-      if (!runtimeKind || runtimeEndpoint.length === 0 || workingDirectory.length === 0) {
-        return null;
-      }
-
-      return {
-        ok: true,
-        runtimeKind,
-        runtimeId: currentSession?.runtimeId ?? null,
-        runId: currentSession?.runId ?? null,
-        runtimeEndpoint,
-        runtimeConnection: {
-          endpoint: runtimeEndpoint,
-          workingDirectory,
-        },
+        return repoPromptOverridesPromise;
       };
-    };
 
-    const loadLiveLiveAgentSessionSnapshot = async (
-      record: AgentSessionRecord,
-      runtimeResolution: Extract<HydrationRuntimeResolution, { ok: true }>,
-    ): Promise<LiveAgentSessionSnapshot | null> => {
-      const externalSessionId = record.externalSessionId ?? record.sessionId;
-      const storedSnapshot = liveAgentSessionStore?.readSnapshot({
-        repoPath,
-        runtimeKind: runtimeResolution.runtimeKind,
-        runtimeEndpoint: runtimeResolution.runtimeEndpoint,
-        workingDirectory: record.workingDirectory,
-        externalSessionId,
+      const shouldReconcileLiveSessions = mode === "reconcile_live";
+      const historyPolicy =
+        options?.historyPolicy ??
+        (shouldHydrateRequestedSession
+          ? "requested_only"
+          : shouldReconcileLiveSessions
+            ? "live_if_empty"
+            : "none");
+
+      setSessionsById((current) => {
+        if (isStaleRepoOperation()) {
+          return current;
+        }
+        const next = { ...current };
+        for (const record of persisted) {
+          const existingSession = next[record.sessionId];
+          if (existingSession) {
+            next[record.sessionId] = mergePersistedSessionRecord(
+              existingSession,
+              record,
+              taskId,
+              existingSession.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
+            );
+            continue;
+          }
+          next[record.sessionId] = {
+            ...fromPersistedSessionRecord(record, taskId),
+            pendingPermissions: [],
+            pendingQuestions: [],
+            promptOverrides: EMPTY_PROMPT_OVERRIDES,
+          };
+        }
+        return next;
       });
-      if (storedSnapshot) {
-        return storedSnapshot;
+
+      if (isStaleRepoOperation()) {
+        return;
       }
 
-      const preloadedSnapshots = options?.preloadedLiveAgentSessionsByKey?.get(
-        liveAgentSessionLookupKey(
-          runtimeResolution.runtimeKind,
-          runtimeResolution.runtimeEndpoint,
-          record.workingDirectory,
-        ),
+      if (!shouldHydrateRequestedSession && !shouldReconcileLiveSessions) {
+        return;
+      }
+
+      const recordsToHydrate = shouldHydrateRequestedSession
+        ? persisted.filter((record) => record.sessionId === requestedSessionId)
+        : persisted;
+
+      const historyHydrationSessionIds = new Set(
+        recordsToHydrate
+          .filter((record) => {
+            if (historyPolicy !== "requested_only") {
+              return false;
+            }
+            return requestedSessionId === null || record.sessionId === requestedSessionId;
+          })
+          .map((record) => record.sessionId),
       );
-      if (preloadedSnapshots) {
-        return (
-          preloadedSnapshots.find((snapshot) => snapshot.externalSessionId === externalSessionId) ??
-          null
+
+      if (recordsToHydrate.length === 0) {
+        return;
+      }
+
+      if (historyHydrationSessionIds.size > 0) {
+        setSessionsById((current) => {
+          const next = { ...current };
+          for (const sessionId of historyHydrationSessionIds) {
+            const existingSession = next[sessionId];
+            if (!existingSession) {
+              continue;
+            }
+            next[sessionId] = {
+              ...existingSession,
+              historyHydrationState: "hydrating",
+            };
+          }
+          return next;
+        });
+      }
+
+      const readCurrentHydratedRuntimeResolution = (
+        record: AgentSessionRecord,
+      ): Extract<HydrationRuntimeResolution, { ok: true }> | null => {
+        const currentSession = sessionsRef.current[record.sessionId];
+        const runtimeKind = currentSession?.runtimeKind ?? null;
+        const runtimeEndpoint = currentSession?.runtimeEndpoint.trim() ?? "";
+        const workingDirectory =
+          currentSession?.workingDirectory.trim() || record.workingDirectory.trim();
+        if (!runtimeKind || runtimeEndpoint.length === 0 || workingDirectory.length === 0) {
+          return null;
+        }
+
+        return {
+          ok: true,
+          runtimeKind,
+          runtimeId: currentSession?.runtimeId ?? null,
+          runId: currentSession?.runId ?? null,
+          runtimeEndpoint,
+          runtimeConnection: {
+            endpoint: runtimeEndpoint,
+            workingDirectory,
+          },
+        };
+      };
+
+      const loadLiveLiveAgentSessionSnapshot = async (
+        record: AgentSessionRecord,
+        runtimeResolution: Extract<HydrationRuntimeResolution, { ok: true }>,
+      ): Promise<LiveAgentSessionSnapshot | null> => {
+        const externalSessionId = record.externalSessionId ?? record.sessionId;
+        const storedSnapshot = liveAgentSessionStore?.readSnapshot({
+          repoPath,
+          runtimeKind: runtimeResolution.runtimeKind,
+          runtimeEndpoint: runtimeResolution.runtimeEndpoint,
+          workingDirectory: record.workingDirectory,
+          externalSessionId,
+        });
+        if (storedSnapshot) {
+          return storedSnapshot;
+        }
+
+        const preloadedSnapshots = options?.preloadedLiveAgentSessionsByKey?.get(
+          liveAgentSessionLookupKey(
+            runtimeResolution.runtimeKind,
+            runtimeResolution.runtimeEndpoint,
+            record.workingDirectory,
+          ),
         );
-      }
-      if (!adapter.listLiveAgentSessionSnapshots) {
-        throw new Error("Live agent session snapshots are unavailable for session hydration.");
-      }
-      const snapshots = await adapter.listLiveAgentSessionSnapshots({
-        runtimeKind: runtimeResolution.runtimeKind,
-        runtimeConnection: runtimeResolution.runtimeConnection,
-        directories: [record.workingDirectory],
+        if (preloadedSnapshots) {
+          return (
+            preloadedSnapshots.find(
+              (snapshot) => snapshot.externalSessionId === externalSessionId,
+            ) ?? null
+          );
+        }
+        if (!adapter.listLiveAgentSessionSnapshots) {
+          throw new Error("Live agent session snapshots are unavailable for session hydration.");
+        }
+        const snapshots = await adapter.listLiveAgentSessionSnapshots({
+          runtimeKind: runtimeResolution.runtimeKind,
+          runtimeConnection: runtimeResolution.runtimeConnection,
+          directories: [record.workingDirectory],
+        });
+        return (
+          snapshots.find((snapshot) => snapshot.externalSessionId === externalSessionId) ?? null
+        );
+      };
+
+      const recordsNeedingRuntimeResolution = recordsToHydrate.filter((record) => {
+        if (!historyHydrationSessionIds.has(record.sessionId)) {
+          return true;
+        }
+        return readCurrentHydratedRuntimeResolution(record) === null;
       });
-      return snapshots.find((snapshot) => snapshot.externalSessionId === externalSessionId) ?? null;
-    };
 
-    const recordsNeedingRuntimeResolution = recordsToHydrate.filter((record) => {
-      if (!historyHydrationSessionIds.has(record.sessionId)) {
-        return true;
-      }
-      return readCurrentHydratedRuntimeResolution(record) === null;
-    });
-
-    const runtimeKindsToInspect = Array.from(
-      new Set(recordsNeedingRuntimeResolution.map((record) => readPersistedRuntimeKind(record))),
-    );
-    const runtimesByKind =
-      options?.preloadedRuntimeLists ??
-      new Map(
-        await Promise.all(
-          runtimeKindsToInspect.map(async (runtimeKind) => {
-            const runtimes = await loadRuntimeListFromQuery(appQueryClient, runtimeKind, repoPath);
-            return [runtimeKind, runtimes] as const;
-          }),
-        ),
+      const runtimeKindsToInspect = Array.from(
+        new Set(recordsNeedingRuntimeResolution.map((record) => readPersistedRuntimeKind(record))),
       );
+      const runtimesByKind =
+        options?.preloadedRuntimeLists ??
+        new Map(
+          await Promise.all(
+            runtimeKindsToInspect.map(async (runtimeKind) => {
+              const runtimes = await loadRuntimeListFromQuery(
+                appQueryClient,
+                runtimeKind,
+                repoPath,
+              );
+              return [runtimeKind, runtimes] as const;
+            }),
+          ),
+        );
 
-    const requiresRunInspection = recordsNeedingRuntimeResolution.some(
-      (record) => record.role === "build" || record.role === "qa",
-    );
-    const liveRuns = requiresRunInspection
-      ? (options?.preloadedRuns ?? (await loadRepoRunsFromQuery(appQueryClient, repoPath)))
-      : [];
-    const ensuredWorkspaceRuntimes = new Map<RuntimeKind, RuntimeInstanceSummary | null>();
+      const requiresRunInspection = recordsNeedingRuntimeResolution.some(
+        (record) => record.role === "build" || record.role === "qa",
+      );
+      const liveRuns = requiresRunInspection
+        ? (options?.preloadedRuns ?? (await loadRepoRunsFromQuery(appQueryClient, repoPath)))
+        : [];
+      const ensuredWorkspaceRuntimes = new Map<RuntimeKind, RuntimeInstanceSummary | null>();
 
-    const ensureWorkspaceRuntime = async (
-      runtimeKind: RuntimeKind,
-    ): Promise<RuntimeInstanceSummary | null> => {
-      if (options?.allowRuntimeEnsure === false) {
-        return null;
-      }
-      if (ensuredWorkspaceRuntimes.has(runtimeKind)) {
-        return ensuredWorkspaceRuntimes.get(runtimeKind) ?? null;
-      }
-      const runtime = await host.runtimeEnsure(repoPath, runtimeKind);
-      ensuredWorkspaceRuntimes.set(runtimeKind, runtime);
-      await appQueryClient.invalidateQueries({
-        queryKey: runtimeQueryKeys.list(runtimeKind, repoPath),
-        exact: true,
-        refetchType: "none",
+      const ensureWorkspaceRuntime = async (
+        runtimeKind: RuntimeKind,
+      ): Promise<RuntimeInstanceSummary | null> => {
+        if (options?.allowRuntimeEnsure === false) {
+          return null;
+        }
+        if (ensuredWorkspaceRuntimes.has(runtimeKind)) {
+          return ensuredWorkspaceRuntimes.get(runtimeKind) ?? null;
+        }
+        const runtime = await host.runtimeEnsure(repoPath, runtimeKind);
+        ensuredWorkspaceRuntimes.set(runtimeKind, runtime);
+        await appQueryClient.invalidateQueries({
+          queryKey: runtimeQueryKeys.list(runtimeKind, repoPath),
+          exact: true,
+          refetchType: "none",
+        });
+        return runtime;
+      };
+
+      const resolveHydrationRuntime = createHydrationRuntimeResolver({
+        repoPath,
+        liveRuns,
+        runtimesByKind,
+        ...(options?.preloadedRuntimeConnectionsByKey
+          ? { preloadedRuntimeConnectionsByKey: options.preloadedRuntimeConnectionsByKey }
+          : {}),
+        ensureWorkspaceRuntime,
       });
-      return runtime;
-    };
 
-    const resolveHydrationRuntime = createHydrationRuntimeResolver({
-      repoPath,
-      liveRuns,
-      runtimesByKind,
-      ...(options?.preloadedRuntimeConnectionsByKey
-        ? { preloadedRuntimeConnectionsByKey: options.preloadedRuntimeConnectionsByKey }
-        : {}),
-      ensureWorkspaceRuntime,
-    });
+      const buildHydrationPreludeMessages = async ({
+        record,
+        resolvedScenario,
+        promptOverrides,
+      }: {
+        record: AgentSessionRecord;
+        resolvedScenario: AgentSessionState["scenario"];
+        promptOverrides: RepoPromptOverrides;
+      }): Promise<AgentSessionState["messages"]> => {
+        const task = taskRef.current.find((entry) => entry.id === taskId);
+        if (!task) {
+          return buildSessionHeaderMessages({
+            sessionId: record.sessionId,
+            role: record.role,
+            scenario: resolvedScenario,
+            systemPrompt: "",
+            startedAt: record.startedAt,
+            includeSystemPrompt: false,
+          });
+        }
 
-    const buildHydrationPreludeMessages = async ({
-      record,
-      resolvedScenario,
-      promptOverrides,
-    }: {
-      record: AgentSessionRecord;
-      resolvedScenario: AgentSessionState["scenario"];
-      promptOverrides: RepoPromptOverrides;
-    }): Promise<AgentSessionState["messages"]> => {
-      const task = taskRef.current.find((entry) => entry.id === taskId);
-      if (!task) {
+        const systemPrompt = buildSessionSystemPrompt({
+          role: record.role,
+          scenario: resolvedScenario,
+          task,
+          promptOverrides,
+        });
+
         return buildSessionHeaderMessages({
           sessionId: record.sessionId,
           role: record.role,
           scenario: resolvedScenario,
-          systemPrompt: "",
+          systemPrompt,
           startedAt: record.startedAt,
-          includeSystemPrompt: false,
         });
-      }
+      };
 
-      const systemPrompt = buildSessionSystemPrompt({
-        role: record.role,
-        scenario: resolvedScenario,
-        task,
+      const buildHydrationSystemPrompt = async ({
+        record,
+        resolvedScenario,
         promptOverrides,
-      });
+      }: {
+        record: AgentSessionRecord;
+        resolvedScenario: AgentSessionState["scenario"];
+        promptOverrides: RepoPromptOverrides;
+      }): Promise<string> => {
+        const task = taskRef.current.find((entry) => entry.id === taskId);
+        if (!task) {
+          return "";
+        }
 
-      return buildSessionHeaderMessages({
-        sessionId: record.sessionId,
-        role: record.role,
-        scenario: resolvedScenario,
-        systemPrompt,
-        startedAt: record.startedAt,
-      });
-    };
-
-    const buildHydrationSystemPrompt = async ({
-      record,
-      resolvedScenario,
-      promptOverrides,
-    }: {
-      record: AgentSessionRecord;
-      resolvedScenario: AgentSessionState["scenario"];
-      promptOverrides: RepoPromptOverrides;
-    }): Promise<string> => {
-      const task = taskRef.current.find((entry) => entry.id === taskId);
-      if (!task) {
-        return "";
-      }
-
-      return buildSessionSystemPrompt({
-        role: record.role,
-        scenario: resolvedScenario,
-        task,
-        promptOverrides,
-      });
-    };
-
-    if (shouldReconcileLiveSessions && !adapter.listLiveAgentSessionSnapshots) {
-      throw new Error(
-        "Live agent session snapshots are unavailable for live session reconciliation.",
-      );
-    }
-
-    const runtimeSessionScanCache = new LiveAgentSessionCache(
-      {
-        listLiveAgentSessionSnapshots: async (input) => {
-          if (!adapter.listLiveAgentSessionSnapshots) {
-            throw new Error("Live agent session snapshots are unavailable for session scanning.");
-          }
-          return adapter.listLiveAgentSessionSnapshots(input);
-        },
-      },
-      options?.preloadedLiveAgentSessionsByKey,
-    );
-    const maybeResumeLiveRecord = createReattachLiveSession({
-      adapter,
-      repoPath,
-      taskId,
-      taskRef,
-      sessionsRef,
-      updateSession,
-      ...(attachSessionListener ? { attachSessionListener } : {}),
-      promptOverrides: EMPTY_PROMPT_OVERRIDES,
-      resolveHydrationRuntime,
-      listLiveAgentSessions: (runtimeKind, runtimeConnection, directories) =>
-        runtimeSessionScanCache.load({
-          runtimeKind,
-          runtimeConnection,
-          directories,
-        }),
-      resumeMissingLiveSession: async ({ record, runtimeKind, runtimeConnection }) => {
-        const promptOverrides = await getRepoPromptOverrides();
-        const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
-        const selectedModel = normalizePersistedSelection(record.selectedModel);
-        const systemPrompt = await buildHydrationSystemPrompt({
-          record,
-          resolvedScenario,
-          promptOverrides,
-        });
-
-        await adapter.resumeSession({
-          sessionId: record.sessionId,
-          externalSessionId: record.externalSessionId ?? record.sessionId,
-          repoPath,
-          runtimeKind,
-          runtimeConnection,
-          workingDirectory: runtimeConnection.workingDirectory,
-          taskId,
+        return buildSessionSystemPrompt({
           role: record.role,
           scenario: resolvedScenario,
-          systemPrompt,
-          ...(selectedModel ? { model: selectedModel } : {}),
+          task,
+          promptOverrides,
         });
-      },
-      isStaleRepoOperation,
-      toLiveSessionState,
-    });
+      };
 
-    if (shouldReconcileLiveSessions) {
+      if (shouldReconcileLiveSessions && !adapter.listLiveAgentSessionSnapshots) {
+        throw new Error(
+          "Live agent session snapshots are unavailable for live session reconciliation.",
+        );
+      }
+
+      const runtimeSessionScanCache = new LiveAgentSessionCache(
+        {
+          listLiveAgentSessionSnapshots: async (input) => {
+            if (!adapter.listLiveAgentSessionSnapshots) {
+              throw new Error("Live agent session snapshots are unavailable for session scanning.");
+            }
+            return adapter.listLiveAgentSessionSnapshots(input);
+          },
+        },
+        options?.preloadedLiveAgentSessionsByKey,
+      );
+      const maybeResumeLiveRecord = createReattachLiveSession({
+        adapter,
+        repoPath,
+        taskId,
+        taskRef,
+        sessionsRef,
+        updateSession,
+        ...(attachSessionListener ? { attachSessionListener } : {}),
+        promptOverrides: EMPTY_PROMPT_OVERRIDES,
+        resolveHydrationRuntime,
+        listLiveAgentSessions: (runtimeKind, runtimeConnection, directories) =>
+          runtimeSessionScanCache.load({
+            runtimeKind,
+            runtimeConnection,
+            directories,
+          }),
+        resumeMissingLiveSession: async ({ record, runtimeKind, runtimeConnection }) => {
+          const promptOverrides = await getRepoPromptOverrides();
+          const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
+          const selectedModel = normalizePersistedSelection(record.selectedModel);
+          const systemPrompt = await buildHydrationSystemPrompt({
+            record,
+            resolvedScenario,
+            promptOverrides,
+          });
+
+          await adapter.resumeSession({
+            sessionId: record.sessionId,
+            externalSessionId: record.externalSessionId ?? record.sessionId,
+            repoPath,
+            runtimeKind,
+            runtimeConnection,
+            workingDirectory: runtimeConnection.workingDirectory,
+            taskId,
+            role: record.role,
+            scenario: resolvedScenario,
+            systemPrompt,
+            ...(selectedModel ? { model: selectedModel } : {}),
+          });
+        },
+        isStaleRepoOperation,
+        toLiveSessionState,
+      });
+
+      if (shouldReconcileLiveSessions) {
+        for (
+          let offset = 0;
+          offset < recordsToHydrate.length;
+          offset += SESSION_HISTORY_HYDRATION_CONCURRENCY
+        ) {
+          if (isStaleRepoOperation()) {
+            return;
+          }
+          const batch = recordsToHydrate.slice(
+            offset,
+            offset + SESSION_HISTORY_HYDRATION_CONCURRENCY,
+          );
+          const reattachResults = await Promise.all(
+            batch.map(async (record) => ({
+              record,
+              reattached: await maybeResumeLiveRecord(record),
+            })),
+          );
+          if (isStaleRepoOperation()) {
+            return;
+          }
+          for (const { record, reattached } of reattachResults) {
+            if (reattached) {
+              continue;
+            }
+            updateSession(
+              record.sessionId,
+              (current) => ({
+                ...current,
+                pendingPermissions: [],
+                pendingQuestions: [],
+              }),
+              { persist: false },
+            );
+          }
+        }
+      }
+
+      const hydrateRecord = async (record: AgentSessionRecord): Promise<void> => {
+        if (isStaleRepoOperation()) {
+          return;
+        }
+
+        const shouldHydrateHistory = historyHydrationSessionIds.has(record.sessionId);
+        const workingDirectory = record.workingDirectory;
+        const runtimeResolution =
+          (shouldHydrateHistory ? readCurrentHydratedRuntimeResolution(record) : null) ??
+          (await resolveHydrationRuntime(record));
+        if (!runtimeResolution.ok) {
+          if (shouldHydrateHistory) {
+            updateSession(
+              record.sessionId,
+              (current) => ({
+                ...current,
+                historyHydrationState: "failed",
+              }),
+              { persist: false },
+            );
+            throw new Error(runtimeResolution.reason);
+          }
+          updateSession(
+            record.sessionId,
+            (current) => ({
+              ...current,
+              runtimeKind: readPersistedRuntimeKind(record),
+              runtimeId: null,
+              runId: null,
+              runtimeEndpoint: "",
+              workingDirectory,
+              promptOverrides: current.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
+            }),
+            { persist: false },
+          );
+          return;
+        }
+        const { runtimeKind, runtimeId, runId, runtimeEndpoint } = runtimeResolution;
+        const externalSessionId = record.externalSessionId ?? record.sessionId;
+        if (!shouldHydrateHistory) {
+          updateSession(
+            record.sessionId,
+            (current) => ({
+              ...current,
+              runtimeKind,
+              runtimeId,
+              runId,
+              runtimeEndpoint,
+              workingDirectory,
+              promptOverrides: current.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
+            }),
+            { persist: false },
+          );
+          return;
+        }
+
+        const promptOverrides = await getRepoPromptOverrides();
+        const preludeMessages = await buildHydrationPreludeMessages({
+          record,
+          resolvedScenario: record.scenario ?? defaultScenarioForRole(record.role),
+          promptOverrides,
+        });
+        const history = await adapter.loadSessionHistory({
+          runtimeKind: runtimeResolution.runtimeKind,
+          runtimeConnection: runtimeResolution.runtimeConnection,
+          externalSessionId,
+          limit: INITIAL_SESSION_HISTORY_LIMIT,
+        });
+        const liveRuntimeSnapshot = await loadLiveLiveAgentSessionSnapshot(
+          record,
+          runtimeResolution,
+        );
+        const liveSessionStatus = liveRuntimeSnapshot
+          ? toLiveSessionState(liveRuntimeSnapshot.status)
+          : null;
+        const livePendingPermissions = liveRuntimeSnapshot?.pendingPermissions ?? [];
+        const livePendingQuestions = liveRuntimeSnapshot?.pendingQuestions ?? [];
+        if (isStaleRepoOperation()) {
+          return;
+        }
+
+        updateSession(
+          record.sessionId,
+          (current) => {
+            return {
+              ...current,
+              runtimeKind,
+              runtimeId,
+              runId,
+              runtimeEndpoint,
+              status: liveSessionStatus ?? current.status,
+              workingDirectory,
+              historyHydrationState: "hydrated",
+              promptOverrides,
+              pendingPermissions: livePendingPermissions,
+              pendingQuestions: livePendingQuestions,
+              messages: [
+                ...preludeMessages,
+                ...historyToChatMessages(history, {
+                  role: record.role,
+                  selectedModel: normalizePersistedSelection(record.selectedModel),
+                }),
+              ],
+            };
+          },
+          { persist: false },
+        );
+      };
+
       for (
         let offset = 0;
         offset < recordsToHydrate.length;
@@ -484,139 +677,35 @@ export const createLoadAgentSessions = ({
           offset,
           offset + SESSION_HISTORY_HYDRATION_CONCURRENCY,
         );
-        const reattachResults = await Promise.all(
-          batch.map(async (record) => ({
-            record,
-            reattached: await maybeResumeLiveRecord(record),
-          })),
-        );
-        if (isStaleRepoOperation()) {
-          return;
-        }
-        for (const { record, reattached } of reattachResults) {
-          if (reattached) {
-            continue;
-          }
-          updateSession(
-            record.sessionId,
-            (current) => ({
-              ...current,
-              pendingPermissions: [],
-              pendingQuestions: [],
+        await Promise.all(
+          batch.map((record) =>
+            hydrateRecord(record).catch((error) => {
+              if (historyHydrationSessionIds.has(record.sessionId)) {
+                updateSession(
+                  record.sessionId,
+                  (current) => ({
+                    ...current,
+                    historyHydrationState: "failed",
+                  }),
+                  { persist: false },
+                );
+              }
+              throw error;
             }),
-            { persist: false },
-          );
-        }
-      }
-    }
-
-    const hydrateRecord = async (record: AgentSessionRecord): Promise<void> => {
-      if (isStaleRepoOperation()) {
-        return;
-      }
-
-      const shouldHydrateHistory = historyHydrationSessionIds.has(record.sessionId);
-      const workingDirectory = record.workingDirectory;
-      const runtimeResolution =
-        (shouldHydrateHistory ? readCurrentHydratedRuntimeResolution(record) : null) ??
-        (await resolveHydrationRuntime(record));
-      if (!runtimeResolution.ok) {
-        if (shouldHydrateHistory) {
-          throw new Error(runtimeResolution.reason);
-        }
-        updateSession(
-          record.sessionId,
-          (current) => ({
-            ...current,
-            runtimeKind: readPersistedRuntimeKind(record),
-            runtimeId: null,
-            runId: null,
-            runtimeEndpoint: "",
-            workingDirectory,
-            promptOverrides: current.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
-          }),
-          { persist: false },
+          ),
         );
-        return;
       }
-      const { runtimeKind, runtimeId, runId, runtimeEndpoint } = runtimeResolution;
-      const externalSessionId = record.externalSessionId ?? record.sessionId;
-      if (!shouldHydrateHistory) {
-        updateSession(
-          record.sessionId,
-          (current) => ({
-            ...current,
-            runtimeKind,
-            runtimeId,
-            runId,
-            runtimeEndpoint,
-            workingDirectory,
-            promptOverrides: current.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
-          }),
-          { persist: false },
-        );
-        return;
-      }
-
-      const promptOverrides = await getRepoPromptOverrides();
-      const preludeMessages = await buildHydrationPreludeMessages({
-        record,
-        resolvedScenario: record.scenario ?? defaultScenarioForRole(record.role),
-        promptOverrides,
-      });
-      const history = await adapter.loadSessionHistory({
-        runtimeKind: runtimeResolution.runtimeKind,
-        runtimeConnection: runtimeResolution.runtimeConnection,
-        externalSessionId,
-        limit: INITIAL_SESSION_HISTORY_LIMIT,
-      });
-      const liveRuntimeSnapshot = await loadLiveLiveAgentSessionSnapshot(record, runtimeResolution);
-      const liveSessionStatus = liveRuntimeSnapshot
-        ? toLiveSessionState(liveRuntimeSnapshot.status)
-        : null;
-      const livePendingPermissions = liveRuntimeSnapshot?.pendingPermissions ?? [];
-      const livePendingQuestions = liveRuntimeSnapshot?.pendingQuestions ?? [];
-      if (isStaleRepoOperation()) {
-        return;
-      }
-
-      updateSession(
-        record.sessionId,
-        (current) => {
-          return {
-            ...current,
-            runtimeKind,
-            runtimeId,
-            runId,
-            runtimeEndpoint,
-            status: liveSessionStatus ?? current.status,
-            workingDirectory,
-            promptOverrides,
-            pendingPermissions: livePendingPermissions,
-            pendingQuestions: livePendingQuestions,
-            messages: [
-              ...preludeMessages,
-              ...historyToChatMessages(history, {
-                role: record.role,
-                selectedModel: normalizePersistedSelection(record.selectedModel),
-              }),
-            ],
-          };
-        },
-        { persist: false },
-      );
     };
 
-    for (
-      let offset = 0;
-      offset < recordsToHydrate.length;
-      offset += SESSION_HISTORY_HYDRATION_CONCURRENCY
-    ) {
-      if (isStaleRepoOperation()) {
-        return;
-      }
-      const batch = recordsToHydrate.slice(offset, offset + SESSION_HISTORY_HYDRATION_CONCURRENCY);
-      await Promise.all(batch.map((record) => hydrateRecord(record)));
+    if (!requestedHistoryKey) {
+      await executeLoad();
+      return;
     }
+
+    const inFlightLoad = executeLoad().finally(() => {
+      inFlightRequestedHistoryLoads.delete(requestedHistoryKey);
+    });
+    inFlightRequestedHistoryLoads.set(requestedHistoryKey, inFlightLoad);
+    await inFlightLoad;
   };
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -25,6 +25,7 @@ import {
   defaultScenarioForRole,
   fromPersistedSessionRecord,
   historyToChatMessages,
+  historyToSessionContextUsage,
 } from "../support/persistence";
 import { buildSessionHeaderMessages, buildSessionSystemPrompt } from "../support/session-prompt";
 import {
@@ -91,6 +92,31 @@ const mergePersistedSessionRecord = (
       persisted.historyHydrationState ??
       DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE,
     promptOverrides,
+  };
+};
+
+const toRequestedHistoryRecordFromSession = (
+  session: AgentSessionState,
+): AgentSessionRecord | null => {
+  const runtimeKind = session.runtimeKind ?? session.selectedModel?.runtimeKind ?? null;
+  if (!runtimeKind) {
+    return null;
+  }
+
+  return {
+    sessionId: session.sessionId,
+    externalSessionId: session.externalSessionId,
+    role: session.role,
+    scenario: session.scenario,
+    startedAt: session.startedAt,
+    workingDirectory: session.workingDirectory,
+    runtimeKind,
+    selectedModel: session.selectedModel
+      ? {
+          ...session.selectedModel,
+          runtimeKind,
+        }
+      : null,
   };
 };
 
@@ -174,9 +200,23 @@ export const createLoadAgentSessions = ({
     }
 
     const executeLoad = async (): Promise<void> => {
-      const persisted = await (options?.persistedRecords
-        ? Promise.resolve(options.persistedRecords)
-        : loadAgentSessionListFromQuery(appQueryClient, repoPath, taskId));
+      const currentRequestedSession = requestedSessionId
+        ? (sessionsRef.current[requestedSessionId] ?? null)
+        : null;
+      const requestedHistoryRecordFromSession =
+        shouldHydrateRequestedSession &&
+        options?.persistedRecords === undefined &&
+        currentRequestedSession &&
+        currentRequestedSession.taskId === taskId
+          ? toRequestedHistoryRecordFromSession(currentRequestedSession)
+          : null;
+      const shouldSkipPersistedSessionReload = requestedHistoryRecordFromSession !== null;
+
+      const persisted = shouldSkipPersistedSessionReload
+        ? [requestedHistoryRecordFromSession]
+        : await (options?.persistedRecords
+            ? Promise.resolve(options.persistedRecords)
+            : loadAgentSessionListFromQuery(appQueryClient, repoPath, taskId));
       if (isStaleRepoOperation()) {
         return;
       }
@@ -197,31 +237,33 @@ export const createLoadAgentSessions = ({
             ? "live_if_empty"
             : "none");
 
-      setSessionsById((current) => {
-        if (isStaleRepoOperation()) {
-          return current;
-        }
-        const next = { ...current };
-        for (const record of persisted) {
-          const existingSession = next[record.sessionId];
-          if (existingSession) {
-            next[record.sessionId] = mergePersistedSessionRecord(
-              existingSession,
-              record,
-              taskId,
-              existingSession.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
-            );
-            continue;
+      if (!shouldSkipPersistedSessionReload) {
+        setSessionsById((current) => {
+          if (isStaleRepoOperation()) {
+            return current;
           }
-          next[record.sessionId] = {
-            ...fromPersistedSessionRecord(record, taskId),
-            pendingPermissions: [],
-            pendingQuestions: [],
-            promptOverrides: EMPTY_PROMPT_OVERRIDES,
-          };
-        }
-        return next;
-      });
+          const next = { ...current };
+          for (const record of persisted) {
+            const existingSession = next[record.sessionId];
+            if (existingSession) {
+              next[record.sessionId] = mergePersistedSessionRecord(
+                existingSession,
+                record,
+                taskId,
+                existingSession.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
+              );
+              continue;
+            }
+            next[record.sessionId] = {
+              ...fromPersistedSessionRecord(record, taskId),
+              pendingPermissions: [],
+              pendingQuestions: [],
+              promptOverrides: EMPTY_PROMPT_OVERRIDES,
+            };
+          }
+          return next;
+        });
+      }
 
       if (isStaleRepoOperation()) {
         return;
@@ -640,6 +682,7 @@ export const createLoadAgentSessions = ({
         updateSession(
           record.sessionId,
           (current) => {
+            const selectedModel = normalizePersistedSelection(record.selectedModel);
             return {
               ...current,
               runtimeKind,
@@ -652,11 +695,12 @@ export const createLoadAgentSessions = ({
               promptOverrides,
               pendingPermissions: livePendingPermissions,
               pendingQuestions: livePendingQuestions,
+              contextUsage: historyToSessionContextUsage(history, selectedModel),
               messages: [
                 ...preludeMessages,
                 ...historyToChatMessages(history, {
                   role: record.role,
-                  selectedModel: normalizePersistedSelection(record.selectedModel),
+                  selectedModel,
                 }),
               ],
             };

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/assistant-meta.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/assistant-meta.ts
@@ -33,6 +33,10 @@ export const toSessionContextUsage = (
 
   return {
     totalTokens,
+    ...(effectiveModel?.providerId ? { providerId: effectiveModel.providerId } : {}),
+    ...(effectiveModel?.modelId ? { modelId: effectiveModel.modelId } : {}),
+    ...(effectiveModel?.variant ? { variant: effectiveModel.variant } : {}),
+    ...(effectiveModel?.profileId ? { profileId: effectiveModel.profileId } : {}),
     ...(typeof modelDescriptor?.contextWindow === "number"
       ? { contextWindow: modelDescriptor.contextWindow }
       : {}),

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/history-hydration.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/history-hydration.ts
@@ -1,0 +1,25 @@
+import type {
+  AgentSessionHistoryHydrationState,
+  AgentSessionState,
+} from "@/types/agent-orchestrator";
+
+export const DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE: AgentSessionHistoryHydrationState =
+  "not_requested";
+
+export const getAgentSessionHistoryHydrationState = (
+  session: Pick<AgentSessionState, "historyHydrationState"> | null | undefined,
+): AgentSessionHistoryHydrationState => {
+  return session?.historyHydrationState ?? DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE;
+};
+
+export const shouldAutoHydrateAgentSessionHistory = (
+  session: Pick<AgentSessionState, "historyHydrationState"> | null | undefined,
+): boolean => {
+  return getAgentSessionHistoryHydrationState(session) === "not_requested";
+};
+
+export const requiresHydratedAgentSessionHistory = (
+  session: Pick<AgentSessionState, "historyHydrationState"> | null | undefined,
+): boolean => {
+  return getAgentSessionHistoryHydrationState(session) !== "hydrated";
+};

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.test.ts
@@ -4,6 +4,7 @@ import type { AgentSessionState } from "@/types/agent-orchestrator";
 import {
   fromPersistedSessionRecord,
   historyToChatMessages,
+  historyToSessionContextUsage,
   toPersistedSessionRecord,
 } from "./persistence";
 
@@ -105,6 +106,70 @@ describe("agent-orchestrator/support/persistence", () => {
       selectedModel: null,
     });
     expect(messages).toEqual([]);
+  });
+
+  test("extracts latest final assistant context usage from hydrated history", () => {
+    const contextUsage = historyToSessionContextUsage(
+      [
+        {
+          messageId: "m-assistant-1",
+          role: "assistant",
+          timestamp: "2026-02-22T08:00:02.000Z",
+          text: "Working",
+          totalTokens: 50,
+          model: {
+            providerId: "openai",
+            modelId: "gpt-5",
+            profileId: "Ares",
+            variant: "high",
+          },
+          parts: [
+            {
+              kind: "step",
+              messageId: "m-assistant-1",
+              partId: "p-step-intermediate",
+              phase: "finish",
+              reason: "length",
+            },
+          ],
+        },
+        {
+          messageId: "m-assistant-2",
+          role: "assistant",
+          timestamp: "2026-02-22T08:00:05.000Z",
+          text: "Done",
+          totalTokens: 123,
+          model: {
+            providerId: "anthropic",
+            modelId: "claude-3-7-sonnet",
+            profileId: "Hephaestus",
+            variant: "max",
+          },
+          parts: [
+            {
+              kind: "step",
+              messageId: "m-assistant-2",
+              partId: "p-step-finish",
+              phase: "finish",
+              reason: "stop",
+            },
+          ],
+        },
+      ],
+      {
+        runtimeKind: "opencode",
+        providerId: "openai",
+        modelId: "gpt-5",
+      },
+    );
+
+    expect(contextUsage).toEqual({
+      totalTokens: 123,
+      providerId: "anthropic",
+      modelId: "claude-3-7-sonnet",
+      profileId: "Hephaestus",
+      variant: "max",
+    });
   });
 
   test("maps history parts into chat timeline entries", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -57,6 +57,7 @@ export const fromPersistedSessionRecord = (
     runId: null,
     runtimeEndpoint: "",
     workingDirectory: session.workingDirectory,
+    historyHydrationState: "not_requested",
     messages: [],
     draftAssistantText: "",
     draftAssistantMessageId: null,
@@ -266,7 +267,7 @@ export const historyToChatMessages = (
       const isFinalAssistantMessage = isFinalAssistantHistoryMessage(message);
       const assistantDurationMs = assistantDurationFromHistory(message, previousUserTimestampMs);
       next.push({
-        id: `history:text:${message.messageId}`,
+        id: message.messageId,
         role: message.role,
         content,
         timestamp: message.timestamp,

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/persistence.ts
@@ -7,7 +7,11 @@ import {
   defaultAgentScenarioForRole,
 } from "@openducktor/core";
 import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
-import type { AgentChatMessage, AgentSessionState } from "@/types/agent-orchestrator";
+import type {
+  AgentChatMessage,
+  AgentSessionContextUsage,
+  AgentSessionState,
+} from "@/types/agent-orchestrator";
 import { formatToolContent } from "../agent-tool-messages";
 import { mergeModelSelection, normalizePersistedSelection } from "./models";
 import { normalizeToolInput, normalizeToolText } from "./tool-messages";
@@ -298,4 +302,33 @@ export const historyToChatMessages = (
   }
 
   return next;
+};
+
+export const historyToSessionContextUsage = (
+  history: AgentSessionHistoryMessage[],
+  selectedModel: AgentModelSelection | null,
+): AgentSessionContextUsage | null => {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index];
+    if (!message || message.role !== "assistant") {
+      continue;
+    }
+    if (!isFinalAssistantHistoryMessage(message)) {
+      continue;
+    }
+    if (typeof message.totalTokens !== "number" || message.totalTokens <= 0) {
+      continue;
+    }
+
+    const effectiveModel = mergeModelSelection(selectedModel, message.model);
+    return {
+      totalTokens: message.totalTokens,
+      ...(effectiveModel?.providerId ? { providerId: effectiveModel.providerId } : {}),
+      ...(effectiveModel?.modelId ? { modelId: effectiveModel.modelId } : {}),
+      ...(effectiveModel?.variant ? { variant: effectiveModel.variant } : {}),
+      ...(effectiveModel?.profileId ? { profileId: effectiveModel.profileId } : {}),
+    };
+  }
+
+  return null;
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -340,13 +340,18 @@ describe("use-agent-orchestrator-operations", () => {
       const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
       const originalLoadSessionHistory = OpencodeSdkAdapter.prototype.loadSessionHistory;
 
-      host.agentSessionsList = async () => [persistedSessionFixture];
+      host.agentSessionsList = async () => [
+        {
+          ...persistedSessionFixture,
+          workingDirectory: "/tmp/repo/worktree",
+        },
+      ];
       host.agentSessionUpsert = async () => {};
       host.specGet = async () => ({ markdown: "", updatedAt: null });
       host.planGet = async () => ({ markdown: "", updatedAt: null });
       host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
       host.buildContinuationTargetGet = async () => ({
-        workingDirectory: "/tmp/repo",
+        workingDirectory: "/tmp/repo/worktree",
         source: "active_build_run",
       });
 
@@ -426,7 +431,12 @@ describe("use-agent-orchestrator-operations", () => {
       const originalLoadSessionTodos = OpencodeSdkAdapter.prototype.loadSessionTodos;
       const originalListAvailableModels = OpencodeSdkAdapter.prototype.listAvailableModels;
 
-      host.agentSessionsList = async () => [persistedSessionFixture];
+      host.agentSessionsList = async () => [
+        {
+          ...persistedSessionFixture,
+          workingDirectory: "/tmp/repo/worktree",
+        },
+      ];
       host.agentSessionUpsert = async () => {};
       host.runtimeList = async () => [
         {
@@ -545,7 +555,7 @@ describe("use-agent-orchestrator-operations", () => {
       host.planGet = async () => ({ markdown: "", updatedAt: null });
       host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
       host.buildContinuationTargetGet = async () => ({
-        workingDirectory: "/tmp/repo",
+        workingDirectory: "/tmp/repo/worktree",
         source: "active_build_run",
       });
 
@@ -958,6 +968,7 @@ describe("use-agent-orchestrator-operations", () => {
                 ...persistedSessionFixture,
                 role: "spec",
                 scenario: "spec_initial",
+                workingDirectory: "/tmp/repo/worktree",
               },
             ],
           },
@@ -1613,6 +1624,7 @@ describe("use-agent-orchestrator-operations", () => {
           ...persistedSessionFixture,
           role: "build",
           scenario: "build_after_human_request_changes",
+          workingDirectory: "/tmp/repo/worktree",
         },
       ];
       host.agentSessionUpsert = async () => {};
@@ -1620,7 +1632,7 @@ describe("use-agent-orchestrator-operations", () => {
       host.planGet = async () => ({ markdown: "", updatedAt: null });
       host.qaGetReport = async () => ({ markdown: "", updatedAt: null });
       host.buildContinuationTargetGet = async () => ({
-        workingDirectory: "/tmp/repo",
+        workingDirectory: "/tmp/repo/worktree",
         source: "active_build_run",
       });
 

--- a/apps/desktop/src/test-utils/shared-test-fixtures.ts
+++ b/apps/desktop/src/test-utils/shared-test-fixtures.ts
@@ -44,6 +44,7 @@ const BASE_AGENT_SESSION_FIXTURE: AgentSessionState = {
   runId: null,
   runtimeEndpoint: "http://127.0.0.1:4444",
   workingDirectory: "/tmp/repo/worktree",
+  historyHydrationState: "hydrated",
   messages: [],
   draftAssistantText: "",
   draftAssistantMessageId: null,

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -96,6 +96,10 @@ export type AgentSessionContextUsage = {
   totalTokens: number;
   contextWindow?: number;
   outputLimit?: number;
+  providerId?: string;
+  modelId?: string;
+  variant?: string;
+  profileId?: string;
 };
 
 export type AgentSessionHistoryHydrationState =

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -98,6 +98,12 @@ export type AgentSessionContextUsage = {
   outputLimit?: number;
 };
 
+export type AgentSessionHistoryHydrationState =
+  | "not_requested"
+  | "hydrating"
+  | "hydrated"
+  | "failed";
+
 export type AgentSessionState = {
   sessionId: string;
   externalSessionId: string;
@@ -111,6 +117,7 @@ export type AgentSessionState = {
   runId: string | null;
   runtimeEndpoint: string;
   workingDirectory: string;
+  historyHydrationState?: AgentSessionHistoryHydrationState;
   messages: AgentChatMessage[];
   draftAssistantText: string;
   draftAssistantMessageId: string | null;

--- a/docs/agent-orchestrator-module-map.md
+++ b/docs/agent-orchestrator-module-map.md
@@ -100,7 +100,7 @@ Must not own:
   - `fork`
 - Uses stale-repo guards across async boundaries.
 - Rolls back newly created remote sessions when the repo context becomes stale.
-- Builder PR generation now goes through this same path using scenario `build_pull_request_generation`, which is `fork`-only.
+- Builder PR generation now goes through this same path using scenario `build_pull_request_generation`, which supports `reuse` and `fork` from an existing Builder session.
 
 `handlers/public-operations.ts`
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -82,7 +82,7 @@ Agent-triggered path:
 
 ### 4) Generate a pull request
 1. The approval flow starts a Builder session with scenario `build_pull_request_generation`.
-2. That scenario is `fork`-only and must start from an existing Builder source session.
+2. That scenario must start from an existing Builder source session and supports `reuse` or `fork`.
 3. The Builder uses provider-native git or GitHub tools to create or update the PR.
 4. Once the PR exists, the Builder calls `odt_set_pull_request`.
 5. `odt_set_pull_request` persists canonical PR metadata into task metadata by resolving the provider record from `providerId + number`.

--- a/docs/runtime-integration-guide.md
+++ b/docs/runtime-integration-guide.md
@@ -213,7 +213,7 @@ Current workflow implications:
 
 - `build_implementation_start` is `fresh` only
 - `build_after_qa_rejected`, `build_after_human_request_changes`, and `build_rebase_conflict_resolution` allow `fresh` and `reuse`
-- `build_pull_request_generation` is `fork` only
+- `build_pull_request_generation` allows `reuse` and `fork`
 - `qa_review` allows `fresh` and `reuse`
 
 This makes `supportsSessionFork` a hard requirement for full Builder compatibility. A runtime that cannot fork an existing Builder session cannot implement the complete OpenDucktor Builder workflow.
@@ -265,7 +265,7 @@ It must also implement the scenario-compatible session lifecycle:
 
 - `startSession(...)` for fresh sessions
 - reuse via existing session registration/resume flows
-- `forkSession(...)` for fork-only scenarios such as `build_pull_request_generation`
+- `forkSession(...)` for scenarios that support forking, including `build_pull_request_generation`
 
 If a runtime does not implement one of these surfaces, the descriptor and adapter surface should reflect that so unsupported operations fail explicitly.
 

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -51,7 +51,7 @@ const makeSessionRecord = (client: OpencodeClient): SessionRecord => ({
   externalSessionId: "external-session-1",
   eventTransportKey: "http://127.0.0.1:12345",
   hasIdleSinceActivity: false,
-  emittedAssistantMessageIds: new Set<string>(),
+  emittedMessageIds: new Set<string>(),
   partsById: new Map(),
   messageRoleById: new Map(),
   pendingDeltasByPartId: new Map(),
@@ -93,6 +93,44 @@ const assistantRoleEvent = (messageId: string): Event =>
   }) as unknown as Event;
 
 describe("event-stream", () => {
+  test("emits user_message when opencode acknowledges a user turn", async () => {
+    const emitted = await runEventStream([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "user-message-1",
+            role: "user",
+            sessionID: "external-session-1",
+            providerID: "openai",
+            modelID: "gpt-5",
+            agent: "Hephaestus",
+            variant: "high",
+            text: "Generate the PR",
+            time: {
+              created: Date.parse("2026-02-22T12:00:03.000Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+    ]);
+
+    const userMessages = emitted.filter((event) => event.type === "user_message");
+    expect(userMessages).toHaveLength(1);
+    if (userMessages[0]?.type !== "user_message") {
+      throw new Error("Expected user_message event");
+    }
+    expect(userMessages[0].messageId).toBe("user-message-1");
+    expect(userMessages[0].message).toBe("Generate the PR");
+    expect(userMessages[0].timestamp).toBe("2026-02-22T12:00:03.000Z");
+    expect(userMessages[0].model).toEqual({
+      providerId: "openai",
+      modelId: "gpt-5",
+      profileId: "Hephaestus",
+      variant: "high",
+    });
+  });
+
   test("deduplicates assistant_message across repeated message.updated events", async () => {
     const assistantEvent = {
       type: "message.updated",

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -305,7 +305,7 @@ describe("event-stream", () => {
     expect(emitted.some((event) => event.type === "assistant_part")).toBe(true);
   });
 
-  test("does not emit session_idle for stop-finished assistant turns without visible text", async () => {
+  test("emits session_idle for stop-finished assistant turns without visible text", async () => {
     const emitted = await runEventStream([
       {
         type: "message.updated",
@@ -330,11 +330,11 @@ describe("event-stream", () => {
     ]);
 
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
-    expect(idleEvents).toHaveLength(0);
+    expect(idleEvents).toHaveLength(1);
     expect(emitted.some((event) => event.type === "assistant_message")).toBe(false);
   });
 
-  test("does not emit session_idle when assistant completion has completed time without finish stop", async () => {
+  test("does not emit session_idle or final assistant_message when completion lacks a stop signal", async () => {
     const emitted = await runEventStream([
       {
         type: "message.updated",
@@ -363,10 +363,10 @@ describe("event-stream", () => {
 
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
     expect(idleEvents).toHaveLength(0);
-    expect(emitted.some((event) => event.type === "assistant_message")).toBe(true);
+    expect(emitted.some((event) => event.type === "assistant_message")).toBe(false);
   });
 
-  test("emits only the upstream session.idle when a terminal assistant update is followed by session.idle", async () => {
+  test("deduplicates upstream session.idle after a terminal assistant update", async () => {
     const emitted = await runEventStream([
       {
         type: "message.updated",
@@ -392,7 +392,7 @@ describe("event-stream", () => {
       {
         type: "session.idle",
         properties: {
-          directory: "/repo",
+          sessionID: "external-session-1",
         },
       } as unknown as Event,
     ]);
@@ -401,12 +401,117 @@ describe("event-stream", () => {
     expect(idleEvents).toHaveLength(1);
   });
 
+  test("emits final assistant_message from known parts when terminal metadata arrives later", async () => {
+    const emitted = await runEventStream([
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "assistant-part-late-1",
+            sessionID: "external-session-1",
+            messageID: "assistant-message-late-final",
+            type: "text",
+            text: "Final answer",
+            time: { start: 1, end: 1 },
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-message-late-final",
+            role: "assistant",
+            sessionID: "external-session-1",
+            providerID: "anthropic",
+            modelID: "claude-sonnet",
+            agent: "Hephaestus",
+            variant: "max",
+            tokens: {
+              input: 10,
+              output: 5,
+            },
+            time: {
+              created: Date.parse("2026-02-22T12:00:06.000Z"),
+              completed: Date.parse("2026-02-22T12:00:08.000Z"),
+            },
+            finish: "stop",
+          },
+        },
+      } as unknown as Event,
+    ]);
+
+    const assistantMessages = emitted.filter((event) => event.type === "assistant_message");
+    expect(assistantMessages).toHaveLength(1);
+    if (assistantMessages[0]?.type !== "assistant_message") {
+      throw new Error("Expected assistant_message event");
+    }
+    expect(assistantMessages[0]).toMatchObject({
+      messageId: "assistant-message-late-final",
+      message: "Final answer",
+      totalTokens: 15,
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet",
+        profileId: "Hephaestus",
+        variant: "max",
+      },
+    });
+
+    const idleEvents = emitted.filter((event) => event.type === "session_idle");
+    expect(idleEvents).toHaveLength(1);
+  });
+
+  test("does not emit idle or final assistant_message from known parts without a stop signal", async () => {
+    const emitted = await runEventStream([
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "assistant-part-late-2",
+            sessionID: "external-session-1",
+            messageID: "assistant-message-late-nonfinal",
+            type: "text",
+            text: "Intermediate answer",
+            time: { start: 1, end: 1 },
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-message-late-nonfinal",
+            role: "assistant",
+            sessionID: "external-session-1",
+            providerID: "anthropic",
+            modelID: "claude-sonnet",
+            agent: "Hephaestus",
+            variant: "max",
+            tokens: {
+              input: 10,
+              output: 5,
+            },
+            time: {
+              created: Date.parse("2026-02-22T12:00:06.000Z"),
+              completed: Date.parse("2026-02-22T12:00:08.000Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+    ]);
+
+    expect(emitted.some((event) => event.type === "assistant_message")).toBe(false);
+    const idleEvents = emitted.filter((event) => event.type === "session_idle");
+    expect(idleEvents).toHaveLength(0);
+  });
+
   test("preserves existing idle state when session.idle arrives before a terminal assistant update", async () => {
     const emitted = await runEventStream([
       {
         type: "session.idle",
         properties: {
-          directory: "/repo",
+          sessionID: "external-session-1",
         },
       } as unknown as Event,
       {
@@ -436,7 +541,7 @@ describe("event-stream", () => {
     expect(idleEvents).toHaveLength(1);
   });
 
-  test("does not emit session_idle across repeated terminal message updates", async () => {
+  test("does not emit duplicate session_idle across repeated terminal message updates", async () => {
     const terminalEvent = {
       type: "message.updated",
       properties: {
@@ -464,6 +569,49 @@ describe("event-stream", () => {
 
     const emitted = await runEventStream([terminalEvent, terminalEvent]);
 
+    const idleEvents = emitted.filter((event) => event.type === "session_idle");
+    expect(idleEvents).toHaveLength(1);
+  });
+
+  test("marks session idle on session.status idle so later terminal updates do not duplicate it", async () => {
+    const emitted = await runEventStream([
+      {
+        type: "session.status",
+        properties: {
+          sessionID: "external-session-1",
+          status: {
+            type: "idle",
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-message-status-idle",
+            role: "assistant",
+            sessionID: "external-session-1",
+            time: {
+              completed: 1,
+            },
+            finish: "stop",
+          },
+          parts: [
+            {
+              id: "text-status-idle-1",
+              sessionID: "external-session-1",
+              messageID: "assistant-message-status-idle",
+              type: "text",
+              text: "Done after idle status",
+              time: { start: 1, end: 1 },
+            },
+          ],
+        },
+      } as unknown as Event,
+    ]);
+
+    const statusEvents = emitted.filter((event) => event.type === "session_status");
+    expect(statusEvents).toHaveLength(1);
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
     expect(idleEvents).toHaveLength(0);
   });

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -54,6 +54,7 @@ const makeSessionRecord = (client: OpencodeClient): SessionRecord => ({
   emittedMessageIds: new Set<string>(),
   partsById: new Map(),
   messageRoleById: new Map(),
+  messageMetadataById: new Map(),
   pendingDeltasByPartId: new Map(),
 });
 
@@ -128,6 +129,102 @@ describe("event-stream", () => {
       modelId: "gpt-5",
       profileId: "Hephaestus",
       variant: "high",
+    });
+  });
+
+  test("emits user_message from stored user text parts when message.updated omits visible text", async () => {
+    const emitted = await runEventStream([
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "user-part-1",
+            sessionID: "external-session-1",
+            messageID: "user-message-2",
+            type: "text",
+            text: "Generate the PR",
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "user-message-2",
+            role: "user",
+            sessionID: "external-session-1",
+            providerID: "openai",
+            modelID: "gpt-5",
+            agent: "Hephaestus",
+            variant: "high",
+            time: {
+              created: Date.parse("2026-02-22T12:00:04.000Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+    ]);
+
+    const userMessages = emitted.filter((event) => event.type === "user_message");
+    expect(userMessages).toHaveLength(1);
+    if (userMessages[0]?.type !== "user_message") {
+      throw new Error("Expected user_message event");
+    }
+    expect(userMessages[0]).toMatchObject({
+      messageId: "user-message-2",
+      message: "Generate the PR",
+      timestamp: "2026-02-22T12:00:04.000Z",
+    });
+  });
+
+  test("emits user_message when user text parts arrive after message.updated", async () => {
+    const emitted = await runEventStream([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "user-message-3",
+            role: "user",
+            sessionID: "external-session-1",
+            providerID: "openai",
+            modelID: "gpt-5",
+            agent: "Hephaestus",
+            variant: "high",
+            time: {
+              created: Date.parse("2026-02-22T12:00:05.000Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "user-part-2",
+            sessionID: "external-session-1",
+            messageID: "user-message-3",
+            type: "text",
+            text: "Ship it",
+          },
+        },
+      } as unknown as Event,
+    ]);
+
+    const userMessages = emitted.filter((event) => event.type === "user_message");
+    expect(userMessages).toHaveLength(1);
+    if (userMessages[0]?.type !== "user_message") {
+      throw new Error("Expected user_message event");
+    }
+    expect(userMessages[0]).toMatchObject({
+      messageId: "user-message-3",
+      message: "Ship it",
+      timestamp: "2026-02-22T12:00:05.000Z",
+      model: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        profileId: "Hephaestus",
+        variant: "high",
+      },
     });
   });
 

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -16,14 +16,14 @@ import {
 } from "../message-normalizers";
 import { toIsoFromEpoch } from "../session-runtime-utils";
 import { mapPartToAgentStreamPart } from "../stream-part-mapper";
-import {
-  readEventInfo,
-  readEventPart,
-  readEventProperties,
-  readMessageCompletedAt,
-} from "./schemas";
+import { readEventInfo, readEventPart, readEventProperties } from "./schemas";
 import type { EventStreamRuntime } from "./shared";
-import { applyDeltaToPart, isReasoningDeltaField, markSessionActive } from "./shared";
+import {
+  applyDeltaToPart,
+  emitSessionIdle,
+  isReasoningDeltaField,
+  markSessionActive,
+} from "./shared";
 
 const emitAssistantPart = (
   runtime: EventStreamRuntime,
@@ -87,6 +87,28 @@ const applyPendingDeltas = (runtime: EventStreamRuntime, partId: string, basePar
 
 const getKnownMessageParts = (runtime: EventStreamRuntime, messageId: string): Part[] => {
   return [...runtime.partsById.values()].filter((part) => part.messageID === messageId);
+};
+
+const hasTerminalStopSignal = (parts: Part[], finish: string | undefined): boolean => {
+  if (finish === "stop") {
+    return true;
+  }
+
+  return parts.some(
+    (part) =>
+      part.type === "step-finish" && typeof part.reason === "string" && part.reason === "stop",
+  );
+};
+
+const rawPartsHaveTerminalStopSignal = (parts: unknown[]): boolean => {
+  return parts.some((part) => {
+    const record = asUnknownRecord(part);
+    return (
+      record !== undefined &&
+      readStringProp(record, ["type"]) === "step-finish" &&
+      readStringProp(record, ["reason"]) === "stop"
+    );
+  });
 };
 
 const emitKnownUserMessage = (
@@ -174,16 +196,19 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     });
   }
 
-  const completedAt = infoRecord ? readMessageCompletedAt(infoRecord) : undefined;
   const finish = infoRecord ? readStringProp(infoRecord, ["finish"]) : undefined;
-  const isTerminalAssistantUpdate =
+  const rawParts = readRawMessageParts(properties, infoRecord);
+  const preserveIdleState =
     messageId !== undefined &&
     role === "assistant" &&
-    (completedAt !== undefined || finish === "stop");
-  const preserveIdleState = isTerminalAssistantUpdate && session?.hasIdleSinceActivity === true;
+    session?.hasIdleSinceActivity === true &&
+    (finish === "stop" ||
+      rawPartsHaveTerminalStopSignal(rawParts) ||
+      (messageId
+        ? hasTerminalStopSignal(getKnownMessageParts(runtime, messageId), finish)
+        : false));
 
   const normalizedParts: Part[] = [];
-  const rawParts = readRawMessageParts(properties, infoRecord);
   if (messageId && rawParts.length > 0) {
     for (const rawPart of rawParts) {
       const rawPartRecord = asUnknownRecord(rawPart);
@@ -244,22 +269,27 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     return true;
   }
 
+  const assistantParts =
+    messageId && role === "assistant"
+      ? normalizedParts.length > 0
+        ? normalizedParts
+        : getKnownMessageParts(runtime, messageId)
+      : [];
+  const hasStopSignal = hasTerminalStopSignal(assistantParts, finish);
   const shouldEmitCompletedMessage =
-    messageId !== undefined &&
-    role === "assistant" &&
-    normalizedParts.length > 0 &&
-    (completedAt !== undefined || finish === "stop");
+    messageId !== undefined && role === "assistant" && assistantParts.length > 0 && hasStopSignal;
   if (!shouldEmitCompletedMessage || !messageId) {
     return true;
   }
 
-  const text = readTextFromParts(normalizedParts);
+  const text = readTextFromParts(assistantParts);
   const visible = sanitizeAssistantMessage(text);
   if (visible.length === 0) {
+    emitSessionIdle(runtime);
     return true;
   }
 
-  const totalTokens = extractMessageTotalTokens(infoRecord, normalizedParts);
+  const totalTokens = extractMessageTotalTokens(infoRecord, assistantParts);
   const assistantModel = readMessageModelSelection(infoRecord);
   const emittedMessageIds = session?.emittedMessageIds;
   if (emittedMessageIds?.has(messageId)) {
@@ -276,6 +306,8 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     ...(assistantModel ? { model: assistantModel } : {}),
   });
   emittedMessageIds?.add(messageId);
+
+  emitSessionIdle(runtime);
   return true;
 };
 

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -2,6 +2,7 @@ import type { Event, Part } from "@opencode-ai/sdk/v2/client";
 import {
   asUnknownRecord,
   readArrayProp,
+  readRecordProp,
   readStringProp,
   readUnknownProp,
   type UnknownRecord,
@@ -9,9 +10,11 @@ import {
 import {
   extractMessageTotalTokens,
   readMessageModelSelection,
+  readTextFromMessageInfo,
   readTextFromParts,
   sanitizeAssistantMessage,
 } from "../message-normalizers";
+import { toIsoFromEpoch } from "../session-runtime-utils";
 import { mapPartToAgentStreamPart } from "../stream-part-mapper";
 import {
   readEventInfo,
@@ -121,6 +124,10 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     ? readStringProp(infoRecord, ["id", "messageID", "messageId", "message_id"])
     : undefined;
   const role = infoRecord ? readStringProp(infoRecord, ["role"]) : undefined;
+  const messageTimestamp = (() => {
+    const infoTime = infoRecord ? readRecordProp(infoRecord, "time") : undefined;
+    return toIsoFromEpoch(infoTime?.created, runtime.now);
+  })();
   const session = runtime.getSession(runtime.sessionId);
   const previousRole = messageId ? runtime.messageRoleById.get(messageId) : undefined;
   if (messageId && role) {
@@ -170,6 +177,32 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
   ) {
     emitKnownAssistantPartsForMessage(runtime, messageId, role, !preserveIdleState);
   }
+
+  if (messageId && role === "user") {
+    const textFromParts = readTextFromParts(normalizedParts);
+    const visible = textFromParts.length > 0 ? textFromParts : readTextFromMessageInfo(infoRecord);
+    if (visible.trim().length === 0) {
+      return true;
+    }
+
+    const messageModel = readMessageModelSelection(infoRecord);
+    const emittedMessageIds = session?.emittedMessageIds;
+    if (emittedMessageIds?.has(messageId)) {
+      return true;
+    }
+
+    runtime.emit(runtime.sessionId, {
+      type: "user_message",
+      sessionId: runtime.sessionId,
+      timestamp: messageTimestamp,
+      messageId,
+      message: visible,
+      ...(messageModel ? { model: messageModel } : {}),
+    });
+    emittedMessageIds?.add(messageId);
+    return true;
+  }
+
   const shouldEmitCompletedMessage =
     messageId !== undefined &&
     role === "assistant" &&
@@ -187,21 +220,21 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
 
   const totalTokens = extractMessageTotalTokens(infoRecord, normalizedParts);
   const assistantModel = readMessageModelSelection(infoRecord);
-  const emittedAssistantMessageIds = session?.emittedAssistantMessageIds;
-  if (emittedAssistantMessageIds?.has(messageId)) {
+  const emittedMessageIds = session?.emittedMessageIds;
+  if (emittedMessageIds?.has(messageId)) {
     return true;
   }
 
   runtime.emit(runtime.sessionId, {
     type: "assistant_message",
     sessionId: runtime.sessionId,
-    timestamp: runtime.now(),
+    timestamp: messageTimestamp,
     messageId,
     message: visible,
     ...(typeof totalTokens === "number" ? { totalTokens } : {}),
     ...(assistantModel ? { model: assistantModel } : {}),
   });
-  emittedAssistantMessageIds?.add(messageId);
+  emittedMessageIds?.add(messageId);
   return true;
 };
 

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -85,6 +85,41 @@ const applyPendingDeltas = (runtime: EventStreamRuntime, partId: string, basePar
   return nextPart;
 };
 
+const getKnownMessageParts = (runtime: EventStreamRuntime, messageId: string): Part[] => {
+  return [...runtime.partsById.values()].filter((part) => part.messageID === messageId);
+};
+
+const emitKnownUserMessage = (
+  runtime: EventStreamRuntime,
+  input: {
+    messageId: string;
+    timestamp: string;
+    model?: ReturnType<typeof readMessageModelSelection>;
+  },
+): boolean => {
+  const session = runtime.getSession(runtime.sessionId);
+  const emittedMessageIds = session?.emittedMessageIds;
+  if (emittedMessageIds?.has(input.messageId)) {
+    return true;
+  }
+
+  const visible = readTextFromParts(getKnownMessageParts(runtime, input.messageId));
+  if (visible.trim().length === 0) {
+    return false;
+  }
+
+  runtime.emit(runtime.sessionId, {
+    type: "user_message",
+    sessionId: runtime.sessionId,
+    timestamp: input.timestamp,
+    messageId: input.messageId,
+    message: visible,
+    ...(input.model ? { model: input.model } : {}),
+  });
+  emittedMessageIds?.add(input.messageId);
+  return true;
+};
+
 const readRawMessageParts = (properties: unknown, info: unknown): unknown[] => {
   const directParts = readArrayProp(properties, "parts");
   if (directParts) {
@@ -128,10 +163,15 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     const infoTime = infoRecord ? readRecordProp(infoRecord, "time") : undefined;
     return toIsoFromEpoch(infoTime?.created, runtime.now);
   })();
+  const messageModel = readMessageModelSelection(infoRecord);
   const session = runtime.getSession(runtime.sessionId);
   const previousRole = messageId ? runtime.messageRoleById.get(messageId) : undefined;
   if (messageId && role) {
     runtime.messageRoleById.set(messageId, role);
+    session?.messageMetadataById.set(messageId, {
+      timestamp: messageTimestamp,
+      ...(messageModel ? { model: messageModel } : {}),
+    });
   }
 
   const completedAt = infoRecord ? readMessageCompletedAt(infoRecord) : undefined;
@@ -179,13 +219,14 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
   }
 
   if (messageId && role === "user") {
-    const textFromParts = readTextFromParts(normalizedParts);
+    const userParts =
+      normalizedParts.length > 0 ? normalizedParts : getKnownMessageParts(runtime, messageId);
+    const textFromParts = readTextFromParts(userParts);
     const visible = textFromParts.length > 0 ? textFromParts : readTextFromMessageInfo(infoRecord);
     if (visible.trim().length === 0) {
       return true;
     }
 
-    const messageModel = readMessageModelSelection(infoRecord);
     const emittedMessageIds = session?.emittedMessageIds;
     if (emittedMessageIds?.has(messageId)) {
       return true;
@@ -316,6 +357,16 @@ const handleMessagePartUpdatedEvent = (event: Event, runtime: EventStreamRuntime
   const nextPart = applyPendingDeltas(runtime, partId, current);
   runtime.partsById.set(partId, nextPart);
   emitAssistantPart(runtime, nextPart);
+  const messageId = nextPart.messageID;
+  const role = runtime.messageRoleById.get(messageId);
+  if (role === "user") {
+    const metadata = runtime.getSession(runtime.sessionId)?.messageMetadataById.get(messageId);
+    emitKnownUserMessage(runtime, {
+      messageId,
+      timestamp: metadata?.timestamp ?? runtime.now(),
+      ...(metadata?.model ? { model: metadata.model } : {}),
+    });
+  }
   return true;
 };
 

--- a/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/session-events.ts
@@ -9,7 +9,7 @@ import {
   readTodoPayload,
 } from "./schemas";
 import type { EventStreamRuntime } from "./shared";
-import { emitSessionIdle, markSessionActive } from "./shared";
+import { emitSessionIdle, markSessionActive, markSessionIdle } from "./shared";
 
 const handleSessionStatusEvent = (event: Event, runtime: EventStreamRuntime): boolean => {
   if (event.type !== "session.status") {
@@ -25,6 +25,8 @@ const handleSessionStatusEvent = (event: Event, runtime: EventStreamRuntime): bo
   if (status.type === "busy" || status.type === "idle") {
     if (status.type === "busy") {
       markSessionActive(runtime);
+    } else {
+      markSessionIdle(runtime);
     }
     runtime.emit(runtime.sessionId, {
       type: "session_status",

--- a/packages/adapters-opencode-sdk/src/event-stream/shared.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/shared.ts
@@ -33,6 +33,13 @@ export const setSessionActive = (session: SessionRecord | undefined): void => {
   session.hasIdleSinceActivity = false;
 };
 
+export const setSessionIdle = (session: SessionRecord | undefined): void => {
+  if (!session) {
+    return;
+  }
+  session.hasIdleSinceActivity = true;
+};
+
 type SessionIdleEmitter = {
   sessionId: string;
   emit: (sessionId: string, event: AgentEvent) => void;
@@ -46,9 +53,7 @@ export const emitIdleForSession = (
   if (session?.hasIdleSinceActivity) {
     return false;
   }
-  if (session) {
-    session.hasIdleSinceActivity = true;
-  }
+  setSessionIdle(session);
   emitter.emit(emitter.sessionId, {
     type: "session_idle",
     sessionId: emitter.sessionId,
@@ -67,6 +72,12 @@ export const markSessionActive = (
   context: Pick<EventStreamContext, "sessionId" | "getSession">,
 ): void => {
   setSessionActive(getSessionRecord(context));
+};
+
+export const markSessionIdle = (
+  context: Pick<EventStreamContext, "sessionId" | "getSession">,
+): void => {
+  setSessionIdle(getSessionRecord(context));
 };
 
 export const emitSessionIdle = (

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1059,6 +1059,60 @@ describe("OpencodeSdkAdapter", () => {
     });
   });
 
+  test("maps acknowledged user message.updated events into user_message", async () => {
+    const streamEvents: Event[] = [
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "user-1",
+            role: "user",
+            sessionID: "session-opencode-1",
+            providerID: "openai",
+            modelID: "gpt-5",
+            agent: "Hephaestus",
+            variant: "high",
+            text: "Generate the pull request",
+            time: {
+              created: Date.parse("2026-02-17T12:00:04Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+    ];
+
+    const mock = makeMockClient({
+      streamEvents,
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const events: AgentEvent[] = [];
+    adapter.subscribeEvents("session-1", (event) => {
+      events.push(event);
+    });
+
+    await startDefaultSession(adapter, "session-1", "spec");
+    await flushAsync();
+
+    const userEvents = events.filter((entry) => entry.type === "user_message");
+    expect(userEvents).toHaveLength(1);
+    expect(userEvents[0]).toMatchObject({
+      type: "user_message",
+      timestamp: "2026-02-17T12:00:04.000Z",
+      messageId: "user-1",
+      message: "Generate the pull request",
+      model: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        profileId: "Hephaestus",
+        variant: "high",
+      },
+    });
+  });
+
   test("includes step-finish total tokens on assistant part events", async () => {
     const streamEvents: Event[] = [
       {

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1059,6 +1059,184 @@ describe("OpencodeSdkAdapter", () => {
     });
   });
 
+  test("synthesizes session_idle from terminal assistant completion when no idle event follows", async () => {
+    const streamEvents: Event[] = [
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-terminal-1",
+            role: "assistant",
+            sessionID: "session-opencode-1",
+            providerID: "openai",
+            modelID: "gpt-5",
+            agent: "Hephaestus",
+            variant: "high",
+            finish: "stop",
+            time: {
+              created: Date.parse("2026-02-17T12:00:03Z"),
+              completed: Date.parse("2026-02-17T12:00:05Z"),
+            },
+          },
+          parts: [
+            {
+              id: "text-terminal-1",
+              sessionID: "session-opencode-1",
+              messageID: "assistant-terminal-1",
+              type: "text",
+              text: "Done",
+              time: { start: 1, end: 1 },
+            },
+          ],
+        },
+      } as unknown as Event,
+    ];
+
+    const mock = makeMockClient({ streamEvents });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const events: AgentEvent[] = [];
+    adapter.subscribeEvents("session-1", (event) => {
+      events.push(event);
+    });
+
+    await startDefaultSession(adapter, "session-1", "spec");
+    await flushAsync();
+
+    const idleEvents = events.filter((entry) => entry.type === "session_idle");
+    expect(idleEvents).toHaveLength(1);
+  });
+
+  test("maps terminal assistant metadata onto previously streamed text parts", async () => {
+    const streamEvents: Event[] = [
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "assistant-text-2",
+            sessionID: "session-opencode-1",
+            messageID: "assistant-2",
+            type: "text",
+            text: "All done",
+            time: { start: 1, end: 1 },
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-2",
+            role: "assistant",
+            sessionID: "session-opencode-1",
+            providerID: "anthropic",
+            modelID: "claude-sonnet",
+            agent: "Hephaestus",
+            variant: "max",
+            finish: "stop",
+            tokens: {
+              input: 8,
+              output: 4,
+            },
+            time: {
+              created: Date.parse("2026-02-17T12:00:06Z"),
+              completed: Date.parse("2026-02-17T12:00:08Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+    ];
+
+    const mock = makeMockClient({ streamEvents });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const events: AgentEvent[] = [];
+    adapter.subscribeEvents("session-1", (event) => {
+      events.push(event);
+    });
+
+    await startDefaultSession(adapter, "session-1", "spec");
+    await flushAsync();
+
+    const assistantMessages = events.filter((entry) => entry.type === "assistant_message");
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0]).toMatchObject({
+      type: "assistant_message",
+      messageId: "assistant-2",
+      message: "All done",
+      totalTokens: 12,
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet",
+        profileId: "Hephaestus",
+        variant: "max",
+      },
+    });
+  });
+
+  test("does not finalize previously streamed assistant text without a stop signal", async () => {
+    const streamEvents: Event[] = [
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "assistant-text-3",
+            sessionID: "session-opencode-1",
+            messageID: "assistant-3",
+            type: "text",
+            text: "Still thinking",
+            time: { start: 1, end: 1 },
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-3",
+            role: "assistant",
+            sessionID: "session-opencode-1",
+            providerID: "anthropic",
+            modelID: "claude-sonnet",
+            agent: "Hephaestus",
+            variant: "max",
+            tokens: {
+              input: 8,
+              output: 4,
+            },
+            time: {
+              created: Date.parse("2026-02-17T12:00:06Z"),
+              completed: Date.parse("2026-02-17T12:00:08Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+    ];
+
+    const mock = makeMockClient({ streamEvents });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const events: AgentEvent[] = [];
+    adapter.subscribeEvents("session-1", (event) => {
+      events.push(event);
+    });
+
+    await startDefaultSession(adapter, "session-1", "spec");
+    await flushAsync();
+
+    expect(events.some((entry) => entry.type === "assistant_message")).toBe(false);
+    expect(events.some((entry) => entry.type === "session_idle")).toBe(false);
+  });
+
   test("maps acknowledged user message.updated events into user_message", async () => {
     const streamEvents: Event[] = [
       {

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1113,6 +1113,71 @@ describe("OpencodeSdkAdapter", () => {
     });
   });
 
+  test("maps user message parts into user_message when message.updated omits text", async () => {
+    const streamEvents: Event[] = [
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "text-user-2",
+            sessionID: "session-opencode-1",
+            messageID: "user-2",
+            type: "text",
+            text: "Generate the pull request",
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "user-2",
+            role: "user",
+            sessionID: "session-opencode-1",
+            providerID: "openai",
+            modelID: "gpt-5",
+            agent: "Hephaestus",
+            variant: "high",
+            time: {
+              created: Date.parse("2026-02-17T12:00:05Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+    ];
+
+    const mock = makeMockClient({
+      streamEvents,
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const events: AgentEvent[] = [];
+    adapter.subscribeEvents("session-1", (event) => {
+      events.push(event);
+    });
+
+    await startDefaultSession(adapter, "session-1", "spec");
+    await flushAsync();
+
+    const userEvents = events.filter((entry) => entry.type === "user_message");
+    expect(userEvents).toHaveLength(1);
+    expect(userEvents[0]).toMatchObject({
+      type: "user_message",
+      timestamp: "2026-02-17T12:00:05.000Z",
+      messageId: "user-2",
+      message: "Generate the pull request",
+      model: {
+        providerId: "openai",
+        modelId: "gpt-5",
+        profileId: "Hephaestus",
+        variant: "high",
+      },
+    });
+  });
+
   test("includes step-finish total tokens on assistant part events", async () => {
     const streamEvents: Event[] = [
       {

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -131,6 +131,7 @@ export const registerSession = (input: {
     emittedMessageIds: new Set<string>(),
     partsById: new Map(),
     messageRoleById: new Map(),
+    messageMetadataById: new Map(),
     pendingDeltasByPartId: new Map(),
   });
 

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -128,7 +128,7 @@ export const registerSession = (input: {
     externalSessionId: input.externalSessionId,
     eventTransportKey,
     hasIdleSinceActivity: false,
-    emittedAssistantMessageIds: new Set<string>(),
+    emittedMessageIds: new Set<string>(),
     partsById: new Map(),
     messageRoleById: new Map(),
     pendingDeltasByPartId: new Map(),

--- a/packages/adapters-opencode-sdk/src/types.test.ts
+++ b/packages/adapters-opencode-sdk/src/types.test.ts
@@ -48,6 +48,7 @@ describe("types", () => {
       emittedMessageIds: new Set<string>(),
       partsById: new Map(),
       messageRoleById: new Map(),
+      messageMetadataById: new Map(),
       pendingDeltasByPartId: new Map(),
     };
     const status: McpServerStatus = { status: "connected" };

--- a/packages/adapters-opencode-sdk/src/types.test.ts
+++ b/packages/adapters-opencode-sdk/src/types.test.ts
@@ -45,7 +45,7 @@ describe("types", () => {
       externalSessionId: "external-session-1",
       eventTransportKey: "http://127.0.0.1:12345",
       hasIdleSinceActivity: false,
-      emittedAssistantMessageIds: new Set<string>(),
+      emittedMessageIds: new Set<string>(),
       partsById: new Map(),
       messageRoleById: new Map(),
       pendingDeltasByPartId: new Map(),

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -19,7 +19,7 @@ export type SessionRecord = {
   externalSessionId: string;
   eventTransportKey: string;
   hasIdleSinceActivity: boolean;
-  emittedAssistantMessageIds: Set<string>;
+  emittedMessageIds: Set<string>;
   partsById: Map<string, import("@opencode-ai/sdk/v2/client").Part>;
   messageRoleById: Map<string, string>;
   pendingDeltasByPartId: Map<string, PendingPartDelta[]>;

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -1,5 +1,9 @@
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2/client";
-import type { AgentSessionSummary, StartAgentSessionInput } from "@openducktor/core";
+import type {
+  AgentModelSelection,
+  AgentSessionSummary,
+  StartAgentSessionInput,
+} from "@openducktor/core";
 import type { PendingPartDelta } from "./event-stream/shared";
 
 /**
@@ -22,6 +26,13 @@ export type SessionRecord = {
   emittedMessageIds: Set<string>;
   partsById: Map<string, import("@opencode-ai/sdk/v2/client").Part>;
   messageRoleById: Map<string, string>;
+  messageMetadataById: Map<
+    string,
+    {
+      timestamp: string;
+      model?: AgentModelSelection;
+    }
+  >;
   pendingDeltasByPartId: Map<string, PendingPartDelta[]>;
   /** Cached workflow tool selection (toolId -> enabled). */
   workflowToolSelectionCache?: Record<string, boolean>;

--- a/packages/contracts/src/agent-workflow-schemas.test.ts
+++ b/packages/contracts/src/agent-workflow-schemas.test.ts
@@ -41,7 +41,7 @@ describe("agent-workflow-schemas", () => {
     expect(defaultStartModeForScenario("build_implementation_start")).toBe("fresh");
     expect(defaultStartModeForScenario("build_after_qa_rejected")).toBe("reuse");
     expect(defaultStartModeForScenario("build_after_human_request_changes")).toBe("reuse");
-    expect(defaultStartModeForScenario("build_pull_request_generation")).toBe("fork");
+    expect(defaultStartModeForScenario("build_pull_request_generation")).toBe("reuse");
     expect(defaultStartModeForScenario("build_rebase_conflict_resolution")).toBe("reuse");
   });
 
@@ -52,7 +52,7 @@ describe("agent-workflow-schemas", () => {
     expect(isScenarioStartModeAllowed("build_implementation_start", "reuse")).toBe(false);
     expect(isScenarioStartModeAllowed("build_after_qa_rejected", "reuse")).toBe(true);
     expect(isScenarioStartModeAllowed("build_after_human_request_changes", "reuse")).toBe(true);
-    expect(isScenarioStartModeAllowed("build_pull_request_generation", "reuse")).toBe(false);
+    expect(isScenarioStartModeAllowed("build_pull_request_generation", "reuse")).toBe(true);
     expect(isScenarioStartModeAllowed("build_pull_request_generation", "fork")).toBe(true);
     expect(isScenarioStartModeAllowed("build_pull_request_generation", "fresh")).toBe(false);
     expect(isScenarioStartModeAllowed("build_rebase_conflict_resolution", "reuse")).toBe(true);

--- a/packages/contracts/src/agent-workflow-schemas.ts
+++ b/packages/contracts/src/agent-workflow-schemas.ts
@@ -92,8 +92,8 @@ export const agentScenarioDefinitionByScenario = {
   build_pull_request_generation: {
     role: "build",
     label: "Generate Pull Request",
-    allowedStartModes: ["fork"],
-    defaultStartMode: "fork",
+    allowedStartModes: ["reuse", "fork"],
+    defaultStartMode: "reuse",
     supportsKickoff: true,
   },
   build_rebase_conflict_resolution: {

--- a/packages/core/src/services/agent-system-prompts.test.ts
+++ b/packages/core/src/services/agent-system-prompts.test.ts
@@ -164,6 +164,22 @@ describe("buildAgentSystemPrompt", () => {
     ]);
   });
 
+  test("pull request generation prompt supports reuse and fork publication flows", () => {
+    const prompt = buildAgentSystemPrompt({
+      role: "build",
+      scenario: "build_pull_request_generation",
+      task: taskContext,
+    });
+
+    expectPromptToContainAll(prompt, [
+      "Scenario: Pull request generation.",
+      "current Builder session or a fork created from it",
+      "Use the runtime's native git and GitHub tools to inspect branch state",
+      'call odt_set_pull_request exactly once with taskId task-42, providerId "github", and the pull request number.',
+    ]);
+    expect(prompt).not.toContain("forked Builder worktree");
+  });
+
   test("qa prompt uses an adversarial evidence-based review rubric", () => {
     const prompt = buildAgentSystemPrompt({
       role: "qa",
@@ -340,6 +356,22 @@ describe("kickoff and permission prompts", () => {
 
     expect(result.prompt).toBe("Planner kickoff task-2 / desc");
     expect(result.templates[0]?.source).toBe("override");
+  });
+
+  test("pull request generation kickoff supports reused sessions and forks", () => {
+    const prompt = buildAgentKickoffPrompt({
+      role: "build",
+      scenario: "build_pull_request_generation",
+      task: {
+        taskId: "task-1",
+      },
+    });
+
+    expectPromptToContainAll(prompt, [
+      "Focus only on pull request publication work for the current Builder session or fork.",
+      'call odt_set_pull_request with taskId task-1, providerId "github", and the pull request number.',
+    ]);
+    expect(prompt).not.toContain("Builder fork");
   });
 
   test("allows enabled empty kickoff override templates", () => {

--- a/packages/core/src/services/agent-system-prompts.ts
+++ b/packages/core/src/services/agent-system-prompts.ts
@@ -501,7 +501,7 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
     template: joinPromptBlocks(
       "Scenario: Pull request generation.",
       bulletSection("Objective", [
-        "Create or update the canonical pull request for this task from the current forked Builder worktree.",
+        "Create or update the canonical pull request for this task from the current Builder session or a fork created from it.",
       ]),
       bulletSection("Required sequence", [
         "Use the runtime's native git and GitHub tools to inspect branch state, push the source branch if needed, and create or update the pull request.",
@@ -593,7 +593,7 @@ const AGENT_PROMPT_DEFINITIONS: Record<AgentPromptTemplateId, AgentPromptTemplat
     purpose: "kickoff",
     builtinVersion: 2,
     template:
-      'Focus only on pull request publication work for this Builder fork.\nInspect branch and remote state, create or update the GitHub pull request, then call odt_set_pull_request with taskId {{task.id}}, providerId "github", and the pull request number.\nUse taskId {{task.id}} for every odt_* tool call.',
+      'Focus only on pull request publication work for the current Builder session or fork.\nInspect branch and remote state, create or update the GitHub pull request, then call odt_set_pull_request with taskId {{task.id}}, providerId "github", and the pull request number.\nUse taskId {{task.id}} for every odt_* tool call.',
   },
   "kickoff.qa_review": {
     id: "kickoff.qa_review",

--- a/packages/core/src/types/agent-orchestrator.ts
+++ b/packages/core/src/types/agent-orchestrator.ts
@@ -299,6 +299,14 @@ export type AgentEvent =
       model?: AgentModelSelection;
     }
   | {
+      type: "user_message";
+      sessionId: string;
+      timestamp: string;
+      messageId: string;
+      message: string;
+      model?: AgentModelSelection;
+    }
+  | {
       type: "assistant_part";
       sessionId: string;
       timestamp: string;


### PR DESCRIPTION
## Summary
- allow `build_pull_request_generation` to start in `reuse` or `fork` mode, default to `reuse`, and align the shared session-start modal, kanban flow, prompts, and docs with that mixed-mode workflow
- fix Opencode live session events so acknowledged user messages, terminal assistant completion, and idle state transitions stay in sync without missing transcript rows, losing final assistant metadata, or flickering session activity
- model explicit session-history hydration, dedupe requested-history loads, and restore attached-session runtime metadata so reused sessions hydrate reliably before follow-up work continues
- speed up hydrated Agent Studio switching by skipping full persisted-session reloads for already loaded sessions, caching context-usage metadata, and avoiding transcript/window work while the loading overlay is active

## Verification
- bun run lint
- bun run typecheck
- bun run test
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull-request generation now supports reusing existing Builder sessions (reuse or fork) and presents selectable start-mode buttons with consistent ordering and labels.
  * Session history hydration/state tracking added so the UI shows when session history is loading.

* **Bug Fixes**
  * More robust runtime connection handling for attached sessions.
  * User messages are processed and surfaced promptly in streams.
  * Chat styling tweaks to border behavior.

* **Documentation**
  * Architecture and integration docs updated to reflect start-mode and hydration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->