### PR TITLE
test(desktop): reduce chat todo test brittleness

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -414,7 +414,6 @@ describe("AgentChatThread", () => {
     expect(bottomStack?.textContent).toContain("Todo");
     expect(bottomStack?.textContent).toContain("Analyze current styling");
     expect(bottomStack?.textContent).toContain("Read layout and pages");
-    expect((bottomStack as HTMLDivElement).className).toContain("pb-2");
     expect((bottomStack as HTMLDivElement).innerHTML.indexOf("Input needed")).toBeLessThan(
       (bottomStack as HTMLDivElement).innerHTML.indexOf("Permission request"),
     );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -240,7 +240,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
       </div>
 
       {hasBottomStack && session ? (
-        <div className="agent-chat-bottom-stack shrink-0 space-y-2 px-4 pb-2 pt-3">
+        <div className="agent-chat-bottom-stack shrink-0 space-y-2 px-4 pb-0 pt-3">
           {session.pendingQuestions.map((request) => (
             <AgentSessionQuestionCard
               key={`${session.sessionId}:${request.requestId}`}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.test.tsx
@@ -26,14 +26,14 @@ const renderPanel = (props: Partial<Parameters<typeof AgentSessionTodoPanel>[0]>
 };
 
 describe("AgentSessionTodoPanel", () => {
-  test("stays hidden when todos are completed-only or cancelled-only", () => {
+  test("stays hidden when todos are completed-only", () => {
     const completedOnly = renderPanel({
       todos: [buildTodoItem({ status: "completed" })],
     });
     expect(completedOnly.container.innerHTML).toBe("");
+  });
 
-    cleanup();
-
+  test("stays hidden when todos are cancelled-only", () => {
     const cancelledOnly = renderPanel({
       todos: [buildTodoItem({ status: "cancelled" })],
     });
@@ -63,7 +63,6 @@ describe("AgentSessionTodoPanel", () => {
 
     const accentBorder = container.querySelector('[style*="border-left-color"]');
     expect(accentBorder).not.toBeNull();
-    expect(accentBorder?.getAttribute("style")).toContain("border-left-color");
 
     expect(screen.queryByRole("list")).toBeNull();
   });
@@ -77,7 +76,9 @@ describe("AgentSessionTodoPanel", () => {
       ],
     });
 
-    expect(screen.getByLabelText("Agent todo list").textContent ?? "").toContain("Next pending item");
+    expect(screen.getByLabelText("Agent todo list").textContent ?? "").toContain(
+      "Next pending item",
+    );
   });
 
   test("uses idle in-progress icon without spinner when session is not working", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.test.tsx
@@ -1,38 +1,47 @@
-import { describe, expect, test } from "bun:test";
-import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { buildTodoItem } from "./agent-chat-test-fixtures";
 import { AgentSessionTodoPanel } from "./agent-session-todo-panel";
 
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  cleanup();
+});
+
 const renderPanel = (props: Partial<Parameters<typeof AgentSessionTodoPanel>[0]> = {}) => {
-  return renderToStaticMarkup(
-    createElement(AgentSessionTodoPanel, {
-      todos: [],
-      collapsed: true,
-      isSessionWorking: false,
-      onToggleCollapse: () => {},
-      ...props,
-    }),
+  return render(
+    <AgentSessionTodoPanel
+      todos={[]}
+      collapsed
+      isSessionWorking={false}
+      onToggleCollapse={() => {}}
+      {...props}
+    />,
   );
 };
 
 describe("AgentSessionTodoPanel", () => {
   test("stays hidden when todos are completed-only or cancelled-only", () => {
-    expect(
-      renderPanel({
-        todos: [buildTodoItem({ status: "completed" })],
-      }),
-    ).toBe("");
+    const completedOnly = renderPanel({
+      todos: [buildTodoItem({ status: "completed" })],
+    });
+    expect(completedOnly.container.innerHTML).toBe("");
 
-    expect(
-      renderPanel({
-        todos: [buildTodoItem({ status: "cancelled" })],
-      }),
-    ).toBe("");
+    cleanup();
+
+    const cancelledOnly = renderPanel({
+      todos: [buildTodoItem({ status: "cancelled" })],
+    });
+    expect(cancelledOnly.container.innerHTML).toBe("");
   });
 
-  test("renders collapsed by default with a single truncating actionable summary", () => {
-    const html = renderPanel({
+  test("renders collapsed by default with a single actionable summary", () => {
+    const { container } = renderPanel({
       collapsed: true,
       accentColor: "#123456",
       todos: [
@@ -42,24 +51,25 @@ describe("AgentSessionTodoPanel", () => {
       ],
     });
 
-    expect(html).toContain("Todo");
-    expect(html).toContain("Current active item");
-    expect(html).not.toContain("Queued item");
-    expect(html).toContain("truncate");
-    expect(html).toContain("border-l border-border/70 pl-3");
-    expect(html).not.toContain("line-clamp-2");
-    expect(html).toContain("w-full rounded-t-xl");
-    expect(html).toContain("border-b-0");
-    expect(html).toContain("border-l-4");
-    expect(html).toContain("border-left-color:#123456");
-    expect(html).toContain('aria-expanded="false"');
-    expect(html).toContain("ml-auto size-4 shrink-0 text-muted-foreground");
-    expect(html).not.toContain("justify-end");
-    expect(html).not.toContain("max-w-md");
+    const section = screen.getByLabelText("Agent todo list");
+    const toggle = screen.getByRole("button", { name: "Expand todo list" });
+    const sectionText = section.textContent ?? "";
+
+    expect(sectionText).toContain("Todo");
+    expect(sectionText).toContain("1/3");
+    expect(sectionText).toContain("Current active item");
+    expect(sectionText).not.toContain("Queued item");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    const accentBorder = container.querySelector('[style*="border-left-color"]');
+    expect(accentBorder).not.toBeNull();
+    expect(accentBorder?.getAttribute("style")).toContain("border-left-color");
+
+    expect(screen.queryByRole("list")).toBeNull();
   });
 
   test("falls back to the next pending todo when nothing is in progress", () => {
-    const html = renderPanel({
+    renderPanel({
       collapsed: true,
       todos: [
         buildTodoItem({ id: "todo-1", content: "Completed work", status: "completed" }),
@@ -67,33 +77,33 @@ describe("AgentSessionTodoPanel", () => {
       ],
     });
 
-    expect(html).toContain("Next pending item");
+    expect(screen.getByLabelText("Agent todo list").textContent ?? "").toContain("Next pending item");
   });
 
   test("uses idle in-progress icon without spinner when session is not working", () => {
-    const html = renderPanel({
+    const { container } = renderPanel({
       collapsed: true,
       isSessionWorking: false,
       todos: [buildTodoItem({ status: "in_progress" })],
     });
 
-    expect(html).toContain("lucide-circle-dot-dashed");
-    expect(html).not.toContain("animate-spin");
+    expect(container.querySelector(".lucide-circle-dot-dashed")).not.toBeNull();
+    expect(container.querySelector(".lucide-loader-circle")).toBeNull();
   });
 
   test("keeps spinner for in-progress todos while the session is working", () => {
-    const html = renderPanel({
+    const { container } = renderPanel({
       collapsed: true,
       isSessionWorking: true,
       todos: [buildTodoItem({ status: "in_progress" })],
     });
 
-    expect(html).toContain("lucide-loader-circle");
-    expect(html).toContain("animate-spin");
+    expect(container.querySelector(".lucide-loader-circle")).not.toBeNull();
+    expect(container.querySelector(".lucide-circle-dot-dashed")).toBeNull();
   });
 
-  test("renders expanded rows with alignment-friendly structure and completed context", () => {
-    const html = renderPanel({
+  test("renders expanded rows with the full visible todo list", () => {
+    renderPanel({
       collapsed: false,
       todos: [
         buildTodoItem({ id: "todo-1", content: "Done item", status: "completed" }),
@@ -105,14 +115,14 @@ describe("AgentSessionTodoPanel", () => {
       ],
     });
 
-    expect(html).toContain("Done item");
-    expect(html).toContain("Active item with a much longer description");
-    expect(html).toContain('aria-expanded="true"');
-    expect(html).toContain("grid grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-x-2");
-    expect(html).toContain("inline-flex h-5 w-5 shrink-0 items-center justify-center");
-    expect(html).toContain("ml-auto size-4 shrink-0 text-muted-foreground");
-    expect(html).toContain("block min-w-0 leading-5");
-    expect(html).toContain("font-medium text-foreground");
-    expect(html).not.toContain("mt-[3px]");
+    const toggle = screen.getByRole("button", { name: "Collapse todo list" });
+    const list = screen.getByRole("list");
+    const rows = within(list).getAllByRole("listitem");
+    const listText = list.textContent ?? "";
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(rows).toHaveLength(2);
+    expect(listText).toContain("Done item");
+    expect(listText).toContain("Active item with a much longer description");
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.test.tsx
@@ -1,13 +1,25 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import { buildTodoItem } from "./agent-chat-test-fixtures";
 import { AgentSessionTodoPanel } from "./agent-session-todo-panel";
 
-(
-  globalThis as typeof globalThis & {
-    IS_REACT_ACT_ENVIRONMENT?: boolean;
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+const previousActEnvironmentValue = reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+
+beforeAll(() => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  if (typeof previousActEnvironmentValue === "undefined") {
+    delete reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+    return;
   }
-).IS_REACT_ACT_ENVIRONMENT = true;
+
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = previousActEnvironmentValue;
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.tsx
@@ -78,10 +78,9 @@ export function AgentSessionTodoPanel({
         className,
       )}
       aria-label="Agent todo list"
-
     >
       <div
-        className="rounded-t-xl border-l-4"
+        className={cn("rounded-t-xl border-l-4", !accentColor && "border-l-transparent")}
         style={accentColor ? { borderLeftColor: accentColor } : undefined}
       >
         <button

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-session-todo-panel.tsx
@@ -74,68 +74,73 @@ export function AgentSessionTodoPanel({
   return (
     <section
       className={cn(
-        "w-full rounded-t-xl border border-input border-b-0 border-l-4 bg-card",
+        "w-full rounded-t-xl border border-input border-b-0 border-l-transparent bg-card",
         className,
       )}
       aria-label="Agent todo list"
-      style={accentColor ? { borderLeftColor: accentColor } : undefined}
-    >
-      <button
-        type="button"
-        className="flex w-full cursor-pointer items-center gap-3 px-3 py-2 text-left hover:bg-muted/70"
-        onClick={onToggleCollapse}
-        aria-label={toggleLabel}
-        aria-expanded={!collapsed}
-      >
-        <div className="flex min-w-0 flex-1 items-center gap-3">
-          <div className="flex shrink-0 items-center gap-2">
-            <ListTodo className="size-4 shrink-0 text-muted-foreground" />
-            <p className="text-[13px] font-semibold text-foreground">Todo</p>
-            <p className="text-[11px] font-medium text-muted-foreground">
-              {completedCount}/{visibleTodos.length}
-            </p>
-          </div>
-          {collapsed ? (
-            <div className="flex min-w-0 flex-1 items-center gap-2 border-l border-border/70 pl-3 text-sm text-foreground">
-              <span className="inline-flex size-4 shrink-0 items-center justify-center">
-                {statusIcon(actionableTodo.status, isSessionWorking)}
-              </span>
-              <span className="truncate">{actionableTodo.content}</span>
-            </div>
-          ) : null}
-          {collapsed ? (
-            <ChevronDown className="ml-auto size-4 shrink-0 text-muted-foreground" />
-          ) : (
-            <ChevronUp className="ml-auto size-4 shrink-0 text-muted-foreground" />
-          )}
-        </div>
-      </button>
 
-      {collapsed ? null : (
-        <div className="border-t border-input/80 px-3 pb-3 pt-2">
-          <ul className="max-h-[40vh] space-y-1 overflow-y-auto overscroll-contain pr-1">
-            {visibleTodos.map((todo) => (
-              <li
-                key={todo.id}
-                className="grid grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-x-2 rounded-md px-1 py-1 text-sm"
-              >
-                <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
-                  {statusIcon(todo.status, isSessionWorking)}
+    >
+      <div
+        className="rounded-t-xl border-l-4"
+        style={accentColor ? { borderLeftColor: accentColor } : undefined}
+      >
+        <button
+          type="button"
+          className="flex w-full cursor-pointer items-center gap-3 px-3 py-2 text-left hover:bg-muted/70"
+          onClick={onToggleCollapse}
+          aria-label={toggleLabel}
+          aria-expanded={!collapsed}
+        >
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            <div className="flex shrink-0 items-center gap-2">
+              <ListTodo className="size-4 shrink-0 text-muted-foreground" />
+              <p className="text-[13px] font-semibold text-foreground">Todo</p>
+              <p className="text-[11px] font-medium text-muted-foreground">
+                {completedCount}/{visibleTodos.length}
+              </p>
+            </div>
+            {collapsed ? (
+              <div className="flex min-w-0 flex-1 items-center gap-2 border-l border-border/70 pl-3 text-sm text-foreground">
+                <span className="inline-flex size-4 shrink-0 items-center justify-center">
+                  {statusIcon(actionableTodo.status, isSessionWorking)}
                 </span>
-                <span
-                  className={cn(
-                    "block min-w-0 leading-5 text-foreground",
-                    todo.status === "in_progress" && "font-medium text-foreground",
-                    todo.status === "completed" && "text-muted-foreground line-through",
-                  )}
+                <span className="truncate">{actionableTodo.content}</span>
+              </div>
+            ) : null}
+            {collapsed ? (
+              <ChevronDown className="ml-auto size-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronUp className="ml-auto size-4 shrink-0 text-muted-foreground" />
+            )}
+          </div>
+        </button>
+
+        {collapsed ? null : (
+          <div className="border-t border-input/80 px-3 pb-3 pt-2">
+            <ul className="max-h-[40vh] space-y-1 overflow-y-auto overscroll-contain pr-1">
+              {visibleTodos.map((todo) => (
+                <li
+                  key={todo.id}
+                  className="grid grid-cols-[1.25rem_minmax(0,1fr)] items-center gap-x-2 rounded-md px-1 py-1 text-sm"
                 >
-                  {todo.content}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+                  <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+                    {statusIcon(todo.status, isSessionWorking)}
+                  </span>
+                  <span
+                    className={cn(
+                      "block min-w-0 leading-5 text-foreground",
+                      todo.status === "in_progress" && "font-medium text-foreground",
+                      todo.status === "completed" && "text-muted-foreground line-through",
+                    )}
+                  >
+                    {todo.content}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## What changed
- adjust the chat todo panel UI layout and accent border structure
- refactor the todo panel tests to assert behavior and accessibility state instead of raw Tailwind class strings
- relax one chat thread test that was still asserting an exact bottom-stack padding class

## Why
The failing tests were coupled to implementation details in the rendered class list. Small layout-only changes in the chat todo UI were causing test failures even when the user-visible behavior stayed correct.

## Impact
- chat todo UI changes remain covered by focused tests
- behavior-level regressions should still be caught
- harmless CSS/layout refactors should stop breaking this test slice

## Validation
- `bun run --filter @openducktor/desktop test agent-session-todo-panel agent-chat-thread`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed bottom padding from the agent chat pending-items stack and adjusted spacing.
  * Reworked the accent border handling on the agent todo panel for more consistent visual styling.

* **Tests**
  * Rewrote tests to use DOM-based queries and lifecycle hooks, improving accessibility and visual-state assertions.
  * Split and clarified hidden/expanded test cases and updated icon/spinner presence checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->