### PR TITLE
perf(desktop): parallelize and cache OpenCode session probes

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use fs2::FileExt;
 use host_domain::{
     DevServerEvent, DevServerGroupState, GitPort, RunEvent, RunSummary, RuntimeCheck,
@@ -40,22 +40,21 @@ mod workspace_policy;
 pub(crate) use events::emit_event;
 pub(crate) use hook_security::{run_parsed_hook_command_allow_failure, validate_hook_trust};
 pub(crate) use opencode_runtime::{
+    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupCancelEpoch,
     opencode_server_parent_pid, process_exists, read_opencode_version,
     resolve_opencode_binary_path, spawn_opencode_server, terminate_child_process,
     terminate_process_by_pid, wait_for_local_server_with_process, wait_for_process_exit_by_pid,
-    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupCancelEpoch,
 };
 pub(crate) use opencode_session_status::{
-    has_live_opencode_session_status, is_unreachable_opencode_session_status_error,
-    load_opencode_session_statuses, OpencodeSessionStatusMap,
+    OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget, has_live_opencode_session_status,
 };
-#[cfg(test)]
-pub(crate) use process_registry::read_opencode_process_registry;
 pub(crate) use process_registry::TrackedOpencodeProcessGuard;
 #[cfg(test)]
+pub(crate) use process_registry::read_opencode_process_registry;
+#[cfg(test)]
 pub(crate) use process_registry::{
-    with_locked_opencode_process_registry, OpencodeProcessRegistryInstance,
-    OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
+    OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH, OpencodeProcessRegistryInstance,
+    with_locked_opencode_process_registry,
 };
 pub(crate) use service_core::{
     AgentRuntimeProcess, CachedRuntimeCheck, DevServerGroupRuntime, RunProcess,
@@ -64,11 +63,11 @@ pub(crate) use service_core::{
 pub use service_core::{AppService, DevServerEmitter, RunEmitter};
 #[cfg(test)]
 pub(crate) use startup_metrics::{
-    build_opencode_startup_event_payload, OpencodeStartupMetricsSnapshot,
+    OpencodeStartupMetricsSnapshot, build_opencode_startup_event_payload,
 };
 pub(crate) use startup_metrics::{
-    StartupEventContext, StartupEventCorrelation, StartupEventPayload,
-    STARTUP_CONFIG_INVALID_REASON,
+    STARTUP_CONFIG_INVALID_REASON, StartupEventContext, StartupEventCorrelation,
+    StartupEventPayload,
 };
 pub(crate) use workflow_rules::{
     derive_agent_workflows, derive_available_actions, validate_transition,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -46,7 +46,9 @@ pub(crate) use opencode_runtime::{
     terminate_process_by_pid, wait_for_local_server_with_process, wait_for_process_exit_by_pid,
 };
 pub(crate) use opencode_session_status::{
-    OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget, has_live_opencode_session_status,
+    OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget,
+    dedupe_probe_targets as dedupe_opencode_session_status_probe_targets,
+    has_live_opencode_session_status,
 };
 pub(crate) use process_registry::TrackedOpencodeProcessGuard;
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -146,7 +146,7 @@ impl fmt::Display for CachedOpencodeSessionStatusProbeError {
 }
 
 impl CachedOpencodeSessionStatusProbeOutcome {
-    fn into_result(&self) -> Result<OpencodeSessionStatusMap> {
+    fn to_result(&self) -> Result<OpencodeSessionStatusMap> {
         match self {
             Self::Statuses(statuses) => Ok(statuses.clone()),
             Self::ActionableError(error) => Err(anyhow!(error.to_string())),
@@ -344,9 +344,8 @@ impl AppService {
                             return Ok(());
                         };
 
-                        let statuses = service
-                            .resolve_cached_probe_outcome(&target)?
-                            .into_result()?;
+                        let statuses =
+                            service.resolve_cached_probe_outcome(&target)?.to_result()?;
                         let mut results = results.lock().map_err(|_| {
                             anyhow!("OpenCode session status batch results lock poisoned")
                         })?;
@@ -375,7 +374,7 @@ impl AppService {
         &self,
         target: &OpencodeSessionStatusProbeTarget,
     ) -> Result<OpencodeSessionStatusMap> {
-        self.resolve_cached_probe_outcome(target)?.into_result()
+        self.resolve_cached_probe_outcome(target)?.to_result()
     }
 
     fn resolve_cached_probe_outcome(
@@ -916,7 +915,7 @@ mod tests {
 
         let outcome = AppService::wait_for_opencode_session_status_flight(&flight)?;
         let error = outcome
-            .into_result()
+            .to_result()
             .expect_err("dropped leader should finish waiters with an error");
         assert!(
             error

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -45,7 +45,7 @@ impl OpencodeSessionStatusProbeTarget {
         };
         Self {
             endpoint,
-            working_directory: working_directory.trim().to_string(),
+            working_directory: working_directory.to_string(),
         }
     }
 
@@ -640,6 +640,64 @@ mod tests {
                 .starts_with("GET /session/status?directory=%2Ftmp%2Frepo+path HTTP/1.1"),
             "unexpected request line: {captured_request}"
         );
+    }
+
+    #[test]
+    fn cached_probe_preserves_trailing_space_in_directory_query() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let request_line = Arc::new(Mutex::new(None::<String>));
+        let request_line_for_thread = Arc::clone(&request_line);
+
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("server should accept request");
+            let mut request_buffer = [0_u8; 4096];
+            let bytes_read = stream
+                .read(&mut request_buffer)
+                .expect("server should read request");
+            let request_text = String::from_utf8_lossy(&request_buffer[..bytes_read]);
+            let first_line = request_text.lines().next().unwrap_or_default().to_string();
+            *request_line_for_thread
+                .lock()
+                .expect("request line lock poisoned") = Some(first_line);
+
+            let body = r#"{"external-session":{"type":"busy"}}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("server should write response");
+            stream.flush().expect("server should flush response");
+        });
+
+        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(port),
+            "/tmp/repo ",
+        );
+        assert_eq!(target.working_directory(), "/tmp/repo ");
+
+        let statuses = service.load_cached_opencode_session_statuses_for_target(&target)?;
+        assert!(matches!(
+            statuses.get("external-session"),
+            Some(OpencodeSessionStatus::Busy)
+        ));
+
+        server.join().expect("server thread should finish");
+        let captured_request = request_line
+            .lock()
+            .expect("request line lock poisoned")
+            .clone()
+            .expect("request line should be captured");
+        assert!(
+            captured_request.starts_with("GET /session/status?directory=%2Ftmp%2Frepo+ HTTP/1.1"),
+            "unexpected request line: {captured_request}"
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -1,13 +1,20 @@
-use anyhow::{anyhow, Context, Result};
+use super::service_core::{
+    AppService, CachedOpencodeSessionStatusProbe, CachedOpencodeSessionStatusProbeOutcome,
+    OpencodeSessionStatusFlight, OpencodeSessionStatusFlightState,
+    OpencodeSessionStatusProbeLimiter,
+};
+use anyhow::{Context, Result, anyhow};
 use host_domain::RuntimeRoute;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::ErrorKind;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
-use std::time::Duration;
-use url::{form_urlencoded, Url};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+use url::{Url, form_urlencoded};
 
-#[derive(serde::Deserialize)]
+#[derive(Clone, Debug, serde::Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub(crate) enum OpencodeSessionStatus {
     Idle,
@@ -23,6 +30,117 @@ pub(crate) enum OpencodeSessionStatus {
 }
 
 pub(crate) type OpencodeSessionStatusMap = HashMap<String, OpencodeSessionStatus>;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct OpencodeSessionStatusProbeTarget {
+    endpoint: String,
+    working_directory: String,
+}
+
+impl OpencodeSessionStatusProbeTarget {
+    pub(crate) fn for_runtime_route(runtime_route: &RuntimeRoute, working_directory: &str) -> Self {
+        let endpoint = match runtime_route {
+            RuntimeRoute::LocalHttp { endpoint } => endpoint.clone(),
+        };
+        Self {
+            endpoint,
+            working_directory: working_directory.trim().to_string(),
+        }
+    }
+
+    fn endpoint(&self) -> &str {
+        self.endpoint.as_str()
+    }
+
+    fn working_directory(&self) -> &str {
+        self.working_directory.as_str()
+    }
+}
+
+struct OpencodeSessionStatusFlightGuard<'a> {
+    service: &'a AppService,
+    target: OpencodeSessionStatusProbeTarget,
+    flight: Arc<OpencodeSessionStatusFlight>,
+    completed: bool,
+}
+
+impl<'a> OpencodeSessionStatusFlightGuard<'a> {
+    fn new(
+        service: &'a AppService,
+        target: &OpencodeSessionStatusProbeTarget,
+        flight: Arc<OpencodeSessionStatusFlight>,
+    ) -> Self {
+        Self {
+            service,
+            target: target.clone(),
+            flight,
+            completed: false,
+        }
+    }
+
+    fn complete(&mut self, outcome: &CachedOpencodeSessionStatusProbeOutcome) -> Result<()> {
+        self.completed = true;
+        self.service
+            .complete_opencode_session_status_flight(&self.target, &self.flight, outcome)
+    }
+}
+
+impl Drop for OpencodeSessionStatusFlightGuard<'_> {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+
+        let aborted = CachedOpencodeSessionStatusProbeOutcome::ActionableError(
+            "OpenCode session status probe aborted unexpectedly".to_string(),
+        );
+        if let Err(error) = self.service.complete_opencode_session_status_flight(
+            &self.target,
+            &self.flight,
+            &aborted,
+        ) {
+            eprintln!(
+                "OpenDucktor warning: failed completing OpenCode session status flight after abort: {error:#}"
+            );
+        }
+    }
+}
+
+struct OpencodeSessionStatusProbePermit {
+    limiter: Arc<OpencodeSessionStatusProbeLimiter>,
+}
+
+impl Drop for OpencodeSessionStatusProbePermit {
+    fn drop(&mut self) {
+        match self.limiter.active.lock() {
+            Ok(mut active) => {
+                if *active > 0 {
+                    *active -= 1;
+                }
+                self.limiter.condvar.notify_one();
+            }
+            Err(poisoned) => {
+                let mut active = poisoned.into_inner();
+                if *active > 0 {
+                    *active -= 1;
+                }
+                self.limiter.condvar.notify_one();
+                eprintln!(
+                    "OpenDucktor warning: OpenCode session status probe limiter lock poisoned during permit release"
+                );
+            }
+        }
+    }
+}
+
+impl CachedOpencodeSessionStatusProbeOutcome {
+    fn into_result(&self) -> Result<OpencodeSessionStatusMap> {
+        match self {
+            Self::Statuses(statuses) => Ok(statuses.clone()),
+            Self::ActionableError(message) => Err(anyhow!(message.clone())),
+        }
+    }
+}
 
 pub(crate) fn is_unreachable_opencode_session_status_error(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
@@ -52,13 +170,21 @@ pub(crate) fn has_live_opencode_session_status(
     )
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn load_opencode_session_statuses(
     runtime_route: &RuntimeRoute,
     working_directory: &str,
 ) -> Result<OpencodeSessionStatusMap> {
-    let endpoint = match runtime_route {
-        RuntimeRoute::LocalHttp { endpoint } => endpoint.as_str(),
-    };
+    let target =
+        OpencodeSessionStatusProbeTarget::for_runtime_route(runtime_route, working_directory);
+    load_opencode_session_statuses_for_target(&target)
+}
+
+fn load_opencode_session_statuses_for_target(
+    target: &OpencodeSessionStatusProbeTarget,
+) -> Result<OpencodeSessionStatusMap> {
+    let endpoint = target.endpoint();
+    let working_directory = target.working_directory();
     let parsed_endpoint = Url::parse(endpoint)
         .with_context(|| format!("Invalid OpenCode runtime endpoint: {endpoint}"))?;
     let host = parsed_endpoint
@@ -143,15 +269,244 @@ fn extract_http_response_body(response: &str) -> String {
         .unwrap_or_default()
 }
 
+impl AppService {
+    pub(super) const OPENCODE_SESSION_STATUS_CACHE_TTL: Duration = Duration::from_secs(1);
+
+    pub(super) fn load_cached_opencode_session_statuses_for_targets(
+        &self,
+        targets: &[OpencodeSessionStatusProbeTarget],
+    ) -> Result<HashMap<OpencodeSessionStatusProbeTarget, OpencodeSessionStatusMap>> {
+        let mut unique_targets = Vec::new();
+        let mut seen = HashSet::new();
+        for target in targets {
+            if seen.insert(target.clone()) {
+                unique_targets.push(target.clone());
+            }
+        }
+
+        if unique_targets.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let worker_count = unique_targets.len().min(
+            self.opencode_session_status_probe_limiter
+                .max_concurrent
+                .max(1),
+        );
+        let queue = Arc::new(Mutex::new(VecDeque::from(unique_targets)));
+        let results = Arc::new(Mutex::new(HashMap::new()));
+
+        thread::scope(|scope| -> Result<()> {
+            let mut handles = Vec::new();
+            for _ in 0..worker_count {
+                let service = self;
+                let queue = Arc::clone(&queue);
+                let results = Arc::clone(&results);
+                handles.push(scope.spawn(move || -> Result<()> {
+                    loop {
+                        let target = {
+                            let mut queue = queue.lock().map_err(|_| {
+                                anyhow!("OpenCode session status batch queue lock poisoned")
+                            })?;
+                            queue.pop_front()
+                        };
+                        let Some(target) = target else {
+                            return Ok(());
+                        };
+
+                        let statuses =
+                            service.load_cached_opencode_session_statuses_for_target(&target)?;
+                        let mut results = results.lock().map_err(|_| {
+                            anyhow!("OpenCode session status batch results lock poisoned")
+                        })?;
+                        results.insert(target, statuses);
+                    }
+                }));
+            }
+
+            for handle in handles {
+                handle
+                    .join()
+                    .map_err(|_| anyhow!("OpenCode session status batch worker panicked"))??;
+            }
+            Ok(())
+        })?;
+
+        let results = results
+            .lock()
+            .map_err(|_| anyhow!("OpenCode session status batch results lock poisoned"))?;
+        Ok(results.clone())
+    }
+
+    fn load_cached_opencode_session_statuses_for_target(
+        &self,
+        target: &OpencodeSessionStatusProbeTarget,
+    ) -> Result<OpencodeSessionStatusMap> {
+        if let Some(cached) = self.cached_opencode_session_status_outcome(target)? {
+            return cached.into_result();
+        }
+
+        let (flight, is_leader) = self.acquire_opencode_session_status_flight(target)?;
+        if !is_leader {
+            let awaited = Self::wait_for_opencode_session_status_flight(&flight)?;
+            return awaited.into_result();
+        }
+
+        let mut flight_guard = OpencodeSessionStatusFlightGuard::new(self, target, flight);
+        let _permit = self.acquire_opencode_session_status_probe_permit()?;
+        let outcome = Self::probe_uncached_opencode_session_status_target(target);
+        self.update_opencode_session_status_cache(target, &outcome)?;
+        flight_guard.complete(&outcome)?;
+        outcome.into_result()
+    }
+
+    fn probe_uncached_opencode_session_status_target(
+        target: &OpencodeSessionStatusProbeTarget,
+    ) -> CachedOpencodeSessionStatusProbeOutcome {
+        match load_opencode_session_statuses_for_target(target) {
+            Ok(statuses) => CachedOpencodeSessionStatusProbeOutcome::Statuses(statuses),
+            Err(error) if is_unreachable_opencode_session_status_error(&error) => {
+                CachedOpencodeSessionStatusProbeOutcome::Statuses(OpencodeSessionStatusMap::new())
+            }
+            Err(error) => {
+                CachedOpencodeSessionStatusProbeOutcome::ActionableError(error.to_string())
+            }
+        }
+    }
+
+    fn cached_opencode_session_status_outcome(
+        &self,
+        target: &OpencodeSessionStatusProbeTarget,
+    ) -> Result<Option<CachedOpencodeSessionStatusProbeOutcome>> {
+        let mut cache = self
+            .opencode_session_status_cache
+            .lock()
+            .map_err(|_| anyhow!("OpenCode session status cache lock poisoned"))?;
+        if let Some(entry) = cache.get(target) {
+            if entry.checked_at.elapsed() <= Self::OPENCODE_SESSION_STATUS_CACHE_TTL {
+                return Ok(Some(entry.outcome.clone()));
+            }
+        }
+
+        cache.remove(target);
+        Ok(None)
+    }
+
+    fn update_opencode_session_status_cache(
+        &self,
+        target: &OpencodeSessionStatusProbeTarget,
+        outcome: &CachedOpencodeSessionStatusProbeOutcome,
+    ) -> Result<()> {
+        let mut cache = self
+            .opencode_session_status_cache
+            .lock()
+            .map_err(|_| anyhow!("OpenCode session status cache lock poisoned"))?;
+        cache.insert(
+            target.clone(),
+            CachedOpencodeSessionStatusProbe {
+                checked_at: Instant::now(),
+                outcome: outcome.clone(),
+            },
+        );
+        Ok(())
+    }
+
+    fn acquire_opencode_session_status_flight(
+        &self,
+        target: &OpencodeSessionStatusProbeTarget,
+    ) -> Result<(Arc<OpencodeSessionStatusFlight>, bool)> {
+        let mut flights = self
+            .opencode_session_status_flights
+            .lock()
+            .map_err(|_| anyhow!("OpenCode session status coordination state lock poisoned"))?;
+        if let Some(existing) = flights.get(target) {
+            return Ok((existing.clone(), false));
+        }
+
+        let flight = Arc::new(OpencodeSessionStatusFlight::new());
+        flights.insert(target.clone(), flight.clone());
+        Ok((flight, true))
+    }
+
+    fn complete_opencode_session_status_flight(
+        &self,
+        target: &OpencodeSessionStatusProbeTarget,
+        flight: &Arc<OpencodeSessionStatusFlight>,
+        outcome: &CachedOpencodeSessionStatusProbeOutcome,
+    ) -> Result<()> {
+        {
+            let mut state = flight
+                .state
+                .lock()
+                .map_err(|_| anyhow!("OpenCode session status coordination state lock poisoned"))?;
+            *state = OpencodeSessionStatusFlightState::Finished(outcome.clone());
+        }
+        flight.condvar.notify_all();
+
+        let mut flights = self
+            .opencode_session_status_flights
+            .lock()
+            .map_err(|_| anyhow!("OpenCode session status coordination registry lock poisoned"))?;
+        flights.remove(target);
+        Ok(())
+    }
+
+    fn wait_for_opencode_session_status_flight(
+        flight: &Arc<OpencodeSessionStatusFlight>,
+    ) -> Result<CachedOpencodeSessionStatusProbeOutcome> {
+        let mut state = flight
+            .state
+            .lock()
+            .map_err(|_| anyhow!("OpenCode session status coordination state lock poisoned"))?;
+        loop {
+            match &*state {
+                OpencodeSessionStatusFlightState::Finished(outcome) => {
+                    return Ok(outcome.clone());
+                }
+                OpencodeSessionStatusFlightState::Loading => {
+                    state = flight.condvar.wait(state).map_err(|_| {
+                        anyhow!("OpenCode session status coordination state lock poisoned")
+                    })?;
+                }
+            }
+        }
+    }
+
+    fn acquire_opencode_session_status_probe_permit(
+        &self,
+    ) -> Result<OpencodeSessionStatusProbePermit> {
+        let limiter = Arc::clone(&self.opencode_session_status_probe_limiter);
+        let mut active = limiter
+            .active
+            .lock()
+            .map_err(|_| anyhow!("OpenCode session status probe limiter lock poisoned"))?;
+        while *active >= limiter.max_concurrent {
+            active = limiter
+                .condvar
+                .wait(active)
+                .map_err(|_| anyhow!("OpenCode session status probe limiter lock poisoned"))?;
+        }
+        *active += 1;
+        drop(active);
+        Ok(OpencodeSessionStatusProbePermit { limiter })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        has_live_opencode_session_status, load_opencode_session_statuses, OpencodeSessionStatus,
+        AppService, OpencodeSessionStatus, OpencodeSessionStatusProbeTarget,
+        has_live_opencode_session_status, load_opencode_session_statuses,
     };
+    use crate::app_service::test_support::build_service_with_state;
+    use anyhow::Result;
     use host_domain::AgentRuntimeKind;
     use std::io::{Read, Write};
     use std::net::TcpListener;
-    use std::sync::{Arc, Mutex};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier, Mutex};
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn load_opencode_session_statuses_sends_directory_query_and_parses_response() {
@@ -211,5 +566,219 @@ mod tests {
                 .starts_with("GET /session/status?directory=%2Ftmp%2Frepo+path HTTP/1.1"),
             "unexpected request line: {captured_request}"
         );
+    }
+
+    #[test]
+    fn cached_probe_reuses_fresh_statuses_without_reconnecting() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let (port, connections, server_handle) = spawn_counting_status_server(
+            1,
+            Duration::ZERO,
+            Ok(r#"{"external-build-session":{"type":"busy"}}"#.to_string()),
+        )?;
+        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(port),
+            "/tmp/repo",
+        );
+
+        let first = service.load_cached_opencode_session_statuses_for_target(&target)?;
+        let second = service.load_cached_opencode_session_statuses_for_target(&target)?;
+        server_handle
+            .join()
+            .expect("status server thread should finish");
+
+        assert!(first.contains_key("external-build-session"));
+        assert!(second.contains_key("external-build-session"));
+        assert_eq!(connections.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn cached_probe_refreshes_when_entry_expires() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let (port, connections, server_handle) = spawn_counting_status_server(
+            2,
+            Duration::ZERO,
+            Ok(r#"{"external-build-session":{"type":"busy"}}"#.to_string()),
+        )?;
+        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(port),
+            "/tmp/repo",
+        );
+
+        service.load_cached_opencode_session_statuses_for_target(&target)?;
+        {
+            let mut cache = service
+                .opencode_session_status_cache
+                .lock()
+                .expect("status cache lock should be available");
+            let entry = cache
+                .get_mut(&target)
+                .expect("fresh cache entry should be present");
+            entry.checked_at = Instant::now()
+                - AppService::OPENCODE_SESSION_STATUS_CACHE_TTL
+                - Duration::from_millis(10);
+        }
+
+        service.load_cached_opencode_session_statuses_for_target(&target)?;
+        server_handle
+            .join()
+            .expect("status server thread should finish");
+
+        assert_eq!(connections.load(Ordering::SeqCst), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_same_target_requests_share_one_underlying_probe() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let (port, connections, server_handle) = spawn_counting_status_server(
+            1,
+            Duration::from_millis(200),
+            Ok(r#"{"external-build-session":{"type":"busy"}}"#.to_string()),
+        )?;
+        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(port),
+            "/tmp/repo",
+        );
+        let barrier = Arc::new(Barrier::new(3));
+
+        thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for _ in 0..2 {
+                let service = &service;
+                let target = target.clone();
+                let barrier = Arc::clone(&barrier);
+                handles.push(scope.spawn(move || {
+                    barrier.wait();
+                    service
+                        .load_cached_opencode_session_statuses_for_target(&target)
+                        .expect("concurrent status probe should succeed")
+                }));
+            }
+
+            barrier.wait();
+            for handle in handles {
+                let statuses = handle.join().expect("probe thread should not panic");
+                assert!(statuses.contains_key("external-build-session"));
+            }
+        });
+
+        server_handle
+            .join()
+            .expect("status server thread should finish");
+        assert_eq!(connections.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn batch_probe_bounds_wall_clock_for_unique_slow_targets() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let mut targets = Vec::new();
+        let mut handles = Vec::new();
+        let mut counters = Vec::new();
+        for index in 0..6 {
+            let (port, connections, server_handle) = spawn_counting_status_server(
+                1,
+                Duration::from_millis(300),
+                Ok(format!(
+                    r#"{{"external-build-session-{index}":{{"type":"busy"}}}}"#
+                )),
+            )?;
+            targets.push(OpencodeSessionStatusProbeTarget::for_runtime_route(
+                &AgentRuntimeKind::Opencode.route_for_port(port),
+                format!("/tmp/repo-{index}").as_str(),
+            ));
+            counters.push(connections);
+            handles.push(server_handle);
+        }
+
+        let started_at = Instant::now();
+        let statuses = service.load_cached_opencode_session_statuses_for_targets(&targets)?;
+        let elapsed = started_at.elapsed();
+
+        for handle in handles {
+            handle.join().expect("status server thread should finish");
+        }
+
+        assert_eq!(statuses.len(), targets.len());
+        assert!(
+            elapsed < Duration::from_millis(1200),
+            "expected bounded parallel latency, observed {elapsed:?}"
+        );
+        for counter in counters {
+            assert_eq!(counter.load(Ordering::SeqCst), 1);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn actionable_probe_failures_are_cached_inside_ttl() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let (port, connections, server_handle) = spawn_counting_status_server(
+            1,
+            Duration::ZERO,
+            Err((500, "session status failed".to_string())),
+        )?;
+        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(port),
+            "/tmp/repo",
+        );
+
+        let first_error = service
+            .load_cached_opencode_session_statuses_for_target(&target)
+            .expect_err("HTTP failures should remain actionable");
+        let second_error = service
+            .load_cached_opencode_session_statuses_for_target(&target)
+            .expect_err("cached HTTP failures should remain actionable");
+        server_handle
+            .join()
+            .expect("status server thread should finish");
+
+        assert!(first_error.to_string().contains("HTTP 500"));
+        assert!(second_error.to_string().contains("HTTP 500"));
+        assert_eq!(connections.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    fn spawn_counting_status_server(
+        expected_connections: usize,
+        delay: Duration,
+        response: Result<String, (u16, String)>,
+    ) -> Result<(u16, Arc<AtomicUsize>, thread::JoinHandle<()>)> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let connections = Arc::new(AtomicUsize::new(0));
+        let connections_for_thread = Arc::clone(&connections);
+
+        let handle = thread::spawn(move || {
+            for _ in 0..expected_connections {
+                let (mut stream, _) = listener.accept().expect("server should accept request");
+                connections_for_thread.fetch_add(1, Ordering::SeqCst);
+
+                let mut request_buffer = [0_u8; 4096];
+                let _ = stream.read(&mut request_buffer);
+                if !delay.is_zero() {
+                    thread::sleep(delay);
+                }
+
+                let response = match &response {
+                    Ok(body) => format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    ),
+                    Err((status, body)) => format!(
+                        "HTTP/1.1 {status} Error\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    ),
+                };
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+
+        Ok((port, connections, handle))
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -154,7 +154,7 @@ impl CachedOpencodeSessionStatusProbeOutcome {
     }
 }
 
-pub(crate) fn is_unreachable_opencode_session_status_error(error: &anyhow::Error) -> bool {
+fn is_unreachable_opencode_session_status_error(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
         cause
             .downcast_ref::<std::io::Error>()
@@ -281,14 +281,15 @@ fn extract_http_response_body(response: &str) -> String {
         .unwrap_or_default()
 }
 
-fn collect_unique_probe_targets(
-    targets: &[OpencodeSessionStatusProbeTarget],
-) -> Vec<OpencodeSessionStatusProbeTarget> {
+pub(crate) fn dedupe_probe_targets<I>(targets: I) -> Vec<OpencodeSessionStatusProbeTarget>
+where
+    I: IntoIterator<Item = OpencodeSessionStatusProbeTarget>,
+{
     let mut unique_targets = Vec::new();
     let mut seen = HashSet::new();
     for target in targets {
         if seen.insert(target.clone()) {
-            unique_targets.push(target.clone());
+            unique_targets.push(target);
         }
     }
     unique_targets
@@ -296,12 +297,13 @@ fn collect_unique_probe_targets(
 
 impl AppService {
     pub(super) const OPENCODE_SESSION_STATUS_CACHE_TTL: Duration = Duration::from_secs(1);
+    const OPENCODE_SESSION_STATUS_BATCH_WORKER_LIMIT: usize = 16;
 
     pub(super) fn load_cached_opencode_session_statuses_for_targets(
         &self,
         targets: &[OpencodeSessionStatusProbeTarget],
     ) -> Result<HashMap<OpencodeSessionStatusProbeTarget, OpencodeSessionStatusMap>> {
-        let unique_targets = collect_unique_probe_targets(targets);
+        let unique_targets = dedupe_probe_targets(targets.iter().cloned());
 
         if unique_targets.is_empty() {
             return Ok(HashMap::new());
@@ -315,19 +317,21 @@ impl AppService {
         unique_targets: Vec<OpencodeSessionStatusProbeTarget>,
     ) -> Result<HashMap<OpencodeSessionStatusProbeTarget, OpencodeSessionStatusMap>> {
         let worker_count = unique_targets.len().min(
-            self.opencode_session_status_probe_limiter
-                .max_concurrent
-                .max(1),
+            Self::OPENCODE_SESSION_STATUS_BATCH_WORKER_LIMIT.max(
+                self.opencode_session_status_probe_limiter
+                    .max_concurrent
+                    .max(1),
+            ),
         );
-        let queue = Arc::new(Mutex::new(VecDeque::from(unique_targets)));
-        let results = Arc::new(Mutex::new(HashMap::new()));
+        let queue = Mutex::new(VecDeque::from(unique_targets));
+        let results = Mutex::new(HashMap::new());
 
         thread::scope(|scope| -> Result<()> {
             let mut handles = Vec::new();
             for _ in 0..worker_count {
                 let service = self;
-                let queue = Arc::clone(&queue);
-                let results = Arc::clone(&results);
+                let queue = &queue;
+                let results = &results;
                 handles.push(scope.spawn(move || -> Result<()> {
                     loop {
                         let target = {
@@ -362,9 +366,11 @@ impl AppService {
         let results = results
             .lock()
             .map_err(|_| anyhow!("OpenCode session status batch results lock poisoned"))?;
-        Ok(results.clone())
+        let mut results = results;
+        Ok(std::mem::take(&mut *results))
     }
 
+    #[cfg(test)]
     fn load_cached_opencode_session_statuses_for_target(
         &self,
         target: &OpencodeSessionStatusProbeTarget,
@@ -419,17 +425,15 @@ impl AppService {
         &self,
         target: &OpencodeSessionStatusProbeTarget,
     ) -> Result<Option<CachedOpencodeSessionStatusProbeOutcome>> {
+        let now = Instant::now();
         let mut cache = self
             .opencode_session_status_cache
             .lock()
             .map_err(|_| anyhow!("OpenCode session status cache lock poisoned"))?;
+        Self::prune_expired_opencode_session_status_cache(&mut cache, now);
         if let Some(entry) = cache.get(target) {
-            if entry.checked_at.elapsed() <= Self::OPENCODE_SESSION_STATUS_CACHE_TTL {
-                return Ok(Some(entry.outcome.clone()));
-            }
+            return Ok(Some(entry.outcome.clone()));
         }
-
-        cache.remove(target);
         Ok(None)
     }
 
@@ -438,18 +442,29 @@ impl AppService {
         target: &OpencodeSessionStatusProbeTarget,
         outcome: &CachedOpencodeSessionStatusProbeOutcome,
     ) -> Result<()> {
+        let now = Instant::now();
         let mut cache = self
             .opencode_session_status_cache
             .lock()
             .map_err(|_| anyhow!("OpenCode session status cache lock poisoned"))?;
+        Self::prune_expired_opencode_session_status_cache(&mut cache, now);
         cache.insert(
             target.clone(),
             CachedOpencodeSessionStatusProbe {
-                checked_at: Instant::now(),
+                checked_at: now,
                 outcome: outcome.clone(),
             },
         );
         Ok(())
+    }
+
+    fn prune_expired_opencode_session_status_cache(
+        cache: &mut HashMap<OpencodeSessionStatusProbeTarget, CachedOpencodeSessionStatusProbe>,
+        now: Instant,
+    ) {
+        cache.retain(|_, entry| {
+            now.duration_since(entry.checked_at) <= Self::OPENCODE_SESSION_STATUS_CACHE_TTL
+        });
     }
 
     fn acquire_opencode_session_status_flight(
@@ -553,8 +568,8 @@ impl AppService {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppService, CachedOpencodeSessionStatusProbeOutcome, OpencodeSessionStatus,
-        OpencodeSessionStatusFlightGuard, OpencodeSessionStatusMap,
+        AppService, CachedOpencodeSessionStatusProbe, CachedOpencodeSessionStatusProbeOutcome,
+        OpencodeSessionStatus, OpencodeSessionStatusFlightGuard, OpencodeSessionStatusMap,
         OpencodeSessionStatusProbeTarget, has_live_opencode_session_status,
         load_opencode_session_statuses,
     };
@@ -686,6 +701,56 @@ mod tests {
             .expect("status server thread should finish");
 
         assert_eq!(connections.load(Ordering::SeqCst), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn cached_probe_prunes_expired_entries_for_other_targets() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let (port, _connections, server_handle) = spawn_counting_status_server(
+            1,
+            Duration::ZERO,
+            Ok(r#"{"external-build-session":{"type":"busy"}}"#.to_string()),
+        )?;
+        let live_target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(port),
+            "/tmp/repo-live",
+        );
+        let stale_target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(9999),
+            "/tmp/repo-stale",
+        );
+
+        {
+            let mut cache = service
+                .opencode_session_status_cache
+                .lock()
+                .expect("status cache lock should be available");
+            cache.insert(
+                stale_target.clone(),
+                CachedOpencodeSessionStatusProbe {
+                    checked_at: Instant::now()
+                        - AppService::OPENCODE_SESSION_STATUS_CACHE_TTL
+                        - Duration::from_millis(10),
+                    outcome: CachedOpencodeSessionStatusProbeOutcome::Statuses(
+                        OpencodeSessionStatusMap::new(),
+                    ),
+                },
+            );
+        }
+
+        let statuses = service.load_cached_opencode_session_statuses_for_target(&live_target)?;
+        server_handle
+            .join()
+            .expect("status server thread should finish");
+
+        assert!(statuses.contains_key("external-build-session"));
+        let cache = service
+            .opencode_session_status_cache
+            .lock()
+            .expect("status cache lock should be available");
+        assert!(!cache.contains_key(&stale_target));
+        assert!(cache.contains_key(&live_target));
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -1,11 +1,12 @@
 use super::service_core::{
-    AppService, CachedOpencodeSessionStatusProbe, CachedOpencodeSessionStatusProbeOutcome,
-    OpencodeSessionStatusFlight, OpencodeSessionStatusFlightState,
-    OpencodeSessionStatusProbeLimiter,
+    AppService, CachedOpencodeSessionStatusProbe, CachedOpencodeSessionStatusProbeError,
+    CachedOpencodeSessionStatusProbeOutcome, OpencodeSessionStatusFlight,
+    OpencodeSessionStatusFlightState, OpencodeSessionStatusProbeLimiter,
 };
 use anyhow::{Context, Result, anyhow};
 use host_domain::RuntimeRoute;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::io::ErrorKind;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
@@ -92,7 +93,7 @@ impl Drop for OpencodeSessionStatusFlightGuard<'_> {
         }
 
         let aborted = CachedOpencodeSessionStatusProbeOutcome::ActionableError(
-            "OpenCode session status probe aborted unexpectedly".to_string(),
+            CachedOpencodeSessionStatusProbeError::ProbeAborted,
         );
         if let Err(error) = self.service.complete_opencode_session_status_flight(
             &self.target,
@@ -133,11 +134,22 @@ impl Drop for OpencodeSessionStatusProbePermit {
     }
 }
 
+impl fmt::Display for CachedOpencodeSessionStatusProbeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProbeFailed(message) => formatter.write_str(message),
+            Self::ProbeAborted => {
+                formatter.write_str("OpenCode session status probe aborted unexpectedly")
+            }
+        }
+    }
+}
+
 impl CachedOpencodeSessionStatusProbeOutcome {
     fn into_result(&self) -> Result<OpencodeSessionStatusMap> {
         match self {
             Self::Statuses(statuses) => Ok(statuses.clone()),
-            Self::ActionableError(message) => Err(anyhow!(message.clone())),
+            Self::ActionableError(error) => Err(anyhow!(error.to_string())),
         }
     }
 }
@@ -269,6 +281,19 @@ fn extract_http_response_body(response: &str) -> String {
         .unwrap_or_default()
 }
 
+fn collect_unique_probe_targets(
+    targets: &[OpencodeSessionStatusProbeTarget],
+) -> Vec<OpencodeSessionStatusProbeTarget> {
+    let mut unique_targets = Vec::new();
+    let mut seen = HashSet::new();
+    for target in targets {
+        if seen.insert(target.clone()) {
+            unique_targets.push(target.clone());
+        }
+    }
+    unique_targets
+}
+
 impl AppService {
     pub(super) const OPENCODE_SESSION_STATUS_CACHE_TTL: Duration = Duration::from_secs(1);
 
@@ -276,18 +301,19 @@ impl AppService {
         &self,
         targets: &[OpencodeSessionStatusProbeTarget],
     ) -> Result<HashMap<OpencodeSessionStatusProbeTarget, OpencodeSessionStatusMap>> {
-        let mut unique_targets = Vec::new();
-        let mut seen = HashSet::new();
-        for target in targets {
-            if seen.insert(target.clone()) {
-                unique_targets.push(target.clone());
-            }
-        }
+        let unique_targets = collect_unique_probe_targets(targets);
 
         if unique_targets.is_empty() {
             return Ok(HashMap::new());
         }
 
+        self.resolve_status_batch(unique_targets)
+    }
+
+    fn resolve_status_batch(
+        &self,
+        unique_targets: Vec<OpencodeSessionStatusProbeTarget>,
+    ) -> Result<HashMap<OpencodeSessionStatusProbeTarget, OpencodeSessionStatusMap>> {
         let worker_count = unique_targets.len().min(
             self.opencode_session_status_probe_limiter
                 .max_concurrent
@@ -314,8 +340,9 @@ impl AppService {
                             return Ok(());
                         };
 
-                        let statuses =
-                            service.load_cached_opencode_session_statuses_for_target(&target)?;
+                        let statuses = service
+                            .resolve_cached_probe_outcome(&target)?
+                            .into_result()?;
                         let mut results = results.lock().map_err(|_| {
                             anyhow!("OpenCode session status batch results lock poisoned")
                         })?;
@@ -342,22 +369,36 @@ impl AppService {
         &self,
         target: &OpencodeSessionStatusProbeTarget,
     ) -> Result<OpencodeSessionStatusMap> {
+        self.resolve_cached_probe_outcome(target)?.into_result()
+    }
+
+    fn resolve_cached_probe_outcome(
+        &self,
+        target: &OpencodeSessionStatusProbeTarget,
+    ) -> Result<CachedOpencodeSessionStatusProbeOutcome> {
         if let Some(cached) = self.cached_opencode_session_status_outcome(target)? {
-            return cached.into_result();
+            return Ok(cached);
         }
 
         let (flight, is_leader) = self.acquire_opencode_session_status_flight(target)?;
         if !is_leader {
-            let awaited = Self::wait_for_opencode_session_status_flight(&flight)?;
-            return awaited.into_result();
+            return Self::wait_for_opencode_session_status_flight(&flight);
         }
 
+        self.resolve_leader_probe_outcome(target, flight)
+    }
+
+    fn resolve_leader_probe_outcome(
+        &self,
+        target: &OpencodeSessionStatusProbeTarget,
+        flight: Arc<OpencodeSessionStatusFlight>,
+    ) -> Result<CachedOpencodeSessionStatusProbeOutcome> {
         let mut flight_guard = OpencodeSessionStatusFlightGuard::new(self, target, flight);
         let _permit = self.acquire_opencode_session_status_probe_permit()?;
         let outcome = Self::probe_uncached_opencode_session_status_target(target);
         self.update_opencode_session_status_cache(target, &outcome)?;
         flight_guard.complete(&outcome)?;
-        outcome.into_result()
+        Ok(outcome)
     }
 
     fn probe_uncached_opencode_session_status_target(
@@ -368,9 +409,9 @@ impl AppService {
             Err(error) if is_unreachable_opencode_session_status_error(&error) => {
                 CachedOpencodeSessionStatusProbeOutcome::Statuses(OpencodeSessionStatusMap::new())
             }
-            Err(error) => {
-                CachedOpencodeSessionStatusProbeOutcome::ActionableError(error.to_string())
-            }
+            Err(error) => CachedOpencodeSessionStatusProbeOutcome::ActionableError(
+                CachedOpencodeSessionStatusProbeError::ProbeFailed(error.to_string()),
+            ),
         }
     }
 
@@ -756,6 +797,40 @@ mod tests {
 
         assert!(first_error.to_string().contains("HTTP 500"));
         assert!(second_error.to_string().contains("HTTP 500"));
+        assert_eq!(connections.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_json_probe_failures_are_cached_inside_ttl() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let (port, connections, server_handle) =
+            spawn_counting_status_server(1, Duration::ZERO, Ok("{not-json}".to_string()))?;
+        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(port),
+            "/tmp/repo",
+        );
+
+        let first_error = service
+            .load_cached_opencode_session_statuses_for_target(&target)
+            .expect_err("parse failures should remain actionable");
+        let second_error = service
+            .load_cached_opencode_session_statuses_for_target(&target)
+            .expect_err("cached parse failures should remain actionable");
+        server_handle
+            .join()
+            .expect("status server thread should finish");
+
+        assert!(
+            first_error
+                .to_string()
+                .contains("Failed parsing OpenCode session status response")
+        );
+        assert!(
+            second_error
+                .to_string()
+                .contains("Failed parsing OpenCode session status response")
+        );
         assert_eq!(connections.load(Ordering::SeqCst), 1);
         Ok(())
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -434,20 +434,37 @@ impl AppService {
         flight: &Arc<OpencodeSessionStatusFlight>,
         outcome: &CachedOpencodeSessionStatusProbeOutcome,
     ) -> Result<()> {
-        {
-            let mut state = flight
-                .state
-                .lock()
-                .map_err(|_| anyhow!("OpenCode session status coordination state lock poisoned"))?;
-            *state = OpencodeSessionStatusFlightState::Finished(outcome.clone());
-        }
-        flight.condvar.notify_all();
+        let mut poisoned = false;
 
-        let mut flights = self
-            .opencode_session_status_flights
-            .lock()
-            .map_err(|_| anyhow!("OpenCode session status coordination registry lock poisoned"))?;
-        flights.remove(target);
+        {
+            let mut state = match flight.state.lock() {
+                Ok(state) => state,
+                Err(poisoned_state) => {
+                    poisoned = true;
+                    poisoned_state.into_inner()
+                }
+            };
+            *state = OpencodeSessionStatusFlightState::Finished(outcome.clone());
+            flight.condvar.notify_all();
+        }
+
+        {
+            let mut flights = match self.opencode_session_status_flights.lock() {
+                Ok(flights) => flights,
+                Err(poisoned_flights) => {
+                    poisoned = true;
+                    poisoned_flights.into_inner()
+                }
+            };
+            flights.remove(target);
+        }
+
+        if poisoned {
+            return Err(anyhow!(
+                "OpenCode session status coordination state lock poisoned"
+            ));
+        }
+
         Ok(())
     }
 
@@ -495,8 +512,10 @@ impl AppService {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppService, OpencodeSessionStatus, OpencodeSessionStatusProbeTarget,
-        has_live_opencode_session_status, load_opencode_session_statuses,
+        AppService, CachedOpencodeSessionStatusProbeOutcome, OpencodeSessionStatus,
+        OpencodeSessionStatusFlightGuard, OpencodeSessionStatusMap,
+        OpencodeSessionStatusProbeTarget, has_live_opencode_session_status,
+        load_opencode_session_statuses,
     };
     use crate::app_service::test_support::build_service_with_state;
     use anyhow::Result;
@@ -738,6 +757,78 @@ mod tests {
         assert!(first_error.to_string().contains("HTTP 500"));
         assert!(second_error.to_string().contains("HTTP 500"));
         assert_eq!(connections.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn session_status_flight_guard_finishes_waiters_when_dropped_uncompleted() -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(1234),
+            "/tmp/runtime-flight-guard",
+        );
+        let (flight, is_leader) = service.acquire_opencode_session_status_flight(&target)?;
+        assert!(is_leader);
+
+        {
+            let _guard = OpencodeSessionStatusFlightGuard::new(&service, &target, flight.clone());
+        }
+
+        let outcome = AppService::wait_for_opencode_session_status_flight(&flight)?;
+        let error = outcome
+            .into_result()
+            .expect_err("dropped leader should finish waiters with an error");
+        assert!(
+            error
+                .to_string()
+                .contains("OpenCode session status probe aborted unexpectedly")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn complete_opencode_session_status_flight_recovers_poisoned_state_and_removes_entry()
+    -> Result<()> {
+        let (service, _task_state, _git_state) = build_service_with_state(vec![]);
+        let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            &AgentRuntimeKind::Opencode.route_for_port(1235),
+            "/tmp/runtime-flight-poison",
+        );
+        let (flight, is_leader) = service.acquire_opencode_session_status_flight(&target)?;
+        assert!(is_leader);
+
+        let poison_handle = thread::spawn({
+            let flight = flight.clone();
+            move || {
+                let _lock = flight
+                    .state
+                    .lock()
+                    .expect("flight state should be available for poisoning");
+                panic!("poison session status flight state");
+            }
+        });
+        assert!(poison_handle.join().is_err());
+
+        let error = service
+            .complete_opencode_session_status_flight(
+                &target,
+                &flight,
+                &CachedOpencodeSessionStatusProbeOutcome::Statuses(OpencodeSessionStatusMap::new()),
+            )
+            .expect_err("poisoned completion should surface an error");
+        assert!(
+            error
+                .to_string()
+                .contains("OpenCode session status coordination state lock poisoned")
+        );
+
+        let flights = service
+            .opencode_session_status_flights
+            .lock()
+            .expect("status flights lock should remain available");
+        assert!(flights.is_empty());
+
         Ok(())
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -79,6 +79,50 @@ struct RunExposurePlan {
     probe_target: Option<super::OpencodeSessionStatusProbeTarget>,
 }
 
+impl RunExposurePlan {
+    fn without_probe(summary: RunSummary) -> Self {
+        Self {
+            summary,
+            external_session_ids: Vec::new(),
+            probe_target: None,
+        }
+    }
+
+    fn with_probe(
+        summary: RunSummary,
+        external_session_ids: Vec<String>,
+        probe_target: super::OpencodeSessionStatusProbeTarget,
+    ) -> Self {
+        Self {
+            summary,
+            external_session_ids,
+            probe_target: Some(probe_target),
+        }
+    }
+
+    fn is_visible(
+        &self,
+        statuses_by_target: &HashMap<
+            super::OpencodeSessionStatusProbeTarget,
+            super::OpencodeSessionStatusMap,
+        >,
+    ) -> Result<bool> {
+        let Some(probe_target) = self.probe_target.as_ref() else {
+            return Ok(true);
+        };
+
+        let statuses = statuses_by_target.get(probe_target).ok_or_else(|| {
+            anyhow!(
+                "Missing cached OpenCode session statuses for run {}",
+                self.summary.run_id
+            )
+        })?;
+        Ok(self.external_session_ids.iter().any(|external_session_id| {
+            super::has_live_opencode_session_status(statuses, external_session_id)
+        }))
+    }
+}
+
 struct RuntimeEnsureFlightGuard<'a> {
     service: &'a AppService,
     runtime_kind: AgentRuntimeKind,
@@ -340,39 +384,37 @@ impl AppService {
             .collect::<Vec<_>>();
         drop(runs);
 
+        let (exposure_plans, probe_targets) = self.build_run_exposure_plans(run_candidates)?;
+        let statuses_by_target =
+            self.load_cached_opencode_session_statuses_for_targets(&probe_targets)?;
+        let mut list = self.visible_run_summaries(exposure_plans, &statuses_by_target)?;
+
+        list.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        Ok(list)
+    }
+
+    fn build_run_exposure_plans(
+        &self,
+        run_candidates: Vec<RunExposureCandidate>,
+    ) -> Result<(
+        Vec<RunExposurePlan>,
+        Vec<super::OpencodeSessionStatusProbeTarget>,
+    )> {
         let mut sessions_by_repo_task = HashMap::new();
         let mut exposure_plans = Vec::with_capacity(run_candidates.len());
         let mut probe_targets = Vec::new();
 
         for run in run_candidates {
             if !run.requires_live_session_check() {
-                exposure_plans.push(RunExposurePlan {
-                    summary: run.summary,
-                    external_session_ids: Vec::new(),
-                    probe_target: None,
-                });
+                exposure_plans.push(RunExposurePlan::without_probe(run.summary));
                 continue;
             }
 
-            let session_cache_key = format!("{}::{}", run.repo_path, run.task_id);
-            if !sessions_by_repo_task.contains_key(session_cache_key.as_str()) {
-                let sessions =
-                    self.agent_sessions_list(run.repo_path.as_str(), run.task_id.as_str())?;
-                sessions_by_repo_task.insert(session_cache_key.clone(), sessions);
-            }
-            let sessions = sessions_by_repo_task
-                .get(session_cache_key.as_str())
-                .ok_or_else(|| {
-                    anyhow!("Missing cached agent sessions for {}", session_cache_key)
-                })?;
+            let sessions = self.sessions_for_run_candidate(&run, &mut sessions_by_repo_task)?;
             let external_session_ids = collect_build_external_session_ids_for_run(&run, sessions);
 
             if external_session_ids.is_empty() {
-                exposure_plans.push(RunExposurePlan {
-                    summary: run.summary,
-                    external_session_ids,
-                    probe_target: None,
-                });
+                exposure_plans.push(RunExposurePlan::without_probe(run.summary));
                 continue;
             }
 
@@ -381,36 +423,48 @@ impl AppService {
                 run.worktree_path.as_str(),
             );
             probe_targets.push(probe_target.clone());
-            exposure_plans.push(RunExposurePlan {
-                summary: run.summary,
+            exposure_plans.push(RunExposurePlan::with_probe(
+                run.summary,
                 external_session_ids,
-                probe_target: Some(probe_target),
-            });
+                probe_target,
+            ));
         }
 
-        let statuses_by_target =
-            self.load_cached_opencode_session_statuses_for_targets(&probe_targets)?;
+        Ok((exposure_plans, probe_targets))
+    }
+
+    fn sessions_for_run_candidate<'a>(
+        &self,
+        run: &RunExposureCandidate,
+        sessions_by_repo_task: &'a mut HashMap<String, Vec<host_domain::AgentSessionDocument>>,
+    ) -> Result<&'a [host_domain::AgentSessionDocument]> {
+        let session_cache_key = format!("{}::{}", run.repo_path, run.task_id);
+        if !sessions_by_repo_task.contains_key(session_cache_key.as_str()) {
+            let sessions =
+                self.agent_sessions_list(run.repo_path.as_str(), run.task_id.as_str())?;
+            sessions_by_repo_task.insert(session_cache_key.clone(), sessions);
+        }
+
+        sessions_by_repo_task
+            .get(session_cache_key.as_str())
+            .map(Vec::as_slice)
+            .ok_or_else(|| anyhow!("Missing cached agent sessions for {}", session_cache_key))
+    }
+
+    fn visible_run_summaries(
+        &self,
+        exposure_plans: Vec<RunExposurePlan>,
+        statuses_by_target: &HashMap<
+            super::OpencodeSessionStatusProbeTarget,
+            super::OpencodeSessionStatusMap,
+        >,
+    ) -> Result<Vec<RunSummary>> {
         let mut list = Vec::new();
         for plan in exposure_plans {
-            let Some(probe_target) = plan.probe_target.as_ref() else {
-                list.push(plan.summary);
-                continue;
-            };
-
-            let statuses = statuses_by_target.get(probe_target).ok_or_else(|| {
-                anyhow!(
-                    "Missing cached OpenCode session statuses for run {}",
-                    plan.summary.run_id
-                )
-            })?;
-            if plan.external_session_ids.iter().any(|external_session_id| {
-                super::has_live_opencode_session_status(statuses, external_session_id)
-            }) {
+            if plan.is_visible(statuses_by_target)? {
                 list.push(plan.summary);
             }
         }
-
-        list.sort_by(|a, b| b.started_at.cmp(&a.started_at));
         Ok(list)
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator.rs
@@ -2,7 +2,7 @@ mod registry;
 mod startup;
 
 use super::AppService;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use host_domain::{
     AgentRuntimeKind, RunState, RunSummary, RuntimeDescriptor, RuntimeInstanceSummary, RuntimeRole,
 };
@@ -42,6 +42,41 @@ pub(super) struct SpawnedRuntimeServer {
     port: u16,
     child: Child,
     opencode_process_guard: super::TrackedOpencodeProcessGuard,
+}
+
+#[derive(Clone)]
+struct RunExposureCandidate {
+    summary: RunSummary,
+    repo_path: String,
+    task_id: String,
+    worktree_path: String,
+}
+
+impl RunExposureCandidate {
+    fn from_run(run: &super::RunProcess) -> Self {
+        Self {
+            summary: run.summary.clone(),
+            repo_path: run.repo_path.clone(),
+            task_id: run.task_id.clone(),
+            worktree_path: run.worktree_path.clone(),
+        }
+    }
+
+    fn requires_live_session_check(&self) -> bool {
+        matches!(
+            self.summary.state,
+            RunState::Starting
+                | RunState::Running
+                | RunState::Blocked
+                | RunState::AwaitingDoneConfirmation
+        )
+    }
+}
+
+struct RunExposurePlan {
+    summary: RunSummary,
+    external_session_ids: Vec<String>,
+    probe_target: Option<super::OpencodeSessionStatusProbeTarget>,
 }
 
 struct RuntimeEnsureFlightGuard<'a> {
@@ -289,10 +324,7 @@ impl AppService {
             .runs
             .lock()
             .map_err(|_| anyhow!("Run state lock poisoned"))?;
-        let mut runtime_statuses_by_worktree = HashMap::new();
-        let mut sessions_by_repo_task = HashMap::new();
-
-        let mut list = runs
+        let run_candidates = runs
             .values()
             .filter(|run| {
                 if let Some(path_key) = repo_key_filter.as_deref() {
@@ -304,18 +336,79 @@ impl AppService {
                     true
                 }
             })
-            .filter_map(|run| {
-                match self.should_expose_run(
-                    run,
-                    &mut runtime_statuses_by_worktree,
-                    &mut sessions_by_repo_task,
-                ) {
-                    Ok(true) => Some(Ok(run.summary.clone())),
-                    Ok(false) => None,
-                    Err(error) => Some(Err(error)),
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
+            .map(RunExposureCandidate::from_run)
+            .collect::<Vec<_>>();
+        drop(runs);
+
+        let mut sessions_by_repo_task = HashMap::new();
+        let mut exposure_plans = Vec::with_capacity(run_candidates.len());
+        let mut probe_targets = Vec::new();
+
+        for run in run_candidates {
+            if !run.requires_live_session_check() {
+                exposure_plans.push(RunExposurePlan {
+                    summary: run.summary,
+                    external_session_ids: Vec::new(),
+                    probe_target: None,
+                });
+                continue;
+            }
+
+            let session_cache_key = format!("{}::{}", run.repo_path, run.task_id);
+            if !sessions_by_repo_task.contains_key(session_cache_key.as_str()) {
+                let sessions =
+                    self.agent_sessions_list(run.repo_path.as_str(), run.task_id.as_str())?;
+                sessions_by_repo_task.insert(session_cache_key.clone(), sessions);
+            }
+            let sessions = sessions_by_repo_task
+                .get(session_cache_key.as_str())
+                .ok_or_else(|| {
+                    anyhow!("Missing cached agent sessions for {}", session_cache_key)
+                })?;
+            let external_session_ids = collect_build_external_session_ids_for_run(&run, sessions);
+
+            if external_session_ids.is_empty() {
+                exposure_plans.push(RunExposurePlan {
+                    summary: run.summary,
+                    external_session_ids,
+                    probe_target: None,
+                });
+                continue;
+            }
+
+            let probe_target = super::OpencodeSessionStatusProbeTarget::for_runtime_route(
+                &run.summary.runtime_route,
+                run.worktree_path.as_str(),
+            );
+            probe_targets.push(probe_target.clone());
+            exposure_plans.push(RunExposurePlan {
+                summary: run.summary,
+                external_session_ids,
+                probe_target: Some(probe_target),
+            });
+        }
+
+        let statuses_by_target =
+            self.load_cached_opencode_session_statuses_for_targets(&probe_targets)?;
+        let mut list = Vec::new();
+        for plan in exposure_plans {
+            let Some(probe_target) = plan.probe_target.as_ref() else {
+                list.push(plan.summary);
+                continue;
+            };
+
+            let statuses = statuses_by_target.get(probe_target).ok_or_else(|| {
+                anyhow!(
+                    "Missing cached OpenCode session statuses for run {}",
+                    plan.summary.run_id
+                )
+            })?;
+            if plan.external_session_ids.iter().any(|external_session_id| {
+                super::has_live_opencode_session_status(statuses, external_session_id)
+            }) {
+                list.push(plan.summary);
+            }
+        }
 
         list.sort_by(|a, b| b.started_at.cmp(&a.started_at));
         Ok(list)
@@ -404,100 +497,43 @@ impl AppService {
             other => Err(anyhow!("Unsupported agent runtime kind: {other}")),
         }
     }
+}
 
-    fn should_expose_run(
-        &self,
-        run: &super::RunProcess,
-        runtime_statuses_by_worktree: &mut HashMap<String, super::OpencodeSessionStatusMap>,
-        sessions_by_repo_task: &mut HashMap<String, Vec<host_domain::AgentSessionDocument>>,
-    ) -> Result<bool> {
-        if !matches!(
-            run.summary.state,
-            RunState::Starting
-                | RunState::Running
-                | RunState::Blocked
-                | RunState::AwaitingDoneConfirmation
-        ) {
-            return Ok(true);
-        }
-
-        let session_cache_key = format!("{}::{}", run.repo_path, run.task_id);
-        if !sessions_by_repo_task.contains_key(session_cache_key.as_str()) {
-            let sessions =
-                self.agent_sessions_list(run.repo_path.as_str(), run.task_id.as_str())?;
-            sessions_by_repo_task.insert(session_cache_key.clone(), sessions);
-        }
-        let sessions = sessions_by_repo_task
-            .get(session_cache_key.as_str())
-            .ok_or_else(|| anyhow!("Missing cached agent sessions for {}", session_cache_key))?;
-        let external_session_ids = sessions
-            .iter()
-            .filter(|session| session.role.trim() == "build")
-            .filter(|session| session.runtime_kind.trim() == run.summary.runtime_kind.as_str())
-            .filter(|session| {
-                super::task_workflow::normalize_path_for_comparison(
-                    session.working_directory.as_str(),
-                ) == super::task_workflow::normalize_path_for_comparison(run.worktree_path.as_str())
-            })
-            .filter_map(|session| {
-                session
-                    .external_session_id
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                    .map(str::to_string)
-            })
-            .collect::<Vec<_>>();
-
-        if external_session_ids.is_empty() {
-            return Ok(true);
-        }
-
-        let worktree_key = super::task_workflow::normalize_path_key(run.worktree_path.as_str());
-        if !runtime_statuses_by_worktree.contains_key(worktree_key.as_str()) {
-            let statuses = match run.summary.runtime_kind {
-                AgentRuntimeKind::Opencode => {
-                    match super::load_opencode_session_statuses(
-                        &run.summary.runtime_route,
-                        run.worktree_path.as_str(),
-                    ) {
-                        Ok(statuses) => statuses,
-                        Err(error)
-                            if super::is_unreachable_opencode_session_status_error(&error) =>
-                        {
-                            super::OpencodeSessionStatusMap::new()
-                        }
-                        Err(error) => return Err(error),
-                    }
-                }
-            };
-            runtime_statuses_by_worktree.insert(worktree_key.clone(), statuses);
-        }
-        let statuses = runtime_statuses_by_worktree
-            .get(worktree_key.as_str())
-            .ok_or_else(|| {
-                anyhow!(
-                    "Missing cached OpenCode session statuses for {}",
-                    worktree_key
-                )
-            })?;
-        Ok(external_session_ids.iter().any(|external_session_id| {
-            super::has_live_opencode_session_status(statuses, external_session_id)
-        }))
-    }
+fn collect_build_external_session_ids_for_run(
+    run: &RunExposureCandidate,
+    sessions: &[host_domain::AgentSessionDocument],
+) -> Vec<String> {
+    sessions
+        .iter()
+        .filter(|session| session.role.trim() == "build")
+        .filter(|session| session.runtime_kind.trim() == run.summary.runtime_kind.as_str())
+        .filter(|session| {
+            super::task_workflow::normalize_path_for_comparison(session.working_directory.as_str())
+                == super::task_workflow::normalize_path_for_comparison(run.worktree_path.as_str())
+        })
+        .filter_map(|session| {
+            session
+                .external_session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::{AppService, RuntimeEnsureFlightGuard};
-    use crate::app_service::test_support::{build_service_with_state, make_task};
     use crate::app_service::RunProcess;
-    use anyhow::{anyhow, Result};
+    use crate::app_service::test_support::{build_service_with_state, make_task};
+    use anyhow::{Result, anyhow};
     use host_domain::{AgentRuntimeKind, AgentSessionDocument, RunSummary, TaskStatus};
     use host_infra_system::RepoConfig;
     use std::io::{Read, Write};
     use std::net::TcpListener;
     use std::thread;
+    use std::time::{Duration, Instant};
 
     fn spawn_opencode_session_status_server(
         response_body: &'static str,
@@ -513,6 +549,31 @@ mod tests {
             if let Ok((mut stream, _)) = listener.accept() {
                 let mut request_buffer = [0_u8; 4096];
                 let _ = stream.read(&mut request_buffer);
+                let _ = stream.write_all(response.as_bytes());
+                let _ = stream.flush();
+            }
+        });
+        Ok((port, handle))
+    }
+
+    fn spawn_delayed_opencode_session_status_server(
+        response_body: String,
+        delay: Duration,
+    ) -> Result<(u16, std::thread::JoinHandle<()>)> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        let handle = std::thread::spawn(move || {
+            if let Ok((mut stream, _)) = listener.accept() {
+                let mut request_buffer = [0_u8; 4096];
+                let _ = stream.read(&mut request_buffer);
+                if !delay.is_zero() {
+                    std::thread::sleep(delay);
+                }
                 let _ = stream.write_all(response.as_bytes());
                 let _ = stream.flush();
             }
@@ -539,9 +600,11 @@ mod tests {
 
         let error = AppService::wait_for_runtime_ensure_flight(&flight)
             .expect_err("dropped leader should finish waiters with an error");
-        assert!(error
-            .to_string()
-            .contains("Runtime ensure aborted unexpectedly"));
+        assert!(
+            error
+                .to_string()
+                .contains("Runtime ensure aborted unexpectedly")
+        );
 
         Ok(())
     }
@@ -574,9 +637,11 @@ mod tests {
                 &Err(anyhow!("simulated startup failure")),
             )
             .expect_err("poisoned completion should surface an error");
-        assert!(error
-            .to_string()
-            .contains("Runtime ensure coordination state lock poisoned"));
+        assert!(
+            error
+                .to_string()
+                .contains("Runtime ensure coordination state lock poisoned")
+        );
 
         let flights = service
             .runtime_ensure_flights
@@ -719,6 +784,93 @@ mod tests {
     }
 
     #[test]
+    fn module_runs_list_batches_unique_slow_status_probes() -> Result<()> {
+        let tasks = (0..6)
+            .map(|index| {
+                make_task(
+                    format!("task-{index}").as_str(),
+                    "task",
+                    TaskStatus::InProgress,
+                )
+            })
+            .collect::<Vec<_>>();
+        let (service, task_state, _git_state) = build_service_with_state(tasks);
+        let mut server_handles = Vec::new();
+        let mut sessions = Vec::new();
+
+        for index in 0..6 {
+            let (port, server_handle) = spawn_delayed_opencode_session_status_server(
+                format!(r#"{{"external-build-session-{index}":{{"type":"busy"}}}}"#),
+                Duration::from_millis(300),
+            )?;
+            server_handles.push(server_handle);
+            sessions.push(AgentSessionDocument {
+                session_id: format!("build-session-{index}"),
+                external_session_id: Some(format!("external-build-session-{index}")),
+                role: "build".to_string(),
+                scenario: "build_implementation_start".to_string(),
+                started_at: "2026-03-17T11:00:00Z".to_string(),
+                runtime_kind: "opencode".to_string(),
+                working_directory: format!("/tmp/repo/worktree-{index}"),
+                selected_model: None,
+            });
+
+            service
+                .runs
+                .lock()
+                .expect("run state lock poisoned")
+                .insert(
+                    format!("run-{index}"),
+                    RunProcess {
+                        summary: RunSummary {
+                            run_id: format!("run-{index}"),
+                            runtime_kind: AgentRuntimeKind::Opencode,
+                            runtime_route: host_domain::RuntimeRoute::LocalHttp {
+                                endpoint: format!("http://127.0.0.1:{port}"),
+                            },
+                            repo_path: "/tmp/repo".to_string(),
+                            task_id: format!("task-{index}"),
+                            branch: format!("odt/task-{index}"),
+                            worktree_path: format!("/tmp/repo/worktree-{index}"),
+                            port,
+                            state: host_domain::RunState::Running,
+                            last_message: None,
+                            started_at: format!("2026-03-17T11:00:0{index}Z"),
+                        },
+                        child: None,
+                        _opencode_process_guard: None,
+                        repo_path: "/tmp/repo".to_string(),
+                        task_id: format!("task-{index}"),
+                        worktree_path: format!("/tmp/repo/worktree-{index}"),
+                        repo_config: RepoConfig::default(),
+                    },
+                );
+        }
+
+        task_state
+            .lock()
+            .expect("task store lock poisoned")
+            .agent_sessions = sessions;
+
+        let started_at = Instant::now();
+        let runs = service.runs_list(Some("/tmp/repo"))?;
+        let elapsed = started_at.elapsed();
+
+        for server_handle in server_handles {
+            server_handle
+                .join()
+                .expect("status server thread should finish");
+        }
+
+        assert_eq!(runs.len(), 6);
+        assert!(
+            elapsed < Duration::from_millis(1200),
+            "expected bounded parallel latency, observed {elapsed:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn module_runtime_stop_reports_missing_runtime() {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
 
@@ -726,9 +878,11 @@ mod tests {
             .runtime_stop("missing-runtime")
             .expect_err("stopping unknown runtime should fail");
 
-        assert!(error
-            .to_string()
-            .contains("Runtime not found: missing-runtime"));
+        assert!(
+            error
+                .to_string()
+                .contains("Runtime not found: missing-runtime")
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/cleanup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/cleanup.rs
@@ -1,7 +1,7 @@
 use super::super::super::{
-    terminate_child_process, AgentRuntimeProcess, AppService, RuntimeCleanupTarget,
+    AgentRuntimeProcess, AppService, RuntimeCleanupTarget, terminate_child_process,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::process::Child;
 
 impl AppService {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/lifecycle.rs
@@ -1,9 +1,9 @@
 use super::super::super::{
-    terminate_child_process, AgentRuntimeProcess, AppService, RuntimeCleanupTarget,
+    AgentRuntimeProcess, AppService, RuntimeCleanupTarget, terminate_child_process,
 };
 use super::super::{RuntimePostStartPolicy, RuntimeStartInput, SpawnedRuntimeServer};
-use anyhow::{anyhow, Result};
-use host_domain::{now_rfc3339, RuntimeInstanceSummary};
+use anyhow::{Result, anyhow};
+use host_domain::{RuntimeInstanceSummary, now_rfc3339};
 use std::collections::HashMap;
 use std::process::Child;
 use std::sync::MutexGuard;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/query.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/query.rs
@@ -1,6 +1,6 @@
 use super::super::super::{AgentRuntimeProcess, AppService};
 use super::super::RuntimeExistingLookup;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use host_domain::RuntimeInstanceSummary;
 use std::collections::{HashMap, HashSet};
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
@@ -1,10 +1,10 @@
 use super::super::{
-    spawn_opencode_server, wait_for_local_server_with_process, AppService,
-    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupEventContext,
-    StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
+    AppService, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
+    STARTUP_CONFIG_INVALID_REASON, StartupEventContext, StartupEventCorrelation,
+    StartupEventPayload, spawn_opencode_server, wait_for_local_server_with_process,
 };
 use super::{RuntimeStartInput, SpawnedRuntimeServer};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use host_domain::{RuntimeRole, TASK_METADATA_NAMESPACE};
 use host_infra_system::pick_free_port;
 use std::path::Path;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
@@ -25,6 +25,41 @@ impl RuntimeEnsureFlight {
     }
 }
 
+pub(super) struct OpencodeSessionStatusFlight {
+    pub(super) state: Mutex<OpencodeSessionStatusFlightState>,
+    pub(super) condvar: Condvar,
+}
+
+pub(super) enum OpencodeSessionStatusFlightState {
+    Loading,
+    Finished(CachedOpencodeSessionStatusProbeOutcome),
+}
+
+impl OpencodeSessionStatusFlight {
+    pub(super) fn new() -> Self {
+        Self {
+            state: Mutex::new(OpencodeSessionStatusFlightState::Loading),
+            condvar: Condvar::new(),
+        }
+    }
+}
+
+pub(super) struct OpencodeSessionStatusProbeLimiter {
+    pub(super) active: Mutex<usize>,
+    pub(super) condvar: Condvar,
+    pub(super) max_concurrent: usize,
+}
+
+impl OpencodeSessionStatusProbeLimiter {
+    pub(super) fn new(max_concurrent: usize) -> Self {
+        Self {
+            active: Mutex::new(0),
+            condvar: Condvar::new(),
+            max_concurrent,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct AppService {
     pub(super) task_store: Arc<dyn TaskStore>,
@@ -35,6 +70,11 @@ pub struct AppService {
     pub(super) agent_runtimes: Arc<Mutex<HashMap<String, AgentRuntimeProcess>>>,
     pub(super) tracked_opencode_processes: Arc<Mutex<HashMap<u32, usize>>>,
     pub(super) runtime_ensure_flights: Arc<Mutex<HashMap<String, Arc<RuntimeEnsureFlight>>>>,
+    pub(super) opencode_session_status_cache:
+        Arc<Mutex<HashMap<OpencodeSessionStatusProbeTarget, CachedOpencodeSessionStatusProbe>>>,
+    pub(super) opencode_session_status_flights:
+        Arc<Mutex<HashMap<OpencodeSessionStatusProbeTarget, Arc<OpencodeSessionStatusFlight>>>>,
+    pub(super) opencode_session_status_probe_limiter: Arc<OpencodeSessionStatusProbeLimiter>,
     pub(super) opencode_process_registry_path: PathBuf,
     pub(super) instance_pid: u32,
     pub(super) initialized_repos: Arc<Mutex<HashSet<String>>>,
@@ -72,6 +112,17 @@ pub(crate) struct RuntimeCleanupTarget {
 pub(crate) struct CachedRuntimeCheck {
     pub(super) checked_at: Instant,
     pub(super) value: RuntimeCheck,
+}
+
+pub(crate) struct CachedOpencodeSessionStatusProbe {
+    pub(super) checked_at: Instant,
+    pub(super) outcome: CachedOpencodeSessionStatusProbeOutcome,
+}
+
+#[derive(Clone)]
+pub(crate) enum CachedOpencodeSessionStatusProbeOutcome {
+    Statuses(OpencodeSessionStatusMap),
+    ActionableError(String),
 }
 
 pub(crate) struct DevServerGroupRuntime {
@@ -119,6 +170,11 @@ impl AppService {
             agent_runtimes: Arc::new(Mutex::new(HashMap::new())),
             tracked_opencode_processes: Arc::new(Mutex::new(HashMap::new())),
             runtime_ensure_flights: Arc::new(Mutex::new(HashMap::new())),
+            opencode_session_status_cache: Arc::new(Mutex::new(HashMap::new())),
+            opencode_session_status_flights: Arc::new(Mutex::new(HashMap::new())),
+            opencode_session_status_probe_limiter: Arc::new(
+                OpencodeSessionStatusProbeLimiter::new(4),
+            ),
             opencode_process_registry_path,
             instance_pid,
             initialized_repos: Arc::new(Mutex::new(HashSet::new())),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/service_core.rs
@@ -122,7 +122,13 @@ pub(crate) struct CachedOpencodeSessionStatusProbe {
 #[derive(Clone)]
 pub(crate) enum CachedOpencodeSessionStatusProbeOutcome {
     Statuses(OpencodeSessionStatusMap),
-    ActionableError(String),
+    ActionableError(CachedOpencodeSessionStatusProbeError),
+}
+
+#[derive(Clone)]
+pub(crate) enum CachedOpencodeSessionStatusProbeError {
+    ProbeFailed(String),
+    ProbeAborted,
 }
 
 pub(crate) struct DevServerGroupRuntime {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/mod.rs
@@ -17,4 +17,4 @@ mod task_context;
 mod task_deletion_service;
 mod task_service;
 
-pub(crate) use cleanup_plans::{normalize_path_for_comparison, normalize_path_key};
+pub(crate) use cleanup_plans::normalize_path_for_comparison;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard.rs
@@ -1,9 +1,8 @@
 use super::cleanup_plans::{normalize_path_for_comparison, normalize_path_key};
 use crate::app_service::{
-    has_live_opencode_session_status, is_unreachable_opencode_session_status_error,
-    load_opencode_session_statuses, service_core::AppService, OpencodeSessionStatusMap,
+    OpencodeSessionStatusProbeTarget, has_live_opencode_session_status, service_core::AppService,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use host_domain::{AgentRuntimeKind, AgentSessionDocument, RunState, RuntimeRole, RuntimeRoute};
 use std::collections::{HashMap, HashSet};
 
@@ -120,29 +119,36 @@ impl<'a> TaskActivityGuard<'a> {
                 worktree_path: run.worktree_path.clone(),
             })
             .collect::<Vec<_>>();
-        let mut runtime_statuses_by_directory = HashMap::<String, OpencodeSessionStatusMap>::new();
         let mut runtime_routes_by_worktree = HashMap::new();
-        let mut has_active_run = false;
+        let mut run_probe_plans = Vec::new();
+        let mut primary_probe_targets = Vec::new();
+
         for run_candidate in &candidate_runs {
             runtime_routes_by_worktree.insert(
                 normalize_path_key(run_candidate.worktree_path.as_str()),
                 run_candidate.runtime_route.clone(),
             );
 
-            if !is_live_build_run_for_task(
-                run_candidate,
-                sessions,
-                &mut runtime_statuses_by_directory,
-            )? {
-                continue;
-            }
-
-            has_active_run = true;
-            break;
+            let external_session_ids = collect_build_external_session_ids(run_candidate, sessions);
+            let primary_target = if external_session_ids.is_empty() {
+                None
+            } else {
+                let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+                    &run_candidate.runtime_route,
+                    run_candidate.worktree_path.as_str(),
+                );
+                primary_probe_targets.push(target.clone());
+                Some(target)
+            };
+            run_probe_plans.push(RunProbePlan {
+                worktree_path: run_candidate.worktree_path.clone(),
+                external_session_ids,
+                primary_target,
+            });
         }
-        let repo_runtime_routes_by_kind = self.collect_repo_runtime_routes_by_kind(repo_path)?;
 
-        let mut active_roles = HashSet::new();
+        let repo_runtime_routes_by_kind = self.collect_repo_runtime_routes_by_kind(repo_path)?;
+        let mut session_probe_plans = Vec::new();
         for session in sessions
             .iter()
             .filter(|session| matches!(session.role.as_str(), "build" | "qa"))
@@ -165,46 +171,127 @@ impl<'a> TaskActivityGuard<'a> {
             let Some(runtime_route) = runtime_route else {
                 continue;
             };
-            if !runtime_statuses_by_directory.contains_key(worktree_key.as_str()) {
-                let mut statuses =
-                    load_session_statuses(runtime_route, session.working_directory.as_str())?;
 
-                if statuses.is_empty() {
-                    if let (Some(primary_route), Some(fallback_route)) =
-                        (worktree_runtime_route, repo_runtime_route)
-                    {
-                        let primary_endpoint = runtime_route_endpoint(primary_route);
-                        let fallback_endpoint = runtime_route_endpoint(fallback_route);
-                        if primary_endpoint != fallback_endpoint {
-                            let fallback_statuses = load_session_statuses(
-                                fallback_route,
-                                session.working_directory.as_str(),
-                            )?;
-                            if !fallback_statuses.is_empty() {
-                                statuses = fallback_statuses;
-                            }
-                        }
-                    }
+            let primary_target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+                runtime_route,
+                session.working_directory.as_str(),
+            );
+            primary_probe_targets.push(primary_target.clone());
+
+            let fallback_target = if let (Some(primary_route), Some(fallback_route)) =
+                (worktree_runtime_route, repo_runtime_route)
+            {
+                let primary_endpoint = runtime_route_endpoint(primary_route);
+                let fallback_endpoint = runtime_route_endpoint(fallback_route);
+                if primary_endpoint != fallback_endpoint {
+                    Some(OpencodeSessionStatusProbeTarget::for_runtime_route(
+                        fallback_route,
+                        session.working_directory.as_str(),
+                    ))
+                } else {
+                    None
                 }
+            } else {
+                None
+            };
 
-                if !statuses.is_empty() {
-                    runtime_statuses_by_directory.insert(worktree_key.clone(), statuses);
-                }
-            }
+            session_probe_plans.push(SessionProbePlan {
+                worktree_key,
+                role: session.role.clone(),
+                external_session_id: external_session_id.to_string(),
+                primary_target,
+                fallback_target,
+            });
+        }
 
-            if runtime_statuses_by_directory
-                .get(worktree_key.as_str())
-                .is_some_and(|statuses| {
+        let primary_statuses_by_target = self
+            .service
+            .load_cached_opencode_session_statuses_for_targets(&primary_probe_targets)?;
+
+        let mut has_active_run = false;
+        for run_probe_plan in &run_probe_plans {
+            let Some(primary_target) = run_probe_plan.primary_target.as_ref() else {
+                has_active_run = true;
+                break;
+            };
+
+            let statuses = primary_statuses_by_target
+                .get(primary_target)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Missing cached OpenCode session statuses for {}",
+                        run_probe_plan.worktree_path
+                    )
+                })?;
+            if run_probe_plan
+                .external_session_ids
+                .iter()
+                .any(|external_session_id| {
                     has_live_opencode_session_status(statuses, external_session_id)
                 })
             {
-                active_roles.insert(session.role.as_str());
+                has_active_run = true;
+                break;
             }
         }
-        let mut active_session_roles = active_roles
-            .into_iter()
-            .map(ToOwned::to_owned)
+
+        let fallback_probe_targets = session_probe_plans
+            .iter()
+            .filter_map(|session_probe_plan| {
+                let primary_statuses =
+                    primary_statuses_by_target.get(&session_probe_plan.primary_target)?;
+                if primary_statuses.is_empty() {
+                    session_probe_plan.fallback_target.clone()
+                } else {
+                    None
+                }
+            })
             .collect::<Vec<_>>();
+        let fallback_statuses_by_target = self
+            .service
+            .load_cached_opencode_session_statuses_for_targets(&fallback_probe_targets)?;
+
+        let mut active_roles = HashSet::new();
+        for session_probe_plan in session_probe_plans {
+            let primary_statuses = primary_statuses_by_target
+                .get(&session_probe_plan.primary_target)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Missing cached OpenCode session statuses for {}",
+                        session_probe_plan.worktree_key
+                    )
+                })?;
+            let statuses = if primary_statuses.is_empty() {
+                if let Some(fallback_target) = session_probe_plan.fallback_target.as_ref() {
+                    let fallback_statuses = fallback_statuses_by_target
+                        .get(fallback_target)
+                        .ok_or_else(|| {
+                            anyhow!(
+                                "Missing cached OpenCode session fallback statuses for {}",
+                                session_probe_plan.worktree_key
+                            )
+                        })?;
+                    if fallback_statuses.is_empty() {
+                        primary_statuses
+                    } else {
+                        fallback_statuses
+                    }
+                } else {
+                    primary_statuses
+                }
+            } else {
+                primary_statuses
+            };
+
+            if has_live_opencode_session_status(
+                statuses,
+                session_probe_plan.external_session_id.as_str(),
+            ) {
+                active_roles.insert(session_probe_plan.role);
+            }
+        }
+
+        let mut active_session_roles = active_roles.into_iter().collect::<Vec<_>>();
         active_session_roles.sort_unstable();
 
         Ok(TaskActiveWorkEvidence {
@@ -283,26 +370,12 @@ fn runtime_route_endpoint(route: &RuntimeRoute) -> &str {
     }
 }
 
-fn load_session_statuses(
-    route: &RuntimeRoute,
-    working_directory: &str,
-) -> Result<OpencodeSessionStatusMap> {
-    load_opencode_session_statuses(route, working_directory).or_else(|error| {
-        if is_unreachable_opencode_session_status_error(&error) {
-            Ok(OpencodeSessionStatusMap::new())
-        } else {
-            Err(error)
-        }
-    })
-}
-
-fn is_live_build_run_for_task(
+fn collect_build_external_session_ids(
     run_summary: &RunProbeCandidate,
     sessions: &[AgentSessionDocument],
-    runtime_statuses_by_directory: &mut HashMap<String, OpencodeSessionStatusMap>,
-) -> Result<bool> {
+) -> Vec<String> {
     let normalized_worktree = normalize_path_for_comparison(run_summary.worktree_path.as_str());
-    let external_session_ids = sessions
+    sessions
         .iter()
         .filter(|session| session.role.trim() == "build")
         .filter(|session| session.runtime_kind.trim() == run_summary.runtime_kind.as_str())
@@ -317,35 +390,7 @@ fn is_live_build_run_for_task(
                 .filter(|value| !value.is_empty())
                 .map(str::to_string)
         })
-        .collect::<Vec<_>>();
-
-    if external_session_ids.is_empty() {
-        return Ok(true);
-    }
-
-    let directory_key = normalize_path_key(run_summary.worktree_path.as_str());
-    if !runtime_statuses_by_directory.contains_key(directory_key.as_str()) {
-        let statuses = load_session_statuses(
-            &run_summary.runtime_route,
-            run_summary.worktree_path.as_str(),
-        )?;
-        if statuses.is_empty() {
-            return Ok(false);
-        }
-        runtime_statuses_by_directory.insert(directory_key.clone(), statuses);
-    }
-
-    let statuses = runtime_statuses_by_directory
-        .get(directory_key.as_str())
-        .ok_or_else(|| {
-            anyhow!(
-                "Missing cached OpenCode session statuses for {}",
-                run_summary.worktree_path
-            )
-        })?;
-    Ok(external_session_ids
-        .iter()
-        .any(|external_session_id| has_live_opencode_session_status(statuses, external_session_id)))
+        .collect()
 }
 
 #[derive(Clone)]
@@ -353,4 +398,18 @@ struct RunProbeCandidate {
     runtime_kind: AgentRuntimeKind,
     runtime_route: RuntimeRoute,
     worktree_path: String,
+}
+
+struct RunProbePlan {
+    worktree_path: String,
+    external_session_ids: Vec<String>,
+    primary_target: Option<OpencodeSessionStatusProbeTarget>,
+}
+
+struct SessionProbePlan {
+    worktree_key: String,
+    role: String,
+    external_session_id: String,
+    primary_target: OpencodeSessionStatusProbeTarget,
+    fallback_target: Option<OpencodeSessionStatusProbeTarget>,
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard.rs
@@ -1,10 +1,12 @@
 use super::cleanup_plans::{normalize_path_for_comparison, normalize_path_key};
 use crate::app_service::{
-    OpencodeSessionStatusProbeTarget, has_live_opencode_session_status, service_core::AppService,
+    OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget, has_live_opencode_session_status,
+    service_core::AppService,
 };
 use anyhow::{Context, Result, anyhow};
 use host_domain::{AgentRuntimeKind, AgentSessionDocument, RunState, RuntimeRole, RuntimeRoute};
 use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 pub(super) struct TaskActivityGuard<'a> {
     service: &'a AppService,
@@ -96,7 +98,44 @@ impl<'a> TaskActivityGuard<'a> {
         sessions: &[AgentSessionDocument],
     ) -> Result<TaskActiveWorkEvidence> {
         let normalized_repo = normalize_path_for_comparison(repo_path);
-        let candidate_runs = self
+        let candidate_runs = self.collect_candidate_runs(&normalized_repo, task_id)?;
+        let runtime_routes_by_worktree = collect_runtime_routes_by_worktree(&candidate_runs);
+        let repo_runtime_routes_by_kind = self.collect_repo_runtime_routes_by_kind(repo_path)?;
+        let probe_plan = self.build_probe_plan(
+            &candidate_runs,
+            sessions,
+            &runtime_routes_by_worktree,
+            &repo_runtime_routes_by_kind,
+        );
+
+        let primary_statuses_by_target = self
+            .service
+            .load_cached_opencode_session_statuses_for_targets(&probe_plan.primary_probe_targets)?;
+        let has_active_run =
+            self.evaluate_run_activity(&probe_plan.run_plans, &primary_statuses_by_target)?;
+
+        let fallback_probe_targets = probe_plan.fallback_probe_targets(&primary_statuses_by_target);
+        let fallback_statuses_by_target = self
+            .service
+            .load_cached_opencode_session_statuses_for_targets(&fallback_probe_targets)?;
+        let active_session_roles = self.collect_active_session_roles(
+            &probe_plan.session_plans,
+            &primary_statuses_by_target,
+            &fallback_statuses_by_target,
+        )?;
+
+        Ok(TaskActiveWorkEvidence {
+            has_active_run,
+            active_session_roles,
+        })
+    }
+
+    fn collect_candidate_runs(
+        &self,
+        normalized_repo: &Path,
+        task_id: &str,
+    ) -> Result<Vec<RunProbeCandidate>> {
+        Ok(self
             .service
             .runs
             .lock()
@@ -118,101 +157,43 @@ impl<'a> TaskActivityGuard<'a> {
                 runtime_route: run.summary.runtime_route.clone(),
                 worktree_path: run.worktree_path.clone(),
             })
-            .collect::<Vec<_>>();
-        let mut runtime_routes_by_worktree = HashMap::new();
-        let mut run_probe_plans = Vec::new();
+            .collect())
+    }
+
+    fn build_probe_plan(
+        &self,
+        candidate_runs: &[RunProbeCandidate],
+        sessions: &[AgentSessionDocument],
+        runtime_routes_by_worktree: &HashMap<String, RuntimeRoute>,
+        repo_runtime_routes_by_kind: &HashMap<AgentRuntimeKind, RuntimeRoute>,
+    ) -> TaskActivityProbePlan {
         let mut primary_probe_targets = Vec::new();
+        let run_plans = build_run_probe_plans(candidate_runs, sessions, &mut primary_probe_targets);
+        let session_plans = build_session_probe_plans(
+            sessions,
+            runtime_routes_by_worktree,
+            repo_runtime_routes_by_kind,
+            &mut primary_probe_targets,
+        );
 
-        for run_candidate in &candidate_runs {
-            runtime_routes_by_worktree.insert(
-                normalize_path_key(run_candidate.worktree_path.as_str()),
-                run_candidate.runtime_route.clone(),
-            );
-
-            let external_session_ids = collect_build_external_session_ids(run_candidate, sessions);
-            let primary_target = if external_session_ids.is_empty() {
-                None
-            } else {
-                let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-                    &run_candidate.runtime_route,
-                    run_candidate.worktree_path.as_str(),
-                );
-                primary_probe_targets.push(target.clone());
-                Some(target)
-            };
-            run_probe_plans.push(RunProbePlan {
-                worktree_path: run_candidate.worktree_path.clone(),
-                external_session_ids,
-                primary_target,
-            });
+        TaskActivityProbePlan {
+            run_plans,
+            session_plans,
+            primary_probe_targets,
         }
+    }
 
-        let repo_runtime_routes_by_kind = self.collect_repo_runtime_routes_by_kind(repo_path)?;
-        let mut session_probe_plans = Vec::new();
-        for session in sessions
-            .iter()
-            .filter(|session| matches!(session.role.as_str(), "build" | "qa"))
-        {
-            let external_session_id = session
-                .external_session_id
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty());
-            let Some(external_session_id) = external_session_id else {
-                continue;
-            };
-
-            let worktree_key = normalize_path_key(session.working_directory.as_str());
-            let fallback_runtime_kind = parse_runtime_kind(session.runtime_kind.as_str());
-            let worktree_runtime_route = runtime_routes_by_worktree.get(worktree_key.as_str());
-            let repo_runtime_route =
-                fallback_runtime_kind.and_then(|kind| repo_runtime_routes_by_kind.get(&kind));
-            let runtime_route = worktree_runtime_route.or(repo_runtime_route);
-            let Some(runtime_route) = runtime_route else {
-                continue;
-            };
-
-            let primary_target = OpencodeSessionStatusProbeTarget::for_runtime_route(
-                runtime_route,
-                session.working_directory.as_str(),
-            );
-            primary_probe_targets.push(primary_target.clone());
-
-            let fallback_target = if let (Some(primary_route), Some(fallback_route)) =
-                (worktree_runtime_route, repo_runtime_route)
-            {
-                let primary_endpoint = runtime_route_endpoint(primary_route);
-                let fallback_endpoint = runtime_route_endpoint(fallback_route);
-                if primary_endpoint != fallback_endpoint {
-                    Some(OpencodeSessionStatusProbeTarget::for_runtime_route(
-                        fallback_route,
-                        session.working_directory.as_str(),
-                    ))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-
-            session_probe_plans.push(SessionProbePlan {
-                worktree_key,
-                role: session.role.clone(),
-                external_session_id: external_session_id.to_string(),
-                primary_target,
-                fallback_target,
-            });
-        }
-
-        let primary_statuses_by_target = self
-            .service
-            .load_cached_opencode_session_statuses_for_targets(&primary_probe_targets)?;
-
-        let mut has_active_run = false;
-        for run_probe_plan in &run_probe_plans {
+    fn evaluate_run_activity(
+        &self,
+        run_plans: &[RunProbePlan],
+        primary_statuses_by_target: &HashMap<
+            OpencodeSessionStatusProbeTarget,
+            OpencodeSessionStatusMap,
+        >,
+    ) -> Result<bool> {
+        for run_probe_plan in run_plans {
             let Some(primary_target) = run_probe_plan.primary_target.as_ref() else {
-                has_active_run = true;
-                break;
+                return Ok(true);
             };
 
             let statuses = primary_statuses_by_target
@@ -230,74 +211,43 @@ impl<'a> TaskActivityGuard<'a> {
                     has_live_opencode_session_status(statuses, external_session_id)
                 })
             {
-                has_active_run = true;
-                break;
+                return Ok(true);
             }
         }
 
-        let fallback_probe_targets = session_probe_plans
-            .iter()
-            .filter_map(|session_probe_plan| {
-                let primary_statuses =
-                    primary_statuses_by_target.get(&session_probe_plan.primary_target)?;
-                if primary_statuses.is_empty() {
-                    session_probe_plan.fallback_target.clone()
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        let fallback_statuses_by_target = self
-            .service
-            .load_cached_opencode_session_statuses_for_targets(&fallback_probe_targets)?;
+        Ok(false)
+    }
 
+    fn collect_active_session_roles(
+        &self,
+        session_plans: &[SessionProbePlan],
+        primary_statuses_by_target: &HashMap<
+            OpencodeSessionStatusProbeTarget,
+            OpencodeSessionStatusMap,
+        >,
+        fallback_statuses_by_target: &HashMap<
+            OpencodeSessionStatusProbeTarget,
+            OpencodeSessionStatusMap,
+        >,
+    ) -> Result<Vec<String>> {
         let mut active_roles = HashSet::new();
-        for session_probe_plan in session_probe_plans {
-            let primary_statuses = primary_statuses_by_target
-                .get(&session_probe_plan.primary_target)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "Missing cached OpenCode session statuses for {}",
-                        session_probe_plan.worktree_key
-                    )
-                })?;
-            let statuses = if primary_statuses.is_empty() {
-                if let Some(fallback_target) = session_probe_plan.fallback_target.as_ref() {
-                    let fallback_statuses = fallback_statuses_by_target
-                        .get(fallback_target)
-                        .ok_or_else(|| {
-                            anyhow!(
-                                "Missing cached OpenCode session fallback statuses for {}",
-                                session_probe_plan.worktree_key
-                            )
-                        })?;
-                    if fallback_statuses.is_empty() {
-                        primary_statuses
-                    } else {
-                        fallback_statuses
-                    }
-                } else {
-                    primary_statuses
-                }
-            } else {
-                primary_statuses
-            };
-
+        for session_probe_plan in session_plans {
+            let statuses = resolve_session_statuses(
+                session_probe_plan,
+                primary_statuses_by_target,
+                fallback_statuses_by_target,
+            )?;
             if has_live_opencode_session_status(
                 statuses,
                 session_probe_plan.external_session_id.as_str(),
             ) {
-                active_roles.insert(session_probe_plan.role);
+                active_roles.insert(session_probe_plan.role.clone());
             }
         }
 
         let mut active_session_roles = active_roles.into_iter().collect::<Vec<_>>();
         active_session_roles.sort_unstable();
-
-        Ok(TaskActiveWorkEvidence {
-            has_active_run,
-            active_session_roles,
-        })
+        Ok(active_session_roles)
     }
 
     fn collect_repo_runtime_routes_by_kind(
@@ -355,6 +305,205 @@ impl TaskActiveWorkEvidence {
 
         blockers.join(", ")
     }
+}
+
+struct TaskActivityProbePlan {
+    run_plans: Vec<RunProbePlan>,
+    session_plans: Vec<SessionProbePlan>,
+    primary_probe_targets: Vec<OpencodeSessionStatusProbeTarget>,
+}
+
+impl TaskActivityProbePlan {
+    fn fallback_probe_targets(
+        &self,
+        primary_statuses_by_target: &HashMap<
+            OpencodeSessionStatusProbeTarget,
+            OpencodeSessionStatusMap,
+        >,
+    ) -> Vec<OpencodeSessionStatusProbeTarget> {
+        dedupe_probe_targets(
+            self.session_plans
+                .iter()
+                .filter_map(|session_probe_plan| {
+                    let primary_statuses =
+                        primary_statuses_by_target.get(&session_probe_plan.primary_target)?;
+                    if primary_statuses.is_empty() {
+                        session_probe_plan.fallback_target.clone()
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        )
+    }
+}
+
+fn build_run_probe_plans(
+    candidate_runs: &[RunProbeCandidate],
+    sessions: &[AgentSessionDocument],
+    primary_probe_targets: &mut Vec<OpencodeSessionStatusProbeTarget>,
+) -> Vec<RunProbePlan> {
+    let mut run_plans = Vec::with_capacity(candidate_runs.len());
+    for run_candidate in candidate_runs {
+        let external_session_ids = collect_build_external_session_ids(run_candidate, sessions);
+        let primary_target = if external_session_ids.is_empty() {
+            None
+        } else {
+            let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+                &run_candidate.runtime_route,
+                run_candidate.worktree_path.as_str(),
+            );
+            primary_probe_targets.push(target.clone());
+            Some(target)
+        };
+        run_plans.push(RunProbePlan {
+            worktree_path: run_candidate.worktree_path.clone(),
+            external_session_ids,
+            primary_target,
+        });
+    }
+    run_plans
+}
+
+fn build_session_probe_plans(
+    sessions: &[AgentSessionDocument],
+    runtime_routes_by_worktree: &HashMap<String, RuntimeRoute>,
+    repo_runtime_routes_by_kind: &HashMap<AgentRuntimeKind, RuntimeRoute>,
+    primary_probe_targets: &mut Vec<OpencodeSessionStatusProbeTarget>,
+) -> Vec<SessionProbePlan> {
+    let mut session_plans = Vec::new();
+    for session in sessions
+        .iter()
+        .filter(|session| matches!(session.role.as_str(), "build" | "qa"))
+    {
+        let external_session_id = session
+            .external_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let Some(external_session_id) = external_session_id else {
+            continue;
+        };
+
+        let worktree_key = normalize_path_key(session.working_directory.as_str());
+        let fallback_runtime_kind = parse_runtime_kind(session.runtime_kind.as_str());
+        let worktree_runtime_route = runtime_routes_by_worktree.get(worktree_key.as_str());
+        let repo_runtime_route =
+            fallback_runtime_kind.and_then(|kind| repo_runtime_routes_by_kind.get(&kind));
+        let runtime_route = worktree_runtime_route.or(repo_runtime_route);
+        let Some(runtime_route) = runtime_route else {
+            continue;
+        };
+
+        let primary_target = OpencodeSessionStatusProbeTarget::for_runtime_route(
+            runtime_route,
+            session.working_directory.as_str(),
+        );
+        primary_probe_targets.push(primary_target.clone());
+        let fallback_target = select_fallback_probe_target(
+            worktree_runtime_route,
+            repo_runtime_route,
+            session.working_directory.as_str(),
+        );
+
+        session_plans.push(SessionProbePlan {
+            worktree_key,
+            role: session.role.clone(),
+            external_session_id: external_session_id.to_string(),
+            primary_target,
+            fallback_target,
+        });
+    }
+    session_plans
+}
+
+fn collect_runtime_routes_by_worktree(
+    candidate_runs: &[RunProbeCandidate],
+) -> HashMap<String, RuntimeRoute> {
+    candidate_runs
+        .iter()
+        .map(|run_candidate| {
+            (
+                normalize_path_key(run_candidate.worktree_path.as_str()),
+                run_candidate.runtime_route.clone(),
+            )
+        })
+        .collect()
+}
+
+fn resolve_session_statuses<'a>(
+    session_probe_plan: &SessionProbePlan,
+    primary_statuses_by_target: &'a HashMap<
+        OpencodeSessionStatusProbeTarget,
+        OpencodeSessionStatusMap,
+    >,
+    fallback_statuses_by_target: &'a HashMap<
+        OpencodeSessionStatusProbeTarget,
+        OpencodeSessionStatusMap,
+    >,
+) -> Result<&'a OpencodeSessionStatusMap> {
+    let primary_statuses = primary_statuses_by_target
+        .get(&session_probe_plan.primary_target)
+        .ok_or_else(|| {
+            anyhow!(
+                "Missing cached OpenCode session statuses for {}",
+                session_probe_plan.worktree_key
+            )
+        })?;
+    if !primary_statuses.is_empty() {
+        return Ok(primary_statuses);
+    }
+
+    let Some(fallback_target) = session_probe_plan.fallback_target.as_ref() else {
+        return Ok(primary_statuses);
+    };
+    let fallback_statuses = fallback_statuses_by_target
+        .get(fallback_target)
+        .ok_or_else(|| {
+            anyhow!(
+                "Missing cached OpenCode session fallback statuses for {}",
+                session_probe_plan.worktree_key
+            )
+        })?;
+    if fallback_statuses.is_empty() {
+        Ok(primary_statuses)
+    } else {
+        Ok(fallback_statuses)
+    }
+}
+
+fn select_fallback_probe_target(
+    worktree_runtime_route: Option<&RuntimeRoute>,
+    repo_runtime_route: Option<&RuntimeRoute>,
+    working_directory: &str,
+) -> Option<OpencodeSessionStatusProbeTarget> {
+    let (Some(primary_route), Some(fallback_route)) = (worktree_runtime_route, repo_runtime_route)
+    else {
+        return None;
+    };
+    let primary_endpoint = runtime_route_endpoint(primary_route);
+    let fallback_endpoint = runtime_route_endpoint(fallback_route);
+    if primary_endpoint == fallback_endpoint {
+        return None;
+    }
+
+    Some(OpencodeSessionStatusProbeTarget::for_runtime_route(
+        fallback_route,
+        working_directory,
+    ))
+}
+
+fn dedupe_probe_targets(
+    targets: Vec<OpencodeSessionStatusProbeTarget>,
+) -> Vec<OpencodeSessionStatusProbeTarget> {
+    let mut unique_targets = Vec::new();
+    let mut seen = HashSet::new();
+    for target in targets {
+        if seen.insert(target.clone()) {
+            unique_targets.push(target);
+        }
+    }
+    unique_targets
 }
 
 fn parse_runtime_kind(value: &str) -> Option<AgentRuntimeKind> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard.rs
@@ -1,6 +1,7 @@
 use super::cleanup_plans::{normalize_path_for_comparison, normalize_path_key};
 use crate::app_service::{
-    OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget, has_live_opencode_session_status,
+    OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget,
+    dedupe_opencode_session_status_probe_targets, has_live_opencode_session_status,
     service_core::AppService,
 };
 use anyhow::{Context, Result, anyhow};
@@ -496,14 +497,7 @@ fn select_fallback_probe_target(
 fn dedupe_probe_targets(
     targets: Vec<OpencodeSessionStatusProbeTarget>,
 ) -> Vec<OpencodeSessionStatusProbeTarget> {
-    let mut unique_targets = Vec::new();
-    let mut seen = HashSet::new();
-    for target in targets {
-        if seen.insert(target.clone()) {
-            unique_targets.push(target);
-        }
-    }
-    unique_targets
+    dedupe_opencode_session_status_probe_targets(targets)
 }
 
 fn parse_runtime_kind(value: &str) -> Option<AgentRuntimeKind> {


### PR DESCRIPTION
## Summary
- add a shared host-side OpenCode session-status coordinator with short-lived TTL caching, same-target in-flight dedupe, and bounded parallel probe execution
- batch run visibility and task activity checks through that shared path so slow or stale runtimes no longer accumulate serial timeout latency across unique targets
- harden poisoned-flight recovery and follow up with a maintainability refactor that uses typed cached probe errors plus clearer planning/evaluation helpers without changing stale, unreachable, or fallback semantics

## Changes
- introduced process-local session-status coordination state in `service_core.rs` for cache entries, in-flight probe tracking, and a bounded probe limiter
- refactored `opencode_session_status.rs` into clearer layers for unique-target collection, batch resolution, single-target cache resolution, leader probe execution, and cached actionable error replay
- updated `runtime_orchestrator.rs` so `runs_list()` first builds exposure plans, batch-loads unique probe targets, and then evaluates visibility from preloaded statuses instead of probing inline per run
- updated `task_activity_guard.rs` so reset/delete activity checks now flow through explicit phases for candidate collection, probe planning, fallback planning, and evidence evaluation while preserving existing repo-runtime fallback behavior
- added cached malformed-JSON failure coverage on top of the existing cache-hit, expiry, concurrency, bounded-latency, and poisoned-flight regression coverage

## Verification
- `cargo test -p host-application`
  - result: `314 passed`
- `rustfmt --edition 2024 --check` on the touched Rust files

## Notes
- this PR contains three commits:
  - `ba809623 perf(desktop): cache and parallelize opencode session probes`
  - `8ee4dd3a fix(desktop): harden session status flight recovery`
  - `88352089 refactor(desktop): clarify session status probe coordination`
- the user explicitly asked for the maintainability follow-up after the initial implementation and QA hardening, so the refactor is included in the same PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized internal module imports and re-exports for consistency.

* **Performance**
  * Faster, more efficient session-status probing with per-target caching (TTL), deduplication, and bounded parallel workers to reduce redundant checks and overall latency.

* **New Features**
  * Improved run/task visibility logic and robust probe coordination that reduces stalls and handles aborted probes more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->