### PR TITLE
fix(desktop): defer chat diff loading until expansion

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx
@@ -1,0 +1,105 @@
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { FileEditData } from "./agent-chat-message-card-model";
+
+let AgentChatFileEditCard: typeof import("./agent-chat-file-edit-card").AgentChatFileEditCard;
+
+const preloaderMock = mock(({ filePath }: { patch: string; filePath: string }) => (
+  <div data-testid="pierre-diff-preloader">{filePath}</div>
+));
+
+const viewerMock = mock(
+  ({ diffStyle, filePath, patch }: { patch: string; filePath: string; diffStyle?: string }) => (
+    <div
+      data-testid="pierre-diff-viewer"
+      data-diff-style={diffStyle ?? ""}
+      data-file-path={filePath}
+      data-patch={patch}
+    >
+      {filePath}
+    </div>
+  ),
+);
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+const previousActEnvironmentValue = reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+
+const buildFileEditData = (overrides: Partial<FileEditData> = {}): FileEditData => ({
+  filePath: "src/example.ts",
+  diff: "@@ -1 +1 @@\n-old\n+new\n",
+  additions: 1,
+  deletions: 1,
+  ...overrides,
+});
+
+beforeAll(async () => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+
+  mock.module("@/components/features/agents/pierre-diff-viewer", () => ({
+    PierreDiffPreloader: preloaderMock,
+    PierreDiffViewer: viewerMock,
+  }));
+
+  ({ AgentChatFileEditCard } = await import("./agent-chat-file-edit-card"));
+});
+
+afterEach(() => {
+  cleanup();
+  preloaderMock.mockClear();
+  viewerMock.mockClear();
+});
+
+afterAll(() => {
+  if (typeof previousActEnvironmentValue === "undefined") {
+    delete reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  } else {
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = previousActEnvironmentValue;
+  }
+
+  mock.restore();
+});
+
+describe("AgentChatFileEditCard", () => {
+  test("does not mount the hidden diff preloader while collapsed", () => {
+    render(<AgentChatFileEditCard data={buildFileEditData()} />);
+
+    expect(screen.queryByTestId("pierre-diff-preloader")).toBeNull();
+    expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
+    expect(preloaderMock).not.toHaveBeenCalled();
+    expect(viewerMock).not.toHaveBeenCalled();
+  });
+
+  test("renders the visible diff viewer after expansion with the existing split view props", () => {
+    render(<AgentChatFileEditCard data={buildFileEditData()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /example\.ts/i }));
+
+    const viewer = screen.getByTestId("pierre-diff-viewer");
+    expect(viewer.getAttribute("data-file-path")).toBe("src/example.ts");
+    expect(viewer.getAttribute("data-patch")).toBe("@@ -1 +1 @@\n-old\n+new\n");
+    expect(viewer.getAttribute("data-diff-style")).toBe("split");
+    expect(preloaderMock).not.toHaveBeenCalled();
+    expect(viewerMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps no-diff cards on the metadata-only path", () => {
+    render(
+      <AgentChatFileEditCard
+        data={buildFileEditData({
+          diff: null,
+          filePath: "src/no-diff.ts",
+          additions: 0,
+          deletions: 0,
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /no-diff\.ts/i })).toBeDefined();
+    expect(screen.queryByTestId("pierre-diff-preloader")).toBeNull();
+    expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
+    expect(preloaderMock).not.toHaveBeenCalled();
+    expect(viewerMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-file-edit-card.tsx
@@ -1,9 +1,6 @@
 import { ChevronDown, ChevronRight, FilePlus, FileText, FileX } from "lucide-react";
 import { memo, type ReactElement, useState } from "react";
-import {
-  PierreDiffPreloader,
-  PierreDiffViewer,
-} from "@/components/features/agents/pierre-diff-viewer";
+import { PierreDiffViewer } from "@/components/features/agents/pierre-diff-viewer";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { FileEditData } from "./agent-chat-message-card-model";
@@ -55,8 +52,6 @@ export const AgentChatFileEditCard = memo(function AgentChatFileEditCard({
       className="my-1.5 overflow-hidden rounded-lg border border-border bg-card text-xs"
       data-testid="agent-chat-file-edit-card"
     >
-      {data.diff ? <PierreDiffPreloader patch={data.diff} filePath={data.filePath} /> : null}
-
       {/* Header */}
       <button
         type="button"


### PR DESCRIPTION
## Summary
- stop `AgentChatFileEditCard` from mounting `PierreDiffPreloader` while file-edit cards remain collapsed
- keep the existing expanded diff viewer behavior intact so diffs still render on demand in split view
- add focused regression coverage for collapsed, expanded, and no-diff chat file-edit paths

## Verification
- `bun test apps/desktop/src/components/features/agents/agent-chat/agent-chat-file-edit-card.test.tsx`
- `bun test apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts`
- `bun test apps/desktop/src/components/features/agents/agent-studio-git-panel/diff-preload-queue.test.ts`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint` (passes with 3 pre-existing unrelated optional-chain warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for file edit card diff display and expansion behavior

* **Refactor**
  * Removed diff preloader UI component from file edit workflow
  * Simplified diff display to show directly when expanding file edit card
  * Streamlined the overall diff viewing experience by eliminating intermediate loading states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->