### PR TITLE
fix(desktop): improve user-stopped session chat notices

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -288,6 +288,26 @@ const renderUserMessageInlineContent = (
   return <p className="whitespace-pre-wrap leading-6">{nodes}</p>;
 };
 
+type SessionNoticeMessageProps = {
+  message: AgentChatMessage;
+  timeLabel: string;
+};
+
+const SessionNoticeMessage = ({ message, timeLabel }: SessionNoticeMessageProps): ReactElement => {
+  const meta = message.meta?.kind === "session_notice" ? message.meta : null;
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0 space-y-1">
+        <p className="text-[11px] font-semibold uppercase tracking-wide opacity-80">
+          {meta?.title ?? "Notice"}
+        </p>
+        <p className="whitespace-pre-wrap leading-6 text-inherit">{message.content}</p>
+      </div>
+      {timeLabel ? <span className="shrink-0 text-[11px] opacity-70">{timeLabel}</span> : null}
+    </div>
+  );
+};
+
 type MessageBodyProps = {
   message: AgentChatMessage;
   assistantAccentColor: string | undefined;
@@ -341,6 +361,10 @@ export const MessageBody = ({
         ) : null}
       </div>
     );
+  }
+
+  if (meta?.kind === "session_notice") {
+    return <SessionNoticeMessage message={message} timeLabel={timeLabel} />;
   }
 
   if (message.role === "system" && message.content.startsWith(SYSTEM_PROMPT_PREFIX)) {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
@@ -35,6 +35,7 @@ type AgentChatMessageCardViewModel = {
   isWorkflowToolMessage: boolean;
   isRegularToolMessage: boolean;
   isSubtaskMessage: boolean;
+  isSessionNoticeMessage: boolean;
   isSystemPromptMessage: boolean;
   isRichCardMessage: boolean;
   articleClassName: string;
@@ -76,6 +77,7 @@ const toArticleClassName = (
   isToolMessage: boolean,
   isWorkflowToolMessage: boolean,
   isSubtaskMessage: boolean,
+  isSessionNoticeMessage: boolean,
   isSystemPromptMessage: boolean,
 ): string => {
   const meta = message.meta;
@@ -84,6 +86,10 @@ const toArticleClassName = (
 
   if (isReasoningMessage) {
     return "text-sm border-none bg-transparent px-0 py-0 text-muted-foreground";
+  }
+
+  if (isSessionNoticeMessage) {
+    return "my-2 rounded-md border border-cancelled-border bg-cancelled-surface px-3 py-2 text-cancelled-surface-foreground";
   }
 
   return cn(
@@ -132,9 +138,11 @@ export const buildAgentChatMessageCardViewModel = ({
   const isWorkflowToolMessage = meta?.kind === "tool" && isOdtWorkflowMutationToolName(meta.tool);
   const isRegularToolMessage = isToolMessage && !isWorkflowToolMessage;
   const isSubtaskMessage = meta?.kind === "subtask";
+  const isSessionNoticeMessage = meta?.kind === "session_notice";
   const isSystemPromptMessage =
     message.role === "system" && message.content.startsWith(SYSTEM_PROMPT_PREFIX);
-  const isRichCardMessage = isToolMessage || isSubtaskMessage || isSystemPromptMessage;
+  const isRichCardMessage =
+    isToolMessage || isSubtaskMessage || isSessionNoticeMessage || isSystemPromptMessage;
   const assistantRole = assistantRoleFromMessage(message, sessionRole);
   const assistantAccentColor = resolveAssistantAgentColor(message, sessionAgentColors);
   const userAccentColor = resolveUserAgentColor(message, sessionAgentColors);
@@ -142,7 +150,11 @@ export const buildAgentChatMessageCardViewModel = ({
     ? message.content.slice(SYSTEM_PROMPT_PREFIX.length).trimStart()
     : "";
   const showSharedHeader =
-    !isUserMessage && !isRegularToolMessage && !isReasoningMessage && !isAssistantMessage;
+    !isUserMessage &&
+    !isRegularToolMessage &&
+    !isReasoningMessage &&
+    !isAssistantMessage &&
+    !isSessionNoticeMessage;
 
   return {
     timeLabel,
@@ -158,6 +170,7 @@ export const buildAgentChatMessageCardViewModel = ({
     isWorkflowToolMessage,
     isRegularToolMessage,
     isSubtaskMessage,
+    isSessionNoticeMessage,
     isSystemPromptMessage,
     isRichCardMessage,
     articleClassName: toArticleClassName(
@@ -168,6 +181,7 @@ export const buildAgentChatMessageCardViewModel = ({
       isToolMessage,
       isWorkflowToolMessage,
       isSubtaskMessage,
+      isSessionNoticeMessage,
       isSystemPromptMessage,
     ),
     articleStyle:

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
@@ -89,7 +89,7 @@ const toArticleClassName = (
   }
 
   if (isSessionNoticeMessage) {
-    return "my-2 rounded-md border border-cancelled-border bg-cancelled-surface px-3 py-2 text-cancelled-surface-foreground";
+    return "text-sm my-2 rounded-md border border-cancelled-border bg-cancelled-surface px-3 py-2 text-cancelled-surface-foreground";
   }
 
   return cn(

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -386,6 +386,35 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).not.toContain("border-destructive-border");
   });
 
+  test("renders user-stopped session notices as cancelled cards", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "session-notice-stopped",
+          role: "system",
+          content: "Session stopped at your request.",
+          timestamp: "2026-02-22T10:21:45.000Z",
+          meta: {
+            kind: "session_notice",
+            tone: "cancelled",
+            reason: "user_stopped",
+            title: "Stopped",
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("border-cancelled-border");
+    expect(html).toContain("bg-cancelled-surface");
+    expect(html).toContain("Session stopped at your request.");
+    expect(html).toContain("Stopped");
+    expect(html).not.toContain("border-destructive-border");
+    expect(html).not.toContain(">System<");
+  });
+
   test("renders system prompt as expandable card", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -778,7 +778,7 @@ describe("agent-orchestrator-session-events", () => {
     handleEvent({
       type: "session_error",
       sessionId: "session-1",
-      message: "boom",
+      message: "Aborted",
       timestamp: "2026-02-22T08:00:10.000Z",
     });
 
@@ -787,9 +787,93 @@ describe("agent-orchestrator-session-events", () => {
     expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(0);
     expect(
       sessionsRef.current["session-1"]?.messages.some((message) =>
-        message.content.includes("Session error:"),
+        message.content.includes("Session error: Aborted"),
       ),
     ).toBe(true);
+  });
+
+  test("renders a cancelled session notice when a user-requested stop aborts", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          role: "build",
+          stopRequestedAt: "2026-02-22T08:00:09.000Z",
+          pendingPermissions: [
+            {
+              requestId: "perm-1",
+              permission: "read",
+              patterns: ["*.md"],
+            },
+          ],
+        }),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "session_error",
+      sessionId: "session-1",
+      message: '{"message":"Aborted"}',
+      timestamp: "2026-02-22T08:00:10.000Z",
+    });
+
+    const lastMessage = sessionsRef.current["session-1"]?.messages.at(-1);
+    expect(lastMessage?.content).toBe("Session stopped at your request.");
+    expect(lastMessage?.meta).toEqual({
+      kind: "session_notice",
+      tone: "cancelled",
+      reason: "user_stopped",
+      title: "Stopped",
+    });
+    expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeNull();
+    expect(
+      sessionsRef.current["session-1"]?.messages.some((message) =>
+        message.content.includes("Session error:"),
+      ),
+    ).toBe(false);
   });
 
   test("handles question/todo updates and terminal finish", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -809,6 +809,21 @@ describe("agent-orchestrator-session-events", () => {
         "session-1": buildSession({
           role: "build",
           stopRequestedAt: "2026-02-22T08:00:09.000Z",
+          messages: [
+            {
+              id: "tool-running",
+              role: "tool",
+              content: "Tool todowrite running...",
+              timestamp: "2026-02-22T08:00:08.000Z",
+              meta: {
+                kind: "tool",
+                partId: "part-tool-running",
+                callId: "call-tool-running",
+                tool: "todowrite",
+                status: "running",
+              },
+            },
+          ],
           pendingPermissions: [
             {
               requestId: "perm-1",
@@ -868,6 +883,16 @@ describe("agent-orchestrator-session-events", () => {
       reason: "user_stopped",
       title: "Stopped",
     });
+    const toolMessage = sessionsRef.current["session-1"]?.messages.find(
+      (message) => message.id === "tool-running",
+    );
+    expect(toolMessage?.meta?.kind).toBe("tool");
+    if (toolMessage?.meta?.kind !== "tool") {
+      throw new Error("Expected tool metadata");
+    }
+    expect(toolMessage.meta.status).toBe("error");
+    expect(toolMessage.meta.error).toBe("Aborted");
+    expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
     expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeNull();
     expect(
       sessionsRef.current["session-1"]?.messages.some((message) =>
@@ -976,6 +1001,21 @@ describe("agent-orchestrator-session-events", () => {
         "session-1": buildSession({
           role: "build",
           stopRequestedAt: "2026-02-22T08:00:09.000Z",
+          messages: [
+            {
+              id: "tool-running",
+              role: "tool",
+              content: "Tool todowrite running...",
+              timestamp: "2026-02-22T08:00:08.000Z",
+              meta: {
+                kind: "tool",
+                partId: "part-tool-running",
+                callId: "call-tool-running",
+                tool: "todowrite",
+                status: "running",
+              },
+            },
+          ],
           pendingPermissions: [
             {
               requestId: "perm-1",
@@ -1049,10 +1089,93 @@ describe("agent-orchestrator-session-events", () => {
       reason: "user_stopped",
       title: "Stopped",
     });
+    const toolMessage = sessionsRef.current["session-1"]?.messages.find(
+      (message) => message.id === "tool-running",
+    );
+    expect(toolMessage?.meta?.kind).toBe("tool");
+    if (toolMessage?.meta?.kind !== "tool") {
+      throw new Error("Expected tool metadata");
+    }
+    expect(toolMessage.meta.status).toBe("error");
+    expect(toolMessage.meta.error).toBe("Session stopped at your request.");
     expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeNull();
     expect(sessionsRef.current["session-1"]?.pendingPermissions).toHaveLength(0);
     expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(0);
     expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
+  });
+
+  test("keeps real failures on the error path even when stop intent was set", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          role: "build",
+          stopRequestedAt: "2026-02-22T08:00:09.000Z",
+        }),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "session_error",
+      sessionId: "session-1",
+      message: "Permission denied",
+      timestamp: "2026-02-22T08:00:10.000Z",
+    });
+
+    expect(sessionsRef.current["session-1"]?.status).toBe("error");
+    expect(
+      sessionsRef.current["session-1"]?.messages.some((message) =>
+        message.content.includes("Session stopped at your request."),
+      ),
+    ).toBe(false);
+    expect(
+      sessionsRef.current["session-1"]?.messages.some((message) =>
+        message.content.includes("Session error: Permission denied"),
+      ),
+    ).toBe(true);
   });
 
   test("finalizes assistant draft through status transitions", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -959,6 +959,102 @@ describe("agent-orchestrator-session-events", () => {
     expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
   });
 
+  test("renders a cancelled session notice when a user-requested stop finishes normally", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          role: "build",
+          stopRequestedAt: "2026-02-22T08:00:09.000Z",
+          pendingPermissions: [
+            {
+              requestId: "perm-1",
+              permission: "read",
+              patterns: ["*.md"],
+            },
+          ],
+          pendingQuestions: [
+            {
+              requestId: "question-1",
+              questions: [
+                {
+                  header: "Confirm",
+                  question: "Confirm",
+                  options: [],
+                  multiple: false,
+                  custom: false,
+                },
+              ],
+            },
+          ],
+        }),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "session_finished",
+      sessionId: "session-1",
+      timestamp: "2026-02-22T08:00:10.000Z",
+      message: "Session stopped",
+    });
+
+    const lastMessage = sessionsRef.current["session-1"]?.messages.at(-1);
+    expect(lastMessage?.content).toBe("Session stopped at your request.");
+    expect(lastMessage?.meta).toEqual({
+      kind: "session_notice",
+      tone: "cancelled",
+      reason: "user_stopped",
+      title: "Stopped",
+    });
+    expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeNull();
+    expect(sessionsRef.current["session-1"]?.pendingPermissions).toHaveLength(0);
+    expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(0);
+    expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
+  });
+
   test("finalizes assistant draft through status transitions", () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const adapter: SessionEventAdapter = {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -12,6 +12,7 @@ import { isDuplicateAssistantMessage, READ_ONLY_ROLES } from "../support/core";
 import { upsertMessage } from "../support/messages";
 import { mergeTodoListPreservingOrder } from "../support/todos";
 import {
+  isStopAbortSessionErrorMessage,
   normalizeRetryStatusMessage,
   normalizeSessionErrorMessage,
 } from "../support/tool-messages";
@@ -402,19 +403,35 @@ export const handleSessionError = (
         outcome: "error",
         errorMessage: sessionErrorMessage,
       });
+      const appendUserStoppedNotice =
+        Boolean(current.stopRequestedAt) && isStopAbortSessionErrorMessage(sessionErrorMessage);
       return {
         ...finalized,
         status: "error",
+        stopRequestedAt: null,
         pendingPermissions: [],
         pendingQuestions: [],
         messages: [
           ...settledMessages,
-          {
-            id: crypto.randomUUID(),
-            role: "system",
-            content: `Session error: ${sessionErrorMessage}`,
-            timestamp: event.timestamp,
-          },
+          appendUserStoppedNotice
+            ? {
+                id: crypto.randomUUID(),
+                role: "system" as const,
+                content: "Session stopped at your request.",
+                timestamp: event.timestamp,
+                meta: {
+                  kind: "session_notice" as const,
+                  tone: "cancelled" as const,
+                  reason: "user_stopped" as const,
+                  title: "Stopped",
+                },
+              }
+            : {
+                id: crypto.randomUUID(),
+                role: "system" as const,
+                content: `Session error: ${sessionErrorMessage}`,
+                timestamp: event.timestamp,
+              },
         ],
       };
     },

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -393,6 +393,27 @@ const buildUserStoppedNoticeMessage = (timestamp: string) => ({
   },
 });
 
+const settleTerminalMessages = (
+  messages: SessionLifecycleEventContext["store"]["sessionsRef"]["current"][string]["messages"],
+  timestamp: string,
+  options?: {
+    outcome?: "completed" | "error";
+    errorMessage?: string;
+    appendUserStoppedNotice?: boolean;
+  },
+) => {
+  const settledMessages = settleDanglingTodoToolMessages(messages, timestamp, {
+    ...(options?.outcome ? { outcome: options.outcome } : {}),
+    ...(options?.errorMessage ? { errorMessage: options.errorMessage } : {}),
+  });
+
+  if (!options?.appendUserStoppedNotice) {
+    return settledMessages;
+  }
+
+  return [...settledMessages, buildUserStoppedNoticeMessage(timestamp)];
+};
+
 export const handleSessionError = (
   context: SessionLifecycleEventContext,
   event: Extract<SessionEvent, { type: "session_error" }>,
@@ -412,29 +433,32 @@ export const handleSessionError = (
           current.messages,
         ),
       );
-      const settledMessages = settleDanglingTodoToolMessages(finalized.messages, event.timestamp, {
-        outcome: "error",
-        errorMessage: sessionErrorMessage,
-      });
       const appendUserStoppedNotice =
         Boolean(current.stopRequestedAt) && isStopAbortSessionErrorMessage(sessionErrorMessage);
       return {
         ...finalized,
-        status: "error",
+        status: appendUserStoppedNotice ? "stopped" : "error",
         stopRequestedAt: null,
         pendingPermissions: [],
         pendingQuestions: [],
-        messages: [
-          ...settledMessages,
-          appendUserStoppedNotice
-            ? buildUserStoppedNoticeMessage(event.timestamp)
-            : {
+        messages: appendUserStoppedNotice
+          ? settleTerminalMessages(finalized.messages, event.timestamp, {
+              outcome: "error",
+              errorMessage: sessionErrorMessage,
+              appendUserStoppedNotice: true,
+            })
+          : [
+              ...settleTerminalMessages(finalized.messages, event.timestamp, {
+                outcome: "error",
+                errorMessage: sessionErrorMessage,
+              }),
+              {
                 id: crypto.randomUUID(),
                 role: "system" as const,
                 content: `Session error: ${sessionErrorMessage}`,
                 timestamp: event.timestamp,
               },
-        ],
+            ],
       };
     },
     { persist: true },
@@ -476,10 +500,15 @@ export const handleSessionFinished = (
       const appendUserStoppedNotice = Boolean(current.stopRequestedAt);
       return {
         ...finalized,
-        messages: [
-          ...settleDanglingTodoToolMessages(finalized.messages, event.timestamp),
-          ...(appendUserStoppedNotice ? [buildUserStoppedNoticeMessage(event.timestamp)] : []),
-        ],
+        messages: settleTerminalMessages(finalized.messages, event.timestamp, {
+          ...(appendUserStoppedNotice
+            ? {
+                outcome: "error" as const,
+                errorMessage: "Session stopped at your request.",
+                appendUserStoppedNotice: true,
+              }
+            : {}),
+        }),
         pendingPermissions: [],
         pendingQuestions: [],
         status: "stopped",

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -380,6 +380,19 @@ export const handleSessionTodosUpdated = (
   );
 };
 
+const buildUserStoppedNoticeMessage = (timestamp: string) => ({
+  id: crypto.randomUUID(),
+  role: "system" as const,
+  content: "Session stopped at your request.",
+  timestamp,
+  meta: {
+    kind: "session_notice" as const,
+    tone: "cancelled" as const,
+    reason: "user_stopped" as const,
+    title: "Stopped",
+  },
+});
+
 export const handleSessionError = (
   context: SessionLifecycleEventContext,
   event: Extract<SessionEvent, { type: "session_error" }>,
@@ -414,18 +427,7 @@ export const handleSessionError = (
         messages: [
           ...settledMessages,
           appendUserStoppedNotice
-            ? {
-                id: crypto.randomUUID(),
-                role: "system" as const,
-                content: "Session stopped at your request.",
-                timestamp: event.timestamp,
-                meta: {
-                  kind: "session_notice" as const,
-                  tone: "cancelled" as const,
-                  reason: "user_stopped" as const,
-                  title: "Stopped",
-                },
-              }
+            ? buildUserStoppedNoticeMessage(event.timestamp)
             : {
                 id: crypto.randomUUID(),
                 role: "system" as const,
@@ -471,12 +473,17 @@ export const handleSessionFinished = (
           current.messages,
         ),
       );
+      const appendUserStoppedNotice = Boolean(current.stopRequestedAt);
       return {
         ...finalized,
-        messages: settleDanglingTodoToolMessages(finalized.messages, event.timestamp),
+        messages: [
+          ...settleDanglingTodoToolMessages(finalized.messages, event.timestamp),
+          ...(appendUserStoppedNotice ? [buildUserStoppedNoticeMessage(event.timestamp)] : []),
+        ],
         pendingPermissions: [],
         pendingQuestions: [],
         status: "stopped",
+        stopRequestedAt: null,
       };
     },
     { persist: true },

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -339,6 +339,21 @@ describe("agent-orchestrator/handlers/session-actions", () => {
         "session-1": buildSession({
           role: "build",
           runId: null,
+          messages: [
+            {
+              id: "tool-running",
+              role: "tool",
+              content: "Tool todowrite running...",
+              timestamp: "2026-02-22T08:00:08.000Z",
+              meta: {
+                kind: "tool",
+                partId: "part-tool-running",
+                callId: "call-tool-running",
+                tool: "todowrite",
+                status: "running",
+              },
+            },
+          ],
           pendingPermissions: [{ requestId: "perm-1", permission: "read", patterns: ["*"] }],
         }),
       },
@@ -418,6 +433,15 @@ describe("agent-orchestrator/handlers/session-actions", () => {
         reason: "user_stopped",
         title: "Stopped",
       });
+      const toolMessage = sessionsRef.current["session-1"]?.messages.find(
+        (message) => message.id === "tool-running",
+      );
+      expect(toolMessage?.meta?.kind).toBe("tool");
+      if (toolMessage?.meta?.kind !== "tool") {
+        throw new Error("Expected tool metadata");
+      }
+      expect(toolMessage.meta.status).toBe("error");
+      expect(toolMessage.meta.error).toBe("Session stopped at your request.");
       expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
       expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeNull();
     } finally {

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { OpencodeSdkAdapter } from "@openducktor/adapters-opencode-sdk";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { attachAgentSessionListener } from "../events/session-events";
 import { createDeferred, createTaskCardFixture } from "../test-utils";
 import { createAgentSessionActions } from "./session-actions";
 
@@ -314,6 +315,116 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
     } finally {
       adapter.hasSession = originalHasSession;
+    }
+  });
+
+  test("preserves the user-stopped notice when local stop emits session_finished", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalHasSession = adapter.hasSession;
+    const originalSubscribeEvents = adapter.subscribeEvents;
+    const originalStopSession = adapter.stopSession;
+    let sessionEventListener: ((event: { type: string; [key: string]: unknown }) => void) | null =
+      null;
+
+    adapter.hasSession = () => true;
+    adapter.subscribeEvents = (_sessionId, listener) => {
+      sessionEventListener = listener as (event: { type: string; [key: string]: unknown }) => void;
+      return () => {
+        sessionEventListener = null;
+      };
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          role: "build",
+          runId: null,
+          pendingPermissions: [{ requestId: "perm-1", permission: "read", patterns: ["*"] }],
+        }),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current[sessionId] = updater(current);
+    };
+
+    const unsubscribe = attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    adapter.stopSession = async (sessionId) => {
+      sessionEventListener?.({
+        type: "session_finished",
+        sessionId,
+        timestamp: "2026-02-22T08:00:10.000Z",
+        message: "Session stopped",
+      });
+    };
+
+    const actions = createAgentSessionActions({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef,
+      taskRef: { current: [] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      unsubscribersRef: { current: new Map([["session-1", unsubscribe]]) },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      attachSessionListener: () => unsubscribe,
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: null,
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {},
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+      persistSessionRecord: async () => {},
+    });
+
+    try {
+      await actions.stopAgentSession("session-1");
+
+      const lastMessage = sessionsRef.current["session-1"]?.messages.at(-1);
+      expect(lastMessage?.content).toBe("Session stopped at your request.");
+      expect(lastMessage?.meta).toEqual({
+        kind: "session_notice",
+        tone: "cancelled",
+        reason: "user_stopped",
+        title: "Stopped",
+      });
+      expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
+      expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeNull();
+    } finally {
+      adapter.hasSession = originalHasSession;
+      adapter.subscribeEvents = originalSubscribeEvents;
+      adapter.stopSession = originalStopSession;
+      unsubscribe();
     }
   });
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts
@@ -237,11 +237,83 @@ describe("agent-orchestrator/handlers/session-actions", () => {
       expect(localStopCalls).toBe(0);
       expect(unsubscribeCalls).toBe(0);
       expect(sessionsRef.current["session-1"]?.status).toBe("running");
+      expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeNull();
       expect(sessionsRef.current["session-1"]?.pendingPermissions).toHaveLength(1);
       expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(1);
     } finally {
       adapter.hasSession = originalHasSession;
       adapter.stopSession = originalStopSession;
+    }
+  });
+
+  test("records stop intent before awaiting authoritative build stop", async () => {
+    const adapter = new OpencodeSdkAdapter();
+    const originalHasSession = adapter.hasSession;
+    const stopDeferred = createDeferred<void>();
+
+    adapter.hasSession = () => false;
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          role: "build",
+          runId: "run-1",
+        }),
+      },
+    };
+
+    const actions = createAgentSessionActions({
+      activeRepo: "/tmp/repo",
+      adapter,
+      setSessionsById: () => {},
+      sessionsRef,
+      taskRef: { current: [] },
+      repoEpochRef: { current: 1 },
+      previousRepoRef: { current: "/tmp/repo" },
+      inFlightStartsByRepoTaskRef: { current: new Map() },
+      unsubscribersRef: { current: new Map() },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession: (sessionId, updater) => {
+        const current = sessionsRef.current[sessionId];
+        if (!current) {
+          return;
+        }
+        sessionsRef.current[sessionId] = updater(current);
+      },
+      attachSessionListener: () => {},
+      ensureRuntime: async () => ({
+        kind: "opencode",
+        runtimeId: null,
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory: "/tmp/repo",
+      }),
+      loadTaskDocuments: async () => ({ specMarkdown: "", planMarkdown: "", qaMarkdown: "" }),
+      loadRepoDefaultModel: async () => null,
+      loadRepoPromptOverrides: async () => ({}),
+      loadAgentSessions: async () => {},
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+      persistSessionRecord: async () => {},
+      stopBuildRun: async () => {
+        await stopDeferred.promise;
+      },
+    });
+
+    try {
+      const stopPromise = actions.stopAgentSession("session-1");
+      await Promise.resolve();
+
+      expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeString();
+      expect(sessionsRef.current["session-1"]?.status).toBe("running");
+
+      stopDeferred.resolve();
+      await stopPromise;
+
+      expect(sessionsRef.current["session-1"]?.stopRequestedAt).toBeNull();
+      expect(sessionsRef.current["session-1"]?.status).toBe("stopped");
+    } finally {
+      adapter.hasSession = originalHasSession;
     }
   });
 

--- a/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.ts
@@ -298,6 +298,15 @@ export const createAgentSessionActions = ({
       return;
     }
 
+    updateSession(
+      sessionId,
+      (current) => ({
+        ...current,
+        stopRequestedAt: now(),
+      }),
+      { persist: false },
+    );
+
     const roleRequiresHostStop = session.role === "build" || session.role === "qa";
     const hasLocalRuntimeSession = adapter.hasSession(sessionId);
 
@@ -306,6 +315,14 @@ export const createAgentSessionActions = ({
         await stopBuildRun(session.runId);
       }
     } catch (error) {
+      updateSession(
+        sessionId,
+        (current) => ({
+          ...current,
+          stopRequestedAt: null,
+        }),
+        { persist: false },
+      );
       throw new Error(
         `Failed to stop ${session.role} session '${sessionId}': ${errorMessage(error)}`,
       );
@@ -340,6 +357,7 @@ export const createAgentSessionActions = ({
         draftAssistantMessageId: null,
         draftReasoningText: "",
         draftReasoningMessageId: null,
+        stopRequestedAt: null,
         pendingPermissions: [],
         pendingQuestions: [],
       };

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/tool-messages.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/tool-messages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
 import {
+  isStopAbortSessionErrorMessage,
   normalizeRetryStatusMessage,
   normalizeSessionErrorMessage,
   resolveToolMessageId,
@@ -41,5 +42,14 @@ describe("agent-orchestrator/support/tool-messages", () => {
   test("normalizes session and retry error messages", () => {
     expect(normalizeSessionErrorMessage('{"message":"Oops"}')).toBe("Oops");
     expect(normalizeRetryStatusMessage('{"message":"Retrying"}')).toBe("Retrying");
+  });
+
+  test("classifies intentional stop abort variants narrowly", () => {
+    expect(isStopAbortSessionErrorMessage("Aborted")).toBe(true);
+    expect(isStopAbortSessionErrorMessage('"Aborted"')).toBe(true);
+    expect(isStopAbortSessionErrorMessage('{"message":"Request cancelled by user"}')).toBe(true);
+    expect(isStopAbortSessionErrorMessage('{"error":{"message":"Operation canceled"}}')).toBe(true);
+    expect(isStopAbortSessionErrorMessage("Permission denied")).toBe(false);
+    expect(isStopAbortSessionErrorMessage("boom")).toBe(false);
   });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/tool-messages.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/tool-messages.ts
@@ -122,6 +122,17 @@ export const normalizeSessionErrorMessage = (value: string): string => {
   }
 };
 
+const STOP_ABORT_SESSION_ERROR_PATTERN =
+  /^(?:aborted|request aborted|operation aborted|the operation was aborted|this operation was aborted|cancel(?:led|ed)|request cancel(?:led|ed)|operation cancel(?:led|ed)|cancel(?:led|ed) by user|request cancel(?:led|ed) by user)$/i;
+
+export const isStopAbortSessionErrorMessage = (value: string): boolean => {
+  const normalized = normalizeSessionErrorMessage(value)
+    .trim()
+    .replace(/[.!]+$/g, "")
+    .replace(/\s+/g, " ");
+  return STOP_ABORT_SESSION_ERROR_PATTERN.test(normalized);
+};
+
 export const normalizeRetryStatusMessage = (value: string): string => {
   const normalized = normalizeSessionErrorMessage(value);
   if (!normalized.startsWith("{")) {

--- a/apps/desktop/src/state/operations/agent-orchestrator/support/tool-messages.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/support/tool-messages.ts
@@ -122,6 +122,8 @@ export const normalizeSessionErrorMessage = (value: string): string => {
   }
 };
 
+// Keep this intentionally narrow and rely on stop intent as a second gate so
+// real runtime failures are not downgraded into user-stopped notices.
 const STOP_ABORT_SESSION_ERROR_PATTERN =
   /^(?:aborted|request aborted|operation aborted|the operation was aborted|this operation was aborted|cancel(?:led|ed)|request cancel(?:led|ed)|operation cancel(?:led|ed)|cancel(?:led|ed) by user|request cancel(?:led|ed) by user)$/i;
 

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -68,6 +68,12 @@ export type AgentChatMessageMeta =
       agent: string;
       prompt: string;
       description: string;
+    }
+  | {
+      kind: "session_notice";
+      tone: "cancelled";
+      reason: "user_stopped";
+      title: string;
     };
 
 export type AgentChatMessage = {
@@ -139,6 +145,7 @@ export type AgentSessionState = {
   selectedModel: AgentModelSelection | null;
   isLoadingModelCatalog: boolean;
   promptOverrides?: RepoPromptOverrides;
+  stopRequestedAt?: string | null;
 };
 
 export type AgentSessionLoadMode = "bootstrap" | "requested_history" | "reconcile_live";


### PR DESCRIPTION
## Summary
- replace raw `Session error: Aborted` transcript rows with a dedicated cancelled session notice card for intentional user stops in Agent Studio
- record transient stop intent in the orchestrator so only real user-requested stop terminal events are reclassified, while genuine failures stay on the error path
- unify terminal stop handling across both `session_error` and `session_finished`, including consistent settlement of dangling todo-tool rows and focused lifecycle/rendering coverage

## Testing
- bun test apps/desktop/src/state/operations/agent-orchestrator/agent-tool-messages.test.ts apps/desktop/src/state/operations/agent-orchestrator/support/tool-messages.test.ts apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts apps/desktop/src/state/operations/agent-orchestrator/handlers/session-actions.test.ts apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint

## Notes
- the stop notice now covers the actual adapter stop path, which emits `session_finished`, in addition to abort-style `session_error` variants
- rebased conflict resolution preserved upstream inline user file-reference rendering in `agent-chat-message-card-content.tsx` alongside the new session notice rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session notice messages that appear when users manually stop agent sessions, displaying "Session stopped at your request" with distinct visual styling to differentiate from error states.

* **Bug Fixes**
  * Improved tool message state management to correctly reflect user-initiated stops versus actual session failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->