### PR TITLE
fix(desktop): show provider and variant in assistant footer

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -1,8 +1,4 @@
-import {
-  type AgentModelSelection,
-  type AgentRole,
-  isOdtWorkflowMutationToolName,
-} from "@openducktor/core";
+import { type AgentRole, isOdtWorkflowMutationToolName } from "@openducktor/core";
 import { Brain, Hammer, MessageSquareQuote } from "lucide-react";
 import { lazy, type ReactElement, Suspense } from "react";
 import type { MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
@@ -150,16 +146,14 @@ const ReasoningMessage = ({ content }: ReasoningMessageProps): ReactElement => {
 
 type AssistantMessageProps = {
   message: AgentChatMessage;
-  sessionSelectedModel: AgentModelSelection | null;
   assistantAccentColor: string | undefined;
 };
 
 const AssistantMessage = ({
   message,
-  sessionSelectedModel,
   assistantAccentColor,
 }: AssistantMessageProps): ReactElement => {
-  const footer = getAssistantFooterData(message, sessionSelectedModel);
+  const footer = getAssistantFooterData(message);
   return (
     <div className="space-y-2">
       <DeferredMarkdownRenderer markdown={message.content} variant="document" />
@@ -178,7 +172,6 @@ const AssistantMessage = ({
 
 type MessageBodyProps = {
   message: AgentChatMessage;
-  sessionSelectedModel: AgentModelSelection | null;
   assistantAccentColor: string | undefined;
   timeLabel: string;
   systemPromptBody: string;
@@ -187,7 +180,6 @@ type MessageBodyProps = {
 
 export const MessageBody = ({
   message,
-  sessionSelectedModel,
   assistantAccentColor,
   timeLabel,
   systemPromptBody,
@@ -274,13 +266,7 @@ export const MessageBody = ({
   }
 
   if (message.role === "assistant") {
-    return (
-      <AssistantMessage
-        message={message}
-        sessionSelectedModel={sessionSelectedModel}
-        assistantAccentColor={assistantAccentColor}
-      />
-    );
+    return <AssistantMessage message={message} assistantAccentColor={assistantAccentColor} />;
   }
 
   return <DeferredMarkdownRenderer markdown={message.content} variant="document" />;

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts
@@ -775,27 +775,36 @@ describe("agent-chat-message-card-model", () => {
             kind: "assistant",
             agentRole: "build",
             isFinal: true,
+            providerId: "openai",
             modelId: "gpt-5",
+            variant: "high",
             profileId: "builder",
           },
         }),
-        {
-          runtimeKind: "opencode",
-          providerId: "openai",
-          modelId: "gpt-4",
-          profileId: "fallback",
-        },
       );
-      expect(footer.infoParts).toEqual(["builder", "gpt-5"]);
+      expect(footer.infoParts).toEqual(["builder", "openai/gpt-5", "high"]);
+    });
+
+    test("omits blank variant and missing provider or model segments", () => {
+      const footer = getAssistantFooterData(
+        createMessage({
+          meta: {
+            kind: "assistant",
+            agentRole: "build",
+            isFinal: true,
+            providerId: "openai",
+            modelId: " ",
+            variant: "   ",
+            profileId: "builder",
+          },
+        }),
+      );
+
+      expect(footer.infoParts).toEqual(["builder", "openai"]);
     });
 
     test("does not show footer for assistant messages without final metadata", () => {
-      const footer = getAssistantFooterData(createMessage(), {
-        runtimeKind: "opencode",
-        providerId: "openai",
-        modelId: "gpt-4o-mini",
-        profileId: "planner-agent",
-      });
+      const footer = getAssistantFooterData(createMessage());
       expect(footer.infoParts).toEqual([]);
     });
 
@@ -806,27 +815,17 @@ describe("agent-chat-message-card-model", () => {
             kind: "assistant",
             agentRole: "spec",
             isFinal: false,
+            providerId: "openai",
             modelId: "gpt-5",
             profileId: "hephaestus",
           },
         }),
-        {
-          runtimeKind: "opencode",
-          providerId: "openai",
-          modelId: "gpt-4o-mini",
-          profileId: "planner-agent",
-        },
       );
       expect(footer.infoParts).toEqual([]);
     });
 
     test("returns empty parts for non-assistant messages and blank metadata", () => {
-      const nonAssistant = getAssistantFooterData(createMessage({ role: "tool" }), {
-        runtimeKind: "opencode",
-        providerId: "openai",
-        modelId: "gpt-4o-mini",
-        profileId: "planner-agent",
-      });
+      const nonAssistant = getAssistantFooterData(createMessage({ role: "tool" }));
       expect(nonAssistant.infoParts).toEqual([]);
 
       const blankMeta = getAssistantFooterData(
@@ -839,12 +838,6 @@ describe("agent-chat-message-card-model", () => {
             profileId: " ",
           },
         }),
-        {
-          runtimeKind: "opencode",
-          providerId: "openai",
-          modelId: "fallback-model",
-          profileId: "fallback-agent",
-        },
       );
       expect(blankMeta.infoParts).toEqual([]);
     });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -438,7 +438,7 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).not.toContain("tracking-wide");
   });
 
-  test("renders assistant footer with agent and model labels", () => {
+  test("renders assistant footer with agent, provider/model, and variant labels", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {
         message: {
@@ -451,7 +451,9 @@ describe("AgentChatMessageCard tool duration", () => {
             agentRole: "planner",
             isFinal: true,
             profileId: "planner-main",
+            providerId: "openai",
             modelId: "gpt-5.3-codex",
+            variant: "high",
           },
         },
         sessionRole: "planner",
@@ -461,7 +463,9 @@ describe("AgentChatMessageCard tool duration", () => {
     );
 
     expect(html).toContain("planner-main");
+    expect(html).toContain("openai/gpt-5.3-codex");
     expect(html).toContain("gpt-5.3-codex");
+    expect(html).toContain("high");
   });
 
   test("hides assistant header and left border in final assistant messages", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.tsx
@@ -38,7 +38,6 @@ export function AgentChatMessageCard({
       />
       <MessageBody
         message={message}
-        sessionSelectedModel={sessionSelectedModel}
         assistantAccentColor={vm.assistantAccentColor}
         timeLabel={vm.timeLabel}
         systemPromptBody={vm.systemPromptBody}

--- a/apps/desktop/src/components/features/agents/agent-chat/message-formatting.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/message-formatting.ts
@@ -1,4 +1,4 @@
-import type { AgentModelSelection, AgentRole } from "@openducktor/core";
+import type { AgentRole } from "@openducktor/core";
 import { toOdtWorkflowToolDisplayName } from "@openducktor/core";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
@@ -77,10 +77,7 @@ export const roleLabel = (
   return "System";
 };
 
-export const getAssistantFooterData = (
-  message: AgentChatMessage,
-  sessionSelectedModel: AgentModelSelection | null,
-): { infoParts: string[] } => {
+export const getAssistantFooterData = (message: AgentChatMessage): { infoParts: string[] } => {
   if (message.role !== "assistant") {
     return { infoParts: [] };
   }
@@ -91,14 +88,24 @@ export const getAssistantFooterData = (
   }
   const parts: string[] = [];
 
-  const agentLabel = assistantMeta.profileId ?? sessionSelectedModel?.profileId;
+  const agentLabel = assistantMeta.profileId;
   if (typeof agentLabel === "string" && agentLabel.trim().length > 0) {
     parts.push(agentLabel.trim());
   }
 
-  const modelLabel = assistantMeta.modelId ?? sessionSelectedModel?.modelId;
-  if (typeof modelLabel === "string" && modelLabel.trim().length > 0) {
-    parts.push(modelLabel.trim());
+  const providerLabel = assistantMeta.providerId;
+  const modelLabel = assistantMeta.modelId;
+  const providerModelLabel = [providerLabel, modelLabel]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .map((value) => value.trim())
+    .join("/");
+  if (providerModelLabel.length > 0) {
+    parts.push(providerModelLabel);
+  }
+
+  const variantLabel = assistantMeta.variant;
+  if (typeof variantLabel === "string" && variantLabel.trim().length > 0) {
+    parts.push(variantLabel.trim());
   }
 
   return { infoParts: parts };


### PR DESCRIPTION
## Summary
- Render final assistant footers as `profile · provider/model · variant` from assistant metadata only.
- Omit blank segments cleanly and avoid session-selected-model fallback.
- Update focused agent chat footer tests to cover the new format and suppression behavior.

## Verification
- `bun test apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-model.test.ts apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts`
- `bun run --filter @openducktor/desktop typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assistant message footers now correctly display provider and model information directly from message metadata, ensuring accurate footer labels in all scenarios.

* **Tests**
  * Updated assistant message footer tests to reflect refined data sourcing from message metadata, including new validation for provider/model combinations and variant labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->