### PR TITLE
feat(agents): support chat attachments

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2223,6 +2223,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1400,6 +1400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +1921,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,12 +2207,14 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "ctrlc",
  "host-application",
  "host-domain",
  "host-infra-beads",
  "host-infra-system",
+ "mime_guess",
  "serde",
  "serde_json",
  "tauri",
@@ -3418,6 +3436,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",
@@ -4122,6 +4141,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "process", "sync", "macros", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
+tokio-util = { version = "0.7", features = ["io"] }
 tower-http = { version = "0.6", features = ["cors"] }
 thiserror = "2"
 tracing = "0.1"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -39,10 +39,12 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 anyhow = "1"
 axum = { version = "0.8", features = ["json"] }
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
+mime_guess = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "process", "sync", "macros", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -2,15 +2,136 @@ use crate::{
     as_error, run_service_blocking, AppState, RepoConfigPayload, RepoSettingsPayload,
     SettingsSnapshotPayload, SettingsSnapshotResponsePayload,
 };
+use base64::Engine;
 use host_application::{
     HookTrustConfirmationPort, HookTrustConfirmationRequest, PreparedHookTrustChallenge,
     RepoConfigUpdate, RepoSettingsUpdate, WorkspaceSettingsSnapshotUpdate,
 };
 use host_infra_system::HookSet;
+use std::path::{Path, PathBuf};
 #[cfg(test)]
 use tauri::Manager;
 use tauri::{AppHandle, State};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+use uuid::Uuid;
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StagedLocalAttachmentPayload {
+    pub path: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedLocalAttachmentPayload {
+    pub path: String,
+}
+
+const LOCAL_ATTACHMENT_STAGE_DIR_NAME: &str = "openducktor-local-attachments";
+
+pub(crate) fn local_attachment_stage_dir() -> PathBuf {
+    std::env::temp_dir().join(LOCAL_ATTACHMENT_STAGE_DIR_NAME)
+}
+
+pub(crate) fn is_staged_local_attachment_path(path: &Path) -> Result<bool, String> {
+    let allowed_dir = local_attachment_stage_dir();
+    if !allowed_dir.exists() {
+        return Ok(false);
+    }
+
+    let canonical_allowed_dir = std::fs::canonicalize(&allowed_dir)
+        .map_err(|error| format!("Failed to resolve staged attachment directory: {error}"))?;
+    let canonical_path = std::fs::canonicalize(path)
+        .map_err(|error| format!("Failed to resolve staged attachment path: {error}"))?;
+    Ok(canonical_path.starts_with(canonical_allowed_dir))
+}
+
+fn sanitize_attachment_filename(name: &str) -> String {
+    let sanitized = name
+        .chars()
+        .map(|character| match character {
+            '/' | '\\' | ':' | '\0' => '_',
+            _ => character,
+        })
+        .collect::<String>();
+    let trimmed = sanitized.trim().trim_matches('.');
+    if trimmed.is_empty() {
+        "attachment.bin".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+pub(crate) fn stage_local_attachment_to_temp(name: &str, base64_data: &str) -> Result<PathBuf, String> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(base64_data)
+        .map_err(|error| format!("Failed to decode attachment payload: {error}"))?;
+    let attachment_dir = local_attachment_stage_dir();
+    std::fs::create_dir_all(&attachment_dir)
+        .map_err(|error| format!("Failed to prepare attachment staging directory: {error}"))?;
+    let file_name = format!(
+        "{}-{}",
+        Uuid::new_v4(),
+        sanitize_attachment_filename(name)
+    );
+    let path = attachment_dir.join(file_name);
+    std::fs::write(&path, bytes)
+        .map_err(|error| format!("Failed to stage local attachment: {error}"))?;
+    Ok(path)
+}
+
+pub(crate) fn resolve_staged_local_attachment_path(path_or_name: &str) -> Result<PathBuf, String> {
+    let trimmed = path_or_name.trim();
+    if trimmed.is_empty() {
+        return Err("Attachment path is required.".to_string());
+    }
+
+    let candidate_path = PathBuf::from(trimmed);
+    if candidate_path.is_absolute() {
+        if is_staged_local_attachment_path(&candidate_path)? {
+            return Ok(candidate_path);
+        }
+        return Err("Attachment path is not a staged local attachment.".to_string());
+    }
+
+    let attachment_dir = local_attachment_stage_dir();
+    let entries = std::fs::read_dir(&attachment_dir)
+        .map_err(|error| format!("Failed to read attachment staging directory: {error}"))?;
+    let suffix = format!("-{trimmed}");
+    let mut matches = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("Failed to read staged attachment entry: {error}"))?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if name == trimmed || name.ends_with(&suffix) {
+            matches.push(path);
+        }
+    }
+
+    match matches.len() {
+        0 => Err(format!("No staged local attachment matches '{trimmed}'.")),
+        1 => Ok(matches.remove(0)),
+        _ => {
+            let mut ranked_matches = matches
+                .into_iter()
+                .map(|path| {
+                    let modified = std::fs::metadata(&path)
+                        .and_then(|metadata| metadata.modified())
+                        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+                    (modified, path)
+                })
+                .collect::<Vec<_>>();
+            ranked_matches.sort_by(|left, right| right.0.cmp(&left.0));
+            ranked_matches
+                .into_iter()
+                .map(|(_, path)| path)
+                .next()
+                .ok_or_else(|| format!("No staged local attachment matches '{trimmed}'."))
+        }
+    }
+}
 
 #[tauri::command]
 pub async fn workspace_list(
@@ -35,6 +156,35 @@ pub async fn workspace_select(
     let selected = as_error(state.service.workspace_select(&repo_path))?;
     super::git::invalidate_worktree_resolution_cache_for_repo(&repo_path)?;
     Ok(selected)
+}
+
+#[tauri::command]
+pub async fn workspace_stage_local_attachment(
+    name: String,
+    _mime: Option<String>,
+    base64_data: String,
+) -> Result<StagedLocalAttachmentPayload, String> {
+    if name.trim().is_empty() {
+        return Err("Attachment name is required.".to_string());
+    }
+    if base64_data.trim().is_empty() {
+        return Err("Attachment payload is required.".to_string());
+    }
+
+    let path = stage_local_attachment_to_temp(&name, &base64_data)?;
+    Ok(StagedLocalAttachmentPayload {
+        path: path.to_string_lossy().into_owned(),
+    })
+}
+
+#[tauri::command]
+pub async fn workspace_resolve_local_attachment_path(
+    path: String,
+) -> Result<ResolvedLocalAttachmentPayload, String> {
+    let resolved = resolve_staged_local_attachment_path(&path)?;
+    Ok(ResolvedLocalAttachmentPayload {
+        path: resolved.to_string_lossy().into_owned(),
+    })
 }
 
 #[tauri::command]
@@ -368,7 +518,8 @@ impl<R: tauri::Runtime> HookTrustConfirmationPort for TauriHookTrustConfirmation
 #[cfg(test)]
 mod tests {
     use super::{
-        format_hook_list, sanitize_hook_preview, workspace_detect_github_repository,
+        format_hook_list, resolve_staged_local_attachment_path, sanitize_hook_preview,
+        stage_local_attachment_to_temp, workspace_detect_github_repository,
         workspace_prepare_trusted_hooks_challenge, workspace_save_repo_settings,
         workspace_save_settings_snapshot, workspace_set_trusted_hooks,
         workspace_update_repo_config,
@@ -425,6 +576,51 @@ mod tests {
             std::env::temp_dir().join(format!("openducktor-workspace-command-{prefix}-{nanos}"));
         fs::create_dir_all(&root).expect("test root should be created");
         root
+    }
+
+    #[test]
+    fn resolve_staged_local_attachment_path_matches_filename_tokens() {
+        let unique_name = format!(
+            "Screenshot-2026-03-16-at-23.48.30-{}.png",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos()
+        );
+        let path = stage_local_attachment_to_temp(
+            &unique_name,
+            "cHJldmlldy1ieXRlcw==",
+        )
+        .expect("attachment should stage");
+
+        let resolved = resolve_staged_local_attachment_path(&unique_name)
+            .expect("filename token should resolve to staged path");
+
+        assert_eq!(resolved, path);
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn resolve_staged_local_attachment_path_prefers_newest_filename_match() {
+        let duplicate_name = format!(
+            "Screenshot-2026-03-16-at-23.48.30-dup-{}.png",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos()
+        );
+        let older = stage_local_attachment_to_temp(&duplicate_name, "b2xkZXI=")
+            .expect("older attachment should stage");
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let newer = stage_local_attachment_to_temp(&duplicate_name, "bmV3ZXI=")
+            .expect("newer attachment should stage");
+
+        let resolved = resolve_staged_local_attachment_path(&duplicate_name)
+            .expect("duplicate filename token should resolve");
+
+        assert_eq!(resolved, newer);
+        let _ = fs::remove_file(older);
+        let _ = fs::remove_file(newer);
     }
 
     fn run_git(args: &[&str], cwd: &Path) {

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -8,6 +8,7 @@ use host_application::{
     RepoConfigUpdate, RepoSettingsUpdate, WorkspaceSettingsSnapshotUpdate,
 };
 use host_infra_system::HookSet;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 #[cfg(test)]
 use tauri::Manager;
@@ -28,6 +29,7 @@ pub struct ResolvedLocalAttachmentPayload {
 }
 
 const LOCAL_ATTACHMENT_STAGE_DIR_NAME: &str = "openducktor-local-attachments";
+const MAX_ATTACHMENT_LOOKUP_DISPLAY_LEN: usize = 128;
 
 pub(crate) fn local_attachment_stage_dir() -> PathBuf {
     std::env::temp_dir().join(LOCAL_ATTACHMENT_STAGE_DIR_NAME)
@@ -50,7 +52,8 @@ fn sanitize_attachment_filename(name: &str) -> String {
     let sanitized = name
         .chars()
         .map(|character| match character {
-            '/' | '\\' | ':' | '\0' => '_',
+            '/' | '\\' | ':' | '\0' | '*' | '?' | '"' | '<' | '>' | '|' | '%' => '_',
+            character if character.is_control() => '_',
             _ => character,
         })
         .collect::<String>();
@@ -60,6 +63,45 @@ fn sanitize_attachment_filename(name: &str) -> String {
     } else {
         trimmed.to_string()
     }
+}
+
+fn sanitize_attachment_lookup_token(path_or_name: &str) -> Result<String, String> {
+    let trimmed = path_or_name.trim();
+    if trimmed.is_empty() {
+        return Err("Attachment path is required.".to_string());
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') || trimmed == "." || trimmed == ".." {
+        return Err("Attachment path must be a staged attachment filename token.".to_string());
+    }
+    Ok(trimmed.to_string())
+}
+
+fn format_attachment_lookup_display_name(token: &str) -> String {
+    let sanitized = token
+        .chars()
+        .map(|character| if character.is_control() { '_' } else { character })
+        .collect::<String>();
+    if sanitized.len() <= MAX_ATTACHMENT_LOOKUP_DISPLAY_LEN {
+        return sanitized;
+    }
+
+    let end = MAX_ATTACHMENT_LOOKUP_DISPLAY_LEN.saturating_sub(3);
+    format!("{}...", &sanitized[..end])
+}
+
+fn read_staged_attachment_original_name(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    if name.len() <= 37 {
+        return Some(name.to_string());
+    }
+
+    let separator_index = name.char_indices().nth(36)?.0;
+    let (uuid_prefix, rest) = name.split_at(separator_index);
+    if !rest.starts_with('-') || Uuid::parse_str(uuid_prefix).is_err() {
+        return Some(name.to_string());
+    }
+
+    Some(rest[1..].to_string())
 }
 
 pub(crate) fn stage_local_attachment_to_temp(name: &str, base64_data: &str) -> Result<PathBuf, String> {
@@ -94,24 +136,33 @@ pub(crate) fn resolve_staged_local_attachment_path(path_or_name: &str) -> Result
         return Err("Attachment path is not a staged local attachment.".to_string());
     }
 
+    let lookup_token = sanitize_attachment_lookup_token(trimmed)?;
+    let display_name = format_attachment_lookup_display_name(&lookup_token);
+
     let attachment_dir = local_attachment_stage_dir();
-    let entries = std::fs::read_dir(&attachment_dir)
-        .map_err(|error| format!("Failed to read attachment staging directory: {error}"))?;
-    let suffix = format!("-{trimmed}");
+    let entries = match std::fs::read_dir(&attachment_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return Err(format!("No staged local attachment matches '{display_name}'."))
+        }
+        Err(error) => {
+            return Err(format!("Failed to read attachment staging directory: {error}"))
+        }
+    };
     let mut matches = Vec::new();
     for entry in entries {
         let entry = entry.map_err(|error| format!("Failed to read staged attachment entry: {error}"))?;
         let path = entry.path();
-        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+        let Some(name) = read_staged_attachment_original_name(&path) else {
             continue;
         };
-        if name == trimmed || name.ends_with(&suffix) {
+        if name == lookup_token {
             matches.push(path);
         }
     }
 
     match matches.len() {
-        0 => Err(format!("No staged local attachment matches '{trimmed}'.")),
+        0 => Err(format!("No staged local attachment matches '{display_name}'.")),
         1 => Ok(matches.remove(0)),
         _ => {
             let mut ranked_matches = matches
@@ -128,7 +179,7 @@ pub(crate) fn resolve_staged_local_attachment_path(path_or_name: &str) -> Result
                 .into_iter()
                 .map(|(_, path)| path)
                 .next()
-                .ok_or_else(|| format!("No staged local attachment matches '{trimmed}'."))
+                .ok_or_else(|| format!("No staged local attachment matches '{display_name}'."))
         }
     }
 }
@@ -171,7 +222,12 @@ pub async fn workspace_stage_local_attachment(
         return Err("Attachment payload is required.".to_string());
     }
 
-    let path = stage_local_attachment_to_temp(&name, &base64_data)?;
+    let path = as_error(
+        run_service_blocking("workspace_stage_local_attachment", move || {
+            stage_local_attachment_to_temp(&name, &base64_data).map_err(anyhow::Error::msg)
+        })
+        .await,
+    )?;
     Ok(StagedLocalAttachmentPayload {
         path: path.to_string_lossy().into_owned(),
     })
@@ -181,7 +237,12 @@ pub async fn workspace_stage_local_attachment(
 pub async fn workspace_resolve_local_attachment_path(
     path: String,
 ) -> Result<ResolvedLocalAttachmentPayload, String> {
-    let resolved = resolve_staged_local_attachment_path(&path)?;
+    let resolved = as_error(
+        run_service_blocking("workspace_resolve_local_attachment_path", move || {
+            resolve_staged_local_attachment_path(&path).map_err(anyhow::Error::msg)
+        })
+        .await,
+    )?;
     Ok(ResolvedLocalAttachmentPayload {
         path: resolved.to_string_lossy().into_owned(),
     })
@@ -621,6 +682,29 @@ mod tests {
         assert_eq!(resolved, newer);
         let _ = fs::remove_file(older);
         let _ = fs::remove_file(newer);
+    }
+
+    #[test]
+    fn resolve_staged_local_attachment_path_does_not_match_broader_suffixes() {
+        let target_name = format!(
+            "notes-{}.pdf",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos()
+        );
+        let broader_name = format!("meeting-{target_name}");
+        let broader = stage_local_attachment_to_temp(&broader_name, "YnJvYWRlcg==")
+            .expect("broader attachment should stage");
+
+        let error = resolve_staged_local_attachment_path(&target_name)
+            .expect_err("suffix-only match should not resolve");
+
+        assert_eq!(
+            error,
+            format!("No staged local attachment matches '{target_name}'.")
+        );
+        let _ = fs::remove_file(broader);
     }
 
     fn run_git(args: &[&str], cwd: &Path) {

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -18,6 +18,7 @@ use serde_json::{json, Value};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
+use tokio_util::io::ReaderStream;
 use tower_http::cors::CorsLayer;
 
 const DEFAULT_BROWSER_BACKEND_HOST: &str = "127.0.0.1";
@@ -146,16 +147,18 @@ async fn local_attachment_preview_handler(
         });
     }
 
-    let bytes = tokio::fs::read(&path).await.map_err(|error| HeadlessCommandError {
+    let file = tokio::fs::File::open(&path).await.map_err(|error| HeadlessCommandError {
         message: format!("Failed to read local attachment preview: {error}"),
         status: StatusCode::INTERNAL_SERVER_ERROR,
     })?;
     let mime = mime_guess::from_path(&path).first_or_octet_stream().to_string();
+    let stream = ReaderStream::new(file);
 
     Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, mime)
-        .body(axum::body::Body::from(bytes))
+        .header(header::CACHE_CONTROL, "no-store, private")
+        .body(axum::body::Body::from_stream(stream))
         .map_err(|error| HeadlessCommandError {
             message: format!("Failed to build local attachment preview response: {error}"),
             status: StatusCode::INTERNAL_SERVER_ERROR,
@@ -212,7 +215,7 @@ mod tests {
     use crate::commands::workspace::stage_local_attachment_to_temp;
     use axum::body::{to_bytes, Body};
     use axum::extract::FromRequest;
-    use axum::http::header::CONTENT_TYPE;
+    use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE};
     use axum::http::Request;
     use host_application::AppService;
     use host_domain::TaskStore;
@@ -310,6 +313,10 @@ mod tests {
         assert_eq!(
             response.headers().get(CONTENT_TYPE),
             Some(&HeaderValue::from_static("image/png"))
+        );
+        assert_eq!(
+            response.headers().get(CACHE_CONTROL),
+            Some(&HeaderValue::from_static("no-store, private"))
         );
         let body = to_bytes(response.into_body(), usize::MAX)
             .await

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -1,18 +1,21 @@
 use super::command_registry::{build_registry, dispatch_command};
 use super::command_support::{HeadlessCommandError, HeadlessState};
 use super::events::{build_sse_response, parse_last_event_id, HeadlessEventBus};
+use crate::commands::workspace::is_staged_local_attachment_path;
 use crate::{
     startup_phase_service_bootstrap, startup_phase_shutdown_hooks, startup_phase_tracing,
 };
 use anyhow::Context;
 use axum::extract::rejection::JsonRejection;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::header;
 use axum::http::{HeaderMap, HeaderValue, Method, StatusCode};
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use serde::Deserialize;
 use serde_json::{json, Value};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
@@ -39,6 +42,7 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
         .route("/health", get(health_handler))
         .route("/events", get(events_handler))
         .route("/dev-server-events", get(dev_server_events_handler))
+        .route("/local-attachment-preview", get(local_attachment_preview_handler))
         .route("/invoke/{command}", post(invoke_handler))
         .layer(browser_backend_cors_layer()?)
         .with_state(HeadlessState {
@@ -110,6 +114,54 @@ async fn invoke_handler(
     }
 }
 
+#[derive(Deserialize)]
+struct LocalAttachmentPreviewQuery {
+    path: String,
+}
+
+async fn local_attachment_preview_handler(
+    Query(query): Query<LocalAttachmentPreviewQuery>,
+) -> Result<Response, HeadlessCommandError> {
+    let path = PathBuf::from(&query.path);
+    let metadata = tokio::fs::metadata(&path).await.map_err(|error| HeadlessCommandError {
+        message: format!("Failed to stat local attachment preview: {error}"),
+        status: StatusCode::NOT_FOUND,
+    })?;
+    if !metadata.is_file() {
+        return Err(HeadlessCommandError {
+            message: "Local attachment preview path must reference a file".to_string(),
+            status: StatusCode::BAD_REQUEST,
+        });
+    }
+    let allowed = is_staged_local_attachment_path(&path).map_err(|error| HeadlessCommandError {
+        message: error,
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+    })?;
+    if !allowed {
+        return Err(HeadlessCommandError {
+            message:
+                "Local attachment preview is only available for staged attachment files."
+                    .to_string(),
+            status: StatusCode::FORBIDDEN,
+        });
+    }
+
+    let bytes = tokio::fs::read(&path).await.map_err(|error| HeadlessCommandError {
+        message: format!("Failed to read local attachment preview: {error}"),
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+    })?;
+    let mime = mime_guess::from_path(&path).first_or_octet_stream().to_string();
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, mime)
+        .body(axum::body::Body::from(bytes))
+        .map_err(|error| HeadlessCommandError {
+            message: format!("Failed to build local attachment preview response: {error}"),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        })
+}
+
 fn json_rejection_error(error: JsonRejection) -> HeadlessCommandError {
     HeadlessCommandError {
         message: error.body_text(),
@@ -157,6 +209,7 @@ fn parse_origin_header(origin: &str) -> anyhow::Result<HeaderValue> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::workspace::stage_local_attachment_to_temp;
     use axum::body::{to_bytes, Body};
     use axum::extract::FromRequest;
     use axum::http::header::CONTENT_TYPE;
@@ -238,6 +291,65 @@ mod tests {
         assert_eq!(
             payload,
             json!({ "error": "Failed to parse the request body as JSON: key must be a string at line 1 column 2" })
+        );
+    }
+
+    #[tokio::test]
+    async fn local_attachment_preview_handler_returns_file_bytes() {
+        let _fixture = test_state_fixture();
+        let preview_path = stage_local_attachment_to_temp("preview.png", "cHJldmlldy1ieXRlcw==")
+            .expect("preview fixture should stage");
+
+        let response = local_attachment_preview_handler(Query(LocalAttachmentPreviewQuery {
+            path: preview_path.to_string_lossy().into_owned(),
+        }))
+        .await
+        .expect("preview request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE),
+            Some(&HeaderValue::from_static("image/png"))
+        );
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should read");
+        assert_eq!(body.as_ref(), b"preview-bytes");
+    }
+
+    #[tokio::test]
+    async fn local_attachment_preview_handler_returns_not_found_for_missing_files() {
+        let _fixture = test_state_fixture();
+        let preview_path = std::env::temp_dir()
+            .join("openducktor-local-attachments")
+            .join("missing.png");
+
+        let error = local_attachment_preview_handler(Query(LocalAttachmentPreviewQuery {
+            path: preview_path.to_string_lossy().into_owned(),
+        }))
+        .await
+        .expect_err("missing preview path should fail");
+
+        assert_eq!(error.status, StatusCode::NOT_FOUND);
+        assert!(error.message.contains("Failed to stat local attachment preview"));
+    }
+
+    #[tokio::test]
+    async fn local_attachment_preview_handler_rejects_nonstaged_paths() {
+        let fixture = test_state_fixture();
+        let preview_path = fixture.root.join("outside-staging.png");
+        fs::write(&preview_path, b"preview-bytes").expect("preview fixture should write");
+
+        let error = local_attachment_preview_handler(Query(LocalAttachmentPreviewQuery {
+            path: preview_path.to_string_lossy().into_owned(),
+        }))
+        .await
+        .expect_err("non-staged preview path should fail");
+
+        assert_eq!(error.status, StatusCode::FORBIDDEN);
+        assert_eq!(
+            error.message,
+            "Local attachment preview is only available for staged attachment files."
         );
     }
 }

--- a/apps/desktop/src-tauri/src/headless/workspace_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/workspace_commands.rs
@@ -4,11 +4,16 @@ use super::command_support::{
     serialize_value, service_error, CommandResult, HeadlessHookTrustConfirmationPort,
     HeadlessState, RepoPathArgs,
 };
+use crate::commands::workspace::{
+    resolve_staged_local_attachment_path, stage_local_attachment_to_temp,
+    ResolvedLocalAttachmentPayload, StagedLocalAttachmentPayload,
+};
 use crate::run_service_blocking_tokio;
 use crate::{
     RepoConfigPayload, RepoSettingsPayload, SettingsSnapshotPayload,
     SettingsSnapshotResponsePayload,
 };
+use anyhow::anyhow;
 use host_application::{RepoConfigUpdate, RepoSettingsUpdate, WorkspaceSettingsSnapshotUpdate};
 use serde::Deserialize;
 use serde_json::Value;
@@ -59,6 +64,21 @@ struct WorkspaceSetTrustedHooksArgs {
     trusted: bool,
     challenge_nonce: Option<String>,
     challenge_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceStageLocalAttachmentArgs {
+    name: String,
+    #[allow(dead_code)]
+    mime: Option<String>,
+    base64_data: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkspaceResolveLocalAttachmentPathArgs {
+    path: String,
 }
 
 pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), String> {
@@ -135,6 +155,12 @@ pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), St
     })?;
     registry.register("workspace_set_trusted_hooks", |state, args| {
         Box::pin(handle_workspace_set_trusted_hooks(state, args))
+    })?;
+    registry.register("workspace_stage_local_attachment", |_state, args| {
+        Box::pin(async move { handle_workspace_stage_local_attachment(args) })
+    })?;
+    registry.register("workspace_resolve_local_attachment_path", |_state, args| {
+        Box::pin(async move { handle_workspace_resolve_local_attachment_path(args) })
     })?;
     registry.register("set_theme", |state, args| {
         Box::pin(async move { handle_set_theme(state, args) })
@@ -259,6 +285,35 @@ async fn handle_workspace_update_global_git_config(
     .await
     .map_err(service_error)?;
     Ok(Value::Null)
+}
+
+fn handle_workspace_stage_local_attachment(args: Value) -> CommandResult {
+    let WorkspaceStageLocalAttachmentArgs {
+        name,
+        mime: _mime,
+        base64_data,
+    } = deserialize_args(args)?;
+    if name.trim().is_empty() {
+        return Err(service_error(anyhow!("Attachment name is required.")));
+    }
+    if base64_data.trim().is_empty() {
+        return Err(service_error(anyhow!("Attachment payload is required.")));
+    }
+
+    let path = stage_local_attachment_to_temp(&name, &base64_data)
+        .map_err(|error| service_error(anyhow!(error)))?;
+    serialize_value(StagedLocalAttachmentPayload {
+        path: path.to_string_lossy().into_owned(),
+    })
+}
+
+fn handle_workspace_resolve_local_attachment_path(args: Value) -> CommandResult {
+    let WorkspaceResolveLocalAttachmentPathArgs { path } = deserialize_args(args)?;
+    let resolved = resolve_staged_local_attachment_path(&path)
+        .map_err(|error| service_error(anyhow!(error)))?;
+    serialize_value(ResolvedLocalAttachmentPayload {
+        path: resolved.to_string_lossy().into_owned(),
+    })
 }
 
 async fn handle_workspace_save_settings_snapshot(

--- a/apps/desktop/src-tauri/src/headless/workspace_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/workspace_commands.rs
@@ -1,8 +1,8 @@
 use super::command_registry::CommandRegistry;
 use super::command_support::{
     deserialize_args, handle_repo_path_operation, handle_repo_path_operation_blocking,
-    serialize_value, service_error, CommandResult, HeadlessHookTrustConfirmationPort,
-    HeadlessState, RepoPathArgs,
+    run_headless_blocking, serialize_value, service_error, CommandResult,
+    HeadlessHookTrustConfirmationPort, HeadlessState, RepoPathArgs,
 };
 use crate::commands::workspace::{
     resolve_staged_local_attachment_path, stage_local_attachment_to_temp,
@@ -157,10 +157,10 @@ pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), St
         Box::pin(handle_workspace_set_trusted_hooks(state, args))
     })?;
     registry.register("workspace_stage_local_attachment", |_state, args| {
-        Box::pin(async move { handle_workspace_stage_local_attachment(args) })
+        Box::pin(async move { handle_workspace_stage_local_attachment(args).await })
     })?;
     registry.register("workspace_resolve_local_attachment_path", |_state, args| {
-        Box::pin(async move { handle_workspace_resolve_local_attachment_path(args) })
+        Box::pin(async move { handle_workspace_resolve_local_attachment_path(args).await })
     })?;
     registry.register("set_theme", |state, args| {
         Box::pin(async move { handle_set_theme(state, args) })
@@ -287,7 +287,7 @@ async fn handle_workspace_update_global_git_config(
     Ok(Value::Null)
 }
 
-fn handle_workspace_stage_local_attachment(args: Value) -> CommandResult {
+async fn handle_workspace_stage_local_attachment(args: Value) -> CommandResult {
     let WorkspaceStageLocalAttachmentArgs {
         name,
         mime: _mime,
@@ -300,17 +300,21 @@ fn handle_workspace_stage_local_attachment(args: Value) -> CommandResult {
         return Err(service_error(anyhow!("Attachment payload is required.")));
     }
 
-    let path = stage_local_attachment_to_temp(&name, &base64_data)
-        .map_err(|error| service_error(anyhow!(error)))?;
+    let path = run_headless_blocking("workspace_stage_local_attachment", move || {
+        stage_local_attachment_to_temp(&name, &base64_data).map_err(anyhow::Error::msg)
+    })
+    .await?;
     serialize_value(StagedLocalAttachmentPayload {
         path: path.to_string_lossy().into_owned(),
     })
 }
 
-fn handle_workspace_resolve_local_attachment_path(args: Value) -> CommandResult {
+async fn handle_workspace_resolve_local_attachment_path(args: Value) -> CommandResult {
     let WorkspaceResolveLocalAttachmentPathArgs { path } = deserialize_args(args)?;
-    let resolved = resolve_staged_local_attachment_path(&path)
-        .map_err(|error| service_error(anyhow!(error)))?;
+    let resolved = run_headless_blocking("workspace_resolve_local_attachment_path", move || {
+        resolve_staged_local_attachment_path(&path).map_err(anyhow::Error::msg)
+    })
+    .await?;
     serialize_value(ResolvedLocalAttachmentPayload {
         path: resolved.to_string_lossy().into_owned(),
     })

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -288,6 +288,8 @@ fn startup_phase_command_registration(
         workspace_save_repo_settings,
         workspace_update_repo_hooks,
         workspace_prepare_trusted_hooks_challenge,
+        workspace_stage_local_attachment,
+        workspace_resolve_local_attachment_path,
         workspace_get_repo_config,
         workspace_detect_github_repository,
         workspace_get_settings_snapshot,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -20,6 +20,12 @@
       }
     ],
     "security": {
+      "assetProtocol": {
+        "enable": true,
+        "scope": {
+          "allow": ["$TEMP/openducktor-local-attachments/**"]
+        }
+      },
       "csp": {
         "default-src": ["'self'"],
         "base-uri": ["'none'"],
@@ -28,7 +34,8 @@
         "form-action": ["'self'"],
         "script-src": ["'self'"],
         "style-src": ["'self'", "'unsafe-inline'"],
-        "img-src": ["'self'", "data:"],
+        "img-src": ["'self'", "data:", "asset:", "http://asset.localhost"],
+        "media-src": ["'self'", "data:", "asset:", "http://asset.localhost"],
         "connect-src": ["ipc:", "http://ipc.localhost", "http://127.0.0.1:*"]
       },
       "devCsp": {
@@ -39,7 +46,8 @@
         "form-action": ["'self'"],
         "script-src": ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
         "style-src": ["'self'", "'unsafe-inline'"],
-        "img-src": ["'self'", "data:"],
+        "img-src": ["'self'", "data:", "asset:", "http://asset.localhost"],
+        "media-src": ["'self'", "data:", "asset:", "http://asset.localhost"],
         "connect-src": [
           "'self'",
           "ipc:",
@@ -59,6 +67,12 @@
     "macOS": {
       "minimumSystemVersion": "12.0"
     },
-    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.ico", "icons/icon.icns"]
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.ico",
+      "icons/icon.icns"
+    ]
   }
 }

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
@@ -38,10 +38,11 @@ describe("AgentChatAttachmentChip", () => {
     fireEvent.click(previewButton);
     await screen.findByText("Image preview");
 
-    const renderedImages = screen.getAllByAltText("preview.png");
-    const dialogImage = renderedImages[renderedImages.length - 1];
-    if (!dialogImage) {
-      throw new Error("Expected preview image in dialog");
+    const dialogImage = screen
+      .getAllByAltText("preview.png")
+      .find((image) => image.className.includes("object-contain"));
+    if (!(dialogImage instanceof HTMLElement)) {
+      throw new Error("Expected fullscreen preview image");
     }
     fireEvent.error(dialogImage);
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AgentChatAttachmentChip } from "./agent-chat-attachment-chip";
+
+const originalCreateObjectUrl = URL.createObjectURL;
+const originalRevokeObjectUrl = URL.revokeObjectURL;
+
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectUrl;
+  URL.revokeObjectURL = originalRevokeObjectUrl;
+});
+
+describe("AgentChatAttachmentChip", () => {
+  test("surfaces preview load failures and closes the dialog", async () => {
+    URL.createObjectURL = () => "blob:preview.png";
+    URL.revokeObjectURL = () => {};
+
+    render(
+      <AgentChatAttachmentChip
+        variant="draft"
+        attachment={{
+          id: "attachment-1",
+          name: "preview.png",
+          kind: "image",
+          mime: "image/png",
+          file: new File(["image"], "preview.png", { type: "image/png" }),
+        }}
+        onRemove={() => {}}
+      />,
+    );
+
+    const previewButton = screen
+      .getAllByRole("button")
+      .find((button) => button.getAttribute("aria-label") === null);
+    if (!previewButton) {
+      throw new Error("Expected preview button");
+    }
+    fireEvent.click(previewButton);
+    await screen.findByText("Image preview");
+
+    const renderedImages = screen.getAllByAltText("preview.png");
+    const dialogImage = renderedImages[renderedImages.length - 1];
+    if (!dialogImage) {
+      throw new Error("Expected preview image in dialog");
+    }
+    fireEvent.error(dialogImage);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Attachment preview is unavailable because "preview.png" could not be read from its original local path.',
+        ),
+      ).toBeDefined();
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Image preview")).toBeNull();
+    });
+  });
+
+  test("does not poison preview opening when the inline thumbnail errors during rerender", async () => {
+    URL.createObjectURL = () => "blob:preview-inline.png";
+    URL.revokeObjectURL = () => {};
+
+    render(
+      <AgentChatAttachmentChip
+        variant="transcript"
+        attachment={{
+          id: "attachment-3",
+          path: "/tmp/preview-inline.png",
+          name: "preview-inline.png",
+          kind: "image",
+          mime: "image/png",
+        }}
+      />,
+    );
+
+    const thumbnailImage = await screen.findByAltText("preview-inline.png");
+    fireEvent.error(thumbnailImage);
+
+    expect(
+      screen.queryByText(
+        'Attachment preview is unavailable because "preview-inline.png" could not be read from its original local path.',
+      ),
+    ).toBeNull();
+
+    const previewButton = screen
+      .getAllByRole("button")
+      .find((button) => button.getAttribute("aria-label") === null);
+    if (!previewButton) {
+      throw new Error("Expected preview button");
+    }
+    fireEvent.click(previewButton);
+
+    await screen.findByText("Image preview");
+  });
+
+  test("exposes the full attachment name on hover", () => {
+    render(
+      <AgentChatAttachmentChip
+        variant="draft"
+        attachment={{
+          id: "attachment-2",
+          name: "very-long-screenshot-file-name-that-should-truncate.png",
+          kind: "pdf",
+          mime: "application/pdf",
+          path: "/tmp/very-long-screenshot-file-name-that-should-truncate.png",
+        }}
+        onRemove={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByTitle("very-long-screenshot-file-name-that-should-truncate.png"),
+    ).toBeDefined();
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.tsx
@@ -1,0 +1,226 @@
+import type { AgentAttachmentReference } from "@openducktor/core";
+import { FileAudio2, FileText, Film, Image as ImageIcon, LoaderCircle, X } from "lucide-react";
+import { type ReactElement, type SyntheticEvent, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import {
+  type AgentChatAttachmentPreviewTarget,
+  useAgentChatAttachmentPreview,
+} from "./use-agent-chat-attachment-preview";
+
+const ATTACHMENT_ICON = {
+  image: ImageIcon,
+  audio: FileAudio2,
+  video: Film,
+  pdf: FileText,
+} as const;
+
+function AttachmentName({ name }: { name: string }): ReactElement {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="min-w-0 truncate text-xs text-foreground" title={name}>
+            {name}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p>{name}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+type DraftAttachmentChipProps = {
+  variant: "draft";
+  attachment: AgentChatAttachmentPreviewTarget;
+  error?: string | null;
+  onRemove: () => void;
+  className?: string;
+};
+
+type TranscriptAttachmentChipProps = {
+  variant: "transcript";
+  attachment: AgentAttachmentReference;
+  className?: string;
+};
+
+export function AgentChatAttachmentChip(
+  props: DraftAttachmentChipProps | TranscriptAttachmentChipProps,
+): ReactElement {
+  const { variant, attachment, className } = props;
+  const Icon = ATTACHMENT_ICON[attachment.kind];
+  const draftProps = variant === "draft" ? props : null;
+  const {
+    dialogOpen,
+    setDialogOpen,
+    resolvedPreviewSrc,
+    previewError,
+    effectiveError,
+    isResolvingPreview,
+    previewable,
+    showResolvedPreview,
+    requestPreviewOpen,
+    markPreviewUnavailable,
+  } = useAgentChatAttachmentPreview({
+    attachment,
+    externalError: draftProps?.error ?? null,
+  });
+  const removable = variant === "draft";
+  const onRemove = draftProps?.onRemove ?? null;
+  const [failedThumbnailSrc, setFailedThumbnailSrc] = useState<string | null>(null);
+  const thumbnailFailed = failedThumbnailSrc !== null && failedThumbnailSrc === resolvedPreviewSrc;
+
+  const handleDialogPreviewMediaError = (
+    event: SyntheticEvent<HTMLImageElement | HTMLVideoElement>,
+  ): void => {
+    const failingSrc =
+      event.currentTarget.currentSrc || event.currentTarget.getAttribute("src") || undefined;
+    markPreviewUnavailable(failingSrc);
+  };
+
+  const handleOpenPreview = (): void => {
+    const previewError = requestPreviewOpen();
+    if (!previewError) {
+      return;
+    }
+    toast.error("Unable to open attachment preview", {
+      description: previewError,
+    });
+  };
+
+  return (
+    <>
+      <div
+        className={cn(
+          "relative flex min-w-0 flex-col overflow-hidden rounded-lg border bg-card",
+          effectiveError ? "border-destructive bg-destructive/5" : "border-border",
+          previewable ? "w-40" : "max-w-full min-w-0",
+          previewable ? "cursor-pointer" : undefined,
+          className,
+        )}
+      >
+        {removable && onRemove ? (
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="absolute right-1 top-1 z-10 size-6 rounded-full bg-card/90 text-muted-foreground hover:bg-card hover:text-foreground"
+            aria-label={`Remove ${attachment.name}`}
+            onClick={onRemove}
+          >
+            <X className="size-3.5" />
+          </Button>
+        ) : null}
+
+        {previewable ? (
+          <button
+            type="button"
+            className="flex w-full cursor-pointer flex-col text-left"
+            onClick={handleOpenPreview}
+          >
+            <div className="flex h-24 max-h-24 items-center justify-center overflow-hidden bg-muted">
+              {showResolvedPreview && !thumbnailFailed ? (
+                attachment.kind === "image" ? (
+                  <img
+                    src={resolvedPreviewSrc ?? undefined}
+                    alt={attachment.name}
+                    className="h-full w-full object-cover"
+                    onError={(event) => {
+                      setFailedThumbnailSrc(
+                        event.currentTarget.currentSrc ||
+                          event.currentTarget.getAttribute("src") ||
+                          resolvedPreviewSrc ||
+                          null,
+                      );
+                    }}
+                  />
+                ) : (
+                  <video
+                    src={resolvedPreviewSrc ?? undefined}
+                    className="h-full w-full object-cover"
+                    muted
+                    playsInline
+                    preload="metadata"
+                    onError={(event) => {
+                      setFailedThumbnailSrc(
+                        event.currentTarget.currentSrc ||
+                          event.currentTarget.getAttribute("src") ||
+                          resolvedPreviewSrc ||
+                          null,
+                      );
+                    }}
+                  >
+                    <track kind="captions" />
+                  </video>
+                )
+              ) : isResolvingPreview ? (
+                <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
+              ) : (
+                <Icon className="size-5 text-muted-foreground" />
+              )}
+            </div>
+            <div className="flex items-center gap-2 px-3 py-2">
+              <Icon className="size-4 shrink-0 text-muted-foreground" />
+              <AttachmentName name={attachment.name} />
+            </div>
+          </button>
+        ) : (
+          <div className="flex items-center gap-2 px-3 py-2">
+            <Icon className="size-4 shrink-0 text-muted-foreground" />
+            <AttachmentName name={attachment.name} />
+          </div>
+        )}
+
+        {effectiveError ? (
+          <p className="border-t border-destructive/20 px-3 py-2 text-[11px] text-destructive">
+            {effectiveError}
+          </p>
+        ) : null}
+      </div>
+
+      {previewable && resolvedPreviewSrc && !previewError ? (
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogContent className="max-w-[min(96vw,72rem)] border-border bg-background">
+            <DialogHeader>
+              <DialogTitle>{attachment.name}</DialogTitle>
+              <DialogDescription>
+                {attachment.kind === "image" ? "Image preview" : "Video preview"}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="max-h-[80vh] overflow-hidden rounded-md border border-border bg-muted">
+              {attachment.kind === "image" ? (
+                <img
+                  src={resolvedPreviewSrc}
+                  alt={attachment.name}
+                  className="max-h-[75vh] w-full object-contain"
+                  onError={handleDialogPreviewMediaError}
+                />
+              ) : (
+                <video
+                  src={resolvedPreviewSrc}
+                  className="max-h-[75vh] w-full object-contain"
+                  controls
+                  autoPlay
+                  onError={handleDialogPreviewMediaError}
+                >
+                  <track kind="captions" />
+                </video>
+              )}
+            </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+    </>
+  );
+}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.tsx
@@ -80,6 +80,20 @@ export function AgentChatAttachmentChip(
   const onRemove = draftProps?.onRemove ?? null;
   const [failedThumbnailSrc, setFailedThumbnailSrc] = useState<string | null>(null);
   const thumbnailFailed = failedThumbnailSrc !== null && failedThumbnailSrc === resolvedPreviewSrc;
+  const showPreviewImage = showResolvedPreview && !thumbnailFailed && attachment.kind === "image";
+  const showPreviewVideo = showResolvedPreview && !thumbnailFailed && attachment.kind === "video";
+  const showPreviewLoader = isResolvingPreview;
+
+  const handleThumbnailError = (
+    event: SyntheticEvent<HTMLImageElement | HTMLVideoElement>,
+  ): void => {
+    setFailedThumbnailSrc(
+      event.currentTarget.currentSrc ||
+        event.currentTarget.getAttribute("src") ||
+        resolvedPreviewSrc ||
+        null,
+    );
+  };
 
   const handleDialogPreviewMediaError = (
     event: SyntheticEvent<HTMLImageElement | HTMLVideoElement>,
@@ -130,41 +144,25 @@ export function AgentChatAttachmentChip(
             onClick={handleOpenPreview}
           >
             <div className="flex h-24 max-h-24 items-center justify-center overflow-hidden bg-muted">
-              {showResolvedPreview && !thumbnailFailed ? (
-                attachment.kind === "image" ? (
-                  <img
-                    src={resolvedPreviewSrc ?? undefined}
-                    alt={attachment.name}
-                    className="h-full w-full object-cover"
-                    onError={(event) => {
-                      setFailedThumbnailSrc(
-                        event.currentTarget.currentSrc ||
-                          event.currentTarget.getAttribute("src") ||
-                          resolvedPreviewSrc ||
-                          null,
-                      );
-                    }}
-                  />
-                ) : (
-                  <video
-                    src={resolvedPreviewSrc ?? undefined}
-                    className="h-full w-full object-cover"
-                    muted
-                    playsInline
-                    preload="metadata"
-                    onError={(event) => {
-                      setFailedThumbnailSrc(
-                        event.currentTarget.currentSrc ||
-                          event.currentTarget.getAttribute("src") ||
-                          resolvedPreviewSrc ||
-                          null,
-                      );
-                    }}
-                  >
-                    <track kind="captions" />
-                  </video>
-                )
-              ) : isResolvingPreview ? (
+              {showPreviewImage ? (
+                <img
+                  src={resolvedPreviewSrc ?? undefined}
+                  alt={attachment.name}
+                  className="h-full w-full object-cover"
+                  onError={handleThumbnailError}
+                />
+              ) : showPreviewVideo ? (
+                <video
+                  src={resolvedPreviewSrc ?? undefined}
+                  className="h-full w-full object-cover"
+                  muted
+                  playsInline
+                  preload="metadata"
+                  onError={handleThumbnailError}
+                >
+                  <track kind="captions" />
+                </video>
+              ) : showPreviewLoader ? (
                 <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
               ) : (
                 <Icon className="size-5 text-muted-foreground" />

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.test.ts
@@ -26,6 +26,32 @@ describe("agent-chat-attachments", () => {
     expect(buildComposerAttachmentFromFile(file)).toBeNull();
   });
 
+  test("rehydrates uncommon supported extensions from their path", () => {
+    const attachment = buildComposerAttachmentFromPath("/tmp/preview.avif");
+
+    expect(attachment).toMatchObject({
+      name: "preview.avif",
+      kind: "image",
+      mime: "image/avif",
+      path: "/tmp/preview.avif",
+    });
+  });
+
+  test("prefers persisted metadata when rebuilding from path", () => {
+    const attachment = buildComposerAttachmentFromPath("/tmp/blob.bin", {
+      name: "recording-from-runtime",
+      kind: "audio",
+      mime: "audio/ogg",
+    });
+
+    expect(attachment).toMatchObject({
+      name: "recording-from-runtime",
+      kind: "audio",
+      mime: "audio/ogg",
+      path: "/tmp/blob.bin",
+    });
+  });
+
   test("validates staged attachments against model capability data", () => {
     const pdfAttachment = buildComposerAttachmentFromPath("/tmp/brief.pdf");
     const imageAttachment = buildComposerAttachmentFromPath("/tmp/photo.png");

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildComposerAttachmentFromFile,
+  buildComposerAttachmentFromPath,
+  validateComposerAttachments,
+} from "./agent-chat-attachments";
+
+describe("agent-chat-attachments", () => {
+  test("classifies supported browser files into composer attachments", () => {
+    const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+
+    const attachment = buildComposerAttachmentFromFile(file);
+
+    expect(attachment).toMatchObject({
+      name: "brief.pdf",
+      kind: "pdf",
+      mime: "application/pdf",
+      file,
+    });
+    expect(attachment?.path).toBeUndefined();
+  });
+
+  test("rejects unsupported files", () => {
+    const file = new File(["zip"], "archive.zip", { type: "application/zip" });
+
+    expect(buildComposerAttachmentFromFile(file)).toBeNull();
+  });
+
+  test("validates staged attachments against model capability data", () => {
+    const pdfAttachment = buildComposerAttachmentFromPath("/tmp/brief.pdf");
+    const imageAttachment = buildComposerAttachmentFromPath("/tmp/photo.png");
+    if (!pdfAttachment || !imageAttachment) {
+      throw new Error("Expected fixture attachments to classify");
+    }
+
+    expect(validateComposerAttachments([pdfAttachment], null)).toEqual({
+      [pdfAttachment.id]: "The selected model does not expose attachment capability data.",
+    });
+
+    expect(
+      validateComposerAttachments([pdfAttachment, imageAttachment], {
+        pdf: true,
+        image: false,
+        audio: false,
+        video: false,
+      }),
+    ).toEqual({
+      [imageAttachment.id]: "The selected model does not support image attachments.",
+    });
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.ts
@@ -5,10 +5,15 @@ import {
 } from "./agent-chat-composer-draft";
 
 const ATTACHMENT_EXTENSION_KIND: Record<string, AgentAttachmentKind> = {
+  ".avif": "image",
   ".png": "image",
   ".jpg": "image",
   ".jpeg": "image",
   ".gif": "image",
+  ".heic": "image",
+  ".heif": "image",
+  ".tif": "image",
+  ".tiff": "image",
   ".webp": "image",
   ".svg": "image",
   ".bmp": "image",
@@ -17,20 +22,29 @@ const ATTACHMENT_EXTENSION_KIND: Record<string, AgentAttachmentKind> = {
   ".m4a": "audio",
   ".aac": "audio",
   ".ogg": "audio",
+  ".oga": "audio",
+  ".opus": "audio",
   ".flac": "audio",
   ".mp4": "video",
+  ".m4v": "video",
   ".mov": "video",
   ".webm": "video",
+  ".ogv": "video",
   ".mkv": "video",
   ".avi": "video",
   ".pdf": "pdf",
 };
 
 const ATTACHMENT_EXTENSION_MIME: Record<string, string> = {
+  ".avif": "image/avif",
   ".png": "image/png",
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
   ".gif": "image/gif",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
   ".webp": "image/webp",
   ".svg": "image/svg+xml",
   ".bmp": "image/bmp",
@@ -39,10 +53,14 @@ const ATTACHMENT_EXTENSION_MIME: Record<string, string> = {
   ".m4a": "audio/mp4",
   ".aac": "audio/aac",
   ".ogg": "audio/ogg",
+  ".oga": "audio/ogg",
+  ".opus": "audio/ogg",
   ".flac": "audio/flac",
   ".mp4": "video/mp4",
+  ".m4v": "video/x-m4v",
   ".mov": "video/quicktime",
   ".webm": "video/webm",
+  ".ogv": "video/ogg",
   ".mkv": "video/x-matroska",
   ".avi": "video/x-msvideo",
   ".pdf": "application/pdf",
@@ -109,13 +127,19 @@ export const buildComposerAttachmentFromFile = (file: File): AgentChatComposerAt
 
 export const buildComposerAttachmentFromPath = (
   path: string,
+  metadata?: Pick<AgentChatComposerAttachment, "kind" | "mime" | "name">,
 ): AgentChatComposerAttachment | null => {
-  const name = readAttachmentNameFromPath(path);
-  const kind = classifyAttachment({ name });
+  const name = metadata?.name ?? readAttachmentNameFromPath(path);
+  const kind =
+    metadata?.kind ??
+    classifyAttachment({
+      name,
+      ...(metadata?.mime ? { mime: metadata.mime } : {}),
+    });
   if (!kind) {
     return null;
   }
-  const mime = inferAttachmentMime(name);
+  const mime = inferAttachmentMime(name, metadata?.mime);
 
   return createComposerAttachment({
     name,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachments.ts
@@ -1,0 +1,158 @@
+import type { AgentAttachmentKind, AgentModelAttachmentSupport } from "@openducktor/core";
+import {
+  type AgentChatComposerAttachment,
+  createComposerAttachment,
+} from "./agent-chat-composer-draft";
+
+const ATTACHMENT_EXTENSION_KIND: Record<string, AgentAttachmentKind> = {
+  ".png": "image",
+  ".jpg": "image",
+  ".jpeg": "image",
+  ".gif": "image",
+  ".webp": "image",
+  ".svg": "image",
+  ".bmp": "image",
+  ".mp3": "audio",
+  ".wav": "audio",
+  ".m4a": "audio",
+  ".aac": "audio",
+  ".ogg": "audio",
+  ".flac": "audio",
+  ".mp4": "video",
+  ".mov": "video",
+  ".webm": "video",
+  ".mkv": "video",
+  ".avi": "video",
+  ".pdf": "pdf",
+};
+
+const ATTACHMENT_EXTENSION_MIME: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".m4a": "audio/mp4",
+  ".aac": "audio/aac",
+  ".ogg": "audio/ogg",
+  ".flac": "audio/flac",
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".webm": "video/webm",
+  ".mkv": "video/x-matroska",
+  ".avi": "video/x-msvideo",
+  ".pdf": "application/pdf",
+};
+
+export const CHAT_ATTACHMENT_ACCEPT = "image/*,audio/*,video/*,.pdf,application/pdf";
+
+const readFileExtension = (name: string): string => {
+  const lastDot = name.lastIndexOf(".");
+  return lastDot >= 0 ? name.slice(lastDot).toLowerCase() : "";
+};
+
+export const readAttachmentNameFromPath = (path: string): string => {
+  const normalized = path.replace(/\\/g, "/");
+  const segments = normalized.split("/");
+  return segments[segments.length - 1] ?? path;
+};
+
+export const classifyAttachment = (input: {
+  name: string;
+  mime?: string;
+}): AgentAttachmentKind | null => {
+  const mime = input.mime?.trim().toLowerCase();
+  if (mime) {
+    if (mime.startsWith("image/")) {
+      return "image";
+    }
+    if (mime.startsWith("audio/")) {
+      return "audio";
+    }
+    if (mime.startsWith("video/")) {
+      return "video";
+    }
+    if (mime === "application/pdf") {
+      return "pdf";
+    }
+  }
+
+  return ATTACHMENT_EXTENSION_KIND[readFileExtension(input.name)] ?? null;
+};
+
+const inferAttachmentMime = (name: string, mime?: string): string | undefined => {
+  const trimmedMime = mime?.trim();
+  if (trimmedMime) {
+    return trimmedMime;
+  }
+  return ATTACHMENT_EXTENSION_MIME[readFileExtension(name)];
+};
+
+export const buildComposerAttachmentFromFile = (file: File): AgentChatComposerAttachment | null => {
+  const kind = classifyAttachment({ name: file.name, mime: file.type });
+  if (!kind) {
+    return null;
+  }
+  const mime = inferAttachmentMime(file.name, file.type);
+
+  return createComposerAttachment({
+    name: file.name,
+    kind,
+    ...(mime ? { mime } : {}),
+    file,
+  });
+};
+
+export const buildComposerAttachmentFromPath = (
+  path: string,
+): AgentChatComposerAttachment | null => {
+  const name = readAttachmentNameFromPath(path);
+  const kind = classifyAttachment({ name });
+  if (!kind) {
+    return null;
+  }
+  const mime = inferAttachmentMime(name);
+
+  return createComposerAttachment({
+    name,
+    kind,
+    path,
+    ...(mime ? { mime } : {}),
+  });
+};
+
+export const isPreviewableAttachmentKind = (kind: AgentAttachmentKind): boolean => {
+  return kind === "image" || kind === "video";
+};
+
+export const readAttachmentValidationError = (
+  attachment: Pick<AgentChatComposerAttachment, "kind">,
+  support: AgentModelAttachmentSupport | null | undefined,
+): string | null => {
+  if (!support) {
+    return "The selected model does not expose attachment capability data.";
+  }
+
+  if (support[attachment.kind]) {
+    return null;
+  }
+
+  return `The selected model does not support ${attachment.kind} attachments.`;
+};
+
+export const validateComposerAttachments = (
+  attachments: AgentChatComposerAttachment[],
+  support: AgentModelAttachmentSupport | null | undefined,
+): Record<string, string> => {
+  return attachments.reduce<Record<string, string>>((acc, attachment) => {
+    const error = readAttachmentValidationError(attachment, support);
+    if (error) {
+      acc[attachment.id] = error;
+    }
+    return acc;
+  }, {});
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-draft.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-draft.test.ts
@@ -29,6 +29,7 @@ describe("applyComposerDraftEdit", () => {
   test("inserts a newline into a text segment and returns a focus target", () => {
     const draft: AgentChatComposerDraft = {
       segments: [createTextSegment("hello world", "text-1")],
+      attachments: [],
     };
 
     const result = applyComposerDraftEdit(draft, {
@@ -40,6 +41,7 @@ describe("applyComposerDraftEdit", () => {
     expect(result).toEqual({
       draft: {
         segments: [expect.objectContaining({ id: "text-1", kind: "text", text: "hello\n world" })],
+        attachments: [],
       },
       focusTarget: {
         segmentId: "text-1",
@@ -55,6 +57,7 @@ describe("applyComposerDraftEdit", () => {
         createSlashCommandSegment(COMMAND, "slash-1"),
         createTextSegment(" after", "text-after"),
       ],
+      attachments: [],
     };
 
     const result = applyComposerDraftEdit(draft, {
@@ -67,6 +70,7 @@ describe("applyComposerDraftEdit", () => {
         segments: [
           expect.objectContaining({ id: "text-before", kind: "text", text: "before  after" }),
         ],
+        attachments: [],
       },
       focusTarget: {
         segmentId: "text-before",
@@ -78,6 +82,7 @@ describe("applyComposerDraftEdit", () => {
   test("only exposes slash autocomplete at the beginning of the draft", () => {
     const draft: AgentChatComposerDraft = {
       segments: [createTextSegment("hello /compact", "text-1")],
+      attachments: [],
     };
 
     expect(readSlashTriggerMatchForDraft(draft, "text-1", 14)).toBeNull();
@@ -90,6 +95,7 @@ describe("applyComposerDraftEdit", () => {
         createSlashCommandSegment(COMMAND, "slash-1"),
         createTextSegment("/compact", "text-2"),
       ],
+      attachments: [],
     };
 
     expect(readSlashTriggerMatchForDraft(draft, "text-2", 8)).toBeNull();
@@ -102,6 +108,7 @@ describe("applyComposerDraftEdit", () => {
         createFileReferenceSegment(FILE, "file-1"),
         createTextSegment(" /compact", "text-2"),
       ],
+      attachments: [],
     };
 
     expect(readSlashTriggerMatchForDraft(draft, "text-2", 9)).toBeNull();
@@ -114,6 +121,7 @@ describe("applyComposerDraftEdit", () => {
         createFileReferenceSegment(FILE, "file-1"),
         createTextSegment("/compact", "text-2"),
       ],
+      attachments: [],
     };
 
     const result = applyComposerDraftEdit(draft, {
@@ -130,6 +138,7 @@ describe("applyComposerDraftEdit", () => {
   test("replaces an @query range with a file reference chip", () => {
     const draft: AgentChatComposerDraft = {
       segments: [createTextSegment("see @src/ma now", "text-1")],
+      attachments: [],
     };
 
     const result = applyComposerDraftEdit(draft, {
@@ -147,6 +156,7 @@ describe("applyComposerDraftEdit", () => {
           expect.objectContaining({ kind: "file_reference", file: FILE }),
           expect.objectContaining({ kind: "text", text: " now" }),
         ],
+        attachments: [],
       },
       focusTarget: {
         segmentId: expect.any(String),
@@ -162,6 +172,7 @@ describe("applyComposerDraftEdit", () => {
         createFileReferenceSegment(FILE, "file-1"),
         createTextSegment(" after", "text-after"),
       ],
+      attachments: [],
     };
 
     const result = applyComposerDraftEdit(draft, {
@@ -174,6 +185,7 @@ describe("applyComposerDraftEdit", () => {
         segments: [
           expect.objectContaining({ id: "text-before", kind: "text", text: "before  after" }),
         ],
+        attachments: [],
       },
       focusTarget: {
         segmentId: "text-before",
@@ -189,6 +201,7 @@ describe("applyComposerDraftEdit", () => {
         createFileReferenceSegment(FILE, "file-1"),
         createTextSegment(" after", "text-after"),
       ],
+      attachments: [],
     };
 
     expect(normalizeComposerDraft(draft)).toEqual({
@@ -197,6 +210,7 @@ describe("applyComposerDraftEdit", () => {
         expect.objectContaining({ id: "file-1", kind: "file_reference", file: FILE }),
         expect.objectContaining({ id: "text-after", kind: "text", text: " after" }),
       ],
+      attachments: [],
     });
   });
 
@@ -225,6 +239,7 @@ describe("applyComposerDraftEdit", () => {
         ),
         createTextSegment("are consistent?", "text-after"),
       ],
+      attachments: [],
     };
 
     expect(draftToSerializedText(draft)).toBe(
@@ -235,6 +250,7 @@ describe("applyComposerDraftEdit", () => {
   test("exposes file autocomplete in the middle of draft text", () => {
     const draft: AgentChatComposerDraft = {
       segments: [createTextSegment("hello @src/ma world", "text-1")],
+      attachments: [],
     };
 
     expect(readFileTriggerMatchForDraft(draft, "text-1", 13)).toEqual({
@@ -247,6 +263,7 @@ describe("applyComposerDraftEdit", () => {
   test("does not expose file autocomplete inside email-like text", () => {
     const draft: AgentChatComposerDraft = {
       segments: [createTextSegment("hello user@example.com", "text-1")],
+      attachments: [],
     };
 
     expect(readFileTriggerMatchForDraft(draft, "text-1", 18)).toBeNull();

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-draft.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-draft.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   type AgentChatComposerDraft,
   applyComposerDraftEdit,
+  createComposerAttachment,
   createFileReferenceSegment,
   createSlashCommandSegment,
   createTextSegment,
@@ -211,6 +212,28 @@ describe("applyComposerDraftEdit", () => {
         expect.objectContaining({ id: "text-after", kind: "text", text: " after" }),
       ],
       attachments: [],
+    });
+  });
+
+  test("preserves attachments when normalizing an empty segment list", () => {
+    const attachment = createComposerAttachment(
+      {
+        name: "brief.pdf",
+        kind: "pdf",
+        mime: "application/pdf",
+        path: "/tmp/brief.pdf",
+      },
+      "attachment-1",
+    );
+
+    expect(
+      normalizeComposerDraft({
+        segments: [],
+        attachments: [attachment],
+      }),
+    ).toEqual({
+      segments: [expect.objectContaining({ kind: "text", text: "" })],
+      attachments: [attachment],
     });
   });
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-draft.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-draft.ts
@@ -198,7 +198,10 @@ export const normalizeComposerDraft = (draft: AgentChatComposerDraft): AgentChat
   }
 
   if (normalized.length === 0) {
-    return createEmptyComposerDraft();
+    return {
+      ...createEmptyComposerDraft(),
+      attachments: draft.attachments ?? [],
+    };
   }
 
   if (normalized[0]?.kind !== "text") {
@@ -500,9 +503,7 @@ export const draftHasMeaningfulContent = (draft: AgentChatComposerDraft): boolea
   });
 };
 
-export const draftHasSlashCommandSegment = (draft: AgentChatComposerDraft): boolean => {
-  return draft.segments.some((segment) => segment.kind === "slash_command");
-};
+export const draftHasSlashCommandSegment = hasExistingSlashCommandSegment;
 
 export const appendAttachmentsToDraft = (
   draft: AgentChatComposerDraft,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-draft.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-draft.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentAttachmentKind,
   AgentFileReference,
   AgentSlashCommand,
   AgentUserMessagePart,
@@ -28,8 +29,19 @@ export type AgentChatComposerSegment =
   | AgentChatComposerSlashCommandSegment
   | AgentChatComposerFileReferenceSegment;
 
+export type AgentChatComposerAttachment = {
+  id: string;
+  name: string;
+  kind: AgentAttachmentKind;
+  mime?: string;
+  path?: string;
+  file?: File;
+  previewUrl?: string;
+};
+
 export type AgentChatComposerDraft = {
   segments: AgentChatComposerSegment[];
+  attachments?: AgentChatComposerAttachment[];
 };
 
 export type AgentChatSlashTriggerMatch = {
@@ -140,8 +152,17 @@ export const createFileReferenceSegment = (
   file,
 });
 
+export const createComposerAttachment = (
+  attachment: Omit<AgentChatComposerAttachment, "id">,
+  id = createSegmentId(),
+): AgentChatComposerAttachment => ({
+  id,
+  ...attachment,
+});
+
 export const createEmptyComposerDraft = (): AgentChatComposerDraft => ({
   segments: [createTextSegment("")],
+  attachments: [],
 });
 
 export const isTextSegment = (
@@ -189,14 +210,24 @@ export const normalizeComposerDraft = (draft: AgentChatComposerDraft): AgentChat
 
   return {
     segments: normalized,
+    attachments: draft.attachments ?? [],
   };
 };
+
+const withDraftSegments = (
+  draft: AgentChatComposerDraft,
+  segments: AgentChatComposerSegment[],
+): AgentChatComposerDraft => ({
+  ...draft,
+  segments,
+});
 
 export const updateTextSegmentInDraft = (
   draft: AgentChatComposerDraft,
   segmentId: string,
   text: string,
 ): AgentChatComposerDraft => ({
+  ...draft,
   segments: draft.segments.map((segment) =>
     segment.kind === "text" && segment.id === segmentId ? { ...segment, text } : segment,
   ),
@@ -244,7 +275,7 @@ const removeNonTextSegmentFromDraft = (
   segments.splice(index - 1, 3, createTextSegment(mergedText, previous.id));
 
   return {
-    draft: { segments },
+    draft: withDraftSegments(draft, segments),
     focusTarget: {
       segmentId: previous.id,
       offset: previous.text.length,
@@ -300,7 +331,7 @@ export const replaceTextRangeWithSlashCommand = (
   segments.splice(index, 1, ...replacement);
 
   return {
-    draft: { segments },
+    draft: withDraftSegments(draft, segments),
     focusTarget: {
       segmentId: afterSegment.id,
       offset: 0,
@@ -333,7 +364,7 @@ export const replaceTextRangeWithFileReference = (
   segments.splice(index, 1, ...replacement);
 
   return {
-    draft: { segments },
+    draft: withDraftSegments(draft, segments),
     focusTarget: {
       segmentId: afterSegment.id,
       offset: 0,
@@ -384,17 +415,72 @@ export const applyComposerDraftEdit = (
 };
 
 export const draftToUserMessageParts = (draft: AgentChatComposerDraft): AgentUserMessagePart[] => {
-  return normalizeComposerDraft(draft).segments.flatMap<AgentUserMessagePart>((segment) => {
-    if (segment.kind === "text") {
-      return segment.text.length > 0 ? [{ kind: "text", text: segment.text }] : [];
-    }
+  const normalizedDraft = normalizeComposerDraft(draft);
+  return [
+    ...normalizedDraft.segments.flatMap<AgentUserMessagePart>((segment) => {
+      if (segment.kind === "text") {
+        return segment.text.length > 0 ? [{ kind: "text", text: segment.text }] : [];
+      }
 
-    if (segment.kind === "file_reference") {
-      return [{ kind: "file_reference", file: segment.file }];
-    }
+      if (segment.kind === "file_reference") {
+        return [{ kind: "file_reference", file: segment.file }];
+      }
 
-    return [{ kind: "slash_command", command: segment.command }];
+      return [{ kind: "slash_command", command: segment.command }];
+    }),
+    ...(normalizedDraft.attachments ?? []).flatMap<AgentUserMessagePart>((attachment) => {
+      if (!attachment.path) {
+        return [];
+      }
+
+      return [
+        {
+          kind: "attachment",
+          attachment: {
+            id: attachment.id,
+            path: attachment.path,
+            name: attachment.name,
+            kind: attachment.kind,
+            ...(attachment.mime ? { mime: attachment.mime } : {}),
+          },
+        },
+      ];
+    }),
+  ];
+};
+
+export const resolveDraftToUserMessageParts = async (
+  draft: AgentChatComposerDraft,
+  resolveAttachmentPath: (attachment: AgentChatComposerAttachment) => Promise<string>,
+): Promise<AgentUserMessagePart[]> => {
+  const parts = draftToUserMessageParts({
+    ...draft,
+    attachments: [],
   });
+
+  const attachmentParts = await Promise.all(
+    (normalizeComposerDraft(draft).attachments ?? []).map(async (attachment) => {
+      const path = attachment.file
+        ? await resolveAttachmentPath(attachment)
+        : (attachment.path ?? (await resolveAttachmentPath(attachment)));
+      if (path.trim().length === 0) {
+        throw new Error(`Attachment "${attachment.name}" is missing a local file path.`);
+      }
+
+      return {
+        kind: "attachment" as const,
+        attachment: {
+          id: attachment.id,
+          path,
+          name: attachment.name,
+          kind: attachment.kind,
+          ...(attachment.mime ? { mime: attachment.mime } : {}),
+        },
+      } satisfies AgentUserMessagePart;
+    }),
+  );
+
+  return [...parts, ...attachmentParts];
 };
 
 export const draftToSerializedText = (draft: AgentChatComposerDraft): string => {
@@ -402,6 +488,10 @@ export const draftToSerializedText = (draft: AgentChatComposerDraft): string => 
 };
 
 export const draftHasMeaningfulContent = (draft: AgentChatComposerDraft): boolean => {
+  if ((draft.attachments ?? []).length > 0) {
+    return true;
+  }
+
   return draftToUserMessageParts(draft).some((part) => {
     if (part.kind === "text") {
       return part.text.trim().length > 0;
@@ -409,6 +499,26 @@ export const draftHasMeaningfulContent = (draft: AgentChatComposerDraft): boolea
     return true;
   });
 };
+
+export const draftHasSlashCommandSegment = (draft: AgentChatComposerDraft): boolean => {
+  return draft.segments.some((segment) => segment.kind === "slash_command");
+};
+
+export const appendAttachmentsToDraft = (
+  draft: AgentChatComposerDraft,
+  attachments: AgentChatComposerAttachment[],
+): AgentChatComposerDraft => ({
+  ...draft,
+  attachments: [...(draft.attachments ?? []), ...attachments],
+});
+
+export const removeAttachmentFromDraft = (
+  draft: AgentChatComposerDraft,
+  attachmentId: string,
+): AgentChatComposerDraft => ({
+  ...draft,
+  attachments: (draft.attachments ?? []).filter((attachment) => attachment.id !== attachmentId),
+});
 
 export const readSlashTriggerMatchForDraft = (
   draft: AgentChatComposerDraft,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import type { AgentFileSearchResult } from "@openducktor/core";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { type ReactElement, useRef, useState } from "react";
-import type { AgentChatComposerDraft } from "./agent-chat-composer-draft";
+import { type AgentChatComposerDraft, createComposerAttachment } from "./agent-chat-composer-draft";
 import { buildFileSearchResult, createComposerDraft } from "./agent-chat-test-fixtures";
 
 let AgentChatComposerEditor: typeof import("./agent-chat-composer-editor").AgentChatComposerEditor;
@@ -107,21 +107,24 @@ const EditorHarness = ({
   const editorRef = useRef<HTMLDivElement>(null);
 
   return (
-    <AgentChatComposerEditor
-      draft={draft}
-      onDraftChange={setDraft}
-      placeholder="Type a message"
-      disabled={false}
-      editorRef={editorRef}
-      onEditorInput={() => {}}
-      onSend={onSend ?? (() => {})}
-      supportsSlashCommands={true}
-      supportsFileSearch={supportsFileSearch}
-      slashCommands={slashCommands}
-      slashCommandsError={slashCommandsError}
-      isSlashCommandsLoading={false}
-      searchFiles={searchFiles}
-    />
+    <>
+      <AgentChatComposerEditor
+        draft={draft}
+        onDraftChange={setDraft}
+        placeholder="Type a message"
+        disabled={false}
+        editorRef={editorRef}
+        onEditorInput={() => {}}
+        onSend={onSend ?? (() => {})}
+        supportsSlashCommands={true}
+        supportsFileSearch={supportsFileSearch}
+        slashCommands={slashCommands}
+        slashCommandsError={slashCommandsError}
+        isSlashCommandsLoading={false}
+        searchFiles={searchFiles}
+      />
+      <output data-testid="draft-state">{JSON.stringify(draft)}</output>
+    </>
   );
 };
 
@@ -561,6 +564,46 @@ describe("AgentChatComposerEditor", () => {
       expect(rendered.container.querySelector("[data-composer-content-root]")?.textContent).toBe(
         "\u200B",
       );
+    });
+  });
+
+  test("preserves staged attachments when clearing a full composer selection", async () => {
+    resetSelectionMocks();
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        initialDraft={{
+          segments: createComposerDraft("hello").segments,
+          attachments: [
+            createComposerAttachment(
+              {
+                name: "screenshot.png",
+                kind: "image",
+                mime: "image/png",
+                path: "/tmp/screenshot.png",
+              },
+              "attachment-1",
+            ),
+          ],
+        }}
+      />,
+    );
+
+    selectAllComposerContents(rendered.container);
+    const editorRoot = selectComposerContentRange(rendered.container);
+    fireEvent.keyDown(editorRoot, { key: "Backspace" });
+
+    await waitFor(() => {
+      const draftState = screen.getByTestId("draft-state").textContent;
+      if (!draftState) {
+        throw new Error("Expected draft state output");
+      }
+      const parsed = JSON.parse(draftState) as AgentChatComposerDraft;
+      expect(parsed.attachments).toHaveLength(1);
+      expect(parsed.attachments?.[0]?.name).toBe("screenshot.png");
+      expect(parsed.segments).toHaveLength(1);
+      expect(parsed.segments[0]).toMatchObject({ kind: "text", text: "" });
     });
   });
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createRef } from "react";
+import { AgentChatComposer } from "./agent-chat-composer";
+import { buildModelSelection } from "./agent-chat-test-fixtures";
+
+const SHARED_CALLBACKS = {
+  onSend: async () => true,
+  onSelectAgent: () => {},
+  onSelectModel: () => {},
+  onSelectVariant: () => {},
+  onStopSession: () => {},
+  onComposerEditorInput: () => {},
+};
+
+const buildModel = () => ({
+  taskId: "task-1",
+  agentStudioReady: true,
+  isReadOnly: false,
+  readOnlyReason: null,
+  busySendBlockedReason: null,
+  draftStateKey: "draft-1",
+  onSend: SHARED_CALLBACKS.onSend,
+  isSending: false,
+  isStarting: false,
+  isSessionWorking: false,
+  isWaitingInput: false,
+  waitingInputPlaceholder: null,
+  isModelSelectionPending: false,
+  selectedModelSelection: buildModelSelection(),
+  selectedModelDescriptor: null,
+  isSelectionCatalogLoading: false,
+  supportsSlashCommands: true,
+  supportsFileSearch: true,
+  slashCommandCatalog: { commands: [] },
+  slashCommands: [],
+  slashCommandsError: null,
+  isSlashCommandsLoading: false,
+  searchFiles: async () => [],
+  agentOptions: [{ value: "Hephaestus (Deep Agent)", label: "Hephaestus (Deep Agent)" }],
+  modelOptions: [{ value: "openai/gpt-5.3-codex", label: "GPT-5.3 Codex" }],
+  modelGroups: [
+    {
+      label: "OpenAI",
+      options: [{ value: "openai/gpt-5.3-codex", label: "GPT-5.3 Codex" }],
+    },
+  ],
+  variantOptions: [{ value: "high", label: "high" }],
+  onSelectAgent: SHARED_CALLBACKS.onSelectAgent,
+  onSelectModel: SHARED_CALLBACKS.onSelectModel,
+  onSelectVariant: SHARED_CALLBACKS.onSelectVariant,
+  sessionAgentColors: {},
+  contextUsage: null,
+  canStopSession: false,
+  onStopSession: SHARED_CALLBACKS.onStopSession,
+  composerFormRef: createRef<HTMLFormElement>(),
+  composerEditorRef: createRef<HTMLDivElement>(),
+  onComposerEditorInput: SHARED_CALLBACKS.onComposerEditorInput,
+  scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+});
+
+describe("AgentChatComposer attachments", () => {
+  test("stages attachments, revalidates on model changes, and removes them", async () => {
+    const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    const { container, rerender } = render(<AgentChatComposer model={buildModel()} />);
+
+    const attachmentInput = container.querySelector('input[type="file"]');
+    if (!(attachmentInput instanceof HTMLInputElement)) {
+      throw new Error("Expected hidden attachment input");
+    }
+
+    fireEvent.change(attachmentInput, {
+      target: { files: [file] },
+    });
+
+    await screen.findByTitle("brief.pdf");
+    expect(
+      screen.getByText("The selected model does not expose attachment capability data."),
+    ).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Send message" }).getAttribute("disabled"),
+    ).not.toBeNull();
+
+    rerender(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          selectedModelDescriptor: {
+            id: "openai/gpt-5.3-codex",
+            providerId: "openai",
+            providerName: "OpenAI",
+            modelId: "gpt-5.3-codex",
+            modelName: "GPT-5.3 Codex",
+            variants: ["high"],
+            contextWindow: 400_000,
+            outputLimit: 128_000,
+            attachmentSupport: {
+              image: false,
+              audio: false,
+              video: false,
+              pdf: true,
+            },
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("The selected model does not expose attachment capability data."),
+      ).toBeNull();
+    });
+    expect(
+      screen.getByRole("button", { name: "Send message" }).getAttribute("disabled"),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove brief.pdf" }));
+
+    await waitFor(() => {
+      expect(screen.queryByTitle("brief.pdf")).toBeNull();
+    });
+    expect(
+      screen.getByRole("button", { name: "Send message" }).getAttribute("disabled"),
+    ).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -123,4 +123,30 @@ describe("AgentChatComposer attachments", () => {
       screen.getByRole("button", { name: "Send message" }).getAttribute("disabled"),
     ).not.toBeNull();
   });
+
+  test("ignores attachment intake while the composer is disabled", async () => {
+    const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    const { container } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          isReadOnly: true,
+          readOnlyReason: "Read-only",
+        }}
+      />,
+    );
+
+    const attachmentInput = container.querySelector('input[type="file"]');
+    if (!(attachmentInput instanceof HTMLInputElement)) {
+      throw new Error("Expected hidden attachment input");
+    }
+
+    fireEvent.change(attachmentInput, {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTitle("brief.pdf")).toBeNull();
+    });
+  });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -49,8 +49,24 @@ export type AgentChatComposerHandle = {
   addFiles: (files: File[]) => void;
 };
 
+const truncateAttachmentDisplayName = (name: string, maxLength = 80): string => {
+  if (name.length <= maxLength) {
+    return name;
+  }
+  return `${name.slice(0, maxLength - 3)}...`;
+};
+
+const renderUnsupportedAttachmentDescription = (name: string): ReactElement => {
+  return (
+    <span>
+      <code>{truncateAttachmentDisplayName(name)}</code> is not an image, audio file, video, or PDF.
+    </span>
+  );
+};
+
 const AgentChatComposerControls = memo(function AgentChatComposerControls({
   onPickAttachments,
+  attachmentIntakeDisabled,
   selectedModelSelection,
   agentOptions,
   modelOptions,
@@ -72,6 +88,7 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
   sendDisabled,
 }: {
   onPickAttachments: () => void;
+  attachmentIntakeDisabled: boolean;
   selectedModelSelection: AgentChatComposerModel["selectedModelSelection"];
   agentOptions: AgentChatComposerModel["agentOptions"];
   modelOptions: AgentChatComposerModel["modelOptions"];
@@ -101,6 +118,7 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
           variant="ghost"
           className="size-7 rounded-full border border-input bg-card text-muted-foreground hover:bg-muted hover:text-foreground"
           aria-label="Add attachment"
+          disabled={attachmentIntakeDisabled}
           onClick={onPickAttachments}
         >
           <Paperclip className="size-3.5" />
@@ -248,6 +266,14 @@ export const AgentChatComposer = forwardRef<
   const latestSendDisabledRef = useRef(false);
   const latestOnSendRef = useRef(onSend);
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
+  const isSubmitting = (isSending && !isSessionWorking) || isStarting || isModelSelectionPending;
+  const isComposerInputDisabled =
+    !agentStudioReady ||
+    isReadOnly ||
+    isModelSelectionPending ||
+    isWaitingInput ||
+    Boolean(busySendBlockedReason);
+  const attachmentIntakeDisabled = isComposerInputDisabled || isSubmitting;
 
   useEffect(() => {
     void draftStateKey;
@@ -262,11 +288,15 @@ export const AgentChatComposer = forwardRef<
 
   const handleAddFiles = useCallback(
     (files: File[]): void => {
+      if (attachmentIntakeDisabled) {
+        return;
+      }
+
       const attachments = files.flatMap((file) => {
         const attachment = buildComposerAttachmentFromFile(file);
         if (!attachment) {
           toast.error("Unsupported attachment type", {
-            description: `${file.name} is not an image, audio file, video, or PDF.`,
+            description: renderUnsupportedAttachmentDescription(file.name),
           });
           return [];
         }
@@ -282,7 +312,7 @@ export const AgentChatComposer = forwardRef<
       });
       onComposerEditorInput();
     },
-    [onComposerEditorInput],
+    [attachmentIntakeDisabled, onComposerEditorInput],
   );
 
   useImperativeHandle(
@@ -294,8 +324,11 @@ export const AgentChatComposer = forwardRef<
   );
 
   const openAttachmentPicker = useCallback((): void => {
+    if (attachmentIntakeDisabled) {
+      return;
+    }
     attachmentInputRef.current?.click();
-  }, []);
+  }, [attachmentIntakeDisabled]);
 
   const attachmentErrors = useMemo(() => {
     return validateComposerAttachments(
@@ -324,7 +357,6 @@ export const AgentChatComposer = forwardRef<
   latestOnSendRef.current = onSend;
   latestSendDisabledRef.current = sendDisabled;
 
-  const isSubmitting = (isSending && !isSessionWorking) || isStarting || isModelSelectionPending;
   const selectorDisabled =
     !taskId || isSelectionCatalogLoading || isSubmitting || !agentStudioReady || isReadOnly;
 
@@ -387,7 +419,11 @@ export const AgentChatComposer = forwardRef<
         return;
       }
       scheduleComposerFocus();
-    } catch {
+    } catch (error) {
+      const description = error instanceof Error ? error.message : String(error);
+      toast.error("Unable to send message", {
+        description,
+      });
       setDraft((currentDraft) =>
         draftHasMeaningfulContent(currentDraft) ? currentDraft : submittedDraft,
       );
@@ -395,12 +431,6 @@ export const AgentChatComposer = forwardRef<
       scheduleComposerFocus();
     }
   }, [onComposerEditorInput, scheduleComposerFocus]);
-  const isComposerInputDisabled =
-    !agentStudioReady ||
-    isReadOnly ||
-    isModelSelectionPending ||
-    isWaitingInput ||
-    Boolean(busySendBlockedReason);
   let composerPlaceholder = "@ for files; / for commands; ! for shell";
   if (isReadOnly && readOnlyReason) {
     composerPlaceholder = readOnlyReason;
@@ -426,6 +456,7 @@ export const AgentChatComposer = forwardRef<
         type="file"
         multiple
         accept={CHAT_ATTACHMENT_ACCEPT}
+        disabled={attachmentIntakeDisabled}
         className="hidden"
         onChange={(event) => {
           const files = Array.from(event.target.files ?? []);
@@ -509,6 +540,7 @@ export const AgentChatComposer = forwardRef<
 
           <AgentChatComposerControls
             onPickAttachments={openAttachmentPicker}
+            attachmentIntakeDisabled={attachmentIntakeDisabled}
             selectedModelSelection={selectedModelSelection}
             agentOptions={agentOptions}
             modelOptions={modelOptions}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -1,14 +1,42 @@
-import { Bot, Brain, BrainCog, LoaderCircle, SendHorizontal, Square } from "lucide-react";
-import { memo, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Bot,
+  Brain,
+  BrainCog,
+  LoaderCircle,
+  Paperclip,
+  SendHorizontal,
+  Square,
+} from "lucide-react";
+import {
+  forwardRef,
+  memo,
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { toast } from "sonner";
 import { BorderRay } from "@/components/ui/border-ray";
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
 import { resolveAgentAccentColor } from "../agent-accent-color";
 import type { AgentChatComposerModel } from "./agent-chat.types";
+import { AgentChatAttachmentChip } from "./agent-chat-attachment-chip";
+import {
+  buildComposerAttachmentFromFile,
+  CHAT_ATTACHMENT_ACCEPT,
+  validateComposerAttachments,
+} from "./agent-chat-attachments";
 import {
   type AgentChatComposerDraft,
+  appendAttachmentsToDraft,
   createEmptyComposerDraft,
   draftHasMeaningfulContent,
+  draftHasSlashCommandSegment,
+  removeAttachmentFromDraft,
 } from "./agent-chat-composer-draft";
 import { AgentChatComposerEditor } from "./agent-chat-composer-editor";
 import {
@@ -17,7 +45,12 @@ import {
 } from "./agent-chat-composer-selection";
 import { AgentContextUsageIndicator } from "./agent-context-usage-indicator";
 
+export type AgentChatComposerHandle = {
+  addFiles: (files: File[]) => void;
+};
+
 const AgentChatComposerControls = memo(function AgentChatComposerControls({
+  onPickAttachments,
   selectedModelSelection,
   agentOptions,
   modelOptions,
@@ -38,6 +71,7 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
   showSubmittingState,
   sendDisabled,
 }: {
+  onPickAttachments: () => void;
   selectedModelSelection: AgentChatComposerModel["selectedModelSelection"];
   agentOptions: AgentChatComposerModel["agentOptions"];
   modelOptions: AgentChatComposerModel["modelOptions"];
@@ -61,6 +95,16 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
   return (
     <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border/80 px-2.5 py-2">
       <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="size-7 rounded-full border border-input bg-card text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label="Add attachment"
+          onClick={onPickAttachments}
+        >
+          <Paperclip className="size-3.5" />
+        </Button>
         <div className="relative">
           <Bot className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
           <Combobox
@@ -156,7 +200,10 @@ const AgentChatComposerControls = memo(function AgentChatComposerControls({
   );
 });
 
-export function AgentChatComposer({ model }: { model: AgentChatComposerModel }): ReactElement {
+export const AgentChatComposer = forwardRef<
+  AgentChatComposerHandle,
+  { model: AgentChatComposerModel }
+>(function AgentChatComposer({ model }, ref): ReactElement {
   const {
     taskId,
     agentStudioReady,
@@ -172,6 +219,7 @@ export function AgentChatComposer({ model }: { model: AgentChatComposerModel }):
     waitingInputPlaceholder,
     isModelSelectionPending,
     selectedModelSelection,
+    selectedModelDescriptor,
     isSelectionCatalogLoading,
     supportsSlashCommands,
     supportsFileSearch,
@@ -199,6 +247,7 @@ export function AgentChatComposer({ model }: { model: AgentChatComposerModel }):
   const latestDraftRef = useRef<AgentChatComposerDraft>(draft);
   const latestSendDisabledRef = useRef(false);
   const latestOnSendRef = useRef(onSend);
+  const attachmentInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     void draftStateKey;
@@ -211,6 +260,53 @@ export function AgentChatComposer({ model }: { model: AgentChatComposerModel }):
     setDraft(nextDraft);
   }, []);
 
+  const handleAddFiles = useCallback(
+    (files: File[]): void => {
+      const attachments = files.flatMap((file) => {
+        const attachment = buildComposerAttachmentFromFile(file);
+        if (!attachment) {
+          toast.error("Unsupported attachment type", {
+            description: `${file.name} is not an image, audio file, video, or PDF.`,
+          });
+          return [];
+        }
+        return [attachment];
+      });
+      if (attachments.length === 0) {
+        return;
+      }
+      setDraft((currentDraft) => {
+        const nextDraft = appendAttachmentsToDraft(currentDraft, attachments);
+        latestDraftRef.current = nextDraft;
+        return nextDraft;
+      });
+      onComposerEditorInput();
+    },
+    [onComposerEditorInput],
+  );
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      addFiles: handleAddFiles,
+    }),
+    [handleAddFiles],
+  );
+
+  const openAttachmentPicker = useCallback((): void => {
+    attachmentInputRef.current?.click();
+  }, []);
+
+  const attachmentErrors = useMemo(() => {
+    return validateComposerAttachments(
+      draft.attachments ?? [],
+      selectedModelDescriptor?.attachmentSupport,
+    );
+  }, [draft.attachments, selectedModelDescriptor?.attachmentSupport]);
+  const hasBlockingAttachments = Object.keys(attachmentErrors).length > 0;
+  const hasSlashAttachmentConflict =
+    (draft.attachments ?? []).length > 0 && draftHasSlashCommandSegment(draft);
+
   const sendDisabled =
     (isSending && !isSessionWorking) ||
     isStarting ||
@@ -218,6 +314,8 @@ export function AgentChatComposer({ model }: { model: AgentChatComposerModel }):
     Boolean(busySendBlockedReason) ||
     isModelSelectionPending ||
     isReadOnly ||
+    hasBlockingAttachments ||
+    hasSlashAttachmentConflict ||
     !taskId ||
     !draftHasMeaningfulContent(draft) ||
     !agentStudioReady;
@@ -323,6 +421,54 @@ export function AgentChatComposer({ model }: { model: AgentChatComposerModel }):
         void handleSubmit();
       }}
     >
+      <input
+        ref={attachmentInputRef}
+        type="file"
+        multiple
+        accept={CHAT_ATTACHMENT_ACCEPT}
+        className="hidden"
+        onChange={(event) => {
+          const files = Array.from(event.target.files ?? []);
+          if (files.length > 0) {
+            handleAddFiles(files);
+          }
+          event.currentTarget.value = "";
+        }}
+      />
+      {(draft.attachments ?? []).length > 0 ? (
+        <section className="mb-0 border border-input border-b-0 border-l-0 bg-card shadow-md">
+          <div
+            className={composerAccentColor ? "border-l-4" : undefined}
+            style={composerAccentColor ? { borderLeftColor: composerAccentColor } : undefined}
+          >
+            <div className="px-3 pb-3 pt-3">
+              <div className="flex flex-wrap gap-3">
+                {(draft.attachments ?? []).map((attachment) => (
+                  <AgentChatAttachmentChip
+                    key={attachment.id}
+                    variant="draft"
+                    attachment={attachment}
+                    error={attachmentErrors[attachment.id] ?? null}
+                    onRemove={() => {
+                      setDraft((currentDraft) => {
+                        const nextDraft = removeAttachmentFromDraft(currentDraft, attachment.id);
+                        latestDraftRef.current = nextDraft;
+                        return nextDraft;
+                      });
+                      onComposerEditorInput();
+                    }}
+                  />
+                ))}
+              </div>
+              {hasSlashAttachmentConflict ? (
+                <p className="mt-3 text-xs text-destructive">
+                  Remove attachments before running a slash command.
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </section>
+      ) : null}
       <div
         className={
           isWaitingInput
@@ -362,6 +508,7 @@ export function AgentChatComposer({ model }: { model: AgentChatComposerModel }):
           />
 
           <AgentChatComposerControls
+            onPickAttachments={openAttachmentPicker}
             selectedModelSelection={selectedModelSelection}
             agentOptions={agentOptions}
             modelOptions={modelOptions}
@@ -386,4 +533,4 @@ export function AgentChatComposer({ model }: { model: AgentChatComposerModel }):
       </div>
     </form>
   );
-}
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card-content.tsx
@@ -8,6 +8,7 @@ import { Fragment, lazy, type ReactElement, type ReactNode, Suspense } from "rea
 import type { MarkdownRendererVariant } from "@/components/ui/markdown-renderer";
 import { cn } from "@/lib/utils";
 import type { AgentChatMessage } from "@/types/agent-orchestrator";
+import { AgentChatAttachmentChip } from "./agent-chat-attachment-chip";
 import { AgentChatFileReferenceChip } from "./agent-chat-file-reference-chip";
 import { hasMarkdownSyntaxHint } from "./agent-chat-markdown-hints";
 import {
@@ -383,14 +384,32 @@ export const MessageBody = ({
   if (message.role === "user") {
     const isQueuedUserMessage = meta?.kind === "user" && meta.state === "queued";
     const userParts = meta?.kind === "user" ? (meta.parts ?? []) : [];
+    const userAttachments = userParts.filter(
+      (part): part is Extract<AgentUserMessageDisplayPart, { kind: "attachment" }> =>
+        part.kind === "attachment",
+    );
     const userText = readRenderableUserMessageText(userParts, message.content);
     const userContent = renderUserMessageInlineContent(userText, userParts);
 
     return (
       <>
         {userContent}
-        {isQueuedUserMessage || timeLabel ? (
-          <div className="mt-2 flex items-end justify-end gap-2">
+        {userAttachments.length > 0 || isQueuedUserMessage || timeLabel ? (
+          <div className="mt-2 flex items-end justify-between gap-3">
+            {userAttachments.length > 0 ? (
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                {userAttachments.map((part) => (
+                  <AgentChatAttachmentChip
+                    key={part.attachment.id}
+                    variant="transcript"
+                    attachment={part.attachment}
+                    className="w-32"
+                  />
+                ))}
+              </div>
+            ) : (
+              <div />
+            )}
             <div className="flex shrink-0 items-center justify-end gap-2 self-end">
               {isQueuedUserMessage ? (
                 <span className="rounded-full border border-pending-border bg-pending-surface px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-pending-surface-foreground">

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-message-card.test.ts
@@ -846,8 +846,50 @@ describe("AgentChatMessageCard tool duration", () => {
     );
 
     expect(html).toContain("Queued");
-    expect(html).toContain("mt-2 flex items-end justify-end gap-2");
+    expect(html).toContain("mt-2 flex items-end justify-between gap-3");
     expect(html).toContain("flex shrink-0 items-center justify-end gap-2 self-end");
-    expect(html).not.toContain("flex min-w-0 flex-1 flex-wrap justify-start gap-2");
+    expect(html).not.toContain("flex min-w-0 flex-wrap items-center gap-2");
+  });
+
+  test("renders attachment chips in the user footer row alongside queued metadata", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentChatMessageCard, {
+        message: {
+          id: "user-attachment-queued",
+          role: "user",
+          content: "please review this screenshot",
+          timestamp: "2026-02-22T10:31:00.000Z",
+          meta: {
+            kind: "user",
+            state: "queued",
+            parts: [
+              {
+                kind: "text",
+                text: "please review this screenshot",
+              },
+              {
+                kind: "attachment",
+                attachment: {
+                  id: "attachment-1",
+                  path: "/tmp/screenshot.png",
+                  name: "screenshot.png",
+                  kind: "image",
+                  mime: "image/png",
+                },
+              },
+            ],
+          },
+        },
+        sessionRole: "build",
+        sessionSelectedModel: null,
+        sessionAgentColors: {},
+      }),
+    );
+
+    expect(html).toContain("Queued");
+    expect(html).toContain("screenshot.png");
+    expect(html).toContain("mt-2 flex items-end justify-between gap-3");
+    expect(html).toContain("flex min-w-0 flex-wrap items-center gap-2");
+    expect(html).toContain("flex shrink-0 items-center justify-end gap-2 self-end");
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-test-fixtures.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-test-fixtures.ts
@@ -150,6 +150,7 @@ export const buildModelSelection = (
 
 export const createComposerDraft = (text: string) => ({
   segments: [createTextSegment(text)],
+  attachments: [],
 });
 
 export const buildFileSearchResult = (

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -460,6 +460,8 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const hasAttachmentMessages = useMemo(() => {
     return session?.messages.some(messageHasAttachmentDisplayParts) ?? false;
   }, [session]);
+  // Attachment-bearing sessions are kept fully materialized because staged turn reveal and
+  // containment can under-measure transcript height during hydration and break bottom pinning.
   const stagedTurns = useAgentChatTurnStaging({
     activeSessionId,
     windowStart,

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -76,6 +76,12 @@ type AgentChatRenderedTurn = {
   isActive: boolean;
 };
 
+const messageHasAttachmentDisplayParts = (message: AgentChatMessage): boolean => {
+  return Boolean(
+    message.meta?.kind === "user" && message.meta.parts?.some((part) => part.kind === "attachment"),
+  );
+};
+
 type AgentChatBottomStackProps = {
   sessionId: string;
   pendingQuestions: AgentSessionState["pendingQuestions"];
@@ -451,10 +457,14 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
   const sessionWorkingDirectory = session?.workingDirectory ?? null;
   const rowKeys = useMemo(() => windowedRows.map((row) => row.key), [windowedRows]);
   const turns = useMemo(() => buildAgentChatWindowTurns(windowedRows), [windowedRows]);
+  const hasAttachmentMessages = useMemo(() => {
+    return session?.messages.some(messageHasAttachmentDisplayParts) ?? false;
+  }, [session]);
   const stagedTurns = useAgentChatTurnStaging({
     activeSessionId,
     windowStart,
     turns,
+    disabled: hasAttachmentMessages,
   });
   const rowRefByKeyRef = useRef<Map<string, (element: HTMLDivElement | null) => void>>(new Map());
   const { registerRowElement } = useAgentChatRowMotion({
@@ -506,7 +516,7 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
       isActive: turn.key === activeTurnKey,
     }));
   }, [activeTurnKey, stagedTurns, windowedRows]);
-  const allowTurnContainment = !isTauriRuntime();
+  const allowTurnContainment = !isTauriRuntime() && !hasAttachmentMessages;
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { createRef } from "react";
+import { AgentChat } from "./agent-chat";
+import { buildModelSelection, buildSession, TEST_ROLE_OPTIONS } from "./agent-chat-test-fixtures";
+
+const buildModel = () => ({
+  thread: {
+    session: buildSession({
+      status: "running" as const,
+      draftAssistantText: "",
+    }),
+    isSessionWorking: true,
+    showThinkingMessages: false,
+    isSessionViewLoading: false,
+    isSessionHistoryLoading: false,
+    isWaitingForRuntimeReadiness: false,
+    roleOptions: TEST_ROLE_OPTIONS,
+    readinessState: "ready" as const,
+    agentStudioReady: true,
+    blockedReason: "",
+    isLoadingChecks: false,
+    onRefreshChecks: () => {},
+    taskSelected: true,
+    canKickoffNewSession: false,
+    kickoffLabel: "Start Spec",
+    onKickoff: () => {},
+    isStarting: false,
+    isSending: false,
+    sessionAgentColors: {},
+    isSubmittingQuestionByRequestId: {},
+    isSubmittingPermissionByRequestId: {},
+    permissionReplyErrorByRequestId: {},
+    onSubmitQuestionAnswers: async () => {},
+    onReplyPermission: async () => {},
+    todoPanelCollapsed: false,
+    onToggleTodoPanel: () => {},
+    messagesContainerRef: createRef<HTMLDivElement>(),
+    scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+    syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
+  },
+  composer: {
+    taskId: "task-1",
+    agentStudioReady: true,
+    isReadOnly: false,
+    readOnlyReason: null,
+    busySendBlockedReason: null,
+    draftStateKey: "draft-1",
+    onSend: async () => true,
+    isSending: false,
+    isStarting: false,
+    isSessionWorking: false,
+    isWaitingInput: false,
+    waitingInputPlaceholder: null,
+    isModelSelectionPending: false,
+    selectedModelSelection: buildModelSelection(),
+    selectedModelDescriptor: {
+      id: "openai/gpt-5.3-codex",
+      providerId: "openai",
+      providerName: "OpenAI",
+      modelId: "gpt-5.3-codex",
+      modelName: "GPT-5.3 Codex",
+      variants: ["high"],
+      contextWindow: 400_000,
+      outputLimit: 128_000,
+      attachmentSupport: {
+        image: false,
+        audio: false,
+        video: false,
+        pdf: true,
+      },
+    },
+    isSelectionCatalogLoading: false,
+    supportsSlashCommands: true,
+    supportsFileSearch: true,
+    slashCommandCatalog: { commands: [] },
+    slashCommands: [],
+    slashCommandsError: null,
+    isSlashCommandsLoading: false,
+    searchFiles: async () => [],
+    agentOptions: [{ value: "Hephaestus (Deep Agent)", label: "Hephaestus (Deep Agent)" }],
+    modelOptions: [{ value: "openai/gpt-5.3-codex", label: "GPT-5.3 Codex" }],
+    modelGroups: [
+      {
+        label: "OpenAI",
+        options: [{ value: "openai/gpt-5.3-codex", label: "GPT-5.3 Codex" }],
+      },
+    ],
+    variantOptions: [{ value: "high", label: "high" }],
+    onSelectAgent: () => {},
+    onSelectModel: () => {},
+    onSelectVariant: () => {},
+    contextUsage: null,
+    canStopSession: false,
+    onStopSession: () => {},
+    composerFormRef: createRef<HTMLFormElement>(),
+    composerEditorRef: createRef<HTMLDivElement>(),
+    onComposerEditorInput: () => {},
+    scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+    sessionAgentColors: {},
+  },
+});
+
+describe("AgentChat attachments", () => {
+  test("shows the drag overlay and stages dropped files in the composer", async () => {
+    const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    const { getByTestId } = render(<AgentChat model={buildModel()} />);
+
+    const dropTarget = getByTestId("agent-chat-drop-target");
+    fireEvent.dragEnter(dropTarget, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [file],
+      },
+    });
+
+    await screen.findByText("Drop files to attach them");
+
+    fireEvent.drop(dropTarget, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [file],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Drop files to attach them")).toBeNull();
+    });
+    await screen.findByTitle("brief.pdf");
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.tsx
@@ -39,6 +39,7 @@ export function AgentChat({
   const composerRef = useRef<AgentChatComposerHandle | null>(null);
   const dropTargetRef = useRef<HTMLDivElement | null>(null);
   const dragDepthRef = useRef(0);
+  const isDraggingFilesRef = useRef(false);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
 
   const handleDragEnter = useCallback((event: DragEvent): void => {
@@ -47,24 +48,21 @@ export function AgentChat({
     }
     event.preventDefault();
     dragDepthRef.current += 1;
+    isDraggingFilesRef.current = true;
     setIsDraggingFiles(true);
   }, []);
 
-  const handleDragOver = useCallback(
-    (event: DragEvent): void => {
-      if (!hasDraggedFiles(event.dataTransfer)) {
-        return;
-      }
-      event.preventDefault();
-      if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = "copy";
-      }
-      if (!isDraggingFiles) {
-        setIsDraggingFiles(true);
-      }
-    },
-    [isDraggingFiles],
-  );
+  const handleDragOver = useCallback((event: DragEvent): void => {
+    if (!hasDraggedFiles(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "copy";
+    }
+    isDraggingFilesRef.current = true;
+    setIsDraggingFiles(true);
+  }, []);
 
   const handleDragLeave = useCallback((event: DragEvent): void => {
     if (!hasDraggedFiles(event.dataTransfer)) {
@@ -73,6 +71,7 @@ export function AgentChat({
     event.preventDefault();
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
     if (dragDepthRef.current === 0) {
+      isDraggingFilesRef.current = false;
       setIsDraggingFiles(false);
     }
   }, []);
@@ -83,6 +82,7 @@ export function AgentChat({
     }
     event.preventDefault();
     dragDepthRef.current = 0;
+    isDraggingFilesRef.current = false;
     setIsDraggingFiles(false);
     const files = Array.from(event.dataTransfer?.files ?? []);
     if (files.length > 0) {
@@ -108,12 +108,31 @@ export function AgentChat({
     const onDrop = (event: DragEvent): void => {
       handleDrop(event);
     };
-    const onWindowDrop = (): void => {
+    const onWindowDragOver = (event: DragEvent): void => {
+      if (dragDepthRef.current === 0 && !isDraggingFilesRef.current) {
+        return;
+      }
+      if (!hasDraggedFiles(event.dataTransfer)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "copy";
+      }
+    };
+    const onWindowDrop = (event: DragEvent): void => {
+      if (hasDraggedFiles(event.dataTransfer)) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
       dragDepthRef.current = 0;
+      isDraggingFilesRef.current = false;
       setIsDraggingFiles(false);
     };
     const onWindowDragEnd = (): void => {
       dragDepthRef.current = 0;
+      isDraggingFilesRef.current = false;
       setIsDraggingFiles(false);
     };
 
@@ -121,6 +140,7 @@ export function AgentChat({
     node.addEventListener("dragover", onDragOver);
     node.addEventListener("dragleave", onDragLeave);
     node.addEventListener("drop", onDrop);
+    window.addEventListener("dragover", onWindowDragOver);
     window.addEventListener("drop", onWindowDrop);
     window.addEventListener("dragend", onWindowDragEnd);
     return () => {
@@ -128,6 +148,7 @@ export function AgentChat({
       node.removeEventListener("dragover", onDragOver);
       node.removeEventListener("dragleave", onDragLeave);
       node.removeEventListener("drop", onDrop);
+      window.removeEventListener("dragover", onWindowDragOver);
       window.removeEventListener("drop", onWindowDrop);
       window.removeEventListener("dragend", onWindowDragEnd);
     };

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.tsx
@@ -1,9 +1,33 @@
-import { memo, type ReactElement, type ReactNode } from "react";
+import {
+  memo,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import type { AgentChatModel } from "./agent-chat.types";
-import { AgentChatComposer } from "./agent-chat-composer";
+import { AgentChatComposer, type AgentChatComposerHandle } from "./agent-chat-composer";
 import { AgentChatThread } from "./agent-chat-thread";
 
 const MemoizedAgentChatThread = memo(AgentChatThread);
+
+const hasDraggedFiles = (dataTransfer: DataTransfer | null | undefined): boolean => {
+  if (!dataTransfer) {
+    return false;
+  }
+
+  if (dataTransfer.files.length > 0) {
+    return true;
+  }
+
+  if (Array.from(dataTransfer.items ?? []).some((item) => item.kind === "file")) {
+    return true;
+  }
+
+  return Array.from(dataTransfer.types ?? []).includes("Files");
+};
 
 export function AgentChat({
   model,
@@ -12,13 +36,124 @@ export function AgentChat({
   model: AgentChatModel;
   header?: ReactNode;
 }): ReactElement {
+  const composerRef = useRef<AgentChatComposerHandle | null>(null);
+  const dropTargetRef = useRef<HTMLDivElement | null>(null);
+  const dragDepthRef = useRef(0);
+  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+
+  const handleDragEnter = useCallback((event: DragEvent): void => {
+    if (!hasDraggedFiles(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    dragDepthRef.current += 1;
+    setIsDraggingFiles(true);
+  }, []);
+
+  const handleDragOver = useCallback(
+    (event: DragEvent): void => {
+      if (!hasDraggedFiles(event.dataTransfer)) {
+        return;
+      }
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "copy";
+      }
+      if (!isDraggingFiles) {
+        setIsDraggingFiles(true);
+      }
+    },
+    [isDraggingFiles],
+  );
+
+  const handleDragLeave = useCallback((event: DragEvent): void => {
+    if (!hasDraggedFiles(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) {
+      setIsDraggingFiles(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback((event: DragEvent): void => {
+    if (!hasDraggedFiles(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    dragDepthRef.current = 0;
+    setIsDraggingFiles(false);
+    const files = Array.from(event.dataTransfer?.files ?? []);
+    if (files.length > 0) {
+      composerRef.current?.addFiles(files);
+    }
+  }, []);
+
+  useEffect(() => {
+    const node = dropTargetRef.current;
+    if (!node) {
+      return;
+    }
+
+    const onDragEnter = (event: DragEvent): void => {
+      handleDragEnter(event);
+    };
+    const onDragOver = (event: DragEvent): void => {
+      handleDragOver(event);
+    };
+    const onDragLeave = (event: DragEvent): void => {
+      handleDragLeave(event);
+    };
+    const onDrop = (event: DragEvent): void => {
+      handleDrop(event);
+    };
+    const onWindowDrop = (): void => {
+      dragDepthRef.current = 0;
+      setIsDraggingFiles(false);
+    };
+    const onWindowDragEnd = (): void => {
+      dragDepthRef.current = 0;
+      setIsDraggingFiles(false);
+    };
+
+    node.addEventListener("dragenter", onDragEnter);
+    node.addEventListener("dragover", onDragOver);
+    node.addEventListener("dragleave", onDragLeave);
+    node.addEventListener("drop", onDrop);
+    window.addEventListener("drop", onWindowDrop);
+    window.addEventListener("dragend", onWindowDragEnd);
+    return () => {
+      node.removeEventListener("dragenter", onDragEnter);
+      node.removeEventListener("dragover", onDragOver);
+      node.removeEventListener("dragleave", onDragLeave);
+      node.removeEventListener("drop", onDrop);
+      window.removeEventListener("drop", onWindowDrop);
+      window.removeEventListener("dragend", onWindowDragEnd);
+    };
+  }, [handleDragEnter, handleDragLeave, handleDragOver, handleDrop]);
+
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
       {header}
       <div className="min-h-0 flex-1 bg-muted">
-        <div className="relative flex h-full min-h-0 flex-col">
+        <div
+          ref={dropTargetRef}
+          data-testid="agent-chat-drop-target"
+          className="relative flex h-full min-h-0 flex-col"
+        >
+          {isDraggingFiles ? (
+            <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-background/85 p-6">
+              <div className="rounded-xl border border-primary bg-card px-6 py-5 text-center shadow-xl">
+                <p className="text-sm font-semibold text-foreground">Drop files to attach them</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Images, audio, video, and PDF files are supported.
+                </p>
+              </div>
+            </div>
+          ) : null}
           <MemoizedAgentChatThread model={model.thread} />
-          <AgentChatComposer model={model.composer} />
+          <AgentChatComposer ref={composerRef} model={model.composer} />
         </div>
       </div>
     </div>

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -1,5 +1,6 @@
 import type {
   AgentFileSearchResult,
+  AgentModelCatalog,
   AgentModelSelection,
   AgentRole,
   AgentSlashCommand,
@@ -63,6 +64,7 @@ export type AgentChatComposerModel = {
   waitingInputPlaceholder?: string | null;
   isModelSelectionPending: boolean;
   selectedModelSelection: AgentModelSelection | null;
+  selectedModelDescriptor?: AgentModelCatalog["models"][number] | null;
   isSelectionCatalogLoading: boolean;
   supportsSlashCommands: boolean;
   supportsFileSearch: boolean;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHookHarness } from "@/test-utils/react-hook-harness";
+import {
+  readAttachmentPreviewLoadFailureMessage,
+  useAgentChatAttachmentPreview,
+} from "./use-agent-chat-attachment-preview";
+
+const originalCreateObjectUrl = URL.createObjectURL;
+const originalRevokeObjectUrl = URL.revokeObjectURL;
+
+afterEach(() => {
+  URL.createObjectURL = originalCreateObjectUrl;
+  URL.revokeObjectURL = originalRevokeObjectUrl;
+});
+
+describe("useAgentChatAttachmentPreview", () => {
+  test("opens file-backed previews and converts load failures into explicit error state", async () => {
+    URL.createObjectURL = () => "blob:preview.png";
+    URL.revokeObjectURL = () => {};
+
+    const harness = createHookHarness(useAgentChatAttachmentPreview, {
+      attachment: {
+        id: "attachment-1",
+        name: "preview.png",
+        kind: "image" as const,
+        mime: "image/png",
+        file: new File(["image"], "preview.png", { type: "image/png" }),
+      },
+      externalError: null,
+    });
+
+    await harness.mount();
+    await harness.waitFor((state) => state.showResolvedPreview === true);
+
+    await harness.run((state) => {
+      expect(state.requestPreviewOpen()).toBeNull();
+    });
+    expect(harness.getLatest().dialogOpen).toBe(true);
+
+    await harness.run((state) => {
+      state.markPreviewUnavailable();
+    });
+
+    expect(harness.getLatest().dialogOpen).toBe(false);
+    expect(harness.getLatest().resolvedPreviewSrc).toBeNull();
+    expect(harness.getLatest().effectiveError).toBe(
+      readAttachmentPreviewLoadFailureMessage("preview.png"),
+    );
+
+    await harness.unmount();
+  });
+
+  test("still allows image preview when the chip is in validation error state", async () => {
+    URL.createObjectURL = () => "blob:preview.png";
+    URL.revokeObjectURL = () => {};
+
+    const harness = createHookHarness(useAgentChatAttachmentPreview, {
+      attachment: {
+        id: "attachment-2",
+        name: "preview.png",
+        kind: "image" as const,
+        mime: "image/png",
+        file: new File(["image"], "preview.png", { type: "image/png" }),
+      },
+      externalError: "The selected model does not support image attachments.",
+    });
+
+    await harness.mount();
+    await harness.waitFor((state) => state.showResolvedPreview === true);
+
+    await harness.run((state) => {
+      expect(state.requestPreviewOpen()).toBeNull();
+    });
+
+    expect(harness.getLatest().dialogOpen).toBe(true);
+    expect(harness.getLatest().effectiveError).toBe(
+      "The selected model does not support image attachments.",
+    );
+
+    await harness.unmount();
+  });
+
+  test("ignores stale preview load errors from an outdated blob url", async () => {
+    URL.createObjectURL = () => "blob:active-preview";
+    URL.revokeObjectURL = () => {};
+
+    const harness = createHookHarness(useAgentChatAttachmentPreview, {
+      attachment: {
+        id: "attachment-3",
+        name: "preview.png",
+        kind: "image" as const,
+        mime: "image/png",
+        file: new File(["image"], "preview.png", { type: "image/png" }),
+      },
+      externalError: null,
+    });
+
+    await harness.mount();
+    await harness.waitFor((state) => state.showResolvedPreview === true);
+
+    await harness.run((state) => {
+      state.markPreviewUnavailable("blob:stale-preview");
+    });
+
+    expect(harness.getLatest().resolvedPreviewSrc).toBe("blob:active-preview");
+    expect(harness.getLatest().effectiveError).toBeNull();
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.ts
@@ -57,7 +57,9 @@ export const useAgentChatAttachmentPreview = ({
     };
   }, [attachment.file, previewable]);
 
-  latestPreviewSrcRef.current = resolvedPreviewSrc ?? objectPreviewUrl;
+  useEffect(() => {
+    latestPreviewSrcRef.current = resolvedPreviewSrc ?? objectPreviewUrl;
+  }, [objectPreviewUrl, resolvedPreviewSrc]);
 
   const markPreviewUnavailable: (failingSrc?: string) => void = useCallback(
     (failingSrc?: string) => {
@@ -120,6 +122,9 @@ export const useAgentChatAttachmentPreview = ({
   const showResolvedPreview = Boolean(resolvedPreviewSrc) && !previewError;
 
   const requestPreviewOpen = useCallback((): string | null => {
+    if (isResolvingPreview) {
+      return null;
+    }
     if (canOpenPreview) {
       setDialogOpen(true);
       return null;
@@ -129,7 +134,7 @@ export const useAgentChatAttachmentPreview = ({
       previewError ??
       "The attachment preview is not available because the local file could not be resolved."
     );
-  }, [canOpenPreview, previewError]);
+  }, [canOpenPreview, isResolvingPreview, previewError]);
 
   return {
     dialogOpen,

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.ts
@@ -1,0 +1,146 @@
+import type { AgentAttachmentReference } from "@openducktor/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { resolveLocalAttachmentPreviewSrc } from "@/lib/local-attachment-files";
+import { isPreviewableAttachmentKind } from "./agent-chat-attachments";
+
+export type AgentChatAttachmentPreviewTarget = {
+  id: string;
+  name: string;
+  kind: AgentAttachmentReference["kind"];
+  mime?: string;
+  path?: string;
+  file?: File;
+};
+
+export type AgentChatAttachmentPreviewState = {
+  dialogOpen: boolean;
+  setDialogOpen: (open: boolean) => void;
+  resolvedPreviewSrc: string | null;
+  previewError: string | null;
+  effectiveError: string | null;
+  isResolvingPreview: boolean;
+  previewable: boolean;
+  showResolvedPreview: boolean;
+  requestPreviewOpen: () => string | null;
+  markPreviewUnavailable: (failingSrc?: string) => void;
+};
+
+export const readAttachmentPreviewLoadFailureMessage = (attachmentName: string): string => {
+  return `Attachment preview is unavailable because "${attachmentName}" could not be read from its original local path.`;
+};
+
+export const useAgentChatAttachmentPreview = ({
+  attachment,
+  externalError,
+}: {
+  attachment: AgentChatAttachmentPreviewTarget;
+  externalError?: string | null;
+}): AgentChatAttachmentPreviewState => {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [resolvedPreviewSrc, setResolvedPreviewSrc] = useState<string | null>(null);
+  const [objectPreviewUrl, setObjectPreviewUrl] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [isResolvingPreview, setIsResolvingPreview] = useState(false);
+  const previewable = isPreviewableAttachmentKind(attachment.kind);
+  const latestPreviewSrcRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!attachment.file || !previewable) {
+      setObjectPreviewUrl(null);
+      return;
+    }
+
+    const nextUrl = URL.createObjectURL(attachment.file);
+    setObjectPreviewUrl(nextUrl);
+    return () => {
+      URL.revokeObjectURL(nextUrl);
+    };
+  }, [attachment.file, previewable]);
+
+  latestPreviewSrcRef.current = resolvedPreviewSrc ?? objectPreviewUrl;
+
+  const markPreviewUnavailable: (failingSrc?: string) => void = useCallback(
+    (failingSrc?: string) => {
+      if (failingSrc && latestPreviewSrcRef.current && failingSrc !== latestPreviewSrcRef.current) {
+        return;
+      }
+      setDialogOpen(false);
+      setResolvedPreviewSrc(null);
+      setPreviewError(readAttachmentPreviewLoadFailureMessage(attachment.name));
+    },
+    [attachment.name],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!previewable || objectPreviewUrl) {
+      setResolvedPreviewSrc(objectPreviewUrl ?? null);
+      setPreviewError(null);
+      setIsResolvingPreview(false);
+      return;
+    }
+    if (!attachment.path) {
+      setResolvedPreviewSrc(null);
+      setPreviewError("Attachment preview is unavailable because the local file path is missing.");
+      setIsResolvingPreview(false);
+      return;
+    }
+
+    setIsResolvingPreview(true);
+    setPreviewError(null);
+    void resolveLocalAttachmentPreviewSrc(attachment.path)
+      .then((src) => {
+        if (cancelled) {
+          return;
+        }
+        setResolvedPreviewSrc(src);
+      })
+      .catch((resolveError) => {
+        if (cancelled) {
+          return;
+        }
+        setResolvedPreviewSrc(null);
+        setPreviewError(
+          resolveError instanceof Error ? resolveError.message : String(resolveError),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsResolvingPreview(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment.path, objectPreviewUrl, previewable]);
+
+  const effectiveError = externalError ?? previewError;
+  const canOpenPreview = previewable && Boolean(resolvedPreviewSrc) && !previewError;
+  const showResolvedPreview = Boolean(resolvedPreviewSrc) && !previewError;
+
+  const requestPreviewOpen = useCallback((): string | null => {
+    if (canOpenPreview) {
+      setDialogOpen(true);
+      return null;
+    }
+
+    return (
+      previewError ??
+      "The attachment preview is not available because the local file could not be resolved."
+    );
+  }, [canOpenPreview, previewError]);
+
+  return {
+    dialogOpen,
+    setDialogOpen,
+    resolvedPreviewSrc,
+    previewError,
+    effectiveError,
+    isResolvingPreview,
+    previewable,
+    showResolvedPreview,
+    requestPreviewOpen,
+    markPreviewUnavailable,
+  };
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -17,7 +17,6 @@ import {
   type AgentChatComposerDraft,
   type AgentChatComposerDraftEditResult,
   applyComposerDraftEdit,
-  createEmptyComposerDraft,
   createTextSegment,
   draftHasMeaningfulContent,
   normalizeComposerDraft,
@@ -355,6 +354,7 @@ const parseComposerDraftFromRoot = (
 
   return normalizeComposerDraft({
     segments: nextSegments.length > 0 ? nextSegments : [createTextSegment("")],
+    attachments: previousDraft.attachments ?? [],
   });
 };
 
@@ -773,7 +773,10 @@ export const useAgentChatComposerEditor = ({
   );
 
   const clearComposerContents = useCallback(() => {
-    const nextDraft = createEmptyComposerDraft();
+    const nextDraft = normalizeComposerDraft({
+      segments: [createTextSegment("")],
+      attachments: latestDraftRef.current.attachments ?? [],
+    });
     const firstSegment = nextDraft.segments[0];
     if (!firstSegment || firstSegment.kind !== "text") {
       return false;

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.test.ts
@@ -55,6 +55,7 @@ describe("useAgentChatTurnStaging", () => {
           activeSessionId,
           windowStart,
           turns: nextTurns,
+          disabled: false,
         }),
       {
         activeSessionId: "session-1",
@@ -93,6 +94,7 @@ describe("useAgentChatTurnStaging", () => {
           activeSessionId,
           windowStart,
           turns: nextTurns,
+          disabled: false,
         }),
       {
         activeSessionId: "session-1",
@@ -124,6 +126,34 @@ describe("useAgentChatTurnStaging", () => {
     expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual(
       expandedTurns.map((turn) => turn.key),
     );
+
+    await harness.unmount();
+  });
+
+  test("returns all turns immediately when staging is disabled", async () => {
+    const turns = buildTurns(6);
+    const harness = createHookHarness(
+      ({ activeSessionId, windowStart, nextTurns, disabled }) =>
+        useAgentChatTurnStaging({
+          activeSessionId,
+          windowStart,
+          turns: nextTurns,
+          disabled,
+        }),
+      {
+        activeSessionId: "session-1",
+        windowStart: 10,
+        nextTurns: turns,
+        disabled: true,
+      },
+    );
+
+    await harness.mount();
+
+    expect(harness.getLatest().map((turn: AgentChatWindowTurn) => turn.key)).toEqual(
+      turns.map((turn) => turn.key),
+    );
+    expect(animationFrameCallbacks.size).toBe(0);
 
     await harness.unmount();
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-turn-staging.ts
@@ -8,12 +8,14 @@ type UseAgentChatTurnStagingArgs = {
   activeSessionId: string | null;
   windowStart: number;
   turns: AgentChatWindowTurn[];
+  disabled?: boolean;
 };
 
 export function useAgentChatTurnStaging({
   activeSessionId,
   windowStart,
   turns,
+  disabled = false,
 }: UseAgentChatTurnStagingArgs): AgentChatWindowTurn[] {
   const [count, setCount] = useState(turns.length);
   const frameRef = useRef<number | null>(null);
@@ -27,6 +29,7 @@ export function useAgentChatTurnStaging({
     }
 
     const shouldStage =
+      !disabled &&
       activeSessionId !== null &&
       windowStart > 0 &&
       turns.length > STAGE_INIT &&
@@ -73,7 +76,7 @@ export function useAgentChatTurnStaging({
         frameRef.current = null;
       }
     };
-  }, [activeSessionId, turns.length, windowStart]);
+  }, [activeSessionId, disabled, turns.length, windowStart]);
 
   return useMemo(() => {
     if (count >= turns.length) {

--- a/apps/desktop/src/lib/local-attachment-files.test.ts
+++ b/apps/desktop/src/lib/local-attachment-files.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { hostClient } from "@/lib/host-client";
+import {
+  buildBrowserLocalAttachmentPreviewUrl,
+  resolveLocalAttachmentPreviewSrc,
+} from "./local-attachment-files";
+
+const originalResolveLocalAttachmentPath = hostClient.workspaceResolveLocalAttachmentPath;
+
+afterEach(() => {
+  hostClient.workspaceResolveLocalAttachmentPath = originalResolveLocalAttachmentPath;
+});
+
+describe("local-attachment-files", () => {
+  test("buildBrowserLocalAttachmentPreviewUrl normalizes the backend base URL", () => {
+    expect(
+      buildBrowserLocalAttachmentPreviewUrl("http://127.0.0.1:14327/", "/tmp/preview.png"),
+    ).toBe("http://127.0.0.1:14327/local-attachment-preview?path=%2Ftmp%2Fpreview.png");
+  });
+
+  test("resolveLocalAttachmentPreviewSrc rejects blank paths before runtime branching", async () => {
+    await expect(resolveLocalAttachmentPreviewSrc("   ")).rejects.toThrow(
+      "Attachment preview is unavailable because the local file path is missing.",
+    );
+  });
+
+  test("resolveLocalAttachmentPreviewSrc resolves staged filename tokens before building browser preview urls", async () => {
+    hostClient.workspaceResolveLocalAttachmentPath = mock(async ({ path }) => ({
+      path: `/tmp/openducktor-local-attachments/uuid-${path}`,
+    }));
+
+    await expect(
+      resolveLocalAttachmentPreviewSrc("Screenshot-2026-03-16-at-23.48.30.png"),
+    ).resolves.toBe(
+      "/tmp/openducktor-local-attachments/uuid-Screenshot-2026-03-16-at-23.48.30.png",
+    );
+  });
+});

--- a/apps/desktop/src/lib/local-attachment-files.test.ts
+++ b/apps/desktop/src/lib/local-attachment-files.test.ts
@@ -24,6 +24,12 @@ describe("local-attachment-files", () => {
     );
   });
 
+  test("resolveLocalAttachmentPreviewSrc treats UNC paths as absolute local paths", async () => {
+    await expect(resolveLocalAttachmentPreviewSrc("\\\\server\\share\\preview.png")).resolves.toBe(
+      "\\\\server\\share\\preview.png",
+    );
+  });
+
   test("resolveLocalAttachmentPreviewSrc resolves staged filename tokens before building browser preview urls", async () => {
     hostClient.workspaceResolveLocalAttachmentPath = mock(async ({ path }) => ({
       path: `/tmp/openducktor-local-attachments/uuid-${path}`,

--- a/apps/desktop/src/lib/local-attachment-files.ts
+++ b/apps/desktop/src/lib/local-attachment-files.ts
@@ -1,0 +1,59 @@
+import { getBrowserBackendUrl, isBrowserAppMode } from "@/lib/browser-mode";
+import { hostClient } from "@/lib/host-client";
+import { isTauriRuntime } from "@/lib/runtime";
+
+const isAbsoluteLocalAttachmentPath = (path: string): boolean => {
+  return path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path);
+};
+
+const bufferToBase64 = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+};
+
+export const stageLocalAttachmentFile = async (file: File): Promise<string> => {
+  const buffer = await file.arrayBuffer();
+  const staged = await hostClient.workspaceStageLocalAttachment({
+    name: file.name,
+    ...(file.type.trim().length > 0 ? { mime: file.type } : {}),
+    base64Data: bufferToBase64(buffer),
+  });
+  return staged.path;
+};
+
+export const buildBrowserLocalAttachmentPreviewUrl = (
+  browserBackendUrl: string,
+  path: string,
+): string => {
+  const baseUrl = browserBackendUrl.replace(/\/$/, "");
+  const query = new URLSearchParams({ path });
+  return `${baseUrl}/local-attachment-preview?${query.toString()}`;
+};
+
+export const resolveLocalAttachmentPreviewSrc = async (path: string): Promise<string> => {
+  const trimmedPath = path.trim();
+  if (trimmedPath.length === 0) {
+    throw new Error("Attachment preview is unavailable because the local file path is missing.");
+  }
+
+  const resolvedPath = isAbsoluteLocalAttachmentPath(trimmedPath)
+    ? trimmedPath
+    : (await hostClient.workspaceResolveLocalAttachmentPath({ path: trimmedPath })).path;
+
+  if (isBrowserAppMode()) {
+    return buildBrowserLocalAttachmentPreviewUrl(getBrowserBackendUrl(), resolvedPath);
+  }
+
+  if (isTauriRuntime()) {
+    const api = await import("@tauri-apps/api/core");
+    return api.convertFileSrc(resolvedPath);
+  }
+
+  return resolvedPath;
+};

--- a/apps/desktop/src/lib/local-attachment-files.ts
+++ b/apps/desktop/src/lib/local-attachment-files.ts
@@ -3,7 +3,7 @@ import { hostClient } from "@/lib/host-client";
 import { isTauriRuntime } from "@/lib/runtime";
 
 const isAbsoluteLocalAttachmentPath = (path: string): boolean => {
-  return path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path);
+  return path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\");
 };
 
 const bufferToBase64 = (buffer: ArrayBuffer): string => {

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -1,5 +1,5 @@
 import type { TaskCard } from "@openducktor/contracts";
-import type { AgentModelSelection, AgentRole } from "@openducktor/core";
+import type { AgentModelCatalog, AgentModelSelection, AgentRole } from "@openducktor/core";
 import type { RefObject } from "react";
 import type {
   AgentChatComposerModel,
@@ -152,6 +152,7 @@ type AgentChatComposerModelArgs = {
   waitingInputPlaceholder?: string | null;
   isModelSelectionPending: boolean;
   selectedModelSelection: AgentModelSelection | null;
+  selectedModelDescriptor?: AgentModelCatalog["models"][number] | null;
   isSelectionCatalogLoading: boolean;
   supportsSlashCommands: boolean;
   supportsFileSearch: boolean;
@@ -228,6 +229,9 @@ export const buildAgentChatComposerModel = (
   waitingInputPlaceholder: args.waitingInputPlaceholder ?? null,
   isModelSelectionPending: args.isModelSelectionPending,
   selectedModelSelection: args.selectedModelSelection,
+  ...(args.selectedModelDescriptor !== undefined
+    ? { selectedModelDescriptor: args.selectedModelDescriptor }
+    : {}),
   isSelectionCatalogLoading: args.isSelectionCatalogLoading,
   supportsSlashCommands: args.supportsSlashCommands,
   supportsFileSearch: args.supportsFileSearch,

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -74,6 +74,7 @@ type UseAgentStudioModelSelectionArgs = {
 type AgentStudioModelSelectionState = {
   selectionForNewSession: AgentModelSelection | null;
   selectedModelSelection: AgentModelSelection | null;
+  selectedModelDescriptor: AgentModelCatalog["models"][number] | null;
   isSelectionCatalogLoading: boolean;
   supportsSlashCommands: boolean;
   supportsFileSearch: boolean;
@@ -628,6 +629,7 @@ export function useAgentStudioModelSelection({
   return {
     selectionForNewSession,
     selectedModelSelection,
+    selectedModelDescriptor: selectedModelEntry,
     isSelectionCatalogLoading,
     supportsSlashCommands,
     supportsFileSearch,

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.test.ts
@@ -83,6 +83,7 @@ const baseArgs: BuildArgs = {
   },
   modelSelection: {
     selectedModelSelection: null,
+    selectedModelDescriptor: null,
     isSelectionCatalogLoading: false,
     supportsSlashCommands: true,
     supportsFileSearch: true,

--- a/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-orchestration-controller.ts
@@ -113,6 +113,7 @@ type AgentStudioPageModelsSessionActionsContext = Parameters<
 type AgentStudioPageModelsModelSelectionContext = Pick<
   ReturnType<typeof useAgentStudioModelSelection>,
   | "selectedModelSelection"
+  | "selectedModelDescriptor"
   | "isSelectionCatalogLoading"
   | "supportsSlashCommands"
   | "supportsFileSearch"
@@ -254,6 +255,7 @@ export function useAgentStudioOrchestrationController({
   const {
     selectionForNewSession,
     selectedModelSelection,
+    selectedModelDescriptor,
     isSelectionCatalogLoading,
     supportsSlashCommands,
     supportsFileSearch,
@@ -307,6 +309,7 @@ export function useAgentStudioOrchestrationController({
     scenario: viewScenario,
     activeSession: viewActiveSession,
     selectedModelSelection,
+    selectedModelDescriptor,
     sessionsForTask: viewSessionsForTask,
     selectedTask: viewSelectedTask,
     agentStudioReady,
@@ -382,6 +385,7 @@ export function useAgentStudioOrchestrationController({
     },
     modelSelection: {
       selectedModelSelection,
+      selectedModelDescriptor,
       isSelectionCatalogLoading,
       supportsSlashCommands,
       supportsFileSearch,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -137,6 +137,7 @@ const createHookArgs = (overrides: HookArgsOverrides = {}): HookArgs => {
     },
     modelSelection: {
       selectedModelSelection: null,
+      selectedModelDescriptor: null,
       isSelectionCatalogLoading: false,
       supportsSlashCommands: true,
       supportsFileSearch: true,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -82,6 +82,7 @@ type AgentStudioReadinessContext = {
 
 type AgentStudioModelSelectionContext = {
   selectedModelSelection: AgentModelSelection | null;
+  selectedModelDescriptor?: AgentChatModel["composer"]["selectedModelDescriptor"];
   isSelectionCatalogLoading: boolean;
   supportsSlashCommands: boolean;
   supportsFileSearch: boolean;
@@ -325,6 +326,7 @@ export function useAgentStudioPageModels({
     isStarting: sessionActions.isStarting,
     chatContextUsage,
     selectedModelSelection: modelSelection.selectedModelSelection,
+    selectedModelDescriptor: modelSelection.selectedModelDescriptor,
     isSelectionCatalogLoading: modelSelection.isSelectionCatalogLoading,
     supportsSlashCommands: modelSelection.supportsSlashCommands,
     supportsFileSearch: modelSelection.supportsFileSearch,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -252,6 +252,7 @@ type UseAgentStudioComposerModelArgs = {
   isStarting: boolean;
   chatContextUsage: AgentChatModel["composer"]["contextUsage"];
   selectedModelSelection: AgentModelSelection | null;
+  selectedModelDescriptor?: AgentChatModel["composer"]["selectedModelDescriptor"];
   isSelectionCatalogLoading: boolean;
   supportsSlashCommands: boolean;
   supportsFileSearch: boolean;
@@ -291,6 +292,7 @@ export const useAgentStudioComposerModel = ({
   isStarting,
   chatContextUsage,
   selectedModelSelection,
+  selectedModelDescriptor,
   isSelectionCatalogLoading,
   supportsSlashCommands,
   supportsFileSearch,
@@ -355,6 +357,7 @@ export const useAgentStudioComposerModel = ({
         waitingInputPlaceholder,
         isModelSelectionPending,
         selectedModelSelection,
+        ...(selectedModelDescriptor !== undefined ? { selectedModelDescriptor } : {}),
         isSelectionCatalogLoading,
         supportsSlashCommands,
         supportsFileSearch,
@@ -407,6 +410,7 @@ export const useAgentStudioComposerModel = ({
       resizeComposerEditor,
       scrollToBottomOnSendRef,
       selectedModelSelection,
+      selectedModelDescriptor,
       selectedRoleAvailable,
       selectedRoleReadOnlyReason,
       slashCommandCatalog,

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.attachments.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.attachments.test.tsx
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { createElement, type PropsWithChildren, type ReactElement } from "react";
+import {
+  type AgentChatComposerDraft,
+  createComposerAttachment,
+  createSlashCommandSegment,
+  createTextSegment,
+} from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
+import { hostClient } from "@/lib/host-client";
+import { clearAppQueryClient } from "@/lib/query-client";
+import { QueryProvider } from "@/lib/query-provider";
+import { ChecksOperationsContext, RuntimeDefinitionsContext } from "@/state/app-state-contexts";
+import { createHookHarness as createCoreHookHarness } from "@/test-utils/react-hook-harness";
+import {
+  createAgentSessionFixture,
+  createTaskCardFixture,
+  enableReactActEnvironment,
+} from "./agent-studio-test-utils";
+import { useAgentStudioSessionActions } from "./use-agent-studio-session-actions";
+
+enableReactActEnvironment();
+
+const stageLocalAttachmentFileMock = mock(async (_args: unknown) => "/tmp/staged-brief.pdf");
+const originalWorkspaceStageLocalAttachment = hostClient.workspaceStageLocalAttachment;
+
+beforeEach(async () => {
+  await clearAppQueryClient();
+  stageLocalAttachmentFileMock.mockClear();
+  hostClient.workspaceStageLocalAttachment = async (args) => ({
+    path: await stageLocalAttachmentFileMock(args as never),
+  });
+});
+
+afterEach(() => {
+  hostClient.workspaceStageLocalAttachment = originalWorkspaceStageLocalAttachment;
+});
+
+type HookArgs = Parameters<typeof useAgentStudioSessionActions>[0];
+
+const createHookHarness = (initialProps: HookArgs) => {
+  const wrapper = ({ children }: PropsWithChildren): ReactElement =>
+    createElement(
+      ChecksOperationsContext.Provider,
+      {
+        value: {
+          refreshRuntimeCheck: async () => ({
+            gitOk: true,
+            gitVersion: null,
+            ghOk: true,
+            ghVersion: null,
+            ghAuthOk: true,
+            ghAuthLogin: null,
+            ghAuthError: null,
+            runtimes: [],
+            errors: [],
+          }),
+          refreshBeadsCheckForRepo: async () => ({
+            beadsOk: true,
+            beadsPath: "/repo/.beads",
+            beadsError: null,
+          }),
+          refreshRepoRuntimeHealthForRepo: async () => ({}),
+          clearActiveBeadsCheck: () => {},
+          clearActiveRepoRuntimeHealth: () => {},
+          setIsLoadingChecks: () => {},
+          hasRuntimeCheck: () => false,
+          hasCachedBeadsCheck: () => false,
+          hasCachedRepoRuntimeHealth: () => false,
+        },
+      },
+      createElement(
+        QueryProvider,
+        { useIsolatedClient: true },
+        createElement(RuntimeDefinitionsContext.Provider, {
+          value: {
+            runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+            isLoadingRuntimeDefinitions: false,
+            runtimeDefinitionsError: null,
+            refreshRuntimeDefinitions: async () => [OPENCODE_RUNTIME_DESCRIPTOR],
+            loadRepoRuntimeCatalog: async () => ({
+              runtime: OPENCODE_RUNTIME_DESCRIPTOR,
+              models: [],
+              defaultModelsByProvider: {},
+              profiles: [],
+            }),
+            loadRepoRuntimeSlashCommands: async () => ({ commands: [] }),
+            loadRepoRuntimeFileSearch: async () => [],
+          },
+          children,
+        }),
+      ),
+    );
+
+  return createCoreHookHarness(useAgentStudioSessionActions, initialProps, { wrapper });
+};
+
+const createBaseArgs = (): HookArgs => ({
+  activeRepo: "/repo",
+  taskId: "task-1",
+  role: "spec",
+  scenario: "spec_initial",
+  activeSession: createAgentSessionFixture({ sessionId: "session-existing" }),
+  selectedModelSelection: null,
+  selectedModelDescriptor: {
+    id: "openai/gpt-5",
+    providerId: "openai",
+    providerName: "OpenAI",
+    modelId: "gpt-5",
+    modelName: "GPT-5",
+    variants: ["default"],
+    contextWindow: 200_000,
+    outputLimit: 8_192,
+    attachmentSupport: {
+      image: false,
+      audio: false,
+      video: false,
+      pdf: true,
+    },
+  },
+  sessionsForTask: [],
+  selectedTask: createTaskCardFixture(),
+  agentStudioReady: true,
+  isActiveTaskHydrated: true,
+  selectionForNewSession: {
+    runtimeKind: "opencode",
+    providerId: "openai",
+    modelId: "gpt-5",
+    variant: "default",
+    profileId: "spec",
+  },
+  repoSettings: null,
+  startAgentSession: async () => "session-new",
+  sendAgentMessage: async () => {},
+  bootstrapTaskSessions: async () => {},
+  hydrateRequestedTaskSessionHistory: async () => {},
+  humanRequestChangesTask: async () => {},
+  answerAgentQuestion: async () => {},
+  updateQuery: () => {},
+});
+
+const createAttachmentDraft = (
+  segments: AgentChatComposerDraft["segments"],
+): AgentChatComposerDraft => {
+  const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+  return {
+    segments,
+    attachments: [
+      createComposerAttachment(
+        {
+          name: "brief.pdf",
+          kind: "pdf",
+          mime: "application/pdf",
+          file,
+        },
+        "attachment-1",
+      ),
+    ],
+  };
+};
+
+describe("useAgentStudioSessionActions attachments", () => {
+  test("stages browser attachments before sending them", async () => {
+    const sendAgentMessage = mock(async () => {});
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      sendAgentMessage,
+    });
+    const draft = createAttachmentDraft([createTextSegment("please review")]);
+    const attachmentFile = draft.attachments?.[0]?.file;
+    if (!(attachmentFile instanceof File)) {
+      throw new Error("Expected draft attachment file");
+    }
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await expect(state.onSend(draft)).resolves.toBe(true);
+    });
+
+    expect(stageLocalAttachmentFileMock).toHaveBeenCalledWith({
+      name: "brief.pdf",
+      mime: "application/pdf",
+      base64Data: "cGRm",
+    });
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
+      { kind: "text", text: "please review" },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "attachment-1",
+          name: "brief.pdf",
+          kind: "pdf",
+          mime: "application/pdf",
+          path: "/tmp/staged-brief.pdf",
+        },
+      },
+    ]);
+
+    await harness.unmount();
+  });
+
+  test("rejects slash-command drafts that also contain attachments", async () => {
+    const sendAgentMessage = mock(async () => {});
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      sendAgentMessage,
+    });
+    const draft = createAttachmentDraft([
+      createSlashCommandSegment(
+        {
+          id: "compact",
+          trigger: "compact",
+          title: "compact",
+          hints: [],
+        },
+        "slash-1",
+      ),
+    ]);
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await expect(state.onSend(draft)).resolves.toBe(false);
+    });
+
+    expect(stageLocalAttachmentFileMock).not.toHaveBeenCalled();
+    expect(sendAgentMessage).not.toHaveBeenCalled();
+
+    await harness.unmount();
+  });
+
+  test("stages attachments even when the browser file exposes an original local path", async () => {
+    const sendAgentMessage = mock(async () => {});
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      sendAgentMessage,
+    });
+    const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    const attachment = createComposerAttachment(
+      {
+        name: "brief.pdf",
+        kind: "pdf",
+        mime: "application/pdf",
+        path: "/Users/example/Desktop/brief.pdf",
+        file,
+      },
+      "attachment-path-file",
+    );
+    const draft: AgentChatComposerDraft = {
+      segments: [createTextSegment("please review")],
+      attachments: [attachment],
+    };
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await expect(state.onSend(draft)).resolves.toBe(true);
+    });
+
+    expect(stageLocalAttachmentFileMock).toHaveBeenCalledWith({
+      name: "brief.pdf",
+      mime: "application/pdf",
+      base64Data: "cGRm",
+    });
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
+      { kind: "text", text: "please review" },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "attachment-path-file",
+          name: "brief.pdf",
+          kind: "pdf",
+          mime: "application/pdf",
+          path: "/tmp/staged-brief.pdf",
+        },
+      },
+    ]);
+
+    await harness.unmount();
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -3,6 +3,7 @@ import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { createElement, type PropsWithChildren, type ReactElement } from "react";
 import {
   type AgentChatComposerDraft,
+  createComposerAttachment,
   createTextSegment,
 } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
 import { clearAppQueryClient } from "@/lib/query-client";
@@ -27,6 +28,27 @@ const createTask = (overrides = {}) => createTaskCardFixture(overrides);
 const createComposerDraft = (text: string): AgentChatComposerDraft => ({
   segments: [createTextSegment(text)],
   attachments: [],
+});
+
+const createAttachmentDraft = (input: {
+  id: string;
+  name: string;
+  kind: "image" | "pdf";
+  mime: string;
+  path: string;
+}): AgentChatComposerDraft => ({
+  segments: [createTextSegment("please review")],
+  attachments: [
+    createComposerAttachment(
+      {
+        name: input.name,
+        kind: input.kind,
+        mime: input.mime,
+        path: input.path,
+      },
+      input.id,
+    ),
+  ],
 });
 
 const createSession = (overrides = {}) => createAgentSessionFixture(overrides);
@@ -553,7 +575,7 @@ describe("useAgentStudioSessionActions", () => {
     await harness.run(async (state) => {
       sendPromise = state.onSend(draft);
     });
-    await harness.waitFor(() => sendAgentMessage.mock.calls.length === 1);
+    await harness.waitFor(() => sendAgentMessage.mock.calls.length === 1, 1_000);
     expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
       { kind: "text", text: "  hello world  " },
     ]);
@@ -590,6 +612,106 @@ describe("useAgentStudioSessionActions", () => {
     });
 
     expect(harness.getLatest().isSending).toBe(false);
+    await harness.unmount();
+  });
+
+  test("onSend allows path-backed attachments when the selected model descriptor supports them", async () => {
+    const sendAgentMessage = mock(async () => {});
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession: createSession({ sessionId: "session-existing" }),
+      selectedModelDescriptor: {
+        id: "openai/gpt-5",
+        providerId: "openai",
+        providerName: "OpenAI",
+        modelId: "gpt-5",
+        modelName: "GPT-5",
+        variants: ["default"],
+        contextWindow: 200_000,
+        outputLimit: 8_192,
+        attachmentSupport: {
+          image: false,
+          audio: false,
+          video: false,
+          pdf: true,
+        },
+      },
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await expect(
+        state.onSend(
+          createAttachmentDraft({
+            id: "pdf-attachment",
+            name: "brief.pdf",
+            kind: "pdf",
+            mime: "application/pdf",
+            path: "/tmp/brief.pdf",
+          }),
+        ),
+      ).resolves.toBe(true);
+    });
+
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
+      { kind: "text", text: "please review" },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "pdf-attachment",
+          name: "brief.pdf",
+          kind: "pdf",
+          mime: "application/pdf",
+          path: "/tmp/brief.pdf",
+        },
+      },
+    ]);
+
+    await harness.unmount();
+  });
+
+  test("onSend blocks path-backed attachments when the selected model descriptor rejects them", async () => {
+    const sendAgentMessage = mock(async () => {});
+    const harness = createHookHarness({
+      ...createBaseArgs(),
+      activeSession: createSession({ sessionId: "session-existing" }),
+      selectedModelDescriptor: {
+        id: "openai/gpt-5",
+        providerId: "openai",
+        providerName: "OpenAI",
+        modelId: "gpt-5",
+        modelName: "GPT-5",
+        variants: ["default"],
+        contextWindow: 200_000,
+        outputLimit: 8_192,
+        attachmentSupport: {
+          image: false,
+          audio: false,
+          video: false,
+          pdf: true,
+        },
+      },
+      sendAgentMessage,
+    });
+
+    await harness.mount();
+    await harness.run(async (state) => {
+      await expect(
+        state.onSend(
+          createAttachmentDraft({
+            id: "image-attachment",
+            name: "preview.png",
+            kind: "image",
+            mime: "image/png",
+            path: "/tmp/preview.png",
+          }),
+        ),
+      ).resolves.toBe(false);
+    });
+
+    expect(sendAgentMessage).not.toHaveBeenCalled();
+
     await harness.unmount();
   });
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.test.tsx
@@ -26,6 +26,7 @@ const createTask = (overrides = {}) => createTaskCardFixture(overrides);
 
 const createComposerDraft = (text: string): AgentChatComposerDraft => ({
   segments: [createTextSegment(text)],
+  attachments: [],
 });
 
 const createSession = (overrides = {}) => createAgentSessionFixture(overrides);
@@ -172,6 +173,7 @@ const createBaseArgs = (): HookArgs => {
     scenario: "spec_initial",
     activeSession: null,
     selectedModelSelection: null,
+    selectedModelDescriptor: null,
     sessionsForTask: [],
     selectedTask: createTask(),
     agentStudioReady: true,
@@ -550,10 +552,11 @@ describe("useAgentStudioSessionActions", () => {
     let sendPromise: Promise<boolean | undefined> | undefined;
     await harness.run(async (state) => {
       sendPromise = state.onSend(draft);
-      expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
-        { kind: "text", text: "  hello world  " },
-      ]);
     });
+    await harness.waitFor(() => sendAgentMessage.mock.calls.length === 1);
+    expect(sendAgentMessage).toHaveBeenCalledWith("session-existing", [
+      { kind: "text", text: "  hello world  " },
+    ]);
     expect(harness.getLatest().isSending).toBe(true);
 
     await harness.run(async () => {

--- a/apps/desktop/src/pages/agents/use-agent-studio-session-actions.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-session-actions.ts
@@ -1,17 +1,25 @@
 import type { TaskCard } from "@openducktor/contracts";
-import type { AgentModelSelection, AgentRole, AgentScenario } from "@openducktor/core";
+import type {
+  AgentModelCatalog,
+  AgentModelSelection,
+  AgentRole,
+  AgentScenario,
+} from "@openducktor/core";
 import { isAgentKickoffScenario } from "@openducktor/core";
 import { useCallback, useEffect, useState } from "react";
 import type { SessionStartModalModel } from "@/components/features/agents";
+import { validateComposerAttachments } from "@/components/features/agents/agent-chat/agent-chat-attachments";
 import {
   type AgentChatComposerDraft,
   draftHasMeaningfulContent,
+  draftHasSlashCommandSegment,
   draftToSerializedText,
-  draftToUserMessageParts,
+  resolveDraftToUserMessageParts,
 } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
 import type { HumanReviewFeedbackModalModel } from "@/features/human-review-feedback/human-review-feedback-types";
 import type { SessionStartRequestReason } from "@/features/session-start";
 import { isAgentSessionWaitingInput } from "@/lib/agent-session-waiting-input";
+import { stageLocalAttachmentFile } from "@/lib/local-attachment-files";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
 import type { AgentSessionState } from "@/types/agent-orchestrator";
 import type { AgentStateContextValue, RepoSettingsInput } from "@/types/state-slices";
@@ -37,6 +45,7 @@ type UseAgentStudioSessionActionsArgs = {
   scenario: AgentScenario;
   activeSession: AgentSessionState | null;
   selectedModelSelection: AgentModelSelection | null;
+  selectedModelDescriptor?: AgentModelCatalog["models"][number] | null;
   sessionsForTask: AgentSessionState[];
   selectedTask: TaskCard | null;
   agentStudioReady: boolean;
@@ -60,6 +69,7 @@ export function useAgentStudioSessionActions({
   scenario,
   activeSession,
   selectedModelSelection,
+  selectedModelDescriptor,
   sessionsForTask,
   selectedTask,
   agentStudioReady,
@@ -198,8 +208,26 @@ export function useAgentStudioSessionActions({
         return false;
       }
 
+      if ((draft.attachments ?? []).length > 0) {
+        if (draftHasSlashCommandSegment(draft)) {
+          return false;
+        }
+
+        const attachmentErrors = validateComposerAttachments(
+          draft.attachments ?? [],
+          selectedModelDescriptor?.attachmentSupport,
+        );
+        if (Object.keys(attachmentErrors).length > 0) {
+          return false;
+        }
+      }
+
       const serializedDraft = draftToSerializedText(draft).trim();
-      if (!draftHasMeaningfulContent(draft) || !serializedDraft || !taskId) {
+      if (
+        !draftHasMeaningfulContent(draft) ||
+        (!serializedDraft && (draft.attachments ?? []).length === 0) ||
+        !taskId
+      ) {
         return false;
       }
       const sendContextKeys = new Set<string>();
@@ -230,7 +258,18 @@ export function useAgentStudioSessionActions({
           }
           return next;
         });
-        await sendAgentMessage(targetSessionId, draftToUserMessageParts(draft));
+        await sendAgentMessage(
+          targetSessionId,
+          await resolveDraftToUserMessageParts(draft, async (attachment) => {
+            if (attachment.file) {
+              return stageLocalAttachmentFile(attachment.file);
+            }
+            if (attachment.path) {
+              return attachment.path;
+            }
+            throw new Error(`Attachment "${attachment.name}" is missing local file data.`);
+          }),
+        );
         return true;
       } finally {
         if (sendContextKeys.size > 0) {
@@ -256,6 +295,7 @@ export function useAgentStudioSessionActions({
       busySendBlockedReason,
       role,
       selectedTask,
+      selectedModelDescriptor?.attachmentSupport,
       sendAgentMessage,
       startSession,
       taskId,

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2/client";
-import type { AgentEvent } from "@openducktor/core";
+import type { AgentEvent, AgentModelSelection, AgentUserMessagePart } from "@openducktor/core";
 import { subscribeOpencodeEvents } from "./event-stream";
 import type { SessionInput, SessionRecord } from "./types";
+import {
+  buildQueuedRequestAttachmentIdentitySignature,
+  buildQueuedRequestSignature,
+} from "./user-message-signatures";
+
+const IMAGE_ATTACHMENT_DISPLAY_PART = {
+  kind: "attachment" as const,
+  attachment: {
+    id: "attachment-image-1",
+    path: "/tmp/local-screenshot.png",
+    name: "Screenshot-2026-03-17-at-12.04.45.png",
+    kind: "image" as const,
+    mime: "image/png",
+  },
+};
 
 const makeClientWithEvents = (events: Event[]): OpencodeClient => {
   return {
@@ -62,6 +77,11 @@ const makeSessionRecord = (client: OpencodeClient): SessionRecord => ({
   messageMetadataById: new Map(),
   pendingDeltasByPartId: new Map(),
 });
+
+const buildQueuedSignature = (message: string, model?: AgentModelSelection | null): string => {
+  const parts: AgentUserMessagePart[] = [{ kind: "text", text: message }];
+  return buildQueuedRequestSignature(parts, model ?? undefined);
+};
 
 const runEventStreamWithSession = async (
   events: Event[],
@@ -566,7 +586,9 @@ describe("event-stream", () => {
         } as unknown as Event,
       ],
       (nextSessionRecord) => {
-        nextSessionRecord.pendingQueuedUserMessages.push({ content: "Ship it" });
+        nextSessionRecord.pendingQueuedUserMessages.push({
+          signature: buildQueuedSignature("Ship it"),
+        });
         nextSessionRecord.activeAssistantMessageId = null;
       },
     );
@@ -648,15 +670,15 @@ describe("event-stream", () => {
       (nextSessionRecord) => {
         nextSessionRecord.activeAssistantMessageId = "msg-100";
         nextSessionRecord.pendingQueuedUserMessages.push(
-          { content: "Ship it" },
+          { signature: buildQueuedSignature("Ship it") },
           {
-            content: "Ship it",
-            model: {
+            signature: buildQueuedSignature("Ship it", {
+              runtimeKind: "opencode",
               providerId: "openai",
               modelId: "gpt-5",
               profileId: "Hephaestus",
               variant: "high",
-            },
+            }),
           },
         );
       },
@@ -669,7 +691,98 @@ describe("event-stream", () => {
       messageId: "msg-200",
       state: "queued",
     });
-    expect(sessionRecord.pendingQueuedUserMessages).toEqual([{ content: "Ship it" }]);
+    expect(sessionRecord.pendingQueuedUserMessages).toEqual([
+      { signature: buildQueuedSignature("Ship it") },
+    ]);
+  });
+
+  test("preserves queued local attachment preview paths when the runtime echoes a non-file attachment url", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [
+        {
+          type: "message.updated",
+          properties: {
+            info: {
+              id: "msg-attachment-1",
+              role: "user",
+              sessionID: "external-session-1",
+              text: "Describe what is in this screenshot",
+              time: {
+                created: Date.parse("2026-02-22T12:00:02.000Z"),
+              },
+            },
+            parts: [
+              {
+                id: "part-text-1",
+                sessionID: "external-session-1",
+                messageID: "msg-attachment-1",
+                type: "text",
+                text: "Describe what is in this screenshot",
+              },
+              {
+                id: "part-file-1",
+                sessionID: "external-session-1",
+                messageID: "msg-attachment-1",
+                type: "file",
+                mime: "image/png",
+                filename: "Screenshot-2026-03-17-at-12.04.45.png",
+                url: "https://files.example.invalid/uploaded-image",
+              },
+            ],
+          },
+        } as unknown as Event,
+      ],
+      (nextSessionRecord) => {
+        nextSessionRecord.pendingQueuedUserMessages.push({
+          signature: buildQueuedRequestSignature(
+            [
+              { kind: "text", text: "Describe what is in this screenshot" },
+              IMAGE_ATTACHMENT_DISPLAY_PART,
+            ] as AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentIdentitySignature: buildQueuedRequestAttachmentIdentitySignature(
+            [
+              { kind: "text", text: "Describe what is in this screenshot" },
+              IMAGE_ATTACHMENT_DISPLAY_PART,
+            ] as AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentParts: [IMAGE_ATTACHMENT_DISPLAY_PART],
+        });
+      },
+    );
+
+    const userMessages = emitted.filter((event) => event.type === "user_message");
+    expect(userMessages).toHaveLength(1);
+    const userMessage = userMessages[0];
+    if (!userMessage || userMessage.type !== "user_message") {
+      throw new Error("Expected user_message event");
+    }
+    expect(userMessage.parts).toContainEqual(
+      expect.objectContaining({
+        kind: "attachment",
+        attachment: expect.objectContaining({
+          path: "/tmp/local-screenshot.png",
+          name: "Screenshot-2026-03-17-at-12.04.45.png",
+          kind: "image",
+          mime: "image/png",
+        }),
+      }),
+    );
+
+    const metadata = sessionRecord.messageMetadataById.get("msg-attachment-1");
+    expect(metadata?.displayParts).toContainEqual(
+      expect.objectContaining({
+        kind: "attachment",
+        attachment: expect.objectContaining({
+          path: "/tmp/local-screenshot.png",
+          name: "Screenshot-2026-03-17-at-12.04.45.png",
+          kind: "image",
+          mime: "image/png",
+        }),
+      }),
+    );
   });
 
   test("reconciles queued follow-ups when a newer assistant becomes pending", async () => {

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -19,6 +19,17 @@ const IMAGE_ATTACHMENT_DISPLAY_PART = {
   },
 };
 
+const PDF_ATTACHMENT_DISPLAY_PART = {
+  kind: "attachment" as const,
+  attachment: {
+    id: "attachment-pdf-1",
+    path: "/tmp/local-brief.pdf",
+    name: "brief.pdf",
+    kind: "pdf" as const,
+    mime: "application/pdf",
+  },
+};
+
 const makeClientWithEvents = (events: Event[]): OpencodeClient => {
   return {
     global: {
@@ -780,6 +791,94 @@ describe("event-stream", () => {
           name: "Screenshot-2026-03-17-at-12.04.45.png",
           kind: "image",
           mime: "image/png",
+        }),
+      }),
+    );
+  });
+
+  test("keeps pdf attachment echoes out of inline file-reference rendering", async () => {
+    const { emitted } = await runEventStreamWithSession(
+      [
+        {
+          type: "message.updated",
+          properties: {
+            info: {
+              id: "msg-pdf-1",
+              role: "user",
+              text: "Summarize this PDF",
+              sessionID: "external-session-1",
+              time: {
+                created: Date.parse("2026-02-22T12:00:02.000Z"),
+              },
+              parts: [
+                {
+                  id: "part-text-1",
+                  sessionID: "external-session-1",
+                  messageID: "msg-pdf-1",
+                  type: "text",
+                  text: "Summarize this PDF",
+                },
+                {
+                  id: "part-file-1",
+                  sessionID: "external-session-1",
+                  messageID: "msg-pdf-1",
+                  type: "file",
+                  mime: "application/pdf",
+                  filename: "brief.pdf",
+                  url: "https://files.example.invalid/brief.pdf",
+                  source: {
+                    type: "file",
+                    path: "brief.pdf",
+                    text: {
+                      value: "brief.pdf",
+                      start: 0,
+                      end: 9,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        } as unknown as Event,
+      ],
+      (nextSessionRecord) => {
+        nextSessionRecord.pendingQueuedUserMessages.push({
+          signature: buildQueuedRequestSignature(
+            [
+              { kind: "text", text: "Summarize this PDF" },
+              PDF_ATTACHMENT_DISPLAY_PART,
+            ] as AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentIdentitySignature: buildQueuedRequestAttachmentIdentitySignature(
+            [
+              { kind: "text", text: "Summarize this PDF" },
+              PDF_ATTACHMENT_DISPLAY_PART,
+            ] as AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentParts: [PDF_ATTACHMENT_DISPLAY_PART],
+        });
+      },
+    );
+
+    const userMessages = emitted.filter((event) => event.type === "user_message");
+    expect(userMessages).toHaveLength(1);
+    const userMessage = userMessages[0];
+    if (!userMessage || userMessage.type !== "user_message") {
+      throw new Error("Expected user_message event");
+    }
+
+    expect(userMessage.parts.filter((part) => part.kind === "attachment")).toHaveLength(1);
+    expect(userMessage.parts.filter((part) => part.kind === "file_reference")).toHaveLength(0);
+    expect(userMessage.parts).toContainEqual(
+      expect.objectContaining({
+        kind: "attachment",
+        attachment: expect.objectContaining({
+          path: "/tmp/local-brief.pdf",
+          name: "brief.pdf",
+          kind: "pdf",
+          mime: "application/pdf",
         }),
       }),
     );

--- a/packages/adapters-opencode-sdk/src/event-stream.test.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream.test.ts
@@ -796,6 +796,80 @@ describe("event-stream", () => {
     );
   });
 
+  test("matches queued attachment sends when the runtime fills user parts through message.part.updated", async () => {
+    const { emitted, sessionRecord } = await runEventStreamWithSession(
+      [
+        {
+          type: "message.updated",
+          properties: {
+            info: {
+              id: "msg-attachment-partial-1",
+              role: "user",
+              sessionID: "external-session-1",
+              text: "Describe what is in this screenshot",
+              time: {
+                created: Date.parse("2026-02-22T12:00:02.000Z"),
+              },
+            },
+          },
+        } as unknown as Event,
+        {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "part-file-partial-1",
+              sessionID: "external-session-1",
+              messageID: "msg-attachment-partial-1",
+              type: "file",
+              mime: "image/png",
+              filename: "Screenshot-2026-03-17-at-12.04.45.png",
+              url: "https://files.example.invalid/uploaded-image",
+            },
+          },
+        } as unknown as Event,
+      ],
+      (nextSessionRecord) => {
+        nextSessionRecord.messageRoleById.set("msg-attachment-partial-1", "user");
+        nextSessionRecord.pendingQueuedUserMessages.push({
+          signature: buildQueuedRequestSignature(
+            [
+              { kind: "text", text: "Describe what is in this screenshot" },
+              IMAGE_ATTACHMENT_DISPLAY_PART,
+            ] as AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentIdentitySignature: buildQueuedRequestAttachmentIdentitySignature(
+            [
+              { kind: "text", text: "Describe what is in this screenshot" },
+              IMAGE_ATTACHMENT_DISPLAY_PART,
+            ] as AgentUserMessagePart[],
+            undefined,
+          ),
+          attachmentParts: [IMAGE_ATTACHMENT_DISPLAY_PART],
+        });
+      },
+    );
+
+    expect(sessionRecord.pendingQueuedUserMessages).toHaveLength(0);
+    const userMessages = emitted.filter((event) => event.type === "user_message");
+    expect(userMessages).toHaveLength(2);
+    const latestUserMessage = userMessages[userMessages.length - 1];
+    if (!latestUserMessage || latestUserMessage.type !== "user_message") {
+      throw new Error("Expected user_message event");
+    }
+    expect(latestUserMessage.parts).toContainEqual(
+      expect.objectContaining({
+        kind: "attachment",
+        attachment: expect.objectContaining({
+          path: "/tmp/local-screenshot.png",
+          name: "Screenshot-2026-03-17-at-12.04.45.png",
+          kind: "image",
+          mime: "image/png",
+        }),
+      }),
+    );
+  });
+
   test("keeps pdf attachment echoes out of inline file-reference rendering", async () => {
     const { emitted } = await runEventStreamWithSession(
       [

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -379,6 +379,8 @@ const emitKnownUserMessage = (
     timestamp: string;
     state: AgentUserMessageState;
     model?: ReturnType<typeof readMessageModelSelection>;
+    visible?: string;
+    displayParts?: import("@openducktor/core").AgentUserMessageDisplayPart[];
   },
 ): boolean => {
   const session = runtime.getSession(runtime.sessionId);
@@ -387,11 +389,13 @@ const emitKnownUserMessage = (
     getKnownMessageParts(runtime, input.messageId),
   );
   const fallbackText = metadata?.text ?? "";
-  const displayParts = ensureVisibleUserTextDisplayParts(
-    knownDisplayParts.length > 0 ? knownDisplayParts : (metadata?.displayParts ?? []),
-    fallbackText,
-  );
-  const textFromParts = readVisibleUserTextFromDisplayParts(displayParts);
+  const displayParts =
+    input.displayParts ??
+    ensureVisibleUserTextDisplayParts(
+      knownDisplayParts.length > 0 ? knownDisplayParts : (metadata?.displayParts ?? []),
+      fallbackText,
+    );
+  const textFromParts = input.visible ?? readVisibleUserTextFromDisplayParts(displayParts);
   const visible = textFromParts.length > 0 ? textFromParts : fallbackText;
   if (visible.trim().length === 0 && displayParts.length === 0) {
     return false;
@@ -705,10 +709,15 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     const currentMetadata = session?.messageMetadataById.get(messageId);
     const normalizedDisplayParts = normalizeUserMessageDisplayParts(userParts);
     const fallbackText = currentMetadata?.text ?? readTextFromMessageInfo(infoRecord);
-    const matchedQueuedSend = takeQueuedUserSendMatch(
-      runtime,
+    const initialVisibleUserMessage = buildVisibleUserMessage({
       fallbackText,
       normalizedDisplayParts,
+      ...(currentMetadata ? { metadata: currentMetadata } : {}),
+    });
+    const matchedQueuedSend = takeQueuedUserSendMatch(
+      runtime,
+      initialVisibleUserMessage.visible,
+      initialVisibleUserMessage.displayParts,
       messageModel,
     );
     const { displayParts, visible } = buildVisibleUserMessage({
@@ -860,10 +869,22 @@ const handleMessagePartUpdatedEvent = (event: Event, runtime: EventStreamRuntime
       getKnownMessageParts(runtime, messageId),
     );
     const fallbackText = metadata?.text ?? "";
+    const initialVisibleUserMessage = buildVisibleUserMessage({
+      fallbackText,
+      normalizedDisplayParts,
+      ...(metadata ? { metadata } : {}),
+    });
+    const matchedQueuedSend = takeQueuedUserSendMatch(
+      runtime,
+      initialVisibleUserMessage.visible,
+      initialVisibleUserMessage.displayParts,
+      metadata?.model,
+    );
     const { displayParts, visible } = buildVisibleUserMessage({
       fallbackText,
       normalizedDisplayParts,
       ...(metadata ? { metadata } : {}),
+      ...(matchedQueuedSend ? { matchedQueuedSend } : {}),
     });
     if (visible.trim().length > 0 || displayParts.length > 0) {
       persistUserMessageMetadata({
@@ -879,11 +900,13 @@ const handleMessagePartUpdatedEvent = (event: Event, runtime: EventStreamRuntime
     emitKnownUserMessage(runtime, {
       messageId,
       timestamp: metadata?.timestamp ?? runtime.now(),
+      visible,
+      displayParts,
       state: resolveLiveUserMessageState(runtime, {
         messageId,
         visible,
         parts: displayParts,
-        matchedQueuedSend: null,
+        matchedQueuedSend,
         ...(metadata?.model ? { model: metadata.model } : {}),
       }),
       ...(metadata?.model ? { model: metadata.model } : {}),

--- a/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
+++ b/packages/adapters-opencode-sdk/src/event-stream/message-events.ts
@@ -11,6 +11,7 @@ import {
 import {
   ensureVisibleUserTextDisplayParts,
   extractMessageTotalTokens,
+  mergePreservedAttachmentDisplayParts,
   normalizeUserMessageDisplayParts,
   readMessageModelSelection,
   readTextFromMessageInfo,
@@ -20,6 +21,11 @@ import {
 } from "../message-normalizers";
 import { toIsoFromEpoch } from "../session-runtime-utils";
 import { mapPartToAgentStreamPart } from "../stream-part-mapper";
+import type { QueuedUserMessageSend, SessionMessageMetadata } from "../types";
+import {
+  buildQueuedDisplayAttachmentIdentitySignature,
+  buildQueuedDisplaySignature,
+} from "../user-message-signatures";
 import {
   readEventInfo,
   readEventPart,
@@ -205,6 +211,7 @@ const updateMessageMetadata = (
     text?: string;
     hasStopSignal?: boolean;
     totalTokens?: number;
+    displayParts?: SessionMessageMetadata["displayParts"];
   },
 ): void => {
   const session = runtime.getSession(runtime.sessionId);
@@ -219,6 +226,7 @@ const updateMessageMetadata = (
   const text = updates.text ?? previous?.text;
   const hasStopSignal = updates.hasStopSignal ?? previous?.hasStopSignal;
   const totalTokens = updates.totalTokens ?? previous?.totalTokens;
+  const displayParts = updates.displayParts ?? previous?.displayParts;
 
   session.messageMetadataById.set(messageId, {
     timestamp,
@@ -227,6 +235,71 @@ const updateMessageMetadata = (
     ...(text ? { text } : {}),
     ...(hasStopSignal !== undefined ? { hasStopSignal } : {}),
     ...(totalTokens !== undefined ? { totalTokens } : {}),
+    ...(displayParts ? { displayParts } : {}),
+  });
+};
+
+type UserDisplayPart = import("@openducktor/core").AgentUserMessageDisplayPart;
+type AttachmentDisplayPart = Extract<UserDisplayPart, { kind: "attachment" }>;
+
+const readPreservedAttachmentParts = (input: {
+  metadata?: SessionMessageMetadata;
+  matchedQueuedSend?: QueuedUserMessageSend | null;
+}): AttachmentDisplayPart[] => {
+  return [
+    ...(input.metadata?.displayParts?.filter(
+      (part): part is AttachmentDisplayPart => part.kind === "attachment",
+    ) ?? []),
+    ...(input.matchedQueuedSend?.attachmentParts ?? []),
+  ];
+};
+
+const buildVisibleUserMessage = (input: {
+  fallbackText: string;
+  normalizedDisplayParts: UserDisplayPart[];
+  metadata?: SessionMessageMetadata;
+  matchedQueuedSend?: QueuedUserMessageSend | null;
+}): {
+  displayParts: UserDisplayPart[];
+  visible: string;
+} => {
+  const mergedDisplayParts = mergePreservedAttachmentDisplayParts(
+    input.normalizedDisplayParts,
+    readPreservedAttachmentParts({
+      ...(input.metadata ? { metadata: input.metadata } : {}),
+      ...(input.matchedQueuedSend ? { matchedQueuedSend: input.matchedQueuedSend } : {}),
+    }),
+  );
+  const displayParts = ensureVisibleUserTextDisplayParts(
+    mergedDisplayParts.length > 0 ? mergedDisplayParts : (input.metadata?.displayParts ?? []),
+    input.fallbackText,
+  );
+  const textFromParts = readVisibleUserTextFromDisplayParts(displayParts);
+  return {
+    displayParts,
+    visible: textFromParts.length > 0 ? textFromParts : input.fallbackText,
+  };
+};
+
+const persistUserMessageMetadata = (input: {
+  session: ReturnType<EventStreamRuntime["getSession"]>;
+  messageId: string;
+  timestamp: string;
+  metadata?: SessionMessageMetadata;
+  model?: ReturnType<typeof readMessageModelSelection>;
+  visible: string;
+  displayParts: UserDisplayPart[];
+}): void => {
+  input.session?.messageMetadataById.set(input.messageId, {
+    timestamp: input.metadata?.timestamp ?? input.timestamp,
+    ...(input.model
+      ? { model: input.model }
+      : input.metadata?.model
+        ? { model: input.metadata.model }
+        : {}),
+    ...(input.metadata?.parentId ? { parentId: input.metadata.parentId } : {}),
+    text: input.visible,
+    ...(input.displayParts.length > 0 ? { displayParts: input.displayParts } : {}),
   });
 };
 
@@ -398,44 +471,37 @@ const readExplicitUserMessageState = (
   return undefined;
 };
 
-const modelsMatch = (
-  left: ReturnType<typeof readMessageModelSelection> | undefined,
-  right: ReturnType<typeof readMessageModelSelection> | undefined,
-): boolean => {
-  if (!left && !right) {
-    return true;
-  }
-  if (!left || !right) {
-    return false;
-  }
-  return (
-    left.providerId === right.providerId &&
-    left.modelId === right.modelId &&
-    left.variant === right.variant &&
-    left.profileId === right.profileId
-  );
-};
-
 const takeQueuedUserSendMatch = (
   runtime: EventStreamRuntime,
   visible: string,
+  parts: import("@openducktor/core").AgentUserMessageDisplayPart[],
   model: ReturnType<typeof readMessageModelSelection> | undefined,
-): boolean => {
+): import("../types").QueuedUserMessageSend | null => {
   const session = runtime.getSession(runtime.sessionId);
   if (!session || session.pendingQueuedUserMessages.length === 0) {
-    return false;
+    return null;
   }
 
-  const normalizedVisible = visible.trim();
+  const signature = buildQueuedDisplaySignature({
+    visible,
+    parts,
+    ...(model ? { model } : {}),
+  });
+  const attachmentIdentitySignature = buildQueuedDisplayAttachmentIdentitySignature({
+    visible,
+    parts,
+    ...(model ? { model } : {}),
+  });
   const matchIndex = session.pendingQueuedUserMessages.findIndex(
-    (entry) => entry.content === normalizedVisible && modelsMatch(entry.model, model),
+    (entry) =>
+      entry.signature === signature ||
+      entry.attachmentIdentitySignature === attachmentIdentitySignature,
   );
   if (matchIndex < 0) {
-    return false;
+    return null;
   }
 
-  session.pendingQueuedUserMessages.splice(matchIndex, 1);
-  return true;
+  return session.pendingQueuedUserMessages.splice(matchIndex, 1)[0] ?? null;
 };
 
 const resolveUserMessageStateFromPendingAssistant = (
@@ -455,8 +521,10 @@ const resolveLiveUserMessageState = (
   input: {
     messageId: string;
     visible: string;
+    parts: import("@openducktor/core").AgentUserMessageDisplayPart[];
     explicitState?: AgentUserMessageState;
     model?: ReturnType<typeof readMessageModelSelection>;
+    matchedQueuedSend?: import("../types").QueuedUserMessageSend | null;
   },
 ): AgentUserMessageState => {
   const session = runtime.getSession(runtime.sessionId);
@@ -464,7 +532,7 @@ const resolveLiveUserMessageState = (
     session,
     input.messageId,
   );
-  const matchedQueuedSend = takeQueuedUserSendMatch(runtime, input.visible, input.model);
+  const matchedQueuedSend = input.matchedQueuedSend;
 
   if (matchedQueuedSend && pendingAssistantState === "queued") {
     return "queued";
@@ -637,28 +705,30 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
     const currentMetadata = session?.messageMetadataById.get(messageId);
     const normalizedDisplayParts = normalizeUserMessageDisplayParts(userParts);
     const fallbackText = currentMetadata?.text ?? readTextFromMessageInfo(infoRecord);
-    const displayParts = ensureVisibleUserTextDisplayParts(
-      normalizedDisplayParts.length > 0
-        ? normalizedDisplayParts
-        : (currentMetadata?.displayParts ?? []),
+    const matchedQueuedSend = takeQueuedUserSendMatch(
+      runtime,
       fallbackText,
+      normalizedDisplayParts,
+      messageModel,
     );
-    const textFromParts = readVisibleUserTextFromDisplayParts(displayParts);
-    const visible = textFromParts.length > 0 ? textFromParts : fallbackText;
+    const { displayParts, visible } = buildVisibleUserMessage({
+      fallbackText,
+      normalizedDisplayParts,
+      ...(currentMetadata ? { metadata: currentMetadata } : {}),
+      ...(matchedQueuedSend ? { matchedQueuedSend } : {}),
+    });
     if (visible.trim().length === 0 && displayParts.length === 0) {
       return true;
     }
 
-    session?.messageMetadataById.set(messageId, {
-      timestamp: currentMetadata?.timestamp ?? messageTimestamp,
-      ...(messageModel
-        ? { model: messageModel }
-        : currentMetadata?.model
-          ? { model: currentMetadata.model }
-          : {}),
-      ...(currentMetadata?.parentId ? { parentId: currentMetadata.parentId } : {}),
-      text: visible,
-      ...(displayParts.length > 0 ? { displayParts } : {}),
+    persistUserMessageMetadata({
+      session,
+      messageId,
+      timestamp: messageTimestamp,
+      ...(currentMetadata ? { metadata: currentMetadata } : {}),
+      ...(messageModel ? { model: messageModel } : {}),
+      visible,
+      displayParts,
     });
 
     const explicitState = readExplicitUserMessageState(infoRecord, properties);
@@ -670,6 +740,8 @@ const handleMessageUpdatedEvent = (event: Event, runtime: EventStreamRuntime): b
       state: resolveLiveUserMessageState(runtime, {
         messageId,
         visible,
+        parts: displayParts,
+        matchedQueuedSend,
         ...(explicitState ? { explicitState } : {}),
         ...(messageModel ? { model: messageModel } : {}),
       }),
@@ -788,19 +860,20 @@ const handleMessagePartUpdatedEvent = (event: Event, runtime: EventStreamRuntime
       getKnownMessageParts(runtime, messageId),
     );
     const fallbackText = metadata?.text ?? "";
-    const displayParts = ensureVisibleUserTextDisplayParts(
-      normalizedDisplayParts.length > 0 ? normalizedDisplayParts : (metadata?.displayParts ?? []),
+    const { displayParts, visible } = buildVisibleUserMessage({
       fallbackText,
-    );
-    const textFromParts = readVisibleUserTextFromDisplayParts(displayParts);
-    const visible = textFromParts.length > 0 ? textFromParts : fallbackText;
+      normalizedDisplayParts,
+      ...(metadata ? { metadata } : {}),
+    });
     if (visible.trim().length > 0 || displayParts.length > 0) {
-      session?.messageMetadataById.set(messageId, {
-        timestamp: metadata?.timestamp ?? runtime.now(),
+      persistUserMessageMetadata({
+        session,
+        messageId,
+        timestamp: runtime.now(),
+        ...(metadata ? { metadata } : {}),
         ...(metadata?.model ? { model: metadata.model } : {}),
-        ...(metadata?.parentId ? { parentId: metadata.parentId } : {}),
-        text: visible,
-        ...(displayParts.length > 0 ? { displayParts } : {}),
+        visible,
+        displayParts,
       });
     }
     emitKnownUserMessage(runtime, {
@@ -809,6 +882,8 @@ const handleMessagePartUpdatedEvent = (event: Event, runtime: EventStreamRuntime
       state: resolveLiveUserMessageState(runtime, {
         messageId,
         visible,
+        parts: displayParts,
+        matchedQueuedSend: null,
         ...(metadata?.model ? { model: metadata.model } : {}),
       }),
       ...(metadata?.model ? { model: metadata.model } : {}),

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, test } from "bun:test";
 import type { Event, OpencodeClient, Part } from "@opencode-ai/sdk/v2";
 import type { AgentEvent } from "@openducktor/core";
 import { OpencodeSdkAdapter } from "./index";
+import type { SessionRecord } from "./types";
+import { buildQueuedRequestSignature } from "./user-message-signatures";
 
 const flushAsync = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+const buildQueuedSignature = (text: string): string =>
+  buildQueuedRequestSignature([{ kind: "text", text }]);
 const defaultRuntimeConnection = {
   endpoint: "http://127.0.0.1:12345",
   workingDirectory: "/repo",
@@ -933,7 +937,7 @@ describe("OpencodeSdkAdapter", () => {
           string,
           {
             activeAssistantMessageId: string | null;
-            pendingQueuedUserMessages: Array<{ content: string }>;
+            pendingQueuedUserMessages: Array<{ signature: string }>;
           }
         >;
       }
@@ -969,7 +973,7 @@ describe("OpencodeSdkAdapter", () => {
           {
             hasIdleSinceActivity: boolean;
             activeAssistantMessageId: string | null;
-            pendingQueuedUserMessages: Array<{ content: string }>;
+            pendingQueuedUserMessages: Array<{ signature: string }>;
           }
         >;
       }
@@ -987,7 +991,9 @@ describe("OpencodeSdkAdapter", () => {
       parts: [{ kind: "text", text: "Queued follow-up" }],
     });
 
-    expect(session.pendingQueuedUserMessages).toEqual([{ content: "Queued follow-up" }]);
+    expect(session.pendingQueuedUserMessages).toEqual([
+      { signature: buildQueuedSignature("Queued follow-up") },
+    ]);
   });
 
   test("sendUserMessage pre-queues follow-ups after a slash command establishes an assistant boundary", async () => {
@@ -1014,7 +1020,7 @@ describe("OpencodeSdkAdapter", () => {
           string,
           {
             activeAssistantMessageId: string | null;
-            pendingQueuedUserMessages: Array<{ content: string }>;
+            pendingQueuedUserMessages: Array<{ signature: string }>;
           }
         >;
       }
@@ -1046,7 +1052,9 @@ describe("OpencodeSdkAdapter", () => {
       parts: [{ kind: "text", text: "Queued follow-up" }],
     });
 
-    expect(session.pendingQueuedUserMessages).toEqual([{ content: "Queued follow-up" }]);
+    expect(session.pendingQueuedUserMessages).toEqual([
+      { signature: buildQueuedSignature("Queued follow-up") },
+    ]);
   });
 
   test("updateSessionModel refreshes the adapter session model used for subsequent prompts", async () => {
@@ -1481,6 +1489,94 @@ describe("OpencodeSdkAdapter", () => {
         },
       },
     ]);
+  });
+
+  test("loadSessionHistory preserves local attachment preview paths from the live session metadata", async () => {
+    const mock = makeMockClient({
+      messagesResponse: [
+        {
+          info: {
+            id: "msg-user-attachment-1",
+            role: "user",
+            text: "Describe this screenshot",
+            time: { created: Date.parse("2026-02-17T11:59:00Z") },
+          },
+          parts: [
+            {
+              id: "file-attachment-1",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-attachment-1",
+              type: "file",
+              mime: "image/png",
+              filename: "Screenshot-2026-03-16-at-23.48.30.png",
+              url: "https://files.example.invalid/uploaded-image",
+            } as Part,
+          ],
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const sessions = (adapter as unknown as { sessions: Map<string, SessionRecord> }).sessions;
+    sessions.set("session-1", {
+      externalSessionId: "session-opencode-1",
+      input: {
+        sessionId: "session-1",
+        repoPath: "/repo",
+        runtimeKind: "opencode",
+        runtimeConnection: defaultRuntimeConnection,
+        workingDirectory: "/repo/feature-worktree",
+        taskId: "task-1",
+        role: "spec",
+        scenario: "spec_initial",
+        systemPrompt: "System prompt",
+      },
+      messageMetadataById: new Map([
+        [
+          "msg-user-attachment-1",
+          {
+            timestamp: "2026-02-17T11:59:00Z",
+            displayParts: [
+              {
+                kind: "attachment",
+                attachment: {
+                  id: "attachment-image-1",
+                  path: "/tmp/local-screenshot.png",
+                  name: "Screenshot-2026-03-16-at-23.48.30.png",
+                  kind: "image",
+                  mime: "image/png",
+                },
+              },
+            ],
+          },
+        ],
+      ]),
+    } as unknown as SessionRecord);
+
+    const history = await adapter.loadSessionHistory({
+      runtimeKind: "opencode",
+      runtimeConnection: defaultRuntimeConnection,
+      externalSessionId: "session-opencode-1",
+      limit: 100,
+    });
+
+    if (history[0]?.role !== "user") {
+      throw new Error("Expected user history entry");
+    }
+    expect(history[0].displayParts).toContainEqual(
+      expect.objectContaining({
+        kind: "attachment",
+        attachment: expect.objectContaining({
+          path: "/tmp/local-screenshot.png",
+          name: "Screenshot-2026-03-16-at-23.48.30.png",
+          kind: "image",
+          mime: "image/png",
+        }),
+      }),
+    );
   });
 
   test("maps message.updated events into assistant parts and assistant message", async () => {

--- a/packages/adapters-opencode-sdk/src/index.test.ts
+++ b/packages/adapters-opencode-sdk/src/index.test.ts
@@ -1523,6 +1523,7 @@ describe("OpencodeSdkAdapter", () => {
     const sessions = (adapter as unknown as { sessions: Map<string, SessionRecord> }).sessions;
     sessions.set("session-1", {
       externalSessionId: "session-opencode-1",
+      eventTransportKey: defaultRuntimeConnection.endpoint,
       input: {
         sessionId: "session-1",
         repoPath: "/repo",
@@ -1574,6 +1575,138 @@ describe("OpencodeSdkAdapter", () => {
           name: "Screenshot-2026-03-16-at-23.48.30.png",
           kind: "image",
           mime: "image/png",
+        }),
+      }),
+    );
+  });
+
+  test("loadSessionHistory only reuses preserved attachment parts from the matching runtime endpoint", async () => {
+    const mock = makeMockClient({
+      messagesResponse: [
+        {
+          info: {
+            id: "msg-user-attachment-1",
+            role: "user",
+            text: "Describe this screenshot",
+            time: { created: Date.parse("2026-02-17T11:59:00Z") },
+          },
+          parts: [
+            {
+              id: "file-attachment-1",
+              sessionID: "session-opencode-1",
+              messageID: "msg-user-attachment-1",
+              type: "file",
+              mime: "image/png",
+              filename: "Screenshot-2026-03-16-at-23.48.30.png",
+              url: "https://files.example.invalid/uploaded-image",
+            } as Part,
+          ],
+        },
+      ],
+    });
+    const adapter = new OpencodeSdkAdapter({
+      createClient: () => mock.client,
+      now: () => "2026-02-17T12:00:00Z",
+    });
+
+    const sessions = (adapter as unknown as { sessions: Map<string, SessionRecord> }).sessions;
+    sessions.set("session-runtime-a", {
+      externalSessionId: "session-opencode-1",
+      eventTransportKey: defaultRuntimeConnection.endpoint,
+      input: {
+        sessionId: "session-runtime-a",
+        repoPath: "/repo",
+        runtimeKind: "opencode",
+        runtimeConnection: defaultRuntimeConnection,
+        workingDirectory: "/repo/feature-worktree",
+        taskId: "task-1",
+        role: "spec",
+        scenario: "spec_initial",
+        systemPrompt: "System prompt",
+      },
+      messageMetadataById: new Map([
+        [
+          "msg-user-attachment-1",
+          {
+            timestamp: "2026-02-17T11:59:00Z",
+            displayParts: [
+              {
+                kind: "attachment",
+                attachment: {
+                  id: "attachment-image-1",
+                  path: "/tmp/runtime-a-screenshot.png",
+                  name: "Screenshot-2026-03-16-at-23.48.30.png",
+                  kind: "image",
+                  mime: "image/png",
+                },
+              },
+            ],
+          },
+        ],
+      ]),
+    } as unknown as SessionRecord);
+    sessions.set("session-runtime-b", {
+      externalSessionId: "session-opencode-1",
+      eventTransportKey: "http://127.0.0.1:12000",
+      input: {
+        sessionId: "session-runtime-b",
+        repoPath: "/repo",
+        runtimeKind: "opencode",
+        runtimeConnection: {
+          endpoint: "http://127.0.0.1:12000",
+          workingDirectory: "/repo",
+        },
+        workingDirectory: "/repo/other-worktree",
+        taskId: "task-1",
+        role: "spec",
+        scenario: "spec_initial",
+        systemPrompt: "System prompt",
+      },
+      messageMetadataById: new Map([
+        [
+          "msg-user-attachment-1",
+          {
+            timestamp: "2026-02-17T11:59:00Z",
+            displayParts: [
+              {
+                kind: "attachment",
+                attachment: {
+                  id: "attachment-image-2",
+                  path: "/tmp/runtime-b-screenshot.png",
+                  name: "Screenshot-2026-03-16-at-23.48.30.png",
+                  kind: "image",
+                  mime: "image/png",
+                },
+              },
+            ],
+          },
+        ],
+      ]),
+    } as unknown as SessionRecord);
+
+    const history = await adapter.loadSessionHistory({
+      runtimeKind: "opencode",
+      runtimeConnection: defaultRuntimeConnection,
+      externalSessionId: "session-opencode-1",
+      limit: 100,
+    });
+
+    if (history[0]?.role !== "user") {
+      throw new Error("Expected user history entry");
+    }
+    expect(history[0].displayParts).toContainEqual(
+      expect.objectContaining({
+        kind: "attachment",
+        attachment: expect.objectContaining({
+          path: "/tmp/runtime-a-screenshot.png",
+        }),
+      }),
+    );
+    expect(history[0].displayParts).not.toContainEqual(
+      expect.objectContaining({
+        kind: "attachment",
+        attachment: expect.objectContaining({
+          path: "/tmp/runtime-b-screenshot.png",
         }),
       }),
     );

--- a/packages/adapters-opencode-sdk/src/message-execution.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
 import { __testExports, sendUserMessage } from "./message-execution";
 import type { SessionRecord } from "./types";
+import {
+  buildQueuedRequestAttachmentIdentitySignature,
+  buildQueuedRequestSignature,
+} from "./user-message-signatures";
 
 const COMMAND = {
   id: "compact",
@@ -28,6 +32,14 @@ const VIDEO_FILE_REFERENCE = {
   path: "recordings/demo.mov",
   name: "demo.mov",
   kind: "video" as const,
+};
+
+const IMAGE_ATTACHMENT = {
+  id: "attachment-image-1",
+  path: "/tmp/diagram.png",
+  name: "diagram.png",
+  kind: "image" as const,
+  mime: "image/png",
 };
 
 const createSession = (overrides?: {
@@ -125,7 +137,15 @@ describe("message-execution", () => {
     });
 
     expect(session.pendingQueuedUserMessages).toEqual([
-      { content: "/compact summarize latest session" },
+      {
+        signature: buildQueuedRequestSignature(
+          [
+            { kind: "slash_command", command: COMMAND },
+            { kind: "text", text: " summarize latest session" },
+          ],
+          undefined,
+        ),
+      },
     ]);
     expect(command).toHaveBeenCalledTimes(1);
     expect(promptAsync).not.toHaveBeenCalled();
@@ -139,7 +159,15 @@ describe("message-execution", () => {
       },
     });
     session.activeAssistantMessageId = "msg-200";
-    const preservedEntry = { content: "/compact summarize latest session" };
+    const preservedEntry = {
+      signature: buildQueuedRequestSignature(
+        [
+          { kind: "slash_command", command: COMMAND },
+          { kind: "text", text: " summarize latest session" },
+        ],
+        undefined,
+      ),
+    };
     session.pendingQueuedUserMessages = [preservedEntry];
 
     await expect(
@@ -244,6 +272,84 @@ describe("message-execution", () => {
       ],
     });
     expect(command).not.toHaveBeenCalled();
+  });
+
+  test("routes local attachments through native prompt file parts without repo source text", async () => {
+    const { session, promptAsync } = createSession();
+
+    await sendUserMessage({
+      session,
+      request: {
+        sessionId: "session-1",
+        parts: [
+          { kind: "text", text: "describe this" },
+          { kind: "attachment", attachment: IMAGE_ATTACHMENT },
+        ],
+      },
+      tools: {},
+    });
+
+    expect(promptAsync).toHaveBeenCalledWith({
+      sessionID: "session-opencode-1",
+      directory: "/repo",
+      tools: {},
+      parts: [
+        { type: "text", text: "describe this" },
+        {
+          type: "file",
+          mime: "image/png",
+          url: "file:///tmp/diagram.png",
+          filename: "diagram.png",
+        },
+      ],
+    });
+  });
+
+  test("tracks attachment sends for transcript reconciliation even when the assistant is idle", async () => {
+    const { session } = createSession();
+
+    await sendUserMessage({
+      session,
+      request: {
+        sessionId: "session-1",
+        parts: [{ kind: "attachment", attachment: IMAGE_ATTACHMENT }],
+      },
+      tools: {},
+    });
+
+    expect(session.pendingQueuedUserMessages).toEqual([
+      {
+        signature: buildQueuedRequestSignature(
+          [{ kind: "attachment", attachment: IMAGE_ATTACHMENT }],
+          undefined,
+        ),
+        attachmentIdentitySignature: buildQueuedRequestAttachmentIdentitySignature(
+          [{ kind: "attachment", attachment: IMAGE_ATTACHMENT }],
+          undefined,
+        ),
+        attachmentParts: [{ kind: "attachment", attachment: IMAGE_ATTACHMENT }],
+      },
+    ]);
+  });
+
+  test("omits file source metadata for local attachments so the runtime accepts the payload schema", async () => {
+    const { session, promptAsync } = createSession();
+
+    await sendUserMessage({
+      session,
+      request: {
+        sessionId: "session-1",
+        parts: [{ kind: "attachment", attachment: IMAGE_ATTACHMENT }],
+      },
+      tools: {},
+    });
+
+    const promptRequest = promptAsync.mock.calls[0]?.[0] as
+      | { parts?: Array<{ type: string; source?: unknown }> }
+      | undefined;
+    const attachmentPart = promptRequest?.parts?.find((part) => part.type === "file");
+    expect(attachmentPart).toBeDefined();
+    expect(attachmentPart?.source).toBeUndefined();
   });
 
   test("encodes file URLs for special characters and relative paths", async () => {
@@ -354,7 +460,27 @@ describe("message-execution", () => {
         tools: {},
       }),
     ).rejects.toThrow(
-      "OpenCode request failed: run slash command: OpenCode slash commands do not support structured file references.",
+      "OpenCode request failed: run slash command: OpenCode slash commands do not support structured attachments or file references.",
+    );
+  });
+
+  test("fails explicitly when a slash command message also contains an attachment", async () => {
+    const { session } = createSession();
+
+    await expect(
+      sendUserMessage({
+        session,
+        request: {
+          sessionId: "session-1",
+          parts: [
+            { kind: "slash_command", command: COMMAND },
+            { kind: "attachment", attachment: IMAGE_ATTACHMENT },
+          ],
+        },
+        tools: {},
+      }),
+    ).rejects.toThrow(
+      "OpenCode request failed: run slash command: OpenCode slash commands do not support structured attachments or file references.",
     );
   });
 

--- a/packages/adapters-opencode-sdk/src/message-execution.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.ts
@@ -1,4 +1,5 @@
 import {
+  type AgentUserMessageDisplayPart,
   buildAgentUserMessagePromptText,
   normalizeAgentUserMessageParts,
   type SendAgentUserMessageInput,
@@ -10,6 +11,10 @@ import { resolveAgainstWorkingDirectory, toFileUrl } from "./path-utils";
 import { normalizeModelInput, resolveAssistantResponseMessageId } from "./payload-mappers";
 import { toOpenCodeRequestError } from "./request-errors";
 import type { SessionRecord } from "./types";
+import {
+  buildQueuedRequestAttachmentIdentitySignature,
+  buildQueuedRequestSignature,
+} from "./user-message-signatures";
 
 type SlashCommandExecutionRequest = {
   command: string;
@@ -21,7 +26,6 @@ type SessionCommandClient = {
 };
 
 type PreparedUserSend = {
-  queuedContent: string;
   execute: (args: {
     session: SessionRecord;
     modelInput: ReturnType<typeof normalizeModelInput>;
@@ -39,7 +43,7 @@ type OpenCodePromptPart =
       mime: string;
       url: string;
       filename: string;
-      source: {
+      source?: {
         type: "file";
         path: string;
         text: {
@@ -91,6 +95,28 @@ const toPromptParts = (
     ...promptText.fileReferences.map((fileReference) =>
       toPromptFilePart(fileReference, workingDirectory),
     ),
+    ...parts.flatMap((part) => {
+      if (part.kind !== "attachment") {
+        return [];
+      }
+
+      const normalizedPath = part.attachment.path.trim();
+      if (normalizedPath.length === 0) {
+        throw new Error("OpenCode attachments require a non-empty path.");
+      }
+      if (!part.attachment.mime || part.attachment.mime.trim().length === 0) {
+        throw new Error(`OpenCode attachment "${part.attachment.name}" is missing a MIME type.`);
+      }
+
+      return [
+        {
+          type: "file" as const,
+          mime: part.attachment.mime,
+          url: toFileUrl(resolveAgainstWorkingDirectory(workingDirectory, normalizedPath)),
+          filename: part.attachment.name,
+        },
+      ];
+    }),
   ];
 };
 
@@ -104,10 +130,14 @@ const toSlashCommandExecutionRequest = (
   if (slashCommandIndexes.length === 0) {
     return null;
   }
-  if (normalizedParts.some((part) => part.kind === "file_reference")) {
+  if (
+    normalizedParts.some((part) => part.kind === "file_reference" || part.kind === "attachment")
+  ) {
     throw toOpenCodeRequestError(
       "run slash command",
-      new Error("OpenCode slash commands do not support structured file references."),
+      new Error(
+        "OpenCode slash commands do not support structured attachments or file references.",
+      ),
     );
   }
   if (slashCommandIndexes.length > 1) {
@@ -139,10 +169,7 @@ const toSlashCommandExecutionRequest = (
 };
 
 const preparePromptSend = (request: SendAgentUserMessageInput): PreparedUserSend => {
-  const queuedContent = serializeAgentUserMessagePartsToText(request.parts).trim();
-
   return {
-    queuedContent,
     execute: async ({ session, modelInput, tools }) => {
       const promptParts = toPromptParts(request.parts, session.input.workingDirectory);
       const promptRequest = {
@@ -173,10 +200,7 @@ const prepareSlashCommandSend = (
   request: SendAgentUserMessageInput,
   slashCommandRequest: SlashCommandExecutionRequest,
 ): PreparedUserSend => {
-  const queuedContent = serializeAgentUserMessagePartsToText(request.parts).trim();
-
   return {
-    queuedContent,
     execute: async ({ session, modelInput }) => {
       const commandClient = session.client.session as SessionCommandClient;
       if (typeof commandClient.command !== "function") {
@@ -210,6 +234,18 @@ const prepareSlashCommandSend = (
   };
 };
 
+const readQueuedAttachmentDisplayParts = (
+  parts: SendAgentUserMessageInput["parts"],
+): Extract<AgentUserMessageDisplayPart, { kind: "attachment" }>[] => {
+  return parts.flatMap((part) => {
+    if (part.kind !== "attachment") {
+      return [];
+    }
+
+    return [{ kind: "attachment", attachment: part.attachment }];
+  });
+};
+
 export const sendUserMessage = async (input: {
   session: SessionRecord;
   request: SendAgentUserMessageInput;
@@ -221,15 +257,24 @@ export const sendUserMessage = async (input: {
   const preparedSend = slashCommandRequest
     ? prepareSlashCommandSend(input.request, slashCommandRequest)
     : preparePromptSend(input.request);
-  const queuedContent = preparedSend.queuedContent;
   const pendingQueuedUserMessages = input.session.pendingQueuedUserMessages ?? [];
   input.session.pendingQueuedUserMessages = pendingQueuedUserMessages;
-  const shouldTrackAsQueued =
-    input.session.activeAssistantMessageId !== null && queuedContent.length > 0;
-  const queuedEntry = shouldTrackAsQueued
+  const queuedAttachmentParts = readQueuedAttachmentDisplayParts(input.request.parts);
+  const shouldTrackPendingSend =
+    normalizeAgentUserMessageParts(input.request.parts).length > 0 &&
+    (input.session.activeAssistantMessageId !== null || queuedAttachmentParts.length > 0);
+  const queuedEntry = shouldTrackPendingSend
     ? {
-        content: queuedContent,
-        ...(model ? { model } : {}),
+        signature: buildQueuedRequestSignature(input.request.parts, model ?? undefined),
+        ...(queuedAttachmentParts.length > 0
+          ? {
+              attachmentIdentitySignature: buildQueuedRequestAttachmentIdentitySignature(
+                input.request.parts,
+                model ?? undefined,
+              ),
+            }
+          : {}),
+        ...(queuedAttachmentParts.length > 0 ? { attachmentParts: queuedAttachmentParts } : {}),
       }
     : null;
 

--- a/packages/adapters-opencode-sdk/src/message-execution.ts
+++ b/packages/adapters-opencode-sdk/src/message-execution.ts
@@ -197,7 +197,7 @@ const preparePromptSend = (request: SendAgentUserMessageInput): PreparedUserSend
 };
 
 const prepareSlashCommandSend = (
-  request: SendAgentUserMessageInput,
+  _request: SendAgentUserMessageInput,
   slashCommandRequest: SlashCommandExecutionRequest,
 ): PreparedUserSend => {
   return {

--- a/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
@@ -105,7 +105,149 @@ describe("message-normalizers", () => {
     ]);
   });
 
-  test("normalizes css and media file reference kinds consistently", () => {
+  test("normalizes local multimodal file parts into attachment display parts", () => {
+    const parts: Part[] = [
+      {
+        id: "image-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "image/png",
+        filename: "diagram.png",
+        url: "file:///tmp/diagram.png",
+      } as Part,
+      {
+        id: "audio-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "audio/mpeg",
+        filename: "meeting.mp3",
+        url: "file:///tmp/meeting.mp3",
+      } as Part,
+      {
+        id: "video-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "video/mp4",
+        filename: "demo.mp4",
+        url: "file:///tmp/demo.mp4",
+      } as Part,
+      {
+        id: "pdf-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "application/pdf",
+        filename: "spec.pdf",
+        url: "file:///tmp/spec.pdf",
+      } as Part,
+    ];
+
+    expect(normalizeUserMessageDisplayParts(parts)).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "image-1",
+          path: "/tmp/diagram.png",
+          name: "diagram.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "audio-1",
+          path: "/tmp/meeting.mp3",
+          name: "meeting.mp3",
+          kind: "audio",
+          mime: "audio/mpeg",
+        },
+      },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "video-1",
+          path: "/tmp/demo.mp4",
+          name: "demo.mp4",
+          kind: "video",
+          mime: "video/mp4",
+        },
+      },
+      {
+        kind: "attachment",
+        attachment: {
+          id: "pdf-1",
+          path: "/tmp/spec.pdf",
+          name: "spec.pdf",
+          kind: "pdf",
+          mime: "application/pdf",
+        },
+      },
+    ]);
+  });
+
+  test("preserves raw filesystem paths returned in attachment urls", () => {
+    const parts: Part[] = [
+      {
+        id: "image-raw-path",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "image/png",
+        filename: "Screenshot 2026-04-01 at 00.33.32.png",
+        url: "/var/folders/example/Screenshot 2026-04-01 at 00.33.32.png",
+      } as Part,
+    ];
+
+    expect(normalizeUserMessageDisplayParts(parts)).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "image-raw-path",
+          path: "/var/folders/example/Screenshot 2026-04-01 at 00.33.32.png",
+          name: "Screenshot 2026-04-01 at 00.33.32.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+    ]);
+  });
+
+  test("falls back to source file path for attachments when the runtime omits a file url", () => {
+    const parts: Part[] = [
+      {
+        id: "image-source-path",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "image/png",
+        filename: "Screenshot 2026-04-01 at 00.33.32.png",
+        url: "",
+        source: {
+          type: "file",
+          path: "/var/folders/example/Screenshot 2026-04-01 at 00.33.32.png",
+        },
+      } as Part,
+    ];
+
+    expect(normalizeUserMessageDisplayParts(parts)).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "image-source-path",
+          path: "/var/folders/example/Screenshot 2026-04-01 at 00.33.32.png",
+          name: "Screenshot 2026-04-01 at 00.33.32.png",
+          kind: "image",
+          mime: "image/png",
+        },
+      },
+    ]);
+  });
+
+  test("normalizes only supported media file attachments without inline source text", () => {
     const parts: Part[] = [
       {
         id: "file-1",
@@ -150,30 +292,23 @@ describe("message-normalizers", () => {
 
     expect(normalizeUserMessageDisplayParts(parts)).toEqual([
       {
-        kind: "file_reference",
-        file: {
-          id: "file-1",
-          path: "src/styles.scss",
-          name: "styles.scss",
-          kind: "css",
-        },
-      },
-      {
-        kind: "file_reference",
-        file: {
+        kind: "attachment",
+        attachment: {
           id: "file-2",
-          path: "assets/preview.webp",
+          path: "/repo/assets/preview.webp",
           name: "preview.webp",
           kind: "image",
+          mime: "image/webp",
         },
       },
       {
-        kind: "file_reference",
-        file: {
+        kind: "attachment",
+        attachment: {
           id: "file-3",
-          path: "recordings/demo.webm",
+          path: "/repo/recordings/demo.webm",
           name: "demo.webm",
           kind: "video",
+          mime: "video/webm",
         },
       },
     ]);
@@ -203,6 +338,16 @@ describe("message-normalizers", () => {
     expect(
       readVisibleUserTextFromDisplayParts([
         {
+          kind: "attachment",
+          attachment: {
+            id: "attachment-1",
+            path: "/tmp/diagram.png",
+            name: "diagram.png",
+            kind: "image",
+            mime: "image/png",
+          },
+        },
+        {
           kind: "file_reference",
           file: {
             id: "file-2",
@@ -218,6 +363,21 @@ describe("message-normalizers", () => {
         },
       ]),
     ).toBe("@src/only.ts");
+
+    expect(
+      readVisibleUserTextFromDisplayParts([
+        {
+          kind: "attachment",
+          attachment: {
+            id: "attachment-2",
+            path: "/tmp/spec.pdf",
+            name: "spec.pdf",
+            kind: "pdf",
+            mime: "application/pdf",
+          },
+        },
+      ]),
+    ).toBe("");
 
     expect(
       readVisibleUserTextFromDisplayParts([

--- a/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.test.ts
@@ -189,6 +189,42 @@ describe("message-normalizers", () => {
     ]);
   });
 
+  test("keeps attachment echoes as attachments when runtime adds non-@ source text", () => {
+    const parts: Part[] = [
+      {
+        id: "pdf-runtime-echo",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "file",
+        mime: "application/pdf",
+        filename: "brief.pdf",
+        url: "file:///tmp/brief.pdf",
+        source: {
+          type: "file",
+          path: "brief.pdf",
+          text: {
+            value: "brief.pdf",
+            start: 0,
+            end: 9,
+          },
+        },
+      } as Part,
+    ];
+
+    expect(normalizeUserMessageDisplayParts(parts)).toEqual([
+      {
+        kind: "attachment",
+        attachment: {
+          id: "pdf-runtime-echo",
+          path: "/tmp/brief.pdf",
+          name: "brief.pdf",
+          kind: "pdf",
+          mime: "application/pdf",
+        },
+      },
+    ]);
+  });
+
   test("preserves raw filesystem paths returned in attachment urls", () => {
     const parts: Part[] = [
       {

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -132,7 +132,9 @@ const normalizeFileReferencePart = (
   part: Extract<Part, { type: "file" }>,
 ): AgentUserMessageDisplayPart | null => {
   const source = part.source;
-  if (source?.type !== "file" || !source.text) {
+  const sourceTextValue = source?.type === "file" ? (source.text?.value?.trim() ?? "") : "";
+  const isRepoFileReference = sourceTextValue.startsWith("@");
+  if (source?.type !== "file" || !source.text || !isRepoFileReference) {
     return normalizeAttachmentPart(part);
   }
   const sourcePath = source?.type === "file" ? source.path.trim() : "";

--- a/packages/adapters-opencode-sdk/src/message-normalizers.ts
+++ b/packages/adapters-opencode-sdk/src/message-normalizers.ts
@@ -24,8 +24,16 @@ const readPathBasename = (filePath: string): string => {
 };
 
 const readFilePathFromUrl = (url: string): string | null => {
+  const trimmedUrl = url.trim();
+  if (trimmedUrl.length === 0) {
+    return null;
+  }
+  if (trimmedUrl.startsWith("/") || /^[A-Za-z]:[\\/]/.test(trimmedUrl)) {
+    return trimmedUrl;
+  }
+
   try {
-    const parsed = new URL(url);
+    const parsed = new URL(trimmedUrl);
     if (parsed.protocol !== "file:") {
       return null;
     }
@@ -58,10 +66,75 @@ const normalizeSourceText = (value: unknown): AgentUserMessageSourceText | undef
   };
 };
 
+const normalizeAttachmentPart = (
+  part: Extract<Part, { type: "file" }>,
+): AgentUserMessageDisplayPart | null => {
+  const sourcePath = part.source?.type === "file" ? part.source.path.trim() : "";
+  const filePath = readFilePathFromUrl(part.url) ?? (sourcePath || part.filename?.trim() || "");
+  if (filePath.length === 0 || !part.mime) {
+    return null;
+  }
+
+  const name = part.filename?.trim() || readPathBasename(filePath);
+  if (part.mime.startsWith("image/")) {
+    return {
+      kind: "attachment",
+      attachment: {
+        id: part.id,
+        path: filePath,
+        name,
+        kind: "image",
+        mime: part.mime,
+      },
+    };
+  }
+  if (part.mime.startsWith("audio/")) {
+    return {
+      kind: "attachment",
+      attachment: {
+        id: part.id,
+        path: filePath,
+        name,
+        kind: "audio",
+        mime: part.mime,
+      },
+    };
+  }
+  if (part.mime.startsWith("video/")) {
+    return {
+      kind: "attachment",
+      attachment: {
+        id: part.id,
+        path: filePath,
+        name,
+        kind: "video",
+        mime: part.mime,
+      },
+    };
+  }
+  if (part.mime === "application/pdf") {
+    return {
+      kind: "attachment",
+      attachment: {
+        id: part.id,
+        path: filePath,
+        name,
+        kind: "pdf",
+        mime: part.mime,
+      },
+    };
+  }
+
+  return null;
+};
+
 const normalizeFileReferencePart = (
   part: Extract<Part, { type: "file" }>,
 ): AgentUserMessageDisplayPart | null => {
   const source = part.source;
+  if (source?.type !== "file" || !source.text) {
+    return normalizeAttachmentPart(part);
+  }
   const sourcePath = source?.type === "file" ? source.path.trim() : "";
   const filePath =
     sourcePath.length > 0
@@ -72,7 +145,7 @@ const normalizeFileReferencePart = (
   }
 
   const name = part.filename?.trim() || readPathBasename(filePath);
-  const sourceText = source?.type === "file" ? normalizeSourceText(source.text) : undefined;
+  const sourceText = normalizeSourceText(source.text);
   return {
     kind: "file_reference",
     file: {
@@ -118,6 +191,47 @@ export const ensureVisibleUserTextDisplayParts = (
   return [{ kind: "text", text: fallbackText }, ...parts];
 };
 
+export const mergePreservedAttachmentDisplayParts = (
+  displayParts: AgentUserMessageDisplayPart[],
+  preservedAttachmentParts: Extract<AgentUserMessageDisplayPart, { kind: "attachment" }>[],
+): AgentUserMessageDisplayPart[] => {
+  if (preservedAttachmentParts.length === 0) {
+    return displayParts;
+  }
+
+  const remainingPreservedAttachments = [...preservedAttachmentParts];
+  const mergedParts = displayParts.map((part) => {
+    if (part.kind !== "attachment") {
+      return part;
+    }
+
+    const preservedIndex = remainingPreservedAttachments.findIndex(
+      (candidate) =>
+        candidate.attachment.name === part.attachment.name &&
+        candidate.attachment.kind === part.attachment.kind &&
+        (candidate.attachment.mime ?? "") === (part.attachment.mime ?? ""),
+    );
+    if (preservedIndex < 0) {
+      return part;
+    }
+
+    const preservedAttachment = remainingPreservedAttachments.splice(preservedIndex, 1)[0];
+    if (!preservedAttachment) {
+      return part;
+    }
+
+    return {
+      ...part,
+      attachment: {
+        ...part.attachment,
+        path: preservedAttachment.attachment.path,
+      },
+    };
+  });
+
+  return [...mergedParts, ...remainingPreservedAttachments];
+};
+
 export const readVisibleUserTextFromDisplayParts = (
   parts: AgentUserMessageDisplayPart[],
 ): string => {
@@ -135,6 +249,10 @@ export const readVisibleUserTextFromDisplayParts = (
   const userMessageParts = parts.flatMap<AgentUserMessagePart>((part) => {
     if (part.kind === "text") {
       return part.synthetic ? [] : [{ kind: "text", text: part.text }];
+    }
+
+    if (part.kind === "attachment") {
+      return [];
     }
 
     return [{ kind: "file_reference", file: part.file }];

--- a/packages/adapters-opencode-sdk/src/message-ops.ts
+++ b/packages/adapters-opencode-sdk/src/message-ops.ts
@@ -4,6 +4,7 @@ import type {
   AgentSessionHistoryMessage,
   AgentSessionTodoItem,
   AgentStreamPart,
+  AgentUserMessageDisplayPart,
   ReplyPermissionInput,
   ReplyQuestionInput,
 } from "@openducktor/core";
@@ -11,6 +12,7 @@ import { unwrapData } from "./data-utils";
 import {
   ensureVisibleUserTextDisplayParts,
   extractMessageTotalTokens,
+  mergePreservedAttachmentDisplayParts,
   normalizeUserMessageDisplayParts,
   readMessageModelSelection,
   readTextFromMessageInfo,
@@ -158,6 +160,7 @@ export const loadSessionHistory = async (
     workingDirectory: string;
     externalSessionId: string;
     limit?: number;
+    preservedDisplayPartsByMessageId?: Map<string, AgentUserMessageDisplayPart[]>;
   },
 ): Promise<AgentSessionHistoryMessage[]> => {
   const client = createClient({
@@ -176,7 +179,15 @@ export const loadSessionHistory = async (
       const displayParts =
         entry.info.role === "user"
           ? ensureVisibleUserTextDisplayParts(
-              normalizeUserMessageDisplayParts(entry.parts),
+              mergePreservedAttachmentDisplayParts(
+                normalizeUserMessageDisplayParts(entry.parts),
+                input.preservedDisplayPartsByMessageId
+                  ?.get(entry.info.id)
+                  ?.filter(
+                    (part): part is Extract<AgentUserMessageDisplayPart, { kind: "attachment" }> =>
+                      part.kind === "attachment",
+                  ) ?? [],
+              ),
               infoText,
             )
           : [];

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -388,9 +388,17 @@ export class OpencodeSdkAdapter
   async loadSessionHistory(
     input: LoadAgentSessionHistoryInput,
   ): Promise<AgentSessionHistoryMessage[]> {
+    const runtimeClientInput = toRuntimeClientInput(
+      input.runtimeConnection,
+      "load session history",
+    );
     const preservedDisplayPartsByMessageId = new Map(
       [...this.sessions.values()]
-        .filter((session) => session.externalSessionId === input.externalSessionId)
+        .filter(
+          (session) =>
+            session.externalSessionId === input.externalSessionId &&
+            session.eventTransportKey === runtimeClientInput.runtimeEndpoint,
+        )
         .flatMap((session) =>
           [...session.messageMetadataById.entries()].flatMap(([messageId, metadata]) =>
             metadata.displayParts ? [[messageId, metadata.displayParts] as const] : [],
@@ -399,7 +407,7 @@ export class OpencodeSdkAdapter
     );
 
     return loadSessionHistory(this.createClient, this.now, {
-      ...toRuntimeClientInput(input.runtimeConnection, "load session history"),
+      ...runtimeClientInput,
       externalSessionId: input.externalSessionId,
       ...(typeof input.limit === "number" ? { limit: input.limit } : {}),
       ...(preservedDisplayPartsByMessageId.size > 0 ? { preservedDisplayPartsByMessageId } : {}),

--- a/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
+++ b/packages/adapters-opencode-sdk/src/opencode-sdk-adapter.ts
@@ -388,10 +388,21 @@ export class OpencodeSdkAdapter
   async loadSessionHistory(
     input: LoadAgentSessionHistoryInput,
   ): Promise<AgentSessionHistoryMessage[]> {
+    const preservedDisplayPartsByMessageId = new Map(
+      [...this.sessions.values()]
+        .filter((session) => session.externalSessionId === input.externalSessionId)
+        .flatMap((session) =>
+          [...session.messageMetadataById.entries()].flatMap(([messageId, metadata]) =>
+            metadata.displayParts ? [[messageId, metadata.displayParts] as const] : [],
+          ),
+        ),
+    );
+
     return loadSessionHistory(this.createClient, this.now, {
       ...toRuntimeClientInput(input.runtimeConnection, "load session history"),
       externalSessionId: input.externalSessionId,
       ...(typeof input.limit === "number" ? { limit: input.limit } : {}),
+      ...(preservedDisplayPartsByMessageId.size > 0 ? { preservedDisplayPartsByMessageId } : {}),
     });
   }
 

--- a/packages/adapters-opencode-sdk/src/payload-mappers.test.ts
+++ b/packages/adapters-opencode-sdk/src/payload-mappers.test.ts
@@ -53,6 +53,14 @@ describe("payload-mappers", () => {
                 context: 200_000,
                 output: 32_000,
               },
+              capabilities: {
+                input: {
+                  image: true,
+                  audio: false,
+                  video: true,
+                  pdf: false,
+                },
+              },
               variants: {
                 high: {},
                 low: {},
@@ -77,6 +85,48 @@ describe("payload-mappers", () => {
         variants: ["high", "low"],
         contextWindow: 200_000,
         outputLimit: 32_000,
+        attachmentSupport: {
+          image: true,
+          audio: false,
+          video: true,
+          pdf: false,
+        },
+      },
+    ]);
+  });
+
+  test("mapProviderListToCatalog falls back to modality arrays when capability flags are absent", () => {
+    const catalog = mapProviderListToCatalog({
+      providers: [
+        {
+          id: "anthropic",
+          name: "Anthropic",
+          models: {
+            "claude-sonnet": {
+              name: "Claude Sonnet",
+              modalities: {
+                input: ["text", "pdf", "image"],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(catalog.models).toEqual([
+      {
+        id: "anthropic/claude-sonnet",
+        providerId: "anthropic",
+        providerName: "Anthropic",
+        modelId: "claude-sonnet",
+        modelName: "Claude Sonnet",
+        variants: [],
+        attachmentSupport: {
+          image: true,
+          audio: false,
+          video: false,
+          pdf: true,
+        },
       },
     ]);
   });

--- a/packages/adapters-opencode-sdk/src/payload-mappers.ts
+++ b/packages/adapters-opencode-sdk/src/payload-mappers.ts
@@ -2,6 +2,8 @@ import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import type { AgentModelCatalog, AgentModelSelection } from "@openducktor/core";
 import { asUnknownRecord, readArrayProp, readRecordProp, readUnknownProp } from "./guards";
 
+const ATTACHMENT_MODALITIES = ["image", "audio", "video", "pdf"] as const;
+
 const toFiniteNumber = (value: unknown): number | null => {
   if (typeof value !== "number" || Number.isNaN(value) || !Number.isFinite(value)) {
     return null;
@@ -67,6 +69,47 @@ export const toToolIdList = (payload: unknown): string[] => {
     .filter((entry) => entry.length > 0 && entry !== "invalid");
 };
 
+const normalizeModelAttachmentSupport = (
+  modelRecord: Record<string, unknown>,
+):
+  | {
+      image: boolean;
+      audio: boolean;
+      video: boolean;
+      pdf: boolean;
+    }
+  | undefined => {
+  const capabilities = readRecordProp(modelRecord, "capabilities");
+  const capabilitiesInput = capabilities ? readRecordProp(capabilities, "input") : undefined;
+  if (capabilities && capabilitiesInput) {
+    return {
+      image: readUnknownProp(capabilitiesInput, "image") === true,
+      audio: readUnknownProp(capabilitiesInput, "audio") === true,
+      video: readUnknownProp(capabilitiesInput, "video") === true,
+      pdf: readUnknownProp(capabilitiesInput, "pdf") === true,
+    };
+  }
+
+  const modalities = readRecordProp(modelRecord, "modalities");
+  const modalitiesInput = modalities ? readArrayProp(modalities, "input") : undefined;
+  if (modalitiesInput) {
+    const supported = new Set(
+      modalitiesInput.filter(
+        (entry): entry is (typeof ATTACHMENT_MODALITIES)[number] =>
+          typeof entry === "string" && ATTACHMENT_MODALITIES.includes(entry as never),
+      ),
+    );
+    return {
+      image: supported.has("image"),
+      audio: supported.has("audio"),
+      video: supported.has("video"),
+      pdf: supported.has("pdf"),
+    };
+  }
+
+  return undefined;
+};
+
 export const mapProviderListToCatalog = (payload: unknown): AgentModelCatalog => {
   const payloadRecord = asUnknownRecord(payload);
   if (!payloadRecord) {
@@ -115,6 +158,7 @@ export const mapProviderListToCatalog = (payload: unknown): AgentModelCatalog =>
         const contextWindow = limitRaw ? (toFiniteNumber(contextRaw) ?? undefined) : undefined;
         const outputLimit = limitRaw ? (toFiniteNumber(outputRaw) ?? undefined) : undefined;
         const variants = variantsRaw ? Object.keys(variantsRaw) : [];
+        const attachmentSupport = normalizeModelAttachmentSupport(modelRecord);
 
         return {
           id: `${providerId}/${modelId}`,
@@ -125,6 +169,7 @@ export const mapProviderListToCatalog = (payload: unknown): AgentModelCatalog =>
           variants,
           ...(typeof contextWindow === "number" ? { contextWindow } : {}),
           ...(typeof outputLimit === "number" ? { outputLimit } : {}),
+          ...(attachmentSupport ? { attachmentSupport } : {}),
         };
       })
       .filter((entry): entry is NonNullable<typeof entry> => entry !== null);

--- a/packages/adapters-opencode-sdk/src/types.ts
+++ b/packages/adapters-opencode-sdk/src/types.ts
@@ -18,8 +18,19 @@ export type SessionInput = Omit<StartAgentSessionInput, "sessionId"> & {
 };
 
 export type QueuedUserMessageSend = {
-  content: string;
+  signature: string;
+  attachmentIdentitySignature?: string;
+  attachmentParts?: Extract<AgentUserMessageDisplayPart, { kind: "attachment" }>[];
+};
+
+export type SessionMessageMetadata = {
+  timestamp: string;
   model?: AgentModelSelection;
+  parentId?: string;
+  text?: string;
+  hasStopSignal?: boolean;
+  totalTokens?: number;
+  displayParts?: AgentUserMessageDisplayPart[];
 };
 
 export type SessionRecord = {
@@ -37,18 +48,7 @@ export type SessionRecord = {
   pendingQueuedUserMessages: QueuedUserMessageSend[];
   partsById: Map<string, import("@opencode-ai/sdk/v2/client").Part>;
   messageRoleById: Map<string, string>;
-  messageMetadataById: Map<
-    string,
-    {
-      timestamp: string;
-      model?: AgentModelSelection;
-      parentId?: string;
-      text?: string;
-      hasStopSignal?: boolean;
-      totalTokens?: number;
-      displayParts?: AgentUserMessageDisplayPart[];
-    }
-  >;
+  messageMetadataById: Map<string, SessionMessageMetadata>;
   pendingDeltasByPartId: Map<string, PendingPartDelta[]>;
   /** Cached workflow tool selection (toolId -> enabled). */
   workflowToolSelectionCache?: Record<string, boolean>;

--- a/packages/adapters-opencode-sdk/src/user-message-signatures.ts
+++ b/packages/adapters-opencode-sdk/src/user-message-signatures.ts
@@ -1,0 +1,153 @@
+import {
+  type AgentModelSelection,
+  type AgentUserMessageDisplayPart,
+  type AgentUserMessagePart,
+  buildAgentUserMessagePromptText,
+  normalizeAgentUserMessageParts,
+  serializeAgentUserMessagePartsToText,
+} from "@openducktor/core";
+
+type ComparableNonTextPart =
+  | {
+      kind: "file_reference";
+      path: string;
+      name: string;
+      sourceText?: {
+        value: string;
+        start: number;
+        end: number;
+      };
+    }
+  | {
+      kind: "attachment";
+      path: string;
+      name: string;
+      attachmentKind: "image" | "audio" | "video" | "pdf";
+      mime?: string;
+    };
+
+type AttachmentPathMode = "strict" | "identity";
+
+const buildComparableSignature = (input: {
+  visible: string;
+  nonTextParts: ComparableNonTextPart[];
+  model?: AgentModelSelection;
+}): string => {
+  const model = input.model;
+  return JSON.stringify({
+    visible: input.visible.trim(),
+    nonTextParts: input.nonTextParts,
+    providerId: model?.providerId ?? null,
+    modelId: model?.modelId ?? null,
+    variant: model?.variant ?? null,
+    profileId: model?.profileId ?? null,
+  });
+};
+
+export const buildQueuedRequestSignature = (
+  parts: AgentUserMessagePart[],
+  model?: AgentModelSelection,
+): string => {
+  return buildQueuedRequestSignatureWithAttachmentPathMode(parts, model, "strict");
+};
+
+export const buildQueuedRequestAttachmentIdentitySignature = (
+  parts: AgentUserMessagePart[],
+  model?: AgentModelSelection,
+): string => {
+  return buildQueuedRequestSignatureWithAttachmentPathMode(parts, model, "identity");
+};
+
+const buildQueuedRequestSignatureWithAttachmentPathMode = (
+  parts: AgentUserMessagePart[],
+  model: AgentModelSelection | undefined,
+  attachmentPathMode: AttachmentPathMode,
+): string => {
+  const normalizedParts = normalizeAgentUserMessageParts(parts);
+  const promptText = buildAgentUserMessagePromptText(normalizedParts);
+  const nonTextParts: ComparableNonTextPart[] = [
+    ...promptText.fileReferences.map(({ file, sourceText }) => ({
+      kind: "file_reference" as const,
+      path: file.path,
+      name: file.name,
+      sourceText,
+    })),
+    ...normalizedParts.flatMap((part) => {
+      if (part.kind !== "attachment") {
+        return [];
+      }
+
+      return [
+        {
+          kind: "attachment" as const,
+          path: attachmentPathMode === "strict" ? part.attachment.path : "",
+          name: part.attachment.name,
+          attachmentKind: part.attachment.kind,
+          ...(part.attachment.mime ? { mime: part.attachment.mime } : {}),
+        },
+      ];
+    }),
+  ];
+
+  return buildComparableSignature({
+    visible: serializeAgentUserMessagePartsToText(normalizedParts),
+    nonTextParts,
+    ...(model ? { model } : {}),
+  });
+};
+
+export const buildQueuedDisplaySignature = (input: {
+  visible: string;
+  parts: AgentUserMessageDisplayPart[];
+  model?: AgentModelSelection;
+}): string => {
+  return buildQueuedDisplaySignatureWithAttachmentPathMode(input, "strict");
+};
+
+export const buildQueuedDisplayAttachmentIdentitySignature = (input: {
+  visible: string;
+  parts: AgentUserMessageDisplayPart[];
+  model?: AgentModelSelection;
+}): string => {
+  return buildQueuedDisplaySignatureWithAttachmentPathMode(input, "identity");
+};
+
+const buildQueuedDisplaySignatureWithAttachmentPathMode = (
+  input: {
+    visible: string;
+    parts: AgentUserMessageDisplayPart[];
+    model?: AgentModelSelection;
+  },
+  attachmentPathMode: AttachmentPathMode,
+): string => {
+  const nonTextParts = input.parts.flatMap((part): ComparableNonTextPart[] => {
+    if (part.kind === "file_reference") {
+      return [
+        {
+          kind: "file_reference",
+          path: part.file.path,
+          name: part.file.name,
+          ...(part.sourceText ? { sourceText: part.sourceText } : {}),
+        },
+      ];
+    }
+    if (part.kind === "attachment") {
+      return [
+        {
+          kind: "attachment",
+          path: attachmentPathMode === "strict" ? part.attachment.path : "",
+          name: part.attachment.name,
+          attachmentKind: part.attachment.kind,
+          ...(part.attachment.mime ? { mime: part.attachment.mime } : {}),
+        },
+      ];
+    }
+    return [];
+  });
+
+  return buildComparableSignature({
+    visible: input.visible,
+    nonTextParts,
+    ...(input.model ? { model: input.model } : {}),
+  });
+};

--- a/packages/adapters-tauri-host/src/index.ts
+++ b/packages/adapters-tauri-host/src/index.ts
@@ -26,6 +26,8 @@ const WORKSPACE_METHODS = [
   "workspaceSaveSettingsSnapshot",
   "workspacePrepareTrustedHooksChallenge",
   "workspaceSetTrustedHooks",
+  "workspaceStageLocalAttachment",
+  "workspaceResolveLocalAttachmentPath",
   "setTheme",
 ] as const satisfies readonly MethodName<TauriWorkspaceClient>[];
 

--- a/packages/adapters-tauri-host/src/workspace-client.ts
+++ b/packages/adapters-tauri-host/src/workspace-client.ts
@@ -69,6 +69,14 @@ export type TrustedHooksProof = {
   fingerprint: string;
 };
 
+export type StagedLocalAttachment = {
+  path: string;
+};
+
+export type ResolvedLocalAttachment = {
+  path: string;
+};
+
 const parseTrustedHooksChallenge = (payload: unknown): TrustedHooksChallenge => {
   if (!payload || typeof payload !== "object") {
     throw new Error("Expected trusted hooks challenge payload from host command");
@@ -100,6 +108,24 @@ const parseTrustedHooksChallenge = (payload: unknown): TrustedHooksChallenge => 
     preStartCount: readCount("preStartCount"),
     postCompleteCount: readCount("postCompleteCount"),
   };
+};
+
+const parseStagedLocalAttachment = (payload: unknown): StagedLocalAttachment => {
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Expected staged local attachment payload from host command");
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  const path = candidate.path;
+  if (typeof path !== "string" || path.trim().length === 0) {
+    throw new Error("Expected non-empty 'path' in staged local attachment payload");
+  }
+
+  return { path };
+};
+
+const parseResolvedLocalAttachment = (payload: unknown): ResolvedLocalAttachment => {
+  return parseStagedLocalAttachment(payload);
 };
 
 const workspaceList = async (invokeFn: InvokeFn): Promise<WorkspaceRecord[]> => {
@@ -222,6 +248,28 @@ const setTheme = async (invokeFn: InvokeFn, theme: string): Promise<void> => {
   await invokeFn("set_theme", { theme });
 };
 
+const workspaceStageLocalAttachment = async (
+  invokeFn: InvokeFn,
+  input: {
+    name: string;
+    mime?: string;
+    base64Data: string;
+  },
+): Promise<StagedLocalAttachment> => {
+  const payload = await invokeFn("workspace_stage_local_attachment", input);
+  return parseStagedLocalAttachment(payload);
+};
+
+const workspaceResolveLocalAttachmentPath = async (
+  invokeFn: InvokeFn,
+  input: {
+    path: string;
+  },
+): Promise<ResolvedLocalAttachment> => {
+  const payload = await invokeFn("workspace_resolve_local_attachment_path", input);
+  return parseResolvedLocalAttachment(payload);
+};
+
 export class TauriWorkspaceClient {
   constructor(private readonly invokeFn: InvokeFn) {}
 
@@ -288,6 +336,20 @@ export class TauriWorkspaceClient {
     challenge?: TrustedHooksProof,
   ): Promise<WorkspaceRecord> {
     return workspaceSetTrustedHooks(this.invokeFn, repoPath, trusted, challenge);
+  }
+
+  async workspaceStageLocalAttachment(input: {
+    name: string;
+    mime?: string;
+    base64Data: string;
+  }): Promise<StagedLocalAttachment> {
+    return workspaceStageLocalAttachment(this.invokeFn, input);
+  }
+
+  async workspaceResolveLocalAttachmentPath(input: {
+    path: string;
+  }): Promise<ResolvedLocalAttachment> {
+    return workspaceResolveLocalAttachmentPath(this.invokeFn, input);
   }
 
   async setTheme(theme: string): Promise<void> {

--- a/packages/core/src/services/agent-user-message-parts.test.ts
+++ b/packages/core/src/services/agent-user-message-parts.test.ts
@@ -20,6 +20,14 @@ const createFileReference = () => ({
   kind: "code" as const,
 });
 
+const createAttachment = () => ({
+  id: "attachment-1",
+  path: "/tmp/diagram.png",
+  name: "diagram.png",
+  kind: "image" as const,
+  mime: "image/png",
+});
+
 describe("agent-user-message-parts", () => {
   test("merges adjacent text parts and trims only boundaries", () => {
     const command = createCommand();
@@ -53,6 +61,7 @@ describe("agent-user-message-parts", () => {
   test("detects meaningful parts only after normalization", () => {
     const command = createCommand();
     const file = createFileReference();
+    const attachment = createAttachment();
 
     expect(
       hasMeaningfulAgentUserMessageParts([
@@ -70,6 +79,12 @@ describe("agent-user-message-parts", () => {
       hasMeaningfulAgentUserMessageParts([
         { kind: "text", text: "   " },
         { kind: "file_reference", file },
+      ]),
+    ).toBe(true);
+    expect(
+      hasMeaningfulAgentUserMessageParts([
+        { kind: "text", text: "   " },
+        { kind: "attachment", attachment },
       ]),
     ).toBe(true);
   });
@@ -152,6 +167,7 @@ describe("agent-user-message-parts", () => {
 
   test("builds upstream prompt text with inline file-reference spans", () => {
     const file = createFileReference();
+    const attachment = createAttachment();
 
     expect(
       buildAgentUserMessagePromptText([
@@ -192,5 +208,40 @@ describe("agent-user-message-parts", () => {
         },
       ],
     });
+
+    expect(
+      buildAgentUserMessagePromptText([
+        { kind: "text", text: "review " },
+        { kind: "attachment", attachment },
+        { kind: "text", text: "with " },
+        { kind: "file_reference", file },
+      ]),
+    ).toEqual({
+      text: "review with @src/index.ts",
+      fileReferences: [
+        {
+          file,
+          sourceText: {
+            value: "@src/index.ts",
+            start: 12,
+            end: 25,
+          },
+        },
+      ],
+    });
+  });
+
+  test("does not flatten attachments into serialized prompt text", () => {
+    const attachment = createAttachment();
+
+    expect(
+      serializeAgentUserMessagePartsToText([
+        { kind: "text", text: "  describe " },
+        { kind: "attachment", attachment },
+        { kind: "text", text: " carefully  " },
+      ]),
+    ).toBe("describe carefully");
+
+    expect(serializeAgentUserMessagePartsToText([{ kind: "attachment", attachment }])).toBe("");
   });
 });

--- a/packages/core/src/services/agent-user-message-parts.ts
+++ b/packages/core/src/services/agent-user-message-parts.ts
@@ -5,14 +5,17 @@ import type {
 
 const WORDLIKE_TEXT_START_PATTERN = /[\p{L}\p{N}_]/u;
 
-const serializeAgentUserMessagePart = (part: AgentUserMessagePart): string => {
+const serializeAgentUserMessagePart = (part: AgentUserMessagePart): string | null => {
   if (part.kind === "text") {
     return part.text;
   }
   if (part.kind === "slash_command") {
     return `/${part.command.trigger}`;
   }
-  return `@${part.file.path}`;
+  if (part.kind === "file_reference") {
+    return `@${part.file.path}`;
+  }
+  return null;
 };
 
 const shouldInsertSyntheticSpaceBeforePart = (
@@ -42,6 +45,20 @@ const trimBoundaryTextPart = (
     ...part,
     text: edge === "start" ? part.text.trimStart() : part.text.trimEnd(),
   };
+};
+
+const collapseLeadingWhitespaceAfterSkippedPart = (
+  existingText: string,
+  nextText: string,
+  skippedStructuredPart: boolean,
+): string => {
+  if (!skippedStructuredPart) {
+    return nextText;
+  }
+  if (!/\s$/u.test(existingText)) {
+    return nextText;
+  }
+  return nextText.replace(/^\s+/u, "");
 };
 
 export const normalizeAgentUserMessageParts = (
@@ -85,13 +102,23 @@ export const serializeAgentUserMessagePartsToText = (parts: AgentUserMessagePart
   const normalized = normalizeAgentUserMessageParts(parts);
   let text = "";
   let previousPart: AgentUserMessagePart | null = null;
+  let skippedStructuredPart = false;
 
   for (const part of normalized) {
     if (shouldInsertSyntheticSpaceBeforePart(previousPart, part)) {
       text += " ";
     }
-    text += serializeAgentUserMessagePart(part);
+    const serializedPart = serializeAgentUserMessagePart(part);
+    if (serializedPart === null) {
+      skippedStructuredPart = true;
+      continue;
+    }
+    text +=
+      part.kind === "text"
+        ? collapseLeadingWhitespaceAfterSkippedPart(text, serializedPart, skippedStructuredPart)
+        : serializedPart;
     previousPart = part;
+    skippedStructuredPart = false;
   }
 
   return text;
@@ -107,6 +134,7 @@ export const buildAgentUserMessagePromptText = (
   let text = "";
   const fileReferences: AgentUserMessagePromptFileReference[] = [];
   let previousPart: AgentUserMessagePart | null = null;
+  let skippedStructuredPart = false;
 
   for (const part of normalized) {
     if (shouldInsertSyntheticSpaceBeforePart(previousPart, part)) {
@@ -115,9 +143,22 @@ export const buildAgentUserMessagePromptText = (
 
     const serializedPart = serializeAgentUserMessagePart(part);
 
+    if (serializedPart === null) {
+      skippedStructuredPart = true;
+      continue;
+    }
+
     if (part.kind === "text" || part.kind === "slash_command") {
-      text += serializedPart;
+      text +=
+        part.kind === "text"
+          ? collapseLeadingWhitespaceAfterSkippedPart(text, serializedPart, skippedStructuredPart)
+          : serializedPart;
       previousPart = part;
+      skippedStructuredPart = false;
+      continue;
+    }
+
+    if (part.kind !== "file_reference") {
       continue;
     }
 
@@ -132,6 +173,7 @@ export const buildAgentUserMessagePromptText = (
       },
     });
     previousPart = part;
+    skippedStructuredPart = false;
   }
 
   return { text, fileReferences };

--- a/packages/core/src/types/agent-orchestrator.ts
+++ b/packages/core/src/types/agent-orchestrator.ts
@@ -62,6 +62,7 @@ export type AgentModelDescriptor = {
   variants: string[];
   contextWindow?: number;
   outputLimit?: number;
+  attachmentSupport?: AgentModelAttachmentSupport;
 };
 
 export type AgentDescriptor = {
@@ -105,6 +106,23 @@ export type AgentFileReference = {
 
 export type AgentFileSearchResult = AgentFileReference;
 
+export type AgentAttachmentKind = "image" | "audio" | "video" | "pdf";
+
+export type AgentModelAttachmentSupport = {
+  image: boolean;
+  audio: boolean;
+  video: boolean;
+  pdf: boolean;
+};
+
+export type AgentAttachmentReference = {
+  id: string;
+  path: string;
+  name: string;
+  kind: AgentAttachmentKind;
+  mime?: string;
+};
+
 export type AgentUserMessagePart =
   | {
       kind: "text";
@@ -117,6 +135,10 @@ export type AgentUserMessagePart =
   | {
       kind: "file_reference";
       file: AgentFileReference;
+    }
+  | {
+      kind: "attachment";
+      attachment: AgentAttachmentReference;
     };
 
 export type AgentUserMessageSourceText = {
@@ -135,6 +157,10 @@ export type AgentUserMessageDisplayPart =
       kind: "file_reference";
       file: AgentFileReference;
       sourceText?: AgentUserMessageSourceText;
+    }
+  | {
+      kind: "attachment";
+      attachment: AgentAttachmentReference;
     };
 
 export type AgentUserMessagePromptFileReference = {


### PR DESCRIPTION
## Summary
- add runtime-driven chat attachments for images, audio, video, and PDFs, including composer staging, drag-and-drop, transcript rendering, and local preview support
- preserve attachment paths across OpenCode live events and history hydration, fix transcript preview regressions, and prevent duplicate PDF attachment rendering
- fix the attachment-related session-load scroll regression for large viewports and tighten the host-side staged-file preview/resolution flow

## Verification
- bun run test
- bun run lint
- bun run typecheck
- bun run build
- bun run check:rust
- bun run test:rust
- live browser verification on the provided attachment preview and session-load scroll repro URLs

## Review
- final code review completed with no material findings remaining in the attachment change set
- React-facing attachment changes were re-checked against the repo's React best-practice guidance after the final cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full file attachment support in agent chat: file picker, drag-and-drop, attachment chips, and send integration.
  * Image/video previewing with fullscreen dialog and inline thumbnail handling.
  * Model-specific attachment capability checks (image/audio/video/PDF).
  * Local staging + preview serving so attachments render reliably across desktop/browser runtimes.
* **Bug Fixes / UX**
  * Composer preserves staged attachments when clearing/selecting content; accurate send gating and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->