### PR TITLE
feat(desktop): add configurable autopilot workflows

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -11,7 +11,8 @@ use host_domain::{
 use host_infra_system::{
     command_exists, copy_configured_worktree_files, remove_worktree, repo_script_fingerprint,
     resolve_central_beads_dir, run_command, run_command_allow_failure_with_env, version_command,
-    ChatSettings, GlobalGitConfig, HookSet, KanbanSettings, PromptOverrides, RepoConfig,
+    AutopilotSettings, ChatSettings, GlobalGitConfig, HookSet, KanbanSettings, PromptOverrides,
+    RepoConfig,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -26,6 +27,7 @@ type SettingsSnapshotTuple = (
     GlobalGitConfig,
     ChatSettings,
     KanbanSettings,
+    AutopilotSettings,
     HashMap<String, RepoConfig>,
     PromptOverrides,
 );
@@ -260,6 +262,7 @@ impl AppService {
             config.git,
             config.chat,
             config.kanban,
+            config.autopilot,
             config.repos,
             config.global_prompt_overrides,
         ))
@@ -275,6 +278,7 @@ impl AppService {
         git: GlobalGitConfig,
         chat: ChatSettings,
         kanban: KanbanSettings,
+        autopilot: AutopilotSettings,
         repos: HashMap<String, RepoConfig>,
         global_prompt_overrides: PromptOverrides,
     ) -> Result<()> {
@@ -293,6 +297,7 @@ impl AppService {
         config.kanban = KanbanSettings {
             done_visible_days: kanban.done_visible_days.max(0),
         };
+        config.autopilot = autopilot;
         config.global_prompt_overrides = global_prompt_overrides;
         for (repo_path, repo_config) in repos {
             config.repos.insert(repo_path, repo_config);
@@ -917,7 +922,7 @@ mod tests {
     fn workspace_get_settings_snapshot_returns_defaulted_chat_settings() {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
 
-        let (_theme, _git, chat, kanban, repos, global_prompt_overrides) = service
+        let (_theme, _git, chat, kanban, _autopilot, repos, global_prompt_overrides) = service
             .workspace_get_settings_snapshot()
             .expect("settings snapshot should load");
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -1,4 +1,7 @@
-use super::{read_opencode_version, resolve_opencode_binary_path, AppService, CachedRuntimeCheck};
+use super::{
+    read_opencode_version, resolve_opencode_binary_path, AppService, CachedRuntimeCheck,
+    WorkspaceSettingsSnapshotUpdate,
+};
 use anyhow::{anyhow, Result};
 use host_domain::{
     BeadsCheck, GitAheadBehind, GitBranch, GitCommitAllRequest, GitCommitAllResult,
@@ -274,16 +277,10 @@ impl AppService {
 
     pub(super) fn workspace_persist_settings_snapshot(
         &self,
-        theme: String,
-        git: GlobalGitConfig,
-        chat: ChatSettings,
-        kanban: KanbanSettings,
-        autopilot: AutopilotSettings,
-        repos: HashMap<String, RepoConfig>,
-        global_prompt_overrides: PromptOverrides,
+        snapshot: WorkspaceSettingsSnapshotUpdate,
     ) -> Result<()> {
         let mut config = self.config_store.load()?;
-        for repo_path in repos.keys() {
+        for repo_path in snapshot.repos.keys() {
             if !config.repos.contains_key(repo_path) {
                 return Err(anyhow!(
                     "Workspace not found in config: {repo_path}. Add/select the workspace before updating configuration."
@@ -291,15 +288,15 @@ impl AppService {
             }
         }
 
-        config.theme = theme;
-        config.git = git;
-        config.chat = chat;
+        config.theme = snapshot.theme;
+        config.git = snapshot.git;
+        config.chat = snapshot.chat;
         config.kanban = KanbanSettings {
-            done_visible_days: kanban.done_visible_days.max(0),
+            done_visible_days: snapshot.kanban.done_visible_days.max(0),
         };
-        config.autopilot = autopilot;
-        config.global_prompt_overrides = global_prompt_overrides;
-        for (repo_path, repo_config) in repos {
+        config.autopilot = snapshot.autopilot;
+        config.global_prompt_overrides = snapshot.global_prompt_overrides;
+        for (repo_path, repo_config) in snapshot.repos {
             config.repos.insert(repo_path, repo_config);
         }
         self.config_store.save(&config)

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -4,8 +4,8 @@ use chrono::{DateTime, Utc};
 use host_domain::WorkspaceRecord;
 use host_infra_system::{
     normalize_hook_set, normalize_repo_dev_servers, repo_script_fingerprint, AgentDefaults,
-    ChatSettings, GitTargetBranch, HookSet, KanbanSettings, PromptOverrides, RepoConfig,
-    RepoDevServerScript, RepoGitConfig,
+    AutopilotSettings, ChatSettings, GitTargetBranch, HookSet, KanbanSettings, PromptOverrides,
+    RepoConfig, RepoDevServerScript, RepoGitConfig,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -48,6 +48,7 @@ pub struct WorkspaceSettingsSnapshotUpdate {
     pub git: host_infra_system::GlobalGitConfig,
     pub chat: ChatSettings,
     pub kanban: KanbanSettings,
+    pub autopilot: AutopilotSettings,
     pub repos: HashMap<String, RepoConfig>,
     pub global_prompt_overrides: PromptOverrides,
 }
@@ -281,6 +282,7 @@ impl AppService {
             update.git,
             update.chat,
             update.kanban,
+            update.autopilot,
             update.repos,
             update.global_prompt_overrides,
         )?;
@@ -454,8 +456,8 @@ mod tests {
     use anyhow::{anyhow, Result};
     use host_domain::TaskStore;
     use host_infra_system::{
-        hook_set_fingerprint, repo_script_fingerprint, AppConfigStore, ChatSettings, GitCliPort,
-        HookSet, PromptOverride, RepoConfig, RepoDevServerScript,
+        hook_set_fingerprint, repo_script_fingerprint, AppConfigStore, AutopilotSettings,
+        ChatSettings, GitCliPort, HookSet, PromptOverride, RepoConfig, RepoDevServerScript,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -885,7 +887,7 @@ mod tests {
         );
         let confirmation = RecordingHookTrustConfirmationPort::default();
 
-        let (theme, git, mut chat, kanban, mut repos, mut global_prompt_overrides) =
+        let (theme, git, mut chat, kanban, autopilot, mut repos, mut global_prompt_overrides) =
             fixture.service.workspace_get_settings_snapshot()?;
         chat.show_thinking_messages = true;
         global_prompt_overrides.insert(
@@ -913,6 +915,7 @@ mod tests {
                 git,
                 chat,
                 kanban,
+                autopilot,
                 repos,
                 global_prompt_overrides,
             },
@@ -942,7 +945,7 @@ mod tests {
         let fixture = setup_fixture("snapshot-chat-roundtrip", HookSet::default());
         let confirmation = RecordingHookTrustConfirmationPort::default();
 
-        let (theme, git, mut chat, kanban, repos, global_prompt_overrides) =
+        let (theme, git, mut chat, kanban, autopilot, repos, global_prompt_overrides) =
             fixture.service.workspace_get_settings_snapshot()?;
         assert_eq!(chat, ChatSettings::default());
         chat.show_thinking_messages = true;
@@ -953,6 +956,7 @@ mod tests {
                 git,
                 chat,
                 kanban,
+                autopilot,
                 repos,
                 global_prompt_overrides,
             },
@@ -964,10 +968,12 @@ mod tests {
             _persisted_git,
             persisted_chat,
             _persisted_kanban,
+            persisted_autopilot,
             _persisted_repos,
             _persisted_global_prompt_overrides,
         ) = fixture.service.workspace_get_settings_snapshot()?;
         assert!(persisted_chat.show_thinking_messages);
+        assert_eq!(persisted_autopilot, AutopilotSettings::default());
         assert_eq!(confirmation.request_count(), 0);
         Ok(())
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workspace_policy.rs
@@ -277,15 +277,7 @@ impl AppService {
             repo_config.trusted_hooks_fingerprint = trusted_hooks_fingerprint;
         }
 
-        self.workspace_persist_settings_snapshot(
-            update.theme,
-            update.git,
-            update.chat,
-            update.kanban,
-            update.autopilot,
-            update.repos,
-            update.global_prompt_overrides,
-        )?;
+        self.workspace_persist_settings_snapshot(update)?;
         self.workspace_list()
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/mod.rs
@@ -9,7 +9,8 @@ pub use normalize::{normalize_hook_set, normalize_repo_dev_servers};
 pub use persistence::resolve_openducktor_base_dir;
 pub use store::{AppConfigStore, RuntimeConfigStore};
 pub use types::{
-    hook_set_fingerprint, repo_script_fingerprint, AgentDefaults, AgentModelDefault, ChatSettings,
+    hook_set_fingerprint, repo_script_fingerprint, AgentDefaults, AgentModelDefault,
+    AutopilotActionId, AutopilotEventId, AutopilotRule, AutopilotSettings, ChatSettings,
     GitMergeMethod, GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig,
     GlobalGitConfig, HookSet, KanbanSettings, OpencodeStartupReadinessConfig, PromptOverride,
     PromptOverrides, RepoConfig, RepoDevServerScript, RepoGitConfig, RuntimeConfig,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
@@ -1,8 +1,9 @@
 use super::types::{
     default_branch_prefix, normalize_git_target_branch_value, repo_script_fingerprint,
-    AgentModelDefault, GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig,
-    HookSet, KanbanSettings, OpencodeStartupReadinessConfig, PromptOverrides, RepoConfig,
-    RepoDevServerScript, RuntimeConfig,
+    AgentModelDefault, AutopilotActionId, AutopilotRule, AutopilotSettings, GitProviderConfig,
+    GitProviderRepository, GitTargetBranch, GlobalConfig, HookSet, KanbanSettings,
+    OpencodeStartupReadinessConfig, PromptOverrides, RepoConfig, RepoDevServerScript,
+    RuntimeConfig, AUTOPILOT_EVENT_ORDER,
 };
 use anyhow::{anyhow, Result};
 use std::collections::HashSet;
@@ -194,8 +195,29 @@ fn normalize_kanban_settings(config: &mut KanbanSettings) {
     config.done_visible_days = config.done_visible_days.max(0);
 }
 
+fn normalize_autopilot_settings(config: &mut AutopilotSettings) {
+    let mut rules_by_event = std::collections::HashMap::new();
+    for mut rule in std::mem::take(&mut config.rules) {
+        let mut seen_actions = HashSet::new();
+        rule.action_ids
+            .retain(|action_id| seen_actions.insert(*action_id));
+        rules_by_event.insert(rule.event_id, rule);
+    }
+
+    config.rules = AUTOPILOT_EVENT_ORDER
+        .into_iter()
+        .map(|event_id| {
+            rules_by_event.remove(&event_id).unwrap_or(AutopilotRule {
+                event_id,
+                action_ids: Vec::<AutopilotActionId>::new(),
+            })
+        })
+        .collect();
+}
+
 pub(super) fn normalize_global_config(config: &mut GlobalConfig) -> Result<()> {
     normalize_kanban_settings(&mut config.kanban);
+    normalize_autopilot_settings(&mut config.autopilot);
     normalize_prompt_overrides(&mut config.global_prompt_overrides);
     for repo in config.repos.values_mut() {
         normalize_repo_config(repo)?;

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -175,6 +175,63 @@ impl Default for KanbanSettings {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum AutopilotEventId {
+    TaskProgressedToSpecReady,
+    TaskProgressedToReadyForDev,
+    TaskProgressedToAiReview,
+    TaskRejectedByQa,
+    TaskProgressedToHumanReview,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum AutopilotActionId {
+    StartSpec,
+    StartBuilder,
+    StartQa,
+    StartReviewQaFeedbacks,
+    StartGeneratePullRequest,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AutopilotRule {
+    pub event_id: AutopilotEventId,
+    #[serde(default)]
+    pub action_ids: Vec<AutopilotActionId>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AutopilotSettings {
+    #[serde(default)]
+    pub rules: Vec<AutopilotRule>,
+}
+
+pub const AUTOPILOT_EVENT_ORDER: [AutopilotEventId; 5] = [
+    AutopilotEventId::TaskProgressedToSpecReady,
+    AutopilotEventId::TaskProgressedToReadyForDev,
+    AutopilotEventId::TaskProgressedToAiReview,
+    AutopilotEventId::TaskRejectedByQa,
+    AutopilotEventId::TaskProgressedToHumanReview,
+];
+
+impl Default for AutopilotSettings {
+    fn default() -> Self {
+        Self {
+            rules: AUTOPILOT_EVENT_ORDER
+                .into_iter()
+                .map(|event_id| AutopilotRule {
+                    event_id,
+                    action_ids: Vec::new(),
+                })
+                .collect(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct HookSet {
@@ -429,6 +486,8 @@ pub struct GlobalConfig {
     #[serde(default)]
     pub kanban: KanbanSettings,
     #[serde(default)]
+    pub autopilot: AutopilotSettings,
+    #[serde(default)]
     pub global_prompt_overrides: PromptOverrides,
     #[serde(default)]
     pub repos: HashMap<String, RepoConfig>,
@@ -445,6 +504,7 @@ impl Default for GlobalConfig {
             git: GlobalGitConfig::default(),
             chat: ChatSettings::default(),
             kanban: KanbanSettings::default(),
+            autopilot: AutopilotSettings::default(),
             global_prompt_overrides: PromptOverrides::default(),
             repos: HashMap::new(),
             recent_repos: Vec::new(),

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -188,7 +188,7 @@ pub enum AutopilotEventId {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum AutopilotActionId {
-    StartSpec,
+    StartPlanner,
     StartBuilder,
     StartQa,
     StartReviewQaFeedbacks,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -11,11 +11,12 @@ pub use beads::{
 };
 pub use config::{
     hook_set_fingerprint, normalize_hook_set, normalize_repo_dev_servers, repo_script_fingerprint,
-    AgentDefaults, AgentModelDefault, AppConfigStore, ChatSettings, GitMergeMethod,
-    GitProviderConfig, GitProviderRepository, GitTargetBranch, GlobalConfig, GlobalGitConfig,
-    HookSet, KanbanSettings, OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides,
-    RepoConfig, RepoDevServerScript, RepoGitConfig, RuntimeConfig, RuntimeConfigStore,
-    SchedulerConfig, SoftGuardrails,
+    AgentDefaults, AgentModelDefault, AppConfigStore, AutopilotActionId, AutopilotEventId,
+    AutopilotRule, AutopilotSettings, ChatSettings, GitMergeMethod, GitProviderConfig,
+    GitProviderRepository, GitTargetBranch, GlobalConfig, GlobalGitConfig, HookSet, KanbanSettings,
+    OpencodeStartupReadinessConfig, PromptOverride, PromptOverrides, RepoConfig,
+    RepoDevServerScript, RepoGitConfig, RuntimeConfig, RuntimeConfigStore, SchedulerConfig,
+    SoftGuardrails,
 };
 pub use git::GitCliPort;
 pub use process::{

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -133,13 +133,14 @@ pub async fn workspace_detect_github_repository(
 pub async fn workspace_get_settings_snapshot(
     state: State<'_, AppState>,
 ) -> Result<SettingsSnapshotResponsePayload, String> {
-    let (theme, git, chat, kanban, repos, global_prompt_overrides) =
+    let (theme, git, chat, kanban, autopilot, repos, global_prompt_overrides) =
         as_error(state.service.workspace_get_settings_snapshot())?;
     Ok(SettingsSnapshotResponsePayload {
         theme,
         git,
         chat,
         kanban,
+        autopilot,
         repos,
         global_prompt_overrides,
     })
@@ -171,6 +172,7 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
         git,
         chat,
         kanban,
+        autopilot,
         repos,
         global_prompt_overrides,
     } = snapshot;
@@ -185,6 +187,7 @@ pub async fn workspace_save_settings_snapshot<R: tauri::Runtime>(
                     git,
                     chat,
                     kanban,
+                    autopilot,
                     repos,
                     global_prompt_overrides,
                 },
@@ -749,7 +752,7 @@ mod tests {
             Some(false),
         );
 
-        let (theme, git, chat, kanban, repos, global_prompt_overrides) = fixture
+        let (theme, git, chat, kanban, autopilot, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -758,6 +761,7 @@ mod tests {
             git,
             chat,
             kanban,
+            autopilot,
             repos,
             global_prompt_overrides,
         };
@@ -800,7 +804,7 @@ mod tests {
             Some(true),
         );
 
-        let (theme, git, chat, kanban, repos, global_prompt_overrides) = fixture
+        let (theme, git, chat, kanban, autopilot, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -809,6 +813,7 @@ mod tests {
             git,
             chat,
             kanban,
+            autopilot,
             repos,
             global_prompt_overrides,
         };
@@ -933,7 +938,7 @@ mod tests {
         let fixture =
             setup_workspace_command_fixture("snapshot-ipc-shared-prompts", HookSet::default());
 
-        let (theme, git, chat, kanban, repos, global_prompt_overrides) = fixture
+        let (theme, git, chat, kanban, autopilot, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -942,6 +947,7 @@ mod tests {
             git,
             chat,
             kanban,
+            autopilot,
             repos,
             global_prompt_overrides,
         };
@@ -992,6 +998,7 @@ mod tests {
                 "git": snapshot.git,
                 "chat": snapshot.chat,
                 "kanban": snapshot.kanban,
+                "autopilot": snapshot.autopilot,
                 "repos": snapshot.repos,
                 "globalPromptOverrides": snapshot.global_prompt_overrides,
             }
@@ -1012,6 +1019,7 @@ mod tests {
             _persisted_git,
             persisted_chat,
             _persisted_kanban,
+            _persisted_autopilot,
             persisted_repos,
             persisted_global,
         ) = fixture
@@ -1057,7 +1065,7 @@ mod tests {
     fn workspace_get_settings_snapshot_returns_defaulted_chat_settings() -> Result<(), String> {
         let fixture = setup_workspace_command_fixture("snapshot-default-chat", HookSet::default());
 
-        let (_theme, _git, chat, kanban, _repos, _global_prompt_overrides) = fixture
+        let (_theme, _git, chat, kanban, _autopilot, _repos, _global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -1073,7 +1081,7 @@ mod tests {
         let fixture =
             setup_workspace_command_fixture("snapshot-chat-roundtrip", HookSet::default());
 
-        let (theme, git, _chat, kanban, repos, global_prompt_overrides) = fixture
+        let (theme, git, _chat, kanban, autopilot, repos, global_prompt_overrides) = fixture
             .service
             .workspace_get_settings_snapshot()
             .map_err(|error| error.to_string())?;
@@ -1083,6 +1091,7 @@ mod tests {
                 "theme": theme.clone(),
                 "git": git.clone(),
                 "kanban": kanban.clone(),
+                "autopilot": autopilot.clone(),
                 "repos": repos.clone(),
                 "globalPromptOverrides": global_prompt_overrides.clone(),
             }
@@ -1102,6 +1111,7 @@ mod tests {
                     "showThinkingMessages": true
                 },
                 "kanban": kanban,
+                "autopilot": autopilot,
                 "repos": repos,
                 "globalPromptOverrides": global_prompt_overrides,
             }
@@ -1114,6 +1124,7 @@ mod tests {
             _reloaded_git,
             reloaded_chat,
             _reloaded_kanban,
+            _reloaded_autopilot,
             _reloaded_repos,
             _reloaded_global,
         ) = fixture

--- a/apps/desktop/src-tauri/src/headless.rs
+++ b/apps/desktop/src-tauri/src/headless.rs
@@ -1190,7 +1190,7 @@ fn handle_workspace_update_repo_hooks(state: &HeadlessState, args: Value) -> Com
 }
 
 fn handle_workspace_get_settings_snapshot(state: &HeadlessState) -> CommandResult {
-    let (theme, git, chat, kanban, repos, global_prompt_overrides) = state
+    let (theme, git, chat, kanban, autopilot, repos, global_prompt_overrides) = state
         .service
         .workspace_get_settings_snapshot()
         .map_err(service_error)?;
@@ -1199,6 +1199,7 @@ fn handle_workspace_get_settings_snapshot(state: &HeadlessState) -> CommandResul
         git,
         chat,
         kanban,
+        autopilot,
         repos,
         global_prompt_overrides,
     })
@@ -1230,6 +1231,7 @@ async fn handle_workspace_save_settings_snapshot(
         git,
         chat,
         kanban,
+        autopilot,
         repos,
         global_prompt_overrides,
     } = snapshot;
@@ -1241,6 +1243,7 @@ async fn handle_workspace_save_settings_snapshot(
                     git,
                     chat,
                     kanban,
+                    autopilot,
                     repos,
                     global_prompt_overrides,
                 },

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -157,6 +157,7 @@ pub(crate) struct SettingsSnapshotPayload {
     git: host_infra_system::GlobalGitConfig,
     chat: host_infra_system::ChatSettings,
     kanban: host_infra_system::KanbanSettings,
+    autopilot: host_infra_system::AutopilotSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
     global_prompt_overrides: host_infra_system::PromptOverrides,
 }
@@ -168,6 +169,7 @@ pub(crate) struct SettingsSnapshotResponsePayload {
     git: host_infra_system::GlobalGitConfig,
     chat: host_infra_system::ChatSettings,
     kanban: host_infra_system::KanbanSettings,
+    autopilot: host_infra_system::AutopilotSettings,
     repos: HashMap<String, host_infra_system::RepoConfig>,
     global_prompt_overrides: host_infra_system::PromptOverrides,
 }

--- a/apps/desktop/src/components/features/settings/settings-autopilot-section.tsx
+++ b/apps/desktop/src/components/features/settings/settings-autopilot-section.tsx
@@ -1,0 +1,92 @@
+import type { AutopilotSettings } from "@openducktor/contracts";
+import type { ReactElement } from "react";
+import { Combobox } from "@/components/ui/combobox";
+import { Label } from "@/components/ui/label";
+import {
+  AUTOPILOT_ACTION_DEFINITIONS,
+  AUTOPILOT_DISABLED_VALUE,
+  AUTOPILOT_EVENT_DEFINITIONS,
+  type AutopilotSelectValue,
+  getAutopilotRule,
+  getAutopilotSelectedValue,
+  setAutopilotRuleAction,
+} from "@/features/autopilot/autopilot-catalog";
+
+type SettingsAutopilotSectionProps = {
+  autopilot: AutopilotSettings;
+  disabled: boolean;
+  onUpdateAutopilot: (updater: (current: AutopilotSettings) => AutopilotSettings) => void;
+};
+
+export function SettingsAutopilotSection({
+  autopilot,
+  disabled,
+  onUpdateAutopilot,
+}: SettingsAutopilotSectionProps): ReactElement {
+  return (
+    <div className="grid gap-4 p-4">
+      <div className="space-y-2">
+        <h3 className="text-sm font-semibold text-foreground">Autopilot</h3>
+        <p className="text-xs text-muted-foreground">
+          Automatically start workflow actions when task transitions are observed while the app is
+          running.
+        </p>
+      </div>
+
+      <div className="grid gap-3 rounded-md border border-border bg-card p-4">
+        {AUTOPILOT_EVENT_DEFINITIONS.map((eventDefinition) => {
+          const rule = getAutopilotRule(autopilot, eventDefinition.id);
+          const selectedValue = getAutopilotSelectedValue(rule);
+          const options = [
+            {
+              value: AUTOPILOT_DISABLED_VALUE,
+              label: "Disabled",
+              description: "Do not trigger an automatic workflow action for this event.",
+            },
+            ...eventDefinition.availableActionIds.map((actionId) => ({
+              value: actionId,
+              label: AUTOPILOT_ACTION_DEFINITIONS[actionId].label,
+              description: AUTOPILOT_ACTION_DEFINITIONS[actionId].description,
+            })),
+          ];
+
+          return (
+            <div
+              key={eventDefinition.id}
+              className="grid gap-3 rounded-md border border-border/70 bg-muted/40 p-3 lg:grid-cols-[minmax(0,1fr)_280px] lg:items-start"
+            >
+              <div className="space-y-1">
+                <Label className="text-sm font-medium text-foreground">
+                  {eventDefinition.label}
+                </Label>
+                <p className="text-xs text-muted-foreground">{eventDefinition.description}</p>
+              </div>
+              <Combobox
+                value={selectedValue}
+                options={options}
+                disabled={disabled}
+                placeholder="Select an action"
+                searchPlaceholder="Search actions..."
+                triggerClassName="justify-between"
+                onValueChange={(value) => {
+                  onUpdateAutopilot((current) =>
+                    setAutopilotRuleAction(
+                      current,
+                      eventDefinition.id,
+                      value as AutopilotSelectValue,
+                    ),
+                  );
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="rounded-md border border-border bg-muted/60 p-3 text-xs text-muted-foreground">
+        Autopilot only reacts to transitions observed during this app session and never replays
+        missed events from while the app was closed.
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/features/settings/settings-modal-constants.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-constants.ts
@@ -2,6 +2,7 @@ import type { AgentPromptTemplateId } from "@openducktor/contracts";
 import { agentPromptTemplateIdValues } from "@openducktor/contracts";
 import { listBuiltinAgentPromptTemplates } from "@openducktor/core";
 import {
+  Bot,
   FolderGit2,
   LayoutGrid,
   type LucideIcon,
@@ -10,7 +11,14 @@ import {
   SlidersHorizontal,
 } from "lucide-react";
 
-export type SettingsSectionId = "general" | "git" | "repositories" | "prompts" | "chat" | "kanban";
+export type SettingsSectionId =
+  | "general"
+  | "git"
+  | "repositories"
+  | "prompts"
+  | "chat"
+  | "kanban"
+  | "autopilot";
 export type RepositorySectionId = "configuration" | "git" | "agents" | "prompts";
 export type PromptRoleTabId = "shared" | "spec" | "planner" | "build" | "qa";
 
@@ -27,6 +35,7 @@ export const SETTINGS_SECTIONS: ReadonlyArray<{
   { id: "prompts", label: "Prompts", icon: MessageSquareText },
   { id: "chat", label: "Chat", icon: MessageSquare },
   { id: "kanban", label: "Kanban", icon: LayoutGrid },
+  { id: "autopilot", label: "Autopilot", icon: Bot },
 ];
 
 export const REPOSITORY_SECTIONS: ReadonlyArray<{

--- a/apps/desktop/src/components/features/settings/settings-modal-constants.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-constants.ts
@@ -2,13 +2,13 @@ import type { AgentPromptTemplateId } from "@openducktor/contracts";
 import { agentPromptTemplateIdValues } from "@openducktor/contracts";
 import { listBuiltinAgentPromptTemplates } from "@openducktor/core";
 import {
-  Bot,
+  Columns3,
   FolderGit2,
-  LayoutGrid,
   type LucideIcon,
   MessageSquare,
   MessageSquareText,
   SlidersHorizontal,
+  Workflow,
 } from "lucide-react";
 
 export type SettingsSectionId =
@@ -34,8 +34,8 @@ export const SETTINGS_SECTIONS: ReadonlyArray<{
   { id: "repositories", label: "Repositories", icon: FolderGit2 },
   { id: "prompts", label: "Prompts", icon: MessageSquareText },
   { id: "chat", label: "Chat", icon: MessageSquare },
-  { id: "kanban", label: "Kanban", icon: LayoutGrid },
-  { id: "autopilot", label: "Autopilot", icon: Bot },
+  { id: "kanban", label: "Kanban", icon: Columns3 },
+  { id: "autopilot", label: "Autopilot", icon: Workflow },
 ];
 
 export const REPOSITORY_SECTIONS: ReadonlyArray<{

--- a/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-content.test.tsx
@@ -9,6 +9,7 @@ const createMockSnapshot = (overrides: Partial<SettingsSnapshot> = {}): Settings
   git: { defaultMergeMethod: "merge_commit" },
   chat: { showThinkingMessages: false },
   kanban: { doneVisibleDays: 1 },
+  autopilot: { rules: [] },
   repos: {},
   globalPromptOverrides: {},
   ...overrides,
@@ -62,6 +63,7 @@ const createMockController = (snapshot: SettingsSnapshot) => ({
     prompts: 0,
     chat: 0,
     kanban: 0,
+    autopilot: 0,
   },
   setSelectedRepoPath: () => {},
   markRepoScriptSaveAttempt: () => {},
@@ -71,6 +73,7 @@ const createMockController = (snapshot: SettingsSnapshot) => ({
   updateGlobalGitConfig: () => {},
   updateGlobalChatSettings: () => {},
   updateGlobalKanbanSettings: () => {},
+  updateGlobalAutopilotSettings: () => {},
   updateGlobalPromptOverrides: () => {},
   updateRepoPromptOverrides: () => {},
   updateSelectedRepoAgentDefault: () => {},
@@ -144,6 +147,28 @@ describe("settings modal content", () => {
     );
 
     expect(html).toContain("General Settings");
+  });
+
+  test("renders autopilot section when section is autopilot", () => {
+    const snapshot = createMockSnapshot();
+    const controller = createMockController(snapshot);
+
+    const html = renderToStaticMarkup(
+      createElement(SettingsModalContent, {
+        section: "autopilot",
+        repositorySection: "configuration",
+        globalPromptRoleTab: "shared",
+        repoPromptRoleTab: "shared",
+        isInteractionDisabled: false,
+        controller,
+        onRepositorySectionChange: () => {},
+        onGlobalPromptRoleTabChange: () => {},
+        onRepoPromptRoleTabChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Autopilot");
+    expect(html).toContain("When a task progresses to Spec Ready");
   });
 
   test("renders prompts section when section is prompts", () => {

--- a/apps/desktop/src/components/features/settings/settings-modal-content.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-content.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { SettingsAutopilotSection } from "./settings-autopilot-section";
 import { SettingsChatSection } from "./settings-chat-section";
 import { GeneralSettingsSection } from "./settings-general-section";
 import { SettingsGitSection } from "./settings-git-section";
@@ -72,6 +73,7 @@ export function SettingsModalContent({
     updateGlobalGitConfig,
     updateGlobalChatSettings,
     updateGlobalKanbanSettings,
+    updateGlobalAutopilotSettings,
     updateGlobalPromptOverrides,
     updateRepoPromptOverrides,
     updateSelectedRepoAgentDefault,
@@ -150,6 +152,16 @@ export function SettingsModalContent({
         kanban={snapshotDraft.kanban}
         disabled={isInteractionDisabled}
         onUpdateKanban={updateGlobalKanbanSettings}
+      />
+    );
+  }
+
+  if (section === "autopilot") {
+    return (
+      <SettingsAutopilotSection
+        autopilot={snapshotDraft.autopilot}
+        disabled={isInteractionDisabled}
+        onUpdateAutopilot={updateGlobalAutopilotSettings}
       />
     );
   }

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
@@ -6,6 +6,7 @@ import {
   type RepoPromptOverrides,
 } from "@openducktor/contracts";
 import {
+  normalizeAutopilotSettingsForSave,
   normalizePromptOverridesForSave,
   normalizeRepoConfigForSave,
   normalizeSnapshotForSave,
@@ -194,6 +195,29 @@ describe("settings-modal-normalization", () => {
     expect(normalized.trustedHooksFingerprint).toBe("fingerprint");
   });
 
+  test("normalizes autopilot settings into canonical event order", () => {
+    const normalized = normalizeAutopilotSettingsForSave({
+      rules: [
+        {
+          eventId: "taskProgressedToHumanReview",
+          actionIds: ["startGeneratePullRequest", "startGeneratePullRequest"],
+        },
+        {
+          eventId: "taskProgressedToSpecReady",
+          actionIds: ["startSpec", "startSpec"],
+        },
+      ],
+    });
+
+    expect(normalized.rules).toEqual([
+      { eventId: "taskProgressedToSpecReady", actionIds: ["startSpec"] },
+      { eventId: "taskProgressedToReadyForDev", actionIds: [] },
+      { eventId: "taskProgressedToAiReview", actionIds: [] },
+      { eventId: "taskRejectedByQa", actionIds: [] },
+      { eventId: "taskProgressedToHumanReview", actionIds: ["startGeneratePullRequest"] },
+    ]);
+  });
+
   test("disables trusted hooks when no hook commands remain after normalization", () => {
     const normalized = normalizeRepoConfigForSave({
       ...createRepoConfig(),
@@ -280,6 +304,9 @@ describe("settings-modal-normalization", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {
         "/repo-a": createRepoConfig(),
       },
@@ -324,6 +351,9 @@ describe("settings-modal-normalization", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {
         "/repo-b": createRepoConfig(),
         "/repo-a": createRepoConfig(),
@@ -345,6 +375,9 @@ describe("settings-modal-normalization", () => {
           },
           kanban: {
             doneVisibleDays: 1,
+          },
+          autopilot: {
+            rules: [],
           },
           repos: {},
           globalPromptOverrides: {},

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
@@ -218,6 +218,22 @@ describe("settings-modal-normalization", () => {
     ]);
   });
 
+  test("preserves explicit empty autopilot actions for a configured event", () => {
+    const normalized = normalizeAutopilotSettingsForSave({
+      rules: [
+        {
+          eventId: "taskProgressedToSpecReady",
+          actionIds: [],
+        },
+      ],
+    });
+
+    expect(normalized.rules[0]).toEqual({
+      eventId: "taskProgressedToSpecReady",
+      actionIds: [],
+    });
+  });
+
   test("disables trusted hooks when no hook commands remain after normalization", () => {
     const normalized = normalizeRepoConfigForSave({
       ...createRepoConfig(),

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.test.ts
@@ -204,13 +204,13 @@ describe("settings-modal-normalization", () => {
         },
         {
           eventId: "taskProgressedToSpecReady",
-          actionIds: ["startSpec", "startSpec"],
+          actionIds: ["startPlanner", "startPlanner"],
         },
       ],
     });
 
     expect(normalized.rules).toEqual([
-      { eventId: "taskProgressedToSpecReady", actionIds: ["startSpec"] },
+      { eventId: "taskProgressedToSpecReady", actionIds: ["startPlanner"] },
       { eventId: "taskProgressedToReadyForDev", actionIds: [] },
       { eventId: "taskProgressedToAiReview", actionIds: [] },
       { eventId: "taskRejectedByQa", actionIds: [] },

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
@@ -1,14 +1,19 @@
 import type {
   AgentPromptTemplateId,
+  AutopilotActionId,
+  AutopilotEventId,
+  AutopilotSettings,
   GlobalGitConfig,
   RepoConfig,
   RepoPromptOverrides,
   SettingsSnapshot,
 } from "@openducktor/contracts";
 import {
+  AUTOPILOT_EVENT_IDS,
+  createDefaultAutopilotSettings,
   DEFAULT_BRANCH_PREFIX,
-  normalizeRepoScriptsWithTrust,
-} from "@/components/features/settings/settings-model";
+} from "@openducktor/contracts";
+import { normalizeRepoScriptsWithTrust } from "@/components/features/settings/settings-model";
 import { normalizeTargetBranch } from "@/lib/target-branch";
 import { DEFAULT_RUNTIME_KIND } from "@/state/agent-runtime-registry";
 
@@ -104,6 +109,31 @@ export const normalizeGlobalGitConfigForSave = (git: GlobalGitConfig): GlobalGit
   defaultMergeMethod: git.defaultMergeMethod,
 });
 
+export const normalizeAutopilotSettingsForSave = (
+  autopilot: AutopilotSettings,
+): AutopilotSettings => {
+  const defaultSettings = createDefaultAutopilotSettings();
+  const rulesByEvent = new Map<AutopilotEventId, AutopilotSettings["rules"][number]>(
+    autopilot.rules.map((rule) => [rule.eventId, rule]),
+  );
+
+  return {
+    rules: AUTOPILOT_EVENT_IDS.map((eventId) => {
+      const actionIds = (rulesByEvent.get(eventId)?.actionIds ?? []).filter(
+        (actionId, index, list) => list.indexOf(actionId) === index,
+      ) as AutopilotActionId[];
+
+      return {
+        eventId,
+        actionIds:
+          actionIds.length > 0
+            ? actionIds
+            : (defaultSettings.rules.find((rule) => rule.eventId === eventId)?.actionIds ?? []),
+      };
+    }),
+  };
+};
+
 export const normalizeSnapshotForSave = (snapshot: SettingsSnapshot): SettingsSnapshot => {
   const repos = Object.fromEntries(
     Object.entries(snapshot.repos).map(([repoPath, repoConfig]) => [
@@ -117,6 +147,7 @@ export const normalizeSnapshotForSave = (snapshot: SettingsSnapshot): SettingsSn
     git: normalizeGlobalGitConfigForSave(snapshot.git),
     chat: snapshot.chat,
     kanban: snapshot.kanban,
+    autopilot: normalizeAutopilotSettingsForSave(snapshot.autopilot),
     repos,
     globalPromptOverrides: normalizePromptOverridesForSave(snapshot.globalPromptOverrides),
   };

--- a/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
+++ b/apps/desktop/src/components/features/settings/settings-modal-normalization.ts
@@ -119,16 +119,16 @@ export const normalizeAutopilotSettingsForSave = (
 
   return {
     rules: AUTOPILOT_EVENT_IDS.map((eventId) => {
-      const actionIds = (rulesByEvent.get(eventId)?.actionIds ?? []).filter(
+      const explicitRule = rulesByEvent.get(eventId);
+      const actionIds = (explicitRule?.actionIds ?? []).filter(
         (actionId, index, list) => list.indexOf(actionId) === index,
       ) as AutopilotActionId[];
 
       return {
         eventId,
-        actionIds:
-          actionIds.length > 0
-            ? actionIds
-            : (defaultSettings.rules.find((rule) => rule.eventId === eventId)?.actionIds ?? []),
+        actionIds: explicitRule
+          ? actionIds
+          : (defaultSettings.rules.find((rule) => rule.eventId === eventId)?.actionIds ?? []),
       };
     }),
   };

--- a/apps/desktop/src/components/features/settings/settings-modal-sidebars.test.tsx
+++ b/apps/desktop/src/components/features/settings/settings-modal-sidebars.test.tsx
@@ -12,6 +12,7 @@ describe("settings modal sidebars", () => {
       prompts: 0,
       chat: 0,
       kanban: 0,
+      autopilot: 0,
     };
 
     const html = renderToStaticMarkup(
@@ -29,6 +30,7 @@ describe("settings modal sidebars", () => {
     expect(html).toContain("Prompts");
     expect(html).toContain("Chat");
     expect(html).toContain("Kanban");
+    expect(html).toContain("Autopilot");
   });
 
   test("renders chat section as active when selected", () => {
@@ -39,6 +41,7 @@ describe("settings modal sidebars", () => {
       prompts: 0,
       chat: 0,
       kanban: 0,
+      autopilot: 0,
     };
 
     const html = renderToStaticMarkup(
@@ -62,6 +65,7 @@ describe("settings modal sidebars", () => {
       prompts: 0,
       chat: 0,
       kanban: 0,
+      autopilot: 0,
     };
 
     const html = renderToStaticMarkup(
@@ -85,6 +89,7 @@ describe("settings modal sidebars", () => {
       prompts: 0,
       chat: 2,
       kanban: 0,
+      autopilot: 0,
     };
 
     const html = renderToStaticMarkup(

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.test.tsx
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
-import type { SettingsSnapshot } from "@openducktor/contracts";
+import { createDefaultAutopilotSettings, type SettingsSnapshot } from "@openducktor/contracts";
 import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
@@ -19,6 +19,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
   kanban: {
     doneVisibleDays: 1,
   },
+  autopilot: createDefaultAutopilotSettings(),
   repos: {
     "/repo": {
       defaultRuntimeKind: "opencode",
@@ -29,6 +30,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
         providers: {},
       },
       trustedHooks: false,
+      trustedHooksFingerprint: undefined,
       hooks: { preStart: [], postComplete: [] },
       devServers: [],
       worktreeFileCopies: [],

--- a/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-controller.ts
@@ -37,6 +37,7 @@ type DirtySections = {
   chat: boolean;
   globalGit: boolean;
   kanban: boolean;
+  autopilot: boolean;
   globalPromptOverrides: boolean;
   repoSettings: boolean;
 };
@@ -45,6 +46,7 @@ const EMPTY_DIRTY_SECTIONS: DirtySections = {
   chat: false,
   globalGit: false,
   kanban: false,
+  autopilot: false,
   globalPromptOverrides: false,
   repoSettings: false,
 };
@@ -97,6 +99,9 @@ export type SettingsModalController = {
   ) => void;
   updateGlobalKanbanSettings: (
     updater: (current: SettingsSnapshot["kanban"]) => SettingsSnapshot["kanban"],
+  ) => void;
+  updateGlobalAutopilotSettings: (
+    updater: (current: SettingsSnapshot["autopilot"]) => SettingsSnapshot["autopilot"],
   ) => void;
   updateGlobalPromptOverrides: (
     updater: (current: RepoPromptOverrides) => RepoPromptOverrides,
@@ -197,6 +202,7 @@ export const useSettingsModalController = ({
     updateGlobalGitConfig: applyGlobalGitConfigUpdate,
     updateGlobalChatSettings: applyGlobalChatSettingsUpdate,
     updateGlobalKanbanSettings: applyGlobalKanbanSettingsUpdate,
+    updateGlobalAutopilotSettings: applyGlobalAutopilotSettingsUpdate,
     updateGlobalPromptOverrides: applyGlobalPromptOverridesUpdate,
     updateRepoPromptOverrides: applyRepoPromptOverridesUpdate,
     updateSelectedRepoAgentDefault: applySelectedRepoAgentDefaultUpdate,
@@ -317,6 +323,14 @@ export const useSettingsModalController = ({
       applyGlobalPromptOverridesUpdate(updater);
     },
     [applyGlobalPromptOverridesUpdate, markDirty],
+  );
+
+  const updateGlobalAutopilotSettings = useCallback(
+    (updater: (current: SettingsSnapshot["autopilot"]) => SettingsSnapshot["autopilot"]): void => {
+      markDirty("autopilot");
+      applyGlobalAutopilotSettingsUpdate(updater);
+    },
+    [applyGlobalAutopilotSettingsUpdate, markDirty],
   );
 
   const updateRepoPromptOverrides = useCallback(
@@ -467,6 +481,7 @@ export const useSettingsModalController = ({
         !dirtySections.chat &&
         !dirtySections.globalGit &&
         !dirtySections.kanban &&
+        !dirtySections.autopilot &&
         !dirtySections.globalPromptOverrides &&
         !dirtySections.repoSettings
       ) {
@@ -477,6 +492,7 @@ export const useSettingsModalController = ({
         dirtySections.globalGit &&
         !dirtySections.chat &&
         !dirtySections.kanban &&
+        !dirtySections.autopilot &&
         !dirtySections.globalPromptOverrides &&
         !dirtySections.repoSettings;
 
@@ -510,6 +526,7 @@ export const useSettingsModalController = ({
     dirtySections.chat,
     dirtySections.globalGit,
     dirtySections.kanban,
+    dirtySections.autopilot,
     dirtySections.globalPromptOverrides,
     dirtySections.repoSettings,
     hasPromptValidationErrors,
@@ -567,6 +584,7 @@ export const useSettingsModalController = ({
     updateGlobalGitConfig,
     updateGlobalChatSettings,
     updateGlobalKanbanSettings,
+    updateGlobalAutopilotSettings,
     updateGlobalPromptOverrides,
     updateRepoPromptOverrides,
     updateSelectedRepoAgentDefault,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.test.tsx
@@ -25,6 +25,9 @@ const createInitialSnapshot = (): SettingsSnapshot => ({
   kanban: {
     doneVisibleDays: 1,
   },
+  autopilot: {
+    rules: [],
+  },
   globalPromptOverrides: {},
   repos: {
     "/repo-a": {

--- a/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-draft-actions.ts
@@ -22,6 +22,9 @@ type SettingsModalDraftActions = {
   updateGlobalKanbanSettings: (
     updater: (current: SettingsSnapshot["kanban"]) => SettingsSnapshot["kanban"],
   ) => void;
+  updateGlobalAutopilotSettings: (
+    updater: (current: SettingsSnapshot["autopilot"]) => SettingsSnapshot["autopilot"],
+  ) => void;
   updateGlobalPromptOverrides: (
     updater: (current: RepoPromptOverrides) => RepoPromptOverrides,
   ) => void;
@@ -128,6 +131,22 @@ export const useSettingsModalDraftActions = ({
     [setSnapshotDraft],
   );
 
+  const updateGlobalAutopilotSettings = useCallback(
+    (updater: (current: SettingsSnapshot["autopilot"]) => SettingsSnapshot["autopilot"]): void => {
+      setSnapshotDraft((current) => {
+        if (!current) {
+          return current;
+        }
+
+        return {
+          ...current,
+          autopilot: updater(current.autopilot),
+        };
+      });
+    },
+    [setSnapshotDraft],
+  );
+
   const updateRepoPromptOverrides = useCallback(
     (updater: (current: RepoPromptOverrides) => RepoPromptOverrides): void => {
       updateSelectedRepoConfig((repoConfig) => ({
@@ -176,6 +195,7 @@ export const useSettingsModalDraftActions = ({
     updateGlobalGitConfig,
     updateGlobalChatSettings,
     updateGlobalKanbanSettings,
+    updateGlobalAutopilotSettings,
     updateGlobalPromptOverrides,
     updateRepoPromptOverrides,
     updateSelectedRepoAgentDefault,

--- a/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.test.tsx
@@ -24,6 +24,9 @@ const createSnapshot = (): SettingsSnapshot => ({
   kanban: {
     doneVisibleDays: 1,
   },
+  autopilot: {
+    rules: [],
+  },
   globalPromptOverrides: {
     "system.scenario.spec_initial": {
       template: "invalid {{task.bad}}",
@@ -90,6 +93,7 @@ describe("useSettingsModalPromptValidation", () => {
       prompts: 0,
       chat: 0,
       kanban: 0,
+      autopilot: 0,
     });
 
     await harness.unmount();
@@ -117,6 +121,7 @@ describe("useSettingsModalPromptValidation", () => {
       prompts: 1,
       chat: 0,
       kanban: 0,
+      autopilot: 0,
     });
     expect(latest.selectedRepoPromptValidationErrors["kickoff.build_implementation_start"]).toBe(
       "Unsupported placeholder: {{unknown.value}}.",

--- a/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.ts
+++ b/apps/desktop/src/components/features/settings/use-settings-modal-prompt-validation.ts
@@ -93,6 +93,7 @@ export const useSettingsModalPromptValidation = ({
     prompts: promptValidationState.globalErrorCount,
     chat: 0,
     kanban: 0,
+    autopilot: 0,
   };
 
   return {

--- a/apps/desktop/src/features/autopilot/autopilot-catalog.test.ts
+++ b/apps/desktop/src/features/autopilot/autopilot-catalog.test.ts
@@ -54,4 +54,25 @@ describe("autopilot-catalog", () => {
       settings,
     );
   });
+
+  test("preserves default-backed rules when updating a partial settings payload", () => {
+    const nextSettings = setAutopilotRuleAction(
+      {
+        rules: [
+          {
+            eventId: "taskProgressedToSpecReady",
+            actionIds: ["startPlanner"],
+          },
+        ],
+      },
+      "taskProgressedToSpecReady",
+      "startBuilder",
+    );
+
+    expect(nextSettings.rules).toHaveLength(5);
+    expect(nextSettings.rules[1]).toEqual({
+      eventId: "taskProgressedToReadyForDev",
+      actionIds: [],
+    });
+  });
 });

--- a/apps/desktop/src/features/autopilot/autopilot-catalog.test.ts
+++ b/apps/desktop/src/features/autopilot/autopilot-catalog.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import type { AutopilotSettings } from "@openducktor/contracts";
+import { getAutopilotSelectedValue, setAutopilotRuleAction } from "./autopilot-catalog";
+
+const createAutopilotSettings = (): AutopilotSettings => ({
+  rules: [
+    {
+      eventId: "taskProgressedToSpecReady",
+      actionIds: ["startPlanner", "startBuilder"],
+    },
+    {
+      eventId: "taskProgressedToReadyForDev",
+      actionIds: [],
+    },
+    {
+      eventId: "taskProgressedToAiReview",
+      actionIds: [],
+    },
+    {
+      eventId: "taskRejectedByQa",
+      actionIds: [],
+    },
+    {
+      eventId: "taskProgressedToHumanReview",
+      actionIds: [],
+    },
+  ],
+});
+
+describe("autopilot-catalog", () => {
+  test("preserves secondary actions when updating the selected action", () => {
+    const nextSettings = setAutopilotRuleAction(
+      createAutopilotSettings(),
+      "taskProgressedToSpecReady",
+      "startBuilder",
+    );
+
+    expect(nextSettings.rules[0]).toEqual({
+      eventId: "taskProgressedToSpecReady",
+      actionIds: ["startBuilder", "startPlanner"],
+    });
+    const updatedRule = nextSettings.rules[0];
+    expect(updatedRule).toBeDefined();
+    if (!updatedRule) {
+      throw new Error("Expected spec-ready Autopilot rule to exist.");
+    }
+    expect(getAutopilotSelectedValue(updatedRule)).toBe("startBuilder");
+  });
+
+  test("returns the original settings object when the selected action is unchanged", () => {
+    const settings = createAutopilotSettings();
+
+    expect(setAutopilotRuleAction(settings, "taskProgressedToSpecReady", "startPlanner")).toBe(
+      settings,
+    );
+  });
+});

--- a/apps/desktop/src/features/autopilot/autopilot-catalog.ts
+++ b/apps/desktop/src/features/autopilot/autopilot-catalog.ts
@@ -120,30 +120,49 @@ export const getAutopilotSelectedValue = (rule: AutopilotRule): AutopilotSelectV
   return rule.actionIds[0] ?? AUTOPILOT_DISABLED_VALUE;
 };
 
+const hasSameActionIds = (
+  left: AutopilotRule["actionIds"],
+  right: AutopilotRule["actionIds"],
+): boolean => {
+  return left.length === right.length && left.every((actionId, index) => actionId === right[index]);
+};
+
 export const setAutopilotRuleAction = (
   settings: AutopilotSettings,
   eventId: AutopilotEventId,
   value: AutopilotSelectValue,
 ): AutopilotSettings => {
-  const nextSettings = createDefaultAutopilotSettings();
   const currentRulesByEvent = new Map<AutopilotEventId, AutopilotRule>(
     settings.rules.map((rule) => [rule.eventId, rule]),
   );
+  let hasChanged = false;
 
-  nextSettings.rules = AUTOPILOT_EVENT_IDS.map((id) => {
+  const rules = AUTOPILOT_EVENT_IDS.map((id) => {
     const currentRule = currentRulesByEvent.get(id) ?? { eventId: id, actionIds: [] };
-    if (id !== eventId) {
-      return {
-        eventId: id,
-        actionIds: [...currentRule.actionIds],
-      };
+    if (!currentRulesByEvent.has(id)) {
+      hasChanged = true;
     }
+
+    if (id !== eventId) {
+      return currentRule;
+    }
+
+    const nextActionIds =
+      value === AUTOPILOT_DISABLED_VALUE
+        ? []
+        : [value, ...currentRule.actionIds.filter((actionId) => actionId !== value)];
+
+    if (hasSameActionIds(currentRule.actionIds, nextActionIds)) {
+      return currentRule;
+    }
+
+    hasChanged = true;
 
     return {
       eventId: id,
-      actionIds: value === AUTOPILOT_DISABLED_VALUE ? [] : [value],
+      actionIds: nextActionIds,
     };
   });
 
-  return nextSettings;
+  return hasChanged ? { ...settings, rules } : settings;
 };

--- a/apps/desktop/src/features/autopilot/autopilot-catalog.ts
+++ b/apps/desktop/src/features/autopilot/autopilot-catalog.ts
@@ -132,13 +132,17 @@ export const setAutopilotRuleAction = (
   eventId: AutopilotEventId,
   value: AutopilotSelectValue,
 ): AutopilotSettings => {
+  const defaultRulesByEvent = new Map<AutopilotEventId, AutopilotRule>(
+    createDefaultAutopilotSettings().rules.map((rule) => [rule.eventId, rule]),
+  );
   const currentRulesByEvent = new Map<AutopilotEventId, AutopilotRule>(
     settings.rules.map((rule) => [rule.eventId, rule]),
   );
   let hasChanged = false;
 
   const rules = AUTOPILOT_EVENT_IDS.map((id) => {
-    const currentRule = currentRulesByEvent.get(id) ?? { eventId: id, actionIds: [] };
+    const currentRule = currentRulesByEvent.get(id) ??
+      defaultRulesByEvent.get(id) ?? { eventId: id, actionIds: [] };
     if (!currentRulesByEvent.has(id)) {
       hasChanged = true;
     }

--- a/apps/desktop/src/features/autopilot/autopilot-catalog.ts
+++ b/apps/desktop/src/features/autopilot/autopilot-catalog.ts
@@ -27,12 +27,13 @@ export type AutopilotEventDefinition = {
 };
 
 export const AUTOPILOT_ACTION_DEFINITIONS: Record<AutopilotActionId, AutopilotActionDefinition> = {
-  startSpec: {
-    id: "startSpec",
-    label: "Start Spec",
-    description: "Start or continue the Spec workflow when a task becomes ready for specification.",
-    role: "spec",
-    scenario: "spec_initial",
+  startPlanner: {
+    id: "startPlanner",
+    label: "Start Planner",
+    description:
+      "Start the Planner workflow when a task becomes ready for implementation planning.",
+    role: "planner",
+    scenario: "planner_initial",
   },
   startBuilder: {
     id: "startBuilder",
@@ -69,7 +70,7 @@ export const AUTOPILOT_EVENT_DEFINITIONS: AutopilotEventDefinition[] = [
     id: "taskProgressedToSpecReady",
     label: "When a task progresses to Spec Ready",
     description: "Observed when a task first enters `spec_ready` while the app is running.",
-    availableActionIds: ["startSpec"],
+    availableActionIds: ["startPlanner"],
   },
   {
     id: "taskProgressedToReadyForDev",

--- a/apps/desktop/src/features/autopilot/autopilot-catalog.ts
+++ b/apps/desktop/src/features/autopilot/autopilot-catalog.ts
@@ -1,0 +1,148 @@
+import type {
+  AutopilotActionId,
+  AutopilotEventId,
+  AutopilotRule,
+  AutopilotSettings,
+} from "@openducktor/contracts";
+import { AUTOPILOT_EVENT_IDS, createDefaultAutopilotSettings } from "@openducktor/contracts";
+import type { AgentRole, AgentScenario } from "@openducktor/core";
+
+export const AUTOPILOT_DISABLED_VALUE = "disabled" as const;
+
+export type AutopilotSelectValue = AutopilotActionId | typeof AUTOPILOT_DISABLED_VALUE;
+
+export type AutopilotActionDefinition = {
+  id: AutopilotActionId;
+  label: string;
+  description: string;
+  role: AgentRole;
+  scenario: AgentScenario;
+};
+
+export type AutopilotEventDefinition = {
+  id: AutopilotEventId;
+  label: string;
+  description: string;
+  availableActionIds: AutopilotActionId[];
+};
+
+export const AUTOPILOT_ACTION_DEFINITIONS: Record<AutopilotActionId, AutopilotActionDefinition> = {
+  startSpec: {
+    id: "startSpec",
+    label: "Start Spec",
+    description: "Start or continue the Spec workflow when a task becomes ready for specification.",
+    role: "spec",
+    scenario: "spec_initial",
+  },
+  startBuilder: {
+    id: "startBuilder",
+    label: "Start Builder",
+    description: "Start or continue Builder implementation when planning is complete.",
+    role: "build",
+    scenario: "build_implementation_start",
+  },
+  startQa: {
+    id: "startQa",
+    label: "Start QA",
+    description: "Start or continue QA review once implementation reaches AI review.",
+    role: "qa",
+    scenario: "qa_review",
+  },
+  startReviewQaFeedbacks: {
+    id: "startReviewQaFeedbacks",
+    label: "Start Review QA Feedbacks",
+    description: "Resume Builder to address rejected QA findings at the root cause.",
+    role: "build",
+    scenario: "build_after_qa_rejected",
+  },
+  startGeneratePullRequest: {
+    id: "startGeneratePullRequest",
+    label: "Start Generate Pull Request",
+    description: "Fork from the latest Builder session to generate or update the pull request.",
+    role: "build",
+    scenario: "build_pull_request_generation",
+  },
+};
+
+export const AUTOPILOT_EVENT_DEFINITIONS: AutopilotEventDefinition[] = [
+  {
+    id: "taskProgressedToSpecReady",
+    label: "When a task progresses to Spec Ready",
+    description: "Observed when a task first enters `spec_ready` while the app is running.",
+    availableActionIds: ["startSpec"],
+  },
+  {
+    id: "taskProgressedToReadyForDev",
+    label: "When a task progresses to Ready for Dev",
+    description: "Observed when a task first enters `ready_for_dev` while the app is running.",
+    availableActionIds: ["startBuilder"],
+  },
+  {
+    id: "taskProgressedToAiReview",
+    label: "When a task progresses to AI Review",
+    description: "Observed when a task first enters `ai_review` while the app is running.",
+    availableActionIds: ["startQa"],
+  },
+  {
+    id: "taskRejectedByQa",
+    label: "When a task is rejected by QA",
+    description: "Observed from the canonical QA rejection state while the app is running.",
+    availableActionIds: ["startReviewQaFeedbacks"],
+  },
+  {
+    id: "taskProgressedToHumanReview",
+    label: "When a task progresses to Human Review",
+    description: "Observed when a task first enters `human_review` while the app is running.",
+    availableActionIds: ["startGeneratePullRequest"],
+  },
+];
+
+export const AUTOPILOT_EVENT_DEFINITION_BY_ID: Record<AutopilotEventId, AutopilotEventDefinition> =
+  Object.fromEntries(
+    AUTOPILOT_EVENT_DEFINITIONS.map((definition) => [definition.id, definition]),
+  ) as Record<AutopilotEventId, AutopilotEventDefinition>;
+
+export const getAutopilotRule = (
+  settings: AutopilotSettings,
+  eventId: AutopilotEventId,
+): AutopilotRule => {
+  return (
+    settings.rules.find((rule) => rule.eventId === eventId) ??
+    createDefaultAutopilotSettings().rules.find((rule) => rule.eventId === eventId) ?? {
+      eventId,
+      actionIds: [],
+    }
+  );
+};
+
+export const getAutopilotSelectedValue = (rule: AutopilotRule): AutopilotSelectValue => {
+  return rule.actionIds[0] ?? AUTOPILOT_DISABLED_VALUE;
+};
+
+export const setAutopilotRuleAction = (
+  settings: AutopilotSettings,
+  eventId: AutopilotEventId,
+  value: AutopilotSelectValue,
+): AutopilotSettings => {
+  const nextSettings = createDefaultAutopilotSettings();
+  const currentRulesByEvent = new Map<AutopilotEventId, AutopilotRule>(
+    settings.rules.map((rule) => [rule.eventId, rule]),
+  );
+
+  nextSettings.rules = AUTOPILOT_EVENT_IDS.map((id) => {
+    const currentRule = currentRulesByEvent.get(id) ?? { eventId: id, actionIds: [] };
+    if (id !== eventId) {
+      return {
+        eventId: id,
+        actionIds: [...currentRule.actionIds],
+      };
+    }
+
+    return {
+      eventId: id,
+      actionIds: value === AUTOPILOT_DISABLED_VALUE ? [] : [value],
+    };
+  });
+
+  return nextSettings;
+};

--- a/apps/desktop/src/pages/agents/agent-studio-types.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-types.ts
@@ -1,0 +1,1 @@
+export type NavigateToTask = (taskId: string, options?: { pinSession?: boolean }) => void;

--- a/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-chat-settings.test.tsx
@@ -18,6 +18,9 @@ const hostMock = {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {},
     }),

--- a/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-fresh-session-creation.test.tsx
@@ -102,6 +102,9 @@ beforeEach(() => {
     kanban: {
       doneVisibleDays: 1,
     },
+    autopilot: {
+      rules: [],
+    },
     repos: {},
     globalPromptOverrides: {},
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -196,6 +196,9 @@ describe("useAgentStudioSessionActions", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {},
     });

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-start-flow.test.tsx
@@ -254,6 +254,9 @@ describe("useAgentStudioSessionStartFlow", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {},
     });

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
@@ -3,7 +3,7 @@ import { closeTaskTab } from "./agents-page-session-tabs";
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 
-type NavigateToTask = (taskId: string) => void;
+type NavigateToTask = (taskId: string, options?: { pinSession?: boolean }) => void;
 
 const focusTaskTabTrigger = (taskId: string): void => {
   globalThis.setTimeout(() => {
@@ -86,7 +86,7 @@ export function useTaskTabActions(args: UseTaskTabActionsArgs): UseTaskTabAction
       }
 
       focusTaskTabTrigger(nextActiveTaskId);
-      navigateToTask(nextActiveTaskId);
+      navigateToTask(nextActiveTaskId, { pinSession: true });
     },
     [
       activeTaskTabId,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
@@ -1,9 +1,8 @@
 import { type Dispatch, type SetStateAction, useCallback } from "react";
+import type { NavigateToTask } from "./agent-studio-types";
 import { closeTaskTab } from "./agents-page-session-tabs";
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
-
-type NavigateToTask = (taskId: string, options?: { pinSession?: boolean }) => void;
 
 const focusTaskTabTrigger = (taskId: string): void => {
   globalThis.setTimeout(() => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
@@ -3,7 +3,7 @@ import { ensureActiveTaskTab, resolveFallbackTaskId } from "./agents-page-sessio
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 
-type NavigateToTask = (taskId: string) => void;
+type NavigateToTask = (taskId: string, options?: { pinSession?: boolean }) => void;
 
 type UseTaskTabSelectionArgs = {
   activeRepo: string | null;
@@ -124,7 +124,7 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
         return [...current, nextTaskId];
       });
       setPersistedActiveTaskId(nextTaskId);
-      navigateToTask(nextTaskId);
+      navigateToTask(nextTaskId, { pinSession: true });
     },
     [
       activeTaskTabId,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
@@ -1,9 +1,8 @@
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
+import type { NavigateToTask } from "./agent-studio-types";
 import { ensureActiveTaskTab, resolveFallbackTaskId } from "./agents-page-session-tabs";
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
-
-type NavigateToTask = (taskId: string, options?: { pinSession?: boolean }) => void;
 
 type UseTaskTabSelectionArgs = {
   activeRepo: string | null;

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -127,7 +127,7 @@ describe("useAgentStudioTaskTabs", () => {
     }
   });
 
-  test("selecting a tab routes as task intent and clears explicit session/role", async () => {
+  test("selecting a tab pins the session chosen for that task", async () => {
     const memoryStorage = createMemoryStorage();
     const originalStorage = globalThis.localStorage;
     Object.defineProperty(globalThis, "localStorage", {
@@ -164,8 +164,76 @@ describe("useAgentStudioTaskTabs", () => {
       const lastUpdate = updateCalls[updateCalls.length - 1];
       expect(lastUpdate).toEqual({
         task: "task-2",
-        session: undefined,
-        agent: undefined,
+        session: "session-2",
+        agent: "spec",
+        scenario: undefined,
+        autostart: undefined,
+        start: undefined,
+      });
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("selecting a tab prefers the current active session over a newer inactive session", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      const taskOne = createTask("task-1");
+      const taskTwo = createTask("task-2");
+      const runningSession = createAgentSessionFixture({
+        sessionId: "session-running",
+        externalSessionId: "ext-session-running",
+        taskId: "task-2",
+        role: "spec",
+        scenario: "spec_initial",
+        status: "running",
+        startedAt: "2026-02-22T09:00:00.000Z",
+      });
+      const newerIdleSession = createAgentSessionFixture({
+        sessionId: "session-newer",
+        externalSessionId: "ext-session-newer",
+        taskId: "task-2",
+        role: "planner",
+        scenario: "planner_initial",
+        status: "idle",
+        startedAt: "2026-02-22T10:00:00.000Z",
+      });
+      const updateCalls: Array<Record<string, string | undefined>> = [];
+
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        taskId: "task-1",
+        selectedTask: taskOne,
+        tasks: [taskOne, taskTwo],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-2", newerIdleSession]]),
+        activeSessionByTaskId: new Map([["task-2", runningSession]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      await harness.mount();
+      await harness.run((state) => {
+        state.handleSelectTab("task-2");
+      });
+
+      expect(updateCalls[updateCalls.length - 1]).toEqual({
+        task: "task-2",
+        session: "session-running",
+        agent: "spec",
         scenario: undefined,
         autostart: undefined,
         start: undefined,
@@ -272,8 +340,8 @@ describe("useAgentStudioTaskTabs", () => {
       const lastUpdate = updateCalls[updateCalls.length - 1];
       expect(lastUpdate).toEqual({
         task: "task-1",
-        session: undefined,
-        agent: undefined,
+        session: "session-1",
+        agent: "spec",
         scenario: undefined,
         autostart: undefined,
         start: undefined,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
@@ -11,11 +11,14 @@ import { useTaskTabActions } from "./use-agent-studio-task-tabs-actions";
 import { useTaskTabPersistence } from "./use-agent-studio-task-tabs-persistence";
 import { useTaskTabSelection } from "./use-agent-studio-task-tabs-selection";
 
-const toTaskQueryUpdate = (taskId: string): QueryUpdate => {
+const toTaskQueryUpdate = (
+  taskId: string,
+  selectedSession?: Pick<AgentSessionState, "sessionId" | "role"> | null,
+): QueryUpdate => {
   return {
     [AGENT_STUDIO_QUERY_KEYS.task]: taskId,
-    [AGENT_STUDIO_QUERY_KEYS.session]: undefined,
-    [AGENT_STUDIO_QUERY_KEYS.agent]: undefined,
+    [AGENT_STUDIO_QUERY_KEYS.session]: selectedSession?.sessionId,
+    [AGENT_STUDIO_QUERY_KEYS.agent]: selectedSession?.role,
     [AGENT_STUDIO_QUERY_KEYS.scenario]: undefined,
     [AGENT_STUDIO_QUERY_KEYS.autostart]: undefined,
     [AGENT_STUDIO_QUERY_KEYS.start]: undefined,
@@ -89,10 +92,13 @@ export function useAgentStudioTaskTabs(args: {
   );
 
   const navigateToTask = useCallback(
-    (nextTaskId: string) => {
-      deferQueryUpdate(toTaskQueryUpdate(nextTaskId));
+    (nextTaskId: string, options?: { pinSession?: boolean }) => {
+      const selectedSession = options?.pinSession
+        ? (activeSessionByTaskId?.get(nextTaskId) ?? latestSessionByTaskId.get(nextTaskId) ?? null)
+        : null;
+      deferQueryUpdate(toTaskQueryUpdate(nextTaskId, selectedSession));
     },
-    [deferQueryUpdate],
+    [activeSessionByTaskId, deferQueryUpdate, latestSessionByTaskId],
   );
 
   const clearTaskSelection = useCallback((): void => {

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -59,6 +59,9 @@ const workspaceGetSettingsSnapshotMock = mock(async () => ({
   kanban: {
     doneVisibleDays: 1,
   },
+  autopilot: {
+    rules: [],
+  },
   repos: {},
   globalPromptOverrides: {} as RepoPromptOverrides,
 }));
@@ -539,6 +542,9 @@ describe("KanbanPage session start modal flow", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+      },
+      autopilot: {
+        rules: [],
       },
       repos: {},
       globalPromptOverrides: {},

--- a/apps/desktop/src/state/app-state-context-values.test.ts
+++ b/apps/desktop/src/state/app-state-context-values.test.ts
@@ -72,6 +72,9 @@ describe("app-state-context-values", () => {
         kanban: {
           doneVisibleDays: 1,
         },
+        autopilot: {
+          rules: [],
+        },
         repos: {},
         globalPromptOverrides: {},
       }),

--- a/apps/desktop/src/state/app-state-provider.tsx
+++ b/apps/desktop/src/state/app-state-provider.tsx
@@ -23,6 +23,7 @@ import {
   AgentStudioStateProvider,
   AppLifecycleStateProvider,
   AppRuntimeProvider,
+  AutopilotProvider,
   ChecksStateProvider,
   DelegationStateProvider,
   SpecStateProvider,
@@ -53,7 +54,9 @@ export function AppStateProvider({ children }: PropsWithChildren): ReactElement 
             <AgentStudioStateProvider agentEngine={agentEngine}>
               <DelegationStateProvider>
                 <WorkspaceStateProvider>
-                  <AppLifecycleStateProvider>{children}</AppLifecycleStateProvider>
+                  <AppLifecycleStateProvider>
+                    <AutopilotProvider>{children}</AutopilotProvider>
+                  </AppLifecycleStateProvider>
                 </WorkspaceStateProvider>
               </DelegationStateProvider>
             </AgentStudioStateProvider>

--- a/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/runtime/runtime.test.ts
@@ -467,6 +467,9 @@ describe("agent-orchestrator-runtime", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {
         "kickoff.spec_initial": {
@@ -540,6 +543,9 @@ describe("agent-orchestrator-runtime", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+      },
+      autopilot: {
+        rules: [],
       },
       repos: {},
       globalPromptOverrides,

--- a/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
+++ b/apps/desktop/src/state/operations/agent-orchestrator/use-agent-orchestrator-operations.test.tsx
@@ -286,6 +286,9 @@ describe("use-agent-orchestrator-operations", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {},
     });

--- a/apps/desktop/src/state/operations/shared/prompt-overrides.test.ts
+++ b/apps/desktop/src/state/operations/shared/prompt-overrides.test.ts
@@ -34,6 +34,7 @@ const createSettingsSnapshot = (): SettingsSnapshot => ({
   repos: {},
   chat: { showThinkingMessages: false },
   kanban: { doneVisibleDays: 1 },
+  autopilot: { rules: [] },
   globalPromptOverrides: {
     "kickoff.spec_initial": {
       template: "global kickoff {{task.id}}",

--- a/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-repo-settings-operations.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { agentPromptTemplateIdValues } from "@openducktor/contracts";
+import { agentPromptTemplateIdValues, type SettingsSnapshot } from "@openducktor/contracts";
 import type { PropsWithChildren, ReactElement } from "react";
 import { clearAppQueryClient } from "@/lib/query-client";
 import { QueryProvider } from "@/lib/query-provider";
@@ -107,6 +107,9 @@ describe("use-repo-settings-operations", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {},
     }));
@@ -135,6 +138,9 @@ describe("use-repo-settings-operations", () => {
         kanban: {
           doneVisibleDays: 1,
         },
+        autopilot: {
+          rules: [],
+        },
         repos: {},
         globalPromptOverrides: {},
       });
@@ -148,6 +154,9 @@ describe("use-repo-settings-operations", () => {
         },
         kanban: {
           doneVisibleDays: 1,
+        },
+        autopilot: {
+          rules: [],
         },
         repos: {},
         globalPromptOverrides: {},
@@ -361,6 +370,9 @@ describe("use-repo-settings-operations", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {},
     }));
@@ -534,6 +546,9 @@ describe("use-repo-settings-operations", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {},
     }));
@@ -562,6 +577,9 @@ describe("use-repo-settings-operations", () => {
         kanban: {
           doneVisibleDays: 1,
         },
+        autopilot: {
+          rules: [],
+        },
         repos: {},
         globalPromptOverrides: {},
       });
@@ -589,6 +607,9 @@ describe("use-repo-settings-operations", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {},
     }));
@@ -605,10 +626,10 @@ describe("use-repo-settings-operations", () => {
       applyWorkspaceRecords,
       applyWorkspaceRecord,
     });
-    const snapshot = {
-      theme: "light" as const,
+    const snapshot: SettingsSnapshot = {
+      theme: "light",
       git: {
-        defaultMergeMethod: "merge_commit" as const,
+        defaultMergeMethod: "merge_commit",
       },
       chat: {
         showThinkingMessages: false,
@@ -616,9 +637,12 @@ describe("use-repo-settings-operations", () => {
       kanban: {
         doneVisibleDays: 1,
       },
+      autopilot: {
+        rules: [],
+      },
       repos: {},
       globalPromptOverrides: {},
-    } as const;
+    };
 
     try {
       await harness.mount();
@@ -684,6 +708,9 @@ describe("use-repo-settings-operations", () => {
       },
       kanban: {
         doneVisibleDays: 1,
+      },
+      autopilot: {
+        rules: [],
       },
       repos: {
         "/repo-a": {

--- a/apps/desktop/src/state/operations/workspace/use-workspace-operations.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-workspace-operations.test.tsx
@@ -250,6 +250,9 @@ const settingsSnapshot = (repoPaths: string[]): SettingsSnapshot => ({
   kanban: {
     doneVisibleDays: 1,
   },
+  autopilot: {
+    rules: [],
+  },
   repos: Object.fromEntries(
     repoPaths.map((repoPath) => [
       repoPath,

--- a/apps/desktop/src/state/providers/autopilot-provider.test.ts
+++ b/apps/desktop/src/state/providers/autopilot-provider.test.ts
@@ -1,15 +1,16 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AgentSessionRecord, RepoConfig, TaskCard } from "@openducktor/contracts";
 import type { AgentModelCatalog } from "@openducktor/core";
 import { QueryClient } from "@tanstack/react-query";
 import { repoConfigQueryOptions } from "@/state/queries/workspace";
 import { createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
 import { MISSING_BUILD_TARGET_ERROR } from "../operations/agent-orchestrator/handlers/start-session-constants";
+import { detectAutopilotEvents, executeAutopilotAction } from "./autopilot-provider";
 
-const startSessionWorkflowMock = mock(async () => undefined);
-
-let detectAutopilotEvents: typeof import("./autopilot-provider").detectAutopilotEvents;
-let executeAutopilotAction: typeof import("./autopilot-provider").executeAutopilotAction;
+const startSessionWorkflowMock = mock(async () => ({
+  sessionId: "session-new",
+  postStartActionError: null,
+}));
 
 const createBuilderSessionRecord = (
   overrides: Partial<AgentSessionRecord> = {},
@@ -103,6 +104,7 @@ const createExecuteArgs = (task: TaskCard) => ({
   resolveBuildContinuationTarget: mock(
     async (): Promise<{ workingDirectory: string } | null> => null,
   ),
+  startSessionWorkflow: startSessionWorkflowMock,
   startAgentSession: mock(async () => {
     throw new Error("startAgentSession should not be called in this test");
   }),
@@ -112,20 +114,12 @@ const createExecuteArgs = (task: TaskCard) => ({
 });
 
 describe("autopilot provider helpers", () => {
-  beforeAll(async () => {
-    mock.module("@/features/session-start/session-start-workflow", () => ({
-      startSessionWorkflow: startSessionWorkflowMock,
-    }));
-    ({ detectAutopilotEvents, executeAutopilotAction } = await import("./autopilot-provider"));
-  });
-
   beforeEach(() => {
     startSessionWorkflowMock.mockReset();
-    startSessionWorkflowMock.mockImplementation(async () => undefined);
-  });
-
-  afterAll(() => {
-    mock.restore();
+    startSessionWorkflowMock.mockImplementation(async () => ({
+      sessionId: "session-new",
+      postStartActionError: null,
+    }));
   });
 
   test("detects status transitions and canonical QA rejection", () => {

--- a/apps/desktop/src/state/providers/autopilot-provider.test.ts
+++ b/apps/desktop/src/state/providers/autopilot-provider.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentSessionRecord, TaskCard } from "@openducktor/contracts";
+import type { QueryClient } from "@tanstack/react-query";
+import { createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
+import { MISSING_BUILD_TARGET_ERROR } from "../operations/agent-orchestrator/handlers/start-session-constants";
+
+const startSessionWorkflowMock = mock(async () => undefined);
+
+let detectAutopilotEvents: typeof import("./autopilot-provider").detectAutopilotEvents;
+let executeAutopilotAction: typeof import("./autopilot-provider").executeAutopilotAction;
+
+const createBuilderSessionRecord = (
+  overrides: Partial<AgentSessionRecord> = {},
+): AgentSessionRecord => ({
+  sessionId: "builder-session-1",
+  externalSessionId: "external-builder-session-1",
+  role: "build",
+  scenario: "build_implementation_start",
+  startedAt: "2026-02-22T10:00:00.000Z",
+  runtimeKind: "opencode",
+  workingDirectory: "/tmp/repo/worktree",
+  selectedModel: {
+    runtimeKind: "opencode",
+    providerId: "openai",
+    modelId: "gpt-5",
+    variant: "high",
+    profileId: "builder",
+  },
+  ...overrides,
+});
+
+const createTask = (overrides: Partial<TaskCard> = {}): TaskCard =>
+  createTaskCardFixture({}, overrides);
+
+const createExecuteArgs = (task: TaskCard) => ({
+  repoPath: "/repo",
+  task,
+  queryClient: {} as QueryClient,
+  loadRepoRuntimeCatalog: mock(async () => {
+    throw new Error("loadRepoRuntimeCatalog should not be called in this test");
+  }),
+  startAgentSession: mock(async () => {
+    throw new Error("startAgentSession should not be called in this test");
+  }),
+  sendAgentMessage: mock(async () => {
+    throw new Error("sendAgentMessage should not be called in this test");
+  }),
+});
+
+describe("autopilot provider helpers", () => {
+  beforeAll(async () => {
+    mock.module("@/features/session-start/session-start-workflow", () => ({
+      startSessionWorkflow: startSessionWorkflowMock,
+    }));
+    ({ detectAutopilotEvents, executeAutopilotAction } = await import("./autopilot-provider"));
+  });
+
+  beforeEach(() => {
+    startSessionWorkflowMock.mockReset();
+    startSessionWorkflowMock.mockImplementation(async () => undefined);
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  test("detects status transitions and canonical QA rejection", () => {
+    const previousSpecTask = createTask({ id: "TASK-1", status: "open" });
+    const currentSpecTask = createTask({ id: "TASK-1", status: "spec_ready" });
+    const previousQaTask = createTask({
+      id: "TASK-2",
+      status: "in_progress",
+      documentSummary: {
+        spec: { has: false },
+        plan: { has: false },
+        qaReport: { has: true, verdict: "not_reviewed" },
+      },
+    });
+    const currentQaTask = createTask({
+      id: "TASK-2",
+      status: "in_progress",
+      documentSummary: {
+        spec: { has: false },
+        plan: { has: false },
+        qaReport: { has: true, verdict: "rejected" },
+      },
+    });
+
+    const observedEvents = detectAutopilotEvents(
+      new Map([
+        [previousSpecTask.id, previousSpecTask],
+        [previousQaTask.id, previousQaTask],
+      ]),
+      [currentSpecTask, currentQaTask],
+    );
+
+    expect(observedEvents).toEqual([
+      { eventId: "taskProgressedToSpecReady", task: currentSpecTask },
+      { eventId: "taskRejectedByQa", task: currentQaTask },
+    ]);
+  });
+
+  test("skips pull request generation when no builder session exists", async () => {
+    const outcome = await executeAutopilotAction({
+      ...createExecuteArgs(createTask({ id: "TASK-PR", status: "human_review" })),
+      actionId: "startGeneratePullRequest",
+    });
+
+    expect(outcome).toEqual({
+      kind: "skipped",
+      message: 'No Builder session is available to fork for task "TASK-PR".',
+    });
+    expect(startSessionWorkflowMock).not.toHaveBeenCalled();
+  });
+
+  test("skips builder follow-up when the build continuation target is missing", async () => {
+    startSessionWorkflowMock.mockImplementationOnce(async () => {
+      throw new Error(MISSING_BUILD_TARGET_ERROR);
+    });
+
+    const outcome = await executeAutopilotAction({
+      ...createExecuteArgs(
+        createTask({
+          id: "TASK-QA",
+          status: "in_progress",
+          agentSessions: [createBuilderSessionRecord()],
+        }),
+      ),
+      actionId: "startReviewQaFeedbacks",
+    });
+
+    expect(outcome).toEqual({
+      kind: "skipped",
+      message: MISSING_BUILD_TARGET_ERROR,
+    });
+  });
+
+  test("surfaces unexpected pull request start failures", async () => {
+    startSessionWorkflowMock.mockImplementationOnce(async () => {
+      throw new Error("workflow failed");
+    });
+
+    await expect(
+      executeAutopilotAction({
+        ...createExecuteArgs(
+          createTask({
+            id: "TASK-PR",
+            status: "human_review",
+            agentSessions: [createBuilderSessionRecord()],
+          }),
+        ),
+        actionId: "startGeneratePullRequest",
+      }),
+    ).rejects.toThrow("workflow failed");
+  });
+});

--- a/apps/desktop/src/state/providers/autopilot-provider.test.ts
+++ b/apps/desktop/src/state/providers/autopilot-provider.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { AgentSessionRecord, TaskCard } from "@openducktor/contracts";
-import type { QueryClient } from "@tanstack/react-query";
+import type { AgentSessionRecord, RepoConfig, TaskCard } from "@openducktor/contracts";
+import type { AgentModelCatalog } from "@openducktor/core";
+import { QueryClient } from "@tanstack/react-query";
+import { repoConfigQueryOptions } from "@/state/queries/workspace";
 import { createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
 import { MISSING_BUILD_TARGET_ERROR } from "../operations/agent-orchestrator/handlers/start-session-constants";
 
@@ -32,13 +34,75 @@ const createBuilderSessionRecord = (
 const createTask = (overrides: Partial<TaskCard> = {}): TaskCard =>
   createTaskCardFixture({}, overrides);
 
+const createRepoConfig = (): RepoConfig => ({
+  defaultRuntimeKind: "opencode",
+  worktreeBasePath: undefined,
+  branchPrefix: "odt",
+  defaultTargetBranch: { remote: "origin", branch: "main" },
+  git: { providers: {} },
+  trustedHooks: false,
+  trustedHooksFingerprint: undefined,
+  hooks: { preStart: [], postComplete: [] },
+  devServers: [],
+  worktreeFileCopies: [],
+  promptOverrides: {},
+  agentDefaults: {
+    spec: undefined,
+    planner: {
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "planner",
+    },
+    build: {
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "builder",
+    },
+    qa: {
+      runtimeKind: "opencode",
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "qa",
+    },
+  },
+});
+
+const createQueryClient = (): QueryClient => {
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(repoConfigQueryOptions("/repo").queryKey, createRepoConfig());
+  return queryClient;
+};
+
 const createExecuteArgs = (task: TaskCard) => ({
   repoPath: "/repo",
   task,
-  queryClient: {} as QueryClient,
-  loadRepoRuntimeCatalog: mock(async () => {
-    throw new Error("loadRepoRuntimeCatalog should not be called in this test");
-  }),
+  queryClient: createQueryClient(),
+  loadRepoRuntimeCatalog: mock(
+    async (): Promise<AgentModelCatalog> => ({
+      models: [
+        {
+          id: "openai",
+          providerId: "openai",
+          providerName: "OpenAI",
+          modelId: "gpt-5",
+          modelName: "GPT-5",
+          variants: ["high"],
+        },
+      ],
+      defaultModelsByProvider: {
+        openai: "gpt-5",
+      },
+      profiles: [{ id: "planner", label: "Planner", mode: "primary" }],
+    }),
+  ),
+  resolveBuildContinuationTarget: mock(
+    async (): Promise<{ workingDirectory: string } | null> => null,
+  ),
   startAgentSession: mock(async () => {
     throw new Error("startAgentSession should not be called in this test");
   }),
@@ -100,6 +164,44 @@ describe("autopilot provider helpers", () => {
     ]);
   });
 
+  test("does not backfill or retrigger unchanged task states", () => {
+    const currentTask = createTask({ id: "TASK-1", status: "spec_ready" });
+
+    expect(detectAutopilotEvents(new Map(), [currentTask])).toEqual([]);
+    expect(detectAutopilotEvents(new Map([[currentTask.id, currentTask]]), [currentTask])).toEqual(
+      [],
+    );
+  });
+
+  test("detects a later re-entry into ai_review after leaving the state", () => {
+    const previousTask = createTask({ id: "TASK-1", status: "human_review" });
+    const currentTask = createTask({ id: "TASK-1", status: "ai_review" });
+
+    expect(
+      detectAutopilotEvents(new Map([[previousTask.id, previousTask]]), [currentTask]),
+    ).toEqual([{ eventId: "taskProgressedToAiReview", task: currentTask }]);
+  });
+
+  test("maps spec_ready automation to the planner scenario", async () => {
+    const args = createExecuteArgs(createTask({ id: "TASK-PLAN", status: "spec_ready" }));
+
+    await executeAutopilotAction({
+      ...args,
+      actionId: "startPlanner",
+    });
+
+    expect(startSessionWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: expect.objectContaining({
+          taskId: "TASK-PLAN",
+          role: "planner",
+          scenario: "planner_initial",
+          startMode: "fresh",
+        }),
+      }),
+    );
+  });
+
   test("skips pull request generation when no builder session exists", async () => {
     const outcome = await executeAutopilotAction({
       ...createExecuteArgs(createTask({ id: "TASK-PR", status: "human_review" })),
@@ -114,10 +216,6 @@ describe("autopilot provider helpers", () => {
   });
 
   test("skips builder follow-up when the build continuation target is missing", async () => {
-    startSessionWorkflowMock.mockImplementationOnce(async () => {
-      throw new Error(MISSING_BUILD_TARGET_ERROR);
-    });
-
     const outcome = await executeAutopilotAction({
       ...createExecuteArgs(
         createTask({
@@ -152,5 +250,74 @@ describe("autopilot provider helpers", () => {
         actionId: "startGeneratePullRequest",
       }),
     ).rejects.toThrow("workflow failed");
+  });
+
+  test("falls back to a fresh builder continuation when the latest builder session targets an older worktree", async () => {
+    const args = createExecuteArgs(
+      createTask({
+        id: "TASK-QA",
+        status: "in_progress",
+        agentSessions: [createBuilderSessionRecord({ workingDirectory: "/tmp/repo/old-worktree" })],
+      }),
+    );
+    args.resolveBuildContinuationTarget.mockResolvedValue({
+      workingDirectory: "/tmp/repo/new-worktree",
+    });
+
+    await executeAutopilotAction({
+      ...args,
+      actionId: "startReviewQaFeedbacks",
+    });
+
+    expect(startSessionWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: expect.objectContaining({
+          startMode: "fresh",
+          targetWorkingDirectory: "/tmp/repo/new-worktree",
+        }),
+      }),
+    );
+  });
+
+  test("reuses QA follow-up only when the latest QA session matches the current continuation target", async () => {
+    const args = createExecuteArgs(
+      createTask({
+        id: "TASK-QA",
+        status: "ai_review",
+        agentSessions: [
+          createBuilderSessionRecord({
+            sessionId: "qa-session-1",
+            role: "qa",
+            scenario: "qa_review",
+            workingDirectory: "/tmp/repo/current-worktree",
+            selectedModel: {
+              runtimeKind: "opencode",
+              providerId: "openai",
+              modelId: "gpt-5",
+              variant: "high",
+              profileId: "qa",
+            },
+          }),
+        ],
+      }),
+    );
+    args.resolveBuildContinuationTarget.mockResolvedValue({
+      workingDirectory: "/tmp/repo/current-worktree",
+    });
+
+    await executeAutopilotAction({
+      ...args,
+      actionId: "startQa",
+    });
+
+    expect(startSessionWorkflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: expect.objectContaining({
+          startMode: "reuse",
+          sourceSessionId: "qa-session-1",
+        }),
+        selection: null,
+      }),
+    );
   });
 });

--- a/apps/desktop/src/state/providers/autopilot-provider.test.ts
+++ b/apps/desktop/src/state/providers/autopilot-provider.test.ts
@@ -5,7 +5,11 @@ import { QueryClient } from "@tanstack/react-query";
 import { repoConfigQueryOptions } from "@/state/queries/workspace";
 import { createTaskCardFixture } from "@/test-utils/shared-test-fixtures";
 import { MISSING_BUILD_TARGET_ERROR } from "../operations/agent-orchestrator/handlers/start-session-constants";
-import { detectAutopilotEvents, executeAutopilotAction } from "./autopilot-provider";
+import {
+  detectAutopilotEvents,
+  executeAutopilotAction,
+  shouldAdvanceAutopilotBaseline,
+} from "./autopilot-provider";
 
 const startSessionWorkflowMock = mock(async () => ({
   sessionId: "session-new",
@@ -165,6 +169,29 @@ describe("autopilot provider helpers", () => {
     expect(detectAutopilotEvents(new Map([[currentTask.id, currentTask]]), [currentTask])).toEqual(
       [],
     );
+  });
+
+  test("keeps the previous baseline when settings are unavailable and an event was observed", () => {
+    const observedEvents = detectAutopilotEvents(
+      new Map([["TASK-1", createTask({ id: "TASK-1", status: "open" })]]),
+      [createTask({ id: "TASK-1", status: "spec_ready" })],
+    );
+
+    expect(
+      shouldAdvanceAutopilotBaseline({
+        observedEvents,
+        hasAutopilotSettings: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("advances the baseline immediately when no event was observed", () => {
+    expect(
+      shouldAdvanceAutopilotBaseline({
+        observedEvents: [],
+        hasAutopilotSettings: false,
+      }),
+    ).toBe(true);
   });
 
   test("detects a later re-entry into ai_review after leaving the state", () => {

--- a/apps/desktop/src/state/providers/autopilot-provider.tsx
+++ b/apps/desktop/src/state/providers/autopilot-provider.tsx
@@ -4,6 +4,7 @@ import type {
   AutopilotEventId,
   TaskCard,
 } from "@openducktor/contracts";
+import { AUTOPILOT_EVENT_IDS } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
 import { getAgentScenarioDefinition } from "@openducktor/core";
 import { type QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -111,13 +112,7 @@ export const detectAutopilotEvents = (
   const observedEvents: AutopilotObservedEvent[] = [];
 
   for (const task of tasks) {
-    for (const eventId of [
-      "taskProgressedToSpecReady",
-      "taskProgressedToReadyForDev",
-      "taskProgressedToAiReview",
-      "taskRejectedByQa",
-      "taskProgressedToHumanReview",
-    ] as const) {
+    for (const eventId of AUTOPILOT_EVENT_IDS) {
       if (detectTaskEvent(previousTasksById.get(task.id), task, eventId)) {
         observedEvents.push({ eventId, task });
       }
@@ -125,6 +120,13 @@ export const detectAutopilotEvents = (
   }
 
   return observedEvents;
+};
+
+export const shouldAdvanceAutopilotBaseline = (params: {
+  observedEvents: AutopilotObservedEvent[];
+  hasAutopilotSettings: boolean;
+}): boolean => {
+  return params.hasAutopilotSettings || params.observedEvents.length === 0;
 };
 
 const findLatestSessionRecordByRole = (
@@ -365,12 +367,15 @@ export function AutopilotProvider({ children }: PropsWithChildren): ReactElement
     }
 
     const observedEvents = detectAutopilotEvents(previousTasksByIdRef.current, tasks);
-    previousTasksByIdRef.current = nextTasksById;
-    if (observedEvents.length === 0) {
-      return;
-    }
-
     const autopilotSettings = settingsSnapshotQuery.data?.autopilot;
+    if (
+      shouldAdvanceAutopilotBaseline({
+        observedEvents,
+        hasAutopilotSettings: Boolean(autopilotSettings),
+      })
+    ) {
+      previousTasksByIdRef.current = nextTasksById;
+    }
     if (!autopilotSettings) {
       return;
     }

--- a/apps/desktop/src/state/providers/autopilot-provider.tsx
+++ b/apps/desktop/src/state/providers/autopilot-provider.tsx
@@ -5,6 +5,7 @@ import type {
   TaskCard,
 } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
+import { getAgentScenarioDefinition } from "@openducktor/core";
 import { type QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
 import { type PropsWithChildren, type ReactElement, useEffect, useRef } from "react";
 import { toast } from "sonner";
@@ -30,6 +31,8 @@ import {
   useTaskDataContext,
 } from "../app-state-contexts";
 import { MISSING_BUILD_TARGET_ERROR } from "../operations/agent-orchestrator/handlers/start-session-constants";
+import { loadBuildContinuationTarget } from "../operations/agent-orchestrator/runtime/runtime";
+import { normalizeWorkingDirectory } from "../operations/agent-orchestrator/support/core";
 import {
   loadRepoConfigFromQuery,
   settingsSnapshotQueryOptions,
@@ -52,8 +55,21 @@ type ExecuteAutopilotActionArgs = {
   actionId: AutopilotActionId;
   queryClient: QueryClient;
   loadRepoRuntimeCatalog: (repoPath: string, runtimeKind: string) => Promise<AgentModelCatalog>;
+  resolveBuildContinuationTarget: (
+    repoPath: string,
+    taskId: string,
+  ) => Promise<{
+    workingDirectory: string;
+  } | null>;
   startAgentSession: AgentStateContextValue["startAgentSession"];
   sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
+};
+
+type ResolvedAutopilotStart = {
+  startMode: "fresh" | "reuse" | "fork";
+  sourceSessionId?: string | null;
+  targetWorkingDirectory?: string | null;
+  preferredSelection?: AgentModelSelection | null;
 };
 
 const ROLE_LABELS = AGENT_ROLE_LABELS as Record<AgentRole, string>;
@@ -189,12 +205,62 @@ const isSkippableAutopilotError = (actionId: AutopilotActionId, error: unknown):
   );
 };
 
+const resolveAutopilotStart = async ({
+  repoPath,
+  task,
+  actionId,
+  resolveBuildContinuationTarget,
+}: Pick<ExecuteAutopilotActionArgs, "repoPath" | "task" | "resolveBuildContinuationTarget"> & {
+  actionId: AutopilotActionId;
+}): Promise<ResolvedAutopilotStart> => {
+  const action = AUTOPILOT_ACTION_DEFINITIONS[actionId];
+  const latestRoleSession = findLatestSessionRecordByRole(task, action.role);
+
+  if (actionId === "startGeneratePullRequest") {
+    return {
+      startMode: "fork",
+      sourceSessionId: latestRoleSession?.sessionId ?? null,
+      preferredSelection: toAgentModelSelection(latestRoleSession?.selectedModel ?? null),
+    };
+  }
+
+  const { allowedStartModes } = getAgentScenarioDefinition(action.scenario);
+  if (!allowedStartModes.includes("reuse")) {
+    return {
+      startMode: "fresh",
+    };
+  }
+
+  const continuationTarget = await resolveBuildContinuationTarget(repoPath, task.id);
+  if (!continuationTarget) {
+    throw new Error(MISSING_BUILD_TARGET_ERROR);
+  }
+
+  if (
+    latestRoleSession &&
+    normalizeWorkingDirectory(latestRoleSession.workingDirectory) ===
+      normalizeWorkingDirectory(continuationTarget.workingDirectory)
+  ) {
+    return {
+      startMode: "reuse",
+      sourceSessionId: latestRoleSession.sessionId,
+      targetWorkingDirectory: continuationTarget.workingDirectory,
+    };
+  }
+
+  return {
+    startMode: "fresh",
+    targetWorkingDirectory: continuationTarget.workingDirectory,
+  };
+};
+
 export const executeAutopilotAction = async ({
   repoPath,
   task,
   actionId,
   queryClient,
   loadRepoRuntimeCatalog,
+  resolveBuildContinuationTarget,
   startAgentSession,
   sendAgentMessage,
 }: ExecuteAutopilotActionArgs): Promise<AutopilotActionOutcome> => {
@@ -209,43 +275,13 @@ export const executeAutopilotAction = async ({
   }
 
   try {
-    if (actionId === "startGeneratePullRequest") {
-      await startSessionWorkflow({
-        activeRepo: repoPath,
-        queryClient,
-        intent: {
-          taskId: task.id,
-          role: action.role,
-          scenario: action.scenario,
-          startMode: "fork",
-          sourceSessionId: latestRoleSession?.sessionId ?? null,
-          postStartAction: "kickoff",
-        },
-        selection: await resolveAutopilotSelection({
-          repoPath,
-          role: action.role,
-          preferredSelection: toAgentModelSelection(latestRoleSession?.selectedModel ?? null),
-          queryClient,
-          loadRepoRuntimeCatalog,
-        }),
-        task,
-        startAgentSession,
-        sendAgentMessage,
-        postStartExecution: "detached",
-        onDetachedPostStartError: (error) => {
-          toast.error(`Autopilot started ${action.label} for ${task.id}, but kickoff failed.`, {
-            description: error.message,
-          });
-        },
-      });
+    const resolvedStart = await resolveAutopilotStart({
+      repoPath,
+      task,
+      actionId,
+      resolveBuildContinuationTarget,
+    });
 
-      return {
-        kind: "started",
-        message: `Started ${action.label} for ${task.id}.`,
-      };
-    }
-
-    const startMode = latestRoleSession ? "reuse" : "fresh";
     await startSessionWorkflow({
       activeRepo: repoPath,
       queryClient,
@@ -253,16 +289,24 @@ export const executeAutopilotAction = async ({
         taskId: task.id,
         role: action.role,
         scenario: action.scenario,
-        startMode,
-        ...(startMode === "reuse" ? { sourceSessionId: latestRoleSession?.sessionId ?? null } : {}),
+        startMode: resolvedStart.startMode,
+        ...(resolvedStart.sourceSessionId
+          ? { sourceSessionId: resolvedStart.sourceSessionId }
+          : {}),
+        ...(resolvedStart.targetWorkingDirectory !== undefined
+          ? { targetWorkingDirectory: resolvedStart.targetWorkingDirectory }
+          : {}),
         postStartAction: "kickoff",
       },
       selection:
-        startMode === "reuse"
+        resolvedStart.startMode === "reuse"
           ? null
           : await resolveAutopilotSelection({
               repoPath,
               role: action.role,
+              ...(resolvedStart.preferredSelection !== undefined
+                ? { preferredSelection: resolvedStart.preferredSelection }
+                : {}),
               queryClient,
               loadRepoRuntimeCatalog,
             }),
@@ -338,6 +382,7 @@ export function AutopilotProvider({ children }: PropsWithChildren): ReactElement
               actionId,
               queryClient,
               loadRepoRuntimeCatalog,
+              resolveBuildContinuationTarget: loadBuildContinuationTarget,
               startAgentSession: agentState.startAgentSession,
               sendAgentMessage: agentState.sendAgentMessage,
             });

--- a/apps/desktop/src/state/providers/autopilot-provider.tsx
+++ b/apps/desktop/src/state/providers/autopilot-provider.tsx
@@ -1,0 +1,370 @@
+import type {
+  AgentSessionRecord,
+  AutopilotActionId,
+  AutopilotEventId,
+  TaskCard,
+} from "@openducktor/contracts";
+import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
+import { type QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type PropsWithChildren, type ReactElement, useEffect, useRef } from "react";
+import { toast } from "sonner";
+import {
+  AUTOPILOT_ACTION_DEFINITIONS,
+  getAutopilotRule,
+} from "@/features/autopilot/autopilot-catalog";
+import {
+  coerceVisibleSelectionToCatalog,
+  pickDefaultVisibleSelectionForCatalog,
+  roleDefaultSelectionFor,
+} from "@/features/session-start/session-start-selection";
+import { startSessionWorkflow } from "@/features/session-start/session-start-workflow";
+import { errorMessage } from "@/lib/errors";
+import { isQaRejectedTask } from "@/lib/task-qa";
+import { AGENT_ROLE_LABELS } from "@/types";
+import type { AgentStateContextValue } from "@/types/state-slices";
+import {
+  AgentStateContext,
+  useActiveRepoContext,
+  useRequiredContext,
+  useRuntimeDefinitionsContext,
+  useTaskDataContext,
+} from "../app-state-contexts";
+import { MISSING_BUILD_TARGET_ERROR } from "../operations/agent-orchestrator/handlers/start-session-constants";
+import {
+  loadRepoConfigFromQuery,
+  settingsSnapshotQueryOptions,
+  toRepoSettingsInput,
+} from "../queries/workspace";
+
+type AutopilotObservedEvent = {
+  eventId: AutopilotEventId;
+  task: TaskCard;
+};
+
+type AutopilotActionOutcome = {
+  kind: "started" | "skipped";
+  message: string;
+};
+
+type ExecuteAutopilotActionArgs = {
+  repoPath: string;
+  task: TaskCard;
+  actionId: AutopilotActionId;
+  queryClient: QueryClient;
+  loadRepoRuntimeCatalog: (repoPath: string, runtimeKind: string) => Promise<AgentModelCatalog>;
+  startAgentSession: AgentStateContextValue["startAgentSession"];
+  sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
+};
+
+const ROLE_LABELS = AGENT_ROLE_LABELS as Record<AgentRole, string>;
+
+const toTaskMap = (tasks: TaskCard[]): Map<string, TaskCard> => {
+  return new Map(tasks.map((task) => [task.id, task]));
+};
+
+const detectTaskEvent = (
+  previousTask: TaskCard | undefined,
+  currentTask: TaskCard,
+  eventId: AutopilotEventId,
+): boolean => {
+  if (!previousTask) {
+    return false;
+  }
+
+  switch (eventId) {
+    case "taskProgressedToSpecReady":
+      return previousTask.status !== "spec_ready" && currentTask.status === "spec_ready";
+    case "taskProgressedToReadyForDev":
+      return previousTask.status !== "ready_for_dev" && currentTask.status === "ready_for_dev";
+    case "taskProgressedToAiReview":
+      return previousTask.status !== "ai_review" && currentTask.status === "ai_review";
+    case "taskRejectedByQa":
+      return !isQaRejectedTask(previousTask) && isQaRejectedTask(currentTask);
+    case "taskProgressedToHumanReview":
+      return previousTask.status !== "human_review" && currentTask.status === "human_review";
+  }
+};
+
+export const detectAutopilotEvents = (
+  previousTasksById: Map<string, TaskCard>,
+  tasks: TaskCard[],
+): AutopilotObservedEvent[] => {
+  const observedEvents: AutopilotObservedEvent[] = [];
+
+  for (const task of tasks) {
+    for (const eventId of [
+      "taskProgressedToSpecReady",
+      "taskProgressedToReadyForDev",
+      "taskProgressedToAiReview",
+      "taskRejectedByQa",
+      "taskProgressedToHumanReview",
+    ] as const) {
+      if (detectTaskEvent(previousTasksById.get(task.id), task, eventId)) {
+        observedEvents.push({ eventId, task });
+      }
+    }
+  }
+
+  return observedEvents;
+};
+
+const findLatestSessionRecordByRole = (
+  task: TaskCard,
+  role: AgentRole,
+): AgentSessionRecord | null => {
+  const matchingSessions = (task.agentSessions ?? [])
+    .filter((session) => session.role === role)
+    .sort((a, b) => b.startedAt.localeCompare(a.startedAt));
+
+  return matchingSessions[0] ?? null;
+};
+
+const toAgentModelSelection = (
+  selection: AgentSessionRecord["selectedModel"],
+): AgentModelSelection | null => {
+  if (!selection) {
+    return null;
+  }
+
+  return {
+    runtimeKind: selection.runtimeKind,
+    providerId: selection.providerId,
+    modelId: selection.modelId,
+    ...(selection.variant ? { variant: selection.variant } : {}),
+    ...(selection.profileId ? { profileId: selection.profileId } : {}),
+  };
+};
+
+const resolveAutopilotSelection = async ({
+  repoPath,
+  role,
+  preferredSelection,
+  queryClient,
+  loadRepoRuntimeCatalog,
+}: {
+  repoPath: string;
+  role: AgentRole;
+  preferredSelection?: AgentModelSelection | null;
+  queryClient: QueryClient;
+  loadRepoRuntimeCatalog: (repoPath: string, runtimeKind: string) => Promise<AgentModelCatalog>;
+}): Promise<AgentModelSelection> => {
+  if (preferredSelection) {
+    return preferredSelection;
+  }
+
+  const repoConfig = await loadRepoConfigFromQuery(queryClient, repoPath);
+  const repoSettings = toRepoSettingsInput(repoConfig);
+  const savedDefaultSelection = roleDefaultSelectionFor(repoSettings, role);
+  const runtimeKind = savedDefaultSelection?.runtimeKind ?? repoSettings.defaultRuntimeKind;
+  const catalog = await loadRepoRuntimeCatalog(repoPath, runtimeKind);
+
+  if (savedDefaultSelection) {
+    const validatedSelection = coerceVisibleSelectionToCatalog(catalog, savedDefaultSelection);
+    if (!validatedSelection) {
+      throw new Error(
+        `Saved default ${ROLE_LABELS[role]} model is not available for runtime ${runtimeKind}.`,
+      );
+    }
+
+    return validatedSelection;
+  }
+
+  const catalogDefaultSelection = pickDefaultVisibleSelectionForCatalog(catalog);
+  if (!catalogDefaultSelection) {
+    throw new Error(
+      `No default ${ROLE_LABELS[role]} model is available for runtime ${runtimeKind}.`,
+    );
+  }
+
+  return catalogDefaultSelection;
+};
+
+const isSkippableAutopilotError = (actionId: AutopilotActionId, error: unknown): boolean => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    actionId !== "startGeneratePullRequest" && error.message.includes(MISSING_BUILD_TARGET_ERROR)
+  );
+};
+
+export const executeAutopilotAction = async ({
+  repoPath,
+  task,
+  actionId,
+  queryClient,
+  loadRepoRuntimeCatalog,
+  startAgentSession,
+  sendAgentMessage,
+}: ExecuteAutopilotActionArgs): Promise<AutopilotActionOutcome> => {
+  const action = AUTOPILOT_ACTION_DEFINITIONS[actionId];
+  const latestRoleSession = findLatestSessionRecordByRole(task, action.role);
+
+  if (actionId === "startGeneratePullRequest" && !latestRoleSession) {
+    return {
+      kind: "skipped",
+      message: `No Builder session is available to fork for task "${task.id}".`,
+    };
+  }
+
+  try {
+    if (actionId === "startGeneratePullRequest") {
+      await startSessionWorkflow({
+        activeRepo: repoPath,
+        queryClient,
+        intent: {
+          taskId: task.id,
+          role: action.role,
+          scenario: action.scenario,
+          startMode: "fork",
+          sourceSessionId: latestRoleSession?.sessionId ?? null,
+          postStartAction: "kickoff",
+        },
+        selection: await resolveAutopilotSelection({
+          repoPath,
+          role: action.role,
+          preferredSelection: toAgentModelSelection(latestRoleSession?.selectedModel ?? null),
+          queryClient,
+          loadRepoRuntimeCatalog,
+        }),
+        task,
+        startAgentSession,
+        sendAgentMessage,
+        postStartExecution: "detached",
+        onDetachedPostStartError: (error) => {
+          toast.error(`Autopilot started ${action.label} for ${task.id}, but kickoff failed.`, {
+            description: error.message,
+          });
+        },
+      });
+
+      return {
+        kind: "started",
+        message: `Started ${action.label} for ${task.id}.`,
+      };
+    }
+
+    const startMode = latestRoleSession ? "reuse" : "fresh";
+    await startSessionWorkflow({
+      activeRepo: repoPath,
+      queryClient,
+      intent: {
+        taskId: task.id,
+        role: action.role,
+        scenario: action.scenario,
+        startMode,
+        ...(startMode === "reuse" ? { sourceSessionId: latestRoleSession?.sessionId ?? null } : {}),
+        postStartAction: "kickoff",
+      },
+      selection:
+        startMode === "reuse"
+          ? null
+          : await resolveAutopilotSelection({
+              repoPath,
+              role: action.role,
+              queryClient,
+              loadRepoRuntimeCatalog,
+            }),
+      task,
+      startAgentSession,
+      sendAgentMessage,
+      postStartExecution: "detached",
+      onDetachedPostStartError: (error) => {
+        toast.error(`Autopilot started ${action.label} for ${task.id}, but kickoff failed.`, {
+          description: error.message,
+        });
+      },
+    });
+
+    return {
+      kind: "started",
+      message: `Started ${action.label} for ${task.id}.`,
+    };
+  } catch (error) {
+    if (isSkippableAutopilotError(actionId, error)) {
+      return {
+        kind: "skipped",
+        message: errorMessage(error),
+      };
+    }
+    throw error;
+  }
+};
+
+export function AutopilotProvider({ children }: PropsWithChildren): ReactElement {
+  const queryClient = useQueryClient();
+  const { activeRepo } = useActiveRepoContext();
+  const { tasks } = useTaskDataContext();
+  const { loadRepoRuntimeCatalog } = useRuntimeDefinitionsContext();
+  const agentState = useRequiredContext(AgentStateContext, "AutopilotProvider");
+  const settingsSnapshotQuery = useQuery(settingsSnapshotQueryOptions());
+  const previousRepoRef = useRef<string | null>(null);
+  const previousTasksByIdRef = useRef<Map<string, TaskCard>>(new Map());
+
+  useEffect(() => {
+    if (!activeRepo) {
+      previousRepoRef.current = null;
+      previousTasksByIdRef.current = new Map();
+      return;
+    }
+
+    const nextTasksById = toTaskMap(tasks);
+    if (previousRepoRef.current !== activeRepo) {
+      previousRepoRef.current = activeRepo;
+      previousTasksByIdRef.current = nextTasksById;
+      return;
+    }
+
+    const observedEvents = detectAutopilotEvents(previousTasksByIdRef.current, tasks);
+    previousTasksByIdRef.current = nextTasksById;
+    if (observedEvents.length === 0) {
+      return;
+    }
+
+    const autopilotSettings = settingsSnapshotQuery.data?.autopilot;
+    if (!autopilotSettings) {
+      return;
+    }
+
+    void (async () => {
+      for (const observedEvent of observedEvents) {
+        const rule = getAutopilotRule(autopilotSettings, observedEvent.eventId);
+        for (const actionId of rule.actionIds) {
+          try {
+            const outcome = await executeAutopilotAction({
+              repoPath: activeRepo,
+              task: observedEvent.task,
+              actionId,
+              queryClient,
+              loadRepoRuntimeCatalog,
+              startAgentSession: agentState.startAgentSession,
+              sendAgentMessage: agentState.sendAgentMessage,
+            });
+
+            if (outcome.kind === "started") {
+              toast.success(`Autopilot: ${outcome.message}`);
+            } else {
+              toast.info(`Autopilot skipped ${observedEvent.task.id}.`, {
+                description: outcome.message,
+              });
+            }
+          } catch (error) {
+            toast.error(`Autopilot failed for ${observedEvent.task.id}.`, {
+              description: errorMessage(error),
+            });
+          }
+        }
+      }
+    })();
+  }, [
+    activeRepo,
+    agentState,
+    loadRepoRuntimeCatalog,
+    queryClient,
+    settingsSnapshotQuery.data?.autopilot,
+    tasks,
+  ]);
+
+  return <>{children}</>;
+}

--- a/apps/desktop/src/state/providers/autopilot-provider.tsx
+++ b/apps/desktop/src/state/providers/autopilot-provider.tsx
@@ -61,9 +61,12 @@ type ExecuteAutopilotActionArgs = {
   ) => Promise<{
     workingDirectory: string;
   } | null>;
+  startSessionWorkflow: StartSessionWorkflowFn;
   startAgentSession: AgentStateContextValue["startAgentSession"];
   sendAgentMessage: AgentStateContextValue["sendAgentMessage"];
 };
+
+type StartSessionWorkflowFn = typeof startSessionWorkflow;
 
 type ResolvedAutopilotStart = {
   startMode: "fresh" | "reuse" | "fork";
@@ -261,6 +264,7 @@ export const executeAutopilotAction = async ({
   queryClient,
   loadRepoRuntimeCatalog,
   resolveBuildContinuationTarget,
+  startSessionWorkflow,
   startAgentSession,
   sendAgentMessage,
 }: ExecuteAutopilotActionArgs): Promise<AutopilotActionOutcome> => {
@@ -383,6 +387,7 @@ export function AutopilotProvider({ children }: PropsWithChildren): ReactElement
               queryClient,
               loadRepoRuntimeCatalog,
               resolveBuildContinuationTarget: loadBuildContinuationTarget,
+              startSessionWorkflow,
               startAgentSession: agentState.startAgentSession,
               sendAgentMessage: agentState.sendAgentMessage,
             });

--- a/apps/desktop/src/state/providers/index.ts
+++ b/apps/desktop/src/state/providers/index.ts
@@ -1,6 +1,7 @@
 export { AgentStudioStateProvider } from "./agent-studio-state-provider";
 export { AppLifecycleStateProvider } from "./app-lifecycle-state-provider";
 export { AppRuntimeProvider } from "./app-runtime-provider";
+export { AutopilotProvider } from "./autopilot-provider";
 export { ChecksStateProvider } from "./checks-state-provider";
 export { DelegationStateProvider } from "./delegation-state-provider";
 export { SpecStateProvider } from "./spec-state-provider";

--- a/packages/contracts/src/config-schemas.test.ts
+++ b/packages/contracts/src/config-schemas.test.ts
@@ -109,4 +109,30 @@ describe("config-schemas", () => {
       { eventId: "taskProgressedToHumanReview", actionIds: ["startGeneratePullRequest"] },
     ]);
   });
+
+  test("merges duplicate rules for the same event", () => {
+    const parsed = settingsSnapshotSchema.parse({
+      theme: "light",
+      git: { defaultMergeMethod: "merge_commit" },
+      repos: {},
+      globalPromptOverrides: {},
+      autopilot: {
+        rules: [
+          {
+            eventId: "taskProgressedToSpecReady",
+            actionIds: ["startPlanner"],
+          },
+          {
+            eventId: "taskProgressedToSpecReady",
+            actionIds: ["startBuilder", "startPlanner"],
+          },
+        ],
+      },
+    });
+
+    expect(parsed.autopilot.rules[0]).toEqual({
+      eventId: "taskProgressedToSpecReady",
+      actionIds: ["startPlanner", "startBuilder"],
+    });
+  });
 });

--- a/packages/contracts/src/config-schemas.test.ts
+++ b/packages/contracts/src/config-schemas.test.ts
@@ -81,6 +81,24 @@ describe("config-schemas", () => {
     expect(parsed.autopilot.rules.every((rule) => rule.actionIds.length === 0)).toBe(true);
   });
 
+  test("creates a fresh autopilot default for each parse", () => {
+    const first = settingsSnapshotSchema.parse({
+      theme: "light",
+      git: { defaultMergeMethod: "merge_commit" },
+      repos: {},
+      globalPromptOverrides: {},
+    });
+    const second = settingsSnapshotSchema.parse({
+      theme: "light",
+      git: { defaultMergeMethod: "merge_commit" },
+      repos: {},
+      globalPromptOverrides: {},
+    });
+
+    expect(first.autopilot).not.toBe(second.autopilot);
+    expect(first.autopilot.rules).not.toBe(second.autopilot.rules);
+  });
+
   test("normalizes autopilot rule order and dedupes actions", () => {
     const parsed = settingsSnapshotSchema.parse({
       theme: "light",

--- a/packages/contracts/src/config-schemas.test.ts
+++ b/packages/contracts/src/config-schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { repoConfigSchema, settingsSnapshotSchema } from "./config-schemas";
+import { AUTOPILOT_EVENT_IDS, repoConfigSchema, settingsSnapshotSchema } from "./config-schemas";
 
 describe("config-schemas", () => {
   test("defaults dev servers to an empty array", () => {
@@ -67,5 +67,46 @@ describe("config-schemas", () => {
     });
 
     expect(parsed.kanban.doneVisibleDays).toBe(1);
+  });
+
+  test("defaults autopilot rules for every supported event", () => {
+    const parsed = settingsSnapshotSchema.parse({
+      theme: "light",
+      git: { defaultMergeMethod: "merge_commit" },
+      repos: {},
+      globalPromptOverrides: {},
+    });
+
+    expect(parsed.autopilot.rules.map((rule) => rule.eventId)).toEqual([...AUTOPILOT_EVENT_IDS]);
+    expect(parsed.autopilot.rules.every((rule) => rule.actionIds.length === 0)).toBe(true);
+  });
+
+  test("normalizes autopilot rule order and dedupes actions", () => {
+    const parsed = settingsSnapshotSchema.parse({
+      theme: "light",
+      git: { defaultMergeMethod: "merge_commit" },
+      repos: {},
+      globalPromptOverrides: {},
+      autopilot: {
+        rules: [
+          {
+            eventId: "taskProgressedToHumanReview",
+            actionIds: ["startGeneratePullRequest", "startGeneratePullRequest"],
+          },
+          {
+            eventId: "taskProgressedToSpecReady",
+            actionIds: ["startSpec", "startSpec"],
+          },
+        ],
+      },
+    });
+
+    expect(parsed.autopilot.rules).toEqual([
+      { eventId: "taskProgressedToSpecReady", actionIds: ["startSpec"] },
+      { eventId: "taskProgressedToReadyForDev", actionIds: [] },
+      { eventId: "taskProgressedToAiReview", actionIds: [] },
+      { eventId: "taskRejectedByQa", actionIds: [] },
+      { eventId: "taskProgressedToHumanReview", actionIds: ["startGeneratePullRequest"] },
+    ]);
   });
 });

--- a/packages/contracts/src/config-schemas.test.ts
+++ b/packages/contracts/src/config-schemas.test.ts
@@ -95,14 +95,14 @@ describe("config-schemas", () => {
           },
           {
             eventId: "taskProgressedToSpecReady",
-            actionIds: ["startSpec", "startSpec"],
+            actionIds: ["startPlanner", "startPlanner"],
           },
         ],
       },
     });
 
     expect(parsed.autopilot.rules).toEqual([
-      { eventId: "taskProgressedToSpecReady", actionIds: ["startSpec"] },
+      { eventId: "taskProgressedToSpecReady", actionIds: ["startPlanner"] },
       { eventId: "taskProgressedToReadyForDev", actionIds: [] },
       { eventId: "taskProgressedToAiReview", actionIds: [] },
       { eventId: "taskRejectedByQa", actionIds: [] },

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -149,9 +149,10 @@ export type AutopilotRule = z.infer<typeof autopilotRuleSchema>;
 const normalizeAutopilotSettings = (value: { rules: AutopilotRule[] }) => {
   const rulesByEvent = new Map<AutopilotEventId, AutopilotRule>();
   for (const rule of value.rules) {
+    const existing = rulesByEvent.get(rule.eventId);
     rulesByEvent.set(rule.eventId, {
       eventId: rule.eventId,
-      actionIds: dedupeValues(rule.actionIds),
+      actionIds: dedupeValues([...(existing?.actionIds ?? []), ...rule.actionIds]),
     });
   }
 

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -189,7 +189,7 @@ export const globalConfigSchema = z.object({
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
   chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
   kanban: kanbanSettingsSchema.default(DEFAULT_KANBAN_SETTINGS),
-  autopilot: autopilotSettingsSchema.default(createDefaultAutopilotSettings()),
+  autopilot: autopilotSettingsSchema.default(() => createDefaultAutopilotSettings()),
   repos: z.record(z.string(), repoConfigSchema).default({}),
   globalPromptOverrides: repoPromptOverridesSchema.default({}),
   recentRepos: z.array(z.string()).default([]),
@@ -201,7 +201,7 @@ export const settingsSnapshotSchema = z.object({
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
   chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
   kanban: kanbanSettingsSchema.default(DEFAULT_KANBAN_SETTINGS),
-  autopilot: autopilotSettingsSchema.default(createDefaultAutopilotSettings()),
+  autopilot: autopilotSettingsSchema.default(() => createDefaultAutopilotSettings()),
   repos: z.record(z.string(), repoConfigSchema).default({}),
   globalPromptOverrides: repoPromptOverridesSchema.default({}),
 });

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -19,6 +19,22 @@ export const DEFAULT_KANBAN_SETTINGS = {
 } as const;
 const DEFAULT_THEME = "light" as const;
 
+export const AUTOPILOT_EVENT_IDS = [
+  "taskProgressedToSpecReady",
+  "taskProgressedToReadyForDev",
+  "taskProgressedToAiReview",
+  "taskRejectedByQa",
+  "taskProgressedToHumanReview",
+] as const;
+
+export const AUTOPILOT_ACTION_IDS = [
+  "startSpec",
+  "startBuilder",
+  "startQa",
+  "startReviewQaFeedbacks",
+  "startGeneratePullRequest",
+] as const;
+
 const nullableToOptional = <T extends z.ZodTypeAny>(schema: T) =>
   z.preprocess((value) => (value === null ? undefined : value), schema.optional());
 
@@ -27,6 +43,8 @@ const trimmedRequiredString = (field: string) =>
     .string()
     .transform((value) => value.trim())
     .refine((value) => value.length > 0, `${field} cannot be blank.`);
+
+const dedupeValues = <T>(values: readonly T[]) => [...new Set(values)];
 
 export const softGuardrailsSchema = z.object({
   cpuHighWatermarkPercent: z
@@ -116,6 +134,48 @@ export const kanbanSettingsSchema = z.object({
 });
 export type KanbanSettings = z.infer<typeof kanbanSettingsSchema>;
 
+export const autopilotEventIdSchema = z.enum(AUTOPILOT_EVENT_IDS);
+export type AutopilotEventId = z.infer<typeof autopilotEventIdSchema>;
+
+export const autopilotActionIdSchema = z.enum(AUTOPILOT_ACTION_IDS);
+export type AutopilotActionId = z.infer<typeof autopilotActionIdSchema>;
+
+export const autopilotRuleSchema = z.object({
+  eventId: autopilotEventIdSchema,
+  actionIds: z.array(autopilotActionIdSchema).default([]).transform(dedupeValues),
+});
+export type AutopilotRule = z.infer<typeof autopilotRuleSchema>;
+
+const normalizeAutopilotSettings = (value: { rules: AutopilotRule[] }) => {
+  const rulesByEvent = new Map<AutopilotEventId, AutopilotRule>();
+  for (const rule of value.rules) {
+    rulesByEvent.set(rule.eventId, {
+      eventId: rule.eventId,
+      actionIds: dedupeValues(rule.actionIds),
+    });
+  }
+
+  return {
+    rules: AUTOPILOT_EVENT_IDS.map(
+      (eventId): AutopilotRule =>
+        rulesByEvent.get(eventId) ?? {
+          eventId,
+          actionIds: [],
+        },
+    ),
+  };
+};
+
+export const autopilotSettingsSchema = z
+  .object({
+    rules: z.array(autopilotRuleSchema).default([]),
+  })
+  .transform(normalizeAutopilotSettings);
+export type AutopilotSettings = z.infer<typeof autopilotSettingsSchema>;
+
+export const createDefaultAutopilotSettings = (): AutopilotSettings =>
+  normalizeAutopilotSettings({ rules: [] });
+
 const themeValueSchema = z.enum(["light", "dark"]);
 
 export const themeSchema = themeValueSchema.default(DEFAULT_THEME);
@@ -128,6 +188,7 @@ export const globalConfigSchema = z.object({
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
   chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
   kanban: kanbanSettingsSchema.default(DEFAULT_KANBAN_SETTINGS),
+  autopilot: autopilotSettingsSchema.default(createDefaultAutopilotSettings()),
   repos: z.record(z.string(), repoConfigSchema).default({}),
   globalPromptOverrides: repoPromptOverridesSchema.default({}),
   recentRepos: z.array(z.string()).default([]),
@@ -139,6 +200,7 @@ export const settingsSnapshotSchema = z.object({
   git: globalGitConfigSchema.default({ defaultMergeMethod: "merge_commit" }),
   chat: chatSettingsSchema.default(DEFAULT_CHAT_SETTINGS),
   kanban: kanbanSettingsSchema.default(DEFAULT_KANBAN_SETTINGS),
+  autopilot: autopilotSettingsSchema.default(createDefaultAutopilotSettings()),
   repos: z.record(z.string(), repoConfigSchema).default({}),
   globalPromptOverrides: repoPromptOverridesSchema.default({}),
 });

--- a/packages/contracts/src/config-schemas.ts
+++ b/packages/contracts/src/config-schemas.ts
@@ -28,7 +28,7 @@ export const AUTOPILOT_EVENT_IDS = [
 ] as const;
 
 export const AUTOPILOT_ACTION_IDS = [
-  "startSpec",
+  "startPlanner",
   "startBuilder",
   "startQa",
   "startReviewQaFeedbacks",

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -14,6 +14,10 @@ import type {
   AgentToolName,
   AgentWorkflowState,
   AgentWorkflows,
+  AutopilotActionId,
+  AutopilotEventId,
+  AutopilotRule,
+  AutopilotSettings,
   BeadsCheck,
   BuildContinuationTarget,
   BuildContinuationTargetSource,
@@ -115,6 +119,12 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "agentSessionStartModeSchema",
   "agentSessionStartModeValues",
   "agentSessionStatusSchema",
+  "AUTOPILOT_ACTION_IDS",
+  "AUTOPILOT_EVENT_IDS",
+  "autopilotActionIdSchema",
+  "autopilotEventIdSchema",
+  "autopilotRuleSchema",
+  "autopilotSettingsSchema",
   "parseAgentSessionTodoPayloadEntry",
   "parseAgentSessionTodoPayloadList",
   "beadsCheckSchema",
@@ -134,6 +144,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "gitConflictOperationSchema",
   "gitConflictSchema",
   "commitsAheadBehindSchema",
+  "createDefaultAutopilotSettings",
   "directMergeRecordSchema",
   "gitDiffScopeSchema",
   "gitMergeMethodSchema",
@@ -251,6 +262,10 @@ type ExportedTypeContract = {
   AgentPromptOverride: AgentPromptOverride;
   AgentPromptTemplateId: AgentPromptTemplateId;
   AgentScenario: AgentScenario;
+  AutopilotActionId: AutopilotActionId;
+  AutopilotEventId: AutopilotEventId;
+  AutopilotRule: AutopilotRule;
+  AutopilotSettings: AutopilotSettings;
   RuntimeInstanceSummary: RuntimeInstanceSummary;
   RuntimeInstanceSummaryRole: RuntimeInstanceSummaryRole;
   BuildContinuationTarget: BuildContinuationTarget;


### PR DESCRIPTION
## Summary
- add a global Autopilot settings section with persisted event-to-action rules and host/frontend wiring for observed workflow handoffs
- map Autopilot events onto the existing planner, builder, QA, and PR session-start flows, including prerequisite checks, continuation-target validation, and focused regression coverage
- polish follow-up UX by aligning settings icons and pinning the chosen Agent Studio session in the URL when switching task tabs so background Autopilot starts do not steal focus

## Testing
- bun run --filter @openducktor/contracts test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop test
- bun run check:rust

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autopilot UI: new Settings > Autopilot section to configure per-event automation rules and actions.
  * Autopilot runtime: app detects task events and can execute automation flows, showing success/info/error toasts.

* **Improvements**
  * Autopilot settings are normalized, persisted with workspace settings, and round-trip across sessions.
  * Settings modal and sidebars updated to include Autopilot.
  * Task tab selection now pins session/agent context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->