### PR TITLE
fix: idle detection after completed assistant updates

### DIFF
--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -198,6 +198,24 @@ const makeMessagePartUpdatedEvent = (input: {
     },
   }) as unknown as Event;
 
+const makeAssistantStepFinishPartUpdatedEvent = (input: {
+  messageId: string;
+  partId: string;
+  reason?: string;
+}): Event =>
+  ({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: input.partId,
+        sessionID: "external-session-1",
+        messageID: input.messageId,
+        type: "step-finish",
+        reason: input.reason ?? "stop",
+      },
+    },
+  }) as unknown as Event;
+
 const makeMessagePartDeltaEvent = (input: {
   messageId: string;
   partId: string;
@@ -1039,6 +1057,34 @@ describe("event-stream", () => {
       throw new Error("Expected assistant_message event");
     }
     expect(assistantMessages[0].message).toBe("Recovered");
+  });
+
+  test("emits a final assistant message when a later step-finish part carries the stop signal", async () => {
+    const emitted = await runEventStream([
+      makeMessagePartUpdatedEvent({
+        messageId: "assistant-message-late-stop-part",
+        partId: "text-late-stop-part-1",
+        text: "Recovered after late stop",
+      }),
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-late-stop-part",
+        completedAt: 1,
+      }),
+      makeAssistantStepFinishPartUpdatedEvent({
+        messageId: "assistant-message-late-stop-part",
+        partId: "step-finish-late-stop-part-1",
+      }),
+    ]);
+
+    const assistantMessages = emitted.filter((event) => event.type === "assistant_message");
+    expect(assistantMessages).toHaveLength(1);
+    if (assistantMessages[0]?.type !== "assistant_message") {
+      throw new Error("Expected assistant_message event");
+    }
+    expect(assistantMessages[0].message).toBe("Recovered after late stop");
+
+    const idleEvents = emitted.filter((event) => event.type === "session_idle");
+    expect(idleEvents).toHaveLength(1);
   });
 
   test("keeps assistant completion monotonic when stale non-terminal updates arrive later", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -712,9 +712,6 @@ describe("event-stream", () => {
       } as unknown as Event,
     ]);
 
-    const assistantMessages = emitted.filter((event) => event.type === "assistant_message");
-    expect(assistantMessages).toHaveLength(1);
-    expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(0);
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
     expect(idleEvents).toHaveLength(1);
   });
@@ -855,6 +852,9 @@ describe("event-stream", () => {
       } as unknown as Event,
     ]);
 
+    const assistantMessages = emitted.filter((event) => event.type === "assistant_message");
+    expect(assistantMessages).toHaveLength(1);
+    expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(0);
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
     expect(idleEvents).toHaveLength(1);
   });

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -712,6 +712,9 @@ describe("event-stream", () => {
       } as unknown as Event,
     ]);
 
+    const assistantMessages = emitted.filter((event) => event.type === "assistant_message");
+    expect(assistantMessages).toHaveLength(1);
+    expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(0);
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
     expect(idleEvents).toHaveLength(1);
   });
@@ -929,6 +932,142 @@ describe("event-stream", () => {
     expect(statusEvents).toHaveLength(1);
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
     expect(idleEvents).toHaveLength(0);
+  });
+
+  test("keeps late terminal part updates out of assistant_part emission once idle", async () => {
+    const client = makeClientWithEvents([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-message-late-part-update",
+            role: "assistant",
+            sessionID: "external-session-1",
+            finish: "stop",
+            time: {
+              completed: 1,
+            },
+          },
+          parts: [
+            {
+              id: "text-late-part-update-1",
+              sessionID: "external-session-1",
+              messageID: "assistant-message-late-part-update",
+              type: "text",
+              text: "Done",
+              time: { start: 1, end: 1 },
+            },
+          ],
+        },
+      } as unknown as Event,
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "text-late-part-update-1",
+            sessionID: "external-session-1",
+            messageID: "assistant-message-late-part-update",
+            type: "text",
+            text: "Done later",
+            time: { start: 1, end: 2 },
+          },
+        },
+      } as unknown as Event,
+    ]);
+    const emitted: AgentEvent[] = [];
+    const sessionRecord = makeSessionRecord(client);
+
+    await subscribeOpencodeEvents({
+      context: {
+        sessionId: "local-session-1",
+        externalSessionId: "external-session-1",
+        input: makeSessionInput(),
+      },
+      client,
+      controller: new AbortController(),
+      now: () => "2026-02-22T12:00:00.000Z",
+      emit: (_sessionId, event) => {
+        emitted.push(event);
+      },
+      getSession: () => sessionRecord,
+    });
+
+    expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(1);
+    expect(emitted.filter((event) => event.type === "assistant_message")).toHaveLength(1);
+    expect(emitted.filter((event) => event.type === "session_idle")).toHaveLength(1);
+
+    const updatedPart = sessionRecord.partsById.get("text-late-part-update-1");
+    if (!updatedPart || updatedPart.type !== "text") {
+      throw new Error("Expected cached assistant text part");
+    }
+    expect(updatedPart.text).toBe("Done later");
+  });
+
+  test("keeps late terminal part deltas out of assistant events once idle", async () => {
+    const client = makeClientWithEvents([
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-message-late-delta",
+            role: "assistant",
+            sessionID: "external-session-1",
+            finish: "stop",
+            time: {
+              completed: 1,
+            },
+          },
+          parts: [
+            {
+              id: "text-late-delta-1",
+              sessionID: "external-session-1",
+              messageID: "assistant-message-late-delta",
+              type: "text",
+              text: "Done",
+              time: { start: 1, end: 1 },
+            },
+          ],
+        },
+      } as unknown as Event,
+      {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "external-session-1",
+          partID: "text-late-delta-1",
+          messageID: "assistant-message-late-delta",
+          field: "text",
+          delta: " later",
+        },
+      } as unknown as Event,
+    ]);
+    const emitted: AgentEvent[] = [];
+    const sessionRecord = makeSessionRecord(client);
+
+    await subscribeOpencodeEvents({
+      context: {
+        sessionId: "local-session-1",
+        externalSessionId: "external-session-1",
+        input: makeSessionInput(),
+      },
+      client,
+      controller: new AbortController(),
+      now: () => "2026-02-22T12:00:00.000Z",
+      emit: (_sessionId, event) => {
+        emitted.push(event);
+      },
+      getSession: () => sessionRecord,
+    });
+
+    expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(1);
+    expect(emitted.filter((event) => event.type === "assistant_delta")).toHaveLength(0);
+    expect(emitted.filter((event) => event.type === "assistant_message")).toHaveLength(1);
+    expect(emitted.filter((event) => event.type === "session_idle")).toHaveLength(1);
+
+    const updatedPart = sessionRecord.partsById.get("text-late-delta-1");
+    if (!updatedPart || updatedPart.type !== "text") {
+      throw new Error("Expected cached assistant text part");
+    }
+    expect(updatedPart.text).toBe("Done later");
   });
 
   test("replays known assistant parts when the assistant role becomes known later", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -63,10 +63,14 @@ const makeSessionRecord = (client: OpencodeClient): SessionRecord => ({
   pendingDeltasByPartId: new Map(),
 });
 
-const runEventStream = async (events: Event[]): Promise<AgentEvent[]> => {
+const runEventStreamWithSession = async (
+  events: Event[],
+  configureSession?: (sessionRecord: SessionRecord) => void,
+): Promise<{ emitted: AgentEvent[]; sessionRecord: SessionRecord }> => {
   const client = makeClientWithEvents(events);
   const emitted: AgentEvent[] = [];
   const sessionRecord = makeSessionRecord(client);
+  configureSession?.(sessionRecord);
 
   await subscribeOpencodeEvents({
     context: {
@@ -83,7 +87,11 @@ const runEventStream = async (events: Event[]): Promise<AgentEvent[]> => {
     getSession: () => sessionRecord,
   });
 
-  return emitted;
+  return { emitted, sessionRecord };
+};
+
+const runEventStream = async (events: Event[]): Promise<AgentEvent[]> => {
+  return (await runEventStreamWithSession(events)).emitted;
 };
 
 const assistantRoleEvent = (messageId: string): Event =>
@@ -95,6 +103,115 @@ const assistantRoleEvent = (messageId: string): Event =>
         role: "assistant",
         sessionID: "external-session-1",
       },
+    },
+  }) as unknown as Event;
+
+const makeSessionIdleEvent = (): Event =>
+  ({
+    type: "session.idle",
+    properties: {
+      sessionID: "external-session-1",
+    },
+  }) as unknown as Event;
+
+const makeSessionStatusIdleEvent = (): Event =>
+  ({
+    type: "session.status",
+    properties: {
+      sessionID: "external-session-1",
+      status: {
+        type: "idle",
+      },
+    },
+  }) as unknown as Event;
+
+const makeAssistantTextPart = (input: {
+  messageId: string;
+  text: string;
+  partId?: string;
+  start?: number;
+  end?: number;
+}): Record<string, unknown> => ({
+  id: input.partId ?? `${input.messageId}-text-1`,
+  sessionID: "external-session-1",
+  messageID: input.messageId,
+  type: "text",
+  text: input.text,
+  time: {
+    start: input.start ?? 1,
+    end: input.end ?? 1,
+  },
+});
+
+const makeAssistantMessageUpdatedEvent = (input: {
+  messageId: string;
+  text?: string;
+  partId?: string;
+  finish?: string;
+  completedAt?: number;
+  parts?: unknown[];
+  info?: Record<string, unknown>;
+}): Event => {
+  const parts =
+    input.parts ??
+    (input.text !== undefined
+      ? [
+          makeAssistantTextPart({
+            messageId: input.messageId,
+            partId: input.partId,
+            text: input.text,
+          }),
+        ]
+      : undefined);
+
+  return {
+    type: "message.updated",
+    properties: {
+      info: {
+        id: input.messageId,
+        role: "assistant",
+        sessionID: "external-session-1",
+        ...(input.finish ? { finish: input.finish } : {}),
+        ...(input.completedAt !== undefined ? { time: { completed: input.completedAt } } : {}),
+        ...input.info,
+      },
+      ...(parts ? { parts } : {}),
+    },
+  } as unknown as Event;
+};
+
+const makeMessagePartUpdatedEvent = (input: {
+  messageId: string;
+  partId: string;
+  text: string;
+  end?: number;
+}): Event =>
+  ({
+    type: "message.part.updated",
+    properties: {
+      part: makeAssistantTextPart({
+        messageId: input.messageId,
+        partId: input.partId,
+        text: input.text,
+        end: input.end,
+      }),
+    },
+  }) as unknown as Event;
+
+const makeMessagePartDeltaEvent = (input: {
+  messageId: string;
+  partId: string;
+  field: string;
+  delta: string;
+}): Event =>
+  ({
+    type: "message.part.delta",
+    properties: {
+      sessionID: "external-session-1",
+      partID: input.partId,
+      messageID: input.messageId,
+      field: input.field,
+      delta: input.delta,
     },
   }) as unknown as Event;
 
@@ -334,41 +451,28 @@ describe("event-stream", () => {
   });
 
   test("does not leave a late queued-send acknowledgement stuck queued after idle", async () => {
-    const client = makeClientWithEvents([
-      {
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "message-200",
-            role: "user",
-            sessionID: "external-session-1",
-            text: "Ship it",
-            time: {
-              created: Date.parse("2026-02-22T12:00:02.000Z"),
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [
+        {
+          type: "message.updated",
+          properties: {
+            info: {
+              id: "message-200",
+              role: "user",
+              sessionID: "external-session-1",
+              text: "Ship it",
+              time: {
+                created: Date.parse("2026-02-22T12:00:02.000Z"),
+              },
             },
           },
-        },
-      } as unknown as Event,
-    ]);
-    const emitted: AgentEvent[] = [];
-    const sessionRecord = makeSessionRecord(client);
-    sessionRecord.pendingQueuedUserMessages.push({ content: "Ship it" });
-    sessionRecord.activeAssistantMessageId = null;
-
-    await subscribeOpencodeEvents({
-      context: {
-        sessionId: "local-session-1",
-        externalSessionId: "external-session-1",
-        input: makeSessionInput(),
+        } as unknown as Event,
+      ],
+      (nextSessionRecord) => {
+        nextSessionRecord.pendingQueuedUserMessages.push({ content: "Ship it" });
+        nextSessionRecord.activeAssistantMessageId = null;
       },
-      client,
-      controller: new AbortController(),
-      now: () => "2026-02-22T12:00:00.000Z",
-      emit: (_sessionId, event) => {
-        emitted.push(event);
-      },
-      getSession: () => sessionRecord,
-    });
+    );
 
     const userMessages = emitted.filter((event) => event.type === "user_message");
     expect(userMessages).toHaveLength(1);
@@ -423,56 +527,43 @@ describe("event-stream", () => {
   });
 
   test("matches queued sends by exact model selection when content repeats", async () => {
-    const client = makeClientWithEvents([
-      {
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "msg-200",
-            role: "user",
-            sessionID: "external-session-1",
-            providerID: "openai",
-            modelID: "gpt-5",
-            agent: "Hephaestus",
-            variant: "high",
-            text: "Ship it",
-            time: {
-              created: Date.parse("2026-02-22T12:00:02.000Z"),
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [
+        {
+          type: "message.updated",
+          properties: {
+            info: {
+              id: "msg-200",
+              role: "user",
+              sessionID: "external-session-1",
+              providerID: "openai",
+              modelID: "gpt-5",
+              agent: "Hephaestus",
+              variant: "high",
+              text: "Ship it",
+              time: {
+                created: Date.parse("2026-02-22T12:00:02.000Z"),
+              },
             },
           },
-        },
-      } as unknown as Event,
-    ]);
-    const emitted: AgentEvent[] = [];
-    const sessionRecord = makeSessionRecord(client);
-    sessionRecord.activeAssistantMessageId = "msg-100";
-    sessionRecord.pendingQueuedUserMessages.push(
-      { content: "Ship it" },
-      {
-        content: "Ship it",
-        model: {
-          providerId: "openai",
-          modelId: "gpt-5",
-          profileId: "Hephaestus",
-          variant: "high",
-        },
+        } as unknown as Event,
+      ],
+      (nextSessionRecord) => {
+        nextSessionRecord.activeAssistantMessageId = "msg-100";
+        nextSessionRecord.pendingQueuedUserMessages.push(
+          { content: "Ship it" },
+          {
+            content: "Ship it",
+            model: {
+              providerId: "openai",
+              modelId: "gpt-5",
+              profileId: "Hephaestus",
+              variant: "high",
+            },
+          },
+        );
       },
     );
-
-    await subscribeOpencodeEvents({
-      context: {
-        sessionId: "local-session-1",
-        externalSessionId: "external-session-1",
-        input: makeSessionInput(),
-      },
-      client,
-      controller: new AbortController(),
-      now: () => "2026-02-22T12:00:00.000Z",
-      emit: (_sessionId, event) => {
-        emitted.push(event);
-      },
-      getSession: () => sessionRecord,
-    });
 
     const userMessages = emitted.filter((event) => event.type === "user_message");
     expect(userMessages).toHaveLength(1);
@@ -544,65 +635,39 @@ describe("event-stream", () => {
   });
 
   test("deduplicates assistant_message across repeated message.updated events", async () => {
-    const assistantEvent = {
-      type: "message.updated",
-      properties: {
-        info: {
-          id: "assistant-message-1",
-          role: "assistant",
-          sessionID: "external-session-1",
-          providerID: "openai",
-          modelID: "gpt-5",
-          agent: "Hephaestus",
-          variant: "high",
-          tokens: {
-            input: 100,
-            output: 20,
-          },
-          time: {
-            completed: 1,
-          },
-          finish: "stop",
+    const assistantEvent = makeAssistantMessageUpdatedEvent({
+      messageId: "assistant-message-1",
+      finish: "stop",
+      completedAt: 1,
+      info: {
+        providerID: "openai",
+        modelID: "gpt-5",
+        agent: "Hephaestus",
+        variant: "high",
+        tokens: {
+          input: 100,
+          output: 20,
         },
-        parts: [
-          {
-            id: "reasoning-1",
-            sessionID: "external-session-1",
-            messageID: "assistant-message-1",
-            type: "reasoning",
-            text: "Plan",
-            time: { start: 1, end: 2 },
-          },
-          {
-            id: "text-1",
-            sessionID: "external-session-1",
-            messageID: "assistant-message-1",
-            type: "text",
-            text: "Done",
-            time: { start: 1, end: 2 },
-          },
-        ],
       },
-    } as unknown as Event;
-
-    const client = makeClientWithEvents([assistantEvent, assistantEvent]);
-    const emitted: AgentEvent[] = [];
-    const sessionRecord = makeSessionRecord(client);
-
-    await subscribeOpencodeEvents({
-      context: {
-        sessionId: "local-session-1",
-        externalSessionId: "external-session-1",
-        input: makeSessionInput(),
-      },
-      client,
-      controller: new AbortController(),
-      now: () => "2026-02-22T12:00:00.000Z",
-      emit: (_sessionId, event) => {
-        emitted.push(event);
-      },
-      getSession: () => sessionRecord,
+      parts: [
+        {
+          id: "reasoning-1",
+          sessionID: "external-session-1",
+          messageID: "assistant-message-1",
+          type: "reasoning",
+          text: "Plan",
+          time: { start: 1, end: 2 },
+        },
+        makeAssistantTextPart({
+          messageId: "assistant-message-1",
+          partId: "text-1",
+          text: "Done",
+          end: 2,
+        }),
+      ],
     });
+
+    const { emitted } = await runEventStreamWithSession([assistantEvent, assistantEvent]);
 
     const assistantMessages = emitted.filter((event) => event.type === "assistant_message");
     expect(assistantMessages).toHaveLength(1);
@@ -683,33 +748,13 @@ describe("event-stream", () => {
 
   test("deduplicates upstream session.idle after a terminal assistant update", async () => {
     const emitted = await runEventStream([
-      {
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "assistant-message-terminal-idle",
-            role: "assistant",
-            sessionID: "external-session-1",
-            finish: "stop",
-          },
-          parts: [
-            {
-              id: "text-terminal-idle-1",
-              sessionID: "external-session-1",
-              messageID: "assistant-message-terminal-idle",
-              type: "text",
-              text: "Done once",
-              time: { start: 1, end: 1 },
-            },
-          ],
-        },
-      } as unknown as Event,
-      {
-        type: "session.idle",
-        properties: {
-          sessionID: "external-session-1",
-        },
-      } as unknown as Event,
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-terminal-idle",
+        finish: "stop",
+        text: "Done once",
+        partId: "text-terminal-idle-1",
+      }),
+      makeSessionIdleEvent(),
     ]);
 
     const idleEvents = emitted.filter((event) => event.type === "session_idle");
@@ -823,33 +868,13 @@ describe("event-stream", () => {
 
   test("preserves existing idle state when session.idle arrives before a terminal assistant update", async () => {
     const emitted = await runEventStream([
-      {
-        type: "session.idle",
-        properties: {
-          sessionID: "external-session-1",
-        },
-      } as unknown as Event,
-      {
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "assistant-message-idle-first",
-            role: "assistant",
-            sessionID: "external-session-1",
-            finish: "stop",
-          },
-          parts: [
-            {
-              id: "text-idle-first-1",
-              sessionID: "external-session-1",
-              messageID: "assistant-message-idle-first",
-              type: "text",
-              text: "Done after idle",
-              time: { start: 1, end: 1 },
-            },
-          ],
-        },
-      } as unknown as Event,
+      makeSessionIdleEvent(),
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-idle-first",
+        finish: "stop",
+        text: "Done after idle",
+        partId: "text-idle-first-1",
+      }),
     ]);
 
     const assistantMessages = emitted.filter((event) => event.type === "assistant_message");
@@ -860,30 +885,13 @@ describe("event-stream", () => {
   });
 
   test("does not emit duplicate session_idle across repeated terminal message updates", async () => {
-    const terminalEvent = {
-      type: "message.updated",
-      properties: {
-        info: {
-          id: "assistant-message-duplicate-terminal",
-          role: "assistant",
-          sessionID: "external-session-1",
-          finish: "stop",
-          time: {
-            completed: 1,
-          },
-        },
-        parts: [
-          {
-            id: "text-duplicate-terminal-1",
-            sessionID: "external-session-1",
-            messageID: "assistant-message-duplicate-terminal",
-            type: "text",
-            text: "Done twice",
-            time: { start: 1, end: 1 },
-          },
-        ],
-      },
-    } as unknown as Event;
+    const terminalEvent = makeAssistantMessageUpdatedEvent({
+      messageId: "assistant-message-duplicate-terminal",
+      finish: "stop",
+      completedAt: 1,
+      text: "Done twice",
+      partId: "text-duplicate-terminal-1",
+    });
 
     const emitted = await runEventStream([terminalEvent, terminalEvent]);
 
@@ -893,39 +901,14 @@ describe("event-stream", () => {
 
   test("marks session idle on session.status idle so later terminal updates do not duplicate it", async () => {
     const emitted = await runEventStream([
-      {
-        type: "session.status",
-        properties: {
-          sessionID: "external-session-1",
-          status: {
-            type: "idle",
-          },
-        },
-      } as unknown as Event,
-      {
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "assistant-message-status-idle",
-            role: "assistant",
-            sessionID: "external-session-1",
-            time: {
-              completed: 1,
-            },
-            finish: "stop",
-          },
-          parts: [
-            {
-              id: "text-status-idle-1",
-              sessionID: "external-session-1",
-              messageID: "assistant-message-status-idle",
-              type: "text",
-              text: "Done after idle status",
-              time: { start: 1, end: 1 },
-            },
-          ],
-        },
-      } as unknown as Event,
+      makeSessionStatusIdleEvent(),
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-status-idle",
+        finish: "stop",
+        completedAt: 1,
+        text: "Done after idle status",
+        partId: "text-status-idle-1",
+      }),
     ]);
 
     const statusEvents = emitted.filter((event) => event.type === "session_status");
@@ -935,62 +918,21 @@ describe("event-stream", () => {
   });
 
   test("keeps late terminal part updates out of assistant_part emission once idle", async () => {
-    const client = makeClientWithEvents([
-      {
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "assistant-message-late-part-update",
-            role: "assistant",
-            sessionID: "external-session-1",
-            finish: "stop",
-            time: {
-              completed: 1,
-            },
-          },
-          parts: [
-            {
-              id: "text-late-part-update-1",
-              sessionID: "external-session-1",
-              messageID: "assistant-message-late-part-update",
-              type: "text",
-              text: "Done",
-              time: { start: 1, end: 1 },
-            },
-          ],
-        },
-      } as unknown as Event,
-      {
-        type: "message.part.updated",
-        properties: {
-          part: {
-            id: "text-late-part-update-1",
-            sessionID: "external-session-1",
-            messageID: "assistant-message-late-part-update",
-            type: "text",
-            text: "Done later",
-            time: { start: 1, end: 2 },
-          },
-        },
-      } as unknown as Event,
+    const { emitted, sessionRecord } = await runEventStreamWithSession([
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-late-part-update",
+        finish: "stop",
+        completedAt: 1,
+        text: "Done",
+        partId: "text-late-part-update-1",
+      }),
+      makeMessagePartUpdatedEvent({
+        messageId: "assistant-message-late-part-update",
+        partId: "text-late-part-update-1",
+        text: "Done later",
+        end: 2,
+      }),
     ]);
-    const emitted: AgentEvent[] = [];
-    const sessionRecord = makeSessionRecord(client);
-
-    await subscribeOpencodeEvents({
-      context: {
-        sessionId: "local-session-1",
-        externalSessionId: "external-session-1",
-        input: makeSessionInput(),
-      },
-      client,
-      controller: new AbortController(),
-      now: () => "2026-02-22T12:00:00.000Z",
-      emit: (_sessionId, event) => {
-        emitted.push(event);
-      },
-      getSession: () => sessionRecord,
-    });
 
     expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(1);
     expect(emitted.filter((event) => event.type === "assistant_message")).toHaveLength(1);
@@ -1004,59 +946,21 @@ describe("event-stream", () => {
   });
 
   test("keeps late terminal part deltas out of assistant events once idle", async () => {
-    const client = makeClientWithEvents([
-      {
-        type: "message.updated",
-        properties: {
-          info: {
-            id: "assistant-message-late-delta",
-            role: "assistant",
-            sessionID: "external-session-1",
-            finish: "stop",
-            time: {
-              completed: 1,
-            },
-          },
-          parts: [
-            {
-              id: "text-late-delta-1",
-              sessionID: "external-session-1",
-              messageID: "assistant-message-late-delta",
-              type: "text",
-              text: "Done",
-              time: { start: 1, end: 1 },
-            },
-          ],
-        },
-      } as unknown as Event,
-      {
-        type: "message.part.delta",
-        properties: {
-          sessionID: "external-session-1",
-          partID: "text-late-delta-1",
-          messageID: "assistant-message-late-delta",
-          field: "text",
-          delta: " later",
-        },
-      } as unknown as Event,
+    const { emitted, sessionRecord } = await runEventStreamWithSession([
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-late-delta",
+        finish: "stop",
+        completedAt: 1,
+        text: "Done",
+        partId: "text-late-delta-1",
+      }),
+      makeMessagePartDeltaEvent({
+        messageId: "assistant-message-late-delta",
+        partId: "text-late-delta-1",
+        field: "text",
+        delta: " later",
+      }),
     ]);
-    const emitted: AgentEvent[] = [];
-    const sessionRecord = makeSessionRecord(client);
-
-    await subscribeOpencodeEvents({
-      context: {
-        sessionId: "local-session-1",
-        externalSessionId: "external-session-1",
-        input: makeSessionInput(),
-      },
-      client,
-      controller: new AbortController(),
-      now: () => "2026-02-22T12:00:00.000Z",
-      emit: (_sessionId, event) => {
-        emitted.push(event);
-      },
-      getSession: () => sessionRecord,
-    });
 
     expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(1);
     expect(emitted.filter((event) => event.type === "assistant_delta")).toHaveLength(0);
@@ -1096,7 +1000,7 @@ describe("event-stream", () => {
   });
 
   test("normalizes todo.updated and ignores unrelated sessions", async () => {
-    const client = makeClientWithEvents([
+    const { emitted } = await runEventStreamWithSession([
       {
         type: "todo.updated",
         properties: {
@@ -1117,24 +1021,6 @@ describe("event-stream", () => {
         },
       } as unknown as Event,
     ]);
-
-    const emitted: AgentEvent[] = [];
-    const sessionRecord = makeSessionRecord(client);
-
-    await subscribeOpencodeEvents({
-      context: {
-        sessionId: "local-session-1",
-        externalSessionId: "external-session-1",
-        input: makeSessionInput(),
-      },
-      client,
-      controller: new AbortController(),
-      now: () => "2026-02-22T12:00:00.000Z",
-      emit: (_sessionId, event) => {
-        emitted.push(event);
-      },
-      getSession: () => sessionRecord,
-    });
 
     const todoEvents = emitted.filter((event) => event.type === "session_todos_updated");
     expect(todoEvents).toHaveLength(1);

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -52,6 +52,7 @@ const makeSessionRecord = (client: OpencodeClient): SessionRecord => ({
   eventTransportKey: "http://127.0.0.1:12345",
   hasIdleSinceActivity: false,
   activeAssistantMessageId: null,
+  completedAssistantMessageIds: new Set<string>(),
   emittedAssistantMessageIds: new Set<string>(),
   emittedUserMessageSignatures: new Map<string, string>(),
   emittedUserMessageStates: new Map(),

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -974,6 +974,109 @@ describe("event-stream", () => {
     expect(updatedPart.text).toBe("Done later");
   });
 
+  test("emits a final assistant message when terminal metadata arrives before idle-preserved parts", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession([
+      makeSessionIdleEvent(),
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-idle-late-part",
+        finish: "stop",
+        completedAt: 1,
+      }),
+      makeMessagePartUpdatedEvent({
+        messageId: "assistant-message-idle-late-part",
+        partId: "text-idle-late-part-1",
+        text: "Recovered final output",
+      }),
+    ]);
+
+    expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(0);
+    expect(emitted.filter((event) => event.type === "assistant_delta")).toHaveLength(0);
+
+    const assistantMessages = emitted.filter((event) => event.type === "assistant_message");
+    expect(assistantMessages).toHaveLength(1);
+    if (assistantMessages[0]?.type !== "assistant_message") {
+      throw new Error("Expected assistant_message event");
+    }
+    expect(assistantMessages[0].message).toBe("Recovered final output");
+
+    const idleEvents = emitted.filter((event) => event.type === "session_idle");
+    expect(idleEvents).toHaveLength(1);
+
+    const updatedPart = sessionRecord.partsById.get("text-idle-late-part-1");
+    if (!updatedPart || updatedPart.type !== "text") {
+      throw new Error("Expected cached assistant text part");
+    }
+    expect(updatedPart.text).toBe("Recovered final output");
+  });
+
+  test("emits a final assistant message after pending deltas are applied to idle-preserved parts", async () => {
+    const emitted = await runEventStream([
+      makeSessionIdleEvent(),
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-idle-late-delta",
+        finish: "stop",
+        completedAt: 1,
+      }),
+      makeMessagePartDeltaEvent({
+        messageId: "assistant-message-idle-late-delta",
+        partId: "text-idle-late-delta-1",
+        field: "text",
+        delta: "Recovered",
+      }),
+      makeMessagePartUpdatedEvent({
+        messageId: "assistant-message-idle-late-delta",
+        partId: "text-idle-late-delta-1",
+        text: "",
+      }),
+    ]);
+
+    expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(0);
+    expect(emitted.filter((event) => event.type === "assistant_delta")).toHaveLength(0);
+
+    const assistantMessages = emitted.filter((event) => event.type === "assistant_message");
+    expect(assistantMessages).toHaveLength(1);
+    if (assistantMessages[0]?.type !== "assistant_message") {
+      throw new Error("Expected assistant_message event");
+    }
+    expect(assistantMessages[0].message).toBe("Recovered");
+  });
+
+  test("keeps assistant completion monotonic when stale non-terminal updates arrive later", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession([
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-stale-update",
+        finish: "stop",
+        completedAt: 1,
+        text: "Done",
+        partId: "text-stale-update-1",
+      }),
+      makeAssistantMessageUpdatedEvent({
+        messageId: "assistant-message-stale-update",
+      }),
+      makeMessagePartDeltaEvent({
+        messageId: "assistant-message-stale-update",
+        partId: "text-stale-update-1",
+        field: "text",
+        delta: " later",
+      }),
+    ]);
+
+    expect(emitted.filter((event) => event.type === "assistant_part")).toHaveLength(1);
+    expect(emitted.filter((event) => event.type === "assistant_delta")).toHaveLength(0);
+    expect(emitted.filter((event) => event.type === "assistant_message")).toHaveLength(1);
+    expect(emitted.filter((event) => event.type === "session_idle")).toHaveLength(1);
+    expect(sessionRecord.completedAssistantMessageIds.has("assistant-message-stale-update")).toBe(
+      true,
+    );
+    expect(sessionRecord.activeAssistantMessageId).toBeNull();
+
+    const updatedPart = sessionRecord.partsById.get("text-stale-update-1");
+    if (!updatedPart || updatedPart.type !== "text") {
+      throw new Error("Expected cached assistant text part");
+    }
+    expect(updatedPart.text).toBe("Done later");
+  });
+
   test("replays known assistant parts when the assistant role becomes known later", async () => {
     const emitted = await runEventStream([
       {

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -251,7 +251,10 @@ const maybeEmitCompletedAssistantMessage = (
     input.info !== undefined
       ? (readMessageModelSelection(input.info) ?? existingMetadata?.model)
       : existingMetadata?.model;
-  const hasStopSignal = input.hasStopSignal ?? existingMetadata?.hasStopSignal ?? false;
+  const hasStopSignal =
+    input.hasStopSignal === true ||
+    existingMetadata?.hasStopSignal === true ||
+    hasTerminalStopSignalInParts(assistantParts, undefined);
   const timestamp = input.timestamp ?? existingMetadata?.timestamp ?? runtime.now();
 
   updateMessageMetadata(runtime, input.messageId, {

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -173,6 +173,10 @@ const updateAssistantMessageCompletionState = (
     return;
   }
 
+  if (!isCompleted && session.completedAssistantMessageIds.has(messageId)) {
+    return;
+  }
+
   const previousActiveAssistantMessageId = session.activeAssistantMessageId;
   if (isCompleted) {
     if (session.activeAssistantMessageId === messageId) {
@@ -181,12 +185,112 @@ const updateAssistantMessageCompletionState = (
     session.completedAssistantMessageIds.add(messageId);
   } else {
     session.activeAssistantMessageId = messageId;
-    session.completedAssistantMessageIds.delete(messageId);
   }
 
   if (previousActiveAssistantMessageId !== session.activeAssistantMessageId) {
     reconcileUserMessageQueuedStates(runtime);
   }
+};
+
+const updateMessageMetadata = (
+  runtime: EventStreamRuntime,
+  messageId: string,
+  updates: {
+    timestamp?: string;
+    model?: ReturnType<typeof readMessageModelSelection>;
+    parentId?: string;
+    text?: string;
+    hasStopSignal?: boolean;
+    totalTokens?: number;
+  },
+): void => {
+  const session = runtime.getSession(runtime.sessionId);
+  if (!session) {
+    return;
+  }
+
+  const previous = session.messageMetadataById.get(messageId);
+  const timestamp = updates.timestamp ?? previous?.timestamp ?? runtime.now();
+  const model = updates.model ?? previous?.model;
+  const parentId = updates.parentId ?? previous?.parentId;
+  const text = updates.text ?? previous?.text;
+  const hasStopSignal = updates.hasStopSignal ?? previous?.hasStopSignal;
+  const totalTokens = updates.totalTokens ?? previous?.totalTokens;
+
+  session.messageMetadataById.set(messageId, {
+    timestamp,
+    ...(model ? { model } : {}),
+    ...(parentId ? { parentId } : {}),
+    ...(text ? { text } : {}),
+    ...(hasStopSignal !== undefined ? { hasStopSignal } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+  });
+};
+
+const maybeEmitCompletedAssistantMessage = (
+  runtime: EventStreamRuntime,
+  input: {
+    messageId: string;
+    timestamp?: string;
+    info?: unknown;
+    hasStopSignal?: boolean;
+  },
+): boolean => {
+  const session = runtime.getSession(runtime.sessionId);
+  if (!session || !isAssistantMessage(runtime, input.messageId)) {
+    return false;
+  }
+
+  const assistantParts = getKnownMessageParts(runtime, input.messageId);
+  const existingMetadata = session.messageMetadataById.get(input.messageId);
+  const totalTokens =
+    input.info !== undefined
+      ? (extractMessageTotalTokens(input.info, assistantParts) ?? existingMetadata?.totalTokens)
+      : existingMetadata?.totalTokens;
+  const assistantModel =
+    input.info !== undefined
+      ? (readMessageModelSelection(input.info) ?? existingMetadata?.model)
+      : existingMetadata?.model;
+  const hasStopSignal = input.hasStopSignal ?? existingMetadata?.hasStopSignal ?? false;
+  const timestamp = input.timestamp ?? existingMetadata?.timestamp ?? runtime.now();
+
+  updateMessageMetadata(runtime, input.messageId, {
+    timestamp,
+    ...(assistantModel ? { model: assistantModel } : {}),
+    hasStopSignal,
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+  });
+
+  if (!hasStopSignal || assistantParts.length === 0) {
+    return false;
+  }
+
+  const text = readTextFromParts(assistantParts);
+  const visible = sanitizeAssistantMessage(text);
+  if (visible.length === 0) {
+    emitSessionIdle(runtime);
+    reconcileUserMessageQueuedStates(runtime);
+    return true;
+  }
+
+  if (session.emittedAssistantMessageIds.has(input.messageId)) {
+    return true;
+  }
+
+  runtime.emit(runtime.sessionId, {
+    type: "assistant_message",
+    sessionId: runtime.sessionId,
+    timestamp,
+    messageId: input.messageId,
+    message: visible,
+    ...(typeof totalTokens === "number" ? { totalTokens } : {}),
+    ...(assistantModel ? { model: assistantModel } : {}),
+  });
+  session.emittedAssistantMessageIds.add(input.messageId);
+
+  emitSessionIdle(runtime);
+  reconcileUserMessageQueuedStates(runtime);
+  return true;
 };
 
 const emitKnownUserMessage = (
@@ -436,7 +540,7 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     : undefined;
   if (messageId && role) {
     runtime.messageRoleById.set(messageId, role);
-    session?.messageMetadataById.set(messageId, {
+    updateMessageMetadata(runtime, messageId, {
       timestamp: messageTimestamp,
       ...(messageModel ? { model: messageModel } : {}),
       ...(parentId ? { parentId } : {}),
@@ -531,49 +635,16 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     });
   }
 
-  const assistantParts =
-    messageId && isAssistantRole
-      ? normalizedParts.length > 0
-        ? normalizedParts
-        : getKnownMessageParts(runtime, messageId)
-      : [];
-  const shouldEmitCompletedMessage =
-    messageId !== undefined &&
-    isAssistantRole &&
-    assistantParts.length > 0 &&
-    assistantMessageHasStopSignal;
-  if (!shouldEmitCompletedMessage || !messageId) {
+  if (!messageId || !isAssistantRole) {
     return true;
   }
 
-  const text = readTextFromParts(assistantParts);
-  const visible = sanitizeAssistantMessage(text);
-  if (visible.length === 0) {
-    emitSessionIdle(runtime);
-    reconcileUserMessageQueuedStates(runtime);
-    return true;
-  }
-
-  const totalTokens = extractMessageTotalTokens(infoRecord, assistantParts);
-  const assistantModel = readMessageModelSelection(infoRecord);
-  const emittedMessageIds = session?.emittedAssistantMessageIds;
-  if (emittedMessageIds?.has(messageId)) {
-    return true;
-  }
-
-  runtime.emit(runtime.sessionId, {
-    type: "assistant_message",
-    sessionId: runtime.sessionId,
-    timestamp: messageTimestamp,
+  maybeEmitCompletedAssistantMessage(runtime, {
     messageId,
-    message: visible,
-    ...(typeof totalTokens === "number" ? { totalTokens } : {}),
-    ...(assistantModel ? { model: assistantModel } : {}),
+    timestamp: messageTimestamp,
+    info: infoRecord,
+    hasStopSignal: assistantMessageHasStopSignal,
   });
-  emittedMessageIds?.add(messageId);
-
-  emitSessionIdle(runtime);
-  reconcileUserMessageQueuedStates(runtime);
   return true;
 };
 
@@ -598,6 +669,9 @@ const handleMessagePartDeltaEvent = (event: Event, runtime: EventStreamRuntime):
     if (updatedPart) {
       runtime.partsById.set(partId, updatedPart);
       emitAssistantPart(runtime, updatedPart);
+      maybeEmitCompletedAssistantMessage(runtime, {
+        messageId: updatedPart.messageID,
+      });
       return true;
     }
   }
@@ -659,6 +733,12 @@ const handleMessagePartUpdatedEvent = (event: Event, runtime: EventStreamRuntime
   emitAssistantPart(runtime, nextPart);
   const messageId = nextPart.messageID;
   const role = runtime.messageRoleById.get(messageId);
+  if (role === "assistant") {
+    maybeEmitCompletedAssistantMessage(runtime, {
+      messageId,
+    });
+    return true;
+  }
   if (role === "user") {
     const session = runtime.getSession(runtime.sessionId);
     const metadata = session?.messageMetadataById.get(messageId);

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -47,6 +47,10 @@ const emitAssistantPart = (
     return false;
   }
 
+  if (shouldPreserveIdleForCompletedAssistantMessage(runtime, mapped.messageId, mappedRole)) {
+    return false;
+  }
+
   if (markActive) {
     markSessionActive(runtime);
   }
@@ -104,6 +108,24 @@ const hasTerminalStopSignal = (parts: Part[], finish: string | undefined): boole
     (part) =>
       part.type === "step-finish" && typeof part.reason === "string" && part.reason === "stop",
   );
+};
+
+const shouldPreserveIdleForCompletedAssistantMessage = (
+  runtime: EventStreamRuntime,
+  messageId: string,
+  roleHint?: string,
+): boolean => {
+  const session = runtime.getSession(runtime.sessionId);
+  if (!session?.hasIdleSinceActivity) {
+    return false;
+  }
+
+  const role = roleHint ?? runtime.messageRoleById.get(messageId);
+  if (role !== "assistant") {
+    return false;
+  }
+
+  return session.completedAssistantMessageIds.has(messageId);
 };
 
 const rawPartsHaveTerminalStopSignal = (parts: unknown[]): boolean => {
@@ -358,6 +380,8 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
   const session = runtime.getSession(runtime.sessionId);
   const previousActiveAssistantMessageId = session?.activeAssistantMessageId ?? null;
   const previousRole = messageId ? runtime.messageRoleById.get(messageId) : undefined;
+  const finish = infoRecord ? readStringProp(infoRecord, ["finish"]) : undefined;
+  const rawParts = readRawMessageParts(properties, infoRecord);
   const parentId = infoRecord
     ? readStringProp(infoRecord, ["parentID", "parentId", "parent_id"])
     : undefined;
@@ -371,30 +395,28 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
   }
 
   if (messageId && role === "assistant") {
-    if (messageCompletedAt === undefined) {
+    const assistantMessageCompleted =
+      messageCompletedAt !== undefined ||
+      finish === "stop" ||
+      rawPartsHaveTerminalStopSignal(rawParts) ||
+      hasTerminalStopSignal(getKnownMessageParts(runtime, messageId), finish);
+
+    if (!assistantMessageCompleted) {
       if (session) {
         session.activeAssistantMessageId = messageId;
       }
-    } else if (session?.activeAssistantMessageId === messageId) {
-      session.activeAssistantMessageId = null;
+      session?.completedAssistantMessageIds.delete(messageId);
+    } else {
+      if (session?.activeAssistantMessageId === messageId) {
+        session.activeAssistantMessageId = null;
+      }
+      session?.completedAssistantMessageIds.add(messageId);
     }
 
     if (previousActiveAssistantMessageId !== (session?.activeAssistantMessageId ?? null)) {
       reconcileUserMessageQueuedStates(runtime);
     }
   }
-
-  const finish = infoRecord ? readStringProp(infoRecord, ["finish"]) : undefined;
-  const rawParts = readRawMessageParts(properties, infoRecord);
-  const preserveIdleState =
-    messageId !== undefined &&
-    role === "assistant" &&
-    session?.hasIdleSinceActivity === true &&
-    (finish === "stop" ||
-      rawPartsHaveTerminalStopSignal(rawParts) ||
-      (messageId
-        ? hasTerminalStopSignal(getKnownMessageParts(runtime, messageId), finish)
-        : false));
 
   const normalizedParts: Part[] = [];
   if (messageId && rawParts.length > 0) {
@@ -418,7 +440,7 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
 
       runtime.partsById.set(rawPartId, partWithPendingDelta);
       normalizedParts.push(partWithPendingDelta);
-      emitAssistantPart(runtime, partWithPendingDelta, role, !preserveIdleState);
+      emitAssistantPart(runtime, partWithPendingDelta, role);
     }
   }
 
@@ -428,7 +450,7 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     previousRole !== "assistant" &&
     normalizedParts.length === 0
   ) {
-    emitKnownAssistantPartsForMessage(runtime, messageId, role, !preserveIdleState);
+    emitKnownAssistantPartsForMessage(runtime, messageId, role);
   }
 
   if (messageId && role === "user") {
@@ -527,7 +549,6 @@ const handleMessagePartDeltaEvent = (event: Event, runtime: EventStreamRuntime):
     const updatedPart = applyDeltaToPart(knownPart, field, delta);
     if (updatedPart) {
       runtime.partsById.set(partId, updatedPart);
-      markSessionActive(runtime);
       emitAssistantPart(runtime, updatedPart);
       return true;
     }
@@ -548,6 +569,9 @@ const handleMessagePartDeltaEvent = (event: Event, runtime: EventStreamRuntime):
   }
   const deltaRole = runtime.messageRoleById.get(messageId);
   if (deltaRole !== "assistant") {
+    return true;
+  }
+  if (shouldPreserveIdleForCompletedAssistantMessage(runtime, messageId, deltaRole)) {
     return true;
   }
   const channel = isReasoningDeltaField(field) ? "reasoning" : "text";

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -31,6 +31,27 @@ import {
   markSessionActive,
 } from "./shared";
 
+const isAssistantMessage = (
+  runtime: EventStreamRuntime,
+  messageId: string,
+  roleHint?: string,
+): boolean => {
+  return (roleHint ?? runtime.messageRoleById.get(messageId)) === "assistant";
+};
+
+const shouldSuppressAssistantStreamingAfterIdle = (
+  runtime: EventStreamRuntime,
+  messageId: string,
+  roleHint?: string,
+): boolean => {
+  const session = runtime.getSession(runtime.sessionId);
+  return Boolean(
+    session?.hasIdleSinceActivity &&
+      isAssistantMessage(runtime, messageId, roleHint) &&
+      session.completedAssistantMessageIds.has(messageId),
+  );
+};
+
 const emitAssistantPart = (
   runtime: EventStreamRuntime,
   part: Part,
@@ -42,12 +63,11 @@ const emitAssistantPart = (
     return false;
   }
 
-  const mappedRole = roleHint ?? runtime.messageRoleById.get(mapped.messageId);
-  if (mappedRole !== "assistant") {
+  if (!isAssistantMessage(runtime, mapped.messageId, roleHint)) {
     return false;
   }
 
-  if (shouldPreserveIdleForCompletedAssistantMessage(runtime, mapped.messageId, mappedRole)) {
+  if (shouldSuppressAssistantStreamingAfterIdle(runtime, mapped.messageId, roleHint)) {
     return false;
   }
 
@@ -70,6 +90,10 @@ const emitKnownAssistantPartsForMessage = (
   roleHint?: string,
   markActive = true,
 ): void => {
+  if (shouldSuppressAssistantStreamingAfterIdle(runtime, messageId, roleHint)) {
+    return;
+  }
+
   for (const part of runtime.partsById.values()) {
     if (part.messageID !== messageId) {
       continue;
@@ -99,7 +123,7 @@ const getKnownMessageParts = (runtime: EventStreamRuntime, messageId: string): P
   return [...runtime.partsById.values()].filter((part) => part.messageID === messageId);
 };
 
-const hasTerminalStopSignal = (parts: Part[], finish: string | undefined): boolean => {
+const hasTerminalStopSignalInParts = (parts: Part[], finish: string | undefined): boolean => {
   if (finish === "stop") {
     return true;
   }
@@ -110,25 +134,7 @@ const hasTerminalStopSignal = (parts: Part[], finish: string | undefined): boole
   );
 };
 
-const shouldPreserveIdleForCompletedAssistantMessage = (
-  runtime: EventStreamRuntime,
-  messageId: string,
-  roleHint?: string,
-): boolean => {
-  const session = runtime.getSession(runtime.sessionId);
-  if (!session?.hasIdleSinceActivity) {
-    return false;
-  }
-
-  const role = roleHint ?? runtime.messageRoleById.get(messageId);
-  if (role !== "assistant") {
-    return false;
-  }
-
-  return session.completedAssistantMessageIds.has(messageId);
-};
-
-const rawPartsHaveTerminalStopSignal = (parts: unknown[]): boolean => {
+const hasTerminalStopSignalInRawParts = (parts: unknown[]): boolean => {
   return parts.some((part) => {
     const record = asUnknownRecord(part);
     return (
@@ -137,6 +143,50 @@ const rawPartsHaveTerminalStopSignal = (parts: unknown[]): boolean => {
       readStringProp(record, ["reason"]) === "stop"
     );
   });
+};
+
+const hasMessageStopSignal = (input: {
+  finish: string | undefined;
+  rawParts: unknown[];
+  parts: Part[];
+}): boolean => {
+  return (
+    hasTerminalStopSignalInRawParts(input.rawParts) ||
+    hasTerminalStopSignalInParts(input.parts, input.finish)
+  );
+};
+
+const isAssistantMessageSettled = (input: {
+  messageCompletedAt: number | undefined;
+  hasStopSignal: boolean;
+}): boolean => {
+  return input.messageCompletedAt !== undefined || input.hasStopSignal;
+};
+
+const updateAssistantMessageCompletionState = (
+  runtime: EventStreamRuntime,
+  messageId: string,
+  isCompleted: boolean,
+): void => {
+  const session = runtime.getSession(runtime.sessionId);
+  if (!session) {
+    return;
+  }
+
+  const previousActiveAssistantMessageId = session.activeAssistantMessageId;
+  if (isCompleted) {
+    if (session.activeAssistantMessageId === messageId) {
+      session.activeAssistantMessageId = null;
+    }
+    session.completedAssistantMessageIds.add(messageId);
+  } else {
+    session.activeAssistantMessageId = messageId;
+    session.completedAssistantMessageIds.delete(messageId);
+  }
+
+  if (previousActiveAssistantMessageId !== session.activeAssistantMessageId) {
+    reconcileUserMessageQueuedStates(runtime);
+  }
 };
 
 const emitKnownUserMessage = (
@@ -378,7 +428,6 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
   const messageCompletedAt = infoRecord ? readMessageCompletedAt(infoRecord) : undefined;
   const messageModel = readMessageModelSelection(infoRecord);
   const session = runtime.getSession(runtime.sessionId);
-  const previousActiveAssistantMessageId = session?.activeAssistantMessageId ?? null;
   const previousRole = messageId ? runtime.messageRoleById.get(messageId) : undefined;
   const finish = infoRecord ? readStringProp(infoRecord, ["finish"]) : undefined;
   const rawParts = readRawMessageParts(properties, infoRecord);
@@ -394,28 +443,25 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     });
   }
 
-  if (messageId && role === "assistant") {
-    const assistantMessageCompleted =
-      messageCompletedAt !== undefined ||
-      finish === "stop" ||
-      rawPartsHaveTerminalStopSignal(rawParts) ||
-      hasTerminalStopSignal(getKnownMessageParts(runtime, messageId), finish);
+  const isAssistantRole = messageId ? isAssistantMessage(runtime, messageId, role) : false;
+  const assistantMessageHasStopSignal =
+    messageId && isAssistantRole
+      ? hasMessageStopSignal({
+          finish,
+          rawParts,
+          parts: getKnownMessageParts(runtime, messageId),
+        })
+      : false;
+  const assistantMessageSettled =
+    messageId && isAssistantRole
+      ? isAssistantMessageSettled({
+          messageCompletedAt,
+          hasStopSignal: assistantMessageHasStopSignal,
+        })
+      : false;
 
-    if (!assistantMessageCompleted) {
-      if (session) {
-        session.activeAssistantMessageId = messageId;
-      }
-      session?.completedAssistantMessageIds.delete(messageId);
-    } else {
-      if (session?.activeAssistantMessageId === messageId) {
-        session.activeAssistantMessageId = null;
-      }
-      session?.completedAssistantMessageIds.add(messageId);
-    }
-
-    if (previousActiveAssistantMessageId !== (session?.activeAssistantMessageId ?? null)) {
-      reconcileUserMessageQueuedStates(runtime);
-    }
+  if (messageId && isAssistantRole) {
+    updateAssistantMessageCompletionState(runtime, messageId, assistantMessageSettled);
   }
 
   const normalizedParts: Part[] = [];
@@ -446,7 +492,7 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
 
   if (
     messageId &&
-    role === "assistant" &&
+    isAssistantRole &&
     previousRole !== "assistant" &&
     normalizedParts.length === 0
   ) {
@@ -486,14 +532,16 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
   }
 
   const assistantParts =
-    messageId && role === "assistant"
+    messageId && isAssistantRole
       ? normalizedParts.length > 0
         ? normalizedParts
         : getKnownMessageParts(runtime, messageId)
       : [];
-  const hasStopSignal = hasTerminalStopSignal(assistantParts, finish);
   const shouldEmitCompletedMessage =
-    messageId !== undefined && role === "assistant" && assistantParts.length > 0 && hasStopSignal;
+    messageId !== undefined &&
+    isAssistantRole &&
+    assistantParts.length > 0 &&
+    assistantMessageHasStopSignal;
   if (!shouldEmitCompletedMessage || !messageId) {
     return true;
   }
@@ -571,7 +619,7 @@ const handleMessagePartDeltaEvent = (event: Event, runtime: EventStreamRuntime):
   if (deltaRole !== "assistant") {
     return true;
   }
-  if (shouldPreserveIdleForCompletedAssistantMessage(runtime, messageId, deltaRole)) {
+  if (shouldSuppressAssistantStreamingAfterIdle(runtime, messageId, deltaRole)) {
     return true;
   }
   const channel = isReasoningDeltaField(field) ? "reasoning" : "text";

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1588,6 +1588,79 @@ describe("OpencodeSdkAdapter", () => {
     });
   });
 
+  test("does not re-emit assistant streaming events after idle is already preserved", async () => {
+    const streamEvents: Event[] = [
+      {
+        type: "session.status",
+        properties: {
+          sessionID: "session-opencode-1",
+          status: {
+            type: "idle",
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-idle-preserved-1",
+            role: "assistant",
+            sessionID: "session-opencode-1",
+            providerID: "openai",
+            modelID: "gpt-5",
+            agent: "Hephaestus",
+            variant: "high",
+            finish: "stop",
+            time: {
+              created: Date.parse("2026-02-17T12:00:06Z"),
+              completed: Date.parse("2026-02-17T12:00:08Z"),
+            },
+          },
+          parts: [
+            {
+              id: "text-idle-preserved-1",
+              sessionID: "session-opencode-1",
+              messageID: "assistant-idle-preserved-1",
+              type: "text",
+              text: "All done",
+              time: { start: 1, end: 1 },
+            },
+          ],
+        },
+      } as unknown as Event,
+      {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "session-opencode-1",
+          partID: "text-idle-preserved-1",
+          messageID: "assistant-idle-preserved-1",
+          field: "text",
+          delta: " later",
+        },
+      } as unknown as Event,
+    ];
+
+    const mock = makeMockClient({ streamEvents });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const events: AgentEvent[] = [];
+    adapter.subscribeEvents("session-1", (event) => {
+      events.push(event);
+    });
+
+    await startDefaultSession(adapter, "session-1", "spec");
+    await flushAsync();
+
+    expect(events.filter((entry) => entry.type === "session_status")).toHaveLength(1);
+    expect(events.filter((entry) => entry.type === "assistant_message")).toHaveLength(1);
+    expect(events.filter((entry) => entry.type === "assistant_part")).toHaveLength(0);
+    expect(events.filter((entry) => entry.type === "assistant_delta")).toHaveLength(0);
+    expect(events.filter((entry) => entry.type === "session_idle")).toHaveLength(0);
+  });
+
   test("does not finalize previously streamed assistant text without a stop signal", async () => {
     const streamEvents: Event[] = [
       {

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1661,6 +1661,78 @@ describe("OpencodeSdkAdapter", () => {
     expect(events.filter((entry) => entry.type === "session_idle")).toHaveLength(0);
   });
 
+  test("emits the final assistant message when idle-preserved parts arrive after terminal metadata", async () => {
+    const streamEvents: Event[] = [
+      {
+        type: "session.status",
+        properties: {
+          sessionID: "session-opencode-1",
+          status: {
+            type: "idle",
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.updated",
+        properties: {
+          info: {
+            id: "assistant-idle-late-part-1",
+            role: "assistant",
+            sessionID: "session-opencode-1",
+            providerID: "openai",
+            modelID: "gpt-5",
+            agent: "Hephaestus",
+            variant: "high",
+            finish: "stop",
+            time: {
+              created: Date.parse("2026-02-17T12:00:06Z"),
+              completed: Date.parse("2026-02-17T12:00:08Z"),
+            },
+          },
+        },
+      } as unknown as Event,
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "text-idle-late-part-1",
+            sessionID: "session-opencode-1",
+            messageID: "assistant-idle-late-part-1",
+            type: "text",
+            text: "Recovered final output",
+            time: { start: 1, end: 1 },
+          },
+        },
+      } as unknown as Event,
+    ];
+
+    const mock = makeMockClient({ streamEvents });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const events: AgentEvent[] = [];
+    adapter.subscribeEvents("session-1", (event) => {
+      events.push(event);
+    });
+
+    await startDefaultSession(adapter, "session-1", "spec");
+    await flushAsync();
+
+    expect(events.filter((entry) => entry.type === "session_status")).toHaveLength(1);
+    expect(events.filter((entry) => entry.type === "assistant_part")).toHaveLength(0);
+    expect(events.filter((entry) => entry.type === "assistant_delta")).toHaveLength(0);
+
+    const assistantMessages = events.filter((entry) => entry.type === "assistant_message");
+    expect(assistantMessages).toHaveLength(1);
+    if (assistantMessages[0]?.type !== "assistant_message") {
+      throw new Error("Expected assistant_message event");
+    }
+    expect(assistantMessages[0].message).toBe("Recovered final output");
+    expect(events.filter((entry) => entry.type === "session_idle")).toHaveLength(0);
+  });
+
   test("does not finalize previously streamed assistant text without a stop signal", async () => {
     const streamEvents: Event[] = [
       {

--- a/packages/adapters-opencode-sdk/src/session-registry.ts
+++ b/packages/adapters-opencode-sdk/src/session-registry.ts
@@ -129,6 +129,7 @@ export const registerSession = (input: {
     eventTransportKey,
     hasIdleSinceActivity: false,
     activeAssistantMessageId: null,
+    completedAssistantMessageIds: new Set<string>(),
     emittedAssistantMessageIds: new Set<string>(),
     emittedUserMessageSignatures: new Map<string, string>(),
     emittedUserMessageStates: new Map(),

--- a/packages/adapters-opencode-sdk/src/types.test.ts
+++ b/packages/adapters-opencode-sdk/src/types.test.ts
@@ -46,6 +46,7 @@ describe("types", () => {
       eventTransportKey: "http://127.0.0.1:12345",
       hasIdleSinceActivity: false,
       activeAssistantMessageId: null,
+      completedAssistantMessageIds: new Set<string>(),
       emittedAssistantMessageIds: new Set<string>(),
       emittedUserMessageSignatures: new Map<string, string>(),
       emittedUserMessageStates: new Map(),

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -29,6 +29,7 @@ export type SessionRecord = {
   eventTransportKey: string;
   hasIdleSinceActivity: boolean;
   activeAssistantMessageId: string | null;
+  completedAssistantMessageIds: Set<string>;
   emittedAssistantMessageIds: Set<string>;
   emittedUserMessageSignatures: Map<string, string>;
   emittedUserMessageStates: Map<string, import("@openducktor/core").AgentUserMessageState>;

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -43,6 +43,8 @@ export type SessionRecord = {
       model?: AgentModelSelection;
       parentId?: string;
       text?: string;
+      hasStopSignal?: boolean;
+      totalTokens?: number;
     }
   >;
   pendingDeltasByPartId: Map<string, PendingPartDelta[]>;


### PR DESCRIPTION
## Summary
- track completed assistant messages in the OpenCode adapter so late assistant part updates and deltas do not reactivate a session after idle has already been established
- keep final assistant message and idle settlement behavior intact while clarifying the event-flow helpers that distinguish settled messages from stop-signaled completions
- add focused adapter and subscription regressions for idle-before-terminal ordering and post-idle assistant updates, plus test builders that make those scenarios easier to maintain

## Testing
- bun run --filter @openducktor/adapters-opencode-sdk test
- bun run --filter @openducktor/adapters-opencode-sdk typecheck
- bun run --filter @openducktor/adapters-opencode-sdk lint
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate or stale assistant streaming after a session becomes idle; ensures completed assistant messages are emitted once and late part/delta events only update cached text without re-emitting.

* **Tests**
  * Added robust test harnesses and event factory helpers; expanded coverage for idle/timing edge cases and assistant completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->