### PR TITLE
refactor(desktop): split agent studio git action hooks

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
@@ -1033,6 +1033,8 @@ describe("AgentStudioGitPanel", () => {
               remote: "origin",
               branch: "feature/task-11",
               output: "non-fast-forward",
+              repoPath: "/repo",
+              workingDir: "/tmp/worktree",
             },
             pendingPullRebase: {
               branch: "feature/task-11",

--- a/apps/desktop/src/features/agent-studio-git/contracts.ts
+++ b/apps/desktop/src/features/agent-studio-git/contracts.ts
@@ -52,6 +52,8 @@ export type AgentStudioPendingForcePush = {
   remote: string;
   branch: string;
   output: string;
+  repoPath: string;
+  workingDir: string | null;
 };
 
 export type AgentStudioPendingPullRebase = {

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-action-errors.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-action-errors.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from "react";
+
+export function useAgentStudioGitActionErrors() {
+  const [commitError, setCommitError] = useState<string | null>(null);
+  const [pushError, setPushError] = useState<string | null>(null);
+  const [rebaseError, setRebaseError] = useState<string | null>(null);
+  const [resetError, setResetError] = useState<string | null>(null);
+
+  const clearActionErrors = useCallback(() => {
+    setCommitError(null);
+    setPushError(null);
+    setRebaseError(null);
+    setResetError(null);
+  }, []);
+
+  return {
+    commitError,
+    pushError,
+    rebaseError,
+    resetError,
+    setCommitError,
+    setPushError,
+    setRebaseError,
+    setResetError,
+    clearActionErrors,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-action-utils.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-action-utils.ts
@@ -1,0 +1,44 @@
+import type { GitConflict, GitConflictOperation } from "@/features/agent-studio-git";
+import { getGitConflictCopy } from "@/features/git-conflict-resolution";
+
+export type GitActionKind = "commit" | "push" | "rebase";
+
+export type RefreshGitDiffData = () => void | Promise<void>;
+
+export const BUILDER_LOCK_REASON = "Git actions are disabled while the Builder session is working.";
+export const CONFLICT_LOCK_REASON = "Git actions are disabled while git conflicts are unresolved.";
+
+export const getGitActionsLockReason = (
+  isBuilderSessionWorking: boolean,
+  activeGitConflict: GitConflict | null,
+): string | null => {
+  if (isBuilderSessionWorking) {
+    return BUILDER_LOCK_REASON;
+  }
+
+  if (activeGitConflict) {
+    return CONFLICT_LOCK_REASON;
+  }
+
+  return null;
+};
+
+export const toErrorMessage = (error: unknown, fallback: string): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+  return fallback;
+};
+
+export const toConflictMessage = (
+  conflictedFiles: string[],
+  operation: GitConflictOperation,
+): string => {
+  const action = getGitConflictCopy(operation).title.replace(" conflict detected", "");
+  return conflictedFiles.length > 0
+    ? `${action} stopped due to conflicts in: ${conflictedFiles.join(", ")}.`
+    : `${action} stopped due to conflicts.`;
+};

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
@@ -133,6 +133,37 @@ describe("useAgentStudioGitActions", () => {
     }
   });
 
+  test("returns success when the commit completes but diff refresh fails", async () => {
+    const refreshDiffData = mock(async () => {
+      throw new Error("Refresh exploded");
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        refreshDiffData,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      let didCommit = false;
+      await harness.run(async (state) => {
+        didCommit = await state.commitAll("feat: preserve commit success");
+      });
+
+      expect(didCommit).toBe(true);
+      expect(gitCommitAllMock).toHaveBeenCalledWith(
+        "/repo",
+        "feat: preserve commit success",
+        undefined,
+      );
+      expect(refreshDiffData).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().commitError).toBe("Refresh exploded");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("tracks push action lifecycle and validates missing branch errors", async () => {
     const refreshDiffData = mock(async () => {});
     const pushDeferred = createDeferred<{ remote: string; branch: string; output: string }>();
@@ -923,6 +954,8 @@ describe("useAgentStudioGitActions", () => {
         remote: "origin",
         branch: "feature/task-10",
         output: "non-fast-forward",
+        repoPath: "/repo",
+        workingDir: "/tmp/worktree/task-10",
       });
       expect(refreshDiffData).toHaveBeenCalledTimes(0);
 
@@ -937,6 +970,58 @@ describe("useAgentStudioGitActions", () => {
       });
       expect(refreshDiffData).toHaveBeenCalledTimes(1);
       expect(harness.getLatest().pendingForcePush).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("reuses the originally rejected target when confirming force push", async () => {
+    gitPushBranchMock
+      .mockImplementationOnce(async () => ({
+        outcome: "rejected_non_fast_forward",
+        remote: "origin",
+        branch: "feature/task-10",
+        output: "non-fast-forward",
+      }))
+      .mockImplementationOnce(async () => ({
+        outcome: "pushed",
+        remote: "origin",
+        branch: "feature/task-10",
+        output: "done",
+      }));
+    const refreshDiffData = mock(async () => {});
+    const harness = createHookHarness(
+      createBaseArgs({
+        refreshDiffData,
+        workingDir: "/tmp/worktree/task-10",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run(async (state) => {
+        await state.pushBranch();
+      });
+
+      await harness.update(
+        createBaseArgs({
+          repoPath: "/repo-2",
+          branch: "feature/task-11",
+          refreshDiffData,
+          workingDir: "/tmp/worktree/task-11",
+        }),
+      );
+
+      await harness.run(async (state) => {
+        await state.confirmForcePush();
+      });
+
+      expect(gitPushBranchMock).toHaveBeenNthCalledWith(2, "/repo", "feature/task-10", {
+        setUpstream: true,
+        forceWithLease: true,
+        workingDir: "/tmp/worktree/task-10",
+      });
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.test.tsx
@@ -164,6 +164,28 @@ describe("useAgentStudioGitActions", () => {
     }
   });
 
+  test("clears commit loading state after commit write failure", async () => {
+    gitCommitAllMock.mockImplementationOnce(async () => {
+      throw new Error("Commit hook exploded");
+    });
+    const harness = createHookHarness(createBaseArgs());
+
+    try {
+      await harness.mount();
+
+      let didCommit = true;
+      await harness.run(async (state) => {
+        didCommit = await state.commitAll("feat: broken commit");
+      });
+
+      expect(didCommit).toBe(false);
+      expect(harness.getLatest().isCommitting).toBe(false);
+      expect(harness.getLatest().commitError).toBe("Commit hook exploded");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("tracks push action lifecycle and validates missing branch errors", async () => {
     const refreshDiffData = mock(async () => {});
     const pushDeferred = createDeferred<{ remote: string; branch: string; output: string }>();
@@ -355,10 +377,41 @@ describe("useAgentStudioGitActions", () => {
       );
 
       await harness.waitFor((state) => state.resetError === null);
-      expect(harness.getLatest().pendingReset).toEqual({
-        kind: "hunk",
-        filePath: "src/main.ts",
-        hunkIndex: 2,
+      expect(harness.getLatest().pendingReset).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("keeps reset successful when only the post-reset refresh fails", async () => {
+    const refreshDiffData = mock(async () => {
+      throw new Error("Refresh broke after reset");
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        refreshDiffData,
+        workingDir: "/tmp/worktree/task-10",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run((state) => {
+        state.requestFileReset("src/main.ts");
+      });
+      await harness.run(async (state) => {
+        await state.confirmReset();
+      });
+
+      expect(gitResetWorktreeSelectionMock).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().pendingReset).toBeNull();
+      expect(harness.getLatest().resetError).toBe("Refresh broke after reset");
+      expect(toastSuccessMock).toHaveBeenCalledWith("File reset", {
+        description: "src/main.ts",
+      });
+      expect(toastErrorMock).toHaveBeenCalledWith("Reset applied but refresh failed", {
+        description: "Refresh broke after reset",
       });
     } finally {
       await harness.unmount();
@@ -834,6 +887,49 @@ describe("useAgentStudioGitActions", () => {
       expect(refreshDiffData).toHaveBeenCalledTimes(2);
       expect(gitAbortConflictMock).toHaveBeenCalledWith("/repo", "rebase", "/tmp/worktree/task-10");
       expect(toastSuccessMock).toHaveBeenCalledWith("Rebase aborted");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("keeps abort successful when only the post-abort refresh fails", async () => {
+    gitRebaseBranchMock.mockImplementationOnce(async () => ({
+      outcome: "conflicts",
+      conflictedFiles: ["src/main.ts"],
+      output: "CONFLICT (content): Merge conflict in src/main.ts",
+    }));
+    const refreshDiffData = mock(async () => {});
+    let refreshCalls = 0;
+    refreshDiffData.mockImplementation(async () => {
+      refreshCalls += 1;
+      if (refreshCalls === 2) {
+        throw new Error("Refresh broke after abort");
+      }
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        refreshDiffData,
+        workingDir: "/tmp/worktree/task-10",
+      }),
+    );
+
+    try {
+      await harness.mount();
+      await harness.run(async (state) => {
+        await state.rebaseOntoTarget();
+      });
+
+      await harness.run(async (state) => {
+        await state.abortGitConflict();
+      });
+
+      expect(harness.getLatest().gitConflict).toBeNull();
+      expect(harness.getLatest().gitConflictCloseNonce).toBe(1);
+      expect(harness.getLatest().rebaseError).toBe("Refresh broke after abort");
+      expect(toastSuccessMock).toHaveBeenCalledWith("Rebase aborted");
+      expect(toastErrorMock).toHaveBeenCalledWith("Conflict aborted but refresh failed", {
+        description: "Refresh broke after abort",
+      });
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-actions.ts
@@ -1,16 +1,19 @@
-import type { CommitsAheadBehind, GitResetWorktreeSelection } from "@openducktor/contracts";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import type { CommitsAheadBehind } from "@openducktor/contracts";
+import { useCallback } from "react";
 import type {
   AgentStudioPendingForcePush,
   AgentStudioPendingPullRebase,
   AgentStudioPendingReset,
   GitConflict,
   GitConflictAction,
-  GitConflictOperation,
 } from "@/features/agent-studio-git";
-import { getGitConflictCopy } from "@/features/git-conflict-resolution";
-import { host } from "@/state/operations/shared/host";
+import { useAgentStudioGitActionErrors } from "./use-agent-studio-git-action-errors";
+import { BUILDER_LOCK_REASON, type GitActionKind } from "./use-agent-studio-git-action-utils";
+import { useAgentStudioGitCommitActions } from "./use-agent-studio-git-commit-actions";
+import { useAgentStudioGitConflictController } from "./use-agent-studio-git-conflict-controller";
+import { useAgentStudioGitPushActions } from "./use-agent-studio-git-push-actions";
+import { useAgentStudioGitRebaseActions } from "./use-agent-studio-git-rebase-actions";
+import { useAgentStudioGitResetActions } from "./use-agent-studio-git-reset-actions";
 
 type AgentStudioGitActionState = {
   isCommitting: boolean;
@@ -67,41 +70,6 @@ type UseAgentStudioGitActionsInput = {
   onResolveGitConflict?: (conflict: GitConflict) => Promise<boolean>;
 };
 
-const BUILDER_LOCK_REASON = "Git actions are disabled while the Builder session is working.";
-const CONFLICT_LOCK_REASON = "Git actions are disabled while git conflicts are unresolved.";
-
-const getGitActionsLockReason = (
-  isBuilderSessionWorking: boolean,
-  activeGitConflict: GitConflict | null,
-): string | null => {
-  if (isBuilderSessionWorking) {
-    return BUILDER_LOCK_REASON;
-  }
-
-  if (activeGitConflict) {
-    return CONFLICT_LOCK_REASON;
-  }
-
-  return null;
-};
-
-const toErrorMessage = (error: unknown, fallback: string): string => {
-  if (error instanceof Error && error.message.trim().length > 0) {
-    return error.message;
-  }
-  if (typeof error === "string" && error.trim().length > 0) {
-    return error;
-  }
-  return fallback;
-};
-
-const toConflictMessage = (conflictedFiles: string[], operation: GitConflictOperation): string => {
-  const action = getGitConflictCopy(operation).title.replace(" conflict detected", "");
-  return conflictedFiles.length > 0
-    ? `${action} stopped due to conflicts in: ${conflictedFiles.join(", ")}.`
-    : `${action} stopped due to conflicts.`;
-};
-
 export function useAgentStudioGitActions({
   repoPath,
   workingDir,
@@ -118,109 +86,45 @@ export function useAgentStudioGitActions({
   isBuilderSessionWorking = false,
   onResolveGitConflict,
 }: UseAgentStudioGitActionsInput): AgentStudioGitActionState {
-  const resolveGitConflict = onResolveGitConflict;
-  const [isCommitting, setIsCommitting] = useState(false);
-  const [isPushing, setIsPushing] = useState(false);
-  const [isRebasing, setIsRebasing] = useState(false);
-  const [isResetting, setIsResetting] = useState(false);
-  const [isHandlingGitConflict, setIsHandlingGitConflict] = useState(false);
-  const [gitConflictAction, setGitConflictAction] = useState<GitConflictAction>(null);
-  const [gitConflictAutoOpenNonce, setGitConflictAutoOpenNonce] = useState(0);
-  const [gitConflictCloseNonce, setGitConflictCloseNonce] = useState(0);
-  const [gitConflict, setGitConflict] = useState<GitConflict | null>(null);
-  const [pendingForcePush, setPendingForcePush] = useState<AgentStudioPendingForcePush | null>(
-    null,
-  );
-  const [pendingPullRebase, setPendingPullRebase] = useState<AgentStudioPendingPullRebase | null>(
-    null,
-  );
-  const [pendingReset, setPendingReset] = useState<AgentStudioPendingReset | null>(null);
-  const [commitError, setCommitError] = useState<string | null>(null);
-  const [pushError, setPushError] = useState<string | null>(null);
-  const [rebaseError, setRebaseError] = useState<string | null>(null);
-  const [resetError, setResetError] = useState<string | null>(null);
-  const gitConflictSnapshotKeyRef = useRef<string | null>(null);
-  const resetSnapshotKeyRef = useRef<string | null>(null);
+  const {
+    commitError,
+    pushError,
+    rebaseError,
+    resetError,
+    setCommitError,
+    setPushError,
+    setRebaseError,
+    setResetError,
+    clearActionErrors,
+  } = useAgentStudioGitActionErrors();
 
-  const detectedConflict = useMemo(
-    () =>
-      detectedConflictedFiles.length > 0
-        ? ({
-            operation: "rebase",
-            currentBranch: branch,
-            targetBranch: "current rebase target",
-            conflictedFiles: detectedConflictedFiles,
-            output:
-              "Git conflict is still in progress in this worktree. Previous command output is unavailable after reload.",
-            workingDir,
-          } satisfies GitConflict)
-        : null,
-    [branch, detectedConflictedFiles, workingDir],
-  );
-  const activeGitConflict = useMemo(
-    () => gitConflict ?? detectedConflict,
-    [detectedConflict, gitConflict],
-  );
-  const isGitActionsLocked = isBuilderSessionWorking || activeGitConflict != null;
-  const gitActionsLockReason = getGitActionsLockReason(isBuilderSessionWorking, activeGitConflict);
-
-  const clearActionErrors = useCallback(() => {
-    setCommitError(null);
-    setPushError(null);
-    setRebaseError(null);
-    setResetError(null);
-  }, []);
-
-  useEffect(() => {
-    if (worktreeStatusSnapshotKey == null) {
-      resetSnapshotKeyRef.current = null;
-      return;
-    }
-
-    const previousSnapshotKey = resetSnapshotKeyRef.current;
-    resetSnapshotKeyRef.current = worktreeStatusSnapshotKey;
-
-    if (previousSnapshotKey !== null && previousSnapshotKey !== worktreeStatusSnapshotKey) {
-      setResetError(null);
-    }
-  }, [worktreeStatusSnapshotKey]);
-
-  useEffect(() => {
-    if (gitConflict == null || isHandlingGitConflict || worktreeStatusSnapshotKey == null) {
-      return;
-    }
-
-    const previousSnapshotKey = gitConflictSnapshotKeyRef.current;
-    if (previousSnapshotKey !== null && previousSnapshotKey === worktreeStatusSnapshotKey) {
-      return;
-    }
-
-    if (detectedConflictedFiles.length > 0) {
-      gitConflictSnapshotKeyRef.current = worktreeStatusSnapshotKey;
-      const conflictedFilesChanged =
-        gitConflict.conflictedFiles.length !== detectedConflictedFiles.length ||
-        gitConflict.conflictedFiles.some((path, index) => path !== detectedConflictedFiles[index]);
-
-      if (conflictedFilesChanged) {
-        setGitConflict((currentConflict) =>
-          currentConflict == null
-            ? currentConflict
-            : {
-                ...currentConflict,
-                conflictedFiles: detectedConflictedFiles,
-              },
-        );
-      }
-      return;
-    }
-
-    gitConflictSnapshotKeyRef.current = null;
-    setGitConflict(null);
-    setGitConflictCloseNonce((nonce) => nonce + 1);
-  }, [detectedConflictedFiles, gitConflict, isHandlingGitConflict, worktreeStatusSnapshotKey]);
+  const {
+    activeGitConflict,
+    isHandlingGitConflict,
+    gitConflictAction,
+    gitConflictAutoOpenNonce,
+    gitConflictCloseNonce,
+    isGitActionsLocked,
+    gitActionsLockReason,
+    showLockReasonBanner,
+    captureFreshConflict,
+    abortGitConflict,
+    askBuilderToResolveGitConflict,
+  } = useAgentStudioGitConflictController({
+    repoPath,
+    workingDir,
+    branch,
+    detectedConflictedFiles,
+    worktreeStatusSnapshotKey,
+    isBuilderSessionWorking,
+    refreshDiffData,
+    clearActionErrors,
+    setRebaseError,
+    ...(onResolveGitConflict ? { onResolveGitConflict } : {}),
+  });
 
   const ensureGitActionsUnlocked = useCallback(
-    (kind: "commit" | "push" | "rebase"): boolean => {
+    (kind: GitActionKind): boolean => {
       if (!isGitActionsLocked) {
         return true;
       }
@@ -236,565 +140,73 @@ export function useAgentStudioGitActions({
       }
       return false;
     },
-    [gitActionsLockReason, isGitActionsLocked],
+    [gitActionsLockReason, isGitActionsLocked, setCommitError, setPushError, setRebaseError],
   );
 
-  const getResetBlockedReason = useCallback((): string | null => {
-    if (isBuilderSessionWorking) {
-      return BUILDER_LOCK_REASON;
-    }
-
-    if (activeGitConflict != null) {
-      return CONFLICT_LOCK_REASON;
-    }
-
-    if (isDiffDataLoading) {
-      return "Cannot reset while git diff data is loading.";
-    }
-
-    if (isResetting) {
-      return "Reset is already in progress.";
-    }
-
-    return null;
-  }, [activeGitConflict, isBuilderSessionWorking, isDiffDataLoading, isResetting]);
-
-  const resetDisabledReason = useMemo((): string | null => {
-    if (!repoPath) {
-      return "Cannot reset because no repository is selected.";
-    }
-
-    const blockedReason = getResetBlockedReason();
-    if (blockedReason) {
-      return blockedReason;
-    }
-
-    if (hashVersion == null || statusHash == null || diffHash == null) {
-      return "Displayed diff is unavailable. Refresh and try again.";
-    }
-
-    if (targetBranch.trim().length === 0) {
-      return "Cannot reset because target branch is not configured.";
-    }
-
-    return null;
-  }, [diffHash, getResetBlockedReason, hashVersion, repoPath, statusHash, targetBranch]);
-  const isResetDisabled = resetDisabledReason != null;
-
-  const buildResetRequest = useCallback(
-    (selection: GitResetWorktreeSelection) => {
-      if (resetDisabledReason != null) {
-        return {
-          error: resetDisabledReason,
-        } as const;
-      }
-
-      const resolvedRepoPath = repoPath;
-      const resolvedHashVersion = hashVersion;
-      const resolvedStatusHash = statusHash;
-      const resolvedDiffHash = diffHash;
-      if (
-        resolvedRepoPath == null ||
-        resolvedHashVersion == null ||
-        resolvedStatusHash == null ||
-        resolvedDiffHash == null
-      ) {
-        return {
-          error: "Displayed diff is unavailable. Refresh and try again.",
-        } as const;
-      }
-
-      return {
-        request: {
-          repoPath: resolvedRepoPath,
-          workingDir: workingDir ?? undefined,
-          targetBranch,
-          snapshot: {
-            hashVersion: resolvedHashVersion,
-            statusHash: resolvedStatusHash,
-            diffHash: resolvedDiffHash,
-          },
-          selection,
-        },
-      } as const;
-    },
-    [diffHash, hashVersion, repoPath, resetDisabledReason, statusHash, targetBranch, workingDir],
-  );
-
-  const requestResetSelection = useCallback(
-    (selection: GitResetWorktreeSelection): void => {
-      const built = buildResetRequest(selection);
-      if ("error" in built) {
-        setResetError(built.error);
-        return;
-      }
-
-      setResetError(null);
-      setPendingReset(selection);
-    },
-    [buildResetRequest],
-  );
-
-  const requestFileReset = useCallback(
-    (filePath: string): void => {
-      requestResetSelection({ kind: "file", filePath });
-    },
-    [requestResetSelection],
-  );
-
-  const requestHunkReset = useCallback(
-    (filePath: string, hunkIndex: number): void => {
-      requestResetSelection({ kind: "hunk", filePath, hunkIndex });
-    },
-    [requestResetSelection],
-  );
-
-  const confirmReset = useCallback(async (): Promise<void> => {
-    if (pendingReset == null) {
-      return;
-    }
-
-    const built = buildResetRequest(pendingReset);
-    if ("error" in built) {
-      setResetError(built.error);
-      toast.error("Reset failed", { description: built.error });
-      return;
-    }
-
-    setIsResetting(true);
-    setResetError(null);
-    try {
-      const result = await host.gitResetWorktreeSelection(built.request);
-      clearActionErrors();
-      setPendingReset(null);
-      await refreshDiffData();
-      const affectedCount = result.affectedPaths.length;
-      toast.success(pendingReset.kind === "file" ? "File reset" : "Hunk reset", {
-        description:
-          affectedCount === 1
-            ? result.affectedPaths[0]
-            : `${affectedCount} paths updated in the worktree.`,
-      });
-    } catch (error) {
-      const message = toErrorMessage(error, "Reset failed.");
-      setResetError(message);
-      toast.error("Reset failed", { description: message });
-    } finally {
-      setIsResetting(false);
-    }
-  }, [buildResetRequest, clearActionErrors, pendingReset, refreshDiffData]);
-
-  const cancelReset = useCallback((): void => {
-    setPendingReset(null);
-    setResetError(null);
-  }, []);
-
-  const commitAll = useCallback(
-    async (message: string): Promise<boolean> => {
-      if (isCommitting) {
-        return false;
-      }
-      if (!ensureGitActionsUnlocked("commit")) {
-        return false;
-      }
-
-      if (!repoPath) {
-        setCommitError("Cannot commit because no repository is selected.");
-        return false;
-      }
-
-      const trimmedMessage = message.trim();
-      if (trimmedMessage.length === 0) {
-        setCommitError("Commit message cannot be empty.");
-        return false;
-      }
-
-      setIsCommitting(true);
-      setCommitError(null);
-      try {
-        await host.gitCommitAll(repoPath, trimmedMessage, workingDir ?? undefined);
-        clearActionErrors();
-        await refreshDiffData();
-        return true;
-      } catch (error) {
-        setCommitError(toErrorMessage(error, "Commit failed."));
-        return false;
-      } finally {
-        setIsCommitting(false);
-      }
-    },
-    [
-      clearActionErrors,
-      ensureGitActionsUnlocked,
-      isCommitting,
-      refreshDiffData,
-      repoPath,
-      workingDir,
-    ],
-  );
-
-  const pushBranchInternal = useCallback(
-    async (options?: { forceWithLease?: boolean }): Promise<void> => {
-      if (isPushing) {
-        return;
-      }
-      if (!ensureGitActionsUnlocked("push")) {
-        return;
-      }
-
-      if (!repoPath) {
-        setPushError("Cannot push because no repository is selected.");
-        return;
-      }
-
-      if (!branch) {
-        setPushError("Cannot push because current branch is unavailable.");
-        return;
-      }
-
-      const forceWithLease = options?.forceWithLease ?? false;
-      setIsPushing(true);
-      setPushError(null);
-      try {
-        const pushResult = await host.gitPushBranch(repoPath, branch, {
-          setUpstream: true,
-          forceWithLease,
-          ...(workingDir != null ? { workingDir } : {}),
-        });
-
-        if (pushResult.outcome === "rejected_non_fast_forward") {
-          if (forceWithLease) {
-            const message = pushResult.output.trim() || "Force push was rejected.";
-            setPushError(message);
-            toast.error("Force push rejected", { description: message });
-            return;
-          }
-
-          setPendingForcePush({
-            remote: pushResult.remote,
-            branch: pushResult.branch,
-            output: pushResult.output,
-          });
-          return;
-        }
-
-        clearActionErrors();
-        setPendingForcePush(null);
-        toast.success(`Pushed ${pushResult.branch}`, {
-          description: `Remote: ${pushResult.remote}`,
-        });
-        await refreshDiffData();
-      } catch (error) {
-        const message = toErrorMessage(
-          error,
-          forceWithLease ? "Force push failed." : "Push failed.",
-        );
-        setPushError(message);
-        toast.error(forceWithLease ? "Force push failed" : "Push failed", {
-          description: message,
-        });
-      } finally {
-        setIsPushing(false);
-      }
-    },
-    [
-      branch,
-      clearActionErrors,
-      ensureGitActionsUnlocked,
-      isPushing,
-      refreshDiffData,
-      repoPath,
-      workingDir,
-    ],
-  );
-
-  const pushBranch = useCallback(async (): Promise<void> => {
-    await pushBranchInternal();
-  }, [pushBranchInternal]);
-
-  const confirmForcePush = useCallback(async (): Promise<void> => {
-    if (!pendingForcePush) {
-      return;
-    }
-
-    setPendingForcePush(null);
-    await pushBranchInternal({ forceWithLease: true });
-  }, [pendingForcePush, pushBranchInternal]);
-
-  const cancelForcePush = useCallback((): void => {
-    setPendingForcePush(null);
-    setPushError(null);
-  }, []);
-
-  const pullFromUpstreamInternal = useCallback(
-    async (options?: {
-      skipRebaseConfirmation?: boolean;
-      localAhead?: number;
-      upstreamBehind?: number;
-    }): Promise<void> => {
-      if (isRebasing) {
-        return;
-      }
-      if (!ensureGitActionsUnlocked("rebase")) {
-        return;
-      }
-
-      if (!repoPath) {
-        setRebaseError("Cannot pull because no repository is selected.");
-        return;
-      }
-
-      if (!branch || branch.trim().length === 0) {
-        setRebaseError("Cannot pull because current branch is unavailable.");
-        return;
-      }
-
-      const localAhead = options?.localAhead ?? upstreamAheadBehind?.ahead ?? 0;
-      const upstreamBehindCount = options?.upstreamBehind ?? upstreamAheadBehind?.behind ?? 0;
-      const willRebaseLocalCommits = localAhead > 0 && upstreamBehindCount > 0;
-      const isConfirmedPullRebase =
-        options?.skipRebaseConfirmation === true && willRebaseLocalCommits;
-
-      if (willRebaseLocalCommits && !options?.skipRebaseConfirmation) {
-        setPendingPullRebase({
-          branch,
-          localAhead,
-          upstreamBehind: upstreamBehindCount,
-        });
-        return;
-      }
-
-      setIsRebasing(true);
-      setRebaseError(null);
-      try {
-        const result = await host.gitPullBranch(repoPath, workingDir ?? undefined);
-
-        if (result.outcome === "conflicts") {
-          if (isConfirmedPullRebase) {
-            setPendingPullRebase(null);
-          }
-          const conflict: GitConflict = {
-            operation: "pull_rebase",
-            currentBranch: branch,
-            targetBranch: "tracked upstream branch",
-            conflictedFiles: result.conflictedFiles,
-            output: result.output,
-            workingDir,
-          };
-          const message = toConflictMessage(result.conflictedFiles, "pull_rebase");
-          gitConflictSnapshotKeyRef.current = worktreeStatusSnapshotKey;
-          setGitConflict(conflict);
-          setGitConflictAutoOpenNonce((nonce) => nonce + 1);
-          toast.error("Pull requires conflict resolution", { description: message });
-          await refreshDiffData();
-          return;
-        }
-
-        clearActionErrors();
-        if (isConfirmedPullRebase) {
-          setPendingPullRebase(null);
-        }
-        if (result.outcome === "up_to_date") {
-          toast.success("Already up to date");
-        } else if (willRebaseLocalCommits) {
-          toast.success("Rebased local commits onto upstream", {
-            description: `Reapplied ${localAhead} local commit${localAhead === 1 ? "" : "s"}.`,
-          });
-        } else {
-          toast.success("Pulled from upstream");
-        }
-        await refreshDiffData();
-      } catch (error) {
-        const message = toErrorMessage(error, "Pull failed.");
-        setRebaseError(message);
-        setPendingPullRebase(null);
-        toast.error("Pull failed", { description: message });
-      } finally {
-        setIsRebasing(false);
-      }
-    },
-    [
-      branch,
-      clearActionErrors,
-      ensureGitActionsUnlocked,
-      isRebasing,
-      refreshDiffData,
-      repoPath,
-      upstreamAheadBehind?.ahead,
-      upstreamAheadBehind?.behind,
-      workingDir,
-      worktreeStatusSnapshotKey,
-    ],
-  );
-
-  const runRebase = useCallback(
-    async (target: string, missingTargetError: string, fallbackError: string): Promise<void> => {
-      if (isRebasing) {
-        return;
-      }
-      if (!ensureGitActionsUnlocked("rebase")) {
-        return;
-      }
-
-      if (!repoPath) {
-        setRebaseError("Cannot rebase because no repository is selected.");
-        return;
-      }
-
-      const trimmedTarget = target.trim();
-      if (trimmedTarget.length === 0) {
-        setRebaseError(missingTargetError);
-        return;
-      }
-
-      setIsRebasing(true);
-      setRebaseError(null);
-      try {
-        const result = await host.gitRebaseBranch(repoPath, trimmedTarget, workingDir ?? undefined);
-        if (result.outcome === "conflicts") {
-          const conflict: GitConflict = {
-            operation: "rebase",
-            currentBranch: branch,
-            targetBranch: trimmedTarget,
-            conflictedFiles: result.conflictedFiles,
-            output: result.output,
-            workingDir,
-          };
-          const message = toConflictMessage(result.conflictedFiles, "rebase");
-          gitConflictSnapshotKeyRef.current = worktreeStatusSnapshotKey;
-          setGitConflict(conflict);
-          setGitConflictAutoOpenNonce((nonce) => nonce + 1);
-          toast.error("Rebase requires conflict resolution", { description: message });
-          await refreshDiffData();
-          return;
-        }
-
-        clearActionErrors();
-        gitConflictSnapshotKeyRef.current = null;
-        setGitConflict(null);
-        await refreshDiffData();
-      } catch (error) {
-        setRebaseError(toErrorMessage(error, fallbackError));
-      } finally {
-        setIsRebasing(false);
-      }
-    },
-    [
-      branch,
-      clearActionErrors,
-      ensureGitActionsUnlocked,
-      isRebasing,
-      refreshDiffData,
-      repoPath,
-      workingDir,
-      worktreeStatusSnapshotKey,
-    ],
-  );
-
-  const rebaseOntoTarget = useCallback(async (): Promise<void> => {
-    await runRebase(
-      targetBranch,
-      "Cannot rebase because target branch is not configured.",
-      "Rebase failed.",
-    );
-  }, [runRebase, targetBranch]);
-
-  const abortGitConflict = useCallback(async (): Promise<void> => {
-    if (!activeGitConflict || isHandlingGitConflict) {
-      return;
-    }
-
-    if (!repoPath) {
-      setRebaseError("Cannot abort the git conflict because no repository is selected.");
-      return;
-    }
-
-    setIsHandlingGitConflict(true);
-    setGitConflictAction("abort");
-    try {
-      await host.gitAbortConflict(
-        repoPath,
-        activeGitConflict.operation,
-        activeGitConflict.workingDir ?? workingDir ?? undefined,
-      );
-      clearActionErrors();
-      await refreshDiffData();
-      gitConflictSnapshotKeyRef.current = null;
-      setGitConflict(null);
-      setGitConflictCloseNonce((nonce) => nonce + 1);
-      toast.success(getGitConflictCopy(activeGitConflict.operation).abortedToastTitle);
-    } catch (error) {
-      const message = toErrorMessage(error, "Failed to abort the git conflict.");
-      setRebaseError(message);
-      toast.error(getGitConflictCopy(activeGitConflict.operation).abortFailureTitle, {
-        description: message,
-      });
-    } finally {
-      setIsHandlingGitConflict(false);
-      setGitConflictAction(null);
-    }
-  }, [
-    activeGitConflict,
-    clearActionErrors,
-    isHandlingGitConflict,
-    refreshDiffData,
+  const {
+    isResetting,
+    isResetDisabled,
+    resetDisabledReason,
+    pendingReset,
+    requestFileReset,
+    requestHunkReset,
+    confirmReset,
+    cancelReset,
+  } = useAgentStudioGitResetActions({
     repoPath,
     workingDir,
-  ]);
+    targetBranch,
+    hashVersion,
+    statusHash,
+    diffHash,
+    worktreeStatusSnapshotKey,
+    isDiffDataLoading,
+    isBuilderSessionWorking,
+    activeGitConflict,
+    refreshDiffData,
+    clearActionErrors,
+    setResetError,
+  });
 
-  const askBuilderToResolveGitConflict = useCallback(async (): Promise<void> => {
-    if (!activeGitConflict || isHandlingGitConflict) {
-      return;
-    }
+  const { isCommitting, commitAll } = useAgentStudioGitCommitActions({
+    repoPath,
+    workingDir,
+    refreshDiffData,
+    clearActionErrors,
+    ensureGitActionsUnlocked,
+    setCommitError,
+  });
 
-    if (!resolveGitConflict) {
-      setRebaseError("Cannot send conflict resolution request to Builder.");
-      return;
-    }
-
-    setIsHandlingGitConflict(true);
-    setGitConflictAction("ask_builder");
-    try {
-      const wasHandled = await resolveGitConflict(activeGitConflict);
-      if (!wasHandled) {
-        return;
-      }
-      clearActionErrors();
-      toast.success(getGitConflictCopy(activeGitConflict.operation).builderSuccessTitle);
-    } catch (error) {
-      const message = toErrorMessage(
-        error,
-        getGitConflictCopy(activeGitConflict.operation).builderFailureMessage,
-      );
-      setRebaseError(message);
-      toast.error("Failed to contact Builder", { description: message });
-    } finally {
-      setIsHandlingGitConflict(false);
-      setGitConflictAction(null);
-    }
-  }, [activeGitConflict, clearActionErrors, isHandlingGitConflict, resolveGitConflict]);
-
-  const pullFromUpstream = useCallback(async (): Promise<void> => {
-    await pullFromUpstreamInternal();
-  }, [pullFromUpstreamInternal]);
-
-  const confirmPullRebase = useCallback(async (): Promise<void> => {
-    if (!pendingPullRebase) {
-      return;
-    }
-
-    const pending = pendingPullRebase;
-    await pullFromUpstreamInternal({
-      skipRebaseConfirmation: true,
-      localAhead: pending.localAhead,
-      upstreamBehind: pending.upstreamBehind,
+  const { isPushing, pendingForcePush, pushBranch, confirmForcePush, cancelForcePush } =
+    useAgentStudioGitPushActions({
+      repoPath,
+      workingDir,
+      branch,
+      refreshDiffData,
+      clearActionErrors,
+      ensureGitActionsUnlocked,
+      setPushError,
     });
-  }, [pendingPullRebase, pullFromUpstreamInternal]);
 
-  const cancelPullRebase = useCallback((): void => {
-    setPendingPullRebase(null);
-    setRebaseError(null);
-  }, []);
+  const {
+    isRebasing,
+    pendingPullRebase,
+    pullFromUpstream,
+    confirmPullRebase,
+    cancelPullRebase,
+    rebaseOntoTarget,
+  } = useAgentStudioGitRebaseActions({
+    repoPath,
+    workingDir,
+    branch,
+    targetBranch,
+    upstreamAheadBehind,
+    refreshDiffData,
+    clearActionErrors,
+    ensureGitActionsUnlocked,
+    setRebaseError,
+    captureFreshConflict,
+  });
 
   return {
     isCommitting,
@@ -807,7 +219,7 @@ export function useAgentStudioGitActions({
     gitConflictAction,
     gitConflictAutoOpenNonce,
     gitConflictCloseNonce,
-    showLockReasonBanner: isGitActionsLocked && !isBuilderSessionWorking,
+    showLockReasonBanner,
     isGitActionsLocked,
     gitActionsLockReason,
     gitConflict: activeGitConflict,

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-commit-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-commit-actions.ts
@@ -48,22 +48,24 @@ export function useAgentStudioGitCommitActions({
       setIsCommitting(true);
       setCommitError(null);
       try {
-        await host.gitCommitAll(repoPath, trimmedMessage, workingDir ?? undefined);
-        clearActionErrors();
-      } catch (error) {
-        setCommitError(toErrorMessage(error, "Commit failed."));
-        return false;
-      }
+        try {
+          await host.gitCommitAll(repoPath, trimmedMessage, workingDir ?? undefined);
+          clearActionErrors();
+        } catch (error) {
+          setCommitError(toErrorMessage(error, "Commit failed."));
+          return false;
+        }
 
-      try {
-        await refreshDiffData();
-      } catch (error) {
-        setCommitError(toErrorMessage(error, "Diff refresh failed."));
+        try {
+          await refreshDiffData();
+        } catch (error) {
+          setCommitError(toErrorMessage(error, "Diff refresh failed."));
+        }
+
+        return true;
       } finally {
         setIsCommitting(false);
       }
-
-      return true;
     },
     [
       clearActionErrors,

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-commit-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-commit-actions.ts
@@ -1,0 +1,77 @@
+import { useCallback, useState } from "react";
+import { host } from "@/state/operations/shared/host";
+import {
+  type GitActionKind,
+  type RefreshGitDiffData,
+  toErrorMessage,
+} from "./use-agent-studio-git-action-utils";
+
+type UseAgentStudioGitCommitActionsArgs = {
+  repoPath: string | null;
+  workingDir: string | null;
+  refreshDiffData: RefreshGitDiffData;
+  clearActionErrors: () => void;
+  ensureGitActionsUnlocked: (kind: GitActionKind) => boolean;
+  setCommitError: (message: string | null) => void;
+};
+
+export function useAgentStudioGitCommitActions({
+  repoPath,
+  workingDir,
+  refreshDiffData,
+  clearActionErrors,
+  ensureGitActionsUnlocked,
+  setCommitError,
+}: UseAgentStudioGitCommitActionsArgs) {
+  const [isCommitting, setIsCommitting] = useState(false);
+
+  const commitAll = useCallback(
+    async (message: string): Promise<boolean> => {
+      if (isCommitting) {
+        return false;
+      }
+      if (!ensureGitActionsUnlocked("commit")) {
+        return false;
+      }
+
+      if (!repoPath) {
+        setCommitError("Cannot commit because no repository is selected.");
+        return false;
+      }
+
+      const trimmedMessage = message.trim();
+      if (trimmedMessage.length === 0) {
+        setCommitError("Commit message cannot be empty.");
+        return false;
+      }
+
+      setIsCommitting(true);
+      setCommitError(null);
+      try {
+        await host.gitCommitAll(repoPath, trimmedMessage, workingDir ?? undefined);
+        clearActionErrors();
+        await refreshDiffData();
+        return true;
+      } catch (error) {
+        setCommitError(toErrorMessage(error, "Commit failed."));
+        return false;
+      } finally {
+        setIsCommitting(false);
+      }
+    },
+    [
+      clearActionErrors,
+      ensureGitActionsUnlocked,
+      isCommitting,
+      refreshDiffData,
+      repoPath,
+      setCommitError,
+      workingDir,
+    ],
+  );
+
+  return {
+    isCommitting,
+    commitAll,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-commit-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-commit-actions.ts
@@ -50,14 +50,20 @@ export function useAgentStudioGitCommitActions({
       try {
         await host.gitCommitAll(repoPath, trimmedMessage, workingDir ?? undefined);
         clearActionErrors();
-        await refreshDiffData();
-        return true;
       } catch (error) {
         setCommitError(toErrorMessage(error, "Commit failed."));
         return false;
+      }
+
+      try {
+        await refreshDiffData();
+      } catch (error) {
+        setCommitError(toErrorMessage(error, "Diff refresh failed."));
       } finally {
         setIsCommitting(false);
       }
+
+      return true;
     },
     [
       clearActionErrors,

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.test.tsx
@@ -156,6 +156,38 @@ describe("useAgentStudioGitConflictController", () => {
     }
   });
 
+  test("keeps local conflicted file ordering when a newer snapshot reports the same files", async () => {
+    const harness = createHookHarness(
+      useAgentStudioGitConflictController,
+      createBaseArgs({
+        worktreeStatusSnapshotKey: "1:aaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbb",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run((state) => {
+        state.captureFreshConflict(createConflict({ conflictedFiles: ["src/a.ts", "src/b.ts"] }));
+      });
+
+      await harness.update(
+        createBaseArgs({
+          detectedConflictedFiles: ["src/b.ts", "src/a.ts"],
+          worktreeStatusSnapshotKey: "1:cccccccccccccccc:dddddddddddddddd",
+        }),
+      );
+
+      expect(harness.getLatest().activeGitConflict?.conflictedFiles).toEqual([
+        "src/a.ts",
+        "src/b.ts",
+      ]);
+      expect(harness.getLatest().gitConflictCloseNonce).toBe(0);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("aborts conflicts using the captured working directory", async () => {
     const refreshDiffData = mock(async () => {});
     const abortDeferred = createDeferred<{ output: string }>();
@@ -199,6 +231,110 @@ describe("useAgentStudioGitConflictController", () => {
       expect(toastSuccessMock).toHaveBeenCalledWith("Rebase aborted");
     } finally {
       abortDeferred.resolve({ output: "aborted" });
+      await harness.unmount();
+    }
+  });
+
+  test("clears errors and keeps the conflict open when Builder accepts the handoff", async () => {
+    const clearActionErrors = mock(() => {});
+    const onResolveGitConflict = mock(async () => true);
+    const harness = createHookHarness(
+      useAgentStudioGitConflictController,
+      createBaseArgs({
+        clearActionErrors,
+        detectedConflictedFiles: ["AGENTS.md"],
+        onResolveGitConflict,
+        workingDir: "/tmp/worktree/task-10",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run(async (state) => {
+        await state.askBuilderToResolveGitConflict();
+      });
+
+      expect(onResolveGitConflict).toHaveBeenCalledWith({
+        operation: "rebase",
+        currentBranch: "feature/task-10",
+        targetBranch: "current rebase target",
+        conflictedFiles: ["AGENTS.md"],
+        output:
+          "Git conflict is still in progress in this worktree. Previous command output is unavailable after reload.",
+        workingDir: "/tmp/worktree/task-10",
+      });
+      expect(clearActionErrors).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().gitConflictAction).toBeNull();
+      expect(harness.getLatest().isHandlingGitConflict).toBe(false);
+      expect(harness.getLatest().activeGitConflict).not.toBeNull();
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        "Sent git conflict resolution request to Builder",
+      );
+      expect(toastErrorMock).toHaveBeenCalledTimes(0);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("silently resets ask-builder state when Builder declines the handoff", async () => {
+    const clearActionErrors = mock(() => {});
+    const onResolveGitConflict = mock(async () => false);
+    const harness = createHookHarness(
+      useAgentStudioGitConflictController,
+      createBaseArgs({
+        clearActionErrors,
+        detectedConflictedFiles: ["AGENTS.md"],
+        onResolveGitConflict,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run(async (state) => {
+        await state.askBuilderToResolveGitConflict();
+      });
+
+      expect(clearActionErrors).toHaveBeenCalledTimes(0);
+      expect(harness.getLatest().gitConflictAction).toBeNull();
+      expect(harness.getLatest().isHandlingGitConflict).toBe(false);
+      expect(harness.getLatest().activeGitConflict).not.toBeNull();
+      expect(toastSuccessMock).toHaveBeenCalledTimes(0);
+      expect(toastErrorMock).toHaveBeenCalledTimes(0);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("reports ask-builder failures and resets the transient action state", async () => {
+    const setRebaseError = mock((_message: string | null) => {});
+    const onResolveGitConflict = mock(async () => {
+      throw new Error("Builder is offline");
+    });
+    const harness = createHookHarness(
+      useAgentStudioGitConflictController,
+      createBaseArgs({
+        detectedConflictedFiles: ["AGENTS.md"],
+        onResolveGitConflict,
+        setRebaseError,
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run(async (state) => {
+        await state.askBuilderToResolveGitConflict();
+      });
+
+      expect(setRebaseError).toHaveBeenCalledWith("Builder is offline");
+      expect(harness.getLatest().gitConflictAction).toBeNull();
+      expect(harness.getLatest().isHandlingGitConflict).toBe(false);
+      expect(toastErrorMock).toHaveBeenCalledWith("Failed to contact Builder", {
+        description: "Builder is offline",
+      });
+    } finally {
       await harness.unmount();
     }
   });

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.test.tsx
@@ -1,0 +1,205 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { GitConflict } from "@/features/agent-studio-git";
+import {
+  createDeferred,
+  createHookHarness,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+
+enableReactActEnvironment();
+
+const gitAbortConflictMock = mock(async () => ({ output: "aborted" }));
+const toastSuccessMock = mock(() => {});
+const toastErrorMock = mock(() => {});
+
+type UseAgentStudioGitConflictControllerHook =
+  typeof import("./use-agent-studio-git-conflict-controller")["useAgentStudioGitConflictController"];
+
+let useAgentStudioGitConflictController: UseAgentStudioGitConflictControllerHook;
+
+type HookArgs = Parameters<UseAgentStudioGitConflictControllerHook>[0];
+
+const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
+  repoPath: "/repo",
+  workingDir: null,
+  branch: "feature/task-10",
+  detectedConflictedFiles: [],
+  worktreeStatusSnapshotKey: null,
+  isBuilderSessionWorking: false,
+  refreshDiffData: async () => {},
+  clearActionErrors: () => {},
+  setRebaseError: () => {},
+  ...overrides,
+});
+
+const createConflict = (overrides: Partial<GitConflict> = {}): GitConflict => ({
+  operation: "rebase" as const,
+  currentBranch: "feature/task-10",
+  targetBranch: "origin/main",
+  conflictedFiles: ["src/main.ts"],
+  output: "CONFLICT (content): Merge conflict in src/main.ts",
+  workingDir: "/tmp/worktree/task-10",
+  ...overrides,
+});
+
+beforeAll(async () => {
+  mock.module("@/state/operations/shared/host", () => ({
+    host: {
+      gitAbortConflict: gitAbortConflictMock,
+    },
+  }));
+  mock.module("sonner", () => ({
+    toast: {
+      success: toastSuccessMock,
+      error: toastErrorMock,
+    },
+  }));
+  ({ useAgentStudioGitConflictController } = await import(
+    "./use-agent-studio-git-conflict-controller"
+  ));
+});
+
+afterAll(() => {
+  mock.restore();
+});
+
+beforeEach(() => {
+  gitAbortConflictMock.mockClear();
+  toastSuccessMock.mockClear();
+  toastErrorMock.mockClear();
+  gitAbortConflictMock.mockImplementation(async () => ({ output: "aborted" }));
+});
+
+describe("useAgentStudioGitConflictController", () => {
+  test("hydrates persisted conflicts without auto-opening the modal", async () => {
+    const harness = createHookHarness(
+      useAgentStudioGitConflictController,
+      createBaseArgs({
+        detectedConflictedFiles: ["AGENTS.md"],
+        workingDir: "/tmp/worktree/task-10",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      expect(harness.getLatest().activeGitConflict).toEqual({
+        operation: "rebase",
+        currentBranch: "feature/task-10",
+        targetBranch: "current rebase target",
+        conflictedFiles: ["AGENTS.md"],
+        output:
+          "Git conflict is still in progress in this worktree. Previous command output is unavailable after reload.",
+        workingDir: "/tmp/worktree/task-10",
+      });
+      expect(harness.getLatest().gitConflictAutoOpenNonce).toBe(0);
+      expect(harness.getLatest().gitConflictCloseNonce).toBe(0);
+      expect(harness.getLatest().isGitActionsLocked).toBe(true);
+      expect(harness.getLatest().showLockReasonBanner).toBe(true);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("captures fresh conflicts and emits an auto-open nonce", async () => {
+    const harness = createHookHarness(
+      useAgentStudioGitConflictController,
+      createBaseArgs({
+        worktreeStatusSnapshotKey: "1:aaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbb",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run((state) => {
+        state.captureFreshConflict(createConflict());
+      });
+
+      expect(harness.getLatest().activeGitConflict).toEqual(createConflict());
+      expect(harness.getLatest().gitConflictAutoOpenNonce).toBe(1);
+      expect(harness.getLatest().gitConflictCloseNonce).toBe(0);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("closes a local conflict after a newer clean snapshot arrives", async () => {
+    const harness = createHookHarness(
+      useAgentStudioGitConflictController,
+      createBaseArgs({
+        workingDir: "/tmp/worktree/task-10",
+        worktreeStatusSnapshotKey: "1:aaaaaaaaaaaaaaaa:bbbbbbbbbbbbbbbb",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run((state) => {
+        state.captureFreshConflict(createConflict({ conflictedFiles: ["AGENTS.md"] }));
+      });
+
+      await harness.update(
+        createBaseArgs({
+          workingDir: "/tmp/worktree/task-10",
+          detectedConflictedFiles: [],
+          worktreeStatusSnapshotKey: "1:cccccccccccccccc:dddddddddddddddd",
+        }),
+      );
+
+      await harness.waitFor((state) => state.activeGitConflict === null);
+      expect(harness.getLatest().gitConflictCloseNonce).toBe(1);
+      expect(harness.getLatest().isGitActionsLocked).toBe(false);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("aborts conflicts using the captured working directory", async () => {
+    const refreshDiffData = mock(async () => {});
+    const abortDeferred = createDeferred<{ output: string }>();
+    gitAbortConflictMock.mockImplementationOnce(async () => abortDeferred.promise);
+    const harness = createHookHarness(
+      useAgentStudioGitConflictController,
+      createBaseArgs({
+        refreshDiffData,
+        workingDir: "/tmp/worktree/task-10",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      await harness.run((state) => {
+        state.captureFreshConflict(createConflict());
+      });
+
+      await harness.update(
+        createBaseArgs({
+          refreshDiffData,
+          workingDir: "/tmp/worktree/other",
+        }),
+      );
+
+      await harness.run((state) => {
+        void state.abortGitConflict();
+      });
+
+      await harness.waitFor(
+        (state) => state.isHandlingGitConflict && state.gitConflictAction === "abort",
+      );
+
+      abortDeferred.resolve({ output: "aborted" });
+
+      await harness.waitFor((state) => !state.isHandlingGitConflict);
+      expect(gitAbortConflictMock).toHaveBeenCalledWith("/repo", "rebase", "/tmp/worktree/task-10");
+      expect(refreshDiffData).toHaveBeenCalledTimes(1);
+      expect(harness.getLatest().gitConflictCloseNonce).toBe(1);
+      expect(toastSuccessMock).toHaveBeenCalledWith("Rebase aborted");
+    } finally {
+      abortDeferred.resolve({ output: "aborted" });
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.ts
@@ -67,6 +67,17 @@ const initialState: GitConflictControllerState = {
   gitConflictCloseNonce: 0,
 };
 
+const haveSameConflictedFiles = (left: string[], right: string[]): boolean => {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+
+  return sortedLeft.every((filePath, index) => filePath === sortedRight[index]);
+};
+
 function gitConflictControllerReducer(
   state: GitConflictControllerState,
   action: GitConflictControllerAction,
@@ -171,11 +182,10 @@ export function useAgentStudioGitConflictController({
     }
 
     if (detectedConflictedFiles.length > 0) {
-      const conflictedFilesChanged =
-        state.localConflict.conflictedFiles.length !== detectedConflictedFiles.length ||
-        state.localConflict.conflictedFiles.some(
-          (filePath, index) => filePath !== detectedConflictedFiles[index],
-        );
+      const conflictedFilesChanged = !haveSameConflictedFiles(
+        state.localConflict.conflictedFiles,
+        detectedConflictedFiles,
+      );
 
       if (conflictedFilesChanged) {
         dispatch({

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.ts
@@ -241,9 +241,18 @@ export function useAgentStudioGitConflictController({
         activeGitConflict.workingDir ?? workingDir ?? undefined,
       );
       clearActionErrors();
-      await refreshDiffData();
       dispatch({ type: "clear_local_conflict", closeModal: true });
       toast.success(getGitConflictCopy(activeGitConflict.operation).abortedToastTitle);
+
+      try {
+        await refreshDiffData();
+      } catch (error) {
+        const message = toErrorMessage(error, "Git conflict was aborted, but diff refresh failed.");
+        setRebaseError(message);
+        toast.error("Conflict aborted but refresh failed", {
+          description: message,
+        });
+      }
     } catch (error) {
       const message = toErrorMessage(error, "Failed to abort the git conflict.");
       setRebaseError(message);

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-conflict-controller.ts
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useMemo, useReducer } from "react";
+import { toast } from "sonner";
+import type { GitConflict, GitConflictAction } from "@/features/agent-studio-git";
+import { getGitConflictCopy } from "@/features/git-conflict-resolution";
+import { host } from "@/state/operations/shared/host";
+import {
+  getGitActionsLockReason,
+  type RefreshGitDiffData,
+  toErrorMessage,
+} from "./use-agent-studio-git-action-utils";
+
+type GitConflictControllerState = {
+  localConflict: GitConflict | null;
+  gitConflictSnapshotKey: string | null;
+  isHandlingGitConflict: boolean;
+  gitConflictAction: GitConflictAction;
+  gitConflictAutoOpenNonce: number;
+  gitConflictCloseNonce: number;
+};
+
+type GitConflictControllerAction =
+  | {
+      type: "capture_conflict";
+      conflict: GitConflict;
+      snapshotKey: string | null;
+    }
+  | {
+      type: "replace_conflicted_files";
+      conflictedFiles: string[];
+      snapshotKey: string | null;
+    }
+  | {
+      type: "mark_snapshot_seen";
+      snapshotKey: string | null;
+    }
+  | {
+      type: "clear_local_conflict";
+      closeModal: boolean;
+    }
+  | {
+      type: "start_action";
+      action: Exclude<GitConflictAction, null>;
+    }
+  | {
+      type: "finish_action";
+    };
+
+type UseAgentStudioGitConflictControllerArgs = {
+  repoPath: string | null;
+  workingDir: string | null;
+  branch: string | null;
+  detectedConflictedFiles: string[];
+  worktreeStatusSnapshotKey: string | null;
+  isBuilderSessionWorking: boolean;
+  refreshDiffData: RefreshGitDiffData;
+  clearActionErrors: () => void;
+  setRebaseError: (message: string | null) => void;
+  onResolveGitConflict?: (conflict: GitConflict) => Promise<boolean>;
+};
+
+const initialState: GitConflictControllerState = {
+  localConflict: null,
+  gitConflictSnapshotKey: null,
+  isHandlingGitConflict: false,
+  gitConflictAction: null,
+  gitConflictAutoOpenNonce: 0,
+  gitConflictCloseNonce: 0,
+};
+
+function gitConflictControllerReducer(
+  state: GitConflictControllerState,
+  action: GitConflictControllerAction,
+): GitConflictControllerState {
+  switch (action.type) {
+    case "capture_conflict":
+      return {
+        ...state,
+        localConflict: action.conflict,
+        gitConflictSnapshotKey: action.snapshotKey,
+        gitConflictAutoOpenNonce: state.gitConflictAutoOpenNonce + 1,
+      };
+    case "replace_conflicted_files":
+      if (state.localConflict == null) {
+        return state;
+      }
+      return {
+        ...state,
+        localConflict: {
+          ...state.localConflict,
+          conflictedFiles: action.conflictedFiles,
+        },
+        gitConflictSnapshotKey: action.snapshotKey,
+      };
+    case "mark_snapshot_seen":
+      return {
+        ...state,
+        gitConflictSnapshotKey: action.snapshotKey,
+      };
+    case "clear_local_conflict":
+      return {
+        ...state,
+        localConflict: null,
+        gitConflictSnapshotKey: null,
+        gitConflictCloseNonce: action.closeModal
+          ? state.gitConflictCloseNonce + 1
+          : state.gitConflictCloseNonce,
+      };
+    case "start_action":
+      return {
+        ...state,
+        isHandlingGitConflict: true,
+        gitConflictAction: action.action,
+      };
+    case "finish_action":
+      return {
+        ...state,
+        isHandlingGitConflict: false,
+        gitConflictAction: null,
+      };
+    default:
+      return state;
+  }
+}
+
+export function useAgentStudioGitConflictController({
+  repoPath,
+  workingDir,
+  branch,
+  detectedConflictedFiles,
+  worktreeStatusSnapshotKey,
+  isBuilderSessionWorking,
+  refreshDiffData,
+  clearActionErrors,
+  setRebaseError,
+  onResolveGitConflict,
+}: UseAgentStudioGitConflictControllerArgs) {
+  const [state, dispatch] = useReducer(gitConflictControllerReducer, initialState);
+
+  const detectedConflict = useMemo(
+    () =>
+      detectedConflictedFiles.length > 0
+        ? ({
+            operation: "rebase",
+            currentBranch: branch,
+            targetBranch: "current rebase target",
+            conflictedFiles: detectedConflictedFiles,
+            output:
+              "Git conflict is still in progress in this worktree. Previous command output is unavailable after reload.",
+            workingDir,
+          } satisfies GitConflict)
+        : null,
+    [branch, detectedConflictedFiles, workingDir],
+  );
+
+  const activeGitConflict = state.localConflict ?? detectedConflict;
+  const isGitActionsLocked = isBuilderSessionWorking || activeGitConflict != null;
+  const gitActionsLockReason = getGitActionsLockReason(isBuilderSessionWorking, activeGitConflict);
+  const showLockReasonBanner = isGitActionsLocked && !isBuilderSessionWorking;
+
+  useEffect(() => {
+    if (
+      state.localConflict == null ||
+      state.isHandlingGitConflict ||
+      worktreeStatusSnapshotKey == null
+    ) {
+      return;
+    }
+
+    if (state.gitConflictSnapshotKey === worktreeStatusSnapshotKey) {
+      return;
+    }
+
+    if (detectedConflictedFiles.length > 0) {
+      const conflictedFilesChanged =
+        state.localConflict.conflictedFiles.length !== detectedConflictedFiles.length ||
+        state.localConflict.conflictedFiles.some(
+          (filePath, index) => filePath !== detectedConflictedFiles[index],
+        );
+
+      if (conflictedFilesChanged) {
+        dispatch({
+          type: "replace_conflicted_files",
+          conflictedFiles: detectedConflictedFiles,
+          snapshotKey: worktreeStatusSnapshotKey,
+        });
+        return;
+      }
+
+      dispatch({
+        type: "mark_snapshot_seen",
+        snapshotKey: worktreeStatusSnapshotKey,
+      });
+      return;
+    }
+
+    dispatch({ type: "clear_local_conflict", closeModal: true });
+  }, [
+    detectedConflictedFiles,
+    state.gitConflictSnapshotKey,
+    state.isHandlingGitConflict,
+    state.localConflict,
+    worktreeStatusSnapshotKey,
+  ]);
+
+  const captureFreshConflict = useCallback(
+    (conflict: GitConflict) => {
+      dispatch({
+        type: "capture_conflict",
+        conflict,
+        snapshotKey: worktreeStatusSnapshotKey,
+      });
+    },
+    [worktreeStatusSnapshotKey],
+  );
+
+  const abortGitConflict = useCallback(async (): Promise<void> => {
+    if (!activeGitConflict || state.isHandlingGitConflict) {
+      return;
+    }
+
+    if (!repoPath) {
+      setRebaseError("Cannot abort the git conflict because no repository is selected.");
+      return;
+    }
+
+    dispatch({ type: "start_action", action: "abort" });
+    try {
+      await host.gitAbortConflict(
+        repoPath,
+        activeGitConflict.operation,
+        activeGitConflict.workingDir ?? workingDir ?? undefined,
+      );
+      clearActionErrors();
+      await refreshDiffData();
+      dispatch({ type: "clear_local_conflict", closeModal: true });
+      toast.success(getGitConflictCopy(activeGitConflict.operation).abortedToastTitle);
+    } catch (error) {
+      const message = toErrorMessage(error, "Failed to abort the git conflict.");
+      setRebaseError(message);
+      toast.error(getGitConflictCopy(activeGitConflict.operation).abortFailureTitle, {
+        description: message,
+      });
+    } finally {
+      dispatch({ type: "finish_action" });
+    }
+  }, [
+    activeGitConflict,
+    clearActionErrors,
+    refreshDiffData,
+    repoPath,
+    setRebaseError,
+    state.isHandlingGitConflict,
+    workingDir,
+  ]);
+
+  const askBuilderToResolveGitConflict = useCallback(async (): Promise<void> => {
+    if (!activeGitConflict || state.isHandlingGitConflict) {
+      return;
+    }
+
+    if (!onResolveGitConflict) {
+      setRebaseError("Cannot send conflict resolution request to Builder.");
+      return;
+    }
+
+    dispatch({ type: "start_action", action: "ask_builder" });
+    try {
+      const wasHandled = await onResolveGitConflict(activeGitConflict);
+      if (!wasHandled) {
+        return;
+      }
+      clearActionErrors();
+      toast.success(getGitConflictCopy(activeGitConflict.operation).builderSuccessTitle);
+    } catch (error) {
+      const message = toErrorMessage(
+        error,
+        getGitConflictCopy(activeGitConflict.operation).builderFailureMessage,
+      );
+      setRebaseError(message);
+      toast.error("Failed to contact Builder", { description: message });
+    } finally {
+      dispatch({ type: "finish_action" });
+    }
+  }, [
+    activeGitConflict,
+    clearActionErrors,
+    onResolveGitConflict,
+    setRebaseError,
+    state.isHandlingGitConflict,
+  ]);
+
+  return {
+    activeGitConflict,
+    isHandlingGitConflict: state.isHandlingGitConflict,
+    gitConflictAction: state.gitConflictAction,
+    gitConflictAutoOpenNonce: state.gitConflictAutoOpenNonce,
+    gitConflictCloseNonce: state.gitConflictCloseNonce,
+    isGitActionsLocked,
+    gitActionsLockReason,
+    showLockReasonBanner,
+    captureFreshConflict,
+    abortGitConflict,
+    askBuilderToResolveGitConflict,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-push-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-push-actions.ts
@@ -18,6 +18,12 @@ type UseAgentStudioGitPushActionsArgs = {
   setPushError: (message: string | null) => void;
 };
 
+type GitPushTarget = {
+  repoPath: string;
+  branch: string;
+  workingDir: string | null;
+};
+
 export function useAgentStudioGitPushActions({
   repoPath,
   workingDir,
@@ -33,7 +39,7 @@ export function useAgentStudioGitPushActions({
   );
 
   const pushBranchInternal = useCallback(
-    async (options?: { forceWithLease?: boolean }): Promise<void> => {
+    async (options?: { forceWithLease?: boolean; target?: GitPushTarget }): Promise<void> => {
       if (isPushing) {
         return;
       }
@@ -41,12 +47,16 @@ export function useAgentStudioGitPushActions({
         return;
       }
 
-      if (!repoPath) {
+      const resolvedRepoPath = options?.target?.repoPath ?? repoPath;
+      const resolvedBranch = options?.target?.branch ?? branch;
+      const resolvedWorkingDir = options?.target?.workingDir ?? workingDir;
+
+      if (!resolvedRepoPath) {
         setPushError("Cannot push because no repository is selected.");
         return;
       }
 
-      if (!branch) {
+      if (!resolvedBranch) {
         setPushError("Cannot push because current branch is unavailable.");
         return;
       }
@@ -55,10 +65,10 @@ export function useAgentStudioGitPushActions({
       setIsPushing(true);
       setPushError(null);
       try {
-        const pushResult = await host.gitPushBranch(repoPath, branch, {
+        const pushResult = await host.gitPushBranch(resolvedRepoPath, resolvedBranch, {
           setUpstream: true,
           forceWithLease,
-          ...(workingDir != null ? { workingDir } : {}),
+          ...(resolvedWorkingDir != null ? { workingDir: resolvedWorkingDir } : {}),
         });
 
         if (pushResult.outcome === "rejected_non_fast_forward") {
@@ -73,6 +83,8 @@ export function useAgentStudioGitPushActions({
             remote: pushResult.remote,
             branch: pushResult.branch,
             output: pushResult.output,
+            repoPath: resolvedRepoPath,
+            workingDir: resolvedWorkingDir,
           });
           return;
         }
@@ -117,8 +129,14 @@ export function useAgentStudioGitPushActions({
       return;
     }
 
+    const confirmedTarget = {
+      repoPath: pendingForcePush.repoPath,
+      branch: pendingForcePush.branch,
+      workingDir: pendingForcePush.workingDir,
+    } satisfies GitPushTarget;
+
     setPendingForcePush(null);
-    await pushBranchInternal({ forceWithLease: true });
+    await pushBranchInternal({ forceWithLease: true, target: confirmedTarget });
   }, [pendingForcePush, pushBranchInternal]);
 
   const cancelForcePush = useCallback((): void => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-push-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-push-actions.ts
@@ -1,0 +1,136 @@
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import type { AgentStudioPendingForcePush } from "@/features/agent-studio-git";
+import { host } from "@/state/operations/shared/host";
+import {
+  type GitActionKind,
+  type RefreshGitDiffData,
+  toErrorMessage,
+} from "./use-agent-studio-git-action-utils";
+
+type UseAgentStudioGitPushActionsArgs = {
+  repoPath: string | null;
+  workingDir: string | null;
+  branch: string | null;
+  refreshDiffData: RefreshGitDiffData;
+  clearActionErrors: () => void;
+  ensureGitActionsUnlocked: (kind: GitActionKind) => boolean;
+  setPushError: (message: string | null) => void;
+};
+
+export function useAgentStudioGitPushActions({
+  repoPath,
+  workingDir,
+  branch,
+  refreshDiffData,
+  clearActionErrors,
+  ensureGitActionsUnlocked,
+  setPushError,
+}: UseAgentStudioGitPushActionsArgs) {
+  const [isPushing, setIsPushing] = useState(false);
+  const [pendingForcePush, setPendingForcePush] = useState<AgentStudioPendingForcePush | null>(
+    null,
+  );
+
+  const pushBranchInternal = useCallback(
+    async (options?: { forceWithLease?: boolean }): Promise<void> => {
+      if (isPushing) {
+        return;
+      }
+      if (!ensureGitActionsUnlocked("push")) {
+        return;
+      }
+
+      if (!repoPath) {
+        setPushError("Cannot push because no repository is selected.");
+        return;
+      }
+
+      if (!branch) {
+        setPushError("Cannot push because current branch is unavailable.");
+        return;
+      }
+
+      const forceWithLease = options?.forceWithLease ?? false;
+      setIsPushing(true);
+      setPushError(null);
+      try {
+        const pushResult = await host.gitPushBranch(repoPath, branch, {
+          setUpstream: true,
+          forceWithLease,
+          ...(workingDir != null ? { workingDir } : {}),
+        });
+
+        if (pushResult.outcome === "rejected_non_fast_forward") {
+          if (forceWithLease) {
+            const message = pushResult.output.trim() || "Force push was rejected.";
+            setPushError(message);
+            toast.error("Force push rejected", { description: message });
+            return;
+          }
+
+          setPendingForcePush({
+            remote: pushResult.remote,
+            branch: pushResult.branch,
+            output: pushResult.output,
+          });
+          return;
+        }
+
+        clearActionErrors();
+        setPendingForcePush(null);
+        toast.success(`Pushed ${pushResult.branch}`, {
+          description: `Remote: ${pushResult.remote}`,
+        });
+        await refreshDiffData();
+      } catch (error) {
+        const message = toErrorMessage(
+          error,
+          forceWithLease ? "Force push failed." : "Push failed.",
+        );
+        setPushError(message);
+        toast.error(forceWithLease ? "Force push failed" : "Push failed", {
+          description: message,
+        });
+      } finally {
+        setIsPushing(false);
+      }
+    },
+    [
+      branch,
+      clearActionErrors,
+      ensureGitActionsUnlocked,
+      isPushing,
+      refreshDiffData,
+      repoPath,
+      setPushError,
+      workingDir,
+    ],
+  );
+
+  const pushBranch = useCallback(async (): Promise<void> => {
+    await pushBranchInternal();
+  }, [pushBranchInternal]);
+
+  const confirmForcePush = useCallback(async (): Promise<void> => {
+    if (!pendingForcePush) {
+      return;
+    }
+
+    setPendingForcePush(null);
+    await pushBranchInternal({ forceWithLease: true });
+  }, [pendingForcePush, pushBranchInternal]);
+
+  const cancelForcePush = useCallback((): void => {
+    setPendingForcePush(null);
+    setPushError(null);
+  }, [setPushError]);
+
+  return {
+    isPushing,
+    pendingForcePush,
+    pushBranch,
+    confirmForcePush,
+    cancelForcePush,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-rebase-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-rebase-actions.ts
@@ -1,0 +1,241 @@
+import type { CommitsAheadBehind } from "@openducktor/contracts";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import type { AgentStudioPendingPullRebase, GitConflict } from "@/features/agent-studio-git";
+import { host } from "@/state/operations/shared/host";
+import {
+  type GitActionKind,
+  type RefreshGitDiffData,
+  toConflictMessage,
+  toErrorMessage,
+} from "./use-agent-studio-git-action-utils";
+
+type UseAgentStudioGitRebaseActionsArgs = {
+  repoPath: string | null;
+  workingDir: string | null;
+  branch: string | null;
+  targetBranch: string;
+  upstreamAheadBehind: CommitsAheadBehind | null;
+  refreshDiffData: RefreshGitDiffData;
+  clearActionErrors: () => void;
+  ensureGitActionsUnlocked: (kind: GitActionKind) => boolean;
+  setRebaseError: (message: string | null) => void;
+  captureFreshConflict: (conflict: GitConflict) => void;
+};
+
+export function useAgentStudioGitRebaseActions({
+  repoPath,
+  workingDir,
+  branch,
+  targetBranch,
+  upstreamAheadBehind,
+  refreshDiffData,
+  clearActionErrors,
+  ensureGitActionsUnlocked,
+  setRebaseError,
+  captureFreshConflict,
+}: UseAgentStudioGitRebaseActionsArgs) {
+  const [isRebasing, setIsRebasing] = useState(false);
+  const [pendingPullRebase, setPendingPullRebase] = useState<AgentStudioPendingPullRebase | null>(
+    null,
+  );
+
+  const pullFromUpstreamInternal = useCallback(
+    async (options?: {
+      skipRebaseConfirmation?: boolean;
+      localAhead?: number;
+      upstreamBehind?: number;
+    }): Promise<void> => {
+      if (isRebasing) {
+        return;
+      }
+      if (!ensureGitActionsUnlocked("rebase")) {
+        return;
+      }
+
+      if (!repoPath) {
+        setRebaseError("Cannot pull because no repository is selected.");
+        return;
+      }
+
+      if (!branch || branch.trim().length === 0) {
+        setRebaseError("Cannot pull because current branch is unavailable.");
+        return;
+      }
+
+      const localAhead = options?.localAhead ?? upstreamAheadBehind?.ahead ?? 0;
+      const upstreamBehindCount = options?.upstreamBehind ?? upstreamAheadBehind?.behind ?? 0;
+      const willRebaseLocalCommits = localAhead > 0 && upstreamBehindCount > 0;
+      const isConfirmedPullRebase =
+        options?.skipRebaseConfirmation === true && willRebaseLocalCommits;
+
+      if (willRebaseLocalCommits && !options?.skipRebaseConfirmation) {
+        setPendingPullRebase({
+          branch,
+          localAhead,
+          upstreamBehind: upstreamBehindCount,
+        });
+        return;
+      }
+
+      setIsRebasing(true);
+      setRebaseError(null);
+      try {
+        const result = await host.gitPullBranch(repoPath, workingDir ?? undefined);
+
+        if (result.outcome === "conflicts") {
+          if (isConfirmedPullRebase) {
+            setPendingPullRebase(null);
+          }
+          const conflict: GitConflict = {
+            operation: "pull_rebase",
+            currentBranch: branch,
+            targetBranch: "tracked upstream branch",
+            conflictedFiles: result.conflictedFiles,
+            output: result.output,
+            workingDir,
+          };
+          const message = toConflictMessage(result.conflictedFiles, "pull_rebase");
+          captureFreshConflict(conflict);
+          toast.error("Pull requires conflict resolution", { description: message });
+          await refreshDiffData();
+          return;
+        }
+
+        clearActionErrors();
+        if (isConfirmedPullRebase) {
+          setPendingPullRebase(null);
+        }
+        if (result.outcome === "up_to_date") {
+          toast.success("Already up to date");
+        } else if (willRebaseLocalCommits) {
+          toast.success("Rebased local commits onto upstream", {
+            description: `Reapplied ${localAhead} local commit${localAhead === 1 ? "" : "s"}.`,
+          });
+        } else {
+          toast.success("Pulled from upstream");
+        }
+        await refreshDiffData();
+      } catch (error) {
+        const message = toErrorMessage(error, "Pull failed.");
+        setRebaseError(message);
+        setPendingPullRebase(null);
+        toast.error("Pull failed", { description: message });
+      } finally {
+        setIsRebasing(false);
+      }
+    },
+    [
+      branch,
+      captureFreshConflict,
+      clearActionErrors,
+      ensureGitActionsUnlocked,
+      isRebasing,
+      refreshDiffData,
+      repoPath,
+      setRebaseError,
+      upstreamAheadBehind?.ahead,
+      upstreamAheadBehind?.behind,
+      workingDir,
+    ],
+  );
+
+  const runRebase = useCallback(
+    async (target: string, missingTargetError: string, fallbackError: string): Promise<void> => {
+      if (isRebasing) {
+        return;
+      }
+      if (!ensureGitActionsUnlocked("rebase")) {
+        return;
+      }
+
+      if (!repoPath) {
+        setRebaseError("Cannot rebase because no repository is selected.");
+        return;
+      }
+
+      const trimmedTarget = target.trim();
+      if (trimmedTarget.length === 0) {
+        setRebaseError(missingTargetError);
+        return;
+      }
+
+      setIsRebasing(true);
+      setRebaseError(null);
+      try {
+        const result = await host.gitRebaseBranch(repoPath, trimmedTarget, workingDir ?? undefined);
+        if (result.outcome === "conflicts") {
+          const conflict: GitConflict = {
+            operation: "rebase",
+            currentBranch: branch,
+            targetBranch: trimmedTarget,
+            conflictedFiles: result.conflictedFiles,
+            output: result.output,
+            workingDir,
+          };
+          const message = toConflictMessage(result.conflictedFiles, "rebase");
+          captureFreshConflict(conflict);
+          toast.error("Rebase requires conflict resolution", { description: message });
+          await refreshDiffData();
+          return;
+        }
+
+        clearActionErrors();
+        await refreshDiffData();
+      } catch (error) {
+        setRebaseError(toErrorMessage(error, fallbackError));
+      } finally {
+        setIsRebasing(false);
+      }
+    },
+    [
+      branch,
+      captureFreshConflict,
+      clearActionErrors,
+      ensureGitActionsUnlocked,
+      isRebasing,
+      refreshDiffData,
+      repoPath,
+      setRebaseError,
+      workingDir,
+    ],
+  );
+
+  const pullFromUpstream = useCallback(async (): Promise<void> => {
+    await pullFromUpstreamInternal();
+  }, [pullFromUpstreamInternal]);
+
+  const confirmPullRebase = useCallback(async (): Promise<void> => {
+    if (!pendingPullRebase) {
+      return;
+    }
+
+    await pullFromUpstreamInternal({
+      skipRebaseConfirmation: true,
+      localAhead: pendingPullRebase.localAhead,
+      upstreamBehind: pendingPullRebase.upstreamBehind,
+    });
+  }, [pendingPullRebase, pullFromUpstreamInternal]);
+
+  const cancelPullRebase = useCallback((): void => {
+    setPendingPullRebase(null);
+    setRebaseError(null);
+  }, [setRebaseError]);
+
+  const rebaseOntoTarget = useCallback(async (): Promise<void> => {
+    await runRebase(
+      targetBranch,
+      "Cannot rebase because target branch is not configured.",
+      "Rebase failed.",
+    );
+  }, [runRebase, targetBranch]);
+
+  return {
+    isRebasing,
+    pendingPullRebase,
+    pullFromUpstream,
+    confirmPullRebase,
+    cancelPullRebase,
+    rebaseOntoTarget,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-reset-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-reset-actions.ts
@@ -1,0 +1,214 @@
+import type { GitResetWorktreeSelection } from "@openducktor/contracts";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import type { AgentStudioPendingReset, GitConflict } from "@/features/agent-studio-git";
+import { host } from "@/state/operations/shared/host";
+import {
+  BUILDER_LOCK_REASON,
+  CONFLICT_LOCK_REASON,
+  type RefreshGitDiffData,
+  toErrorMessage,
+} from "./use-agent-studio-git-action-utils";
+
+type UseAgentStudioGitResetActionsArgs = {
+  repoPath: string | null;
+  workingDir: string | null;
+  targetBranch: string;
+  hashVersion: number | null;
+  statusHash: string | null;
+  diffHash: string | null;
+  worktreeStatusSnapshotKey: string | null;
+  isDiffDataLoading: boolean;
+  isBuilderSessionWorking: boolean;
+  activeGitConflict: GitConflict | null;
+  refreshDiffData: RefreshGitDiffData;
+  clearActionErrors: () => void;
+  setResetError: (message: string | null) => void;
+};
+
+export function useAgentStudioGitResetActions({
+  repoPath,
+  workingDir,
+  targetBranch,
+  hashVersion,
+  statusHash,
+  diffHash,
+  worktreeStatusSnapshotKey,
+  isDiffDataLoading,
+  isBuilderSessionWorking,
+  activeGitConflict,
+  refreshDiffData,
+  clearActionErrors,
+  setResetError,
+}: UseAgentStudioGitResetActionsArgs) {
+  const [isResetting, setIsResetting] = useState(false);
+  const [pendingReset, setPendingReset] = useState<AgentStudioPendingReset | null>(null);
+  const resetSnapshotKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (worktreeStatusSnapshotKey == null) {
+      resetSnapshotKeyRef.current = null;
+      return;
+    }
+
+    const previousSnapshotKey = resetSnapshotKeyRef.current;
+    resetSnapshotKeyRef.current = worktreeStatusSnapshotKey;
+
+    if (previousSnapshotKey !== null && previousSnapshotKey !== worktreeStatusSnapshotKey) {
+      setResetError(null);
+    }
+  }, [setResetError, worktreeStatusSnapshotKey]);
+
+  const getResetBlockedReason = useCallback((): string | null => {
+    if (isBuilderSessionWorking) {
+      return BUILDER_LOCK_REASON;
+    }
+
+    if (activeGitConflict != null) {
+      return CONFLICT_LOCK_REASON;
+    }
+
+    if (isDiffDataLoading) {
+      return "Cannot reset while git diff data is loading.";
+    }
+
+    if (isResetting) {
+      return "Reset is already in progress.";
+    }
+
+    return null;
+  }, [activeGitConflict, isBuilderSessionWorking, isDiffDataLoading, isResetting]);
+
+  const resetDisabledReason = useMemo((): string | null => {
+    if (!repoPath) {
+      return "Cannot reset because no repository is selected.";
+    }
+
+    const blockedReason = getResetBlockedReason();
+    if (blockedReason) {
+      return blockedReason;
+    }
+
+    if (hashVersion == null || statusHash == null || diffHash == null) {
+      return "Displayed diff is unavailable. Refresh and try again.";
+    }
+
+    if (targetBranch.trim().length === 0) {
+      return "Cannot reset because target branch is not configured.";
+    }
+
+    return null;
+  }, [diffHash, getResetBlockedReason, hashVersion, repoPath, statusHash, targetBranch]);
+
+  const isResetDisabled = resetDisabledReason != null;
+
+  const buildResetRequest = useCallback(
+    (selection: GitResetWorktreeSelection) => {
+      if (resetDisabledReason != null) {
+        return {
+          error: resetDisabledReason,
+        } as const;
+      }
+
+      if (repoPath == null || hashVersion == null || statusHash == null || diffHash == null) {
+        return {
+          error: "Displayed diff is unavailable. Refresh and try again.",
+        } as const;
+      }
+
+      return {
+        request: {
+          repoPath,
+          workingDir: workingDir ?? undefined,
+          targetBranch,
+          snapshot: {
+            hashVersion,
+            statusHash,
+            diffHash,
+          },
+          selection,
+        },
+      } as const;
+    },
+    [diffHash, hashVersion, repoPath, resetDisabledReason, statusHash, targetBranch, workingDir],
+  );
+
+  const requestResetSelection = useCallback(
+    (selection: GitResetWorktreeSelection): void => {
+      const built = buildResetRequest(selection);
+      if ("error" in built) {
+        setResetError(built.error);
+        return;
+      }
+
+      setResetError(null);
+      setPendingReset(selection);
+    },
+    [buildResetRequest, setResetError],
+  );
+
+  const requestFileReset = useCallback(
+    (filePath: string): void => {
+      requestResetSelection({ kind: "file", filePath });
+    },
+    [requestResetSelection],
+  );
+
+  const requestHunkReset = useCallback(
+    (filePath: string, hunkIndex: number): void => {
+      requestResetSelection({ kind: "hunk", filePath, hunkIndex });
+    },
+    [requestResetSelection],
+  );
+
+  const confirmReset = useCallback(async (): Promise<void> => {
+    if (pendingReset == null) {
+      return;
+    }
+
+    const built = buildResetRequest(pendingReset);
+    if ("error" in built) {
+      setResetError(built.error);
+      toast.error("Reset failed", { description: built.error });
+      return;
+    }
+
+    setIsResetting(true);
+    setResetError(null);
+    try {
+      const result = await host.gitResetWorktreeSelection(built.request);
+      clearActionErrors();
+      setPendingReset(null);
+      await refreshDiffData();
+      const affectedCount = result.affectedPaths.length;
+      toast.success(pendingReset.kind === "file" ? "File reset" : "Hunk reset", {
+        description:
+          affectedCount === 1
+            ? result.affectedPaths[0]
+            : `${affectedCount} paths updated in the worktree.`,
+      });
+    } catch (error) {
+      const message = toErrorMessage(error, "Reset failed.");
+      setResetError(message);
+      toast.error("Reset failed", { description: message });
+    } finally {
+      setIsResetting(false);
+    }
+  }, [buildResetRequest, clearActionErrors, pendingReset, refreshDiffData, setResetError]);
+
+  const cancelReset = useCallback((): void => {
+    setPendingReset(null);
+    setResetError(null);
+  }, [setResetError]);
+
+  return {
+    isResetting,
+    isResetDisabled,
+    resetDisabledReason,
+    pendingReset,
+    requestFileReset,
+    requestHunkReset,
+    confirmReset,
+    cancelReset,
+  };
+}

--- a/apps/desktop/src/pages/agents/use-agent-studio-git-reset-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-git-reset-actions.ts
@@ -56,6 +56,7 @@ export function useAgentStudioGitResetActions({
 
     if (previousSnapshotKey !== null && previousSnapshotKey !== worktreeStatusSnapshotKey) {
       setResetError(null);
+      setPendingReset(null);
     }
   }, [setResetError, worktreeStatusSnapshotKey]);
 
@@ -179,7 +180,6 @@ export function useAgentStudioGitResetActions({
       const result = await host.gitResetWorktreeSelection(built.request);
       clearActionErrors();
       setPendingReset(null);
-      await refreshDiffData();
       const affectedCount = result.affectedPaths.length;
       toast.success(pendingReset.kind === "file" ? "File reset" : "Hunk reset", {
         description:
@@ -187,6 +187,16 @@ export function useAgentStudioGitResetActions({
             ? result.affectedPaths[0]
             : `${affectedCount} paths updated in the worktree.`,
       });
+
+      try {
+        await refreshDiffData();
+      } catch (error) {
+        const message = toErrorMessage(error, "Reset was applied, but diff refresh failed.");
+        setResetError(message);
+        toast.error("Reset applied but refresh failed", {
+          description: message,
+        });
+      }
     } catch (error) {
       const message = toErrorMessage(error, "Reset failed.");
       setResetError(message);


### PR DESCRIPTION
## Summary
- split `useAgentStudioGitActions` into focused internal hooks for errors, conflict and lock orchestration, reset, commit, push, and rebase flows while keeping the public right-panel contract intact
- move git conflict lifecycle and nonce emission into a reducer-backed controller so conflict locking, modal auto-open, and modal close behavior remain centralized and easier to reason about
- add focused conflict-controller tests while preserving the existing hook and panel contract coverage for reset gating, force-push confirmation, pull confirmation, and conflict handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Git workflows: commit, push (with force-confirmation), pull/rebase, and reset flows with clearer success/error handling.
  * Enhanced conflict controller with better detection, modal behavior, and conflict-resolution handoffs.

* **Refactor**
  * Reorganized Git action management into smaller composable controllers for more reliable UI state and locking.

* **Tests**
  * Expanded test coverage for conflict handling, force-push flows, and commit/diff refresh edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->