### PR TITLE
refactor(desktop): split task approval flow orchestration

### DIFF
--- a/apps/desktop/src/pages/kanban/task-approval-flow-direct-merge.ts
+++ b/apps/desktop/src/pages/kanban/task-approval-flow-direct-merge.ts
@@ -1,0 +1,127 @@
+import type { TaskApprovalContext } from "@openducktor/contracts";
+import type { QueryClient } from "@tanstack/react-query";
+import type { GitConflict } from "@/features/agent-studio-git";
+import { canonicalTargetBranch, checkoutTargetBranch } from "@/lib/target-branch";
+import { host } from "@/state/operations/shared/host";
+import {
+  invalidateTaskApprovalContextQuery,
+  loadTaskApprovalContextFromQuery,
+} from "@/state/queries/task-approval";
+import type { TaskApprovalFlowReadyState } from "./task-approval-flow-state";
+
+type SubmitDirectMergeApprovalArgs = {
+  approval: TaskApprovalFlowReadyState;
+  queryClient: QueryClient;
+  repoPath: string;
+  refreshTasks: () => Promise<void>;
+};
+
+type CompleteDirectMergeApprovalArgs = {
+  approval: TaskApprovalFlowReadyState;
+  repoPath: string;
+  refreshTasks: () => Promise<void>;
+};
+
+export type SubmitDirectMergeApprovalResult =
+  | {
+      outcome: "conflicts";
+      conflict: GitConflict;
+    }
+  | {
+      outcome: "task_closed";
+      successDescription: string;
+    }
+  | {
+      outcome: "await_completion";
+      approvalContext: TaskApprovalContext;
+    };
+
+const normalizeConflict = (
+  conflict: NonNullable<
+    Awaited<ReturnType<typeof host.taskDirectMerge>> extends infer TResult
+      ? TResult extends { outcome: "conflicts"; conflict: infer TConflict }
+        ? TConflict
+        : never
+      : never
+  >,
+): GitConflict => ({
+  ...conflict,
+  currentBranch: conflict.currentBranch ?? null,
+  workingDir: conflict.workingDir ?? null,
+});
+
+export async function submitDirectMergeApproval({
+  approval,
+  queryClient,
+  repoPath,
+  refreshTasks,
+}: SubmitDirectMergeApprovalArgs): Promise<SubmitDirectMergeApprovalResult> {
+  const approvalContext = approval.approvalContext;
+  const directMergeResult = await host.taskDirectMerge(repoPath, approval.taskId, {
+    mergeMethod: approval.mergeMethod,
+    squashCommitMessage:
+      approval.mergeMethod === "squash"
+        ? approval.squashCommitMessage.trim() || undefined
+        : undefined,
+  });
+
+  if (directMergeResult.outcome === "conflicts") {
+    return {
+      outcome: "conflicts",
+      conflict: normalizeConflict(directMergeResult.conflict),
+    };
+  }
+
+  await refreshTasks();
+  if (directMergeResult.task.status === "closed") {
+    return {
+      outcome: "task_closed",
+      successDescription: canonicalTargetBranch(approvalContext.targetBranch),
+    };
+  }
+
+  await invalidateTaskApprovalContextQuery(queryClient, repoPath, approval.taskId);
+  const nextApprovalContext = await loadTaskApprovalContextFromQuery(
+    queryClient,
+    repoPath,
+    approval.taskId,
+  );
+  if (!nextApprovalContext.directMerge) {
+    throw new Error(
+      "Local direct merge completed, but the task did not enter a resumable completion state.",
+    );
+  }
+
+  return {
+    outcome: "await_completion",
+    approvalContext: nextApprovalContext,
+  };
+}
+
+export async function completeDirectMergeApproval({
+  approval,
+  repoPath,
+  refreshTasks,
+}: CompleteDirectMergeApprovalArgs): Promise<{ successDescription: string }> {
+  const approvalContext = approval.approvalContext;
+  const publishTarget = approvalContext.publishTarget;
+
+  if (publishTarget) {
+    if (!publishTarget.remote) {
+      throw new Error("The configured target branch does not have a publish remote.");
+    }
+    const pushResult = await host.gitPushBranch(repoPath, checkoutTargetBranch(publishTarget), {
+      remote: publishTarget.remote,
+    });
+    if (pushResult.outcome !== "pushed") {
+      throw new Error(pushResult.output);
+    }
+  }
+
+  await host.taskDirectMergeComplete(repoPath, approval.taskId);
+  await refreshTasks();
+
+  return {
+    successDescription: canonicalTargetBranch(publishTarget ?? approvalContext.targetBranch),
+  };
+}

--- a/apps/desktop/src/pages/kanban/task-approval-flow-direct-merge.ts
+++ b/apps/desktop/src/pages/kanban/task-approval-flow-direct-merge.ts
@@ -9,6 +9,8 @@ import {
 } from "@/state/queries/task-approval";
 import type { TaskApprovalFlowReadyState } from "./task-approval-flow-state";
 
+const DIRECT_MERGE_PUSH_FAILURE_MESSAGE = "Git push failed with no output.";
+
 type SubmitDirectMergeApprovalArgs = {
   approval: TaskApprovalFlowReadyState;
   queryClient: QueryClient;
@@ -114,7 +116,7 @@ export async function completeDirectMergeApproval({
       remote: publishTarget.remote,
     });
     if (pushResult.outcome !== "pushed") {
-      throw new Error(pushResult.output);
+      throw new Error(pushResult.output.trim() || DIRECT_MERGE_PUSH_FAILURE_MESSAGE);
     }
   }
 

--- a/apps/desktop/src/pages/kanban/task-approval-flow-git-conflict.ts
+++ b/apps/desktop/src/pages/kanban/task-approval-flow-git-conflict.ts
@@ -1,0 +1,11 @@
+import type { GitConflict } from "@/features/agent-studio-git";
+import { host } from "@/state/operations/shared/host";
+
+export const abortTaskApprovalGitConflict = (repoPath: string, conflict: GitConflict) =>
+  host.gitAbortConflict(repoPath, conflict.operation, conflict.workingDir ?? undefined);
+
+export const askBuilderToResolveTaskApprovalGitConflict = (
+  conflict: GitConflict,
+  taskId: string,
+  onResolveGitConflict: (conflict: GitConflict, taskId: string) => Promise<boolean>,
+): Promise<boolean> => onResolveGitConflict(conflict, taskId);

--- a/apps/desktop/src/pages/kanban/task-approval-flow-pull-request.ts
+++ b/apps/desktop/src/pages/kanban/task-approval-flow-pull-request.ts
@@ -1,0 +1,42 @@
+import { host } from "@/state/operations/shared/host";
+import type { TaskApprovalFlowReadyState } from "./task-approval-flow-state";
+
+type SubmitPullRequestApprovalArgs = {
+  approval: TaskApprovalFlowReadyState;
+  repoPath: string;
+  requestPullRequestGeneration: (taskId: string) => Promise<string | undefined>;
+  refreshTasks: () => Promise<void>;
+};
+
+export type SubmitPullRequestApprovalResult =
+  | { outcome: "generation_started" }
+  | { outcome: "generation_cancelled" }
+  | {
+      outcome: "pull_request_created";
+      pullRequest: Awaited<ReturnType<typeof host.taskPullRequestUpsert>>;
+    };
+
+export async function submitPullRequestApproval({
+  approval,
+  repoPath,
+  requestPullRequestGeneration,
+  refreshTasks,
+}: SubmitPullRequestApprovalArgs): Promise<SubmitPullRequestApprovalResult> {
+  if (approval.pullRequestDraftMode === "generate_ai") {
+    const sessionId = await requestPullRequestGeneration(approval.taskId);
+    return sessionId ? { outcome: "generation_started" } : { outcome: "generation_cancelled" };
+  }
+
+  const pullRequest = await host.taskPullRequestUpsert(
+    repoPath,
+    approval.taskId,
+    approval.title,
+    approval.body,
+  );
+  await refreshTasks();
+
+  return {
+    outcome: "pull_request_created",
+    pullRequest,
+  };
+}

--- a/apps/desktop/src/pages/kanban/task-approval-flow-state.ts
+++ b/apps/desktop/src/pages/kanban/task-approval-flow-state.ts
@@ -1,0 +1,179 @@
+import type { TaskApprovalContext } from "@openducktor/contracts";
+import type { PullRequestDraftMode, TaskApprovalMode } from "./kanban-page-model-types";
+
+export type TaskApprovalFlowStage = "approval" | "complete_direct_merge";
+export type TaskApprovalMergeMethod = "merge_commit" | "squash" | "rebase";
+
+export type TaskApprovalFlowOpenState = {
+  kind: "open";
+  phase: "loading" | "ready" | "submitting";
+  stage: TaskApprovalFlowStage;
+  taskId: string;
+  mode: TaskApprovalMode;
+  mergeMethod: TaskApprovalMergeMethod;
+  pullRequestDraftMode: PullRequestDraftMode;
+  title: string;
+  body: string;
+  squashCommitMessage: string;
+  squashCommitMessageTouched: boolean;
+  errorMessage: string | null;
+  approvalContext: TaskApprovalContext | null;
+};
+
+export type TaskApprovalFlowReadyState = TaskApprovalFlowOpenState & {
+  phase: "ready";
+  approvalContext: TaskApprovalContext;
+};
+
+export type TaskApprovalFlowState = { kind: "closed" } | TaskApprovalFlowOpenState;
+
+type TaskApprovalFlowOpenPayload = {
+  taskId: string;
+  mode: TaskApprovalMode;
+  pullRequestDraftMode: PullRequestDraftMode;
+  title: string;
+  body: string;
+  errorMessage: string | null;
+};
+
+type TaskApprovalFlowAction =
+  | ({ type: "open_loading" } & TaskApprovalFlowOpenPayload)
+  | ({
+      type: "load_succeeded";
+      approvalContext: TaskApprovalContext;
+    } & TaskApprovalFlowOpenPayload)
+  | { type: "close" }
+  | { type: "start_submitting" }
+  | { type: "return_to_editable"; errorMessage: string | null }
+  | { type: "clear_error" }
+  | { type: "set_mode"; mode: TaskApprovalMode }
+  | { type: "set_merge_method"; mergeMethod: TaskApprovalMergeMethod }
+  | {
+      type: "set_pull_request_draft_mode";
+      pullRequestDraftMode: PullRequestDraftMode;
+    }
+  | { type: "set_title"; title: string }
+  | { type: "set_body"; body: string }
+  | { type: "set_squash_commit_message"; squashCommitMessage: string }
+  | { type: "enter_direct_merge_completion"; approvalContext: TaskApprovalContext };
+
+export const CLOSED_TASK_APPROVAL_STATE: TaskApprovalFlowState = {
+  kind: "closed",
+};
+
+export const determineDefaultTaskApprovalMode = (
+  context: TaskApprovalContext | undefined,
+): TaskApprovalMode => {
+  const githubProvider = context?.providers?.find((entry) => entry.providerId === "github");
+  return githubProvider?.available ? "pull_request" : "direct_merge";
+};
+
+export const resolveTaskApprovalStage = (
+  approvalContext: TaskApprovalContext | null,
+): TaskApprovalFlowStage => (approvalContext?.directMerge ? "complete_direct_merge" : "approval");
+
+export const isTaskApprovalOpen = (
+  state: TaskApprovalFlowState,
+): state is TaskApprovalFlowOpenState => state.kind === "open";
+
+export const isTaskApprovalReady = (
+  state: TaskApprovalFlowState,
+): state is TaskApprovalFlowReadyState =>
+  state.kind === "open" && state.phase === "ready" && state.approvalContext !== null;
+
+const buildTaskApprovalLoadingState = (
+  payload: TaskApprovalFlowOpenPayload,
+): TaskApprovalFlowOpenState => ({
+  kind: "open",
+  phase: "loading",
+  stage: "approval",
+  taskId: payload.taskId,
+  mode: payload.mode,
+  mergeMethod: "merge_commit",
+  pullRequestDraftMode: payload.pullRequestDraftMode,
+  title: payload.title,
+  body: payload.body,
+  squashCommitMessage: "",
+  squashCommitMessageTouched: false,
+  errorMessage: payload.errorMessage,
+  approvalContext: null,
+});
+
+const buildTaskApprovalLoadedState = (
+  payload: TaskApprovalFlowOpenPayload & { approvalContext: TaskApprovalContext },
+): TaskApprovalFlowOpenState => ({
+  kind: "open",
+  phase: "ready",
+  stage: resolveTaskApprovalStage(payload.approvalContext),
+  taskId: payload.taskId,
+  mode: payload.mode,
+  mergeMethod: payload.approvalContext.defaultMergeMethod,
+  pullRequestDraftMode: payload.pullRequestDraftMode,
+  title: payload.title,
+  body: payload.body,
+  squashCommitMessage: payload.approvalContext.suggestedSquashCommitMessage ?? "",
+  squashCommitMessageTouched: false,
+  errorMessage: payload.errorMessage,
+  approvalContext: payload.approvalContext,
+});
+
+export function taskApprovalFlowReducer(
+  state: TaskApprovalFlowState,
+  action: TaskApprovalFlowAction,
+): TaskApprovalFlowState {
+  switch (action.type) {
+    case "open_loading":
+      return buildTaskApprovalLoadingState(action);
+    case "load_succeeded":
+      return buildTaskApprovalLoadedState(action);
+    case "close":
+      return CLOSED_TASK_APPROVAL_STATE;
+    case "start_submitting":
+      return state.kind === "open" ? { ...state, phase: "submitting" } : state;
+    case "return_to_editable":
+      return state.kind === "open"
+        ? { ...state, phase: "ready", errorMessage: action.errorMessage }
+        : state;
+    case "clear_error":
+      return state.kind === "open" ? { ...state, errorMessage: null } : state;
+    case "set_mode":
+      return state.kind === "open" ? { ...state, mode: action.mode, errorMessage: null } : state;
+    case "set_merge_method":
+      return state.kind === "open"
+        ? { ...state, mergeMethod: action.mergeMethod, errorMessage: null }
+        : state;
+    case "set_pull_request_draft_mode":
+      return state.kind === "open"
+        ? {
+            ...state,
+            pullRequestDraftMode: action.pullRequestDraftMode,
+            errorMessage: null,
+          }
+        : state;
+    case "set_title":
+      return state.kind === "open" ? { ...state, title: action.title, errorMessage: null } : state;
+    case "set_body":
+      return state.kind === "open" ? { ...state, body: action.body, errorMessage: null } : state;
+    case "set_squash_commit_message":
+      return state.kind === "open"
+        ? {
+            ...state,
+            squashCommitMessage: action.squashCommitMessage,
+            squashCommitMessageTouched: true,
+            errorMessage: null,
+          }
+        : state;
+    case "enter_direct_merge_completion":
+      return state.kind === "open"
+        ? {
+            ...state,
+            phase: "ready",
+            stage: "complete_direct_merge",
+            approvalContext: action.approvalContext,
+            errorMessage: null,
+          }
+        : state;
+    default:
+      return state;
+  }
+}

--- a/apps/desktop/src/pages/kanban/task-approval-flow-state.ts
+++ b/apps/desktop/src/pages/kanban/task-approval-flow-state.ts
@@ -131,7 +131,7 @@ export function taskApprovalFlowReducer(
     case "start_submitting":
       return state.kind === "open" ? { ...state, phase: "submitting" } : state;
     case "return_to_editable":
-      return state.kind === "open"
+      return state.kind === "open" && state.phase === "submitting"
         ? { ...state, phase: "ready", errorMessage: action.errorMessage }
         : state;
     case "clear_error":

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -42,12 +42,14 @@ const defaultGitPushBranch = async () => ({
   branch: "main",
   output: "",
 });
+const defaultGitAbortConflict = async () => {};
 
 const taskApprovalContextGetMock = mock(defaultTaskApprovalContextGet);
 const taskDirectMergeMock = mock(defaultTaskDirectMerge);
 const taskDirectMergeCompleteMock = mock(defaultTaskDirectMergeComplete);
 const taskPullRequestUpsertMock = mock(defaultTaskPullRequestUpsert);
 const gitPushBranchMock = mock(defaultGitPushBranch);
+const gitAbortConflictMock = mock(defaultGitAbortConflict);
 const toastLoadingMock = mock(() => "toast-id");
 const toastSuccessMock = mock(() => {});
 const toastErrorMock = mock(() => {});
@@ -67,6 +69,7 @@ const buildMockedHost = () => ({
   taskDirectMergeComplete: taskDirectMergeCompleteMock,
   taskPullRequestUpsert: taskPullRequestUpsertMock,
   gitPushBranch: gitPushBranchMock,
+  gitAbortConflict: gitAbortConflictMock,
   agentSessionsList: async () => [
     {
       ...createAgentSessionFixture({
@@ -106,6 +109,7 @@ const HOST_METHOD_NAMES = [
   "taskDirectMergeComplete",
   "taskPullRequestUpsert",
   "gitPushBranch",
+  "gitAbortConflict",
   "agentSessionsList",
   "specGet",
   "planGet",
@@ -142,33 +146,7 @@ const restoreHostMocks = async (): Promise<void> => {
   Object.assign(hostModule.host, originalHostMethods);
 };
 
-let latestHarnessValue: {
-  taskApprovalModal: {
-    open: boolean;
-    stage: "approval" | "complete_direct_merge";
-    isLoading: boolean;
-    mode: "direct_merge" | "pull_request";
-    mergeMethod: "merge_commit" | "squash" | "rebase";
-    pullRequestDraftMode: "manual" | "generate_ai";
-    pullRequestAvailable: boolean;
-    pullRequestUnavailableReason: string | null;
-    isSubmitting: boolean;
-    squashCommitMessage: string;
-    squashCommitMessageTouched: boolean;
-    hasSuggestedSquashCommitMessage: boolean;
-    hasUncommittedChanges: boolean;
-    uncommittedFileCount: number;
-    errorMessage: string | null;
-    onOpenChange: (open: boolean) => void;
-    onModeChange: (mode: "direct_merge" | "pull_request") => void;
-    onMergeMethodChange: (mergeMethod: "merge_commit" | "squash" | "rebase") => void;
-    onPullRequestDraftModeChange: (mode: "manual" | "generate_ai") => void;
-    onSquashCommitMessageChange: (value: string) => void;
-    onConfirm: () => void;
-    onCompleteDirectMerge: () => void;
-  } | null;
-  openTaskApproval: (taskId: string) => void;
-} | null = null;
+let latestHarnessValue: ReturnType<typeof useTaskApprovalFlow> | null = null;
 
 function createDeferred<TValue>() {
   let resolvePromise!: (value: TValue) => void;
@@ -212,6 +190,40 @@ const waitForTaskApprovalModalClosed = async (timeoutMs = 1000): Promise<void> =
   );
 };
 
+const createTaskApprovalContextFixture = (
+  overrides: Partial<TaskApprovalContext> = {},
+): TaskApprovalContext => ({
+  taskId: "TASK-1",
+  taskStatus: "human_review",
+  workingDirectory: "/repo/.worktrees/task-1",
+  sourceBranch: "odt/TASK-1",
+  targetBranch: { remote: "origin", branch: "main" },
+  publishTarget: { remote: "origin", branch: "main" },
+  defaultMergeMethod: "merge_commit",
+  hasUncommittedChanges: false,
+  uncommittedFileCount: 0,
+  pullRequest: undefined,
+  directMerge: undefined,
+  suggestedSquashCommitMessage: undefined,
+  providers: [],
+  ...overrides,
+});
+
+const createConflictDirectMergeResult = (
+  overrides: { currentBranch?: string; workingDir?: string } = {},
+) =>
+  ({
+    outcome: "conflicts" as const,
+    conflict: {
+      operation: "direct_merge_merge_commit" as const,
+      currentBranch: overrides.currentBranch,
+      targetBranch: "main",
+      conflictedFiles: ["src/app.ts"],
+      output: "conflict output",
+      workingDir: overrides.workingDir,
+    },
+  }) as unknown as Awaited<ReturnType<typeof defaultTaskDirectMerge>>;
+
 describe("useTaskApprovalFlow", () => {
   beforeEach(async () => {
     await applyHostMocks();
@@ -235,6 +247,8 @@ describe("useTaskApprovalFlow", () => {
     taskPullRequestUpsertMock.mockImplementation(defaultTaskPullRequestUpsert);
     gitPushBranchMock.mockClear();
     gitPushBranchMock.mockImplementation(defaultGitPushBranch);
+    gitAbortConflictMock.mockClear();
+    gitAbortConflictMock.mockImplementation(defaultGitAbortConflict);
   });
 
   afterAll(async () => {
@@ -550,6 +564,72 @@ describe("useTaskApprovalFlow", () => {
     });
   });
 
+  test("ignores a stale approval-context response from a superseded open cycle", async () => {
+    const firstContext = createDeferred<TaskApprovalContext>();
+    taskApprovalContextGetMock.mockImplementationOnce(
+      (async () => firstContext.promise) as unknown as never,
+    );
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createTaskApprovalContextFixture({
+        taskId: "TASK-2",
+        defaultMergeMethod: "rebase",
+        hasUncommittedChanges: false,
+        providers: [],
+      }) as unknown as never,
+    );
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [
+          createTaskCardFixture({ id: "TASK-1", title: "Task 1" }),
+          createTaskCardFixture({ id: "TASK-2", title: "Task 2" }),
+        ],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+    });
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-2");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
+    expect(latestHarnessValue?.taskApprovalModal?.mergeMethod).toBe("rebase");
+    expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(false);
+
+    firstContext.resolve(
+      createTaskApprovalContextFixture({
+        defaultMergeMethod: "squash",
+        hasUncommittedChanges: true,
+        uncommittedFileCount: 3,
+      }),
+    );
+
+    await act(async () => {
+      await firstContext.promise;
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
+    expect(latestHarnessValue?.taskApprovalModal?.mergeMethod).toBe("rebase");
+    expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(false);
+    expect(latestHarnessValue?.taskApprovalModal?.uncommittedFileCount).toBe(0);
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
   test("publishes and completes a pending direct merge", async () => {
     taskDirectMergeMock.mockResolvedValueOnce({
       outcome: "completed" as const,
@@ -618,7 +698,9 @@ describe("useTaskApprovalFlow", () => {
       await Promise.resolve();
     });
 
-    expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
+    await waitFor(() => {
+      expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
+    });
 
     await act(async () => {
       latestHarnessValue?.taskApprovalModal?.onCompleteDirectMerge();
@@ -687,6 +769,280 @@ describe("useTaskApprovalFlow", () => {
     expect(taskDirectMergeCompleteMock).not.toHaveBeenCalled();
     await waitForTaskApprovalModalClosed();
     expect(latestHarnessValue?.taskApprovalModal).toBeNull();
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("opens the git conflict dialog when direct merge returns conflicts", async () => {
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+    );
+    taskDirectMergeMock.mockResolvedValueOnce(createConflictDirectMergeResult());
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal).toBeNull();
+    expect(latestHarnessValue?.taskGitConflictDialog?.open).toBe(true);
+    expect(latestHarnessValue?.taskGitConflictDialog?.conflict).toEqual({
+      operation: "direct_merge_merge_commit",
+      currentBranch: null,
+      targetBranch: "main",
+      conflictedFiles: ["src/app.ts"],
+      output: "conflict output",
+      workingDir: null,
+    });
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("reopens approval in direct_merge mode after aborting a git conflict", async () => {
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+    );
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+    );
+    taskDirectMergeMock.mockResolvedValueOnce(
+      createConflictDirectMergeResult({
+        currentBranch: "odt/TASK-1",
+        workingDir: "/repo/.worktrees/task-1",
+      }),
+    );
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      latestHarnessValue?.taskGitConflictDialog?.onAbort();
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    expect(gitAbortConflictMock).toHaveBeenCalledWith(
+      "/repo",
+      "direct_merge_merge_commit",
+      "/repo/.worktrees/task-1",
+    );
+    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
+    expect(latestHarnessValue?.taskGitConflictDialog).toBeNull();
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("keeps the git conflict dialog open when Ask Builder does not start a resolution session", async () => {
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+    );
+    taskDirectMergeMock.mockResolvedValueOnce(
+      createConflictDirectMergeResult({
+        currentBranch: "odt/TASK-1",
+        workingDir: "/repo/.worktrees/task-1",
+      }),
+    );
+    const onResolveGitConflictMock = mock(async () => false);
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+        onResolveGitConflict: onResolveGitConflictMock,
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      latestHarnessValue?.taskGitConflictDialog?.onAskBuilder();
+      await Promise.resolve();
+    });
+
+    expect(onResolveGitConflictMock).toHaveBeenCalledWith(
+      expect.objectContaining({ operation: "direct_merge_merge_commit" }),
+      "TASK-1",
+    );
+    expect(latestHarnessValue?.taskGitConflictDialog?.open).toBe(true);
+    expect(latestHarnessValue?.taskGitConflictDialog?.isHandlingConflict).toBe(false);
+    expect(latestHarnessValue?.taskGitConflictDialog?.conflictAction).toBeNull();
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("surfaces Ask Builder failures without closing the git conflict dialog", async () => {
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+    );
+    taskDirectMergeMock.mockResolvedValueOnce(
+      createConflictDirectMergeResult({
+        currentBranch: "odt/TASK-1",
+        workingDir: "/repo/.worktrees/task-1",
+      }),
+    );
+    const onResolveGitConflictMock = mock(async () => {
+      throw new Error("Builder unavailable");
+    });
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+        onResolveGitConflict: onResolveGitConflictMock,
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      latestHarnessValue?.taskGitConflictDialog?.onAskBuilder();
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskGitConflictDialog?.open).toBe(true);
+    expect(latestHarnessValue?.taskGitConflictDialog?.isHandlingConflict).toBe(false);
+    expect(latestHarnessValue?.taskGitConflictDialog?.conflictAction).toBeNull();
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Failed to contact Builder",
+      expect.objectContaining({ description: "Builder unavailable" }),
+    );
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("creates a pull request manually, refreshes tasks, and closes the modal", async () => {
+    const refreshTasksMock = mock(async () => {});
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createTaskApprovalContextFixture({
+        providers: [
+          {
+            providerId: "github",
+            enabled: true,
+            available: true,
+            reason: undefined,
+          },
+        ],
+      }) as unknown as never,
+    );
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [
+          createTaskCardFixture({
+            id: "TASK-1",
+            title: "Ship approval flow",
+            description: "Task description",
+          }),
+        ],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: refreshTasksMock,
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      await Promise.resolve();
+    });
+
+    await waitForTaskApprovalModalClosed();
+    expect(taskPullRequestUpsertMock).toHaveBeenCalledWith(
+      "/repo",
+      "TASK-1",
+      "Ship approval flow",
+      "Task description",
+    );
+    expect(refreshTasksMock).toHaveBeenCalledTimes(1);
+    await waitForTaskApprovalModalClosed();
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Pull request created",
+      expect.objectContaining({ description: "PR #17" }),
+    );
 
     await act(async () => {
       await harness.unmount();
@@ -900,6 +1256,62 @@ describe("useTaskApprovalFlow", () => {
       expect.objectContaining({ description: "Generation crashed" }),
     );
     expect(taskPullRequestUpsertMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("keeps direct-merge completion recoverable when publish configuration is incomplete", async () => {
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createTaskApprovalContextFixture({
+        publishTarget: { branch: "main" },
+        directMerge: {
+          method: "merge_commit",
+          sourceBranch: "odt/TASK-1",
+          targetBranch: { branch: "main" },
+          mergedAt: "2026-03-12T12:00:00Z",
+        },
+      }) as unknown as never,
+    );
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onCompleteDirectMerge();
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
+    expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
+    expect(latestHarnessValue?.taskApprovalModal?.isSubmitting).toBe(false);
+    expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBe(
+      "The configured target branch does not have a publish remote.",
+    );
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Failed to finish direct merge",
+      expect.objectContaining({
+        description: "The configured target branch does not have a publish remote.",
+      }),
+    );
 
     await act(async () => {
       await harness.unmount();

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -1192,6 +1192,106 @@ describe("useTaskApprovalFlow", () => {
     });
   });
 
+  test("does not let a stale PR-generation cancellation unlock a newer loading modal", async () => {
+    const requestPullRequestGenerationDeferred = createDeferred<string | undefined>();
+    const requestPullRequestGenerationMock = mock(
+      async () => requestPullRequestGenerationDeferred.promise,
+    );
+    const secondApprovalContext = createDeferred<TaskApprovalContext>();
+
+    taskApprovalContextGetMock.mockImplementation((async (_repoPath: string, taskId: string) => {
+      if (taskId === "TASK-1") {
+        return createTaskApprovalContextFixture({
+          taskId,
+          providers: [
+            {
+              providerId: "github",
+              enabled: true,
+              available: true,
+              reason: undefined,
+            },
+          ],
+        });
+      }
+
+      return secondApprovalContext.promise;
+    }) as unknown as never);
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [
+          createTaskCardFixture({ id: "TASK-1", title: "Task 1" }),
+          createTaskCardFixture({ id: "TASK-2", title: "Task 2" }),
+        ],
+        requestPullRequestGeneration: requestPullRequestGenerationMock,
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onModeChange("pull_request");
+      latestHarnessValue?.taskApprovalModal?.onPullRequestDraftModeChange("generate_ai");
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-1");
+    expect(latestHarnessValue?.taskApprovalModal?.isSubmitting).toBe(true);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-2");
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
+    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
+
+    requestPullRequestGenerationDeferred.resolve(undefined);
+
+    await act(async () => {
+      await requestPullRequestGenerationDeferred.promise;
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
+    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
+    expect(latestHarnessValue?.taskApprovalModal?.isSubmitting).toBe(false);
+
+    secondApprovalContext.resolve(
+      createTaskApprovalContextFixture({
+        taskId: "TASK-2",
+        providers: [],
+      }),
+    );
+
+    await act(async () => {
+      await secondApprovalContext.promise;
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
+    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
   test("keeps the modal open when pull request generation cannot start", async () => {
     taskApprovalContextGetMock.mockResolvedValue({
       taskId: "TASK-1",
@@ -1311,6 +1411,62 @@ describe("useTaskApprovalFlow", () => {
       expect.objectContaining({
         description: "The configured target branch does not have a publish remote.",
       }),
+    );
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("uses a fallback message when direct-merge publish fails without output", async () => {
+    gitPushBranchMock.mockResolvedValueOnce({
+      outcome: "rejected" as const,
+      remote: "origin",
+      branch: "main",
+      output: "",
+    } as unknown as never);
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createTaskApprovalContextFixture({
+        directMerge: {
+          method: "merge_commit",
+          sourceBranch: "odt/TASK-1",
+          targetBranch: { remote: "origin", branch: "main" },
+          mergedAt: "2026-03-12T12:00:00Z",
+        },
+      }) as unknown as never,
+    );
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onCompleteDirectMerge();
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBe(
+      "Git push failed with no output.",
+    );
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Failed to finish direct merge",
+      expect.objectContaining({ description: "Git push failed with no output." }),
     );
 
     await act(async () => {

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -1,36 +1,32 @@
 import type { TaskApprovalContext, TaskCard } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useReducer, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { GitConflict, GitConflictAction } from "@/features/agent-studio-git";
 import { getGitConflictCopy } from "@/features/git-conflict-resolution";
 import { errorMessage } from "@/lib/errors";
 import { openExternalUrl } from "@/lib/open-external-url";
-import { canonicalTargetBranch, checkoutTargetBranch } from "@/lib/target-branch";
-import { host } from "@/state/operations/shared/host";
 import {
-  invalidateTaskApprovalContextQuery,
   loadTaskApprovalContextFromQuery,
   taskApprovalQueryKeys,
 } from "@/state/queries/task-approval";
 import type { TaskApprovalModalModel } from "./kanban-page-model-types";
-
-type ApprovalState = {
-  open: boolean;
-  stage: "approval" | "complete_direct_merge";
-  taskId: string;
-  isLoading: boolean;
-  mode: "direct_merge" | "pull_request";
-  mergeMethod: "merge_commit" | "squash" | "rebase";
-  pullRequestDraftMode: "manual" | "generate_ai";
-  title: string;
-  body: string;
-  squashCommitMessage: string;
-  squashCommitMessageTouched: boolean;
-  isSubmitting: boolean;
-  errorMessage: string | null;
-  approvalContext: TaskApprovalContext | null;
-};
+import {
+  completeDirectMergeApproval,
+  submitDirectMergeApproval,
+} from "./task-approval-flow-direct-merge";
+import {
+  abortTaskApprovalGitConflict,
+  askBuilderToResolveTaskApprovalGitConflict,
+} from "./task-approval-flow-git-conflict";
+import { submitPullRequestApproval } from "./task-approval-flow-pull-request";
+import {
+  CLOSED_TASK_APPROVAL_STATE,
+  determineDefaultTaskApprovalMode,
+  isTaskApprovalOpen,
+  isTaskApprovalReady,
+  taskApprovalFlowReducer,
+} from "./task-approval-flow-state";
 
 type UseTaskApprovalFlowArgs = {
   activeRepo: string | null;
@@ -40,7 +36,6 @@ type UseTaskApprovalFlowArgs = {
   onResolveGitConflict?: (conflict: GitConflict, taskId: string) => Promise<boolean>;
 };
 
-const INITIAL_STATE: ApprovalState | null = null;
 const INITIAL_GIT_CONFLICT_STATE: {
   open: boolean;
   taskId: string | null;
@@ -54,10 +49,6 @@ const INITIAL_GIT_CONFLICT_STATE: {
   isHandlingConflict: false,
   conflictAction: null,
 };
-
-const resolveApprovalStage = (
-  approvalContext: TaskApprovalContext | null,
-): ApprovalState["stage"] => (approvalContext?.directMerge ? "complete_direct_merge" : "approval");
 
 export function useTaskApprovalFlow({
   activeRepo,
@@ -90,13 +81,13 @@ export function useTaskApprovalFlow({
   ) => void;
 } {
   const queryClient = useQueryClient();
-  const [state, setState] = useState<ApprovalState | null>(INITIAL_STATE);
+  const [state, dispatch] = useReducer(taskApprovalFlowReducer, CLOSED_TASK_APPROVAL_STATE);
   const [gitConflictState, setGitConflictState] = useState(INITIAL_GIT_CONFLICT_STATE);
   const approvalRequestVersionRef = useRef(0);
 
   const reset = useCallback(() => {
     approvalRequestVersionRef.current += 1;
-    setState(INITIAL_STATE);
+    dispatch({ type: "close" });
   }, []);
 
   const closeGitConflict = useCallback(() => {
@@ -119,33 +110,23 @@ export function useTaskApprovalFlow({
       const task = tasks.find((entry) => entry.id === taskId);
       const requestVersion = ++approvalRequestVersionRef.current;
 
-      const determineDefaultMode = (
-        context: TaskApprovalContext | undefined,
-      ): "direct_merge" | "pull_request" => {
-        const githubProvider = context?.providers?.find((entry) => entry.providerId === "github");
-        return githubProvider?.available ? "pull_request" : "direct_merge";
-      };
-
       const cachedContext = queryClient.getQueryData(
         taskApprovalQueryKeys.context(activeRepo, taskId),
       ) as TaskApprovalContext | undefined;
-      const effectiveMode = options?.mode ?? determineDefaultMode(cachedContext);
+      const effectiveMode = options?.mode ?? determineDefaultTaskApprovalMode(cachedContext);
+      const title = task?.title ?? "";
+      const body = task?.description ?? "";
+      const pullRequestDraftMode = options?.pullRequestDraftMode ?? "manual";
+      const openErrorMessage = options?.errorMessage ?? null;
 
-      setState({
-        open: true,
-        stage: "approval",
+      dispatch({
+        type: "open_loading",
         taskId,
-        isLoading: true,
         mode: effectiveMode,
-        mergeMethod: "merge_commit",
-        pullRequestDraftMode: options?.pullRequestDraftMode ?? "manual",
-        title: task?.title ?? "",
-        body: task?.description ?? "",
-        squashCommitMessage: "",
-        squashCommitMessageTouched: false,
-        isSubmitting: false,
-        errorMessage: options?.errorMessage ?? null,
-        approvalContext: null,
+        pullRequestDraftMode,
+        title,
+        body,
+        errorMessage: openErrorMessage,
       });
 
       void (async () => {
@@ -158,21 +139,16 @@ export function useTaskApprovalFlow({
           if (approvalRequestVersionRef.current !== requestVersion) {
             return;
           }
-          const updatedEffectiveMode = options?.mode ?? determineDefaultMode(approvalContext);
-          setState({
-            open: true,
-            stage: resolveApprovalStage(approvalContext),
+          const updatedEffectiveMode =
+            options?.mode ?? determineDefaultTaskApprovalMode(approvalContext);
+          dispatch({
+            type: "load_succeeded",
             taskId,
-            isLoading: false,
             mode: updatedEffectiveMode,
-            mergeMethod: approvalContext.defaultMergeMethod,
-            pullRequestDraftMode: options?.pullRequestDraftMode ?? "manual",
-            title: task?.title ?? "",
-            body: task?.description ?? "",
-            squashCommitMessage: approvalContext.suggestedSquashCommitMessage ?? "",
-            squashCommitMessageTouched: false,
-            isSubmitting: false,
-            errorMessage: options?.errorMessage ?? null,
+            pullRequestDraftMode,
+            title,
+            body,
+            errorMessage: openErrorMessage,
             approvalContext,
           });
         } catch (error) {
@@ -190,109 +166,79 @@ export function useTaskApprovalFlow({
   );
 
   const confirm = useCallback((): void => {
-    if (!state || !activeRepo || state.isLoading || !state.approvalContext) {
+    if (!activeRepo || !isTaskApprovalReady(state)) {
       return;
     }
-    const approvalContext = state.approvalContext;
+    const approvalState = state;
 
     void (async () => {
-      setState((current) => (current ? { ...current, isSubmitting: true } : current));
+      dispatch({ type: "start_submitting" });
       try {
-        if (state.mode === "direct_merge") {
-          const directMergeResult = await host.taskDirectMerge(activeRepo, state.taskId, {
-            mergeMethod: state.mergeMethod,
-            squashCommitMessage:
-              state.mergeMethod === "squash"
-                ? state.squashCommitMessage.trim() || undefined
-                : undefined,
+        if (approvalState.mode === "direct_merge") {
+          const directMergeResult = await submitDirectMergeApproval({
+            approval: approvalState,
+            queryClient,
+            repoPath: activeRepo,
+            refreshTasks,
           });
           if (directMergeResult.outcome === "conflicts") {
             reset();
             setGitConflictState({
               open: true,
-              taskId: state.taskId,
-              conflict: {
-                ...directMergeResult.conflict,
-                currentBranch: directMergeResult.conflict.currentBranch ?? null,
-                workingDir: directMergeResult.conflict.workingDir ?? null,
-              },
+              taskId: approvalState.taskId,
+              conflict: directMergeResult.conflict,
               isHandlingConflict: false,
               conflictAction: null,
             });
             return;
           }
-          const mergedTask = directMergeResult.task;
-          await refreshTasks();
-          if (mergedTask.status === "closed") {
+
+          if (directMergeResult.outcome === "task_closed") {
             reset();
             toast.success("Task approved", {
-              description: canonicalTargetBranch(approvalContext.targetBranch),
+              description: directMergeResult.successDescription,
             });
             return;
           }
 
-          await invalidateTaskApprovalContextQuery(queryClient, activeRepo, state.taskId);
-          const nextApprovalContext = await loadTaskApprovalContextFromQuery(
-            queryClient,
-            activeRepo,
-            state.taskId,
-          );
-          if (!nextApprovalContext.directMerge) {
-            throw new Error(
-              "Local direct merge completed, but the task did not enter a resumable completion state.",
-            );
-          }
-
-          setState((current) =>
-            current
-              ? {
-                  ...current,
-                  stage: "complete_direct_merge",
-                  isSubmitting: false,
-                  approvalContext: nextApprovalContext,
-                  errorMessage: null,
-                }
-              : current,
-          );
-          return;
-        }
-
-        if (state.pullRequestDraftMode === "generate_ai") {
-          const sessionId = await requestPullRequestGeneration(state.taskId);
-          if (sessionId) {
-            reset();
-          } else {
-            setState((current) =>
-              current ? { ...current, isSubmitting: false, errorMessage: null } : current,
-            );
-          }
-          return;
-        } else {
-          const pullRequest = await host.taskPullRequestUpsert(
-            activeRepo,
-            state.taskId,
-            state.title,
-            state.body,
-          );
-          toast.success("Pull request created", {
-            description: `PR #${pullRequest.number}`,
-            action: {
-              label: "Open",
-              onClick: () => {
-                void openExternalUrl(pullRequest.url).catch((error) => {
-                  toast.error("Failed to open pull request", {
-                    description: errorMessage(error),
-                  });
-                });
-              },
-            },
+          dispatch({
+            type: "enter_direct_merge_completion",
+            approvalContext: directMergeResult.approvalContext,
           });
+          return;
         }
 
-        await refreshTasks();
+        const pullRequestResult = await submitPullRequestApproval({
+          approval: approvalState,
+          repoPath: activeRepo,
+          requestPullRequestGeneration,
+          refreshTasks,
+        });
+        if (pullRequestResult.outcome === "generation_started") {
+          reset();
+          return;
+        }
+        if (pullRequestResult.outcome === "generation_cancelled") {
+          dispatch({ type: "return_to_editable", errorMessage: null });
+          return;
+        }
+
+        toast.success("Pull request created", {
+          description: `PR #${pullRequestResult.pullRequest.number}`,
+          action: {
+            label: "Open",
+            onClick: () => {
+              void openExternalUrl(pullRequestResult.pullRequest.url).catch((error) => {
+                toast.error("Failed to open pull request", {
+                  description: errorMessage(error),
+                });
+              });
+            },
+          },
+        });
         reset();
       } catch (error) {
-        setState((current) => (current ? { ...current, isSubmitting: false } : current));
+        dispatch({ type: "return_to_editable", errorMessage: null });
         toast.error("Approval failed", {
           description: errorMessage(error),
         });
@@ -306,6 +252,7 @@ export function useTaskApprovalFlow({
     }
 
     const conflict = gitConflictState.conflict;
+    const taskId = gitConflictState.taskId;
     void (async () => {
       setGitConflictState((current) => ({
         ...current,
@@ -313,15 +260,11 @@ export function useTaskApprovalFlow({
         conflictAction: "abort",
       }));
       try {
-        await host.gitAbortConflict(
-          activeRepo,
-          conflict.operation,
-          conflict.workingDir ?? undefined,
-        );
+        await abortTaskApprovalGitConflict(activeRepo, conflict);
         toast.success(getGitConflictCopy(conflict.operation).abortedToastTitle);
         closeGitConflict();
-        if (gitConflictState.taskId) {
-          openTaskApproval(gitConflictState.taskId, {
+        if (taskId) {
+          openTaskApproval(taskId, {
             mode: "direct_merge",
           });
         }
@@ -357,7 +300,11 @@ export function useTaskApprovalFlow({
         conflictAction: "ask_builder",
       }));
       try {
-        const wasHandled = await onResolveGitConflict(conflict, taskId);
+        const wasHandled = await askBuilderToResolveTaskApprovalGitConflict(
+          conflict,
+          taskId,
+          onResolveGitConflict,
+        );
         if (!wasHandled) {
           setGitConflictState((current) => ({
             ...current,
@@ -383,41 +330,27 @@ export function useTaskApprovalFlow({
   }, [closeGitConflict, gitConflictState, onResolveGitConflict, reset]);
 
   const completeDirectMerge = useCallback((): void => {
-    if (!state || !activeRepo || !state.approvalContext) {
+    if (!activeRepo || !isTaskApprovalReady(state)) {
       return;
     }
 
-    const approvalContext = state.approvalContext;
-    const publishTarget = approvalContext.publishTarget;
+    const approvalState = state;
     void (async () => {
-      setState((current) =>
-        current ? { ...current, isSubmitting: true, errorMessage: null } : current,
-      );
+      dispatch({ type: "clear_error" });
+      dispatch({ type: "start_submitting" });
       try {
-        if (publishTarget) {
-          if (!publishTarget.remote) {
-            throw new Error("The configured target branch does not have a publish remote.");
-          }
-          const result = await host.gitPushBranch(activeRepo, checkoutTargetBranch(publishTarget), {
-            remote: publishTarget.remote,
-          });
-          if (result.outcome !== "pushed") {
-            throw new Error(result.output);
-          }
-        }
-        await host.taskDirectMergeComplete(activeRepo, state.taskId);
-        await refreshTasks();
+        const result = await completeDirectMergeApproval({
+          approval: approvalState,
+          repoPath: activeRepo,
+          refreshTasks,
+        });
         reset();
         toast.success("Task moved to Done", {
-          description: publishTarget
-            ? canonicalTargetBranch(publishTarget)
-            : canonicalTargetBranch(approvalContext.targetBranch),
+          description: result.successDescription,
         });
       } catch (error) {
         const description = errorMessage(error);
-        setState((current) =>
-          current ? { ...current, isSubmitting: false, errorMessage: description } : current,
-        );
+        dispatch({ type: "return_to_editable", errorMessage: description });
         toast.error("Failed to finish direct merge", {
           description,
         });
@@ -441,7 +374,7 @@ export function useTaskApprovalFlow({
       }
     : null;
 
-  if (!state) {
+  if (!isTaskApprovalOpen(state)) {
     return {
       taskApprovalModal: null,
       taskGitConflictDialog,
@@ -454,10 +387,10 @@ export function useTaskApprovalFlow({
 
   return {
     taskApprovalModal: {
-      open: state.open,
+      open: true,
       stage: state.stage,
       taskId: state.taskId,
-      isLoading: state.isLoading,
+      isLoading: state.phase === "loading",
       mode: state.mode,
       mergeMethod: state.mergeMethod,
       pullRequestDraftMode: state.pullRequestDraftMode,
@@ -473,38 +406,21 @@ export function useTaskApprovalFlow({
       squashCommitMessage: state.squashCommitMessage,
       squashCommitMessageTouched: state.squashCommitMessageTouched,
       hasSuggestedSquashCommitMessage: approvalContext?.suggestedSquashCommitMessage != null,
-      isSubmitting: state.isSubmitting,
+      isSubmitting: state.phase === "submitting",
       errorMessage: state.errorMessage,
       onOpenChange: (open) => {
         if (!open) {
           reset();
         }
       },
-      onModeChange: (mode) =>
-        setState((current) => (current ? { ...current, mode, errorMessage: null } : current)),
-      onMergeMethodChange: (mergeMethod) =>
-        setState((current) =>
-          current ? { ...current, mergeMethod, errorMessage: null } : current,
-        ),
+      onModeChange: (mode) => dispatch({ type: "set_mode", mode }),
+      onMergeMethodChange: (mergeMethod) => dispatch({ type: "set_merge_method", mergeMethod }),
       onPullRequestDraftModeChange: (pullRequestDraftMode) =>
-        setState((current) =>
-          current ? { ...current, pullRequestDraftMode, errorMessage: null } : current,
-        ),
-      onTitleChange: (title) =>
-        setState((current) => (current ? { ...current, title, errorMessage: null } : current)),
-      onBodyChange: (body) =>
-        setState((current) => (current ? { ...current, body, errorMessage: null } : current)),
+        dispatch({ type: "set_pull_request_draft_mode", pullRequestDraftMode }),
+      onTitleChange: (title) => dispatch({ type: "set_title", title }),
+      onBodyChange: (body) => dispatch({ type: "set_body", body }),
       onSquashCommitMessageChange: (squashCommitMessage) =>
-        setState((current) =>
-          current
-            ? {
-                ...current,
-                squashCommitMessage,
-                squashCommitMessageTouched: true,
-                errorMessage: null,
-              }
-            : current,
-        ),
+        dispatch({ type: "set_squash_commit_message", squashCommitMessage }),
       onConfirm: confirm,
       onSkipDirectMergeCompletion: reset,
       onCompleteDirectMerge: completeDirectMerge,


### PR DESCRIPTION
## Summary
- split `useTaskApprovalFlow` into a reducer-backed modal state model plus focused direct-merge, pull-request, and git-conflict helpers
- preserve the existing Kanban approval behavior while making stale open-cycle handling and direct-merge completion transitions explicit
- expand approval-flow coverage for stale responses, manual PR success, conflict recovery branches, and direct-merge completion recoverability

## Verification
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced task approval workflows with direct merge capability and conflict detection.
  * Added pull request creation within the approval process.
  * Improved git conflict handling and resolution in task approvals.

* **Refactor**
  * Restructured task approval state management for improved maintainability.

* **Tests**
  * Added comprehensive test coverage for task approval workflows and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->