### PR TITLE
fix(desktop): restore canonical agent studio tab role selection

### DIFF
--- a/apps/desktop/src/pages/agents/agent-studio-types.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-types.ts
@@ -1,1 +1,1 @@
-export type NavigateToTask = (taskId: string) => void;
+export type NavigateToTaskIntent = (taskId: string) => void;

--- a/apps/desktop/src/pages/agents/agent-studio-types.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-types.ts
@@ -1,1 +1,1 @@
-export type NavigateToTask = (taskId: string, options?: { pinSession?: boolean }) => void;
+export type NavigateToTask = (taskId: string) => void;

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -334,6 +334,31 @@ describe("useAgentStudioPageModels", () => {
     await harness.unmount();
   });
 
+  test("keeps build workspace document selection aligned to the resolved active session", async () => {
+    const buildSession = createSession("session-build", "external-build", {
+      role: "build",
+      scenario: "build_implementation_start",
+    });
+    const harness = createHookHarness(
+      createHookArgs({
+        core: {
+          role: "qa",
+          activeSession: buildSession,
+          sessionsForTask: [buildSession],
+        },
+        documents: {
+          specDoc: createDocumentState("spec"),
+          planDoc: createDocumentState("plan"),
+          qaDoc: createDocumentState("qa"),
+        },
+      }),
+    );
+
+    await harness.mount();
+    expect(harness.getLatest().agentStudioWorkspaceSidebarModel.activeDocument).toBeNull();
+    await harness.unmount();
+  });
+
   test("includes pending permission count in header stats", async () => {
     const permissionSession = createSession("session-1", "external-1", {
       status: "running",

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-session-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-session-sync.test.tsx
@@ -206,4 +206,33 @@ describe("useAgentStudioQuerySessionSync", () => {
       await harness.unmount();
     }
   });
+
+  test("does not repin build selection for review tasks during task-only navigation", async () => {
+    const scheduleQueryUpdate = mock((_updates: Record<string, string | undefined>) => {});
+    const activeSession = createAgentSessionFixture({
+      runtimeKind: "opencode",
+      sessionId: "session-build",
+      externalSessionId: "ext-session-build",
+      taskId: "task-1",
+      role: "build",
+      scenario: "build_implementation_start",
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        taskIdParam: "task-1",
+        sessionParam: null,
+        taskId: "task-1",
+        activeSession,
+        roleFromQuery: "qa",
+        scheduleQueryUpdate,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      expect(scheduleQueryUpdate).toHaveBeenCalledTimes(0);
+    } finally {
+      await harness.unmount();
+    }
+  });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
@@ -434,4 +434,77 @@ describe("useAgentStudioSelectionController", () => {
       await harness.unmount();
     }
   });
+
+  test("keeps build selected after task-tab navigation settles on a human_review task", async () => {
+    const updateQuery = mock(() => {});
+    const taskOne = createTask("task-1");
+    const humanReviewTask = createTaskCardFixture({
+      id: "task-2",
+      title: "task-2",
+      status: "human_review",
+    });
+    const buildSession = createSession("task-2", "session-build", {
+      role: "build",
+      scenario: "build_implementation_start",
+      startedAt: "2026-02-22T10:00:00.000Z",
+      status: "idle",
+    });
+    const qaSession = createSession("task-2", "session-qa", {
+      role: "qa",
+      scenario: "qa_review",
+      startedAt: "2026-02-22T11:00:00.000Z",
+      status: "idle",
+    });
+
+    const harness = createHookHarness(
+      createBaseArgs({
+        tasks: [taskOne, humanReviewTask],
+        sessions: [buildSession, qaSession],
+        taskIdParam: "task-1",
+        sessionParam: null,
+        hasExplicitRoleParam: false,
+        roleFromQuery: "qa",
+        updateQuery,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run((state) => {
+        state.handleSelectTab("task-2");
+      });
+
+      expect(harness.getLatest().viewTaskId).toBe("task-2");
+      expect(harness.getLatest().viewActiveSession?.sessionId).toBe("session-build");
+      expect(harness.getLatest().viewRole).toBe("build");
+      expect(updateQuery).toHaveBeenCalledWith({
+        task: "task-2",
+        session: undefined,
+        agent: undefined,
+        scenario: undefined,
+        autostart: undefined,
+        start: undefined,
+      });
+
+      await harness.update(
+        createBaseArgs({
+          tasks: [taskOne, humanReviewTask],
+          sessions: [buildSession, qaSession],
+          taskIdParam: "task-2",
+          sessionParam: null,
+          hasExplicitRoleParam: false,
+          roleFromQuery: "qa",
+          updateQuery,
+        }),
+      );
+
+      expect(harness.getLatest().viewTaskId).toBe("task-2");
+      expect(harness.getLatest().viewActiveSession?.sessionId).toBe("session-build");
+      expect(harness.getLatest().viewRole).toBe("build");
+      expect(harness.getLatest().viewScenario).toBe("build_implementation_start");
+    } finally {
+      await harness.unmount();
+    }
+  });
 });

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
@@ -85,7 +85,7 @@ export function useTaskTabActions(args: UseTaskTabActionsArgs): UseTaskTabAction
       }
 
       focusTaskTabTrigger(nextActiveTaskId);
-      navigateToTask(nextActiveTaskId, { pinSession: true });
+      navigateToTask(nextActiveTaskId);
     },
     [
       activeTaskTabId,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-actions.ts
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction, useCallback } from "react";
-import type { NavigateToTask } from "./agent-studio-types";
+import type { NavigateToTaskIntent } from "./agent-studio-types";
 import { closeTaskTab } from "./agents-page-session-tabs";
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
@@ -23,7 +23,7 @@ type UseTaskTabActionsArgs = {
   clearComposerInput: () => void;
   onContextSwitchIntent: (() => void) | undefined;
   clearTaskSelection: () => void;
-  navigateToTask: NavigateToTask;
+  navigateToTaskIntent: NavigateToTaskIntent;
   handleSelectTab: (nextTaskId: string) => void;
   setOpenTaskTabs: SetState<string[]>;
   setPersistedActiveTaskId: SetState<string | null>;
@@ -42,7 +42,7 @@ export function useTaskTabActions(args: UseTaskTabActionsArgs): UseTaskTabAction
     clearComposerInput,
     onContextSwitchIntent,
     clearTaskSelection,
-    navigateToTask,
+    navigateToTaskIntent,
     handleSelectTab,
     setOpenTaskTabs,
     setPersistedActiveTaskId,
@@ -85,13 +85,13 @@ export function useTaskTabActions(args: UseTaskTabActionsArgs): UseTaskTabAction
       }
 
       focusTaskTabTrigger(nextActiveTaskId);
-      navigateToTask(nextActiveTaskId);
+      navigateToTaskIntent(nextActiveTaskId);
     },
     [
       activeTaskTabId,
       clearComposerInput,
       clearTaskSelection,
-      navigateToTask,
+      navigateToTaskIntent,
       onContextSwitchIntent,
       setIntentActiveTaskId,
       setOpenTaskTabs,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
@@ -123,7 +123,7 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
         return [...current, nextTaskId];
       });
       setPersistedActiveTaskId(nextTaskId);
-      navigateToTask(nextTaskId, { pinSession: true });
+      navigateToTask(nextTaskId);
     },
     [
       activeTaskTabId,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useRef } from "react";
-import type { NavigateToTask } from "./agent-studio-types";
+import type { NavigateToTaskIntent } from "./agent-studio-types";
 import { ensureActiveTaskTab, resolveFallbackTaskId } from "./agents-page-session-tabs";
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
@@ -13,7 +13,7 @@ type UseTaskTabSelectionArgs = {
   tabsStorageHydratedRepo: string | null;
   clearComposerInput: () => void;
   onContextSwitchIntent: (() => void) | undefined;
-  navigateToTask: NavigateToTask;
+  navigateToTaskIntent: NavigateToTaskIntent;
   setOpenTaskTabs: SetState<string[]>;
   setPersistedActiveTaskId: SetState<string | null>;
   setIntentActiveTaskId: SetState<string | null>;
@@ -35,7 +35,7 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
     tabsStorageHydratedRepo,
     clearComposerInput,
     onContextSwitchIntent,
-    navigateToTask,
+    navigateToTaskIntent,
     setOpenTaskTabs,
     setPersistedActiveTaskId,
     setIntentActiveTaskId,
@@ -88,10 +88,10 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
       return;
     }
     appliedFallbackKeyRef.current = fallbackKey;
-    navigateToTask(fallbackTaskId);
+    navigateToTaskIntent(fallbackTaskId);
   }, [
     activeRepo,
-    navigateToTask,
+    navigateToTaskIntent,
     persistedActiveTaskId,
     tabTaskIds,
     tabsStorageHydratedRepo,
@@ -123,12 +123,12 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
         return [...current, nextTaskId];
       });
       setPersistedActiveTaskId(nextTaskId);
-      navigateToTask(nextTaskId);
+      navigateToTaskIntent(nextTaskId);
     },
     [
       activeTaskTabId,
       clearComposerInput,
-      navigateToTask,
+      navigateToTaskIntent,
       onContextSwitchIntent,
       setIntentActiveTaskId,
       setOpenTaskTabs,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -127,7 +127,7 @@ describe("useAgentStudioTaskTabs", () => {
     }
   });
 
-  test("selecting a tab pins the session chosen for that task", async () => {
+  test("selecting a tab keeps navigation task-scoped without pinning a session", async () => {
     const memoryStorage = createMemoryStorage();
     const originalStorage = globalThis.localStorage;
     Object.defineProperty(globalThis, "localStorage", {
@@ -164,8 +164,8 @@ describe("useAgentStudioTaskTabs", () => {
       const lastUpdate = updateCalls[updateCalls.length - 1];
       expect(lastUpdate).toEqual({
         task: "task-2",
-        session: "session-2",
-        agent: "spec",
+        session: undefined,
+        agent: undefined,
         scenario: undefined,
         autostart: undefined,
         start: undefined,
@@ -180,7 +180,7 @@ describe("useAgentStudioTaskTabs", () => {
     }
   });
 
-  test("selecting a tab prefers the current active session over a newer inactive session", async () => {
+  test("selecting a tab does not manufacture session authority for review tasks", async () => {
     const memoryStorage = createMemoryStorage();
     const originalStorage = globalThis.localStorage;
     Object.defineProperty(globalThis, "localStorage", {
@@ -191,12 +191,12 @@ describe("useAgentStudioTaskTabs", () => {
     try {
       const taskOne = createTask("task-1");
       const taskTwo = createTask("task-2");
-      const runningSession = createAgentSessionFixture({
-        sessionId: "session-running",
-        externalSessionId: "ext-session-running",
+      const runningBuildSession = createAgentSessionFixture({
+        sessionId: "session-build",
+        externalSessionId: "ext-session-build",
         taskId: "task-2",
-        role: "spec",
-        scenario: "spec_initial",
+        role: "build",
+        scenario: "build_implementation_start",
         status: "running",
         startedAt: "2026-02-22T09:00:00.000Z",
       });
@@ -204,8 +204,8 @@ describe("useAgentStudioTaskTabs", () => {
         sessionId: "session-newer",
         externalSessionId: "ext-session-newer",
         taskId: "task-2",
-        role: "planner",
-        scenario: "planner_initial",
+        role: "qa",
+        scenario: "qa_review",
         status: "idle",
         startedAt: "2026-02-22T10:00:00.000Z",
       });
@@ -218,7 +218,7 @@ describe("useAgentStudioTaskTabs", () => {
         tasks: [taskOne, taskTwo],
         isLoadingTasks: false,
         latestSessionByTaskId: new Map([["task-2", newerIdleSession]]),
-        activeSessionByTaskId: new Map([["task-2", runningSession]]),
+        activeSessionByTaskId: new Map([["task-2", runningBuildSession]]),
         updateQuery: (updates) => {
           updateCalls.push(updates);
         },
@@ -232,8 +232,8 @@ describe("useAgentStudioTaskTabs", () => {
 
       expect(updateCalls[updateCalls.length - 1]).toEqual({
         task: "task-2",
-        session: "session-running",
-        agent: "spec",
+        session: undefined,
+        agent: undefined,
         scenario: undefined,
         autostart: undefined,
         start: undefined,
@@ -306,7 +306,6 @@ describe("useAgentStudioTaskTabs", () => {
 
       const taskOne = createTask("task-1");
       const taskTwo = createTask("task-2");
-      const fallbackSession = createSession("task-1", "session-1");
       const updateCalls: Array<Record<string, string | undefined>> = [];
       const clearComposerInput = mock(() => {});
 
@@ -316,7 +315,7 @@ describe("useAgentStudioTaskTabs", () => {
         selectedTask: taskOne,
         tasks: [taskOne, taskTwo],
         isLoadingTasks: false,
-        latestSessionByTaskId: new Map([["task-1", fallbackSession]]),
+        latestSessionByTaskId: new Map([["task-1", createSession("task-1", "session-1")]]),
         updateQuery: (updates) => {
           updateCalls.push(updates);
         },
@@ -340,8 +339,8 @@ describe("useAgentStudioTaskTabs", () => {
       const lastUpdate = updateCalls[updateCalls.length - 1];
       expect(lastUpdate).toEqual({
         task: "task-1",
-        session: "session-1",
-        agent: "spec",
+        session: undefined,
+        agent: undefined,
         scenario: undefined,
         autostart: undefined,
         start: undefined,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
@@ -11,7 +11,7 @@ import { useTaskTabActions } from "./use-agent-studio-task-tabs-actions";
 import { useTaskTabPersistence } from "./use-agent-studio-task-tabs-persistence";
 import { useTaskTabSelection } from "./use-agent-studio-task-tabs-selection";
 
-const toTaskQueryUpdate = (taskId: string): QueryUpdate => {
+const toTaskIntentQueryUpdate = (taskId: string): QueryUpdate => {
   return {
     [AGENT_STUDIO_QUERY_KEYS.task]: taskId,
     [AGENT_STUDIO_QUERY_KEYS.session]: undefined,
@@ -88,9 +88,9 @@ export function useAgentStudioTaskTabs(args: {
     [openTaskTabs, selectableTaskIds],
   );
 
-  const navigateToTask = useCallback(
+  const navigateToTaskIntent = useCallback(
     (nextTaskId: string) => {
-      deferQueryUpdate(toTaskQueryUpdate(nextTaskId));
+      deferQueryUpdate(toTaskIntentQueryUpdate(nextTaskId));
     },
     [deferQueryUpdate],
   );
@@ -108,7 +108,7 @@ export function useAgentStudioTaskTabs(args: {
     tabsStorageHydratedRepo,
     clearComposerInput,
     onContextSwitchIntent,
-    navigateToTask,
+    navigateToTaskIntent,
     setOpenTaskTabs,
     setPersistedActiveTaskId,
     setIntentActiveTaskId,
@@ -151,7 +151,7 @@ export function useAgentStudioTaskTabs(args: {
     clearComposerInput,
     onContextSwitchIntent,
     clearTaskSelection,
-    navigateToTask,
+    navigateToTaskIntent,
     handleSelectTab,
     setOpenTaskTabs,
     setPersistedActiveTaskId,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
@@ -11,14 +11,11 @@ import { useTaskTabActions } from "./use-agent-studio-task-tabs-actions";
 import { useTaskTabPersistence } from "./use-agent-studio-task-tabs-persistence";
 import { useTaskTabSelection } from "./use-agent-studio-task-tabs-selection";
 
-const toTaskQueryUpdate = (
-  taskId: string,
-  selectedSession?: Pick<AgentSessionState, "sessionId" | "role"> | null,
-): QueryUpdate => {
+const toTaskQueryUpdate = (taskId: string): QueryUpdate => {
   return {
     [AGENT_STUDIO_QUERY_KEYS.task]: taskId,
-    [AGENT_STUDIO_QUERY_KEYS.session]: selectedSession?.sessionId,
-    [AGENT_STUDIO_QUERY_KEYS.agent]: selectedSession?.role,
+    [AGENT_STUDIO_QUERY_KEYS.session]: undefined,
+    [AGENT_STUDIO_QUERY_KEYS.agent]: undefined,
     [AGENT_STUDIO_QUERY_KEYS.scenario]: undefined,
     [AGENT_STUDIO_QUERY_KEYS.autostart]: undefined,
     [AGENT_STUDIO_QUERY_KEYS.start]: undefined,
@@ -92,13 +89,10 @@ export function useAgentStudioTaskTabs(args: {
   );
 
   const navigateToTask = useCallback(
-    (nextTaskId: string, options?: { pinSession?: boolean }) => {
-      const selectedSession = options?.pinSession
-        ? (activeSessionByTaskId?.get(nextTaskId) ?? latestSessionByTaskId.get(nextTaskId) ?? null)
-        : null;
-      deferQueryUpdate(toTaskQueryUpdate(nextTaskId, selectedSession));
+    (nextTaskId: string) => {
+      deferQueryUpdate(toTaskQueryUpdate(nextTaskId));
     },
-    [activeSessionByTaskId, deferQueryUpdate, latestSessionByTaskId],
+    [deferQueryUpdate],
   );
 
   const clearTaskSelection = useCallback((): void => {


### PR DESCRIPTION
## Summary
- stop Agent Studio task tabs from manufacturing explicit session and agent query authority during implicit task switches
- keep review-status tasks on the resolver-chosen build session while preserving explicit session deep links and reflective query sync
- add regression coverage for task tabs, selection controller, query sync, and page models around the build-vs-QA tab switching flow

## Verification
- bun run --filter @openducktor/desktop test -- use-agent-studio-task-tabs use-agent-studio-selection-controller use-agent-studio-query-session-sync use-agent-studio-page-models
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified task navigation in agent studio. Task selection no longer automatically persists session selection state in the navigation payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->