### PR TITLE
feat(desktop): add global error handling with crash recovery UI

### DIFF
--- a/apps/desktop/src/components/errors/app-crash-shell.test.tsx
+++ b/apps/desktop/src/components/errors/app-crash-shell.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { lazy, Suspense } from "react";
 import { AppCrashShell } from "./app-crash-shell";
 
 if (typeof globalThis.PromiseRejectionEvent === "undefined") {
@@ -226,6 +227,203 @@ describe("AppCrashShell", () => {
           configurable: true,
         });
       }
+    });
+  });
+
+  describe("lazy-load failure", () => {
+    test("shows fatal error page when a lazy module fails to load", async () => {
+      const LazyBroken = lazy(() =>
+        Promise.reject(new Error("Failed to fetch dynamically imported module")),
+      );
+
+      render(
+        <AppCrashShell>
+          <Suspense fallback={<div data-testid="loading">Loading...</div>}>
+            <LazyBroken />
+          </Suspense>
+        </AppCrashShell>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-title")).toBeDefined();
+      });
+
+      expect(screen.getByTestId("fatal-error-message").textContent).toBe(
+        "Failed to fetch dynamically imported module",
+      );
+      expect(screen.getByTestId("fatal-error-retry")).toBeDefined();
+    });
+  });
+
+  describe("error listener narrowing", () => {
+    test("ignores plain Event (resource load error) dispatched on window", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      expect(screen.getByTestId("healthy-app")).toBeDefined();
+
+      act(() => {
+        const resourceError = new Event("error");
+        window.dispatchEvent(resourceError);
+      });
+
+      expect(screen.getByTestId("healthy-app")).toBeDefined();
+      expect(screen.queryByTestId("fatal-error-title")).toBeNull();
+    });
+
+    test("ignores ErrorEvent without an error object (cross-origin script error)", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      act(() => {
+        const crossOriginError = new ErrorEvent("error", {
+          message: "Script error.",
+        });
+        window.dispatchEvent(crossOriginError);
+      });
+
+      expect(screen.getByTestId("healthy-app")).toBeDefined();
+      expect(screen.queryByTestId("fatal-error-title")).toBeNull();
+    });
+  });
+
+  describe("listener lifecycle", () => {
+    test("removes listeners on unmount", () => {
+      const originalRemoveEventListener = window.removeEventListener;
+      const removedListeners: string[] = [];
+      const removeListenerSpy = mock((type: string, ...args: unknown[]) => {
+        removedListeners.push(type);
+        return originalRemoveEventListener.call(
+          window,
+          type,
+          ...(args as [EventListenerOrEventListenerObject]),
+        );
+      });
+      window.removeEventListener =
+        removeListenerSpy as unknown as typeof window.removeEventListener;
+
+      try {
+        const { unmount } = render(
+          <AppCrashShell>
+            <div>App</div>
+          </AppCrashShell>,
+        );
+
+        unmount();
+
+        expect(removedListeners).toContain("error");
+        expect(removedListeners).toContain("unhandledrejection");
+      } finally {
+        window.removeEventListener = originalRemoveEventListener;
+      }
+    });
+
+    test("does not re-register listeners on rerender", () => {
+      const originalAddEventListener = window.addEventListener;
+      let addCount = 0;
+      const addListenerSpy = mock((type: string, ...args: unknown[]) => {
+        if (type === "error" || type === "unhandledrejection") {
+          addCount++;
+        }
+        return originalAddEventListener.call(
+          window,
+          type,
+          ...(args as [EventListenerOrEventListenerObject]),
+        );
+      });
+      window.addEventListener = addListenerSpy as unknown as typeof window.addEventListener;
+
+      try {
+        const { rerender } = render(
+          <AppCrashShell>
+            <div>First render</div>
+          </AppCrashShell>,
+        );
+
+        const countAfterMount = addCount;
+
+        rerender(
+          <AppCrashShell>
+            <div>Second render</div>
+          </AppCrashShell>,
+        );
+
+        rerender(
+          <AppCrashShell>
+            <div>Third render</div>
+          </AppCrashShell>,
+        );
+
+        expect(addCount).toBe(countAfterMount);
+      } finally {
+        window.addEventListener = originalAddEventListener;
+      }
+    });
+  });
+
+  describe("structured logging", () => {
+    function findStructuredLogCall(
+      errorMock: ReturnType<typeof mock>,
+      sourceFilter: string,
+    ): unknown[] {
+      const calls = errorMock.mock.calls as unknown[][];
+      const match = calls.find(
+        (args) => typeof args[0] === "string" && args[0].includes(sourceFilter),
+      );
+      if (!match) throw new Error(`No console.error call matching "${sourceFilter}"`);
+      return match;
+    }
+
+    test("logs structured context with raw value on boundary crash", async () => {
+      render(
+        <AppCrashShell>
+          <ThrowingChild shouldThrow={true} />
+        </AppCrashShell>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-title")).toBeDefined();
+      });
+
+      const structuredCall = findStructuredLogCall(consoleErrorMock, "[AppCrashShell]");
+      const context = structuredCall[structuredCall.length - 1] as Record<string, unknown>;
+      expect(context.source).toBe("boundary");
+      expect(context.rawValue).toBeInstanceOf(Error);
+      expect(context.timestamp).toBeDefined();
+    });
+
+    test("logs structured context with raw event on browser error", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      act(() => {
+        const errorEvent = new ErrorEvent("error", {
+          error: new Error("async boom"),
+          message: "Uncaught Error",
+        });
+        window.dispatchEvent(errorEvent);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-title")).toBeDefined();
+      });
+
+      const structuredCall = findStructuredLogCall(
+        consoleErrorMock,
+        "[AppCrashShell] Fatal error (error)",
+      );
+      const context = structuredCall[structuredCall.length - 1] as Record<string, unknown>;
+      expect(context.source).toBe("error");
+      expect(context.rawValue).toBeInstanceOf(ErrorEvent);
     });
   });
 });

--- a/apps/desktop/src/components/errors/app-crash-shell.test.tsx
+++ b/apps/desktop/src/components/errors/app-crash-shell.test.tsx
@@ -1,20 +1,10 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { lazy, Suspense } from "react";
+import { ensurePromiseRejectionEventPolyfill } from "@/test-utils/promise-rejection-event-polyfill";
 import { AppCrashShell } from "./app-crash-shell";
 
-if (typeof globalThis.PromiseRejectionEvent === "undefined") {
-  (globalThis as Record<string, unknown>).PromiseRejectionEvent =
-    class PromiseRejectionEvent extends Event {
-      readonly reason: unknown;
-      readonly promise: Promise<unknown>;
-      constructor(type: string, init: { reason?: unknown; promise: Promise<unknown> }) {
-        super(type);
-        this.reason = init.reason;
-        this.promise = init.promise;
-      }
-    };
-}
+ensurePromiseRejectionEventPolyfill();
 
 const originalConsoleError = console.error;
 let consoleErrorMock: ReturnType<typeof mock>;
@@ -122,6 +112,29 @@ describe("AppCrashShell", () => {
       expect(screen.getByTestId("fatal-error-title").textContent).toBe("TypeError");
     });
 
+    test("captures ErrorEvent with a falsy thrown payload", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      act(() => {
+        const errorEvent = new ErrorEvent("error", {
+          error: 0,
+          message: "",
+        });
+        window.dispatchEvent(errorEvent);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-title")).toBeDefined();
+      });
+
+      expect(screen.getByTestId("fatal-error-title").textContent).toBe("Uncaught error");
+      expect(screen.getByTestId("fatal-error-message").textContent).toBe("0");
+    });
+
     test("captures unhandled rejection events", async () => {
       render(
         <AppCrashShell>
@@ -142,6 +155,54 @@ describe("AppCrashShell", () => {
       });
 
       expect(screen.getByTestId("fatal-error-message").textContent).toBe("Unhandled async error");
+    });
+
+    test("prevents default handling for fatal browser error events", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      const errorEvent = new ErrorEvent("error", {
+        cancelable: true,
+        error: new Error("prevent default"),
+        message: "Uncaught Error",
+      });
+
+      act(() => {
+        window.dispatchEvent(errorEvent);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-title")).toBeDefined();
+      });
+
+      expect(errorEvent.defaultPrevented).toBe(true);
+    });
+
+    test("prevents default handling for fatal unhandled rejection events", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      const rejectionEvent = new PromiseRejectionEvent("unhandledrejection", {
+        cancelable: true,
+        promise: Promise.resolve(),
+        reason: new Error("prevent duplicate rejection logging"),
+      });
+
+      act(() => {
+        window.dispatchEvent(rejectionEvent);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-title")).toBeDefined();
+      });
+
+      expect(rejectionEvent.defaultPrevented).toBe(true);
     });
 
     test("ignores duplicate errors when already in fatal state", async () => {
@@ -172,6 +233,70 @@ describe("AppCrashShell", () => {
       });
 
       expect(screen.getByTestId("fatal-error-message").textContent).toBe("First error");
+    });
+
+    test("keeps the first fatal report when multiple errors fire in the same tick", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      act(() => {
+        window.dispatchEvent(
+          new ErrorEvent("error", {
+            error: new Error("First same-tick error"),
+            message: "first",
+          }),
+        );
+        window.dispatchEvent(
+          new ErrorEvent("error", {
+            error: new Error("Second same-tick error"),
+            message: "second",
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-message")).toBeDefined();
+      });
+
+      expect(screen.getByTestId("fatal-error-message").textContent).toBe("First same-tick error");
+    });
+
+    test("captures a new fatal event immediately after retry clears the shell", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      act(() => {
+        window.dispatchEvent(
+          new ErrorEvent("error", {
+            error: new Error("First fatal event"),
+            message: "first",
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-retry")).toBeDefined();
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByTestId("fatal-error-retry"));
+        window.dispatchEvent(
+          new ErrorEvent("error", {
+            error: new Error("Second fatal event"),
+            message: "second",
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-message").textContent).toBe("Second fatal event");
+      });
     });
   });
 

--- a/apps/desktop/src/components/errors/app-crash-shell.test.tsx
+++ b/apps/desktop/src/components/errors/app-crash-shell.test.tsx
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AppCrashShell } from "./app-crash-shell";
+
+if (typeof globalThis.PromiseRejectionEvent === "undefined") {
+  (globalThis as Record<string, unknown>).PromiseRejectionEvent =
+    class PromiseRejectionEvent extends Event {
+      readonly reason: unknown;
+      readonly promise: Promise<unknown>;
+      constructor(type: string, init: { reason?: unknown; promise: Promise<unknown> }) {
+        super(type);
+        this.reason = init.reason;
+        this.promise = init.promise;
+      }
+    };
+}
+
+const originalConsoleError = console.error;
+let consoleErrorMock: ReturnType<typeof mock>;
+
+beforeEach(() => {
+  consoleErrorMock = mock(() => {});
+  console.error = consoleErrorMock as unknown as typeof console.error;
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }): React.ReactElement {
+  if (shouldThrow) {
+    throw new Error("Test render explosion");
+  }
+  return <div data-testid="healthy-app">App is running</div>;
+}
+
+describe("AppCrashShell", () => {
+  describe("normal operation", () => {
+    test("renders children when no error occurs", () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      expect(screen.getByTestId("healthy-app")).toBeDefined();
+    });
+  });
+
+  describe("React error boundary", () => {
+    test("shows fatal error page when child throws during render", async () => {
+      render(
+        <AppCrashShell>
+          <ThrowingChild shouldThrow={true} />
+        </AppCrashShell>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-title")).toBeDefined();
+      });
+
+      expect(screen.getByTestId("fatal-error-title").textContent).toBe("Error");
+      expect(screen.getByTestId("fatal-error-message").textContent).toBe("Test render explosion");
+      expect(screen.getByTestId("fatal-error-retry")).toBeDefined();
+      expect(screen.getByTestId("fatal-error-go-kanban")).toBeDefined();
+    });
+
+    test("retry button remounts children with fresh error boundary", async () => {
+      let shouldThrow = true;
+
+      function ControlledThrower(): React.ReactElement {
+        if (shouldThrow) {
+          throw new Error("First render fails");
+        }
+        return <div data-testid="recovered-app">Recovered</div>;
+      }
+
+      render(
+        <AppCrashShell>
+          <ControlledThrower />
+        </AppCrashShell>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-retry")).toBeDefined();
+      });
+
+      shouldThrow = false;
+      fireEvent.click(screen.getByTestId("fatal-error-retry"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("recovered-app")).toBeDefined();
+      });
+
+      expect(screen.getByTestId("recovered-app").textContent).toBe("Recovered");
+    });
+  });
+
+  describe("browser error listeners", () => {
+    test("captures window error events", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      expect(screen.getByTestId("healthy-app")).toBeDefined();
+
+      act(() => {
+        const errorEvent = new ErrorEvent("error", {
+          error: new TypeError("Cannot read property 'foo' of null"),
+          message: "Uncaught TypeError",
+        });
+        window.dispatchEvent(errorEvent);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-title")).toBeDefined();
+      });
+
+      expect(screen.getByTestId("fatal-error-title").textContent).toBe("TypeError");
+    });
+
+    test("captures unhandled rejection events", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      act(() => {
+        const rejectionEvent = new PromiseRejectionEvent("unhandledrejection", {
+          promise: Promise.resolve(),
+          reason: new Error("Unhandled async error"),
+        });
+        window.dispatchEvent(rejectionEvent);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-title")).toBeDefined();
+      });
+
+      expect(screen.getByTestId("fatal-error-message").textContent).toBe("Unhandled async error");
+    });
+
+    test("ignores duplicate errors when already in fatal state", async () => {
+      render(
+        <AppCrashShell>
+          <div data-testid="healthy-app">App is running</div>
+        </AppCrashShell>,
+      );
+
+      act(() => {
+        const firstError = new ErrorEvent("error", {
+          error: new Error("First error"),
+          message: "first",
+        });
+        window.dispatchEvent(firstError);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-message")).toBeDefined();
+      });
+
+      act(() => {
+        const secondError = new ErrorEvent("error", {
+          error: new Error("Second error should be ignored"),
+          message: "second",
+        });
+        window.dispatchEvent(secondError);
+      });
+
+      expect(screen.getByTestId("fatal-error-message").textContent).toBe("First error");
+    });
+  });
+
+  describe("fatal error page UI", () => {
+    test("shows stack trace toggle when stack is present", async () => {
+      render(
+        <AppCrashShell>
+          <ThrowingChild shouldThrow={true} />
+        </AppCrashShell>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("fatal-error-toggle-details")).toBeDefined();
+      });
+
+      expect(screen.queryByTestId("fatal-error-stack")).toBeNull();
+
+      fireEvent.click(screen.getByTestId("fatal-error-toggle-details"));
+
+      expect(screen.getByTestId("fatal-error-stack")).toBeDefined();
+      expect(screen.getByTestId("fatal-error-stack").textContent).toContain(
+        "Test render explosion",
+      );
+    });
+
+    test("go to kanban navigates via location.replace", async () => {
+      const originalReplace = window.location.replace;
+      const replaceMock = mock(() => {});
+      Object.defineProperty(window.location, "replace", {
+        value: replaceMock,
+        writable: true,
+        configurable: true,
+      });
+
+      try {
+        render(
+          <AppCrashShell>
+            <ThrowingChild shouldThrow={true} />
+          </AppCrashShell>,
+        );
+
+        await waitFor(() => {
+          expect(screen.getByTestId("fatal-error-go-kanban")).toBeDefined();
+        });
+
+        fireEvent.click(screen.getByTestId("fatal-error-go-kanban"));
+
+        expect(replaceMock).toHaveBeenCalledWith("/kanban");
+      } finally {
+        Object.defineProperty(window.location, "replace", {
+          value: originalReplace,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+  });
+});

--- a/apps/desktop/src/components/errors/app-crash-shell.tsx
+++ b/apps/desktop/src/components/errors/app-crash-shell.tsx
@@ -1,0 +1,71 @@
+import { type ReactElement, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { AppErrorBoundary } from "./app-error-boundary";
+import { FatalErrorPage } from "./fatal-error-page";
+import { buildFatalErrorReport, type FatalErrorReport } from "./fatal-error-report";
+
+interface AppCrashShellProps {
+  children: ReactNode;
+}
+
+export function AppCrashShell({ children }: AppCrashShellProps): ReactElement {
+  const [fatalReport, setFatalReport] = useState<FatalErrorReport | null>(null);
+  const [resetKey, setResetKey] = useState(0);
+
+  const reportRef = useRef(fatalReport);
+  reportRef.current = fatalReport;
+
+  const handleCrash = useCallback((report: FatalErrorReport) => {
+    if (reportRef.current !== null) return;
+    console.error("[AppCrashShell] Fatal error captured:", report.title, report.message);
+    setFatalReport(report);
+  }, []);
+
+  useEffect(() => {
+    const onError = (event: ErrorEvent): void => {
+      if (reportRef.current !== null) return;
+      const report = buildFatalErrorReport(event, "error");
+      console.error("[AppCrashShell] Browser error event:", report.title, report.message);
+      setFatalReport(report);
+    };
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
+      if (reportRef.current !== null) return;
+      const report = buildFatalErrorReport(event, "unhandledrejection");
+      console.error("[AppCrashShell] Unhandled rejection:", report.title, report.message);
+      setFatalReport(report);
+    };
+
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onUnhandledRejection);
+
+    return () => {
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onUnhandledRejection);
+    };
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    setFatalReport(null);
+    setResetKey((k) => k + 1);
+  }, []);
+
+  const handleNavigateToKanban = useCallback(() => {
+    window.location.replace("/kanban");
+  }, []);
+
+  if (fatalReport) {
+    return (
+      <FatalErrorPage
+        report={fatalReport}
+        onRetry={handleRetry}
+        onNavigateToKanban={handleNavigateToKanban}
+      />
+    );
+  }
+
+  return (
+    <AppErrorBoundary key={resetKey} onCrash={handleCrash}>
+      {children}
+    </AppErrorBoundary>
+  );
+}

--- a/apps/desktop/src/components/errors/app-crash-shell.tsx
+++ b/apps/desktop/src/components/errors/app-crash-shell.tsx
@@ -11,28 +11,32 @@ export function AppCrashShell({ children }: AppCrashShellProps): ReactElement {
   const [fatalReport, setFatalReport] = useState<FatalErrorReport | null>(null);
   const [resetKey, setResetKey] = useState(0);
 
-  const reportRef = useRef(fatalReport);
-  reportRef.current = fatalReport;
+  const reportRef = useRef<FatalErrorReport | null>(null);
 
-  const handleCrash = useCallback((report: FatalErrorReport) => {
-    if (reportRef.current !== null) return;
-    setFatalReport(report);
-  }, []);
+  const reportFatal = useCallback(
+    (report: FatalErrorReport, rawValue: unknown, componentStack?: string): void => {
+      if (reportRef.current !== null) return;
+      reportRef.current = report;
+      logFatalError(report, rawValue, componentStack);
+      setFatalReport(report);
+    },
+    [],
+  );
 
   useEffect(() => {
     const onError = (event: Event): void => {
       if (reportRef.current !== null) return;
-      if (!(event instanceof ErrorEvent) || !event.error) return;
+      if (!(event instanceof ErrorEvent) || event.error == null) return;
+      event.preventDefault();
       const report = buildFatalErrorReport(event, "error");
-      logFatalError(report, event);
-      setFatalReport(report);
+      reportFatal(report, event);
     };
 
     const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
       if (reportRef.current !== null) return;
+      event.preventDefault();
       const report = buildFatalErrorReport(event, "unhandledrejection");
-      logFatalError(report, event);
-      setFatalReport(report);
+      reportFatal(report, event);
     };
 
     window.addEventListener("error", onError as EventListener);
@@ -42,9 +46,10 @@ export function AppCrashShell({ children }: AppCrashShellProps): ReactElement {
       window.removeEventListener("error", onError as EventListener);
       window.removeEventListener("unhandledrejection", onUnhandledRejection);
     };
-  }, []);
+  }, [reportFatal]);
 
   const handleRetry = useCallback(() => {
+    reportRef.current = null;
     setFatalReport(null);
     setResetKey((k) => k + 1);
   }, []);
@@ -64,7 +69,7 @@ export function AppCrashShell({ children }: AppCrashShellProps): ReactElement {
   }
 
   return (
-    <AppErrorBoundary key={resetKey} onCrash={handleCrash}>
+    <AppErrorBoundary key={resetKey} onCrash={reportFatal}>
       {children}
     </AppErrorBoundary>
   );

--- a/apps/desktop/src/components/errors/app-crash-shell.tsx
+++ b/apps/desktop/src/components/errors/app-crash-shell.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { AppErrorBoundary } from "./app-error-boundary";
 import { FatalErrorPage } from "./fatal-error-page";
-import { buildFatalErrorReport, type FatalErrorReport } from "./fatal-error-report";
+import { buildFatalErrorReport, type FatalErrorReport, logFatalError } from "./fatal-error-report";
 
 interface AppCrashShellProps {
   children: ReactNode;
@@ -16,30 +16,30 @@ export function AppCrashShell({ children }: AppCrashShellProps): ReactElement {
 
   const handleCrash = useCallback((report: FatalErrorReport) => {
     if (reportRef.current !== null) return;
-    console.error("[AppCrashShell] Fatal error captured:", report.title, report.message);
     setFatalReport(report);
   }, []);
 
   useEffect(() => {
-    const onError = (event: ErrorEvent): void => {
+    const onError = (event: Event): void => {
       if (reportRef.current !== null) return;
+      if (!(event instanceof ErrorEvent) || !event.error) return;
       const report = buildFatalErrorReport(event, "error");
-      console.error("[AppCrashShell] Browser error event:", report.title, report.message);
+      logFatalError(report, event);
       setFatalReport(report);
     };
 
     const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
       if (reportRef.current !== null) return;
       const report = buildFatalErrorReport(event, "unhandledrejection");
-      console.error("[AppCrashShell] Unhandled rejection:", report.title, report.message);
+      logFatalError(report, event);
       setFatalReport(report);
     };
 
-    window.addEventListener("error", onError);
+    window.addEventListener("error", onError as EventListener);
     window.addEventListener("unhandledrejection", onUnhandledRejection);
 
     return () => {
-      window.removeEventListener("error", onError);
+      window.removeEventListener("error", onError as EventListener);
       window.removeEventListener("unhandledrejection", onUnhandledRejection);
     };
   }, []);

--- a/apps/desktop/src/components/errors/app-error-boundary.tsx
+++ b/apps/desktop/src/components/errors/app-error-boundary.tsx
@@ -20,9 +20,7 @@ export class AppErrorBoundary extends Component<Props, State> {
   override componentDidCatch(error: Error, info: ErrorInfo): void {
     const report = buildFatalErrorReport(error, "boundary");
     if (info.componentStack) {
-      report.stack = [report.stack, "Component stack:", info.componentStack]
-        .filter(Boolean)
-        .join("\n");
+      report.componentStack = info.componentStack;
     }
     logFatalError(report, error, info.componentStack ?? undefined);
     this.props.onCrash(report);

--- a/apps/desktop/src/components/errors/app-error-boundary.tsx
+++ b/apps/desktop/src/components/errors/app-error-boundary.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { buildFatalErrorReport, type FatalErrorReport } from "./fatal-error-report";
+import { buildFatalErrorReport, type FatalErrorReport, logFatalError } from "./fatal-error-report";
 
 interface Props {
   children: ReactNode;
@@ -24,6 +24,7 @@ export class AppErrorBoundary extends Component<Props, State> {
         .filter(Boolean)
         .join("\n");
     }
+    logFatalError(report, error, info.componentStack ?? undefined);
     this.props.onCrash(report);
   }
 

--- a/apps/desktop/src/components/errors/app-error-boundary.tsx
+++ b/apps/desktop/src/components/errors/app-error-boundary.tsx
@@ -1,0 +1,36 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { buildFatalErrorReport, type FatalErrorReport } from "./fatal-error-report";
+
+interface Props {
+  children: ReactNode;
+  onCrash: (report: FatalErrorReport) => void;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class AppErrorBoundary extends Component<Props, State> {
+  override state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    const report = buildFatalErrorReport(error, "boundary");
+    if (info.componentStack) {
+      report.stack = [report.stack, "Component stack:", info.componentStack]
+        .filter(Boolean)
+        .join("\n");
+    }
+    this.props.onCrash(report);
+  }
+
+  override render(): ReactNode {
+    if (this.state.hasError) {
+      return null;
+    }
+    return this.props.children;
+  }
+}

--- a/apps/desktop/src/components/errors/app-error-boundary.tsx
+++ b/apps/desktop/src/components/errors/app-error-boundary.tsx
@@ -1,9 +1,9 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { buildFatalErrorReport, type FatalErrorReport, logFatalError } from "./fatal-error-report";
+import { buildFatalErrorReport, type FatalErrorReport } from "./fatal-error-report";
 
 interface Props {
   children: ReactNode;
-  onCrash: (report: FatalErrorReport) => void;
+  onCrash: (report: FatalErrorReport, error: unknown, componentStack?: string) => void;
 }
 
 interface State {
@@ -22,8 +22,7 @@ export class AppErrorBoundary extends Component<Props, State> {
     if (info.componentStack) {
       report.componentStack = info.componentStack;
     }
-    logFatalError(report, error, info.componentStack ?? undefined);
-    this.props.onCrash(report);
+    this.props.onCrash(report, error, info.componentStack ?? undefined);
   }
 
   override render(): ReactNode {

--- a/apps/desktop/src/components/errors/fatal-error-page.test.tsx
+++ b/apps/desktop/src/components/errors/fatal-error-page.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { FatalErrorPage } from "./fatal-error-page";
+import type { FatalErrorReport } from "./fatal-error-report";
+
+const noop = (): void => {};
+
+function createReport(overrides: Partial<FatalErrorReport> = {}): FatalErrorReport {
+  return {
+    title: "Error",
+    message: "Something failed",
+    stack: undefined,
+    source: "error",
+    timestamp: "2026-04-01T17:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("FatalErrorPage", () => {
+  test("shows JavaScript stack details when the stack is meaningful", () => {
+    render(
+      <FatalErrorPage
+        report={createReport({ stack: "Error: boom\n    at renderApp (src/main.tsx:42:7)" })}
+        onRetry={noop}
+        onNavigateToKanban={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("fatal-error-toggle-details"));
+
+    expect(screen.getByTestId("fatal-error-stack").textContent).toContain("renderApp");
+    expect(screen.queryByTestId("fatal-error-location")).toBeNull();
+  });
+
+  test("falls back to source location when the stack is low-value", () => {
+    render(
+      <FatalErrorPage
+        report={createReport({ stack: "@", location: "http://localhost:1420/src/main.tsx:42:7" })}
+        onRetry={noop}
+        onNavigateToKanban={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("fatal-error-toggle-details"));
+
+    expect(screen.queryByTestId("fatal-error-stack")).toBeNull();
+    expect(screen.getByTestId("fatal-error-location").textContent).toBe(
+      "http://localhost:1420/src/main.tsx:42:7",
+    );
+  });
+
+  test("shows React component stack when available", () => {
+    render(
+      <FatalErrorPage
+        report={createReport({ componentStack: "\n    at BrokenPanel\n    at App" })}
+        onRetry={noop}
+        onNavigateToKanban={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("fatal-error-toggle-details"));
+
+    expect(screen.getByTestId("fatal-error-component-stack").textContent).toContain("BrokenPanel");
+  });
+});

--- a/apps/desktop/src/components/errors/fatal-error-page.tsx
+++ b/apps/desktop/src/components/errors/fatal-error-page.tsx
@@ -1,0 +1,120 @@
+import { type ReactElement, useState } from "react";
+import type { FatalErrorReport } from "./fatal-error-report";
+
+const SOURCE_LABELS: Record<FatalErrorReport["source"], string> = {
+  boundary: "React render error",
+  error: "Uncaught runtime error",
+  unhandledrejection: "Unhandled promise rejection",
+};
+
+interface FatalErrorPageProps {
+  report: FatalErrorReport;
+  onRetry: () => void;
+  onNavigateToKanban: () => void;
+}
+
+export function FatalErrorPage({
+  report,
+  onRetry,
+  onNavigateToKanban,
+}: FatalErrorPageProps): ReactElement {
+  const [showDetails, setShowDetails] = useState(false);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <div className="w-full max-w-lg rounded-xl border border-border bg-card p-8 shadow-sm">
+        <div className="mb-6 flex flex-col items-center text-center">
+          <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-destructive/10">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="size-7 text-destructive"
+              aria-hidden="true"
+            >
+              <circle cx={12} cy={12} r={10} />
+              <line x1={12} y1={8} x2={12} y2={12} />
+              <line x1={12} y1={16} x2={12.01} y2={16} />
+            </svg>
+          </div>
+
+          <h1 className="text-xl font-semibold text-foreground">Something went wrong</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            An unexpected error caused the application to crash. You can try reloading — your data
+            is safe.
+          </p>
+        </div>
+
+        <div className="mb-6 rounded-lg border border-border bg-muted/50 p-4">
+          <p className="text-sm font-medium text-foreground" data-testid="fatal-error-title">
+            {report.title}
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground" data-testid="fatal-error-message">
+            {report.message}
+          </p>
+          <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+            <span>{SOURCE_LABELS[report.source]}</span>
+            <span aria-hidden="true">·</span>
+            <time dateTime={report.timestamp}>{formatTimestamp(report.timestamp)}</time>
+          </div>
+        </div>
+
+        {report.stack && (
+          <div className="mb-6">
+            <button
+              type="button"
+              onClick={() => setShowDetails((prev) => !prev)}
+              className="text-xs font-medium text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              data-testid="fatal-error-toggle-details"
+            >
+              {showDetails ? "Hide details" : "Show details"}
+            </button>
+            {showDetails && (
+              <pre
+                className="mt-2 max-h-48 overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed text-muted-foreground"
+                data-testid="fatal-error-stack"
+              >
+                {report.stack}
+              </pre>
+            )}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex h-9 flex-1 cursor-pointer items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            data-testid="fatal-error-retry"
+          >
+            Try again
+          </button>
+          <button
+            type="button"
+            onClick={onNavigateToKanban}
+            className="inline-flex h-9 flex-1 cursor-pointer items-center justify-center rounded-md border border-input bg-card px-4 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            data-testid="fatal-error-go-kanban"
+          >
+            Go to Kanban
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}

--- a/apps/desktop/src/components/errors/fatal-error-page.tsx
+++ b/apps/desktop/src/components/errors/fatal-error-page.tsx
@@ -22,7 +22,7 @@ export function FatalErrorPage({
   const detailSections = getDetailSections(report);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+    <div role="alert" className="flex min-h-screen items-center justify-center bg-background p-6">
       <div className="w-full max-w-lg rounded-xl border border-border bg-card p-8 shadow-sm">
         <div className="mb-6 flex flex-col items-center text-center">
           <div className="mb-4 flex size-14 items-center justify-center rounded-full bg-destructive/10">

--- a/apps/desktop/src/components/errors/fatal-error-page.tsx
+++ b/apps/desktop/src/components/errors/fatal-error-page.tsx
@@ -49,14 +49,17 @@ export function FatalErrorPage({
           </p>
         </div>
 
-        <div className="mb-6 rounded-lg border border-border bg-muted/50 p-4">
-          <p className="text-sm font-medium text-foreground" data-testid="fatal-error-title">
+        <div className="mb-6 rounded-xl border border-destructive-border bg-destructive-surface px-4 py-3 text-sm text-destructive-muted shadow-sm">
+          <p
+            className="font-medium text-destructive-surface-foreground"
+            data-testid="fatal-error-title"
+          >
             {report.title}
           </p>
-          <p className="mt-1 text-sm text-muted-foreground" data-testid="fatal-error-message">
+          <p className="mt-1" data-testid="fatal-error-message">
             {report.message}
           </p>
-          <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="mt-2 flex items-center gap-2 text-xs text-destructive-muted">
             <span>{SOURCE_LABELS[report.source]}</span>
             <span aria-hidden="true">·</span>
             <time dateTime={report.timestamp}>{formatTimestamp(report.timestamp)}</time>

--- a/apps/desktop/src/components/errors/fatal-error-page.tsx
+++ b/apps/desktop/src/components/errors/fatal-error-page.tsx
@@ -19,6 +19,7 @@ export function FatalErrorPage({
   onNavigateToKanban,
 }: FatalErrorPageProps): ReactElement {
   const [showDetails, setShowDetails] = useState(false);
+  const detailSections = getDetailSections(report);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-6">
@@ -66,7 +67,7 @@ export function FatalErrorPage({
           </div>
         </div>
 
-        {report.stack && (
+        {detailSections.length > 0 && (
           <div className="mb-6">
             <button
               type="button"
@@ -77,12 +78,28 @@ export function FatalErrorPage({
               {showDetails ? "Hide details" : "Show details"}
             </button>
             {showDetails && (
-              <pre
-                className="mt-2 max-h-48 overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed text-muted-foreground"
-                data-testid="fatal-error-stack"
+              <div
+                className="mt-2 space-y-3 rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed text-muted-foreground"
+                data-testid="fatal-error-details"
               >
-                {report.stack}
-              </pre>
+                {detailSections.map((section) => (
+                  <div key={section.label} className="space-y-1">
+                    <p className="font-medium text-foreground">{section.label}</p>
+                    {section.kind === "pre" ? (
+                      <pre
+                        className="overflow-auto whitespace-pre-wrap"
+                        data-testid={section.testId}
+                      >
+                        {section.value}
+                      </pre>
+                    ) : (
+                      <p className="break-all" data-testid={section.testId}>
+                        {section.value}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
             )}
           </div>
         )}
@@ -108,6 +125,54 @@ export function FatalErrorPage({
       </div>
     </div>
   );
+}
+
+function getDetailSections(report: FatalErrorReport): Array<{
+  kind: "pre" | "text";
+  label: string;
+  value: string;
+  testId: string;
+}> {
+  const sections: Array<{ kind: "pre" | "text"; label: string; value: string; testId: string }> =
+    [];
+
+  if (hasMeaningfulStack(report.stack)) {
+    sections.push({
+      kind: "pre",
+      label: "JavaScript stack",
+      value: report.stack,
+      testId: "fatal-error-stack",
+    });
+  }
+
+  if (report.componentStack) {
+    sections.push({
+      kind: "pre",
+      label: "React component stack",
+      value: report.componentStack,
+      testId: "fatal-error-component-stack",
+    });
+  }
+
+  if (report.location) {
+    sections.push({
+      kind: "text",
+      label: "Location",
+      value: report.location,
+      testId: "fatal-error-location",
+    });
+  }
+
+  return sections;
+}
+
+function hasMeaningfulStack(stack: string | undefined): stack is string {
+  if (!stack) {
+    return false;
+  }
+
+  const normalized = stack.replace(/\s+/g, "");
+  return normalized !== "" && !/^@+$/.test(normalized);
 }
 
 function formatTimestamp(iso: string): string {

--- a/apps/desktop/src/components/errors/fatal-error-page.tsx
+++ b/apps/desktop/src/components/errors/fatal-error-page.tsx
@@ -90,19 +90,19 @@ export function FatalErrorPage({
         <div className="flex flex-col gap-2 sm:flex-row">
           <button
             type="button"
-            onClick={onRetry}
-            className="inline-flex h-9 flex-1 cursor-pointer items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-            data-testid="fatal-error-retry"
-          >
-            Try again
-          </button>
-          <button
-            type="button"
             onClick={onNavigateToKanban}
             className="inline-flex h-9 flex-1 cursor-pointer items-center justify-center rounded-md border border-input bg-card px-4 text-sm font-medium text-foreground transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
             data-testid="fatal-error-go-kanban"
           >
             Go to Kanban
+          </button>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex h-9 flex-1 cursor-pointer items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            data-testid="fatal-error-retry"
+          >
+            Reload app
           </button>
         </div>
       </div>

--- a/apps/desktop/src/components/errors/fatal-error-report.test.ts
+++ b/apps/desktop/src/components/errors/fatal-error-report.test.ts
@@ -54,6 +54,19 @@ describe("buildFatalErrorReport", () => {
       expect(report.source).toBe("error");
     });
 
+    test("captures source location from ErrorEvent", () => {
+      const event = new ErrorEvent("error", {
+        error: new Error("boom"),
+        filename: "http://localhost:1420/src/main.tsx",
+        lineno: 42,
+        colno: 7,
+      });
+
+      const report = buildFatalErrorReport(event, "error");
+
+      expect(report.location).toBe("http://localhost:1420/src/main.tsx:42:7");
+    });
+
     test("handles ErrorEvent without inner Error", () => {
       const event = new ErrorEvent("error", {
         message: "Script error.",

--- a/apps/desktop/src/components/errors/fatal-error-report.test.ts
+++ b/apps/desktop/src/components/errors/fatal-error-report.test.ts
@@ -1,18 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { ensurePromiseRejectionEventPolyfill } from "@/test-utils/promise-rejection-event-polyfill";
 import { buildFatalErrorReport, logFatalError } from "./fatal-error-report";
 
-if (typeof globalThis.PromiseRejectionEvent === "undefined") {
-  (globalThis as Record<string, unknown>).PromiseRejectionEvent =
-    class PromiseRejectionEvent extends Event {
-      readonly reason: unknown;
-      readonly promise: Promise<unknown>;
-      constructor(type: string, init: { reason?: unknown; promise: Promise<unknown> }) {
-        super(type);
-        this.reason = init.reason;
-        this.promise = init.promise;
-      }
-    };
-}
+ensurePromiseRejectionEventPolyfill();
 
 describe("buildFatalErrorReport", () => {
   describe("Error instances", () => {

--- a/apps/desktop/src/components/errors/fatal-error-report.test.ts
+++ b/apps/desktop/src/components/errors/fatal-error-report.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
-import { buildFatalErrorReport } from "./fatal-error-report";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { buildFatalErrorReport, logFatalError } from "./fatal-error-report";
 
 if (typeof globalThis.PromiseRejectionEvent === "undefined") {
   (globalThis as Record<string, unknown>).PromiseRejectionEvent =
@@ -147,5 +147,49 @@ describe("buildFatalErrorReport", () => {
       expect(report.title).toBe("Unknown error");
       expect(report.message).toBe("[object Object]");
     });
+  });
+});
+
+describe("logFatalError", () => {
+  const originalConsoleError = console.error;
+  let consoleErrorMock: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    consoleErrorMock = mock(() => {});
+    console.error = consoleErrorMock as unknown as typeof console.error;
+  });
+
+  afterEach(() => {
+    console.error = originalConsoleError;
+  });
+
+  test("logs structured metadata with raw value", () => {
+    const rawError = new TypeError("test");
+    const report = buildFatalErrorReport(rawError, "boundary");
+
+    logFatalError(report, rawError);
+
+    expect(consoleErrorMock).toHaveBeenCalledTimes(1);
+    const args = consoleErrorMock.mock.calls[0] as unknown[];
+    expect(args[0]).toContain("[AppCrashShell]");
+    expect(args[0]).toContain("boundary");
+
+    const context = args[args.length - 1] as Record<string, unknown>;
+    expect(context.source).toBe("boundary");
+    expect(context.rawValue).toBe(rawError);
+    expect(context.timestamp).toBeDefined();
+    expect(context.componentStack).toBeUndefined();
+  });
+
+  test("includes component stack when provided", () => {
+    const rawError = new Error("crash");
+    const report = buildFatalErrorReport(rawError, "boundary");
+    const componentStack = "\n    at BrokenComponent\n    at App";
+
+    logFatalError(report, rawError, componentStack);
+
+    const args = consoleErrorMock.mock.calls[0] as unknown[];
+    const context = args[args.length - 1] as Record<string, unknown>;
+    expect(context.componentStack).toBe(componentStack);
   });
 });

--- a/apps/desktop/src/components/errors/fatal-error-report.test.ts
+++ b/apps/desktop/src/components/errors/fatal-error-report.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { buildFatalErrorReport } from "./fatal-error-report";
+
+if (typeof globalThis.PromiseRejectionEvent === "undefined") {
+  (globalThis as Record<string, unknown>).PromiseRejectionEvent =
+    class PromiseRejectionEvent extends Event {
+      readonly reason: unknown;
+      readonly promise: Promise<unknown>;
+      constructor(type: string, init: { reason?: unknown; promise: Promise<unknown> }) {
+        super(type);
+        this.reason = init.reason;
+        this.promise = init.promise;
+      }
+    };
+}
+
+describe("buildFatalErrorReport", () => {
+  describe("Error instances", () => {
+    test("extracts name, message, and stack from an Error", () => {
+      const error = new TypeError("Cannot read property 'x' of undefined");
+
+      const report = buildFatalErrorReport(error, "boundary");
+
+      expect(report.title).toBe("TypeError");
+      expect(report.message).toBe("Cannot read property 'x' of undefined");
+      expect(report.stack).toBeDefined();
+      expect(report.source).toBe("boundary");
+      expect(report.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    test("falls back to 'Error' title when name is empty", () => {
+      const error = new Error("something failed");
+      error.name = "";
+
+      const report = buildFatalErrorReport(error, "error");
+
+      expect(report.title).toBe("Error");
+    });
+  });
+
+  describe("ErrorEvent", () => {
+    test("unwraps inner Error from ErrorEvent", () => {
+      const inner = new RangeError("out of range");
+      const event = new ErrorEvent("error", {
+        error: inner,
+        message: "Uncaught RangeError: out of range",
+      });
+
+      const report = buildFatalErrorReport(event, "error");
+
+      expect(report.title).toBe("RangeError");
+      expect(report.message).toBe("out of range");
+      expect(report.stack).toBeDefined();
+      expect(report.source).toBe("error");
+    });
+
+    test("handles ErrorEvent without inner Error", () => {
+      const event = new ErrorEvent("error", {
+        message: "Script error.",
+      });
+
+      const report = buildFatalErrorReport(event, "error");
+
+      expect(report.title).toBe("Uncaught error");
+      expect(report.message).toBe("Script error.");
+      expect(report.stack).toBeUndefined();
+    });
+  });
+
+  describe("PromiseRejectionEvent", () => {
+    test("unwraps Error reason", () => {
+      const reason = new Error("async failure");
+      const event = new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason,
+      });
+
+      const report = buildFatalErrorReport(event, "unhandledrejection");
+
+      expect(report.title).toBe("Error");
+      expect(report.message).toBe("async failure");
+      expect(report.source).toBe("unhandledrejection");
+    });
+
+    test("handles string reason", () => {
+      const event = new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason: "something broke",
+      });
+
+      const report = buildFatalErrorReport(event, "unhandledrejection");
+
+      expect(report.title).toBe("Unhandled promise rejection");
+      expect(report.message).toBe("something broke");
+    });
+
+    test("handles non-string, non-Error reason", () => {
+      const event = new PromiseRejectionEvent("unhandledrejection", {
+        promise: Promise.resolve(),
+        reason: { code: 42 },
+      });
+
+      const report = buildFatalErrorReport(event, "unhandledrejection");
+
+      expect(report.title).toBe("Unhandled promise rejection");
+      expect(report.message).toBe('{"code":42}');
+    });
+  });
+
+  describe("string values", () => {
+    test("uses string directly as message", () => {
+      const report = buildFatalErrorReport("network timeout", "error");
+
+      expect(report.title).toBe("Error");
+      expect(report.message).toBe("network timeout");
+      expect(report.stack).toBeUndefined();
+    });
+  });
+
+  describe("unknown values", () => {
+    test("handles null", () => {
+      const report = buildFatalErrorReport(null, "boundary");
+
+      expect(report.title).toBe("Unknown error");
+      expect(report.message).toBe("null");
+    });
+
+    test("handles undefined", () => {
+      const report = buildFatalErrorReport(undefined, "boundary");
+
+      expect(report.title).toBe("Unknown error");
+    });
+
+    test("handles objects", () => {
+      const report = buildFatalErrorReport({ status: 500 }, "error");
+
+      expect(report.title).toBe("Unknown error");
+      expect(report.message).toBe('{"status":500}');
+    });
+
+    test("handles circular references gracefully", () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+
+      const report = buildFatalErrorReport(circular, "error");
+
+      expect(report.title).toBe("Unknown error");
+      expect(report.message).toBe("[object Object]");
+    });
+  });
+});

--- a/apps/desktop/src/components/errors/fatal-error-report.ts
+++ b/apps/desktop/src/components/errors/fatal-error-report.ts
@@ -3,6 +3,8 @@ export interface FatalErrorReport {
   message: string;
   /** Present only when the original caught value carried a stack trace. */
   stack: string | undefined;
+  componentStack?: string;
+  location?: string;
   source: "boundary" | "error" | "unhandledrejection";
   /** ISO-8601 timestamp. */
   timestamp: string;
@@ -29,11 +31,13 @@ export function buildFatalErrorReport(
 
   if (value instanceof ErrorEvent) {
     const inner = value.error;
+    const location = formatErrorLocation(value);
     if (inner instanceof Error) {
       return {
         title: inner.name || "Error",
         message: inner.message,
         stack: inner.stack,
+        ...(location ? { location } : {}),
         source,
         timestamp,
       };
@@ -42,6 +46,7 @@ export function buildFatalErrorReport(
       title: "Uncaught error",
       message: value.message || String(inner ?? value),
       stack: undefined,
+      ...(location ? { location } : {}),
       source,
       timestamp,
     };
@@ -107,6 +112,9 @@ export function logFatalError(
     timestamp: report.timestamp,
     rawValue,
   };
+  if (report.location) {
+    context.location = report.location;
+  }
   if (componentStack) {
     context.componentStack = componentStack;
   }
@@ -118,6 +126,31 @@ export function logFatalError(
     report.message,
     context,
   );
+}
+
+function formatErrorLocation(event: ErrorEvent): string | undefined {
+  const line = event.lineno > 0 ? event.lineno : null;
+  const column = event.colno > 0 ? event.colno : null;
+
+  if (event.filename) {
+    if (line === null) {
+      return event.filename;
+    }
+    if (column === null) {
+      return `${event.filename}:${line}`;
+    }
+    return `${event.filename}:${line}:${column}`;
+  }
+
+  if (line === null) {
+    return undefined;
+  }
+
+  if (column === null) {
+    return `line ${line}`;
+  }
+
+  return `line ${line}, column ${column}`;
 }
 
 function safeStringify(value: unknown): string {

--- a/apps/desktop/src/components/errors/fatal-error-report.ts
+++ b/apps/desktop/src/components/errors/fatal-error-report.ts
@@ -90,6 +90,36 @@ export function buildFatalErrorReport(
   };
 }
 
+/**
+ * Centralized fatal-error logger.
+ *
+ * Emits a structured `console.error` with the normalized report metadata,
+ * the **original raw thrown value / event** (so devtools can inspect the live
+ * object), and an optional React component stack when available.
+ */
+export function logFatalError(
+  report: FatalErrorReport,
+  rawValue: unknown,
+  componentStack?: string,
+): void {
+  const context: Record<string, unknown> = {
+    source: report.source,
+    timestamp: report.timestamp,
+    rawValue,
+  };
+  if (componentStack) {
+    context.componentStack = componentStack;
+  }
+
+  console.error(
+    `[AppCrashShell] Fatal error (${report.source}):`,
+    report.title,
+    "-",
+    report.message,
+    context,
+  );
+}
+
 function safeStringify(value: unknown): string {
   try {
     const json = JSON.stringify(value);

--- a/apps/desktop/src/components/errors/fatal-error-report.ts
+++ b/apps/desktop/src/components/errors/fatal-error-report.ts
@@ -1,0 +1,100 @@
+export interface FatalErrorReport {
+  title: string;
+  message: string;
+  /** Present only when the original caught value carried a stack trace. */
+  stack: string | undefined;
+  source: "boundary" | "error" | "unhandledrejection";
+  /** ISO-8601 timestamp. */
+  timestamp: string;
+}
+
+/**
+ * Duck-type check for PromiseRejectionEvent since the constructor is not
+ * available in every JS runtime (e.g. Bun).
+ */
+function isPromiseRejectionLike(value: unknown): value is Event & { reason: unknown } {
+  return (
+    typeof Event !== "undefined" &&
+    value instanceof Event &&
+    value.type === "unhandledrejection" &&
+    "reason" in value
+  );
+}
+
+export function buildFatalErrorReport(
+  value: unknown,
+  source: FatalErrorReport["source"],
+): FatalErrorReport {
+  const timestamp = new Date().toISOString();
+
+  if (value instanceof ErrorEvent) {
+    const inner = value.error;
+    if (inner instanceof Error) {
+      return {
+        title: inner.name || "Error",
+        message: inner.message,
+        stack: inner.stack,
+        source,
+        timestamp,
+      };
+    }
+    return {
+      title: "Uncaught error",
+      message: value.message || String(inner ?? value),
+      stack: undefined,
+      source,
+      timestamp,
+    };
+  }
+
+  if (isPromiseRejectionLike(value)) {
+    const reason = value.reason;
+    if (reason instanceof Error) {
+      return {
+        title: reason.name || "Unhandled rejection",
+        message: reason.message,
+        stack: reason.stack,
+        source,
+        timestamp,
+      };
+    }
+    return {
+      title: "Unhandled promise rejection",
+      message: typeof reason === "string" ? reason : safeStringify(reason),
+      stack: undefined,
+      source,
+      timestamp,
+    };
+  }
+
+  if (value instanceof Error) {
+    return {
+      title: value.name || "Error",
+      message: value.message,
+      stack: value.stack,
+      source,
+      timestamp,
+    };
+  }
+
+  if (typeof value === "string") {
+    return { title: "Error", message: value, stack: undefined, source, timestamp };
+  }
+
+  return {
+    title: "Unknown error",
+    message: safeStringify(value),
+    stack: undefined,
+    source,
+    timestamp,
+  };
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    const json = JSON.stringify(value);
+    return typeof json === "string" ? json : String(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { AppCrashShell } from "@/components/errors/app-crash-shell";
 import { applyThemeToDocument } from "@/components/layout/theme-dom";
 import { appQueryClient } from "@/lib/query-client";
 import { loadSettingsSnapshotFromQuery } from "@/state/queries/workspace";
@@ -15,9 +16,11 @@ if (!rootElement) {
 const renderApp = (): void => {
   createRoot(rootElement).render(
     <StrictMode>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <AppCrashShell>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AppCrashShell>
     </StrictMode>,
   );
 };

--- a/apps/desktop/src/test-utils/promise-rejection-event-polyfill.ts
+++ b/apps/desktop/src/test-utils/promise-rejection-event-polyfill.ts
@@ -1,0 +1,17 @@
+export function ensurePromiseRejectionEventPolyfill(): void {
+  if (typeof globalThis.PromiseRejectionEvent !== "undefined") {
+    return;
+  }
+
+  (globalThis as Record<string, unknown>).PromiseRejectionEvent =
+    class PromiseRejectionEvent extends Event {
+      readonly reason: unknown;
+      readonly promise: Promise<unknown>;
+
+      constructor(type: string, init: EventInit & { reason?: unknown; promise: Promise<unknown> }) {
+        super(type, init);
+        this.reason = init.reason;
+        this.promise = init.promise;
+      }
+    };
+}


### PR DESCRIPTION
## Summary
- add a root `AppCrashShell` and class-based `AppErrorBoundary` so uncaught React render/lifecycle/lazy-load failures replace the white screen with a dedicated fatal recovery page
- route browser `error` and `unhandledrejection` events into the same fatal recovery flow, preserve structured diagnostics with the raw error/event for debugging, and filter non-fatal resource/script-error cases out of the global crash path
- add focused desktop coverage for render crashes, lazy-load rejection, retry/remount behavior, safe-path navigation, listener lifecycle/stability, structured logging, and polish the fatal page so its error surface and recovery actions match the rest of the app

## Verification
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop test`

## Notes
- the primary recovery action is now labeled `Reload app` to match its actual behavior: it clears fatal state and remounts the React app tree under a fresh error boundary
- the fatal error summary now uses the same destructive surface styling pattern used by existing app error surfaces, and `Go to Kanban` is presented before `Reload app`