### PR TITLE
fix: chat autoscroll when composer grows multiline

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-scroll-regression.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-scroll-regression.test.tsx
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { act, type ReactElement, useRef, useState } from "react";
+import type { AgentChatWindowRow } from "./agent-chat-thread-windowing";
+import { COMPOSER_TEXTAREA_MIN_HEIGHT_PX, useAgentChatLayout } from "./use-agent-chat-layout";
+import { useAgentChatWindow } from "./use-agent-chat-window";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type MockResizeObserverController = {
+  callback: ResizeObserverCallback;
+  observer: ResizeObserver;
+  observedElements: Set<Element>;
+};
+
+const createRows = (count: number): AgentChatWindowRow[] =>
+  Array.from({ length: count }, (_, index) => ({
+    kind: "message" as const,
+    key: `session-1:msg-${index}`,
+    message: {
+      id: `msg-${index}`,
+      role: "assistant" as const,
+      content: `Message ${index}`,
+      timestamp: "2026-02-20T10:01:00.000Z",
+      meta: {
+        kind: "assistant" as const,
+        agentRole: "spec" as const,
+        isFinal: true,
+        profileId: "Hephaestus (Deep Agent)",
+        durationMs: 1000,
+      },
+    },
+  }));
+
+const mockResizeObserverControllers = new Set<MockResizeObserverController>();
+
+class MockResizeObserver implements ResizeObserver {
+  private readonly observedElements = new Set<Element>();
+
+  constructor(callback: ResizeObserverCallback) {
+    mockResizeObserverControllers.add({
+      callback,
+      observer: this,
+      observedElements: this.observedElements,
+    });
+  }
+
+  disconnect(): void {
+    this.observedElements.clear();
+  }
+
+  observe(target: Element): void {
+    this.observedElements.add(target);
+  }
+
+  unobserve(target: Element): void {
+    this.observedElements.delete(target);
+  }
+}
+
+const triggerResizeObservers = (): void => {
+  for (const controller of mockResizeObserverControllers) {
+    if (controller.observedElements.size === 0) {
+      continue;
+    }
+
+    controller.callback(
+      Array.from(controller.observedElements).map((target) => ({
+        borderBoxSize: [] as ResizeObserverSize[],
+        contentBoxSize: [] as ResizeObserverSize[],
+        contentRect: {} as DOMRectReadOnly,
+        devicePixelContentBoxSize: [] as ResizeObserverSize[],
+        target,
+      })),
+      controller.observer,
+    );
+  }
+};
+
+function ChatScrollRegressionHarness(): ReactElement {
+  const [input, setInput] = useState("");
+  const { messagesContainerRef, composerTextareaRef, resizeComposerTextarea } = useAgentChatLayout({
+    input,
+    activeSessionId: "session-1",
+  });
+  const messagesContentRef = useRef<HTMLDivElement | null>(null);
+  const { isNearBottom } = useAgentChatWindow({
+    rows: createRows(80),
+    activeSessionId: "session-1",
+    isSessionViewLoading: false,
+    messagesContainerRef,
+    messagesContentRef,
+  });
+
+  return (
+    <div>
+      <div ref={messagesContainerRef} data-testid="messages-container">
+        <div ref={messagesContentRef} data-testid="messages-content" />
+      </div>
+      <textarea
+        ref={composerTextareaRef}
+        data-testid="composer"
+        data-multiline={input.includes("\n") ? "true" : "false"}
+        rows={1}
+        value={input}
+        onChange={(event) => setInput(event.currentTarget.value)}
+        onInput={resizeComposerTextarea}
+      />
+      <button
+        type="button"
+        data-testid="grow-composer"
+        onClick={() => setInput("line one\nline two")}
+      >
+        Grow composer
+      </button>
+      <output data-testid="is-near-bottom">{String(isNearBottom)}</output>
+    </div>
+  );
+}
+
+describe("agent chat scroll regression", () => {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+  beforeEach(() => {
+    mockResizeObserverControllers.clear();
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(16);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = mock(() => undefined) as typeof cancelAnimationFrame;
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  test("keeps the transcript pinned after returning to bottom and growing the composer", async () => {
+    render(<ChatScrollRegressionHarness />);
+
+    const container = screen.getByTestId("messages-container") as HTMLDivElement & {
+      scrollTo: ReturnType<typeof mock>;
+      scrollTop: number;
+      scrollHeight: number;
+      clientHeight: number;
+    };
+    const content = screen.getByTestId("messages-content") as HTMLDivElement & {
+      scrollHeight: number;
+    };
+    const textarea = screen.getByTestId("composer") as HTMLTextAreaElement;
+    const scrollTo = mock(() => undefined);
+
+    Object.defineProperty(container, "scrollTo", {
+      configurable: true,
+      value: scrollTo,
+    });
+    Object.defineProperty(container, "scrollHeight", {
+      configurable: true,
+      writable: true,
+      value: 1000,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      configurable: true,
+      writable: true,
+      value: 300,
+    });
+    Object.defineProperty(container, "scrollTop", {
+      configurable: true,
+      writable: true,
+      value: 700,
+    });
+    Object.defineProperty(content, "scrollHeight", {
+      configurable: true,
+      writable: true,
+      value: 1000,
+    });
+    Object.defineProperty(textarea, "scrollHeight", {
+      configurable: true,
+      get: () => (textarea.dataset.multiline === "true" ? 120 : COMPOSER_TEXTAREA_MIN_HEIGHT_PX),
+    });
+
+    await act(async () => {
+      fireEvent.scroll(container);
+    });
+
+    container.scrollTop = 500;
+    await act(async () => {
+      fireEvent.scroll(container);
+    });
+    expect(screen.getByTestId("is-near-bottom").textContent).toBe("false");
+
+    container.scrollTop = 700;
+    await act(async () => {
+      fireEvent.scroll(container);
+    });
+    expect(screen.getByTestId("is-near-bottom").textContent).toBe("true");
+
+    scrollTo.mockClear();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("grow-composer"));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      fireEvent.input(textarea);
+    });
+    expect(textarea.dataset.multiline).toBe("true");
+
+    container.clientHeight = 220;
+    await act(async () => {
+      fireEvent.scroll(container);
+      triggerResizeObservers();
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 1000,
+      behavior: "auto",
+    });
+    expect(screen.getByTestId("is-near-bottom").textContent).toBe("true");
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -425,6 +425,75 @@ describe("AgentChatThread", () => {
     rendered.unmount();
   });
 
+  test("adds bottom spacing before the composer when the last bottom-stack item is a question", async () => {
+    const rendered = render(
+      createElement(AgentChatThread, {
+        model: {
+          ...buildBaseModel(),
+          session: buildSession({
+            pendingQuestions: [buildQuestionRequest()],
+            pendingPermissions: [],
+            todos: [],
+          }),
+        },
+      }),
+    );
+    await act(flush);
+
+    const bottomStack = rendered.container.querySelector(".agent-chat-bottom-stack");
+    expect(bottomStack?.className).toContain("pb-3");
+
+    rendered.unmount();
+  });
+
+  test("adds bottom spacing before the composer when the last bottom-stack item is a permission", async () => {
+    const rendered = render(
+      createElement(AgentChatThread, {
+        model: {
+          ...buildBaseModel(),
+          session: buildSession({
+            pendingQuestions: [],
+            pendingPermissions: [buildPermissionRequest()],
+            todos: [],
+          }),
+        },
+      }),
+    );
+    await act(flush);
+
+    const bottomStack = rendered.container.querySelector(".agent-chat-bottom-stack");
+    expect(bottomStack?.className).toContain("pb-3");
+
+    rendered.unmount();
+  });
+
+  test("keeps the todo panel flush with the composer when todo is the last bottom-stack item", async () => {
+    const rendered = render(
+      createElement(AgentChatThread, {
+        model: {
+          ...buildBaseModel(),
+          session: buildSession({
+            pendingQuestions: [buildQuestionRequest()],
+            pendingPermissions: [],
+            todos: [
+              buildTodoItem({
+                id: "todo-1",
+                content: "Read layout and pages",
+                status: "in_progress",
+              }),
+            ],
+          }),
+        },
+      }),
+    );
+    await act(flush);
+
+    const bottomStack = rendered.container.querySelector(".agent-chat-bottom-stack");
+    expect(bottomStack?.className).toContain("pb-0");
+
+    rendered.unmount();
+  });
+
   test("refreshes rendered rows when the session gains new visible rows", async () => {
     const messages = Array.from({ length: 80 }, (_, index) =>
       buildMessage("user", `Message ${index + 1}`, {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -145,6 +145,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
         session.pendingPermissions.length > 0 ||
         hasVisibleTodo),
   );
+  const shouldAddComposerGap = hasBottomStack && !hasVisibleTodo;
 
   const resolveRowRef = (rowKey: string) => {
     const cached = rowRefByKeyRef.current.get(rowKey);
@@ -253,7 +254,12 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
       </div>
 
       {hasBottomStack && session ? (
-        <div className="agent-chat-bottom-stack shrink-0 space-y-2 px-4 pb-0 pt-3">
+        <div
+          className={cn(
+            "agent-chat-bottom-stack shrink-0 space-y-2 px-4 pt-3",
+            shouldAddComposerGap ? "pb-3" : "pb-0",
+          )}
+        >
           {session.pendingQuestions.map((request) => (
             <AgentSessionQuestionCard
               key={`${session.sessionId}:${request.requestId}`}

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
@@ -99,6 +99,49 @@ describe("use-agent-chat-layout helpers", () => {
     expect(assignedOverflowValues).toEqual([]);
   });
 
+  test("resizeComposerTextareaElement writes an explicit height after a no-op probe with no prior inline height", () => {
+    const styleState = {
+      height: "",
+      overflowY: "hidden" as "auto" | "hidden",
+    };
+    const assignedHeights: string[] = [];
+    const style = {} as CSSStyleDeclaration;
+
+    Object.defineProperty(style, "height", {
+      configurable: true,
+      get: () => styleState.height,
+      set: (value: string) => {
+        assignedHeights.push(value);
+        styleState.height = value;
+      },
+    });
+    Object.defineProperty(style, "overflowY", {
+      configurable: true,
+      get: () => styleState.overflowY,
+      set: (value: "auto" | "hidden") => {
+        styleState.overflowY = value;
+      },
+    });
+
+    const textarea = {
+      getBoundingClientRect: () => ({ height: COMPOSER_TEXTAREA_MIN_HEIGHT_PX }),
+      style,
+      value: "draft",
+      get scrollHeight() {
+        return COMPOSER_TEXTAREA_MIN_HEIGHT_PX;
+      },
+    } as unknown as HTMLTextAreaElement;
+
+    const result = resizeComposerTextareaElement(textarea);
+
+    expect(result).toEqual({
+      didHeightChange: false,
+      overflowY: "hidden",
+    });
+    expect(assignedHeights).toEqual(["auto", "44px"]);
+    expect(styleState.height).toBe("44px");
+  });
+
   test("resizeComposerTextareaElement shrinks a non-empty multiline draft after browser-faithful remeasure", () => {
     const styleState = {
       height: "120px",

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
@@ -54,6 +54,49 @@ describe("use-agent-chat-layout helpers", () => {
     expect(styleState.overflowY).toBe("hidden");
   });
 
+  test("resizeComposerTextareaElement skips no-op multiline style writes when the layout is unchanged", () => {
+    const styleState = {
+      height: "120px",
+      overflowY: "hidden" as "auto" | "hidden",
+    };
+    const assignedHeights: string[] = [];
+    const assignedOverflowValues: Array<"auto" | "hidden"> = [];
+    const style = {} as CSSStyleDeclaration;
+
+    Object.defineProperty(style, "height", {
+      configurable: true,
+      get: () => styleState.height,
+      set: (value: string) => {
+        assignedHeights.push(value);
+        styleState.height = value;
+      },
+    });
+    Object.defineProperty(style, "overflowY", {
+      configurable: true,
+      get: () => styleState.overflowY,
+      set: (value: "auto" | "hidden") => {
+        assignedOverflowValues.push(value);
+        styleState.overflowY = value;
+      },
+    });
+
+    const textarea = {
+      getBoundingClientRect: () => ({ height: 120 }),
+      scrollHeight: 120,
+      style,
+      value: "line one\nline two",
+    } as unknown as HTMLTextAreaElement;
+
+    const result = resizeComposerTextareaElement(textarea);
+
+    expect(result).toEqual({
+      didHeightChange: false,
+      overflowY: "hidden",
+    });
+    expect(assignedHeights).toEqual([]);
+    expect(assignedOverflowValues).toEqual([]);
+  });
+
   test("resizeComposerTextareaElement shrinks the composer when content becomes shorter", () => {
     const styleState = {
       height: "120px",

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
@@ -54,7 +54,7 @@ describe("use-agent-chat-layout helpers", () => {
     expect(styleState.overflowY).toBe("hidden");
   });
 
-  test("resizeComposerTextareaElement skips no-op multiline style writes when the layout is unchanged", () => {
+  test("resizeComposerTextareaElement restores multiline height after measurement when the layout is unchanged", () => {
     const styleState = {
       height: "120px",
       overflowY: "hidden" as "auto" | "hidden",
@@ -82,9 +82,11 @@ describe("use-agent-chat-layout helpers", () => {
 
     const textarea = {
       getBoundingClientRect: () => ({ height: 120 }),
-      scrollHeight: 120,
       style,
       value: "line one\nline two",
+      get scrollHeight() {
+        return 120;
+      },
     } as unknown as HTMLTextAreaElement;
 
     const result = resizeComposerTextareaElement(textarea);
@@ -93,24 +95,50 @@ describe("use-agent-chat-layout helpers", () => {
       didHeightChange: false,
       overflowY: "hidden",
     });
-    expect(assignedHeights).toEqual([]);
+    expect(assignedHeights).toEqual(["auto", "120px"]);
     expect(assignedOverflowValues).toEqual([]);
   });
 
-  test("resizeComposerTextareaElement shrinks the composer when content becomes shorter", () => {
+  test("resizeComposerTextareaElement shrinks a non-empty multiline draft after browser-faithful remeasure", () => {
     const styleState = {
       height: "120px",
-      overflowY: "hidden" as const,
+      overflowY: "hidden" as "auto" | "hidden",
     };
+    const assignedHeights: string[] = [];
+    const style = {} as CSSStyleDeclaration;
+
+    Object.defineProperty(style, "height", {
+      configurable: true,
+      get: () => styleState.height,
+      set: (value: string) => {
+        assignedHeights.push(value);
+        styleState.height = value;
+      },
+    });
+    Object.defineProperty(style, "overflowY", {
+      configurable: true,
+      get: () => styleState.overflowY,
+      set: (value: "auto" | "hidden") => {
+        styleState.overflowY = value;
+      },
+    });
+
     const textarea = {
       getBoundingClientRect: () => ({ height: 120 }),
-      scrollHeight: 40,
-      style: styleState,
+      style,
       value: "draft",
+      get scrollHeight() {
+        return styleState.height === "auto" ? COMPOSER_TEXTAREA_MIN_HEIGHT_PX : 120;
+      },
     } as unknown as HTMLTextAreaElement;
 
-    resizeComposerTextareaElement(textarea);
+    const result = resizeComposerTextareaElement(textarea);
 
+    expect(result).toEqual({
+      didHeightChange: true,
+      overflowY: "hidden",
+    });
+    expect(assignedHeights).toEqual(["auto", "44px"]);
     expect(styleState.height).toBe("44px");
     expect(styleState.overflowY).toBe("hidden");
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -57,10 +57,13 @@ export const resizeComposerTextareaElement = (
   textarea.style.height = "auto";
   const layout = computeComposerTextareaLayout(textarea.scrollHeight);
   const didHeightChange = Math.abs(currentHeight - layout.heightPx) > 0.5;
+  const nextInlineHeight = `${layout.heightPx}px`;
   if (didHeightChange) {
-    textarea.style.height = `${layout.heightPx}px`;
-  } else if (textarea.style.height !== previousInlineHeight) {
+    textarea.style.height = nextInlineHeight;
+  } else if (previousInlineHeight.length > 0 && textarea.style.height !== previousInlineHeight) {
     textarea.style.height = previousInlineHeight;
+  } else if (textarea.style.height !== nextInlineHeight) {
+    textarea.style.height = nextInlineHeight;
   }
   if (textarea.style.overflowY !== layout.overflowY) {
     textarea.style.overflowY = layout.overflowY;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -50,10 +50,14 @@ export const resizeComposerTextareaElement = (
     };
   }
 
+  const previousInlineHeight = textarea.style.height;
+  textarea.style.height = "auto";
   const layout = computeComposerTextareaLayout(textarea.scrollHeight);
   const didHeightChange = Math.abs(currentHeight - layout.heightPx) > 0.5;
   if (didHeightChange) {
     textarea.style.height = `${layout.heightPx}px`;
+  } else if (textarea.style.height !== previousInlineHeight) {
+    textarea.style.height = previousInlineHeight;
   }
   if (textarea.style.overflowY !== layout.overflowY) {
     textarea.style.overflowY = layout.overflowY;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -50,6 +50,9 @@ export const resizeComposerTextareaElement = (
     };
   }
 
+  // The browser only reports a shrink-capable scrollHeight after the inline height
+  // stops constraining the textarea, so we remeasure at auto height and then restore
+  // the previous inline value when the final layout is unchanged.
   const previousInlineHeight = textarea.style.height;
   textarea.style.height = "auto";
   const layout = computeComposerTextareaLayout(textarea.scrollHeight);

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -38,7 +38,9 @@ export const resizeComposerTextareaElement = (
   if (isEmptyDraft) {
     const nextHeight = COMPOSER_TEXTAREA_MIN_HEIGHT_PX;
     const didHeightChange = Math.abs(currentHeight - nextHeight) > 0.5;
-    textarea.style.height = `${nextHeight}px`;
+    if (didHeightChange) {
+      textarea.style.height = `${nextHeight}px`;
+    }
     if (textarea.style.overflowY !== "hidden") {
       textarea.style.overflowY = "hidden";
     }
@@ -48,10 +50,11 @@ export const resizeComposerTextareaElement = (
     };
   }
 
-  textarea.style.height = "auto";
   const layout = computeComposerTextareaLayout(textarea.scrollHeight);
   const didHeightChange = Math.abs(currentHeight - layout.heightPx) > 0.5;
-  textarea.style.height = `${layout.heightPx}px`;
+  if (didHeightChange) {
+    textarea.style.height = `${layout.heightPx}px`;
+  }
   if (textarea.style.overflowY !== layout.overflowY) {
     textarea.style.overflowY = layout.overflowY;
   }

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -329,7 +329,10 @@ export function useAgentChatScrollController({
       const nearTop = nextScrollTop <= CHAT_SCROLL_EDGE_THRESHOLD_PX;
 
       const shouldPreservePinnedState =
-        isPinnedToBottomRef.current && !didScrollTopChange && !nearBottom;
+        previousScrollTop !== null &&
+        isPinnedToBottomRef.current &&
+        !didScrollTopChange &&
+        !nearBottom;
 
       const isEffectivelyPinned =
         isBottomAutoFollowAnimationRef.current || nearBottom || shouldPreservePinnedState;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -43,6 +43,7 @@ export function useAgentChatScrollController({
   const scrollAnimationCleanupRef = useRef<(() => void) | null>(null);
   const isBottomAutoFollowAnimationRef = useRef(false);
   const isUpdatingRef = useRef(false);
+  const lastScrollTopRef = useRef<number | null>(null);
   const pendingScrollAnchorRef = useRef<{ rowKey: string; topOffset: number } | null>(null);
 
   const getRowElementByKey = useCallback(
@@ -317,12 +318,21 @@ export function useAgentChatScrollController({
     }
 
     const handleScroll = () => {
+      const previousScrollTop = lastScrollTopRef.current;
+      const nextScrollTop = container.scrollTop;
+      lastScrollTopRef.current = nextScrollTop;
+      const didScrollTopChange =
+        previousScrollTop !== null && Math.abs(nextScrollTop - previousScrollTop) > 0.5;
       const nearBottom =
-        container.scrollHeight - container.scrollTop - container.clientHeight <=
+        container.scrollHeight - nextScrollTop - container.clientHeight <=
         CHAT_SCROLL_EDGE_THRESHOLD_PX;
-      const nearTop = container.scrollTop <= CHAT_SCROLL_EDGE_THRESHOLD_PX;
+      const nearTop = nextScrollTop <= CHAT_SCROLL_EDGE_THRESHOLD_PX;
 
-      const isEffectivelyPinned = isBottomAutoFollowAnimationRef.current || nearBottom;
+      const shouldPreservePinnedState =
+        isPinnedToBottomRef.current && !didScrollTopChange && !nearBottom;
+
+      const isEffectivelyPinned =
+        isBottomAutoFollowAnimationRef.current || nearBottom || shouldPreservePinnedState;
 
       setIsNearBottom(isEffectivelyPinned);
       setIsNearTop(nearTop);

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -151,7 +151,12 @@ const getLatestResult = (latestResultRef: { current: HookResult | null }): HookR
 
 const mountHarness = async (
   props: HarnessProps,
-  options?: { attachContainer?: boolean; attachContent?: boolean },
+  options?: {
+    attachContainer?: boolean;
+    attachContent?: boolean;
+    containerFactory?: () => MockMessagesContainer;
+    contentFactory?: () => MockMessagesContent;
+  },
 ): Promise<{
   getLatestResult: () => HookResult;
   messagesContainerRef: ReturnType<typeof createHarness>["messagesContainerRef"];
@@ -159,13 +164,21 @@ const mountHarness = async (
   update: (nextProps: HarnessProps) => Promise<void>;
   unmount: () => Promise<void>;
 }> => {
+  const resolvedOptions = options ?? {};
   const { latestResultRef, messagesContainerRef, messagesContentRef } = createHarness();
-  const shouldAttachContent = options?.attachContent ?? options?.attachContainer ?? false;
-  if (options?.attachContainer) {
-    setRefCurrent(messagesContainerRef, createMessagesContainer());
+  const shouldAttachContent =
+    resolvedOptions.attachContent ?? resolvedOptions.attachContainer ?? false;
+  if (resolvedOptions.attachContainer) {
+    setRefCurrent(
+      messagesContainerRef,
+      resolvedOptions.containerFactory?.() ?? createMessagesContainer(),
+    );
   }
   if (shouldAttachContent) {
-    setRefCurrent(messagesContentRef, createMessagesContent());
+    setRefCurrent(
+      messagesContentRef,
+      resolvedOptions.contentFactory?.() ?? createMessagesContent(),
+    );
   }
 
   const harness = createSharedHookHarness((nextProps: HarnessProps) => {
@@ -739,6 +752,33 @@ describe("useAgentChatWindow", () => {
     const result = harness.getLatestResult();
     expect(result.isNearBottom).toBe(true);
     expect(result.isNearTop).toBe(false);
+
+    await harness.unmount();
+  });
+
+  test("does not preserve bottom pinning on the initial scroll sample when the container starts away from bottom", async () => {
+    const harness = await mountHarness(
+      {
+        rows: createRows(80),
+        activeSessionId: null,
+        isSessionViewLoading: false,
+      },
+      {
+        attachContainer: true,
+        containerFactory: () => {
+          const container = createMessagesContainer();
+          container.scrollTop = 500;
+          return container;
+        },
+      },
+    );
+
+    await act(async () => {
+      await flush();
+    });
+
+    expect(harness.getLatestResult().isNearBottom).toBe(false);
+    expect(harness.getLatestResult().isNearTop).toBe(false);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -743,6 +743,69 @@ describe("useAgentChatWindow", () => {
     await harness.unmount();
   });
 
+  test("keeps bottom pinning sticky after the user scrolls back to bottom before composer resize", async () => {
+    const harness = await mountHarness(
+      {
+        rows: createRows(80),
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+      },
+      { attachContainer: true },
+    );
+
+    const container = harness.messagesContainerRef.current as
+      | (MockMessagesContainer & { clientHeight: number })
+      | null;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+
+    const latestScrollListenerCall = container.addEventListener.mock.calls
+      .filter(([eventName]) => eventName === "scroll")
+      .at(-1);
+    const latestScrollListener = latestScrollListenerCall?.[1];
+    if (typeof latestScrollListener !== "function") {
+      throw new Error("Expected scroll listener");
+    }
+
+    container.scrollTop = 500;
+    await act(async () => {
+      latestScrollListener(new Event("scroll"));
+      await flush();
+    });
+
+    expect(harness.getLatestResult().isNearBottom).toBe(false);
+
+    container.scrollTop = container.scrollHeight - container.clientHeight;
+    await act(async () => {
+      latestScrollListener(new Event("scroll"));
+      await flush();
+    });
+
+    expect(harness.getLatestResult().isNearBottom).toBe(true);
+
+    container.scrollTo.mockClear();
+    Object.assign(container, { clientHeight: 220 });
+
+    await act(async () => {
+      latestScrollListener(new Event("scroll"));
+      await flush();
+    });
+
+    await act(async () => {
+      triggerResizeObservers();
+      await flush();
+    });
+
+    expect(container.scrollTo).toHaveBeenCalledWith({
+      top: container.scrollHeight,
+      behavior: "auto",
+    });
+    expect(harness.getLatestResult().isNearBottom).toBe(true);
+
+    await harness.unmount();
+  });
+
   test("does not auto-scroll to bottom when container height changes while not near bottom", async () => {
     const harness = await mountHarness(
       {


### PR DESCRIPTION
## Summary

- preserve agent chat bottom-following while the composer grows or shrinks, including after the user scrolls away and returns to bottom
- harden textarea shrink measurement for non-empty drafts and document the required auto-height probe behavior
- keep question and permission cards visually separated from the composer while leaving the todo panel flush

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run check:rust`
- [x] `bun run test:rust`
- [ ] Not applicable

## Checklist

- [ ] I updated docs when behavior, workflows, runtime contracts, or setup changed
- [x] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [x] I linked related issues or context below

## Related Issues

- OpenDucktor task: `openducktor-aad`

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes are described below

## Additional Context

- Added a rendered regression test for the composer-grow scroll path in `apps/desktop/src/components/features/agents/agent-chat/agent-chat-scroll-regression.test.tsx`.
- Follow-up review fixes harden the initial scroll sample handling and the first no-op textarea remeasure path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Better preserves scroll position when the composer grows, keeping view pinned to bottom when appropriate.
  * More robust scroll pinning that stays sticky after returning to bottom.
  * Composer resizing avoids unnecessary height changes to reduce visual jank.
  * Bottom spacing now adjusts based on visible bottom items for correct layout spacing.

* **Tests**
  * Added regression and unit tests covering scroll, pinning, composer resize, and bottom-stack spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->