### PR TITLE
fix(desktop): recover agent studio sessions during runtime startup

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { getAgentChatThreadState } from "./agent-chat-thread-state";
+
+describe("getAgentChatThreadState", () => {
+  test("keeps runtime waiting separate from transcript hiding", () => {
+    const state = getAgentChatThreadState({
+      isSessionViewLoading: false,
+      isSessionHistoryLoading: false,
+      isWaitingForRuntimeReadiness: true,
+      readinessState: "checking",
+      blockedReason: "",
+      isTranscriptRenderDeferred: false,
+    });
+
+    expect(state.showRuntimeCheckingOverlay).toBe(true);
+    expect(state.hideTranscriptWhileHydrating).toBe(false);
+    expect(state.isTranscriptLoading).toBe(false);
+  });
+
+  test("treats history hydration as transcript-loading state", () => {
+    const state = getAgentChatThreadState({
+      isSessionViewLoading: false,
+      isSessionHistoryLoading: true,
+      isWaitingForRuntimeReadiness: false,
+      readinessState: "ready",
+      blockedReason: "",
+      isTranscriptRenderDeferred: false,
+    });
+
+    expect(state.isTranscriptLoading).toBe(true);
+    expect(state.hideTranscriptWhileHydrating).toBe(true);
+    expect(state.showRuntimeCheckingOverlay).toBe(false);
+  });
+
+  test("shows blocked card only for explicit blocked reason", () => {
+    const visible = getAgentChatThreadState({
+      isSessionViewLoading: false,
+      isSessionHistoryLoading: false,
+      isWaitingForRuntimeReadiness: false,
+      readinessState: "blocked",
+      blockedReason: "Runtime unavailable",
+      isTranscriptRenderDeferred: false,
+    });
+    const hidden = getAgentChatThreadState({
+      isSessionViewLoading: false,
+      isSessionHistoryLoading: false,
+      isWaitingForRuntimeReadiness: false,
+      readinessState: "blocked",
+      blockedReason: "",
+      isTranscriptRenderDeferred: false,
+    });
+
+    expect(visible.showRuntimeBlockedCard).toBe(true);
+    expect(hidden.showRuntimeBlockedCard).toBe(false);
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
@@ -33,7 +33,8 @@ export const getAgentChatThreadState = ({
   return {
     isTranscriptLoading,
     hideTranscriptWhileHydrating,
-    showRuntimeCheckingOverlay: isWaitingForRuntimeReadiness && readinessState === "checking",
+    showRuntimeCheckingOverlay:
+      isWaitingForRuntimeReadiness && (readinessState === "checking" || readinessState === "ready"),
     showRuntimeBlockedCard: readinessState === "blocked" && Boolean(blockedReason),
   };
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread-state.ts
@@ -1,0 +1,39 @@
+import type { AgentChatThreadModel } from "./agent-chat.types";
+
+type BuildAgentChatThreadStateArgs = Pick<
+  AgentChatThreadModel,
+  | "isSessionViewLoading"
+  | "isSessionHistoryLoading"
+  | "isWaitingForRuntimeReadiness"
+  | "readinessState"
+  | "blockedReason"
+> & {
+  isTranscriptRenderDeferred: boolean;
+};
+
+export type AgentChatThreadState = {
+  isTranscriptLoading: boolean;
+  hideTranscriptWhileHydrating: boolean;
+  showRuntimeCheckingOverlay: boolean;
+  showRuntimeBlockedCard: boolean;
+};
+
+export const getAgentChatThreadState = ({
+  isSessionViewLoading,
+  isSessionHistoryLoading,
+  isWaitingForRuntimeReadiness,
+  readinessState,
+  blockedReason,
+  isTranscriptRenderDeferred,
+}: BuildAgentChatThreadStateArgs): AgentChatThreadState => {
+  const isTranscriptLoading =
+    isSessionViewLoading || isSessionHistoryLoading || isTranscriptRenderDeferred;
+  const hideTranscriptWhileHydrating = isSessionHistoryLoading || isTranscriptRenderDeferred;
+
+  return {
+    isTranscriptLoading,
+    hideTranscriptWhileHydrating,
+    showRuntimeCheckingOverlay: isWaitingForRuntimeReadiness && readinessState === "checking",
+    showRuntimeBlockedCard: readinessState === "blocked" && Boolean(blockedReason),
+  };
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -184,7 +184,7 @@ describe("AgentChatThread", () => {
     expect(html).not.toContain("Agent is thinking...");
   });
 
-  test("renders loading state when active session has no renderable rows yet", () => {
+  test("keeps the transcript area blank when active session has no renderable rows yet", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatThread, {
         model: {
@@ -200,7 +200,8 @@ describe("AgentChatThread", () => {
       }),
     );
 
-    expect(html).toContain("Loading session history...");
+    expect(html).not.toContain("Loading session history...");
+    expect(html).not.toContain("Loading session...");
   });
 
   test("renders blank transcript area when session has messages but all were filtered", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -302,6 +302,26 @@ describe("AgentChatThread", () => {
     expect(html).toContain("Cached transcript");
   });
 
+  test("renders the runtime-starting overlay while waiting for a worktree runtime after page readiness succeeds", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatThread, {
+        model: {
+          ...buildBaseModel(),
+          readinessState: "ready",
+          agentStudioReady: true,
+          isWaitingForRuntimeReadiness: true,
+          session: buildSession({
+            messages: [buildMessage("assistant", "Cached transcript", { id: "assistant-1" })],
+          }),
+        },
+      }),
+    );
+
+    expect(html).toContain("Runtime is starting");
+    expect(html).toContain("Waiting for runtime and MCP health before loading this session.");
+    expect(html).toContain("Cached transcript");
+  });
+
   test("does not show the runtime-starting overlay for generic readiness checks without a waiting session", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatThread, {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -23,6 +23,7 @@ const buildBaseModel = () => ({
   showThinkingMessages: false,
   isSessionViewLoading: false,
   isSessionHistoryLoading: false,
+  isWaitingForRuntimeReadiness: false,
   roleOptions: TEST_ROLE_OPTIONS,
   readinessState: "ready" as const,
   agentStudioReady: true,
@@ -287,6 +288,7 @@ describe("AgentChatThread", () => {
           ...buildBaseModel(),
           readinessState: "checking",
           agentStudioReady: false,
+          isWaitingForRuntimeReadiness: true,
           session: buildSession({
             messages: [buildMessage("assistant", "Cached transcript", { id: "assistant-1" })],
           }),
@@ -296,6 +298,25 @@ describe("AgentChatThread", () => {
 
     expect(html).toContain("Runtime is starting");
     expect(html).toContain("Waiting for runtime and MCP health before loading this session.");
+    expect(html).toContain("Cached transcript");
+  });
+
+  test("does not show the runtime-starting overlay for generic readiness checks without a waiting session", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatThread, {
+        model: {
+          ...buildBaseModel(),
+          readinessState: "checking",
+          agentStudioReady: false,
+          isWaitingForRuntimeReadiness: false,
+          session: buildSession({
+            messages: [buildMessage("assistant", "Cached transcript", { id: "assistant-1" })],
+          }),
+        },
+      }),
+    );
+
+    expect(html).not.toContain("Runtime is starting");
     expect(html).toContain("Cached transcript");
   });
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -24,6 +24,7 @@ const buildBaseModel = () => ({
   isSessionViewLoading: false,
   isSessionHistoryLoading: false,
   roleOptions: TEST_ROLE_OPTIONS,
+  readinessState: "ready" as const,
   agentStudioReady: true,
   blockedReason: "",
   isLoadingChecks: false,
@@ -267,6 +268,7 @@ describe("AgentChatThread", () => {
       createElement(AgentChatThread, {
         model: {
           ...buildBaseModel(),
+          readinessState: "blocked",
           agentStudioReady: false,
           blockedReason: "OpenCode runtime is unavailable",
           session: null,
@@ -276,6 +278,25 @@ describe("AgentChatThread", () => {
 
     expect(html).toContain("OpenCode runtime is unavailable");
     expect(html).toContain("Recheck");
+  });
+
+  test("renders the runtime-starting overlay without unmounting transcript content", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatThread, {
+        model: {
+          ...buildBaseModel(),
+          readinessState: "checking",
+          agentStudioReady: false,
+          session: buildSession({
+            messages: [buildMessage("assistant", "Cached transcript", { id: "assistant-1" })],
+          }),
+        },
+      }),
+    );
+
+    expect(html).toContain("Runtime is starting");
+    expect(html).toContain("Waiting for runtime and MCP health before loading this session.");
+    expect(html).toContain("Cached transcript");
   });
 
   test("renders transcript messages and question cards without synthetic draft rows", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -6,6 +6,7 @@ import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { resolveAgentAccentColor } from "../agent-accent-color";
 import type { AgentChatThreadModel } from "./agent-chat.types";
 import { AgentChatThreadRow } from "./agent-chat-thread-row";
+import { getAgentChatThreadState } from "./agent-chat-thread-state";
 import type { AgentChatWindowRow } from "./agent-chat-thread-windowing";
 import { buildAgentChatWindowRows } from "./agent-chat-thread-windowing";
 import { AgentSessionPermissionCard } from "./agent-session-permission-card";
@@ -87,11 +88,19 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const { isTranscriptRenderDeferred } = useAgentChatDeferredTranscript({
     activeSessionId,
   });
-  const isTranscriptLoading =
-    isSessionViewLoading || isSessionHistoryLoading || isTranscriptRenderDeferred;
-  const hideTranscriptWhileHydrating = isSessionHistoryLoading || isTranscriptRenderDeferred;
-  const showRuntimeCheckingOverlay = isWaitingForRuntimeReadiness && readinessState === "checking";
-  const showRuntimeBlockedCard = readinessState === "blocked" && blockedReason;
+  const {
+    isTranscriptLoading,
+    hideTranscriptWhileHydrating,
+    showRuntimeCheckingOverlay,
+    showRuntimeBlockedCard,
+  } = getAgentChatThreadState({
+    isSessionViewLoading,
+    isSessionHistoryLoading,
+    isWaitingForRuntimeReadiness,
+    readinessState,
+    blockedReason,
+    isTranscriptRenderDeferred,
+  });
 
   const rows = useMemo(() => {
     if (!session || hideTranscriptWhileHydrating) {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -238,10 +238,9 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
             </div>
           ) : null}
 
-          {session ? (
-            rows.length > 0 ? (
-              hideTranscriptWhileHydrating ? null : (
-                windowedRows.map((row) => (
+          {session
+            ? rows.length > 0 && !hideTranscriptWhileHydrating
+              ? windowedRows.map((row) => (
                   <AgentChatThreadMotionRow
                     key={row.key}
                     row={row}
@@ -252,13 +251,8 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
                     resolveRowRef={resolveRowRef}
                   />
                 ))
-              )
-            ) : session.messages.length === 0 && !hideTranscriptWhileHydrating ? (
-              <div className="rounded-lg border border-dashed border-input bg-card p-4 text-sm text-muted-foreground">
-                Loading session history...
-              </div>
-            ) : null
-          ) : null}
+              : null
+            : null}
         </div>
         {showLoadingOverlay ? (
           <div className="absolute inset-0 z-30 flex items-center justify-center bg-muted/85">

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -58,6 +58,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     showThinkingMessages,
     isSessionViewLoading,
     isSessionHistoryLoading,
+    isWaitingForRuntimeReadiness,
     readinessState,
     agentStudioReady,
     blockedReason,
@@ -89,7 +90,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const isTranscriptLoading =
     isSessionViewLoading || isSessionHistoryLoading || isTranscriptRenderDeferred;
   const hideTranscriptWhileHydrating = isSessionHistoryLoading || isTranscriptRenderDeferred;
-  const showRuntimeCheckingOverlay = readinessState === "checking";
+  const showRuntimeCheckingOverlay = isWaitingForRuntimeReadiness && readinessState === "checking";
   const showRuntimeBlockedCard = readinessState === "blocked" && blockedReason;
 
   const rows = useMemo(() => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -58,6 +58,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     showThinkingMessages,
     isSessionViewLoading,
     isSessionHistoryLoading,
+    readinessState,
     agentStudioReady,
     blockedReason,
     isLoadingChecks,
@@ -88,6 +89,8 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const isTranscriptLoading =
     isSessionViewLoading || isSessionHistoryLoading || isTranscriptRenderDeferred;
   const hideTranscriptWhileHydrating = isSessionHistoryLoading || isTranscriptRenderDeferred;
+  const showRuntimeCheckingOverlay = readinessState === "checking";
+  const showRuntimeBlockedCard = readinessState === "blocked" && blockedReason;
 
   const rows = useMemo(() => {
     if (!session || hideTranscriptWhileHydrating) {
@@ -165,30 +168,46 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
-      {!agentStudioReady ? (
-        <div className="mx-4 mt-4 flex items-start justify-between gap-3 rounded-lg border border-destructive-border bg-destructive-surface px-3 py-2 text-sm text-destructive-muted">
-          <div className="flex min-w-0 items-start gap-2">
-            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
-            <p className="min-w-0">{blockedReason}</p>
-          </div>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-7 border-destructive-border bg-card text-destructive-muted hover:bg-destructive-surface"
-            disabled={isLoadingChecks}
-            onClick={onRefreshChecks}
-          >
-            <RefreshCcw className={cn("size-3.5", isLoadingChecks ? "animate-spin" : "")} />
-            Recheck
-          </Button>
-        </div>
-      ) : null}
-
       <div
         ref={messagesContainerRef}
         className="agent-chat-scroll-region hide-scrollbar relative min-h-0 flex-1 overflow-y-auto px-4 pb-4 pt-4"
       >
+        {showRuntimeCheckingOverlay ? (
+          <div className="sticky top-0 z-20 mb-4">
+            <div className="mx-auto flex max-w-3xl items-start gap-3 rounded-xl border border-border bg-card/95 px-4 py-3 text-sm shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/85">
+              <div className="mt-0.5 rounded-full bg-muted p-2 text-muted-foreground">
+                <LoaderCircle className="size-4 animate-spin" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-foreground">Runtime is starting</p>
+                <p className="text-muted-foreground">
+                  Waiting for runtime and MCP health before loading this session.
+                </p>
+              </div>
+            </div>
+          </div>
+        ) : null}
+
+        {showRuntimeBlockedCard ? (
+          <div className="mb-4 flex items-start justify-between gap-3 rounded-xl border border-destructive-border bg-destructive-surface px-4 py-3 text-sm text-destructive-muted shadow-sm">
+            <div className="flex min-w-0 items-start gap-2">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+              <p className="min-w-0">{blockedReason}</p>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-8 border-destructive-border bg-card text-destructive-muted hover:bg-destructive-surface"
+              disabled={isLoadingChecks}
+              onClick={onRefreshChecks}
+            >
+              <RefreshCcw className={cn("size-3.5", isLoadingChecks ? "animate-spin" : "")} />
+              Recheck
+            </Button>
+          </div>
+        ) : null}
+
         <div ref={messagesContentRef} className="space-y-1">
           {!session ? (
             <div className="space-y-3 rounded-lg border border-dashed border-input bg-card p-4 text-sm text-muted-foreground">
@@ -241,7 +260,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
           ) : null}
         </div>
         {showLoadingOverlay ? (
-          <div className="absolute inset-0 z-30 flex items-center justify-center bg-muted">
+          <div className="absolute inset-0 z-30 flex items-center justify-center bg-muted/85">
             <div className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm">
               <LoaderCircle className="size-3.5 animate-spin" />
               Loading session...

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -19,6 +19,7 @@ const buildModel = () => ({
     showThinkingMessages: false,
     isSessionViewLoading: false,
     isSessionHistoryLoading: false,
+    isWaitingForRuntimeReadiness: false,
     roleOptions: TEST_ROLE_OPTIONS,
     readinessState: "ready" as const,
     agentStudioReady: true,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -20,6 +20,7 @@ const buildModel = () => ({
     isSessionViewLoading: false,
     isSessionHistoryLoading: false,
     roleOptions: TEST_ROLE_OPTIONS,
+    readinessState: "ready" as const,
     agentStudioReady: true,
     blockedReason: "",
     isLoadingChecks: false,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -21,6 +21,7 @@ export type AgentChatThreadModel = {
   showThinkingMessages: boolean;
   isSessionViewLoading: boolean;
   isSessionHistoryLoading: boolean;
+  isWaitingForRuntimeReadiness: boolean;
   roleOptions: AgentRoleOption[];
   readinessState: "ready" | "checking" | "blocked";
   agentStudioReady: boolean;

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -22,6 +22,7 @@ export type AgentChatThreadModel = {
   isSessionViewLoading: boolean;
   isSessionHistoryLoading: boolean;
   roleOptions: AgentRoleOption[];
+  readinessState: "ready" | "checking" | "blocked";
   agentStudioReady: boolean;
   blockedReason: string | null;
   isLoadingChecks: boolean;

--- a/apps/desktop/src/pages/agents/agent-studio-session-runtime.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-session-runtime.ts
@@ -1,0 +1,32 @@
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+
+const WORKTREE_RUNTIME_ROLES = new Set<AgentSessionState["role"]>(["build", "qa"]);
+
+type RuntimeAttachmentState = Pick<AgentSessionState, "runId" | "runtimeId" | "runtimeEndpoint">;
+type WorktreeRuntimeRole = Pick<AgentSessionState, "role">;
+
+export const requiresLiveWorktreeRuntime = (
+  session: WorktreeRuntimeRole | null | undefined,
+): boolean => {
+  return Boolean(session && WORKTREE_RUNTIME_ROLES.has(session.role));
+};
+
+export const hasAttachedSessionRuntime = (
+  session: RuntimeAttachmentState | null | undefined,
+): boolean => {
+  if (!session) {
+    return false;
+  }
+
+  return (
+    session.runId !== null ||
+    session.runtimeId !== null ||
+    session.runtimeEndpoint.trim().length > 0
+  );
+};
+
+export const isWaitingForAttachedWorktreeRuntime = (
+  session: (WorktreeRuntimeRole & RuntimeAttachmentState) | null | undefined,
+): boolean => {
+  return requiresLiveWorktreeRuntime(session) && !hasAttachedSessionRuntime(session);
+};

--- a/apps/desktop/src/pages/agents/agent-studio-task-hydration-state.test.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-task-hydration-state.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { getAgentStudioTaskHydrationDecision } from "./agent-studio-task-hydration-state";
+
+describe("getAgentStudioTaskHydrationDecision", () => {
+  test("waits while page readiness is still unavailable", () => {
+    const decision = getAgentStudioTaskHydrationDecision({
+      activeRepo: "/repo-a",
+      activeTaskId: "task-1",
+      activeSession: {
+        sessionId: "session-1",
+        role: "planner",
+        runId: null,
+        runtimeId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+      },
+      historyHydrationState: "failed",
+      sessionNeedsHydration: true,
+      agentStudioReadinessState: "checking",
+      waitingRecoveryKey: null,
+      postReadyFailureRecoveryKey: null,
+    });
+
+    expect(decision.isWaitingForRuntimeReadiness).toBe(true);
+    expect(decision.shouldHydrateSessionHistory).toBe(false);
+  });
+
+  test("waits for a build session runtime attachment even after page readiness turns ready", () => {
+    const decision = getAgentStudioTaskHydrationDecision({
+      activeRepo: "/repo-a",
+      activeTaskId: "task-1",
+      activeSession: {
+        sessionId: "session-1",
+        role: "build",
+        runId: null,
+        runtimeId: null,
+        runtimeEndpoint: "",
+      },
+      historyHydrationState: "not_requested",
+      sessionNeedsHydration: true,
+      agentStudioReadinessState: "ready",
+      waitingRecoveryKey: null,
+      postReadyFailureRecoveryKey: null,
+    });
+
+    expect(decision.shouldWaitForSessionRuntime).toBe(true);
+    expect(decision.isWaitingForRuntimeReadiness).toBe(true);
+    expect(decision.shouldHydrateSessionHistory).toBe(false);
+  });
+
+  test("hydrates a remembered waiting session once readiness is restored", () => {
+    const decision = getAgentStudioTaskHydrationDecision({
+      activeRepo: "/repo-a",
+      activeTaskId: "task-1",
+      activeSession: {
+        sessionId: "session-1",
+        role: "planner",
+        runId: null,
+        runtimeId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+      },
+      historyHydrationState: "failed",
+      sessionNeedsHydration: true,
+      agentStudioReadinessState: "ready",
+      waitingRecoveryKey: "/repo-a::task-1::session-1",
+      postReadyFailureRecoveryKey: null,
+    });
+
+    expect(decision.isRecoveringWaitingSession).toBe(true);
+    expect(decision.shouldHydrateSessionHistory).toBe(true);
+  });
+
+  test("blocks automatic recovery after a sticky post-ready failure", () => {
+    const decision = getAgentStudioTaskHydrationDecision({
+      activeRepo: "/repo-a",
+      activeTaskId: "task-1",
+      activeSession: {
+        sessionId: "session-1",
+        role: "planner",
+        runId: null,
+        runtimeId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+      },
+      historyHydrationState: "failed",
+      sessionNeedsHydration: true,
+      agentStudioReadinessState: "ready",
+      waitingRecoveryKey: "/repo-a::task-1::session-1",
+      postReadyFailureRecoveryKey: "/repo-a::task-1::session-1",
+    });
+
+    expect(decision.blockedFromAutomaticRecovery).toBe(true);
+    expect(decision.isWaitingForRuntimeReadiness).toBe(false);
+    expect(decision.shouldHydrateSessionHistory).toBe(false);
+  });
+});

--- a/apps/desktop/src/pages/agents/agent-studio-task-hydration-state.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-task-hydration-state.ts
@@ -4,7 +4,7 @@ import type {
 } from "@/types/agent-orchestrator";
 import { isWaitingForAttachedWorktreeRuntime } from "./agent-studio-session-runtime";
 
-type AgentStudioReadinessState = "ready" | "checking" | "blocked";
+export type AgentStudioReadinessState = "ready" | "checking" | "blocked";
 
 type TaskHydrationSessionState = Pick<
   AgentSessionState,

--- a/apps/desktop/src/pages/agents/agent-studio-task-hydration-state.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-task-hydration-state.ts
@@ -1,0 +1,100 @@
+import type {
+  AgentSessionHistoryHydrationState,
+  AgentSessionState,
+} from "@/types/agent-orchestrator";
+import { isWaitingForAttachedWorktreeRuntime } from "./agent-studio-session-runtime";
+
+type AgentStudioReadinessState = "ready" | "checking" | "blocked";
+
+type TaskHydrationSessionState = Pick<
+  AgentSessionState,
+  "sessionId" | "role" | "runId" | "runtimeId" | "runtimeEndpoint"
+>;
+
+type GetAgentStudioTaskHydrationDecisionArgs = {
+  activeRepo: string | null;
+  activeTaskId: string;
+  activeSession: TaskHydrationSessionState | null;
+  historyHydrationState: AgentSessionHistoryHydrationState;
+  sessionNeedsHydration: boolean;
+  agentStudioReadinessState: AgentStudioReadinessState;
+  waitingRecoveryKey: string | null;
+  postReadyFailureRecoveryKey: string | null;
+};
+
+export type AgentStudioTaskHydrationDecision = {
+  activeRecoveryKey: string | null;
+  blockedFromAutomaticRecovery: boolean;
+  shouldWaitForSessionRuntime: boolean;
+  isWaitingForRuntimeReadiness: boolean;
+  isRecoveringWaitingSession: boolean;
+  shouldHydrateSessionHistory: boolean;
+};
+
+export const toRecoverySelectionKey = ({
+  activeRepo,
+  activeTaskId,
+  activeSessionId,
+}: {
+  activeRepo: string | null;
+  activeTaskId: string;
+  activeSessionId: string | null;
+}): string | null => {
+  if (!activeRepo || !activeTaskId || !activeSessionId) {
+    return null;
+  }
+
+  return `${activeRepo}::${activeTaskId}::${activeSessionId}`;
+};
+
+export const getAgentStudioTaskHydrationDecision = ({
+  activeRepo,
+  activeTaskId,
+  activeSession,
+  historyHydrationState,
+  sessionNeedsHydration,
+  agentStudioReadinessState,
+  waitingRecoveryKey,
+  postReadyFailureRecoveryKey,
+}: GetAgentStudioTaskHydrationDecisionArgs): AgentStudioTaskHydrationDecision => {
+  const activeRecoveryKey = toRecoverySelectionKey({
+    activeRepo,
+    activeTaskId,
+    activeSessionId: activeSession?.sessionId ?? null,
+  });
+  const blockedFromAutomaticRecovery =
+    activeRecoveryKey !== null && postReadyFailureRecoveryKey === activeRecoveryKey;
+  const shouldWaitForSessionRuntime =
+    activeRecoveryKey !== null &&
+    agentStudioReadinessState === "ready" &&
+    sessionNeedsHydration &&
+    isWaitingForAttachedWorktreeRuntime(activeSession) &&
+    !blockedFromAutomaticRecovery;
+  const isWaitingForRuntimeReadiness =
+    activeRecoveryKey !== null &&
+    sessionNeedsHydration &&
+    !blockedFromAutomaticRecovery &&
+    (agentStudioReadinessState !== "ready" || shouldWaitForSessionRuntime);
+  const isRecoveringWaitingSession =
+    activeRecoveryKey !== null &&
+    agentStudioReadinessState === "ready" &&
+    !shouldWaitForSessionRuntime &&
+    waitingRecoveryKey === activeRecoveryKey &&
+    sessionNeedsHydration;
+  const shouldHydrateSessionHistory =
+    activeRecoveryKey !== null &&
+    agentStudioReadinessState === "ready" &&
+    !shouldWaitForSessionRuntime &&
+    sessionNeedsHydration &&
+    !blockedFromAutomaticRecovery &&
+    (historyHydrationState === "not_requested" || waitingRecoveryKey === activeRecoveryKey);
+
+  return {
+    activeRecoveryKey,
+    blockedFromAutomaticRecovery,
+    shouldWaitForSessionRuntime,
+    isWaitingForRuntimeReadiness,
+    isRecoveringWaitingSession,
+    shouldHydrateSessionHistory,
+  };
+};

--- a/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
@@ -277,6 +277,7 @@ describe("agents-page-view-model", () => {
       isSessionViewLoading: false,
       isSessionHistoryLoading: false,
       roleOptions: [{ role: "spec", label: "Spec", icon: Sparkles }],
+      agentStudioReadinessState: "ready",
       agentStudioReady: true,
       agentStudioBlockedReason: "",
       isLoadingChecks: false,
@@ -330,6 +331,7 @@ describe("agents-page-view-model", () => {
     expect(model.thread.taskSelected).toBe(false);
     expect(model.thread.isSessionWorking).toBe(true);
     expect(model.thread.showThinkingMessages).toBe(true);
+    expect(model.thread.readinessState).toBe("ready");
     expect(model.composer.contextUsage).toEqual({ totalTokens: 10, contextWindow: 100 });
 
     model.thread.onRefreshChecks();

--- a/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.test.ts
@@ -276,6 +276,7 @@ describe("agents-page-view-model", () => {
       showThinkingMessages: true,
       isSessionViewLoading: false,
       isSessionHistoryLoading: false,
+      isWaitingForRuntimeReadiness: false,
       roleOptions: [{ role: "spec", label: "Spec", icon: Sparkles }],
       agentStudioReadinessState: "ready",
       agentStudioReady: true,

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -110,6 +110,7 @@ type AgentChatThreadModelArgs = {
   showThinkingMessages: boolean;
   isSessionViewLoading: boolean;
   isSessionHistoryLoading: boolean;
+  isWaitingForRuntimeReadiness: boolean;
   roleOptions: AgentRoleOption[];
   agentStudioReadinessState: "ready" | "checking" | "blocked";
   agentStudioReady: boolean;
@@ -181,6 +182,7 @@ export const buildAgentChatThreadModel = (
   showThinkingMessages: args.showThinkingMessages,
   isSessionViewLoading: args.isSessionViewLoading,
   isSessionHistoryLoading: args.isSessionHistoryLoading,
+  isWaitingForRuntimeReadiness: args.isWaitingForRuntimeReadiness,
   roleOptions: args.roleOptions,
   readinessState: args.agentStudioReadinessState,
   agentStudioReady: args.agentStudioReady,

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -111,6 +111,7 @@ type AgentChatThreadModelArgs = {
   isSessionViewLoading: boolean;
   isSessionHistoryLoading: boolean;
   roleOptions: AgentRoleOption[];
+  agentStudioReadinessState: "ready" | "checking" | "blocked";
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
   isLoadingChecks: boolean;
@@ -181,6 +182,7 @@ export const buildAgentChatThreadModel = (
   isSessionViewLoading: args.isSessionViewLoading,
   isSessionHistoryLoading: args.isSessionHistoryLoading,
   roleOptions: args.roleOptions,
+  readinessState: args.agentStudioReadinessState,
   agentStudioReady: args.agentStudioReady,
   blockedReason: args.agentStudioBlockedReason,
   isLoadingChecks: args.isLoadingChecks,

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -15,6 +15,7 @@ import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import { AGENT_ROLE_LABELS } from "@/types";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentWorkflowStepState } from "@/types/agent-workflow";
+import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-state";
 import type { SessionCreateOption } from "./agents-page-session-tabs";
 
 export const buildRoleLabelByRole = (roleOptions: AgentRoleOption[]): Record<AgentRole, string> => {
@@ -112,7 +113,7 @@ type AgentChatThreadModelArgs = {
   isSessionHistoryLoading: boolean;
   isWaitingForRuntimeReadiness: boolean;
   roleOptions: AgentRoleOption[];
-  agentStudioReadinessState: "ready" | "checking" | "blocked";
+  agentStudioReadinessState: AgentStudioReadinessState;
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
   isLoadingChecks: boolean;

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -32,6 +32,7 @@ type QuerySyncState = {
   sessionParam: string;
   hasExplicitRoleParam: boolean;
   roleFromQuery: "planner";
+  scenarioFromQuery: "planner_initial";
   navigationPersistenceError: Error | null;
   retryNavigationPersistence: typeof retryNavigationPersistence;
   updateQuery: typeof updateQuery;
@@ -61,6 +62,7 @@ type SelectionState = {
 };
 
 type ReadinessState = {
+  agentStudioReadinessState: "ready" | "checking" | "blocked";
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
   isLoadingChecks: boolean;
@@ -153,6 +155,7 @@ let querySyncState: QuerySyncState = {
   sessionParam: "session-1",
   hasExplicitRoleParam: false,
   roleFromQuery: "planner" as const,
+  scenarioFromQuery: "planner_initial" as const,
   navigationPersistenceError: new Error("navigation failed"),
   retryNavigationPersistence,
   updateQuery,
@@ -180,6 +183,7 @@ let selectionState: SelectionState = {
   handleSelectTab,
 };
 let readinessState: ReadinessState = {
+  agentStudioReadinessState: "ready",
   agentStudioReady: true,
   agentStudioBlockedReason: null,
   isLoadingChecks: false,
@@ -373,6 +377,7 @@ beforeEach(async () => {
     sessionParam: "session-1",
     hasExplicitRoleParam: false,
     roleFromQuery: "planner",
+    scenarioFromQuery: "planner_initial",
     navigationPersistenceError: new Error("navigation failed"),
     retryNavigationPersistence,
     updateQuery,
@@ -400,6 +405,7 @@ beforeEach(async () => {
     handleSelectTab,
   };
   readinessState = {
+    agentStudioReadinessState: "ready",
     agentStudioReady: true,
     agentStudioBlockedReason: null,
     isLoadingChecks: false,

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -137,6 +137,16 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
 
   const clearComposerInput = signalContextSwitchIntent;
 
+  const readiness = useAgentStudioReadiness({
+    activeRepo,
+    runtimeDefinitions,
+    isLoadingRuntimeDefinitions,
+    runtimeDefinitionsError,
+    runtimeHealthByRuntime,
+    isLoadingChecks,
+    refreshChecks,
+  });
+
   const selection = useAgentStudioSelectionController({
     activeRepo,
     tasks,
@@ -148,6 +158,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     roleFromQuery,
     scenarioFromQuery,
     updateQuery: scheduleQueryUpdate,
+    agentStudioReadinessState: readiness.agentStudioReadinessState,
     hydrateRequestedTaskSessionHistory,
     readSessionModelCatalog,
     readSessionTodos,
@@ -233,16 +244,6 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     roleFromQuery,
     isActiveTaskHydrated: selection.isActiveTaskHydrated,
     scheduleQueryUpdate,
-  });
-
-  const readiness = useAgentStudioReadiness({
-    activeRepo,
-    runtimeDefinitions,
-    isLoadingRuntimeDefinitions,
-    runtimeDefinitionsError,
-    runtimeHealthByRuntime,
-    isLoadingChecks,
-    refreshChecks,
   });
 
   const orchestration = useAgentStudioOrchestrationController({

--- a/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.test.tsx
@@ -41,6 +41,7 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
         modelCatalog: null,
         isLoadingModelCatalog: true,
       }),
+      agentStudioReadinessState: "ready",
       readSessionModelCatalog,
       readSessionTodos,
     });
@@ -70,6 +71,7 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
         modelCatalog: null,
         isLoadingModelCatalog: true,
       }),
+      agentStudioReadinessState: "ready",
       readSessionModelCatalog,
       readSessionTodos,
     });
@@ -83,6 +85,54 @@ describe("useAgentStudioActiveSessionRuntimeData", () => {
       catalogLoad.resolve(CATALOG);
       await harness.waitFor((state) => state !== null && state.isLoadingModelCatalog === false);
 
+      expect(harness.getLatest()?.modelCatalog).toEqual(CATALOG);
+      expect(harness.getLatest()?.isLoadingModelCatalog).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("waits for readiness before querying runtime-backed session data", async () => {
+    const readSessionModelCatalog = mock(async () => CATALOG);
+    const readSessionTodos = mock(async () => []);
+    const session = createAgentSessionFixture({
+      sessionId: "session-1",
+      externalSessionId: "external-1",
+      runtimeKind: "opencode",
+      runtimeEndpoint: "http://127.0.0.1:4444",
+      workingDirectory: "/repo",
+      modelCatalog: null,
+      isLoadingModelCatalog: true,
+    });
+    const harness = createHookHarness(useAgentStudioActiveSessionRuntimeData, {
+      session,
+      agentStudioReadinessState: "checking",
+      readSessionModelCatalog,
+      readSessionTodos,
+    });
+
+    try {
+      await harness.mount();
+
+      expect(readSessionModelCatalog).not.toHaveBeenCalled();
+      expect(readSessionTodos).not.toHaveBeenCalled();
+      expect(harness.getLatest()?.isLoadingModelCatalog).toBe(true);
+
+      await harness.update({
+        session,
+        agentStudioReadinessState: "ready",
+        readSessionModelCatalog,
+        readSessionTodos,
+      });
+      await harness.waitFor((state) =>
+        Boolean(
+          state?.modelCatalog?.models[0]?.id === CATALOG.models[0]?.id &&
+            state?.isLoadingModelCatalog === false,
+        ),
+      );
+
+      expect(readSessionModelCatalog).toHaveBeenCalledTimes(1);
+      expect(readSessionTodos).toHaveBeenCalledTimes(1);
       expect(harness.getLatest()?.modelCatalog).toEqual(CATALOG);
       expect(harness.getLatest()?.isLoadingModelCatalog).toBe(false);
     } finally {

--- a/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
@@ -13,10 +13,11 @@ import {
 } from "@/state/queries/agent-session-runtime";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { hasAttachedSessionRuntime } from "./agent-studio-session-runtime";
+import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-state";
 
 type UseAgentStudioActiveSessionRuntimeDataArgs = {
   session: AgentSessionState | null;
-  agentStudioReadinessState: "ready" | "checking" | "blocked";
+  agentStudioReadinessState: AgentStudioReadinessState;
   readSessionModelCatalog: (
     runtimeKind: NonNullable<AgentSessionState["runtimeKind"]>,
     runtimeConnection: AgentRuntimeConnection,

--- a/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
@@ -12,6 +12,7 @@ import {
   sessionTodosQueryOptions,
 } from "@/state/queries/agent-session-runtime";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { hasAttachedSessionRuntime } from "./agent-studio-session-runtime";
 
 type UseAgentStudioActiveSessionRuntimeDataArgs = {
   session: AgentSessionState | null;
@@ -29,9 +30,16 @@ type UseAgentStudioActiveSessionRuntimeDataArgs = {
 
 const toRuntimeQueryInput = (session: AgentSessionState | null) => {
   const runtimeKind = session?.runtimeKind ?? session?.selectedModel?.runtimeKind;
+  const hasRuntimeAttachment = hasAttachedSessionRuntime(session);
   const runtimeEndpoint = session?.runtimeEndpoint.trim() ?? "";
   const workingDirectory = session?.workingDirectory.trim() ?? "";
-  if (!session || !runtimeKind || runtimeEndpoint.length === 0 || workingDirectory.length === 0) {
+  if (
+    !session ||
+    !runtimeKind ||
+    !hasRuntimeAttachment ||
+    runtimeEndpoint.length === 0 ||
+    workingDirectory.length === 0
+  ) {
     return null;
   }
   return {

--- a/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-active-session-runtime-data.ts
@@ -15,6 +15,7 @@ import type { AgentSessionState } from "@/types/agent-orchestrator";
 
 type UseAgentStudioActiveSessionRuntimeDataArgs = {
   session: AgentSessionState | null;
+  agentStudioReadinessState: "ready" | "checking" | "blocked";
   readSessionModelCatalog: (
     runtimeKind: NonNullable<AgentSessionState["runtimeKind"]>,
     runtimeConnection: AgentRuntimeConnection,
@@ -44,11 +45,15 @@ const toRuntimeQueryInput = (session: AgentSessionState | null) => {
 
 export const useAgentStudioActiveSessionRuntimeData = ({
   session,
+  agentStudioReadinessState,
   readSessionModelCatalog,
   readSessionTodos,
 }: UseAgentStudioActiveSessionRuntimeDataArgs): AgentSessionState | null => {
   const runtimeQueryInput = toRuntimeQueryInput(session);
-  const shouldHydrateRuntimeData = runtimeQueryInput !== null && session?.status !== "starting";
+  const shouldHydrateRuntimeData =
+    agentStudioReadinessState === "ready" &&
+    runtimeQueryInput !== null &&
+    session?.status !== "starting";
   const catalogQuery = useQuery({
     queryKey:
       shouldHydrateRuntimeData && runtimeQueryInput

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -36,6 +36,7 @@ const baseArgs: BuildArgs = {
     isActiveTaskHydrationFailed: false,
     isViewSessionHistoryHydrationFailed: false,
     isViewSessionHistoryHydrating: false,
+    isViewSessionWaitingForRuntimeReadiness: false,
   },
   sessions: {
     viewSessionsForTask: [session],
@@ -118,6 +119,7 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(mapped.core.role).toBe("planner");
     expect(mapped.core.contextSwitchVersion).toBe(4);
     expect(mapped.core.isSessionHistoryHydrationFailed).toBe(false);
+    expect(mapped.core.isWaitingForRuntimeReadiness).toBe(false);
     expect(mapped.taskTabs.onCreateTab).toBe(onCreateTab);
     expect(mapped.taskTabs.onCloseTab).toBe(onCloseTab);
     expect(mapped.documents.planDoc.markdown).toBe("# doc");

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -55,6 +55,7 @@ const baseArgs: BuildArgs = {
     qaDoc: taskDocument,
   },
   readiness: {
+    agentStudioReadinessState: "ready",
     agentStudioReady: true,
     agentStudioBlockedReason: "",
     isLoadingChecks: false,
@@ -120,6 +121,7 @@ describe("buildAgentStudioPageModelsArgs", () => {
     expect(mapped.taskTabs.onCreateTab).toBe(onCreateTab);
     expect(mapped.taskTabs.onCloseTab).toBe(onCloseTab);
     expect(mapped.documents.planDoc.markdown).toBe("# doc");
+    expect(mapped.readiness.agentStudioReadinessState).toBe("ready");
     expect(mapped.modelSelection.onSelectAgent).toBe(handleSelectAgent);
     expect(mapped.modelSelection.onSelectModel).toBe(handleSelectModel);
     expect(mapped.modelSelection.onSelectVariant).toBe(handleSelectVariant);

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -20,6 +20,7 @@ export type AgentStudioOrchestrationSelectionContext = AgentStudioSelectionContr
 };
 
 export type AgentStudioOrchestrationReadinessContext = {
+  agentStudioReadinessState: "ready" | "checking" | "blocked";
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
   isLoadingChecks: boolean;

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -5,6 +5,7 @@ import type {
 import type { HumanReviewFeedbackModalModel } from "@/features/human-review-feedback/human-review-feedback-types";
 import type { AgentStateContextValue, RepoSettingsInput } from "@/types/state-slices";
 import type { AgentStudioQueryUpdate as QueryUpdate } from "./agent-studio-navigation";
+import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-state";
 import { useAgentSessionPermissionActions } from "./use-agent-session-permission-actions";
 import { useAgentStudioChatSettings } from "./use-agent-studio-chat-settings";
 import { useAgentStudioDocuments } from "./use-agent-studio-documents";
@@ -20,7 +21,7 @@ export type AgentStudioOrchestrationSelectionContext = AgentStudioSelectionContr
 };
 
 export type AgentStudioOrchestrationReadinessContext = {
-  agentStudioReadinessState: "ready" | "checking" | "blocked";
+  agentStudioReadinessState: AgentStudioReadinessState;
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
   isLoadingChecks: boolean;

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -81,6 +81,7 @@ type AgentStudioPageModelsViewContext = Pick<
   | "isActiveTaskHydrationFailed"
   | "isViewSessionHistoryHydrationFailed"
   | "isViewSessionHistoryHydrating"
+  | "isViewSessionWaitingForRuntimeReadiness"
 >;
 
 type AgentStudioPageModelsSessionsContext = Pick<
@@ -171,6 +172,7 @@ export const buildAgentStudioPageModelsArgs = ({
         view.viewTaskId && !view.isActiveTaskHydrated && !view.isActiveTaskHydrationFailed,
       ),
       isSessionHistoryHydrating: view.isViewSessionHistoryHydrating,
+      isWaitingForRuntimeReadiness: view.isViewSessionWaitingForRuntimeReadiness,
       isSessionHistoryHydrationFailed: view.isViewSessionHistoryHydrationFailed,
       contextSwitchVersion: view.contextSwitchVersion,
     },
@@ -331,6 +333,7 @@ export function useAgentStudioOrchestrationController({
       isActiveTaskHydrationFailed: selection.isActiveTaskHydrationFailed,
       isViewSessionHistoryHydrationFailed: selection.isViewSessionHistoryHydrationFailed,
       isViewSessionHistoryHydrating: selection.isViewSessionHistoryHydrating,
+      isViewSessionWaitingForRuntimeReadiness: selection.isViewSessionWaitingForRuntimeReadiness,
     },
     sessions: {
       viewSessionsForTask,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -82,6 +82,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     selectedTask: createTask(),
     isTaskHydrating: false,
     isSessionHistoryHydrating: false,
+    isWaitingForRuntimeReadiness: false,
     isSessionHistoryHydrationFailed: false,
     contextSwitchVersion: 0,
     ...overrides.core,
@@ -222,6 +223,43 @@ describe("useAgentStudioPageModels", () => {
     expect(onKickoff).toHaveBeenCalledTimes(1);
     expect(onSend).toHaveBeenCalledTimes(1);
     expect(onStopSession).toHaveBeenCalledTimes(1);
+
+    await harness.unmount();
+  });
+
+  test("keeps transcript visible while waiting for runtime readiness", async () => {
+    const cachedSession = createSession("session-waiting", "external-waiting", {
+      messages: [
+        {
+          id: "assistant-cached",
+          role: "assistant",
+          content: "Cached transcript",
+          timestamp: "2026-02-22T08:00:05.000Z",
+        },
+      ],
+    });
+    const harness = createHookHarness(
+      createHookArgs({
+        core: {
+          activeSession: cachedSession,
+          sessionsForTask: [cachedSession],
+          isSessionHistoryHydrating: false,
+          isWaitingForRuntimeReadiness: true,
+        },
+        readiness: {
+          agentStudioReadinessState: "checking",
+          agentStudioReady: false,
+        },
+      }),
+    );
+
+    await harness.mount();
+
+    const thread = harness.getLatest().agentChatModel.thread;
+    expect(thread.isSessionHistoryLoading).toBe(false);
+    expect(thread.isWaitingForRuntimeReadiness).toBe(true);
+    expect(thread.readinessState).toBe("checking");
+    expect(thread.session?.messages[0]?.content).toBe("Cached transcript");
 
     await harness.unmount();
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -107,6 +107,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
       ...overrides.documents,
     },
     readiness: {
+      agentStudioReadinessState: "ready",
       agentStudioReady: true,
       agentStudioBlockedReason: "",
       isLoadingChecks: false,
@@ -208,6 +209,7 @@ describe("useAgentStudioPageModels", () => {
       totalTokens: 12,
       contextWindow: 100,
     });
+    expect(state.agentChatModel.thread.readinessState).toBe("ready");
     expect(state.agentChatModel.thread.isSessionWorking).toBe(true);
     expect(state.agentChatModel.thread.showThinkingMessages).toBe(false);
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -71,6 +71,7 @@ type AgentStudioSessionActionsContext = {
 };
 
 type AgentStudioReadinessContext = {
+  agentStudioReadinessState: "ready" | "checking" | "blocked";
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
   isLoadingChecks: boolean;
@@ -279,6 +280,7 @@ export function useAgentStudioPageModels({
     isSessionHistoryLoading: core.isSessionHistoryHydrating,
     taskId: core.taskId,
     activeSessionAgentColors: modelSelection.activeSessionAgentColors,
+    agentStudioReadinessState: readiness.agentStudioReadinessState,
     agentStudioReady: readiness.agentStudioReady,
     agentStudioBlockedReason: readiness.agentStudioBlockedReason,
     isLoadingChecks: readiness.isLoadingChecks,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -7,6 +7,7 @@ import { useAgentChatLayout } from "@/components/features/agents/agent-chat/use-
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents/agent-studio-task-tabs";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-state";
 import { ROLE_OPTIONS } from "./agents-page-constants";
 import type { SessionCreateOption } from "./agents-page-session-tabs";
 import {
@@ -72,7 +73,7 @@ type AgentStudioSessionActionsContext = {
 };
 
 type AgentStudioReadinessContext = {
-  agentStudioReadinessState: "ready" | "checking" | "blocked";
+  agentStudioReadinessState: AgentStudioReadinessState;
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
   isLoadingChecks: boolean;

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -38,6 +38,7 @@ type AgentStudioCoreContext = {
   activeSession: AgentSessionState | null;
   isTaskHydrating: boolean;
   isSessionHistoryHydrating: boolean;
+  isWaitingForRuntimeReadiness: boolean;
   isSessionHistoryHydrationFailed: boolean;
   contextSwitchVersion: number;
 };
@@ -278,6 +279,7 @@ export function useAgentStudioPageModels({
     showThinkingMessages: chatSettings.showThinkingMessages,
     isContextSwitching,
     isSessionHistoryLoading: core.isSessionHistoryHydrating,
+    isWaitingForRuntimeReadiness: core.isWaitingForRuntimeReadiness,
     taskId: core.taskId,
     activeSessionAgentColors: modelSelection.activeSessionAgentColors,
     agentStudioReadinessState: readiness.agentStudioReadinessState,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
@@ -18,6 +18,7 @@ const createHookArgs = (showThinkingMessages = false): HookArgs => ({
   isSessionHistoryLoading: false,
   taskId: "task-1",
   activeSessionAgentColors: {},
+  agentStudioReadinessState: "ready",
   agentStudioReady: true,
   agentStudioBlockedReason: "",
   isLoadingChecks: false,
@@ -64,6 +65,21 @@ describe("useAgentStudioThreadModel", () => {
 
     await harness.mount();
     expect(harness.getLatest().isSessionWorking).toBe(true);
+
+    await harness.unmount();
+  });
+
+  test("forwards readiness state into the thread model", async () => {
+    const harness = createHookHarness({
+      ...createHookArgs(false),
+      agentStudioReadinessState: "blocked",
+      agentStudioReady: false,
+      agentStudioBlockedReason: "Runtime unavailable",
+    });
+
+    await harness.mount();
+    expect(harness.getLatest().readinessState).toBe("blocked");
+    expect(harness.getLatest().blockedReason).toBe("Runtime unavailable");
 
     await harness.unmount();
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.test.tsx
@@ -16,6 +16,7 @@ const createHookArgs = (showThinkingMessages = false): HookArgs => ({
   showThinkingMessages,
   isContextSwitching: false,
   isSessionHistoryLoading: false,
+  isWaitingForRuntimeReadiness: false,
   taskId: "task-1",
   activeSessionAgentColors: {},
   agentStudioReadinessState: "ready",
@@ -80,6 +81,22 @@ describe("useAgentStudioThreadModel", () => {
     await harness.mount();
     expect(harness.getLatest().readinessState).toBe("blocked");
     expect(harness.getLatest().blockedReason).toBe("Runtime unavailable");
+
+    await harness.unmount();
+  });
+
+  test("forwards runtime-waiting separately from history loading", async () => {
+    const harness = createHookHarness({
+      ...createHookArgs(false),
+      agentStudioReadinessState: "checking",
+      agentStudioReady: false,
+      isWaitingForRuntimeReadiness: true,
+      isSessionHistoryLoading: false,
+    });
+
+    await harness.mount();
+    expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(true);
+    expect(harness.getLatest().isSessionHistoryLoading).toBe(false);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -95,6 +95,7 @@ type UseAgentStudioThreadModelArgs = {
   showThinkingMessages: boolean;
   isContextSwitching: boolean;
   isSessionHistoryLoading: boolean;
+  isWaitingForRuntimeReadiness: boolean;
   taskId: string;
   activeSessionAgentColors: Record<string, string>;
   agentStudioReadinessState: "ready" | "checking" | "blocked";
@@ -126,6 +127,7 @@ export const useAgentStudioThreadModel = ({
   showThinkingMessages,
   isContextSwitching,
   isSessionHistoryLoading,
+  isWaitingForRuntimeReadiness,
   taskId,
   activeSessionAgentColors,
   agentStudioReadinessState,
@@ -173,6 +175,7 @@ export const useAgentStudioThreadModel = ({
         showThinkingMessages,
         isSessionViewLoading: isContextSwitching,
         isSessionHistoryLoading,
+        isWaitingForRuntimeReadiness,
         roleOptions: ROLE_OPTIONS,
         agentStudioReadinessState,
         agentStudioReady,
@@ -208,6 +211,7 @@ export const useAgentStudioThreadModel = ({
       handleRefreshChecks,
       isContextSwitching,
       isSessionHistoryLoading,
+      isWaitingForRuntimeReadiness,
       isLoadingChecks,
       isSessionWorking,
       isSending,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -97,6 +97,7 @@ type UseAgentStudioThreadModelArgs = {
   isSessionHistoryLoading: boolean;
   taskId: string;
   activeSessionAgentColors: Record<string, string>;
+  agentStudioReadinessState: "ready" | "checking" | "blocked";
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
   isLoadingChecks: boolean;
@@ -127,6 +128,7 @@ export const useAgentStudioThreadModel = ({
   isSessionHistoryLoading,
   taskId,
   activeSessionAgentColors,
+  agentStudioReadinessState,
   agentStudioReady,
   agentStudioBlockedReason,
   isLoadingChecks,
@@ -172,6 +174,7 @@ export const useAgentStudioThreadModel = ({
         isSessionViewLoading: isContextSwitching,
         isSessionHistoryLoading,
         roleOptions: ROLE_OPTIONS,
+        agentStudioReadinessState,
         agentStudioReady,
         agentStudioBlockedReason,
         isLoadingChecks,
@@ -196,6 +199,7 @@ export const useAgentStudioThreadModel = ({
       }),
     [
       activeSessionAgentColors,
+      agentStudioReadinessState,
       agentStudioBlockedReason,
       agentStudioReady,
       canKickoffNewSession,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -6,6 +6,7 @@ import type { AgentChatModel } from "@/components/features/agents/agent-chat/age
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import { getAgentSessionWaitingInputPlaceholder } from "@/lib/agent-session-waiting-input";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-state";
 import { ROLE_OPTIONS } from "./agents-page-constants";
 import type { SessionCreateOption } from "./agents-page-session-tabs";
 import {
@@ -98,7 +99,7 @@ type UseAgentStudioThreadModelArgs = {
   isWaitingForRuntimeReadiness: boolean;
   taskId: string;
   activeSessionAgentColors: Record<string, string>;
-  agentStudioReadinessState: "ready" | "checking" | "blocked";
+  agentStudioReadinessState: AgentStudioReadinessState;
   agentStudioReady: boolean;
   agentStudioBlockedReason: string | null;
   isLoadingChecks: boolean;

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
@@ -40,6 +40,7 @@ const createHookHarness = (initialProps: HookArgs) =>
 
 const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   activeRepo: null,
+  agentStudioReadinessState: "ready",
   tasks: [createTask("task-1"), createTask("task-2")],
   isLoadingTasks: false,
   sessions: [],

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -9,6 +9,7 @@ import type {
 import { useMemo, useRef } from "react";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentStudioQueryUpdate as QueryUpdate } from "./agent-studio-navigation";
+import type { AgentStudioReadinessState } from "./agent-studio-task-hydration-state";
 import {
   resolveAgentStudioSessionSelection,
   resolveAgentStudioTaskId,
@@ -19,7 +20,7 @@ import { useAgentStudioTaskTabs } from "./use-agent-studio-task-tabs";
 
 type UseAgentStudioSelectionControllerArgs = {
   activeRepo: string | null;
-  agentStudioReadinessState: "ready" | "checking" | "blocked";
+  agentStudioReadinessState: AgentStudioReadinessState;
   tasks: TaskCard[];
   isLoadingTasks: boolean;
   sessions: AgentSessionState[];

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -70,6 +70,7 @@ export type AgentStudioSelectionControllerResult = {
   isViewSessionHistoryHydrated: boolean;
   isViewSessionHistoryHydrationFailed: boolean;
   isViewSessionHistoryHydrating: boolean;
+  isViewSessionWaitingForRuntimeReadiness: boolean;
 };
 
 const ACTIVE_SESSION_STATUS = new Set<AgentSessionState["status"]>(["starting", "running"]);
@@ -334,6 +335,7 @@ export function useAgentStudioSelectionController({
     isActiveSessionHistoryHydrated,
     isActiveSessionHistoryHydrationFailed,
     isActiveSessionHistoryHydrating,
+    isWaitingForRuntimeReadiness,
   } = useAgentStudioTaskHydration({
     activeRepo,
     activeTaskId: viewTaskId,
@@ -366,5 +368,6 @@ export function useAgentStudioSelectionController({
     isViewSessionHistoryHydrated: isActiveSessionHistoryHydrated,
     isViewSessionHistoryHydrationFailed: isActiveSessionHistoryHydrationFailed,
     isViewSessionHistoryHydrating: isActiveSessionHistoryHydrating,
+    isViewSessionWaitingForRuntimeReadiness: isWaitingForRuntimeReadiness,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -19,6 +19,7 @@ import { useAgentStudioTaskTabs } from "./use-agent-studio-task-tabs";
 
 type UseAgentStudioSelectionControllerArgs = {
   activeRepo: string | null;
+  agentStudioReadinessState: "ready" | "checking" | "blocked";
   tasks: TaskCard[];
   isLoadingTasks: boolean;
   sessions: AgentSessionState[];
@@ -144,6 +145,7 @@ export const buildSessionsByTaskIdWithCache = (
 
 export function useAgentStudioSelectionController({
   activeRepo,
+  agentStudioReadinessState,
   tasks,
   isLoadingTasks,
   sessions,
@@ -220,6 +222,7 @@ export function useAgentStudioSelectionController({
   ]);
   const hydratedActiveSession = useAgentStudioActiveSessionRuntimeData({
     session: activeSession,
+    agentStudioReadinessState,
     readSessionModelCatalog,
     readSessionTodos,
   });
@@ -318,6 +321,7 @@ export function useAgentStudioSelectionController({
   const viewActiveSession = viewSelection.activeSession;
   const hydratedViewActiveSession = useAgentStudioActiveSessionRuntimeData({
     session: viewActiveSession,
+    agentStudioReadinessState,
     readSessionModelCatalog,
     readSessionTodos,
   });
@@ -334,6 +338,7 @@ export function useAgentStudioSelectionController({
     activeRepo,
     activeTaskId: viewTaskId,
     activeSession: hydratedViewActiveSession,
+    agentStudioReadinessState,
     hydrateRequestedTaskSessionHistory,
   });
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -152,7 +152,8 @@ describe("useAgentStudioTaskHydration", () => {
       await harness.mount();
 
       expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
-      expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(true);
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(true);
+      expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(false);
       expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(false);
 
       await harness.update(
@@ -201,6 +202,7 @@ describe("useAgentStudioTaskHydration", () => {
       await harness.mount();
 
       expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(true);
       expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(false);
 
       await harness.update(
@@ -214,6 +216,53 @@ describe("useAgentStudioTaskHydration", () => {
 
       expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
       expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("does not auto-retry a real post-ready hydration failure after readiness flaps", async () => {
+    const hydrateRequestedTaskSessionHistory = mock(async () => {
+      throw new Error("post-ready failure");
+    });
+    const failedSession = createSession({ historyHydrationState: "not_requested" });
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeSession: failedSession,
+        agentStudioReadinessState: "ready",
+        hydrateRequestedTaskSessionHistory,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.isActiveSessionHistoryHydrationFailed);
+
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(false);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: createSession({ historyHydrationState: "failed" }),
+          agentStudioReadinessState: "checking",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(false);
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(true);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: createSession({ historyHydrationState: "failed" }),
+          agentStudioReadinessState: "ready",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(true);
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(false);
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -216,6 +216,28 @@ describe("useAgentStudioTaskHydration", () => {
 
       expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
       expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(false);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: createSession({ historyHydrationState: "failed" }),
+          agentStudioReadinessState: "checking",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(false);
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(true);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: createSession({ historyHydrationState: "failed" }),
+          agentStudioReadinessState: "ready",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(true);
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -412,6 +412,59 @@ describe("useAgentStudioTaskHydration", () => {
     }
   });
 
+  test("waits for a build session runtime attachment before hydrating restored session history", async () => {
+    const hydrateRequestedTaskSessionHistory = mock(async (): Promise<void> => {});
+    const buildSessionWaitingForRuntime = createSession({
+      role: "build",
+      scenario: "build_implementation_start",
+      status: "stopped",
+      runId: null,
+      runtimeId: null,
+      runtimeEndpoint: "",
+      historyHydrationState: "not_requested",
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeSession: buildSessionWaitingForRuntime,
+        agentStudioReadinessState: "ready",
+        hydrateRequestedTaskSessionHistory,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(true);
+      expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(false);
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(false);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: createSession({
+            role: "build",
+            scenario: "build_implementation_start",
+            status: "stopped",
+            runId: "run-1",
+            runtimeId: null,
+            runtimeEndpoint: "http://127.0.0.1:4444",
+            historyHydrationState: "not_requested",
+          }),
+          agentStudioReadinessState: "ready",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+
+      await harness.waitFor(() => hydrateRequestedTaskSessionHistory.mock.calls.length === 1);
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
+        taskId: "task-1",
+        sessionId: "session-1",
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("skips requested history hydration for a live session that already has local messages", async () => {
     const hydrateRequestedTaskSessionHistory = mock(async (): Promise<void> => {});
     const harness = createHookHarness(

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import {
+  createDeferred,
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
@@ -17,6 +18,7 @@ const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   activeRepo: "/repo-a",
   activeTaskId: "task-1",
   activeSession: null,
+  agentStudioReadinessState: "ready",
   hydrateRequestedTaskSessionHistory: async () => {},
   ...overrides,
 });
@@ -129,6 +131,89 @@ describe("useAgentStudioTaskHydration", () => {
       expect(harness.getLatest().isActiveTaskHydrationFailed).toBe(false);
       expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(false);
       expect(harness.getLatest().isActiveSessionHistoryHydrated).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("waits for readiness before hydrating and retries the same waiting session once ready", async () => {
+    const hydrationRequest = createDeferred<void>();
+    const hydrateRequestedTaskSessionHistory = mock(() => hydrationRequest.promise);
+    const waitingSession = createSession({ historyHydrationState: "failed" });
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeSession: waitingSession,
+        agentStudioReadinessState: "checking",
+        hydrateRequestedTaskSessionHistory,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
+      expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(true);
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(false);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: waitingSession,
+          agentStudioReadinessState: "ready",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+      await harness.waitFor(() => hydrateRequestedTaskSessionHistory.mock.calls.length === 1);
+
+      expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(true);
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(false);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: createSession({ historyHydrationState: "hydrated" }),
+          agentStudioReadinessState: "ready",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+      hydrationRequest.resolve();
+
+      expect(harness.getLatest().isActiveSessionHistoryHydrated).toBe(true);
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(false);
+    } finally {
+      hydrationRequest.resolve();
+      await harness.unmount();
+    }
+  });
+
+  test("surfaces a real failure if readiness-triggered recovery also fails", async () => {
+    const hydrateRequestedTaskSessionHistory = mock(async () => {
+      throw new Error("recovery failed");
+    });
+    const waitingSession = createSession({ historyHydrationState: "failed" });
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeSession: waitingSession,
+        agentStudioReadinessState: "checking",
+        hydrateRequestedTaskSessionHistory,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
+      expect(harness.getLatest().isActiveSessionHistoryHydrationFailed).toBe(false);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: waitingSession,
+          agentStudioReadinessState: "ready",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+      await harness.waitFor((state) => state.isActiveSessionHistoryHydrationFailed);
+
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().isActiveSessionHistoryHydrating).toBe(false);
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -268,6 +268,62 @@ describe("useAgentStudioTaskHydration", () => {
     }
   });
 
+  test("only auto-recovers the currently selected failed session after selection changes while waiting", async () => {
+    const hydrateRequestedTaskSessionHistory = mock(async (): Promise<void> => {});
+    const firstFailedSession = createSession({
+      sessionId: "session-1",
+      externalSessionId: "external-1",
+      historyHydrationState: "failed",
+    });
+    const secondFailedSession = createSession({
+      sessionId: "session-2",
+      externalSessionId: "external-2",
+      historyHydrationState: "failed",
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeSession: firstFailedSession,
+        agentStudioReadinessState: "checking",
+        hydrateRequestedTaskSessionHistory,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(true);
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: secondFailedSession,
+          agentStudioReadinessState: "checking",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(true);
+      expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
+
+      await harness.update(
+        createBaseArgs({
+          activeSession: secondFailedSession,
+          agentStudioReadinessState: "ready",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+      await harness.waitFor(() => hydrateRequestedTaskSessionHistory.mock.calls.length === 1);
+
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
+        taskId: "task-1",
+        sessionId: "session-2",
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("skips requested history hydration for a live session that already has local messages", async () => {
     const hydrateRequestedTaskSessionHistory = mock(async (): Promise<void> => {});
     const harness = createHookHarness(

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.test.tsx
@@ -324,6 +324,72 @@ describe("useAgentStudioTaskHydration", () => {
     }
   });
 
+  test("recovers a waiting failed session after navigating away and back once readiness is healthy", async () => {
+    const hydrateRequestedTaskSessionHistory = mock(async (): Promise<void> => {});
+    const failedSession = createSession({
+      sessionId: "session-1",
+      externalSessionId: "external-1",
+      taskId: "task-1",
+      historyHydrationState: "failed",
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        activeTaskId: "task-1",
+        activeSession: failedSession,
+        agentStudioReadinessState: "checking",
+        hydrateRequestedTaskSessionHistory,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(true);
+
+      await harness.update(
+        createBaseArgs({
+          activeTaskId: "task-2",
+          activeSession: null,
+          agentStudioReadinessState: "checking",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+
+      expect(harness.getLatest().isWaitingForRuntimeReadiness).toBe(false);
+      expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
+
+      await harness.update(
+        createBaseArgs({
+          activeTaskId: "task-2",
+          activeSession: null,
+          agentStudioReadinessState: "ready",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+
+      expect(hydrateRequestedTaskSessionHistory).not.toHaveBeenCalled();
+
+      await harness.update(
+        createBaseArgs({
+          activeTaskId: "task-1",
+          activeSession: failedSession,
+          agentStudioReadinessState: "ready",
+          hydrateRequestedTaskSessionHistory,
+        }),
+      );
+      await harness.waitFor(() => hydrateRequestedTaskSessionHistory.mock.calls.length === 1);
+
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(1);
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledWith({
+        taskId: "task-1",
+        sessionId: "session-1",
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("skips requested history hydration for a live session that already has local messages", async () => {
     const hydrateRequestedTaskSessionHistory = mock(async (): Promise<void> => {});
     const harness = createHookHarness(

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -22,6 +22,7 @@ type UseAgentStudioTaskHydrationResult = {
   isActiveSessionHistoryHydrated: boolean;
   isActiveSessionHistoryHydrationFailed: boolean;
   isActiveSessionHistoryHydrating: boolean;
+  isWaitingForRuntimeReadiness: boolean;
 };
 
 export function useAgentStudioTaskHydration({
@@ -37,13 +38,17 @@ export function useAgentStudioTaskHydration({
     status: "idle" | "pending" | "failed";
   }>({ sessionId: null, status: "idle" });
   const [waitingSessionId, setWaitingSessionId] = useState<string | null>(null);
+  const [postReadyFailureSessionId, setPostReadyFailureSessionId] = useState<string | null>(null);
   const historyHydrationState = getAgentSessionHistoryHydrationState(activeSession);
   const sessionNeedsHydration = requiresHydratedAgentSessionHistory(activeSession);
   const isReadinessReady = agentStudioReadinessState === "ready";
+  const blockedFromAutomaticRecovery =
+    Boolean(activeSessionId) && postReadyFailureSessionId === activeSessionId;
   const isWaitingForReadiness =
     Boolean(activeRepo && activeTaskId && activeSessionId) &&
     !isReadinessReady &&
-    sessionNeedsHydration;
+    sessionNeedsHydration &&
+    !blockedFromAutomaticRecovery;
   const isRecoveringWaitingSession =
     Boolean(activeSessionId && activeRepo && activeTaskId) &&
     isReadinessReady &&
@@ -53,16 +58,32 @@ export function useAgentStudioTaskHydration({
     Boolean(activeRepo && activeTaskId && activeSessionId) &&
     isReadinessReady &&
     sessionNeedsHydration &&
+    !blockedFromAutomaticRecovery &&
     (historyHydrationState === "not_requested" || waitingSessionId === activeSessionId);
 
   useEffect(() => {
     if (!activeSessionId || !sessionNeedsHydration) {
       setWaitingSessionId((current) => (current === null ? current : null));
+      setPostReadyFailureSessionId((current) => (current === null ? current : null));
       return;
     }
 
+    if (historyHydrationState === "hydrated") {
+      setPostReadyFailureSessionId((current) => (current === activeSessionId ? null : current));
+    }
+
     if (!isReadinessReady) {
-      setWaitingSessionId(activeSessionId);
+      setWaitingSessionId((current) => {
+        if (blockedFromAutomaticRecovery) {
+          return current === activeSessionId ? null : current;
+        }
+
+        if (historyHydrationState !== "failed") {
+          return current;
+        }
+
+        return current ?? activeSessionId;
+      });
       return;
     }
 
@@ -71,6 +92,7 @@ export function useAgentStudioTaskHydration({
     }
   }, [
     activeSessionId,
+    blockedFromAutomaticRecovery,
     historyHydrationState,
     isReadinessReady,
     sessionNeedsHydration,
@@ -85,7 +107,7 @@ export function useAgentStudioTaskHydration({
 
     if (!shouldHydrateSessionHistory) {
       setRequestState((current) =>
-        current.sessionId === activeSessionId && current.status !== "idle"
+        current.sessionId === activeSessionId && current.status === "pending"
           ? { sessionId: activeSessionId, status: "idle" }
           : current,
       );
@@ -104,6 +126,7 @@ export function useAgentStudioTaskHydration({
             : current,
         );
         setWaitingSessionId((current) => (current === activeSessionId ? null : current));
+        setPostReadyFailureSessionId((current) => (current === activeSessionId ? null : current));
       })
       .catch(() => {
         setRequestState((current) =>
@@ -111,6 +134,9 @@ export function useAgentStudioTaskHydration({
             ? { sessionId: activeSessionId, status: "failed" }
             : current,
         );
+        if (waitingSessionId !== activeSessionId) {
+          setPostReadyFailureSessionId(activeSessionId);
+        }
         setWaitingSessionId((current) => (current === activeSessionId ? null : current));
       });
   }, [
@@ -118,6 +144,7 @@ export function useAgentStudioTaskHydration({
     activeTaskId,
     hydrateRequestedTaskSessionHistory,
     shouldHydrateSessionHistory,
+    waitingSessionId,
   ]);
 
   const isRequestPending =
@@ -137,10 +164,8 @@ export function useAgentStudioTaskHydration({
         isRequestFailed
       : false,
     isActiveSessionHistoryHydrating: activeSessionId
-      ? isWaitingForReadiness ||
-        shouldShowPendingHydrationState ||
-        historyHydrationState === "hydrating" ||
-        isRequestPending
+      ? shouldShowPendingHydrationState || historyHydrationState === "hydrating" || isRequestPending
       : false,
+    isWaitingForRuntimeReadiness: activeSessionId ? isWaitingForReadiness : false,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -4,13 +4,16 @@ import {
   requiresHydratedAgentSessionHistory,
 } from "@/state/operations/agent-orchestrator/support/history-hydration";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-import { getAgentStudioTaskHydrationDecision } from "./agent-studio-task-hydration-state";
+import {
+  type AgentStudioReadinessState,
+  getAgentStudioTaskHydrationDecision,
+} from "./agent-studio-task-hydration-state";
 
 type UseAgentStudioTaskHydrationParams = {
   activeRepo: string | null;
   activeTaskId: string;
   activeSession: AgentSessionState | null;
-  agentStudioReadinessState: "ready" | "checking" | "blocked";
+  agentStudioReadinessState: AgentStudioReadinessState;
   hydrateRequestedTaskSessionHistory: (input: {
     taskId: string;
     sessionId: string;
@@ -46,7 +49,6 @@ export function useAgentStudioTaskHydration({
   const sessionNeedsHydration = requiresHydratedAgentSessionHistory(activeSession);
   const {
     activeRecoveryKey,
-    blockedFromAutomaticRecovery,
     shouldWaitForSessionRuntime,
     isWaitingForRuntimeReadiness,
     isRecoveringWaitingSession,
@@ -81,10 +83,6 @@ export function useAgentStudioTaskHydration({
 
     if (isWaitingForRuntimeReadiness) {
       setWaitingRecoveryKey((current) => {
-        if (blockedFromAutomaticRecovery) {
-          return current === activeRecoveryKey ? null : current;
-        }
-
         if (historyHydrationState === "failed") {
           return activeRecoveryKey;
         }
@@ -104,7 +102,6 @@ export function useAgentStudioTaskHydration({
   }, [
     activeRecoveryKey,
     activeRepo,
-    blockedFromAutomaticRecovery,
     historyHydrationState,
     isWaitingForRuntimeReadiness,
     shouldWaitForSessionRuntime,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -4,8 +4,7 @@ import {
   requiresHydratedAgentSessionHistory,
 } from "@/state/operations/agent-orchestrator/support/history-hydration";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
-
-const WORKTREE_RUNTIME_ROLES = new Set<AgentSessionState["role"]>(["build", "qa"]);
+import { getAgentStudioTaskHydrationDecision } from "./agent-studio-task-hydration-state";
 
 type UseAgentStudioTaskHydrationParams = {
   activeRepo: string | null;
@@ -27,22 +26,6 @@ type UseAgentStudioTaskHydrationResult = {
   isWaitingForRuntimeReadiness: boolean;
 };
 
-const toRecoverySelectionKey = ({
-  activeRepo,
-  activeTaskId,
-  activeSessionId,
-}: {
-  activeRepo: string | null;
-  activeTaskId: string;
-  activeSessionId: string | null;
-}): string | null => {
-  if (!activeRepo || !activeTaskId || !activeSessionId) {
-    return null;
-  }
-
-  return `${activeRepo}::${activeTaskId}::${activeSessionId}`;
-};
-
 export function useAgentStudioTaskHydration({
   activeRepo,
   activeTaskId,
@@ -51,7 +34,6 @@ export function useAgentStudioTaskHydration({
   hydrateRequestedTaskSessionHistory,
 }: UseAgentStudioTaskHydrationParams): UseAgentStudioTaskHydrationResult {
   const activeSessionId = activeSession?.sessionId ?? null;
-  const activeSessionRole = activeSession?.role ?? null;
   const [requestState, setRequestState] = useState<{
     sessionId: string | null;
     status: "idle" | "pending" | "failed";
@@ -62,46 +44,23 @@ export function useAgentStudioTaskHydration({
   );
   const historyHydrationState = getAgentSessionHistoryHydrationState(activeSession);
   const sessionNeedsHydration = requiresHydratedAgentSessionHistory(activeSession);
-  const isReadinessReady = agentStudioReadinessState === "ready";
-  const activeRecoveryKey = toRecoverySelectionKey({
+  const {
+    activeRecoveryKey,
+    blockedFromAutomaticRecovery,
+    shouldWaitForSessionRuntime,
+    isWaitingForRuntimeReadiness,
+    isRecoveringWaitingSession,
+    shouldHydrateSessionHistory,
+  } = getAgentStudioTaskHydrationDecision({
     activeRepo,
     activeTaskId,
-    activeSessionId,
+    activeSession,
+    historyHydrationState,
+    sessionNeedsHydration,
+    agentStudioReadinessState,
+    waitingRecoveryKey,
+    postReadyFailureRecoveryKey,
   });
-  const blockedFromAutomaticRecovery =
-    Boolean(activeRecoveryKey) && postReadyFailureRecoveryKey === activeRecoveryKey;
-  const requiresLiveWorktreeRuntime =
-    activeSessionRole !== null && WORKTREE_RUNTIME_ROLES.has(activeSessionRole);
-  const isMissingAttachedRuntime =
-    requiresLiveWorktreeRuntime &&
-    activeSession !== null &&
-    activeSession.runId === null &&
-    activeSession.runtimeId === null &&
-    activeSession.runtimeEndpoint.trim().length === 0;
-  const shouldWaitForSessionRuntime =
-    Boolean(activeRecoveryKey) &&
-    isReadinessReady &&
-    sessionNeedsHydration &&
-    isMissingAttachedRuntime &&
-    !blockedFromAutomaticRecovery;
-  const isWaitingForReadiness =
-    Boolean(activeRecoveryKey) &&
-    (!isReadinessReady || shouldWaitForSessionRuntime) &&
-    sessionNeedsHydration &&
-    !blockedFromAutomaticRecovery;
-  const isRecoveringWaitingSession =
-    Boolean(activeRecoveryKey) &&
-    isReadinessReady &&
-    !shouldWaitForSessionRuntime &&
-    waitingRecoveryKey === activeRecoveryKey &&
-    sessionNeedsHydration;
-  const shouldHydrateSessionHistory =
-    Boolean(activeRecoveryKey) &&
-    isReadinessReady &&
-    !shouldWaitForSessionRuntime &&
-    sessionNeedsHydration &&
-    !blockedFromAutomaticRecovery &&
-    (historyHydrationState === "not_requested" || waitingRecoveryKey === activeRecoveryKey);
 
   useEffect(() => {
     if (!activeRepo) {
@@ -120,7 +79,7 @@ export function useAgentStudioTaskHydration({
       return;
     }
 
-    if (!isReadinessReady || shouldWaitForSessionRuntime) {
+    if (isWaitingForRuntimeReadiness) {
       setWaitingRecoveryKey((current) => {
         if (blockedFromAutomaticRecovery) {
           return current === activeRecoveryKey ? null : current;
@@ -147,7 +106,7 @@ export function useAgentStudioTaskHydration({
     activeRepo,
     blockedFromAutomaticRecovery,
     historyHydrationState,
-    isReadinessReady,
+    isWaitingForRuntimeReadiness,
     shouldWaitForSessionRuntime,
     sessionNeedsHydration,
     waitingRecoveryKey,
@@ -215,13 +174,13 @@ export function useAgentStudioTaskHydration({
     isActiveSessionHistoryHydrated: activeSessionId ? historyHydrationState === "hydrated" : false,
     isActiveSessionHistoryHydrationFailed: activeSessionId
       ? (historyHydrationState === "failed" &&
-          !isWaitingForReadiness &&
+          !isWaitingForRuntimeReadiness &&
           !isRecoveringWaitingSession) ||
         isRequestFailed
       : false,
     isActiveSessionHistoryHydrating: activeSessionId
       ? shouldShowPendingHydrationState || historyHydrationState === "hydrating" || isRequestPending
       : false,
-    isWaitingForRuntimeReadiness: activeSessionId ? isWaitingForReadiness : false,
+    isWaitingForRuntimeReadiness: activeSessionId ? isWaitingForRuntimeReadiness : false,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -25,6 +25,22 @@ type UseAgentStudioTaskHydrationResult = {
   isWaitingForRuntimeReadiness: boolean;
 };
 
+const toRecoverySelectionKey = ({
+  activeRepo,
+  activeTaskId,
+  activeSessionId,
+}: {
+  activeRepo: string | null;
+  activeTaskId: string;
+  activeSessionId: string | null;
+}): string | null => {
+  if (!activeRepo || !activeTaskId || !activeSessionId) {
+    return null;
+  }
+
+  return `${activeRepo}::${activeTaskId}::${activeSessionId}`;
+};
+
 export function useAgentStudioTaskHydration({
   activeRepo,
   activeTaskId,
@@ -37,66 +53,80 @@ export function useAgentStudioTaskHydration({
     sessionId: string | null;
     status: "idle" | "pending" | "failed";
   }>({ sessionId: null, status: "idle" });
-  const [waitingSessionId, setWaitingSessionId] = useState<string | null>(null);
-  const [postReadyFailureSessionId, setPostReadyFailureSessionId] = useState<string | null>(null);
+  const [waitingRecoveryKey, setWaitingRecoveryKey] = useState<string | null>(null);
+  const [postReadyFailureRecoveryKey, setPostReadyFailureRecoveryKey] = useState<string | null>(
+    null,
+  );
   const historyHydrationState = getAgentSessionHistoryHydrationState(activeSession);
   const sessionNeedsHydration = requiresHydratedAgentSessionHistory(activeSession);
   const isReadinessReady = agentStudioReadinessState === "ready";
+  const activeRecoveryKey = toRecoverySelectionKey({
+    activeRepo,
+    activeTaskId,
+    activeSessionId,
+  });
   const blockedFromAutomaticRecovery =
-    Boolean(activeSessionId) && postReadyFailureSessionId === activeSessionId;
+    Boolean(activeRecoveryKey) && postReadyFailureRecoveryKey === activeRecoveryKey;
   const isWaitingForReadiness =
-    Boolean(activeRepo && activeTaskId && activeSessionId) &&
+    Boolean(activeRecoveryKey) &&
     !isReadinessReady &&
     sessionNeedsHydration &&
     !blockedFromAutomaticRecovery;
   const isRecoveringWaitingSession =
-    Boolean(activeSessionId && activeRepo && activeTaskId) &&
+    Boolean(activeRecoveryKey) &&
     isReadinessReady &&
-    waitingSessionId === activeSessionId &&
+    waitingRecoveryKey === activeRecoveryKey &&
     sessionNeedsHydration;
   const shouldHydrateSessionHistory =
-    Boolean(activeRepo && activeTaskId && activeSessionId) &&
+    Boolean(activeRecoveryKey) &&
     isReadinessReady &&
     sessionNeedsHydration &&
     !blockedFromAutomaticRecovery &&
-    (historyHydrationState === "not_requested" || waitingSessionId === activeSessionId);
+    (historyHydrationState === "not_requested" || waitingRecoveryKey === activeRecoveryKey);
 
   useEffect(() => {
-    if (!activeSessionId || !sessionNeedsHydration) {
-      setWaitingSessionId((current) => (current === null ? current : null));
-      setPostReadyFailureSessionId((current) => (current === null ? current : null));
+    if (!activeRepo) {
+      setWaitingRecoveryKey(null);
+      setPostReadyFailureRecoveryKey(null);
       return;
     }
 
-    if (historyHydrationState === "hydrated") {
-      setPostReadyFailureSessionId((current) => (current === activeSessionId ? null : current));
+    if (!activeRecoveryKey) {
+      return;
+    }
+
+    if (!sessionNeedsHydration) {
+      setWaitingRecoveryKey((current) => (current === activeRecoveryKey ? null : current));
+      setPostReadyFailureRecoveryKey((current) => (current === activeRecoveryKey ? null : current));
+      return;
     }
 
     if (!isReadinessReady) {
-      setWaitingSessionId((current) => {
+      setWaitingRecoveryKey((current) => {
         if (blockedFromAutomaticRecovery) {
-          return current === activeSessionId ? null : current;
+          return current === activeRecoveryKey ? null : current;
         }
 
         if (historyHydrationState !== "failed") {
           return current;
         }
 
-        return activeSessionId;
+        return activeRecoveryKey;
       });
       return;
     }
 
-    if (waitingSessionId === activeSessionId && historyHydrationState === "hydrated") {
-      setWaitingSessionId(null);
+    if (waitingRecoveryKey === activeRecoveryKey && historyHydrationState === "hydrated") {
+      setWaitingRecoveryKey(null);
     }
   }, [
-    activeSessionId,
+    activeRecoveryKey,
+    activeRepo,
     blockedFromAutomaticRecovery,
     historyHydrationState,
     isReadinessReady,
     sessionNeedsHydration,
-    waitingSessionId,
+    waitingRecoveryKey,
   ]);
 
   useEffect(() => {
@@ -125,8 +155,10 @@ export function useAgentStudioTaskHydration({
             ? { sessionId: activeSessionId, status: "idle" }
             : current,
         );
-        setWaitingSessionId((current) => (current === activeSessionId ? null : current));
-        setPostReadyFailureSessionId((current) => (current === activeSessionId ? null : current));
+        setWaitingRecoveryKey((current) => (current === activeRecoveryKey ? null : current));
+        setPostReadyFailureRecoveryKey((current) =>
+          current === activeRecoveryKey ? null : current,
+        );
       })
       .catch(() => {
         setRequestState((current) =>
@@ -134,17 +166,18 @@ export function useAgentStudioTaskHydration({
             ? { sessionId: activeSessionId, status: "failed" }
             : current,
         );
-        if (waitingSessionId !== activeSessionId) {
-          setPostReadyFailureSessionId(activeSessionId);
+        if (waitingRecoveryKey !== activeRecoveryKey) {
+          setPostReadyFailureRecoveryKey(activeRecoveryKey);
         }
-        setWaitingSessionId((current) => (current === activeSessionId ? null : current));
+        setWaitingRecoveryKey((current) => (current === activeRecoveryKey ? null : current));
       });
   }, [
+    activeRecoveryKey,
     activeSessionId,
     activeTaskId,
     hydrateRequestedTaskSessionHistory,
     shouldHydrateSessionHistory,
-    waitingSessionId,
+    waitingRecoveryKey,
   ]);
 
   const isRequestPending =

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -5,6 +5,8 @@ import {
 } from "@/state/operations/agent-orchestrator/support/history-hydration";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 
+const WORKTREE_RUNTIME_ROLES = new Set<AgentSessionState["role"]>(["build", "qa"]);
+
 type UseAgentStudioTaskHydrationParams = {
   activeRepo: string | null;
   activeTaskId: string;
@@ -49,6 +51,7 @@ export function useAgentStudioTaskHydration({
   hydrateRequestedTaskSessionHistory,
 }: UseAgentStudioTaskHydrationParams): UseAgentStudioTaskHydrationResult {
   const activeSessionId = activeSession?.sessionId ?? null;
+  const activeSessionRole = activeSession?.role ?? null;
   const [requestState, setRequestState] = useState<{
     sessionId: string | null;
     status: "idle" | "pending" | "failed";
@@ -67,19 +70,35 @@ export function useAgentStudioTaskHydration({
   });
   const blockedFromAutomaticRecovery =
     Boolean(activeRecoveryKey) && postReadyFailureRecoveryKey === activeRecoveryKey;
+  const requiresLiveWorktreeRuntime =
+    activeSessionRole !== null && WORKTREE_RUNTIME_ROLES.has(activeSessionRole);
+  const isMissingAttachedRuntime =
+    requiresLiveWorktreeRuntime &&
+    activeSession !== null &&
+    activeSession.runId === null &&
+    activeSession.runtimeId === null &&
+    activeSession.runtimeEndpoint.trim().length === 0;
+  const shouldWaitForSessionRuntime =
+    Boolean(activeRecoveryKey) &&
+    isReadinessReady &&
+    sessionNeedsHydration &&
+    isMissingAttachedRuntime &&
+    !blockedFromAutomaticRecovery;
   const isWaitingForReadiness =
     Boolean(activeRecoveryKey) &&
-    !isReadinessReady &&
+    (!isReadinessReady || shouldWaitForSessionRuntime) &&
     sessionNeedsHydration &&
     !blockedFromAutomaticRecovery;
   const isRecoveringWaitingSession =
     Boolean(activeRecoveryKey) &&
     isReadinessReady &&
+    !shouldWaitForSessionRuntime &&
     waitingRecoveryKey === activeRecoveryKey &&
     sessionNeedsHydration;
   const shouldHydrateSessionHistory =
     Boolean(activeRecoveryKey) &&
     isReadinessReady &&
+    !shouldWaitForSessionRuntime &&
     sessionNeedsHydration &&
     !blockedFromAutomaticRecovery &&
     (historyHydrationState === "not_requested" || waitingRecoveryKey === activeRecoveryKey);
@@ -101,17 +120,21 @@ export function useAgentStudioTaskHydration({
       return;
     }
 
-    if (!isReadinessReady) {
+    if (!isReadinessReady || shouldWaitForSessionRuntime) {
       setWaitingRecoveryKey((current) => {
         if (blockedFromAutomaticRecovery) {
           return current === activeRecoveryKey ? null : current;
         }
 
-        if (historyHydrationState !== "failed") {
-          return current;
+        if (historyHydrationState === "failed") {
+          return activeRecoveryKey;
         }
 
-        return activeRecoveryKey;
+        if (shouldWaitForSessionRuntime) {
+          return current ?? activeRecoveryKey;
+        }
+
+        return current;
       });
       return;
     }
@@ -125,6 +148,7 @@ export function useAgentStudioTaskHydration({
     blockedFromAutomaticRecovery,
     historyHydrationState,
     isReadinessReady,
+    shouldWaitForSessionRuntime,
     sessionNeedsHydration,
     waitingRecoveryKey,
   ]);

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -166,7 +166,7 @@ export function useAgentStudioTaskHydration({
             ? { sessionId: activeSessionId, status: "failed" }
             : current,
         );
-        if (waitingRecoveryKey !== activeRecoveryKey) {
+        if (activeRecoveryKey) {
           setPostReadyFailureRecoveryKey(activeRecoveryKey);
         }
         setWaitingRecoveryKey((current) => (current === activeRecoveryKey ? null : current));
@@ -177,7 +177,6 @@ export function useAgentStudioTaskHydration({
     activeTaskId,
     hydrateRequestedTaskSessionHistory,
     shouldHydrateSessionHistory,
-    waitingRecoveryKey,
   ]);
 
   const isRequestPending =

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -82,7 +82,7 @@ export function useAgentStudioTaskHydration({
           return current;
         }
 
-        return current ?? activeSessionId;
+        return activeSessionId;
       });
       return;
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-hydration.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import {
   getAgentSessionHistoryHydrationState,
-  shouldAutoHydrateAgentSessionHistory,
+  requiresHydratedAgentSessionHistory,
 } from "@/state/operations/agent-orchestrator/support/history-hydration";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 
@@ -9,6 +9,7 @@ type UseAgentStudioTaskHydrationParams = {
   activeRepo: string | null;
   activeTaskId: string;
   activeSession: AgentSessionState | null;
+  agentStudioReadinessState: "ready" | "checking" | "blocked";
   hydrateRequestedTaskSessionHistory: (input: {
     taskId: string;
     sessionId: string;
@@ -27,6 +28,7 @@ export function useAgentStudioTaskHydration({
   activeRepo,
   activeTaskId,
   activeSession,
+  agentStudioReadinessState,
   hydrateRequestedTaskSessionHistory,
 }: UseAgentStudioTaskHydrationParams): UseAgentStudioTaskHydrationResult {
   const activeSessionId = activeSession?.sessionId ?? null;
@@ -34,10 +36,46 @@ export function useAgentStudioTaskHydration({
     sessionId: string | null;
     status: "idle" | "pending" | "failed";
   }>({ sessionId: null, status: "idle" });
+  const [waitingSessionId, setWaitingSessionId] = useState<string | null>(null);
   const historyHydrationState = getAgentSessionHistoryHydrationState(activeSession);
+  const sessionNeedsHydration = requiresHydratedAgentSessionHistory(activeSession);
+  const isReadinessReady = agentStudioReadinessState === "ready";
+  const isWaitingForReadiness =
+    Boolean(activeRepo && activeTaskId && activeSessionId) &&
+    !isReadinessReady &&
+    sessionNeedsHydration;
+  const isRecoveringWaitingSession =
+    Boolean(activeSessionId && activeRepo && activeTaskId) &&
+    isReadinessReady &&
+    waitingSessionId === activeSessionId &&
+    sessionNeedsHydration;
   const shouldHydrateSessionHistory =
     Boolean(activeRepo && activeTaskId && activeSessionId) &&
-    shouldAutoHydrateAgentSessionHistory(activeSession);
+    isReadinessReady &&
+    sessionNeedsHydration &&
+    (historyHydrationState === "not_requested" || waitingSessionId === activeSessionId);
+
+  useEffect(() => {
+    if (!activeSessionId || !sessionNeedsHydration) {
+      setWaitingSessionId((current) => (current === null ? current : null));
+      return;
+    }
+
+    if (!isReadinessReady) {
+      setWaitingSessionId(activeSessionId);
+      return;
+    }
+
+    if (waitingSessionId === activeSessionId && historyHydrationState === "hydrated") {
+      setWaitingSessionId(null);
+    }
+  }, [
+    activeSessionId,
+    historyHydrationState,
+    isReadinessReady,
+    sessionNeedsHydration,
+    waitingSessionId,
+  ]);
 
   useEffect(() => {
     if (!activeSessionId) {
@@ -65,6 +103,7 @@ export function useAgentStudioTaskHydration({
             ? { sessionId: activeSessionId, status: "idle" }
             : current,
         );
+        setWaitingSessionId((current) => (current === activeSessionId ? null : current));
       })
       .catch(() => {
         setRequestState((current) =>
@@ -72,6 +111,7 @@ export function useAgentStudioTaskHydration({
             ? { sessionId: activeSessionId, status: "failed" }
             : current,
         );
+        setWaitingSessionId((current) => (current === activeSessionId ? null : current));
       });
   }, [
     activeSessionId,
@@ -91,10 +131,16 @@ export function useAgentStudioTaskHydration({
     isActiveTaskHydrationFailed: false,
     isActiveSessionHistoryHydrated: activeSessionId ? historyHydrationState === "hydrated" : false,
     isActiveSessionHistoryHydrationFailed: activeSessionId
-      ? historyHydrationState === "failed" || isRequestFailed
+      ? (historyHydrationState === "failed" &&
+          !isWaitingForReadiness &&
+          !isRecoveringWaitingSession) ||
+        isRequestFailed
       : false,
     isActiveSessionHistoryHydrating: activeSessionId
-      ? shouldShowPendingHydrationState || historyHydrationState === "hydrating" || isRequestPending
+      ? isWaitingForReadiness ||
+        shouldShowPendingHydrationState ||
+        historyHydrationState === "hydrating" ||
+        isRequestPending
       : false,
   };
 }

--- a/apps/desktop/src/pages/agents/use-agents-page-readiness.ts
+++ b/apps/desktop/src/pages/agents/use-agents-page-readiness.ts
@@ -98,6 +98,16 @@ export function useAgentStudioReadiness({
     : null;
 
   const agentStudioReady = Boolean(activeRepo && healthyRuntimeDefinition);
+  const agentStudioReadinessState = (() => {
+    if (agentStudioReady) {
+      return "ready";
+    }
+    if (activeRepo && (isLoadingRuntimeDefinitions || isLoadingChecks || isRuntimeHealthPending)) {
+      return "checking";
+    }
+
+    return "blocked";
+  })();
   const agentStudioBlockedReason = (() => {
     if (agentStudioReady) {
       return null;
@@ -128,6 +138,7 @@ export function useAgentStudioReadiness({
   })();
 
   return {
+    agentStudioReadinessState,
     agentStudioReady,
     agentStudioBlockedReason,
     isLoadingChecks,


### PR DESCRIPTION
## Summary
- gate selected-session hydration and runtime-backed reads on Agent Studio readiness, and auto-recover the currently selected waiting session once readiness or the session's worktree runtime becomes available
- replace the rough startup/session-history loading presentation with a thread-local runtime-starting overlay while keeping transcript visibility and explicit post-ready failures intact
- extract hydration/runtime attachment and thread loading decisions into focused helpers with direct tests to make the startup recovery flow easier to maintain

## Verification
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime readiness states added with a "Runtime is starting" overlay and a blocked error card with retry.

* **Bug Fixes**
  * Transcript loading and hiding now coordinate with hydration and runtime readiness to avoid flicker or premature hiding.

* **Chores**
  * Session recovery and history hydration logic refined to gate on runtime attachment/readiness.

* **Tests**
  * New and updated tests covering readiness, hydration, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->