### PR TITLE
refactor(desktop): split load session hydration stages

### DIFF
--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSessionRecord } from "@openducktor/contracts";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
+import {
+  hydrateSessionRecordsStage,
+  preparePersistedSessionMergeStage,
+  type SessionLoadIntent,
+} from "./load-sessions-stages";
+
+const createSession = (overrides: Partial<AgentSessionState> = {}): AgentSessionState => ({
+  sessionId: "session-1",
+  externalSessionId: "external-1",
+  taskId: "task-1",
+  role: "build",
+  scenario: "build_implementation_start",
+  status: "idle",
+  startedAt: "2026-03-01T09:00:00.000Z",
+  runtimeKind: "opencode",
+  runtimeId: null,
+  runId: null,
+  runtimeEndpoint: "",
+  workingDirectory: "/tmp/repo/worktree",
+  messages: [],
+  draftAssistantText: "",
+  draftAssistantMessageId: null,
+  draftReasoningText: "",
+  draftReasoningMessageId: null,
+  contextUsage: null,
+  pendingPermissions: [],
+  pendingQuestions: [],
+  todos: [],
+  modelCatalog: null,
+  selectedModel: null,
+  isLoadingModelCatalog: false,
+  promptOverrides: {},
+  ...overrides,
+});
+
+const createRecord = (overrides: Partial<AgentSessionRecord> = {}): AgentSessionRecord => ({
+  sessionId: "session-1",
+  externalSessionId: "external-1",
+  role: "build",
+  scenario: "build_implementation_start",
+  startedAt: "2026-03-01T09:00:00.000Z",
+  workingDirectory: "/tmp/repo/worktree",
+  runtimeKind: "opencode",
+  selectedModel: null,
+  ...overrides,
+});
+
+const createIntent = (overrides: Partial<SessionLoadIntent> = {}): SessionLoadIntent => ({
+  repoPath: "/tmp/repo",
+  taskId: "task-1",
+  mode: "bootstrap",
+  requestedSessionId: null,
+  requestedHistoryKey: null,
+  shouldHydrateRequestedSession: false,
+  shouldReconcileLiveSessions: false,
+  historyPolicy: "none",
+  ...overrides,
+});
+
+const createStateHarness = (sessions: Record<string, AgentSessionState>) => {
+  let state = sessions;
+  const sessionsRef = { current: state };
+  return {
+    sessionsRef,
+    setSessionsById: (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    },
+    updateSession: (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    },
+    getState: () => state,
+  };
+};
+
+describe("load-sessions-stages", () => {
+  test("uses the in-memory requested session record without reloading persisted sessions", async () => {
+    const existingSession = createSession({ runtimeEndpoint: "http://127.0.0.1:4444" });
+    const stateHarness = createStateHarness({ "session-1": existingSession });
+    let persistedLoads = 0;
+    let setCalls = 0;
+
+    const output = await preparePersistedSessionMergeStage({
+      intent: createIntent({
+        mode: "requested_history",
+        requestedSessionId: "session-1",
+        requestedHistoryKey: "/tmp/repo::task-1::session-1",
+        shouldHydrateRequestedSession: true,
+        historyPolicy: "requested_only",
+      }),
+      sessionsRef: stateHarness.sessionsRef,
+      setSessionsById: (updater) => {
+        setCalls += 1;
+        stateHarness.setSessionsById(updater);
+      },
+      isStaleRepoOperation: () => false,
+      loadPersistedRecords: async () => {
+        persistedLoads += 1;
+        return [createRecord()];
+      },
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    expect(persistedLoads).toBe(0);
+    expect(setCalls).toBe(0);
+    expect(output.recordsToHydrate).toHaveLength(1);
+    expect(output.recordsToHydrate[0]?.sessionId).toBe("session-1");
+    expect(output.historyHydrationSessionIds.has("session-1")).toBe(true);
+  });
+
+  test("merges persisted records while preserving in-memory pending input", async () => {
+    const existingSession = createSession({
+      pendingPermissions: [{ requestId: "perm-current", permission: "read", patterns: [".env"] }],
+      pendingQuestions: [
+        {
+          requestId: "question-current",
+          questions: [{ header: "Confirm", question: "Ship it?", options: [] }],
+        },
+      ],
+    });
+    const stateHarness = createStateHarness({ "session-1": existingSession });
+
+    await preparePersistedSessionMergeStage({
+      intent: createIntent(),
+      sessionsRef: stateHarness.sessionsRef,
+      setSessionsById: stateHarness.setSessionsById,
+      isStaleRepoOperation: () => false,
+      loadPersistedRecords: async () => [
+        createRecord({
+          startedAt: "2026-03-01T10:00:00.000Z",
+          workingDirectory: "/tmp/repo/updated-worktree",
+        }),
+      ],
+      loadRepoPromptOverrides: async () => ({}),
+    });
+
+    const nextSession = stateHarness.getState()["session-1"];
+    expect(nextSession?.startedAt).toBe("2026-03-01T10:00:00.000Z");
+    expect(nextSession?.pendingPermissions).toEqual(existingSession.pendingPermissions);
+    expect(nextSession?.pendingQuestions).toEqual(existingSession.pendingQuestions);
+  });
+
+  test("marks requested-history hydration failed when runtime resolution fails", async () => {
+    const stateHarness = createStateHarness({ "session-1": createSession() });
+    let promptLoads = 0;
+
+    await expect(
+      hydrateSessionRecordsStage({
+        adapter: {
+          hasSession: () => false,
+          listLiveAgentSessionSnapshots: async () => [],
+          loadSessionHistory: async () => [],
+          resumeSession: async (input) => ({
+            sessionId: input.sessionId,
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            scenario: input.scenario,
+            startedAt: "2026-03-01T09:00:00.000Z",
+            status: "idle",
+            runtimeKind: input.runtimeKind,
+          }),
+        },
+        setSessionsById: stateHarness.setSessionsById,
+        updateSession: stateHarness.updateSession,
+        isStaleRepoOperation: () => false,
+        recordsToHydrate: [createRecord()],
+        historyHydrationSessionIds: new Set(["session-1"]),
+        runtimePlanner: {
+          readCurrentHydratedRuntimeResolution: () => null,
+          resolveHydrationRuntime: async () => ({
+            ok: false,
+            runtimeKind: "opencode",
+            reason: "No live runtime found for working directory /tmp/repo/worktree.",
+          }),
+          loadLiveAgentSessionSnapshot: async () => null,
+        },
+        promptAssembler: {
+          buildHydrationPreludeMessages: async () => [],
+          buildHydrationSystemPrompt: async () => "",
+        },
+        getRepoPromptOverrides: async () => {
+          promptLoads += 1;
+          return {};
+        },
+      }),
+    ).rejects.toThrow("No live runtime found for working directory /tmp/repo/worktree.");
+
+    expect(promptLoads).toBe(0);
+    expect(stateHarness.getState()["session-1"]?.historyHydrationState).toBe("failed");
+  });
+});

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from "bun:test";
-import type { AgentSessionRecord } from "@openducktor/contracts";
+import type {
+  AgentSessionRecord,
+  RuntimeInstanceSummary,
+  RuntimeKind,
+  TaskCard,
+} from "@openducktor/contracts";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
+import { liveAgentSessionLookupKey, runtimeWorkingDirectoryKey } from "./live-agent-session-cache";
 import {
+  createHydrationPromptAssemblerStage,
+  createRuntimeResolutionPlannerStage,
   hydrateSessionRecordsStage,
   preparePersistedSessionMergeStage,
   type SessionLoadIntent,
@@ -90,6 +99,51 @@ const createStateHarness = (sessions: Record<string, AgentSessionState>) => {
     getState: () => state,
   };
 };
+
+const taskFixture: TaskCard = {
+  id: "task-1",
+  title: "Refactor loader",
+  description: "Split hydration into explicit stages",
+  notes: "",
+  status: "ready_for_dev",
+  priority: 2,
+  issueType: "task",
+  aiReviewEnabled: true,
+  availableActions: [],
+  labels: [],
+  subtaskIds: [],
+  documentSummary: {
+    spec: { has: false },
+    plan: { has: false },
+    qaReport: { has: false, verdict: "not_reviewed" },
+  },
+  agentWorkflows: {
+    spec: { required: false, canSkip: true, available: false, completed: false },
+    planner: { required: false, canSkip: true, available: false, completed: false },
+    builder: { required: true, canSkip: false, available: false, completed: false },
+    qa: { required: false, canSkip: true, available: false, completed: false },
+  },
+  updatedAt: "2026-03-01T09:00:00.000Z",
+  createdAt: "2026-03-01T09:00:00.000Z",
+};
+
+const createRuntime = (
+  workingDirectory: string,
+  runtimeKind: RuntimeKind = "opencode",
+): RuntimeInstanceSummary => ({
+  kind: runtimeKind,
+  runtimeId: "runtime-1",
+  repoPath: "/tmp/repo",
+  taskId: null,
+  role: "workspace",
+  workingDirectory,
+  runtimeRoute: {
+    type: "local_http",
+    endpoint: "http://127.0.0.1:4444",
+  },
+  startedAt: "2026-03-01T09:00:00.000Z",
+  descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+});
 
 describe("load-sessions-stages", () => {
   test("uses the in-memory requested session record without reloading persisted sessions", async () => {
@@ -205,5 +259,162 @@ describe("load-sessions-stages", () => {
 
     expect(promptLoads).toBe(0);
     expect(stateHarness.getState()["session-1"]?.historyHydrationState).toBe("failed");
+  });
+
+  test("runtime planner reuses current hydrated runtime and preloaded live snapshots", async () => {
+    const workingDirectory = "/tmp/repo/worktree";
+    const stateHarness = createStateHarness({
+      "session-1": createSession({
+        runtimeKind: "opencode",
+        runtimeId: "runtime-current",
+        runId: "run-current",
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        workingDirectory,
+      }),
+    });
+    const liveSnapshot = {
+      externalSessionId: "external-1",
+      title: "Builder Session",
+      role: "build",
+      scenario: "build_implementation_start",
+      startedAt: "2026-03-01T09:00:00.000Z",
+      status: { type: "busy" as const },
+      pendingPermissions: [],
+      pendingQuestions: [],
+      workingDirectory,
+    };
+    let snapshotLoads = 0;
+
+    const planner = await createRuntimeResolutionPlannerStage({
+      intent: createIntent({
+        mode: "requested_history",
+        requestedSessionId: "session-1",
+        requestedHistoryKey: "/tmp/repo::task-1::session-1",
+        shouldHydrateRequestedSession: true,
+        historyPolicy: "requested_only",
+      }),
+      options: {
+        preloadedRuntimeLists: new Map<RuntimeKind, RuntimeInstanceSummary[]>([
+          ["opencode", [createRuntime(workingDirectory)]],
+        ]),
+        preloadedRuntimeConnectionsByKey: new Map([
+          [
+            runtimeWorkingDirectoryKey("opencode", workingDirectory),
+            { endpoint: "http://127.0.0.1:4444", workingDirectory },
+          ],
+        ]),
+        preloadedLiveAgentSessionsByKey: new Map([
+          [
+            liveAgentSessionLookupKey("opencode", "http://127.0.0.1:4444", workingDirectory),
+            [liveSnapshot],
+          ],
+        ]),
+        allowRuntimeEnsure: false,
+      },
+      adapter: {
+        hasSession: () => false,
+        loadSessionHistory: async () => [],
+        resumeSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+        listLiveAgentSessionSnapshots: async () => {
+          snapshotLoads += 1;
+          return [];
+        },
+      },
+      sessionsRef: stateHarness.sessionsRef,
+      recordsToHydrate: [createRecord({ role: "planner", workingDirectory })],
+      historyHydrationSessionIds: new Set(["session-1"]),
+    });
+
+    const reusedResolution = planner.readCurrentHydratedRuntimeResolution(
+      createRecord({ role: "planner", workingDirectory }),
+    );
+
+    expect(reusedResolution).toEqual({
+      ok: true,
+      runtimeKind: "opencode",
+      runtimeId: "runtime-current",
+      runId: "run-current",
+      runtimeEndpoint: "http://127.0.0.1:4444",
+      runtimeConnection: {
+        endpoint: "http://127.0.0.1:4444",
+        workingDirectory,
+      },
+    });
+
+    const snapshot = await planner.loadLiveAgentSessionSnapshot(
+      createRecord({ role: "planner", workingDirectory }),
+      {
+        ok: true,
+        runtimeKind: "opencode",
+        runtimeId: "runtime-current",
+        runId: "run-current",
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        runtimeConnection: {
+          endpoint: "http://127.0.0.1:4444",
+          workingDirectory,
+        },
+      },
+    );
+
+    expect(snapshot).toEqual(liveSnapshot);
+    expect(snapshotLoads).toBe(0);
+  });
+
+  test("prompt assembler omits system prompt when the task is unavailable", async () => {
+    const assembler = createHydrationPromptAssemblerStage({
+      taskId: "task-1",
+      taskRef: { current: [] },
+    });
+
+    const prelude = await assembler.buildHydrationPreludeMessages({
+      record: createRecord({ role: "planner", scenario: "planner_initial" }),
+      resolvedScenario: "planner_initial",
+      promptOverrides: {},
+    });
+    const systemPrompt = await assembler.buildHydrationSystemPrompt({
+      record: createRecord({ role: "planner", scenario: "planner_initial" }),
+      resolvedScenario: "planner_initial",
+      promptOverrides: {},
+    });
+
+    expect(systemPrompt).toBe("");
+    expect(prelude).toHaveLength(1);
+    expect(prelude[0]).toMatchObject({
+      id: "history:session-start:session-1",
+      content: "Session started (planner - planner_initial)",
+    });
+  });
+
+  test("prompt assembler builds system prompt and header messages when the task exists", async () => {
+    const assembler = createHydrationPromptAssemblerStage({
+      taskId: "task-1",
+      taskRef: { current: [taskFixture] },
+    });
+
+    const systemPrompt = await assembler.buildHydrationSystemPrompt({
+      record: createRecord({ role: "planner", scenario: "planner_initial" }),
+      resolvedScenario: "planner_initial",
+      promptOverrides: {},
+    });
+    const prelude = await assembler.buildHydrationPreludeMessages({
+      record: createRecord({ role: "planner", scenario: "planner_initial" }),
+      resolvedScenario: "planner_initial",
+      promptOverrides: {},
+    });
+
+    expect(systemPrompt.length).toBeGreaterThan(0);
+    expect(prelude).toHaveLength(2);
+    expect(prelude[1]).toMatchObject({
+      id: "history:system-prompt:session-1",
+      content: `System prompt:\n\n${systemPrompt}`,
+    });
   });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts
@@ -100,7 +100,7 @@ const createStateHarness = (sessions: Record<string, AgentSessionState>) => {
   };
 };
 
-const taskFixture: TaskCard = {
+const createTaskFixture = (): TaskCard => ({
   id: "task-1",
   title: "Refactor loader",
   description: "Split hydration into explicit stages",
@@ -125,7 +125,7 @@ const taskFixture: TaskCard = {
   },
   updatedAt: "2026-03-01T09:00:00.000Z",
   createdAt: "2026-03-01T09:00:00.000Z",
-};
+});
 
 const createRuntime = (
   workingDirectory: string,
@@ -259,6 +259,106 @@ describe("load-sessions-stages", () => {
 
     expect(promptLoads).toBe(0);
     expect(stateHarness.getState()["session-1"]?.historyHydrationState).toBe("failed");
+  });
+
+  test("skips requested-history failure updates when the repo becomes stale during runtime resolution", async () => {
+    let stale = false;
+    const initialSession = createSession({ historyHydrationState: "hydrating" });
+    const stateHarness = createStateHarness({ "session-1": initialSession });
+
+    await hydrateSessionRecordsStage({
+      adapter: {
+        hasSession: () => false,
+        listLiveAgentSessionSnapshots: async () => [],
+        loadSessionHistory: async () => [],
+        resumeSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+      },
+      setSessionsById: stateHarness.setSessionsById,
+      updateSession: stateHarness.updateSession,
+      isStaleRepoOperation: () => stale,
+      recordsToHydrate: [createRecord()],
+      historyHydrationSessionIds: new Set(["session-1"]),
+      runtimePlanner: {
+        readCurrentHydratedRuntimeResolution: () => null,
+        resolveHydrationRuntime: async () => {
+          stale = true;
+          return {
+            ok: false,
+            runtimeKind: "opencode",
+            reason: "No live runtime found for working directory /tmp/repo/worktree.",
+          };
+        },
+        loadLiveAgentSessionSnapshot: async () => null,
+      },
+      promptAssembler: {
+        buildHydrationPreludeMessages: async () => [],
+        buildHydrationSystemPrompt: async () => "",
+      },
+      getRepoPromptOverrides: async () => ({}),
+    });
+
+    expect(stateHarness.getState()["session-1"]).toEqual(initialSession);
+  });
+
+  test("skips runtime projection when the repo becomes stale during runtime resolution", async () => {
+    let stale = false;
+    const initialSession = createSession();
+    const stateHarness = createStateHarness({ "session-1": initialSession });
+
+    await hydrateSessionRecordsStage({
+      adapter: {
+        hasSession: () => false,
+        listLiveAgentSessionSnapshots: async () => [],
+        loadSessionHistory: async () => [],
+        resumeSession: async (input) => ({
+          sessionId: input.sessionId,
+          externalSessionId: input.externalSessionId,
+          role: input.role,
+          scenario: input.scenario,
+          startedAt: "2026-03-01T09:00:00.000Z",
+          status: "idle",
+          runtimeKind: input.runtimeKind,
+        }),
+      },
+      setSessionsById: stateHarness.setSessionsById,
+      updateSession: stateHarness.updateSession,
+      isStaleRepoOperation: () => stale,
+      recordsToHydrate: [createRecord()],
+      historyHydrationSessionIds: new Set(),
+      runtimePlanner: {
+        readCurrentHydratedRuntimeResolution: () => null,
+        resolveHydrationRuntime: async () => {
+          stale = true;
+          return {
+            ok: true,
+            runtimeKind: "opencode",
+            runtimeId: "runtime-1",
+            runId: null,
+            runtimeEndpoint: "http://127.0.0.1:4444",
+            runtimeConnection: {
+              endpoint: "http://127.0.0.1:4444",
+              workingDirectory: "/tmp/repo/worktree",
+            },
+          };
+        },
+        loadLiveAgentSessionSnapshot: async () => null,
+      },
+      promptAssembler: {
+        buildHydrationPreludeMessages: async () => [],
+        buildHydrationSystemPrompt: async () => "",
+      },
+      getRepoPromptOverrides: async () => ({}),
+    });
+
+    expect(stateHarness.getState()["session-1"]).toEqual(initialSession);
   });
 
   test("runtime planner reuses current hydrated runtime and preloaded live snapshots", async () => {
@@ -396,7 +496,7 @@ describe("load-sessions-stages", () => {
   test("prompt assembler builds system prompt and header messages when the task exists", async () => {
     const assembler = createHydrationPromptAssemblerStage({
       taskId: "task-1",
-      taskRef: { current: [taskFixture] },
+      taskRef: { current: [createTaskFixture()] },
     });
 
     const systemPrompt = await assembler.buildHydrationSystemPrompt({

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -1,0 +1,870 @@
+import type {
+  AgentSessionRecord,
+  RepoPromptOverrides,
+  RuntimeInstanceSummary,
+  RuntimeKind,
+  TaskCard,
+} from "@openducktor/contracts";
+import type { AgentEnginePort, LiveAgentSessionSnapshot } from "@openducktor/core";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { appQueryClient } from "@/lib/query-client";
+import { loadRuntimeListFromQuery, runtimeQueryKeys } from "@/state/queries/runtime";
+import { loadRepoRunsFromQuery } from "@/state/queries/tasks";
+import type {
+  AgentSessionHistoryHydrationPolicy,
+  AgentSessionLoadMode,
+  AgentSessionLoadOptions,
+  AgentSessionState,
+} from "@/types/agent-orchestrator";
+import { host } from "../../shared/host";
+import { DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE } from "../support/history-hydration";
+import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
+import {
+  defaultScenarioForRole,
+  fromPersistedSessionRecord,
+  historyToChatMessages,
+  historyToSessionContextUsage,
+} from "../support/persistence";
+import { buildSessionHeaderMessages, buildSessionSystemPrompt } from "../support/session-prompt";
+import {
+  createHydrationRuntimeResolver,
+  type ResolvedHydrationRuntime,
+  readPersistedRuntimeKind,
+} from "./hydration-runtime-resolution";
+import { LiveAgentSessionCache, liveAgentSessionLookupKey } from "./live-agent-session-cache";
+import type { LiveAgentSessionStore } from "./live-agent-session-store";
+import { createReattachLiveSession } from "./reattach-live-session";
+
+export type UpdateSession = (
+  sessionId: string,
+  updater: (current: AgentSessionState) => AgentSessionState,
+  options?: { persist?: boolean },
+) => void;
+
+export type SessionLifecycleAdapter = Pick<
+  AgentEnginePort,
+  "hasSession" | "loadSessionHistory" | "resumeSession" | "listLiveAgentSessionSnapshots"
+> & {
+  listLiveAgentSessionSnapshots?: AgentEnginePort["listLiveAgentSessionSnapshots"];
+};
+
+export type SessionLoadIntent = {
+  repoPath: string;
+  taskId: string;
+  mode: AgentSessionLoadMode;
+  requestedSessionId: string | null;
+  requestedHistoryKey: string | null;
+  shouldHydrateRequestedSession: boolean;
+  shouldReconcileLiveSessions: boolean;
+  historyPolicy: AgentSessionHistoryHydrationPolicy;
+};
+
+export type PersistedSessionMergeStageInput = {
+  intent: SessionLoadIntent;
+  options?: AgentSessionLoadOptions;
+  sessionsRef: MutableRefObject<Record<string, AgentSessionState>>;
+  setSessionsById: Dispatch<SetStateAction<Record<string, AgentSessionState>>>;
+  isStaleRepoOperation: () => boolean;
+  loadPersistedRecords: () => Promise<AgentSessionRecord[]>;
+  loadRepoPromptOverrides: (repoPath: string) => Promise<RepoPromptOverrides>;
+};
+
+export type PersistedSessionMergeStageOutput = {
+  persistedRecords: AgentSessionRecord[];
+  recordsToHydrate: AgentSessionRecord[];
+  historyHydrationSessionIds: Set<string>;
+  getRepoPromptOverrides: () => Promise<RepoPromptOverrides>;
+};
+
+export type HydrationRuntimePlanner = {
+  readCurrentHydratedRuntimeResolution: (
+    record: AgentSessionRecord,
+  ) => Extract<ResolvedHydrationRuntime, { ok: true }> | null;
+  resolveHydrationRuntime: (record: AgentSessionRecord) => Promise<ResolvedHydrationRuntime>;
+  loadLiveAgentSessionSnapshot: (
+    record: AgentSessionRecord,
+    runtimeResolution: Extract<ResolvedHydrationRuntime, { ok: true }>,
+  ) => Promise<LiveAgentSessionSnapshot | null>;
+};
+
+export type RuntimeResolutionPlannerStageInput = {
+  intent: SessionLoadIntent;
+  options?: AgentSessionLoadOptions;
+  adapter: SessionLifecycleAdapter;
+  sessionsRef: MutableRefObject<Record<string, AgentSessionState>>;
+  liveAgentSessionStore?: LiveAgentSessionStore;
+  recordsToHydrate: AgentSessionRecord[];
+  historyHydrationSessionIds: Set<string>;
+};
+
+export type HydrationPromptAssembler = {
+  buildHydrationPreludeMessages: (input: {
+    record: AgentSessionRecord;
+    resolvedScenario: AgentSessionState["scenario"];
+    promptOverrides: RepoPromptOverrides;
+  }) => Promise<AgentSessionState["messages"]>;
+  buildHydrationSystemPrompt: (input: {
+    record: AgentSessionRecord;
+    resolvedScenario: AgentSessionState["scenario"];
+    promptOverrides: RepoPromptOverrides;
+  }) => Promise<string>;
+};
+
+export type PromptAssemblerStageInput = {
+  taskId: string;
+  taskRef: MutableRefObject<TaskCard[]>;
+};
+
+export type LiveReconciliationStageInput = {
+  intent: SessionLoadIntent;
+  options?: AgentSessionLoadOptions;
+  adapter: SessionLifecycleAdapter;
+  taskRef: MutableRefObject<TaskCard[]>;
+  sessionsRef: MutableRefObject<Record<string, AgentSessionState>>;
+  updateSession: UpdateSession;
+  attachSessionListener?: (repoPath: string, sessionId: string) => void;
+  isStaleRepoOperation: () => boolean;
+  recordsToHydrate: AgentSessionRecord[];
+  runtimePlanner: HydrationRuntimePlanner;
+  promptAssembler: HydrationPromptAssembler;
+  getRepoPromptOverrides: () => Promise<RepoPromptOverrides>;
+};
+
+export type LiveReconciliationStageOutput = {
+  reattachedSessionIds: Set<string>;
+};
+
+export type HistoryHydrationStageInput = {
+  adapter: SessionLifecycleAdapter;
+  setSessionsById: Dispatch<SetStateAction<Record<string, AgentSessionState>>>;
+  updateSession: UpdateSession;
+  isStaleRepoOperation: () => boolean;
+  recordsToHydrate: AgentSessionRecord[];
+  historyHydrationSessionIds: Set<string>;
+  runtimePlanner: HydrationRuntimePlanner;
+  promptAssembler: HydrationPromptAssembler;
+  getRepoPromptOverrides: () => Promise<RepoPromptOverrides>;
+};
+
+const INITIAL_SESSION_HISTORY_LIMIT = 600;
+const SESSION_HISTORY_HYDRATION_CONCURRENCY = 3;
+const EMPTY_PROMPT_OVERRIDES: RepoPromptOverrides = {};
+
+const mergePersistedSessionRecord = (
+  current: AgentSessionState,
+  record: AgentSessionRecord,
+  taskId: string,
+  promptOverrides: RepoPromptOverrides,
+): AgentSessionState => {
+  const persisted = fromPersistedSessionRecord(record, taskId);
+  const shouldPreserveCurrentWorkingDirectory = current.runtimeEndpoint.trim().length > 0;
+
+  return {
+    ...current,
+    externalSessionId: persisted.externalSessionId,
+    taskId: persisted.taskId,
+    role: persisted.role,
+    scenario: persisted.scenario,
+    startedAt: persisted.startedAt,
+    workingDirectory: shouldPreserveCurrentWorkingDirectory
+      ? current.workingDirectory
+      : persisted.workingDirectory,
+    pendingPermissions: current.pendingPermissions,
+    pendingQuestions: current.pendingQuestions,
+    selectedModel: mergeModelSelection(current.selectedModel, persisted.selectedModel ?? undefined),
+    historyHydrationState:
+      current.historyHydrationState ??
+      persisted.historyHydrationState ??
+      DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE,
+    promptOverrides,
+  };
+};
+
+export const mergeHydratedMessages = (
+  hydratedMessages: AgentSessionState["messages"],
+  currentMessages: AgentSessionState["messages"],
+): AgentSessionState["messages"] => {
+  const currentMessageById = new Map(currentMessages.map((message) => [message.id, message]));
+  const mergeSameMessageId = (
+    hydratedMessage: AgentSessionState["messages"][number],
+    currentMessage: AgentSessionState["messages"][number] | undefined,
+  ): AgentSessionState["messages"][number] => {
+    if (!currentMessage) {
+      return hydratedMessage;
+    }
+
+    const hydratedIsQueuedUser =
+      hydratedMessage.role === "user" &&
+      hydratedMessage.meta?.kind === "user" &&
+      hydratedMessage.meta.state === "queued";
+    const currentIsQueuedUser =
+      currentMessage.role === "user" &&
+      currentMessage.meta?.kind === "user" &&
+      currentMessage.meta.state === "queued";
+
+    if (currentIsQueuedUser && !hydratedIsQueuedUser) {
+      const mergedMeta =
+        currentMessage.meta && hydratedMessage.meta
+          ? { ...currentMessage.meta, ...hydratedMessage.meta }
+          : (hydratedMessage.meta ?? currentMessage.meta);
+      return {
+        ...currentMessage,
+        ...hydratedMessage,
+        ...(mergedMeta ? { meta: mergedMeta } : {}),
+      };
+    }
+
+    return currentMessage;
+  };
+  const mergedMessages = hydratedMessages.map((message) =>
+    mergeSameMessageId(message, currentMessageById.get(message.id)),
+  );
+  const hydratedMessageIds = new Set(hydratedMessages.map((message) => message.id));
+
+  for (const message of currentMessages) {
+    if (hydratedMessageIds.has(message.id)) {
+      continue;
+    }
+    mergedMessages.push(message);
+  }
+
+  return mergedMessages;
+};
+
+const toRequestedHistoryRecordFromSession = (
+  session: AgentSessionState,
+): AgentSessionRecord | null => {
+  const runtimeKind = session.runtimeKind ?? session.selectedModel?.runtimeKind ?? null;
+  if (!runtimeKind) {
+    return null;
+  }
+
+  return {
+    sessionId: session.sessionId,
+    externalSessionId: session.externalSessionId,
+    role: session.role,
+    scenario: session.scenario,
+    startedAt: session.startedAt,
+    workingDirectory: session.workingDirectory,
+    runtimeKind,
+    selectedModel: session.selectedModel
+      ? {
+          ...session.selectedModel,
+          runtimeKind,
+        }
+      : null,
+  };
+};
+
+const toLiveSessionState = (
+  status: LiveAgentSessionSnapshot["status"],
+): AgentSessionState["status"] => {
+  if (status.type === "busy" || status.type === "retry") {
+    return "running";
+  }
+  return "idle";
+};
+
+export const preparePersistedSessionMergeStage = async ({
+  intent,
+  options,
+  sessionsRef,
+  setSessionsById,
+  isStaleRepoOperation,
+  loadPersistedRecords,
+  loadRepoPromptOverrides,
+}: PersistedSessionMergeStageInput): Promise<PersistedSessionMergeStageOutput> => {
+  const currentRequestedSession = intent.requestedSessionId
+    ? (sessionsRef.current[intent.requestedSessionId] ?? null)
+    : null;
+  const requestedHistoryRecordFromSession =
+    intent.shouldHydrateRequestedSession &&
+    options?.persistedRecords === undefined &&
+    currentRequestedSession &&
+    currentRequestedSession.taskId === intent.taskId
+      ? toRequestedHistoryRecordFromSession(currentRequestedSession)
+      : null;
+  const shouldSkipPersistedSessionReload = requestedHistoryRecordFromSession !== null;
+
+  const persistedRecords = shouldSkipPersistedSessionReload
+    ? [requestedHistoryRecordFromSession]
+    : await loadPersistedRecords();
+  if (isStaleRepoOperation()) {
+    return {
+      persistedRecords,
+      recordsToHydrate: [],
+      historyHydrationSessionIds: new Set<string>(),
+      getRepoPromptOverrides: () => Promise.resolve(EMPTY_PROMPT_OVERRIDES),
+    };
+  }
+
+  let repoPromptOverridesPromise: Promise<RepoPromptOverrides> | null = null;
+  const getRepoPromptOverrides = (): Promise<RepoPromptOverrides> => {
+    if (repoPromptOverridesPromise === null) {
+      repoPromptOverridesPromise = loadRepoPromptOverrides(intent.repoPath);
+    }
+    return repoPromptOverridesPromise;
+  };
+
+  if (!shouldSkipPersistedSessionReload) {
+    setSessionsById((current) => {
+      if (isStaleRepoOperation()) {
+        return current;
+      }
+      const next = { ...current };
+      for (const record of persistedRecords) {
+        const existingSession = next[record.sessionId];
+        if (existingSession) {
+          next[record.sessionId] = mergePersistedSessionRecord(
+            existingSession,
+            record,
+            intent.taskId,
+            existingSession.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
+          );
+          continue;
+        }
+        next[record.sessionId] = {
+          ...fromPersistedSessionRecord(record, intent.taskId),
+          pendingPermissions: [],
+          pendingQuestions: [],
+          promptOverrides: EMPTY_PROMPT_OVERRIDES,
+        };
+      }
+      return next;
+    });
+  }
+
+  if (isStaleRepoOperation()) {
+    return {
+      persistedRecords,
+      recordsToHydrate: [],
+      historyHydrationSessionIds: new Set<string>(),
+      getRepoPromptOverrides,
+    };
+  }
+
+  const recordsToHydrate = intent.shouldHydrateRequestedSession
+    ? persistedRecords.filter((record) => record.sessionId === intent.requestedSessionId)
+    : persistedRecords;
+  const historyHydrationSessionIds = new Set(
+    recordsToHydrate
+      .filter((record) => {
+        if (intent.historyPolicy !== "requested_only") {
+          return false;
+        }
+        return intent.requestedSessionId === null || record.sessionId === intent.requestedSessionId;
+      })
+      .map((record) => record.sessionId),
+  );
+
+  return {
+    persistedRecords,
+    recordsToHydrate,
+    historyHydrationSessionIds,
+    getRepoPromptOverrides,
+  };
+};
+
+export const createRuntimeResolutionPlannerStage = async ({
+  intent,
+  options,
+  adapter,
+  sessionsRef,
+  liveAgentSessionStore,
+  recordsToHydrate,
+  historyHydrationSessionIds,
+}: RuntimeResolutionPlannerStageInput): Promise<HydrationRuntimePlanner> => {
+  const readCurrentHydratedRuntimeResolution = (
+    record: AgentSessionRecord,
+  ): Extract<ResolvedHydrationRuntime, { ok: true }> | null => {
+    const currentSession = sessionsRef.current[record.sessionId];
+    const runtimeKind = currentSession?.runtimeKind ?? null;
+    const runtimeEndpoint = currentSession?.runtimeEndpoint.trim() ?? "";
+    const workingDirectory =
+      currentSession?.workingDirectory.trim() || record.workingDirectory.trim();
+    if (!runtimeKind || runtimeEndpoint.length === 0 || workingDirectory.length === 0) {
+      return null;
+    }
+
+    return {
+      ok: true,
+      runtimeKind,
+      runtimeId: currentSession?.runtimeId ?? null,
+      runId: currentSession?.runId ?? null,
+      runtimeEndpoint,
+      runtimeConnection: {
+        endpoint: runtimeEndpoint,
+        workingDirectory,
+      },
+    };
+  };
+
+  const recordsNeedingRuntimeResolution = recordsToHydrate.filter((record) => {
+    if (!historyHydrationSessionIds.has(record.sessionId)) {
+      return true;
+    }
+    return readCurrentHydratedRuntimeResolution(record) === null;
+  });
+
+  const runtimeKindsToInspect = Array.from(
+    new Set(recordsNeedingRuntimeResolution.map((record) => readPersistedRuntimeKind(record))),
+  );
+  const runtimesByKind =
+    options?.preloadedRuntimeLists ??
+    new Map(
+      await Promise.all(
+        runtimeKindsToInspect.map(async (runtimeKind) => {
+          const runtimes = await loadRuntimeListFromQuery(
+            appQueryClient,
+            runtimeKind,
+            intent.repoPath,
+          );
+          return [runtimeKind, runtimes] as const;
+        }),
+      ),
+    );
+
+  const requiresRunInspection = recordsNeedingRuntimeResolution.some(
+    (record) => record.role === "build" || record.role === "qa",
+  );
+  const liveRuns = requiresRunInspection
+    ? (options?.preloadedRuns ?? (await loadRepoRunsFromQuery(appQueryClient, intent.repoPath)))
+    : [];
+  const ensuredWorkspaceRuntimes = new Map<RuntimeKind, RuntimeInstanceSummary | null>();
+
+  const ensureWorkspaceRuntime = async (
+    runtimeKind: RuntimeKind,
+  ): Promise<RuntimeInstanceSummary | null> => {
+    if (options?.allowRuntimeEnsure === false) {
+      return null;
+    }
+    if (ensuredWorkspaceRuntimes.has(runtimeKind)) {
+      return ensuredWorkspaceRuntimes.get(runtimeKind) ?? null;
+    }
+    const runtime = await host.runtimeEnsure(intent.repoPath, runtimeKind);
+    ensuredWorkspaceRuntimes.set(runtimeKind, runtime);
+    await appQueryClient.invalidateQueries({
+      queryKey: runtimeQueryKeys.list(runtimeKind, intent.repoPath),
+      exact: true,
+      refetchType: "none",
+    });
+    return runtime;
+  };
+
+  const resolveHydrationRuntime = createHydrationRuntimeResolver({
+    repoPath: intent.repoPath,
+    liveRuns,
+    runtimesByKind,
+    ...(options?.preloadedRuntimeConnectionsByKey
+      ? { preloadedRuntimeConnectionsByKey: options.preloadedRuntimeConnectionsByKey }
+      : {}),
+    ensureWorkspaceRuntime,
+  });
+
+  const loadLiveAgentSessionSnapshot = async (
+    record: AgentSessionRecord,
+    runtimeResolution: Extract<ResolvedHydrationRuntime, { ok: true }>,
+  ): Promise<LiveAgentSessionSnapshot | null> => {
+    const resolvedWorkingDirectory = runtimeResolution.runtimeConnection.workingDirectory;
+    const externalSessionId = record.externalSessionId ?? record.sessionId;
+    const storedSnapshot = liveAgentSessionStore?.readSnapshot({
+      repoPath: intent.repoPath,
+      runtimeKind: runtimeResolution.runtimeKind,
+      runtimeEndpoint: runtimeResolution.runtimeEndpoint,
+      workingDirectory: resolvedWorkingDirectory,
+      externalSessionId,
+    });
+    if (storedSnapshot) {
+      return storedSnapshot;
+    }
+
+    const preloadedSnapshots = options?.preloadedLiveAgentSessionsByKey?.get(
+      liveAgentSessionLookupKey(
+        runtimeResolution.runtimeKind,
+        runtimeResolution.runtimeEndpoint,
+        resolvedWorkingDirectory,
+      ),
+    );
+    if (preloadedSnapshots) {
+      return (
+        preloadedSnapshots.find((snapshot) => snapshot.externalSessionId === externalSessionId) ??
+        null
+      );
+    }
+    if (!adapter.listLiveAgentSessionSnapshots) {
+      throw new Error("Live agent session snapshots are unavailable for session hydration.");
+    }
+    const snapshots = await adapter.listLiveAgentSessionSnapshots({
+      runtimeKind: runtimeResolution.runtimeKind,
+      runtimeConnection: runtimeResolution.runtimeConnection,
+      directories: [resolvedWorkingDirectory],
+    });
+    return snapshots.find((snapshot) => snapshot.externalSessionId === externalSessionId) ?? null;
+  };
+
+  return {
+    readCurrentHydratedRuntimeResolution,
+    resolveHydrationRuntime,
+    loadLiveAgentSessionSnapshot,
+  };
+};
+
+export const createHydrationPromptAssemblerStage = ({
+  taskId,
+  taskRef,
+}: PromptAssemblerStageInput): HydrationPromptAssembler => {
+  const buildHydrationPreludeMessages = async ({
+    record,
+    resolvedScenario,
+    promptOverrides,
+  }: {
+    record: AgentSessionRecord;
+    resolvedScenario: AgentSessionState["scenario"];
+    promptOverrides: RepoPromptOverrides;
+  }): Promise<AgentSessionState["messages"]> => {
+    const task = taskRef.current.find((entry) => entry.id === taskId);
+    if (!task) {
+      return buildSessionHeaderMessages({
+        sessionId: record.sessionId,
+        role: record.role,
+        scenario: resolvedScenario,
+        systemPrompt: "",
+        startedAt: record.startedAt,
+        includeSystemPrompt: false,
+      });
+    }
+
+    const systemPrompt = buildSessionSystemPrompt({
+      role: record.role,
+      scenario: resolvedScenario,
+      task,
+      promptOverrides,
+    });
+
+    return buildSessionHeaderMessages({
+      sessionId: record.sessionId,
+      role: record.role,
+      scenario: resolvedScenario,
+      systemPrompt,
+      startedAt: record.startedAt,
+    });
+  };
+
+  const buildHydrationSystemPrompt = async ({
+    record,
+    resolvedScenario,
+    promptOverrides,
+  }: {
+    record: AgentSessionRecord;
+    resolvedScenario: AgentSessionState["scenario"];
+    promptOverrides: RepoPromptOverrides;
+  }): Promise<string> => {
+    const task = taskRef.current.find((entry) => entry.id === taskId);
+    if (!task) {
+      return "";
+    }
+
+    return buildSessionSystemPrompt({
+      role: record.role,
+      scenario: resolvedScenario,
+      task,
+      promptOverrides,
+    });
+  };
+
+  return {
+    buildHydrationPreludeMessages,
+    buildHydrationSystemPrompt,
+  };
+};
+
+export const reconcileLiveSessionsStage = async ({
+  intent,
+  options,
+  adapter,
+  taskRef,
+  sessionsRef,
+  updateSession,
+  attachSessionListener,
+  isStaleRepoOperation,
+  recordsToHydrate,
+  runtimePlanner,
+  promptAssembler,
+  getRepoPromptOverrides,
+}: LiveReconciliationStageInput): Promise<LiveReconciliationStageOutput> => {
+  if (!intent.shouldReconcileLiveSessions) {
+    return { reattachedSessionIds: new Set<string>() };
+  }
+  if (!adapter.listLiveAgentSessionSnapshots) {
+    throw new Error(
+      "Live agent session snapshots are unavailable for live session reconciliation.",
+    );
+  }
+
+  const runtimeSessionScanCache = new LiveAgentSessionCache(
+    {
+      listLiveAgentSessionSnapshots: async (input) => {
+        if (!adapter.listLiveAgentSessionSnapshots) {
+          throw new Error("Live agent session snapshots are unavailable for session scanning.");
+        }
+        return adapter.listLiveAgentSessionSnapshots(input);
+      },
+    },
+    options?.preloadedLiveAgentSessionsByKey,
+  );
+  const maybeResumeLiveRecord = createReattachLiveSession({
+    adapter,
+    repoPath: intent.repoPath,
+    taskId: intent.taskId,
+    taskRef,
+    sessionsRef,
+    updateSession,
+    ...(attachSessionListener ? { attachSessionListener } : {}),
+    promptOverrides: EMPTY_PROMPT_OVERRIDES,
+    resolveHydrationRuntime: runtimePlanner.resolveHydrationRuntime,
+    listLiveAgentSessions: (runtimeKind, runtimeConnection, directories) =>
+      runtimeSessionScanCache.load({
+        runtimeKind,
+        runtimeConnection,
+        directories,
+      }),
+    resumeMissingLiveSession: async ({ record, runtimeKind, runtimeConnection }) => {
+      const promptOverrides = await getRepoPromptOverrides();
+      const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
+      const selectedModel = normalizePersistedSelection(record.selectedModel);
+      const systemPrompt = await promptAssembler.buildHydrationSystemPrompt({
+        record,
+        resolvedScenario,
+        promptOverrides,
+      });
+
+      await adapter.resumeSession({
+        sessionId: record.sessionId,
+        externalSessionId: record.externalSessionId ?? record.sessionId,
+        repoPath: intent.repoPath,
+        runtimeKind,
+        runtimeConnection,
+        workingDirectory: runtimeConnection.workingDirectory,
+        taskId: intent.taskId,
+        role: record.role,
+        scenario: resolvedScenario,
+        systemPrompt,
+        ...(selectedModel ? { model: selectedModel } : {}),
+      });
+    },
+    isStaleRepoOperation,
+    toLiveSessionState,
+  });
+
+  const reattachedSessionIds = new Set<string>();
+  for (
+    let offset = 0;
+    offset < recordsToHydrate.length;
+    offset += SESSION_HISTORY_HYDRATION_CONCURRENCY
+  ) {
+    if (isStaleRepoOperation()) {
+      return { reattachedSessionIds };
+    }
+    const batch = recordsToHydrate.slice(offset, offset + SESSION_HISTORY_HYDRATION_CONCURRENCY);
+    const reattachResults = await Promise.all(
+      batch.map(async (record) => ({
+        record,
+        reattached: await maybeResumeLiveRecord(record),
+      })),
+    );
+    if (isStaleRepoOperation()) {
+      return { reattachedSessionIds };
+    }
+    for (const { record, reattached } of reattachResults) {
+      if (reattached) {
+        reattachedSessionIds.add(record.sessionId);
+        continue;
+      }
+      updateSession(
+        record.sessionId,
+        (current) => ({
+          ...current,
+          pendingPermissions: [],
+          pendingQuestions: [],
+        }),
+        { persist: false },
+      );
+    }
+  }
+
+  return { reattachedSessionIds };
+};
+
+export const hydrateSessionRecordsStage = async ({
+  adapter,
+  setSessionsById,
+  updateSession,
+  isStaleRepoOperation,
+  recordsToHydrate,
+  historyHydrationSessionIds,
+  runtimePlanner,
+  promptAssembler,
+  getRepoPromptOverrides,
+}: HistoryHydrationStageInput): Promise<void> => {
+  if (recordsToHydrate.length === 0) {
+    return;
+  }
+
+  if (historyHydrationSessionIds.size > 0) {
+    setSessionsById((current) => {
+      const next = { ...current };
+      for (const sessionId of historyHydrationSessionIds) {
+        const existingSession = next[sessionId];
+        if (!existingSession) {
+          continue;
+        }
+        next[sessionId] = {
+          ...existingSession,
+          historyHydrationState: "hydrating",
+        };
+      }
+      return next;
+    });
+  }
+
+  const hydrateRecord = async (record: AgentSessionRecord): Promise<void> => {
+    if (isStaleRepoOperation()) {
+      return;
+    }
+
+    const shouldHydrateHistory = historyHydrationSessionIds.has(record.sessionId);
+    const runtimeResolution =
+      (shouldHydrateHistory ? runtimePlanner.readCurrentHydratedRuntimeResolution(record) : null) ??
+      (await runtimePlanner.resolveHydrationRuntime(record));
+    if (!runtimeResolution.ok) {
+      if (shouldHydrateHistory) {
+        updateSession(
+          record.sessionId,
+          (current) => ({
+            ...current,
+            historyHydrationState: "failed",
+          }),
+          { persist: false },
+        );
+        throw new Error(runtimeResolution.reason);
+      }
+      updateSession(
+        record.sessionId,
+        (current) => ({
+          ...current,
+          runtimeKind: readPersistedRuntimeKind(record),
+          runtimeId: null,
+          runId: null,
+          runtimeEndpoint: "",
+          workingDirectory: record.workingDirectory,
+          promptOverrides: current.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
+        }),
+        { persist: false },
+      );
+      return;
+    }
+
+    const { runtimeKind, runtimeId, runId, runtimeEndpoint, runtimeConnection } = runtimeResolution;
+    const workingDirectory = runtimeConnection.workingDirectory;
+    if (!shouldHydrateHistory) {
+      updateSession(
+        record.sessionId,
+        (current) => ({
+          ...current,
+          runtimeKind,
+          runtimeId,
+          runId,
+          runtimeEndpoint,
+          workingDirectory,
+          promptOverrides: current.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
+        }),
+        { persist: false },
+      );
+      return;
+    }
+
+    const promptOverrides = await getRepoPromptOverrides();
+    const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
+    const preludeMessages = await promptAssembler.buildHydrationPreludeMessages({
+      record,
+      resolvedScenario,
+      promptOverrides,
+    });
+    const history = await adapter.loadSessionHistory({
+      runtimeKind,
+      runtimeConnection,
+      externalSessionId: record.externalSessionId ?? record.sessionId,
+      limit: INITIAL_SESSION_HISTORY_LIMIT,
+    });
+    const liveRuntimeSnapshot = await runtimePlanner.loadLiveAgentSessionSnapshot(
+      record,
+      runtimeResolution,
+    );
+    const liveSessionStatus = liveRuntimeSnapshot
+      ? toLiveSessionState(liveRuntimeSnapshot.status)
+      : null;
+    const livePendingPermissions = liveRuntimeSnapshot?.pendingPermissions ?? [];
+    const livePendingQuestions = liveRuntimeSnapshot?.pendingQuestions ?? [];
+    if (isStaleRepoOperation()) {
+      return;
+    }
+
+    updateSession(
+      record.sessionId,
+      (current) => {
+        const selectedModel = normalizePersistedSelection(record.selectedModel);
+        const hydratedMessages = [
+          ...preludeMessages,
+          ...historyToChatMessages(history, {
+            role: record.role,
+            selectedModel,
+          }),
+        ];
+        return {
+          ...current,
+          runtimeKind,
+          runtimeId,
+          runId,
+          runtimeEndpoint,
+          status: liveSessionStatus ?? current.status,
+          workingDirectory,
+          historyHydrationState: "hydrated",
+          promptOverrides,
+          pendingPermissions: livePendingPermissions,
+          pendingQuestions: livePendingQuestions,
+          contextUsage: historyToSessionContextUsage(history, selectedModel),
+          messages: mergeHydratedMessages(hydratedMessages, current.messages),
+        };
+      },
+      { persist: false },
+    );
+  };
+
+  for (
+    let offset = 0;
+    offset < recordsToHydrate.length;
+    offset += SESSION_HISTORY_HYDRATION_CONCURRENCY
+  ) {
+    if (isStaleRepoOperation()) {
+      return;
+    }
+    const batch = recordsToHydrate.slice(offset, offset + SESSION_HISTORY_HYDRATION_CONCURRENCY);
+    await Promise.all(
+      batch.map((record) =>
+        hydrateRecord(record).catch((error) => {
+          if (historyHydrationSessionIds.has(record.sessionId)) {
+            updateSession(
+              record.sessionId,
+              (current) => ({
+                ...current,
+                historyHydrationState: "failed",
+              }),
+              { persist: false },
+            );
+          }
+          throw error;
+        }),
+      ),
+    );
+  }
+};

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -43,7 +43,7 @@ export type UpdateSession = (
 
 export type SessionLifecycleAdapter = Pick<
   AgentEnginePort,
-  "hasSession" | "loadSessionHistory" | "resumeSession" | "listLiveAgentSessionSnapshots"
+  "hasSession" | "loadSessionHistory" | "resumeSession"
 > & {
   listLiveAgentSessionSnapshots?: AgentEnginePort["listLiveAgentSessionSnapshots"];
 };
@@ -623,6 +623,9 @@ export const reconcileLiveSessionsStage = async ({
       }),
     resumeMissingLiveSession: async ({ record, runtimeKind, runtimeConnection }) => {
       const promptOverrides = await getRepoPromptOverrides();
+      if (isStaleRepoOperation()) {
+        return;
+      }
       const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
       const selectedModel = normalizePersistedSelection(record.selectedModel);
       const systemPrompt = await promptAssembler.buildHydrationSystemPrompt({
@@ -630,6 +633,9 @@ export const reconcileLiveSessionsStage = async ({
         resolvedScenario,
         promptOverrides,
       });
+      if (isStaleRepoOperation()) {
+        return;
+      }
 
       await adapter.resumeSession({
         sessionId: record.sessionId,
@@ -729,6 +735,9 @@ export const hydrateSessionRecordsStage = async ({
     const runtimeResolution =
       (shouldHydrateHistory ? runtimePlanner.readCurrentHydratedRuntimeResolution(record) : null) ??
       (await runtimePlanner.resolveHydrationRuntime(record));
+    if (isStaleRepoOperation()) {
+      return;
+    }
     if (!runtimeResolution.ok) {
       if (shouldHydrateHistory) {
         updateSession(

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.ts
@@ -119,8 +119,6 @@ export type LiveReconciliationStageInput = {
   intent: SessionLoadIntent;
   options?: AgentSessionLoadOptions;
   adapter: SessionLifecycleAdapter;
-  taskRef: MutableRefObject<TaskCard[]>;
-  sessionsRef: MutableRefObject<Record<string, AgentSessionState>>;
   updateSession: UpdateSession;
   attachSessionListener?: (repoPath: string, sessionId: string) => void;
   isStaleRepoOperation: () => boolean;
@@ -582,8 +580,6 @@ export const reconcileLiveSessionsStage = async ({
   intent,
   options,
   adapter,
-  taskRef,
-  sessionsRef,
   updateSession,
   attachSessionListener,
   isStaleRepoOperation,
@@ -615,9 +611,6 @@ export const reconcileLiveSessionsStage = async ({
   const maybeResumeLiveRecord = createReattachLiveSession({
     adapter,
     repoPath: intent.repoPath,
-    taskId: intent.taskId,
-    taskRef,
-    sessionsRef,
     updateSession,
     ...(attachSessionListener ? { attachSessionListener } : {}),
     promptOverrides: EMPTY_PROMPT_OVERRIDES,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -973,6 +973,282 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(promptOverrideLoads).toBe(2);
   });
 
+  test("hydrates transcript history after live reattach when reconcile uses live_if_empty", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    let attachedToAdapter = false;
+    let historyLoads = 0;
+    let resumeCalls = 0;
+
+    const persistedRecords = [
+      persistedSessionRecord({
+        runtimeKind: "opencode",
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        taskId: "task-1",
+        role: "planner",
+        scenario: "planner_initial",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+        workingDirectory: "/tmp/repo",
+      }),
+    ];
+    const runtimeLists = new Map<"opencode", RuntimeInstanceSummary[]>([
+      [
+        "opencode",
+        [
+          {
+            kind: "opencode",
+            runtimeId: "runtime-1",
+            repoPath: "/tmp/repo",
+            taskId: null,
+            role: "workspace",
+            workingDirectory: "/tmp/repo",
+            runtimeRoute: {
+              type: "local_http",
+              endpoint: "http://127.0.0.1:4444",
+            },
+            startedAt: "2026-02-22T08:00:00.000Z",
+            descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+          },
+        ],
+      ],
+    ]);
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        hasSession: () => attachedToAdapter,
+        listLiveAgentSessionSnapshots: async () => [
+          {
+            externalSessionId: "external-1",
+            title: "PLANNER task-1",
+            role: "planner",
+            scenario: "planner_initial",
+            workingDirectory: "/tmp/repo",
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+            pendingPermissions: [],
+            pendingQuestions: [],
+          },
+        ],
+        loadSessionHistory: async () => {
+          historyLoads += 1;
+          return [
+            {
+              messageId: "history-1",
+              role: "assistant",
+              timestamp: "2026-02-22T08:00:01.000Z",
+              text: "Hydrated from reconcile",
+              parts: [
+                {
+                  kind: "text",
+                  messageId: "history-1",
+                  partId: "part-1",
+                  text: "Hydrated from reconcile",
+                  completed: true,
+                },
+              ],
+            },
+          ];
+        },
+        resumeSession: async (input) => {
+          resumeCalls += 1;
+          attachedToAdapter = true;
+          return {
+            sessionId: input.sessionId,
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            scenario: input.scenario,
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: "running",
+            runtimeKind: input.runtimeKind,
+          };
+        },
+      }),
+      repoEpochRef: { current: 2 },
+      activeRepoRef: { current: "/tmp/repo" },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      attachSessionListener: () => {},
+      loadRepoPromptOverrides: async () => ({}),
+      loadTaskDocuments: async () => ({
+        specMarkdown: "",
+        planMarkdown: "",
+        qaMarkdown: "",
+      }),
+    });
+
+    await loadAgentSessions("task-1", {
+      mode: "reconcile_live",
+      persistedRecords,
+      preloadedRuntimeLists: runtimeLists,
+      historyPolicy: "live_if_empty",
+    });
+
+    expect(resumeCalls).toBe(1);
+    expect(historyLoads).toBe(1);
+    expect(state["session-1"]?.historyHydrationState).toBe("hydrated");
+    expect(state["session-1"]?.messages.map((message) => message.content)).toEqual([
+      "Session started (planner - planner_initial)",
+      expect.stringContaining("System prompt:"),
+      "Hydrated from reconcile",
+    ]);
+  });
+
+  test("does not resume a live session after the repo changes while prompt overrides are loading", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    let resumeCalls = 0;
+    const repoEpochRef = { current: 2 };
+    const previousRepoRef = { current: "/tmp/repo" as string | null };
+    const promptOverridesDeferred = createDeferred<Record<string, never>>();
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        hasSession: () => false,
+        listLiveAgentSessionSnapshots: async () => [
+          {
+            externalSessionId: "external-1",
+            title: "PLANNER task-1",
+            role: "planner",
+            scenario: "planner_initial",
+            workingDirectory: "/tmp/repo",
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: { type: "busy" },
+            pendingPermissions: [],
+            pendingQuestions: [],
+          },
+        ],
+        resumeSession: async (input) => {
+          resumeCalls += 1;
+          return {
+            sessionId: input.sessionId,
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            scenario: input.scenario,
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: "running",
+            runtimeKind: input.runtimeKind,
+          };
+        },
+      }),
+      repoEpochRef,
+      activeRepoRef: { current: "/tmp/repo" },
+      previousRepoRef,
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      attachSessionListener: () => {
+        throw new Error("should not attach stale session");
+      },
+      loadRepoPromptOverrides: async () => promptOverridesDeferred.promise,
+      loadTaskDocuments: async () => ({
+        specMarkdown: "",
+        planMarkdown: "",
+        qaMarkdown: "",
+      }),
+    });
+
+    const loadPromise = loadAgentSessions("task-1", {
+      mode: "reconcile_live",
+      persistedRecords: [
+        persistedSessionRecord({
+          runtimeKind: "opencode",
+          sessionId: "session-1",
+          externalSessionId: "external-1",
+          taskId: "task-1",
+          role: "planner",
+          scenario: "planner_initial",
+          startedAt: "2026-02-22T08:00:00.000Z",
+          updatedAt: "2026-02-22T08:00:00.000Z",
+          workingDirectory: "/tmp/repo",
+        }),
+      ],
+      preloadedRuntimeLists: new Map([
+        [
+          "opencode",
+          [
+            {
+              kind: "opencode",
+              runtimeId: "runtime-1",
+              repoPath: "/tmp/repo",
+              taskId: null,
+              role: "workspace",
+              workingDirectory: "/tmp/repo",
+              runtimeRoute: {
+                type: "local_http",
+                endpoint: "http://127.0.0.1:4444",
+              },
+              startedAt: "2026-02-22T08:00:00.000Z",
+              descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+            },
+          ],
+        ],
+      ]),
+      historyPolicy: "none",
+    });
+
+    repoEpochRef.current = 3;
+    previousRepoRef.current = "/tmp/other-repo";
+    promptOverridesDeferred.resolve({});
+    await loadPromise;
+
+    expect(resumeCalls).toBe(0);
+    expect(state["session-1"]?.runtimeEndpoint ?? "").toBe("");
+  });
+
   test("reuses the trusted live agent session store for requested session hydration", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = {
       current: {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts
@@ -745,6 +745,234 @@ describe("agent-orchestrator-load-sessions", () => {
     expect(runtimeEnsureCalls).toEqual([]);
   });
 
+  test("composes bootstrap, requested history hydration, and live reconciliation without cross-mode regressions", async () => {
+    const sessionsRef: { current: Record<string, AgentSessionState> } = { current: {} };
+    let state: Record<string, AgentSessionState> = {};
+    let attachedToAdapter = false;
+    let liveSnapshotLoads = 0;
+    let historyLoads = 0;
+    let resumeCalls = 0;
+    let attachedListeners = 0;
+    let promptOverrideLoads = 0;
+
+    const persistedRecords = [
+      persistedSessionRecord({
+        runtimeKind: "opencode",
+        sessionId: "session-1",
+        externalSessionId: "external-1",
+        taskId: "task-1",
+        role: "planner",
+        scenario: "planner_initial",
+        startedAt: "2026-02-22T08:00:00.000Z",
+        updatedAt: "2026-02-22T08:00:00.000Z",
+        workingDirectory: "/tmp/repo",
+      }),
+    ];
+    const runtimeLists = new Map<"opencode", RuntimeInstanceSummary[]>([
+      [
+        "opencode",
+        [
+          {
+            kind: "opencode",
+            runtimeId: "runtime-1",
+            repoPath: "/tmp/repo",
+            taskId: null,
+            role: "workspace",
+            workingDirectory: "/tmp/repo",
+            runtimeRoute: {
+              type: "local_http",
+              endpoint: "http://127.0.0.1:4444",
+            },
+            startedAt: "2026-02-22T08:00:00.000Z",
+            descriptor: OPENCODE_RUNTIME_DESCRIPTOR,
+          },
+        ],
+      ],
+    ]);
+
+    const setSessionsById = (
+      updater:
+        | Record<string, AgentSessionState>
+        | ((current: Record<string, AgentSessionState>) => Record<string, AgentSessionState>),
+    ) => {
+      state = typeof updater === "function" ? updater(state) : updater;
+      sessionsRef.current = state;
+    };
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = state[sessionId];
+      if (!current) {
+        return;
+      }
+      state = {
+        ...state,
+        [sessionId]: updater(current),
+      };
+      sessionsRef.current = state;
+    };
+
+    const loadAgentSessions = createLoadAgentSessions({
+      activeRepo: "/tmp/repo",
+      adapter: createAdapter({
+        hasSession: () => attachedToAdapter,
+        listLiveAgentSessionSnapshots: async () => {
+          liveSnapshotLoads += 1;
+          return [
+            {
+              externalSessionId: "external-1",
+              title: "PLANNER task-1",
+              role: "planner",
+              scenario: "planner_initial",
+              workingDirectory: "/tmp/repo",
+              startedAt: "2026-02-22T08:00:00.000Z",
+              status: { type: "busy" },
+              pendingPermissions: [
+                { requestId: "permission-live", permission: "read", patterns: ["README.md"] },
+              ],
+              pendingQuestions: [
+                {
+                  requestId: "question-live",
+                  questions: [
+                    {
+                      header: "Confirm",
+                      question: "Continue?",
+                      options: [{ label: "Yes", description: "Proceed" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ];
+        },
+        loadSessionHistory: async () => {
+          historyLoads += 1;
+          return [
+            {
+              messageId: "history-1",
+              role: "assistant",
+              timestamp: "2026-02-22T08:00:01.000Z",
+              text: "Requested history",
+              parts: [
+                {
+                  kind: "text",
+                  messageId: "history-1",
+                  partId: "part-1",
+                  text: "Requested history",
+                  completed: true,
+                },
+              ],
+            },
+          ];
+        },
+        resumeSession: async (input) => {
+          resumeCalls += 1;
+          attachedToAdapter = true;
+          return {
+            sessionId: input.sessionId,
+            externalSessionId: input.externalSessionId,
+            role: input.role,
+            scenario: input.scenario,
+            startedAt: "2026-02-22T08:00:00.000Z",
+            status: "running",
+            runtimeKind: input.runtimeKind,
+          };
+        },
+      }),
+      repoEpochRef: { current: 2 },
+      activeRepoRef: { current: "/tmp/repo" },
+      previousRepoRef: { current: "/tmp/repo" },
+      sessionsRef,
+      setSessionsById,
+      taskRef: { current: [taskFixture] },
+      updateSession,
+      attachSessionListener: () => {
+        attachedListeners += 1;
+      },
+      loadRepoPromptOverrides: async () => {
+        promptOverrideLoads += 1;
+        return {};
+      },
+      loadTaskDocuments: async () => ({
+        specMarkdown: "",
+        planMarkdown: "",
+        qaMarkdown: "",
+      }),
+    });
+
+    await loadAgentSessions("task-1", {
+      mode: "bootstrap",
+      persistedRecords,
+      preloadedRuntimeLists: runtimeLists,
+      historyPolicy: "none",
+    });
+
+    expect(state["session-1"]).toMatchObject({
+      status: "stopped",
+      runtimeEndpoint: "",
+      messages: [],
+      pendingPermissions: [],
+      pendingQuestions: [],
+    });
+    expect(historyLoads).toBe(0);
+    expect(resumeCalls).toBe(0);
+    expect(attachedListeners).toBe(0);
+    expect(promptOverrideLoads).toBe(0);
+
+    await loadAgentSessions("task-1", {
+      mode: "requested_history",
+      targetSessionId: "session-1",
+      persistedRecords,
+      preloadedRuntimeLists: runtimeLists,
+      historyPolicy: "requested_only",
+    });
+
+    const hydratedSession = state["session-1"];
+    expect(hydratedSession).toMatchObject({
+      status: "running",
+      runtimeEndpoint: "http://127.0.0.1:4444",
+      historyHydrationState: "hydrated",
+      pendingPermissions: [
+        { requestId: "permission-live", permission: "read", patterns: ["README.md"] },
+      ],
+    });
+    expect(hydratedSession?.pendingQuestions).toHaveLength(1);
+    expect(hydratedSession?.messages.map((message) => message.content)).toEqual([
+      "Session started (planner - planner_initial)",
+      expect.stringContaining("System prompt:"),
+      "Requested history",
+    ]);
+    expect(historyLoads).toBe(1);
+    expect(resumeCalls).toBe(0);
+    expect(attachedListeners).toBe(0);
+
+    const hydratedMessageIds = hydratedSession?.messages.map((message) => message.id) ?? [];
+
+    await loadAgentSessions("task-1", {
+      mode: "reconcile_live",
+      persistedRecords,
+      preloadedRuntimeLists: runtimeLists,
+      historyPolicy: "live_if_empty",
+    });
+
+    expect(historyLoads).toBe(1);
+    expect(resumeCalls).toBe(1);
+    expect(attachedListeners).toBe(1);
+    expect(liveSnapshotLoads).toBe(2);
+    expect(state["session-1"]?.messages.map((message) => message.id)).toEqual(hydratedMessageIds);
+    expect(state["session-1"]).toMatchObject({
+      status: "running",
+      runtimeEndpoint: "http://127.0.0.1:4444",
+      historyHydrationState: "hydrated",
+      pendingPermissions: [
+        { requestId: "permission-live", permission: "read", patterns: ["README.md"] },
+      ],
+    });
+    expect(state["session-1"]?.pendingQuestions).toHaveLength(1);
+    expect(promptOverrideLoads).toBe(2);
+  });
+
   test("reuses the trusted live agent session store for requested session hydration", async () => {
     const sessionsRef: { current: Record<string, AgentSessionState> } = {
       current: {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -149,7 +149,7 @@ export const createLoadAgentSessions = ({
       });
       const promptAssembler = createHydrationPromptAssemblerStage({ taskId, taskRef });
 
-      await reconcileLiveSessionsStage({
+      const { reattachedSessionIds } = await reconcileLiveSessionsStage({
         intent,
         ...(options ? { options } : {}),
         adapter,
@@ -165,13 +165,24 @@ export const createLoadAgentSessions = ({
         return;
       }
 
+      const effectiveHistoryHydrationSessionIds = new Set(historyHydrationSessionIds);
+      if (intent.historyPolicy === "live_if_empty") {
+        for (const sessionId of reattachedSessionIds) {
+          const currentSession = sessionsRef.current[sessionId];
+          if (!currentSession || currentSession.messages.length > 0) {
+            continue;
+          }
+          effectiveHistoryHydrationSessionIds.add(sessionId);
+        }
+      }
+
       await hydrateSessionRecordsStage({
         adapter,
         setSessionsById,
         updateSession,
         isStaleRepoOperation,
         recordsToHydrate,
-        historyHydrationSessionIds,
+        historyHydrationSessionIds: effectiveHistoryHydrationSessionIds,
         runtimePlanner,
         promptAssembler,
         getRepoPromptOverrides,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -153,8 +153,6 @@ export const createLoadAgentSessions = ({
         intent,
         ...(options ? { options } : {}),
         adapter,
-        taskRef,
-        sessionsRef,
         updateSession,
         ...(attachSessionListener ? { attachSessionListener } : {}),
         isStaleRepoOperation,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.ts
@@ -1,187 +1,21 @@
-import type {
-  AgentSessionRecord,
-  RepoPromptOverrides,
-  RuntimeInstanceSummary,
-  RuntimeKind,
-  TaskCard,
-} from "@openducktor/contracts";
-import type {
-  AgentEnginePort,
-  AgentRuntimeConnection,
-  LiveAgentSessionSnapshot,
-} from "@openducktor/core";
+import type { RepoPromptOverrides, TaskCard } from "@openducktor/contracts";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import { appQueryClient } from "@/lib/query-client";
 import { loadAgentSessionListFromQuery } from "@/state/queries/agent-sessions";
-import { loadRuntimeListFromQuery, runtimeQueryKeys } from "@/state/queries/runtime";
-import { loadRepoRunsFromQuery } from "@/state/queries/tasks";
 import type { AgentSessionLoadOptions, AgentSessionState } from "@/types/agent-orchestrator";
-import { host } from "../../shared/host";
 import type { TaskDocuments } from "../runtime/runtime";
 import { createRepoStaleGuard } from "../support/core";
-import { DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE } from "../support/history-hydration";
-import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
-import {
-  defaultScenarioForRole,
-  fromPersistedSessionRecord,
-  historyToChatMessages,
-  historyToSessionContextUsage,
-} from "../support/persistence";
-import { buildSessionHeaderMessages, buildSessionSystemPrompt } from "../support/session-prompt";
-import {
-  createHydrationRuntimeResolver,
-  readPersistedRuntimeKind,
-} from "./hydration-runtime-resolution";
-import { LiveAgentSessionCache, liveAgentSessionLookupKey } from "./live-agent-session-cache";
 import type { LiveAgentSessionStore } from "./live-agent-session-store";
-import { createReattachLiveSession } from "./reattach-live-session";
-
-type UpdateSession = (
-  sessionId: string,
-  updater: (current: AgentSessionState) => AgentSessionState,
-  options?: { persist?: boolean },
-) => void;
-
-type SessionLifecycleAdapter = Pick<
-  AgentEnginePort,
-  "hasSession" | "loadSessionHistory" | "resumeSession" | "listLiveAgentSessionSnapshots"
-> & {
-  listLiveAgentSessionSnapshots?: AgentEnginePort["listLiveAgentSessionSnapshots"];
-};
-
-const INITIAL_SESSION_HISTORY_LIMIT = 600;
-const SESSION_HISTORY_HYDRATION_CONCURRENCY = 3;
-const EMPTY_PROMPT_OVERRIDES: RepoPromptOverrides = {};
-
-type HydrationRuntimeResolution =
-  | {
-      ok: true;
-      runtimeKind: RuntimeKind;
-      runtimeId: string | null;
-      runId: string | null;
-      runtimeEndpoint: string;
-      runtimeConnection: AgentRuntimeConnection;
-    }
-  | {
-      ok: false;
-      runtimeKind: RuntimeKind;
-      reason: string;
-    };
-
-const mergePersistedSessionRecord = (
-  current: AgentSessionState,
-  record: AgentSessionRecord,
-  taskId: string,
-  promptOverrides: RepoPromptOverrides,
-): AgentSessionState => {
-  const persisted = fromPersistedSessionRecord(record, taskId);
-  const shouldPreserveCurrentWorkingDirectory = current.runtimeEndpoint.trim().length > 0;
-
-  return {
-    ...current,
-    externalSessionId: persisted.externalSessionId,
-    taskId: persisted.taskId,
-    role: persisted.role,
-    scenario: persisted.scenario,
-    startedAt: persisted.startedAt,
-    workingDirectory: shouldPreserveCurrentWorkingDirectory
-      ? current.workingDirectory
-      : persisted.workingDirectory,
-    pendingPermissions: current.pendingPermissions,
-    pendingQuestions: current.pendingQuestions,
-    selectedModel: mergeModelSelection(current.selectedModel, persisted.selectedModel ?? undefined),
-    historyHydrationState:
-      current.historyHydrationState ??
-      persisted.historyHydrationState ??
-      DEFAULT_AGENT_SESSION_HISTORY_HYDRATION_STATE,
-    promptOverrides,
-  };
-};
-
-const mergeHydratedMessages = (
-  hydratedMessages: AgentSessionState["messages"],
-  currentMessages: AgentSessionState["messages"],
-): AgentSessionState["messages"] => {
-  const currentMessageById = new Map(currentMessages.map((message) => [message.id, message]));
-  const mergeSameMessageId = (
-    hydratedMessage: AgentSessionState["messages"][number],
-    currentMessage: AgentSessionState["messages"][number] | undefined,
-  ): AgentSessionState["messages"][number] => {
-    if (!currentMessage) {
-      return hydratedMessage;
-    }
-
-    const hydratedIsQueuedUser =
-      hydratedMessage.role === "user" &&
-      hydratedMessage.meta?.kind === "user" &&
-      hydratedMessage.meta.state === "queued";
-    const currentIsQueuedUser =
-      currentMessage.role === "user" &&
-      currentMessage.meta?.kind === "user" &&
-      currentMessage.meta.state === "queued";
-
-    if (currentIsQueuedUser && !hydratedIsQueuedUser) {
-      const mergedMeta =
-        currentMessage.meta && hydratedMessage.meta
-          ? { ...currentMessage.meta, ...hydratedMessage.meta }
-          : (hydratedMessage.meta ?? currentMessage.meta);
-      return {
-        ...currentMessage,
-        ...hydratedMessage,
-        ...(mergedMeta ? { meta: mergedMeta } : {}),
-      };
-    }
-
-    return currentMessage;
-  };
-  const mergedMessages = hydratedMessages.map((message) =>
-    mergeSameMessageId(message, currentMessageById.get(message.id)),
-  );
-  const hydratedMessageIds = new Set(hydratedMessages.map((message) => message.id));
-
-  for (const message of currentMessages) {
-    if (hydratedMessageIds.has(message.id)) {
-      continue;
-    }
-    mergedMessages.push(message);
-  }
-
-  return mergedMessages;
-};
-
-const toRequestedHistoryRecordFromSession = (
-  session: AgentSessionState,
-): AgentSessionRecord | null => {
-  const runtimeKind = session.runtimeKind ?? session.selectedModel?.runtimeKind ?? null;
-  if (!runtimeKind) {
-    return null;
-  }
-
-  return {
-    sessionId: session.sessionId,
-    externalSessionId: session.externalSessionId,
-    role: session.role,
-    scenario: session.scenario,
-    startedAt: session.startedAt,
-    workingDirectory: session.workingDirectory,
-    runtimeKind,
-    selectedModel: session.selectedModel
-      ? {
-          ...session.selectedModel,
-          runtimeKind,
-        }
-      : null,
-  };
-};
-
-const toLiveSessionState = (
-  status: LiveAgentSessionSnapshot["status"],
-): AgentSessionState["status"] => {
-  if (status.type === "busy" || status.type === "retry") {
-    return "running";
-  }
-  return "idle";
-};
+import {
+  createHydrationPromptAssemblerStage,
+  createRuntimeResolutionPlannerStage,
+  hydrateSessionRecordsStage,
+  preparePersistedSessionMergeStage,
+  reconcileLiveSessionsStage,
+  type SessionLifecycleAdapter,
+  type SessionLoadIntent,
+  type UpdateSession,
+} from "./load-sessions-stages";
 
 type CreateLoadAgentSessionsArgs = {
   activeRepo: string | null;
@@ -222,6 +56,36 @@ export const createLoadAgentSessions = ({
   const buildRequestedHistoryKey = (repoPath: string, taskId: string, sessionId: string): string =>
     `${repoPath}::${taskId}::${sessionId}`;
 
+  const buildLoadIntent = (
+    repoPath: string,
+    taskId: string,
+    options?: AgentSessionLoadOptions,
+  ): SessionLoadIntent => {
+    const mode = options?.mode ?? "bootstrap";
+    const requestedSessionId = options?.targetSessionId?.trim() || null;
+    const shouldHydrateRequestedSession =
+      mode === "requested_history" && requestedSessionId !== null;
+    const shouldReconcileLiveSessions = mode === "reconcile_live";
+    return {
+      repoPath,
+      taskId,
+      mode,
+      requestedSessionId,
+      requestedHistoryKey: shouldHydrateRequestedSession
+        ? buildRequestedHistoryKey(repoPath, taskId, requestedSessionId)
+        : null,
+      shouldHydrateRequestedSession,
+      shouldReconcileLiveSessions,
+      historyPolicy:
+        options?.historyPolicy ??
+        (shouldHydrateRequestedSession
+          ? "requested_only"
+          : shouldReconcileLiveSessions
+            ? "live_if_empty"
+            : "none"),
+    };
+  };
+
   return async (taskId: string, options?: AgentSessionLoadOptions): Promise<void> => {
     if (!activeRepo || taskId.trim().length === 0) {
       return;
@@ -238,13 +102,8 @@ export const createLoadAgentSessions = ({
       return;
     }
 
-    const mode = options?.mode ?? "bootstrap";
-    const requestedSessionId = options?.targetSessionId?.trim() || null;
-    const shouldHydrateRequestedSession =
-      mode === "requested_history" && requestedSessionId !== null;
-    const requestedHistoryKey = shouldHydrateRequestedSession
-      ? buildRequestedHistoryKey(repoPath, taskId, requestedSessionId)
-      : null;
+    const intent = buildLoadIntent(repoPath, taskId, options);
+    const requestedHistoryKey = intent.requestedHistoryKey;
     if (requestedHistoryKey) {
       const existingLoad = inFlightRequestedHistoryLoads.get(requestedHistoryKey);
       if (existingLoad) {
@@ -254,548 +113,71 @@ export const createLoadAgentSessions = ({
     }
 
     const executeLoad = async (): Promise<void> => {
-      const currentRequestedSession = requestedSessionId
-        ? (sessionsRef.current[requestedSessionId] ?? null)
-        : null;
-      const requestedHistoryRecordFromSession =
-        shouldHydrateRequestedSession &&
-        options?.persistedRecords === undefined &&
-        currentRequestedSession &&
-        currentRequestedSession.taskId === taskId
-          ? toRequestedHistoryRecordFromSession(currentRequestedSession)
-          : null;
-      const shouldSkipPersistedSessionReload = requestedHistoryRecordFromSession !== null;
-
-      const persisted = shouldSkipPersistedSessionReload
-        ? [requestedHistoryRecordFromSession]
-        : await (options?.persistedRecords
-            ? Promise.resolve(options.persistedRecords)
-            : loadAgentSessionListFromQuery(appQueryClient, repoPath, taskId));
-      if (isStaleRepoOperation()) {
-        return;
-      }
-      let repoPromptOverridesPromise: Promise<RepoPromptOverrides> | null = null;
-      const getRepoPromptOverrides = (): Promise<RepoPromptOverrides> => {
-        if (repoPromptOverridesPromise === null) {
-          repoPromptOverridesPromise = loadRepoPromptOverrides(repoPath);
-        }
-        return repoPromptOverridesPromise;
-      };
-
-      const shouldReconcileLiveSessions = mode === "reconcile_live";
-      const historyPolicy =
-        options?.historyPolicy ??
-        (shouldHydrateRequestedSession
-          ? "requested_only"
-          : shouldReconcileLiveSessions
-            ? "live_if_empty"
-            : "none");
-
-      if (!shouldSkipPersistedSessionReload) {
-        setSessionsById((current) => {
-          if (isStaleRepoOperation()) {
-            return current;
-          }
-          const next = { ...current };
-          for (const record of persisted) {
-            const existingSession = next[record.sessionId];
-            if (existingSession) {
-              next[record.sessionId] = mergePersistedSessionRecord(
-                existingSession,
-                record,
-                taskId,
-                existingSession.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
-              );
-              continue;
-            }
-            next[record.sessionId] = {
-              ...fromPersistedSessionRecord(record, taskId),
-              pendingPermissions: [],
-              pendingQuestions: [],
-              promptOverrides: EMPTY_PROMPT_OVERRIDES,
-            };
-          }
-          return next;
+      const { recordsToHydrate, historyHydrationSessionIds, getRepoPromptOverrides } =
+        await preparePersistedSessionMergeStage({
+          intent,
+          ...(options ? { options } : {}),
+          sessionsRef,
+          setSessionsById,
+          isStaleRepoOperation,
+          loadPersistedRecords: async () =>
+            options?.persistedRecords
+              ? Promise.resolve(options.persistedRecords)
+              : loadAgentSessionListFromQuery(appQueryClient, repoPath, taskId),
+          loadRepoPromptOverrides,
         });
-      }
-
       if (isStaleRepoOperation()) {
         return;
       }
 
-      if (!shouldHydrateRequestedSession && !shouldReconcileLiveSessions) {
+      if (!intent.shouldHydrateRequestedSession && !intent.shouldReconcileLiveSessions) {
         return;
       }
-
-      const recordsToHydrate = shouldHydrateRequestedSession
-        ? persisted.filter((record) => record.sessionId === requestedSessionId)
-        : persisted;
-
-      const historyHydrationSessionIds = new Set(
-        recordsToHydrate
-          .filter((record) => {
-            if (historyPolicy !== "requested_only") {
-              return false;
-            }
-            return requestedSessionId === null || record.sessionId === requestedSessionId;
-          })
-          .map((record) => record.sessionId),
-      );
 
       if (recordsToHydrate.length === 0) {
         return;
       }
 
-      if (historyHydrationSessionIds.size > 0) {
-        setSessionsById((current) => {
-          const next = { ...current };
-          for (const sessionId of historyHydrationSessionIds) {
-            const existingSession = next[sessionId];
-            if (!existingSession) {
-              continue;
-            }
-            next[sessionId] = {
-              ...existingSession,
-              historyHydrationState: "hydrating",
-            };
-          }
-          return next;
-        });
-      }
-
-      const readCurrentHydratedRuntimeResolution = (
-        record: AgentSessionRecord,
-      ): Extract<HydrationRuntimeResolution, { ok: true }> | null => {
-        const currentSession = sessionsRef.current[record.sessionId];
-        const runtimeKind = currentSession?.runtimeKind ?? null;
-        const runtimeEndpoint = currentSession?.runtimeEndpoint.trim() ?? "";
-        const workingDirectory =
-          currentSession?.workingDirectory.trim() || record.workingDirectory.trim();
-        if (!runtimeKind || runtimeEndpoint.length === 0 || workingDirectory.length === 0) {
-          return null;
-        }
-
-        return {
-          ok: true,
-          runtimeKind,
-          runtimeId: currentSession?.runtimeId ?? null,
-          runId: currentSession?.runId ?? null,
-          runtimeEndpoint,
-          runtimeConnection: {
-            endpoint: runtimeEndpoint,
-            workingDirectory,
-          },
-        };
-      };
-
-      const loadLiveLiveAgentSessionSnapshot = async (
-        record: AgentSessionRecord,
-        runtimeResolution: Extract<HydrationRuntimeResolution, { ok: true }>,
-      ): Promise<LiveAgentSessionSnapshot | null> => {
-        const resolvedWorkingDirectory = runtimeResolution.runtimeConnection.workingDirectory;
-        const externalSessionId = record.externalSessionId ?? record.sessionId;
-        const storedSnapshot = liveAgentSessionStore?.readSnapshot({
-          repoPath,
-          runtimeKind: runtimeResolution.runtimeKind,
-          runtimeEndpoint: runtimeResolution.runtimeEndpoint,
-          workingDirectory: resolvedWorkingDirectory,
-          externalSessionId,
-        });
-        if (storedSnapshot) {
-          return storedSnapshot;
-        }
-
-        const preloadedSnapshots = options?.preloadedLiveAgentSessionsByKey?.get(
-          liveAgentSessionLookupKey(
-            runtimeResolution.runtimeKind,
-            runtimeResolution.runtimeEndpoint,
-            resolvedWorkingDirectory,
-          ),
-        );
-        if (preloadedSnapshots) {
-          return (
-            preloadedSnapshots.find(
-              (snapshot) => snapshot.externalSessionId === externalSessionId,
-            ) ?? null
-          );
-        }
-        if (!adapter.listLiveAgentSessionSnapshots) {
-          throw new Error("Live agent session snapshots are unavailable for session hydration.");
-        }
-        const snapshots = await adapter.listLiveAgentSessionSnapshots({
-          runtimeKind: runtimeResolution.runtimeKind,
-          runtimeConnection: runtimeResolution.runtimeConnection,
-          directories: [resolvedWorkingDirectory],
-        });
-        return (
-          snapshots.find((snapshot) => snapshot.externalSessionId === externalSessionId) ?? null
-        );
-      };
-
-      const recordsNeedingRuntimeResolution = recordsToHydrate.filter((record) => {
-        if (!historyHydrationSessionIds.has(record.sessionId)) {
-          return true;
-        }
-        return readCurrentHydratedRuntimeResolution(record) === null;
-      });
-
-      const runtimeKindsToInspect = Array.from(
-        new Set(recordsNeedingRuntimeResolution.map((record) => readPersistedRuntimeKind(record))),
-      );
-      const runtimesByKind =
-        options?.preloadedRuntimeLists ??
-        new Map(
-          await Promise.all(
-            runtimeKindsToInspect.map(async (runtimeKind) => {
-              const runtimes = await loadRuntimeListFromQuery(
-                appQueryClient,
-                runtimeKind,
-                repoPath,
-              );
-              return [runtimeKind, runtimes] as const;
-            }),
-          ),
-        );
-
-      const requiresRunInspection = recordsNeedingRuntimeResolution.some(
-        (record) => record.role === "build" || record.role === "qa",
-      );
-      const liveRuns = requiresRunInspection
-        ? (options?.preloadedRuns ?? (await loadRepoRunsFromQuery(appQueryClient, repoPath)))
-        : [];
-      const ensuredWorkspaceRuntimes = new Map<RuntimeKind, RuntimeInstanceSummary | null>();
-
-      const ensureWorkspaceRuntime = async (
-        runtimeKind: RuntimeKind,
-      ): Promise<RuntimeInstanceSummary | null> => {
-        if (options?.allowRuntimeEnsure === false) {
-          return null;
-        }
-        if (ensuredWorkspaceRuntimes.has(runtimeKind)) {
-          return ensuredWorkspaceRuntimes.get(runtimeKind) ?? null;
-        }
-        const runtime = await host.runtimeEnsure(repoPath, runtimeKind);
-        ensuredWorkspaceRuntimes.set(runtimeKind, runtime);
-        await appQueryClient.invalidateQueries({
-          queryKey: runtimeQueryKeys.list(runtimeKind, repoPath),
-          exact: true,
-          refetchType: "none",
-        });
-        return runtime;
-      };
-
-      const resolveHydrationRuntime = createHydrationRuntimeResolver({
-        repoPath,
-        liveRuns,
-        runtimesByKind,
-        ...(options?.preloadedRuntimeConnectionsByKey
-          ? { preloadedRuntimeConnectionsByKey: options.preloadedRuntimeConnectionsByKey }
-          : {}),
-        ensureWorkspaceRuntime,
-      });
-
-      const buildHydrationPreludeMessages = async ({
-        record,
-        resolvedScenario,
-        promptOverrides,
-      }: {
-        record: AgentSessionRecord;
-        resolvedScenario: AgentSessionState["scenario"];
-        promptOverrides: RepoPromptOverrides;
-      }): Promise<AgentSessionState["messages"]> => {
-        const task = taskRef.current.find((entry) => entry.id === taskId);
-        if (!task) {
-          return buildSessionHeaderMessages({
-            sessionId: record.sessionId,
-            role: record.role,
-            scenario: resolvedScenario,
-            systemPrompt: "",
-            startedAt: record.startedAt,
-            includeSystemPrompt: false,
-          });
-        }
-
-        const systemPrompt = buildSessionSystemPrompt({
-          role: record.role,
-          scenario: resolvedScenario,
-          task,
-          promptOverrides,
-        });
-
-        return buildSessionHeaderMessages({
-          sessionId: record.sessionId,
-          role: record.role,
-          scenario: resolvedScenario,
-          systemPrompt,
-          startedAt: record.startedAt,
-        });
-      };
-
-      const buildHydrationSystemPrompt = async ({
-        record,
-        resolvedScenario,
-        promptOverrides,
-      }: {
-        record: AgentSessionRecord;
-        resolvedScenario: AgentSessionState["scenario"];
-        promptOverrides: RepoPromptOverrides;
-      }): Promise<string> => {
-        const task = taskRef.current.find((entry) => entry.id === taskId);
-        if (!task) {
-          return "";
-        }
-
-        return buildSessionSystemPrompt({
-          role: record.role,
-          scenario: resolvedScenario,
-          task,
-          promptOverrides,
-        });
-      };
-
-      if (shouldReconcileLiveSessions && !adapter.listLiveAgentSessionSnapshots) {
-        throw new Error(
-          "Live agent session snapshots are unavailable for live session reconciliation.",
-        );
-      }
-
-      const runtimeSessionScanCache = new LiveAgentSessionCache(
-        {
-          listLiveAgentSessionSnapshots: async (input) => {
-            if (!adapter.listLiveAgentSessionSnapshots) {
-              throw new Error("Live agent session snapshots are unavailable for session scanning.");
-            }
-            return adapter.listLiveAgentSessionSnapshots(input);
-          },
-        },
-        options?.preloadedLiveAgentSessionsByKey,
-      );
-      const maybeResumeLiveRecord = createReattachLiveSession({
+      const runtimePlanner = await createRuntimeResolutionPlannerStage({
+        intent,
+        ...(options ? { options } : {}),
         adapter,
-        repoPath,
-        taskId,
+        sessionsRef,
+        ...(liveAgentSessionStore ? { liveAgentSessionStore } : {}),
+        recordsToHydrate,
+        historyHydrationSessionIds,
+      });
+      const promptAssembler = createHydrationPromptAssemblerStage({ taskId, taskRef });
+
+      await reconcileLiveSessionsStage({
+        intent,
+        ...(options ? { options } : {}),
+        adapter,
         taskRef,
         sessionsRef,
         updateSession,
         ...(attachSessionListener ? { attachSessionListener } : {}),
-        promptOverrides: EMPTY_PROMPT_OVERRIDES,
-        resolveHydrationRuntime,
-        listLiveAgentSessions: (runtimeKind, runtimeConnection, directories) =>
-          runtimeSessionScanCache.load({
-            runtimeKind,
-            runtimeConnection,
-            directories,
-          }),
-        resumeMissingLiveSession: async ({ record, runtimeKind, runtimeConnection }) => {
-          const promptOverrides = await getRepoPromptOverrides();
-          const resolvedScenario = record.scenario ?? defaultScenarioForRole(record.role);
-          const selectedModel = normalizePersistedSelection(record.selectedModel);
-          const systemPrompt = await buildHydrationSystemPrompt({
-            record,
-            resolvedScenario,
-            promptOverrides,
-          });
-
-          await adapter.resumeSession({
-            sessionId: record.sessionId,
-            externalSessionId: record.externalSessionId ?? record.sessionId,
-            repoPath,
-            runtimeKind,
-            runtimeConnection,
-            workingDirectory: runtimeConnection.workingDirectory,
-            taskId,
-            role: record.role,
-            scenario: resolvedScenario,
-            systemPrompt,
-            ...(selectedModel ? { model: selectedModel } : {}),
-          });
-        },
         isStaleRepoOperation,
-        toLiveSessionState,
+        recordsToHydrate,
+        runtimePlanner,
+        promptAssembler,
+        getRepoPromptOverrides,
       });
-
-      if (shouldReconcileLiveSessions) {
-        for (
-          let offset = 0;
-          offset < recordsToHydrate.length;
-          offset += SESSION_HISTORY_HYDRATION_CONCURRENCY
-        ) {
-          if (isStaleRepoOperation()) {
-            return;
-          }
-          const batch = recordsToHydrate.slice(
-            offset,
-            offset + SESSION_HISTORY_HYDRATION_CONCURRENCY,
-          );
-          const reattachResults = await Promise.all(
-            batch.map(async (record) => ({
-              record,
-              reattached: await maybeResumeLiveRecord(record),
-            })),
-          );
-          if (isStaleRepoOperation()) {
-            return;
-          }
-          for (const { record, reattached } of reattachResults) {
-            if (reattached) {
-              continue;
-            }
-            updateSession(
-              record.sessionId,
-              (current) => ({
-                ...current,
-                pendingPermissions: [],
-                pendingQuestions: [],
-              }),
-              { persist: false },
-            );
-          }
-        }
+      if (isStaleRepoOperation()) {
+        return;
       }
 
-      const hydrateRecord = async (record: AgentSessionRecord): Promise<void> => {
-        if (isStaleRepoOperation()) {
-          return;
-        }
-
-        const shouldHydrateHistory = historyHydrationSessionIds.has(record.sessionId);
-        const runtimeResolution =
-          (shouldHydrateHistory ? readCurrentHydratedRuntimeResolution(record) : null) ??
-          (await resolveHydrationRuntime(record));
-        if (!runtimeResolution.ok) {
-          if (shouldHydrateHistory) {
-            updateSession(
-              record.sessionId,
-              (current) => ({
-                ...current,
-                historyHydrationState: "failed",
-              }),
-              { persist: false },
-            );
-            throw new Error(runtimeResolution.reason);
-          }
-          updateSession(
-            record.sessionId,
-            (current) => ({
-              ...current,
-              runtimeKind: readPersistedRuntimeKind(record),
-              runtimeId: null,
-              runId: null,
-              runtimeEndpoint: "",
-              workingDirectory,
-              promptOverrides: current.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
-            }),
-            { persist: false },
-          );
-          return;
-        }
-        const { runtimeKind, runtimeId, runId, runtimeEndpoint, runtimeConnection } =
-          runtimeResolution;
-        const workingDirectory = runtimeConnection.workingDirectory;
-        const externalSessionId = record.externalSessionId ?? record.sessionId;
-        if (!shouldHydrateHistory) {
-          updateSession(
-            record.sessionId,
-            (current) => ({
-              ...current,
-              runtimeKind,
-              runtimeId,
-              runId,
-              runtimeEndpoint,
-              workingDirectory,
-              promptOverrides: current.promptOverrides ?? EMPTY_PROMPT_OVERRIDES,
-            }),
-            { persist: false },
-          );
-          return;
-        }
-
-        const promptOverrides = await getRepoPromptOverrides();
-        const preludeMessages = await buildHydrationPreludeMessages({
-          record,
-          resolvedScenario: record.scenario ?? defaultScenarioForRole(record.role),
-          promptOverrides,
-        });
-        const history = await adapter.loadSessionHistory({
-          runtimeKind: runtimeResolution.runtimeKind,
-          runtimeConnection: runtimeResolution.runtimeConnection,
-          externalSessionId,
-          limit: INITIAL_SESSION_HISTORY_LIMIT,
-        });
-        const liveRuntimeSnapshot = await loadLiveLiveAgentSessionSnapshot(
-          record,
-          runtimeResolution,
-        );
-        const liveSessionStatus = liveRuntimeSnapshot
-          ? toLiveSessionState(liveRuntimeSnapshot.status)
-          : null;
-        const livePendingPermissions = liveRuntimeSnapshot?.pendingPermissions ?? [];
-        const livePendingQuestions = liveRuntimeSnapshot?.pendingQuestions ?? [];
-        if (isStaleRepoOperation()) {
-          return;
-        }
-
-        updateSession(
-          record.sessionId,
-          (current) => {
-            const selectedModel = normalizePersistedSelection(record.selectedModel);
-            const hydratedMessages = [
-              ...preludeMessages,
-              ...historyToChatMessages(history, {
-                role: record.role,
-                selectedModel,
-              }),
-            ];
-            return {
-              ...current,
-              runtimeKind,
-              runtimeId,
-              runId,
-              runtimeEndpoint,
-              status: liveSessionStatus ?? current.status,
-              workingDirectory,
-              historyHydrationState: "hydrated",
-              promptOverrides,
-              pendingPermissions: livePendingPermissions,
-              pendingQuestions: livePendingQuestions,
-              contextUsage: historyToSessionContextUsage(history, selectedModel),
-              messages: mergeHydratedMessages(hydratedMessages, current.messages),
-            };
-          },
-          { persist: false },
-        );
-      };
-
-      for (
-        let offset = 0;
-        offset < recordsToHydrate.length;
-        offset += SESSION_HISTORY_HYDRATION_CONCURRENCY
-      ) {
-        if (isStaleRepoOperation()) {
-          return;
-        }
-        const batch = recordsToHydrate.slice(
-          offset,
-          offset + SESSION_HISTORY_HYDRATION_CONCURRENCY,
-        );
-        await Promise.all(
-          batch.map((record) =>
-            hydrateRecord(record).catch((error) => {
-              if (historyHydrationSessionIds.has(record.sessionId)) {
-                updateSession(
-                  record.sessionId,
-                  (current) => ({
-                    ...current,
-                    historyHydrationState: "failed",
-                  }),
-                  { persist: false },
-                );
-              }
-              throw error;
-            }),
-          ),
-        );
-      }
+      await hydrateSessionRecordsStage({
+        adapter,
+        setSessionsById,
+        updateSession,
+        isStaleRepoOperation,
+        recordsToHydrate,
+        historyHydrationSessionIds,
+        runtimePlanner,
+        promptAssembler,
+        getRepoPromptOverrides,
+      });
     };
 
     if (!requestedHistoryKey) {

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
@@ -53,9 +53,6 @@ describe("reattach-live-session", () => {
         hasSession: () => false,
       },
       repoPath: "/tmp/repo",
-      taskId: "task-1",
-      taskRef: { current: [] },
-      sessionsRef: { current: { "session-1": sessionStateFixture } },
       updateSession: (sessionId, updater) => {
         if (sessionId !== "session-1") {
           return;
@@ -113,9 +110,6 @@ describe("reattach-live-session", () => {
         hasSession: () => true,
       },
       repoPath: "/tmp/repo",
-      taskId: "task-1",
-      taskRef: { current: [] },
-      sessionsRef: { current: { "session-1": sessionStateFixture } },
       updateSession: (sessionId, updater) => {
         if (sessionId !== "session-1") {
           return;
@@ -158,9 +152,6 @@ describe("reattach-live-session", () => {
         hasSession: () => false,
       },
       repoPath: "/tmp/repo",
-      taskId: "task-1",
-      taskRef: { current: [] },
-      sessionsRef: { current: { "session-1": sessionStateFixture } },
       updateSession: (sessionId, updater) => {
         if (sessionId !== "session-1") {
           return;
@@ -220,9 +211,6 @@ describe("reattach-live-session", () => {
         hasSession: () => false,
       },
       repoPath: "/tmp/repo",
-      taskId: "task-1",
-      taskRef: { current: [] },
-      sessionsRef: { current: { "session-1": sessionStateFixture } },
       updateSession: () => {
         throw new Error("should not update stale session");
       },

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts
@@ -146,4 +146,127 @@ describe("reattach-live-session", () => {
     expect(reattached).toBe(false);
     expect(state.pendingPermissions).toEqual(sessionStateFixture.pendingPermissions);
   });
+
+  test("does not attach or update when the repo becomes stale after resume", async () => {
+    let state = sessionStateFixture;
+    let attachedSessionId: string | null = null;
+    let stale = false;
+    let resumeCalls = 0;
+
+    const reattachLiveSession = createReattachLiveSession({
+      adapter: {
+        hasSession: () => false,
+      },
+      repoPath: "/tmp/repo",
+      taskId: "task-1",
+      taskRef: { current: [] },
+      sessionsRef: { current: { "session-1": sessionStateFixture } },
+      updateSession: (sessionId, updater) => {
+        if (sessionId !== "session-1") {
+          return;
+        }
+        state = updater(state);
+      },
+      attachSessionListener: (_repoPath, sessionId) => {
+        attachedSessionId = sessionId;
+      },
+      promptOverrides: {},
+      resolveHydrationRuntime: async () => ({
+        ok: true,
+        runtimeKind: "opencode",
+        runtimeId: "runtime-1",
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        runtimeConnection: {
+          endpoint: "http://127.0.0.1:4444",
+          workingDirectory: "/tmp/repo/worktree",
+        },
+      }),
+      resumeMissingLiveSession: async () => {
+        resumeCalls += 1;
+        stale = true;
+      },
+      listLiveAgentSessions: async () => [
+        {
+          externalSessionId: "external-1",
+          title: "Session",
+          role: "build",
+          scenario: "build_implementation_start",
+          startedAt: "2026-03-22T12:00:00.000Z",
+          status: { type: "busy" },
+          pendingPermissions: [],
+          pendingQuestions: [],
+          workingDirectory: "/tmp/repo/worktree",
+        },
+      ],
+      isStaleRepoOperation: () => stale,
+      toLiveSessionState: () => "running",
+    });
+
+    const reattached = await reattachLiveSession(sessionRecordFixture);
+
+    expect(resumeCalls).toBe(1);
+    expect(reattached).toBe(false);
+    expect(attachedSessionId).toBeNull();
+    expect(state).toEqual(sessionStateFixture);
+  });
+
+  test("does not resume when the repo becomes stale after live lookup", async () => {
+    let stale = false;
+    let resumeCalls = 0;
+
+    const reattachLiveSession = createReattachLiveSession({
+      adapter: {
+        hasSession: () => false,
+      },
+      repoPath: "/tmp/repo",
+      taskId: "task-1",
+      taskRef: { current: [] },
+      sessionsRef: { current: { "session-1": sessionStateFixture } },
+      updateSession: () => {
+        throw new Error("should not update stale session");
+      },
+      attachSessionListener: () => {
+        throw new Error("should not attach stale session");
+      },
+      promptOverrides: {},
+      resolveHydrationRuntime: async () => ({
+        ok: true,
+        runtimeKind: "opencode",
+        runtimeId: "runtime-1",
+        runId: null,
+        runtimeEndpoint: "http://127.0.0.1:4444",
+        runtimeConnection: {
+          endpoint: "http://127.0.0.1:4444",
+          workingDirectory: "/tmp/repo/worktree",
+        },
+      }),
+      resumeMissingLiveSession: async () => {
+        resumeCalls += 1;
+      },
+      listLiveAgentSessions: async () => {
+        stale = true;
+        return [
+          {
+            externalSessionId: "external-1",
+            title: "Session",
+            role: "build",
+            scenario: "build_implementation_start",
+            startedAt: "2026-03-22T12:00:00.000Z",
+            status: { type: "busy" },
+            pendingPermissions: [],
+            pendingQuestions: [],
+            workingDirectory: "/tmp/repo/worktree",
+          },
+        ];
+      },
+      isStaleRepoOperation: () => stale,
+      toLiveSessionState: () => "running",
+    });
+
+    const reattached = await reattachLiveSession(sessionRecordFixture);
+
+    expect(reattached).toBe(false);
+    expect(resumeCalls).toBe(0);
+  });
 });

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
@@ -46,7 +46,7 @@ export const createReattachLiveSession = ({
   resolveHydrationRuntime,
   listLiveAgentSessions,
   resumeMissingLiveSession,
-  isStaleRepoOperation: _isStaleRepoOperation,
+  isStaleRepoOperation,
   toLiveSessionState,
 }: CreateReattachLiveSessionArgs) => {
   return async (record: AgentSessionRecord): Promise<boolean> => {
@@ -55,6 +55,9 @@ export const createReattachLiveSession = ({
     }
 
     const runtimeResolution = await resolveHydrationRuntime(record);
+    if (isStaleRepoOperation()) {
+      return false;
+    }
     if (!runtimeResolution.ok) {
       return false;
     }
@@ -66,6 +69,9 @@ export const createReattachLiveSession = ({
       runtimeResolution.runtimeConnection,
       [record.workingDirectory],
     );
+    if (isStaleRepoOperation()) {
+      return false;
+    }
     const liveSession = liveAgentSessions.find(
       (session) => session.externalSessionId === externalSessionId,
     );
@@ -86,8 +92,14 @@ export const createReattachLiveSession = ({
         runtimeKind: runtimeResolution.runtimeKind,
         runtimeConnection: runtimeResolution.runtimeConnection,
       });
+      if (isStaleRepoOperation()) {
+        return false;
+      }
     }
 
+    if (isStaleRepoOperation()) {
+      return false;
+    }
     attachSessionListener(repoPath, record.sessionId);
     updateSession(
       record.sessionId,

--- a/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.ts
@@ -1,17 +1,16 @@
-import type { AgentSessionRecord, RuntimeKind, TaskCard } from "@openducktor/contracts";
+import type { AgentSessionRecord, RuntimeKind } from "@openducktor/contracts";
 import type { AgentRuntimeConnection, LiveAgentSessionSnapshot } from "@openducktor/core";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { mergeModelSelection, normalizePersistedSelection } from "../support/models";
 import type { ResolvedHydrationRuntime } from "./hydration-runtime-resolution";
+
+const STALE_REPO_ABORT = Symbol("stale-repo-abort");
 
 type CreateReattachLiveSessionArgs = {
   adapter: {
     hasSession?: (sessionId: string) => boolean;
   };
   repoPath: string;
-  taskId: string;
-  taskRef: { current: TaskCard[] };
-  sessionsRef: { current: Record<string, AgentSessionState> };
   updateSession: (
     sessionId: string,
     updater: (current: AgentSessionState) => AgentSessionState,
@@ -37,9 +36,6 @@ type CreateReattachLiveSessionArgs = {
 export const createReattachLiveSession = ({
   adapter,
   repoPath,
-  taskId: _taskId,
-  taskRef: _taskRef,
-  sessionsRef: _sessionsRef,
   updateSession,
   attachSessionListener,
   promptOverrides,
@@ -49,13 +45,20 @@ export const createReattachLiveSession = ({
   isStaleRepoOperation,
   toLiveSessionState,
 }: CreateReattachLiveSessionArgs) => {
+  const awaitUnlessStale = async <T>(
+    operation: Promise<T>,
+  ): Promise<T | typeof STALE_REPO_ABORT> => {
+    const result = await operation;
+    return isStaleRepoOperation() ? STALE_REPO_ABORT : result;
+  };
+
   return async (record: AgentSessionRecord): Promise<boolean> => {
     if (typeof adapter.hasSession !== "function" || !attachSessionListener) {
       return false;
     }
 
-    const runtimeResolution = await resolveHydrationRuntime(record);
-    if (isStaleRepoOperation()) {
+    const runtimeResolution = await awaitUnlessStale(resolveHydrationRuntime(record));
+    if (runtimeResolution === STALE_REPO_ABORT) {
       return false;
     }
     if (!runtimeResolution.ok) {
@@ -64,12 +67,12 @@ export const createReattachLiveSession = ({
 
     const externalSessionId = record.externalSessionId ?? record.sessionId;
     const attachedExistingSession = adapter.hasSession(record.sessionId);
-    const liveAgentSessions = await listLiveAgentSessions(
-      runtimeResolution.runtimeKind,
-      runtimeResolution.runtimeConnection,
-      [record.workingDirectory],
+    const liveAgentSessions = await awaitUnlessStale(
+      listLiveAgentSessions(runtimeResolution.runtimeKind, runtimeResolution.runtimeConnection, [
+        record.workingDirectory,
+      ]),
     );
-    if (isStaleRepoOperation()) {
+    if (liveAgentSessions === STALE_REPO_ABORT) {
       return false;
     }
     const liveSession = liveAgentSessions.find(
@@ -87,12 +90,14 @@ export const createReattachLiveSession = ({
           `Cannot reattach live session ${record.sessionId} without a resumeMissingLiveSession handler.`,
         );
       }
-      await resumeMissingLiveSession({
-        record,
-        runtimeKind: runtimeResolution.runtimeKind,
-        runtimeConnection: runtimeResolution.runtimeConnection,
-      });
-      if (isStaleRepoOperation()) {
+      const resumeResult = await awaitUnlessStale(
+        resumeMissingLiveSession({
+          record,
+          runtimeKind: runtimeResolution.runtimeKind,
+          runtimeConnection: runtimeResolution.runtimeConnection,
+        }),
+      );
+      if (resumeResult === STALE_REPO_ABORT) {
         return false;
       }
     }

--- a/docs/agent-orchestrator-module-map.md
+++ b/docs/agent-orchestrator-module-map.md
@@ -28,6 +28,7 @@ Files:
 - `lifecycle/repo-session-hydration-service.ts`
 - `lifecycle/session-hydration-operations.ts`
 - `lifecycle/load-sessions.ts`
+- `lifecycle/load-sessions-stages.ts`
 - `lifecycle/reattach-live-session.ts`
 - `lifecycle/live-agent-session-cache.ts`
 - `lifecycle/hydration-runtime-resolution.ts`
@@ -126,11 +127,17 @@ Must not own:
 
 `lifecycle/load-sessions.ts`
 
-- Implements hydration mechanics:
+- Composition entrypoint for session loading intents.
+- Owns stale-guard setup, requested-history dedupe, and stage ordering.
+
+`lifecycle/load-sessions-stages.ts`
+
+- Implements the typed hydration stages used by `load-sessions.ts`:
   - persisted record merge
-  - requested history load
-  - runtime pending-input load
-  - runtime route reuse when a live session is already attached
+  - runtime resolution planning
+  - prompt/prelude assembly
+  - live reconciliation
+  - requested-history hydration
 
 `lifecycle/reattach-live-session.ts`
 


### PR DESCRIPTION
## Summary
- split `createLoadAgentSessions` into explicit persisted-merge, runtime-planner, live-reconciliation, prompt-assembler, and history-hydration stages so each mode is testable without the old monolithic closure
- enforce stale-repo checks inside the live reattach/resume helper after each awaited boundary and tighten the helper/stage contracts to only accept the dependencies they actually use
- add focused stage/helper coverage plus a composition regression that exercises `bootstrap`, `requested_history`, and `reconcile_live` together through the real loader entrypoint

## Testing
- `bun test apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions.test.ts`
- `bun test apps/desktop/src/state/operations/agent-orchestrator/lifecycle/reattach-live-session.test.ts`
- `bun test apps/desktop/src/state/operations/agent-orchestrator/lifecycle/load-sessions-stages.test.ts`
- `bun run --filter @openducktor/desktop lint`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized session loading into a modular, staged pipeline and simplified control flow; removed unused reattach parameters.

* **Bug Fixes**
  * Improved stale-repo guarding to avoid resuming/attaching sessions or applying stale updates.

* **Behavior**
  * Merged persisted session history preserves in-memory pending permissions/questions; system prompts assembled only when task data exists.

* **Tests**
  * Added extensive tests covering lifecycle stages, hydration, runtime resolution, prompt assembly, and stale-repo scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->