### PR TITLE
fix(desktop): harden Agent Studio repo switching

### DIFF
--- a/apps/desktop/src/pages/agents/agent-studio-repo-persistence-test-utils.ts
+++ b/apps/desktop/src/pages/agents/agent-studio-repo-persistence-test-utils.ts
@@ -1,0 +1,68 @@
+import { toContextStorageKey } from "./agent-studio-navigation";
+import { toTabsStorageKey } from "./agents-page-selection";
+import { toPersistedTaskTabs } from "./agents-page-session-tabs";
+
+export type TestStorageLike = Pick<
+  Storage,
+  "getItem" | "setItem" | "removeItem" | "clear" | "key"
+> & {
+  readonly length: number;
+};
+
+export const createMemoryStorage = (): TestStorageLike => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+};
+
+export const withMockedLocalStorage = async <T>(
+  storage: TestStorageLike,
+  run: () => Promise<T> | T,
+): Promise<T> => {
+  const originalStorage = globalThis.localStorage;
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: originalStorage,
+    });
+  }
+};
+
+export const seedRepoNavigationContexts = (
+  storage: Pick<Storage, "setItem">,
+  contexts: Record<string, Record<string, unknown>>,
+): void => {
+  for (const [repoPath, context] of Object.entries(contexts)) {
+    storage.setItem(toContextStorageKey(repoPath), JSON.stringify(context));
+  }
+};
+
+export const seedRepoTaskTabs = (
+  storage: Pick<Storage, "setItem">,
+  tabsByRepo: Record<string, { tabs: string[]; activeTaskId: string | null }>,
+): void => {
+  for (const [repoPath, persistedTabs] of Object.entries(tabsByRepo)) {
+    storage.setItem(toTabsStorageKey(repoPath), toPersistedTaskTabs(persistedTabs));
+  }
+};

--- a/apps/desktop/src/pages/agents/query-sync/agent-studio-navigation.ts
+++ b/apps/desktop/src/pages/agents/query-sync/agent-studio-navigation.ts
@@ -164,6 +164,26 @@ export const isSameNavigationState = (
   );
 };
 
+export const clearAgentStudioNavigationState = (
+  current: AgentStudioNavigationState,
+): AgentStudioNavigationState => {
+  return {
+    ...current,
+    taskId: "",
+    sessionId: null,
+    role: null,
+    scenario: null,
+  };
+};
+
+export const hasAgentStudioNavigationSelection = (
+  navigation: AgentStudioNavigationState,
+): boolean => {
+  return Boolean(
+    navigation.taskId || navigation.sessionId || navigation.role || navigation.scenario,
+  );
+};
+
 export const parsePersistedContext = (raw: string): PersistedAgentStudioContext => {
   let parsed: unknown;
   try {

--- a/apps/desktop/src/pages/agents/query-sync/use-agent-studio-query-session-sync.ts
+++ b/apps/desktop/src/pages/agents/query-sync/use-agent-studio-query-session-sync.ts
@@ -5,6 +5,7 @@ import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { AGENT_STUDIO_QUERY_KEYS, type AgentStudioQueryUpdate } from "./agent-studio-navigation";
 
 type UseAgentStudioQuerySessionSyncArgs = {
+  isRepoNavigationBoundaryPending: boolean;
   isLoadingTasks: boolean;
   tasks: TaskCard[];
   taskIdParam: string;
@@ -18,6 +19,7 @@ type UseAgentStudioQuerySessionSyncArgs = {
 };
 
 export function useAgentStudioQuerySessionSync({
+  isRepoNavigationBoundaryPending,
   isLoadingTasks,
   tasks,
   taskIdParam,
@@ -30,6 +32,9 @@ export function useAgentStudioQuerySessionSync({
   scheduleQueryUpdate,
 }: UseAgentStudioQuerySessionSyncArgs): void {
   useEffect(() => {
+    if (isRepoNavigationBoundaryPending) {
+      return;
+    }
     if (isLoadingTasks) {
       return;
     }
@@ -47,16 +52,30 @@ export function useAgentStudioQuerySessionSync({
       [AGENT_STUDIO_QUERY_KEYS.autostart]: undefined,
       [AGENT_STUDIO_QUERY_KEYS.start]: undefined,
     });
-  }, [isLoadingTasks, scheduleQueryUpdate, selectedSessionById, sessionParam, taskIdParam, tasks]);
+  }, [
+    isLoadingTasks,
+    isRepoNavigationBoundaryPending,
+    scheduleQueryUpdate,
+    selectedSessionById,
+    sessionParam,
+    taskIdParam,
+    tasks,
+  ]);
 
   useEffect(() => {
+    if (isRepoNavigationBoundaryPending) {
+      return;
+    }
     if (!selectedSessionById || taskIdParam) {
       return;
     }
     scheduleQueryUpdate({ [AGENT_STUDIO_QUERY_KEYS.task]: selectedSessionById.taskId });
-  }, [scheduleQueryUpdate, selectedSessionById, taskIdParam]);
+  }, [isRepoNavigationBoundaryPending, scheduleQueryUpdate, selectedSessionById, taskIdParam]);
 
   useEffect(() => {
+    if (isRepoNavigationBoundaryPending) {
+      return;
+    }
     if (!sessionParam) {
       return;
     }
@@ -71,9 +90,19 @@ export function useAgentStudioQuerySessionSync({
       return;
     }
     scheduleQueryUpdate({ [AGENT_STUDIO_QUERY_KEYS.session]: undefined });
-  }, [isActiveTaskHydrated, scheduleQueryUpdate, selectedSessionById, sessionParam, taskId]);
+  }, [
+    isActiveTaskHydrated,
+    isRepoNavigationBoundaryPending,
+    scheduleQueryUpdate,
+    selectedSessionById,
+    sessionParam,
+    taskId,
+  ]);
 
   useEffect(() => {
+    if (isRepoNavigationBoundaryPending) {
+      return;
+    }
     if (!activeSession) {
       return;
     }
@@ -97,5 +126,12 @@ export function useAgentStudioQuerySessionSync({
       return;
     }
     scheduleQueryUpdate(updates);
-  }, [activeSession, roleFromQuery, scheduleQueryUpdate, sessionParam, taskIdParam]);
+  }, [
+    activeSession,
+    isRepoNavigationBoundaryPending,
+    roleFromQuery,
+    scheduleQueryUpdate,
+    sessionParam,
+    taskIdParam,
+  ]);
 }

--- a/apps/desktop/src/pages/agents/query-sync/use-agent-studio-query-sync.ts
+++ b/apps/desktop/src/pages/agents/query-sync/use-agent-studio-query-sync.ts
@@ -22,6 +22,7 @@ export function useAgentStudioQuerySync({
   hasExplicitRoleParam: boolean;
   roleFromQuery: AgentRole;
   scenarioFromQuery: AgentScenario | null;
+  isRepoNavigationBoundaryPending: boolean;
   navigationPersistenceError: Error | null;
   retryNavigationPersistence: () => void;
   updateQuery: (updates: AgentStudioQueryUpdate) => void;
@@ -32,11 +33,12 @@ export function useAgentStudioQuerySync({
     setSearchParams,
   });
 
-  const { persistenceError, retryPersistenceRestore } = useRepoNavigationPersistence({
-    activeRepo,
-    navigation,
-    setNavigation,
-  });
+  const { isRepoNavigationBoundaryPending, persistenceError, retryPersistenceRestore } =
+    useRepoNavigationPersistence({
+      activeRepo,
+      navigation,
+      setNavigation,
+    });
 
   const hasExplicitRoleParam = navigation.role !== null;
   const roleFromQuery: AgentRole = navigation.role ?? "spec";
@@ -47,6 +49,7 @@ export function useAgentStudioQuerySync({
     hasExplicitRoleParam,
     roleFromQuery,
     scenarioFromQuery: navigation.scenario,
+    isRepoNavigationBoundaryPending,
     navigationPersistenceError: persistenceError,
     retryNavigationPersistence: retryPersistenceRestore,
     updateQuery,

--- a/apps/desktop/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
+++ b/apps/desktop/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
@@ -24,6 +24,28 @@ type UseRepoNavigationPersistenceResult = {
   retryPersistenceRestore: () => void;
 };
 
+export const resolveRepoNavigationBoundaryPending = ({
+  activeRepo,
+  lastActiveRepo,
+  boundaryRepo,
+  boundaryStatePending,
+}: {
+  activeRepo: string | null;
+  lastActiveRepo: string | null;
+  boundaryRepo: string | null;
+  boundaryStatePending: boolean;
+}): boolean => {
+  if (!activeRepo) {
+    return false;
+  }
+
+  return (
+    (Boolean(lastActiveRepo) && lastActiveRepo !== activeRepo) ||
+    boundaryRepo === activeRepo ||
+    boundaryStatePending
+  );
+};
+
 const readPersistedContextPayload = (storageKey: string): string | null => {
   try {
     return globalThis.localStorage.getItem(storageKey);
@@ -57,8 +79,14 @@ export function useRepoNavigationPersistence({
   const persistedContextPayloadRef = useRef<string | null>(null);
   const pendingContextPersistRef = useRef<{ key: string; payload: string } | null>(null);
   const pendingPersistTimeoutIdRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
-  const [isRepoNavigationBoundaryPending, setIsRepoNavigationBoundaryPending] = useState(false);
+  const [boundaryStatePending, setBoundaryStatePending] = useState(false);
   const [persistenceError, setPersistenceError] = useState<Error | null>(null);
+  const isRepoNavigationBoundaryPending = resolveRepoNavigationBoundaryPending({
+    activeRepo,
+    lastActiveRepo: lastActiveRepoRef.current,
+    boundaryRepo: pendingRepoNavigationBoundaryRepoRef.current,
+    boundaryStatePending,
+  });
 
   const flushPendingContextPersist = useCallback((): void => {
     const pendingPersist = pendingContextPersistRef.current;
@@ -108,7 +136,7 @@ export function useRepoNavigationPersistence({
     restoredContextRepoRef.current = null;
     persistedContextPayloadRef.current = null;
     pendingRepoNavigationBoundaryRepoRef.current = previousRepo && activeRepo ? activeRepo : null;
-    setIsRepoNavigationBoundaryPending(Boolean(pendingRepoNavigationBoundaryRepoRef.current));
+    setBoundaryStatePending(Boolean(pendingRepoNavigationBoundaryRepoRef.current));
 
     if (persistenceError) {
       setPersistenceError(null);
@@ -121,7 +149,7 @@ export function useRepoNavigationPersistence({
         return;
       }
       pendingRepoNavigationBoundaryRepoRef.current = null;
-      setIsRepoNavigationBoundaryPending(false);
+      setBoundaryStatePending(false);
       restoredContextRepoRef.current = null;
       persistedContextPayloadRef.current = null;
       setPersistenceError(null);
@@ -139,7 +167,7 @@ export function useRepoNavigationPersistence({
 
     if (!hasAgentStudioNavigationSelection(navigation)) {
       pendingRepoNavigationBoundaryRepoRef.current = null;
-      setIsRepoNavigationBoundaryPending(false);
+      setBoundaryStatePending(false);
       return;
     }
 

--- a/apps/desktop/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
+++ b/apps/desktop/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
@@ -24,26 +24,30 @@ type UseRepoNavigationPersistenceResult = {
   retryPersistenceRestore: () => void;
 };
 
-export const resolveRepoNavigationBoundaryPending = ({
+export type RepoNavigationBoundaryPhase = "idle" | "detecting" | "clearing";
+
+export const resolveRepoNavigationBoundaryPhase = ({
   activeRepo,
   lastActiveRepo,
   boundaryRepo,
-  boundaryStatePending,
 }: {
   activeRepo: string | null;
   lastActiveRepo: string | null;
   boundaryRepo: string | null;
-  boundaryStatePending: boolean;
-}): boolean => {
+}): RepoNavigationBoundaryPhase => {
   if (!activeRepo) {
-    return false;
+    return "idle";
   }
 
-  return (
-    (Boolean(lastActiveRepo) && lastActiveRepo !== activeRepo) ||
-    boundaryRepo === activeRepo ||
-    boundaryStatePending
-  );
+  if (Boolean(lastActiveRepo) && lastActiveRepo !== activeRepo) {
+    return "detecting";
+  }
+
+  if (boundaryRepo === activeRepo) {
+    return "clearing";
+  }
+
+  return "idle";
 };
 
 const readPersistedContextPayload = (storageKey: string): string | null => {
@@ -74,19 +78,18 @@ export function useRepoNavigationPersistence({
   setNavigation,
 }: UseRepoNavigationPersistenceArgs): UseRepoNavigationPersistenceResult {
   const lastActiveRepoRef = useRef<string | null>(activeRepo);
-  const pendingRepoNavigationBoundaryRepoRef = useRef<string | null>(null);
   const restoredContextRepoRef = useRef<string | null>(null);
   const persistedContextPayloadRef = useRef<string | null>(null);
   const pendingContextPersistRef = useRef<{ key: string; payload: string } | null>(null);
   const pendingPersistTimeoutIdRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
-  const [boundaryStatePending, setBoundaryStatePending] = useState(false);
+  const [boundaryRepo, setBoundaryRepo] = useState<string | null>(null);
   const [persistenceError, setPersistenceError] = useState<Error | null>(null);
-  const isRepoNavigationBoundaryPending = resolveRepoNavigationBoundaryPending({
+  const repoNavigationBoundaryPhase = resolveRepoNavigationBoundaryPhase({
     activeRepo,
     lastActiveRepo: lastActiveRepoRef.current,
-    boundaryRepo: pendingRepoNavigationBoundaryRepoRef.current,
-    boundaryStatePending,
+    boundaryRepo,
   });
+  const isRepoNavigationBoundaryPending = repoNavigationBoundaryPhase !== "idle";
 
   const flushPendingContextPersist = useCallback((): void => {
     const pendingPersist = pendingContextPersistRef.current;
@@ -135,8 +138,7 @@ export function useRepoNavigationPersistence({
     lastActiveRepoRef.current = activeRepo;
     restoredContextRepoRef.current = null;
     persistedContextPayloadRef.current = null;
-    pendingRepoNavigationBoundaryRepoRef.current = previousRepo && activeRepo ? activeRepo : null;
-    setBoundaryStatePending(Boolean(pendingRepoNavigationBoundaryRepoRef.current));
+    setBoundaryRepo(previousRepo && activeRepo ? activeRepo : null);
 
     if (persistenceError) {
       setPersistenceError(null);
@@ -148,8 +150,7 @@ export function useRepoNavigationPersistence({
       if (!tryFlushPendingContextPersist()) {
         return;
       }
-      pendingRepoNavigationBoundaryRepoRef.current = null;
-      setBoundaryStatePending(false);
+      setBoundaryRepo(null);
       restoredContextRepoRef.current = null;
       persistedContextPayloadRef.current = null;
       setPersistenceError(null);
@@ -157,22 +158,17 @@ export function useRepoNavigationPersistence({
   }, [activeRepo, tryFlushPendingContextPersist]);
 
   useEffect(() => {
-    if (
-      !activeRepo ||
-      pendingRepoNavigationBoundaryRepoRef.current !== activeRepo ||
-      !isRepoNavigationBoundaryPending
-    ) {
+    if (!activeRepo || repoNavigationBoundaryPhase !== "clearing") {
       return;
     }
 
     if (!hasAgentStudioNavigationSelection(navigation)) {
-      pendingRepoNavigationBoundaryRepoRef.current = null;
-      setBoundaryStatePending(false);
+      setBoundaryRepo(null);
       return;
     }
 
     setNavigation((current) => clearAgentStudioNavigationState(current));
-  }, [activeRepo, isRepoNavigationBoundaryPending, navigation, setNavigation]);
+  }, [activeRepo, navigation, repoNavigationBoundaryPhase, setNavigation]);
 
   useEffect(() => {
     if (!activeRepo) {
@@ -181,10 +177,7 @@ export function useRepoNavigationPersistence({
     if (persistenceError) {
       return;
     }
-    if (
-      isRepoNavigationBoundaryPending ||
-      pendingRepoNavigationBoundaryRepoRef.current === activeRepo
-    ) {
+    if (isRepoNavigationBoundaryPending) {
       return;
     }
     if (restoredContextRepoRef.current === activeRepo) {
@@ -223,7 +216,6 @@ export function useRepoNavigationPersistence({
     if (
       !activeRepo ||
       isRepoNavigationBoundaryPending ||
-      pendingRepoNavigationBoundaryRepoRef.current === activeRepo ||
       persistenceError ||
       restoredContextRepoRef.current !== activeRepo
     ) {

--- a/apps/desktop/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
+++ b/apps/desktop/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
@@ -204,7 +204,7 @@ export function useRepoNavigationPersistence({
     }
 
     setNavigation((current) => {
-      if (current.taskId || current.sessionId) {
+      if (hasAgentStudioNavigationSelection(current)) {
         return current;
       }
 

--- a/apps/desktop/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
+++ b/apps/desktop/src/pages/agents/query-sync/use-repo-navigation-persistence.ts
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { errorMessage } from "@/lib/errors";
 import {
   type AgentStudioNavigationState,
+  clearAgentStudioNavigationState,
+  hasAgentStudioNavigationSelection,
   type PersistedAgentStudioContext,
   parsePersistedContext,
   restoreNavigationFromPersistedContext,
@@ -17,6 +19,7 @@ type UseRepoNavigationPersistenceArgs = {
 };
 
 type UseRepoNavigationPersistenceResult = {
+  isRepoNavigationBoundaryPending: boolean;
   persistenceError: Error | null;
   retryPersistenceRestore: () => void;
 };
@@ -49,10 +52,12 @@ export function useRepoNavigationPersistence({
   setNavigation,
 }: UseRepoNavigationPersistenceArgs): UseRepoNavigationPersistenceResult {
   const lastActiveRepoRef = useRef<string | null>(activeRepo);
+  const pendingRepoNavigationBoundaryRepoRef = useRef<string | null>(null);
   const restoredContextRepoRef = useRef<string | null>(null);
   const persistedContextPayloadRef = useRef<string | null>(null);
   const pendingContextPersistRef = useRef<{ key: string; payload: string } | null>(null);
   const pendingPersistTimeoutIdRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+  const [isRepoNavigationBoundaryPending, setIsRepoNavigationBoundaryPending] = useState(false);
   const [persistenceError, setPersistenceError] = useState<Error | null>(null);
 
   const flushPendingContextPersist = useCallback((): void => {
@@ -98,7 +103,13 @@ export function useRepoNavigationPersistence({
       return;
     }
 
+    const previousRepo = lastActiveRepoRef.current;
     lastActiveRepoRef.current = activeRepo;
+    restoredContextRepoRef.current = null;
+    persistedContextPayloadRef.current = null;
+    pendingRepoNavigationBoundaryRepoRef.current = previousRepo && activeRepo ? activeRepo : null;
+    setIsRepoNavigationBoundaryPending(Boolean(pendingRepoNavigationBoundaryRepoRef.current));
+
     if (persistenceError) {
       setPersistenceError(null);
     }
@@ -109,6 +120,8 @@ export function useRepoNavigationPersistence({
       if (!tryFlushPendingContextPersist()) {
         return;
       }
+      pendingRepoNavigationBoundaryRepoRef.current = null;
+      setIsRepoNavigationBoundaryPending(false);
       restoredContextRepoRef.current = null;
       persistedContextPayloadRef.current = null;
       setPersistenceError(null);
@@ -116,10 +129,34 @@ export function useRepoNavigationPersistence({
   }, [activeRepo, tryFlushPendingContextPersist]);
 
   useEffect(() => {
+    if (
+      !activeRepo ||
+      pendingRepoNavigationBoundaryRepoRef.current !== activeRepo ||
+      !isRepoNavigationBoundaryPending
+    ) {
+      return;
+    }
+
+    if (!hasAgentStudioNavigationSelection(navigation)) {
+      pendingRepoNavigationBoundaryRepoRef.current = null;
+      setIsRepoNavigationBoundaryPending(false);
+      return;
+    }
+
+    setNavigation((current) => clearAgentStudioNavigationState(current));
+  }, [activeRepo, isRepoNavigationBoundaryPending, navigation, setNavigation]);
+
+  useEffect(() => {
     if (!activeRepo) {
       return;
     }
     if (persistenceError) {
+      return;
+    }
+    if (
+      isRepoNavigationBoundaryPending ||
+      pendingRepoNavigationBoundaryRepoRef.current === activeRepo
+    ) {
       return;
     }
     if (restoredContextRepoRef.current === activeRepo) {
@@ -152,10 +189,16 @@ export function useRepoNavigationPersistence({
 
       return restoreNavigationFromPersistedContext(current, persisted);
     });
-  }, [activeRepo, persistenceError, setNavigation]);
+  }, [activeRepo, isRepoNavigationBoundaryPending, persistenceError, setNavigation]);
 
   useEffect(() => {
-    if (!activeRepo || persistenceError || restoredContextRepoRef.current !== activeRepo) {
+    if (
+      !activeRepo ||
+      isRepoNavigationBoundaryPending ||
+      pendingRepoNavigationBoundaryRepoRef.current === activeRepo ||
+      persistenceError ||
+      restoredContextRepoRef.current !== activeRepo
+    ) {
       return;
     }
 
@@ -196,6 +239,7 @@ export function useRepoNavigationPersistence({
     };
   }, [
     activeRepo,
+    isRepoNavigationBoundaryPending,
     navigation,
     persistenceError,
     surfacePersistenceWriteError,
@@ -223,6 +267,7 @@ export function useRepoNavigationPersistence({
   }, [tryFlushPendingContextPersist]);
 
   return {
+    isRepoNavigationBoundaryPending,
     persistenceError,
     retryPersistenceRestore,
   };

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -195,40 +195,41 @@ let readinessState: ReadinessState = {
 };
 const rightPanelToggleModel = { label: "Toggle panel" };
 const rightPanelModel = { kind: "documents" };
+const baseSessionStartModal: SessionStartModalModel = {
+  open: true,
+  title: "Start Planner Session",
+  description: "Pick a model and launch a session.",
+  confirmLabel: "Start session",
+  selectedModelSelection: null,
+  selectedRuntimeKind: "opencode",
+  runtimeOptions: [],
+  supportsProfiles: true,
+  supportsVariants: true,
+  isSelectionCatalogLoading: false,
+  agentOptions: [],
+  modelOptions: [],
+  modelGroups: [],
+  variantOptions: [],
+  availableStartModes: ["fresh"],
+  selectedStartMode: "fresh",
+  existingSessionOptions: [],
+  selectedSourceSessionId: "",
+  onSelectStartMode: mock(() => {}),
+  onSelectSourceSession: mock(() => {}),
+  onSelectRuntime: mock(() => {}),
+  onSelectAgent: mock(() => {}),
+  onSelectModel: mock(() => {}),
+  onSelectVariant: mock(() => {}),
+  isStarting: false,
+  onOpenChange: mock(() => {}),
+  onConfirm: mock(() => {}),
+};
 let orchestrationState: OrchestrationState = {
   repoSettings: null,
   chatSettingsLoadError: new Error("chat settings failed"),
   retryChatSettingsLoad,
   humanReviewFeedbackModal: { kind: "feedback" },
-  sessionStartModal: {
-    open: true,
-    title: "Start Planner Session",
-    description: "Pick a model and launch a session.",
-    confirmLabel: "Start session",
-    selectedModelSelection: null,
-    selectedRuntimeKind: "opencode",
-    runtimeOptions: [],
-    supportsProfiles: true,
-    supportsVariants: true,
-    isSelectionCatalogLoading: false,
-    agentOptions: [],
-    modelOptions: [],
-    modelGroups: [],
-    variantOptions: [],
-    availableStartModes: ["fresh"],
-    selectedStartMode: "fresh",
-    existingSessionOptions: [],
-    selectedSourceSessionId: "",
-    onSelectStartMode: mock(() => {}),
-    onSelectSourceSession: mock(() => {}),
-    onSelectRuntime: mock(() => {}),
-    onSelectAgent: mock(() => {}),
-    onSelectModel: mock(() => {}),
-    onSelectVariant: mock(() => {}),
-    isStarting: false,
-    onOpenChange: mock(() => {}),
-    onConfirm: mock(() => {}),
-  },
+  sessionStartModal: { ...baseSessionStartModal },
   startSessionRequest: async () => undefined,
   activeTabValue: "task-1",
   agentStudioTaskTabsModel: { tabs: [] },
@@ -330,10 +331,6 @@ beforeEach(async () => {
   mock.restore();
   registerModuleMocks();
   ({ useAgentsPageShellModel } = await import("./use-agents-page-shell-model"));
-  const sessionStartModal = orchestrationState.sessionStartModal;
-  if (!sessionStartModal) {
-    throw new Error("Expected base session start modal fixture.");
-  }
   workspaceState = {
     activeRepo: "/repo",
     activeBranch: "main",
@@ -424,7 +421,7 @@ beforeEach(async () => {
     retryChatSettingsLoad,
     humanReviewFeedbackModal: { kind: "feedback" },
     sessionStartModal: {
-      ...sessionStartModal,
+      ...baseSessionStartModal,
     },
     startSessionRequest: async () => undefined,
     activeTabValue: "task-1",
@@ -522,6 +519,38 @@ describe("useAgentsPageShellModel", () => {
       expect(state.hasSelectedTask).toBe(false);
       expect(state.sessionStartModal).toBeNull();
       expect(state.mergedPullRequestModal).toBeNull();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("keeps the shell stable while repo-boundary reset clears stale Agent Studio selection", async () => {
+    querySyncState = {
+      ...querySyncState,
+      isRepoNavigationBoundaryPending: true,
+    };
+    selectionState = {
+      ...selectionState,
+      viewTaskId: "",
+      viewSelectedTask: null,
+      viewActiveSession: null,
+      taskId: "",
+      activeSession: null,
+      selectedSessionById: {},
+      sessionsForTask: [],
+      viewSessionsForTask: [],
+    };
+
+    const harness = createHookHarness();
+
+    try {
+      await harness.mount();
+
+      const state = harness.getLatest();
+      expect(state.activeRepo).toBe("/repo");
+      expect(state.hasSelectedTask).toBe(false);
+      expect(state.isRightPanelVisible).toBe(true);
+      expect(state.taskDetailsSheet).not.toBeNull();
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.test.tsx
@@ -33,6 +33,7 @@ type QuerySyncState = {
   hasExplicitRoleParam: boolean;
   roleFromQuery: "planner";
   scenarioFromQuery: "planner_initial";
+  isRepoNavigationBoundaryPending: boolean;
   navigationPersistenceError: Error | null;
   retryNavigationPersistence: typeof retryNavigationPersistence;
   updateQuery: typeof updateQuery;
@@ -158,6 +159,7 @@ let querySyncState: QuerySyncState = {
   hasExplicitRoleParam: false,
   roleFromQuery: "planner" as const,
   scenarioFromQuery: "planner_initial" as const,
+  isRepoNavigationBoundaryPending: false,
   navigationPersistenceError: new Error("navigation failed"),
   retryNavigationPersistence,
   updateQuery,
@@ -382,6 +384,7 @@ beforeEach(async () => {
     hasExplicitRoleParam: false,
     roleFromQuery: "planner",
     scenarioFromQuery: "planner_initial",
+    isRepoNavigationBoundaryPending: false,
     navigationPersistenceError: new Error("navigation failed"),
     retryNavigationPersistence,
     updateQuery,

--- a/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
+++ b/apps/desktop/src/pages/agents/shell/use-agents-page-shell-model.tsx
@@ -115,6 +115,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
     hasExplicitRoleParam,
     roleFromQuery,
     scenarioFromQuery,
+    isRepoNavigationBoundaryPending,
     navigationPersistenceError,
     retryNavigationPersistence,
     updateQuery,
@@ -150,6 +151,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
 
   const selection = useAgentStudioSelectionController({
     activeRepo,
+    isRepoNavigationBoundaryPending,
     tasks,
     isLoadingTasks: isForegroundLoadingTasks,
     sessions,
@@ -235,6 +237,7 @@ export function useAgentsPageShellModel(): AgentsPageShellModel {
   ]);
 
   useAgentStudioQuerySessionSync({
+    isRepoNavigationBoundaryPending,
     isLoadingTasks: isForegroundLoadingTasks,
     tasks,
     taskIdParam,

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-session-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-session-sync.test.tsx
@@ -29,6 +29,7 @@ const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useHookHarness, initialProps);
 
 const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
+  isRepoNavigationBoundaryPending: false,
   isLoadingTasks: false,
   tasks: [createTask("task-1")],
   taskIdParam: "task-1",
@@ -104,6 +105,29 @@ describe("useAgentStudioQuerySessionSync", () => {
         taskIdParam: "missing-task",
         sessionParam: "session-2",
         taskId: "",
+        scheduleQueryUpdate,
+      }),
+    );
+
+    try {
+      await harness.mount();
+      expect(scheduleQueryUpdate).toHaveBeenCalledTimes(0);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("skips query reconciliation while repo navigation boundary reset is pending", async () => {
+    const scheduleQueryUpdate = mock((_updates: Record<string, string | undefined>) => {});
+    const selectedSession = createSession("task-2", "session-2");
+    const harness = createHookHarness(
+      createBaseArgs({
+        isRepoNavigationBoundaryPending: true,
+        tasks: [createTask("task-1"), createTask("task-2")],
+        taskIdParam: "task-1",
+        sessionParam: "session-2",
+        selectedSessionById: selectedSession,
+        taskId: "task-1",
         scheduleQueryUpdate,
       }),
     );

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
@@ -2,6 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { useState } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
 import {
+  createMemoryStorage,
+  seedRepoNavigationContexts,
+  withMockedLocalStorage,
+} from "./agent-studio-repo-persistence-test-utils";
+import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
@@ -12,30 +17,6 @@ enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioQuerySync>[0];
 type SearchParamsCall = Parameters<SetURLSearchParams>;
-
-type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem" | "clear" | "key"> & {
-  readonly length: number;
-};
-
-const createMemoryStorage = (): StorageLike => {
-  const store = new Map<string, string>();
-  return {
-    getItem: (key) => store.get(key) ?? null,
-    setItem: (key, value) => {
-      store.set(key, value);
-    },
-    removeItem: (key) => {
-      store.delete(key);
-    },
-    clear: () => {
-      store.clear();
-    },
-    key: (index) => Array.from(store.keys())[index] ?? null,
-    get length() {
-      return store.size;
-    },
-  };
-};
 
 const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useAgentStudioQuerySync, initialProps);
@@ -339,21 +320,11 @@ describe("useAgentStudioQuerySync", () => {
 
   test("restores repo-scoped URL context when switching back to a previous repository", async () => {
     const memoryStorage = createMemoryStorage();
-    const originalStorage = globalThis.localStorage;
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      value: memoryStorage,
-    });
-
-    try {
-      memoryStorage.setItem(
-        toContextStorageKey("/repo-a"),
-        JSON.stringify({ taskId: "task-a", role: "spec", sessionId: "session-a" }),
-      );
-      memoryStorage.setItem(
-        toContextStorageKey("/repo-b"),
-        JSON.stringify({ taskId: "task-b", role: "planner", sessionId: "session-b" }),
-      );
+    await withMockedLocalStorage(memoryStorage, async () => {
+      seedRepoNavigationContexts(memoryStorage, {
+        "/repo-a": { taskId: "task-a", role: "spec", sessionId: "session-a" },
+        "/repo-b": { taskId: "task-b", role: "planner", sessionId: "session-b" },
+      });
 
       const harness = createStatefulQuerySyncHarness({
         activeRepo: "/repo-a",
@@ -375,31 +346,16 @@ describe("useAgentStudioQuerySync", () => {
       expect(latest.roleFromQuery).toBe("spec");
 
       await harness.unmount();
-    } finally {
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        value: originalStorage,
-      });
-    }
+    });
   });
 
   test("rapid repo changes keep the final repository context authoritative", async () => {
     const memoryStorage = createMemoryStorage();
-    const originalStorage = globalThis.localStorage;
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      value: memoryStorage,
-    });
-
-    try {
-      memoryStorage.setItem(
-        toContextStorageKey("/repo-a"),
-        JSON.stringify({ taskId: "task-a", role: "spec", sessionId: "session-a" }),
-      );
-      memoryStorage.setItem(
-        toContextStorageKey("/repo-b"),
-        JSON.stringify({ taskId: "task-b", role: "planner", sessionId: "session-b" }),
-      );
+    await withMockedLocalStorage(memoryStorage, async () => {
+      seedRepoNavigationContexts(memoryStorage, {
+        "/repo-a": { taskId: "task-a", role: "spec", sessionId: "session-a" },
+        "/repo-b": { taskId: "task-b", role: "planner", sessionId: "session-b" },
+      });
 
       const harness = createStatefulQuerySyncHarness({
         activeRepo: "/repo-a",
@@ -419,12 +375,7 @@ describe("useAgentStudioQuerySync", () => {
       expect(latest.roleFromQuery).toBe("spec");
 
       await harness.unmount();
-    } finally {
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        value: originalStorage,
-      });
-    }
+    });
   });
 
   test("flushes pending context persistence on unmount cleanup", async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
@@ -337,6 +337,96 @@ describe("useAgentStudioQuerySync", () => {
     }
   });
 
+  test("restores repo-scoped URL context when switching back to a previous repository", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toContextStorageKey("/repo-a"),
+        JSON.stringify({ taskId: "task-a", role: "spec", sessionId: "session-a" }),
+      );
+      memoryStorage.setItem(
+        toContextStorageKey("/repo-b"),
+        JSON.stringify({ taskId: "task-b", role: "planner", sessionId: "session-b" }),
+      );
+
+      const harness = createStatefulQuerySyncHarness({
+        activeRepo: "/repo-a",
+        initialSearchParams: "",
+      });
+
+      await harness.mount();
+      await harness.waitFor((state) => state.taskIdParam === "task-a");
+
+      await harness.update({ activeRepo: "/repo-b", initialSearchParams: "" });
+      await harness.waitFor((state) => state.taskIdParam === "task-b");
+
+      await harness.update({ activeRepo: "/repo-a", initialSearchParams: "" });
+      await harness.waitFor((state) => state.taskIdParam === "task-a");
+
+      const latest = harness.getLatest();
+      expect(latest.taskIdParam).toBe("task-a");
+      expect(latest.sessionParam).toBe("session-a");
+      expect(latest.roleFromQuery).toBe("spec");
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("rapid repo changes keep the final repository context authoritative", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toContextStorageKey("/repo-a"),
+        JSON.stringify({ taskId: "task-a", role: "spec", sessionId: "session-a" }),
+      );
+      memoryStorage.setItem(
+        toContextStorageKey("/repo-b"),
+        JSON.stringify({ taskId: "task-b", role: "planner", sessionId: "session-b" }),
+      );
+
+      const harness = createStatefulQuerySyncHarness({
+        activeRepo: "/repo-a",
+        initialSearchParams: "",
+      });
+
+      await harness.mount();
+      await harness.waitFor((state) => state.taskIdParam === "task-a");
+
+      await harness.update({ activeRepo: "/repo-b", initialSearchParams: "" });
+      await harness.update({ activeRepo: "/repo-a", initialSearchParams: "" });
+      await harness.waitFor((state) => state.taskIdParam === "task-a");
+
+      const latest = harness.getLatest();
+      expect(latest.taskIdParam).toBe("task-a");
+      expect(latest.sessionParam).toBe("session-a");
+      expect(latest.roleFromQuery).toBe("spec");
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
   test("flushes pending context persistence on unmount cleanup", async () => {
     const memoryStorage = createMemoryStorage();
     const originalStorage = globalThis.localStorage;

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { useState } from "react";
 import type { SetURLSearchParams } from "react-router-dom";
 import {
   createHookHarness as createSharedHookHarness,
@@ -38,6 +39,38 @@ const createMemoryStorage = (): StorageLike => {
 
 const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useAgentStudioQuerySync, initialProps);
+
+const createStatefulQuerySyncHarness = (
+  initialProps: Pick<HookArgs, "activeRepo"> & { initialSearchParams: string },
+) =>
+  createSharedHookHarness(
+    ({
+      activeRepo,
+      initialSearchParams,
+    }: Pick<HookArgs, "activeRepo"> & {
+      initialSearchParams: string;
+    }) => {
+      const [searchParams, setSearchParamsState] = useState(
+        () => new URLSearchParams(initialSearchParams),
+      );
+      const setSearchParams: SetURLSearchParams = (nextInit) => {
+        if (nextInit instanceof URLSearchParams) {
+          setSearchParamsState(new URLSearchParams(nextInit));
+          return;
+        }
+
+        throw new Error("Expected URLSearchParams update in test harness");
+      };
+
+      return useAgentStudioQuerySync({
+        activeRepo,
+        navigationType: "REPLACE",
+        searchParams,
+        setSearchParams,
+      });
+    },
+    initialProps,
+  );
 
 describe("useAgentStudioQuerySync", () => {
   test("parses initial search params and syncs updates through a root-owned URL effect", async () => {
@@ -248,6 +281,53 @@ describe("useAgentStudioQuerySync", () => {
       expect(latest.sessionParam).toBe("session-from-url");
       expect(latest.roleFromQuery).toBe("spec");
       expect(latest.hasExplicitRoleParam).toBe(true);
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("clears stale URL authority on repo switch before restoring the next repo context", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toContextStorageKey("/repo-b"),
+        JSON.stringify({
+          taskId: "task-from-repo-b",
+          role: "planner",
+          sessionId: "session-from-repo-b",
+        }),
+      );
+
+      const harness = createStatefulQuerySyncHarness({
+        activeRepo: "/repo-a",
+        initialSearchParams: "task=task-from-repo-a&session=session-from-repo-a&agent=build",
+      });
+
+      await harness.mount();
+
+      await harness.update({
+        activeRepo: "/repo-b",
+        initialSearchParams: "task=task-from-repo-a&session=session-from-repo-a&agent=build",
+      });
+
+      await harness.waitFor((state) => state.taskIdParam === "task-from-repo-b");
+
+      const latest = harness.getLatest();
+      expect(latest.isRepoNavigationBoundaryPending).toBeFalse();
+      expect(latest.taskIdParam).toBe("task-from-repo-b");
+      expect(latest.sessionParam).toBe("session-from-repo-b");
+      expect(latest.roleFromQuery).toBe("planner");
+
       await harness.unmount();
     } finally {
       Object.defineProperty(globalThis, "localStorage", {

--- a/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-query-sync.test.tsx
@@ -273,13 +273,7 @@ describe("useAgentStudioQuerySync", () => {
 
   test("clears stale URL authority on repo switch before restoring the next repo context", async () => {
     const memoryStorage = createMemoryStorage();
-    const originalStorage = globalThis.localStorage;
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      value: memoryStorage,
-    });
-
-    try {
+    await withMockedLocalStorage(memoryStorage, async () => {
       memoryStorage.setItem(
         toContextStorageKey("/repo-b"),
         JSON.stringify({
@@ -310,12 +304,7 @@ describe("useAgentStudioQuerySync", () => {
       expect(latest.roleFromQuery).toBe("planner");
 
       await harness.unmount();
-    } finally {
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        value: originalStorage,
-      });
-    }
+    });
   });
 
   test("restores repo-scoped URL context when switching back to a previous repository", async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
@@ -40,6 +40,7 @@ const createHookHarness = (initialProps: HookArgs) =>
 
 const createBaseArgs = (overrides: Partial<HookArgs> = {}): HookArgs => ({
   activeRepo: null,
+  isRepoNavigationBoundaryPending: false,
   agentStudioReadinessState: "ready",
   tasks: [createTask("task-1"), createTask("task-2")],
   isLoadingTasks: false,
@@ -144,6 +145,39 @@ describe("useAgentStudioSelectionController", () => {
       expect(latest.activeSession?.sessionId).toBe("session-2");
       expect(latest.viewTaskId).toBe("task-2");
       expect(latest.viewActiveSession?.sessionId).toBe("session-2");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("suppresses stale query task and session selection while repo boundary reset is pending", async () => {
+    const staleSession = createSession("task-1", "session-1", {
+      role: "build",
+      scenario: "build_implementation_start",
+      status: "running",
+    });
+    const harness = createHookHarness(
+      createBaseArgs({
+        isRepoNavigationBoundaryPending: true,
+        sessions: [staleSession],
+        taskIdParam: "task-1",
+        sessionParam: "session-1",
+        hasExplicitRoleParam: true,
+        roleFromQuery: "build",
+        scenarioFromQuery: "build_implementation_start",
+      }),
+    );
+
+    try {
+      await harness.mount();
+
+      const latest = harness.getLatest();
+      expect(latest.selectedSessionById).toBeNull();
+      expect(latest.taskId).toBe("");
+      expect(latest.selectedTask).toBeNull();
+      expect(latest.activeSession).toBeNull();
+      expect(latest.viewTaskId).toBe("");
+      expect(latest.viewActiveSession).toBeNull();
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.test.tsx
@@ -151,7 +151,13 @@ describe("useAgentStudioSelectionController", () => {
   });
 
   test("suppresses stale query task and session selection while repo boundary reset is pending", async () => {
+    const readSessionModelCatalog = mock(async () => emptyCatalog);
+    const readSessionTodos = mock(async () => []);
+    const hydrateRequestedTaskSessionHistory = mock(async () => {});
     const staleSession = createSession("task-1", "session-1", {
+      runtimeKind: "opencode",
+      runtimeEndpoint: "http://runtime",
+      workingDirectory: "/repo-a",
       role: "build",
       scenario: "build_implementation_start",
       status: "running",
@@ -165,6 +171,9 @@ describe("useAgentStudioSelectionController", () => {
         hasExplicitRoleParam: true,
         roleFromQuery: "build",
         scenarioFromQuery: "build_implementation_start",
+        readSessionModelCatalog,
+        readSessionTodos,
+        hydrateRequestedTaskSessionHistory,
       }),
     );
 
@@ -178,6 +187,9 @@ describe("useAgentStudioSelectionController", () => {
       expect(latest.activeSession).toBeNull();
       expect(latest.viewTaskId).toBe("");
       expect(latest.viewActiveSession).toBeNull();
+      expect(readSessionModelCatalog).toHaveBeenCalledTimes(0);
+      expect(readSessionTodos).toHaveBeenCalledTimes(0);
+      expect(hydrateRequestedTaskSessionHistory).toHaveBeenCalledTimes(0);
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -20,6 +20,7 @@ import { useAgentStudioTaskTabs } from "./use-agent-studio-task-tabs";
 
 type UseAgentStudioSelectionControllerArgs = {
   activeRepo: string | null;
+  isRepoNavigationBoundaryPending: boolean;
   agentStudioReadinessState: AgentStudioReadinessState;
   tasks: TaskCard[];
   isLoadingTasks: boolean;
@@ -147,6 +148,7 @@ export const buildSessionsByTaskIdWithCache = (
 
 export function useAgentStudioSelectionController({
   activeRepo,
+  isRepoNavigationBoundaryPending,
   agentStudioReadinessState,
   tasks,
   isLoadingTasks,
@@ -164,6 +166,15 @@ export function useAgentStudioSelectionController({
   onContextSwitchIntent,
 }: UseAgentStudioSelectionControllerArgs): AgentStudioSelectionControllerResult {
   const sessionsByTaskSortCacheRef = useRef<SessionsByTaskSortCache>(new Map());
+  const effectiveTaskIdParam = isRepoNavigationBoundaryPending ? "" : taskIdParam;
+  const effectiveSessionParam = isRepoNavigationBoundaryPending ? null : sessionParam;
+  const effectiveHasExplicitRoleParam = isRepoNavigationBoundaryPending
+    ? false
+    : hasExplicitRoleParam;
+  const effectiveRoleFromQuery: AgentRole = isRepoNavigationBoundaryPending
+    ? "spec"
+    : roleFromQuery;
+  const effectiveScenarioFromQuery = isRepoNavigationBoundaryPending ? null : scenarioFromQuery;
 
   const tasksById = useMemo(() => {
     return new Map(tasks.map((task) => [task.id, task]));
@@ -183,12 +194,12 @@ export function useAgentStudioSelectionController({
   }, [sessions]);
 
   const selectedSessionById = useMemo(
-    () => (sessionParam ? (sessionsById.get(sessionParam) ?? null) : null),
-    [sessionParam, sessionsById],
+    () => (effectiveSessionParam ? (sessionsById.get(effectiveSessionParam) ?? null) : null),
+    [effectiveSessionParam, sessionsById],
   );
 
   const taskId = resolveAgentStudioTaskId({
-    taskIdParam,
+    taskIdParam: effectiveTaskIdParam,
     selectedSessionById,
   });
 
@@ -207,19 +218,19 @@ export function useAgentStudioSelectionController({
   const activeSession = useMemo(() => {
     return resolveAgentStudioSessionSelection({
       sessionsForTask,
-      sessionParam,
-      hasExplicitRoleParam,
-      roleFromQuery,
+      sessionParam: effectiveSessionParam,
+      hasExplicitRoleParam: effectiveHasExplicitRoleParam,
+      roleFromQuery: effectiveRoleFromQuery,
       selectedTask,
-      fallbackRole: roleFromQuery,
-      scenarioFromQuery,
+      fallbackRole: effectiveRoleFromQuery,
+      scenarioFromQuery: effectiveScenarioFromQuery,
     }).activeSession;
   }, [
-    hasExplicitRoleParam,
-    roleFromQuery,
-    scenarioFromQuery,
+    effectiveHasExplicitRoleParam,
+    effectiveRoleFromQuery,
+    effectiveScenarioFromQuery,
+    effectiveSessionParam,
     selectedTask,
-    sessionParam,
     sessionsForTask,
   ]);
   const hydratedActiveSession = useAgentStudioActiveSessionRuntimeData({
@@ -288,34 +299,34 @@ export function useAgentStudioSelectionController({
   }, [sessionsByTaskId, viewTaskId]);
 
   const viewSessionParam = useMemo(() => {
-    if (!sessionParam) {
+    if (!effectiveSessionParam) {
       return null;
     }
 
     const belongsToViewTask = viewSessionsForTask.some(
-      (session) => session.sessionId === sessionParam,
+      (session) => session.sessionId === effectiveSessionParam,
     );
-    return belongsToViewTask ? sessionParam : null;
-  }, [sessionParam, viewSessionsForTask]);
+    return belongsToViewTask ? effectiveSessionParam : null;
+  }, [effectiveSessionParam, viewSessionsForTask]);
 
   const isViewTaskDetachedFromQuery = Boolean(viewTaskId && taskId && viewTaskId !== taskId);
-  const hasViewRoleSelection = hasExplicitRoleParam && !isViewTaskDetachedFromQuery;
+  const hasViewRoleSelection = effectiveHasExplicitRoleParam && !isViewTaskDetachedFromQuery;
 
   const viewSelection = useMemo(() => {
     return resolveAgentStudioSessionSelection({
       sessionsForTask: viewSessionsForTask,
       sessionParam: viewSessionParam,
       hasExplicitRoleParam: hasViewRoleSelection,
-      roleFromQuery,
+      roleFromQuery: effectiveRoleFromQuery,
       selectedTask: viewSelectedTask,
-      fallbackRole: isViewTaskDetachedFromQuery ? "spec" : roleFromQuery,
-      scenarioFromQuery,
+      fallbackRole: isViewTaskDetachedFromQuery ? "spec" : effectiveRoleFromQuery,
+      scenarioFromQuery: effectiveScenarioFromQuery,
     });
   }, [
     hasViewRoleSelection,
     isViewTaskDetachedFromQuery,
-    roleFromQuery,
-    scenarioFromQuery,
+    effectiveRoleFromQuery,
+    effectiveScenarioFromQuery,
     viewSelectedTask,
     viewSessionParam,
     viewSessionsForTask,

--- a/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-selection-controller.ts
@@ -273,6 +273,7 @@ export function useAgentStudioSelectionController({
     handleCloseTab,
   } = useAgentStudioTaskTabs({
     activeRepo,
+    isRepoNavigationBoundaryPending,
     taskId,
     selectedTask,
     tasks,

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs-selection.ts
@@ -6,6 +6,7 @@ type SetState<T> = Dispatch<SetStateAction<T>>;
 
 type UseTaskTabSelectionArgs = {
   activeRepo: string | null;
+  isRepoNavigationBoundaryPending: boolean;
   taskId: string;
   openTaskTabs: string[];
   persistedActiveTaskId: string | null;
@@ -28,6 +29,7 @@ type UseTaskTabSelectionResult = {
 export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSelectionResult {
   const {
     activeRepo,
+    isRepoNavigationBoundaryPending,
     taskId,
     openTaskTabs,
     persistedActiveTaskId,
@@ -70,7 +72,7 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
   }, [intentActiveTaskId, setIntentActiveTaskId, tabTaskIds, taskId]);
 
   useEffect(() => {
-    if (!activeRepo || tabsStorageHydratedRepo !== activeRepo) {
+    if (!activeRepo || tabsStorageHydratedRepo !== activeRepo || isRepoNavigationBoundaryPending) {
       return;
     }
     if (taskId || tabTaskIds.length === 0) {
@@ -91,6 +93,7 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
     navigateToTaskIntent(fallbackTaskId);
   }, [
     activeRepo,
+    isRepoNavigationBoundaryPending,
     navigateToTaskIntent,
     persistedActiveTaskId,
     tabTaskIds,
@@ -99,10 +102,10 @@ export function useTaskTabSelection(args: UseTaskTabSelectionArgs): UseTaskTabSe
   ]);
 
   useEffect(() => {
-    if (!activeRepo || taskId) {
+    if (!activeRepo || taskId || isRepoNavigationBoundaryPending) {
       appliedFallbackKeyRef.current = null;
     }
-  }, [activeRepo, taskId]);
+  }, [activeRepo, isRepoNavigationBoundaryPending, taskId]);
 
   const handleSelectTab = useCallback(
     (nextTaskId: string): void => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -551,6 +551,86 @@ describe("useAgentStudioTaskTabs", () => {
     }
   });
 
+  test("restores repo-scoped fallback tabs when switching away and back", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toTabsStorageKey("/repo-a"),
+        toPersistedTaskTabs({
+          tabs: ["task-a"],
+          activeTaskId: "task-a",
+        }),
+      );
+      memoryStorage.setItem(
+        toTabsStorageKey("/repo-b"),
+        toPersistedTaskTabs({
+          tabs: ["task-b"],
+          activeTaskId: "task-b",
+        }),
+      );
+
+      const updateCalls: Array<Record<string, string | undefined>> = [];
+      const harness = createHookHarness({
+        activeRepo: "/repo-a",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-a")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-a", createSession("task-a", "session-a")]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      await harness.mount();
+      await harness.waitFor(() => updateCalls.length === 1);
+
+      await harness.update({
+        activeRepo: "/repo-b",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-b")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-b", createSession("task-b", "session-b")]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+      await harness.waitFor(() => updateCalls.length === 2);
+
+      await harness.update({
+        activeRepo: "/repo-a",
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-a")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-a", createSession("task-a", "session-a-2")]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+      await harness.waitFor(() => updateCalls.length === 3);
+
+      expect(updateCalls.map((call) => call.task)).toEqual(["task-a", "task-b", "task-a"]);
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
   test("removes a task tab when the selected task becomes closed and routes to the first remaining tab", async () => {
     const memoryStorage = createMemoryStorage();
     const originalStorage = globalThis.localStorage;

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -535,13 +535,7 @@ describe("useAgentStudioTaskTabs", () => {
 
   test("suppresses fallback routing while repo navigation boundary is pending", async () => {
     const memoryStorage = createMemoryStorage();
-    const originalStorage = globalThis.localStorage;
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      value: memoryStorage,
-    });
-
-    try {
+    await withMockedLocalStorage(memoryStorage, async () => {
       memoryStorage.setItem(
         toTabsStorageKey("/repo-b"),
         toPersistedTaskTabs({
@@ -571,12 +565,7 @@ describe("useAgentStudioTaskTabs", () => {
       expect(harness.getLatest().activeTaskTabId).toBe("task-b");
 
       await harness.unmount();
-    } finally {
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        value: originalStorage,
-      });
-    }
+    });
   });
 
   test("restores repo-scoped fallback tabs when switching away and back", async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -533,6 +533,52 @@ describe("useAgentStudioTaskTabs", () => {
     }
   });
 
+  test("suppresses fallback routing while repo navigation boundary is pending", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toTabsStorageKey("/repo-b"),
+        toPersistedTaskTabs({
+          tabs: ["task-b"],
+          activeTaskId: "task-b",
+        }),
+      );
+
+      const updateCalls: Array<Record<string, string | undefined>> = [];
+      const harness = createHookHarness({
+        activeRepo: "/repo-b",
+        isRepoNavigationBoundaryPending: true,
+        taskId: "",
+        selectedTask: null,
+        tasks: [createTask("task-b")],
+        isLoadingTasks: false,
+        latestSessionByTaskId: new Map([["task-b", createSession("task-b", "session-b")]]),
+        updateQuery: (updates) => {
+          updateCalls.push(updates);
+        },
+        clearComposerInput: () => {},
+      });
+
+      await harness.mount();
+
+      expect(updateCalls).toHaveLength(0);
+      expect(harness.getLatest().activeTaskTabId).toBe("task-b");
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
   test("restores repo-scoped fallback tabs when switching away and back", async () => {
     const memoryStorage = createMemoryStorage();
     await withMockedLocalStorage(memoryStorage, async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.test.tsx
@@ -1,5 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
+  createMemoryStorage,
+  seedRepoTaskTabs,
+  type TestStorageLike,
+  withMockedLocalStorage,
+} from "./agent-studio-repo-persistence-test-utils";
+import {
   createAgentSessionFixture,
   createHookHarness as createSharedHookHarness,
   createTaskCardFixture,
@@ -13,35 +19,11 @@ enableReactActEnvironment();
 
 type HookArgs = Parameters<typeof useAgentStudioTaskTabs>[0];
 
-type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem" | "clear" | "key"> & {
-  readonly length: number;
-};
-
-const createMemoryStorage = (): StorageLike => {
-  const store = new Map<string, string>();
-  return {
-    getItem: (key) => store.get(key) ?? null,
-    setItem: (key, value) => {
-      store.set(key, value);
-    },
-    removeItem: (key) => {
-      store.delete(key);
-    },
-    clear: () => {
-      store.clear();
-    },
-    key: (index) => Array.from(store.keys())[index] ?? null,
-    get length() {
-      return store.size;
-    },
-  };
-};
-
 const createThrowingStorage = (args: {
   throwOnGetItem?: boolean;
   throwOnSetItem?: boolean;
   message?: string;
-}): StorageLike => {
+}): TestStorageLike => {
   const store = new Map<string, string>();
   const message = args.message ?? "storage unavailable";
   return {
@@ -553,27 +535,11 @@ describe("useAgentStudioTaskTabs", () => {
 
   test("restores repo-scoped fallback tabs when switching away and back", async () => {
     const memoryStorage = createMemoryStorage();
-    const originalStorage = globalThis.localStorage;
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      value: memoryStorage,
-    });
-
-    try {
-      memoryStorage.setItem(
-        toTabsStorageKey("/repo-a"),
-        toPersistedTaskTabs({
-          tabs: ["task-a"],
-          activeTaskId: "task-a",
-        }),
-      );
-      memoryStorage.setItem(
-        toTabsStorageKey("/repo-b"),
-        toPersistedTaskTabs({
-          tabs: ["task-b"],
-          activeTaskId: "task-b",
-        }),
-      );
+    await withMockedLocalStorage(memoryStorage, async () => {
+      seedRepoTaskTabs(memoryStorage, {
+        "/repo-a": { tabs: ["task-a"], activeTaskId: "task-a" },
+        "/repo-b": { tabs: ["task-b"], activeTaskId: "task-b" },
+      });
 
       const updateCalls: Array<Record<string, string | undefined>> = [];
       const harness = createHookHarness({
@@ -623,12 +589,7 @@ describe("useAgentStudioTaskTabs", () => {
       expect(updateCalls.map((call) => call.task)).toEqual(["task-a", "task-b", "task-a"]);
 
       await harness.unmount();
-    } finally {
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        value: originalStorage,
-      });
-    }
+    });
   });
 
   test("removes a task tab when the selected task becomes closed and routes to the first remaining tab", async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-task-tabs.ts
@@ -33,6 +33,7 @@ const toClearTaskQueryUpdate = (): QueryUpdate => ({
 
 export function useAgentStudioTaskTabs(args: {
   activeRepo: string | null;
+  isRepoNavigationBoundaryPending?: boolean;
   taskId: string;
   selectedTask: TaskCard | null;
   tasks: TaskCard[];
@@ -53,6 +54,7 @@ export function useAgentStudioTaskTabs(args: {
 } {
   const {
     activeRepo,
+    isRepoNavigationBoundaryPending = false,
     taskId,
     selectedTask,
     tasks,
@@ -101,6 +103,7 @@ export function useAgentStudioTaskTabs(args: {
 
   const { tabTaskIds, activeTaskTabId, handleSelectTab } = useTaskTabSelection({
     activeRepo,
+    isRepoNavigationBoundaryPending,
     taskId: taskIdForTabs,
     openTaskTabs: selectableOpenTaskTabs,
     persistedActiveTaskId,

--- a/apps/desktop/src/pages/agents/use-repo-navigation-persistence.test.tsx
+++ b/apps/desktop/src/pages/agents/use-repo-navigation-persistence.test.tsx
@@ -5,7 +5,10 @@ import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
-import { useRepoNavigationPersistence } from "./use-repo-navigation-persistence";
+import {
+  resolveRepoNavigationBoundaryPending,
+  useRepoNavigationPersistence,
+} from "./use-repo-navigation-persistence";
 
 enableReactActEnvironment();
 
@@ -126,6 +129,25 @@ const createHookHarness = (initialProps: HookArgs) =>
   createSharedHookHarness(useHookHarness, initialProps);
 
 describe("useRepoNavigationPersistence", () => {
+  test("treats the first render after a repo change as boundary-pending before effects run", () => {
+    expect(
+      resolveRepoNavigationBoundaryPending({
+        activeRepo: "/repo-b",
+        lastActiveRepo: "/repo-a",
+        boundaryRepo: null,
+        boundaryStatePending: false,
+      }),
+    ).toBeTrue();
+    expect(
+      resolveRepoNavigationBoundaryPending({
+        activeRepo: "/repo-a",
+        lastActiveRepo: "/repo-a",
+        boundaryRepo: null,
+        boundaryStatePending: false,
+      }),
+    ).toBeFalse();
+  });
+
   test("restores persisted repo context when navigation has no explicit task selection", async () => {
     const memoryStorage = createMemoryStorage();
     const originalStorage = globalThis.localStorage;
@@ -432,6 +454,118 @@ describe("useRepoNavigationPersistence", () => {
       const repoBWrites = writes.filter((entry) => entry.key === toContextStorageKey("/repo-b"));
       expect(repoBWrites.some((entry) => entry.value.includes("task-a"))).toBeFalse();
       expect(repoBWrites.some((entry) => entry.value.includes("session-a"))).toBeFalse();
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("restores repo-scoped context when switching back to a previous repository", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toContextStorageKey("/repo-a"),
+        JSON.stringify({
+          taskId: "task-a",
+          role: "spec",
+          sessionId: "session-a",
+        }),
+      );
+      memoryStorage.setItem(
+        toContextStorageKey("/repo-b"),
+        JSON.stringify({
+          taskId: "task-b",
+          role: "planner",
+          sessionId: "session-b",
+        }),
+      );
+
+      const harness = createHookHarness({
+        activeRepo: "/repo-a",
+      });
+
+      await harness.mount();
+      await harness.waitFor((state) => state.navigation.taskId === "task-a");
+
+      await harness.update({
+        activeRepo: "/repo-b",
+      });
+      await harness.waitFor((state) => state.navigation.taskId === "task-b");
+
+      await harness.update({
+        activeRepo: "/repo-a",
+      });
+      await harness.waitFor((state) => state.navigation.taskId === "task-a");
+
+      expect(harness.getLatest().navigation).toEqual({
+        taskId: "task-a",
+        sessionId: "session-a",
+        role: "spec",
+        scenario: null,
+      });
+
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("rapid repo changes leave the final repository context restored", async () => {
+    const memoryStorage = createMemoryStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: memoryStorage,
+    });
+
+    try {
+      memoryStorage.setItem(
+        toContextStorageKey("/repo-a"),
+        JSON.stringify({
+          taskId: "task-a",
+          role: "spec",
+          sessionId: "session-a",
+        }),
+      );
+      memoryStorage.setItem(
+        toContextStorageKey("/repo-b"),
+        JSON.stringify({
+          taskId: "task-b",
+          role: "planner",
+          sessionId: "session-b",
+        }),
+      );
+
+      const harness = createHookHarness({
+        activeRepo: "/repo-a",
+      });
+
+      await harness.mount();
+      await harness.waitFor((state) => state.navigation.taskId === "task-a");
+
+      await harness.update({ activeRepo: "/repo-b" });
+      await harness.update({ activeRepo: "/repo-a" });
+      await harness.waitFor((state) => state.navigation.taskId === "task-a");
+
+      expect(harness.getLatest().navigation).toEqual({
+        taskId: "task-a",
+        sessionId: "session-a",
+        role: "spec",
+        scenario: null,
+      });
 
       await harness.unmount();
     } finally {

--- a/apps/desktop/src/pages/agents/use-repo-navigation-persistence.test.tsx
+++ b/apps/desktop/src/pages/agents/use-repo-navigation-persistence.test.tsx
@@ -2,11 +2,17 @@ import { describe, expect, test } from "bun:test";
 import { useState } from "react";
 import { type AgentStudioNavigationState, toContextStorageKey } from "./agent-studio-navigation";
 import {
+  createMemoryStorage,
+  seedRepoNavigationContexts,
+  type TestStorageLike,
+  withMockedLocalStorage,
+} from "./agent-studio-repo-persistence-test-utils";
+import {
   createHookHarness as createSharedHookHarness,
   enableReactActEnvironment,
 } from "./agent-studio-test-utils";
 import {
-  resolveRepoNavigationBoundaryPending,
+  resolveRepoNavigationBoundaryPhase,
   useRepoNavigationPersistence,
 } from "./use-repo-navigation-persistence";
 
@@ -17,35 +23,11 @@ type HookArgs = {
   initialNavigation?: AgentStudioNavigationState;
 };
 
-type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem" | "clear" | "key"> & {
-  readonly length: number;
-};
-
-const createMemoryStorage = (): StorageLike => {
-  const store = new Map<string, string>();
-  return {
-    getItem: (key) => store.get(key) ?? null,
-    setItem: (key, value) => {
-      store.set(key, value);
-    },
-    removeItem: (key) => {
-      store.delete(key);
-    },
-    clear: () => {
-      store.clear();
-    },
-    key: (index) => Array.from(store.keys())[index] ?? null,
-    get length() {
-      return store.size;
-    },
-  };
-};
-
 const createRecordingStorage = () => {
   const store = new Map<string, string>();
   const writes: Array<{ key: string; value: string }> = [];
 
-  const storage: StorageLike = {
+  const storage: TestStorageLike = {
     getItem: (key) => store.get(key) ?? null,
     setItem: (key, value) => {
       writes.push({ key, value });
@@ -70,29 +52,29 @@ const createThrowingStorage = (args: {
   throwOnGetItem?: boolean;
   throwOnSetItem?: boolean;
   message?: string;
-}): StorageLike => {
+}): TestStorageLike => {
   const store = new Map<string, string>();
   const message = args.message ?? "storage unavailable";
   return {
-    getItem: (key) => {
+    getItem: (key: string) => {
       if (args.throwOnGetItem) {
         throw new Error(message);
       }
       return store.get(key) ?? null;
     },
-    setItem: (key, value) => {
+    setItem: (key: string, value: string) => {
       if (args.throwOnSetItem) {
         throw new Error(message);
       }
       store.set(key, value);
     },
-    removeItem: (key) => {
+    removeItem: (key: string) => {
       store.delete(key);
     },
     clear: () => {
       store.clear();
     },
-    key: (index) => Array.from(store.keys())[index] ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
     get length() {
       return store.size;
     },
@@ -131,21 +113,19 @@ const createHookHarness = (initialProps: HookArgs) =>
 describe("useRepoNavigationPersistence", () => {
   test("treats the first render after a repo change as boundary-pending before effects run", () => {
     expect(
-      resolveRepoNavigationBoundaryPending({
+      resolveRepoNavigationBoundaryPhase({
         activeRepo: "/repo-b",
         lastActiveRepo: "/repo-a",
         boundaryRepo: null,
-        boundaryStatePending: false,
       }),
-    ).toBeTrue();
+    ).toBe("detecting");
     expect(
-      resolveRepoNavigationBoundaryPending({
+      resolveRepoNavigationBoundaryPhase({
         activeRepo: "/repo-a",
         lastActiveRepo: "/repo-a",
         boundaryRepo: null,
-        boundaryStatePending: false,
       }),
-    ).toBeFalse();
+    ).toBe("idle");
   });
 
   test("restores persisted repo context when navigation has no explicit task selection", async () => {
@@ -466,29 +446,11 @@ describe("useRepoNavigationPersistence", () => {
 
   test("restores repo-scoped context when switching back to a previous repository", async () => {
     const memoryStorage = createMemoryStorage();
-    const originalStorage = globalThis.localStorage;
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      value: memoryStorage,
-    });
-
-    try {
-      memoryStorage.setItem(
-        toContextStorageKey("/repo-a"),
-        JSON.stringify({
-          taskId: "task-a",
-          role: "spec",
-          sessionId: "session-a",
-        }),
-      );
-      memoryStorage.setItem(
-        toContextStorageKey("/repo-b"),
-        JSON.stringify({
-          taskId: "task-b",
-          role: "planner",
-          sessionId: "session-b",
-        }),
-      );
+    await withMockedLocalStorage(memoryStorage, async () => {
+      seedRepoNavigationContexts(memoryStorage, {
+        "/repo-a": { taskId: "task-a", role: "spec", sessionId: "session-a" },
+        "/repo-b": { taskId: "task-b", role: "planner", sessionId: "session-b" },
+      });
 
       const harness = createHookHarness({
         activeRepo: "/repo-a",
@@ -515,39 +477,16 @@ describe("useRepoNavigationPersistence", () => {
       });
 
       await harness.unmount();
-    } finally {
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        value: originalStorage,
-      });
-    }
+    });
   });
 
   test("rapid repo changes leave the final repository context restored", async () => {
     const memoryStorage = createMemoryStorage();
-    const originalStorage = globalThis.localStorage;
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      value: memoryStorage,
-    });
-
-    try {
-      memoryStorage.setItem(
-        toContextStorageKey("/repo-a"),
-        JSON.stringify({
-          taskId: "task-a",
-          role: "spec",
-          sessionId: "session-a",
-        }),
-      );
-      memoryStorage.setItem(
-        toContextStorageKey("/repo-b"),
-        JSON.stringify({
-          taskId: "task-b",
-          role: "planner",
-          sessionId: "session-b",
-        }),
-      );
+    await withMockedLocalStorage(memoryStorage, async () => {
+      seedRepoNavigationContexts(memoryStorage, {
+        "/repo-a": { taskId: "task-a", role: "spec", sessionId: "session-a" },
+        "/repo-b": { taskId: "task-b", role: "planner", sessionId: "session-b" },
+      });
 
       const harness = createHookHarness({
         activeRepo: "/repo-a",
@@ -568,12 +507,7 @@ describe("useRepoNavigationPersistence", () => {
       });
 
       await harness.unmount();
-    } finally {
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        value: originalStorage,
-      });
-    }
+    });
   });
 
   test("surfaces actionable error when context storage persistence fails and allows retry", async () => {

--- a/apps/desktop/src/pages/agents/use-repo-navigation-persistence.test.tsx
+++ b/apps/desktop/src/pages/agents/use-repo-navigation-persistence.test.tsx
@@ -168,6 +168,41 @@ describe("useRepoNavigationPersistence", () => {
     }
   });
 
+  test("does not override explicit role-only selection with persisted repo context", async () => {
+    const memoryStorage = createMemoryStorage();
+    await withMockedLocalStorage(memoryStorage, async () => {
+      seedRepoNavigationContexts(memoryStorage, {
+        "/repo": {
+          taskId: "task-from-context",
+          role: "qa",
+          sessionId: "session-from-context",
+          scenario: "qa_review",
+        },
+      });
+
+      const harness = createHookHarness({
+        activeRepo: "/repo",
+        initialNavigation: {
+          taskId: "",
+          sessionId: null,
+          role: "planner",
+          scenario: "planner_initial",
+        },
+      });
+
+      await harness.mount();
+
+      expect(harness.getLatest().navigation).toEqual({
+        taskId: "",
+        sessionId: null,
+        role: "planner",
+        scenario: "planner_initial",
+      });
+
+      await harness.unmount();
+    });
+  });
+
   test("flushes pending persistence during unmount cleanup", async () => {
     const memoryStorage = createMemoryStorage();
     const originalStorage = globalThis.localStorage;
@@ -389,13 +424,7 @@ describe("useRepoNavigationPersistence", () => {
 
   test("clears stale repo navigation before restoring and persisting the next repo context", async () => {
     const { storage, writes } = createRecordingStorage();
-    const originalStorage = globalThis.localStorage;
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      value: storage,
-    });
-
-    try {
+    await withMockedLocalStorage(storage, async () => {
       storage.setItem(
         toContextStorageKey("/repo-b"),
         JSON.stringify({
@@ -436,12 +465,7 @@ describe("useRepoNavigationPersistence", () => {
       expect(repoBWrites.some((entry) => entry.value.includes("session-a"))).toBeFalse();
 
       await harness.unmount();
-    } finally {
-      Object.defineProperty(globalThis, "localStorage", {
-        configurable: true,
-        value: originalStorage,
-      });
-    }
+    });
   });
 
   test("restores repo-scoped context when switching back to a previous repository", async () => {

--- a/apps/desktop/src/pages/agents/use-repo-navigation-persistence.test.tsx
+++ b/apps/desktop/src/pages/agents/use-repo-navigation-persistence.test.tsx
@@ -38,6 +38,31 @@ const createMemoryStorage = (): StorageLike => {
   };
 };
 
+const createRecordingStorage = () => {
+  const store = new Map<string, string>();
+  const writes: Array<{ key: string; value: string }> = [];
+
+  const storage: StorageLike = {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      writes.push({ key, value });
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+
+  return { storage, writes };
+};
+
 const createThrowingStorage = (args: {
   throwOnGetItem?: boolean;
   throwOnSetItem?: boolean;
@@ -81,14 +106,16 @@ const useHookHarness = ({ activeRepo, initialNavigation }: HookArgs) => {
     },
   );
 
-  const { persistenceError, retryPersistenceRestore } = useRepoNavigationPersistence({
-    activeRepo,
-    navigation,
-    setNavigation,
-  });
+  const { isRepoNavigationBoundaryPending, persistenceError, retryPersistenceRestore } =
+    useRepoNavigationPersistence({
+      activeRepo,
+      navigation,
+      setNavigation,
+    });
 
   return {
     navigation,
+    isRepoNavigationBoundaryPending,
     persistenceError,
     retryPersistenceRestore,
     setNavigation,
@@ -349,6 +376,63 @@ describe("useRepoNavigationPersistence", () => {
       await harness.waitFor((state) => state.navigation.taskId === "task-from-repo-b");
 
       expect(harness.getLatest().persistenceError).toBeNull();
+      await harness.unmount();
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        configurable: true,
+        value: originalStorage,
+      });
+    }
+  });
+
+  test("clears stale repo navigation before restoring and persisting the next repo context", async () => {
+    const { storage, writes } = createRecordingStorage();
+    const originalStorage = globalThis.localStorage;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: storage,
+    });
+
+    try {
+      storage.setItem(
+        toContextStorageKey("/repo-b"),
+        JSON.stringify({
+          taskId: "task-b",
+          role: "planner",
+          sessionId: "session-b",
+        }),
+      );
+
+      const harness = createHookHarness({
+        activeRepo: "/repo-a",
+        initialNavigation: {
+          taskId: "task-a",
+          sessionId: "session-a",
+          role: "build",
+          scenario: "build_implementation_start",
+        },
+      });
+
+      await harness.mount();
+
+      await harness.update({
+        activeRepo: "/repo-b",
+      });
+
+      await harness.waitFor((state) => state.navigation.taskId === "task-b");
+
+      expect(harness.getLatest().isRepoNavigationBoundaryPending).toBeFalse();
+      expect(harness.getLatest().navigation).toEqual({
+        taskId: "task-b",
+        sessionId: "session-b",
+        role: "planner",
+        scenario: null,
+      });
+
+      const repoBWrites = writes.filter((entry) => entry.key === toContextStorageKey("/repo-b"));
+      expect(repoBWrites.some((entry) => entry.value.includes("task-a"))).toBeFalse();
+      expect(repoBWrites.some((entry) => entry.value.includes("session-a"))).toBeFalse();
+
       await harness.unmount();
     } finally {
       Object.defineProperty(globalThis, "localStorage", {

--- a/apps/desktop/src/pages/agents/use-repo-navigation-persistence.ts
+++ b/apps/desktop/src/pages/agents/use-repo-navigation-persistence.ts
@@ -1,1 +1,4 @@
-export { useRepoNavigationPersistence } from "./query-sync/use-repo-navigation-persistence";
+export {
+  resolveRepoNavigationBoundaryPending,
+  useRepoNavigationPersistence,
+} from "./query-sync/use-repo-navigation-persistence";

--- a/apps/desktop/src/pages/agents/use-repo-navigation-persistence.ts
+++ b/apps/desktop/src/pages/agents/use-repo-navigation-persistence.ts
@@ -1,4 +1,4 @@
 export {
-  resolveRepoNavigationBoundaryPending,
+  resolveRepoNavigationBoundaryPhase,
   useRepoNavigationPersistence,
 } from "./query-sync/use-repo-navigation-persistence";


### PR DESCRIPTION
## Summary
- make repository switches a hard Agent Studio context boundary so stale task, session, and query state cannot leak across repos
- restore repo-scoped Agent Studio navigation and task tabs safely when returning to a repository, including rapid switch paths
- add regression coverage for repo-boundary sanitization, repo return restoration, and tab fallback suppression during restore

## Verification
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved repository switching in Agent Studio with automatic state cleanup and restoration.

* **Bug Fixes**
  * Prevents stale query updates during repository transitions.
  * Preserves and restores task selection when returning to previously visited repositories.
  * Clears outdated selection state when switching between repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->