### PR TITLE
fix(desktop): keep agent studio add tab visible next to tabs

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { Tabs } from "@/components/ui/tabs";
@@ -48,6 +49,7 @@ describe("AgentStudioTaskTabs", () => {
     expect(html).toContain("border-b-transparent");
     expect(html).toContain("after:bg-card");
     expect(html).toContain("overflow-x-auto");
+    expect(html).toContain("hide-scrollbar");
     expect(html).not.toContain("overflow-y-visible");
     expect(html).not.toContain("rounded-full border");
     expect(html).not.toContain("bg-card/80");
@@ -95,6 +97,11 @@ describe("AgentStudioTaskTabs", () => {
     );
 
     expect(html).toContain("Hide documents panel");
+
+    const newTabButtonIndex = html.indexOf('aria-label="Open new task tab"');
+    const rightPanelToggleIndex = html.indexOf('aria-label="Hide documents panel"');
+    expect(newTabButtonIndex).toBeGreaterThan(-1);
+    expect(rightPanelToggleIndex).toBeGreaterThan(newTabButtonIndex);
   });
 
   test("keeps new-tab button enabled while tab tasks are loading", () => {
@@ -115,5 +122,32 @@ describe("AgentStudioTaskTabs", () => {
 
     expect(html).toMatch(/aria-label="Open new task tab"/);
     expect(html).not.toMatch(/aria-label="Open new task tab"[^>]*disabled/);
+  });
+
+  test("keeps the new-tab button outside the horizontal scroll region", () => {
+    const { container } = render(
+      createElement(
+        Tabs,
+        { value: "task-1" },
+        createElement(AgentStudioTaskTabs, {
+          model: buildModel(),
+          rightPanelToggleModel: {
+            kind: "documents",
+            isOpen: true,
+            onToggle: () => {},
+          },
+        }),
+      ),
+    );
+
+    const scrollRegion = container.querySelector(".hide-scrollbar.overflow-x-auto");
+    const newTabButton = screen.getByRole("button", { name: "Open new task tab" });
+    const rightPanelToggle = screen.getByRole("button", { name: "Hide documents panel" });
+
+    expect(scrollRegion).not.toBeNull();
+    expect(scrollRegion?.contains(newTabButton)).toBeFalse();
+    expect(
+      newTabButton.compareDocumentPosition(rightPanelToggle) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -50,6 +50,7 @@ describe("AgentStudioTaskTabs", () => {
     expect(html).toContain("after:bg-card");
     expect(html).toContain("overflow-x-auto");
     expect(html).toContain("hide-scrollbar");
+    expect(html).toContain("max-w-full overflow-x-auto");
     expect(html).not.toContain("overflow-y-visible");
     expect(html).not.toContain("rounded-full border");
     expect(html).not.toContain("bg-card/80");

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -50,16 +50,31 @@ describe("AgentStudioTaskTabs", () => {
     expect(html).toContain("after:bg-card");
     expect(html).toContain("overflow-x-auto");
     expect(html).toContain("hide-scrollbar");
-    expect(html).toContain("max-w-full overflow-x-auto");
+    expect(html).toContain("max-w-full");
     expect(html).not.toContain("overflow-y-visible");
     expect(html).not.toContain("rounded-full border");
     expect(html).not.toContain("bg-card/80");
     expect(html).toContain("bg-studio-chrome");
     expect(html).toContain("size-[1.4rem]");
 
-    const lastTabCloseIndex = html.lastIndexOf("Close tab for Ship QA checklist");
-    const newTabButtonIndex = html.indexOf('aria-label="Open new task tab"');
-    expect(newTabButtonIndex).toBeGreaterThan(lastTabCloseIndex);
+    const { unmount } = render(
+      createElement(
+        Tabs,
+        { value: "task-1" },
+        createElement(AgentStudioTaskTabs, { model: buildModel() }),
+      ),
+    );
+
+    const newTabButton = screen.getByRole("button", { name: "Open new task tab" });
+    const lastTabCloseButton = screen.getByRole("button", {
+      name: "Close tab for Ship QA checklist",
+    });
+
+    expect(
+      lastTabCloseButton.compareDocumentPosition(newTabButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    unmount();
   });
 
   test("shows empty-state copy when no tabs are open", () => {
@@ -99,10 +114,29 @@ describe("AgentStudioTaskTabs", () => {
 
     expect(html).toContain("Hide documents panel");
 
-    const newTabButtonIndex = html.indexOf('aria-label="Open new task tab"');
-    const rightPanelToggleIndex = html.indexOf('aria-label="Hide documents panel"');
-    expect(newTabButtonIndex).toBeGreaterThan(-1);
-    expect(rightPanelToggleIndex).toBeGreaterThan(newTabButtonIndex);
+    const { unmount } = render(
+      createElement(
+        Tabs,
+        { value: "task-1" },
+        createElement(AgentStudioTaskTabs, {
+          model: buildModel(),
+          rightPanelToggleModel: {
+            kind: "documents",
+            isOpen: true,
+            onToggle: () => {},
+          },
+        }),
+      ),
+    );
+
+    const newTabButton = screen.getByRole("button", { name: "Open new task tab" });
+    const rightPanelToggle = screen.getByRole("button", { name: "Hide documents panel" });
+
+    expect(
+      newTabButton.compareDocumentPosition(rightPanelToggle) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    unmount();
   });
 
   test("keeps new-tab button enabled while tab tasks are loading", () => {
@@ -126,7 +160,7 @@ describe("AgentStudioTaskTabs", () => {
   });
 
   test("keeps the new-tab button outside the horizontal scroll region", () => {
-    const { container } = render(
+    render(
       createElement(
         Tabs,
         { value: "task-1" },
@@ -141,7 +175,8 @@ describe("AgentStudioTaskTabs", () => {
       ),
     );
 
-    const scrollRegion = container.querySelector(".hide-scrollbar.overflow-x-auto");
+    const tabList = screen.getByRole("tablist", { name: "Agent Studio task tabs" });
+    const scrollRegion = tabList.parentElement?.parentElement;
     const newTabButton = screen.getByRole("button", { name: "Open new task tab" });
     const rightPanelToggle = screen.getByRole("button", { name: "Hide documents panel" });
 

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -106,84 +106,86 @@ export function AgentStudioTaskTabs({
   return (
     <div className="bg-studio-chrome px-2 pt-1.5 pb-0">
       <div className="flex min-w-0 items-center gap-1">
-        <div className="hide-scrollbar min-w-0 flex-1 overflow-x-auto">
-          <div className="inline-flex h-10 min-w-max items-center gap-1 px-2">
-            {hasAnyTab ? (
-              <TabsList
-                aria-label="Agent Studio task tabs"
-                className="h-auto min-h-10 w-max justify-start gap-1 rounded-none bg-transparent p-0"
-              >
-                {tabs.map((tab) => (
-                  <div
-                    key={tab.taskId}
-                    data-active={tab.isActive ? "true" : "false"}
-                    className={cn(
-                      "group relative z-1 inline-flex h-10 shrink-0 items-center gap-1 rounded-t-[10px] pl-2 pr-1",
-                      "transition-colors",
-                      tab.isActive
-                        ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
-                        : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
-                    )}
-                  >
-                    <TabsTrigger
-                      id={`agent-studio-tab-${tab.taskId}`}
-                      value={tab.taskId}
-                      className={cn(
-                        "h-9 max-w-[19rem] cursor-pointer justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
-                        "text-inherit data-[state=active]:bg-transparent data-[state=active]:text-inherit data-[state=active]:shadow-none",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                      )}
-                    >
-                      <span
-                        role="img"
-                        aria-label={statusLabelByTab(tab.status)}
-                        title={statusLabelByTab(tab.status)}
-                        className="inline-flex size-5 shrink-0 items-center justify-center"
-                      >
-                        {statusIconByTab(tab.status)}
-                      </span>
-                      <span className="max-w-52 truncate">{tab.taskTitle}</span>
-                    </TabsTrigger>
-                    <button
-                      type="button"
-                      className={cn(
-                        "mr-1 cursor-pointer rounded-md p-1 text-muted-foreground transition hover:bg-secondary hover:text-foreground",
-                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                        "opacity-60 group-hover:opacity-100 data-[active=true]:opacity-100",
-                      )}
+        <div className="flex min-w-0 flex-1 items-center gap-1">
+          <div className="hide-scrollbar min-w-0 max-w-full overflow-x-auto">
+            <div className="inline-flex h-10 min-w-max items-center gap-1 px-2">
+              {hasAnyTab ? (
+                <TabsList
+                  aria-label="Agent Studio task tabs"
+                  className="h-auto min-h-10 w-max justify-start gap-1 rounded-none bg-transparent p-0"
+                >
+                  {tabs.map((tab) => (
+                    <div
+                      key={tab.taskId}
                       data-active={tab.isActive ? "true" : "false"}
-                      tabIndex={tab.isActive ? 0 : -1}
-                      aria-label={`Close tab for ${tab.taskTitle}`}
-                      onClick={(event) => {
-                        event.preventDefault();
-                        event.stopPropagation();
-                        onCloseTab(tab.taskId);
-                      }}
+                      className={cn(
+                        "group relative z-1 inline-flex h-10 shrink-0 items-center gap-1 rounded-t-[10px] pl-2 pr-1",
+                        "transition-colors",
+                        tab.isActive
+                          ? "z-10 border-input border-b-transparent bg-card text-foreground hover:bg-card after:absolute after:right-0 after:bottom-0 after:left-0 after:h-px after:bg-card"
+                          : "border-input border-b-input bg-secondary text-foreground hover:bg-muted",
+                      )}
                     >
-                      <X className="size-3.5" />
-                    </button>
-                  </div>
-                ))}
-              </TabsList>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                Open a task tab to start working with an agent.
-              </p>
-            )}
+                      <TabsTrigger
+                        id={`agent-studio-tab-${tab.taskId}`}
+                        value={tab.taskId}
+                        className={cn(
+                          "h-9 max-w-[19rem] cursor-pointer justify-start gap-2 rounded-t-[8px] border-none bg-transparent px-0 pr-1 text-sm font-medium leading-none",
+                          "text-inherit data-[state=active]:bg-transparent data-[state=active]:text-inherit data-[state=active]:shadow-none",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                        )}
+                      >
+                        <span
+                          role="img"
+                          aria-label={statusLabelByTab(tab.status)}
+                          title={statusLabelByTab(tab.status)}
+                          className="inline-flex size-5 shrink-0 items-center justify-center"
+                        >
+                          {statusIconByTab(tab.status)}
+                        </span>
+                        <span className="max-w-52 truncate">{tab.taskTitle}</span>
+                      </TabsTrigger>
+                      <button
+                        type="button"
+                        className={cn(
+                          "mr-1 cursor-pointer rounded-md p-1 text-muted-foreground transition hover:bg-secondary hover:text-foreground",
+                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                          "opacity-60 group-hover:opacity-100 data-[active=true]:opacity-100",
+                        )}
+                        data-active={tab.isActive ? "true" : "false"}
+                        tabIndex={tab.isActive ? 0 : -1}
+                        aria-label={`Close tab for ${tab.taskTitle}`}
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                          onCloseTab(tab.taskId);
+                        }}
+                      >
+                        <X className="size-3.5" />
+                      </button>
+                    </div>
+                  ))}
+                </TabsList>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Open a task tab to start working with an agent.
+                </p>
+              )}
+            </div>
           </div>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            aria-label="Open new task tab"
+            className="h-10 w-10 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+            disabled={!canOpenCreateDialog}
+            onClick={() => setIsCreateDialogOpen(true)}
+          >
+            <Plus className="size-[1.4rem]" />
+            <span className="sr-only">New Tab</span>
+          </Button>
         </div>
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          aria-label="Open new task tab"
-          className="h-10 w-10 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-          disabled={!canOpenCreateDialog}
-          onClick={() => setIsCreateDialogOpen(true)}
-        >
-          <Plus className="size-[1.4rem]" />
-          <span className="sr-only">New Tab</span>
-        </Button>
         {rightPanelToggleModel ? (
           <div className="flex shrink-0 items-center pl-0.5">
             <AgentStudioRightPanelToggleButton model={rightPanelToggleModel} />

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -106,7 +106,7 @@ export function AgentStudioTaskTabs({
   return (
     <div className="bg-studio-chrome px-2 pt-1.5 pb-0">
       <div className="flex min-w-0 items-center gap-1">
-        <div className="min-w-0 flex-1 overflow-x-auto">
+        <div className="hide-scrollbar min-w-0 flex-1 overflow-x-auto">
           <div className="inline-flex h-10 min-w-max items-center gap-1 px-2">
             {hasAnyTab ? (
               <TabsList
@@ -170,20 +170,20 @@ export function AgentStudioTaskTabs({
                 Open a task tab to start working with an agent.
               </p>
             )}
-            <Button
-              type="button"
-              size="icon"
-              variant="ghost"
-              aria-label="Open new task tab"
-              className="h-10 w-10 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-              disabled={!canOpenCreateDialog}
-              onClick={() => setIsCreateDialogOpen(true)}
-            >
-              <Plus className="size-[1.4rem]" />
-              <span className="sr-only">New Tab</span>
-            </Button>
           </div>
         </div>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          aria-label="Open new task tab"
+          className="h-10 w-10 shrink-0 rounded-md border-none border-transparent bg-transparent p-0 text-studio-chrome-foreground shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+          disabled={!canOpenCreateDialog}
+          onClick={() => setIsCreateDialogOpen(true)}
+        >
+          <Plus className="size-[1.4rem]" />
+          <span className="sr-only">New Tab</span>
+        </Button>
         {rightPanelToggleModel ? (
           <div className="flex shrink-0 items-center pl-0.5">
             <AgentStudioRightPanelToggleButton model={rightPanelToggleModel} />

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.tsx
@@ -108,7 +108,7 @@ export function AgentStudioTaskTabs({
       <div className="flex min-w-0 items-center gap-1">
         <div className="flex min-w-0 flex-1 items-center gap-1">
           <div className="hide-scrollbar min-w-0 max-w-full overflow-x-auto">
-            <div className="inline-flex h-10 min-w-max items-center gap-1 px-2">
+            <div className="inline-flex h-10 min-w-max items-center gap-1 pl-2">
               {hasAnyTab ? (
                 <TabsList
                   aria-label="Agent Studio task tabs"


### PR DESCRIPTION
## Summary
- hide the Agent Studio task-tab scrollbar with the shared `hide-scrollbar` utility while preserving horizontal scrolling
- keep the `+` new-tab button outside the horizontal scroll region so it stays visible when tabs overflow
- keep the `+` button immediately adjacent to the visible tabs and before the right-panel toggle, with focused component test coverage for layout and ordering

## Verification
- bun run --filter @openducktor/desktop test -- src/components/features/agents/agent-studio-task-tabs.test.tsx
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the task tabs layout to position the "Open new task tab" button outside the horizontal scrollable region.
  * Adjusted tab container styling for improved layout organization.

* **Tests**
  * Enhanced test coverage for tab layout, styling classes, and DOM element ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->