### PR TITLE
perf(desktop): parallelize diagnostics refresh checks

### DIFF
--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -9,6 +9,7 @@ import {
 import type { PropsWithChildren, ReactElement } from "react";
 import { QueryProvider } from "@/lib/query-provider";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
+import { createDeferred } from "@/test-utils/shared-test-fixtures";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import { host } from "../shared/host";
 
@@ -350,6 +351,79 @@ describe("use-checks", () => {
     }
   });
 
+  test("refreshChecks starts independent probes in parallel", async () => {
+    const runtimeDeferred = createDeferred<RuntimeCheck>();
+    const beadsDeferred = createDeferred<BeadsCheck>();
+    const runtimeHealthDeferred = createDeferred<RepoRuntimeHealthCheck>();
+    let runtimeCallCount = 0;
+    let beadsCallCount = 0;
+    let runtimeHealthCallCount = 0;
+    const runtimeCheck = mock(async (_force?: boolean): Promise<RuntimeCheck> => {
+      runtimeCallCount += 1;
+      return runtimeCallCount === 1 ? makeRuntimeCheck() : runtimeDeferred.promise;
+    });
+    const beadsCheck = mock(async (): Promise<BeadsCheck> => {
+      beadsCallCount += 1;
+      return beadsCallCount === 1 ? makeBeadsCheck() : beadsDeferred.promise;
+    });
+    repoHealthHandler = async () => {
+      runtimeHealthCallCount += 1;
+      return runtimeHealthCallCount === 1 ? makeRepoHealth() : runtimeHealthDeferred.promise;
+    };
+
+    const original = {
+      runtimeCheck: host.runtimeCheck,
+      beadsCheck: host.beadsCheck,
+    };
+    host.runtimeCheck = runtimeCheck;
+    host.beadsCheck = beadsCheck;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    let refreshPromise: Promise<void> | null = null;
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => {
+        return (
+          value.runtimeCheck !== null &&
+          value.activeBeadsCheck !== null &&
+          value.activeRepoRuntimeHealthByRuntime.opencode != null &&
+          value.isLoadingChecks === false
+        );
+      });
+      runtimeCheck.mockClear();
+      beadsCheck.mockClear();
+      checkRepoRuntimeHealthMock.mockClear();
+
+      await harness.run((value) => {
+        refreshPromise = value.refreshChecks();
+      });
+      await harness.waitFor((value) => value.isLoadingChecks === true);
+
+      expect(runtimeCheck).toHaveBeenCalledTimes(1);
+      expect(runtimeCheck.mock.calls[0]).toEqual([true]);
+      expect(beadsCheck).toHaveBeenCalledTimes(1);
+      expect(checkRepoRuntimeHealthMock).toHaveBeenCalledTimes(1);
+      expect(checkRepoRuntimeHealthMock.mock.calls[0]).toEqual(["/repo-a", "opencode"]);
+
+      runtimeDeferred.resolve(makeRuntimeCheck());
+      beadsDeferred.resolve(makeBeadsCheck());
+      runtimeHealthDeferred.resolve(makeRepoHealth());
+      await harness.run(async () => {
+        await refreshPromise;
+      });
+      await harness.waitFor((value) => value.isLoadingChecks === false);
+    } finally {
+      await harness.unmount();
+      host.runtimeCheck = original.runtimeCheck;
+      host.beadsCheck = original.beadsCheck;
+    }
+  });
+
   test("refreshChecks forces a fresh runtime check and surfaces errors", async () => {
     let callCount = 0;
     const runtimeCheck = mock(
@@ -363,11 +437,15 @@ describe("use-checks", () => {
           reject(new Error("runtime down"));
         }),
     );
+    const beadsCheck = mock(async (): Promise<BeadsCheck> => makeBeadsCheck());
+    repoHealthHandler = async () => makeRepoHealth();
 
     const original = {
       runtimeCheck: host.runtimeCheck,
+      beadsCheck: host.beadsCheck,
     };
     host.runtimeCheck = runtimeCheck;
+    host.beadsCheck = beadsCheck;
 
     const harness = createHookHarness({
       activeRepo: "/repo-a",
@@ -393,6 +471,82 @@ describe("use-checks", () => {
     } finally {
       await harness.unmount();
       host.runtimeCheck = original.runtimeCheck;
+      host.beadsCheck = original.beadsCheck;
+    }
+  });
+
+  test("refreshChecks waits for all failed probes before surfacing unavailable diagnostics", async () => {
+    const runtimeDeferred = createDeferred<RuntimeCheck>();
+    const beadsDeferred = createDeferred<BeadsCheck>();
+    const runtimeHealthDeferred = createDeferred<RepoRuntimeHealthCheck>();
+    let runtimeCallCount = 0;
+    let beadsCallCount = 0;
+    let runtimeHealthCallCount = 0;
+    const runtimeCheck = mock(async (_force?: boolean): Promise<RuntimeCheck> => {
+      runtimeCallCount += 1;
+      return runtimeCallCount === 1 ? makeRuntimeCheck() : runtimeDeferred.promise;
+    });
+    const beadsCheck = mock(async (): Promise<BeadsCheck> => {
+      beadsCallCount += 1;
+      return beadsCallCount === 1 ? makeBeadsCheck() : beadsDeferred.promise;
+    });
+    repoHealthHandler = async () => {
+      runtimeHealthCallCount += 1;
+      return runtimeHealthCallCount === 1 ? makeRepoHealth() : runtimeHealthDeferred.promise;
+    };
+
+    const original = {
+      runtimeCheck: host.runtimeCheck,
+      beadsCheck: host.beadsCheck,
+    };
+    host.runtimeCheck = runtimeCheck;
+    host.beadsCheck = beadsCheck;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    let refreshPromise: Promise<void> | null = null;
+
+    try {
+      await harness.mount();
+      await harness.waitFor((value) => {
+        return (
+          value.runtimeCheck !== null &&
+          value.activeBeadsCheck !== null &&
+          value.activeRepoRuntimeHealthByRuntime.opencode != null &&
+          value.isLoadingChecks === false
+        );
+      });
+      runtimeCheck.mockClear();
+      beadsCheck.mockClear();
+      checkRepoRuntimeHealthMock.mockClear();
+
+      await harness.run((value) => {
+        refreshPromise = value.refreshChecks();
+      });
+      await harness.waitFor((value) => value.isLoadingChecks === true);
+
+      runtimeDeferred.reject(new Error("runtime down"));
+      await Promise.resolve();
+      expect(toastError).not.toHaveBeenCalled();
+
+      beadsDeferred.reject(new Error("beads down"));
+      runtimeHealthDeferred.resolve(makeRepoHealth());
+      await harness.run(async () => {
+        await refreshPromise;
+      });
+      await harness.waitFor((value) => value.isLoadingChecks === false);
+
+      expect(toastError).toHaveBeenCalledWith("Diagnostics check unavailable", {
+        description: "runtime down | beads down",
+      });
+      expect(harness.getLatest().isLoadingChecks).toBe(false);
+    } finally {
+      await harness.unmount();
+      host.runtimeCheck = original.runtimeCheck;
+      host.beadsCheck = original.beadsCheck;
     }
   });
 

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -154,13 +154,18 @@ const createHookHarness = (initialArgs: HookHarnessArgs) => {
 
 type HookHarness = ReturnType<typeof createHookHarness>;
 
-const waitForInitialChecksToSettle = async (harness: HookHarness) => {
+const waitForInitialChecksToSettle = async (
+  harness: HookHarness,
+  runtimeKinds: RuntimeKind[] = ["opencode"],
+) => {
   await harness.mount();
   await harness.waitFor((value) => {
     return (
       value.runtimeCheck !== null &&
       value.activeBeadsCheck !== null &&
-      value.activeRepoRuntimeHealthByRuntime.opencode != null &&
+      runtimeKinds.every(
+        (runtimeKind) => value.activeRepoRuntimeHealthByRuntime[runtimeKind] != null,
+      ) &&
       value.isLoadingChecks === false
     );
   });
@@ -545,6 +550,82 @@ describe("use-checks", () => {
       await harness.unmount();
       host.runtimeCheck = original.runtimeCheck;
       host.beadsCheck = original.beadsCheck;
+    }
+  });
+
+  test("refreshChecks times out hung probes and clears loading state", async () => {
+    let runtimeCallCount = 0;
+    let beadsCallCount = 0;
+    const beadsDeferred = createDeferred<BeadsCheck>();
+    const runtimeCheck = mock(async (_force?: boolean): Promise<RuntimeCheck> => {
+      runtimeCallCount += 1;
+      if (runtimeCallCount === 1) {
+        return makeRuntimeCheck();
+      }
+      throw new Error("runtime down");
+    });
+    const beadsCheck = mock(async (): Promise<BeadsCheck> => {
+      beadsCallCount += 1;
+      return beadsCallCount === 1 ? makeBeadsCheck() : beadsDeferred.promise;
+    });
+    repoHealthHandler = async () => makeRepoHealth();
+
+    const original = {
+      runtimeCheck: host.runtimeCheck,
+      beadsCheck: host.beadsCheck,
+    };
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    const setTimeoutMock = mock((handler: TimerHandler, _delay?: number) => {
+      if (typeof handler !== "function") {
+        throw new Error("Expected timeout callback function");
+      }
+      return originalSetTimeout(() => {
+        handler();
+      }, 0);
+    });
+    const clearTimeoutMock = mock((timeoutId: ReturnType<typeof globalThis.setTimeout>) => {
+      originalClearTimeout(timeoutId);
+    });
+
+    host.runtimeCheck = runtimeCheck;
+    host.beadsCheck = beadsCheck;
+    globalThis.setTimeout = setTimeoutMock as unknown as typeof globalThis.setTimeout;
+    globalThis.clearTimeout = clearTimeoutMock as unknown as typeof globalThis.clearTimeout;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    let refreshPromise: Promise<void> | null = null;
+
+    try {
+      await waitForInitialChecksToSettle(harness);
+      runtimeCheck.mockClear();
+      beadsCheck.mockClear();
+      checkRepoRuntimeHealthMock.mockClear();
+
+      await harness.run((value) => {
+        refreshPromise = value.refreshChecks();
+      });
+      await harness.waitFor((value) => value.isLoadingChecks === true);
+      await harness.run(async () => {
+        await refreshPromise;
+      });
+      await harness.waitFor((value) => value.isLoadingChecks === false);
+
+      expect(toastError).toHaveBeenCalledWith("Diagnostics check unavailable", {
+        description: "runtime: runtime down | beads: Timed out after 5000ms",
+      });
+      expect(harness.getLatest().isLoadingChecks).toBe(false);
+    } finally {
+      await harness.unmount();
+      host.runtimeCheck = original.runtimeCheck;
+      host.beadsCheck = original.beadsCheck;
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+      beadsDeferred.reject(new Error("cleanup"));
     }
   });
 

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -152,6 +152,20 @@ const createHookHarness = (initialArgs: HookHarnessArgs) => {
   };
 };
 
+type HookHarness = ReturnType<typeof createHookHarness>;
+
+const waitForInitialChecksToSettle = async (harness: HookHarness) => {
+  await harness.mount();
+  await harness.waitFor((value) => {
+    return (
+      value.runtimeCheck !== null &&
+      value.activeBeadsCheck !== null &&
+      value.activeRepoRuntimeHealthByRuntime.opencode != null &&
+      value.isLoadingChecks === false
+    );
+  });
+};
+
 beforeAll(async () => {
   mock.module("sonner", () => ({
     toast: {
@@ -386,15 +400,7 @@ describe("use-checks", () => {
     let refreshPromise: Promise<void> | null = null;
 
     try {
-      await harness.mount();
-      await harness.waitFor((value) => {
-        return (
-          value.runtimeCheck !== null &&
-          value.activeBeadsCheck !== null &&
-          value.activeRepoRuntimeHealthByRuntime.opencode != null &&
-          value.isLoadingChecks === false
-        );
-      });
+      await waitForInitialChecksToSettle(harness);
       runtimeCheck.mockClear();
       beadsCheck.mockClear();
       checkRepoRuntimeHealthMock.mockClear();
@@ -465,7 +471,7 @@ describe("use-checks", () => {
       expect(runtimeCheck.mock.calls[0]).toEqual([false]);
       expect(runtimeCheck.mock.calls[1]).toEqual([true]);
       expect(toastError).toHaveBeenCalledWith("Diagnostics check unavailable", {
-        description: "runtime down",
+        description: "runtime: runtime down",
       });
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
@@ -510,15 +516,7 @@ describe("use-checks", () => {
     let refreshPromise: Promise<void> | null = null;
 
     try {
-      await harness.mount();
-      await harness.waitFor((value) => {
-        return (
-          value.runtimeCheck !== null &&
-          value.activeBeadsCheck !== null &&
-          value.activeRepoRuntimeHealthByRuntime.opencode != null &&
-          value.isLoadingChecks === false
-        );
-      });
+      await waitForInitialChecksToSettle(harness);
       runtimeCheck.mockClear();
       beadsCheck.mockClear();
       checkRepoRuntimeHealthMock.mockClear();
@@ -540,7 +538,7 @@ describe("use-checks", () => {
       await harness.waitFor((value) => value.isLoadingChecks === false);
 
       expect(toastError).toHaveBeenCalledWith("Diagnostics check unavailable", {
-        description: "runtime down | beads down",
+        description: "runtime: runtime down | beads: beads down",
       });
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -75,13 +75,15 @@ const buildRuntimeHealthErrorMap = (
   ) as RepoRuntimeHealthMap;
 };
 
-const getSettledErrorDescriptions = (results: PromiseSettledResult<unknown>[]): string[] => {
-  return results.flatMap((result) => {
+const getSettledErrorDescriptions = (
+  results: Array<{ label: string; result: PromiseSettledResult<unknown> }>,
+): string[] => {
+  return results.flatMap(({ label, result }) => {
     if (result.status === "fulfilled") {
       return [];
     }
 
-    return [errorMessage(result.reason)];
+    return [`${label}: ${errorMessage(result.reason)}`];
   });
 };
 
@@ -188,9 +190,9 @@ export function useChecks({
         refreshRepoRuntimeHealthForRepo(activeRepo, true),
       ]);
       const unavailableDetails = getSettledErrorDescriptions([
-        runtimeResult,
-        beadsResult,
-        runtimeHealthResult,
+        { label: "runtime", result: runtimeResult },
+        { label: "beads", result: beadsResult },
+        { label: "runtime health", result: runtimeHealthResult },
       ]);
 
       if (unavailableDetails.length > 0) {

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -75,6 +75,24 @@ const buildRuntimeHealthErrorMap = (
   ) as RepoRuntimeHealthMap;
 };
 
+const getSettledErrorDescriptions = (results: PromiseSettledResult<unknown>[]): string[] => {
+  return results.flatMap((result) => {
+    if (result.status === "fulfilled") {
+      return [];
+    }
+
+    return [errorMessage(result.reason)];
+  });
+};
+
+const getSettledValue = <T>(result: PromiseSettledResult<T>): T => {
+  if (result.status === "rejected") {
+    throw result.reason;
+  }
+
+  return result.value;
+};
+
 export function useChecks({
   activeRepo,
   runtimeDefinitions,
@@ -164,9 +182,27 @@ export function useChecks({
 
     setIsManualLoadingChecks(true);
     try {
-      const runtime = await refreshRuntimeCheck(true);
-      const beads = await refreshBeadsCheckForRepo(activeRepo, true);
-      const runtimeHealthByRuntime = await refreshRepoRuntimeHealthForRepo(activeRepo, true);
+      const [runtimeResult, beadsResult, runtimeHealthResult] = await Promise.allSettled([
+        refreshRuntimeCheck(true),
+        refreshBeadsCheckForRepo(activeRepo, true),
+        refreshRepoRuntimeHealthForRepo(activeRepo, true),
+      ]);
+      const unavailableDetails = getSettledErrorDescriptions([
+        runtimeResult,
+        beadsResult,
+        runtimeHealthResult,
+      ]);
+
+      if (unavailableDetails.length > 0) {
+        toast.error("Diagnostics check unavailable", {
+          description: unavailableDetails.join(" | "),
+        });
+        return;
+      }
+
+      const runtime = getSettledValue(runtimeResult);
+      const beads = getSettledValue(beadsResult);
+      const runtimeHealthByRuntime = getSettledValue(runtimeHealthResult);
       const runtimesHealthy = runtime.runtimes.every((runtimeEntry) => runtimeEntry.ok);
       const runtimeHealthEntries = runtimeDefinitions.map(
         (definition) => runtimeHealthByRuntime[definition.kind],

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -19,7 +19,6 @@ import {
   repoRuntimeHealthQueryOptions,
   runtimeCheckQueryOptions,
 } from "../../queries/checks";
-import { host } from "../shared/host";
 
 type UseChecksArgs = {
   activeRepo: string | null;
@@ -119,9 +118,12 @@ export function useChecks({
   const refreshRuntimeCheck = useCallback(
     async (force = false): Promise<RuntimeCheck> => {
       if (force) {
-        const check = await host.runtimeCheck(true);
-        queryClient.setQueryData(checksQueryKeys.runtime(), check);
-        return check;
+        await queryClient.invalidateQueries({
+          queryKey: checksQueryKeys.runtime(),
+          exact: true,
+          refetchType: "none",
+        });
+        return queryClient.fetchQuery(runtimeCheckQueryOptions(true));
       }
 
       return loadRuntimeCheckFromQuery(queryClient);
@@ -233,8 +235,6 @@ export function useChecks({
         ].join(" | ");
         toast.error("Diagnostics check failed", { description: details });
       }
-    } catch (error) {
-      toast.error("Diagnostics check unavailable", { description: errorMessage(error) });
     } finally {
       setIsManualLoadingChecks(false);
     }

--- a/apps/desktop/src/state/queries/checks.ts
+++ b/apps/desktop/src/state/queries/checks.ts
@@ -13,6 +13,7 @@ import { host } from "../operations/host";
 const RUNTIME_CHECK_STALE_TIME_MS = 5 * 60_000;
 const BEADS_CHECK_STALE_TIME_MS = 60_000;
 const RUNTIME_HEALTH_STALE_TIME_MS = 60_000;
+const DIAGNOSTICS_QUERY_TIMEOUT_MS = 5_000;
 
 const buildRuntimeHealthErrorCheck = (
   runtimeHealthError: string,
@@ -34,6 +35,23 @@ const buildRuntimeHealthErrorCheck = (
 const normalizeRuntimeKinds = (runtimeKinds: RuntimeKind[]): RuntimeKind[] =>
   [...runtimeKinds].sort();
 
+const withDiagnosticsQueryTimeout = async <T>(promise: Promise<T>): Promise<T> => {
+  let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeoutId = globalThis.setTimeout(() => {
+      reject(new Error(`Timed out after ${DIAGNOSTICS_QUERY_TIMEOUT_MS}ms`));
+    }, DIAGNOSTICS_QUERY_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutId !== null) {
+      globalThis.clearTimeout(timeoutId);
+    }
+  }
+};
+
 export const checksQueryKeys = {
   all: ["checks"] as const,
   runtime: () => [...checksQueryKeys.all, "runtime"] as const,
@@ -47,17 +65,17 @@ export const checksQueryKeys = {
     ] as const,
 };
 
-export const runtimeCheckQueryOptions = () =>
+export const runtimeCheckQueryOptions = (force = false) =>
   queryOptions({
     queryKey: checksQueryKeys.runtime(),
-    queryFn: (): Promise<RuntimeCheck> => host.runtimeCheck(false),
+    queryFn: (): Promise<RuntimeCheck> => withDiagnosticsQueryTimeout(host.runtimeCheck(force)),
     staleTime: RUNTIME_CHECK_STALE_TIME_MS,
   });
 
 export const beadsCheckQueryOptions = (repoPath: string) =>
   queryOptions({
     queryKey: checksQueryKeys.beads(repoPath),
-    queryFn: (): Promise<BeadsCheck> => host.beadsCheck(repoPath),
+    queryFn: (): Promise<BeadsCheck> => withDiagnosticsQueryTimeout(host.beadsCheck(repoPath)),
     staleTime: BEADS_CHECK_STALE_TIME_MS,
   });
 
@@ -77,7 +95,9 @@ export const repoRuntimeHealthQueryOptions = (
     queryFn: async (): Promise<RepoRuntimeHealthMap> => {
       const checks = await Promise.all(
         runtimeDefinitions.map(async (definition) => {
-          const check = await checkRepoRuntimeHealth(repoPath, definition.kind).catch((error) =>
+          const check = await withDiagnosticsQueryTimeout(
+            checkRepoRuntimeHealth(repoPath, definition.kind),
+          ).catch((error) =>
             buildRuntimeHealthErrorCheck(errorMessage(error), new Date().toISOString()),
           );
           return [definition.kind, check] as const;


### PR DESCRIPTION
## Summary
- run manual diagnostics refresh probes for runtime, Beads, and repo runtime health concurrently instead of serially
- preserve the existing diagnostics toast split while aggregating rejected probe failures only after all probes settle, with source labels for unavailable errors
- add focused `use-checks` coverage for concurrent start behavior, delayed failure reporting, and the shared initial-checks test setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced diagnostic check error reporting with combined failure descriptions when multiple checks fail.
  * Added 5-second timeout handling for diagnostic checks to prevent indefinite hangs.
  * Improved concurrent execution of runtime, beads, and per-repository health checks for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->