### PR TITLE
fix(desktop): improve session error transcript notices

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
@@ -89,7 +89,10 @@ const toArticleClassName = (
   }
 
   if (isSessionNoticeMessage) {
-    return "text-sm my-2 rounded-md border border-cancelled-border bg-cancelled-surface px-3 py-2 text-cancelled-surface-foreground";
+    const sessionNoticeTone = meta?.kind === "session_notice" ? meta.tone : "cancelled";
+    return sessionNoticeTone === "error"
+      ? "text-sm my-2 rounded-md border border-destructive-border bg-destructive-surface px-3 py-2 text-destructive-surface-foreground"
+      : "text-sm my-2 rounded-md border border-cancelled-border bg-cancelled-surface px-3 py-2 text-cancelled-surface-foreground";
   }
 
   return cn(

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-view-model.ts
@@ -14,6 +14,13 @@ import {
   SYSTEM_PROMPT_PREFIX,
 } from "./agent-chat-message-card-model";
 
+const SESSION_NOTICE_TONE_CLASS_NAMES = {
+  cancelled:
+    "text-sm my-2 rounded-md border border-cancelled-border bg-cancelled-surface px-3 py-2 text-cancelled-surface-foreground",
+  error:
+    "text-sm my-2 rounded-md border border-destructive-border bg-destructive-surface px-3 py-2 text-destructive-surface-foreground",
+} as const;
+
 type AgentChatMessageCardViewModelInput = {
   message: AgentChatMessage;
   sessionRole: AgentRole | null;
@@ -90,9 +97,7 @@ const toArticleClassName = (
 
   if (isSessionNoticeMessage) {
     const sessionNoticeTone = meta?.kind === "session_notice" ? meta.tone : "cancelled";
-    return sessionNoticeTone === "error"
-      ? "text-sm my-2 rounded-md border border-destructive-border bg-destructive-surface px-3 py-2 text-destructive-surface-foreground"
-      : "text-sm my-2 rounded-md border border-cancelled-border bg-cancelled-surface px-3 py-2 text-cancelled-surface-foreground";
+    return SESSION_NOTICE_TONE_CLASS_NAMES[sessionNoticeTone];
   }
 
   return cn(

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -415,6 +415,35 @@ describe("AgentChatMessageCard tool duration", () => {
     expect(html).not.toContain(">System<");
   });
 
+  test("renders session error notices as destructive cards", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "session-notice-error",
+          role: "system",
+          content: "Our servers are currently overloaded. Please try again later.",
+          timestamp: "2026-02-22T10:21:50.000Z",
+          meta: {
+            kind: "session_notice",
+            tone: "error",
+            reason: "session_error",
+            title: "Error",
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("border-destructive-border");
+    expect(html).toContain("bg-destructive-surface");
+    expect(html).toContain("Our servers are currently overloaded. Please try again later.");
+    expect(html).toContain("Error");
+    expect(html).not.toContain("border-cancelled-border");
+    expect(html).not.toContain(">System<");
+  });
+
   test("renders system prompt as expandable card", () => {
     const html = renderToStaticMarkup(
       createElement(AgentChatMessageCard, {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -701,7 +701,7 @@ describe("agent-orchestrator-session-events", () => {
     ).toBe(true);
   });
 
-  test("clears pending requests when session_error is received", () => {
+  test("records session_error as an error notice and clears pending requests", () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const adapter: SessionEventAdapter = {
       subscribeEvents: (_sessionId, handler) => {
@@ -785,11 +785,14 @@ describe("agent-orchestrator-session-events", () => {
     expect(sessionsRef.current["session-1"]?.status).toBe("error");
     expect(sessionsRef.current["session-1"]?.pendingPermissions).toHaveLength(0);
     expect(sessionsRef.current["session-1"]?.pendingQuestions).toHaveLength(0);
-    expect(
-      sessionsRef.current["session-1"]?.messages.some((message) =>
-        message.content.includes("Session error: Aborted"),
-      ),
-    ).toBe(true);
+    const lastMessage = sessionsRef.current["session-1"]?.messages.at(-1);
+    expect(lastMessage?.content).toBe("Aborted");
+    expect(lastMessage?.meta).toEqual({
+      kind: "session_notice",
+      tone: "error",
+      reason: "session_error",
+      title: "Error",
+    });
   });
 
   test("renders a cancelled session notice when a user-requested stop aborts", () => {
@@ -1171,11 +1174,14 @@ describe("agent-orchestrator-session-events", () => {
         message.content.includes("Session stopped at your request."),
       ),
     ).toBe(false);
-    expect(
-      sessionsRef.current["session-1"]?.messages.some((message) =>
-        message.content.includes("Session error: Permission denied"),
-      ),
-    ).toBe(true);
+    const lastMessage = sessionsRef.current["session-1"]?.messages.at(-1);
+    expect(lastMessage?.content).toBe("Permission denied");
+    expect(lastMessage?.meta).toEqual({
+      kind: "session_notice",
+      tone: "error",
+      reason: "session_error",
+      title: "Error",
+    });
   });
 
   test("finalizes assistant draft through status transitions", () => {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -795,6 +795,78 @@ describe("agent-orchestrator-session-events", () => {
     });
   });
 
+  test("normalizes JSON-wrapped session_error payloads before rendering the error notice", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          role: "build",
+        }),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "session_error",
+      sessionId: "session-1",
+      message: '{"message":"Our servers are currently overloaded. Please try again later."}',
+      timestamp: "2026-02-22T08:00:10.000Z",
+    });
+
+    const lastMessage = sessionsRef.current["session-1"]?.messages.at(-1);
+    expect(lastMessage?.content).toBe(
+      "Our servers are currently overloaded. Please try again later.",
+    );
+    expect(lastMessage?.meta).toEqual({
+      kind: "session_notice",
+      tone: "error",
+      reason: "session_error",
+      title: "Error",
+    });
+  });
+
   test("renders a cancelled session notice when a user-requested stop aborts", () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const adapter: SessionEventAdapter = {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -380,31 +380,48 @@ export const handleSessionTodosUpdated = (
   );
 };
 
-const buildUserStoppedNoticeMessage = (timestamp: string) => ({
+const buildSessionNoticeMessage = ({
+  timestamp,
+  content,
+  tone,
+  reason,
+  title,
+}: {
+  timestamp: string;
+  content: string;
+  tone: "cancelled" | "error";
+  reason: "user_stopped" | "session_error";
+  title: string;
+}) => ({
   id: crypto.randomUUID(),
   role: "system" as const,
-  content: "Session stopped at your request.",
+  content,
   timestamp,
   meta: {
     kind: "session_notice" as const,
-    tone: "cancelled" as const,
-    reason: "user_stopped" as const,
-    title: "Stopped",
+    tone,
+    reason,
+    title,
   },
 });
 
-const buildSessionErrorNoticeMessage = (timestamp: string, message: string) => ({
-  id: crypto.randomUUID(),
-  role: "system" as const,
-  content: message,
-  timestamp,
-  meta: {
-    kind: "session_notice" as const,
-    tone: "error" as const,
-    reason: "session_error" as const,
+const buildUserStoppedNoticeMessage = (timestamp: string) =>
+  buildSessionNoticeMessage({
+    timestamp,
+    content: "Session stopped at your request.",
+    tone: "cancelled",
+    reason: "user_stopped",
+    title: "Stopped",
+  });
+
+const buildSessionErrorNoticeMessage = (timestamp: string, message: string) =>
+  buildSessionNoticeMessage({
+    timestamp,
+    content: message,
+    tone: "error",
+    reason: "session_error",
     title: "Error",
-  },
-});
+  });
 
 const settleTerminalMessages = (
   messages: SessionLifecycleEventContext["store"]["sessionsRef"]["current"][string]["messages"],

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -393,6 +393,19 @@ const buildUserStoppedNoticeMessage = (timestamp: string) => ({
   },
 });
 
+const buildSessionErrorNoticeMessage = (timestamp: string, message: string) => ({
+  id: crypto.randomUUID(),
+  role: "system" as const,
+  content: message,
+  timestamp,
+  meta: {
+    kind: "session_notice" as const,
+    tone: "error" as const,
+    reason: "session_error" as const,
+    title: "Error",
+  },
+});
+
 const settleTerminalMessages = (
   messages: SessionLifecycleEventContext["store"]["sessionsRef"]["current"][string]["messages"],
   timestamp: string,
@@ -452,12 +465,7 @@ export const handleSessionError = (
                 outcome: "error",
                 errorMessage: sessionErrorMessage,
               }),
-              {
-                id: crypto.randomUUID(),
-                role: "system" as const,
-                content: `Session error: ${sessionErrorMessage}`,
-                timestamp: event.timestamp,
-              },
+              buildSessionErrorNoticeMessage(event.timestamp, sessionErrorMessage),
             ],
       };
     },

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -384,25 +384,38 @@ const buildSessionNoticeMessage = ({
   timestamp,
   content,
   tone,
-  reason,
   title,
-}: {
-  timestamp: string;
-  content: string;
-  tone: "cancelled" | "error";
-  reason: "user_stopped" | "session_error";
-  title: string;
-}) => ({
+}:
+  | {
+      timestamp: string;
+      content: string;
+      tone: "cancelled";
+      title: string;
+    }
+  | {
+      timestamp: string;
+      content: string;
+      tone: "error";
+      title: string;
+    }) => ({
   id: crypto.randomUUID(),
   role: "system" as const,
   content,
   timestamp,
-  meta: {
-    kind: "session_notice" as const,
-    tone,
-    reason,
-    title,
-  },
+  meta:
+    tone === "cancelled"
+      ? {
+          kind: "session_notice" as const,
+          tone: "cancelled" as const,
+          reason: "user_stopped" as const,
+          title,
+        }
+      : {
+          kind: "session_notice" as const,
+          tone: "error" as const,
+          reason: "session_error" as const,
+          title,
+        },
 });
 
 const buildUserStoppedNoticeMessage = (timestamp: string) =>
@@ -410,7 +423,6 @@ const buildUserStoppedNoticeMessage = (timestamp: string) =>
     timestamp,
     content: "Session stopped at your request.",
     tone: "cancelled",
-    reason: "user_stopped",
     title: "Stopped",
   });
 
@@ -419,7 +431,6 @@ const buildSessionErrorNoticeMessage = (timestamp: string, message: string) =>
     timestamp,
     content: message,
     tone: "error",
-    reason: "session_error",
     title: "Error",
   });
 

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -71,8 +71,8 @@ export type AgentChatMessageMeta =
     }
   | {
       kind: "session_notice";
-      tone: "cancelled";
-      reason: "user_stopped";
+      tone: "cancelled" | "error";
+      reason: "user_stopped" | "session_error";
       title: string;
     };
 

--- a/apps/desktop/src/types/agent-orchestrator.ts
+++ b/apps/desktop/src/types/agent-orchestrator.ts
@@ -71,8 +71,14 @@ export type AgentChatMessageMeta =
     }
   | {
       kind: "session_notice";
-      tone: "cancelled" | "error";
-      reason: "user_stopped" | "session_error";
+      tone: "cancelled";
+      reason: "user_stopped";
+      title: string;
+    }
+  | {
+      kind: "session_notice";
+      tone: "error";
+      reason: "session_error";
       title: string;
     };
 


### PR DESCRIPTION
## Summary
- render non-stop `session_error` events as rich `session_notice` transcript cards instead of raw `System` text rows
- keep the normalized provider/runtime error text visible, preserve the cancelled notice path for user-requested stops, and use destructive semantic tokens for error styling
- consolidate session notice construction/styling helpers and add focused lifecycle and rendering coverage, including JSON-wrapped error payload normalization

## Testing
- bun test src/state/operations/agent-orchestrator/events/session-events.test.ts src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
- bun run typecheck
- bun test
- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session error notices now display with distinctive error styling and a clear "Error" label, improving visibility of critical issues.

* **Bug Fixes**
  * Fixed session notice styling to appropriately reflect the type of notice (cancelled vs. error) rather than always showing cancelled styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->