### PR TITLE
fix: tauri chat composer scroll stability

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1292,7 +1292,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "host-application"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "host-domain"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "host-infra-beads"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "host-infra-system"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "host-test-support"
-version = "0.1.0"
+version = "0.0.1"
 
 [[package]]
 name = "html5ever"
@@ -2187,7 +2187,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openducktor-desktop"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -16,6 +16,10 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.0.1"
+edition = "2021"
+
 [lib]
 name = "openducktor_desktop_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openducktor-desktop"
-version = "0.1.0"
+version = "0.0.1"
 description = "OpenDucktor Desktop"
 authors = ["OpenDucktor"]
 edition = "2021"

--- a/apps/desktop/src-tauri/crates/host-application/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-application/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-application"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/src-tauri/crates/host-application/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-application/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "host-application"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/apps/desktop/src-tauri/crates/host-domain/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-domain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "host-domain"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/apps/desktop/src-tauri/crates/host-domain/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-domain"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-infra-beads"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "host-infra-beads"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-infra-system"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "host-infra-system"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 anyhow = "1"

--- a/apps/desktop/src-tauri/crates/host-test-support/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-test-support"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/src-tauri/crates/host-test-support/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "host-test-support"
-version = "0.0.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-scroll-regression.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-scroll-regression.test.tsx
@@ -83,9 +83,11 @@ const triggerResizeObservers = (): void => {
 
 function ChatScrollRegressionHarness(): ReactElement {
   const [input, setInput] = useState("");
+  const syncBottomAfterComposerLayoutRef = useRef<(() => void) | null>(null);
   const { messagesContainerRef, composerTextareaRef, resizeComposerTextarea } = useAgentChatLayout({
     input,
     activeSessionId: "session-1",
+    syncBottomAfterComposerLayoutRef,
   });
   const messagesContentRef = useRef<HTMLDivElement | null>(null);
   const { isNearBottom } = useAgentChatWindow({
@@ -94,6 +96,7 @@ function ChatScrollRegressionHarness(): ReactElement {
     isSessionViewLoading: false,
     messagesContainerRef,
     messagesContentRef,
+    syncBottomAfterComposerLayoutRef,
   });
 
   return (

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -44,6 +44,7 @@ const buildBaseModel = () => ({
   onToggleTodoPanel: () => {},
   messagesContainerRef: createRef<HTMLDivElement>(),
   scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+  syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
 });
 
 const flush = async (): Promise<void> => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -78,6 +78,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     onToggleTodoPanel,
     messagesContainerRef,
     scrollToBottomOnSendRef,
+    syncBottomAfterComposerLayoutRef,
   } = model;
   const isTranscriptLoading = isSessionViewLoading || isSessionHistoryLoading;
   const hideTranscriptWhileHydrating = isSessionHistoryLoading;
@@ -108,6 +109,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     isSessionViewLoading: isTranscriptLoading,
     messagesContainerRef,
     messagesContentRef,
+    syncBottomAfterComposerLayoutRef,
   });
 
   useLayoutEffect(() => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -40,6 +40,7 @@ const buildModel = () => ({
     onToggleTodoPanel: () => {},
     messagesContainerRef: createRef<HTMLDivElement>(),
     scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+    syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
   },
   composer: {
     taskId: "task-1",

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -38,6 +38,7 @@ export type AgentChatThreadModel = {
   onToggleTodoPanel: () => void;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
   scrollToBottomOnSendRef: MutableRefObject<(() => void) | null>;
+  syncBottomAfterComposerLayoutRef: MutableRefObject<(() => void) | null>;
 };
 
 export type AgentChatComposerModel = {

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
@@ -54,7 +54,7 @@ describe("use-agent-chat-layout helpers", () => {
     expect(styleState.overflowY).toBe("hidden");
   });
 
-  test("resizeComposerTextareaElement restores multiline height after measurement when the layout is unchanged", () => {
+  test("resizeComposerTextareaElement keeps multiline height stable when the layout is unchanged", () => {
     const styleState = {
       height: "120px",
       overflowY: "hidden" as "auto" | "hidden",
@@ -95,11 +95,68 @@ describe("use-agent-chat-layout helpers", () => {
       didHeightChange: false,
       overflowY: "hidden",
     });
-    expect(assignedHeights).toEqual(["auto", "120px"]);
+    expect(assignedHeights).toEqual([]);
     expect(assignedOverflowValues).toEqual([]);
   });
 
-  test("resizeComposerTextareaElement writes an explicit height after a no-op probe with no prior inline height", () => {
+  test("resizeComposerTextareaElement shrinks a non-empty multiline draft using hidden measurement", () => {
+    const styleState = {
+      height: "120px",
+      overflowY: "hidden" as "auto" | "hidden",
+    };
+    const assignedHeights: string[] = [];
+    const style = {} as CSSStyleDeclaration;
+    const measurementClone = {
+      style: {} as CSSStyleDeclaration,
+      scrollHeight: COMPOSER_TEXTAREA_MIN_HEIGHT_PX,
+      value: "",
+      rows: 1,
+      setAttribute: () => {},
+      remove: () => {},
+    } as unknown as HTMLTextAreaElement;
+
+    Object.defineProperty(style, "height", {
+      configurable: true,
+      get: () => styleState.height,
+      set: (value: string) => {
+        assignedHeights.push(value);
+        styleState.height = value;
+      },
+    });
+    Object.defineProperty(style, "overflowY", {
+      configurable: true,
+      get: () => styleState.overflowY,
+      set: (value: "auto" | "hidden") => {
+        styleState.overflowY = value;
+      },
+    });
+
+    const textarea = {
+      clientWidth: 320,
+      cloneNode: () => measurementClone,
+      getBoundingClientRect: () => ({ height: 120 }),
+      ownerDocument: {
+        body: {
+          appendChild: () => {},
+        },
+      },
+      style,
+      rows: 1,
+      scrollHeight: 120,
+      value: "line one\nline two",
+    } as unknown as HTMLTextAreaElement;
+
+    const result = resizeComposerTextareaElement(textarea);
+
+    expect(result).toEqual({
+      didHeightChange: true,
+      overflowY: "hidden",
+    });
+    expect(assignedHeights).toEqual(["44px"]);
+    expect(styleState.height).toBe("44px");
+  });
+
+  test("resizeComposerTextareaElement skips no-op writes for single-line drafts already at min height", () => {
     const styleState = {
       height: "",
       overflowY: "hidden" as "auto" | "hidden",
@@ -138,52 +195,8 @@ describe("use-agent-chat-layout helpers", () => {
       didHeightChange: false,
       overflowY: "hidden",
     });
-    expect(assignedHeights).toEqual(["auto", "44px"]);
-    expect(styleState.height).toBe("44px");
-  });
-
-  test("resizeComposerTextareaElement shrinks a non-empty multiline draft after browser-faithful remeasure", () => {
-    const styleState = {
-      height: "120px",
-      overflowY: "hidden" as "auto" | "hidden",
-    };
-    const assignedHeights: string[] = [];
-    const style = {} as CSSStyleDeclaration;
-
-    Object.defineProperty(style, "height", {
-      configurable: true,
-      get: () => styleState.height,
-      set: (value: string) => {
-        assignedHeights.push(value);
-        styleState.height = value;
-      },
-    });
-    Object.defineProperty(style, "overflowY", {
-      configurable: true,
-      get: () => styleState.overflowY,
-      set: (value: "auto" | "hidden") => {
-        styleState.overflowY = value;
-      },
-    });
-
-    const textarea = {
-      getBoundingClientRect: () => ({ height: 120 }),
-      style,
-      value: "draft",
-      get scrollHeight() {
-        return styleState.height === "auto" ? COMPOSER_TEXTAREA_MIN_HEIGHT_PX : 120;
-      },
-    } as unknown as HTMLTextAreaElement;
-
-    const result = resizeComposerTextareaElement(textarea);
-
-    expect(result).toEqual({
-      didHeightChange: true,
-      overflowY: "hidden",
-    });
-    expect(assignedHeights).toEqual(["auto", "44px"]);
-    expect(styleState.height).toBe("44px");
-    expect(styleState.overflowY).toBe("hidden");
+    expect(assignedHeights).toEqual([]);
+    expect(styleState.height).toBe("");
   });
 
   test("resizeComposerTextareaElement clamps empty drafts to minimum height", () => {
@@ -296,6 +309,79 @@ describe("use-agent-chat-layout helpers", () => {
     }
     secondFrame(16);
     expect(styleState.height).toBe("44px");
+
+    await harness.unmount();
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  test("requests a bottom resync only when composer height changes while the transcript is near bottom", async () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((_id: number) => undefined) as typeof cancelAnimationFrame;
+
+    let syncBottomAfterComposerLayoutCallCount = 0;
+    const syncBottomAfterComposerLayoutRef = {
+      current: () => {
+        syncBottomAfterComposerLayoutCallCount += 1;
+      },
+    } as { current: (() => void) | null };
+    const harness = createSharedHookHarness(
+      ({ activeSessionId, input }: { activeSessionId: string | null; input: string }) => {
+        return useAgentChatLayout({
+          activeSessionId,
+          input,
+          syncBottomAfterComposerLayoutRef,
+        });
+      },
+      { activeSessionId: "session-1", input: "" },
+    );
+
+    await harness.mount();
+
+    const state = harness.getLatest() as LayoutHookState;
+    state.messagesContainerRef.current = {
+      scrollHeight: 1000,
+      scrollTop: 700,
+      clientHeight: 300,
+    } as HTMLDivElement;
+
+    const styleState = {
+      height: "44px",
+      overflowY: "hidden" as const,
+    };
+    const textarea = {
+      getBoundingClientRect: () => ({ height: 44 }),
+      scrollHeight: 120,
+      style: styleState,
+      value: "line one\nline two",
+    } as unknown as HTMLTextAreaElement;
+    state.composerTextareaRef.current = textarea;
+
+    await harness.update({ activeSessionId: "session-1", input: "line one\nline two" });
+
+    expect(styleState.height).toBe("120px");
+    expect(syncBottomAfterComposerLayoutCallCount).toBe(1);
+
+    state.messagesContainerRef.current = {
+      scrollHeight: 1000,
+      scrollTop: 700,
+      clientHeight: 300,
+    } as HTMLDivElement;
+    Object.assign(textarea, {
+      scrollHeight: 120,
+      value: "line one\nline tw",
+    });
+
+    await harness.update({ activeSessionId: "session-1", input: "line one\nline tw" });
+
+    expect(styleState.height).toBe("120px");
+    expect(syncBottomAfterComposerLayoutCallCount).toBe(1);
 
     await harness.unmount();
     globalThis.requestAnimationFrame = originalRequestAnimationFrame;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.test.ts
@@ -132,12 +132,37 @@ describe("use-agent-chat-layout helpers", () => {
     });
 
     const textarea = {
-      clientWidth: 320,
       cloneNode: () => measurementClone,
-      getBoundingClientRect: () => ({ height: 120 }),
+      getBoundingClientRect: () => ({ height: 120, width: 320 }),
       ownerDocument: {
         body: {
           appendChild: () => {},
+        },
+        defaultView: {
+          getComputedStyle: () =>
+            ({
+              boxSizing: "border-box",
+              fontFamily: "monospace",
+              fontSize: "14px",
+              fontStyle: "normal",
+              fontWeight: "400",
+              letterSpacing: "normal",
+              lineHeight: "20px",
+              paddingTop: "8px",
+              paddingRight: "12px",
+              paddingBottom: "8px",
+              paddingLeft: "12px",
+              textIndent: "0px",
+              textTransform: "none",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              wordSpacing: "0px",
+              overflowWrap: "break-word",
+              borderTopWidth: "1px",
+              borderRightWidth: "1px",
+              borderBottomWidth: "1px",
+              borderLeftWidth: "1px",
+            }) satisfies Partial<CSSStyleDeclaration>,
         },
       },
       style,
@@ -154,6 +179,9 @@ describe("use-agent-chat-layout helpers", () => {
     });
     expect(assignedHeights).toEqual(["44px"]);
     expect(styleState.height).toBe("44px");
+    expect(measurementClone.style.width).toBe("320px");
+    expect(measurementClone.style.paddingTop).toBe("8px");
+    expect(measurementClone.style.lineHeight).toBe("20px");
   });
 
   test("resizeComposerTextareaElement skips no-op writes for single-line drafts already at min height", () => {
@@ -247,145 +275,151 @@ describe("use-agent-chat-layout helpers", () => {
     const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
     const queuedFrameCallbacks: FrameRequestCallback[] = [];
 
-    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      queuedFrameCallbacks.push(callback);
-      return queuedFrameCallbacks.length;
-    }) as typeof requestAnimationFrame;
-    globalThis.cancelAnimationFrame = ((_id: number) => undefined) as typeof cancelAnimationFrame;
+    try {
+      globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+        queuedFrameCallbacks.push(callback);
+        return queuedFrameCallbacks.length;
+      }) as typeof requestAnimationFrame;
+      globalThis.cancelAnimationFrame = ((_id: number) => undefined) as typeof cancelAnimationFrame;
 
-    const harness = createSharedHookHarness(
-      ({ activeSessionId, input }: { activeSessionId: string | null; input: string }) => {
-        return useAgentChatLayout({ activeSessionId, input });
-      },
-      { activeSessionId: "session-1", input: "" },
-    );
+      const harness = createSharedHookHarness(
+        ({ activeSessionId, input }: { activeSessionId: string | null; input: string }) => {
+          return useAgentChatLayout({ activeSessionId, input });
+        },
+        { activeSessionId: "session-1", input: "" },
+      );
 
-    await harness.mount();
+      await harness.mount();
 
-    const state = harness.getLatest() as LayoutHookState;
-    const styleState = {
-      height: "44px",
-      overflowY: "hidden" as const,
-    };
-    const textarea = {
-      getBoundingClientRect: () => ({ height: 44 }),
-      scrollHeight: 120,
-      style: styleState,
-      value: "",
-    } as unknown as HTMLTextAreaElement;
-    state.composerTextareaRef.current = textarea;
+      const state = harness.getLatest() as LayoutHookState;
+      const styleState = {
+        height: "44px",
+        overflowY: "hidden" as const,
+      };
+      const textarea = {
+        getBoundingClientRect: () => ({ height: 44 }),
+        scrollHeight: 120,
+        style: styleState,
+        value: "",
+      } as unknown as HTMLTextAreaElement;
+      state.composerTextareaRef.current = textarea;
 
-    const pendingInitFrames = queuedFrameCallbacks.splice(0);
-    for (const callback of pendingInitFrames) {
-      callback(0);
+      const pendingInitFrames = queuedFrameCallbacks.splice(0);
+      for (const callback of pendingInitFrames) {
+        callback(0);
+      }
+
+      queuedFrameCallbacks.length = 0;
+      textarea.value = "line one\nline two";
+      await harness.update({ activeSessionId: "session-1", input: "line one\nline two" });
+
+      expect(queuedFrameCallbacks).toHaveLength(1);
+      const firstFrame = queuedFrameCallbacks.shift();
+      if (!firstFrame) {
+        throw new Error("Expected queued frame callback");
+      }
+      firstFrame(0);
+      expect(styleState.height).toBe("120px");
+
+      queuedFrameCallbacks.length = 0;
+      await harness.update({ activeSessionId: "session-1", input: "line one\nline two" });
+      expect(queuedFrameCallbacks).toHaveLength(0);
+
+      Object.assign(textarea, {
+        value: "",
+        scrollHeight: 20,
+      });
+      await harness.update({ activeSessionId: "session-1", input: "" });
+      expect(queuedFrameCallbacks).toHaveLength(1);
+
+      const secondFrame = queuedFrameCallbacks.shift();
+      if (!secondFrame) {
+        throw new Error("Expected queued frame callback");
+      }
+      secondFrame(16);
+      expect(styleState.height).toBe("44px");
+
+      await harness.unmount();
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
     }
-
-    queuedFrameCallbacks.length = 0;
-    textarea.value = "line one\nline two";
-    await harness.update({ activeSessionId: "session-1", input: "line one\nline two" });
-
-    expect(queuedFrameCallbacks).toHaveLength(1);
-    const firstFrame = queuedFrameCallbacks.shift();
-    if (!firstFrame) {
-      throw new Error("Expected queued frame callback");
-    }
-    firstFrame(0);
-    expect(styleState.height).toBe("120px");
-
-    queuedFrameCallbacks.length = 0;
-    await harness.update({ activeSessionId: "session-1", input: "line one\nline two" });
-    expect(queuedFrameCallbacks).toHaveLength(0);
-
-    Object.assign(textarea, {
-      value: "",
-      scrollHeight: 20,
-    });
-    await harness.update({ activeSessionId: "session-1", input: "" });
-    expect(queuedFrameCallbacks).toHaveLength(1);
-
-    const secondFrame = queuedFrameCallbacks.shift();
-    if (!secondFrame) {
-      throw new Error("Expected queued frame callback");
-    }
-    secondFrame(16);
-    expect(styleState.height).toBe("44px");
-
-    await harness.unmount();
-    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
-    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
   });
 
   test("requests a bottom resync only when composer height changes while the transcript is near bottom", async () => {
     const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
     const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
 
-    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
-      callback(0);
-      return 1;
-    }) as typeof requestAnimationFrame;
-    globalThis.cancelAnimationFrame = ((_id: number) => undefined) as typeof cancelAnimationFrame;
+    try {
+      globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      }) as typeof requestAnimationFrame;
+      globalThis.cancelAnimationFrame = ((_id: number) => undefined) as typeof cancelAnimationFrame;
 
-    let syncBottomAfterComposerLayoutCallCount = 0;
-    const syncBottomAfterComposerLayoutRef = {
-      current: () => {
-        syncBottomAfterComposerLayoutCallCount += 1;
-      },
-    } as { current: (() => void) | null };
-    const harness = createSharedHookHarness(
-      ({ activeSessionId, input }: { activeSessionId: string | null; input: string }) => {
-        return useAgentChatLayout({
-          activeSessionId,
-          input,
-          syncBottomAfterComposerLayoutRef,
-        });
-      },
-      { activeSessionId: "session-1", input: "" },
-    );
+      let syncBottomAfterComposerLayoutCallCount = 0;
+      const syncBottomAfterComposerLayoutRef = {
+        current: () => {
+          syncBottomAfterComposerLayoutCallCount += 1;
+        },
+      } as { current: (() => void) | null };
+      const harness = createSharedHookHarness(
+        ({ activeSessionId, input }: { activeSessionId: string | null; input: string }) => {
+          return useAgentChatLayout({
+            activeSessionId,
+            input,
+            syncBottomAfterComposerLayoutRef,
+          });
+        },
+        { activeSessionId: "session-1", input: "" },
+      );
 
-    await harness.mount();
+      await harness.mount();
 
-    const state = harness.getLatest() as LayoutHookState;
-    state.messagesContainerRef.current = {
-      scrollHeight: 1000,
-      scrollTop: 700,
-      clientHeight: 300,
-    } as HTMLDivElement;
+      const state = harness.getLatest() as LayoutHookState;
+      state.messagesContainerRef.current = {
+        scrollHeight: 1000,
+        scrollTop: 700,
+        clientHeight: 300,
+      } as HTMLDivElement;
 
-    const styleState = {
-      height: "44px",
-      overflowY: "hidden" as const,
-    };
-    const textarea = {
-      getBoundingClientRect: () => ({ height: 44 }),
-      scrollHeight: 120,
-      style: styleState,
-      value: "line one\nline two",
-    } as unknown as HTMLTextAreaElement;
-    state.composerTextareaRef.current = textarea;
+      const styleState = {
+        height: "44px",
+        overflowY: "hidden" as const,
+      };
+      const textarea = {
+        getBoundingClientRect: () => ({ height: 44 }),
+        scrollHeight: 120,
+        style: styleState,
+        value: "line one\nline two",
+      } as unknown as HTMLTextAreaElement;
+      state.composerTextareaRef.current = textarea;
 
-    await harness.update({ activeSessionId: "session-1", input: "line one\nline two" });
+      await harness.update({ activeSessionId: "session-1", input: "line one\nline two" });
 
-    expect(styleState.height).toBe("120px");
-    expect(syncBottomAfterComposerLayoutCallCount).toBe(1);
+      expect(styleState.height).toBe("120px");
+      expect(syncBottomAfterComposerLayoutCallCount).toBe(1);
 
-    state.messagesContainerRef.current = {
-      scrollHeight: 1000,
-      scrollTop: 700,
-      clientHeight: 300,
-    } as HTMLDivElement;
-    Object.assign(textarea, {
-      scrollHeight: 120,
-      value: "line one\nline tw",
-    });
+      state.messagesContainerRef.current = {
+        scrollHeight: 1000,
+        scrollTop: 700,
+        clientHeight: 300,
+      } as HTMLDivElement;
+      Object.assign(textarea, {
+        scrollHeight: 120,
+        value: "line one\nline tw",
+      });
 
-    await harness.update({ activeSessionId: "session-1", input: "line one\nline tw" });
+      await harness.update({ activeSessionId: "session-1", input: "line one\nline tw" });
 
-    expect(styleState.height).toBe("120px");
-    expect(syncBottomAfterComposerLayoutCallCount).toBe(1);
+      expect(styleState.height).toBe("120px");
+      expect(syncBottomAfterComposerLayoutCallCount).toBe(1);
 
-    await harness.unmount();
-    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
-    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+      await harness.unmount();
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
   });
 
   test("initializes textarea height when ref becomes available after first mount", async () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -29,6 +29,30 @@ const readComposerTextareaHeight = (textarea: HTMLTextAreaElement): number => {
   return textarea.getBoundingClientRect().height;
 };
 
+const CLONE_MEASUREMENT_STYLE_PROPERTIES = [
+  "boxSizing",
+  "fontFamily",
+  "fontSize",
+  "fontStyle",
+  "fontWeight",
+  "letterSpacing",
+  "lineHeight",
+  "paddingTop",
+  "paddingRight",
+  "paddingBottom",
+  "paddingLeft",
+  "textIndent",
+  "textTransform",
+  "whiteSpace",
+  "wordBreak",
+  "wordSpacing",
+  "overflowWrap",
+  "borderTopWidth",
+  "borderRightWidth",
+  "borderBottomWidth",
+  "borderLeftWidth",
+] as const satisfies ReadonlyArray<keyof CSSStyleDeclaration>;
+
 const measureComposerTextareaScrollHeight = (textarea: HTMLTextAreaElement): number => {
   const ownerDocument = textarea.ownerDocument;
   const body = ownerDocument?.body;
@@ -37,15 +61,24 @@ const measureComposerTextareaScrollHeight = (textarea: HTMLTextAreaElement): num
   }
 
   const clone = textarea.cloneNode(false) as HTMLTextAreaElement;
+  const getComputedStyleFn =
+    ownerDocument.defaultView?.getComputedStyle ?? globalThis.getComputedStyle;
+  if (typeof getComputedStyleFn === "function") {
+    const computedStyle = getComputedStyleFn(textarea);
+    for (const property of CLONE_MEASUREMENT_STYLE_PROPERTIES) {
+      clone.style[property] = computedStyle[property];
+    }
+  }
+
   clone.value = textarea.value;
   clone.rows = textarea.rows;
   clone.setAttribute("aria-hidden", "true");
   clone.setAttribute("tabindex", "-1");
 
-  const width = textarea.clientWidth || textarea.getBoundingClientRect().width;
+  const width = textarea.getBoundingClientRect().width;
   clone.style.position = "absolute";
   clone.style.top = "0";
-  clone.style.left = "0";
+  clone.style.left = "-9999px";
   clone.style.height = "0px";
   clone.style.minHeight = "0px";
   clone.style.maxHeight = "none";

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -1,4 +1,6 @@
+import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+import { CHAT_SCROLL_EDGE_THRESHOLD_PX } from "./agent-chat-window-shared";
 
 export const COMPOSER_TEXTAREA_MIN_HEIGHT_PX = 44;
 export const COMPOSER_TEXTAREA_MAX_HEIGHT_PX = 220;
@@ -27,6 +29,40 @@ const readComposerTextareaHeight = (textarea: HTMLTextAreaElement): number => {
   return textarea.getBoundingClientRect().height;
 };
 
+const measureComposerTextareaScrollHeight = (textarea: HTMLTextAreaElement): number => {
+  const ownerDocument = textarea.ownerDocument;
+  const body = ownerDocument?.body;
+  if (!ownerDocument || !body || typeof textarea.cloneNode !== "function") {
+    return textarea.scrollHeight;
+  }
+
+  const clone = textarea.cloneNode(false) as HTMLTextAreaElement;
+  clone.value = textarea.value;
+  clone.rows = textarea.rows;
+  clone.setAttribute("aria-hidden", "true");
+  clone.setAttribute("tabindex", "-1");
+
+  const width = textarea.clientWidth || textarea.getBoundingClientRect().width;
+  clone.style.position = "absolute";
+  clone.style.top = "0";
+  clone.style.left = "0";
+  clone.style.height = "0px";
+  clone.style.minHeight = "0px";
+  clone.style.maxHeight = "none";
+  clone.style.overflowY = "hidden";
+  clone.style.visibility = "hidden";
+  clone.style.pointerEvents = "none";
+  clone.style.zIndex = "-1";
+  if (width > 0) {
+    clone.style.width = `${width}px`;
+  }
+
+  body.appendChild(clone);
+  const measuredScrollHeight = clone.scrollHeight;
+  clone.remove();
+  return measuredScrollHeight;
+};
+
 export const resizeComposerTextareaElement = (
   textarea: HTMLTextAreaElement,
 ): {
@@ -50,19 +86,11 @@ export const resizeComposerTextareaElement = (
     };
   }
 
-  // The browser only reports a shrink-capable scrollHeight after the inline height
-  // stops constraining the textarea, so we remeasure at auto height and then restore
-  // the previous inline value when the final layout is unchanged.
-  const previousInlineHeight = textarea.style.height;
-  textarea.style.height = "auto";
-  const layout = computeComposerTextareaLayout(textarea.scrollHeight);
+  const layout = computeComposerTextareaLayout(measureComposerTextareaScrollHeight(textarea));
+
   const didHeightChange = Math.abs(currentHeight - layout.heightPx) > 0.5;
   const nextInlineHeight = `${layout.heightPx}px`;
   if (didHeightChange) {
-    textarea.style.height = nextInlineHeight;
-  } else if (previousInlineHeight.length > 0 && textarea.style.height !== previousInlineHeight) {
-    textarea.style.height = previousInlineHeight;
-  } else if (textarea.style.height !== nextInlineHeight) {
     textarea.style.height = nextInlineHeight;
   }
   if (textarea.style.overflowY !== layout.overflowY) {
@@ -77,6 +105,7 @@ export const resizeComposerTextareaElement = (
 type UseAgentChatLayoutInput = {
   input: string;
   activeSessionId: string | null;
+  syncBottomAfterComposerLayoutRef?: MutableRefObject<(() => void) | null>;
 };
 
 type UseAgentChatLayoutResult = {
@@ -89,6 +118,7 @@ type UseAgentChatLayoutResult = {
 export const useAgentChatLayout = ({
   input,
   activeSessionId,
+  syncBottomAfterComposerLayoutRef,
 }: UseAgentChatLayoutInput): UseAgentChatLayoutResult => {
   const messagesContainerRef = useRef<HTMLDivElement | null>(null);
   const composerFormRef = useRef<HTMLFormElement | null>(null);
@@ -103,8 +133,17 @@ export const useAgentChatLayout = ({
       return;
     }
 
-    resizeComposerTextareaElement(textarea);
-  }, []);
+    const container = messagesContainerRef.current;
+    const wasNearBottom =
+      container !== null
+        ? container.scrollHeight - container.scrollTop - container.clientHeight <=
+          CHAT_SCROLL_EDGE_THRESHOLD_PX
+        : false;
+    const { didHeightChange } = resizeComposerTextareaElement(textarea);
+    if (wasNearBottom && didHeightChange) {
+      syncBottomAfterComposerLayoutRef?.current?.();
+    }
+  }, [syncBottomAfterComposerLayoutRef]);
 
   const resizeComposerTextarea = useCallback((): void => {
     const requestAnimationFrameFn = globalThis.requestAnimationFrame;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-resize-sync.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-resize-sync.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 type UseAgentChatResizeSyncInput = {
   messagesContainerRef: RefObject<HTMLDivElement | null>;
   messagesContentRef: RefObject<HTMLDivElement | null>;
-  syncBottomIfPinned: () => void;
+  syncBottomIfPinned: (options?: { forcePinned?: boolean }) => void;
 };
 
 export function useAgentChatResizeSync({

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -16,6 +16,7 @@ type UseAgentChatScrollControllerResult = {
   isNearTop: boolean;
   isAutoFollowingToBottom: boolean;
   isPinnedToBottomRef: MutableRefObject<boolean>;
+  userScrollIntentVersionRef: MutableRefObject<number>;
   suppressSentinelsRef: MutableRefObject<boolean>;
   isUpdatingRef: MutableRefObject<boolean>;
   hasPendingScrollRequest: () => boolean;
@@ -36,6 +37,7 @@ export function useAgentChatScrollController({
   const [isNearTop, setIsNearTop] = useState(initialWindow.start === 0);
   const [isAutoFollowingToBottom, setIsAutoFollowingToBottom] = useState(false);
   const isPinnedToBottomRef = useRef(true);
+  const userScrollIntentVersionRef = useRef(0);
   const pendingScrollRequestRef = useRef<PendingScrollRequest | null>(null);
   const suppressSentinelsRef = useRef(false);
   const sentinelUnlockFrameRef = useRef<number | null>(null);
@@ -321,6 +323,10 @@ export function useAgentChatScrollController({
       return;
     }
 
+    const registerUserScrollIntent = () => {
+      userScrollIntentVersionRef.current += 1;
+    };
+
     const handleScroll = () => {
       const previousScrollTop = lastScrollTopRef.current;
       const nextScrollTop = container.scrollTop;
@@ -347,8 +353,14 @@ export function useAgentChatScrollController({
     };
 
     handleScroll();
+    container.addEventListener("wheel", registerUserScrollIntent, { passive: true });
+    container.addEventListener("touchstart", registerUserScrollIntent, { passive: true });
+    container.addEventListener("pointerdown", registerUserScrollIntent, { passive: true });
     container.addEventListener("scroll", handleScroll, { passive: true });
     return () => {
+      container.removeEventListener("wheel", registerUserScrollIntent);
+      container.removeEventListener("touchstart", registerUserScrollIntent);
+      container.removeEventListener("pointerdown", registerUserScrollIntent);
       container.removeEventListener("scroll", handleScroll);
     };
   }, [messagesContainerRef]);
@@ -367,6 +379,7 @@ export function useAgentChatScrollController({
     isNearTop,
     isAutoFollowingToBottom,
     isPinnedToBottomRef,
+    userScrollIntentVersionRef,
     suppressSentinelsRef,
     isUpdatingRef,
     hasPendingScrollRequest: () => pendingScrollRequestRef.current !== null,

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-scroll-controller.ts
@@ -20,7 +20,7 @@ type UseAgentChatScrollControllerResult = {
   isUpdatingRef: MutableRefObject<boolean>;
   hasPendingScrollRequest: () => boolean;
   captureScrollAnchor: (rowKey: string) => void;
-  syncBottomIfPinned: () => void;
+  syncBottomIfPinned: (options?: { forcePinned?: boolean }) => void;
   scrollToBottomOnSend: () => void;
   requestWindowScroll: (request: PendingScrollRequest) => void;
   applyPendingScrollRequest: () => void;
@@ -222,40 +222,44 @@ export function useAgentChatScrollController({
     });
   }, [animateScrollTo, cancelScrollAnimation, messagesContainerRef]);
 
-  const syncBottomIfPinned = useCallback(() => {
-    const container = messagesContainerRef.current;
-    if (!container) {
-      return;
-    }
+  const syncBottomIfPinned = useCallback(
+    (options?: { forcePinned?: boolean }) => {
+      const container = messagesContainerRef.current;
+      if (!container) {
+        return;
+      }
+      const forcePinned = options?.forcePinned === true;
 
-    if (pendingScrollRequestRef.current?.target === "bottom" || suppressSentinelsRef.current) {
-      return;
-    }
+      if (pendingScrollRequestRef.current?.target === "bottom" || suppressSentinelsRef.current) {
+        return;
+      }
 
-    if (isUpdatingRef.current && !isPinnedToBottomRef.current) {
-      return;
-    }
+      if (isUpdatingRef.current && !isPinnedToBottomRef.current && !forcePinned) {
+        return;
+      }
 
-    if (isBottomAutoFollowAnimationRef.current) {
+      if (isBottomAutoFollowAnimationRef.current) {
+        setIsNearBottom(true);
+        return;
+      }
+
+      const distanceFromBottom =
+        container.scrollHeight - container.scrollTop - container.clientHeight;
+      const isWithinBottomThreshold = distanceFromBottom <= CHAT_SCROLL_EDGE_THRESHOLD_PX;
+      if (!forcePinned && !isPinnedToBottomRef.current && !isWithinBottomThreshold) {
+        return;
+      }
+
+      container.scrollTo({
+        top: container.scrollHeight,
+        behavior: "auto",
+      });
+      isPinnedToBottomRef.current = true;
       setIsNearBottom(true);
-      return;
-    }
-
-    const distanceFromBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
-    const isWithinBottomThreshold = distanceFromBottom <= CHAT_SCROLL_EDGE_THRESHOLD_PX;
-    if (!isPinnedToBottomRef.current && !isWithinBottomThreshold) {
-      return;
-    }
-
-    container.scrollTo({
-      top: container.scrollHeight,
-      behavior: "auto",
-    });
-    isPinnedToBottomRef.current = true;
-    setIsNearBottom(true);
-    setIsNearTop(false);
-  }, [messagesContainerRef]);
+      setIsNearTop(false);
+    },
+    [messagesContainerRef],
+  );
 
   const setBottomAnchoredState = useCallback((windowStart: number) => {
     setIsNearBottom(true);

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -15,6 +15,7 @@ type HarnessProps = {
   rows: AgentChatWindowRow[];
   activeSessionId: string | null;
   isSessionViewLoading: boolean;
+  syncBottomAfterComposerLayoutRef?: { current: (() => void) | null };
 };
 
 type HookResult = ReturnType<typeof useAgentChatWindow>;
@@ -73,6 +74,11 @@ const createHarness = () => {
       ...props,
       messagesContainerRef,
       messagesContentRef,
+      ...(props.syncBottomAfterComposerLayoutRef
+        ? {
+            syncBottomAfterComposerLayoutRef: props.syncBottomAfterComposerLayoutRef,
+          }
+        : {}),
     });
     latestResultRef.current = result;
     return null;
@@ -186,6 +192,11 @@ const mountHarness = async (
       ...nextProps,
       messagesContainerRef,
       messagesContentRef,
+      ...(nextProps.syncBottomAfterComposerLayoutRef
+        ? {
+            syncBottomAfterComposerLayoutRef: nextProps.syncBottomAfterComposerLayoutRef,
+          }
+        : {}),
     });
     latestResultRef.current = result;
     return result;
@@ -834,6 +845,59 @@ describe("useAgentChatWindow", () => {
 
     await act(async () => {
       triggerResizeObservers();
+      await flush();
+    });
+
+    expect(container.scrollTo).toHaveBeenCalledWith({
+      top: container.scrollHeight,
+      behavior: "auto",
+    });
+    expect(harness.getLatestResult().isNearBottom).toBe(true);
+
+    await harness.unmount();
+  });
+
+  test("restores bottom pinning after a composer-layout sync when transient scroll drift breaks bottom threshold", async () => {
+    const syncBottomAfterComposerLayoutRef = { current: null } as { current: (() => void) | null };
+    const harness = await mountHarness(
+      {
+        rows: createRows(80),
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+        syncBottomAfterComposerLayoutRef,
+      },
+      { attachContainer: true },
+    );
+
+    const container = harness.messagesContainerRef.current as
+      | (MockMessagesContainer & { clientHeight: number })
+      | null;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+
+    const latestScrollListenerCall = container.addEventListener.mock.calls
+      .filter(([eventName]) => eventName === "scroll")
+      .at(-1);
+    const latestScrollListener = latestScrollListenerCall?.[1];
+    if (typeof latestScrollListener !== "function") {
+      throw new Error("Expected scroll listener");
+    }
+
+    container.scrollTo.mockClear();
+    Object.assign(container, {
+      scrollTop: 660,
+      clientHeight: 220,
+    });
+
+    const syncBottomAfterComposerLayout = syncBottomAfterComposerLayoutRef.current;
+    if (typeof syncBottomAfterComposerLayout !== "function") {
+      throw new Error("Expected composer layout sync callback");
+    }
+
+    await act(async () => {
+      latestScrollListener(new Event("scroll"));
+      syncBottomAfterComposerLayout();
       await flush();
     });
 

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -910,6 +910,99 @@ describe("useAgentChatWindow", () => {
     await harness.unmount();
   });
 
+  test("cancels composer-layout sync when the user starts scrolling during the settle window", async () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+    const queuedFrameCallbacks: FrameRequestCallback[] = [];
+
+    try {
+      globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+        queuedFrameCallbacks.push(callback);
+        return queuedFrameCallbacks.length;
+      }) as typeof requestAnimationFrame;
+      globalThis.cancelAnimationFrame = (() => undefined) as typeof cancelAnimationFrame;
+
+      const syncBottomAfterComposerLayoutRef = { current: null } as {
+        current: (() => void) | null;
+      };
+      const harness = await mountHarness(
+        {
+          rows: createRows(80),
+          activeSessionId: "session-1",
+          isSessionViewLoading: false,
+          syncBottomAfterComposerLayoutRef,
+        },
+        { attachContainer: true },
+      );
+
+      const container = harness.messagesContainerRef.current as
+        | (MockMessagesContainer & { clientHeight: number })
+        | null;
+      if (!container) {
+        throw new Error("Expected messages container");
+      }
+
+      const latestScrollListenerCall = container.addEventListener.mock.calls
+        .filter(([eventName]) => eventName === "scroll")
+        .at(-1);
+      const latestScrollListener = latestScrollListenerCall?.[1];
+      if (typeof latestScrollListener !== "function") {
+        throw new Error("Expected scroll listener");
+      }
+
+      const userScrollIntentListenerCall = container.addEventListener.mock.calls
+        .filter(([eventName]) => eventName === "wheel")
+        .at(-1);
+      const userScrollIntentListener = userScrollIntentListenerCall?.[1];
+      if (typeof userScrollIntentListener !== "function") {
+        throw new Error("Expected user scroll intent listener");
+      }
+
+      container.scrollTo.mockClear();
+      Object.assign(container, {
+        scrollTop: 660,
+        clientHeight: 220,
+      });
+
+      const syncBottomAfterComposerLayout = syncBottomAfterComposerLayoutRef.current;
+      if (typeof syncBottomAfterComposerLayout !== "function") {
+        throw new Error("Expected composer layout sync callback");
+      }
+
+      await act(async () => {
+        latestScrollListener(new Event("scroll"));
+        syncBottomAfterComposerLayout();
+      });
+
+      const firstSettleFrame = queuedFrameCallbacks.shift();
+      if (!firstSettleFrame) {
+        throw new Error("Expected first settle frame");
+      }
+
+      await act(async () => {
+        firstSettleFrame(0);
+      });
+
+      const secondSettleFrame = queuedFrameCallbacks.shift();
+      if (!secondSettleFrame) {
+        throw new Error("Expected second settle frame");
+      }
+
+      await act(async () => {
+        userScrollIntentListener(new Event("wheel"));
+        secondSettleFrame(16);
+        await flush();
+      });
+
+      expect(container.scrollTo).not.toHaveBeenCalled();
+
+      await harness.unmount();
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+      globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
   test("does not auto-scroll to bottom when container height changes while not near bottom", async () => {
     const harness = await mountHarness(
       {

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
@@ -1,5 +1,5 @@
-import type { RefCallback, RefObject } from "react";
-import { useLayoutEffect } from "react";
+import type { MutableRefObject, RefCallback, RefObject } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import type { AgentChatWindowRow } from "./agent-chat-thread-windowing";
 import { clampWindowRange, createBottomAnchoredWindow } from "./agent-chat-window-shared";
 import { useAgentChatResizeSync } from "./use-agent-chat-resize-sync";
@@ -13,6 +13,7 @@ type UseAgentChatWindowInput = {
   isSessionViewLoading: boolean;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
   messagesContentRef: RefObject<HTMLDivElement | null>;
+  syncBottomAfterComposerLayoutRef?: MutableRefObject<(() => void) | null>;
 };
 
 type UseAgentChatWindowResult = {
@@ -35,7 +36,10 @@ export function useAgentChatWindow({
   isSessionViewLoading,
   messagesContainerRef,
   messagesContentRef,
+  syncBottomAfterComposerLayoutRef,
 }: UseAgentChatWindowInput): UseAgentChatWindowResult {
+  const composerLayoutSyncFrameRef = useRef<number | null>(null);
+  const composerLayoutSyncSettleFrameRef = useRef<number | null>(null);
   const rowCount = rows.length;
   const initialWindow = createBottomAnchoredWindow(rowCount);
   const {
@@ -67,6 +71,47 @@ export function useAgentChatWindow({
     messagesContentRef,
     syncBottomIfPinned,
   });
+
+  useEffect(() => {
+    if (!syncBottomAfterComposerLayoutRef) {
+      return;
+    }
+
+    const cancelScheduledComposerLayoutSync = () => {
+      if (composerLayoutSyncFrameRef.current !== null) {
+        globalThis.cancelAnimationFrame(composerLayoutSyncFrameRef.current);
+        composerLayoutSyncFrameRef.current = null;
+      }
+      if (composerLayoutSyncSettleFrameRef.current !== null) {
+        globalThis.cancelAnimationFrame(composerLayoutSyncSettleFrameRef.current);
+        composerLayoutSyncSettleFrameRef.current = null;
+      }
+    };
+
+    syncBottomAfterComposerLayoutRef.current = () => {
+      cancelScheduledComposerLayoutSync();
+      const requestAnimationFrameFn = globalThis.requestAnimationFrame;
+      if (typeof requestAnimationFrameFn !== "function") {
+        syncBottomIfPinned({ forcePinned: true });
+        return;
+      }
+
+      composerLayoutSyncFrameRef.current = requestAnimationFrameFn(() => {
+        composerLayoutSyncFrameRef.current = null;
+        composerLayoutSyncSettleFrameRef.current = requestAnimationFrameFn(() => {
+          composerLayoutSyncSettleFrameRef.current = null;
+          syncBottomIfPinned({ forcePinned: true });
+        });
+      });
+    };
+
+    return () => {
+      cancelScheduledComposerLayoutSync();
+      if (syncBottomAfterComposerLayoutRef.current) {
+        syncBottomAfterComposerLayoutRef.current = null;
+      }
+    };
+  }, [syncBottomAfterComposerLayoutRef, syncBottomIfPinned]);
   const { windowRange, scrollToBottom, scrollToTop, shiftWindowUp, shiftWindowDown } =
     useAgentChatWindowRangeController({
       rows,

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
@@ -40,6 +40,7 @@ export function useAgentChatWindow({
 }: UseAgentChatWindowInput): UseAgentChatWindowResult {
   const composerLayoutSyncFrameRef = useRef<number | null>(null);
   const composerLayoutSyncSettleFrameRef = useRef<number | null>(null);
+  const composerLayoutSyncTokenRef = useRef(0);
   const rowCount = rows.length;
   const initialWindow = createBottomAnchoredWindow(rowCount);
   const {
@@ -47,6 +48,7 @@ export function useAgentChatWindow({
     isNearTop,
     isAutoFollowingToBottom,
     isPinnedToBottomRef,
+    userScrollIntentVersionRef,
     suppressSentinelsRef,
     isUpdatingRef,
     hasPendingScrollRequest,
@@ -78,6 +80,7 @@ export function useAgentChatWindow({
     }
 
     const cancelScheduledComposerLayoutSync = () => {
+      composerLayoutSyncTokenRef.current += 1;
       if (composerLayoutSyncFrameRef.current !== null) {
         globalThis.cancelAnimationFrame(composerLayoutSyncFrameRef.current);
         composerLayoutSyncFrameRef.current = null;
@@ -96,10 +99,20 @@ export function useAgentChatWindow({
         return;
       }
 
+      const scheduledToken = composerLayoutSyncTokenRef.current + 1;
+      composerLayoutSyncTokenRef.current = scheduledToken;
+      const scheduledUserScrollIntentVersion = userScrollIntentVersionRef.current;
+
       composerLayoutSyncFrameRef.current = requestAnimationFrameFn(() => {
         composerLayoutSyncFrameRef.current = null;
         composerLayoutSyncSettleFrameRef.current = requestAnimationFrameFn(() => {
           composerLayoutSyncSettleFrameRef.current = null;
+          if (composerLayoutSyncTokenRef.current !== scheduledToken) {
+            return;
+          }
+          if (userScrollIntentVersionRef.current !== scheduledUserScrollIntentVersion) {
+            return;
+          }
           syncBottomIfPinned({ forcePinned: true });
         });
       });
@@ -111,7 +124,8 @@ export function useAgentChatWindow({
         syncBottomAfterComposerLayoutRef.current = null;
       }
     };
-  }, [syncBottomAfterComposerLayoutRef, syncBottomIfPinned]);
+  }, [syncBottomAfterComposerLayoutRef, syncBottomIfPinned, userScrollIntentVersionRef]);
+
   const { windowRange, scrollToBottom, scrollToTop, shiftWindowUp, shiftWindowDown } =
     useAgentChatWindowRangeController({
       rows,

--- a/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
@@ -296,6 +296,7 @@ describe("agents-page-view-model", () => {
       onToggleTodoPanel,
       messagesContainerRef: { current: null },
       scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+      syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
       input: "message",
       isReadOnly: false,
       readOnlyReason: null,

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -131,6 +131,7 @@ type AgentChatThreadModelArgs = {
   onToggleTodoPanel: () => void;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
   scrollToBottomOnSendRef: React.MutableRefObject<(() => void) | null>;
+  syncBottomAfterComposerLayoutRef: React.MutableRefObject<(() => void) | null>;
 };
 
 type AgentChatComposerModelArgs = {
@@ -195,6 +196,7 @@ export const buildAgentChatThreadModel = (
   onToggleTodoPanel: args.onToggleTodoPanel,
   messagesContainerRef: args.messagesContainerRef,
   scrollToBottomOnSendRef: args.scrollToBottomOnSendRef,
+  syncBottomAfterComposerLayoutRef: args.syncBottomAfterComposerLayoutRef,
 });
 
 export const buildAgentChatComposerModel = (

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -142,11 +142,13 @@ export function useAgentStudioPageModels({
     isSessionHistoryHydrating: core.isSessionHistoryHydrating,
     contextSwitchVersion: core.contextSwitchVersion,
   });
+  const syncBottomAfterComposerLayoutRef = useRef<(() => void) | null>(null);
 
   const { messagesContainerRef, composerFormRef, composerTextareaRef, resizeComposerTextarea } =
     useAgentChatLayout({
       input: composer.input,
       activeSessionId: threadSession?.sessionId ?? null,
+      syncBottomAfterComposerLayoutRef,
     });
 
   const scrollToBottomOnSendRef = useRef<(() => void) | null>(null);
@@ -291,6 +293,7 @@ export function useAgentStudioPageModels({
     onToggleTodoPanel: handleToggleTodoPanel,
     messagesContainerRef,
     scrollToBottomOnSendRef,
+    syncBottomAfterComposerLayoutRef,
   });
 
   const agentChatComposerModel = useAgentStudioComposerModel({

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
@@ -37,6 +37,7 @@ const createHookArgs = (showThinkingMessages = false): HookArgs => ({
   onToggleTodoPanel: () => {},
   messagesContainerRef: createRef<HTMLDivElement>(),
   scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+  syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
 });
 
 const createHookHarness = (initialProps: HookArgs) =>

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -116,6 +116,7 @@ type UseAgentStudioThreadModelArgs = {
   onToggleTodoPanel: () => void;
   messagesContainerRef: RefObject<HTMLDivElement | null>;
   scrollToBottomOnSendRef: React.MutableRefObject<(() => void) | null>;
+  syncBottomAfterComposerLayoutRef: React.MutableRefObject<(() => void) | null>;
 };
 
 export const useAgentStudioThreadModel = ({
@@ -145,6 +146,7 @@ export const useAgentStudioThreadModel = ({
   onToggleTodoPanel,
   messagesContainerRef,
   scrollToBottomOnSendRef,
+  syncBottomAfterComposerLayoutRef,
 }: UseAgentStudioThreadModelArgs): ReturnType<typeof buildAgentChatThreadModel> => {
   const handleRefreshChecks = useCallback((): void => {
     void refreshChecks();
@@ -190,6 +192,7 @@ export const useAgentStudioThreadModel = ({
         onToggleTodoPanel,
         messagesContainerRef,
         scrollToBottomOnSendRef,
+        syncBottomAfterComposerLayoutRef,
       }),
     [
       activeSessionAgentColors,
@@ -218,6 +221,7 @@ export const useAgentStudioThreadModel = ({
       threadSession,
       todoPanelCollapsed,
       onToggleTodoPanel,
+      syncBottomAfterComposerLayoutRef,
     ],
   );
 };


### PR DESCRIPTION
## Summary

- include the queued version manifest fix from `ee97d414` so the branch carries the pending Cargo version alignment
- thread a composer-layout sync callback through the agent chat models so bottom pinning can recover after genuine composer height changes
- replace live textarea `height = \"auto\"` remeasurement with hidden clone measurement so multiline typing and shrink paths stay stable in Tauri

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run check:rust`
- [x] `bun run test:rust`
- [ ] Not applicable

## Checklist

- [ ] I updated docs when behavior, workflows, runtime contracts, or setup changed
- [x] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [x] I linked related issues or context below

## Related Issues

- Follow-up after merged chat scroll PR and local Tauri verification

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes are described below

## Additional Context

- New rendered regression coverage lives in `apps/desktop/src/components/features/agents/agent-chat/agent-chat-scroll-regression.test.tsx`.
- The root-cause fix measures shrinkable textarea height in a hidden clone instead of mutating the live textarea during input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal package versions.

* **Improvements**
  * Enhanced scroll synchronization in agent chat to improve behavior when the message composer layout changes, ensuring the chat view remains properly positioned.

* **Tests**
  * Expanded test coverage for scroll and layout synchronization in agent chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->