### PR TITLE
fix(desktop): refresh task documents after workflow writes

### DIFF
--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -1,8 +1,13 @@
+import type { TaskMetadataReadOptions } from "@openducktor/adapters-tauri-host";
 import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { host } from "@/state/operations/host";
 import { resolveLatestDocumentPayload } from "@/state/queries/document-utils";
-import { documentQueryKeyForSection, TASK_DOCUMENT_STALE_TIME_MS } from "@/state/queries/documents";
+import {
+  documentQueryKeyForSection,
+  fetchTaskDocumentFromQueryWithLoader,
+  TASK_DOCUMENT_STALE_TIME_MS,
+} from "@/state/queries/documents";
 import type { TaskDocumentPayload } from "@/types/task-documents";
 
 export type DocumentSectionKey = "spec" | "plan" | "qa";
@@ -16,12 +21,24 @@ export type TaskDocumentState = {
 };
 
 type TaskDocumentLoaders = {
-  loadSpecDocument: (taskId: string) => Promise<TaskDocumentPayload>;
-  loadPlanDocument: (taskId: string) => Promise<TaskDocumentPayload>;
-  loadQaReportDocument: (taskId: string) => Promise<TaskDocumentPayload>;
+  loadSpecDocument: (
+    taskId: string,
+    options?: TaskMetadataReadOptions,
+  ) => Promise<TaskDocumentPayload>;
+  loadPlanDocument: (
+    taskId: string,
+    options?: TaskMetadataReadOptions,
+  ) => Promise<TaskDocumentPayload>;
+  loadQaReportDocument: (
+    taskId: string,
+    options?: TaskMetadataReadOptions,
+  ) => Promise<TaskDocumentPayload>;
 };
 
-type SectionLoaders = Record<DocumentSectionKey, (taskId: string) => Promise<TaskDocumentPayload>>;
+type SectionLoaders = Record<
+  DocumentSectionKey,
+  (taskId: string, options?: TaskMetadataReadOptions) => Promise<TaskDocumentPayload>
+>;
 
 const DISABLED_TASK_ID = "__disabled__";
 
@@ -44,14 +61,21 @@ const toErrorMessage = (error: unknown): string =>
 
 const createHostDocumentLoader = <TResult extends { markdown: string; updatedAt: string | null }>(
   cacheScope: string,
-  readDocument: (repoPath: string, taskId: string) => Promise<TResult>,
-): ((taskId: string) => Promise<TaskDocumentPayload>) => {
-  return async (nextTaskId: string): Promise<TaskDocumentPayload> => {
+  readDocument: (
+    repoPath: string,
+    taskId: string,
+    options?: TaskMetadataReadOptions,
+  ) => Promise<TResult>,
+): ((taskId: string, options?: TaskMetadataReadOptions) => Promise<TaskDocumentPayload>) => {
+  return async (
+    nextTaskId: string,
+    options?: TaskMetadataReadOptions,
+  ): Promise<TaskDocumentPayload> => {
     if (!cacheScope) {
       throw new Error("Select a repository before loading task documents.");
     }
 
-    const document = await readDocument(cacheScope, nextTaskId);
+    const document = await readDocument(cacheScope, nextTaskId, options);
     return {
       markdown: document.markdown,
       updatedAt: document.updatedAt,
@@ -70,7 +94,7 @@ const createDocumentQueryOptions = ({
   cacheScope: string;
   taskId: string;
   section: DocumentSectionKey;
-  loader: (taskId: string) => Promise<TaskDocumentPayload>;
+  loader: (taskId: string, options?: TaskMetadataReadOptions) => Promise<TaskDocumentPayload>;
 }) => {
   const queryKey = documentQueryKeyForSection(cacheScope, taskId, section);
   return queryOptions({
@@ -211,20 +235,17 @@ export function useTaskDocuments(
       const options = queryOptionsBySection[section];
       const loadDocument = sectionLoaders[section];
       void queryClient.cancelQueries({ queryKey: options.queryKey, exact: true });
-      void queryClient
-        .fetchQuery({
-          ...options,
-          queryFn: async (): Promise<TaskDocumentPayload> => {
-            const incoming = await loadDocument(taskId);
-            const current = queryClient.getQueryData<TaskDocumentPayload>(options.queryKey);
-            return resolveLatestDocumentPayload(current, incoming);
-          },
-          staleTime: 0,
-        })
-        .catch(() => undefined);
+      void fetchTaskDocumentFromQueryWithLoader(
+        queryClient,
+        cacheScope,
+        taskId,
+        section,
+        loadDocument,
+        { forceFresh: true },
+      ).catch(() => undefined);
       return true;
     },
-    [enabled, queryClient, queryOptionsBySection, sectionLoaders, taskId],
+    [cacheScope, enabled, queryClient, queryOptionsBySection, sectionLoaders, taskId],
   );
 
   const applyDocumentUpdate = useCallback(

--- a/apps/desktop/src/components/features/task-details/use-task-documents.ts
+++ b/apps/desktop/src/components/features/task-details/use-task-documents.ts
@@ -1,11 +1,10 @@
-import type { TaskMetadataReadOptions } from "@openducktor/adapters-tauri-host";
 import { queryOptions, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { host } from "@/state/operations/host";
 import { resolveLatestDocumentPayload } from "@/state/queries/document-utils";
 import {
   documentQueryKeyForSection,
-  fetchTaskDocumentFromQueryWithLoader,
+  fetchFreshTaskDocumentFromQuery,
   TASK_DOCUMENT_STALE_TIME_MS,
 } from "@/state/queries/documents";
 import type { TaskDocumentPayload } from "@/types/task-documents";
@@ -21,24 +20,12 @@ export type TaskDocumentState = {
 };
 
 type TaskDocumentLoaders = {
-  loadSpecDocument: (
-    taskId: string,
-    options?: TaskMetadataReadOptions,
-  ) => Promise<TaskDocumentPayload>;
-  loadPlanDocument: (
-    taskId: string,
-    options?: TaskMetadataReadOptions,
-  ) => Promise<TaskDocumentPayload>;
-  loadQaReportDocument: (
-    taskId: string,
-    options?: TaskMetadataReadOptions,
-  ) => Promise<TaskDocumentPayload>;
+  loadSpecDocument: (taskId: string) => Promise<TaskDocumentPayload>;
+  loadPlanDocument: (taskId: string) => Promise<TaskDocumentPayload>;
+  loadQaReportDocument: (taskId: string) => Promise<TaskDocumentPayload>;
 };
 
-type SectionLoaders = Record<
-  DocumentSectionKey,
-  (taskId: string, options?: TaskMetadataReadOptions) => Promise<TaskDocumentPayload>
->;
+type SectionLoaders = Record<DocumentSectionKey, (taskId: string) => Promise<TaskDocumentPayload>>;
 
 const DISABLED_TASK_ID = "__disabled__";
 
@@ -61,21 +48,14 @@ const toErrorMessage = (error: unknown): string =>
 
 const createHostDocumentLoader = <TResult extends { markdown: string; updatedAt: string | null }>(
   cacheScope: string,
-  readDocument: (
-    repoPath: string,
-    taskId: string,
-    options?: TaskMetadataReadOptions,
-  ) => Promise<TResult>,
-): ((taskId: string, options?: TaskMetadataReadOptions) => Promise<TaskDocumentPayload>) => {
-  return async (
-    nextTaskId: string,
-    options?: TaskMetadataReadOptions,
-  ): Promise<TaskDocumentPayload> => {
+  readDocument: (repoPath: string, taskId: string) => Promise<TResult>,
+): ((taskId: string) => Promise<TaskDocumentPayload>) => {
+  return async (nextTaskId: string): Promise<TaskDocumentPayload> => {
     if (!cacheScope) {
       throw new Error("Select a repository before loading task documents.");
     }
 
-    const document = await readDocument(cacheScope, nextTaskId, options);
+    const document = await readDocument(cacheScope, nextTaskId);
     return {
       markdown: document.markdown,
       updatedAt: document.updatedAt,
@@ -94,7 +74,7 @@ const createDocumentQueryOptions = ({
   cacheScope: string;
   taskId: string;
   section: DocumentSectionKey;
-  loader: (taskId: string, options?: TaskMetadataReadOptions) => Promise<TaskDocumentPayload>;
+  loader: (taskId: string) => Promise<TaskDocumentPayload>;
 }) => {
   const queryKey = documentQueryKeyForSection(cacheScope, taskId, section);
   return queryOptions({
@@ -233,19 +213,13 @@ export function useTaskDocuments(
       }
 
       const options = queryOptionsBySection[section];
-      const loadDocument = sectionLoaders[section];
       void queryClient.cancelQueries({ queryKey: options.queryKey, exact: true });
-      void fetchTaskDocumentFromQueryWithLoader(
-        queryClient,
-        cacheScope,
-        taskId,
-        section,
-        loadDocument,
-        { forceFresh: true },
-      ).catch(() => undefined);
+      void fetchFreshTaskDocumentFromQuery(queryClient, cacheScope, taskId, section).catch(
+        () => undefined,
+      );
       return true;
     },
-    [cacheScope, enabled, queryClient, queryOptionsBySection, sectionLoaders, taskId],
+    [cacheScope, enabled, queryClient, queryOptionsBySection, taskId],
   );
 
   const applyDocumentUpdate = useCallback(

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -291,7 +291,8 @@ describe("useAgentStudioDocuments", () => {
         markdown: "# Updated spec",
         updatedAt: "2026-02-22T09:00:00.000Z",
       });
-      expect(reloadDocumentMock).not.toHaveBeenCalled();
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
+      expect(reloadDocumentMock).toHaveBeenCalledWith("spec");
     } finally {
       await harness.unmount();
     }
@@ -357,70 +358,42 @@ describe("useAgentStudioDocuments", () => {
         markdown: "# Saved plan",
         updatedAt: null,
       });
-      expect(reloadDocumentMock).not.toHaveBeenCalled();
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
+      expect(reloadDocumentMock).toHaveBeenCalledWith("plan");
     } finally {
       await harness.unmount();
     }
   });
 
-  test("retries completed tool messages after loading clears for spec/plan/qa", async () => {
-    const scenarios = [
-      { tool: "odt_set_spec", section: "spec" as const, sessionId: "session-spec-loading" },
-      { tool: "odt_set_plan", section: "plan" as const, sessionId: "session-plan-loading" },
-      { tool: "odt_qa_rejected", section: "qa" as const, sessionId: "session-qa-loading" },
-    ] as const;
-
-    for (const scenario of scenarios) {
-      reloadDocumentMock.mockClear();
-      applyDocumentUpdateMock.mockClear();
-
-      setTaskDocumentsState({
-        specDoc: createDocumentState({
-          markdown: "",
-          updatedAt: null,
-          isLoading: scenario.section === "spec",
-        }),
-        planDoc: createDocumentState({
-          markdown: "",
-          updatedAt: null,
-          isLoading: scenario.section === "plan",
-        }),
-        qaDoc: createDocumentState({
-          markdown: "",
-          updatedAt: null,
-          isLoading: scenario.section === "qa",
-        }),
-      });
-
-      const activeSession = createAgentSessionFixture({
+  test("dedupes completed tool refreshes for the same message across rerenders", async () => {
+    const baseArgs = {
+      ...createBaseArgs(),
+      selectedTask: null,
+      activeSession: createAgentSessionFixture({
         runtimeKind: "opencode",
-        sessionId: scenario.sessionId,
-        messages: [createCompletedToolMessage({ tool: scenario.tool, input: {}, output: "done" })],
-      });
+        sessionId: "session-dedupe",
+        messages: [
+          createCompletedToolMessage({
+            id: "message-dedupe",
+            tool: "odt_set_plan",
+            input: { markdown: "# Saved plan" },
+            output: "done",
+          }),
+        ],
+      }),
+    };
+    const harness = createHookHarness(baseArgs);
 
-      const baseArgs = {
-        ...createBaseArgs(),
-        selectedTask: null,
-        activeSession,
-      };
-      const harness = createHookHarness(baseArgs);
+    try {
+      await harness.mount();
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
+      expect(reloadDocumentMock).toHaveBeenCalledWith("plan");
 
-      try {
-        await harness.mount();
-        expect(reloadDocumentMock).not.toHaveBeenCalled();
+      await harness.update(baseArgs);
 
-        setTaskDocumentsState({
-          specDoc: createDocumentState({ markdown: "", updatedAt: null, isLoading: false }),
-          planDoc: createDocumentState({ markdown: "", updatedAt: null, isLoading: false }),
-          qaDoc: createDocumentState({ markdown: "", updatedAt: null, isLoading: false }),
-        });
-        await harness.update(baseArgs);
-
-        expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
-        expect(reloadDocumentMock).toHaveBeenCalledWith(scenario.section);
-      } finally {
-        await harness.unmount();
-      }
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
+    } finally {
+      await harness.unmount();
     }
   });
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -397,6 +397,47 @@ describe("useAgentStudioDocuments", () => {
     }
   });
 
+  test("waits for repo context before processing completed workflow document events", async () => {
+    const toolMessage = createCompletedToolMessage({
+      id: "message-repo-hydration",
+      tool: "odt_set_plan",
+      input: { markdown: "# Hydrated plan" },
+      output: "completed 2026-02-22T09:15:00.000Z",
+    });
+    const baseArgs = {
+      ...createBaseArgs(),
+      selectedTask: null,
+      activeRepo: null,
+      activeSession: createAgentSessionFixture({
+        runtimeKind: "opencode",
+        sessionId: "session-repo-hydration",
+        messages: [toolMessage],
+      }),
+    };
+    const harness = createHookHarness(baseArgs);
+
+    try {
+      await harness.mount();
+      expect(applyDocumentUpdateMock).not.toHaveBeenCalled();
+      expect(reloadDocumentMock).not.toHaveBeenCalled();
+
+      await harness.update({
+        ...baseArgs,
+        activeRepo: "/repo",
+      });
+
+      expect(applyDocumentUpdateMock).toHaveBeenCalledTimes(1);
+      expect(applyDocumentUpdateMock).toHaveBeenCalledWith("plan", {
+        markdown: "# Hydrated plan",
+        updatedAt: "2026-02-22T09:15:00.000Z",
+      });
+      expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
+      expect(reloadDocumentMock).toHaveBeenCalledWith("plan");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("resets processed tool-event context when switching sessions", async () => {
     setTaskDocumentsState({
       specDoc: createDocumentState({

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.test.tsx
@@ -366,20 +366,19 @@ describe("useAgentStudioDocuments", () => {
   });
 
   test("dedupes completed tool refreshes for the same message across rerenders", async () => {
+    const toolMessage = createCompletedToolMessage({
+      id: "message-dedupe",
+      tool: "odt_set_plan",
+      input: { markdown: "# Saved plan" },
+      output: "done",
+    });
     const baseArgs = {
       ...createBaseArgs(),
       selectedTask: null,
       activeSession: createAgentSessionFixture({
         runtimeKind: "opencode",
         sessionId: "session-dedupe",
-        messages: [
-          createCompletedToolMessage({
-            id: "message-dedupe",
-            tool: "odt_set_plan",
-            input: { markdown: "# Saved plan" },
-            output: "done",
-          }),
-        ],
+        messages: [toolMessage],
       }),
     };
     const harness = createHookHarness(baseArgs);
@@ -389,7 +388,14 @@ describe("useAgentStudioDocuments", () => {
       expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
       expect(reloadDocumentMock).toHaveBeenCalledWith("plan");
 
-      await harness.update(baseArgs);
+      await harness.update({
+        ...baseArgs,
+        activeSession: createAgentSessionFixture({
+          runtimeKind: "opencode",
+          sessionId: "session-dedupe",
+          messages: [toolMessage],
+        }),
+      });
 
       expect(reloadDocumentMock).toHaveBeenCalledTimes(1);
     } finally {

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
@@ -137,6 +137,9 @@ export function useAgentStudioDocuments({
       if (!target) {
         continue;
       }
+      if (!activeRepo) {
+        continue;
+      }
 
       const completionInfo =
         extractCompletionTimestamp(meta.output) ?? extractCompletionTimestamp(message.content);
@@ -165,10 +168,20 @@ export function useAgentStudioDocuments({
         }
       }
 
-      reloadDocument(target.section);
-      processedDocumentToolEventsRef.current.add(eventKey);
+      if (reloadDocument(target.section)) {
+        processedDocumentToolEventsRef.current.add(eventKey);
+      }
     }
-  }, [activeSession, applyDocumentUpdate, planDoc, qaDoc, reloadDocument, specDoc, taskId]);
+  }, [
+    activeRepo,
+    activeSession,
+    applyDocumentUpdate,
+    planDoc,
+    qaDoc,
+    reloadDocument,
+    specDoc,
+    taskId,
+  ]);
 
   return {
     specDoc,

--- a/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-documents.ts
@@ -71,7 +71,6 @@ export function useAgentStudioDocuments({
 
   const documentContextKey = `${taskId}:${activeSession?.sessionId ?? ""}`;
   const processedDocumentToolEventsRef = useRef(new Set<string>());
-  const documentReloadAttemptsRef = useRef(new Map<string, number>());
   const refreshedTaskVersionsRef = useRef(new Set<string>());
   const taskDocumentVersionKey =
     taskId && selectedTask
@@ -92,7 +91,6 @@ export function useAgentStudioDocuments({
   // biome-ignore lint/correctness/useExhaustiveDependencies: Context key intentionally controls reset boundary.
   useEffect(() => {
     processedDocumentToolEventsRef.current.clear();
-    documentReloadAttemptsRef.current.clear();
     refreshedTaskVersionsRef.current.clear();
   }, [documentContextKey]);
 
@@ -167,37 +165,8 @@ export function useAgentStudioDocuments({
         }
       }
 
-      if (
-        completionInfo !== null &&
-        effectiveUpdatedAtTimestamp !== null &&
-        effectiveUpdatedAtTimestamp >= completionInfo.timestamp
-      ) {
-        processedDocumentToolEventsRef.current.add(eventKey);
-        documentReloadAttemptsRef.current.delete(eventKey);
-        continue;
-      }
-
-      if (hasInputMarkdown) {
-        processedDocumentToolEventsRef.current.add(eventKey);
-        documentReloadAttemptsRef.current.delete(eventKey);
-        continue;
-      }
-
-      if (target.state.isLoading) {
-        continue;
-      }
-
-      const attempts = documentReloadAttemptsRef.current.get(eventKey) ?? 0;
-      if (attempts >= 6) {
-        processedDocumentToolEventsRef.current.add(eventKey);
-        documentReloadAttemptsRef.current.delete(eventKey);
-        continue;
-      }
-
-      const triggered = reloadDocument(target.section);
-      if (triggered) {
-        documentReloadAttemptsRef.current.set(eventKey, attempts + 1);
-      }
+      reloadDocument(target.section);
+      processedDocumentToolEventsRef.current.add(eventKey);
     }
   }, [activeSession, applyDocumentUpdate, planDoc, qaDoc, reloadDocument, specDoc, taskId]);
 

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
@@ -17,6 +17,44 @@ reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
 type HookArgs = Parameters<typeof useSpecOperations>[0];
 type HookResult = ReturnType<typeof useSpecOperations>;
 
+const emptyDocument = { markdown: "", updatedAt: null as string | null };
+
+const createTaskDocumentHostReaders = (readers: {
+  spec?: (
+    repoPath: string,
+    taskId: string,
+  ) => Promise<{ markdown: string; updatedAt: string | null }>;
+  plan?: (
+    repoPath: string,
+    taskId: string,
+  ) => Promise<{ markdown: string; updatedAt: string | null }>;
+  qa?: (
+    repoPath: string,
+    taskId: string,
+  ) => Promise<{ markdown: string; updatedAt: string | null }>;
+}) => {
+  const resolveSection = async (repoPath: string, taskId: string, section: string) => {
+    if (section === "spec") {
+      return readers.spec ? readers.spec(repoPath, taskId) : emptyDocument;
+    }
+
+    if (section === "plan") {
+      return readers.plan ? readers.plan(repoPath, taskId) : emptyDocument;
+    }
+
+    return readers.qa ? readers.qa(repoPath, taskId) : emptyDocument;
+  };
+
+  return {
+    taskDocumentGet: mock(async (repoPath: string, taskId: string, section: string) =>
+      resolveSection(repoPath, taskId, section),
+    ),
+    taskDocumentGetFresh: mock(async (repoPath: string, taskId: string, section: string) =>
+      resolveSection(repoPath, taskId, section),
+    ),
+  };
+};
+
 const createHookHarness = (initialArgs: HookArgs) => {
   let latest: HookResult | null = null;
   const currentArgs = initialArgs;
@@ -86,11 +124,18 @@ describe("use-spec-operations", () => {
       markdown: "",
       updatedAt: null,
     }));
+    const { taskDocumentGet, taskDocumentGetFresh } = createTaskDocumentHostReaders({
+      spec: specGet,
+    });
 
     const original = {
       specGet: host.specGet,
+      taskDocumentGet: host.taskDocumentGet,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
     };
     host.specGet = specGet;
+    host.taskDocumentGet = taskDocumentGet;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
 
     const harness = createHookHarness({ activeRepo: "/repo-a" });
 
@@ -98,11 +143,13 @@ describe("use-spec-operations", () => {
       await harness.mount();
       const spec = await harness.getLatest().loadSpec("task-1");
 
-      expect(specGet).toHaveBeenCalledWith("/repo-a", "task-1", undefined);
+      expect(specGet).toHaveBeenCalledWith("/repo-a", "task-1");
       expect(spec).toBe(defaultSpecTemplateMarkdown);
     } finally {
       await harness.unmount();
       host.specGet = original.specGet;
+      host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
     }
   });
 
@@ -118,16 +165,23 @@ describe("use-spec-operations", () => {
       currentSpecUpdatedAt = "2026-02-22T10:30:00.000Z";
       return { updatedAt: "2026-02-22T10:30:00.000Z" };
     });
+    const { taskDocumentGet, taskDocumentGetFresh } = createTaskDocumentHostReaders({
+      spec: specGet,
+    });
     const tasksList = mock(async () => []);
     const runsList = mock(async () => []);
 
     const original = {
       specGet: host.specGet,
+      taskDocumentGet: host.taskDocumentGet,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
       setSpec: host.setSpec,
       tasksList: host.tasksList,
       runsList: host.runsList,
     };
     host.specGet = specGet;
+    host.taskDocumentGet = taskDocumentGet;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
     host.setSpec = setSpec;
     host.tasksList = tasksList;
     host.runsList = runsList;
@@ -151,6 +205,8 @@ describe("use-spec-operations", () => {
     } finally {
       await harness.unmount();
       host.specGet = original.specGet;
+      host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
       host.setSpec = original.setSpec;
       host.tasksList = original.tasksList;
       host.runsList = original.runsList;
@@ -184,6 +240,11 @@ describe("use-spec-operations", () => {
       currentPlanUpdatedAt = "2026-02-22T10:04:00.000Z";
       return { updatedAt: "2026-02-22T10:04:00.000Z" };
     });
+    const { taskDocumentGet, taskDocumentGetFresh } = createTaskDocumentHostReaders({
+      spec: specGet,
+      plan: planGet,
+      qa: qaGetReport,
+    });
     const tasksList = mock(async () => []);
     const runsList = mock(async () => []);
 
@@ -191,6 +252,8 @@ describe("use-spec-operations", () => {
       specGet: host.specGet,
       planGet: host.planGet,
       qaGetReport: host.qaGetReport,
+      taskDocumentGet: host.taskDocumentGet,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
       saveSpecDocument: host.saveSpecDocument,
       savePlanDocument: host.savePlanDocument,
       tasksList: host.tasksList,
@@ -199,6 +262,8 @@ describe("use-spec-operations", () => {
     host.specGet = specGet;
     host.planGet = planGet;
     host.qaGetReport = qaGetReport;
+    host.taskDocumentGet = taskDocumentGet;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
     host.saveSpecDocument = saveSpecDocument;
     host.savePlanDocument = savePlanDocument;
     host.tasksList = tasksList;
@@ -230,9 +295,9 @@ describe("use-spec-operations", () => {
         updatedAt: "2026-02-22T10:04:00.000Z",
       });
 
-      expect(specGet).toHaveBeenCalledWith("/repo-a", "task-1", undefined);
-      expect(planGet).toHaveBeenCalledWith("/repo-a", "task-1", undefined);
-      expect(qaGetReport).toHaveBeenCalledWith("/repo-a", "task-1", undefined);
+      expect(specGet).toHaveBeenCalledWith("/repo-a", "task-1");
+      expect(planGet).toHaveBeenCalledWith("/repo-a", "task-1");
+      expect(qaGetReport).toHaveBeenCalledWith("/repo-a", "task-1");
       expect(saveSpecDocument).toHaveBeenCalledWith({
         repoPath: "/repo-a",
         taskId: "task-1",
@@ -248,6 +313,8 @@ describe("use-spec-operations", () => {
       host.specGet = original.specGet;
       host.planGet = original.planGet;
       host.qaGetReport = original.qaGetReport;
+      host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
       host.saveSpecDocument = original.saveSpecDocument;
       host.savePlanDocument = original.savePlanDocument;
       host.tasksList = original.tasksList;
@@ -301,11 +368,17 @@ describe("use-spec-operations", () => {
       currentPlanUpdatedAt = "2026-02-22T10:04:00.000Z";
       return { updatedAt: "2026-02-22T10:04:00.000Z" };
     });
+    const { taskDocumentGet, taskDocumentGetFresh } = createTaskDocumentHostReaders({
+      spec: specGet,
+      plan: planGet,
+    });
     const tasksList = mock(async () => []);
     const runsList = mock(async () => []);
     const original = {
       specGet: host.specGet,
       planGet: host.planGet,
+      taskDocumentGet: host.taskDocumentGet,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
       saveSpecDocument: host.saveSpecDocument,
       savePlanDocument: host.savePlanDocument,
       tasksList: host.tasksList,
@@ -313,6 +386,8 @@ describe("use-spec-operations", () => {
     };
     host.specGet = specGet;
     host.planGet = planGet;
+    host.taskDocumentGet = taskDocumentGet;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
     host.saveSpecDocument = saveSpecDocument;
     host.savePlanDocument = savePlanDocument;
     host.tasksList = tasksList;
@@ -385,6 +460,8 @@ describe("use-spec-operations", () => {
       await harness.unmount();
       host.specGet = original.specGet;
       host.planGet = original.planGet;
+      host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
       host.saveSpecDocument = original.saveSpecDocument;
       host.savePlanDocument = original.savePlanDocument;
       host.tasksList = original.tasksList;
@@ -428,15 +505,22 @@ describe("use-spec-operations", () => {
       currentSpecUpdatedAt = "2026-02-22T10:06:00.000Z";
       return { updatedAt: "2026-02-22T10:06:00.000Z" };
     });
+    const { taskDocumentGet, taskDocumentGetFresh } = createTaskDocumentHostReaders({
+      spec: specGet,
+    });
     const tasksList = mock(async () => []);
     const runsList = mock(async () => []);
     const original = {
       specGet: host.specGet,
+      taskDocumentGet: host.taskDocumentGet,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
       setSpec: host.setSpec,
       tasksList: host.tasksList,
       runsList: host.runsList,
     };
     host.specGet = specGet;
+    host.taskDocumentGet = taskDocumentGet;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
     host.setSpec = setSpec;
     host.tasksList = tasksList;
     host.runsList = runsList;
@@ -488,6 +572,8 @@ describe("use-spec-operations", () => {
     } finally {
       await harness.unmount();
       host.specGet = original.specGet;
+      host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
       host.setSpec = original.setSpec;
       host.tasksList = original.tasksList;
       host.runsList = original.runsList;
@@ -533,11 +619,17 @@ describe("use-spec-operations", () => {
     }));
     const saveSpecDocument = mock(async () => ({ updatedAt: "2026-02-22T10:01:00.000Z" }));
     const savePlanDocument = mock(async () => ({ updatedAt: "2026-02-22T10:01:00.000Z" }));
+    const { taskDocumentGet, taskDocumentGetFresh } = createTaskDocumentHostReaders({
+      spec: specGet,
+      plan: planGet,
+    });
     const tasksList = mock(async () => []);
     const runsList = mock(async () => []);
     const original = {
       specGet: host.specGet,
       planGet: host.planGet,
+      taskDocumentGet: host.taskDocumentGet,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
       saveSpecDocument: host.saveSpecDocument,
       savePlanDocument: host.savePlanDocument,
       tasksList: host.tasksList,
@@ -545,6 +637,8 @@ describe("use-spec-operations", () => {
     };
     host.specGet = specGet;
     host.planGet = planGet;
+    host.taskDocumentGet = taskDocumentGet;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
     host.saveSpecDocument = saveSpecDocument;
     host.savePlanDocument = savePlanDocument;
     host.tasksList = tasksList;
@@ -591,6 +685,8 @@ describe("use-spec-operations", () => {
       await harness.unmount();
       host.specGet = original.specGet;
       host.planGet = original.planGet;
+      host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
       host.saveSpecDocument = original.saveSpecDocument;
       host.savePlanDocument = original.savePlanDocument;
       host.tasksList = original.tasksList;

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
@@ -17,7 +17,9 @@ reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
 type HookArgs = Parameters<typeof useSpecOperations>[0];
 type HookResult = ReturnType<typeof useSpecOperations>;
 
-const emptyDocument = { markdown: "", updatedAt: null as string | null };
+const createEmptyDocument = () => ({ markdown: "", updatedAt: null as string | null });
+
+type TaskDocumentSection = "spec" | "plan" | "qa";
 
 const createTaskDocumentHostReaders = (readers: {
   spec?: (
@@ -33,24 +35,29 @@ const createTaskDocumentHostReaders = (readers: {
     taskId: string,
   ) => Promise<{ markdown: string; updatedAt: string | null }>;
 }) => {
-  const resolveSection = async (repoPath: string, taskId: string, section: string) => {
+  const resolveSection = async (repoPath: string, taskId: string, section: TaskDocumentSection) => {
     if (section === "spec") {
-      return readers.spec ? readers.spec(repoPath, taskId) : emptyDocument;
+      return readers.spec ? readers.spec(repoPath, taskId) : createEmptyDocument();
     }
 
     if (section === "plan") {
-      return readers.plan ? readers.plan(repoPath, taskId) : emptyDocument;
+      return readers.plan ? readers.plan(repoPath, taskId) : createEmptyDocument();
     }
 
-    return readers.qa ? readers.qa(repoPath, taskId) : emptyDocument;
+    if (section === "qa") {
+      return readers.qa ? readers.qa(repoPath, taskId) : createEmptyDocument();
+    }
+
+    throw new Error(`Unexpected task document section: ${section satisfies never}`);
   };
 
   return {
-    taskDocumentGet: mock(async (repoPath: string, taskId: string, section: string) =>
+    taskDocumentGet: mock(async (repoPath: string, taskId: string, section: TaskDocumentSection) =>
       resolveSection(repoPath, taskId, section),
     ),
-    taskDocumentGetFresh: mock(async (repoPath: string, taskId: string, section: string) =>
-      resolveSection(repoPath, taskId, section),
+    taskDocumentGetFresh: mock(
+      async (repoPath: string, taskId: string, section: TaskDocumentSection) =>
+        resolveSection(repoPath, taskId, section),
     ),
   };
 };

--- a/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-spec-operations.test.tsx
@@ -98,7 +98,7 @@ describe("use-spec-operations", () => {
       await harness.mount();
       const spec = await harness.getLatest().loadSpec("task-1");
 
-      expect(specGet).toHaveBeenCalledWith("/repo-a", "task-1");
+      expect(specGet).toHaveBeenCalledWith("/repo-a", "task-1", undefined);
       expect(spec).toBe(defaultSpecTemplateMarkdown);
     } finally {
       await harness.unmount();
@@ -230,9 +230,9 @@ describe("use-spec-operations", () => {
         updatedAt: "2026-02-22T10:04:00.000Z",
       });
 
-      expect(specGet).toHaveBeenCalledWith("/repo-a", "task-1");
-      expect(planGet).toHaveBeenCalledWith("/repo-a", "task-1");
-      expect(qaGetReport).toHaveBeenCalledWith("/repo-a", "task-1");
+      expect(specGet).toHaveBeenCalledWith("/repo-a", "task-1", undefined);
+      expect(planGet).toHaveBeenCalledWith("/repo-a", "task-1", undefined);
+      expect(qaGetReport).toHaveBeenCalledWith("/repo-a", "task-1", undefined);
       expect(saveSpecDocument).toHaveBeenCalledWith({
         repoPath: "/repo-a",
         taskId: "task-1",

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -713,25 +713,39 @@ describe("use-task-operations", () => {
     let currentPlanUpdatedAt: string | null = null;
     const tasksList = mock(async () => [makeTask("A", currentStatus)]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
-    const specGet = mock(async () => ({ markdown: "", updatedAt: null }));
-    const planGet = mock(async () => ({
-      markdown: currentPlanMarkdown,
-      updatedAt: currentPlanUpdatedAt,
-    }));
-    const qaGetReport = mock(async () => ({ markdown: "", updatedAt: null }));
+    const taskDocumentGet = mock(async (_repoPath: string, _taskId: string, section: string) => {
+      if (section === "plan") {
+        return {
+          markdown: currentPlanMarkdown,
+          updatedAt: currentPlanUpdatedAt,
+        };
+      }
+
+      return { markdown: "", updatedAt: null };
+    });
+    const taskDocumentGetFresh = mock(
+      async (_repoPath: string, _taskId: string, section: string) => {
+        if (section === "plan") {
+          return {
+            markdown: currentPlanMarkdown,
+            updatedAt: currentPlanUpdatedAt,
+          };
+        }
+
+        return { markdown: "", updatedAt: null };
+      },
+    );
 
     const original = {
       tasksList: host.tasksList,
       runsList: host.runsList,
-      specGet: host.specGet,
-      planGet: host.planGet,
-      qaGetReport: host.qaGetReport,
+      taskDocumentGet: host.taskDocumentGet,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
     };
     host.tasksList = tasksList;
     host.runsList = runsList;
-    host.specGet = specGet;
-    host.planGet = planGet;
-    host.qaGetReport = qaGetReport;
+    host.taskDocumentGet = taskDocumentGet;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
 
     const queryClient = createQueryClient();
     let latest: {
@@ -790,7 +804,7 @@ describe("use-task-operations", () => {
 
       tasksList.mockClear();
       runsList.mockClear();
-      planGet.mockClear();
+      taskDocumentGetFresh.mockClear();
       currentStatus = "in_progress";
       currentPlanMarkdown = "# New plan";
       currentPlanUpdatedAt = "2026-03-28T00:00:00.000Z";
@@ -811,7 +825,7 @@ describe("use-task-operations", () => {
         3000,
       );
 
-      expect(planGet).toHaveBeenCalledWith("/repo", "A", { forceFresh: true });
+      expect(host.taskDocumentGetFresh).toHaveBeenCalledWith("/repo", "A", "plan");
       expect(tasksList).toHaveBeenCalledWith("/repo");
       expect(
         queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(
@@ -822,9 +836,8 @@ describe("use-task-operations", () => {
       await harness.unmount();
       host.tasksList = original.tasksList;
       host.runsList = original.runsList;
-      host.specGet = original.specGet;
-      host.planGet = original.planGet;
-      host.qaGetReport = original.qaGetReport;
+      host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
     }
   });
 

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -713,7 +713,7 @@ describe("use-task-operations", () => {
     let currentPlanUpdatedAt: string | null = null;
     const tasksList = mock(async () => [makeTask("A", currentStatus)]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
-    const taskDocumentGet = mock(async (_repoPath: string, _taskId: string, section: string) => {
+    const readTaskDocument = async (_repoPath: string, _taskId: string, section: string) => {
       if (section === "plan") {
         return {
           markdown: currentPlanMarkdown,
@@ -722,19 +722,9 @@ describe("use-task-operations", () => {
       }
 
       return { markdown: "", updatedAt: null };
-    });
-    const taskDocumentGetFresh = mock(
-      async (_repoPath: string, _taskId: string, section: string) => {
-        if (section === "plan") {
-          return {
-            markdown: currentPlanMarkdown,
-            updatedAt: currentPlanUpdatedAt,
-          };
-        }
-
-        return { markdown: "", updatedAt: null };
-      },
-    );
+    };
+    const taskDocumentGet = mock(readTaskDocument);
+    const taskDocumentGetFresh = mock(readTaskDocument);
 
     const original = {
       tasksList: host.tasksList,

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -811,7 +811,7 @@ describe("use-task-operations", () => {
         3000,
       );
 
-      expect(planGet).toHaveBeenCalledWith("/repo", "A");
+      expect(planGet).toHaveBeenCalledWith("/repo", "A", { forceFresh: true });
       expect(tasksList).toHaveBeenCalledWith("/repo");
       expect(
         queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(

--- a/apps/desktop/src/state/queries/documents.test.ts
+++ b/apps/desktop/src/state/queries/documents.test.ts
@@ -3,7 +3,7 @@ import { createQueryClient } from "@/lib/query-client";
 import { host } from "@/state/operations/host";
 import {
   documentQueryKeys,
-  fetchTaskDocumentFromQuery,
+  fetchFreshTaskDocumentFromQuery,
   refreshCachedTaskDocumentQueries,
 } from "./documents";
 
@@ -17,13 +17,20 @@ describe("documents query helpers", () => {
     mock.restore();
   });
 
-  test("fetchTaskDocumentFromQuery performs a force-fresh authoritative read and updates the cache", async () => {
+  test("fetchFreshTaskDocumentFromQuery performs an authoritative read and updates the cache", async () => {
     const queryClient = createQueryClient();
-    const specGet = mock(async () =>
+    const taskDocumentGet = mock(async () =>
+      createDocumentPayload("# Spec V1", "2026-03-28T09:00:00.000Z"),
+    );
+    const taskDocumentGetFresh = mock(async () =>
       createDocumentPayload("# Spec V2", "2026-03-28T10:00:00.000Z"),
     );
-    const originalSpecGet = host.specGet;
-    host.specGet = specGet;
+    const original = {
+      taskDocumentGet: host.taskDocumentGet,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
+    };
+    host.taskDocumentGet = taskDocumentGet;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
 
     queryClient.setQueryData(documentQueryKeys.spec("/repo", "task-1"), {
       markdown: "# Spec V1",
@@ -31,33 +38,38 @@ describe("documents query helpers", () => {
     });
 
     try {
-      const document = await fetchTaskDocumentFromQuery(queryClient, "/repo", "task-1", "spec", {
-        forceFresh: true,
-      });
+      const document = await fetchFreshTaskDocumentFromQuery(
+        queryClient,
+        "/repo",
+        "task-1",
+        "spec",
+      );
 
       expect(document).toEqual({
         markdown: "# Spec V2",
         updatedAt: "2026-03-28T10:00:00.000Z",
       });
-      expect(specGet).toHaveBeenCalledWith("/repo", "task-1", { forceFresh: true });
+      expect(taskDocumentGet).not.toHaveBeenCalled();
+      expect(taskDocumentGetFresh).toHaveBeenCalledWith("/repo", "task-1", "spec");
       expect(
         queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(
           documentQueryKeys.spec("/repo", "task-1"),
         ),
       ).toEqual({ markdown: "# Spec V2", updatedAt: "2026-03-28T10:00:00.000Z" });
     } finally {
-      host.specGet = originalSpecGet;
+      host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
       queryClient.clear();
     }
   });
 
-  test("fetchTaskDocumentFromQuery preserves newer optimistic content when the incoming payload is older", async () => {
+  test("fetchFreshTaskDocumentFromQuery preserves newer optimistic content when the incoming payload is older", async () => {
     const queryClient = createQueryClient();
-    const specGet = mock(async () =>
+    const taskDocumentGetFresh = mock(async () =>
       createDocumentPayload("# Spec V1", "2026-03-28T09:00:00.000Z"),
     );
-    const originalSpecGet = host.specGet;
-    host.specGet = specGet;
+    const originalTaskDocumentGetFresh = host.taskDocumentGetFresh;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
 
     queryClient.setQueryData(documentQueryKeys.spec("/repo", "task-1"), {
       markdown: "# Optimistic spec",
@@ -65,9 +77,12 @@ describe("documents query helpers", () => {
     });
 
     try {
-      const document = await fetchTaskDocumentFromQuery(queryClient, "/repo", "task-1", "spec", {
-        forceFresh: true,
-      });
+      const document = await fetchFreshTaskDocumentFromQuery(
+        queryClient,
+        "/repo",
+        "task-1",
+        "spec",
+      );
 
       expect(document).toEqual({
         markdown: "# Optimistic spec",
@@ -79,30 +94,30 @@ describe("documents query helpers", () => {
         ),
       ).toEqual({ markdown: "# Optimistic spec", updatedAt: "2026-03-28T10:00:00.000Z" });
     } finally {
-      host.specGet = originalSpecGet;
+      host.taskDocumentGetFresh = originalTaskDocumentGetFresh;
       queryClient.clear();
     }
   });
 
   test("refreshCachedTaskDocumentQueries force-refreshes only cached sections", async () => {
     const queryClient = createQueryClient();
-    const specGet = mock(async () =>
-      createDocumentPayload("# Spec V2", "2026-03-28T10:00:00.000Z"),
+    const taskDocumentGet = mock(async () =>
+      createDocumentPayload("# Cached", "2026-03-28T09:00:00.000Z"),
     );
-    const planGet = mock(async () =>
-      createDocumentPayload("# Plan V2", "2026-03-28T10:05:00.000Z"),
-    );
-    const qaGetReport = mock(async () =>
-      createDocumentPayload("# QA V2", "2026-03-28T10:10:00.000Z"),
+    const taskDocumentGetFresh = mock(
+      async (_repoPath: string, _taskId: string, section: string) => {
+        if (section === "plan") {
+          return createDocumentPayload("# Plan V2", "2026-03-28T10:05:00.000Z");
+        }
+        return createDocumentPayload("# QA V2", "2026-03-28T10:10:00.000Z");
+      },
     );
     const original = {
-      specGet: host.specGet,
-      planGet: host.planGet,
-      qaGetReport: host.qaGetReport,
+      taskDocumentGet: host.taskDocumentGet,
+      taskDocumentGetFresh: host.taskDocumentGetFresh,
     };
-    host.specGet = specGet;
-    host.planGet = planGet;
-    host.qaGetReport = qaGetReport;
+    host.taskDocumentGet = taskDocumentGet;
+    host.taskDocumentGetFresh = taskDocumentGetFresh;
 
     queryClient.setQueryData(documentQueryKeys.plan("/repo", "task-1"), {
       markdown: "# Plan V1",
@@ -116,9 +131,9 @@ describe("documents query helpers", () => {
     try {
       await refreshCachedTaskDocumentQueries(queryClient, "/repo", "task-1");
 
-      expect(specGet).not.toHaveBeenCalled();
-      expect(planGet).toHaveBeenCalledWith("/repo", "task-1", { forceFresh: true });
-      expect(qaGetReport).toHaveBeenCalledWith("/repo", "task-1", { forceFresh: true });
+      expect(taskDocumentGet).not.toHaveBeenCalled();
+      expect(taskDocumentGetFresh).toHaveBeenCalledWith("/repo", "task-1", "plan");
+      expect(taskDocumentGetFresh).toHaveBeenCalledWith("/repo", "task-1", "qa");
       expect(
         queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(
           documentQueryKeys.plan("/repo", "task-1"),
@@ -130,9 +145,8 @@ describe("documents query helpers", () => {
         ),
       ).toEqual({ markdown: "# QA V2", updatedAt: "2026-03-28T10:10:00.000Z" });
     } finally {
-      host.specGet = original.specGet;
-      host.planGet = original.planGet;
-      host.qaGetReport = original.qaGetReport;
+      host.taskDocumentGet = original.taskDocumentGet;
+      host.taskDocumentGetFresh = original.taskDocumentGetFresh;
       queryClient.clear();
     }
   });

--- a/apps/desktop/src/state/queries/documents.test.ts
+++ b/apps/desktop/src/state/queries/documents.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createQueryClient } from "@/lib/query-client";
+import { host } from "@/state/operations/host";
+import {
+  documentQueryKeys,
+  fetchTaskDocumentFromQuery,
+  refreshCachedTaskDocumentQueries,
+} from "./documents";
+
+const createDocumentPayload = (markdown = "", updatedAt: string | null = null) => ({
+  markdown,
+  updatedAt,
+});
+
+describe("documents query helpers", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("fetchTaskDocumentFromQuery performs a force-fresh authoritative read and updates the cache", async () => {
+    const queryClient = createQueryClient();
+    const specGet = mock(async () =>
+      createDocumentPayload("# Spec V2", "2026-03-28T10:00:00.000Z"),
+    );
+    const originalSpecGet = host.specGet;
+    host.specGet = specGet;
+
+    queryClient.setQueryData(documentQueryKeys.spec("/repo", "task-1"), {
+      markdown: "# Spec V1",
+      updatedAt: "2026-03-28T09:00:00.000Z",
+    });
+
+    try {
+      const document = await fetchTaskDocumentFromQuery(queryClient, "/repo", "task-1", "spec", {
+        forceFresh: true,
+      });
+
+      expect(document).toEqual({
+        markdown: "# Spec V2",
+        updatedAt: "2026-03-28T10:00:00.000Z",
+      });
+      expect(specGet).toHaveBeenCalledWith("/repo", "task-1", { forceFresh: true });
+      expect(
+        queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(
+          documentQueryKeys.spec("/repo", "task-1"),
+        ),
+      ).toEqual({ markdown: "# Spec V2", updatedAt: "2026-03-28T10:00:00.000Z" });
+    } finally {
+      host.specGet = originalSpecGet;
+      queryClient.clear();
+    }
+  });
+
+  test("fetchTaskDocumentFromQuery preserves newer optimistic content when the incoming payload is older", async () => {
+    const queryClient = createQueryClient();
+    const specGet = mock(async () =>
+      createDocumentPayload("# Spec V1", "2026-03-28T09:00:00.000Z"),
+    );
+    const originalSpecGet = host.specGet;
+    host.specGet = specGet;
+
+    queryClient.setQueryData(documentQueryKeys.spec("/repo", "task-1"), {
+      markdown: "# Optimistic spec",
+      updatedAt: "2026-03-28T10:00:00.000Z",
+    });
+
+    try {
+      const document = await fetchTaskDocumentFromQuery(queryClient, "/repo", "task-1", "spec", {
+        forceFresh: true,
+      });
+
+      expect(document).toEqual({
+        markdown: "# Optimistic spec",
+        updatedAt: "2026-03-28T10:00:00.000Z",
+      });
+      expect(
+        queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(
+          documentQueryKeys.spec("/repo", "task-1"),
+        ),
+      ).toEqual({ markdown: "# Optimistic spec", updatedAt: "2026-03-28T10:00:00.000Z" });
+    } finally {
+      host.specGet = originalSpecGet;
+      queryClient.clear();
+    }
+  });
+
+  test("refreshCachedTaskDocumentQueries force-refreshes only cached sections", async () => {
+    const queryClient = createQueryClient();
+    const specGet = mock(async () =>
+      createDocumentPayload("# Spec V2", "2026-03-28T10:00:00.000Z"),
+    );
+    const planGet = mock(async () =>
+      createDocumentPayload("# Plan V2", "2026-03-28T10:05:00.000Z"),
+    );
+    const qaGetReport = mock(async () =>
+      createDocumentPayload("# QA V2", "2026-03-28T10:10:00.000Z"),
+    );
+    const original = {
+      specGet: host.specGet,
+      planGet: host.planGet,
+      qaGetReport: host.qaGetReport,
+    };
+    host.specGet = specGet;
+    host.planGet = planGet;
+    host.qaGetReport = qaGetReport;
+
+    queryClient.setQueryData(documentQueryKeys.plan("/repo", "task-1"), {
+      markdown: "# Plan V1",
+      updatedAt: "2026-03-28T09:05:00.000Z",
+    });
+    queryClient.setQueryData(documentQueryKeys.qaReport("/repo", "task-1"), {
+      markdown: "# QA V1",
+      updatedAt: "2026-03-28T09:10:00.000Z",
+    });
+
+    try {
+      await refreshCachedTaskDocumentQueries(queryClient, "/repo", "task-1");
+
+      expect(specGet).not.toHaveBeenCalled();
+      expect(planGet).toHaveBeenCalledWith("/repo", "task-1", { forceFresh: true });
+      expect(qaGetReport).toHaveBeenCalledWith("/repo", "task-1", { forceFresh: true });
+      expect(
+        queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(
+          documentQueryKeys.plan("/repo", "task-1"),
+        ),
+      ).toEqual({ markdown: "# Plan V2", updatedAt: "2026-03-28T10:05:00.000Z" });
+      expect(
+        queryClient.getQueryData<{ markdown: string; updatedAt: string | null }>(
+          documentQueryKeys.qaReport("/repo", "task-1"),
+        ),
+      ).toEqual({ markdown: "# QA V2", updatedAt: "2026-03-28T10:10:00.000Z" });
+    } finally {
+      host.specGet = original.specGet;
+      host.planGet = original.planGet;
+      host.qaGetReport = original.qaGetReport;
+      queryClient.clear();
+    }
+  });
+});

--- a/apps/desktop/src/state/queries/documents.ts
+++ b/apps/desktop/src/state/queries/documents.ts
@@ -1,5 +1,8 @@
+import type { TaskMetadataReadOptions } from "@openducktor/adapters-tauri-host";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
+import type { TaskDocumentPayload } from "@/types/task-documents";
 import { host } from "../operations/host";
+import { resolveLatestDocumentPayload } from "./document-utils";
 
 export const TASK_DOCUMENT_STALE_TIME_MS = 60_000;
 
@@ -9,6 +12,11 @@ export type TaskDocument = {
 };
 
 export type TaskDocumentSection = "spec" | "plan" | "qa";
+
+export type TaskDocumentLoader = (
+  taskId: string,
+  options?: TaskMetadataReadOptions,
+) => Promise<TaskDocumentPayload>;
 
 export const documentQueryKeys = {
   all: ["task-documents"] as const,
@@ -36,44 +44,97 @@ export const documentQueryKeyForSection = (
   return documentQueryKeys.qaReport(repoPath, taskId);
 };
 
-const specDocumentQueryOptions = (repoPath: string, taskId: string) =>
+const loadTaskDocumentFromHost = async (
+  repoPath: string,
+  taskId: string,
+  section: TaskDocumentSection,
+  options?: TaskMetadataReadOptions,
+): Promise<TaskDocument> => {
+  if (section === "spec") {
+    const spec = await host.specGet(repoPath, taskId, options);
+    return {
+      markdown: spec.markdown,
+      updatedAt: spec.updatedAt,
+    };
+  }
+
+  if (section === "plan") {
+    const plan = await host.planGet(repoPath, taskId, options);
+    return {
+      markdown: plan.markdown,
+      updatedAt: plan.updatedAt,
+    };
+  }
+
+  const report = await host.qaGetReport(repoPath, taskId, options);
+  return {
+    markdown: report.markdown,
+    updatedAt: report.updatedAt,
+  };
+};
+
+const taskDocumentQueryOptions = (repoPath: string, taskId: string, section: TaskDocumentSection) =>
   queryOptions({
-    queryKey: documentQueryKeys.spec(repoPath, taskId),
-    queryFn: async (): Promise<TaskDocument> => {
-      const spec = await host.specGet(repoPath, taskId);
-      return {
-        markdown: spec.markdown,
-        updatedAt: spec.updatedAt,
-      };
-    },
+    queryKey: documentQueryKeyForSection(repoPath, taskId, section),
+    queryFn: async (): Promise<TaskDocument> => loadTaskDocumentFromHost(repoPath, taskId, section),
     staleTime: TASK_DOCUMENT_STALE_TIME_MS,
   });
 
-const planDocumentQueryOptions = (repoPath: string, taskId: string) =>
-  queryOptions({
-    queryKey: documentQueryKeys.plan(repoPath, taskId),
-    queryFn: async (): Promise<TaskDocument> => {
-      const plan = await host.planGet(repoPath, taskId);
-      return {
-        markdown: plan.markdown,
-        updatedAt: plan.updatedAt,
-      };
+const fetchTaskDocumentWithLoader = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+  section: TaskDocumentSection,
+  loader: TaskDocumentLoader,
+  options?: TaskMetadataReadOptions,
+): Promise<TaskDocumentPayload> => {
+  const queryKey = documentQueryKeyForSection(repoPath, taskId, section);
+  const forceFresh = options?.forceFresh === true;
+  return queryClient.fetchQuery({
+    queryKey,
+    queryFn: async (): Promise<TaskDocumentPayload> => {
+      const incoming = await loader(taskId, options);
+      const current = queryClient.getQueryData<TaskDocumentPayload>(queryKey);
+      return resolveLatestDocumentPayload(current, incoming);
     },
-    staleTime: TASK_DOCUMENT_STALE_TIME_MS,
+    staleTime: forceFresh ? 0 : TASK_DOCUMENT_STALE_TIME_MS,
   });
+};
 
-const qaReportDocumentQueryOptions = (repoPath: string, taskId: string) =>
-  queryOptions({
-    queryKey: documentQueryKeys.qaReport(repoPath, taskId),
-    queryFn: async (): Promise<TaskDocument> => {
-      const report = await host.qaGetReport(repoPath, taskId);
-      return {
-        markdown: report.markdown,
-        updatedAt: report.updatedAt,
-      };
-    },
-    staleTime: TASK_DOCUMENT_STALE_TIME_MS,
-  });
+const hostDocumentLoaderForSection = (
+  repoPath: string,
+  section: TaskDocumentSection,
+): TaskDocumentLoader => {
+  return (taskId, options) => loadTaskDocumentFromHost(repoPath, taskId, section, options);
+};
+
+export const fetchTaskDocumentFromQuery = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+  section: TaskDocumentSection,
+  options?: TaskMetadataReadOptions,
+): Promise<TaskDocumentPayload> => {
+  return fetchTaskDocumentWithLoader(
+    queryClient,
+    repoPath,
+    taskId,
+    section,
+    hostDocumentLoaderForSection(repoPath, section),
+    options,
+  );
+};
+
+export const fetchTaskDocumentFromQueryWithLoader = (
+  queryClient: QueryClient,
+  repoPath: string,
+  taskId: string,
+  section: TaskDocumentSection,
+  loader: TaskDocumentLoader,
+  options?: TaskMetadataReadOptions,
+): Promise<TaskDocumentPayload> => {
+  return fetchTaskDocumentWithLoader(queryClient, repoPath, taskId, section, loader, options);
+};
 
 const cachedTaskDocumentSections = (
   queryClient: QueryClient,
@@ -138,24 +199,9 @@ export const refreshCachedTaskDocumentQueries = async (
 ): Promise<void> => {
   const cachedSections = cachedTaskDocumentSections(queryClient, repoPath, taskId);
   await Promise.all(
-    cachedSections.map((section) => {
-      if (section === "spec") {
-        return queryClient.fetchQuery({
-          ...specDocumentQueryOptions(repoPath, taskId),
-          staleTime: 0,
-        });
-      }
-      if (section === "plan") {
-        return queryClient.fetchQuery({
-          ...planDocumentQueryOptions(repoPath, taskId),
-          staleTime: 0,
-        });
-      }
-      return queryClient.fetchQuery({
-        ...qaReportDocumentQueryOptions(repoPath, taskId),
-        staleTime: 0,
-      });
-    }),
+    cachedSections.map((section) =>
+      fetchTaskDocumentFromQuery(queryClient, repoPath, taskId, section, { forceFresh: true }),
+    ),
   );
 };
 
@@ -163,16 +209,19 @@ export const loadSpecDocumentFromQuery = (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
-): Promise<TaskDocument> => queryClient.fetchQuery(specDocumentQueryOptions(repoPath, taskId));
+): Promise<TaskDocument> =>
+  queryClient.fetchQuery(taskDocumentQueryOptions(repoPath, taskId, "spec"));
 
 export const loadPlanDocumentFromQuery = (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
-): Promise<TaskDocument> => queryClient.fetchQuery(planDocumentQueryOptions(repoPath, taskId));
+): Promise<TaskDocument> =>
+  queryClient.fetchQuery(taskDocumentQueryOptions(repoPath, taskId, "plan"));
 
 export const loadQaReportDocumentFromQuery = (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
-): Promise<TaskDocument> => queryClient.fetchQuery(qaReportDocumentQueryOptions(repoPath, taskId));
+): Promise<TaskDocument> =>
+  queryClient.fetchQuery(taskDocumentQueryOptions(repoPath, taskId, "qa"));

--- a/apps/desktop/src/state/queries/documents.ts
+++ b/apps/desktop/src/state/queries/documents.ts
@@ -1,4 +1,3 @@
-import type { TaskMetadataReadOptions } from "@openducktor/adapters-tauri-host";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import type { TaskDocumentPayload } from "@/types/task-documents";
 import { host } from "../operations/host";
@@ -13,10 +12,7 @@ export type TaskDocument = {
 
 export type TaskDocumentSection = "spec" | "plan" | "qa";
 
-export type TaskDocumentLoader = (
-  taskId: string,
-  options?: TaskMetadataReadOptions,
-) => Promise<TaskDocumentPayload>;
+type TaskDocumentReadMode = "default" | "forceFresh";
 
 export const documentQueryKeys = {
   all: ["task-documents"] as const,
@@ -48,64 +44,37 @@ const loadTaskDocumentFromHost = async (
   repoPath: string,
   taskId: string,
   section: TaskDocumentSection,
-  options?: TaskMetadataReadOptions,
+  mode: TaskDocumentReadMode = "default",
 ): Promise<TaskDocument> => {
-  if (section === "spec") {
-    const spec = await host.specGet(repoPath, taskId, options);
-    return {
-      markdown: spec.markdown,
-      updatedAt: spec.updatedAt,
-    };
-  }
-
-  if (section === "plan") {
-    const plan = await host.planGet(repoPath, taskId, options);
-    return {
-      markdown: plan.markdown,
-      updatedAt: plan.updatedAt,
-    };
-  }
-
-  const report = await host.qaGetReport(repoPath, taskId, options);
-  return {
-    markdown: report.markdown,
-    updatedAt: report.updatedAt,
-  };
+  const readDocument = mode === "forceFresh" ? host.taskDocumentGetFresh : host.taskDocumentGet;
+  return readDocument(repoPath, taskId, section);
 };
 
 const taskDocumentQueryOptions = (repoPath: string, taskId: string, section: TaskDocumentSection) =>
   queryOptions({
     queryKey: documentQueryKeyForSection(repoPath, taskId, section),
-    queryFn: async (): Promise<TaskDocument> => loadTaskDocumentFromHost(repoPath, taskId, section),
+    queryFn: async (): Promise<TaskDocument> =>
+      loadTaskDocumentFromHost(repoPath, taskId, section, "default"),
     staleTime: TASK_DOCUMENT_STALE_TIME_MS,
   });
 
-const fetchTaskDocumentWithLoader = (
+const fetchTaskDocumentWithMode = (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
   section: TaskDocumentSection,
-  loader: TaskDocumentLoader,
-  options?: TaskMetadataReadOptions,
+  mode: TaskDocumentReadMode,
 ): Promise<TaskDocumentPayload> => {
   const queryKey = documentQueryKeyForSection(repoPath, taskId, section);
-  const forceFresh = options?.forceFresh === true;
   return queryClient.fetchQuery({
     queryKey,
     queryFn: async (): Promise<TaskDocumentPayload> => {
-      const incoming = await loader(taskId, options);
+      const incoming = await loadTaskDocumentFromHost(repoPath, taskId, section, mode);
       const current = queryClient.getQueryData<TaskDocumentPayload>(queryKey);
       return resolveLatestDocumentPayload(current, incoming);
     },
-    staleTime: forceFresh ? 0 : TASK_DOCUMENT_STALE_TIME_MS,
+    staleTime: mode === "forceFresh" ? 0 : TASK_DOCUMENT_STALE_TIME_MS,
   });
-};
-
-const hostDocumentLoaderForSection = (
-  repoPath: string,
-  section: TaskDocumentSection,
-): TaskDocumentLoader => {
-  return (taskId, options) => loadTaskDocumentFromHost(repoPath, taskId, section, options);
 };
 
 export const fetchTaskDocumentFromQuery = (
@@ -113,27 +82,17 @@ export const fetchTaskDocumentFromQuery = (
   repoPath: string,
   taskId: string,
   section: TaskDocumentSection,
-  options?: TaskMetadataReadOptions,
 ): Promise<TaskDocumentPayload> => {
-  return fetchTaskDocumentWithLoader(
-    queryClient,
-    repoPath,
-    taskId,
-    section,
-    hostDocumentLoaderForSection(repoPath, section),
-    options,
-  );
+  return fetchTaskDocumentWithMode(queryClient, repoPath, taskId, section, "default");
 };
 
-export const fetchTaskDocumentFromQueryWithLoader = (
+export const fetchFreshTaskDocumentFromQuery = (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
   section: TaskDocumentSection,
-  loader: TaskDocumentLoader,
-  options?: TaskMetadataReadOptions,
 ): Promise<TaskDocumentPayload> => {
-  return fetchTaskDocumentWithLoader(queryClient, repoPath, taskId, section, loader, options);
+  return fetchTaskDocumentWithMode(queryClient, repoPath, taskId, section, "forceFresh");
 };
 
 const cachedTaskDocumentSections = (
@@ -200,7 +159,7 @@ export const refreshCachedTaskDocumentQueries = async (
   const cachedSections = cachedTaskDocumentSections(queryClient, repoPath, taskId);
   await Promise.all(
     cachedSections.map((section) =>
-      fetchTaskDocumentFromQuery(queryClient, repoPath, taskId, section, { forceFresh: true }),
+      fetchFreshTaskDocumentFromQuery(queryClient, repoPath, taskId, section),
     ),
   );
 };

--- a/docs/agent-orchestrator-module-map.md
+++ b/docs/agent-orchestrator-module-map.md
@@ -74,6 +74,7 @@ Owns:
 - request/response reads for the currently viewed session
 - TanStack Query caching for model catalog, todos, repo config, task docs, and other stable host reads
 - build-tools panel reads such as git diff state and dev-server state
+- authoritative task-document refreshes after workflow mutations; the event stream may request a refresh, but `apps/desktop/src/state/queries/documents.ts` owns the fresh read path
 
 Must not own:
 - session existence

--- a/docs/tanstack-query-cache-strategy.md
+++ b/docs/tanstack-query-cache-strategy.md
@@ -106,6 +106,8 @@ Examples:
 - document reads
 - worktree status reads
 
+Task documents keep their normal `60 sec` stale time for ordinary viewing, but workflow-driven refreshes use explicit force-fresh fetches in `apps/desktop/src/state/queries/documents.ts` so external ODT document writes bypass stale adapter metadata without adding polling or focus refetching.
+
 ## Mutation strategy
 
 We do not depend on background refetch heuristics for correctness.

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1415,9 +1415,7 @@ describe("TauriHostClient", () => {
 
     expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V1");
     expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V1");
-    expect((await client.specGet("/repo", "task-1", { forceFresh: true })).markdown).toBe(
-      "Spec V2",
-    );
+    expect((await client.taskDocumentGetFresh("/repo", "task-1", "spec")).markdown).toBe("Spec V2");
     expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V2");
 
     expect(calls.map((entry) => entry.command)).toEqual(["task_metadata_get", "task_metadata_get"]);
@@ -1448,8 +1446,8 @@ describe("TauriHostClient", () => {
     });
 
     const staleRead = client.specGet("/repo", "task-1");
-    const freshSpecRead = client.specGet("/repo", "task-1", { forceFresh: true });
-    const freshPlanRead = client.planGet("/repo", "task-1", { forceFresh: true });
+    const freshSpecRead = client.taskDocumentGetFresh("/repo", "task-1", "spec");
+    const freshPlanRead = client.taskDocumentGetFresh("/repo", "task-1", "plan");
 
     freshReadPromise.resolve(makeTaskMetadataPayload("Spec V2"));
 

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1403,6 +1403,68 @@ describe("TauriHostClient", () => {
     ]);
   });
 
+  test("forceFresh metadata reads bypass stale cache and repopulate steady-state reads", async () => {
+    let metadataReadCount = 0;
+    const { client, calls } = createClient((command) => {
+      if (command === "task_metadata_get") {
+        metadataReadCount += 1;
+        return makeTaskMetadataPayload(metadataReadCount === 1 ? "Spec V1" : "Spec V2");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V1");
+    expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V1");
+    expect((await client.specGet("/repo", "task-1", { forceFresh: true })).markdown).toBe(
+      "Spec V2",
+    );
+    expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V2");
+
+    expect(calls.map((entry) => entry.command)).toEqual(["task_metadata_get", "task_metadata_get"]);
+  });
+
+  test("forceFresh metadata reads do not get stuck behind older in-flight reads", async () => {
+    let metadataReadCount = 0;
+    const createDeferredMetadataRead = () => {
+      let resolve!: (value: ReturnType<typeof makeTaskMetadataPayload>) => void;
+      const promise = new Promise<ReturnType<typeof makeTaskMetadataPayload>>((nextResolve) => {
+        resolve = nextResolve;
+      });
+      return { promise, resolve };
+    };
+    const staleReadPromise = createDeferredMetadataRead();
+    const freshReadPromise = createDeferredMetadataRead();
+    const { client, calls } = createClient((command) => {
+      if (command === "task_metadata_get") {
+        metadataReadCount += 1;
+        if (metadataReadCount === 1) {
+          return staleReadPromise.promise;
+        }
+        if (metadataReadCount === 2) {
+          return freshReadPromise.promise;
+        }
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const staleRead = client.specGet("/repo", "task-1");
+    const freshSpecRead = client.specGet("/repo", "task-1", { forceFresh: true });
+    const freshPlanRead = client.planGet("/repo", "task-1", { forceFresh: true });
+
+    freshReadPromise.resolve(makeTaskMetadataPayload("Spec V2"));
+
+    expect((await freshSpecRead).markdown).toBe("Spec V2");
+    expect((await freshPlanRead).markdown).toBe("Plan Body");
+
+    staleReadPromise.resolve(makeTaskMetadataPayload("Spec V1"));
+
+    expect((await staleRead).markdown).toBe("Spec V1");
+    expect((await client.specGet("/repo", "task-1")).markdown).toBe("Spec V2");
+    expect((await client.planGet("/repo", "task-1")).markdown).toBe("Plan Body");
+
+    expect(calls.map((entry) => entry.command)).toEqual(["task_metadata_get", "task_metadata_get"]);
+  });
+
   test("metadata cache invalidates after spec mutations", async () => {
     let metadataReadCount = 0;
     const { client, calls } = createClient((command) => {

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -149,6 +149,7 @@ const bindDelegates = <
 
 export type TauriHostClient = TauriHostClientApi & PlannerTools;
 export type { BuildRespondInput } from "./build-runtime-client";
+export type { TaskMetadataReadOptions } from "./task-metadata-cache";
 
 const createTauriHostClientApi = (invokeFn: InvokeFn): TauriHostClientApi => {
   const metadataCache = new TaskMetadataCache();

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -45,6 +45,9 @@ const TASK_METHODS = [
   "savePlanDocument",
   "planGet",
   "taskMetadataGet",
+  "taskMetadataGetFresh",
+  "taskDocumentGet",
+  "taskDocumentGetFresh",
   "qaGetReport",
   "qaApproved",
   "qaRejected",
@@ -149,7 +152,6 @@ const bindDelegates = <
 
 export type TauriHostClient = TauriHostClientApi & PlannerTools;
 export type { BuildRespondInput } from "./build-runtime-client";
-export type { TaskMetadataReadOptions } from "./task-metadata-cache";
 
 const createTauriHostClientApi = (invokeFn: InvokeFn): TauriHostClientApi => {
   const metadataCache = new TaskMetadataCache();

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -45,6 +45,9 @@ export type SavePlanDocumentInput = {
   markdown: string;
 };
 
+export type TaskDocumentSection = "spec" | "plan" | "qa";
+export type TaskDocumentReadResult = { markdown: string; updatedAt: string | null };
+
 export class TauriTaskClient {
   constructor(
     private readonly invokeFn: InvokeFn,
@@ -57,6 +60,34 @@ export class TauriTaskClient {
     options?: TaskMetadataReadOptions,
   ): Promise<ParsedTaskMetadata> {
     return this.metadataCache.get(this.invokeFn, repoPath, taskId, options);
+  }
+
+  private async readTaskDocument(
+    repoPath: string,
+    taskId: string,
+    section: TaskDocumentSection,
+    options?: TaskMetadataReadOptions,
+  ): Promise<TaskDocumentReadResult> {
+    const payload = await this.readTaskMetadata(repoPath, taskId, options);
+
+    if (section === "spec") {
+      return {
+        markdown: payload.spec.markdown,
+        updatedAt: payload.spec.updatedAt ?? null,
+      };
+    }
+
+    if (section === "plan") {
+      return {
+        markdown: payload.plan.markdown,
+        updatedAt: payload.plan.updatedAt ?? null,
+      };
+    }
+
+    return {
+      markdown: payload.qaReport?.markdown ?? "",
+      updatedAt: payload.qaReport?.updatedAt ?? null,
+    };
   }
 
   private invalidateTaskMetadata(repoPath: string, taskId: string): void {
@@ -153,16 +184,8 @@ export class TauriTaskClient {
     return taskCardSchema.parse(payload);
   }
 
-  async specGet(
-    repoPath: string,
-    taskId: string,
-    options?: TaskMetadataReadOptions,
-  ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.readTaskMetadata(repoPath, taskId, options);
-    return {
-      markdown: payload.spec.markdown,
-      updatedAt: payload.spec.updatedAt ?? null,
-    };
+  async specGet(repoPath: string, taskId: string): Promise<TaskDocumentReadResult> {
+    return this.readTaskDocument(repoPath, taskId, "spec");
   }
 
   async setSpec(input: SetSpecInput): Promise<SetSpecOutput> {
@@ -214,36 +237,36 @@ export class TauriTaskClient {
     return parseUpdatedAtResult(payload, "plan_save_document");
   }
 
-  async planGet(
-    repoPath: string,
-    taskId: string,
-    options?: TaskMetadataReadOptions,
-  ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.readTaskMetadata(repoPath, taskId, options);
-    return {
-      markdown: payload.plan.markdown,
-      updatedAt: payload.plan.updatedAt ?? null,
-    };
+  async planGet(repoPath: string, taskId: string): Promise<TaskDocumentReadResult> {
+    return this.readTaskDocument(repoPath, taskId, "plan");
   }
 
-  async taskMetadataGet(
-    repoPath: string,
-    taskId: string,
-    options?: TaskMetadataReadOptions,
-  ): Promise<ParsedTaskMetadata> {
-    return this.readTaskMetadata(repoPath, taskId, options);
+  async taskMetadataGet(repoPath: string, taskId: string): Promise<ParsedTaskMetadata> {
+    return this.readTaskMetadata(repoPath, taskId);
   }
 
-  async qaGetReport(
+  async taskMetadataGetFresh(repoPath: string, taskId: string): Promise<ParsedTaskMetadata> {
+    return this.readTaskMetadata(repoPath, taskId, { forceFresh: true });
+  }
+
+  async taskDocumentGet(
     repoPath: string,
     taskId: string,
-    options?: TaskMetadataReadOptions,
-  ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.readTaskMetadata(repoPath, taskId, options);
-    return {
-      markdown: payload.qaReport?.markdown ?? "",
-      updatedAt: payload.qaReport?.updatedAt ?? null,
-    };
+    section: TaskDocumentSection,
+  ): Promise<TaskDocumentReadResult> {
+    return this.readTaskDocument(repoPath, taskId, section);
+  }
+
+  async taskDocumentGetFresh(
+    repoPath: string,
+    taskId: string,
+    section: TaskDocumentSection,
+  ): Promise<TaskDocumentReadResult> {
+    return this.readTaskDocument(repoPath, taskId, section, { forceFresh: true });
+  }
+
+  async qaGetReport(repoPath: string, taskId: string): Promise<TaskDocumentReadResult> {
+    return this.readTaskDocument(repoPath, taskId, "qa");
   }
 
   async qaApproved(repoPath: string, taskId: string, markdown: string): Promise<TaskCard> {

--- a/packages/adapters-tauri-host/src/task-client.ts
+++ b/packages/adapters-tauri-host/src/task-client.ts
@@ -14,7 +14,11 @@ import {
 import type { SetPlanOutput, SetSpecOutput } from "@openducktor/core";
 import type { InvokeFn } from "./invoke-utils";
 import { parseArray, parseOkResult, parseUpdatedAtResult } from "./invoke-utils";
-import type { ParsedTaskMetadata, TaskMetadataCache } from "./task-metadata-cache";
+import type {
+  ParsedTaskMetadata,
+  TaskMetadataCache,
+  TaskMetadataReadOptions,
+} from "./task-metadata-cache";
 
 export type SetSpecInput = {
   taskId: string;
@@ -47,8 +51,12 @@ export class TauriTaskClient {
     private readonly metadataCache: TaskMetadataCache,
   ) {}
 
-  private readTaskMetadata(repoPath: string, taskId: string): Promise<ParsedTaskMetadata> {
-    return this.metadataCache.get(this.invokeFn, repoPath, taskId);
+  private readTaskMetadata(
+    repoPath: string,
+    taskId: string,
+    options?: TaskMetadataReadOptions,
+  ): Promise<ParsedTaskMetadata> {
+    return this.metadataCache.get(this.invokeFn, repoPath, taskId, options);
   }
 
   private invalidateTaskMetadata(repoPath: string, taskId: string): void {
@@ -148,8 +156,9 @@ export class TauriTaskClient {
   async specGet(
     repoPath: string,
     taskId: string,
+    options?: TaskMetadataReadOptions,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.readTaskMetadata(repoPath, taskId);
+    const payload = await this.readTaskMetadata(repoPath, taskId, options);
     return {
       markdown: payload.spec.markdown,
       updatedAt: payload.spec.updatedAt ?? null,
@@ -208,23 +217,29 @@ export class TauriTaskClient {
   async planGet(
     repoPath: string,
     taskId: string,
+    options?: TaskMetadataReadOptions,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.readTaskMetadata(repoPath, taskId);
+    const payload = await this.readTaskMetadata(repoPath, taskId, options);
     return {
       markdown: payload.plan.markdown,
       updatedAt: payload.plan.updatedAt ?? null,
     };
   }
 
-  async taskMetadataGet(repoPath: string, taskId: string): Promise<ParsedTaskMetadata> {
-    return this.readTaskMetadata(repoPath, taskId);
+  async taskMetadataGet(
+    repoPath: string,
+    taskId: string,
+    options?: TaskMetadataReadOptions,
+  ): Promise<ParsedTaskMetadata> {
+    return this.readTaskMetadata(repoPath, taskId, options);
   }
 
   async qaGetReport(
     repoPath: string,
     taskId: string,
+    options?: TaskMetadataReadOptions,
   ): Promise<{ markdown: string; updatedAt: string | null }> {
-    const payload = await this.readTaskMetadata(repoPath, taskId);
+    const payload = await this.readTaskMetadata(repoPath, taskId, options);
     return {
       markdown: payload.qaReport?.markdown ?? "",
       updatedAt: payload.qaReport?.updatedAt ?? null,

--- a/packages/adapters-tauri-host/src/task-metadata-cache.ts
+++ b/packages/adapters-tauri-host/src/task-metadata-cache.ts
@@ -10,6 +10,10 @@ export type ParsedTaskMetadata = Omit<TaskMetadataPayload, "agentSessions"> & {
   agentSessions: AgentSessionRecord[];
 };
 
+export type TaskMetadataReadOptions = {
+  forceFresh?: boolean;
+};
+
 const parseAgentSessions = (entries: unknown[], taskId: string): AgentSessionRecord[] => {
   const sessions: AgentSessionRecord[] = [];
   const invalidEntries: string[] = [];
@@ -37,7 +41,10 @@ const parseAgentSessions = (entries: unknown[], taskId: string): AgentSessionRec
 
 export class TaskMetadataCache {
   private readonly inFlight = new Map<string, Promise<ParsedTaskMetadata>>();
+  private readonly forceFreshInFlight = new Map<string, Promise<ParsedTaskMetadata>>();
   private readonly cache = new Map<string, ParsedTaskMetadata>();
+  private readonly latestFetchTokenByKey = new Map<string, number>();
+  private nextFetchToken = 0;
 
   private key(repoPath: string, taskId: string): string {
     return `${repoPath}::${taskId}`;
@@ -47,6 +54,8 @@ export class TaskMetadataCache {
     const cacheKey = this.key(repoPath, taskId);
     this.cache.delete(cacheKey);
     this.inFlight.delete(cacheKey);
+    this.forceFreshInFlight.delete(cacheKey);
+    this.latestFetchTokenByKey.delete(cacheKey);
   }
 
   invalidateRepo(repoPath: string): void {
@@ -60,19 +69,47 @@ export class TaskMetadataCache {
         this.inFlight.delete(cacheKey);
       }
     }
+    for (const cacheKey of [...this.forceFreshInFlight.keys()]) {
+      if (cacheKey.startsWith(`${repoPath}::`)) {
+        this.forceFreshInFlight.delete(cacheKey);
+      }
+    }
+    for (const cacheKey of [...this.latestFetchTokenByKey.keys()]) {
+      if (cacheKey.startsWith(`${repoPath}::`)) {
+        this.latestFetchTokenByKey.delete(cacheKey);
+      }
+    }
   }
 
-  async get(invokeFn: InvokeFn, repoPath: string, taskId: string): Promise<ParsedTaskMetadata> {
+  private fetchMetadata(
+    invokeFn: InvokeFn,
+    repoPath: string,
+    taskId: string,
+    options: TaskMetadataReadOptions,
+  ): Promise<ParsedTaskMetadata> {
     const cacheKey = this.key(repoPath, taskId);
-    const cached = this.cache.get(cacheKey);
-    if (cached) {
-      return cached;
+    const forceFresh = options.forceFresh === true;
+
+    const activeForceFresh = this.forceFreshInFlight.get(cacheKey);
+    if (activeForceFresh) {
+      return activeForceFresh;
     }
 
-    const inflight = this.inFlight.get(cacheKey);
-    if (inflight) {
-      return inflight;
+    if (!forceFresh) {
+      const cached = this.cache.get(cacheKey);
+      if (cached) {
+        return Promise.resolve(cached);
+      }
+
+      const inflight = this.inFlight.get(cacheKey);
+      if (inflight) {
+        return inflight;
+      }
     }
+
+    const fetchToken = this.nextFetchToken + 1;
+    this.nextFetchToken = fetchToken;
+    this.latestFetchTokenByKey.set(cacheKey, fetchToken);
 
     const next = invokeFn("task_metadata_get", { repoPath, taskId })
       .then((payload) => {
@@ -82,17 +119,40 @@ export class TaskMetadataCache {
           agentSessions: parseAgentSessions(parsed.agentSessions, taskId),
         };
 
-        if (this.inFlight.get(cacheKey) === next) {
+        if (this.latestFetchTokenByKey.get(cacheKey) === fetchToken) {
           this.cache.set(cacheKey, metadata);
         }
 
         return metadata;
       })
       .finally(() => {
-        this.inFlight.delete(cacheKey);
+        if (forceFresh) {
+          if (this.forceFreshInFlight.get(cacheKey) === next) {
+            this.forceFreshInFlight.delete(cacheKey);
+          }
+          return;
+        }
+
+        if (this.inFlight.get(cacheKey) === next) {
+          this.inFlight.delete(cacheKey);
+        }
       });
 
-    this.inFlight.set(cacheKey, next);
+    if (forceFresh) {
+      this.forceFreshInFlight.set(cacheKey, next);
+    } else {
+      this.inFlight.set(cacheKey, next);
+    }
+
     return next;
+  }
+
+  async get(
+    invokeFn: InvokeFn,
+    repoPath: string,
+    taskId: string,
+    options: TaskMetadataReadOptions = {},
+  ): Promise<ParsedTaskMetadata> {
+    return this.fetchMetadata(invokeFn, repoPath, taskId, options);
   }
 }


### PR DESCRIPTION
## Summary
- fix the stale task-document root cause by adding explicit fresh-read paths in the Tauri host adapter for externally persisted spec, plan, and QA documents
- centralize authoritative document refreshes in the desktop query layer and make Agent Studio trigger one authoritative refresh after completed workflow document writes
- add regression coverage for stale metadata refreshes, task-detail refresh propagation, and Agent Studio document updates, plus document the refresh ownership

## Verification
- bun run typecheck
- bun run lint
- bun run test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified document loading and refresh flow across spec/plan/qa for consistent behavior.
  * Simplified event handling to trigger single, deduplicated document reloads after workflow events.

* **New Features**
  * Host client and cache now support explicit "force-fresh" reads to surface external document updates reliably.

* **Tests**
  * Added and updated tests covering fresh-read behavior, deduplication, and cache-refresh edge cases.

* **Documentation**
  * Clarified ownership and cache/refresh strategy for task-document reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->