### PR TITLE
fix(desktop): make chat composer Shift+Enter render immediately

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -139,6 +139,24 @@ const getLastTextSegment = (container: HTMLElement): HTMLElement => {
   return editable;
 };
 
+const collapseSelectionOnEditorRoot = (container: HTMLElement): HTMLElement => {
+  const editorRoot = getEditorRoot(container);
+  const collapsedRange = document.createRange();
+  collapsedRange.setStart(editorRoot, 0);
+  collapsedRange.collapse(true);
+  const selection = globalThis.getSelection?.();
+  selection?.removeAllRanges();
+  selection?.addRange(collapsedRange);
+  return editorRoot;
+};
+
+const expectComposerText = async (container: HTMLElement, text: string): Promise<void> => {
+  await waitFor(() => {
+    const contentRoot = container.querySelector("[data-composer-content-root]");
+    expect(contentRoot?.textContent).toBe(text);
+  });
+};
+
 const typeIntoEditor = (container: HTMLElement, value: string): HTMLElement => {
   const editable = getLastTextSegment(container);
   editable.textContent = value;
@@ -582,10 +600,7 @@ describe("AgentChatComposerEditor", () => {
     const editable = typeIntoEditor(rendered.container, "hello");
     fireEvent.keyDown(editable, { key: "Enter", shiftKey: true });
 
-    await waitFor(() => {
-      const updatedEditable = rendered.container.querySelector("[data-composer-content-root]");
-      expect(updatedEditable?.textContent).toBe("hello\n");
-    });
+    await expectComposerText(rendered.container, "hello\n");
   });
 
   test("inserts a newline from beforeinput line-break events", async () => {
@@ -604,10 +619,7 @@ describe("AgentChatComposerEditor", () => {
       }),
     );
 
-    await waitFor(() => {
-      const updatedEditable = rendered.container.querySelector("[data-composer-content-root]");
-      expect(updatedEditable?.textContent).toBe("hello\n");
-    });
+    await expectComposerText(rendered.container, "hello\n");
   });
 
   test("falls back to the last known caret offset when shift-enter keydown loses selection", async () => {
@@ -621,10 +633,7 @@ describe("AgentChatComposerEditor", () => {
 
     fireEvent.keyDown(editable, { key: "Enter", shiftKey: true });
 
-    await waitFor(() => {
-      const updatedEditable = rendered.container.querySelector("[data-composer-content-root]");
-      expect(updatedEditable?.textContent).toBe("hello\n");
-    });
+    await expectComposerText(rendered.container, "hello\n");
   });
 
   test("repairs the first shift-enter when selection is collapsed on the editor root", async () => {
@@ -637,20 +646,10 @@ describe("AgentChatComposerEditor", () => {
       />,
     );
 
-    const editorRoot = getEditorRoot(rendered.container);
-    const collapsedRange = document.createRange();
-    collapsedRange.setStart(editorRoot, 0);
-    collapsedRange.collapse(true);
-    const selection = globalThis.getSelection?.();
-    selection?.removeAllRanges();
-    selection?.addRange(collapsedRange);
-
+    const editorRoot = collapseSelectionOnEditorRoot(rendered.container);
     fireEvent.keyDown(editorRoot, { key: "Enter", shiftKey: true });
 
-    await waitFor(() => {
-      const updatedEditable = rendered.container.querySelector("[data-composer-content-root]");
-      expect(updatedEditable?.textContent).toBe("hello\n");
-    });
+    await expectComposerText(rendered.container, "hello\n");
   });
 
   test("renders empty trailing text segments as inline blocks for caret placement after slash chips", async () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -6,6 +6,14 @@ import type { AgentChatComposerDraft } from "./agent-chat-composer-draft";
 import { buildFileSearchResult, createComposerDraft } from "./agent-chat-test-fixtures";
 
 let AgentChatComposerEditor: typeof import("./agent-chat-composer-editor").AgentChatComposerEditor;
+const renderMockEditableTextContent = (text: string): string => {
+  if (text.length === 0) {
+    return "\u200B";
+  }
+
+  return text.endsWith("\n") ? `${text}\u200B` : text;
+};
+
 const setCaretOffsetWithinElementMock = mock((element: HTMLElement, logicalOffset: number) => {
   const selection =
     element.ownerDocument.defaultView?.getSelection() ?? globalThis.getSelection?.();
@@ -15,7 +23,9 @@ const setCaretOffsetWithinElementMock = mock((element: HTMLElement, logicalOffse
 
   let textNode = element.firstChild;
   if (!(textNode instanceof Text)) {
-    textNode = element.ownerDocument.createTextNode((element.textContent ?? "") || "\u200B");
+    textNode = element.ownerDocument.createTextNode(
+      renderMockEditableTextContent((element.textContent ?? "").replace(/\u200B/g, "")),
+    );
     element.replaceChildren(textNode);
   }
 
@@ -38,6 +48,7 @@ beforeAll(async () => {
     EMPTY_TEXT_SEGMENT_SENTINEL: "\u200B",
     readEditableTextContent: (element: HTMLElement): string =>
       (element.textContent ?? "").replace(/\u200B/g, ""),
+    renderEditableTextContent: renderMockEditableTextContent,
     getCaretOffsetWithinElement: getCaretOffsetWithinElementMock,
     insertTextAtCaretWithinElement: (
       element: HTMLElement,
@@ -153,7 +164,7 @@ const collapseSelectionOnEditorRoot = (container: HTMLElement): HTMLElement => {
 const expectComposerText = async (container: HTMLElement, text: string): Promise<void> => {
   await waitFor(() => {
     const contentRoot = container.querySelector("[data-composer-content-root]");
-    expect(contentRoot?.textContent).toBe(text);
+    expect((contentRoot?.textContent ?? "").replace(/\u200B/g, "")).toBe(text);
   });
 };
 
@@ -650,6 +661,18 @@ describe("AgentChatComposerEditor", () => {
     fireEvent.keyDown(editorRoot, { key: "Enter", shiftKey: true });
 
     await expectComposerText(rendered.container, "hello\n");
+  });
+
+  test("renders a trailing sentinel after the first shift-enter so the final blank line is visible", async () => {
+    resetSelectionMocks();
+    const rendered = render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
+
+    const editable = typeIntoEditor(rendered.container, "hello");
+    fireEvent.keyDown(editable, { key: "Enter", shiftKey: true });
+
+    await waitFor(() => {
+      expect(getLastTextSegment(rendered.container).textContent).toBe("hello\n\u200B");
+    });
   });
 
   test("renders empty trailing text segments as inline blocks for caret placement after slash chips", async () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -6,7 +6,28 @@ import type { AgentChatComposerDraft } from "./agent-chat-composer-draft";
 import { buildFileSearchResult, createComposerDraft } from "./agent-chat-test-fixtures";
 
 let AgentChatComposerEditor: typeof import("./agent-chat-composer-editor").AgentChatComposerEditor;
-const setCaretOffsetWithinElementMock = mock(() => {});
+const setCaretOffsetWithinElementMock = mock((element: HTMLElement, logicalOffset: number) => {
+  const selection =
+    element.ownerDocument.defaultView?.getSelection() ?? globalThis.getSelection?.();
+  if (!selection) {
+    return;
+  }
+
+  let textNode = element.firstChild;
+  if (!(textNode instanceof Text)) {
+    textNode = element.ownerDocument.createTextNode((element.textContent ?? "") || "\u200B");
+    element.replaceChildren(textNode);
+  }
+
+  const textContent = textNode.textContent ?? "";
+  const boundedOffset =
+    textContent === "\u200B" ? 1 : Math.max(0, Math.min(logicalOffset, textContent.length));
+  const range = element.ownerDocument.createRange();
+  range.setStart(textNode, boundedOffset);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+});
 const getCaretOffsetWithinElementMock = mock(
   (element: HTMLElement): number | null =>
     (element.textContent ?? "").replace(/\u200B/g, "").length,
@@ -599,6 +620,32 @@ describe("AgentChatComposerEditor", () => {
       .mockImplementationOnce(() => null);
 
     fireEvent.keyDown(editable, { key: "Enter", shiftKey: true });
+
+    await waitFor(() => {
+      const updatedEditable = rendered.container.querySelector("[data-composer-content-root]");
+      expect(updatedEditable?.textContent).toBe("hello\n");
+    });
+  });
+
+  test("repairs the first shift-enter when selection is collapsed on the editor root", async () => {
+    resetSelectionMocks();
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        initialDraft={createComposerDraft("hello")}
+      />,
+    );
+
+    const editorRoot = getEditorRoot(rendered.container);
+    const collapsedRange = document.createRange();
+    collapsedRange.setStart(editorRoot, 0);
+    collapsedRange.collapse(true);
+    const selection = globalThis.getSelection?.();
+    selection?.removeAllRanges();
+    selection?.addRange(collapsedRange);
+
+    fireEvent.keyDown(editorRoot, { key: "Enter", shiftKey: true });
 
     await waitFor(() => {
       const updatedEditable = rendered.container.querySelector("[data-composer-content-root]");

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
@@ -8,8 +8,8 @@ import {
 } from "./agent-chat-composer-draft";
 import { AgentChatComposerFileMenu } from "./agent-chat-composer-file-menu";
 import {
-  EMPTY_TEXT_SEGMENT_SENTINEL,
   readEditableTextContent,
+  renderEditableTextContent,
 } from "./agent-chat-composer-selection";
 import { AgentChatComposerSlashMenu } from "./agent-chat-composer-slash-menu";
 import {
@@ -117,9 +117,9 @@ const buildComposerContentMarkup = (draft: AgentChatComposerDraft): string => {
           : "inline",
       );
 
-      return `<span data-segment-id="${escapeHtml(segment.id)}" data-text-segment-id="${escapeHtml(segment.id)}" class="${escapeHtml(className)}">${
-        segment.text.length > 0 ? escapeHtml(segment.text) : EMPTY_TEXT_SEGMENT_SENTINEL
-      }</span>`;
+      return `<span data-segment-id="${escapeHtml(segment.id)}" data-text-segment-id="${escapeHtml(segment.id)}" class="${escapeHtml(className)}">${escapeHtml(
+        renderEditableTextContent(segment.text),
+      )}</span>`;
     })
     .join("");
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-selection.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-selection.ts
@@ -4,12 +4,18 @@ export const readEditableTextContent = (element: HTMLElement): string => {
   return (element.textContent ?? "").split(EMPTY_TEXT_SEGMENT_SENTINEL).join("");
 };
 
+export const renderEditableTextContent = (text: string): string => {
+  if (text.length === 0) {
+    return EMPTY_TEXT_SEGMENT_SENTINEL;
+  }
+
+  return text.endsWith("\n") ? `${text}${EMPTY_TEXT_SEGMENT_SENTINEL}` : text;
+};
+
 const normalizeEditableTextNode = (element: HTMLElement): Text => {
   const ownerDocument = element.ownerDocument;
   const normalizedText = readEditableTextContent(element);
-  const textNode = ownerDocument.createTextNode(
-    normalizedText.length > 0 ? normalizedText : EMPTY_TEXT_SEGMENT_SENTINEL,
-  );
+  const textNode = ownerDocument.createTextNode(renderEditableTextContent(normalizedText));
   element.replaceChildren(textNode);
   return textNode;
 };

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -641,6 +641,35 @@ export const useAgentChatComposerEditor = ({
     [rememberSelectionTarget, repairCollapsedSelection, syncMenusForSelectionTarget],
   );
 
+  const resolveSelectionTargetForLineBreak = useCallback(
+    (
+      root: HTMLDivElement,
+      sourceDraft: AgentChatComposerDraft,
+      activeSelection: ActiveTextSelection | null,
+    ): TextSelectionTarget | null => {
+      if (activeSelection) {
+        return resolveTextSelectionTarget(sourceDraft, {
+          segmentId: activeSelection.segmentId,
+          offset: activeSelection.caretOffset ?? activeSelection.text.length,
+        });
+      }
+
+      const repairedSelection = repairCollapsedSelection(root, sourceDraft);
+      if (repairedSelection) {
+        return resolveTextSelectionTarget(sourceDraft, {
+          segmentId: repairedSelection.segmentId,
+          offset: repairedSelection.caretOffset ?? repairedSelection.text.length,
+        });
+      }
+
+      return (
+        resolveTextSelectionTarget(sourceDraft, rememberedSelectionRef.current) ??
+        getLastTextSelectionTarget(sourceDraft)
+      );
+    },
+    [repairCollapsedSelection],
+  );
+
   useEffect(() => {
     if (!disabled && supportsSlashCommands) {
       return;
@@ -876,12 +905,7 @@ export const useAgentChatComposerEditor = ({
       closeFileMenu();
 
       void insertNewlineAtSelectionTarget(
-        activeSelection
-          ? {
-              segmentId: activeSelection.segmentId,
-              offset: activeSelection.caretOffset ?? activeSelection.text.length,
-            }
-          : rememberedSelectionRef.current,
+        resolveSelectionTargetForLineBreak(event.currentTarget, sourceDraft, activeSelection),
       );
     },
     [
@@ -890,6 +914,7 @@ export const useAgentChatComposerEditor = ({
       insertNewlineAtSelectionTarget,
       rememberSelectionTarget,
       repairCollapsedSelection,
+      resolveSelectionTargetForLineBreak,
     ],
   );
 
@@ -1019,12 +1044,7 @@ export const useAgentChatComposerEditor = ({
       if (event.key === "Enter" && event.shiftKey) {
         event.preventDefault();
         void insertNewlineAtSelectionTarget(
-          activeSelection
-            ? {
-                segmentId: activeSelection.segmentId,
-                offset: activeSelection.caretOffset ?? activeSelection.text.length,
-              }
-            : rememberedSelectionRef.current,
+          resolveSelectionTargetForLineBreak(root, sourceDraft, activeSelection),
         );
         return;
       }
@@ -1083,6 +1103,7 @@ export const useAgentChatComposerEditor = ({
       insertNewlineAtSelectionTarget,
       onSend,
       repairCollapsedSelection,
+      resolveSelectionTargetForLineBreak,
       selectFileSearchResult,
       selectSlashCommand,
       slashMenuState,

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -116,6 +116,20 @@ const clampTextSelectionOffset = (text: string, offset: number): number => {
   return Math.max(0, Math.min(offset, text.length));
 };
 
+const resolveSelectionTargetFromActiveSelection = (
+  draft: AgentChatComposerDraft,
+  activeSelection: ActiveTextSelection | null,
+): TextSelectionTarget | null => {
+  if (!activeSelection) {
+    return null;
+  }
+
+  return resolveTextSelectionTarget(draft, {
+    segmentId: activeSelection.segmentId,
+    offset: activeSelection.caretOffset ?? activeSelection.text.length,
+  });
+};
+
 const resolveTextSelectionTarget = (
   draft: AgentChatComposerDraft,
   selectionTarget: TextSelectionTarget | null,
@@ -455,6 +469,13 @@ export const useAgentChatComposerEditor = ({
     [],
   );
 
+  const getFallbackSelectionTarget = useCallback((sourceDraft: AgentChatComposerDraft) => {
+    return (
+      resolveTextSelectionTarget(sourceDraft, rememberedSelectionRef.current) ??
+      getLastTextSelectionTarget(sourceDraft)
+    );
+  }, []);
+
   const repairCollapsedSelection = useCallback(
     (root: HTMLDivElement, sourceDraft: AgentChatComposerDraft): ActiveTextSelection | null => {
       const selection =
@@ -463,9 +484,7 @@ export const useAgentChatComposerEditor = ({
         return null;
       }
 
-      const fallbackTarget =
-        resolveTextSelectionTarget(sourceDraft, rememberedSelectionRef.current) ??
-        getLastTextSelectionTarget(sourceDraft);
+      const fallbackTarget = getFallbackSelectionTarget(sourceDraft);
       if (!fallbackTarget) {
         return null;
       }
@@ -477,9 +496,34 @@ export const useAgentChatComposerEditor = ({
       }
 
       rememberSelectionTarget(sourceDraft, fallbackTarget);
-      return readActiveTextSelection(root);
+      const repairedElement = root.querySelector<HTMLElement>(
+        `[data-text-segment-id="${CSS.escape(fallbackTarget.segmentId)}"]`,
+      );
+      if (!repairedElement) {
+        return null;
+      }
+
+      return {
+        segmentId: fallbackTarget.segmentId,
+        element: repairedElement,
+        text: readEditableTextContent(repairedElement),
+        caretOffset: fallbackTarget.offset,
+      };
     },
-    [focusTextSegment, rememberSelectionTarget, setPendingFocusTarget],
+    [focusTextSegment, getFallbackSelectionTarget, rememberSelectionTarget, setPendingFocusTarget],
+  );
+
+  const resolveActiveTextSelection = useCallback(
+    (
+      root: HTMLDivElement,
+      sourceDraft: AgentChatComposerDraft,
+      eventTarget?: EventTarget | null,
+    ) => {
+      return (
+        readActiveTextSelection(root, eventTarget) ?? repairCollapsedSelection(root, sourceDraft)
+      );
+    },
+    [repairCollapsedSelection],
   );
 
   const focusTextSegmentWithMemory = useCallback(
@@ -627,18 +671,15 @@ export const useAgentChatComposerEditor = ({
       sourceDraft: AgentChatComposerDraft,
       eventTarget?: EventTarget | null,
     ) => {
-      const activeSelection =
-        readActiveTextSelection(root, eventTarget) ?? repairCollapsedSelection(root, sourceDraft);
-      const selectionTarget = activeSelection
-        ? resolveTextSelectionTarget(sourceDraft, {
-            segmentId: activeSelection.segmentId,
-            offset: activeSelection.caretOffset ?? activeSelection.text.length,
-          })
-        : null;
+      const activeSelection = resolveActiveTextSelection(root, sourceDraft, eventTarget);
+      const selectionTarget = resolveSelectionTargetFromActiveSelection(
+        sourceDraft,
+        activeSelection,
+      );
       rememberSelectionTarget(sourceDraft, selectionTarget);
       syncMenusForSelectionTarget(sourceDraft, selectionTarget);
     },
-    [rememberSelectionTarget, repairCollapsedSelection, syncMenusForSelectionTarget],
+    [rememberSelectionTarget, resolveActiveTextSelection, syncMenusForSelectionTarget],
   );
 
   const resolveSelectionTargetForLineBreak = useCallback(
@@ -647,27 +688,14 @@ export const useAgentChatComposerEditor = ({
       sourceDraft: AgentChatComposerDraft,
       activeSelection: ActiveTextSelection | null,
     ): TextSelectionTarget | null => {
-      if (activeSelection) {
-        return resolveTextSelectionTarget(sourceDraft, {
-          segmentId: activeSelection.segmentId,
-          offset: activeSelection.caretOffset ?? activeSelection.text.length,
-        });
-      }
-
-      const repairedSelection = repairCollapsedSelection(root, sourceDraft);
-      if (repairedSelection) {
-        return resolveTextSelectionTarget(sourceDraft, {
-          segmentId: repairedSelection.segmentId,
-          offset: repairedSelection.caretOffset ?? repairedSelection.text.length,
-        });
-      }
-
+      const resolvedActiveSelection =
+        activeSelection ?? resolveActiveTextSelection(root, sourceDraft);
       return (
-        resolveTextSelectionTarget(sourceDraft, rememberedSelectionRef.current) ??
-        getLastTextSelectionTarget(sourceDraft)
+        resolveSelectionTargetFromActiveSelection(sourceDraft, resolvedActiveSelection) ??
+        getFallbackSelectionTarget(sourceDraft)
       );
     },
-    [repairCollapsedSelection],
+    [getFallbackSelectionTarget, resolveActiveTextSelection],
   );
 
   useEffect(() => {
@@ -819,12 +847,10 @@ export const useAgentChatComposerEditor = ({
     (root: HTMLDivElement) => {
       const activeSelection = readActiveTextSelection(root);
       const nextDraft = parseComposerDraftFromRoot(root, latestDraftRef.current);
-      const activeSelectionTarget = activeSelection
-        ? resolveTextSelectionTarget(nextDraft, {
-            segmentId: activeSelection.segmentId,
-            offset: activeSelection.caretOffset ?? activeSelection.text.length,
-          })
-        : null;
+      const activeSelectionTarget = resolveSelectionTargetFromActiveSelection(
+        nextDraft,
+        activeSelection,
+      );
       const nextSelectionTarget =
         activeSelectionTarget ??
         deriveTextSelectionTargetAfterInput(
@@ -864,17 +890,19 @@ export const useAgentChatComposerEditor = ({
   const handleEditorBeforeInput = useCallback(
     (event: ReactFormEvent<HTMLDivElement>) => {
       const sourceDraft = latestDraftRef.current;
-      const activeSelection =
-        readActiveTextSelection(event.currentTarget, event.target) ??
-        repairCollapsedSelection(event.currentTarget, sourceDraft);
+      const activeSelection = resolveActiveTextSelection(
+        event.currentTarget,
+        sourceDraft,
+        event.target,
+      );
       const nativeEvent = event.nativeEvent as { inputType?: unknown; data?: unknown };
       const inputType = typeof nativeEvent.inputType === "string" ? nativeEvent.inputType : null;
       const data = typeof nativeEvent.data === "string" ? nativeEvent.data : null;
-      if (activeSelection && activeSelection.segmentId.length > 0) {
-        const selectionTarget = resolveTextSelectionTarget(sourceDraft, {
-          segmentId: activeSelection.segmentId,
-          offset: activeSelection.caretOffset ?? activeSelection.text.length,
-        });
+      const selectionTarget = resolveSelectionTargetFromActiveSelection(
+        sourceDraft,
+        activeSelection,
+      );
+      if (selectionTarget) {
         rememberSelectionTarget(sourceDraft, selectionTarget);
         pendingInputStateRef.current = selectionTarget
           ? {
@@ -913,7 +941,7 @@ export const useAgentChatComposerEditor = ({
       closeFileMenu,
       insertNewlineAtSelectionTarget,
       rememberSelectionTarget,
-      repairCollapsedSelection,
+      resolveActiveTextSelection,
       resolveSelectionTargetForLineBreak,
     ],
   );
@@ -940,12 +968,9 @@ export const useAgentChatComposerEditor = ({
 
       const sourceDraft = latestDraftRef.current;
       const activeSelection = readActiveTextSelection(event.currentTarget, event.target);
-      const selectionTarget = activeSelection
-        ? resolveTextSelectionTarget(sourceDraft, {
-            segmentId: activeSelection.segmentId,
-            offset: activeSelection.caretOffset ?? activeSelection.text.length,
-          })
-        : resolveTextSelectionTarget(sourceDraft, rememberedSelectionRef.current);
+      const selectionTarget =
+        resolveSelectionTargetFromActiveSelection(sourceDraft, activeSelection) ??
+        resolveTextSelectionTarget(sourceDraft, rememberedSelectionRef.current);
 
       rememberSelectionTarget(sourceDraft, selectionTarget);
       syncMenusForSelectionTarget(sourceDraft, selectionTarget);
@@ -1049,7 +1074,7 @@ export const useAgentChatComposerEditor = ({
         return;
       }
 
-      const repairedSelection = activeSelection ?? repairCollapsedSelection(root, sourceDraft);
+      const repairedSelection = activeSelection ?? resolveActiveTextSelection(root, sourceDraft);
       if (!repairedSelection) {
         return;
       }
@@ -1102,7 +1127,7 @@ export const useAgentChatComposerEditor = ({
       focusTextSegmentWithMemory,
       insertNewlineAtSelectionTarget,
       onSend,
-      repairCollapsedSelection,
+      resolveActiveTextSelection,
       resolveSelectionTargetForLineBreak,
       selectFileSearchResult,
       selectSlashCommand,


### PR DESCRIPTION
## Summary
- fix the chat composer so the first `Shift+Enter` visibly inserts a new line in Tauri/WebKit instead of storing an invisible trailing newline
- centralize composer selection recovery so keydown and beforeinput line-break handling resolve the same caret target and repair collapsed root selections consistently
- add regression coverage for first-press `Shift+Enter`, lost-caret recovery, root-collapsed selection recovery, and trailing-line rendering with the hidden sentinel used for WebKit contenteditable behavior

## Root Cause
The original bug was not only selection bookkeeping. In Tauri/WebKit, the first `Shift+Enter` could leave the composer with a trailing `\n` that did not render a visible final blank line in the contenteditable surface. That made the first line break appear to do nothing, while the second one finally became visible.

## Implementation Notes
- add `renderEditableTextContent(...)` to preserve a hidden trailing sentinel after terminal newlines while still reading logical text without sentinels
- render text segments through that normalized content path in the composer editor so trailing blank lines remain visible/editable in WebKit
- simplify selection-target derivation in `use-agent-chat-composer-editor.ts` so active selection, repaired selection, and remembered fallback selection go through shared helpers instead of duplicated branches

## Testing
- `bun test apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of text selection and caret positioning in the agent chat composer, particularly when inserting line breaks.
  * Enhanced visibility of empty lines and line-break formatting in the composer editor.

* **Tests**
  * Added comprehensive test coverage for text selection repair behavior and line-break insertion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->