### PR TITLE
fix: show all apply_patch file edits in chat

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
@@ -51,7 +51,10 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
   const hasDiff = Boolean(data.diff);
 
   return (
-    <div className="my-1.5 overflow-hidden rounded-lg border border-border bg-card text-xs">
+    <div
+      className="my-1.5 overflow-hidden rounded-lg border border-border bg-card text-xs"
+      data-testid="agent-chat-file-edit-card"
+    >
       {data.diff ? <PierreDiffPreloader patch={data.diff} filePath={data.filePath} /> : null}
 
       {/* Header */}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -1028,6 +1028,80 @@ describe("agent-chat-message-card-model", () => {
       ]);
     });
 
+    test("extracts all file edit data from a multi-file unified diff without diff headers", () => {
+      const data = extractAllFileEditData(
+        createToolMeta({
+          tool: "apply_patch",
+          input: {
+            patch:
+              "--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+              "--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1 @@\n-old\n+new\n",
+          },
+        }),
+      );
+
+      expect(data).toEqual([
+        {
+          filePath: "src/first.ts",
+          diff: "--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n",
+          additions: 1,
+          deletions: 1,
+        },
+        {
+          filePath: "src/second.ts",
+          diff: "--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1 @@\n-old\n+new\n",
+          additions: 1,
+          deletions: 1,
+        },
+      ]);
+    });
+
+    test("extracts quoted paths and strips diff timestamps", () => {
+      const data = extractAllFileEditData(
+        createToolMeta({
+          tool: "apply_patch",
+          metadata: {
+            diff:
+              'diff --git "a/src/file with spaces.ts" "b/src/file with spaces.ts"\n' +
+              '--- "a/src/file with spaces.ts"\t2026-03-28 12:00:00 +0000\n' +
+              '+++ "b/src/file with spaces.ts"\t2026-03-28 12:00:00 +0000\n' +
+              "@@ -1 +1 @@\n-old\n+new\n",
+          },
+        }),
+      );
+
+      expect(data).toEqual([
+        {
+          filePath: "src/file with spaces.ts",
+          diff:
+            'diff --git "a/src/file with spaces.ts" "b/src/file with spaces.ts"\n' +
+            '--- "a/src/file with spaces.ts"\t2026-03-28 12:00:00 +0000\n' +
+            '+++ "b/src/file with spaces.ts"\t2026-03-28 12:00:00 +0000\n' +
+            "@@ -1 +1 @@\n-old\n+new\n",
+          additions: 1,
+          deletions: 1,
+        },
+      ]);
+    });
+
+    test("counts content lines that begin with three diff markers", () => {
+      const data = extractFileEditData(
+        createToolMeta({
+          input: { filePath: "src/symbols.ts" },
+          metadata: {
+            diff: "--- a/src/symbols.ts\n+++ b/src/symbols.ts\n@@ -1,2 +1,2 @@\n----old\n----gone\n++++added\n++++kept\n",
+          },
+        }),
+      );
+
+      expect(data).toEqual({
+        filePath: "src/symbols.ts",
+        diff: "--- a/src/symbols.ts\n+++ b/src/symbols.ts\n@@ -1,2 +1,2 @@\n----old\n----gone\n++++added\n++++kept\n",
+        additions: 2,
+        deletions: 2,
+      });
+    });
+
     test("extractAllFileEditData preserves single-file behavior", () => {
       const meta = createToolMeta({
         tool: "apply_patch",
@@ -1097,6 +1171,24 @@ describe("agent-chat-message-card-model", () => {
       ).toBe("");
     });
 
+    test("uses neutral multi-file summaries while file edit tools are still running", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "apply_patch",
+            status: "running",
+            input: {
+              patch:
+                "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+                "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1 @@\n-old\n+new\n",
+            },
+            output: "",
+          }),
+          "",
+        ),
+      ).toBe("2 files");
+    });
+
     test("preserves file edit summaries until the tool succeeds", () => {
       expect(
         buildToolSummary(
@@ -1111,6 +1203,19 @@ describe("agent-chat-message-card-model", () => {
           "",
         ),
       ).toBe("src/patch.ts");
+    });
+
+    test("keeps completed file edit summaries when no file cards can be built", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "apply_patch",
+            status: "completed",
+            output: "Success. Updated 3 files",
+          }),
+          "",
+        ),
+      ).toBe("Success. Updated 3 files");
     });
 
     test("uses input taskId for read_task summaries", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -3,6 +3,7 @@ import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import {
   assistantRoleFromMessage,
   buildToolSummary,
+  extractAllFileEditData,
   extractFileEditData,
   formatRawJsonLikeText,
   formatTime,
@@ -964,6 +965,93 @@ describe("agent-chat-message-card-model", () => {
       });
     });
 
+    test("extracts all file edit data from a multi-file git patch", () => {
+      const data = extractAllFileEditData(
+        createToolMeta({
+          tool: "apply_patch",
+          input: {
+            patch:
+              "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+              "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n" +
+              "diff --git a/src/third.ts b/src/third.ts\n--- a/src/third.ts\n+++ b/src/third.ts\n@@ -1,2 +1 @@\n-old\n-remove\n+new\n",
+          },
+        }),
+      );
+
+      expect(data).toEqual([
+        {
+          filePath: "src/first.ts",
+          diff: "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n",
+          additions: 1,
+          deletions: 1,
+        },
+        {
+          filePath: "src/second.ts",
+          diff: "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+          additions: 2,
+          deletions: 1,
+        },
+        {
+          filePath: "src/third.ts",
+          diff: "diff --git a/src/third.ts b/src/third.ts\n--- a/src/third.ts\n+++ b/src/third.ts\n@@ -1,2 +1 @@\n-old\n-remove\n+new\n",
+          additions: 1,
+          deletions: 2,
+        },
+      ]);
+    });
+
+    test("extracts all file edit data from a multi-file classic diff", () => {
+      const data = extractAllFileEditData(
+        createToolMeta({
+          tool: "apply_patch",
+          metadata: {
+            diff:
+              "Index: src/first.ts\n==================================================\n--- src/first.ts\n+++ src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+              "Index: src/second.ts\n==================================================\n--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+          },
+        }),
+      );
+
+      expect(data).toEqual([
+        {
+          filePath: "src/first.ts",
+          diff: "--- src/first.ts\n+++ src/first.ts\n@@ -1 +1 @@\n-old\n+new\n",
+          additions: 1,
+          deletions: 1,
+        },
+        {
+          filePath: "src/second.ts",
+          diff: "--- src/second.ts\n+++ src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+          additions: 2,
+          deletions: 1,
+        },
+      ]);
+    });
+
+    test("extractAllFileEditData preserves single-file behavior", () => {
+      const meta = createToolMeta({
+        tool: "apply_patch",
+        input: {
+          patch: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new",
+        },
+      });
+      const singleFileEditData = extractFileEditData(meta);
+
+      expect(singleFileEditData).not.toBeNull();
+      expect(extractAllFileEditData(meta)).toEqual(singleFileEditData ? [singleFileEditData] : []);
+    });
+
+    test("extractAllFileEditData returns an empty array when no file path is extractable", () => {
+      expect(
+        extractAllFileEditData(
+          createToolMeta({
+            tool: "apply_patch",
+            input: { patch: "@@ -1 +1 @@\n-old\n+new" },
+          }),
+        ),
+      ).toEqual([]);
+    });
+
     test("returns null when no file path can be extracted", () => {
       expect(
         extractFileEditData(
@@ -977,6 +1065,38 @@ describe("agent-chat-message-card-model", () => {
   });
 
   describe("tool summary helpers", () => {
+    test("summarizes multi-file apply_patch output by file count", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "apply_patch",
+            input: {
+              patch:
+                "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+                "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1 @@\n-old\n+new\n",
+            },
+            output: "Updated 2 files",
+          }),
+          "",
+        ),
+      ).toBe("2 files modified");
+    });
+
+    test("preserves single-file apply_patch summaries", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "apply_patch",
+            input: {
+              patch: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new",
+            },
+            output: "Updated 1 file",
+          }),
+          "",
+        ),
+      ).toBe("src/patch.ts");
+    });
+
     test("uses input taskId for read_task summaries", () => {
       expect(
         buildToolSummary(

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -1065,7 +1065,7 @@ describe("agent-chat-message-card-model", () => {
   });
 
   describe("tool summary helpers", () => {
-    test("summarizes multi-file apply_patch output by file count", () => {
+    test("omits summaries for successful multi-file apply_patch tool calls", () => {
       expect(
         buildToolSummary(
           createToolMeta({
@@ -1079,10 +1079,10 @@ describe("agent-chat-message-card-model", () => {
           }),
           "",
         ),
-      ).toBe("2 files modified");
+      ).toBe("");
     });
 
-    test("preserves single-file apply_patch summaries", () => {
+    test("omits summaries for successful single-file apply_patch tool calls", () => {
       expect(
         buildToolSummary(
           createToolMeta({
@@ -1091,6 +1091,22 @@ describe("agent-chat-message-card-model", () => {
               patch: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new",
             },
             output: "Updated 1 file",
+          }),
+          "",
+        ),
+      ).toBe("");
+    });
+
+    test("preserves file edit summaries until the tool succeeds", () => {
+      expect(
+        buildToolSummary(
+          createToolMeta({
+            tool: "apply_patch",
+            status: "running",
+            input: {
+              patch: "--- a/src/patch.ts\n+++ b/src/patch.ts\n@@ -1 +1 @@\n-old\n+new",
+            },
+            output: "",
           }),
           "",
         ),

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.ts
@@ -21,6 +21,7 @@ export {
 export type { FileEditData } from "./tool-summary-builder";
 export {
   buildToolSummary,
+  extractAllFileEditData,
   extractFileEditData,
   getToolDuration,
   isFileEditTool,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-tool-presenters.tsx
@@ -18,7 +18,7 @@ import { isTodoToolName } from "@/state/operations/agent-orchestrator/agent-tool
 import { AgentChatFileEditCard } from "./agent-chat-file-edit-card";
 import {
   buildToolSummary,
-  extractFileEditData,
+  extractAllFileEditData,
   formatRawJsonLikeText,
   getToolDuration,
   getToolLifecyclePhase,
@@ -353,8 +353,12 @@ export const RegularToolMessage = ({
 
       {isFileEditTool(meta.tool) &&
         (() => {
-          const fileEditData = extractFileEditData(meta, sessionWorkingDirectory);
-          return fileEditData ? <AgentChatFileEditCard data={fileEditData} /> : null;
+          const allFileEditData = extractAllFileEditData(meta, sessionWorkingDirectory);
+          return allFileEditData.length > 0
+            ? allFileEditData.map((data) => (
+                <AgentChatFileEditCard key={data.filePath} data={data} />
+              ))
+            : null;
         })()}
     </div>
   );

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -227,6 +227,9 @@ describe("AgentChatMessageCard tool duration", () => {
       }),
     );
 
+    const fileEditCardMatches = html.match(/data-testid="agent-chat-file-edit-card"/g) ?? [];
+
+    expect(fileEditCardMatches).toHaveLength(2);
     expect(html).not.toContain("2 files modified");
     expect(html).toContain("src/");
     expect(html).toContain("first.ts");

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -199,7 +199,7 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).not.toContain("/repo/apps/web/src/contexts/AuthContext.tsx");
   });
 
-  test("renders one file edit card per file in a multi-file apply_patch result", () => {
+  test("renders one file edit card per file in a multi-file apply_patch result without a summary description", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {
         message: {
@@ -227,7 +227,7 @@ describe("AgentChatMessageCard tool duration", () => {
       }),
     );
 
-    expect(html).toContain("2 files modified");
+    expect(html).not.toContain("2 files modified");
     expect(html).toContain("src/");
     expect(html).toContain("first.ts");
     expect(html).toContain("second.ts");

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -199,6 +199,42 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).not.toContain("/repo/apps/web/src/contexts/AuthContext.tsx");
   });
 
+  test("renders one file edit card per file in a multi-file apply_patch result", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "tool-multi-file-apply-patch",
+          role: "tool",
+          content: "Tool apply_patch completed",
+          timestamp: "2026-02-22T10:20:36.000Z",
+          meta: {
+            kind: "tool",
+            partId: "part-multi-file-apply-patch",
+            callId: "call-multi-file-apply-patch",
+            tool: "apply_patch",
+            status: "completed",
+            input: {
+              patch:
+                "diff --git a/src/first.ts b/src/first.ts\n--- a/src/first.ts\n+++ b/src/first.ts\n@@ -1 +1 @@\n-old\n+new\n" +
+                "diff --git a/src/second.ts b/src/second.ts\n--- a/src/second.ts\n+++ b/src/second.ts\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+            },
+            output: "Updated 2 files",
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("2 files modified");
+    expect(html).toContain("src/");
+    expect(html).toContain("first.ts");
+    expect(html).toContain("second.ts");
+    expect(html).toContain("+1");
+    expect(html).toContain("+2");
+  });
+
   test("renders workflow tool executing state with blue styling and running label", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {

--- a/apps/desktop/src/components/features/agents/agent-chat/file-edit-tool.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/file-edit-tool.ts
@@ -1,4 +1,4 @@
-import { selectRenderableDiff } from "../renderable-patch";
+import { patchMatchesFile, selectRenderableDiff, splitPatchCandidates } from "../renderable-patch";
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
 import { extractPathFromInput } from "./tool-input-utils";
 import { relativizeDisplayPath } from "./tool-path-utils";
@@ -28,6 +28,115 @@ export type FileEditData = {
   deletions: number;
 };
 
+const extractRawDiff = (meta: ToolMeta): string | null => {
+  return typeof meta.metadata?.diff === "string"
+    ? meta.metadata.diff
+    : typeof meta.input?.patch === "string"
+      ? (meta.input.patch as string)
+      : typeof meta.output === "string" && meta.output.includes("@@")
+        ? meta.output
+        : null;
+};
+
+const countDiffChanges = (diff: string | null): Pick<FileEditData, "additions" | "deletions"> => {
+  let additions = 0;
+  let deletions = 0;
+
+  if (!diff) {
+    return { additions, deletions };
+  }
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      additions++;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      deletions++;
+    }
+  }
+
+  return { additions, deletions };
+};
+
+const buildFileEditData = (
+  filePath: string,
+  rawDiff: string | null,
+  workingDirectory?: string | null,
+): FileEditData => {
+  const displayPath = relativizeDisplayPath(filePath, workingDirectory);
+  const diff = rawDiff
+    ? (selectRenderableDiff(rawDiff, displayPath) ??
+      (displayPath !== filePath ? selectRenderableDiff(rawDiff, filePath) : null))
+    : null;
+  const { additions, deletions } = countDiffChanges(diff);
+
+  return {
+    filePath: displayPath,
+    diff,
+    additions,
+    deletions,
+  };
+};
+
+const normalizePatchPath = (value: string | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed === "/dev/null") {
+    return null;
+  }
+
+  return trimmed.replace(/^[ab]\//, "");
+};
+
+const extractPatchFilePath = (candidate: string): string | null => {
+  const nextPath = normalizePatchPath(/^\+\+\+\s+(.+)$/m.exec(candidate)?.[1]);
+  if (nextPath) {
+    return nextPath;
+  }
+
+  const previousPath = normalizePatchPath(/^---\s+(.+)$/m.exec(candidate)?.[1]);
+  if (previousPath) {
+    return previousPath;
+  }
+
+  const indexPath = normalizePatchPath(/^Index:\s+(.+)$/m.exec(candidate)?.[1]);
+  if (indexPath) {
+    return indexPath;
+  }
+
+  return normalizePatchPath(/^diff --git a\/(.+?) b\//m.exec(candidate)?.[1]);
+};
+
+export const extractAllFileEditData = (
+  meta: ToolMeta,
+  workingDirectory?: string | null,
+): FileEditData[] => {
+  const rawDiff = extractRawDiff(meta);
+  if (rawDiff) {
+    const fileEditData: FileEditData[] = [];
+    const seenPaths = new Set<string>();
+
+    for (const candidate of splitPatchCandidates(rawDiff)) {
+      const filePath = extractPatchFilePath(candidate);
+      if (!filePath || seenPaths.has(filePath) || !patchMatchesFile(candidate, filePath)) {
+        continue;
+      }
+
+      fileEditData.push(buildFileEditData(filePath, candidate, workingDirectory));
+      seenPaths.add(filePath);
+    }
+
+    if (fileEditData.length > 0) {
+      return fileEditData;
+    }
+  }
+
+  const fileEditData = extractFileEditData(meta, workingDirectory);
+  return fileEditData ? [fileEditData] : [];
+};
+
 export const extractFileEditData = (
   meta: ToolMeta,
   workingDirectory?: string | null,
@@ -54,30 +163,5 @@ export const extractFileEditData = (
     return null;
   }
 
-  filePath = relativizeDisplayPath(filePath, workingDirectory);
-
-  const rawDiff =
-    typeof meta.metadata?.diff === "string"
-      ? meta.metadata.diff
-      : typeof meta.input?.patch === "string"
-        ? (meta.input.patch as string)
-        : typeof meta.output === "string" && meta.output.includes("@@")
-          ? meta.output
-          : null;
-
-  const diff = rawDiff ? selectRenderableDiff(rawDiff, filePath) : null;
-
-  let additions = 0;
-  let deletions = 0;
-  if (diff) {
-    for (const line of diff.split("\n")) {
-      if (line.startsWith("+") && !line.startsWith("+++")) {
-        additions++;
-      } else if (line.startsWith("-") && !line.startsWith("---")) {
-        deletions++;
-      }
-    }
-  }
-
-  return { filePath, diff, additions, deletions };
+  return buildFileEditData(filePath, extractRawDiff(meta), workingDirectory);
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/file-edit-tool.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/file-edit-tool.ts
@@ -21,6 +21,9 @@ export const isFileEditTool = (toolName: string): boolean => {
   return FILE_EDIT_TOOLS.has(toolName.toLowerCase());
 };
 
+const HEADER_ADDITION_PREFIX = "+++ ";
+const HEADER_DELETION_PREFIX = "--- ";
+
 export type FileEditData = {
   filePath: string;
   diff: string | null;
@@ -47,9 +50,13 @@ const countDiffChanges = (diff: string | null): Pick<FileEditData, "additions" |
   }
 
   for (const line of diff.split("\n")) {
-    if (line.startsWith("+") && !line.startsWith("+++")) {
+    if (line.startsWith(HEADER_ADDITION_PREFIX) || line.startsWith(HEADER_DELETION_PREFIX)) {
+      continue;
+    }
+
+    if (line.startsWith("+")) {
       additions++;
-    } else if (line.startsWith("-") && !line.startsWith("---")) {
+    } else if (line.startsWith("-")) {
       deletions++;
     }
   }
@@ -82,12 +89,38 @@ const normalizePatchPath = (value: string | undefined): string | null => {
     return null;
   }
 
-  const trimmed = value.trim();
+  let trimmed = value.trim().replace(/\t.*$/, "");
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    trimmed = trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+  }
+
   if (trimmed.length === 0 || trimmed === "/dev/null") {
     return null;
   }
 
   return trimmed.replace(/^[ab]\//, "");
+};
+
+const extractDiffGitPaths = (
+  candidate: string,
+): { previousPath: string; nextPath: string } | null => {
+  const line = /^diff --git\s+(.+)$/m.exec(candidate)?.[1];
+  if (!line) {
+    return null;
+  }
+
+  const match = /^(?:"((?:[^"\\]|\\.)*)"|(\S+))\s+(?:"((?:[^"\\]|\\.)*)"|(\S+))$/.exec(line.trim());
+  if (!match) {
+    return null;
+  }
+
+  const previousPath = normalizePatchPath(match[1] ?? match[2]);
+  const nextPath = normalizePatchPath(match[3] ?? match[4]);
+  if (!previousPath || !nextPath) {
+    return null;
+  }
+
+  return { previousPath, nextPath };
 };
 
 const extractPatchFilePath = (candidate: string): string | null => {
@@ -106,7 +139,7 @@ const extractPatchFilePath = (candidate: string): string | null => {
     return indexPath;
   }
 
-  return normalizePatchPath(/^diff --git a\/(.+?) b\//m.exec(candidate)?.[1]);
+  return extractDiffGitPaths(candidate)?.nextPath ?? null;
 };
 
 export const extractAllFileEditData = (
@@ -120,12 +153,17 @@ export const extractAllFileEditData = (
 
     for (const candidate of splitPatchCandidates(rawDiff)) {
       const filePath = extractPatchFilePath(candidate);
-      if (!filePath || seenPaths.has(filePath) || !patchMatchesFile(candidate, filePath)) {
+      if (!filePath || !patchMatchesFile(candidate, filePath)) {
         continue;
       }
 
-      fileEditData.push(buildFileEditData(filePath, candidate, workingDirectory));
-      seenPaths.add(filePath);
+      const data = buildFileEditData(filePath, candidate, workingDirectory);
+      if (seenPaths.has(data.filePath)) {
+        continue;
+      }
+
+      fileEditData.push(data);
+      seenPaths.add(data.filePath);
     }
 
     if (fileEditData.length > 0) {
@@ -145,9 +183,9 @@ export const extractFileEditData = (
 
   if (!filePath && typeof meta.input?.patch === "string") {
     const patchContent = meta.input.patch as string;
-    const diffMatch = /^---\s+a\/(.+)$/m.exec(patchContent);
-    if (diffMatch?.[1]) {
-      filePath = diffMatch[1];
+    const patchFilePath = extractPatchFilePath(patchContent);
+    if (patchFilePath) {
+      filePath = patchFilePath;
     }
   }
 

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-summary-builder.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-summary-builder.ts
@@ -1,4 +1,4 @@
 export type { FileEditData } from "./file-edit-tool";
-export { extractFileEditData, isFileEditTool } from "./file-edit-tool";
+export { extractAllFileEditData, extractFileEditData, isFileEditTool } from "./file-edit-tool";
 export { getToolDuration } from "./tool-duration";
 export { buildToolSummary } from "./tool-summary";

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
@@ -1,5 +1,6 @@
 import { isTodoToolName } from "@/state/operations/agent-orchestrator/agent-tool-messages";
 import type { ToolMeta } from "./agent-chat-message-card-model.types";
+import { extractAllFileEditData, isFileEditTool } from "./file-edit-tool";
 import { extractPathFromInput, readInputString } from "./tool-input-utils";
 import { getToolLifecyclePhase, hasNonEmptyText } from "./tool-lifecycle";
 import { relativizeDisplayPath, relativizeSearchSummary } from "./tool-path-utils";
@@ -251,6 +252,18 @@ export const buildToolSummary = (
   if (searchSummary) {
     return compactText(relativizeSearchSummary(searchSummary, workingDirectory), 160);
   }
+
+  if (isFileEditTool(lowerTool)) {
+    const allFileEditData = extractAllFileEditData(meta, workingDirectory);
+    if (allFileEditData.length > 1) {
+      return `${allFileEditData.length} files modified`;
+    }
+    const singleFileEditData = allFileEditData[0];
+    if (singleFileEditData) {
+      return compactText(singleFileEditData.filePath, 160);
+    }
+  }
+
   if (path && lowerTool !== "glob" && lowerTool !== "grep") {
     return compactText(relativizeDisplayPath(path, workingDirectory), 160);
   }

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
@@ -239,6 +239,10 @@ export const buildToolSummary = (
     return compactText(meta.error, 220);
   }
 
+  if (isFileEditTool(lowerTool) && lifecyclePhase === "completed") {
+    return "";
+  }
+
   if (typeof meta.preview === "string" && meta.preview.trim().length > 0) {
     return compactText(normalizeDisplaySummary(lowerTool, meta.preview, workingDirectory), 160);
   }

--- a/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/tool-summary.ts
@@ -197,6 +197,9 @@ export const buildToolSummary = (
   const lowerTool = meta.tool.toLowerCase();
   const isTodoTool = isTodoToolName(lowerTool);
   const lifecyclePhase = getToolLifecyclePhase(meta);
+  const fileEditData = isFileEditTool(lowerTool)
+    ? extractAllFileEditData(meta, workingDirectory)
+    : [];
 
   if (
     lowerTool === "read_task" ||
@@ -239,7 +242,7 @@ export const buildToolSummary = (
     return compactText(meta.error, 220);
   }
 
-  if (isFileEditTool(lowerTool) && lifecyclePhase === "completed") {
+  if (lifecyclePhase === "completed" && fileEditData.length > 0) {
     return "";
   }
 
@@ -257,15 +260,15 @@ export const buildToolSummary = (
     return compactText(relativizeSearchSummary(searchSummary, workingDirectory), 160);
   }
 
-  if (isFileEditTool(lowerTool)) {
-    const allFileEditData = extractAllFileEditData(meta, workingDirectory);
-    if (allFileEditData.length > 1) {
-      return `${allFileEditData.length} files modified`;
-    }
-    const singleFileEditData = allFileEditData[0];
-    if (singleFileEditData) {
-      return compactText(singleFileEditData.filePath, 160);
-    }
+  if (fileEditData.length > 1) {
+    return lifecyclePhase === "completed"
+      ? `${fileEditData.length} files modified`
+      : `${fileEditData.length} files`;
+  }
+
+  const singleFileEditData = fileEditData[0];
+  if (singleFileEditData) {
+    return compactText(singleFileEditData.filePath, 160);
   }
 
   if (path && lowerTool !== "glob" && lowerTool !== "grep") {

--- a/apps/desktop/src/components/features/agents/renderable-patch.ts
+++ b/apps/desktop/src/components/features/agents/renderable-patch.ts
@@ -2,6 +2,7 @@ import { getSingularPatch } from "@pierre/diffs";
 
 const GIT_DIFF_HEADER = /^diff --git /m;
 const CLASSIC_DIFF_HEADER = /^Index: /m;
+const UNIFIED_MULTI_FILE_HEADER = /^--- .+\n\+\+\+ .+/m;
 
 export function normalizePatchCandidate(candidate: string, filePath: string): string {
   const trimmed = candidate.trim();
@@ -39,6 +40,13 @@ export function splitPatchCandidates(rawDiff: string): string[] {
   if (CLASSIC_DIFF_HEADER.test(trimmed)) {
     return trimmed
       .split(/(?=^Index: )/m)
+      .map((chunk) => chunk.trim())
+      .filter((chunk) => chunk.length > 0);
+  }
+
+  if (UNIFIED_MULTI_FILE_HEADER.test(trimmed)) {
+    return trimmed
+      .split(/(?=^--- .+\n\+\+\+ .+)/m)
       .map((chunk) => chunk.trim())
       .filter((chunk) => chunk.length > 0);
   }

--- a/apps/desktop/src/components/features/agents/renderable-patch.ts
+++ b/apps/desktop/src/components/features/agents/renderable-patch.ts
@@ -23,7 +23,7 @@ export function normalizePatchCandidate(candidate: string, filePath: string): st
   return `${normalized}\n`;
 }
 
-function splitPatchCandidates(rawDiff: string): string[] {
+export function splitPatchCandidates(rawDiff: string): string[] {
   const trimmed = rawDiff.trim();
   if (trimmed.length === 0) {
     return [];
@@ -46,7 +46,7 @@ function splitPatchCandidates(rawDiff: string): string[] {
   return [trimmed];
 }
 
-function patchMatchesFile(candidate: string, filePath: string): boolean {
+export function patchMatchesFile(candidate: string, filePath: string): boolean {
   const normalizedPath = filePath.replaceAll("\\", "/");
   const quotedPath = normalizedPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const suffixPattern = new RegExp(`(^|[\\s"'])((a|b)/)?${quotedPath}($|[\\s"'])`, "m");


### PR DESCRIPTION
## Summary
- show every file touched by multi-file `apply_patch` calls in the chat, with one Pierre diff row per file
- summarize file edit tools from parsed diff data and hide successful file-edit row descriptions when the diff cards already provide the useful context
- add regression coverage for multi-file git/classic diffs, summary behavior, and rendered chat rows

## Verification
- `bun run test`
- `bun run lint`
- `bun run typecheck`
- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File edits now display per-file cards for multi-file patches and show compact single-file summaries when appropriate.
  * Summaries better reflect running vs completed edit operations (e.g., "N files" while running, "N files modified" when done).

* **Tests**
  * Added tests covering multi-file patch parsing, quoted filenames, timestamp stripping, and per-file display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->