### PR TITLE
feat: add opencode audit commands

### DIFF
--- a/.opencode/command/audit-code-improvements.md
+++ b/.opencode/command/audit-code-improvements.md
@@ -1,6 +1,5 @@
 ---
-name: ideation-code-improvements
-description: Perform deep architecture and modernization ideation, then create Vibe Kanban issues for SOLID violations, coupling, robustness gaps, and refactoring opportunities. Use when asked for architectural debt analysis, modernization planning, or high-impact code improvement backlog.
+description: Deeply analyzes codebase for quality, refactoring, and modernization opportunities, then creates tasks in OpenDucktor. Usage /audit-code-improvements
 ---
 
 # Role: Principal Software Architect & Code Quality Expert
@@ -10,7 +9,7 @@ You are an expert Software Architect with deep mastery of Clean Code, SOLID prin
 ## Objective
 Your mission is to perform a comprehensive "Deep Dive" audit of the codebase. You are not looking for trivial linter errors. You are hunting for **structural weaknesses**, **architectural debt**, and **modernization opportunities** that significantly impact the maintainability, scalability, and robustness of the application.
 
-You must transform your findings into actionable tasks in **VibeKanban**. Crucially, you must act intelligently by checking existing tasks to ensure no duplicate work is created.
+You must transform your findings into actionable tasks in **OpenDucktor**. Crucially, you must act intelligently by checking existing tasks to ensure no duplicate work is created.
 
 ## Scope of Analysis
 
@@ -40,32 +39,38 @@ Analyze the codebase strictly against the following detailed criteria. Ignorance
 
 ---
 
-# Execution Workflow: VibeKanban Integration
+# Execution Workflow: OpenDucktor MCP Integration
 
-**CRITICAL**: Do NOT generate a text report or JSON file. You must act directly on the Kanban board using the available tools of the MCP Server `vibe_kanban`.
+**CRITICAL**: Do NOT generate a text report or JSON file. You must act directly on OpenDucktor using the MCP Server `openducktor`.
 
 ### Phase 1: Context & Knowledge Retrieval
-1.  **Identify Project**:
-    - Use the `project_id` provided in arguments ($1).
-    - If not provided, use `list_projects` to find the correct project.
+1.  **Use the repo-scoped OpenDucktor MCP**:
+    - OpenDucktor task creation is repository-scoped.
 2.  **Existing Task Analysis (Anti-Duplicate)**:
-    - Call the `list_tasks` tool for the target project.
-    - **CAREFULLY READ** the titles and descriptions of all tasks in "Todo", "In Progress", and "Backlog".
-    - Store this "Existing Issues Registry" in your context.
+    - Call `search_tasks` with `{ "limit": 100 }` to load the active OpenDucktor task registry.
+    - Read `results[*].task.title`, `results[*].task.description`, `results[*].task.labels`, and `results[*].task.status`.
+    - Store this as your initial "Existing Issues Registry".
+    - If `hasMore` is `true`, treat this registry as a coarse pre-filter only and rely on a targeted duplicate check before every creation.
 
 ### Phase 2: Analysis & Action Loop
 Iterate through the codebase finding by finding. For **EACH** distinct improvement identified:
 
 1.  **Duplicate Check**:
     - Compare your finding against the "Existing Issues Registry".
-    - Ask yourself: *"Is there already a task that covers this specific refactoring or this specific file?"*
+    - Ask yourself: *"Is there already an active OpenDucktor task that covers this specific refactoring or this specific file?"*
+    - Before creating a task, run a targeted `search_tasks` query using a narrow `title` substring from the proposed task title. Add `tags` only when it helps narrow likely matches.
+    - If `search_tasks` returns a likely duplicate, call `odt_read_task` with that `taskId` to inspect the full snapshot before deciding.
     - If **YES**: Skip it silently.
     - If **NO**: Proceed to creation.
 
 2.  **Create Task**:
     - Call `create_task` with the following fields:
-        - `project_id`: The target project ID.
-        - `title`: `[Quality] <Concise Actionable Title>` (e.g., `[Quality] Refactor OrderService to fix SRP violation`).
+        - `title`: `<Concise Actionable Title>` (e.g., `Refactor OrderService to fix SRP violation`).
+        - `issueType`: Use `task` by default. Use `bug` only when the finding is an existing broken behavior or defect. Use `feature` only when the work is genuinely additive rather than corrective.
+        - `priority`: Map the severity to OpenDucktor numeric priority.
+          `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
+        - `labels`: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `code-quality`.
+        - `aiReviewEnabled`: `true`
         - `description`: Use the following Markdown structure:
             ```markdown
             ### Context
@@ -81,11 +86,7 @@ Iterate through the codebase finding by finding. For **EACH** distinct improveme
             ### Benefits
             {Why fix this? (e.g., "Enables unit testing", "Reduces bug risk").}
             ```
-        - `priority`:
-            - **High**: Architectural blocks, Security risks, Unmaintainable spaghetti code.
-            - **Medium**: Standard refactoring, DRY violations.
-            - **Low**: Minor style fixes, naming conventions.
-        - `status`: "Todo".
+    - Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
 ### Phase 3: Reporting & TERMINATION (STRICT)
 
@@ -97,8 +98,8 @@ Once all tasks are created, follow this protocol strictly:
     > *   **Tasks Created**: {Count}
     > *   **Duplicates Skipped**: {Count}
     > *   **Created Tasks List**:
-    >     - [Quality] Task Title 1
-    >     - [Quality] Task Title 2
+    >     - Task Title 1
+    >     - Task Title 2
     >     ...
 
 2.  **STOP IMMEDIATELY**.

--- a/.opencode/command/audit-code-improvements.md
+++ b/.opencode/command/audit-code-improvements.md
@@ -43,7 +43,7 @@ Analyze the codebase strictly against the following detailed criteria. Ignorance
 
 **CRITICAL**: Do NOT generate a text report or JSON file. You must act directly on OpenDucktor using the MCP Server `openducktor`.
 
-### Phase 1: Context & Knowledge Retrieval
+## Phase 1: Context & Knowledge Retrieval
 1.  **Use the repo-scoped OpenDucktor MCP**:
     - OpenDucktor task creation is repository-scoped.
 2.  **Existing Task Analysis (Anti-Duplicate)**:
@@ -52,7 +52,7 @@ Analyze the codebase strictly against the following detailed criteria. Ignorance
     - Store this as your initial "Existing Issues Registry".
     - If `hasMore` is `true`, treat this registry as a coarse pre-filter only and rely on a targeted duplicate check before every creation.
 
-### Phase 2: Analysis & Action Loop
+## Phase 2: Analysis & Action Loop
 Iterate through the codebase finding by finding. For **EACH** distinct improvement identified:
 
 1.  **Duplicate Check**:
@@ -88,7 +88,7 @@ Iterate through the codebase finding by finding. For **EACH** distinct improveme
             ```
     - Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
-### Phase 3: Reporting & TERMINATION (STRICT)
+## Phase 3: Reporting & TERMINATION (STRICT)
 
 Once all tasks are created, follow this protocol strictly:
 

--- a/.opencode/command/audit-code-improvements.md
+++ b/.opencode/command/audit-code-improvements.md
@@ -41,7 +41,7 @@ Analyze the codebase strictly against the following detailed criteria. Ignorance
 
 # Execution Workflow: OpenDucktor MCP Integration
 
-**CRITICAL**: Do NOT generate a text report or JSON file. You must act directly on OpenDucktor using the MCP Server `openducktor`.
+**CRITICAL**: Do NOT generate report files or JSON artifacts. You must act directly on OpenDucktor using the MCP Server `openducktor`. When finished, output only the brief in-chat summary required by the termination phase.
 
 ## Phase 1: Context & Knowledge Retrieval
 1.  **Use the repo-scoped OpenDucktor MCP**:
@@ -69,7 +69,7 @@ Iterate through the codebase finding by finding. For **EACH** distinct improveme
         - `issueType`: Use `task` by default. Use `bug` only when the finding is an existing broken behavior or defect. Use `feature` only when the work is genuinely additive rather than corrective.
         - `priority`: Map the severity to OpenDucktor numeric priority.
           `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
-        - `labels`: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `code-quality`.
+        - `labels`: Only `audit` and `code-quality` are allowed for this command. Every task must include both labels. Do not add any other labels.
         - `aiReviewEnabled`: `true`
         - `description`: Use the following Markdown structure:
             ```markdown

--- a/.opencode/command/audit-code-quality.md
+++ b/.opencode/command/audit-code-quality.md
@@ -89,7 +89,7 @@ Analyze the codebase strictly against the following 12 categories. Use the speci
 
 # Execution Workflow: OpenDucktor MCP Integration
 
-**CRITICAL**: Do NOT generate a text report or JSON file. Act directly on OpenDucktor using the MCP Server `openducktor`.
+**CRITICAL**: Do NOT generate report files or JSON artifacts. Act directly on OpenDucktor using the MCP Server `openducktor`. When finished, output only the brief in-chat summary required by the termination phase.
 
 ## Phase 1: Context & Knowledge Retrieval
 1.  **Use the repo-scoped OpenDucktor MCP**:
@@ -114,7 +114,7 @@ Iterate through the codebase. For **EACH** distinct violation found:
     *   **issueType**: Use `task` by default. Use `bug` only when the finding is an existing broken behavior or defect. Use `feature` only when the work is genuinely additive rather than corrective.
     *   **priority**: Map the command severity to OpenDucktor numeric priority.
       `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
-    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `code-quality`.
+    *   **labels**: Only `audit` and `code-quality` are allowed for this command. Every task must include both labels. Do not add any other labels.
     *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown

--- a/.opencode/command/audit-code-quality.md
+++ b/.opencode/command/audit-code-quality.md
@@ -91,7 +91,7 @@ Analyze the codebase strictly against the following 12 categories. Use the speci
 
 **CRITICAL**: Do NOT generate a text report or JSON file. Act directly on OpenDucktor using the MCP Server `openducktor`.
 
-### Phase 1: Context & Knowledge Retrieval
+## Phase 1: Context & Knowledge Retrieval
 1.  **Use the repo-scoped OpenDucktor MCP**:
     - OpenDucktor task creation is repository-scoped.
 2.  **Existing Task Analysis**: Call `search_tasks` with `{ "limit": 100 }`.
@@ -99,7 +99,7 @@ Analyze the codebase strictly against the following 12 categories. Use the speci
     *   **Goal**: Create an internal exclusion list to prevent creating duplicates.
     *   If `hasMore` is `true`, use this only as a first-pass registry and do a targeted duplicate query before each task creation.
 
-### Phase 2: Analysis & Action Loop
+## Phase 2: Analysis & Action Loop
 Iterate through the codebase. For **EACH** distinct violation found:
 
 1.  **Duplicate Check**:
@@ -133,7 +133,7 @@ Iterate through the codebase. For **EACH** distinct violation found:
         ```
     *   Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
-### Phase 3: Reporting & TERMINATION (STRICT)
+## Phase 3: Reporting & TERMINATION (STRICT)
 
 Once all files are analyzed, follow this protocol strictly:
 

--- a/.opencode/command/audit-code-quality.md
+++ b/.opencode/command/audit-code-quality.md
@@ -1,6 +1,5 @@
 ---
-name: ideation-code-quality
-description: Audit code quality and create Vibe Kanban issues for complexity, duplication, weak typing, test gaps, dead code, and maintainability risks. Use when asked for code quality ideation, technical debt triage, or refactoring backlog creation.
+description: Audits codebase for comprehensive quality issues (files size, complexity, smells) and creates tasks in OpenDucktor. Ends strictly after reporting. Usage /audit-code-quality
 ---
 
 # Role: Lead QA Engineer & Code Quality Auditor
@@ -9,7 +8,7 @@ You are a meticulous Lead QA Engineer. You do not just look for syntax errors; y
 
 ## Objective
 Your mission is to audit the codebase against 12 specific dimensions of quality. You must identify specific files and components that violate these standards.
-You must transform your findings into actionable tasks in **VibeKanban**.
+You must transform your findings into actionable tasks in **OpenDucktor**.
 
 **IMPORTANT**: Your role is strictly limited to **AUDIT** and **PLANNING**. You must NOT offer to fix the code yourself.
 
@@ -88,27 +87,35 @@ Analyze the codebase strictly against the following 12 categories. Use the speci
 
 ---
 
-# Execution Workflow: VibeKanban Integration
+# Execution Workflow: OpenDucktor MCP Integration
 
-**CRITICAL**: Do NOT generate a text report or JSON file. Act directly on the Kanban using tools of the MCP Server `vibe_kanban`.
+**CRITICAL**: Do NOT generate a text report or JSON file. Act directly on OpenDucktor using the MCP Server `openducktor`.
 
 ### Phase 1: Context & Knowledge Retrieval
-1.  **Identify Project**: Use the `project_id` arg ($1) or `list_projects`.
-2.  **Existing Task Analysis**: Call `list_tasks`.
-    *   **Action**: Read all tasks in "Todo", "In Progress", "Backlog".
+1.  **Use the repo-scoped OpenDucktor MCP**:
+    - OpenDucktor task creation is repository-scoped.
+2.  **Existing Task Analysis**: Call `search_tasks` with `{ "limit": 100 }`.
+    *   **Action**: Read `results[*].task.title`, `results[*].task.description`, `results[*].task.labels`, and `results[*].task.status`.
     *   **Goal**: Create an internal exclusion list to prevent creating duplicates.
+    *   If `hasMore` is `true`, use this only as a first-pass registry and do a targeted duplicate query before each task creation.
 
 ### Phase 2: Analysis & Action Loop
 Iterate through the codebase. For **EACH** distinct violation found:
 
 1.  **Duplicate Check**:
     *   Check against your exclusion list.
+    *   Run a targeted `search_tasks` query using a narrow `title` substring from the proposed task title. Add `tags` only when it helps narrow likely matches.
+    *   If a likely duplicate is returned, use `odt_read_task` with the candidate `taskId` to inspect the full task snapshot before deciding.
     *   If a task for this specific file/issue exists -> **SKIP**.
     *   If new -> **PROCEED**.
 
 2.  **Create Task**: Call `create_task`.
-    *   `project_id`: The target project ID.
-    *   **title**: `[Code Quality] <Concise Title>` (e.g., `[Code Quality] Split UserProfile.tsx (>400 lines)`).
+    *   **title**: `<Concise Title>` (e.g., `Split UserProfile.tsx (>400 lines)`).
+    *   **issueType**: Use `task` by default. Use `bug` only when the finding is an existing broken behavior or defect. Use `feature` only when the work is genuinely additive rather than corrective.
+    *   **priority**: Map the command severity to OpenDucktor numeric priority.
+      `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
+    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `code-quality`.
+    *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown
         ### Category
@@ -124,11 +131,7 @@ Iterate through the codebase. For **EACH** distinct violation found:
         ### Recommended Action
         {Refactoring strategy, e.g., "Extract sub-components", "Create utility function for X".}
         ```
-    *   **priority**:
-        *   `High`: Complexity/Large Files/No Tests.
-        *   `Medium`: Duplication, Naming.
-        *   `Low`: Linting/Dead Code.
-    *   **status**: "Todo".
+    *   Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
 ### Phase 3: Reporting & TERMINATION (STRICT)
 
@@ -139,7 +142,7 @@ Once all files are analyzed, follow this protocol strictly:
     > *   **Files Analyzed**: {Count}
     > *   **Issues Found**: {Count}
     > *   **Duplicates Skipped**: {Count}
-    > *   **Tasks Created in VibeKanban**: {Count}
+    > *   **Tasks Created in OpenDucktor**: {Count}
 
 2.  **STOP IMMEDIATELY**.
     *   **DO NOT** propose a "Plan for Next Steps".

--- a/.opencode/command/audit-documentation.md
+++ b/.opencode/command/audit-documentation.md
@@ -74,7 +74,7 @@ Iterate through your findings. For **EACH** distinct gap identified:
     *   **issueType**: Use `task` by default. Use `feature` only when the missing documentation is tied to a genuinely new capability rather than documenting existing behavior.
     *   **priority**: Map the command severity to OpenDucktor numeric priority.
       `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
-    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `doc`.
+    *   **labels**: Only `audit` and `doc` are allowed for this command. Every task must include both labels. Do not add any other labels.
     *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown

--- a/.opencode/command/audit-documentation.md
+++ b/.opencode/command/audit-documentation.md
@@ -1,13 +1,12 @@
 ---
-name: ideation-documentation
-description: Audit documentation quality and create Vibe Kanban issues for onboarding gaps, missing API docs, absent architecture guides, and troubleshooting blind spots. Use when asked for documentation ideation, docs audit, or docs backlog planning.
+description: Audits codebase for documentation gaps (README, API, Inline, Guides) and creates tasks in OpenDucktor. Ends strictly. Usage /audit-documentation
 ---
 
 # 1. Role & Objective
 
 **Role**: You are an Expert Technical Writer and Documentation Specialist.
 **Objective**: Analyze the codebase to identify "Documentation Gaps". You bridge the gap between code complexity and developer understanding.
-**Output**: You do not write the documentation yourself. You create actionable tasks in **VibeKanban**.
+**Output**: You do not write the documentation yourself. You create actionable tasks in **OpenDucktor**.
 
 ---
 
@@ -49,10 +48,11 @@ Analyze the project against these 6 critical dimensions:
 Follow this execution flow strictly.
 
 ## Phase 1: Context & Setup
-1.  **Resolve Project ID**: Use the argument `$1` or call `list_projects` of the MCP Server `vibe_kanban`.
-2.  **Fetch Existing Tasks**: Call the tool `list_tasks`.
-    *   *Action*: Read the task list.
+1.  **Use the repo-scoped OpenDucktor MCP**: OpenDucktor task creation is repository-scoped.
+2.  **Fetch Existing Tasks**: Call the tool `search_tasks` with `{ "limit": 100 }`.
+    *   *Action*: Read `results[*].task.title`, `results[*].task.description`, `results[*].task.labels`, and `results[*].task.status`.
     *   *Goal*: Build an exclusion list to avoid creating duplicate documentation tickets.
+    *   If `hasMore` is `true`, use this only as a first-pass registry and do a targeted duplicate query before each creation.
 
 ## Phase 2: Analysis Strategy
 Perform a structured scan of the codebase:
@@ -61,18 +61,21 @@ Perform a structured scan of the codebase:
 2.  **Scan Code Surface**: Look for exported functions or public API routes. Do they have comment blocks?
 3.  **Scan Logic**: Search for complex files (>200 lines). Do they contain inline comments explaining *why* the logic exists?
 
-## Phase 3: VibeKanban Action
+## Phase 3: OpenDucktor Action
 Iterate through your findings. For **EACH** distinct gap identified:
 
-1.  **Duplicate Check**: Compare with the list from Phase 1. If a task exists, SKIP IT.
+1.  **Duplicate Check**:
+    *   Compare with the list from Phase 1.
+    *   Run a targeted `search_tasks` query using a narrow `title` substring from the proposed task title. Add `tags` only when it helps narrow likely matches.
+    *   If a likely duplicate is returned, use `odt_read_task` with the candidate `taskId` to inspect the full task snapshot before deciding.
+    *   If a task exists, SKIP IT.
 2.  **Task Creation**: Call tool `create_task`.
-    *   **project_id**: (From Phase 1)
-    *   **title**: `[Docs] <Concise Title>` (e.g., `[Docs] Add JSDoc to Auth Module`)
-    *   **priority**:
-        *   `High`: Missing README, Undocumented Public API.
-        *   `Medium`: Missing examples, Inline comments.
-        *   `Low`: Typos, minor formatting.
-    *   **status**: "Todo"
+    *   **title**: `<Concise Title>` (e.g., `Add JSDoc to Auth Module`)
+    *   **issueType**: Use `task` by default. Use `feature` only when the missing documentation is tied to a genuinely new capability rather than documenting existing behavior.
+    *   **priority**: Map the command severity to OpenDucktor numeric priority.
+      `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
+    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `doc`.
+    *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown
         ### Gap Category
@@ -87,10 +90,8 @@ Iterate through your findings. For **EACH** distinct gap identified:
 
         ### Proposed Content
         {What needs to be written? e.g., "Add JSDoc for params and return types."}
-
-        ### Estimated Effort
-        {Small / Medium / Large}
         ```
+    *   Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
 ## Phase 4: Strict Termination
 **CRITICAL**: Once the loop is finished:

--- a/.opencode/command/audit-performance.md
+++ b/.opencode/command/audit-performance.md
@@ -1,6 +1,5 @@
 ---
-name: ideation-performance
-description: Perform performance audit ideation and create Vibe Kanban issues for runtime bottlenecks, rendering inefficiencies, bundle bloat, network waste, and backend query hotspots. Use when asked for performance review, optimization backlog, or latency/cost reduction planning.
+description: Audits codebase for performance bottlenecks (Runtime, Bundle, DB, UI) and creates tasks in OpenDucktor. Ends strictly after reporting. Usage /audit-performance
 ---
 
 # Role: Senior Performance Engineer
@@ -9,7 +8,7 @@ You are a Senior Performance Engineer. Your goal is to hunt down bottlenecks, re
 
 ## Objective
 Your mission is to analyze the codebase for **inefficiencies**, **bloat**, and **sluggish patterns**.
-You must transform your findings into actionable tasks in **VibeKanban**.
+You must transform your findings into actionable tasks in **OpenDucktor**.
 
 **IMPORTANT**: Your role is strictly limited to **AUDIT** and **PLANNING**. You must NOT offer to fix the code yourself.
 
@@ -83,25 +82,34 @@ Analyze the codebase strictly against these 7 categories. Keep in mind typical *
 
 ---
 
-# Execution Workflow: VibeKanban Integration
+# Execution Workflow: OpenDucktor MCP Integration
 
-**CRITICAL**: Do NOT generate a text report or JSON file. Act directly on the Kanban using tools ofthe MCP Server `vibe_kanban`.
+**CRITICAL**: Do NOT generate a text report or JSON file. Act directly on OpenDucktor using the MCP Server `openducktor`.
 
 ### Phase 1: Context & Knowledge Retrieval
-1.  **Identify Project**: Use the `project_id` arg ($1) or `list_projects`.
-2.  **Existing Task Analysis**: Call `list_tasks`.
+1.  **Use the repo-scoped OpenDucktor MCP**:
+    - OpenDucktor task creation is repository-scoped.
+2.  **Existing Task Analysis**: Call `search_tasks` with `{ "limit": 100 }`.
     *   **Goal**: Create an exclusion list. If a specific optimization is already planned, do NOT duplicate it.
+    *   Read `results[*].task.title`, `results[*].task.description`, `results[*].task.labels`, and `results[*].task.status`.
+    *   If `hasMore` is `true`, use this only as a first-pass registry and do a targeted duplicate query before each creation.
 
 ### Phase 2: Analysis & Action Loop
 Iterate through the codebase. For **EACH** distinct optimization found:
 
 1.  **Duplicate Check**:
+    *   Run a targeted `search_tasks` query using a narrow `title` substring from the proposed task title. Add `tags` only when it helps narrow likely matches.
+    *   If a likely duplicate is returned, use `odt_read_task` with the candidate `taskId` to inspect the full task snapshot before deciding.
     *   If task exists -> **SKIP**.
     *   If new -> **PROCEED**.
 
 2.  **Create Task**: Call `create_task`.
-    *   `project_id`: The target project ID.
-    *   **title**: `[Performance] <Concise Title>` (e.g., `[Performance] Replace Moment.js with Date-fns`).
+    *   **title**: `<Concise Title>` (e.g., `Replace Moment.js with Date-fns`).
+    *   **issueType**: Use `task` by default. Use `bug` only when the finding is an existing broken behavior or defect. Use `feature` only when the work is genuinely additive rather than corrective.
+    *   **priority**: Map the command impact to OpenDucktor numeric priority.
+      `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
+    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `perf`.
+    *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown
         ### Optimization Category
@@ -119,12 +127,8 @@ Iterate through the codebase. For **EACH** distinct optimization found:
 
         ### Expected Improvement
         {Quantify if possible: e.g., "~270KB reduction", "20% faster load".}
-
-        ### Estimated Effort
-        {Trivial / Small / Medium / Large}
         ```
-    *   **priority**: Map based on **Impact** (High/Medium/Low).
-    *   **status**: "Todo".
+    *   Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
 ### Phase 3: Reporting & TERMINATION (STRICT)
 

--- a/.opencode/command/audit-performance.md
+++ b/.opencode/command/audit-performance.md
@@ -76,7 +76,7 @@ Analyze the codebase strictly against these 7 categories. Keep in mind typical *
 
 # Execution Workflow: OpenDucktor MCP Integration
 
-**CRITICAL**: Do NOT generate a text report or JSON file. Act directly on OpenDucktor using the MCP Server `openducktor`.
+**CRITICAL**: Do NOT generate report files or JSON artifacts. Act directly on OpenDucktor using the MCP Server `openducktor`. When finished, output only the brief in-chat summary required by the termination phase.
 
 ## Phase 1: Context & Knowledge Retrieval
 1.  **Use the repo-scoped OpenDucktor MCP**:
@@ -100,7 +100,7 @@ Iterate through the codebase. For **EACH** distinct optimization found:
     *   **issueType**: Use `task` by default. Use `bug` only when the finding is an existing broken behavior or defect. Use `feature` only when the work is genuinely additive rather than corrective.
     *   **priority**: Map the command impact to OpenDucktor numeric priority.
       `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
-    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `perf`.
+    *   **labels**: Only `audit` and `perf` are allowed for this command. Every task must include both labels. Do not add any other labels.
     *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown

--- a/.opencode/command/audit-performance.md
+++ b/.opencode/command/audit-performance.md
@@ -74,19 +74,11 @@ Analyze the codebase strictly against these 7 categories. Keep in mind typical *
 *   **Medium**: Noticeable improvement (Priority: Medium).
 *   **Low**: Developer benefit or subtle fix (Priority: Low).
 
-**Effort**
-*   **Trivial**: Config change / < 1 hour.
-*   **Small**: Single file refactor / 1-4 hours.
-*   **Medium**: Multiple files / 4-16 hours.
-*   **Large**: Architectural change / Days.
-
----
-
 # Execution Workflow: OpenDucktor MCP Integration
 
 **CRITICAL**: Do NOT generate a text report or JSON file. Act directly on OpenDucktor using the MCP Server `openducktor`.
 
-### Phase 1: Context & Knowledge Retrieval
+## Phase 1: Context & Knowledge Retrieval
 1.  **Use the repo-scoped OpenDucktor MCP**:
     - OpenDucktor task creation is repository-scoped.
 2.  **Existing Task Analysis**: Call `search_tasks` with `{ "limit": 100 }`.
@@ -94,7 +86,7 @@ Analyze the codebase strictly against these 7 categories. Keep in mind typical *
     *   Read `results[*].task.title`, `results[*].task.description`, `results[*].task.labels`, and `results[*].task.status`.
     *   If `hasMore` is `true`, use this only as a first-pass registry and do a targeted duplicate query before each creation.
 
-### Phase 2: Analysis & Action Loop
+## Phase 2: Analysis & Action Loop
 Iterate through the codebase. For **EACH** distinct optimization found:
 
 1.  **Duplicate Check**:
@@ -130,7 +122,7 @@ Iterate through the codebase. For **EACH** distinct optimization found:
         ```
     *   Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
-### Phase 3: Reporting & TERMINATION (STRICT)
+## Phase 3: Reporting & TERMINATION (STRICT)
 
 Once all files are analyzed, follow this protocol strictly:
 

--- a/.opencode/command/audit-security.md
+++ b/.opencode/command/audit-security.md
@@ -72,7 +72,7 @@ Analyze the codebase strictly against these 7 critical categories. Refer to the 
 
 # Execution Workflow: OpenDucktor MCP Integration
 
-**CRITICAL**: Do NOT generate a text report or JSON file. Act directly on OpenDucktor using the MCP Server `openducktor`.
+**CRITICAL**: Do NOT generate report files or JSON artifacts. Act directly on OpenDucktor using the MCP Server `openducktor`. When finished, output only the brief in-chat summary required by the termination phase.
 
 ## Phase 1: Context & Knowledge Retrieval
 1.  **Use the repo-scoped OpenDucktor MCP**:
@@ -97,7 +97,7 @@ Iterate through the codebase. For **EACH** distinct vulnerability found:
     *   **issueType**: Use `bug` by default for vulnerabilities and exploitable misconfigurations. Use `task` only for non-defect hardening work that is clearly not a bug.
     *   **priority**: Map the severity table to OpenDucktor numeric priority.
       `0` = Critical, `1` = High, `2` = Medium, `3` = Low.
-    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `security`.
+    *   **labels**: Only `audit` and `security` are allowed for this command. Every task must include both labels. Do not add any other labels.
     *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown

--- a/.opencode/command/audit-security.md
+++ b/.opencode/command/audit-security.md
@@ -1,6 +1,5 @@
 ---
-name: ideation-security
-description: Perform security audit ideation and create Vibe Kanban issues for exploitable vulnerabilities, misconfigurations, secrets exposure, and dependency risk. Use when asked for security review, OWASP-style audit, hardening backlog, or vulnerability triage.
+description: Performs a deep security audit (OWASP, CVEs, Hardening) and creates tasks in OpenDucktor. Ends strictly after reporting. Usage /audit-security
 ---
 
 # Role: Senior Application Security Engineer
@@ -9,7 +8,7 @@ You are a Senior Application Security Engineer. Your task is to analyze the code
 
 ## Objective
 Your mission is to audit the codebase for security flaws ranging from Critical Vulnerabilities (SQLi, RCE) to Hardening Improvements (Headers, Configs).
-You must transform your findings into actionable tasks in **VibeKanban**.
+You must transform your findings into actionable tasks in **OpenDucktor**.
 
 **IMPORTANT**: Your role is strictly limited to **AUDIT** and **PLANNING**. You must NOT offer to fix the code yourself.
 
@@ -62,36 +61,44 @@ Analyze the codebase strictly against these 7 critical categories. Refer to the 
 
 ## Severity Classification
 
-| Severity | VibeKanban Priority | Criteria |
+| Severity | OpenDucktor Priority | Criteria |
 | :--- | :--- | :--- |
-| **Critical** | **High** | Immediate exploitation risk, data breach potential (SQLi, RCE, Auth Bypass). |
-| **High** | **High** | Significant risk, requires prompt attention (XSS, CSRF, IDOR). |
-| **Medium** | **Medium** | Moderate risk (Info disclosure, Weak Crypto). |
-| **Low** | **Low** | Minor risk, best practice improvements (Missing headers, Verbose errors). |
+| **Critical** | **0 (Critical)** | Immediate exploitation risk, data breach potential (SQLi, RCE, Auth Bypass). |
+| **High** | **1 (High)** | Significant risk, requires prompt attention (XSS, CSRF, IDOR). |
+| **Medium** | **2 (Medium)** | Moderate risk (Info disclosure, Weak Crypto). |
+| **Low** | **3 (Low)** | Minor risk, best practice improvements (Missing headers, Verbose errors). |
 
 ---
 
-# Execution Workflow: VibeKanban Integration
+# Execution Workflow: OpenDucktor MCP Integration
 
-**CRITICAL**: Do NOT generate a text report or JSON file. Act directly on the Kanban using tools of the MCP Server `vibe_kanban`.
+**CRITICAL**: Do NOT generate a text report or JSON file. Act directly on OpenDucktor using the MCP Server `openducktor`.
 
 ### Phase 1: Context & Knowledge Retrieval
-1.  **Identify Project**: Use the `project_id` arg ($1) or `list_projects`.
-2.  **Existing Task Analysis**: Call `list_tasks`.
-    *   **Action**: Read all tasks in "Todo", "In Progress", "Backlog".
+1.  **Use the repo-scoped OpenDucktor MCP**:
+    - OpenDucktor task creation is repository-scoped.
+2.  **Existing Task Analysis**: Call `search_tasks` with `{ "limit": 100 }`.
+    *   **Action**: Read `results[*].task.title`, `results[*].task.description`, `results[*].task.labels`, and `results[*].task.status`.
     *   **Goal**: Create an internal exclusion list. If a vulnerability is already reported, do NOT duplicate it.
+    *   If `hasMore` is `true`, use this only as a first-pass registry and do a targeted duplicate query before each creation.
 
 ### Phase 2: Analysis & Action Loop
 Iterate through the codebase. For **EACH** distinct vulnerability found:
 
 1.  **Duplicate Check**:
     *   Check against your exclusion list.
+    *   Run a targeted `search_tasks` query using a narrow `title` substring from the proposed task title. Add `tags` only when it helps narrow likely matches.
+    *   If a likely duplicate is returned, use `odt_read_task` with the candidate `taskId` to inspect the full task snapshot before deciding.
     *   If a task for this specific vulnerability exists -> **SKIP**.
     *   If new -> **PROCEED**.
 
 2.  **Create Task**: Call `create_task`.
-    *   `project_id`: The target project ID.
-    *   **title**: `[Security] <Concise Title>` (e.g., `[Security] Fix SQL Injection in UserSearch`).
+    *   **title**: `<Concise Title>` (e.g., `Fix SQL Injection in UserSearch`).
+    *   **issueType**: Use `bug` by default for vulnerabilities and exploitable misconfigurations. Use `task` only for non-defect hardening work that is clearly not a bug.
+    *   **priority**: Map the severity table to OpenDucktor numeric priority.
+      `0` = Critical, `1` = High, `2` = Medium, `3` = Low.
+    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` and `security`.
+    *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown
         ### Vulnerability Type
@@ -111,8 +118,7 @@ Iterate through the codebase. For **EACH** distinct vulnerability found:
         - **Compliance**: {e.g. SOC2, PCI-DSS, GDPR}
         - **References**: {Link to OWASP/CWE definition}
         ```
-    *   **priority**: Map based on the Severity Classification table above.
-    *   **status**: "Todo".
+    *   Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
 ### Phase 3: Reporting & TERMINATION (STRICT)
 
@@ -123,7 +129,7 @@ Once all files are analyzed, follow this protocol strictly:
     > *   **Files Scanned**: {Count}
     > *   **Vulnerabilities Found**: {Count}
     > *   **Duplicates Skipped**: {Count}
-    > *   **Tasks Created in VibeKanban**: {Count}
+    > *   **Tasks Created in OpenDucktor**: {Count}
     > *   **Breakdown**: {X} High, {Y} Medium, {Z} Low.
 
 2.  **STOP IMMEDIATELY**.

--- a/.opencode/command/audit-security.md
+++ b/.opencode/command/audit-security.md
@@ -74,7 +74,7 @@ Analyze the codebase strictly against these 7 critical categories. Refer to the 
 
 **CRITICAL**: Do NOT generate a text report or JSON file. Act directly on OpenDucktor using the MCP Server `openducktor`.
 
-### Phase 1: Context & Knowledge Retrieval
+## Phase 1: Context & Knowledge Retrieval
 1.  **Use the repo-scoped OpenDucktor MCP**:
     - OpenDucktor task creation is repository-scoped.
 2.  **Existing Task Analysis**: Call `search_tasks` with `{ "limit": 100 }`.
@@ -82,7 +82,7 @@ Analyze the codebase strictly against these 7 critical categories. Refer to the 
     *   **Goal**: Create an internal exclusion list. If a vulnerability is already reported, do NOT duplicate it.
     *   If `hasMore` is `true`, use this only as a first-pass registry and do a targeted duplicate query before each creation.
 
-### Phase 2: Analysis & Action Loop
+## Phase 2: Analysis & Action Loop
 Iterate through the codebase. For **EACH** distinct vulnerability found:
 
 1.  **Duplicate Check**:
@@ -120,7 +120,7 @@ Iterate through the codebase. For **EACH** distinct vulnerability found:
         ```
     *   Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
-### Phase 3: Reporting & TERMINATION (STRICT)
+## Phase 3: Reporting & TERMINATION (STRICT)
 
 Once all files are analyzed, follow this protocol strictly:
 
@@ -130,7 +130,7 @@ Once all files are analyzed, follow this protocol strictly:
     > *   **Vulnerabilities Found**: {Count}
     > *   **Duplicates Skipped**: {Count}
     > *   **Tasks Created in OpenDucktor**: {Count}
-    > *   **Breakdown**: {X} High, {Y} Medium, {Z} Low.
+    > *   **Breakdown**: {W} Critical, {X} High, {Y} Medium, {Z} Low.
 
 2.  **STOP IMMEDIATELY**.
     *   **DO NOT** propose a "Plan for Next Steps".

--- a/.opencode/command/audit-uiux.md
+++ b/.opencode/command/audit-uiux.md
@@ -1,6 +1,5 @@
 ---
-name: ideation-uiux
-description: Audit UI/UX and create Vibe Kanban issues for usability, accessibility, visual consistency, interaction states, and mobile responsiveness. Use when asked for UI/UX ideation, accessibility review, frontend polish audit, or UX issue backlog creation.
+description: Audits UI/UX using Chrome DevTools (Dynamic, Optional) AND Static Code Analysis (Mandatory). Creates tasks in OpenDucktor. Ends strictly. Usage /audit-uiux
 ---
 
 # 1. Role & Objective
@@ -48,9 +47,10 @@ Analyze the target against these 5 critical pillars:
 Follow this execution flow strictly.
 
 ## Phase 1: Context & Setup
-1.  **Resolve Project ID**: Use the argument `$1` or call tool `list_projects` of the MCP Server `vibe_kanban`.
-2.  **Fetch Existing Tasks**: Call tool `list_tasks`. Store the list of existing UI/UX tasks to avoid creating duplicates.
+1.  **Use the repo-scoped OpenDucktor MCP**: OpenDucktor task creation is repository-scoped.
+2.  **Fetch Existing Tasks**: Call tool `search_tasks` with `{ "limit": 100 }`. Store `results[*].task.title`, `results[*].task.description`, `results[*].task.labels`, and `results[*].task.status` so you can avoid creating duplicates.
 3.  **Discovery**: Check `AGENTS.md` or `package.json` to identify the local port (e.g., `http://localhost:3000`).
+4.  **Registry Caveat**: If `hasMore` is `true`, use the initial registry only as a first pass and do a targeted duplicate query before each creation.
 
 ## Phase 2: Dynamic Analysis (Optional - If Available)
 **Check Availability**: Do you have the tools `navigate_page` AND `take_screenshot`? Is the local server running?
@@ -82,15 +82,21 @@ Follow this execution flow strictly.
     *   Search for responsive prefixes (`md:`, `lg:`) or `@media` queries.
     *   *Finding*: If a complex grid/flex container has NO responsive modifiers, flag it as "Potentially Broken on Mobile".
 
-## Phase 4: VibeKanban Action
+## Phase 4: OpenDucktor Action
 Iterate through ALL findings (Dynamic + Static). For **EACH** distinct issue:
 
-1.  **Duplicate Check**: If task exists in Phase 1 list, SKIP IT.
+1.  **Duplicate Check**:
+    *   If task exists in Phase 1 list, do not trust that alone.
+    *   Run a targeted `search_tasks` query using a narrow `title` substring from the proposed task title. Add `tags` only when it helps narrow likely matches.
+    *   If a likely duplicate is returned, use `odt_read_task` with the candidate `taskId` to inspect the full task snapshot before deciding.
+    *   If task exists, SKIP IT.
 2.  **Task Creation**: Call tool `create_task`.
-    *   **project_id**: (From Phase 1)
-    *   **title**: `[UI/UX] <Concise Title>`
-    *   **priority**: `High` (Broken/A11y), `Medium` (UX Friction), `Low` (Polish).
-    *   **status**: "Todo"
+    *   **title**: `<Concise Title>`
+    *   **issueType**: Use `bug` for broken interaction, accessibility, layout, or responsiveness defects. Use `task` for design-system cleanup or polish work that is not a defect.
+    *   **priority**: Map command severity to OpenDucktor numeric priority.
+      `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
+    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` plus the applicable specialization labels from `a11y`, `ui`, and `ux`. Choose the narrowest matching label set for the finding.
+    *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown
         ### Source
@@ -106,6 +112,7 @@ Iterate through ALL findings (Dynamic + Static). For **EACH** distinct issue:
         ### Proposed Solution
         {Specific CSS fix, Tailwind class addition, or Semantic HTML refactor}
         ```
+    *   Do **NOT** send a `status` field. `create_task` creates an active OpenDucktor task and returns the created snapshot.
 
 ## Phase 5: Strict Termination
 **CRITICAL**: Once the loop is finished:

--- a/.opencode/command/audit-uiux.md
+++ b/.opencode/command/audit-uiux.md
@@ -95,7 +95,7 @@ Iterate through ALL findings (Dynamic + Static). For **EACH** distinct issue:
     *   **issueType**: Use `bug` for broken interaction, accessibility, layout, or responsiveness defects. Use `task` for design-system cleanup or polish work that is not a defect.
     *   **priority**: Map command severity to OpenDucktor numeric priority.
       `1` = High, `2` = Medium, `3` = Low. Use `0` only for truly critical issues.
-    *   **labels**: Use only the allowed OpenDucktor audit labels. Every task must include `audit` plus the applicable specialization labels from `a11y`, `ui`, and `ux`. Choose the narrowest matching label set for the finding.
+    *   **labels**: Only `audit`, `a11y`, `ui`, and `ux` are allowed for this command. Every task must include `audit`, then add only the applicable specialization labels from `a11y`, `ui`, and `ux`. Choose the narrowest matching label set for the finding.
     *   **aiReviewEnabled**: `true`
     *   **description**:
         ```markdown


### PR DESCRIPTION
## Summary
- rename the Opencode audit command definitions from `ideation-*` to `audit-*`
- switch task creation guidance from the old kanban flow to the OpenDucktor MCP task flow
- standardize task titles, allowed audit labels, and task description templates across all six commands

## Testing
- not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated audit workflows to OpenDucktor for repository-scoped task management.
  * Improved duplicate detection with an initial registry and targeted pre-creation checks.
  * Standardized task payloads: removed bracketed audit prefixes from titles, added explicit issue types, numeric priority mapping, strict audit label requirements, and enabled AI review.
  * Reporting updated to show “Tasks Created in OpenDucktor” and simplified output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->