### PR TITLE
fix(desktop): align force push dialog with info callouts

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.test.tsx
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { render, screen } from "@testing-library/react";
 import { act } from "react";
+import { ForcePushDialog } from "./force-push-dialog";
 
 (
   globalThis as typeof globalThis & {
@@ -9,14 +10,19 @@ import { act } from "react";
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe("ForcePushDialog", () => {
-  let ForcePushDialog: typeof import("./force-push-dialog")["ForcePushDialog"];
+  let rendered: ReturnType<typeof render> | null = null;
 
-  beforeEach(async () => {
-    ({ ForcePushDialog } = await import("./force-push-dialog"));
+  afterEach(async () => {
+    if (rendered) {
+      await act(async () => {
+        rendered?.unmount();
+      });
+      rendered = null;
+    }
   });
 
   test("uses the info surface styling and body spacing for the safety content", async () => {
-    const rendered = render(
+    rendered = render(
       <ForcePushDialog
         pendingForcePush={{
           remote: "origin",
@@ -33,14 +39,18 @@ describe("ForcePushDialog", () => {
 
     const body = screen.getByTestId("agent-studio-git-force-push-body");
     const safetyNote = screen.getByTestId("agent-studio-git-force-push-safety-note");
+    const leaseCode = screen.getByText("--force-with-lease");
+    const forceCode = screen.getByText("--force");
 
     expect(body.className).toContain("space-y-4");
     expect(safetyNote.className).toContain("border-info-border");
     expect(safetyNote.className).toContain("bg-info-surface");
     expect(safetyNote.className).toContain("text-info-surface-foreground");
-
-    await act(async () => {
-      rendered.unmount();
-    });
+    expect(leaseCode.className).toContain("border-info-border");
+    expect(leaseCode.className).toContain("bg-info-surface/60");
+    expect(leaseCode.className).toContain("text-info-surface-foreground");
+    expect(forceCode.className).toContain("border-info-border");
+    expect(forceCode.className).toContain("bg-info-surface/60");
+    expect(forceCode.className).toContain("text-info-surface-foreground");
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.test.tsx
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ForcePushDialog", () => {
+  let ForcePushDialog: typeof import("./force-push-dialog")["ForcePushDialog"];
+
+  beforeEach(async () => {
+    ({ ForcePushDialog } = await import("./force-push-dialog"));
+  });
+
+  test("uses the info surface styling and body spacing for the safety content", async () => {
+    const rendered = render(
+      <ForcePushDialog
+        pendingForcePush={{
+          remote: "origin",
+          branch: "feature/task-11",
+          output: "non-fast-forward",
+          repoPath: "/repo",
+          workingDir: "/tmp/worktree",
+        }}
+        isPushing={false}
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+
+    const body = screen.getByTestId("agent-studio-git-force-push-body");
+    const safetyNote = screen.getByTestId("agent-studio-git-force-push-safety-note");
+
+    expect(body.className).toContain("space-y-4");
+    expect(safetyNote.className).toContain("border-info-border");
+    expect(safetyNote.className).toContain("bg-info-surface");
+    expect(safetyNote.className).toContain("text-info-surface-foreground");
+
+    await act(async () => {
+      rendered.unmount();
+    });
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
@@ -47,40 +47,42 @@ export const ForcePushDialog = memo(function ForcePushDialog({
       confirmIcon={ArrowUp}
       contentTestId="agent-studio-git-force-push-modal"
     >
-      <div className="rounded-xl border border-border bg-muted/35 px-4 py-4">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-          Branch
-        </p>
-        <div className="mt-2">
-          <code className={INLINE_CODE_CLASS_NAME}>{pendingForcePush?.branch ?? ""}</code>
-        </div>
-      </div>
-
-      <div
-        className="rounded-xl border border-border bg-muted/50 px-4 py-4"
-        data-testid="agent-studio-git-force-push-safety-note"
-      >
-        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-          Retry mode
-        </p>
-        <p className="mt-2 text-sm leading-6 text-muted-foreground">
-          The retry uses <code className={INLINE_CODE_CLASS_NAME}>--force-with-lease</code>. Git
-          checks that the remote branch still points to the commit you last fetched. If someone
-          pushed in the meantime, the retry fails instead of overwriting their work. This panel
-          never uses <code className={INLINE_CODE_CLASS_NAME}>--force</code>.
-        </p>
-      </div>
-
-      {pendingForcePush ? (
-        <div className="rounded-xl border border-border bg-muted/40 px-4 py-4">
+      <div className="space-y-4" data-testid="agent-studio-git-force-push-body">
+        <div className="rounded-xl border border-border bg-muted/35 px-4 py-4">
           <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-            Git output
+            Branch
           </p>
-          <pre className="mt-3 max-h-40 overflow-auto rounded-lg border border-border bg-background/80 p-3 text-xs whitespace-pre-wrap text-foreground">
-            {pendingForcePush.output}
-          </pre>
+          <div className="mt-2">
+            <code className={INLINE_CODE_CLASS_NAME}>{pendingForcePush?.branch ?? ""}</code>
+          </div>
         </div>
-      ) : null}
+
+        <div
+          className="rounded-xl border border-info-border bg-info-surface px-4 py-4 text-info-surface-foreground"
+          data-testid="agent-studio-git-force-push-safety-note"
+        >
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-info-surface-foreground">
+            Retry mode
+          </p>
+          <p className="mt-2 text-sm leading-6 text-info-surface-foreground">
+            The retry uses <code className={INLINE_CODE_CLASS_NAME}>--force-with-lease</code>. Git
+            checks that the remote branch still points to the commit you last fetched. If someone
+            pushed in the meantime, the retry fails instead of overwriting their work. This panel
+            never uses <code className={INLINE_CODE_CLASS_NAME}>--force</code>.
+          </p>
+        </div>
+
+        {pendingForcePush ? (
+          <div className="rounded-xl border border-border bg-muted/40 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Git output
+            </p>
+            <pre className="mt-3 max-h-40 overflow-auto rounded-lg border border-border bg-background/80 p-3 text-xs whitespace-pre-wrap text-foreground">
+              {pendingForcePush.output}
+            </pre>
+          </div>
+        ) : null}
+      </div>
     </GitConfirmationDialog>
   );
 });

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/force-push-dialog.tsx
@@ -11,6 +11,8 @@ type ForcePushDialogProps = {
   onConfirm: () => void;
 };
 
+const INFO_INLINE_CODE_CLASS_NAME = `${INLINE_CODE_CLASS_NAME} border-info-border bg-info-surface/60 text-info-surface-foreground`;
+
 export const ForcePushDialog = memo(function ForcePushDialog({
   pendingForcePush,
   isPushing,
@@ -61,14 +63,12 @@ export const ForcePushDialog = memo(function ForcePushDialog({
           className="rounded-xl border border-info-border bg-info-surface px-4 py-4 text-info-surface-foreground"
           data-testid="agent-studio-git-force-push-safety-note"
         >
-          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-info-surface-foreground">
-            Retry mode
-          </p>
-          <p className="mt-2 text-sm leading-6 text-info-surface-foreground">
-            The retry uses <code className={INLINE_CODE_CLASS_NAME}>--force-with-lease</code>. Git
-            checks that the remote branch still points to the commit you last fetched. If someone
-            pushed in the meantime, the retry fails instead of overwriting their work. This panel
-            never uses <code className={INLINE_CODE_CLASS_NAME}>--force</code>.
+          <p className="text-[11px] font-semibold uppercase tracking-[0.14em]">Retry mode</p>
+          <p className="mt-2 text-sm leading-6">
+            The retry uses <code className={INFO_INLINE_CODE_CLASS_NAME}>--force-with-lease</code>.
+            Git checks that the remote branch still points to the commit you last fetched. If
+            someone pushed in the meantime, the retry fails instead of overwriting their work. This
+            panel never uses <code className={INFO_INLINE_CODE_CLASS_NAME}>--force</code>.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- switch the Force Push modal safety note to the repo's semantic info-surface styling
- add explicit spacing between the modal body sections for clearer layout
- keep the inline code chips inside the info callout on the same semantic palette
- tighten the focused dialog test to use static imports and guaranteed teardown

## Testing Checklist
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run check:rust`
- [x] `bun run test:rust`

## Checklist
- [x] Change set is focused on the Force Push modal styling task
- [x] Frontend regression coverage updated for the touched behavior
- [x] No follow-up work intentionally left open in this PR

## Related Issues
- OpenDucktor task: `openducktor-jnr`

## Breaking Changes
- None

## Additional Context
- This is a UI-only change for the Agent Studio Force Push confirmation flow.
- The style update uses the repo's existing semantic info-surface tokens rather than hardcoded colors.