### PR TITLE
Periodically refresh PR status for active repo tasks

### DIFF
--- a/apps/desktop/src-tauri/src/commands/build.rs
+++ b/apps/desktop/src-tauri/src/commands/build.rs
@@ -279,12 +279,14 @@ pub async fn repo_pull_request_sync(
     state: State<'_, AppState>,
     repo_path: String,
 ) -> Result<serde_json::Value, String> {
-    as_error(
-        state
-            .service
+    let service = state.service.clone();
+    let result = run_service_blocking("repo_pull_request_sync", move || {
+        service
             .repo_pull_request_sync(&repo_path)
-            .map(|ok| serde_json::json!({ "ok": ok })),
-    )
+            .map(|ok| serde_json::json!({ "ok": ok }))
+    })
+    .await;
+    as_error(result)
 }
 
 #[tauri::command]

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -118,6 +118,8 @@ let checksState = {
   refreshChecks: async () => undefined,
 };
 let tasksState: TasksStateContextValue = {
+  isForegroundLoadingTasks: false,
+  isRefreshingTasksInBackground: false,
   isLoadingTasks: false,
   tasks: [task],
   runs: [],
@@ -340,6 +342,8 @@ beforeEach(async () => {
     refreshChecks: async () => undefined,
   };
   tasksState = {
+    isForegroundLoadingTasks: false,
+    isRefreshingTasksInBackground: false,
     isLoadingTasks: false,
     tasks: [task],
     runs: [],

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -74,7 +74,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     useChecksOperationsContext();
   const { runtimeHealthByRuntime, isLoadingChecks, refreshChecks } = useChecksState();
   const {
-    isLoadingTasks,
+    isForegroundLoadingTasks,
     tasks,
     runs,
     syncPullRequests,
@@ -151,7 +151,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
   const selection = useAgentStudioSelectionController({
     activeRepo,
     tasks,
-    isLoadingTasks,
+    isLoadingTasks: isForegroundLoadingTasks,
     sessions,
     taskIdParam,
     sessionParam,
@@ -235,7 +235,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
   ]);
 
   useAgentStudioQuerySessionSync({
-    isLoadingTasks,
+    isLoadingTasks: isForegroundLoadingTasks,
     tasks,
     taskIdParam,
     sessionParam,
@@ -252,6 +252,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     selection: {
       ...selection,
       contextSwitchVersion,
+      isLoadingTasks: isForegroundLoadingTasks,
     },
     readiness,
     draftStateKey,

--- a/apps/desktop/src/pages/kanban/kanban-page.test.tsx
+++ b/apps/desktop/src/pages/kanban/kanban-page.test.tsx
@@ -424,6 +424,8 @@ describe("KanbanPage session start modal flow", () => {
         updateAgentSessionModel: updateAgentSessionModelMock,
       }),
       useTasksState: () => ({
+        isForegroundLoadingTasks: false,
+        isRefreshingTasksInBackground: false,
         tasks: [currentTaskFixture],
         runs: [],
         isLoadingTasks: false,

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.test.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { isKanbanForegroundLoading } from "./use-kanban-page-models";
+
+describe("isKanbanForegroundLoading", () => {
+  test("keeps the initial empty-board load as foreground loading", () => {
+    expect(
+      isKanbanForegroundLoading({
+        hasActiveRepo: true,
+        isLoadingTasks: false,
+        isSettingsPending: false,
+        doneVisibleDays: 1,
+        isKanbanPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("ignores background kanban refetches after the board already has data", () => {
+    expect(
+      isKanbanForegroundLoading({
+        hasActiveRepo: true,
+        isLoadingTasks: false,
+        isSettingsPending: false,
+        doneVisibleDays: 1,
+        isKanbanPending: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("keeps manual task refreshes as foreground loading", () => {
+    expect(
+      isKanbanForegroundLoading({
+        hasActiveRepo: true,
+        isLoadingTasks: true,
+        isSettingsPending: false,
+        doneVisibleDays: 1,
+        isKanbanPending: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.test.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.test.ts
@@ -6,7 +6,7 @@ describe("isKanbanForegroundLoading", () => {
     expect(
       isKanbanForegroundLoading({
         hasActiveRepo: true,
-        isLoadingTasks: false,
+        isForegroundLoadingTasks: false,
         isSettingsPending: false,
         doneVisibleDays: 1,
         isKanbanPending: true,
@@ -18,7 +18,7 @@ describe("isKanbanForegroundLoading", () => {
     expect(
       isKanbanForegroundLoading({
         hasActiveRepo: true,
-        isLoadingTasks: false,
+        isForegroundLoadingTasks: false,
         isSettingsPending: false,
         doneVisibleDays: 1,
         isKanbanPending: false,
@@ -30,7 +30,7 @@ describe("isKanbanForegroundLoading", () => {
     expect(
       isKanbanForegroundLoading({
         hasActiveRepo: true,
-        isLoadingTasks: true,
+        isForegroundLoadingTasks: true,
         isSettingsPending: false,
         doneVisibleDays: 1,
         isKanbanPending: false,

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
@@ -23,13 +23,13 @@ type UseKanbanPageModelsArgs = {
 
 export const isKanbanForegroundLoading = (args: {
   hasActiveRepo: boolean;
-  isLoadingTasks: boolean;
+  isForegroundLoadingTasks: boolean;
   isSettingsPending: boolean;
   doneVisibleDays: number | undefined;
   isKanbanPending: boolean;
 }): boolean => {
-  if (args.isLoadingTasks || !args.hasActiveRepo || args.isSettingsPending) {
-    return args.isLoadingTasks || (args.hasActiveRepo && args.isSettingsPending);
+  if (args.isForegroundLoadingTasks || !args.hasActiveRepo || args.isSettingsPending) {
+    return args.isForegroundLoadingTasks || (args.hasActiveRepo && args.isSettingsPending);
   }
 
   return args.doneVisibleDays !== undefined && args.isKanbanPending;
@@ -57,7 +57,7 @@ export function useKanbanPageModels({
     linkMergedPullRequest,
     cancelLinkMergedPullRequest,
     unlinkPullRequest,
-    isLoadingTasks,
+    isForegroundLoadingTasks,
     detectingPullRequestTaskId,
     linkingMergedPullRequestTaskId,
     pendingMergedPullRequest,
@@ -113,7 +113,7 @@ export function useKanbanPageModels({
   const kanbanTasks = activeRepo ? (kanbanTaskListQuery.data ?? []) : [];
   const isLoadingKanbanTasks = isKanbanForegroundLoading({
     hasActiveRepo: activeRepo !== null,
-    isLoadingTasks,
+    isForegroundLoadingTasks,
     isSettingsPending: settingsSnapshotQuery.isPending,
     doneVisibleDays,
     isKanbanPending: kanbanTaskListQuery.isPending,

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
@@ -21,6 +21,20 @@ type UseKanbanPageModelsArgs = {
   onCloseDetails: () => void;
 };
 
+export const isKanbanForegroundLoading = (args: {
+  hasActiveRepo: boolean;
+  isLoadingTasks: boolean;
+  isSettingsPending: boolean;
+  doneVisibleDays: number | undefined;
+  isKanbanPending: boolean;
+}): boolean => {
+  if (args.isLoadingTasks || !args.hasActiveRepo || args.isSettingsPending) {
+    return args.isLoadingTasks || (args.hasActiveRepo && args.isSettingsPending);
+  }
+
+  return args.doneVisibleDays !== undefined && args.isKanbanPending;
+};
+
 export function useKanbanPageModels({
   onOpenDetails,
   onCloseDetails,
@@ -97,12 +111,13 @@ export function useKanbanPageModels({
   }, [kanbanTaskListQuery.error, kanbanTaskListQuery.isError]);
 
   const kanbanTasks = activeRepo ? (kanbanTaskListQuery.data ?? []) : [];
-  const isLoadingKanbanTasks =
-    isLoadingTasks ||
-    (activeRepo !== null &&
-      (settingsSnapshotQuery.isPending ||
-        (doneVisibleDays !== undefined &&
-          (kanbanTaskListQuery.isPending || kanbanTaskListQuery.isFetching))));
+  const isLoadingKanbanTasks = isKanbanForegroundLoading({
+    hasActiveRepo: activeRepo !== null,
+    isLoadingTasks,
+    isSettingsPending: settingsSnapshotQuery.isPending,
+    doneVisibleDays,
+    isKanbanPending: kanbanTaskListQuery.isPending,
+  });
   const navigate = useNavigate();
 
   const sessionStartFlow = useKanbanSessionStartFlow({

--- a/apps/desktop/src/state/app-state-context-values.test.ts
+++ b/apps/desktop/src/state/app-state-context-values.test.ts
@@ -95,6 +95,8 @@ describe("app-state-context-values", () => {
       refreshChecks: async () => {},
     };
     const tasksValue: TasksStateContextValue = {
+      isForegroundLoadingTasks: false,
+      isRefreshingTasksInBackground: false,
       isLoadingTasks: false,
       detectingPullRequestTaskId: null,
       linkingMergedPullRequestTaskId: null,

--- a/apps/desktop/src/state/app-state-contexts.ts
+++ b/apps/desktop/src/state/app-state-contexts.ts
@@ -75,8 +75,13 @@ export type TaskDataContextValue = {
   runs: RunSummary[];
 };
 
+export type TaskRefreshOptions = {
+  trigger?: "manual" | "scheduled";
+};
+
 export type TaskControlContextValue = {
   refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
+  refreshTasksWithOptions: (options?: TaskRefreshOptions) => Promise<void>;
   clearTaskData: () => void;
   setIsLoadingTasks: (value: boolean) => void;
 };

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -29,7 +29,67 @@ const createDeferred = <T,>() => {
   };
 };
 
+type WindowEventTargetOverride = typeof globalThis & {
+  addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+  removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
+  dispatchEvent: (event: Event) => boolean;
+};
+
+const createVisibilityStateController = () => {
+  let visibilityState: DocumentVisibilityState = "visible";
+  const windowTarget = new EventTarget();
+  const originalVisibilityState = Object.getOwnPropertyDescriptor(document, "visibilityState");
+  const originalDocumentDispatchEventDescriptor = Object.getOwnPropertyDescriptor(
+    document,
+    "dispatchEvent",
+  );
+  const originalAddEventListener = globalThis.addEventListener.bind(globalThis);
+  const originalRemoveEventListener = globalThis.removeEventListener.bind(globalThis);
+  const originalDispatchEvent = globalThis.dispatchEvent.bind(globalThis);
+
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => visibilityState,
+  });
+
+  Object.defineProperty(document, "dispatchEvent", {
+    configurable: true,
+    writable: true,
+    value: EventTarget.prototype.dispatchEvent.bind(document),
+  });
+  (globalThis as WindowEventTargetOverride).addEventListener =
+    windowTarget.addEventListener.bind(windowTarget);
+  (globalThis as WindowEventTargetOverride).removeEventListener =
+    windowTarget.removeEventListener.bind(windowTarget);
+  (globalThis as WindowEventTargetOverride).dispatchEvent =
+    windowTarget.dispatchEvent.bind(windowTarget);
+
+  return {
+    set(value: DocumentVisibilityState) {
+      visibilityState = value;
+    },
+    restore() {
+      if (originalVisibilityState) {
+        Object.defineProperty(document, "visibilityState", originalVisibilityState);
+      } else {
+        Reflect.deleteProperty(document, "visibilityState");
+      }
+      if (originalDocumentDispatchEventDescriptor) {
+        Object.defineProperty(document, "dispatchEvent", originalDocumentDispatchEventDescriptor);
+      } else {
+        Reflect.deleteProperty(document, "dispatchEvent");
+      }
+      (globalThis as WindowEventTargetOverride).addEventListener = originalAddEventListener;
+      (globalThis as WindowEventTargetOverride).removeEventListener = originalRemoveEventListener;
+      (globalThis as WindowEventTargetOverride).dispatchEvent = originalDispatchEvent;
+    },
+  };
+};
+
+let visibilityStateController: ReturnType<typeof createVisibilityStateController>;
+
 beforeEach(() => {
+  visibilityStateController = createVisibilityStateController();
   mock.module("@/lib/host-client", () => ({
     createHostBridge: () => ({
       client: createTauriHostClient(async () => {
@@ -83,6 +143,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  visibilityStateController.restore();
   mock.restore();
 });
 
@@ -112,6 +173,7 @@ describe("useAppLifecycle", () => {
           beadsError: null,
         })),
         refreshTaskData,
+        refreshTasksWithOptions: mock(async () => {}),
         clearBranchData: mock(() => {}),
       } satisfies HookArgs,
     });
@@ -207,6 +269,7 @@ describe("useAppLifecycle", () => {
         beadsError: null,
       })),
       refreshTaskData: mock(async () => taskLoadDeferred.promise),
+      refreshTasksWithOptions: mock(async () => {}),
       clearBranchData: mock(() => {}),
     };
 
@@ -243,6 +306,150 @@ describe("useAppLifecycle", () => {
     }
   });
 
+  test("runs periodic PR sync only while visible and restarts the cadence on visibility changes", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTasksWithOptions = mock(async () => {});
+    const baseArgs: HookArgs = {
+      activeRepo: "/repo",
+      setEvents: mock((_updater) => {}),
+      setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => {}),
+      refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+      refreshBeadsCheckForRepo: mock(async () => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      })),
+      refreshTaskData: mock(async () => {}),
+      refreshTasksWithOptions,
+      clearBranchData: mock(() => {}),
+      pullRequestSyncIntervalMs: 20,
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+
+    visibilityStateController.set("hidden");
+    const harness = createSharedHookHarness(Harness, { args: baseArgs });
+
+    try {
+      await harness.mount();
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 15));
+      });
+
+      expect(refreshTasksWithOptions).not.toHaveBeenCalled();
+
+      await harness.run(() => {
+        visibilityStateController.set("visible");
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      expect(refreshTasksWithOptions).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+
+      const visibleCallCount = refreshTasksWithOptions.mock.calls.length;
+      expect(visibleCallCount).toBeGreaterThan(0);
+      expect(refreshTasksWithOptions).toHaveBeenCalledWith({ trigger: "scheduled" });
+
+      await harness.run(() => {
+        visibilityStateController.set("hidden");
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+
+      expect(refreshTasksWithOptions).toHaveBeenCalledTimes(visibleCallCount);
+
+      await harness.run(() => {
+        visibilityStateController.set("visible");
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      expect(refreshTasksWithOptions).toHaveBeenCalledTimes(visibleCallCount);
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+
+      expect(refreshTasksWithOptions.mock.calls.length).toBeGreaterThan(visibleCallCount);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("switches the periodic PR sync timer when the active repo changes", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTasksForRepoA = mock(async () => {});
+    const refreshTasksForRepoB = mock(async () => {});
+    const baseArgs: HookArgs = {
+      activeRepo: "/repo-a",
+      setEvents: mock((_updater) => {}),
+      setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => {}),
+      refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+      refreshBeadsCheckForRepo: mock(async () => ({
+        beadsOk: true,
+        beadsPath: "/repo-a/.beads",
+        beadsError: null,
+      })),
+      refreshTaskData: mock(async () => {}),
+      refreshTasksWithOptions: refreshTasksForRepoA,
+      clearBranchData: mock(() => {}),
+      pullRequestSyncIntervalMs: 20,
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+
+    const harness = createSharedHookHarness(Harness, { args: baseArgs });
+
+    try {
+      await harness.mount();
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+
+      const repoACallCount = refreshTasksForRepoA.mock.calls.length;
+      expect(repoACallCount).toBeGreaterThan(0);
+      expect(refreshTasksForRepoB).not.toHaveBeenCalled();
+
+      await harness.update({
+        args: {
+          ...baseArgs,
+          activeRepo: "/repo-b",
+          refreshTasksWithOptions: refreshTasksForRepoB,
+        },
+      });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+
+      expect(refreshTasksForRepoA).toHaveBeenCalledTimes(repoACallCount);
+      expect(refreshTasksForRepoB.mock.calls.length).toBeGreaterThan(0);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("does not block repo diagnostics load on branch refresh completion", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = Parameters<typeof useAppLifecycle>[0];
@@ -272,6 +479,7 @@ describe("useAppLifecycle", () => {
         beadsError: null,
       })),
       refreshTaskData: mock(async () => taskLoadDeferred.promise),
+      refreshTasksWithOptions: mock(async () => {}),
       clearBranchData: mock(() => {}),
     };
 
@@ -340,6 +548,7 @@ describe("useAppLifecycle", () => {
         beadsError: null,
       })),
       refreshTaskData: mock(async () => taskDeferred.promise),
+      refreshTasksWithOptions: mock(async () => {}),
       clearBranchData: mock(() => {}),
     };
 
@@ -410,6 +619,7 @@ describe("useAppLifecycle", () => {
       refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
       refreshBeadsCheckForRepo: mock(async () => beadsDeferred.promise),
       refreshTaskData: mock(async () => taskDeferred.promise),
+      refreshTasksWithOptions: mock(async () => {}),
       clearBranchData: mock(() => {}),
       beadsPreparationToastDelayMs: 5,
     };
@@ -476,6 +686,7 @@ describe("useAppLifecycle", () => {
         beadsError: null,
       })),
       refreshTaskData: mock(async () => taskDeferred.promise),
+      refreshTasksWithOptions: mock(async () => {}),
       clearBranchData: mock(() => {}),
       beadsPreparationToastDelayMs: 5,
     };
@@ -531,6 +742,7 @@ describe("useAppLifecycle", () => {
       refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
       refreshBeadsCheckForRepo: mock(async () => beadsDeferred.promise),
       refreshTaskData: mock(async () => {}),
+      refreshTasksWithOptions: mock(async () => {}),
       clearBranchData: mock(() => {}),
       beadsPreparationToastDelayMs: 15,
     };
@@ -589,6 +801,7 @@ describe("useAppLifecycle", () => {
       refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
       refreshBeadsCheckForRepo: mock(async () => beadsDeferred.promise),
       refreshTaskData: mock(async () => {}),
+      refreshTasksWithOptions: mock(async () => {}),
       clearBranchData: mock(() => {}),
       beadsPreparationToastDelayMs: 5,
     };

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -29,6 +29,40 @@ const createDeferred = <T,>() => {
   };
 };
 
+const createIntervalController = () => {
+  let nextIntervalId = 1;
+  const callbacks = new Map<number, () => void>();
+  const originalSetInterval = globalThis.setInterval.bind(globalThis);
+  const originalClearInterval = globalThis.clearInterval.bind(globalThis);
+
+  globalThis.setInterval = ((handler: TimerHandler) => {
+    if (typeof handler !== "function") {
+      throw new Error("Expected interval handler to be a function in lifecycle tests");
+    }
+
+    const intervalId = nextIntervalId;
+    nextIntervalId += 1;
+    callbacks.set(intervalId, handler as () => void);
+    return intervalId as unknown as ReturnType<typeof setInterval>;
+  }) as unknown as typeof setInterval;
+
+  globalThis.clearInterval = ((intervalId: ReturnType<typeof setInterval>) => {
+    callbacks.delete(intervalId as unknown as number);
+  }) as unknown as typeof clearInterval;
+
+  return {
+    tick(): void {
+      for (const callback of [...callbacks.values()]) {
+        callback();
+      }
+    },
+    restore(): void {
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    },
+  };
+};
+
 type WindowEventTargetOverride = typeof globalThis & {
   addEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
   removeEventListener: (type: string, listener: EventListenerOrEventListenerObject) => void;
@@ -334,15 +368,12 @@ describe("useAppLifecycle", () => {
       return null;
     };
 
+    const intervalController = createIntervalController();
     visibilityStateController.set("hidden");
     const harness = createSharedHookHarness(Harness, { args: baseArgs });
 
     try {
       await harness.mount();
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 15));
-      });
 
       expect(refreshTasksWithOptions).not.toHaveBeenCalled();
 
@@ -353,9 +384,8 @@ describe("useAppLifecycle", () => {
 
       expect(refreshTasksWithOptions).not.toHaveBeenCalled();
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 25));
-      });
+      intervalController.tick();
+      await harness.waitFor(() => refreshTasksWithOptions.mock.calls.length === 1, 1000);
 
       const visibleCallCount = refreshTasksWithOptions.mock.calls.length;
       expect(visibleCallCount).toBeGreaterThan(0);
@@ -366,9 +396,7 @@ describe("useAppLifecycle", () => {
         document.dispatchEvent(new Event("visibilitychange"));
       });
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 25));
-      });
+      intervalController.tick();
 
       expect(refreshTasksWithOptions).toHaveBeenCalledTimes(visibleCallCount);
 
@@ -379,13 +407,16 @@ describe("useAppLifecycle", () => {
 
       expect(refreshTasksWithOptions).toHaveBeenCalledTimes(visibleCallCount);
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 25));
-      });
+      intervalController.tick();
+      await harness.waitFor(
+        () => refreshTasksWithOptions.mock.calls.length === visibleCallCount + 1,
+        1000,
+      );
 
       expect(refreshTasksWithOptions.mock.calls.length).toBeGreaterThan(visibleCallCount);
     } finally {
       await harness.unmount();
+      intervalController.restore();
     }
   });
 
@@ -418,14 +449,14 @@ describe("useAppLifecycle", () => {
       return null;
     };
 
+    const intervalController = createIntervalController();
     const harness = createSharedHookHarness(Harness, { args: baseArgs });
 
     try {
       await harness.mount();
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 25));
-      });
+      intervalController.tick();
+      await harness.waitFor(() => refreshTasksForRepoA.mock.calls.length === 1, 1000);
 
       const repoACallCount = refreshTasksForRepoA.mock.calls.length;
       expect(repoACallCount).toBeGreaterThan(0);
@@ -439,14 +470,14 @@ describe("useAppLifecycle", () => {
         },
       });
 
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 25));
-      });
+      intervalController.tick();
+      await harness.waitFor(() => refreshTasksForRepoB.mock.calls.length === 1, 1000);
 
       expect(refreshTasksForRepoA).toHaveBeenCalledTimes(repoACallCount);
       expect(refreshTasksForRepoB.mock.calls.length).toBeGreaterThan(0);
     } finally {
       await harness.unmount();
+      intervalController.restore();
     }
   });
 

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -3,10 +3,12 @@ import { type Dispatch, type SetStateAction, useEffect, useLayoutEffect, useRef 
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { hostBridge } from "@/lib/host-client";
+import type { TaskRefreshOptions } from "@/state/app-state-contexts";
 import { summarizeTaskLoadError } from "@/state/tasks/task-load-errors";
 import { prependRunEvent } from "./app-lifecycle-model";
 
 const BEADS_PREPARATION_TOAST_DELAY_MS = 1_000;
+const PULL_REQUEST_SYNC_INTERVAL_MS = 5 * 60 * 1_000;
 
 type UseAppLifecycleArgs = {
   activeRepo: string | null;
@@ -23,8 +25,10 @@ type UseAppLifecycleArgs = {
     beadsError?: string | null;
   }>;
   refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
+  refreshTasksWithOptions: (options?: TaskRefreshOptions) => Promise<void>;
   clearBranchData: () => void;
   beadsPreparationToastDelayMs?: number;
+  pullRequestSyncIntervalMs?: number;
 };
 
 export function useAppLifecycle({
@@ -36,17 +40,21 @@ export function useAppLifecycle({
   refreshRuntimeCheck,
   refreshBeadsCheckForRepo,
   refreshTaskData,
+  refreshTasksWithOptions,
   clearBranchData,
   beadsPreparationToastDelayMs = BEADS_PREPARATION_TOAST_DELAY_MS,
+  pullRequestSyncIntervalMs = PULL_REQUEST_SYNC_INTERVAL_MS,
 }: UseAppLifecycleArgs): void {
   const repoLoadVersionRef = useRef(0);
   const activeRepoRef = useRef(activeRepo);
   const refreshTaskDataRef = useRef(refreshTaskData);
+  const refreshTasksWithOptionsRef = useRef(refreshTasksWithOptions);
 
   useLayoutEffect(() => {
     activeRepoRef.current = activeRepo;
     refreshTaskDataRef.current = refreshTaskData;
-  }, [activeRepo, refreshTaskData]);
+    refreshTasksWithOptionsRef.current = refreshTasksWithOptions;
+  }, [activeRepo, refreshTaskData, refreshTasksWithOptions]);
 
   useEffect(() => {
     Promise.allSettled([refreshWorkspaces(), refreshRuntimeCheck(false)]).then(
@@ -218,4 +226,42 @@ export function useAppLifecycle({
     refreshRuntimeCheck,
     refreshTaskData,
   ]);
+
+  useEffect(() => {
+    if (!activeRepo || typeof document === "undefined") {
+      return;
+    }
+
+    let pullRequestSyncIntervalId: ReturnType<typeof setInterval> | null = null;
+
+    const clearPullRequestSyncInterval = (): void => {
+      if (pullRequestSyncIntervalId !== null) {
+        clearInterval(pullRequestSyncIntervalId);
+        pullRequestSyncIntervalId = null;
+      }
+    };
+
+    const restartPullRequestSyncInterval = (): void => {
+      clearPullRequestSyncInterval();
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+
+      pullRequestSyncIntervalId = setInterval(() => {
+        void refreshTasksWithOptionsRef.current({ trigger: "scheduled" });
+      }, pullRequestSyncIntervalMs);
+    };
+
+    const handleVisibilityChange = (): void => {
+      restartPullRequestSyncInterval();
+    };
+
+    restartPullRequestSyncInterval();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      clearPullRequestSyncInterval();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [activeRepo, pullRequestSyncIntervalMs]);
 }

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -505,10 +505,62 @@ describe("use-task-operations", () => {
     }
   });
 
-  test("refreshTasks continues loading task data when pull request sync fails", async () => {
+  test("refreshTasks stops before task data refresh when pull request sync fails", async () => {
     const repoPullRequestSync = mock(async () => {
       throw new Error("gh auth expired");
     });
+    const tasksList = mock(async () => [makeTask("A", "open")]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+
+    const original = {
+      repoPullRequestSync: host.repoPullRequestSync,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+      toastError: toast.error,
+    };
+    host.repoPullRequestSync = repoPullRequestSync;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A");
+      tasksList.mockClear();
+      runsList.mockClear();
+
+      await harness.run(async (value) => {
+        await value.refreshTasks();
+      });
+
+      expect(repoPullRequestSync).toHaveBeenCalledWith("/repo");
+      expect(tasksList).not.toHaveBeenCalled();
+      expect(runsList).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith("Failed to refresh tasks", {
+        description: "Task store unavailable. gh auth expired",
+      });
+    } finally {
+      await harness.unmount();
+      host.repoPullRequestSync = original.repoPullRequestSync;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+      toast.error = original.toastError;
+    }
+  });
+
+  test("scheduled and manual refresh join the same in-flight repo sync", async () => {
+    const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
+    const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);
     const tasksList = mock(async () => [makeTask("A", "open")]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
 
@@ -532,18 +584,113 @@ describe("use-task-operations", () => {
 
     try {
       await harness.mount();
-      await harness.run(async (value) => {
-        await value.refreshTasks();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A");
+      tasksList.mockClear();
+      runsList.mockClear();
+
+      let scheduledRefreshPromise: Promise<void> | null = null;
+      await harness.run((value) => {
+        scheduledRefreshPromise = value.refreshTasksWithOptions({ trigger: "scheduled" });
       });
 
-      expect(repoPullRequestSync).toHaveBeenCalledWith("/repo");
-      expect(tasksList).toHaveBeenCalledWith("/repo");
-      expect(harness.getLatest().tasks.map((task) => task.id)).toEqual(["A"]);
+      expect(repoPullRequestSync).toHaveBeenCalledTimes(1);
+
+      let manualRefreshPromise: Promise<void> | null = null;
+      await harness.run((value) => {
+        manualRefreshPromise = value.refreshTasks();
+      });
+      await harness.waitFor((value) => value.isLoadingTasks, 1000);
+
+      expect(repoPullRequestSync).toHaveBeenCalledTimes(1);
+
+      if (!scheduledRefreshPromise || !manualRefreshPromise) {
+        throw new Error("Expected both refresh promises to be created");
+      }
+
+      await harness.run(async () => {
+        repoPullRequestSyncDeferred.resolve({ ok: true });
+        await Promise.all([scheduledRefreshPromise, manualRefreshPromise]);
+      });
+      await harness.waitFor((value) => !value.isLoadingTasks, 1000);
+
+      expect(tasksList).toHaveBeenCalledTimes(1);
+      expect(runsList).toHaveBeenCalledTimes(1);
+    } finally {
+      repoPullRequestSyncDeferred.resolve({ ok: true });
+      await harness.unmount();
+      host.repoPullRequestSync = original.repoPullRequestSync;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+    }
+  });
+
+  test("scheduled refresh dedupes repeated identical failures and resets after success", async () => {
+    let shouldFailPullRequestSync = true;
+    const repoPullRequestSync = mock(async () => {
+      if (shouldFailPullRequestSync) {
+        throw new Error("gh auth expired");
+      }
+
+      return { ok: true };
+    });
+    const tasksList = mock(async () => [makeTask("A", "open")]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+
+    const original = {
+      repoPullRequestSync: host.repoPullRequestSync,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+      toastError: toast.error,
+    };
+    host.repoPullRequestSync = repoPullRequestSync;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A");
+      toastError.mockClear();
+
+      await harness.run(async (value) => {
+        await value.refreshTasksWithOptions({ trigger: "scheduled" });
+      });
+      await harness.run(async (value) => {
+        await value.refreshTasksWithOptions({ trigger: "scheduled" });
+      });
+
+      expect(toastError).toHaveBeenCalledTimes(1);
+      expect(toastError).toHaveBeenCalledWith("Failed to refresh tasks", {
+        description: "Task store unavailable. gh auth expired",
+      });
+
+      shouldFailPullRequestSync = false;
+      await harness.run(async (value) => {
+        await value.refreshTasksWithOptions({ trigger: "scheduled" });
+      });
+
+      shouldFailPullRequestSync = true;
+      await harness.run(async (value) => {
+        await value.refreshTasksWithOptions({ trigger: "scheduled" });
+      });
+
+      expect(toastError).toHaveBeenCalledTimes(2);
     } finally {
       await harness.unmount();
       host.repoPullRequestSync = original.repoPullRequestSync;
       host.tasksList = original.tasksList;
       host.runsList = original.runsList;
+      toast.error = original.toastError;
     }
   });
 

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -743,6 +743,83 @@ describe("use-task-operations", () => {
     }
   });
 
+  test("scheduled and manual refresh share one toast when the joined repo sync fails", async () => {
+    const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
+    const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);
+    const tasksList = mock(async () => [makeTask("A", "open")]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+    const toastError = mock((_message: string, _options?: { description?: string }) => "");
+    const consoleWarn = mock(() => {});
+
+    const original = {
+      repoPullRequestSync: host.repoPullRequestSync,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+      toastError: toast.error,
+      consoleWarn: console.warn,
+    };
+    host.repoPullRequestSync = repoPullRequestSync;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+    (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+    console.warn = consoleWarn as unknown as typeof console.warn;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A");
+
+      let scheduledRefreshPromise: Promise<void> | null = null;
+      await harness.run((value) => {
+        scheduledRefreshPromise = value.refreshTasksWithOptions({ trigger: "scheduled" });
+      });
+
+      let manualRefreshPromise: Promise<void> | null = null;
+      await harness.run((value) => {
+        manualRefreshPromise = value.refreshTasks();
+      });
+      await harness.waitFor((value) => value.isLoadingTasks, 1000);
+
+      if (!scheduledRefreshPromise || !manualRefreshPromise) {
+        throw new Error("Expected both refresh promises to be created");
+      }
+
+      await harness.run(async () => {
+        repoPullRequestSyncDeferred.reject(new Error("gh auth expired"));
+        await Promise.all([scheduledRefreshPromise, manualRefreshPromise]);
+      });
+      await harness.waitFor((value) => !value.isLoadingTasks, 1000);
+
+      expect(toastError).toHaveBeenCalledTimes(1);
+      expect(toastError).toHaveBeenCalledWith("Failed to refresh tasks", {
+        description: "Task store unavailable. gh auth expired",
+      });
+      expect(consoleWarn).toHaveBeenCalledTimes(1);
+      expect(consoleWarn).toHaveBeenCalledWith(TASK_REFRESH_WARNING, {
+        repoPath: "/repo",
+        trigger: "scheduled",
+        description: "Task store unavailable. gh auth expired",
+        error: "gh auth expired",
+      });
+    } finally {
+      repoPullRequestSyncDeferred.resolve({ ok: true });
+      await harness.unmount();
+      host.repoPullRequestSync = original.repoPullRequestSync;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+      toast.error = original.toastError;
+      console.warn = original.consoleWarn;
+    }
+  });
+
   test("scheduled refresh keeps task loading state in background while repo data refetch is in flight", async () => {
     const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
     const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);
@@ -828,17 +905,20 @@ describe("use-task-operations", () => {
     const tasksList = mock(async () => [makeTask("A", "open")]);
     const runsList = mock(async (): Promise<RunSummary[]> => []);
     const toastError = mock((_message: string, _options?: { description?: string }) => "");
+    const consoleWarn = mock(() => {});
 
     const original = {
       repoPullRequestSync: host.repoPullRequestSync,
       tasksList: host.tasksList,
       runsList: host.runsList,
       toastError: toast.error,
+      consoleWarn: console.warn,
     };
     host.repoPullRequestSync = repoPullRequestSync;
     host.tasksList = tasksList;
     host.runsList = runsList;
     (toast as { error: typeof toast.error }).error = toastError as unknown as typeof toast.error;
+    console.warn = consoleWarn as unknown as typeof console.warn;
 
     const harness = createHookHarness({
       activeRepo: "/repo",
@@ -865,6 +945,7 @@ describe("use-task-operations", () => {
       expect(toastError).toHaveBeenCalledWith("Failed to refresh tasks", {
         description: "Task store unavailable. gh auth expired",
       });
+      expect(consoleWarn).toHaveBeenCalledTimes(2);
 
       shouldFailPullRequestSync = false;
       await harness.run(async (value) => {
@@ -877,12 +958,14 @@ describe("use-task-operations", () => {
       });
 
       expect(toastError).toHaveBeenCalledTimes(2);
+      expect(consoleWarn).toHaveBeenCalledTimes(3);
     } finally {
       await harness.unmount();
       host.repoPullRequestSync = original.repoPullRequestSync;
       host.tasksList = original.tasksList;
       host.runsList = original.runsList;
       toast.error = original.toastError;
+      console.warn = original.consoleWarn;
     }
   });
 

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -156,6 +156,11 @@ type TaskAndKanbanHarnessState = {
   isFetchingKanban: boolean;
 };
 
+type ScheduledKanbanRefetchScenario = {
+  initialTasks: TaskCard[];
+  expectedVisibleTaskId: string | undefined;
+};
+
 const createTaskAndKanbanHarness = (initialArgs: HookArgs, doneVisibleDays = 1) => {
   let latest: TaskAndKanbanHarnessState | null = null;
   const currentArgs = initialArgs;
@@ -215,6 +220,117 @@ const createTaskAndKanbanHarness = (initialArgs: HookArgs, doneVisibleDays = 1) 
       await sharedHarness.unmount();
     },
   };
+};
+
+const assertScheduledKanbanRefetchStaysBackground = async ({
+  initialTasks,
+  expectedVisibleTaskId,
+}: ScheduledKanbanRefetchScenario): Promise<void> => {
+  const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
+  let repoTaskListCallCount = 0;
+  let kanbanTaskListCallCount = 0;
+  let runsListCallCount = 0;
+  const repoTaskRefreshDeferred = createDeferred<TaskCard[]>();
+  const kanbanRefreshDeferred = createDeferred<TaskCard[]>();
+  const runsRefreshDeferred = createDeferred<RunSummary[]>();
+  const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);
+  const tasksList = mock(async (_repoPath: string, doneVisibleDays?: number) => {
+    if (typeof doneVisibleDays === "number") {
+      kanbanTaskListCallCount += 1;
+      return kanbanTaskListCallCount === 1 ? initialTasks : kanbanRefreshDeferred.promise;
+    }
+
+    repoTaskListCallCount += 1;
+    return repoTaskListCallCount === 1 ? initialTasks : repoTaskRefreshDeferred.promise;
+  });
+  const runsList = mock(async (): Promise<RunSummary[]> => {
+    runsListCallCount += 1;
+    return runsListCallCount === 1 ? [] : runsRefreshDeferred.promise;
+  });
+
+  const original = {
+    repoPullRequestSync: host.repoPullRequestSync,
+    tasksList: host.tasksList,
+    runsList: host.runsList,
+  };
+  host.repoPullRequestSync = repoPullRequestSync;
+  host.tasksList = tasksList;
+  host.runsList = runsList;
+
+  const harness = createTaskAndKanbanHarness({
+    activeRepo: "/repo",
+    refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+      beadsOk: true,
+      beadsPath: "/repo/.beads",
+      beadsError: null,
+    }),
+  });
+
+  try {
+    await harness.mount();
+    await harness.waitFor(
+      (value) =>
+        !value.isPendingKanban &&
+        !value.isFetchingKanban &&
+        value.kanbanTasks[0]?.id === expectedVisibleTaskId &&
+        value.kanbanTasks.length === initialTasks.length,
+      1000,
+    );
+
+    let scheduledRefreshPromise: Promise<void> | null = null;
+    await harness.run((value) => {
+      scheduledRefreshPromise = value.operations.refreshTasksWithOptions({ trigger: "scheduled" });
+    });
+
+    await harness.run(async () => {
+      repoPullRequestSyncDeferred.resolve({ ok: true });
+    });
+    await harness.waitFor(
+      (value) => !value.isPendingKanban && value.isFetchingKanban && kanbanTaskListCallCount >= 2,
+      1000,
+    );
+
+    if (!scheduledRefreshPromise) {
+      throw new Error("Expected scheduled refresh promise to be created");
+    }
+
+    const latest = harness.getLatest();
+    const foregroundLoading = isKanbanForegroundLoading({
+      hasActiveRepo: true,
+      isForegroundLoadingTasks: latest.operations.isForegroundLoadingTasks,
+      isSettingsPending: false,
+      doneVisibleDays: 1,
+      isKanbanPending: latest.isPendingKanban,
+    });
+
+    expect(repoTaskListCallCount).toBeGreaterThanOrEqual(2);
+    expect(latest.operations.isForegroundLoadingTasks).toBe(false);
+    expect(latest.operations.isRefreshingTasksInBackground).toBe(true);
+    expect(foregroundLoading).toBe(false);
+    expect(foregroundLoading && latest.kanbanTasks.length === 0).toBe(false);
+    expect(latest.kanbanTasks[0]?.id).toBe(expectedVisibleTaskId);
+
+    await harness.run(async () => {
+      repoTaskRefreshDeferred.resolve(initialTasks);
+      kanbanRefreshDeferred.resolve(initialTasks);
+      runsRefreshDeferred.resolve([]);
+      await scheduledRefreshPromise;
+    });
+
+    await harness.waitFor(
+      (value) => !value.operations.isRefreshingTasksInBackground && !value.isFetchingKanban,
+      1000,
+    );
+  } finally {
+    repoPullRequestSyncDeferred.resolve({ ok: true });
+    repoTaskRefreshDeferred.resolve(initialTasks);
+    kanbanRefreshDeferred.resolve(initialTasks);
+    runsRefreshDeferred.resolve([]);
+    await harness.unmount();
+    host.repoPullRequestSync = original.repoPullRequestSync;
+    host.tasksList = original.tasksList;
+    host.runsList = original.runsList;
+  }
 };
 
 describe("use-task-operations", () => {
@@ -687,205 +803,17 @@ describe("use-task-operations", () => {
   });
 
   test("scheduled refresh keeps an empty kanban board out of foreground loading during post-sync refetch", async () => {
-    const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
-    let repoTaskListCallCount = 0;
-    let kanbanTaskListCallCount = 0;
-    let runsListCallCount = 0;
-    const repoTaskRefreshDeferred = createDeferred<TaskCard[]>();
-    const kanbanRefreshDeferred = createDeferred<TaskCard[]>();
-    const runsRefreshDeferred = createDeferred<RunSummary[]>();
-    const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);
-    const tasksList = mock(async (_repoPath: string, doneVisibleDays?: number) => {
-      if (typeof doneVisibleDays === "number") {
-        kanbanTaskListCallCount += 1;
-        return kanbanTaskListCallCount === 1 ? [] : kanbanRefreshDeferred.promise;
-      }
-
-      repoTaskListCallCount += 1;
-      return repoTaskListCallCount === 1 ? [] : repoTaskRefreshDeferred.promise;
+    await assertScheduledKanbanRefetchStaysBackground({
+      initialTasks: [],
+      expectedVisibleTaskId: undefined,
     });
-    const runsList = mock(async (): Promise<RunSummary[]> => {
-      runsListCallCount += 1;
-      return runsListCallCount === 1 ? [] : runsRefreshDeferred.promise;
-    });
-
-    const original = {
-      repoPullRequestSync: host.repoPullRequestSync,
-      tasksList: host.tasksList,
-      runsList: host.runsList,
-    };
-    host.repoPullRequestSync = repoPullRequestSync;
-    host.tasksList = tasksList;
-    host.runsList = runsList;
-
-    const harness = createTaskAndKanbanHarness({
-      activeRepo: "/repo",
-      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
-        beadsOk: true,
-        beadsPath: "/repo/.beads",
-        beadsError: null,
-      }),
-    });
-
-    try {
-      await harness.mount();
-      await harness.waitFor(
-        (value) =>
-          !value.isPendingKanban && !value.isFetchingKanban && value.kanbanTasks.length === 0,
-        1000,
-      );
-
-      let scheduledRefreshPromise: Promise<void> | null = null;
-      await harness.run((value) => {
-        scheduledRefreshPromise = value.operations.refreshTasksWithOptions({
-          trigger: "scheduled",
-        });
-      });
-
-      await harness.run(async () => {
-        repoPullRequestSyncDeferred.resolve({ ok: true });
-      });
-      await harness.waitFor(
-        (value) => !value.isPendingKanban && value.isFetchingKanban && kanbanTaskListCallCount >= 2,
-        1000,
-      );
-
-      if (!scheduledRefreshPromise) {
-        throw new Error("Expected scheduled refresh promise to be created");
-      }
-
-      const latest = harness.getLatest();
-      const foregroundLoading = isKanbanForegroundLoading({
-        hasActiveRepo: true,
-        isLoadingTasks: latest.operations.isLoadingTasks,
-        isSettingsPending: false,
-        doneVisibleDays: 1,
-        isKanbanPending: latest.isPendingKanban,
-      });
-
-      expect(repoTaskListCallCount).toBeGreaterThanOrEqual(2);
-      expect(foregroundLoading).toBe(false);
-      expect(foregroundLoading && latest.kanbanTasks.length === 0).toBe(false);
-
-      await harness.run(async () => {
-        repoTaskRefreshDeferred.resolve([]);
-        kanbanRefreshDeferred.resolve([]);
-        runsRefreshDeferred.resolve([]);
-        await scheduledRefreshPromise;
-      });
-    } finally {
-      repoPullRequestSyncDeferred.resolve({ ok: true });
-      repoTaskRefreshDeferred.resolve([]);
-      kanbanRefreshDeferred.resolve([]);
-      runsRefreshDeferred.resolve([]);
-      await harness.unmount();
-      host.repoPullRequestSync = original.repoPullRequestSync;
-      host.tasksList = original.tasksList;
-      host.runsList = original.runsList;
-    }
   });
 
   test("scheduled refresh keeps visible kanban tasks out of foreground loading during post-sync refetch", async () => {
-    const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
-    let repoTaskListCallCount = 0;
-    let kanbanTaskListCallCount = 0;
-    let runsListCallCount = 0;
-    const repoTaskRefreshDeferred = createDeferred<TaskCard[]>();
-    const kanbanRefreshDeferred = createDeferred<TaskCard[]>();
-    const runsRefreshDeferred = createDeferred<RunSummary[]>();
-    const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);
-    const tasksList = mock(async (_repoPath: string, doneVisibleDays?: number) => {
-      if (typeof doneVisibleDays === "number") {
-        kanbanTaskListCallCount += 1;
-        return kanbanTaskListCallCount === 1
-          ? [makeTask("A", "open")]
-          : kanbanRefreshDeferred.promise;
-      }
-
-      repoTaskListCallCount += 1;
-      return repoTaskListCallCount === 1
-        ? [makeTask("A", "open")]
-        : repoTaskRefreshDeferred.promise;
+    await assertScheduledKanbanRefetchStaysBackground({
+      initialTasks: [makeTask("A", "open")],
+      expectedVisibleTaskId: "A",
     });
-    const runsList = mock(async (): Promise<RunSummary[]> => {
-      runsListCallCount += 1;
-      return runsListCallCount === 1 ? [] : runsRefreshDeferred.promise;
-    });
-
-    const original = {
-      repoPullRequestSync: host.repoPullRequestSync,
-      tasksList: host.tasksList,
-      runsList: host.runsList,
-    };
-    host.repoPullRequestSync = repoPullRequestSync;
-    host.tasksList = tasksList;
-    host.runsList = runsList;
-
-    const harness = createTaskAndKanbanHarness({
-      activeRepo: "/repo",
-      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
-        beadsOk: true,
-        beadsPath: "/repo/.beads",
-        beadsError: null,
-      }),
-    });
-
-    try {
-      await harness.mount();
-      await harness.waitFor(
-        (value) =>
-          !value.isPendingKanban && !value.isFetchingKanban && value.kanbanTasks[0]?.id === "A",
-        1000,
-      );
-
-      let scheduledRefreshPromise: Promise<void> | null = null;
-      await harness.run((value) => {
-        scheduledRefreshPromise = value.operations.refreshTasksWithOptions({
-          trigger: "scheduled",
-        });
-      });
-
-      await harness.run(async () => {
-        repoPullRequestSyncDeferred.resolve({ ok: true });
-      });
-      await harness.waitFor(
-        (value) => !value.isPendingKanban && value.isFetchingKanban && kanbanTaskListCallCount >= 2,
-        1000,
-      );
-
-      if (!scheduledRefreshPromise) {
-        throw new Error("Expected scheduled refresh promise to be created");
-      }
-
-      const latest = harness.getLatest();
-      const foregroundLoading = isKanbanForegroundLoading({
-        hasActiveRepo: true,
-        isLoadingTasks: latest.operations.isLoadingTasks,
-        isSettingsPending: false,
-        doneVisibleDays: 1,
-        isKanbanPending: latest.isPendingKanban,
-      });
-
-      expect(repoTaskListCallCount).toBeGreaterThanOrEqual(2);
-      expect(foregroundLoading).toBe(false);
-      expect(latest.kanbanTasks[0]?.id).toBe("A");
-
-      await harness.run(async () => {
-        repoTaskRefreshDeferred.resolve([makeTask("A", "open")]);
-        kanbanRefreshDeferred.resolve([makeTask("A", "open")]);
-        runsRefreshDeferred.resolve([]);
-        await scheduledRefreshPromise;
-      });
-    } finally {
-      repoPullRequestSyncDeferred.resolve({ ok: true });
-      repoTaskRefreshDeferred.resolve([makeTask("A", "open")]);
-      kanbanRefreshDeferred.resolve([makeTask("A", "open")]);
-      runsRefreshDeferred.resolve([]);
-      await harness.unmount();
-      host.repoPullRequestSync = original.repoPullRequestSync;
-      host.tasksList = original.tasksList;
-      host.runsList = original.runsList;
-    }
   });
 
   test("scheduled refresh dedupes repeated identical failures and resets after success", async () => {

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -820,6 +820,100 @@ describe("use-task-operations", () => {
     }
   });
 
+  test("an earlier manual refresh cannot clear a later repo refresh loading state", async () => {
+    const repoARefreshDeferred = createDeferred<{ ok: boolean }>();
+    const repoBRefreshDeferred = createDeferred<{ ok: boolean }>();
+    const repoPullRequestSync = mock(async (repoPath: string) => {
+      if (repoPath === "/repo-a") {
+        return repoARefreshDeferred.promise;
+      }
+
+      if (repoPath === "/repo-b") {
+        return repoBRefreshDeferred.promise;
+      }
+
+      throw new Error(`Unexpected repo path ${repoPath}`);
+    });
+    const tasksList = mock(async (repoPath: string) => {
+      if (repoPath === "/repo-a") {
+        return [makeTask("A", "open")];
+      }
+
+      return [makeTask("B", "open")];
+    });
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+
+    const original = {
+      repoPullRequestSync: host.repoPullRequestSync,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+    };
+    host.repoPullRequestSync = repoPullRequestSync;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: "/repo-a/.beads",
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A", 1000);
+
+      let repoAManualRefresh: Promise<void> | null = null;
+      await harness.run((value) => {
+        repoAManualRefresh = value.refreshTasks();
+      });
+      await harness.waitFor((value) => value.isLoadingTasks, 1000);
+
+      await harness.updateArgs({
+        activeRepo: "/repo-b",
+        refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+          beadsOk: true,
+          beadsPath: "/repo-b/.beads",
+          beadsError: null,
+        }),
+      });
+      await harness.waitFor((value) => value.tasks[0]?.id === "B", 1000);
+      await harness.waitFor((value) => !value.isLoadingTasks, 1000);
+
+      let repoBManualRefresh: Promise<void> | null = null;
+      await harness.run((value) => {
+        repoBManualRefresh = value.refreshTasks();
+      });
+      await harness.waitFor((value) => value.isLoadingTasks, 1000);
+
+      if (!repoAManualRefresh || !repoBManualRefresh) {
+        throw new Error("Expected both manual refresh promises to be created");
+      }
+
+      await harness.run(async () => {
+        repoARefreshDeferred.resolve({ ok: true });
+        await repoAManualRefresh;
+      });
+
+      expect(harness.getLatest().isLoadingTasks).toBe(true);
+
+      await harness.run(async () => {
+        repoBRefreshDeferred.resolve({ ok: true });
+        await repoBManualRefresh;
+      });
+      await harness.waitFor((value) => !value.isLoadingTasks, 1000);
+    } finally {
+      repoARefreshDeferred.resolve({ ok: true });
+      repoBRefreshDeferred.resolve({ ok: true });
+      await harness.unmount();
+      host.repoPullRequestSync = original.repoPullRequestSync;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+    }
+  });
+
   test("scheduled refresh keeps task loading state in background while repo data refetch is in flight", async () => {
     const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
     const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -624,6 +624,65 @@ describe("use-task-operations", () => {
     }
   });
 
+  test("scheduled refresh keeps task loading state in background while repo data refetch is in flight", async () => {
+    const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
+    const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);
+    const tasksList = mock(async () => [makeTask("A", "open")]);
+    const runsList = mock(async (): Promise<RunSummary[]> => []);
+
+    const original = {
+      repoPullRequestSync: host.repoPullRequestSync,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+    };
+    host.repoPullRequestSync = repoPullRequestSync;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo",
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => value.tasks[0]?.id === "A");
+      tasksList.mockClear();
+      runsList.mockClear();
+
+      let scheduledRefreshPromise: Promise<void> | null = null;
+      await harness.run((value) => {
+        scheduledRefreshPromise = value.refreshTasksWithOptions({ trigger: "scheduled" });
+      });
+
+      expect(harness.getLatest().isLoadingTasks).toBe(false);
+      expect(repoPullRequestSync).toHaveBeenCalledTimes(1);
+
+      if (!scheduledRefreshPromise) {
+        throw new Error("Expected scheduled refresh promise to be created");
+      }
+
+      await harness.run(async () => {
+        repoPullRequestSyncDeferred.resolve({ ok: true });
+        await scheduledRefreshPromise;
+      });
+
+      expect(harness.getLatest().isLoadingTasks).toBe(false);
+      expect(tasksList).toHaveBeenCalledTimes(1);
+      expect(runsList).toHaveBeenCalledTimes(1);
+    } finally {
+      repoPullRequestSyncDeferred.resolve({ ok: true });
+      await harness.unmount();
+      host.repoPullRequestSync = original.repoPullRequestSync;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+    }
+  });
+
   test("scheduled refresh dedupes repeated identical failures and resets after success", async () => {
     let shouldFailPullRequestSync = true;
     const repoPullRequestSync = mock(async () => {

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.test.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { useTaskDocuments } from "@/components/features/task-details/use-task-documents";
 import { createQueryClient } from "@/lib/query-client";
 import { QueryProvider } from "@/lib/query-provider";
+import { isKanbanForegroundLoading } from "@/pages/kanban/use-kanban-page-models";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { documentQueryKeys } from "../../queries/documents";
@@ -151,6 +152,7 @@ const createHookHarness = (initialArgs: HookArgs) => {
 type TaskAndKanbanHarnessState = {
   operations: ReturnType<typeof useTaskOperations>;
   kanbanTasks: TaskCard[];
+  isPendingKanban: boolean;
   isFetchingKanban: boolean;
 };
 
@@ -168,6 +170,7 @@ const createTaskAndKanbanHarness = (initialArgs: HookArgs, doneVisibleDays = 1) 
     latest = {
       operations,
       kanbanTasks: args.activeRepo ? (kanbanTaskListQuery.data ?? []) : [],
+      isPendingKanban: args.activeRepo !== null && kanbanTaskListQuery.isPending,
       isFetchingKanban:
         args.activeRepo !== null &&
         (kanbanTaskListQuery.isPending || kanbanTaskListQuery.isFetching),
@@ -676,6 +679,208 @@ describe("use-task-operations", () => {
       expect(runsList).toHaveBeenCalledTimes(1);
     } finally {
       repoPullRequestSyncDeferred.resolve({ ok: true });
+      await harness.unmount();
+      host.repoPullRequestSync = original.repoPullRequestSync;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+    }
+  });
+
+  test("scheduled refresh keeps an empty kanban board out of foreground loading during post-sync refetch", async () => {
+    const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
+    let repoTaskListCallCount = 0;
+    let kanbanTaskListCallCount = 0;
+    let runsListCallCount = 0;
+    const repoTaskRefreshDeferred = createDeferred<TaskCard[]>();
+    const kanbanRefreshDeferred = createDeferred<TaskCard[]>();
+    const runsRefreshDeferred = createDeferred<RunSummary[]>();
+    const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);
+    const tasksList = mock(async (_repoPath: string, doneVisibleDays?: number) => {
+      if (typeof doneVisibleDays === "number") {
+        kanbanTaskListCallCount += 1;
+        return kanbanTaskListCallCount === 1 ? [] : kanbanRefreshDeferred.promise;
+      }
+
+      repoTaskListCallCount += 1;
+      return repoTaskListCallCount === 1 ? [] : repoTaskRefreshDeferred.promise;
+    });
+    const runsList = mock(async (): Promise<RunSummary[]> => {
+      runsListCallCount += 1;
+      return runsListCallCount === 1 ? [] : runsRefreshDeferred.promise;
+    });
+
+    const original = {
+      repoPullRequestSync: host.repoPullRequestSync,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+    };
+    host.repoPullRequestSync = repoPullRequestSync;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+
+    const harness = createTaskAndKanbanHarness({
+      activeRepo: "/repo",
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (value) =>
+          !value.isPendingKanban && !value.isFetchingKanban && value.kanbanTasks.length === 0,
+        1000,
+      );
+
+      let scheduledRefreshPromise: Promise<void> | null = null;
+      await harness.run((value) => {
+        scheduledRefreshPromise = value.operations.refreshTasksWithOptions({
+          trigger: "scheduled",
+        });
+      });
+
+      await harness.run(async () => {
+        repoPullRequestSyncDeferred.resolve({ ok: true });
+      });
+      await harness.waitFor(
+        (value) => !value.isPendingKanban && value.isFetchingKanban && kanbanTaskListCallCount >= 2,
+        1000,
+      );
+
+      if (!scheduledRefreshPromise) {
+        throw new Error("Expected scheduled refresh promise to be created");
+      }
+
+      const latest = harness.getLatest();
+      const foregroundLoading = isKanbanForegroundLoading({
+        hasActiveRepo: true,
+        isLoadingTasks: latest.operations.isLoadingTasks,
+        isSettingsPending: false,
+        doneVisibleDays: 1,
+        isKanbanPending: latest.isPendingKanban,
+      });
+
+      expect(repoTaskListCallCount).toBeGreaterThanOrEqual(2);
+      expect(foregroundLoading).toBe(false);
+      expect(foregroundLoading && latest.kanbanTasks.length === 0).toBe(false);
+
+      await harness.run(async () => {
+        repoTaskRefreshDeferred.resolve([]);
+        kanbanRefreshDeferred.resolve([]);
+        runsRefreshDeferred.resolve([]);
+        await scheduledRefreshPromise;
+      });
+    } finally {
+      repoPullRequestSyncDeferred.resolve({ ok: true });
+      repoTaskRefreshDeferred.resolve([]);
+      kanbanRefreshDeferred.resolve([]);
+      runsRefreshDeferred.resolve([]);
+      await harness.unmount();
+      host.repoPullRequestSync = original.repoPullRequestSync;
+      host.tasksList = original.tasksList;
+      host.runsList = original.runsList;
+    }
+  });
+
+  test("scheduled refresh keeps visible kanban tasks out of foreground loading during post-sync refetch", async () => {
+    const repoPullRequestSyncDeferred = createDeferred<{ ok: boolean }>();
+    let repoTaskListCallCount = 0;
+    let kanbanTaskListCallCount = 0;
+    let runsListCallCount = 0;
+    const repoTaskRefreshDeferred = createDeferred<TaskCard[]>();
+    const kanbanRefreshDeferred = createDeferred<TaskCard[]>();
+    const runsRefreshDeferred = createDeferred<RunSummary[]>();
+    const repoPullRequestSync = mock(async () => repoPullRequestSyncDeferred.promise);
+    const tasksList = mock(async (_repoPath: string, doneVisibleDays?: number) => {
+      if (typeof doneVisibleDays === "number") {
+        kanbanTaskListCallCount += 1;
+        return kanbanTaskListCallCount === 1
+          ? [makeTask("A", "open")]
+          : kanbanRefreshDeferred.promise;
+      }
+
+      repoTaskListCallCount += 1;
+      return repoTaskListCallCount === 1
+        ? [makeTask("A", "open")]
+        : repoTaskRefreshDeferred.promise;
+    });
+    const runsList = mock(async (): Promise<RunSummary[]> => {
+      runsListCallCount += 1;
+      return runsListCallCount === 1 ? [] : runsRefreshDeferred.promise;
+    });
+
+    const original = {
+      repoPullRequestSync: host.repoPullRequestSync,
+      tasksList: host.tasksList,
+      runsList: host.runsList,
+    };
+    host.repoPullRequestSync = repoPullRequestSync;
+    host.tasksList = tasksList;
+    host.runsList = runsList;
+
+    const harness = createTaskAndKanbanHarness({
+      activeRepo: "/repo",
+      refreshBeadsCheckForRepo: async (): Promise<BeadsCheck> => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      }),
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (value) =>
+          !value.isPendingKanban && !value.isFetchingKanban && value.kanbanTasks[0]?.id === "A",
+        1000,
+      );
+
+      let scheduledRefreshPromise: Promise<void> | null = null;
+      await harness.run((value) => {
+        scheduledRefreshPromise = value.operations.refreshTasksWithOptions({
+          trigger: "scheduled",
+        });
+      });
+
+      await harness.run(async () => {
+        repoPullRequestSyncDeferred.resolve({ ok: true });
+      });
+      await harness.waitFor(
+        (value) => !value.isPendingKanban && value.isFetchingKanban && kanbanTaskListCallCount >= 2,
+        1000,
+      );
+
+      if (!scheduledRefreshPromise) {
+        throw new Error("Expected scheduled refresh promise to be created");
+      }
+
+      const latest = harness.getLatest();
+      const foregroundLoading = isKanbanForegroundLoading({
+        hasActiveRepo: true,
+        isLoadingTasks: latest.operations.isLoadingTasks,
+        isSettingsPending: false,
+        doneVisibleDays: 1,
+        isKanbanPending: latest.isPendingKanban,
+      });
+
+      expect(repoTaskListCallCount).toBeGreaterThanOrEqual(2);
+      expect(foregroundLoading).toBe(false);
+      expect(latest.kanbanTasks[0]?.id).toBe("A");
+
+      await harness.run(async () => {
+        repoTaskRefreshDeferred.resolve([makeTask("A", "open")]);
+        kanbanRefreshDeferred.resolve([makeTask("A", "open")]);
+        runsRefreshDeferred.resolve([]);
+        await scheduledRefreshPromise;
+      });
+    } finally {
+      repoPullRequestSyncDeferred.resolve({ ok: true });
+      repoTaskRefreshDeferred.resolve([makeTask("A", "open")]);
+      kanbanRefreshDeferred.resolve([makeTask("A", "open")]);
+      runsRefreshDeferred.resolve([]);
       await harness.unmount();
       host.repoPullRequestSync = original.repoPullRequestSync;
       host.tasksList = original.tasksList;

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -551,8 +551,7 @@ export function useTaskOperations({
   const tasks = activeRepo ? (repoTaskDataQuery.data?.tasks ?? []) : [];
   const runs = activeRepo ? (repoTaskDataQuery.data?.runs ?? []) : [];
   const isLoadingTasks =
-    isManualLoadingTasks ||
-    (activeRepo !== null && (repoTaskDataQuery.isPending || repoTaskDataQuery.isFetching));
+    isManualLoadingTasks || (activeRepo !== null && repoTaskDataQuery.isPending);
 
   return {
     tasks,

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -33,6 +33,8 @@ type UseTaskOperationsArgs = {
 type UseTaskOperationsResult = {
   tasks: TaskCard[];
   runs: RunSummary[];
+  isForegroundLoadingTasks: boolean;
+  isRefreshingTasksInBackground: boolean;
   isLoadingTasks: boolean;
   detectingPullRequestTaskId: string | null;
   linkingMergedPullRequestTaskId: string | null;
@@ -550,12 +552,17 @@ export function useTaskOperations({
 
   const tasks = activeRepo ? (repoTaskDataQuery.data?.tasks ?? []) : [];
   const runs = activeRepo ? (repoTaskDataQuery.data?.runs ?? []) : [];
-  const isLoadingTasks =
+  const isForegroundLoadingTasks =
     isManualLoadingTasks || (activeRepo !== null && repoTaskDataQuery.isPending);
+  const isRefreshingTasksInBackground =
+    activeRepo !== null && repoTaskDataQuery.isFetching && !isForegroundLoadingTasks;
+  const isLoadingTasks = isForegroundLoadingTasks;
 
   return {
     tasks,
     runs,
+    isForegroundLoadingTasks,
+    isRefreshingTasksInBackground,
     isLoadingTasks,
     detectingPullRequestTaskId,
     linkingMergedPullRequestTaskId,

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -11,6 +11,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
+import type { TaskRefreshOptions } from "@/state/app-state-contexts";
 import { documentQueryKeys } from "@/state/queries/documents";
 import { refreshRepoTaskViewsFromQuery } from "@/state/queries/task-view-sync";
 import { summarizeTaskLoadError } from "@/state/tasks/task-load-errors";
@@ -40,6 +41,7 @@ type UseTaskOperationsResult = {
   setIsLoadingTasks: (value: boolean) => void;
   clearTaskData: () => void;
   refreshTaskData: (repoPath: string, taskId?: string) => Promise<void>;
+  refreshTasksWithOptions: (options?: TaskRefreshOptions) => Promise<void>;
   refreshTasks: () => Promise<void>;
   syncPullRequests: (taskId: string) => Promise<void>;
   linkMergedPullRequest: () => Promise<void>;
@@ -100,6 +102,11 @@ export function useTaskOperations({
 }: UseTaskOperationsArgs): UseTaskOperationsResult {
   const queryClient = useQueryClient();
   const [isManualLoadingTasks, setIsManualLoadingTasks] = useState(false);
+  const inFlightTaskRefreshRef = useRef<{ repoPath: string; promise: Promise<void> } | null>(null);
+  const lastScheduledTaskRefreshErrorRef = useRef<{
+    repoPath: string;
+    description: string;
+  } | null>(null);
   const [detectingPullRequestTaskId, setDetectingPullRequestTaskId] = useState<string | null>(null);
   const [linkingMergedPullRequestTaskId, setLinkingMergedPullRequestTaskId] = useState<
     string | null
@@ -120,6 +127,7 @@ export function useTaskOperations({
     activeRepoRef.current = activeRepo;
     if (previousActiveRepo !== activeRepo) {
       setIsManualLoadingTasks(false);
+      lastScheduledTaskRefreshErrorRef.current = null;
       setDetectingPullRequestTaskId(null);
       setLinkingMergedPullRequestTaskId(null);
       setUnlinkingPullRequestTaskId(null);
@@ -136,6 +144,37 @@ export function useTaskOperations({
       );
     },
     [queryClient],
+  );
+
+  const runRepoTaskRefresh = useCallback(
+    async (repoPath: string): Promise<void> => {
+      const beads = await refreshBeadsCheckForRepo(repoPath, false);
+      if (!beads.beadsOk) {
+        throw new Error(beads.beadsError ?? "Beads store is not initialized for this repository.");
+      }
+
+      await host.repoPullRequestSync(repoPath);
+      await refreshTaskData(repoPath);
+    },
+    [refreshBeadsCheckForRepo, refreshTaskData],
+  );
+
+  const getRepoTaskRefreshPromise = useCallback(
+    (repoPath: string): Promise<void> => {
+      const inFlightRefresh = inFlightTaskRefreshRef.current;
+      if (inFlightRefresh && inFlightRefresh.repoPath === repoPath) {
+        return inFlightRefresh.promise;
+      }
+
+      const promise = runRepoTaskRefresh(repoPath).finally(() => {
+        if (inFlightTaskRefreshRef.current?.promise === promise) {
+          inFlightTaskRefreshRef.current = null;
+        }
+      });
+      inFlightTaskRefreshRef.current = { repoPath, promise };
+      return promise;
+    },
+    [runRepoTaskRefresh],
   );
 
   const refreshTaskMutationViews = useCallback(
@@ -188,34 +227,46 @@ export function useTaskOperations({
     [activeRepo, refreshTaskMutationViews],
   );
 
-  const refreshTasks = useCallback(async (): Promise<void> => {
-    if (!activeRepo) {
-      return;
-    }
-
-    setIsManualLoadingTasks(true);
-    try {
-      const beads = await refreshBeadsCheckForRepo(activeRepo, false);
-      if (!beads.beadsOk) {
-        const details = beads.beadsError ?? "Beads store is not initialized for this repository.";
-        toast.error("Task store unavailable", { description: details });
+  const refreshTasksWithOptions = useCallback(
+    async (options?: TaskRefreshOptions): Promise<void> => {
+      if (!activeRepo) {
         return;
       }
 
-      try {
-        await host.repoPullRequestSync(activeRepo);
-      } catch (error) {
-        console.warn("Pull request sync failed during task refresh", errorMessage(error));
+      const repoPath = activeRepo;
+      const trigger = options?.trigger ?? "manual";
+      if (trigger === "manual") {
+        setIsManualLoadingTasks(true);
       }
-      await refreshTaskData(activeRepo);
-    } catch (error) {
-      toast.error("Failed to refresh tasks", {
-        description: summarizeTaskLoadError(error),
-      });
-    } finally {
-      setIsManualLoadingTasks(false);
-    }
-  }, [activeRepo, refreshBeadsCheckForRepo, refreshTaskData]);
+
+      try {
+        await getRepoTaskRefreshPromise(repoPath);
+        lastScheduledTaskRefreshErrorRef.current = null;
+      } catch (error) {
+        const description = summarizeTaskLoadError(error);
+        if (trigger === "scheduled") {
+          const lastError = lastScheduledTaskRefreshErrorRef.current;
+          if (lastError?.repoPath !== repoPath || lastError.description !== description) {
+            lastScheduledTaskRefreshErrorRef.current = { repoPath, description };
+            toast.error("Failed to refresh tasks", { description });
+          }
+        } else {
+          toast.error("Failed to refresh tasks", {
+            description,
+          });
+        }
+      } finally {
+        if (trigger === "manual") {
+          setIsManualLoadingTasks(false);
+        }
+      }
+    },
+    [activeRepo, getRepoTaskRefreshPromise],
+  );
+
+  const refreshTasks = useCallback(async (): Promise<void> => {
+    await refreshTasksWithOptions({ trigger: "manual" });
+  }, [refreshTasksWithOptions]);
 
   const syncPullRequests = useCallback(
     async (taskId: string): Promise<void> => {
@@ -490,6 +541,7 @@ export function useTaskOperations({
 
   const clearTaskData = useCallback(() => {
     setIsManualLoadingTasks(false);
+    lastScheduledTaskRefreshErrorRef.current = null;
     setDetectingPullRequestTaskId(null);
     setLinkingMergedPullRequestTaskId(null);
     setUnlinkingPullRequestTaskId(null);
@@ -513,6 +565,7 @@ export function useTaskOperations({
     setIsLoadingTasks: setIsManualLoadingTasks,
     clearTaskData,
     refreshTaskData,
+    refreshTasksWithOptions,
     refreshTasks,
     syncPullRequests,
     linkMergedPullRequest,

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -65,6 +65,8 @@ type TaskMutationRefreshStrategy =
   | { kind: "task"; taskId: string }
   | { kind: "remove-task"; taskIds: string[] };
 
+const TASK_REFRESH_WARNING = "Pull request sync failed during task refresh";
+
 const collectTaskDeletionIds = (
   tasks: TaskCard[],
   taskId: string,
@@ -105,7 +107,7 @@ export function useTaskOperations({
   const queryClient = useQueryClient();
   const [isManualLoadingTasks, setIsManualLoadingTasks] = useState(false);
   const inFlightTaskRefreshRef = useRef<{ repoPath: string; promise: Promise<void> } | null>(null);
-  const lastScheduledTaskRefreshErrorRef = useRef<{
+  const lastTaskRefreshToastRef = useRef<{
     repoPath: string;
     description: string;
   } | null>(null);
@@ -129,7 +131,7 @@ export function useTaskOperations({
     activeRepoRef.current = activeRepo;
     if (previousActiveRepo !== activeRepo) {
       setIsManualLoadingTasks(false);
-      lastScheduledTaskRefreshErrorRef.current = null;
+      lastTaskRefreshToastRef.current = null;
       setDetectingPullRequestTaskId(null);
       setLinkingMergedPullRequestTaskId(null);
       setUnlinkingPullRequestTaskId(null);
@@ -162,10 +164,10 @@ export function useTaskOperations({
   );
 
   const getRepoTaskRefreshPromise = useCallback(
-    (repoPath: string): Promise<void> => {
+    (repoPath: string): { promise: Promise<void>; joinedExisting: boolean } => {
       const inFlightRefresh = inFlightTaskRefreshRef.current;
       if (inFlightRefresh && inFlightRefresh.repoPath === repoPath) {
-        return inFlightRefresh.promise;
+        return { promise: inFlightRefresh.promise, joinedExisting: true };
       }
 
       const promise = runRepoTaskRefresh(repoPath).finally(() => {
@@ -174,7 +176,7 @@ export function useTaskOperations({
         }
       });
       inFlightTaskRefreshRef.current = { repoPath, promise };
-      return promise;
+      return { promise, joinedExisting: false };
     },
     [runRepoTaskRefresh],
   );
@@ -241,18 +243,30 @@ export function useTaskOperations({
         setIsManualLoadingTasks(true);
       }
 
+      const { promise, joinedExisting } = getRepoTaskRefreshPromise(repoPath);
+
       try {
-        await getRepoTaskRefreshPromise(repoPath);
-        lastScheduledTaskRefreshErrorRef.current = null;
+        await promise;
+        lastTaskRefreshToastRef.current = null;
       } catch (error) {
         const description = summarizeTaskLoadError(error);
-        if (trigger === "scheduled") {
-          const lastError = lastScheduledTaskRefreshErrorRef.current;
-          if (lastError?.repoPath !== repoPath || lastError.description !== description) {
-            lastScheduledTaskRefreshErrorRef.current = { repoPath, description };
-            toast.error("Failed to refresh tasks", { description });
-          }
-        } else {
+        if (!joinedExisting) {
+          console.warn(TASK_REFRESH_WARNING, {
+            repoPath,
+            trigger,
+            description,
+            error: errorMessage(error),
+          });
+        }
+
+        const lastToast = lastTaskRefreshToastRef.current;
+        const shouldDeduplicateToast =
+          lastToast?.repoPath === repoPath &&
+          lastToast.description === description &&
+          (trigger === "scheduled" || joinedExisting);
+
+        if (!shouldDeduplicateToast) {
+          lastTaskRefreshToastRef.current = { repoPath, description };
           toast.error("Failed to refresh tasks", {
             description,
           });
@@ -543,7 +557,7 @@ export function useTaskOperations({
 
   const clearTaskData = useCallback(() => {
     setIsManualLoadingTasks(false);
-    lastScheduledTaskRefreshErrorRef.current = null;
+    lastTaskRefreshToastRef.current = null;
     setDetectingPullRequestTaskId(null);
     setLinkingMergedPullRequestTaskId(null);
     setUnlinkingPullRequestTaskId(null);

--- a/apps/desktop/src/state/operations/tasks/use-task-operations.ts
+++ b/apps/desktop/src/state/operations/tasks/use-task-operations.ts
@@ -106,6 +106,7 @@ export function useTaskOperations({
 }: UseTaskOperationsArgs): UseTaskOperationsResult {
   const queryClient = useQueryClient();
   const [isManualLoadingTasks, setIsManualLoadingTasks] = useState(false);
+  const manualRefreshTokenRef = useRef(0);
   const inFlightTaskRefreshRef = useRef<{ repoPath: string; promise: Promise<void> } | null>(null);
   const lastTaskRefreshToastRef = useRef<{
     repoPath: string;
@@ -130,6 +131,7 @@ export function useTaskOperations({
     const previousActiveRepo = activeRepoRef.current;
     activeRepoRef.current = activeRepo;
     if (previousActiveRepo !== activeRepo) {
+      manualRefreshTokenRef.current += 1;
       setIsManualLoadingTasks(false);
       lastTaskRefreshToastRef.current = null;
       setDetectingPullRequestTaskId(null);
@@ -239,7 +241,10 @@ export function useTaskOperations({
 
       const repoPath = activeRepo;
       const trigger = options?.trigger ?? "manual";
+      let manualRefreshToken: number | null = null;
       if (trigger === "manual") {
+        manualRefreshTokenRef.current += 1;
+        manualRefreshToken = manualRefreshTokenRef.current;
         setIsManualLoadingTasks(true);
       }
 
@@ -272,7 +277,11 @@ export function useTaskOperations({
           });
         }
       } finally {
-        if (trigger === "manual") {
+        if (
+          trigger === "manual" &&
+          manualRefreshToken !== null &&
+          manualRefreshTokenRef.current === manualRefreshToken
+        ) {
           setIsManualLoadingTasks(false);
         }
       }
@@ -556,6 +565,7 @@ export function useTaskOperations({
   );
 
   const clearTaskData = useCallback(() => {
+    manualRefreshTokenRef.current += 1;
     setIsManualLoadingTasks(false);
     lastTaskRefreshToastRef.current = null;
     setDetectingPullRequestTaskId(null);

--- a/apps/desktop/src/state/providers/app-lifecycle-state-provider.tsx
+++ b/apps/desktop/src/state/providers/app-lifecycle-state-provider.tsx
@@ -12,7 +12,7 @@ export function AppLifecycleStateProvider({ children }: PropsWithChildren): Reac
   const { activeRepo } = useActiveRepoContext();
   const { refreshWorkspaces, refreshBranches, clearBranchData } = useWorkspaceOperationsContext();
   const { refreshRuntimeCheck, refreshBeadsCheckForRepo } = useChecksOperationsContext();
-  const { refreshTaskData } = useTaskControlContext();
+  const { refreshTaskData, refreshTasksWithOptions } = useTaskControlContext();
   const { setEvents, setRunCompletionSignal } = useDelegationEventsContext();
 
   useAppLifecycle({
@@ -24,6 +24,7 @@ export function AppLifecycleStateProvider({ children }: PropsWithChildren): Reac
     refreshRuntimeCheck,
     refreshBeadsCheckForRepo,
     refreshTaskData,
+    refreshTasksWithOptions,
     clearBranchData,
   });
 

--- a/apps/desktop/src/state/providers/tasks-state-provider.tsx
+++ b/apps/desktop/src/state/providers/tasks-state-provider.tsx
@@ -26,6 +26,7 @@ export function TasksStateProvider({ children }: PropsWithChildren): ReactElemen
     clearTaskData,
     refreshTaskData,
     refreshTasks,
+    refreshTasksWithOptions,
     syncPullRequests,
     linkMergedPullRequest,
     cancelLinkMergedPullRequest,
@@ -105,10 +106,11 @@ export function TasksStateProvider({ children }: PropsWithChildren): ReactElemen
   const taskControlValue = useMemo<TaskControlContextValue>(
     () => ({
       refreshTaskData,
+      refreshTasksWithOptions,
       clearTaskData,
       setIsLoadingTasks,
     }),
-    [clearTaskData, refreshTaskData, setIsLoadingTasks],
+    [clearTaskData, refreshTaskData, refreshTasksWithOptions, setIsLoadingTasks],
   );
 
   return (

--- a/apps/desktop/src/state/providers/tasks-state-provider.tsx
+++ b/apps/desktop/src/state/providers/tasks-state-provider.tsx
@@ -17,6 +17,8 @@ export function TasksStateProvider({ children }: PropsWithChildren): ReactElemen
   const {
     tasks,
     runs,
+    isForegroundLoadingTasks,
+    isRefreshingTasksInBackground,
     isLoadingTasks,
     detectingPullRequestTaskId,
     linkingMergedPullRequestTaskId,
@@ -48,6 +50,8 @@ export function TasksStateProvider({ children }: PropsWithChildren): ReactElemen
   const tasksStateValue = useMemo(
     () =>
       buildTasksStateValue({
+        isForegroundLoadingTasks,
+        isRefreshingTasksInBackground,
         isLoadingTasks,
         detectingPullRequestTaskId,
         linkingMergedPullRequestTaskId,
@@ -78,6 +82,8 @@ export function TasksStateProvider({ children }: PropsWithChildren): ReactElemen
       detectingPullRequestTaskId,
       humanApproveTask,
       humanRequestChangesTask,
+      isForegroundLoadingTasks,
+      isRefreshingTasksInBackground,
       isLoadingTasks,
       linkMergedPullRequest,
       linkingMergedPullRequestTaskId,

--- a/apps/desktop/src/types/state-slices.ts
+++ b/apps/desktop/src/types/state-slices.ts
@@ -92,6 +92,8 @@ export type ChecksStateContextValue = {
 };
 
 export type TasksStateContextValue = {
+  isForegroundLoadingTasks: boolean;
+  isRefreshingTasksInBackground: boolean;
   isLoadingTasks: boolean;
   detectingPullRequestTaskId: string | null;
   linkingMergedPullRequestTaskId: string | null;


### PR DESCRIPTION
## Summary
- add a visible-only 5 minute PR sync scheduler at the app lifecycle layer for the active repo, reusing the same shared refresh orchestration as the manual Kanban refresh
- keep scheduled refresh non-overlapping and background-only by clarifying foreground vs background task loading semantics instead of duplicating sync logic or relying on query focus heuristics
- expand desktop regression coverage for lifecycle scheduling, shared refresh behavior, and the post-sync Kanban refetch window while preserving the existing Rust host PR-close workflow

## Verification
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- rtk cargo test -p host-application approval_workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled PR sync with configurable interval that pauses when the tab is hidden.
  * New refresh API accepting options (manual vs scheduled) and a ref-backed timer to ensure latest callback usage.
  * Added exported helper to compute Kanban foreground-loading state.

* **Refactor**
  * Split task loading into foreground vs background states; added per-repo in-flight deduplication and toast dedupe.

* **Tests**
  * Extensive tests for scheduling, visibility behavior, concurrency, refresh semantics, and Kanban foreground-loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->