### PR TITLE
fix(desktop): stabilize diagnostics timeout handling

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -39,6 +39,7 @@ mod workspace_policy;
 
 pub(crate) use events::emit_event;
 pub(crate) use hook_security::{run_parsed_hook_command_allow_failure, validate_hook_trust};
+pub use opencode_runtime::OpencodeStartupWaitFailure;
 pub(crate) use opencode_runtime::{
     OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupCancelEpoch,
     opencode_server_parent_pid, process_exists, read_opencode_version,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
@@ -11,9 +11,10 @@ pub(crate) use process_lifecycle::{
     resolve_opencode_binary_path, terminate_child_process, terminate_process_by_pid,
     wait_for_process_exit_by_pid,
 };
+pub use startup_readiness::OpencodeStartupWaitFailure;
 pub(crate) use startup_readiness::{
-    wait_for_local_server_with_process, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
-    StartupCancelEpoch,
+    wait_for_local_server_with_process, OpencodeStartupReadinessPolicy,
+    OpencodeStartupWaitReport, StartupCancelEpoch,
 };
 
 pub(crate) fn spawn_opencode_server(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/startup_readiness/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/startup_readiness/mod.rs
@@ -2,6 +2,7 @@ mod policy;
 mod probe_runtime;
 mod wait_loop;
 
+pub use policy::OpencodeStartupWaitFailure;
 pub(crate) use policy::{
     OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupCancelEpoch,
 };

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/startup_readiness/policy.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/startup_readiness/policy.rs
@@ -85,11 +85,17 @@ impl OpencodeStartupWaitReport {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct OpencodeStartupWaitFailure {
+pub struct OpencodeStartupWaitFailure {
     pub port: u16,
     pub reason: &'static str,
     pub details: String,
-    pub report: OpencodeStartupWaitReport,
+    report: OpencodeStartupWaitReport,
+}
+
+impl OpencodeStartupWaitFailure {
+    pub(crate) fn report(&self) -> OpencodeStartupWaitReport {
+        self.report
+    }
 }
 
 impl std::fmt::Display for OpencodeStartupWaitFailure {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/startup.rs
@@ -1,10 +1,10 @@
 use super::super::{
-    AppService, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
-    STARTUP_CONFIG_INVALID_REASON, StartupEventContext, StartupEventCorrelation,
-    StartupEventPayload, spawn_opencode_server, wait_for_local_server_with_process,
+    spawn_opencode_server, wait_for_local_server_with_process, AppService,
+    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupEventContext,
+    StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
 };
 use super::{RuntimeStartInput, SpawnedRuntimeServer};
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use host_domain::{RuntimeRole, TASK_METADATA_NAMESPACE};
 use host_infra_system::pick_free_port;
 use std::path::Path;
@@ -101,7 +101,7 @@ impl AppService {
                         )),
                         Some(startup_policy),
                     ),
-                    error.report,
+                    error.report(),
                     error.reason,
                 ));
                 let startup_error = anyhow!(error).context(input.startup_error_context.clone());

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -2174,7 +2174,7 @@ fn opencode_startup_readiness_policy_uses_config_overrides() -> Result<()> {
     let runtime_config_store = RuntimeConfigStore::from_user_settings_store(&config_store);
     let config = RuntimeConfig {
         opencode_startup: OpencodeStartupReadinessConfig {
-            timeout_ms: 12_345,
+            timeout_ms: 15_345,
             connect_timeout_ms: 456,
             initial_retry_delay_ms: 33,
             max_retry_delay_ms: 99,
@@ -2189,7 +2189,7 @@ fn opencode_startup_readiness_policy_uses_config_overrides() -> Result<()> {
     });
     let service = AppService::new(task_store, config_store);
     let policy = service.opencode_startup_readiness_policy()?;
-    assert_eq!(policy.timeout, Duration::from_millis(12_345));
+    assert_eq!(policy.timeout, Duration::from_millis(15_345));
     assert_eq!(policy.connect_timeout, Duration::from_millis(456));
     assert_eq!(policy.initial_retry_delay, Duration::from_millis(33));
     assert_eq!(policy.max_retry_delay, Duration::from_millis(99));

--- a/apps/desktop/src-tauri/crates/host-application/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/lib.rs
@@ -3,6 +3,6 @@ mod app_service;
 pub use app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
 pub use app_service::{
     AppService, DevServerEmitter, HookTrustConfirmationPort, HookTrustConfirmationRequest,
-    PreparedHookTrustChallenge, RepoConfigUpdate, RepoSettingsUpdate, RunEmitter,
+    OpencodeStartupWaitFailure, PreparedHookTrustChallenge, RepoConfigUpdate, RepoSettingsUpdate, RunEmitter,
     WorkspaceSettingsSnapshotUpdate,
 };

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/normalize.rs
@@ -181,7 +181,7 @@ pub(super) fn normalize_repo_config(repo: &mut RepoConfig) -> Result<()> {
 pub(super) fn normalize_opencode_startup_readiness_config(
     config: &mut OpencodeStartupReadinessConfig,
 ) {
-    config.timeout_ms = config.timeout_ms.clamp(250, 120_000);
+    config.timeout_ms = config.timeout_ms.clamp(15_000, 120_000);
     config.connect_timeout_ms = config.connect_timeout_ms.clamp(25, 10_000);
     config.initial_retry_delay_ms = config.initial_retry_delay_ms.clamp(5, 5_000);
     config.max_retry_delay_ms = config.max_retry_delay_ms.clamp(10, 10_000);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/runtime_config.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/tests/runtime_config.rs
@@ -2,6 +2,8 @@ use super::{OpencodeStartupReadinessConfig, RuntimeConfig, TestRuntimeStoreHarne
 
 #[test]
 fn runtime_store_defaults_and_normalizes_startup_readiness() {
+    assert_eq!(RuntimeConfig::default().opencode_startup.timeout_ms, 15_000);
+
     let harness = TestRuntimeStoreHarness::new("runtime-config-startup-readiness");
     let store = harness.store();
     let config = RuntimeConfig {
@@ -20,9 +22,29 @@ fn runtime_store_defaults_and_normalizes_startup_readiness() {
         .load()
         .expect("runtime config should load")
         .opencode_startup;
-    assert_eq!(readiness.timeout_ms, 250);
+    assert_eq!(readiness.timeout_ms, 15_000);
     assert_eq!(readiness.connect_timeout_ms, 25);
     assert_eq!(readiness.initial_retry_delay_ms, 3_000);
     assert_eq!(readiness.max_retry_delay_ms, 3_000);
     assert_eq!(readiness.child_check_interval_ms, 10);
+}
+
+#[test]
+fn runtime_store_preserves_higher_custom_startup_timeout() {
+    let harness = TestRuntimeStoreHarness::new("runtime-config-startup-readiness-high-timeout");
+    let store = harness.store();
+    let config = RuntimeConfig {
+        opencode_startup: OpencodeStartupReadinessConfig {
+            timeout_ms: 30_000,
+            ..RuntimeConfig::default().opencode_startup
+        },
+        ..RuntimeConfig::default()
+    };
+    store.save(&config).expect("save config");
+
+    let readiness = store
+        .load()
+        .expect("runtime config should load")
+        .opencode_startup;
+    assert_eq!(readiness.timeout_ms, 30_000);
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/config/types.rs
@@ -441,7 +441,7 @@ pub struct OpencodeStartupReadinessConfig {
 }
 
 const fn default_opencode_startup_timeout_ms() -> u64 {
-    8_000
+    15_000
 }
 const fn default_opencode_startup_connect_timeout_ms() -> u64 {
     250

--- a/apps/desktop/src-tauri/src/commands/runtime.rs
+++ b/apps/desktop/src-tauri/src/commands/runtime.rs
@@ -1,9 +1,25 @@
-use crate::{as_error, run_service_blocking, AppState};
+use crate::{as_error, run_service_blocking, runtime_ensure_failure_kind, AppState};
 use host_domain::{
     BeadsCheck, BuildContinuationTarget, RuntimeCheck, RuntimeDescriptor, RuntimeInstanceSummary,
     SystemCheck,
 };
 use tauri::State;
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeEnsureCommandError {
+    message: String,
+    failure_kind: Option<&'static str>,
+}
+
+impl RuntimeEnsureCommandError {
+    fn from_anyhow(error: anyhow::Error) -> Self {
+        Self {
+            message: format!("{error:#}"),
+            failure_kind: runtime_ensure_failure_kind(&error),
+        }
+    }
+}
 
 #[tauri::command]
 pub async fn system_check(
@@ -95,13 +111,13 @@ pub async fn runtime_ensure(
     state: State<'_, AppState>,
     runtime_kind: String,
     repo_path: String,
-) -> Result<RuntimeInstanceSummary, String> {
+) -> Result<RuntimeInstanceSummary, RuntimeEnsureCommandError> {
     let service = state.service.clone();
     let result = run_service_blocking("runtime_ensure", move || {
         service.runtime_ensure(&runtime_kind, &repo_path)
     })
     .await;
-    as_error(result)
+    result.map_err(RuntimeEnsureCommandError::from_anyhow)
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/headless/command_support.rs
+++ b/apps/desktop/src-tauri/src/headless/command_support.rs
@@ -24,6 +24,7 @@ pub(super) struct HeadlessState {
 pub(super) struct HeadlessCommandError {
     pub(super) message: String,
     pub(super) status: StatusCode,
+    pub(super) failure_kind: Option<String>,
 }
 
 impl HeadlessCommandError {
@@ -31,6 +32,7 @@ impl HeadlessCommandError {
         Self {
             message: message.into(),
             status: StatusCode::BAD_REQUEST,
+            failure_kind: None,
         }
     }
 
@@ -38,6 +40,7 @@ impl HeadlessCommandError {
         Self {
             message: message.into(),
             status: StatusCode::INTERNAL_SERVER_ERROR,
+            failure_kind: None,
         }
     }
 
@@ -45,17 +48,26 @@ impl HeadlessCommandError {
         Self {
             message: message.into(),
             status: StatusCode::NOT_FOUND,
+            failure_kind: None,
         }
     }
 }
 
 impl IntoResponse for HeadlessCommandError {
     fn into_response(self) -> axum::response::Response {
+        let payload = match self.failure_kind {
+            Some(failure_kind) => json!({
+                "error": self.message,
+                "failureKind": failure_kind,
+            }),
+            None => json!({
+                "error": self.message,
+            }),
+        };
+
         (
             self.status,
-            Json(json!({
-                "error": self.message,
-            })),
+            Json(payload),
         )
             .into_response()
     }

--- a/apps/desktop/src-tauri/src/headless/runtime_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/runtime_commands.rs
@@ -4,6 +4,7 @@ use super::command_support::{
     serialize_value, service_error, CommandResult, HeadlessState, RepoTaskArgs,
 };
 use super::events::{make_dev_server_emitter, make_emitter};
+use crate::runtime_ensure_failure_kind;
 use host_application::{BuildResponseAction, CleanupMode};
 use host_domain::AgentRuntimeKind;
 use serde::Deserialize;
@@ -302,7 +303,12 @@ async fn handle_runtime_ensure(state: &HeadlessState, args: Value) -> CommandRes
             service.runtime_ensure(runtime_kind.as_str(), &repo_path)
         })
         .await
-        .map_err(service_error)?,
+        .map_err(|error| {
+            let failure_kind = runtime_ensure_failure_kind(&error).map(str::to_string);
+            let mut command_error = service_error(error);
+            command_error.failure_kind = failure_kind;
+            command_error
+        })?,
     )
 }
 

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -127,16 +127,19 @@ async fn local_attachment_preview_handler(
     let metadata = tokio::fs::metadata(&path).await.map_err(|error| HeadlessCommandError {
         message: format!("Failed to stat local attachment preview: {error}"),
         status: StatusCode::NOT_FOUND,
+        failure_kind: None,
     })?;
     if !metadata.is_file() {
         return Err(HeadlessCommandError {
             message: "Local attachment preview path must reference a file".to_string(),
             status: StatusCode::BAD_REQUEST,
+            failure_kind: None,
         });
     }
     let allowed = is_staged_local_attachment_path(&path).map_err(|error| HeadlessCommandError {
         message: error,
         status: StatusCode::INTERNAL_SERVER_ERROR,
+        failure_kind: None,
     })?;
     if !allowed {
         return Err(HeadlessCommandError {
@@ -144,12 +147,14 @@ async fn local_attachment_preview_handler(
                 "Local attachment preview is only available for staged attachment files."
                     .to_string(),
             status: StatusCode::FORBIDDEN,
+            failure_kind: None,
         });
     }
 
     let file = tokio::fs::File::open(&path).await.map_err(|error| HeadlessCommandError {
         message: format!("Failed to read local attachment preview: {error}"),
         status: StatusCode::INTERNAL_SERVER_ERROR,
+        failure_kind: None,
     })?;
     let mime = mime_guess::from_path(&path).first_or_octet_stream().to_string();
     let stream = ReaderStream::new(file);
@@ -162,6 +167,7 @@ async fn local_attachment_preview_handler(
         .map_err(|error| HeadlessCommandError {
             message: format!("Failed to build local attachment preview response: {error}"),
             status: StatusCode::INTERNAL_SERVER_ERROR,
+            failure_kind: None,
         })
 }
 
@@ -169,6 +175,7 @@ fn json_rejection_error(error: JsonRejection) -> HeadlessCommandError {
     HeadlessCommandError {
         message: error.body_text(),
         status: error.status(),
+        failure_kind: None,
     }
 }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -178,6 +178,17 @@ pub(crate) fn as_error<T>(result: anyhow::Result<T>) -> Result<T, String> {
     result.map_err(|error| format!("{error:#}"))
 }
 
+pub(crate) fn runtime_ensure_failure_kind(error: &anyhow::Error) -> Option<&'static str> {
+    error.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<host_application::OpencodeStartupWaitFailure>()
+            .map(|failure| match failure.reason {
+                "timeout" => "timeout",
+                _ => "error",
+            })
+    })
+}
+
 pub(crate) async fn run_service_blocking<T, F>(
     operation_name: &'static str,
     operation: F,

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -138,9 +138,11 @@ describe("buildDiagnosticsPanelModel", () => {
         opencode: {
           runtimeOk: true,
           runtimeError: null,
+          runtimeFailureKind: null,
           runtime: runtimeSummary,
           mcpOk: true,
           mcpError: null,
+          mcpFailureKind: null,
           mcpServerName: "openducktor",
           mcpServerStatus: "connected",
           mcpServerError: null,
@@ -195,9 +197,11 @@ describe("buildDiagnosticsPanelModel", () => {
         opencode: {
           runtimeOk: true,
           runtimeError: null,
+          runtimeFailureKind: null,
           runtime: runtimeSummary,
           mcpOk: true,
           mcpError: null,
+          mcpFailureKind: null,
           mcpServerName: "openducktor",
           mcpServerStatus: "connected",
           mcpServerError: null,
@@ -257,9 +261,11 @@ describe("buildDiagnosticsPanelModel", () => {
         opencode: {
           runtimeOk: true,
           runtimeError: null,
+          runtimeFailureKind: null,
           runtime: runtimeSummary,
           mcpOk: true,
           mcpError: null,
+          mcpFailureKind: null,
           mcpServerName: "openducktor",
           mcpServerStatus: "connected",
           mcpServerError: null,
@@ -323,9 +329,11 @@ describe("buildDiagnosticsPanelModel", () => {
         opencode: {
           runtimeOk: false,
           runtimeError: "runtime failed",
+          runtimeFailureKind: "error",
           runtime: null,
           mcpOk: false,
           mcpError: "mcp unavailable",
+          mcpFailureKind: "error",
           mcpServerName: "openducktor",
           mcpServerStatus: null,
           mcpServerError: "server unavailable",
@@ -390,9 +398,11 @@ describe("buildDiagnosticsPanelModel", () => {
         opencode: {
           runtimeOk: true,
           runtimeError: null,
+          runtimeFailureKind: null,
           runtime: runtimeSummary,
           mcpOk: false,
           mcpError: "mcp unavailable",
+          mcpFailureKind: "error",
           mcpServerName: "openducktor",
           mcpServerStatus: null,
           mcpServerError: null,
@@ -406,5 +416,63 @@ describe("buildDiagnosticsPanelModel", () => {
 
     const mcpSection = model.sections.find((section) => section.key === "mcp:opencode");
     expect(mcpSection?.errors).toEqual(["mcp unavailable"]);
+  });
+
+  test("shows timeout-specific badges and messages while runtime health is warming up", () => {
+    const model = buildDiagnosticsPanelModel({
+      activeRepo: "/repo",
+      activeWorkspace: {
+        path: "/repo",
+        isActive: true,
+        hasConfig: true,
+        configuredWorktreeBasePath: "/worktrees",
+        defaultWorktreeBasePath: "/Users/dev/.openducktor/worktrees/repo",
+        effectiveWorktreeBasePath: "/worktrees",
+      },
+      runtimeDefinitions,
+      isLoadingRuntimeDefinitions: false,
+      runtimeDefinitionsError: null,
+      runtimeCheck: {
+        gitOk: true,
+        gitVersion: "git version 2.50.1",
+        ghOk: true,
+        ghVersion: "gh version 2.73.0",
+        ghAuthOk: true,
+        ghAuthLogin: "octocat",
+        ghAuthError: null,
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        errors: [],
+      },
+      beadsCheck: {
+        beadsOk: true,
+        beadsPath: "/Users/dev/.openducktor/beads/repo/.beads",
+        beadsError: null,
+      },
+      runtimeHealthByRuntime: {
+        opencode: {
+          runtimeOk: false,
+          runtimeError: "Timed out waiting for OpenCode runtime startup readiness",
+          runtimeFailureKind: "timeout",
+          runtime: null,
+          mcpOk: false,
+          mcpError: "Runtime is unavailable, so MCP cannot be verified.",
+          mcpFailureKind: "timeout",
+          mcpServerName: "openducktor",
+          mcpServerStatus: null,
+          mcpServerError: "Runtime is unavailable, so MCP cannot be verified.",
+          availableToolIds: [],
+          checkedAt: "2026-02-20T12:01:00.000Z",
+          errors: ["Timed out waiting for OpenCode runtime startup readiness"],
+        },
+      },
+      isLoadingChecks: false,
+    });
+
+    const runtimeSection = model.sections.find((section) => section.key === "runtime:opencode");
+    const mcpSection = model.sections.find((section) => section.key === "mcp:opencode");
+
+    expect(runtimeSection?.badge).toEqual({ label: "Starting", variant: "warning" });
+    expect(runtimeSection?.errors[0]).toContain("Retrying automatically");
+    expect(mcpSection?.badge).toEqual({ label: "Retrying", variant: "warning" });
   });
 });

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -548,7 +548,7 @@ describe("buildDiagnosticsPanelModel", () => {
 
     expect(model.isSummaryChecking).toBe(false);
     expect(model.sections[1]?.badge).toEqual({ label: "Retrying", variant: "warning" });
-    expect(model.sections[1]?.errors[0]).toContain("CLI tools is not yet available");
+    expect(model.sections[1]?.errors[0]).toContain("CLI tools are not yet available");
     expect(model.sections[4]?.badge).toEqual({ label: "Retrying", variant: "warning" });
     expect(model.sections[4]?.errors[0]).toContain("Beads store is not yet available");
   });

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -30,6 +30,8 @@ describe("buildDiagnosticsPanelModel", () => {
       runtimeDefinitionsError: null,
       runtimeCheck: null,
       beadsCheck: null,
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {},
       isLoadingChecks: false,
     });
@@ -58,6 +60,8 @@ describe("buildDiagnosticsPanelModel", () => {
       runtimeDefinitionsError: null,
       runtimeCheck: null,
       beadsCheck: null,
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {},
       isLoadingChecks: true,
     });
@@ -96,6 +100,8 @@ describe("buildDiagnosticsPanelModel", () => {
         beadsPath: "/Users/dev/.openducktor/beads/repo/.beads",
         beadsError: null,
       },
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {},
       isLoadingChecks: false,
     });
@@ -134,6 +140,8 @@ describe("buildDiagnosticsPanelModel", () => {
         beadsPath: "/Users/dev/.openducktor/beads/repo/.beads",
         beadsError: null,
       },
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {
         opencode: {
           runtimeOk: true,
@@ -193,6 +201,8 @@ describe("buildDiagnosticsPanelModel", () => {
         beadsPath: "/Users/dev/.openducktor/beads/repo/.beads",
         beadsError: null,
       },
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {
         opencode: {
           runtimeOk: true,
@@ -257,6 +267,8 @@ describe("buildDiagnosticsPanelModel", () => {
         beadsPath: "/Users/dev/.openducktor/beads/fairnest/.beads",
         beadsError: null,
       },
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {
         opencode: {
           runtimeOk: true,
@@ -325,6 +337,8 @@ describe("buildDiagnosticsPanelModel", () => {
         beadsPath: null,
         beadsError: "beads init failed",
       },
+      runtimeCheckFailureKind: "error",
+      beadsCheckFailureKind: "error",
       runtimeHealthByRuntime: {
         opencode: {
           runtimeOk: false,
@@ -394,6 +408,8 @@ describe("buildDiagnosticsPanelModel", () => {
         beadsPath: "/Users/dev/.openducktor/beads/repo/.beads",
         beadsError: null,
       },
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {
         opencode: {
           runtimeOk: true,
@@ -448,6 +464,8 @@ describe("buildDiagnosticsPanelModel", () => {
         beadsPath: "/Users/dev/.openducktor/beads/repo/.beads",
         beadsError: null,
       },
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {
         opencode: {
           runtimeOk: false,
@@ -506,6 +524,8 @@ describe("buildDiagnosticsPanelModel", () => {
         beadsPath: null,
         beadsError: "Timed out after 15000ms",
       },
+      runtimeCheckFailureKind: "timeout",
+      beadsCheckFailureKind: "timeout",
       runtimeHealthByRuntime: {
         opencode: {
           runtimeOk: true,

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -475,4 +475,61 @@ describe("buildDiagnosticsPanelModel", () => {
     expect(runtimeSection?.errors[0]).toContain("Retrying automatically");
     expect(mcpSection?.badge).toEqual({ label: "Retrying", variant: "warning" });
   });
+
+  test("shows timeout-specific cli tools and beads states instead of leaving them checking", () => {
+    const model = buildDiagnosticsPanelModel({
+      activeRepo: "/repo",
+      activeWorkspace: {
+        path: "/repo",
+        isActive: true,
+        hasConfig: true,
+        configuredWorktreeBasePath: "/worktrees",
+        defaultWorktreeBasePath: "/Users/dev/.openducktor/worktrees/repo",
+        effectiveWorktreeBasePath: "/worktrees",
+      },
+      runtimeDefinitions,
+      isLoadingRuntimeDefinitions: false,
+      runtimeDefinitionsError: null,
+      runtimeCheck: {
+        gitOk: false,
+        gitVersion: null,
+        ghOk: false,
+        ghVersion: null,
+        ghAuthOk: false,
+        ghAuthLogin: null,
+        ghAuthError: "Timed out after 15000ms",
+        runtimes: [{ kind: "opencode", ok: false, version: null }],
+        errors: ["Timed out after 15000ms"],
+      },
+      beadsCheck: {
+        beadsOk: false,
+        beadsPath: null,
+        beadsError: "Timed out after 15000ms",
+      },
+      runtimeHealthByRuntime: {
+        opencode: {
+          runtimeOk: true,
+          runtimeError: null,
+          runtimeFailureKind: null,
+          runtime: runtimeSummary,
+          mcpOk: true,
+          mcpError: null,
+          mcpFailureKind: null,
+          mcpServerName: "openducktor",
+          mcpServerStatus: "connected",
+          mcpServerError: null,
+          availableToolIds: [],
+          checkedAt: "2026-02-20T12:01:00.000Z",
+          errors: [],
+        },
+      },
+      isLoadingChecks: false,
+    });
+
+    expect(model.isSummaryChecking).toBe(false);
+    expect(model.sections[1]?.badge).toEqual({ label: "Retrying", variant: "warning" });
+    expect(model.sections[1]?.errors[0]).toContain("CLI tools is not yet available");
+    expect(model.sections[4]?.badge).toEqual({ label: "Retrying", variant: "warning" });
+    expect(model.sections[4]?.errors[0]).toContain("Beads store is not yet available");
+  });
 });

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.test.ts
@@ -547,9 +547,69 @@ describe("buildDiagnosticsPanelModel", () => {
     });
 
     expect(model.isSummaryChecking).toBe(false);
+    expect(model.criticalReasons).toEqual(
+      expect.arrayContaining(["Runtime CLI checks still retrying", "Beads store still retrying"]),
+    );
     expect(model.sections[1]?.badge).toEqual({ label: "Retrying", variant: "warning" });
     expect(model.sections[1]?.errors[0]).toContain("CLI tools are not yet available");
     expect(model.sections[4]?.badge).toEqual({ label: "Retrying", variant: "warning" });
     expect(model.sections[4]?.errors[0]).toContain("Beads store is not yet available");
+  });
+
+  test("treats GitHub CLI auth failures as CLI issues even without query failure classification", () => {
+    const model = buildDiagnosticsPanelModel({
+      activeRepo: "/repo",
+      activeWorkspace: {
+        path: "/repo",
+        isActive: true,
+        hasConfig: true,
+        configuredWorktreeBasePath: "/worktrees",
+        defaultWorktreeBasePath: "/Users/dev/.openducktor/worktrees/repo",
+        effectiveWorktreeBasePath: "/worktrees",
+      },
+      runtimeDefinitions,
+      isLoadingRuntimeDefinitions: false,
+      runtimeDefinitionsError: null,
+      runtimeCheck: {
+        gitOk: true,
+        gitVersion: "git version 2.50.1",
+        ghOk: false,
+        ghVersion: null,
+        ghAuthOk: false,
+        ghAuthLogin: null,
+        ghAuthError: "gh auth missing",
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        errors: ["gh auth missing"],
+      },
+      beadsCheck: {
+        beadsOk: true,
+        beadsPath: "/Users/dev/.openducktor/beads/repo/.beads",
+        beadsError: null,
+      },
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
+      runtimeHealthByRuntime: {
+        opencode: {
+          runtimeOk: true,
+          runtimeError: null,
+          runtimeFailureKind: null,
+          runtime: runtimeSummary,
+          mcpOk: true,
+          mcpError: null,
+          mcpFailureKind: null,
+          mcpServerName: "openducktor",
+          mcpServerStatus: "connected",
+          mcpServerError: null,
+          availableToolIds: [],
+          checkedAt: "2026-02-20T12:01:00.000Z",
+          errors: [],
+        },
+      },
+      isLoadingChecks: false,
+    });
+
+    expect(model.criticalReasons).toContain("Runtime CLI checks failing");
+    expect(model.sections[1]?.badge).toEqual({ label: "Issue", variant: "danger" });
+    expect(model.sections[1]?.errors).toEqual(["gh auth missing"]);
   });
 });

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
@@ -7,7 +7,11 @@ import type {
 } from "@openducktor/contracts";
 import { runtimeLabelFor } from "@/lib/agent-runtime";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import { buildTimeoutToastDescription } from "@/state/operations/workspace/check-diagnostics";
+import {
+  buildTimeoutToastDescription,
+  hasBeadsCheckFailure,
+  hasRuntimeCheckFailure,
+} from "@/state/operations/workspace/check-diagnostics";
 import type { RepoRuntimeFailureKind, RepoRuntimeHealthMap } from "@/types/diagnostics";
 import { buildDiagnosticsSummary, type DiagnosticsSummary } from "./diagnostics-model";
 
@@ -142,8 +146,12 @@ export const buildDiagnosticsPanelModel = (
     if (runtimeDefinitionsError) {
       criticalReasons.push(runtimeDefinitionsError);
     }
-    if (runtimeCheck && (!runtimeCheck.gitOk || runtimeCheck.runtimes.some((entry) => !entry.ok))) {
-      criticalReasons.push("Runtime CLI checks failing");
+    if (hasRuntimeCheckFailure(runtimeCheck)) {
+      criticalReasons.push(
+        runtimeCheckFailureKind === "timeout"
+          ? "Runtime CLI checks still retrying"
+          : "Runtime CLI checks failing",
+      );
     }
     for (const { definition, runtimeHealth } of runtimeEntries) {
       if (runtimeHealth?.runtimeOk === false) {
@@ -161,8 +169,12 @@ export const buildDiagnosticsPanelModel = (
         );
       }
     }
-    if (beadsCheck?.beadsOk === false) {
-      criticalReasons.push("Beads store unavailable");
+    if (hasBeadsCheckFailure(beadsCheck)) {
+      criticalReasons.push(
+        beadsCheckFailureKind === "timeout"
+          ? "Beads store still retrying"
+          : "Beads store unavailable",
+      );
     }
   }
 
@@ -217,10 +229,7 @@ export const buildDiagnosticsPanelModel = (
           label: runtimeEntry.kind,
           value: runtimeEntry.ok ? (runtimeEntry.version ?? "detected") : "missing",
         }));
-  const cliToolsHealthy =
-    runtimeCheck === null
-      ? null
-      : runtimeCheck.gitOk && runtimeCheck.runtimes.every((entry) => entry.ok);
+  const cliToolsHealthy = runtimeCheck === null ? null : !hasRuntimeCheckFailure(runtimeCheck);
 
   const cliToolsSection: DiagnosticsSectionModel = {
     key: "cli-tools",

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
@@ -7,7 +7,7 @@ import type {
 } from "@openducktor/contracts";
 import { runtimeLabelFor } from "@/lib/agent-runtime";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import type { RepoRuntimeHealthMap } from "@/types/diagnostics";
+import type { RepoRuntimeFailureKind, RepoRuntimeHealthMap } from "@/types/diagnostics";
 import {
   buildDiagnosticsSummary,
   type DiagnosticsSummary,
@@ -54,6 +54,46 @@ type BuildDiagnosticsPanelModelInput = {
   isLoadingChecks: boolean;
 };
 
+const buildTimeoutDiagnosticsMessage = (label: string, detail: string | null): string => {
+  if (!detail) {
+    return `${label} is not yet available. Retrying automatically.`;
+  }
+
+  return `${label} is not yet available. Retrying automatically. Latest detail: ${detail}`;
+};
+
+const getFailureBadge = (
+  ok: boolean | null,
+  failureKind: RepoRuntimeFailureKind,
+  labels: { healthy: string; timeout: string; error: string; checking: string },
+): DiagnosticsSectionModel["badge"] => {
+  if (ok === null) {
+    return {
+      label: labels.checking,
+      variant: "secondary",
+    };
+  }
+
+  if (ok) {
+    return {
+      label: labels.healthy,
+      variant: "success",
+    };
+  }
+
+  if (failureKind === "timeout") {
+    return {
+      label: labels.timeout,
+      variant: "warning",
+    };
+  }
+
+  return {
+    label: labels.error,
+    variant: "danger",
+  };
+};
+
 export const buildDiagnosticsPanelModel = (
   input: BuildDiagnosticsPanelModelInput,
 ): DiagnosticsPanelModel => {
@@ -90,10 +130,18 @@ export const buildDiagnosticsPanelModel = (
     }
     for (const { definition, runtimeHealth } of runtimeEntries) {
       if (runtimeHealth?.runtimeOk === false) {
-        criticalReasons.push(`${definition.label} runtime unavailable`);
+        criticalReasons.push(
+          runtimeHealth.runtimeFailureKind === "timeout"
+            ? `${definition.label} runtime is still starting`
+            : `${definition.label} runtime unavailable`,
+        );
       }
       if (definition.capabilities.supportsMcpStatus && runtimeHealth?.mcpOk === false) {
-        criticalReasons.push(`${definition.label} OpenDucktor MCP unavailable`);
+        criticalReasons.push(
+          runtimeHealth.mcpFailureKind === "timeout"
+            ? `${definition.label} OpenDucktor MCP is still starting`
+            : `${definition.label} OpenDucktor MCP unavailable`,
+        );
       }
     }
     if (beadsCheck?.beadsOk === false) {
@@ -186,11 +234,16 @@ export const buildDiagnosticsPanelModel = (
     const runtimeSection: DiagnosticsSectionModel = {
       key: `runtime:${definition.kind}`,
       title: `${definition.label} Runtime`,
-      badge: {
-        label:
-          runtimeHealth == null ? "Checking" : runtimeHealth.runtimeOk ? "Running" : "Unavailable",
-        variant: healthVariant(runtimeHealth?.runtimeOk ?? null),
-      },
+      badge: getFailureBadge(
+        runtimeHealth?.runtimeOk ?? null,
+        runtimeHealth?.runtimeFailureKind ?? null,
+        {
+          healthy: "Running",
+          timeout: "Starting",
+          error: "Unavailable",
+          checking: "Checking",
+        },
+      ),
       rows: runtimeHealth?.runtime
         ? [
             {
@@ -213,7 +266,17 @@ export const buildDiagnosticsPanelModel = (
             },
           ]
         : [],
-      errors: runtimeHealth?.runtimeError ? [runtimeHealth.runtimeError] : [],
+      errors:
+        runtimeHealth?.runtimeError == null
+          ? []
+          : [
+              runtimeHealth.runtimeFailureKind === "timeout"
+                ? buildTimeoutDiagnosticsMessage(
+                    `${definition.label} runtime`,
+                    runtimeHealth.runtimeError,
+                  )
+                : runtimeHealth.runtimeError,
+            ],
       ...(activeRepo
         ? runtimeHealth == null
           ? { emptyMessage: "Runtime health is loading..." }
@@ -228,11 +291,12 @@ export const buildDiagnosticsPanelModel = (
     const mcpSection: DiagnosticsSectionModel = {
       key: `mcp:${definition.kind}`,
       title: `${definition.label} MCP`,
-      badge: {
-        label:
-          runtimeHealth == null ? "Checking" : runtimeHealth.mcpOk ? "Connected" : "Unavailable",
-        variant: healthVariant(runtimeHealth?.mcpOk ?? null),
-      },
+      badge: getFailureBadge(runtimeHealth?.mcpOk ?? null, runtimeHealth?.mcpFailureKind ?? null, {
+        healthy: "Connected",
+        timeout: "Retrying",
+        error: "Unavailable",
+        checking: "Checking",
+      }),
       rows: activeRepo
         ? [
             {
@@ -257,7 +321,14 @@ export const buildDiagnosticsPanelModel = (
         : [],
       errors:
         runtimeHealth?.mcpServerError || runtimeHealth?.mcpError
-          ? [runtimeHealth.mcpServerError ?? runtimeHealth.mcpError ?? ""]
+          ? [
+              runtimeHealth.mcpFailureKind === "timeout"
+                ? buildTimeoutDiagnosticsMessage(
+                    `${definition.label} OpenDucktor MCP`,
+                    runtimeHealth.mcpServerError ?? runtimeHealth.mcpError,
+                  )
+                : (runtimeHealth.mcpServerError ?? runtimeHealth.mcpError ?? ""),
+            ]
           : [],
       ...(activeRepo
         ? runtimeHealth == null

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
@@ -7,11 +7,7 @@ import type {
 } from "@openducktor/contracts";
 import { runtimeLabelFor } from "@/lib/agent-runtime";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import {
-  classifyRepoRuntimeFailure,
-  type RepoRuntimeFailureKind,
-  type RepoRuntimeHealthMap,
-} from "@/types/diagnostics";
+import type { RepoRuntimeFailureKind, RepoRuntimeHealthMap } from "@/types/diagnostics";
 import {
   buildDiagnosticsSummary,
   type DiagnosticsSummary,
@@ -54,6 +50,8 @@ type BuildDiagnosticsPanelModelInput = {
   runtimeDefinitionsError: string | null;
   runtimeCheck: RuntimeCheck | null;
   beadsCheck: BeadsCheck | null;
+  runtimeCheckFailureKind: RepoRuntimeFailureKind;
+  beadsCheckFailureKind: RepoRuntimeFailureKind;
   runtimeHealthByRuntime: RepoRuntimeHealthMap;
   isLoadingChecks: boolean;
 };
@@ -109,6 +107,8 @@ export const buildDiagnosticsPanelModel = (
     runtimeDefinitionsError,
     runtimeCheck,
     beadsCheck,
+    runtimeCheckFailureKind,
+    beadsCheckFailureKind,
     runtimeHealthByRuntime,
     isLoadingChecks,
   } = input;
@@ -123,8 +123,6 @@ export const buildDiagnosticsPanelModel = (
   const isRuntimeHealthPending = runtimeDefinitions.some(
     (definition) => runtimeHealthByRuntime[definition.kind] === undefined,
   );
-  const runtimeCheckFailureKind = classifyRepoRuntimeFailure(runtimeCheck?.errors[0] ?? null);
-  const beadsFailureKind = classifyRepoRuntimeFailure(beadsCheck?.beadsError ?? null);
 
   const criticalReasons: string[] = [];
   if (activeRepo) {
@@ -361,13 +359,15 @@ export const buildDiagnosticsPanelModel = (
       label:
         beadsCheck === null
           ? "Checking"
-          : beadsFailureKind === "timeout"
+          : beadsCheckFailureKind === "timeout"
             ? "Retrying"
             : beadsCheck.beadsOk
               ? "Ready"
               : "Unavailable",
       variant:
-        beadsFailureKind === "timeout" ? "warning" : healthVariant(beadsCheck?.beadsOk ?? null),
+        beadsCheckFailureKind === "timeout"
+          ? "warning"
+          : healthVariant(beadsCheck?.beadsOk ?? null),
     },
     rows:
       activeRepo && beadsCheck?.beadsPath
@@ -381,7 +381,7 @@ export const buildDiagnosticsPanelModel = (
           ]
         : [],
     errors:
-      beadsFailureKind === "timeout"
+      beadsCheckFailureKind === "timeout"
         ? [buildTimeoutDiagnosticsMessage("Beads store", beadsCheck?.beadsError ?? null)]
         : beadsCheck?.beadsError
           ? [beadsCheck.beadsError]

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
@@ -7,7 +7,11 @@ import type {
 } from "@openducktor/contracts";
 import { runtimeLabelFor } from "@/lib/agent-runtime";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import type { RepoRuntimeFailureKind, RepoRuntimeHealthMap } from "@/types/diagnostics";
+import {
+  classifyRepoRuntimeFailure,
+  type RepoRuntimeFailureKind,
+  type RepoRuntimeHealthMap,
+} from "@/types/diagnostics";
 import {
   buildDiagnosticsSummary,
   type DiagnosticsSummary,
@@ -119,6 +123,8 @@ export const buildDiagnosticsPanelModel = (
   const isRuntimeHealthPending = runtimeDefinitions.some(
     (definition) => runtimeHealthByRuntime[definition.kind] === undefined,
   );
+  const runtimeCheckFailureKind = classifyRepoRuntimeFailure(runtimeCheck?.errors[0] ?? null);
+  const beadsFailureKind = classifyRepoRuntimeFailure(beadsCheck?.beadsError ?? null);
 
   const criticalReasons: string[] = [];
   if (activeRepo) {
@@ -208,14 +214,19 @@ export const buildDiagnosticsPanelModel = (
       label:
         runtimeCheck === null
           ? "Checking"
-          : runtimeCheck.gitOk && runtimeCheck.runtimes.every((entry) => entry.ok)
-            ? "Available"
-            : "Issue",
-      variant: healthVariant(
-        runtimeCheck === null
-          ? null
-          : runtimeCheck.gitOk && runtimeCheck.runtimes.every((entry) => entry.ok),
-      ),
+          : runtimeCheckFailureKind === "timeout"
+            ? "Retrying"
+            : runtimeCheck.gitOk && runtimeCheck.runtimes.every((entry) => entry.ok)
+              ? "Available"
+              : "Issue",
+      variant:
+        runtimeCheckFailureKind === "timeout"
+          ? "warning"
+          : healthVariant(
+              runtimeCheck === null
+                ? null
+                : runtimeCheck.gitOk && runtimeCheck.runtimes.every((entry) => entry.ok),
+            ),
     },
     rows: runtimeCheck
       ? [
@@ -224,9 +235,12 @@ export const buildDiagnosticsPanelModel = (
           ...cliRuntimeRows,
         ]
       : [],
-    errors: runtimeDefinitionsError
-      ? [runtimeDefinitionsError, ...(runtimeCheck?.errors ?? [])]
-      : (runtimeCheck?.errors ?? []),
+    errors:
+      runtimeDefinitionsError != null
+        ? [runtimeDefinitionsError, ...(runtimeCheck?.errors ?? [])]
+        : runtimeCheckFailureKind === "timeout"
+          ? [buildTimeoutDiagnosticsMessage("CLI tools", runtimeCheck?.errors[0] ?? null)]
+          : (runtimeCheck?.errors ?? []),
     ...(runtimeCheck ? {} : { emptyMessage: "Runtime checks are loading..." }),
   };
 
@@ -344,8 +358,16 @@ export const buildDiagnosticsPanelModel = (
     key: "beads-store",
     title: "Beads Store",
     badge: {
-      label: beadsCheck === null ? "Checking" : beadsCheck.beadsOk ? "Ready" : "Unavailable",
-      variant: healthVariant(beadsCheck?.beadsOk ?? null),
+      label:
+        beadsCheck === null
+          ? "Checking"
+          : beadsFailureKind === "timeout"
+            ? "Retrying"
+            : beadsCheck.beadsOk
+              ? "Ready"
+              : "Unavailable",
+      variant:
+        beadsFailureKind === "timeout" ? "warning" : healthVariant(beadsCheck?.beadsOk ?? null),
     },
     rows:
       activeRepo && beadsCheck?.beadsPath
@@ -358,7 +380,12 @@ export const buildDiagnosticsPanelModel = (
             },
           ]
         : [],
-    errors: beadsCheck?.beadsError ? [beadsCheck.beadsError] : [],
+    errors:
+      beadsFailureKind === "timeout"
+        ? [buildTimeoutDiagnosticsMessage("Beads store", beadsCheck?.beadsError ?? null)]
+        : beadsCheck?.beadsError
+          ? [beadsCheck.beadsError]
+          : [],
     ...(activeRepo ? {} : { emptyMessage: "Select a repository first." }),
   };
 

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-model.ts
@@ -7,12 +7,9 @@ import type {
 } from "@openducktor/contracts";
 import { runtimeLabelFor } from "@/lib/agent-runtime";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
+import { buildTimeoutToastDescription } from "@/state/operations/workspace/check-diagnostics";
 import type { RepoRuntimeFailureKind, RepoRuntimeHealthMap } from "@/types/diagnostics";
-import {
-  buildDiagnosticsSummary,
-  type DiagnosticsSummary,
-  healthVariant,
-} from "./diagnostics-model";
+import { buildDiagnosticsSummary, type DiagnosticsSummary } from "./diagnostics-model";
 
 export type DiagnosticKeyValueRowModel = {
   label: string;
@@ -56,14 +53,6 @@ type BuildDiagnosticsPanelModelInput = {
   isLoadingChecks: boolean;
 };
 
-const buildTimeoutDiagnosticsMessage = (label: string, detail: string | null): string => {
-  if (!detail) {
-    return `${label} is not yet available. Retrying automatically.`;
-  }
-
-  return `${label} is not yet available. Retrying automatically. Latest detail: ${detail}`;
-};
-
 const getFailureBadge = (
   ok: boolean | null,
   failureKind: RepoRuntimeFailureKind,
@@ -94,6 +83,30 @@ const getFailureBadge = (
     label: labels.error,
     variant: "danger",
   };
+};
+
+const buildFailureMessages = ({
+  label,
+  detail,
+  failureKind,
+  availabilityVerb,
+}: {
+  label: string;
+  detail: string | null;
+  failureKind: RepoRuntimeFailureKind;
+  availabilityVerb?: "is" | "are";
+}): string[] => {
+  if (failureKind === "timeout") {
+    return [
+      buildTimeoutToastDescription(
+        label,
+        detail,
+        availabilityVerb ? { availabilityVerb } : undefined,
+      ),
+    ];
+  }
+
+  return detail ? [detail] : [];
 };
 
 export const buildDiagnosticsPanelModel = (
@@ -204,28 +217,20 @@ export const buildDiagnosticsPanelModel = (
           label: runtimeEntry.kind,
           value: runtimeEntry.ok ? (runtimeEntry.version ?? "detected") : "missing",
         }));
+  const cliToolsHealthy =
+    runtimeCheck === null
+      ? null
+      : runtimeCheck.gitOk && runtimeCheck.runtimes.every((entry) => entry.ok);
 
   const cliToolsSection: DiagnosticsSectionModel = {
     key: "cli-tools",
     title: "CLI Tools",
-    badge: {
-      label:
-        runtimeCheck === null
-          ? "Checking"
-          : runtimeCheckFailureKind === "timeout"
-            ? "Retrying"
-            : runtimeCheck.gitOk && runtimeCheck.runtimes.every((entry) => entry.ok)
-              ? "Available"
-              : "Issue",
-      variant:
-        runtimeCheckFailureKind === "timeout"
-          ? "warning"
-          : healthVariant(
-              runtimeCheck === null
-                ? null
-                : runtimeCheck.gitOk && runtimeCheck.runtimes.every((entry) => entry.ok),
-            ),
-    },
+    badge: getFailureBadge(cliToolsHealthy, runtimeCheckFailureKind, {
+      healthy: "Available",
+      timeout: "Retrying",
+      error: "Issue",
+      checking: "Checking",
+    }),
     rows: runtimeCheck
       ? [
           { label: "Git", value: runtimeCheck.gitVersion ?? "missing" },
@@ -236,9 +241,12 @@ export const buildDiagnosticsPanelModel = (
     errors:
       runtimeDefinitionsError != null
         ? [runtimeDefinitionsError, ...(runtimeCheck?.errors ?? [])]
-        : runtimeCheckFailureKind === "timeout"
-          ? [buildTimeoutDiagnosticsMessage("CLI tools", runtimeCheck?.errors[0] ?? null)]
-          : (runtimeCheck?.errors ?? []),
+        : buildFailureMessages({
+            label: "CLI tools",
+            detail: runtimeCheck?.errors[0] ?? null,
+            failureKind: runtimeCheckFailureKind,
+            availabilityVerb: "are",
+          }),
     ...(runtimeCheck ? {} : { emptyMessage: "Runtime checks are loading..." }),
   };
 
@@ -278,17 +286,11 @@ export const buildDiagnosticsPanelModel = (
             },
           ]
         : [],
-      errors:
-        runtimeHealth?.runtimeError == null
-          ? []
-          : [
-              runtimeHealth.runtimeFailureKind === "timeout"
-                ? buildTimeoutDiagnosticsMessage(
-                    `${definition.label} runtime`,
-                    runtimeHealth.runtimeError,
-                  )
-                : runtimeHealth.runtimeError,
-            ],
+      errors: buildFailureMessages({
+        label: `${definition.label} runtime`,
+        detail: runtimeHealth?.runtimeError ?? null,
+        failureKind: runtimeHealth?.runtimeFailureKind ?? null,
+      }),
       ...(activeRepo
         ? runtimeHealth == null
           ? { emptyMessage: "Runtime health is loading..." }
@@ -331,17 +333,11 @@ export const buildDiagnosticsPanelModel = (
             },
           ]
         : [],
-      errors:
-        runtimeHealth?.mcpServerError || runtimeHealth?.mcpError
-          ? [
-              runtimeHealth.mcpFailureKind === "timeout"
-                ? buildTimeoutDiagnosticsMessage(
-                    `${definition.label} OpenDucktor MCP`,
-                    runtimeHealth.mcpServerError ?? runtimeHealth.mcpError,
-                  )
-                : (runtimeHealth.mcpServerError ?? runtimeHealth.mcpError ?? ""),
-            ]
-          : [],
+      errors: buildFailureMessages({
+        label: `${definition.label} OpenDucktor MCP`,
+        detail: runtimeHealth?.mcpServerError ?? runtimeHealth?.mcpError ?? null,
+        failureKind: runtimeHealth?.mcpFailureKind ?? null,
+      }),
       ...(activeRepo
         ? runtimeHealth == null
           ? { emptyMessage: "MCP health is loading..." }
@@ -355,20 +351,12 @@ export const buildDiagnosticsPanelModel = (
   const beadsStoreSection: DiagnosticsSectionModel = {
     key: "beads-store",
     title: "Beads Store",
-    badge: {
-      label:
-        beadsCheck === null
-          ? "Checking"
-          : beadsCheckFailureKind === "timeout"
-            ? "Retrying"
-            : beadsCheck.beadsOk
-              ? "Ready"
-              : "Unavailable",
-      variant:
-        beadsCheckFailureKind === "timeout"
-          ? "warning"
-          : healthVariant(beadsCheck?.beadsOk ?? null),
-    },
+    badge: getFailureBadge(beadsCheck?.beadsOk ?? null, beadsCheckFailureKind, {
+      healthy: "Ready",
+      timeout: "Retrying",
+      error: "Unavailable",
+      checking: "Checking",
+    }),
     rows:
       activeRepo && beadsCheck?.beadsPath
         ? [
@@ -380,12 +368,11 @@ export const buildDiagnosticsPanelModel = (
             },
           ]
         : [],
-    errors:
-      beadsCheckFailureKind === "timeout"
-        ? [buildTimeoutDiagnosticsMessage("Beads store", beadsCheck?.beadsError ?? null)]
-        : beadsCheck?.beadsError
-          ? [beadsCheck.beadsError]
-          : [],
+    errors: buildFailureMessages({
+      label: "Beads store",
+      detail: beadsCheck?.beadsError ?? null,
+      failureKind: beadsCheckFailureKind,
+    }),
     ...(activeRepo ? {} : { emptyMessage: "Select a repository first." }),
   };
 

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-sections.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-sections.test.ts
@@ -61,6 +61,7 @@ describe("DiagnosticsPanelSections", () => {
         opencode: {
           runtimeOk: true,
           runtimeError: null,
+          runtimeFailureKind: null,
           runtime: {
             kind: "opencode",
             runtimeId: "runtime-1",
@@ -77,6 +78,7 @@ describe("DiagnosticsPanelSections", () => {
           },
           mcpOk: true,
           mcpError: null,
+          mcpFailureKind: null,
           mcpServerName: "openducktor",
           mcpServerStatus: "connected",
           mcpServerError: null,
@@ -135,9 +137,11 @@ describe("DiagnosticsPanelSections", () => {
         opencode: {
           runtimeOk: false,
           runtimeError: "runtime failed",
+          runtimeFailureKind: "error",
           runtime: null,
           mcpOk: false,
           mcpError: "mcp unavailable",
+          mcpFailureKind: "error",
           mcpServerName: "openducktor",
           mcpServerStatus: null,
           mcpServerError: "server unavailable",

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel-sections.test.ts
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel-sections.test.ts
@@ -15,6 +15,8 @@ describe("DiagnosticsPanelSections", () => {
       runtimeDefinitionsError: null,
       runtimeCheck: null,
       beadsCheck: null,
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {},
       isLoadingChecks: false,
     });
@@ -57,6 +59,8 @@ describe("DiagnosticsPanelSections", () => {
         beadsPath: "/Users/dev/.openducktor/beads/fairnest/.beads",
         beadsError: null,
       },
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {
         opencode: {
           runtimeOk: true,
@@ -133,6 +137,8 @@ describe("DiagnosticsPanelSections", () => {
         beadsPath: null,
         beadsError: "beads init failed",
       },
+      runtimeCheckFailureKind: "error",
+      beadsCheckFailureKind: "error",
       runtimeHealthByRuntime: {
         opencode: {
           runtimeOk: false,

--- a/apps/desktop/src/components/features/diagnostics/diagnostics-panel.tsx
+++ b/apps/desktop/src/components/features/diagnostics/diagnostics-panel.tsx
@@ -23,8 +23,15 @@ export function DiagnosticsPanel(): ReactElement {
     useRuntimeDefinitionsContext();
   const { refreshRepoRuntimeHealthForRepo, hasCachedRepoRuntimeHealth } =
     useChecksOperationsContext();
-  const { runtimeCheck, beadsCheck, runtimeHealthByRuntime, refreshChecks, isLoadingChecks } =
-    useChecksState();
+  const {
+    runtimeCheck,
+    beadsCheck,
+    runtimeCheckFailureKind,
+    beadsCheckFailureKind,
+    runtimeHealthByRuntime,
+    refreshChecks,
+    isLoadingChecks,
+  } = useChecksState();
   const [isOpen, setOpen] = useState(false);
   const autoOpenedByRepoRef = useRef<Set<string>>(new Set());
 
@@ -38,6 +45,8 @@ export function DiagnosticsPanel(): ReactElement {
         runtimeDefinitionsError,
         runtimeCheck,
         beadsCheck,
+        runtimeCheckFailureKind,
+        beadsCheckFailureKind,
         runtimeHealthByRuntime,
         isLoadingChecks,
       }),
@@ -45,9 +54,11 @@ export function DiagnosticsPanel(): ReactElement {
       activeRepo,
       activeWorkspace,
       beadsCheck,
+      beadsCheckFailureKind,
       isLoadingChecks,
       isLoadingRuntimeDefinitions,
       runtimeCheck,
+      runtimeCheckFailureKind,
       runtimeDefinitions,
       runtimeDefinitionsError,
       runtimeHealthByRuntime,

--- a/apps/desktop/src/lib/browser-live-client.ts
+++ b/apps/desktop/src/lib/browser-live-client.ts
@@ -12,22 +12,35 @@ type BrowserSseChannel = {
 const sseChannels = new Map<string, BrowserSseChannel>();
 let nextSseListenerId = 0;
 
-export const readBrowserLiveErrorMessage = async (response: Response): Promise<string> => {
+const readBrowserLiveErrorPayload = async (
+  response: Response,
+): Promise<{ message: string; payload: unknown | null }> => {
   const text = await response.text().catch(() => "");
   const trimmedText = text.trim();
 
   if (trimmedText) {
     try {
-      const payload = JSON.parse(trimmedText) as { error?: unknown };
+      const payload = JSON.parse(trimmedText) as { error?: unknown; message?: unknown };
       if (typeof payload.error === "string" && payload.error.trim()) {
-        return payload.error;
+        return { message: payload.error, payload };
+      }
+      if (typeof payload.message === "string" && payload.message.trim()) {
+        return { message: payload.message, payload };
       }
     } catch {}
 
-    return trimmedText;
+    return { message: trimmedText, payload: null };
   }
 
-  return `Browser backend request failed with status ${response.status}.`;
+  return {
+    message: `Browser backend request failed with status ${response.status}.`,
+    payload: null,
+  };
+};
+
+export const readBrowserLiveErrorMessage = async (response: Response): Promise<string> => {
+  const { message } = await readBrowserLiveErrorPayload(response);
+  return message;
 };
 
 const createHttpInvoke = () => {
@@ -43,7 +56,8 @@ const createHttpInvoke = () => {
     });
 
     if (!response.ok) {
-      throw new Error(await readBrowserLiveErrorMessage(response));
+      const { message, payload } = await readBrowserLiveErrorPayload(response);
+      throw new Error(message, payload ? { cause: payload } : undefined);
     }
 
     return (await response.json()) as T;

--- a/apps/desktop/src/pages/agents/use-agents-page-readiness.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agents-page-readiness.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
+import { useAgentStudioReadiness } from "./use-agents-page-readiness";
+
+describe("useAgentStudioReadiness", () => {
+  test("returns timeout-specific blocked copy while runtime health is warming up", async () => {
+    let latest: ReturnType<typeof useAgentStudioReadiness> | null = null;
+
+    const Harness = ({ args }: { args: Parameters<typeof useAgentStudioReadiness>[0] }) => {
+      latest = useAgentStudioReadiness(args);
+      return null;
+    };
+
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        isLoadingRuntimeDefinitions: false,
+        runtimeDefinitionsError: null,
+        runtimeHealthByRuntime: {
+          opencode: {
+            runtimeOk: false,
+            runtimeError: "Timed out waiting for OpenCode runtime startup readiness",
+            runtimeFailureKind: "timeout",
+            runtime: null,
+            mcpOk: false,
+            mcpError: "Runtime is unavailable, so MCP cannot be verified.",
+            mcpFailureKind: "timeout",
+            mcpServerName: "openducktor",
+            mcpServerStatus: null,
+            mcpServerError: "Runtime is unavailable, so MCP cannot be verified.",
+            availableToolIds: [],
+            checkedAt: "2026-02-20T12:01:00.000Z",
+            errors: ["Timed out waiting for OpenCode runtime startup readiness"],
+          },
+        },
+        isLoadingChecks: false,
+        refreshChecks: async () => {},
+      },
+    });
+
+    try {
+      await harness.mount();
+      if (!latest) {
+        throw new Error("Expected readiness hook to mount");
+      }
+
+      const readiness = latest as ReturnType<typeof useAgentStudioReadiness>;
+      expect(readiness.agentStudioReadinessState).toBe("blocked");
+      expect(readiness.agentStudioBlockedReason).toContain("Retrying automatically");
+      expect(readiness.agentStudioBlockedReason).toContain("OpenCode runtime");
+    } finally {
+      await harness.unmount();
+    }
+  });
+});

--- a/apps/desktop/src/pages/agents/use-agents-page-readiness.ts
+++ b/apps/desktop/src/pages/agents/use-agents-page-readiness.ts
@@ -1,19 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { useChecksState } from "@/state";
 import type { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
+import { buildTimeoutToastDescription } from "@/state/operations/workspace/check-diagnostics";
 import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import type {
   AgentStudioOrchestrationReadinessContext,
   AgentStudioOrchestrationSelectionContext,
 } from "./use-agent-studio-orchestration-controller";
-
-const buildTimeoutBlockedReason = (label: string, detail: string | null): string => {
-  if (!detail) {
-    return `${label} is not yet available. Retrying automatically.`;
-  }
-
-  return `${label} is not yet available. Retrying automatically. Latest detail: ${detail}`;
-};
 
 const getBlockedRuntimeReason = (
   runtimeLabel: string,
@@ -25,14 +18,14 @@ const getBlockedRuntimeReason = (
 
   if (runtimeHealth.runtimeOk === false) {
     return runtimeHealth.runtimeFailureKind === "timeout"
-      ? buildTimeoutBlockedReason(`${runtimeLabel} runtime`, runtimeHealth.runtimeError)
+      ? buildTimeoutToastDescription(`${runtimeLabel} runtime`, runtimeHealth.runtimeError)
       : runtimeHealth.runtimeError;
   }
 
   if (runtimeHealth.mcpOk === false) {
     const detail = runtimeHealth.mcpServerError ?? runtimeHealth.mcpError;
     return runtimeHealth.mcpFailureKind === "timeout"
-      ? buildTimeoutBlockedReason(`${runtimeLabel} OpenDucktor MCP`, detail)
+      ? buildTimeoutToastDescription(`${runtimeLabel} OpenDucktor MCP`, detail)
       : detail;
   }
 

--- a/apps/desktop/src/pages/agents/use-agents-page-readiness.ts
+++ b/apps/desktop/src/pages/agents/use-agents-page-readiness.ts
@@ -1,10 +1,43 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { useChecksState } from "@/state";
 import type { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
+import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import type {
   AgentStudioOrchestrationReadinessContext,
   AgentStudioOrchestrationSelectionContext,
 } from "./use-agent-studio-orchestration-controller";
+
+const buildTimeoutBlockedReason = (label: string, detail: string | null): string => {
+  if (!detail) {
+    return `${label} is not yet available. Retrying automatically.`;
+  }
+
+  return `${label} is not yet available. Retrying automatically. Latest detail: ${detail}`;
+};
+
+const getBlockedRuntimeReason = (
+  runtimeLabel: string,
+  runtimeHealth: RepoRuntimeHealthCheck | null,
+): string | null => {
+  if (!runtimeHealth) {
+    return null;
+  }
+
+  if (runtimeHealth.runtimeOk === false) {
+    return runtimeHealth.runtimeFailureKind === "timeout"
+      ? buildTimeoutBlockedReason(`${runtimeLabel} runtime`, runtimeHealth.runtimeError)
+      : runtimeHealth.runtimeError;
+  }
+
+  if (runtimeHealth.mcpOk === false) {
+    const detail = runtimeHealth.mcpServerError ?? runtimeHealth.mcpError;
+    return runtimeHealth.mcpFailureKind === "timeout"
+      ? buildTimeoutBlockedReason(`${runtimeLabel} OpenDucktor MCP`, detail)
+      : detail;
+  }
+
+  return null;
+};
 
 type UseRunCompletionRecoverySignalArgs = {
   activeSession: AgentStudioOrchestrationSelectionContext["viewActiveSession"];
@@ -129,8 +162,9 @@ export function useAgentStudioReadiness({
     }
 
     return (
-      blockedRuntimeHealth?.runtimeError ??
-      blockedRuntimeHealth?.mcpError ??
+      (blockedRuntimeDefinition
+        ? getBlockedRuntimeReason(blockedRuntimeDefinition.label, blockedRuntimeHealth)
+        : null) ??
       (runtimeDefinitions.length === 0
         ? "No agent runtimes are available."
         : "No configured runtime is ready for Agent Studio.")

--- a/apps/desktop/src/state/app-state-context-values.test.ts
+++ b/apps/desktop/src/state/app-state-context-values.test.ts
@@ -90,6 +90,8 @@ describe("app-state-context-values", () => {
     const checksValue: ChecksStateContextValue = {
       runtimeCheck: null,
       beadsCheck: null,
+      runtimeCheckFailureKind: null,
+      beadsCheckFailureKind: null,
       runtimeHealthByRuntime: {},
       isLoadingChecks: false,
       refreshChecks: async () => {},

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -58,16 +58,10 @@ export function useAppLifecycle({
 
   useEffect(() => {
     Promise.allSettled([refreshWorkspaces(), refreshRuntimeCheck(false)]).then(
-      ([workspaceResult, runtimeResult]) => {
+      ([workspaceResult]) => {
         if (workspaceResult.status === "rejected") {
           toast.error("Workspace load failed", {
             description: errorMessage(workspaceResult.reason),
-          });
-        }
-
-        if (runtimeResult.status === "rejected") {
-          toast.error("Runtime checks unavailable", {
-            description: errorMessage(runtimeResult.reason),
           });
         }
       },
@@ -190,7 +184,7 @@ export function useAppLifecycle({
     });
 
     Promise.allSettled([taskLoadPromise, runtimeCheckPromise])
-      .then(([tasksResult, runtimeResult]) => {
+      .then(([tasksResult]) => {
         if (isStaleRepoLoad()) {
           return;
         }
@@ -198,12 +192,6 @@ export function useAppLifecycle({
         if (tasksResult.status === "rejected") {
           toast.error("Repository tasks unavailable", {
             description: summarizeTaskLoadError(tasksResult.reason),
-          });
-        }
-
-        if (runtimeResult.status === "rejected") {
-          toast.error("Runtime checks unavailable", {
-            description: errorMessage(runtimeResult.reason),
           });
         }
       })

--- a/apps/desktop/src/state/operations/shared/runtime-catalog.test.ts
+++ b/apps/desktop/src/state/operations/shared/runtime-catalog.test.ts
@@ -9,6 +9,12 @@ import { createRuntimeCatalogOperations } from "./runtime-catalog";
 
 type CatalogDependencies = Parameters<typeof createRuntimeCatalogOperations>[0];
 type RuntimeSummary = Awaited<ReturnType<CatalogDependencies["ensureRuntime"]>>;
+const withFailureKind = <T extends Error>(
+  error: T,
+  failureKind: "timeout" | "error",
+): T & {
+  failureKind: "timeout" | "error";
+} => Object.assign(error, { failureKind });
 
 const runtimeFixture: RuntimeSummary = {
   kind: "opencode",
@@ -317,7 +323,10 @@ describe("opencode-catalog", () => {
     const runtimeTimeoutOperations = createRuntimeCatalogOperations(
       createDeps({
         ensureRuntime: async () => {
-          throw new Error("Timed out waiting for OpenCode runtime startup readiness");
+          throw withFailureKind(
+            new Error("OpenCode startup probe failed reason=timeout after 15000ms"),
+            "timeout",
+          );
         },
       }),
     );
@@ -332,7 +341,10 @@ describe("opencode-catalog", () => {
     const mcpTimeoutOperations = createRuntimeCatalogOperations(
       createDeps({
         getMcpStatus: async () => {
-          throw new Error("OpenCode startup probe failed reason=timeout after 15000ms");
+          throw withFailureKind(
+            new Error("OpenCode startup probe failed reason=timeout after 15000ms"),
+            "timeout",
+          );
         },
       }),
     );

--- a/apps/desktop/src/state/operations/shared/runtime-catalog.test.ts
+++ b/apps/desktop/src/state/operations/shared/runtime-catalog.test.ts
@@ -231,7 +231,9 @@ describe("opencode-catalog", () => {
     expect(result.mcpOk).toBe(false);
     expect(result.availableToolIds).toEqual([]);
     expect(result.runtimeError).toContain("runtime unavailable");
+    expect(result.runtimeFailureKind).toBe("error");
     expect(result.mcpError).toContain("MCP cannot be verified");
+    expect(result.mcpFailureKind).toBe("error");
     expect(result.mcpServerName).toBe("openducktor");
     expect(result.errors).toEqual([
       "runtime unavailable",
@@ -306,7 +308,41 @@ describe("opencode-catalog", () => {
     expect(result.mcpOk).toBe(false);
     expect(result.runtime).toEqual(runtimeFixture);
     expect(result.mcpError).toBe("Failed to query runtime MCP status: status unavailable");
+    expect(result.runtimeFailureKind).toBeNull();
+    expect(result.mcpFailureKind).toBe("error");
     expect(result.errors).toEqual(["Failed to query runtime MCP status: status unavailable"]);
+  });
+
+  test("classifies timeout-shaped runtime and MCP failures distinctly", async () => {
+    const runtimeTimeoutOperations = createRuntimeCatalogOperations(
+      createDeps({
+        ensureRuntime: async () => {
+          throw new Error("Timed out waiting for OpenCode runtime startup readiness");
+        },
+      }),
+    );
+    const runtimeTimeoutResult = await runtimeTimeoutOperations.checkRepoRuntimeHealth(
+      "/tmp/repo",
+      "opencode",
+    );
+
+    expect(runtimeTimeoutResult.runtimeFailureKind).toBe("timeout");
+    expect(runtimeTimeoutResult.mcpFailureKind).toBe("timeout");
+
+    const mcpTimeoutOperations = createRuntimeCatalogOperations(
+      createDeps({
+        getMcpStatus: async () => {
+          throw new Error("OpenCode startup probe failed reason=timeout after 15000ms");
+        },
+      }),
+    );
+    const mcpTimeoutResult = await mcpTimeoutOperations.checkRepoRuntimeHealth(
+      "/tmp/repo",
+      "opencode",
+    );
+
+    expect(mcpTimeoutResult.runtimeFailureKind).toBeNull();
+    expect(mcpTimeoutResult.mcpFailureKind).toBe("timeout");
   });
 
   test("treats MCP status as optional when the runtime does not support it", async () => {

--- a/apps/desktop/src/state/operations/shared/runtime-catalog.ts
+++ b/apps/desktop/src/state/operations/shared/runtime-catalog.ts
@@ -15,7 +15,7 @@ import { errorMessage } from "@/lib/errors";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
 import { appQueryClient } from "@/lib/query-client";
 import { ensureRuntimeListFromQuery } from "@/state/queries/runtime";
-import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
+import { classifyRepoRuntimeFailure, type RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import { host } from "./host";
 
 type RuntimeMcpServerStatus = {
@@ -109,12 +109,15 @@ const toRuntimeUnavailableHealthCheck = (
   checkedAt: string,
 ): RepoRuntimeHealthCheck => {
   const unavailableMessage = "Runtime is unavailable, so MCP cannot be verified.";
+  const runtimeFailureKind = classifyRepoRuntimeFailure(runtimeError);
   return {
     runtimeOk: false,
     runtimeError,
+    runtimeFailureKind,
     runtime: null,
     mcpOk: false,
     mcpError: unavailableMessage,
+    mcpFailureKind: runtimeFailureKind,
     mcpServerName: ODT_MCP_SERVER_NAME,
     mcpServerStatus: null,
     mcpServerError: unavailableMessage,
@@ -129,12 +132,15 @@ const toMcpStatusFailedHealthCheck = (
   mcpError: string,
   checkedAt: string,
 ): RepoRuntimeHealthCheck => {
+  const mcpFailureKind = classifyRepoRuntimeFailure(mcpError);
   return {
     runtimeOk: true,
     runtimeError: null,
+    runtimeFailureKind: null,
     runtime,
     mcpOk: false,
     mcpError,
+    mcpFailureKind,
     mcpServerName: ODT_MCP_SERVER_NAME,
     mcpServerStatus: null,
     mcpServerError: mcpError,
@@ -151,9 +157,11 @@ const toRepoRuntimeHealthCheckWithoutMcpStatus = (
   return {
     runtimeOk: true,
     runtimeError: null,
+    runtimeFailureKind: null,
     runtime,
     mcpOk: true,
     mcpError: null,
+    mcpFailureKind: null,
     mcpServerName: ODT_MCP_SERVER_NAME,
     mcpServerStatus: null,
     mcpServerError: null,
@@ -180,9 +188,11 @@ const toRepoRuntimeHealthCheck = ({
   return {
     runtimeOk: true,
     runtimeError: null,
+    runtimeFailureKind: null,
     runtime,
     mcpOk,
     mcpError,
+    mcpFailureKind: classifyRepoRuntimeFailure(mcpError),
     mcpServerName: ODT_MCP_SERVER_NAME,
     mcpServerStatus,
     mcpServerError: mcpServerError ?? null,

--- a/apps/desktop/src/state/operations/shared/runtime-catalog.ts
+++ b/apps/desktop/src/state/operations/shared/runtime-catalog.ts
@@ -15,7 +15,7 @@ import { errorMessage } from "@/lib/errors";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
 import { appQueryClient } from "@/lib/query-client";
 import { ensureRuntimeListFromQuery } from "@/state/queries/runtime";
-import { classifyRepoRuntimeFailure, type RepoRuntimeHealthCheck } from "@/types/diagnostics";
+import type { RepoRuntimeFailureKind, RepoRuntimeHealthCheck } from "@/types/diagnostics";
 import { host } from "./host";
 
 type RuntimeMcpServerStatus = {
@@ -83,7 +83,10 @@ type McpProbeResult =
 type NormalizedMcpStatus = {
   mcpServerStatus: string | null;
   mcpServerError: string | null;
+  mcpFailureKind: RepoRuntimeFailureKind;
 };
+
+type NonNullRepoRuntimeFailureKind = Exclude<RepoRuntimeFailureKind, null>;
 
 const ACTIVE_RUN_STATES = new Set<RunSummary["state"]>([
   "starting",
@@ -104,12 +107,28 @@ const shouldReconnectMcp = (status: string | null): boolean => {
   return status !== null && status !== "connected";
 };
 
+const readFailureKind = (error: unknown): NonNullRepoRuntimeFailureKind | null => {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  const candidate = (error as { failureKind?: unknown }).failureKind;
+  return candidate === "timeout" || candidate === "error" ? candidate : null;
+};
+
+const toErrorFailure = (
+  error: unknown,
+): { message: string; failureKind: NonNullRepoRuntimeFailureKind } => ({
+  message: errorMessage(error),
+  failureKind: readFailureKind(error) ?? "error",
+});
+
 const toRuntimeUnavailableHealthCheck = (
   runtimeError: string,
+  runtimeFailureKind: NonNullRepoRuntimeFailureKind,
   checkedAt: string,
 ): RepoRuntimeHealthCheck => {
   const unavailableMessage = "Runtime is unavailable, so MCP cannot be verified.";
-  const runtimeFailureKind = classifyRepoRuntimeFailure(runtimeError);
   return {
     runtimeOk: false,
     runtimeError,
@@ -130,9 +149,9 @@ const toRuntimeUnavailableHealthCheck = (
 const toMcpStatusFailedHealthCheck = (
   runtime: RuntimeInstanceSummary,
   mcpError: string,
+  mcpFailureKind: NonNullRepoRuntimeFailureKind,
   checkedAt: string,
 ): RepoRuntimeHealthCheck => {
-  const mcpFailureKind = classifyRepoRuntimeFailure(mcpError);
   return {
     runtimeOk: true,
     runtimeError: null,
@@ -192,7 +211,7 @@ const toRepoRuntimeHealthCheck = ({
     runtime,
     mcpOk,
     mcpError,
-    mcpFailureKind: classifyRepoRuntimeFailure(mcpError),
+    mcpFailureKind: mcpOk ? null : "error",
     mcpServerName: ODT_MCP_SERVER_NAME,
     mcpServerStatus,
     mcpServerError: mcpServerError ?? null,
@@ -204,20 +223,22 @@ const toRepoRuntimeHealthCheck = ({
 
 const resolveMcpStatusError = (
   statusByServer: Record<string, RuntimeMcpServerStatus>,
-): { status: string | null; error: string | null } => {
+): { status: string | null; error: string | null; failureKind: RepoRuntimeFailureKind } => {
   const serverStatus = statusByServer[ODT_MCP_SERVER_NAME];
   if (!serverStatus) {
     return {
       status: null,
       error: `MCP server '${ODT_MCP_SERVER_NAME}' is not configured for this runtime.`,
+      failureKind: "error",
     };
   }
   if (serverStatus.status === "connected") {
-    return { status: serverStatus.status, error: null };
+    return { status: serverStatus.status, error: null, failureKind: null };
   }
   return {
     status: serverStatus.status,
     error: serverStatus.error ?? `MCP server '${ODT_MCP_SERVER_NAME}' is ${serverStatus.status}.`,
+    failureKind: "error",
   };
 };
 
@@ -252,10 +273,14 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
         runtimeInput: toRuntimeInput(runtime, runtimeKind),
       };
     } catch (error) {
-      const runtimeError = errorMessage(error);
+      const runtimeError = toErrorFailure(error);
       return {
         ok: false,
-        result: toRuntimeUnavailableHealthCheck(runtimeError, checkedAt),
+        result: toRuntimeUnavailableHealthCheck(
+          runtimeError.message,
+          runtimeError.failureKind,
+          checkedAt,
+        ),
       };
     }
   };
@@ -275,13 +300,15 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
         statusByServer,
       };
     } catch (error) {
-      const rawMessage = errorMessage(error);
+      const mcpStatusError = toErrorFailure(error);
+      const rawMessage = mcpStatusError.message;
       if (!deps.shouldRestartRuntimeForMcpStatusError(runtimeKind, rawMessage)) {
         return {
           ok: false,
           result: toMcpStatusFailedHealthCheck(
             runtimeProbe.runtime,
             `Failed to query runtime MCP status: ${rawMessage}`,
+            mcpStatusError.failureKind,
             checkedAt,
           ),
         };
@@ -296,6 +323,7 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
             result: toMcpStatusFailedHealthCheck(
               runtimeProbe.runtime,
               `Failed to query runtime MCP status: ${rawMessage}. Automatic runtime restart was skipped because an active run is using this runtime.`,
+              mcpStatusError.failureKind,
               checkedAt,
             ),
           };
@@ -311,11 +339,13 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
           statusByServer,
         };
       } catch (retryError) {
+        const retriedMcpStatusError = toErrorFailure(retryError);
         return {
           ok: false,
           result: toMcpStatusFailedHealthCheck(
             restartedRuntime ?? runtimeProbe.runtime,
-            `Failed to query runtime MCP status: ${errorMessage(retryError)}`,
+            `Failed to query runtime MCP status: ${retriedMcpStatusError.message}`,
+            retriedMcpStatusError.failureKind,
             checkedAt,
           ),
         };
@@ -327,7 +357,11 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
     runtimeInput: ListCatalogInput,
     statusByServer: Record<string, RuntimeMcpServerStatus>,
   ): Promise<NormalizedMcpStatus> => {
-    let { status: mcpServerStatus, error: mcpServerError } = resolveMcpStatusError(statusByServer);
+    let {
+      status: mcpServerStatus,
+      error: mcpServerError,
+      failureKind: mcpFailureKind,
+    } = resolveMcpStatusError(statusByServer);
 
     if (shouldReconnectMcp(mcpServerStatus)) {
       try {
@@ -339,17 +373,20 @@ export const createRuntimeCatalogOperations = (deps: RuntimeCatalogDependencies)
         const refreshedStatus = resolveMcpStatusError(refreshedStatusByServer);
         mcpServerStatus = refreshedStatus.status;
         mcpServerError = refreshedStatus.error;
+        mcpFailureKind = refreshedStatus.failureKind;
       } catch (error) {
         const reconnectError = errorMessage(error);
         mcpServerError = mcpServerError
           ? `${mcpServerError} (reconnect failed: ${reconnectError})`
           : `Failed to reconnect MCP server '${ODT_MCP_SERVER_NAME}': ${reconnectError}`;
+        mcpFailureKind = "error";
       }
     }
 
     return {
       mcpServerStatus,
       mcpServerError,
+      mcpFailureKind,
     };
   };
 

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
@@ -104,6 +104,40 @@ describe("check-diagnostics helpers", () => {
     );
   });
 
+  test("treats GitHub CLI and auth failures as CLI toast-level issues", () => {
+    const issues = buildDiagnosticsToastIssues({
+      activeRepo: "/repo",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+      runtimeCheck: {
+        gitOk: true,
+        gitVersion: "git version 2.50.1",
+        ghOk: false,
+        ghVersion: null,
+        ghAuthOk: false,
+        ghAuthLogin: null,
+        ghAuthError: "gh auth missing",
+        runtimes: [{ kind: "opencode", ok: true, version: "1.2.9" }],
+        errors: ["gh auth missing"],
+      },
+      runtimeCheckError: null,
+      runtimeCheckFailureKind: null,
+      beadsCheck: null,
+      beadsCheckError: null,
+      beadsCheckFailureKind: null,
+      runtimeHealthByRuntime: {},
+    });
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "diagnostics:cli-tools",
+          severity: "error",
+          description: "gh auth missing",
+        }),
+      ]),
+    );
+  });
+
   test("computes retry plan per diagnostics family", () => {
     expect(
       buildDiagnosticsRetryPlan({

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import type { RepoRuntimeHealthCheck } from "@/types/diagnostics";
+import {
+  buildBeadsCheckErrorState,
+  buildDiagnosticsRetryPlan,
+  buildDiagnosticsToastIssues,
+  buildRuntimeCheckErrorState,
+  buildRuntimeHealthErrorMap,
+} from "./check-diagnostics";
+
+const makeRepoHealth = (
+  overrides: Partial<RepoRuntimeHealthCheck> = {},
+): RepoRuntimeHealthCheck => ({
+  runtimeOk: true,
+  runtimeError: null,
+  runtimeFailureKind: null,
+  runtime: null,
+  mcpOk: true,
+  mcpError: null,
+  mcpFailureKind: null,
+  mcpServerName: "openducktor",
+  mcpServerStatus: "connected",
+  mcpServerError: null,
+  availableToolIds: [],
+  checkedAt: "2026-02-22T08:00:00.000Z",
+  errors: [],
+  ...overrides,
+});
+
+describe("check-diagnostics helpers", () => {
+  test("projects runtime and beads query failures into concrete error states", () => {
+    expect(
+      buildRuntimeCheckErrorState([OPENCODE_RUNTIME_DESCRIPTOR], "Timed out after 15000ms"),
+    ).toEqual(
+      expect.objectContaining({
+        gitOk: false,
+        ghAuthError: "Timed out after 15000ms",
+        runtimes: [{ kind: "opencode", ok: false, version: null }],
+      }),
+    );
+
+    expect(buildBeadsCheckErrorState("beads offline")).toEqual({
+      beadsOk: false,
+      beadsPath: null,
+      beadsError: "beads offline",
+    });
+  });
+
+  test("builds toast issues across cli, beads, and runtime health checks", () => {
+    const issues = buildDiagnosticsToastIssues({
+      activeRepo: "/repo",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+      runtimeCheckError: "Timed out after 15000ms",
+      runtimeCheckFailureKind: "timeout",
+      beadsCheckError: "beads offline",
+      beadsCheckFailureKind: "error",
+      runtimeHealthByRuntime: {
+        opencode: makeRepoHealth({
+          runtimeOk: false,
+          runtimeError: "Timed out waiting for OpenCode runtime startup readiness",
+          runtimeFailureKind: "timeout",
+        }),
+      },
+    });
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "diagnostics:cli-tools", severity: "timeout" }),
+        expect.objectContaining({ id: "diagnostics:beads-store", severity: "error" }),
+        expect.objectContaining({ id: "diagnostics:runtime:opencode", severity: "timeout" }),
+      ]),
+    );
+  });
+
+  test("computes retry plan per diagnostics family", () => {
+    expect(
+      buildDiagnosticsRetryPlan({
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        runtimeCheckFailureKind: "timeout",
+        runtimeCheckFetching: false,
+        beadsCheckFailureKind: "error",
+        beadsCheckFetching: false,
+        runtimeHealthByRuntime: buildRuntimeHealthErrorMap(
+          [OPENCODE_RUNTIME_DESCRIPTOR],
+          "runtime health failed",
+          "2026-02-22T08:00:00.000Z",
+        ),
+        runtimeHealthFetching: false,
+      }),
+    ).toEqual({
+      retryRuntimeCheck: true,
+      retryBeadsCheck: false,
+      retryRuntimeHealth: false,
+    });
+
+    expect(
+      buildDiagnosticsRetryPlan({
+        activeRepo: "/repo",
+        runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+        runtimeCheckFailureKind: null,
+        runtimeCheckFetching: false,
+        beadsCheckFailureKind: "timeout",
+        beadsCheckFetching: true,
+        runtimeHealthByRuntime: {
+          opencode: makeRepoHealth({
+            mcpOk: false,
+            mcpError: "OpenCode startup probe failed reason=timeout after 15000ms",
+            mcpFailureKind: "timeout",
+          }),
+        },
+        runtimeHealthFetching: false,
+      }),
+    ).toEqual({
+      retryRuntimeCheck: false,
+      retryBeadsCheck: false,
+      retryRuntimeHealth: true,
+    });
+  });
+});

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.test.ts
@@ -51,8 +51,10 @@ describe("check-diagnostics helpers", () => {
     const issues = buildDiagnosticsToastIssues({
       activeRepo: "/repo",
       runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+      runtimeCheck: null,
       runtimeCheckError: "Timed out after 15000ms",
       runtimeCheckFailureKind: "timeout",
+      beadsCheck: null,
       beadsCheckError: "beads offline",
       beadsCheckFailureKind: "error",
       runtimeHealthByRuntime: {
@@ -69,6 +71,35 @@ describe("check-diagnostics helpers", () => {
         expect.objectContaining({ id: "diagnostics:cli-tools", severity: "timeout" }),
         expect.objectContaining({ id: "diagnostics:beads-store", severity: "error" }),
         expect.objectContaining({ id: "diagnostics:runtime:opencode", severity: "timeout" }),
+      ]),
+    );
+  });
+
+  test("restores unhealthy cli and beads payload toasts even without query failures", () => {
+    const issues = buildDiagnosticsToastIssues({
+      activeRepo: "/repo",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+      runtimeCheck: buildRuntimeCheckErrorState([OPENCODE_RUNTIME_DESCRIPTOR], "git missing"),
+      runtimeCheckError: null,
+      runtimeCheckFailureKind: null,
+      beadsCheck: buildBeadsCheckErrorState("beads offline"),
+      beadsCheckError: null,
+      beadsCheckFailureKind: null,
+      runtimeHealthByRuntime: {},
+    });
+
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "diagnostics:cli-tools",
+          severity: "error",
+          description: "git missing",
+        }),
+        expect.objectContaining({
+          id: "diagnostics:beads-store",
+          severity: "error",
+          description: "beads offline",
+        }),
       ]),
     );
   });

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
@@ -44,6 +44,20 @@ export const buildBeadsCheckErrorState = (beadsCheckError: string): BeadsCheck =
   beadsError: beadsCheckError,
 });
 
+export const hasRuntimeCheckFailure = (runtimeCheck: RuntimeCheck | null): boolean => {
+  return (
+    runtimeCheck !== null &&
+    (!runtimeCheck.gitOk ||
+      !runtimeCheck.ghOk ||
+      !runtimeCheck.ghAuthOk ||
+      runtimeCheck.runtimes.some((entry) => !entry.ok))
+  );
+};
+
+export const hasBeadsCheckFailure = (beadsCheck: BeadsCheck | null): boolean => {
+  return beadsCheck?.beadsOk === false;
+};
+
 export const buildRuntimeHealthErrorMap = (
   runtimeDefinitions: RuntimeDescriptor[],
   runtimeHealthError: string,
@@ -148,9 +162,10 @@ export const buildDiagnosticsToastIssues = ({
 
   const issues: DiagnosticsToastIssue[] = [];
 
-  const runtimeCheckDetail = runtimeCheckError ?? runtimeCheck?.errors[0] ?? null;
+  const runtimeCheckDetail =
+    runtimeCheckError ?? runtimeCheck?.errors[0] ?? runtimeCheck?.ghAuthError ?? null;
   const runtimeCheckIssueSeverity =
-    runtimeCheckFailureKind ?? (runtimeCheck?.gitOk === false ? "error" : null);
+    runtimeCheckFailureKind ?? (hasRuntimeCheckFailure(runtimeCheck) ? "error" : null);
 
   if (runtimeCheckDetail && runtimeCheckIssueSeverity !== null) {
     issues.push(
@@ -165,7 +180,7 @@ export const buildDiagnosticsToastIssues = ({
 
   const beadsCheckDetail = beadsCheckError ?? beadsCheck?.beadsError ?? null;
   const beadsCheckIssueSeverity =
-    beadsCheckFailureKind ?? (beadsCheck?.beadsOk === false ? "error" : null);
+    beadsCheckFailureKind ?? (hasBeadsCheckFailure(beadsCheck) ? "error" : null);
 
   if (beadsCheckDetail && beadsCheckIssueSeverity !== null) {
     issues.push(

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
@@ -6,17 +6,66 @@ import type {
   RepoRuntimeHealthMap,
 } from "@/types/diagnostics";
 
+type NonNullRepoRuntimeFailureKind = Exclude<RepoRuntimeFailureKind, null>;
+type AvailabilityVerb = "is" | "are";
+
 export type DiagnosticsToastIssue = {
   id: string;
   title: string;
   description: string;
-  severity: Exclude<RepoRuntimeFailureKind, null>;
+  severity: NonNullRepoRuntimeFailureKind;
 };
 
 export type DiagnosticsRetryPlan = {
   retryRuntimeCheck: boolean;
   retryBeadsCheck: boolean;
   retryRuntimeHealth: boolean;
+};
+
+type DiagnosticsIssueMeta = {
+  id: string;
+  label: string;
+  availabilityVerb: AvailabilityVerb;
+};
+
+type DiagnosticsIssueCandidate = DiagnosticsIssueMeta & {
+  detail: string | null;
+  failureKind: NonNullRepoRuntimeFailureKind;
+};
+
+type BuildDiagnosticsToastIssuesArgs = {
+  activeRepo: string | null;
+  runtimeDefinitions: RuntimeDescriptor[];
+  runtimeCheck: RuntimeCheck | null;
+  runtimeCheckError: string | null;
+  runtimeCheckFailureKind: RepoRuntimeFailureKind;
+  beadsCheck: BeadsCheck | null;
+  beadsCheckError: string | null;
+  beadsCheckFailureKind: RepoRuntimeFailureKind;
+  runtimeHealthByRuntime: RepoRuntimeHealthMap;
+};
+
+type BuildDiagnosticsRetryPlanArgs = {
+  activeRepo: string | null;
+  runtimeDefinitions: RuntimeDescriptor[];
+  runtimeCheckFailureKind: RepoRuntimeFailureKind;
+  runtimeCheckFetching: boolean;
+  beadsCheckFailureKind: RepoRuntimeFailureKind;
+  beadsCheckFetching: boolean;
+  runtimeHealthByRuntime: RepoRuntimeHealthMap;
+  runtimeHealthFetching: boolean;
+};
+
+const CLI_TOOLS_ISSUE_META: DiagnosticsIssueMeta = {
+  id: "diagnostics:cli-tools",
+  label: "CLI tools",
+  availabilityVerb: "are",
+};
+
+const BEADS_STORE_ISSUE_META: DiagnosticsIssueMeta = {
+  id: "diagnostics:beads-store",
+  label: "Beads store",
+  availabilityVerb: "is",
 };
 
 export const buildRuntimeCheckErrorState = (
@@ -63,30 +112,28 @@ export const buildRuntimeHealthErrorMap = (
   runtimeHealthError: string,
   checkedAt: string,
 ): RepoRuntimeHealthMap => {
-  return Object.fromEntries(
-    runtimeDefinitions.map((definition) => [
-      definition.kind,
-      {
-        runtimeOk: false,
-        runtimeError: runtimeHealthError,
-        runtimeFailureKind: "error",
-        runtime: null,
-        mcpOk: false,
-        mcpError: runtimeHealthError,
-        mcpFailureKind: "error",
-        mcpServerName: ODT_MCP_SERVER_NAME,
-        mcpServerStatus: null,
-        mcpServerError: runtimeHealthError,
-        availableToolIds: [],
-        checkedAt,
-        errors: [runtimeHealthError],
-      } satisfies RepoRuntimeHealthCheck,
-    ]),
-  ) as RepoRuntimeHealthMap;
+  return runtimeDefinitions.reduce<RepoRuntimeHealthMap>((runtimeHealthMap, definition) => {
+    runtimeHealthMap[definition.kind] = {
+      runtimeOk: false,
+      runtimeError: runtimeHealthError,
+      runtimeFailureKind: "error",
+      runtime: null,
+      mcpOk: false,
+      mcpError: runtimeHealthError,
+      mcpFailureKind: "error",
+      mcpServerName: ODT_MCP_SERVER_NAME,
+      mcpServerStatus: null,
+      mcpServerError: runtimeHealthError,
+      availableToolIds: [],
+      checkedAt,
+      errors: [runtimeHealthError],
+    } satisfies RepoRuntimeHealthCheck;
+    return runtimeHealthMap;
+  }, {});
 };
 
 type TimeoutMessageOptions = {
-  availabilityVerb?: "is" | "are";
+  availabilityVerb?: AvailabilityVerb;
 };
 
 export const buildTimeoutToastDescription = (
@@ -112,18 +159,14 @@ const buildDiagnosticsToastIssue = ({
   label,
   detail,
   failureKind,
-}: {
-  id: string;
-  label: string;
-  detail: string | null;
-  failureKind: Exclude<RepoRuntimeFailureKind, null>;
-}): DiagnosticsToastIssue => {
+  availabilityVerb,
+}: DiagnosticsIssueCandidate): DiagnosticsToastIssue => {
   return failureKind === "timeout"
     ? {
         id,
         title: `${label} not yet available`,
         description: buildTimeoutToastDescription(label, detail, {
-          availabilityVerb: label === "CLI tools" ? "are" : "is",
+          availabilityVerb,
         }),
         severity: failureKind,
       }
@@ -133,6 +176,92 @@ const buildDiagnosticsToastIssue = ({
         description: buildErrorToastDescription(label, detail),
         severity: failureKind,
       };
+};
+
+const buildDiagnosticsIssueCandidate = (
+  meta: DiagnosticsIssueMeta,
+  detail: string | null,
+  failureKind: RepoRuntimeFailureKind,
+): DiagnosticsIssueCandidate | null => {
+  if (detail === null || failureKind === null) {
+    return null;
+  }
+
+  return {
+    ...meta,
+    detail,
+    failureKind,
+  };
+};
+
+const getRuntimeCheckIssueCandidate = (
+  runtimeCheck: RuntimeCheck | null,
+  runtimeCheckError: string | null,
+  runtimeCheckFailureKind: RepoRuntimeFailureKind,
+): DiagnosticsIssueCandidate | null => {
+  const detail = runtimeCheckError ?? runtimeCheck?.errors[0] ?? runtimeCheck?.ghAuthError ?? null;
+  const failureKind =
+    runtimeCheckFailureKind ?? (hasRuntimeCheckFailure(runtimeCheck) ? "error" : null);
+  return buildDiagnosticsIssueCandidate(CLI_TOOLS_ISSUE_META, detail, failureKind);
+};
+
+const getBeadsCheckIssueCandidate = (
+  beadsCheck: BeadsCheck | null,
+  beadsCheckError: string | null,
+  beadsCheckFailureKind: RepoRuntimeFailureKind,
+): DiagnosticsIssueCandidate | null => {
+  const detail = beadsCheckError ?? beadsCheck?.beadsError ?? null;
+  const failureKind = beadsCheckFailureKind ?? (hasBeadsCheckFailure(beadsCheck) ? "error" : null);
+  return buildDiagnosticsIssueCandidate(BEADS_STORE_ISSUE_META, detail, failureKind);
+};
+
+const getRuntimeHealthIssueCandidates = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  runtimeHealthByRuntime: RepoRuntimeHealthMap,
+): DiagnosticsIssueCandidate[] => {
+  const issueCandidates: DiagnosticsIssueCandidate[] = [];
+
+  for (const definition of runtimeDefinitions) {
+    const runtimeHealth = runtimeHealthByRuntime[definition.kind];
+    if (!runtimeHealth) {
+      continue;
+    }
+
+    const runtimeIssue = buildDiagnosticsIssueCandidate(
+      {
+        id: `diagnostics:runtime:${definition.kind}`,
+        label: `${definition.label} runtime`,
+        availabilityVerb: "is",
+      },
+      runtimeHealth.runtimeError,
+      runtimeHealth.runtimeOk ? null : runtimeHealth.runtimeFailureKind,
+    );
+
+    if (runtimeIssue !== null) {
+      issueCandidates.push(runtimeIssue);
+      continue;
+    }
+
+    if (!definition.capabilities.supportsMcpStatus) {
+      continue;
+    }
+
+    const mcpIssue = buildDiagnosticsIssueCandidate(
+      {
+        id: `diagnostics:mcp:${definition.kind}`,
+        label: `${definition.label} OpenDucktor MCP`,
+        availabilityVerb: "is",
+      },
+      runtimeHealth.mcpServerError ?? runtimeHealth.mcpError,
+      runtimeHealth.mcpOk ? null : runtimeHealth.mcpFailureKind,
+    );
+
+    if (mcpIssue !== null) {
+      issueCandidates.push(mcpIssue);
+    }
+  }
+
+  return issueCandidates;
 };
 
 export const buildDiagnosticsToastIssues = ({
@@ -145,89 +274,18 @@ export const buildDiagnosticsToastIssues = ({
   beadsCheckError,
   beadsCheckFailureKind,
   runtimeHealthByRuntime,
-}: {
-  activeRepo: string | null;
-  runtimeDefinitions: RuntimeDescriptor[];
-  runtimeCheck: RuntimeCheck | null;
-  runtimeCheckError: string | null;
-  runtimeCheckFailureKind: RepoRuntimeFailureKind;
-  beadsCheck: BeadsCheck | null;
-  beadsCheckError: string | null;
-  beadsCheckFailureKind: RepoRuntimeFailureKind;
-  runtimeHealthByRuntime: RepoRuntimeHealthMap;
-}): DiagnosticsToastIssue[] => {
+}: BuildDiagnosticsToastIssuesArgs): DiagnosticsToastIssue[] => {
   if (activeRepo === null) {
     return [];
   }
 
-  const issues: DiagnosticsToastIssue[] = [];
-
-  const runtimeCheckDetail =
-    runtimeCheckError ?? runtimeCheck?.errors[0] ?? runtimeCheck?.ghAuthError ?? null;
-  const runtimeCheckIssueSeverity =
-    runtimeCheckFailureKind ?? (hasRuntimeCheckFailure(runtimeCheck) ? "error" : null);
-
-  if (runtimeCheckDetail && runtimeCheckIssueSeverity !== null) {
-    issues.push(
-      buildDiagnosticsToastIssue({
-        id: "diagnostics:cli-tools",
-        label: "CLI tools",
-        detail: runtimeCheckDetail,
-        failureKind: runtimeCheckIssueSeverity,
-      }),
-    );
-  }
-
-  const beadsCheckDetail = beadsCheckError ?? beadsCheck?.beadsError ?? null;
-  const beadsCheckIssueSeverity =
-    beadsCheckFailureKind ?? (hasBeadsCheckFailure(beadsCheck) ? "error" : null);
-
-  if (beadsCheckDetail && beadsCheckIssueSeverity !== null) {
-    issues.push(
-      buildDiagnosticsToastIssue({
-        id: "diagnostics:beads-store",
-        label: "Beads store",
-        detail: beadsCheckDetail,
-        failureKind: beadsCheckIssueSeverity,
-      }),
-    );
-  }
-
-  for (const definition of runtimeDefinitions) {
-    const runtimeHealth = runtimeHealthByRuntime[definition.kind];
-    if (!runtimeHealth) {
-      continue;
-    }
-
-    if (runtimeHealth.runtimeOk === false && runtimeHealth.runtimeFailureKind !== null) {
-      issues.push(
-        buildDiagnosticsToastIssue({
-          id: `diagnostics:runtime:${definition.kind}`,
-          label: `${definition.label} runtime`,
-          detail: runtimeHealth.runtimeError,
-          failureKind: runtimeHealth.runtimeFailureKind,
-        }),
-      );
-      continue;
-    }
-
-    if (
-      definition.capabilities.supportsMcpStatus &&
-      runtimeHealth.mcpOk === false &&
-      runtimeHealth.mcpFailureKind !== null
-    ) {
-      issues.push(
-        buildDiagnosticsToastIssue({
-          id: `diagnostics:mcp:${definition.kind}`,
-          label: `${definition.label} OpenDucktor MCP`,
-          detail: runtimeHealth.mcpServerError ?? runtimeHealth.mcpError,
-          failureKind: runtimeHealth.mcpFailureKind,
-        }),
-      );
-    }
-  }
-
-  return issues;
+  return [
+    getRuntimeCheckIssueCandidate(runtimeCheck, runtimeCheckError, runtimeCheckFailureKind),
+    getBeadsCheckIssueCandidate(beadsCheck, beadsCheckError, beadsCheckFailureKind),
+    ...getRuntimeHealthIssueCandidates(runtimeDefinitions, runtimeHealthByRuntime),
+  ]
+    .filter((issueCandidate) => issueCandidate !== null)
+    .map((issueCandidate) => buildDiagnosticsToastIssue(issueCandidate));
 };
 
 export const hasRuntimeHealthTimeoutIssue = (
@@ -256,24 +314,19 @@ export const buildDiagnosticsRetryPlan = ({
   beadsCheckFetching,
   runtimeHealthByRuntime,
   runtimeHealthFetching,
-}: {
-  activeRepo: string | null;
-  runtimeDefinitions: RuntimeDescriptor[];
-  runtimeCheckFailureKind: RepoRuntimeFailureKind;
-  runtimeCheckFetching: boolean;
-  beadsCheckFailureKind: RepoRuntimeFailureKind;
-  beadsCheckFetching: boolean;
-  runtimeHealthByRuntime: RepoRuntimeHealthMap;
-  runtimeHealthFetching: boolean;
-}): DiagnosticsRetryPlan => {
+}: BuildDiagnosticsRetryPlanArgs): DiagnosticsRetryPlan => {
+  const retryRuntimeCheck = runtimeCheckFailureKind === "timeout" && !runtimeCheckFetching;
+  const retryBeadsCheck =
+    activeRepo !== null && beadsCheckFailureKind === "timeout" && !beadsCheckFetching;
+  const retryRuntimeHealth =
+    activeRepo !== null &&
+    runtimeDefinitions.length > 0 &&
+    hasRuntimeHealthTimeoutIssue(runtimeDefinitions, runtimeHealthByRuntime) &&
+    !runtimeHealthFetching;
+
   return {
-    retryRuntimeCheck: runtimeCheckFailureKind === "timeout" && !runtimeCheckFetching,
-    retryBeadsCheck:
-      activeRepo !== null && beadsCheckFailureKind === "timeout" && !beadsCheckFetching,
-    retryRuntimeHealth:
-      activeRepo !== null &&
-      runtimeDefinitions.length > 0 &&
-      hasRuntimeHealthTimeoutIssue(runtimeDefinitions, runtimeHealthByRuntime) &&
-      !runtimeHealthFetching,
+    retryRuntimeCheck,
+    retryBeadsCheck,
+    retryRuntimeHealth,
   };
 };

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
@@ -71,12 +71,22 @@ export const buildRuntimeHealthErrorMap = (
   ) as RepoRuntimeHealthMap;
 };
 
-export const buildTimeoutToastDescription = (label: string, detail: string | null): string => {
+type TimeoutMessageOptions = {
+  availabilityVerb?: "is" | "are";
+};
+
+export const buildTimeoutToastDescription = (
+  label: string,
+  detail: string | null,
+  options?: TimeoutMessageOptions,
+): string => {
+  const availabilityVerb = options?.availabilityVerb ?? "is";
+
   if (!detail) {
-    return `${label} is not yet available. Retrying automatically.`;
+    return `${label} ${availabilityVerb} not yet available. Retrying automatically.`;
   }
 
-  return `${label} is not yet available. Retrying automatically. Latest detail: ${detail}`;
+  return `${label} ${availabilityVerb} not yet available. Retrying automatically. Latest detail: ${detail}`;
 };
 
 const buildErrorToastDescription = (label: string, detail: string | null): string => {
@@ -98,7 +108,9 @@ const buildDiagnosticsToastIssue = ({
     ? {
         id,
         title: `${label} not yet available`,
-        description: buildTimeoutToastDescription(label, detail),
+        description: buildTimeoutToastDescription(label, detail, {
+          availabilityVerb: label === "CLI tools" ? "are" : "is",
+        }),
         severity: failureKind,
       }
     : {
@@ -112,16 +124,20 @@ const buildDiagnosticsToastIssue = ({
 export const buildDiagnosticsToastIssues = ({
   activeRepo,
   runtimeDefinitions,
+  runtimeCheck,
   runtimeCheckError,
   runtimeCheckFailureKind,
+  beadsCheck,
   beadsCheckError,
   beadsCheckFailureKind,
   runtimeHealthByRuntime,
 }: {
   activeRepo: string | null;
   runtimeDefinitions: RuntimeDescriptor[];
+  runtimeCheck: RuntimeCheck | null;
   runtimeCheckError: string | null;
   runtimeCheckFailureKind: RepoRuntimeFailureKind;
+  beadsCheck: BeadsCheck | null;
   beadsCheckError: string | null;
   beadsCheckFailureKind: RepoRuntimeFailureKind;
   runtimeHealthByRuntime: RepoRuntimeHealthMap;
@@ -132,24 +148,32 @@ export const buildDiagnosticsToastIssues = ({
 
   const issues: DiagnosticsToastIssue[] = [];
 
-  if (runtimeCheckError && runtimeCheckFailureKind !== null) {
+  const runtimeCheckDetail = runtimeCheckError ?? runtimeCheck?.errors[0] ?? null;
+  const runtimeCheckIssueSeverity =
+    runtimeCheckFailureKind ?? (runtimeCheck?.gitOk === false ? "error" : null);
+
+  if (runtimeCheckDetail && runtimeCheckIssueSeverity !== null) {
     issues.push(
       buildDiagnosticsToastIssue({
         id: "diagnostics:cli-tools",
         label: "CLI tools",
-        detail: runtimeCheckError,
-        failureKind: runtimeCheckFailureKind,
+        detail: runtimeCheckDetail,
+        failureKind: runtimeCheckIssueSeverity,
       }),
     );
   }
 
-  if (beadsCheckError && beadsCheckFailureKind !== null) {
+  const beadsCheckDetail = beadsCheckError ?? beadsCheck?.beadsError ?? null;
+  const beadsCheckIssueSeverity =
+    beadsCheckFailureKind ?? (beadsCheck?.beadsOk === false ? "error" : null);
+
+  if (beadsCheckDetail && beadsCheckIssueSeverity !== null) {
     issues.push(
       buildDiagnosticsToastIssue({
         id: "diagnostics:beads-store",
         label: "Beads store",
-        detail: beadsCheckError,
-        failureKind: beadsCheckFailureKind,
+        detail: beadsCheckDetail,
+        failureKind: beadsCheckIssueSeverity,
       }),
     );
   }

--- a/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
+++ b/apps/desktop/src/state/operations/workspace/check-diagnostics.ts
@@ -1,0 +1,240 @@
+import type { BeadsCheck, RuntimeCheck, RuntimeDescriptor } from "@openducktor/contracts";
+import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
+import type {
+  RepoRuntimeFailureKind,
+  RepoRuntimeHealthCheck,
+  RepoRuntimeHealthMap,
+} from "@/types/diagnostics";
+
+export type DiagnosticsToastIssue = {
+  id: string;
+  title: string;
+  description: string;
+  severity: Exclude<RepoRuntimeFailureKind, null>;
+};
+
+export type DiagnosticsRetryPlan = {
+  retryRuntimeCheck: boolean;
+  retryBeadsCheck: boolean;
+  retryRuntimeHealth: boolean;
+};
+
+export const buildRuntimeCheckErrorState = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  runtimeCheckError: string,
+): RuntimeCheck => ({
+  gitOk: false,
+  gitVersion: null,
+  ghOk: false,
+  ghVersion: null,
+  ghAuthOk: false,
+  ghAuthLogin: null,
+  ghAuthError: runtimeCheckError,
+  runtimes: runtimeDefinitions.map((definition) => ({
+    kind: definition.kind,
+    ok: false,
+    version: null,
+  })),
+  errors: [runtimeCheckError],
+});
+
+export const buildBeadsCheckErrorState = (beadsCheckError: string): BeadsCheck => ({
+  beadsOk: false,
+  beadsPath: null,
+  beadsError: beadsCheckError,
+});
+
+export const buildRuntimeHealthErrorMap = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  runtimeHealthError: string,
+  checkedAt: string,
+): RepoRuntimeHealthMap => {
+  return Object.fromEntries(
+    runtimeDefinitions.map((definition) => [
+      definition.kind,
+      {
+        runtimeOk: false,
+        runtimeError: runtimeHealthError,
+        runtimeFailureKind: "error",
+        runtime: null,
+        mcpOk: false,
+        mcpError: runtimeHealthError,
+        mcpFailureKind: "error",
+        mcpServerName: ODT_MCP_SERVER_NAME,
+        mcpServerStatus: null,
+        mcpServerError: runtimeHealthError,
+        availableToolIds: [],
+        checkedAt,
+        errors: [runtimeHealthError],
+      } satisfies RepoRuntimeHealthCheck,
+    ]),
+  ) as RepoRuntimeHealthMap;
+};
+
+export const buildTimeoutToastDescription = (label: string, detail: string | null): string => {
+  if (!detail) {
+    return `${label} is not yet available. Retrying automatically.`;
+  }
+
+  return `${label} is not yet available. Retrying automatically. Latest detail: ${detail}`;
+};
+
+const buildErrorToastDescription = (label: string, detail: string | null): string => {
+  return detail ?? `${label} is unavailable.`;
+};
+
+const buildDiagnosticsToastIssue = ({
+  id,
+  label,
+  detail,
+  failureKind,
+}: {
+  id: string;
+  label: string;
+  detail: string | null;
+  failureKind: Exclude<RepoRuntimeFailureKind, null>;
+}): DiagnosticsToastIssue => {
+  return failureKind === "timeout"
+    ? {
+        id,
+        title: `${label} not yet available`,
+        description: buildTimeoutToastDescription(label, detail),
+        severity: failureKind,
+      }
+    : {
+        id,
+        title: `${label} unavailable`,
+        description: buildErrorToastDescription(label, detail),
+        severity: failureKind,
+      };
+};
+
+export const buildDiagnosticsToastIssues = ({
+  activeRepo,
+  runtimeDefinitions,
+  runtimeCheckError,
+  runtimeCheckFailureKind,
+  beadsCheckError,
+  beadsCheckFailureKind,
+  runtimeHealthByRuntime,
+}: {
+  activeRepo: string | null;
+  runtimeDefinitions: RuntimeDescriptor[];
+  runtimeCheckError: string | null;
+  runtimeCheckFailureKind: RepoRuntimeFailureKind;
+  beadsCheckError: string | null;
+  beadsCheckFailureKind: RepoRuntimeFailureKind;
+  runtimeHealthByRuntime: RepoRuntimeHealthMap;
+}): DiagnosticsToastIssue[] => {
+  if (activeRepo === null) {
+    return [];
+  }
+
+  const issues: DiagnosticsToastIssue[] = [];
+
+  if (runtimeCheckError && runtimeCheckFailureKind !== null) {
+    issues.push(
+      buildDiagnosticsToastIssue({
+        id: "diagnostics:cli-tools",
+        label: "CLI tools",
+        detail: runtimeCheckError,
+        failureKind: runtimeCheckFailureKind,
+      }),
+    );
+  }
+
+  if (beadsCheckError && beadsCheckFailureKind !== null) {
+    issues.push(
+      buildDiagnosticsToastIssue({
+        id: "diagnostics:beads-store",
+        label: "Beads store",
+        detail: beadsCheckError,
+        failureKind: beadsCheckFailureKind,
+      }),
+    );
+  }
+
+  for (const definition of runtimeDefinitions) {
+    const runtimeHealth = runtimeHealthByRuntime[definition.kind];
+    if (!runtimeHealth) {
+      continue;
+    }
+
+    if (runtimeHealth.runtimeOk === false && runtimeHealth.runtimeFailureKind !== null) {
+      issues.push(
+        buildDiagnosticsToastIssue({
+          id: `diagnostics:runtime:${definition.kind}`,
+          label: `${definition.label} runtime`,
+          detail: runtimeHealth.runtimeError,
+          failureKind: runtimeHealth.runtimeFailureKind,
+        }),
+      );
+      continue;
+    }
+
+    if (
+      definition.capabilities.supportsMcpStatus &&
+      runtimeHealth.mcpOk === false &&
+      runtimeHealth.mcpFailureKind !== null
+    ) {
+      issues.push(
+        buildDiagnosticsToastIssue({
+          id: `diagnostics:mcp:${definition.kind}`,
+          label: `${definition.label} OpenDucktor MCP`,
+          detail: runtimeHealth.mcpServerError ?? runtimeHealth.mcpError,
+          failureKind: runtimeHealth.mcpFailureKind,
+        }),
+      );
+    }
+  }
+
+  return issues;
+};
+
+export const hasRuntimeHealthTimeoutIssue = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  runtimeHealthByRuntime: RepoRuntimeHealthMap,
+): boolean => {
+  return runtimeDefinitions.some((definition) => {
+    const runtimeHealth = runtimeHealthByRuntime[definition.kind];
+    if (!runtimeHealth) {
+      return false;
+    }
+
+    return (
+      runtimeHealth.runtimeFailureKind === "timeout" ||
+      (definition.capabilities.supportsMcpStatus && runtimeHealth.mcpFailureKind === "timeout")
+    );
+  });
+};
+
+export const buildDiagnosticsRetryPlan = ({
+  activeRepo,
+  runtimeDefinitions,
+  runtimeCheckFailureKind,
+  runtimeCheckFetching,
+  beadsCheckFailureKind,
+  beadsCheckFetching,
+  runtimeHealthByRuntime,
+  runtimeHealthFetching,
+}: {
+  activeRepo: string | null;
+  runtimeDefinitions: RuntimeDescriptor[];
+  runtimeCheckFailureKind: RepoRuntimeFailureKind;
+  runtimeCheckFetching: boolean;
+  beadsCheckFailureKind: RepoRuntimeFailureKind;
+  beadsCheckFetching: boolean;
+  runtimeHealthByRuntime: RepoRuntimeHealthMap;
+  runtimeHealthFetching: boolean;
+}): DiagnosticsRetryPlan => {
+  return {
+    retryRuntimeCheck: runtimeCheckFailureKind === "timeout" && !runtimeCheckFetching,
+    retryBeadsCheck:
+      activeRepo !== null && beadsCheckFailureKind === "timeout" && !beadsCheckFetching,
+    retryRuntimeHealth:
+      activeRepo !== null &&
+      runtimeDefinitions.length > 0 &&
+      hasRuntimeHealthTimeoutIssue(runtimeDefinitions, runtimeHealthByRuntime) &&
+      !runtimeHealthFetching,
+  };
+};

--- a/apps/desktop/src/state/operations/workspace/use-check-diagnostics-effects.ts
+++ b/apps/desktop/src/state/operations/workspace/use-check-diagnostics-effects.ts
@@ -1,0 +1,132 @@
+import type { BeadsCheck, RuntimeCheck } from "@openducktor/contracts";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import type { RepoRuntimeHealthMap } from "@/types/diagnostics";
+import type { DiagnosticsRetryPlan, DiagnosticsToastIssue } from "./check-diagnostics";
+
+const RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS = 2_000;
+
+export function useDiagnosticsToasts(diagnosticsToastIssues: DiagnosticsToastIssue[]): void {
+  const issueSignaturesRef = useRef(new Map<string, string>());
+
+  useEffect(() => {
+    const nextIssueIds = new Set(diagnosticsToastIssues.map((issue) => issue.id));
+
+    for (const issueId of [...issueSignaturesRef.current.keys()]) {
+      if (nextIssueIds.has(issueId)) {
+        continue;
+      }
+
+      toast.dismiss(issueId);
+      issueSignaturesRef.current.delete(issueId);
+    }
+
+    for (const issue of diagnosticsToastIssues) {
+      const signature = `${issue.severity}:${issue.title}:${issue.description}`;
+      if (issueSignaturesRef.current.get(issue.id) === signature) {
+        continue;
+      }
+
+      if (issue.severity === "timeout") {
+        toast(issue.title, {
+          id: issue.id,
+          description: issue.description,
+          duration: Number.POSITIVE_INFINITY,
+        });
+      } else {
+        toast.error(issue.title, {
+          id: issue.id,
+          description: issue.description,
+          duration: Number.POSITIVE_INFINITY,
+        });
+      }
+
+      issueSignaturesRef.current.set(issue.id, signature);
+    }
+  }, [diagnosticsToastIssues]);
+
+  useEffect(() => {
+    return () => {
+      for (const issueId of issueSignaturesRef.current.keys()) {
+        toast.dismiss(issueId);
+      }
+      issueSignaturesRef.current.clear();
+    };
+  }, []);
+}
+
+type UseDiagnosticsRetrySchedulerArgs = {
+  activeRepo: string | null;
+  retryPlan: DiagnosticsRetryPlan;
+  refreshRuntimeCheck: (force?: boolean) => Promise<RuntimeCheck>;
+  refreshBeadsCheckForRepo: (repoPath: string, force?: boolean) => Promise<BeadsCheck>;
+  refreshRepoRuntimeHealthForRepo: (
+    repoPath: string,
+    force?: boolean,
+  ) => Promise<RepoRuntimeHealthMap>;
+};
+
+export function useDiagnosticsRetryScheduler({
+  activeRepo,
+  retryPlan,
+  refreshRuntimeCheck,
+  refreshBeadsCheckForRepo,
+  refreshRepoRuntimeHealthForRepo,
+}: UseDiagnosticsRetrySchedulerArgs): void {
+  const diagnosticsRetryTimeoutRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (diagnosticsRetryTimeoutRef.current !== null) {
+      globalThis.clearTimeout(diagnosticsRetryTimeoutRef.current);
+      diagnosticsRetryTimeoutRef.current = null;
+    }
+
+    if (
+      !retryPlan.retryRuntimeCheck &&
+      !retryPlan.retryBeadsCheck &&
+      !retryPlan.retryRuntimeHealth
+    ) {
+      return;
+    }
+
+    diagnosticsRetryTimeoutRef.current = globalThis.setTimeout(() => {
+      diagnosticsRetryTimeoutRef.current = null;
+      const retries: Promise<unknown>[] = [];
+
+      if (retryPlan.retryRuntimeCheck) {
+        retries.push(refreshRuntimeCheck(true));
+      }
+
+      if (retryPlan.retryBeadsCheck && activeRepo !== null) {
+        retries.push(refreshBeadsCheckForRepo(activeRepo, true));
+      }
+
+      if (retryPlan.retryRuntimeHealth && activeRepo !== null) {
+        retries.push(refreshRepoRuntimeHealthForRepo(activeRepo, true));
+      }
+
+      void Promise.allSettled(retries);
+    }, RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS);
+
+    return () => {
+      if (diagnosticsRetryTimeoutRef.current !== null) {
+        globalThis.clearTimeout(diagnosticsRetryTimeoutRef.current);
+        diagnosticsRetryTimeoutRef.current = null;
+      }
+    };
+  }, [
+    activeRepo,
+    refreshBeadsCheckForRepo,
+    refreshRepoRuntimeHealthForRepo,
+    refreshRuntimeCheck,
+    retryPlan,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      if (diagnosticsRetryTimeoutRef.current !== null) {
+        globalThis.clearTimeout(diagnosticsRetryTimeoutRef.current);
+      }
+    };
+  }, []);
+}

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -166,6 +166,8 @@ const captureDeferredRejection = <T,>(promise: Promise<T>): Promise<T> => {
   return promise;
 };
 
+const REFRESH_CHECKS_WAIT_TIMEOUT_MS = 1_000;
+
 const waitForInitialChecksToSettle = async (
   harness: HookHarness,
   runtimeKinds: RuntimeKind[] = ["opencode"],
@@ -515,7 +517,10 @@ describe("use-checks", () => {
       await harness.run((value) => {
         refreshPromise = captureDeferredRejection(value.refreshChecks());
       });
-      await harness.waitFor((value) => value.isLoadingChecks === true);
+      await harness.waitFor(
+        (value) => value.isLoadingChecks === true,
+        REFRESH_CHECKS_WAIT_TIMEOUT_MS,
+      );
 
       expect(runtimeCheck).toHaveBeenCalledTimes(1);
       expect(runtimeCheck.mock.calls[0]).toEqual([true]);
@@ -529,7 +534,10 @@ describe("use-checks", () => {
       await harness.run(async () => {
         await refreshPromise;
       });
-      await harness.waitFor((value) => value.isLoadingChecks === false);
+      await harness.waitFor(
+        (value) => value.isLoadingChecks === false,
+        REFRESH_CHECKS_WAIT_TIMEOUT_MS,
+      );
     } finally {
       await harness.unmount();
       host.runtimeCheck = original.runtimeCheck;
@@ -636,7 +644,10 @@ describe("use-checks", () => {
       await harness.run((value) => {
         refreshPromise = captureDeferredRejection(value.refreshChecks());
       });
-      await harness.waitFor((value) => value.isLoadingChecks === true);
+      await harness.waitFor(
+        (value) => value.isLoadingChecks === true,
+        REFRESH_CHECKS_WAIT_TIMEOUT_MS,
+      );
 
       runtimeDeferred.reject(new Error("runtime down"));
       await Promise.resolve();
@@ -647,7 +658,10 @@ describe("use-checks", () => {
       await harness.run(async () => {
         await expect(refreshPromise).rejects.toThrow("runtime down");
       });
-      await harness.waitFor((value) => value.isLoadingChecks === false);
+      await harness.waitFor(
+        (value) => value.isLoadingChecks === false,
+        REFRESH_CHECKS_WAIT_TIMEOUT_MS,
+      );
 
       expect(toastError).toHaveBeenCalledWith(
         "CLI tools unavailable",
@@ -726,11 +740,17 @@ describe("use-checks", () => {
       await harness.run((value) => {
         refreshPromise = captureDeferredRejection(value.refreshChecks());
       });
-      await harness.waitFor((value) => value.isLoadingChecks === true);
+      await harness.waitFor(
+        (value) => value.isLoadingChecks === true,
+        REFRESH_CHECKS_WAIT_TIMEOUT_MS,
+      );
       await harness.run(async () => {
         await expect(refreshPromise).rejects.toThrow("runtime down");
       });
-      await harness.waitFor((value) => value.isLoadingChecks === false);
+      await harness.waitFor(
+        (value) => value.isLoadingChecks === false,
+        REFRESH_CHECKS_WAIT_TIMEOUT_MS,
+      );
 
       expect(toastError).toHaveBeenCalledWith(
         "CLI tools unavailable",

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -50,9 +50,11 @@ const makeRepoHealth = (
 ): RepoRuntimeHealthCheck => ({
   runtimeOk: true,
   runtimeError: null,
+  runtimeFailureKind: null,
   runtime: null,
   mcpOk: true,
   mcpError: null,
+  mcpFailureKind: null,
   mcpServerName: "openducktor",
   mcpServerStatus: "connected",
   mcpServerError: null,
@@ -72,8 +74,13 @@ const MOCK_RUNTIME_DESCRIPTOR: RuntimeDescriptor = {
   },
 };
 
-const toastError = mock((_message: string, _options?: { description?: string }) => {});
-const toastSuccess = mock((_message: string, _options?: { description?: string }) => {});
+const toastMessage = mock(
+  (_message: string, _options?: { description?: string; id?: string; duration?: number }) => {},
+);
+const toastError = mock(
+  (_message: string, _options?: { description?: string; id?: string; duration?: number }) => {},
+);
+const toastDismiss = mock((_toastId?: string | number) => {});
 let repoHealthHandler = async (
   _repoPath: string,
   _runtimeKind: RuntimeKind,
@@ -173,19 +180,26 @@ const waitForInitialChecksToSettle = async (
 
 beforeAll(async () => {
   mock.module("sonner", () => ({
-    toast: {
-      error: (message: string, options?: { description?: string }) => toastError(message, options),
-      success: (message: string, options?: { description?: string }) =>
-        toastSuccess(message, options),
-    },
+    toast: Object.assign(
+      (message: string, options?: { description?: string; id?: string; duration?: number }) =>
+        toastMessage(message, options),
+      {
+        error: (
+          message: string,
+          options?: { description?: string; id?: string; duration?: number },
+        ) => toastError(message, options),
+        dismiss: (toastId?: string | number) => toastDismiss(toastId),
+      },
+    ),
   }));
   ({ useChecks } = await import("./use-checks"));
 });
 
 beforeEach(async () => {
   Object.assign(host, originalHostMethods);
+  toastMessage.mockClear();
   toastError.mockClear();
-  toastSuccess.mockClear();
+  toastDismiss.mockClear();
   checkRepoRuntimeHealthMock.mockClear();
   repoHealthHandler = async () => makeRepoHealth();
 });
@@ -329,17 +343,19 @@ describe("use-checks", () => {
     }
   });
 
-  test("refreshChecks reports unhealthy diagnostics details", async () => {
+  test("deduplicates runtime health error toasts across manual refreshes", async () => {
     const runtimeCheck = mock(
-      async (_force?: boolean): Promise<RuntimeCheck> =>
-        makeRuntimeCheck({ gitOk: false, errors: ["git unavailable"] }),
+      async (_force?: boolean): Promise<RuntimeCheck> => makeRuntimeCheck(),
     );
-    const beadsCheck = mock(
-      async (): Promise<BeadsCheck> =>
-        makeBeadsCheck({ beadsOk: false, beadsError: "missing .beads" }),
-    );
+    const beadsCheck = mock(async (): Promise<BeadsCheck> => makeBeadsCheck());
     repoHealthHandler = async () =>
-      makeRepoHealth({ mcpOk: false, mcpError: "mcp offline", errors: ["mcp offline"] });
+      makeRepoHealth({
+        mcpOk: false,
+        mcpError: "mcp offline",
+        mcpFailureKind: "error",
+        mcpServerError: "mcp offline",
+        errors: ["mcp offline"],
+      });
 
     const original = {
       runtimeCheck: host.runtimeCheck,
@@ -354,14 +370,23 @@ describe("use-checks", () => {
     });
 
     try {
-      await harness.mount();
+      await waitForInitialChecksToSettle(harness);
+      await harness.waitFor(() => toastError.mock.calls.length === 1);
+
+      expect(toastError).toHaveBeenCalledWith(
+        "OpenCode OpenDucktor MCP unavailable",
+        expect.objectContaining({
+          id: "diagnostics:mcp:opencode",
+          description: "mcp offline",
+        }),
+      );
+
+      toastError.mockClear();
       await harness.run(async (value) => {
         await value.refreshChecks();
       });
 
-      expect(toastError).toHaveBeenCalledWith("Diagnostics check failed", {
-        description: "git unavailable | beads: missing .beads | mcp offline",
-      });
+      expect(toastError).not.toHaveBeenCalled();
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
@@ -475,9 +500,13 @@ describe("use-checks", () => {
       expect(runtimeCheck).toHaveBeenCalledTimes(2);
       expect(runtimeCheck.mock.calls[0]).toEqual([false]);
       expect(runtimeCheck.mock.calls[1]).toEqual([true]);
-      expect(toastError).toHaveBeenCalledWith("Diagnostics check unavailable", {
-        description: "runtime: runtime down",
-      });
+      expect(toastError).toHaveBeenCalledWith(
+        "Diagnostics check unavailable",
+        expect.objectContaining({
+          id: "diagnostics:manual-unavailable",
+          description: "runtime: runtime down",
+        }),
+      );
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
@@ -542,9 +571,13 @@ describe("use-checks", () => {
       });
       await harness.waitFor((value) => value.isLoadingChecks === false);
 
-      expect(toastError).toHaveBeenCalledWith("Diagnostics check unavailable", {
-        description: "runtime: runtime down | beads: beads down",
-      });
+      expect(toastError).toHaveBeenCalledWith(
+        "Diagnostics check unavailable",
+        expect.objectContaining({
+          id: "diagnostics:manual-unavailable",
+          description: "runtime: runtime down | beads: beads down",
+        }),
+      );
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
@@ -615,9 +648,13 @@ describe("use-checks", () => {
       });
       await harness.waitFor((value) => value.isLoadingChecks === false);
 
-      expect(toastError).toHaveBeenCalledWith("Diagnostics check unavailable", {
-        description: "runtime: runtime down | beads: Timed out after 5000ms",
-      });
+      expect(toastError).toHaveBeenCalledWith(
+        "Diagnostics check unavailable",
+        expect.objectContaining({
+          id: "diagnostics:manual-unavailable",
+          description: "runtime: runtime down | beads: Timed out after 15000ms",
+        }),
+      );
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
       await harness.unmount();
@@ -747,6 +784,95 @@ describe("use-checks", () => {
       );
     } finally {
       await harness.unmount();
+    }
+  });
+
+  test("retries timeout-classified runtime health without duplicating toasts", async () => {
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+    let scheduledRetryCount = 0;
+    globalThis.setTimeout = ((handler: TimerHandler, delay?: number) => {
+      if (typeof handler !== "function") {
+        throw new Error("Expected retry timer handler to be a function");
+      }
+
+      if (delay === 2_000) {
+        scheduledRetryCount += 1;
+        return originalSetTimeout(() => {}, 60_000);
+      }
+
+      return originalSetTimeout(() => {
+        handler();
+      }, delay);
+    }) as unknown as typeof globalThis.setTimeout;
+    globalThis.clearTimeout = ((timerId: ReturnType<typeof globalThis.setTimeout>) => {
+      return originalClearTimeout(timerId);
+    }) as typeof globalThis.clearTimeout;
+
+    let callCount = 0;
+    repoHealthHandler = async () => {
+      callCount += 1;
+
+      if (callCount < 3) {
+        return makeRepoHealth({
+          runtimeOk: false,
+          runtimeError: "Timed out waiting for OpenCode runtime startup readiness",
+          runtimeFailureKind: "timeout",
+          mcpOk: false,
+          mcpError: "Runtime is unavailable, so MCP cannot be verified.",
+          mcpFailureKind: "timeout",
+          errors: [
+            "Timed out waiting for OpenCode runtime startup readiness",
+            "Runtime is unavailable, so MCP cannot be verified.",
+          ],
+        });
+      }
+
+      return makeRepoHealth();
+    };
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (value) =>
+          value.activeRepoRuntimeHealthByRuntime.opencode?.runtimeFailureKind === "timeout" &&
+          value.isLoadingChecks === false,
+        5000,
+      );
+
+      expect(toastMessage).toHaveBeenCalledWith(
+        "OpenCode runtime not yet available",
+        expect.objectContaining({
+          id: "diagnostics:runtime:opencode",
+        }),
+      );
+      expect(scheduledRetryCount).toBeGreaterThan(0);
+
+      await harness.run(async () => {
+        await harness.getLatest().refreshRepoRuntimeHealthForRepo("/repo-a", true);
+      });
+      await harness.waitFor(() => checkRepoRuntimeHealthMock.mock.calls.length === 2, 1000);
+      expect(toastMessage).toHaveBeenCalledTimes(1);
+
+      await harness.run(async () => {
+        await harness.getLatest().refreshRepoRuntimeHealthForRepo("/repo-a", true);
+      });
+      await harness.waitFor(
+        (value) => value.activeRepoRuntimeHealthByRuntime.opencode?.runtimeOk === true,
+        1000,
+      );
+
+      expect(toastMessage).toHaveBeenCalledTimes(1);
+      expect(toastDismiss).toHaveBeenCalledWith("diagnostics:runtime:opencode");
+    } finally {
+      await harness.unmount();
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
     }
   });
 });

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -164,6 +164,7 @@ type HookHarness = ReturnType<typeof createHookHarness>;
 const waitForInitialChecksToSettle = async (
   harness: HookHarness,
   runtimeKinds: RuntimeKind[] = ["opencode"],
+  timeoutMs = 1_000,
 ) => {
   await harness.mount();
   await harness.waitFor((value) => {
@@ -175,7 +176,7 @@ const waitForInitialChecksToSettle = async (
       ) &&
       value.isLoadingChecks === false
     );
-  });
+  }, timeoutMs);
 };
 
 beforeAll(async () => {
@@ -370,8 +371,8 @@ describe("use-checks", () => {
     });
 
     try {
-      await waitForInitialChecksToSettle(harness);
-      await harness.waitFor(() => toastError.mock.calls.length === 1);
+      await waitForInitialChecksToSettle(harness, ["opencode"], 1_000);
+      await harness.waitFor(() => toastError.mock.calls.length === 1, 1_000);
 
       expect(toastError).toHaveBeenCalledWith(
         "OpenCode OpenDucktor MCP unavailable",
@@ -388,6 +389,77 @@ describe("use-checks", () => {
 
       expect(toastError).not.toHaveBeenCalled();
       expect(harness.getLatest().isLoadingChecks).toBe(false);
+    } finally {
+      await harness.unmount();
+      host.runtimeCheck = original.runtimeCheck;
+      host.beadsCheck = original.beadsCheck;
+    }
+  });
+
+  test("shows cli and beads toasts for unhealthy successful payloads", async () => {
+    let runtimeCallCount = 0;
+    let beadsCallCount = 0;
+    const runtimeCheck = mock(async (): Promise<RuntimeCheck> => {
+      runtimeCallCount += 1;
+      return runtimeCallCount === 1
+        ? makeRuntimeCheck()
+        : makeRuntimeCheck({
+            gitOk: false,
+            gitVersion: null,
+            ghOk: false,
+            ghVersion: null,
+            ghAuthOk: false,
+            ghAuthLogin: null,
+            ghAuthError: "git missing",
+            runtimes: [{ kind: "opencode", ok: false, version: null }],
+            errors: ["git missing"],
+          });
+    });
+    const beadsCheck = mock(async (): Promise<BeadsCheck> => {
+      beadsCallCount += 1;
+      return beadsCallCount === 1
+        ? makeBeadsCheck()
+        : makeBeadsCheck({
+            beadsOk: false,
+            beadsPath: null,
+            beadsError: "beads offline",
+          });
+    });
+
+    const original = {
+      runtimeCheck: host.runtimeCheck,
+      beadsCheck: host.beadsCheck,
+    };
+    host.runtimeCheck = runtimeCheck;
+    host.beadsCheck = beadsCheck;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    try {
+      await waitForInitialChecksToSettle(harness, ["opencode"], 1_000);
+      toastError.mockClear();
+
+      await harness.run(async (value) => {
+        await value.refreshChecks();
+      });
+
+      expect(toastError).toHaveBeenCalledWith(
+        "CLI tools unavailable",
+        expect.objectContaining({
+          id: "diagnostics:cli-tools",
+          description: "git missing",
+        }),
+      );
+      expect(toastError).toHaveBeenCalledWith(
+        "Beads store unavailable",
+        expect.objectContaining({
+          id: "diagnostics:beads-store",
+          description: "beads offline",
+        }),
+      );
     } finally {
       await harness.unmount();
       host.runtimeCheck = original.runtimeCheck;

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -161,6 +161,11 @@ const createHookHarness = (initialArgs: HookHarnessArgs) => {
 
 type HookHarness = ReturnType<typeof createHookHarness>;
 
+const captureDeferredRejection = <T,>(promise: Promise<T>): Promise<T> => {
+  void promise.catch(() => {});
+  return promise;
+};
+
 const waitForInitialChecksToSettle = async (
   harness: HookHarness,
   runtimeKinds: RuntimeKind[] = ["opencode"],
@@ -508,7 +513,7 @@ describe("use-checks", () => {
       checkRepoRuntimeHealthMock.mockClear();
 
       await harness.run((value) => {
-        refreshPromise = value.refreshChecks();
+        refreshPromise = captureDeferredRejection(value.refreshChecks());
       });
       await harness.waitFor((value) => value.isLoadingChecks === true);
 
@@ -629,7 +634,7 @@ describe("use-checks", () => {
       checkRepoRuntimeHealthMock.mockClear();
 
       await harness.run((value) => {
-        refreshPromise = value.refreshChecks();
+        refreshPromise = captureDeferredRejection(value.refreshChecks());
       });
       await harness.waitFor((value) => value.isLoadingChecks === true);
 
@@ -719,7 +724,7 @@ describe("use-checks", () => {
       checkRepoRuntimeHealthMock.mockClear();
 
       await harness.run((value) => {
-        refreshPromise = value.refreshChecks();
+        refreshPromise = captureDeferredRejection(value.refreshChecks());
       });
       await harness.waitFor((value) => value.isLoadingChecks === true);
       await harness.run(async () => {

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -713,6 +713,8 @@ describe("use-checks", () => {
         (value) =>
           value.runtimeCheck?.errors[0] === "Timed out after 15000ms" &&
           value.activeBeadsCheck?.beadsError === "Timed out after 15000ms" &&
+          value.runtimeCheckFailureKind === "timeout" &&
+          value.beadsCheckFailureKind === "timeout" &&
           value.isLoadingChecks === false,
         1000,
       );

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -682,10 +682,15 @@ describe("use-checks", () => {
     };
     const originalSetTimeout = globalThis.setTimeout;
     const originalClearTimeout = globalThis.clearTimeout;
-    const setTimeoutMock = mock((handler: TimerHandler, _delay?: number) => {
+    const setTimeoutMock = mock((handler: TimerHandler, delay?: number) => {
       if (typeof handler !== "function") {
         throw new Error("Expected timeout callback function");
       }
+
+      if (delay === 2_000) {
+        return originalSetTimeout(() => {}, 60_000);
+      }
+
       return originalSetTimeout(() => {
         handler();
       }, 0);

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -501,10 +501,10 @@ describe("use-checks", () => {
       expect(runtimeCheck.mock.calls[0]).toEqual([false]);
       expect(runtimeCheck.mock.calls[1]).toEqual([true]);
       expect(toastError).toHaveBeenCalledWith(
-        "Diagnostics check unavailable",
+        "CLI tools unavailable",
         expect.objectContaining({
-          id: "diagnostics:manual-unavailable",
-          description: "runtime: runtime down",
+          id: "diagnostics:cli-tools",
+          description: "runtime down",
         }),
       );
       expect(harness.getLatest().isLoadingChecks).toBe(false);
@@ -572,11 +572,12 @@ describe("use-checks", () => {
       await harness.waitFor((value) => value.isLoadingChecks === false);
 
       expect(toastError).toHaveBeenCalledWith(
-        "Diagnostics check unavailable",
-        expect.objectContaining({
-          id: "diagnostics:manual-unavailable",
-          description: "runtime: runtime down | beads: beads down",
-        }),
+        "CLI tools unavailable",
+        expect.objectContaining({ id: "diagnostics:cli-tools", description: "runtime down" }),
+      );
+      expect(toastError).toHaveBeenCalledWith(
+        "Beads store unavailable",
+        expect.objectContaining({ id: "diagnostics:beads-store", description: "beads down" }),
       );
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
@@ -649,11 +650,15 @@ describe("use-checks", () => {
       await harness.waitFor((value) => value.isLoadingChecks === false);
 
       expect(toastError).toHaveBeenCalledWith(
-        "Diagnostics check unavailable",
+        "CLI tools unavailable",
         expect.objectContaining({
-          id: "diagnostics:manual-unavailable",
-          description: "runtime: runtime down | beads: Timed out after 15000ms",
+          id: "diagnostics:cli-tools",
+          description: "runtime down",
         }),
+      );
+      expect(toastMessage).toHaveBeenCalledWith(
+        "Beads store not yet available",
+        expect.objectContaining({ id: "diagnostics:beads-store" }),
       );
       expect(harness.getLatest().isLoadingChecks).toBe(false);
     } finally {
@@ -662,6 +667,71 @@ describe("use-checks", () => {
       host.beadsCheck = original.beadsCheck;
       globalThis.setTimeout = originalSetTimeout;
       globalThis.clearTimeout = originalClearTimeout;
+      beadsDeferred.reject(new Error("cleanup"));
+    }
+  });
+
+  test("projects runtime and beads query timeouts into concrete states instead of leaving checks pending", async () => {
+    const runtimeDeferred = createDeferred<RuntimeCheck>();
+    const beadsDeferred = createDeferred<BeadsCheck>();
+    const original = {
+      runtimeCheck: host.runtimeCheck,
+      beadsCheck: host.beadsCheck,
+    };
+    const originalSetTimeout = globalThis.setTimeout;
+    const originalClearTimeout = globalThis.clearTimeout;
+
+    host.runtimeCheck = mock(async () => runtimeDeferred.promise);
+    host.beadsCheck = mock(async () => beadsDeferred.promise);
+    repoHealthHandler = async () => makeRepoHealth();
+
+    globalThis.setTimeout = ((handler: TimerHandler, delay?: number) => {
+      if (typeof handler !== "function") {
+        throw new Error("Expected timeout callback function");
+      }
+
+      if (delay === 2_000) {
+        return originalSetTimeout(() => {}, 60_000);
+      }
+
+      return originalSetTimeout(() => {
+        handler();
+      }, 0);
+    }) as unknown as typeof globalThis.setTimeout;
+    globalThis.clearTimeout = ((timeoutId: ReturnType<typeof globalThis.setTimeout>) => {
+      originalClearTimeout(timeoutId);
+    }) as typeof globalThis.clearTimeout;
+
+    const harness = createHookHarness({
+      activeRepo: "/repo-a",
+      runtimeDefinitions: [OPENCODE_RUNTIME_DESCRIPTOR],
+    });
+
+    try {
+      await harness.mount();
+      await harness.waitFor(
+        (value) =>
+          value.runtimeCheck?.errors[0] === "Timed out after 15000ms" &&
+          value.activeBeadsCheck?.beadsError === "Timed out after 15000ms" &&
+          value.isLoadingChecks === false,
+        1000,
+      );
+
+      expect(toastMessage).toHaveBeenCalledWith(
+        "CLI tools not yet available",
+        expect.objectContaining({ id: "diagnostics:cli-tools" }),
+      );
+      expect(toastMessage).toHaveBeenCalledWith(
+        "Beads store not yet available",
+        expect.objectContaining({ id: "diagnostics:beads-store" }),
+      );
+    } finally {
+      await harness.unmount();
+      host.runtimeCheck = original.runtimeCheck;
+      host.beadsCheck = original.beadsCheck;
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+      runtimeDeferred.reject(new Error("cleanup"));
       beadsDeferred.reject(new Error("cleanup"));
     }
   });

--- a/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
+++ b/apps/desktop/src/state/operations/workspace/use-checks.test.tsx
@@ -566,8 +566,9 @@ describe("use-checks", () => {
         await value.refreshRuntimeCheck();
       });
       await harness.run(async (value) => {
-        await value.refreshChecks();
+        await expect(value.refreshChecks()).rejects.toThrow("runtime down");
       });
+      await harness.waitFor(() => toastError.mock.calls.length === 1, 1_000);
 
       expect(runtimeCheck).toHaveBeenCalledTimes(2);
       expect(runtimeCheck.mock.calls[0]).toEqual([false]);
@@ -639,7 +640,7 @@ describe("use-checks", () => {
       beadsDeferred.reject(new Error("beads down"));
       runtimeHealthDeferred.resolve(makeRepoHealth());
       await harness.run(async () => {
-        await refreshPromise;
+        await expect(refreshPromise).rejects.toThrow("runtime down");
       });
       await harness.waitFor((value) => value.isLoadingChecks === false);
 
@@ -722,7 +723,7 @@ describe("use-checks", () => {
       });
       await harness.waitFor((value) => value.isLoadingChecks === true);
       await harness.run(async () => {
-        await refreshPromise;
+        await expect(refreshPromise).rejects.toThrow("runtime down");
       });
       await harness.waitFor((value) => value.isLoadingChecks === false);
 

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -163,11 +163,21 @@ export function useChecks({
         refreshBeadsCheckForRepo(activeRepo, true),
         refreshRepoRuntimeHealthForRepo(activeRepo, true),
       ]);
-      const runtime = runtimeResult.status === "fulfilled" ? runtimeResult.value : null;
-      const beads = beadsResult.status === "fulfilled" ? beadsResult.value : null;
+
+      if (runtimeResult.status === "rejected") {
+        throw runtimeResult.reason;
+      }
+
+      if (beadsResult.status === "rejected") {
+        throw beadsResult.reason;
+      }
+
       if (runtimeHealthResult.status === "rejected") {
         throw runtimeHealthResult.reason;
       }
+
+      const runtime = runtimeResult.value;
+      const beads = beadsResult.value;
 
       if (runtime && beads && runtime.gitOk && beads.beadsOk) {
         return;

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -8,22 +8,29 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
-import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import {
-  classifyRepoRuntimeFailure,
-  type RepoRuntimeFailureKind,
-  type RepoRuntimeHealthCheck,
-  type RepoRuntimeHealthMap,
+import type {
+  RepoRuntimeFailureKind,
+  RepoRuntimeHealthCheck,
+  RepoRuntimeHealthMap,
 } from "@/types/diagnostics";
 import {
   beadsCheckQueryOptions,
   checksQueryKeys,
+  classifyDiagnosticsQueryError,
   loadBeadsCheckFromQuery,
   loadRepoRuntimeHealthFromQuery,
   loadRuntimeCheckFromQuery,
   repoRuntimeHealthQueryOptions,
   runtimeCheckQueryOptions,
 } from "../../queries/checks";
+import {
+  buildBeadsCheckErrorState,
+  buildDiagnosticsRetryPlan,
+  buildDiagnosticsToastIssues,
+  buildRuntimeCheckErrorState,
+  buildRuntimeHealthErrorMap,
+  type DiagnosticsToastIssue,
+} from "./check-diagnostics";
 
 type UseChecksArgs = {
   activeRepo: string | null;
@@ -36,7 +43,9 @@ type UseChecksArgs = {
 
 type UseChecksResult = {
   runtimeCheck: RuntimeCheck | null;
+  runtimeCheckFailureKind: RepoRuntimeFailureKind;
   activeBeadsCheck: BeadsCheck | null;
+  beadsCheckFailureKind: RepoRuntimeFailureKind;
   activeRepoRuntimeHealthByRuntime: RepoRuntimeHealthMap;
   isLoadingChecks: boolean;
   setIsLoadingChecks: (value: boolean) => void;
@@ -54,66 +63,7 @@ type UseChecksResult = {
   clearActiveRepoRuntimeHealth: () => void;
 };
 
-type DiagnosticsToastIssue = {
-  id: string;
-  title: string;
-  description: string;
-  severity: Exclude<RepoRuntimeFailureKind, null>;
-};
-
 const RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS = 2_000;
-
-const buildRuntimeCheckErrorState = (
-  runtimeDefinitions: RuntimeDescriptor[],
-  runtimeCheckError: string,
-): RuntimeCheck => ({
-  gitOk: false,
-  gitVersion: null,
-  ghOk: false,
-  ghVersion: null,
-  ghAuthOk: false,
-  ghAuthLogin: null,
-  ghAuthError: runtimeCheckError,
-  runtimes: runtimeDefinitions.map((definition) => ({
-    kind: definition.kind,
-    ok: false,
-    version: null,
-  })),
-  errors: [runtimeCheckError],
-});
-
-const buildBeadsCheckErrorState = (beadsCheckError: string): BeadsCheck => ({
-  beadsOk: false,
-  beadsPath: null,
-  beadsError: beadsCheckError,
-});
-
-const buildRuntimeHealthErrorMap = (
-  runtimeDefinitions: RuntimeDescriptor[],
-  runtimeHealthError: string,
-  checkedAt: string,
-): RepoRuntimeHealthMap => {
-  return Object.fromEntries(
-    runtimeDefinitions.map((definition) => [
-      definition.kind,
-      {
-        runtimeOk: false,
-        runtimeError: runtimeHealthError,
-        runtimeFailureKind: "error",
-        runtime: null,
-        mcpOk: false,
-        mcpError: runtimeHealthError,
-        mcpFailureKind: "error",
-        mcpServerName: ODT_MCP_SERVER_NAME,
-        mcpServerStatus: null,
-        mcpServerError: runtimeHealthError,
-        availableToolIds: [],
-        checkedAt,
-        errors: [runtimeHealthError],
-      },
-    ]),
-  ) as RepoRuntimeHealthMap;
-};
 
 const getSettledValue = <T>(result: PromiseSettledResult<T>): T => {
   if (result.status === "rejected") {
@@ -121,44 +71,6 @@ const getSettledValue = <T>(result: PromiseSettledResult<T>): T => {
   }
 
   return result.value;
-};
-
-const buildTimeoutToastDescription = (label: string, detail: string | null): string => {
-  if (!detail) {
-    return `${label} is not yet available. Retrying automatically.`;
-  }
-
-  return `${label} is not yet available. Retrying automatically. Latest detail: ${detail}`;
-};
-
-const buildErrorToastDescription = (label: string, detail: string | null): string => {
-  return detail ?? `${label} is unavailable.`;
-};
-
-const buildRuntimeHealthToastIssue = ({
-  id,
-  label,
-  detail,
-  failureKind,
-}: {
-  id: string;
-  label: string;
-  detail: string | null;
-  failureKind: Exclude<RepoRuntimeFailureKind, null>;
-}): DiagnosticsToastIssue => {
-  return failureKind === "timeout"
-    ? {
-        id,
-        title: `${label} not yet available`,
-        description: buildTimeoutToastDescription(label, detail),
-        severity: failureKind,
-      }
-    : {
-        id,
-        title: `${label} unavailable`,
-        description: buildErrorToastDescription(label, detail),
-        severity: failureKind,
-      };
 };
 
 export function useChecks({
@@ -343,8 +255,11 @@ export function useChecks({
     runtimeHealthQuery.error,
     runtimeHealthQuery.errorUpdatedAt,
   ]);
-  const runtimeCheckError = runtimeCheckQuery.error ? errorMessage(runtimeCheckQuery.error) : null;
-  const runtimeCheckFailureKind = classifyRepoRuntimeFailure(runtimeCheckError);
+  const runtimeCheckQueryFailure = runtimeCheckQuery.error
+    ? classifyDiagnosticsQueryError(runtimeCheckQuery.error)
+    : null;
+  const runtimeCheckError = runtimeCheckQueryFailure?.message ?? null;
+  const runtimeCheckFailureKind = runtimeCheckQueryFailure?.failureKind ?? null;
   const runtimeCheckState = useMemo((): RuntimeCheck | null => {
     if (runtimeCheckQuery.data) {
       return runtimeCheckQuery.data;
@@ -356,8 +271,11 @@ export function useChecks({
 
     return null;
   }, [runtimeCheckError, runtimeCheckQuery.data, runtimeDefinitions]);
-  const beadsCheckError = beadsCheckQuery.error ? errorMessage(beadsCheckQuery.error) : null;
-  const beadsCheckFailureKind = classifyRepoRuntimeFailure(beadsCheckError);
+  const beadsCheckQueryFailure = beadsCheckQuery.error
+    ? classifyDiagnosticsQueryError(beadsCheckQuery.error)
+    : null;
+  const beadsCheckError = beadsCheckQueryFailure?.message ?? null;
+  const beadsCheckFailureKind = beadsCheckQueryFailure?.failureKind ?? null;
   const activeBeadsCheck = useMemo((): BeadsCheck | null => {
     if (activeRepo === null) {
       return null;
@@ -373,84 +291,26 @@ export function useChecks({
 
     return null;
   }, [activeRepo, beadsCheckError, beadsCheckQuery.data]);
-  const diagnosticsToastIssues = useMemo((): DiagnosticsToastIssue[] => {
-    if (activeRepo === null) {
-      return [];
-    }
-
-    const issues: DiagnosticsToastIssue[] = [];
-
-    if (runtimeCheckError && runtimeCheckFailureKind !== null) {
-      issues.push(
-        buildRuntimeHealthToastIssue({
-          id: "diagnostics:cli-tools",
-          label: "CLI tools",
-          detail: runtimeCheckError,
-          failureKind: runtimeCheckFailureKind,
-        }),
-      );
-    }
-
-    if (beadsCheckError && beadsCheckFailureKind !== null) {
-      issues.push(
-        buildRuntimeHealthToastIssue({
-          id: "diagnostics:beads-store",
-          label: "Beads store",
-          detail: beadsCheckError,
-          failureKind: beadsCheckFailureKind,
-        }),
-      );
-    }
-
-    issues.push(
-      ...runtimeDefinitions.flatMap((definition) => {
-        const runtimeHealth = activeRepoRuntimeHealthByRuntime[definition.kind];
-        if (!runtimeHealth) {
-          return [];
-        }
-
-        if (runtimeHealth.runtimeOk === false && runtimeHealth.runtimeFailureKind !== null) {
-          return [
-            buildRuntimeHealthToastIssue({
-              id: `diagnostics:runtime:${definition.kind}`,
-              label: `${definition.label} runtime`,
-              detail: runtimeHealth.runtimeError,
-              failureKind: runtimeHealth.runtimeFailureKind,
-            }),
-          ];
-        }
-
-        if (
-          definition.capabilities.supportsMcpStatus &&
-          runtimeHealth.mcpOk === false &&
-          runtimeHealth.mcpFailureKind !== null
-        ) {
-          return [
-            buildRuntimeHealthToastIssue({
-              id: `diagnostics:mcp:${definition.kind}`,
-              label: `${definition.label} OpenDucktor MCP`,
-              detail: runtimeHealth.mcpServerError ?? runtimeHealth.mcpError,
-              failureKind: runtimeHealth.mcpFailureKind,
-            }),
-          ];
-        }
-
-        return [];
+  const diagnosticsToastIssues = useMemo(
+    (): DiagnosticsToastIssue[] =>
+      buildDiagnosticsToastIssues({
+        activeRepo,
+        runtimeDefinitions,
+        runtimeCheckError,
+        runtimeCheckFailureKind,
+        beadsCheckError,
+        beadsCheckFailureKind,
+        runtimeHealthByRuntime: activeRepoRuntimeHealthByRuntime,
       }),
-    );
-
-    return issues;
-  }, [
-    activeRepo,
-    activeRepoRuntimeHealthByRuntime,
-    beadsCheckError,
-    beadsCheckFailureKind,
-    runtimeCheckError,
-    runtimeCheckFailureKind,
-    runtimeDefinitions,
-  ]);
-  const hasDiagnosticsTimeoutIssue = diagnosticsToastIssues.some(
-    (issue) => issue.severity === "timeout",
+    [
+      activeRepo,
+      activeRepoRuntimeHealthByRuntime,
+      beadsCheckError,
+      beadsCheckFailureKind,
+      runtimeCheckError,
+      runtimeCheckFailureKind,
+      runtimeDefinitions,
+    ],
   );
 
   useEffect(() => {
@@ -495,20 +355,21 @@ export function useChecks({
       diagnosticsRetryTimeoutRef.current = null;
     }
 
-    const shouldRetryRuntimeCheckTimeout =
-      runtimeCheckFailureKind === "timeout" && !runtimeCheckQuery.isFetching;
-    const shouldRetryBeadsCheckTimeout =
-      activeRepo !== null && beadsCheckFailureKind === "timeout" && !beadsCheckQuery.isFetching;
-    const shouldRetryRuntimeHealthTimeout =
-      activeRepo !== null &&
-      hasDiagnosticsTimeoutIssue &&
-      runtimeDefinitions.length > 0 &&
-      !runtimeHealthQuery.isFetching;
+    const retryPlan = buildDiagnosticsRetryPlan({
+      activeRepo,
+      runtimeDefinitions,
+      runtimeCheckFailureKind,
+      runtimeCheckFetching: runtimeCheckQuery.isFetching,
+      beadsCheckFailureKind,
+      beadsCheckFetching: beadsCheckQuery.isFetching,
+      runtimeHealthByRuntime: activeRepoRuntimeHealthByRuntime,
+      runtimeHealthFetching: runtimeHealthQuery.isFetching,
+    });
 
     if (
-      !shouldRetryRuntimeCheckTimeout &&
-      !shouldRetryBeadsCheckTimeout &&
-      !shouldRetryRuntimeHealthTimeout
+      !retryPlan.retryRuntimeCheck &&
+      !retryPlan.retryBeadsCheck &&
+      !retryPlan.retryRuntimeHealth
     ) {
       return;
     }
@@ -517,15 +378,15 @@ export function useChecks({
       diagnosticsRetryTimeoutRef.current = null;
       const retries: Promise<unknown>[] = [];
 
-      if (shouldRetryRuntimeCheckTimeout) {
+      if (retryPlan.retryRuntimeCheck) {
         retries.push(refreshRuntimeCheck(true));
       }
 
-      if (shouldRetryBeadsCheckTimeout && activeRepo !== null) {
+      if (retryPlan.retryBeadsCheck && activeRepo !== null) {
         retries.push(refreshBeadsCheckForRepo(activeRepo, true));
       }
 
-      if (shouldRetryRuntimeHealthTimeout && activeRepo !== null) {
+      if (retryPlan.retryRuntimeHealth && activeRepo !== null) {
         retries.push(refreshRepoRuntimeHealthForRepo(activeRepo, true));
       }
 
@@ -540,15 +401,15 @@ export function useChecks({
     };
   }, [
     activeRepo,
+    activeRepoRuntimeHealthByRuntime,
     beadsCheckFailureKind,
     beadsCheckQuery.isFetching,
-    hasDiagnosticsTimeoutIssue,
     refreshBeadsCheckForRepo,
     refreshRepoRuntimeHealthForRepo,
     refreshRuntimeCheck,
     runtimeCheckFailureKind,
     runtimeCheckQuery.isFetching,
-    runtimeDefinitions.length,
+    runtimeDefinitions,
     runtimeHealthQuery.isFetching,
   ]);
 
@@ -574,7 +435,9 @@ export function useChecks({
 
   return {
     runtimeCheck: runtimeCheckState,
+    runtimeCheckFailureKind,
     activeBeadsCheck,
+    beadsCheckFailureKind,
     activeRepoRuntimeHealthByRuntime,
     isLoadingChecks,
     setIsLoadingChecks: setIsManualLoadingChecks,

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -65,14 +65,6 @@ type UseChecksResult = {
 
 const RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS = 2_000;
 
-const getSettledValue = <T>(result: PromiseSettledResult<T>): T => {
-  if (result.status === "rejected") {
-    throw result.reason;
-  }
-
-  return result.value;
-};
-
 export function useChecks({
   activeRepo,
   runtimeDefinitions,
@@ -174,7 +166,10 @@ export function useChecks({
       ]);
       const runtime = runtimeResult.status === "fulfilled" ? runtimeResult.value : null;
       const beads = beadsResult.status === "fulfilled" ? beadsResult.value : null;
-      getSettledValue(runtimeHealthResult);
+      if (runtimeHealthResult.status === "rejected") {
+        throw runtimeHealthResult.reason;
+      }
+
       if (runtime && beads && runtime.gitOk && beads.beadsOk) {
         return;
       }
@@ -296,17 +291,21 @@ export function useChecks({
       buildDiagnosticsToastIssues({
         activeRepo,
         runtimeDefinitions,
+        runtimeCheck: runtimeCheckState,
         runtimeCheckError,
         runtimeCheckFailureKind,
+        beadsCheck: activeBeadsCheck,
         beadsCheckError,
         beadsCheckFailureKind,
         runtimeHealthByRuntime: activeRepoRuntimeHealthByRuntime,
       }),
     [
       activeRepo,
+      activeBeadsCheck,
       activeRepoRuntimeHealthByRuntime,
       beadsCheckError,
       beadsCheckFailureKind,
+      runtimeCheckState,
       runtimeCheckError,
       runtimeCheckFailureKind,
       runtimeDefinitions,

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -5,8 +5,7 @@ import type {
   RuntimeKind,
 } from "@openducktor/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { useCallback, useMemo, useState } from "react";
 import { errorMessage } from "@/lib/errors";
 import type {
   RepoRuntimeFailureKind,
@@ -31,6 +30,10 @@ import {
   buildRuntimeHealthErrorMap,
   type DiagnosticsToastIssue,
 } from "./check-diagnostics";
+import {
+  useDiagnosticsRetryScheduler,
+  useDiagnosticsToasts,
+} from "./use-check-diagnostics-effects";
 
 type UseChecksArgs = {
   activeRepo: string | null;
@@ -63,8 +66,6 @@ type UseChecksResult = {
   clearActiveRepoRuntimeHealth: () => void;
 };
 
-const RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS = 2_000;
-
 export function useChecks({
   activeRepo,
   runtimeDefinitions,
@@ -72,8 +73,6 @@ export function useChecks({
 }: UseChecksArgs): UseChecksResult {
   const queryClient = useQueryClient();
   const [isManualLoadingChecks, setIsManualLoadingChecks] = useState(false);
-  const issueSignaturesRef = useRef(new Map<string, string>());
-  const diagnosticsRetryTimeoutRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
   const runtimeCheckQuery = useQuery(runtimeCheckQueryOptions());
   const beadsCheckQuery = useQuery({
     ...beadsCheckQueryOptions(activeRepo ?? "__disabled__"),
@@ -312,118 +311,38 @@ export function useChecks({
     ],
   );
 
-  useEffect(() => {
-    const nextIssueIds = new Set(diagnosticsToastIssues.map((issue) => issue.id));
-
-    for (const issueId of [...issueSignaturesRef.current.keys()]) {
-      if (nextIssueIds.has(issueId)) {
-        continue;
-      }
-
-      toast.dismiss(issueId);
-      issueSignaturesRef.current.delete(issueId);
-    }
-
-    for (const issue of diagnosticsToastIssues) {
-      const signature = `${issue.severity}:${issue.title}:${issue.description}`;
-      if (issueSignaturesRef.current.get(issue.id) === signature) {
-        continue;
-      }
-
-      if (issue.severity === "timeout") {
-        toast(issue.title, {
-          id: issue.id,
-          description: issue.description,
-          duration: Number.POSITIVE_INFINITY,
-        });
-      } else {
-        toast.error(issue.title, {
-          id: issue.id,
-          description: issue.description,
-          duration: Number.POSITIVE_INFINITY,
-        });
-      }
-
-      issueSignaturesRef.current.set(issue.id, signature);
-    }
-  }, [diagnosticsToastIssues]);
-
-  useEffect(() => {
-    if (diagnosticsRetryTimeoutRef.current !== null) {
-      globalThis.clearTimeout(diagnosticsRetryTimeoutRef.current);
-      diagnosticsRetryTimeoutRef.current = null;
-    }
-
-    const retryPlan = buildDiagnosticsRetryPlan({
+  const diagnosticsRetryPlan = useMemo(
+    () =>
+      buildDiagnosticsRetryPlan({
+        activeRepo,
+        runtimeDefinitions,
+        runtimeCheckFailureKind,
+        runtimeCheckFetching: runtimeCheckQuery.isFetching,
+        beadsCheckFailureKind,
+        beadsCheckFetching: beadsCheckQuery.isFetching,
+        runtimeHealthByRuntime: activeRepoRuntimeHealthByRuntime,
+        runtimeHealthFetching: runtimeHealthQuery.isFetching,
+      }),
+    [
       activeRepo,
-      runtimeDefinitions,
-      runtimeCheckFailureKind,
-      runtimeCheckFetching: runtimeCheckQuery.isFetching,
+      activeRepoRuntimeHealthByRuntime,
       beadsCheckFailureKind,
-      beadsCheckFetching: beadsCheckQuery.isFetching,
-      runtimeHealthByRuntime: activeRepoRuntimeHealthByRuntime,
-      runtimeHealthFetching: runtimeHealthQuery.isFetching,
-    });
+      beadsCheckQuery.isFetching,
+      runtimeCheckFailureKind,
+      runtimeCheckQuery.isFetching,
+      runtimeDefinitions,
+      runtimeHealthQuery.isFetching,
+    ],
+  );
 
-    if (
-      !retryPlan.retryRuntimeCheck &&
-      !retryPlan.retryBeadsCheck &&
-      !retryPlan.retryRuntimeHealth
-    ) {
-      return;
-    }
-
-    diagnosticsRetryTimeoutRef.current = globalThis.setTimeout(() => {
-      diagnosticsRetryTimeoutRef.current = null;
-      const retries: Promise<unknown>[] = [];
-
-      if (retryPlan.retryRuntimeCheck) {
-        retries.push(refreshRuntimeCheck(true));
-      }
-
-      if (retryPlan.retryBeadsCheck && activeRepo !== null) {
-        retries.push(refreshBeadsCheckForRepo(activeRepo, true));
-      }
-
-      if (retryPlan.retryRuntimeHealth && activeRepo !== null) {
-        retries.push(refreshRepoRuntimeHealthForRepo(activeRepo, true));
-      }
-
-      void Promise.allSettled(retries);
-    }, RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS);
-
-    return () => {
-      if (diagnosticsRetryTimeoutRef.current !== null) {
-        globalThis.clearTimeout(diagnosticsRetryTimeoutRef.current);
-        diagnosticsRetryTimeoutRef.current = null;
-      }
-    };
-  }, [
+  useDiagnosticsToasts(diagnosticsToastIssues);
+  useDiagnosticsRetryScheduler({
     activeRepo,
-    activeRepoRuntimeHealthByRuntime,
-    beadsCheckFailureKind,
-    beadsCheckQuery.isFetching,
+    retryPlan: diagnosticsRetryPlan,
+    refreshRuntimeCheck,
     refreshBeadsCheckForRepo,
     refreshRepoRuntimeHealthForRepo,
-    refreshRuntimeCheck,
-    runtimeCheckFailureKind,
-    runtimeCheckQuery.isFetching,
-    runtimeDefinitions,
-    runtimeHealthQuery.isFetching,
-  ]);
-
-  useEffect(() => {
-    return () => {
-      if (diagnosticsRetryTimeoutRef.current !== null) {
-        globalThis.clearTimeout(diagnosticsRetryTimeoutRef.current);
-      }
-
-      for (const issueId of issueSignaturesRef.current.keys()) {
-        toast.dismiss(issueId);
-      }
-      issueSignaturesRef.current.clear();
-    };
-  }, []);
+  });
 
   const isLoadingChecks =
     isManualLoadingChecks ||

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -9,11 +9,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import {
-  classifyRepoRuntimeFailure,
-  type RepoRuntimeFailureKind,
-  type RepoRuntimeHealthCheck,
-  type RepoRuntimeHealthMap,
+import type {
+  RepoRuntimeFailureKind,
+  RepoRuntimeHealthCheck,
+  RepoRuntimeHealthMap,
 } from "@/types/diagnostics";
 import {
   beadsCheckQueryOptions,
@@ -75,11 +74,11 @@ const buildRuntimeHealthErrorMap = (
       {
         runtimeOk: false,
         runtimeError: runtimeHealthError,
-        runtimeFailureKind: classifyRepoRuntimeFailure(runtimeHealthError),
+        runtimeFailureKind: "error",
         runtime: null,
         mcpOk: false,
         mcpError: runtimeHealthError,
-        mcpFailureKind: classifyRepoRuntimeFailure(runtimeHealthError),
+        mcpFailureKind: "error",
         mcpServerName: ODT_MCP_SERVER_NAME,
         mcpServerStatus: null,
         mcpServerError: runtimeHealthError,

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -5,11 +5,16 @@ import type {
   RuntimeKind,
 } from "@openducktor/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import type { RepoRuntimeHealthCheck, RepoRuntimeHealthMap } from "@/types/diagnostics";
+import {
+  classifyRepoRuntimeFailure,
+  type RepoRuntimeFailureKind,
+  type RepoRuntimeHealthCheck,
+  type RepoRuntimeHealthMap,
+} from "@/types/diagnostics";
 import {
   beadsCheckQueryOptions,
   checksQueryKeys,
@@ -49,6 +54,16 @@ type UseChecksResult = {
   clearActiveRepoRuntimeHealth: () => void;
 };
 
+type DiagnosticsToastIssue = {
+  id: string;
+  title: string;
+  description: string;
+  severity: Exclude<RepoRuntimeFailureKind, null>;
+};
+
+const RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS = 2_000;
+const MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID = "diagnostics:manual-unavailable";
+
 const buildRuntimeHealthErrorMap = (
   runtimeDefinitions: RuntimeDescriptor[],
   runtimeHealthError: string,
@@ -60,9 +75,11 @@ const buildRuntimeHealthErrorMap = (
       {
         runtimeOk: false,
         runtimeError: runtimeHealthError,
+        runtimeFailureKind: classifyRepoRuntimeFailure(runtimeHealthError),
         runtime: null,
         mcpOk: false,
         mcpError: runtimeHealthError,
+        mcpFailureKind: classifyRepoRuntimeFailure(runtimeHealthError),
         mcpServerName: ODT_MCP_SERVER_NAME,
         mcpServerStatus: null,
         mcpServerError: runtimeHealthError,
@@ -94,6 +111,44 @@ const getSettledValue = <T>(result: PromiseSettledResult<T>): T => {
   return result.value;
 };
 
+const buildTimeoutToastDescription = (label: string, detail: string | null): string => {
+  if (!detail) {
+    return `${label} is not yet available. Retrying automatically.`;
+  }
+
+  return `${label} is not yet available. Retrying automatically. Latest detail: ${detail}`;
+};
+
+const buildErrorToastDescription = (label: string, detail: string | null): string => {
+  return detail ?? `${label} is unavailable.`;
+};
+
+const buildRuntimeHealthToastIssue = ({
+  id,
+  label,
+  detail,
+  failureKind,
+}: {
+  id: string;
+  label: string;
+  detail: string | null;
+  failureKind: Exclude<RepoRuntimeFailureKind, null>;
+}): DiagnosticsToastIssue => {
+  return failureKind === "timeout"
+    ? {
+        id,
+        title: `${label} not yet available`,
+        description: buildTimeoutToastDescription(label, detail),
+        severity: failureKind,
+      }
+    : {
+        id,
+        title: `${label} unavailable`,
+        description: buildErrorToastDescription(label, detail),
+        severity: failureKind,
+      };
+};
+
 export function useChecks({
   activeRepo,
   runtimeDefinitions,
@@ -101,6 +156,10 @@ export function useChecks({
 }: UseChecksArgs): UseChecksResult {
   const queryClient = useQueryClient();
   const [isManualLoadingChecks, setIsManualLoadingChecks] = useState(false);
+  const issueSignaturesRef = useRef(new Map<string, string>());
+  const runtimeHealthRetryTimeoutRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(
+    null,
+  );
   const runtimeCheckQuery = useQuery(runtimeCheckQueryOptions());
   const beadsCheckQuery = useQuery({
     ...beadsCheckQueryOptions(activeRepo ?? "__disabled__"),
@@ -194,57 +253,29 @@ export function useChecks({
       const unavailableDetails = getSettledErrorDescriptions([
         { label: "runtime", result: runtimeResult },
         { label: "beads", result: beadsResult },
-        { label: "runtime health", result: runtimeHealthResult },
       ]);
 
       if (unavailableDetails.length > 0) {
         toast.error("Diagnostics check unavailable", {
+          id: MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID,
           description: unavailableDetails.join(" | "),
+          duration: Number.POSITIVE_INFINITY,
         });
         return;
       }
 
+      toast.dismiss(MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID);
+
       const runtime = getSettledValue(runtimeResult);
       const beads = getSettledValue(beadsResult);
-      const runtimeHealthByRuntime = getSettledValue(runtimeHealthResult);
-      const runtimesHealthy = runtime.runtimes.every((runtimeEntry) => runtimeEntry.ok);
-      const runtimeHealthEntries = runtimeDefinitions.map(
-        (definition) => runtimeHealthByRuntime[definition.kind],
-      );
-      const runtimeServersHealthy = runtimeHealthEntries.every(
-        (entry) => entry?.runtimeOk !== false,
-      );
-      const runtimeMcpHealthy = runtimeDefinitions.every((definition) => {
-        const health = runtimeHealthByRuntime[definition.kind];
-        if (!definition.capabilities.supportsMcpStatus) {
-          return true;
-        }
-        return health?.mcpOk !== false;
-      });
-      if (
-        !runtime.gitOk ||
-        !runtimesHealthy ||
-        !beads.beadsOk ||
-        !runtimeServersHealthy ||
-        !runtimeMcpHealthy
-      ) {
-        const details = [
-          ...runtime.errors,
-          ...(beads.beadsError ? [`beads: ${beads.beadsError}`] : []),
-          ...runtimeHealthEntries.flatMap((entry) => entry?.errors ?? []),
-        ].join(" | ");
-        toast.error("Diagnostics check failed", { description: details });
+      getSettledValue(runtimeHealthResult);
+      if (runtime.gitOk && beads.beadsOk) {
+        toast.dismiss(MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID);
       }
     } finally {
       setIsManualLoadingChecks(false);
     }
-  }, [
-    activeRepo,
-    refreshBeadsCheckForRepo,
-    refreshRepoRuntimeHealthForRepo,
-    refreshRuntimeCheck,
-    runtimeDefinitions,
-  ]);
+  }, [activeRepo, refreshBeadsCheckForRepo, refreshRepoRuntimeHealthForRepo, refreshRuntimeCheck]);
 
   const hasCachedBeadsCheck = useCallback(
     (repoPath: string): boolean => {
@@ -318,6 +349,134 @@ export function useChecks({
     runtimeHealthQuery.error,
     runtimeHealthQuery.errorUpdatedAt,
   ]);
+  const runtimeHealthToastIssues = useMemo((): DiagnosticsToastIssue[] => {
+    if (activeRepo === null) {
+      return [];
+    }
+
+    return runtimeDefinitions.flatMap((definition) => {
+      const runtimeHealth = activeRepoRuntimeHealthByRuntime[definition.kind];
+      if (!runtimeHealth) {
+        return [];
+      }
+
+      if (runtimeHealth.runtimeOk === false && runtimeHealth.runtimeFailureKind !== null) {
+        return [
+          buildRuntimeHealthToastIssue({
+            id: `diagnostics:runtime:${definition.kind}`,
+            label: `${definition.label} runtime`,
+            detail: runtimeHealth.runtimeError,
+            failureKind: runtimeHealth.runtimeFailureKind,
+          }),
+        ];
+      }
+
+      if (
+        definition.capabilities.supportsMcpStatus &&
+        runtimeHealth.mcpOk === false &&
+        runtimeHealth.mcpFailureKind !== null
+      ) {
+        return [
+          buildRuntimeHealthToastIssue({
+            id: `diagnostics:mcp:${definition.kind}`,
+            label: `${definition.label} OpenDucktor MCP`,
+            detail: runtimeHealth.mcpServerError ?? runtimeHealth.mcpError,
+            failureKind: runtimeHealth.mcpFailureKind,
+          }),
+        ];
+      }
+
+      return [];
+    });
+  }, [activeRepo, activeRepoRuntimeHealthByRuntime, runtimeDefinitions]);
+  const hasRuntimeHealthTimeoutIssue = runtimeHealthToastIssues.some(
+    (issue) => issue.severity === "timeout",
+  );
+
+  useEffect(() => {
+    const nextIssueIds = new Set(runtimeHealthToastIssues.map((issue) => issue.id));
+
+    for (const issueId of [...issueSignaturesRef.current.keys()]) {
+      if (nextIssueIds.has(issueId)) {
+        continue;
+      }
+
+      toast.dismiss(issueId);
+      issueSignaturesRef.current.delete(issueId);
+    }
+
+    for (const issue of runtimeHealthToastIssues) {
+      const signature = `${issue.severity}:${issue.title}:${issue.description}`;
+      if (issueSignaturesRef.current.get(issue.id) === signature) {
+        continue;
+      }
+
+      if (issue.severity === "timeout") {
+        toast(issue.title, {
+          id: issue.id,
+          description: issue.description,
+          duration: Number.POSITIVE_INFINITY,
+        });
+      } else {
+        toast.error(issue.title, {
+          id: issue.id,
+          description: issue.description,
+          duration: Number.POSITIVE_INFINITY,
+        });
+      }
+
+      issueSignaturesRef.current.set(issue.id, signature);
+    }
+  }, [runtimeHealthToastIssues]);
+
+  useEffect(() => {
+    if (runtimeHealthRetryTimeoutRef.current !== null) {
+      globalThis.clearTimeout(runtimeHealthRetryTimeoutRef.current);
+      runtimeHealthRetryTimeoutRef.current = null;
+    }
+
+    if (
+      activeRepo === null ||
+      !hasRuntimeHealthTimeoutIssue ||
+      runtimeHealthQuery.isFetching ||
+      runtimeDefinitions.length === 0
+    ) {
+      return;
+    }
+
+    runtimeHealthRetryTimeoutRef.current = globalThis.setTimeout(() => {
+      runtimeHealthRetryTimeoutRef.current = null;
+      void refreshRepoRuntimeHealthForRepo(activeRepo, true).catch(() => undefined);
+    }, RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS);
+
+    return () => {
+      if (runtimeHealthRetryTimeoutRef.current !== null) {
+        globalThis.clearTimeout(runtimeHealthRetryTimeoutRef.current);
+        runtimeHealthRetryTimeoutRef.current = null;
+      }
+    };
+  }, [
+    activeRepo,
+    hasRuntimeHealthTimeoutIssue,
+    refreshRepoRuntimeHealthForRepo,
+    runtimeDefinitions.length,
+    runtimeHealthQuery.isFetching,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      if (runtimeHealthRetryTimeoutRef.current !== null) {
+        globalThis.clearTimeout(runtimeHealthRetryTimeoutRef.current);
+      }
+
+      for (const issueId of issueSignaturesRef.current.keys()) {
+        toast.dismiss(issueId);
+      }
+      toast.dismiss(MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID);
+      issueSignaturesRef.current.clear();
+    };
+  }, []);
+
   const isLoadingChecks =
     isManualLoadingChecks ||
     runtimeCheckQuery.isFetching ||

--- a/apps/desktop/src/state/operations/workspace/use-checks.ts
+++ b/apps/desktop/src/state/operations/workspace/use-checks.ts
@@ -9,10 +9,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import type {
-  RepoRuntimeFailureKind,
-  RepoRuntimeHealthCheck,
-  RepoRuntimeHealthMap,
+import {
+  classifyRepoRuntimeFailure,
+  type RepoRuntimeFailureKind,
+  type RepoRuntimeHealthCheck,
+  type RepoRuntimeHealthMap,
 } from "@/types/diagnostics";
 import {
   beadsCheckQueryOptions,
@@ -61,7 +62,31 @@ type DiagnosticsToastIssue = {
 };
 
 const RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS = 2_000;
-const MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID = "diagnostics:manual-unavailable";
+
+const buildRuntimeCheckErrorState = (
+  runtimeDefinitions: RuntimeDescriptor[],
+  runtimeCheckError: string,
+): RuntimeCheck => ({
+  gitOk: false,
+  gitVersion: null,
+  ghOk: false,
+  ghVersion: null,
+  ghAuthOk: false,
+  ghAuthLogin: null,
+  ghAuthError: runtimeCheckError,
+  runtimes: runtimeDefinitions.map((definition) => ({
+    kind: definition.kind,
+    ok: false,
+    version: null,
+  })),
+  errors: [runtimeCheckError],
+});
+
+const buildBeadsCheckErrorState = (beadsCheckError: string): BeadsCheck => ({
+  beadsOk: false,
+  beadsPath: null,
+  beadsError: beadsCheckError,
+});
 
 const buildRuntimeHealthErrorMap = (
   runtimeDefinitions: RuntimeDescriptor[],
@@ -88,18 +113,6 @@ const buildRuntimeHealthErrorMap = (
       },
     ]),
   ) as RepoRuntimeHealthMap;
-};
-
-const getSettledErrorDescriptions = (
-  results: Array<{ label: string; result: PromiseSettledResult<unknown> }>,
-): string[] => {
-  return results.flatMap(({ label, result }) => {
-    if (result.status === "fulfilled") {
-      return [];
-    }
-
-    return [`${label}: ${errorMessage(result.reason)}`];
-  });
 };
 
 const getSettledValue = <T>(result: PromiseSettledResult<T>): T => {
@@ -156,9 +169,7 @@ export function useChecks({
   const queryClient = useQueryClient();
   const [isManualLoadingChecks, setIsManualLoadingChecks] = useState(false);
   const issueSignaturesRef = useRef(new Map<string, string>());
-  const runtimeHealthRetryTimeoutRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(
-    null,
-  );
+  const diagnosticsRetryTimeoutRef = useRef<ReturnType<typeof globalThis.setTimeout> | null>(null);
   const runtimeCheckQuery = useQuery(runtimeCheckQueryOptions());
   const beadsCheckQuery = useQuery({
     ...beadsCheckQueryOptions(activeRepo ?? "__disabled__"),
@@ -249,27 +260,11 @@ export function useChecks({
         refreshBeadsCheckForRepo(activeRepo, true),
         refreshRepoRuntimeHealthForRepo(activeRepo, true),
       ]);
-      const unavailableDetails = getSettledErrorDescriptions([
-        { label: "runtime", result: runtimeResult },
-        { label: "beads", result: beadsResult },
-      ]);
-
-      if (unavailableDetails.length > 0) {
-        toast.error("Diagnostics check unavailable", {
-          id: MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID,
-          description: unavailableDetails.join(" | "),
-          duration: Number.POSITIVE_INFINITY,
-        });
-        return;
-      }
-
-      toast.dismiss(MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID);
-
-      const runtime = getSettledValue(runtimeResult);
-      const beads = getSettledValue(beadsResult);
+      const runtime = runtimeResult.status === "fulfilled" ? runtimeResult.value : null;
+      const beads = beadsResult.status === "fulfilled" ? beadsResult.value : null;
       getSettledValue(runtimeHealthResult);
-      if (runtime.gitOk && beads.beadsOk) {
-        toast.dismiss(MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID);
+      if (runtime && beads && runtime.gitOk && beads.beadsOk) {
+        return;
       }
     } finally {
       setIsManualLoadingChecks(false);
@@ -348,52 +343,118 @@ export function useChecks({
     runtimeHealthQuery.error,
     runtimeHealthQuery.errorUpdatedAt,
   ]);
-  const runtimeHealthToastIssues = useMemo((): DiagnosticsToastIssue[] => {
+  const runtimeCheckError = runtimeCheckQuery.error ? errorMessage(runtimeCheckQuery.error) : null;
+  const runtimeCheckFailureKind = classifyRepoRuntimeFailure(runtimeCheckError);
+  const runtimeCheckState = useMemo((): RuntimeCheck | null => {
+    if (runtimeCheckQuery.data) {
+      return runtimeCheckQuery.data;
+    }
+
+    if (runtimeCheckError) {
+      return buildRuntimeCheckErrorState(runtimeDefinitions, runtimeCheckError);
+    }
+
+    return null;
+  }, [runtimeCheckError, runtimeCheckQuery.data, runtimeDefinitions]);
+  const beadsCheckError = beadsCheckQuery.error ? errorMessage(beadsCheckQuery.error) : null;
+  const beadsCheckFailureKind = classifyRepoRuntimeFailure(beadsCheckError);
+  const activeBeadsCheck = useMemo((): BeadsCheck | null => {
+    if (activeRepo === null) {
+      return null;
+    }
+
+    if (beadsCheckQuery.data) {
+      return beadsCheckQuery.data;
+    }
+
+    if (beadsCheckError) {
+      return buildBeadsCheckErrorState(beadsCheckError);
+    }
+
+    return null;
+  }, [activeRepo, beadsCheckError, beadsCheckQuery.data]);
+  const diagnosticsToastIssues = useMemo((): DiagnosticsToastIssue[] => {
     if (activeRepo === null) {
       return [];
     }
 
-    return runtimeDefinitions.flatMap((definition) => {
-      const runtimeHealth = activeRepoRuntimeHealthByRuntime[definition.kind];
-      if (!runtimeHealth) {
+    const issues: DiagnosticsToastIssue[] = [];
+
+    if (runtimeCheckError && runtimeCheckFailureKind !== null) {
+      issues.push(
+        buildRuntimeHealthToastIssue({
+          id: "diagnostics:cli-tools",
+          label: "CLI tools",
+          detail: runtimeCheckError,
+          failureKind: runtimeCheckFailureKind,
+        }),
+      );
+    }
+
+    if (beadsCheckError && beadsCheckFailureKind !== null) {
+      issues.push(
+        buildRuntimeHealthToastIssue({
+          id: "diagnostics:beads-store",
+          label: "Beads store",
+          detail: beadsCheckError,
+          failureKind: beadsCheckFailureKind,
+        }),
+      );
+    }
+
+    issues.push(
+      ...runtimeDefinitions.flatMap((definition) => {
+        const runtimeHealth = activeRepoRuntimeHealthByRuntime[definition.kind];
+        if (!runtimeHealth) {
+          return [];
+        }
+
+        if (runtimeHealth.runtimeOk === false && runtimeHealth.runtimeFailureKind !== null) {
+          return [
+            buildRuntimeHealthToastIssue({
+              id: `diagnostics:runtime:${definition.kind}`,
+              label: `${definition.label} runtime`,
+              detail: runtimeHealth.runtimeError,
+              failureKind: runtimeHealth.runtimeFailureKind,
+            }),
+          ];
+        }
+
+        if (
+          definition.capabilities.supportsMcpStatus &&
+          runtimeHealth.mcpOk === false &&
+          runtimeHealth.mcpFailureKind !== null
+        ) {
+          return [
+            buildRuntimeHealthToastIssue({
+              id: `diagnostics:mcp:${definition.kind}`,
+              label: `${definition.label} OpenDucktor MCP`,
+              detail: runtimeHealth.mcpServerError ?? runtimeHealth.mcpError,
+              failureKind: runtimeHealth.mcpFailureKind,
+            }),
+          ];
+        }
+
         return [];
-      }
+      }),
+    );
 
-      if (runtimeHealth.runtimeOk === false && runtimeHealth.runtimeFailureKind !== null) {
-        return [
-          buildRuntimeHealthToastIssue({
-            id: `diagnostics:runtime:${definition.kind}`,
-            label: `${definition.label} runtime`,
-            detail: runtimeHealth.runtimeError,
-            failureKind: runtimeHealth.runtimeFailureKind,
-          }),
-        ];
-      }
-
-      if (
-        definition.capabilities.supportsMcpStatus &&
-        runtimeHealth.mcpOk === false &&
-        runtimeHealth.mcpFailureKind !== null
-      ) {
-        return [
-          buildRuntimeHealthToastIssue({
-            id: `diagnostics:mcp:${definition.kind}`,
-            label: `${definition.label} OpenDucktor MCP`,
-            detail: runtimeHealth.mcpServerError ?? runtimeHealth.mcpError,
-            failureKind: runtimeHealth.mcpFailureKind,
-          }),
-        ];
-      }
-
-      return [];
-    });
-  }, [activeRepo, activeRepoRuntimeHealthByRuntime, runtimeDefinitions]);
-  const hasRuntimeHealthTimeoutIssue = runtimeHealthToastIssues.some(
+    return issues;
+  }, [
+    activeRepo,
+    activeRepoRuntimeHealthByRuntime,
+    beadsCheckError,
+    beadsCheckFailureKind,
+    runtimeCheckError,
+    runtimeCheckFailureKind,
+    runtimeDefinitions,
+  ]);
+  const hasDiagnosticsTimeoutIssue = diagnosticsToastIssues.some(
     (issue) => issue.severity === "timeout",
   );
 
   useEffect(() => {
-    const nextIssueIds = new Set(runtimeHealthToastIssues.map((issue) => issue.id));
+    const nextIssueIds = new Set(diagnosticsToastIssues.map((issue) => issue.id));
 
     for (const issueId of [...issueSignaturesRef.current.keys()]) {
       if (nextIssueIds.has(issueId)) {
@@ -404,7 +465,7 @@ export function useChecks({
       issueSignaturesRef.current.delete(issueId);
     }
 
-    for (const issue of runtimeHealthToastIssues) {
+    for (const issue of diagnosticsToastIssues) {
       const signature = `${issue.severity}:${issue.title}:${issue.description}`;
       if (issueSignaturesRef.current.get(issue.id) === signature) {
         continue;
@@ -426,52 +487,80 @@ export function useChecks({
 
       issueSignaturesRef.current.set(issue.id, signature);
     }
-  }, [runtimeHealthToastIssues]);
+  }, [diagnosticsToastIssues]);
 
   useEffect(() => {
-    if (runtimeHealthRetryTimeoutRef.current !== null) {
-      globalThis.clearTimeout(runtimeHealthRetryTimeoutRef.current);
-      runtimeHealthRetryTimeoutRef.current = null;
+    if (diagnosticsRetryTimeoutRef.current !== null) {
+      globalThis.clearTimeout(diagnosticsRetryTimeoutRef.current);
+      diagnosticsRetryTimeoutRef.current = null;
     }
 
+    const shouldRetryRuntimeCheckTimeout =
+      runtimeCheckFailureKind === "timeout" && !runtimeCheckQuery.isFetching;
+    const shouldRetryBeadsCheckTimeout =
+      activeRepo !== null && beadsCheckFailureKind === "timeout" && !beadsCheckQuery.isFetching;
+    const shouldRetryRuntimeHealthTimeout =
+      activeRepo !== null &&
+      hasDiagnosticsTimeoutIssue &&
+      runtimeDefinitions.length > 0 &&
+      !runtimeHealthQuery.isFetching;
+
     if (
-      activeRepo === null ||
-      !hasRuntimeHealthTimeoutIssue ||
-      runtimeHealthQuery.isFetching ||
-      runtimeDefinitions.length === 0
+      !shouldRetryRuntimeCheckTimeout &&
+      !shouldRetryBeadsCheckTimeout &&
+      !shouldRetryRuntimeHealthTimeout
     ) {
       return;
     }
 
-    runtimeHealthRetryTimeoutRef.current = globalThis.setTimeout(() => {
-      runtimeHealthRetryTimeoutRef.current = null;
-      void refreshRepoRuntimeHealthForRepo(activeRepo, true).catch(() => undefined);
+    diagnosticsRetryTimeoutRef.current = globalThis.setTimeout(() => {
+      diagnosticsRetryTimeoutRef.current = null;
+      const retries: Promise<unknown>[] = [];
+
+      if (shouldRetryRuntimeCheckTimeout) {
+        retries.push(refreshRuntimeCheck(true));
+      }
+
+      if (shouldRetryBeadsCheckTimeout && activeRepo !== null) {
+        retries.push(refreshBeadsCheckForRepo(activeRepo, true));
+      }
+
+      if (shouldRetryRuntimeHealthTimeout && activeRepo !== null) {
+        retries.push(refreshRepoRuntimeHealthForRepo(activeRepo, true));
+      }
+
+      void Promise.allSettled(retries);
     }, RUNTIME_HEALTH_TIMEOUT_RETRY_DELAY_MS);
 
     return () => {
-      if (runtimeHealthRetryTimeoutRef.current !== null) {
-        globalThis.clearTimeout(runtimeHealthRetryTimeoutRef.current);
-        runtimeHealthRetryTimeoutRef.current = null;
+      if (diagnosticsRetryTimeoutRef.current !== null) {
+        globalThis.clearTimeout(diagnosticsRetryTimeoutRef.current);
+        diagnosticsRetryTimeoutRef.current = null;
       }
     };
   }, [
     activeRepo,
-    hasRuntimeHealthTimeoutIssue,
+    beadsCheckFailureKind,
+    beadsCheckQuery.isFetching,
+    hasDiagnosticsTimeoutIssue,
+    refreshBeadsCheckForRepo,
     refreshRepoRuntimeHealthForRepo,
+    refreshRuntimeCheck,
+    runtimeCheckFailureKind,
+    runtimeCheckQuery.isFetching,
     runtimeDefinitions.length,
     runtimeHealthQuery.isFetching,
   ]);
 
   useEffect(() => {
     return () => {
-      if (runtimeHealthRetryTimeoutRef.current !== null) {
-        globalThis.clearTimeout(runtimeHealthRetryTimeoutRef.current);
+      if (diagnosticsRetryTimeoutRef.current !== null) {
+        globalThis.clearTimeout(diagnosticsRetryTimeoutRef.current);
       }
 
       for (const issueId of issueSignaturesRef.current.keys()) {
         toast.dismiss(issueId);
       }
-      toast.dismiss(MANUAL_DIAGNOSTICS_UNAVAILABLE_TOAST_ID);
       issueSignaturesRef.current.clear();
     };
   }, []);
@@ -484,8 +573,8 @@ export function useChecks({
         (runtimeDefinitions.length > 0 && runtimeHealthQuery.isFetching)));
 
   return {
-    runtimeCheck: runtimeCheckQuery.data ?? null,
-    activeBeadsCheck: activeRepo === null ? null : (beadsCheckQuery.data ?? null),
+    runtimeCheck: runtimeCheckState,
+    activeBeadsCheck,
     activeRepoRuntimeHealthByRuntime,
     isLoadingChecks,
     setIsLoadingChecks: setIsManualLoadingChecks,

--- a/apps/desktop/src/state/providers/checks-state-provider.tsx
+++ b/apps/desktop/src/state/providers/checks-state-provider.tsx
@@ -26,7 +26,9 @@ export function ChecksStateProvider({
   const { runtimeDefinitions } = useRuntimeDefinitionsContext();
   const {
     runtimeCheck,
+    runtimeCheckFailureKind,
     activeBeadsCheck,
+    beadsCheckFailureKind,
     activeRepoRuntimeHealthByRuntime,
     isLoadingChecks,
     setIsLoadingChecks,
@@ -50,15 +52,19 @@ export function ChecksStateProvider({
       buildChecksStateValue({
         runtimeCheck,
         beadsCheck: activeBeadsCheck,
+        runtimeCheckFailureKind,
+        beadsCheckFailureKind,
         runtimeHealthByRuntime: activeRepoRuntimeHealthByRuntime,
         isLoadingChecks,
         refreshChecks,
       }),
     [
       activeBeadsCheck,
+      beadsCheckFailureKind,
       activeRepoRuntimeHealthByRuntime,
       isLoadingChecks,
       refreshChecks,
+      runtimeCheckFailureKind,
       runtimeCheck,
     ],
   );

--- a/apps/desktop/src/state/queries/checks.test.ts
+++ b/apps/desktop/src/state/queries/checks.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
+import { QueryClient } from "@tanstack/react-query";
+import { repoRuntimeHealthQueryOptions } from "./checks";
+
+describe("repoRuntimeHealthQueryOptions", () => {
+  test("treats unexpected query-layer timeout throws as hard errors", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    try {
+      const result = await queryClient.fetchQuery(
+        repoRuntimeHealthQueryOptions("/repo", [OPENCODE_RUNTIME_DESCRIPTOR], async () => {
+          throw new Error("Timed out after 15000ms");
+        }),
+      );
+
+      expect(result.opencode).toEqual(
+        expect.objectContaining({
+          runtimeOk: false,
+          runtimeError: "Timed out after 15000ms",
+          runtimeFailureKind: "error",
+          mcpOk: false,
+          mcpFailureKind: "error",
+        }),
+      );
+    } finally {
+      queryClient.clear();
+    }
+  });
+});

--- a/apps/desktop/src/state/queries/checks.test.ts
+++ b/apps/desktop/src/state/queries/checks.test.ts
@@ -21,6 +21,38 @@ describe("classifyDiagnosticsQueryError", () => {
       failureKind: "error",
     });
   });
+
+  test("treats non-startup timeout wording as a hard runtime-health failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    try {
+      const result = await queryClient.fetchQuery(
+        repoRuntimeHealthQueryOptions("/repo", [OPENCODE_RUNTIME_DESCRIPTOR], async () => ({
+          runtimeOk: false,
+          runtimeError: "Process timed out while reading repository config",
+          runtimeFailureKind: "error",
+          runtime: null,
+          mcpOk: false,
+          mcpError: "Runtime is unavailable, so MCP cannot be verified.",
+          mcpFailureKind: "error",
+          mcpServerName: "openducktor",
+          mcpServerStatus: null,
+          mcpServerError: "Runtime is unavailable, so MCP cannot be verified.",
+          availableToolIds: [],
+          checkedAt: "2026-02-22T08:00:00.000Z",
+          errors: ["Process timed out while reading repository config"],
+        })),
+      );
+
+      expect(result.opencode?.runtimeFailureKind).toBe("error");
+    } finally {
+      queryClient.clear();
+    }
+  });
 });
 
 describe("repoRuntimeHealthQueryOptions", () => {

--- a/apps/desktop/src/state/queries/checks.test.ts
+++ b/apps/desktop/src/state/queries/checks.test.ts
@@ -1,7 +1,27 @@
 import { describe, expect, test } from "bun:test";
 import { OPENCODE_RUNTIME_DESCRIPTOR } from "@openducktor/contracts";
 import { QueryClient } from "@tanstack/react-query";
-import { repoRuntimeHealthQueryOptions } from "./checks";
+import {
+  classifyDiagnosticsQueryError,
+  DiagnosticsQueryTimeoutError,
+  repoRuntimeHealthQueryOptions,
+} from "./checks";
+
+describe("classifyDiagnosticsQueryError", () => {
+  test("keeps query timeout errors explicit", () => {
+    expect(classifyDiagnosticsQueryError(new DiagnosticsQueryTimeoutError(15_000))).toEqual({
+      message: "Timed out after 15000ms",
+      failureKind: "timeout",
+    });
+  });
+
+  test("treats generic thrown errors as hard failures", () => {
+    expect(classifyDiagnosticsQueryError(new Error("Timed out after 15000ms"))).toEqual({
+      message: "Timed out after 15000ms",
+      failureKind: "error",
+    });
+  });
+});
 
 describe("repoRuntimeHealthQueryOptions", () => {
   test("treats unexpected query-layer timeout throws as hard errors", async () => {

--- a/apps/desktop/src/state/queries/checks.ts
+++ b/apps/desktop/src/state/queries/checks.ts
@@ -7,13 +7,17 @@ import type {
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { errorMessage } from "@/lib/errors";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import type { RepoRuntimeHealthCheck, RepoRuntimeHealthMap } from "@/types/diagnostics";
+import {
+  classifyRepoRuntimeFailure,
+  type RepoRuntimeHealthCheck,
+  type RepoRuntimeHealthMap,
+} from "@/types/diagnostics";
 import { host } from "../operations/host";
 
 const RUNTIME_CHECK_STALE_TIME_MS = 5 * 60_000;
 const BEADS_CHECK_STALE_TIME_MS = 60_000;
 const RUNTIME_HEALTH_STALE_TIME_MS = 60_000;
-const DIAGNOSTICS_QUERY_TIMEOUT_MS = 5_000;
+const DIAGNOSTICS_QUERY_TIMEOUT_MS = 15_000;
 
 const buildRuntimeHealthErrorCheck = (
   runtimeHealthError: string,
@@ -21,9 +25,11 @@ const buildRuntimeHealthErrorCheck = (
 ): RepoRuntimeHealthCheck => ({
   runtimeOk: false,
   runtimeError: runtimeHealthError,
+  runtimeFailureKind: classifyRepoRuntimeFailure(runtimeHealthError),
   runtime: null,
   mcpOk: false,
   mcpError: runtimeHealthError,
+  mcpFailureKind: classifyRepoRuntimeFailure(runtimeHealthError),
   mcpServerName: ODT_MCP_SERVER_NAME,
   mcpServerStatus: null,
   mcpServerError: runtimeHealthError,

--- a/apps/desktop/src/state/queries/checks.ts
+++ b/apps/desktop/src/state/queries/checks.ts
@@ -54,7 +54,7 @@ export class DiagnosticsQueryTimeoutError extends Error {
 
 export const classifyDiagnosticsQueryError = (
   error: unknown,
-): { message: string; failureKind: RepoRuntimeFailureKind } => {
+): { message: string; failureKind: Exclude<RepoRuntimeFailureKind, null> } => {
   if (error instanceof DiagnosticsQueryTimeoutError) {
     return {
       message: error.message,
@@ -128,9 +128,14 @@ export const repoRuntimeHealthQueryOptions = (
     queryFn: async (): Promise<RepoRuntimeHealthMap> => {
       const checks = await Promise.all(
         runtimeDefinitions.map(async (definition) => {
-          const check = await checkRepoRuntimeHealth(repoPath, definition.kind).catch((error) =>
-            buildRuntimeHealthErrorCheck(errorMessage(error), new Date().toISOString()),
-          );
+          let check: RepoRuntimeHealthCheck;
+
+          try {
+            check = await checkRepoRuntimeHealth(repoPath, definition.kind);
+          } catch (error) {
+            check = buildRuntimeHealthErrorCheck(errorMessage(error), new Date().toISOString());
+          }
+
           return [definition.kind, check] as const;
         }),
       );

--- a/apps/desktop/src/state/queries/checks.ts
+++ b/apps/desktop/src/state/queries/checks.ts
@@ -7,7 +7,11 @@ import type {
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { errorMessage } from "@/lib/errors";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import type { RepoRuntimeHealthCheck, RepoRuntimeHealthMap } from "@/types/diagnostics";
+import type {
+  RepoRuntimeFailureKind,
+  RepoRuntimeHealthCheck,
+  RepoRuntimeHealthMap,
+} from "@/types/diagnostics";
 import { host } from "../operations/host";
 
 const RUNTIME_CHECK_STALE_TIME_MS = 5 * 60_000;
@@ -37,11 +41,38 @@ const buildRuntimeHealthErrorCheck = (
 const normalizeRuntimeKinds = (runtimeKinds: RuntimeKind[]): RuntimeKind[] =>
   [...runtimeKinds].sort();
 
+export class DiagnosticsQueryTimeoutError extends Error {
+  readonly failureKind = "timeout" as const;
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(`Timed out after ${timeoutMs}ms`);
+    this.name = "DiagnosticsQueryTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export const classifyDiagnosticsQueryError = (
+  error: unknown,
+): { message: string; failureKind: RepoRuntimeFailureKind } => {
+  if (error instanceof DiagnosticsQueryTimeoutError) {
+    return {
+      message: error.message,
+      failureKind: error.failureKind,
+    };
+  }
+
+  return {
+    message: errorMessage(error),
+    failureKind: "error",
+  };
+};
+
 const withDiagnosticsQueryTimeout = async <T>(promise: Promise<T>): Promise<T> => {
   let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
   const timeoutPromise = new Promise<never>((_resolve, reject) => {
     timeoutId = globalThis.setTimeout(() => {
-      reject(new Error(`Timed out after ${DIAGNOSTICS_QUERY_TIMEOUT_MS}ms`));
+      reject(new DiagnosticsQueryTimeoutError(DIAGNOSTICS_QUERY_TIMEOUT_MS));
     }, DIAGNOSTICS_QUERY_TIMEOUT_MS);
   });
 

--- a/apps/desktop/src/state/queries/checks.ts
+++ b/apps/desktop/src/state/queries/checks.ts
@@ -7,11 +7,7 @@ import type {
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { errorMessage } from "@/lib/errors";
 import { ODT_MCP_SERVER_NAME } from "@/lib/openducktor-mcp";
-import {
-  classifyRepoRuntimeFailure,
-  type RepoRuntimeHealthCheck,
-  type RepoRuntimeHealthMap,
-} from "@/types/diagnostics";
+import type { RepoRuntimeHealthCheck, RepoRuntimeHealthMap } from "@/types/diagnostics";
 import { host } from "../operations/host";
 
 const RUNTIME_CHECK_STALE_TIME_MS = 5 * 60_000;
@@ -25,11 +21,11 @@ const buildRuntimeHealthErrorCheck = (
 ): RepoRuntimeHealthCheck => ({
   runtimeOk: false,
   runtimeError: runtimeHealthError,
-  runtimeFailureKind: classifyRepoRuntimeFailure(runtimeHealthError),
+  runtimeFailureKind: "error",
   runtime: null,
   mcpOk: false,
   mcpError: runtimeHealthError,
-  mcpFailureKind: classifyRepoRuntimeFailure(runtimeHealthError),
+  mcpFailureKind: "error",
   mcpServerName: ODT_MCP_SERVER_NAME,
   mcpServerStatus: null,
   mcpServerError: runtimeHealthError,
@@ -101,9 +97,7 @@ export const repoRuntimeHealthQueryOptions = (
     queryFn: async (): Promise<RepoRuntimeHealthMap> => {
       const checks = await Promise.all(
         runtimeDefinitions.map(async (definition) => {
-          const check = await withDiagnosticsQueryTimeout(
-            checkRepoRuntimeHealth(repoPath, definition.kind),
-          ).catch((error) =>
+          const check = await checkRepoRuntimeHealth(repoPath, definition.kind).catch((error) =>
             buildRuntimeHealthErrorCheck(errorMessage(error), new Date().toISOString()),
           );
           return [definition.kind, check] as const;

--- a/apps/desktop/src/types/diagnostics.ts
+++ b/apps/desktop/src/types/diagnostics.ts
@@ -2,18 +2,6 @@ import type { RuntimeInstanceSummary } from "@openducktor/contracts";
 
 export type RepoRuntimeFailureKind = "timeout" | "error" | null;
 
-const DIAGNOSTICS_TIMEOUT_PATTERNS = [/reason=timeout\b/i, /timed out waiting for\b/i];
-
-export const classifyRepoRuntimeFailure = (message: string | null): RepoRuntimeFailureKind => {
-  if (!message) {
-    return null;
-  }
-
-  return DIAGNOSTICS_TIMEOUT_PATTERNS.some((pattern) => pattern.test(message))
-    ? "timeout"
-    : "error";
-};
-
 export type RepoRuntimeHealthCheck = {
   runtimeOk: boolean;
   runtimeError: string | null;

--- a/apps/desktop/src/types/diagnostics.ts
+++ b/apps/desktop/src/types/diagnostics.ts
@@ -1,11 +1,27 @@
 import type { RuntimeInstanceSummary } from "@openducktor/contracts";
 
+export type RepoRuntimeFailureKind = "timeout" | "error" | null;
+
+const DIAGNOSTICS_TIMEOUT_PATTERNS = [/reason=timeout\b/i, /timed out/i];
+
+export const classifyRepoRuntimeFailure = (message: string | null): RepoRuntimeFailureKind => {
+  if (!message) {
+    return null;
+  }
+
+  return DIAGNOSTICS_TIMEOUT_PATTERNS.some((pattern) => pattern.test(message))
+    ? "timeout"
+    : "error";
+};
+
 export type RepoRuntimeHealthCheck = {
   runtimeOk: boolean;
   runtimeError: string | null;
+  runtimeFailureKind: RepoRuntimeFailureKind;
   runtime: RuntimeInstanceSummary | null;
   mcpOk: boolean;
   mcpError: string | null;
+  mcpFailureKind: RepoRuntimeFailureKind;
   mcpServerName: string;
   mcpServerStatus: string | null;
   mcpServerError: string | null;

--- a/apps/desktop/src/types/diagnostics.ts
+++ b/apps/desktop/src/types/diagnostics.ts
@@ -2,7 +2,7 @@ import type { RuntimeInstanceSummary } from "@openducktor/contracts";
 
 export type RepoRuntimeFailureKind = "timeout" | "error" | null;
 
-const DIAGNOSTICS_TIMEOUT_PATTERNS = [/reason=timeout\b/i, /timed out/i];
+const DIAGNOSTICS_TIMEOUT_PATTERNS = [/reason=timeout\b/i, /timed out waiting for\b/i];
 
 export const classifyRepoRuntimeFailure = (message: string | null): RepoRuntimeFailureKind => {
   if (!message) {

--- a/apps/desktop/src/types/state-slices.ts
+++ b/apps/desktop/src/types/state-slices.ts
@@ -31,7 +31,7 @@ import type {
   AgentUserMessagePart,
 } from "@openducktor/core";
 import type { AgentSessionLoadOptions, AgentSessionState } from "./agent-orchestrator";
-import type { RepoRuntimeHealthMap } from "./diagnostics";
+import type { RepoRuntimeFailureKind, RepoRuntimeHealthMap } from "./diagnostics";
 
 export type RepoAgentDefaultInput = {
   runtimeKind?: RuntimeKind;
@@ -86,6 +86,8 @@ export type WorkspaceStateContextValue = {
 export type ChecksStateContextValue = {
   runtimeCheck: RuntimeCheck | null;
   beadsCheck: BeadsCheck | null;
+  runtimeCheckFailureKind: RepoRuntimeFailureKind;
+  beadsCheckFailureKind: RepoRuntimeFailureKind;
   runtimeHealthByRuntime: RepoRuntimeHealthMap;
   isLoadingChecks: boolean;
   refreshChecks: () => Promise<void>;

--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.test.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
-import { listAvailableSlashCommands, searchFiles } from "./catalog-and-mcp";
+import { getMcpStatus, listAvailableSlashCommands, searchFiles } from "./catalog-and-mcp";
+import { OpenCodeRequestError } from "./request-errors";
 
 describe("catalog-and-mcp listAvailableSlashCommands", () => {
   test("normalizes command payloads into a slash catalog", async () => {
@@ -214,5 +215,29 @@ describe("catalog-and-mcp searchFiles", () => {
     ).rejects.toThrow(
       "OpenCode request failed: search files: Invalid file search payload: expected an array of file paths.",
     );
+  });
+});
+
+describe("catalog-and-mcp getMcpStatus", () => {
+  test("wraps MCP status timeouts with structured failure metadata", async () => {
+    const status = mock(async () => {
+      const failure = new Error("socket closed");
+      Object.assign(failure, { code: "ETIMEDOUT" });
+      throw failure;
+    });
+
+    try {
+      await getMcpStatus((() => ({ mcp: { status } })) as never, {
+        runtimeEndpoint: "http://127.0.0.1:1234",
+        workingDirectory: "/repo",
+      });
+      throw new Error("Expected getMcpStatus to reject");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OpenCodeRequestError);
+      expect((error as OpenCodeRequestError).message).toBe(
+        "OpenCode request failed: get mcp status (code=ETIMEDOUT): socket closed",
+      );
+      expect((error as OpenCodeRequestError).failureKind).toBe("timeout");
+    }
   });
 });

--- a/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
+++ b/packages/adapters-opencode-sdk/src/catalog-and-mcp.ts
@@ -293,30 +293,34 @@ export const getMcpStatus = async (
     workingDirectory: string;
   },
 ): Promise<Record<string, McpServerStatus>> => {
-  const client = createClient({
-    runtimeEndpoint: input.runtimeEndpoint,
-    workingDirectory: input.workingDirectory,
-  });
-  const response = await client.mcp.status({
-    directory: input.workingDirectory,
-  });
-  const payload = unwrapData(response, "get mcp status");
-  const statusPayload = asUnknownRecord(payload);
-  if (!statusPayload) {
-    throw new Error("Invalid MCP status payload: expected an object keyed by server name.");
-  }
-
-  const statusByServer: Record<string, McpServerStatus> = {};
-  for (const [name, rawStatus] of Object.entries(statusPayload)) {
-    const status = readStringProp(rawStatus, ["status"]);
-    if (!status || status.trim().length === 0) {
-      continue;
+  try {
+    const client = createClient({
+      runtimeEndpoint: input.runtimeEndpoint,
+      workingDirectory: input.workingDirectory,
+    });
+    const response = await client.mcp.status({
+      directory: input.workingDirectory,
+    });
+    const payload = unwrapData(response, "get mcp status");
+    const statusPayload = asUnknownRecord(payload);
+    if (!statusPayload) {
+      throw new Error("Invalid MCP status payload: expected an object keyed by server name.");
     }
-    const error = readStringProp(rawStatus, ["error"]);
-    statusByServer[name] = error && error.trim().length > 0 ? { status, error } : { status };
-  }
 
-  return statusByServer;
+    const statusByServer: Record<string, McpServerStatus> = {};
+    for (const [name, rawStatus] of Object.entries(statusPayload)) {
+      const status = readStringProp(rawStatus, ["status"]);
+      if (!status || status.trim().length === 0) {
+        continue;
+      }
+      const error = readStringProp(rawStatus, ["error"]);
+      statusByServer[name] = error && error.trim().length > 0 ? { status, error } : { status };
+    }
+
+    return statusByServer;
+  } catch (error) {
+    throw toOpenCodeRequestError("get mcp status", error);
+  }
 };
 
 export const connectMcpServer = async (

--- a/packages/adapters-opencode-sdk/src/request-errors.test.ts
+++ b/packages/adapters-opencode-sdk/src/request-errors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { OpenCodeRequestError, toOpenCodeRequestError } from "./request-errors";
+
+describe("request-errors", () => {
+  test("preserves structured metadata for already-prefixed errors", () => {
+    const prefixedError = new Error(
+      "OpenCode request failed: get mcp status (504 Gateway Timeout, code=ETIMEDOUT): socket closed",
+    );
+    Object.assign(prefixedError, {
+      failureKind: "timeout",
+      status: 504,
+      statusText: "Gateway Timeout",
+      code: "ETIMEDOUT",
+    });
+
+    const wrapped = toOpenCodeRequestError("get mcp status", prefixedError);
+
+    expect(wrapped).toBeInstanceOf(OpenCodeRequestError);
+    expect(wrapped.message).toBe(prefixedError.message);
+    expect(wrapped.failureKind).toBe("timeout");
+    expect(wrapped.status).toBe(504);
+    expect(wrapped.statusText).toBe("Gateway Timeout");
+    expect(wrapped.code).toBe("ETIMEDOUT");
+  });
+
+  test("classifies and preserves response metadata when wrapping plain errors", () => {
+    const wrapped = toOpenCodeRequestError("get mcp status", new Error("socket closed"), {
+      status: 504,
+      statusText: "Gateway Timeout",
+    });
+
+    expect(wrapped).toBeInstanceOf(OpenCodeRequestError);
+    expect(wrapped.message).toBe(
+      "OpenCode request failed: get mcp status (504 Gateway Timeout): socket closed",
+    );
+    expect(wrapped.failureKind).toBe("timeout");
+    expect(wrapped.status).toBe(504);
+    expect(wrapped.statusText).toBe("Gateway Timeout");
+  });
+});

--- a/packages/adapters-opencode-sdk/src/request-errors.ts
+++ b/packages/adapters-opencode-sdk/src/request-errors.ts
@@ -3,6 +3,50 @@ type ResponseMetadata = {
   statusText?: unknown;
 };
 
+export type OpenCodeRequestFailureKind = "timeout" | "error";
+
+const TIMEOUT_STATUS_CODES = new Set([408, 504]);
+const TIMEOUT_ERROR_CODES = new Set([
+  "ABORT_ERR",
+  "ECONNABORTED",
+  "ETIMEDOUT",
+  "TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+]);
+
+export class OpenCodeRequestError extends Error {
+  readonly status?: number;
+  readonly statusText?: string;
+  readonly code?: string;
+  readonly failureKind: OpenCodeRequestFailureKind;
+
+  constructor(
+    message: string,
+    failure: {
+      failureKind: OpenCodeRequestFailureKind;
+      status?: number;
+      statusText?: string;
+      code?: string;
+    },
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "OpenCodeRequestError";
+    this.failureKind = failure.failureKind;
+    if (failure.status !== undefined) {
+      this.status = failure.status;
+    }
+    if (failure.statusText !== undefined) {
+      this.statusText = failure.statusText;
+    }
+    if (failure.code !== undefined) {
+      this.code = failure.code;
+    }
+  }
+}
+
 const readUnknownProp = (value: unknown, key: string): unknown => {
   if (!value || typeof value !== "object") {
     return undefined;
@@ -18,6 +62,42 @@ const readStringProp = (value: unknown, key: string): string | undefined => {
 const readNumberProp = (value: unknown, key: string): number | undefined => {
   const candidate = readUnknownProp(value, key);
   return typeof candidate === "number" ? candidate : undefined;
+};
+
+const readStringPropFromSources = (sources: unknown[], key: string): string | undefined => {
+  for (const source of sources) {
+    const candidate = readStringProp(source, key);
+    if (candidate) {
+      return candidate;
+    }
+  }
+  return undefined;
+};
+
+const readNumberPropFromSources = (sources: unknown[], key: string): number | undefined => {
+  for (const source of sources) {
+    const candidate = readNumberProp(source, key);
+    if (candidate !== undefined) {
+      return candidate;
+    }
+  }
+  return undefined;
+};
+
+const classifyOpenCodeRequestFailureKind = (failure: {
+  status: number | undefined;
+  code: string | undefined;
+}): OpenCodeRequestFailureKind => {
+  if (typeof failure.status === "number" && TIMEOUT_STATUS_CODES.has(failure.status)) {
+    return "timeout";
+  }
+
+  const normalizedCode = failure.code?.trim().toUpperCase();
+  if (normalizedCode && TIMEOUT_ERROR_CODES.has(normalizedCode)) {
+    return "timeout";
+  }
+
+  return "error";
 };
 
 const buildOpenCodeRequestErrorMessage = (
@@ -57,38 +137,67 @@ export const toOpenCodeRequestError = (
   action: string,
   error: unknown,
   response?: ResponseMetadata,
-): Error => {
+): OpenCodeRequestError => {
   const prefix = `OpenCode request failed: ${action}`;
   if (error instanceof Error && error.message.startsWith(prefix)) {
-    return error;
+    return error instanceof OpenCodeRequestError
+      ? error
+      : new OpenCodeRequestError(
+          error.message,
+          {
+            failureKind:
+              typeof (error as { failureKind?: unknown }).failureKind === "string" &&
+              ((error as { failureKind?: unknown }).failureKind === "timeout" ||
+                (error as { failureKind?: unknown }).failureKind === "error")
+                ? ((error as { failureKind?: unknown }).failureKind as OpenCodeRequestFailureKind)
+                : "error",
+          },
+          { cause: error.cause },
+        );
   }
+
+  const sources = [error, readUnknownProp(error, "cause"), readUnknownProp(error, "data")];
 
   const message =
     (error instanceof Error && error.message.trim().length > 0 ? error.message : undefined) ??
-    readStringProp(error, "message") ??
-    readStringProp(readUnknownProp(error, "data"), "message") ??
+    readStringPropFromSources(sources, "message") ??
     prefix;
-  const status = readNumberProp(error, "status");
-  const statusText = readStringProp(error, "statusText");
-  const codeRaw = readUnknownProp(error, "code");
+  const status = readNumberPropFromSources(sources, "status");
+  const statusText = readStringPropFromSources(sources, "statusText");
+  const codeRaw =
+    readUnknownProp(error, "code") ??
+    readUnknownProp(readUnknownProp(error, "cause"), "code") ??
+    readUnknownProp(readUnknownProp(error, "data"), "code");
   const code =
     typeof codeRaw === "string" || typeof codeRaw === "number" ? String(codeRaw) : undefined;
+  const resolvedStatus =
+    typeof status === "number"
+      ? status
+      : typeof response?.status === "number"
+        ? response.status
+        : undefined;
+  const resolvedStatusText =
+    statusText ??
+    (typeof response?.statusText === "string" && response.statusText.trim().length > 0
+      ? response.statusText
+      : undefined);
 
-  return new Error(
+  return new OpenCodeRequestError(
     buildOpenCodeRequestErrorMessage(action, {
       message,
-      ...(typeof status === "number"
-        ? { status }
-        : typeof response?.status === "number"
-          ? { status: response.status }
-          : {}),
-      ...(statusText
-        ? { statusText }
-        : typeof response?.statusText === "string" && response.statusText.trim().length > 0
-          ? { statusText: response.statusText }
-          : {}),
+      ...(resolvedStatus !== undefined ? { status: resolvedStatus } : {}),
+      ...(resolvedStatusText ? { statusText: resolvedStatusText } : {}),
       ...(code ? { code } : {}),
     }),
+    {
+      failureKind: classifyOpenCodeRequestFailureKind({
+        status: resolvedStatus,
+        code,
+      }),
+      ...(resolvedStatus !== undefined ? { status: resolvedStatus } : {}),
+      ...(resolvedStatusText ? { statusText: resolvedStatusText } : {}),
+      ...(code ? { code } : {}),
+    },
     error instanceof Error ? { cause: error } : undefined,
   );
 };

--- a/packages/adapters-opencode-sdk/src/request-errors.ts
+++ b/packages/adapters-opencode-sdk/src/request-errors.ts
@@ -5,6 +5,19 @@ type ResponseMetadata = {
 
 export type OpenCodeRequestFailureKind = "timeout" | "error";
 
+type OpenCodeRequestErrorInit = {
+  failureKind: OpenCodeRequestFailureKind;
+  status?: number;
+  statusText?: string;
+  code?: string;
+};
+
+type NormalizedRequestFailure = OpenCodeRequestErrorInit & {
+  message: string;
+  cause?: unknown;
+  hasPrefixedMessage: boolean;
+};
+
 const TIMEOUT_STATUS_CODES = new Set([408, 504]);
 const TIMEOUT_ERROR_CODES = new Set([
   "ABORT_ERR",
@@ -22,16 +35,7 @@ export class OpenCodeRequestError extends Error {
   readonly code?: string;
   readonly failureKind: OpenCodeRequestFailureKind;
 
-  constructor(
-    message: string,
-    failure: {
-      failureKind: OpenCodeRequestFailureKind;
-      status?: number;
-      statusText?: string;
-      code?: string;
-    },
-    options?: ErrorOptions,
-  ) {
+  constructor(message: string, failure: OpenCodeRequestErrorInit, options?: ErrorOptions) {
     super(message, options);
     this.name = "OpenCodeRequestError";
     this.failureKind = failure.failureKind;
@@ -64,6 +68,13 @@ const readNumberProp = (value: unknown, key: string): number | undefined => {
   return typeof candidate === "number" ? candidate : undefined;
 };
 
+const readCodeProp = (value: unknown, key: string): string | undefined => {
+  const candidate = readUnknownProp(value, key);
+  return typeof candidate === "string" || typeof candidate === "number"
+    ? String(candidate)
+    : undefined;
+};
+
 const readStringPropFromSources = (sources: unknown[], key: string): string | undefined => {
   for (const source of sources) {
     const candidate = readStringProp(source, key);
@@ -82,6 +93,21 @@ const readNumberPropFromSources = (sources: unknown[], key: string): number | un
     }
   }
   return undefined;
+};
+
+const readCodePropFromSources = (sources: unknown[], key: string): string | undefined => {
+  for (const source of sources) {
+    const candidate = readCodeProp(source, key);
+    if (candidate !== undefined) {
+      return candidate;
+    }
+  }
+  return undefined;
+};
+
+const readFailureKind = (value: unknown): OpenCodeRequestFailureKind | undefined => {
+  const candidate = readUnknownProp(value, "failureKind");
+  return candidate === "timeout" || candidate === "error" ? candidate : undefined;
 };
 
 const classifyOpenCodeRequestFailureKind = (failure: {
@@ -133,43 +159,33 @@ const buildOpenCodeRequestErrorMessage = (
   return `${base}: ${failure.message}`;
 };
 
-export const toOpenCodeRequestError = (
+const buildFailureSources = (error: unknown): unknown[] => {
+  return [error, readUnknownProp(error, "cause"), readUnknownProp(error, "data")];
+};
+
+const extractRequestFailure = (
   action: string,
   error: unknown,
   response?: ResponseMetadata,
-): OpenCodeRequestError => {
+): NormalizedRequestFailure => {
   const prefix = `OpenCode request failed: ${action}`;
-  if (error instanceof Error && error.message.startsWith(prefix)) {
-    return error instanceof OpenCodeRequestError
-      ? error
-      : new OpenCodeRequestError(
-          error.message,
-          {
-            failureKind:
-              typeof (error as { failureKind?: unknown }).failureKind === "string" &&
-              ((error as { failureKind?: unknown }).failureKind === "timeout" ||
-                (error as { failureKind?: unknown }).failureKind === "error")
-                ? ((error as { failureKind?: unknown }).failureKind as OpenCodeRequestFailureKind)
-                : "error",
-          },
-          { cause: error.cause },
-        );
+
+  if (error instanceof OpenCodeRequestError) {
+    return {
+      message: error.message,
+      failureKind: error.failureKind,
+      hasPrefixedMessage: true,
+      ...(error.status !== undefined ? { status: error.status } : {}),
+      ...(error.statusText !== undefined ? { statusText: error.statusText } : {}),
+      ...(error.code !== undefined ? { code: error.code } : {}),
+      ...(error.cause !== undefined ? { cause: error.cause } : {}),
+    };
   }
 
-  const sources = [error, readUnknownProp(error, "cause"), readUnknownProp(error, "data")];
-
-  const message =
-    (error instanceof Error && error.message.trim().length > 0 ? error.message : undefined) ??
-    readStringPropFromSources(sources, "message") ??
-    prefix;
+  const sources = buildFailureSources(error);
   const status = readNumberPropFromSources(sources, "status");
   const statusText = readStringPropFromSources(sources, "statusText");
-  const codeRaw =
-    readUnknownProp(error, "code") ??
-    readUnknownProp(readUnknownProp(error, "cause"), "code") ??
-    readUnknownProp(readUnknownProp(error, "data"), "code");
-  const code =
-    typeof codeRaw === "string" || typeof codeRaw === "number" ? String(codeRaw) : undefined;
+  const code = readCodePropFromSources(sources, "code");
   const resolvedStatus =
     typeof status === "number"
       ? status
@@ -182,22 +198,64 @@ export const toOpenCodeRequestError = (
       ? response.statusText
       : undefined);
 
-  return new OpenCodeRequestError(
-    buildOpenCodeRequestErrorMessage(action, {
-      message,
+  if (error instanceof Error && error.message.startsWith(prefix)) {
+    return {
+      message: error.message,
+      failureKind:
+        readFailureKind(error) ??
+        classifyOpenCodeRequestFailureKind({
+          status: resolvedStatus,
+          code,
+        }),
+      hasPrefixedMessage: true,
       ...(resolvedStatus !== undefined ? { status: resolvedStatus } : {}),
-      ...(resolvedStatusText ? { statusText: resolvedStatusText } : {}),
-      ...(code ? { code } : {}),
+      ...(resolvedStatusText !== undefined ? { statusText: resolvedStatusText } : {}),
+      ...(code !== undefined ? { code } : {}),
+      ...(error.cause !== undefined ? { cause: error.cause } : {}),
+    };
+  }
+
+  const message =
+    (error instanceof Error && error.message.trim().length > 0 ? error.message : undefined) ??
+    readStringPropFromSources(sources, "message") ??
+    prefix;
+
+  return {
+    message,
+    failureKind: classifyOpenCodeRequestFailureKind({
+      status: resolvedStatus,
+      code,
     }),
+    hasPrefixedMessage: false,
+    ...(resolvedStatus !== undefined ? { status: resolvedStatus } : {}),
+    ...(resolvedStatusText !== undefined ? { statusText: resolvedStatusText } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(error instanceof Error ? { cause: error } : {}),
+  };
+};
+
+export const toOpenCodeRequestError = (
+  action: string,
+  error: unknown,
+  response?: ResponseMetadata,
+): OpenCodeRequestError => {
+  const failure = extractRequestFailure(action, error, response);
+
+  return new OpenCodeRequestError(
+    failure.hasPrefixedMessage
+      ? failure.message
+      : buildOpenCodeRequestErrorMessage(action, {
+          message: failure.message,
+          ...(failure.status !== undefined ? { status: failure.status } : {}),
+          ...(failure.statusText !== undefined ? { statusText: failure.statusText } : {}),
+          ...(failure.code !== undefined ? { code: failure.code } : {}),
+        }),
     {
-      failureKind: classifyOpenCodeRequestFailureKind({
-        status: resolvedStatus,
-        code,
-      }),
-      ...(resolvedStatus !== undefined ? { status: resolvedStatus } : {}),
-      ...(resolvedStatusText ? { statusText: resolvedStatusText } : {}),
-      ...(code ? { code } : {}),
+      failureKind: failure.failureKind,
+      ...(failure.status !== undefined ? { status: failure.status } : {}),
+      ...(failure.statusText !== undefined ? { statusText: failure.statusText } : {}),
+      ...(failure.code !== undefined ? { code: failure.code } : {}),
     },
-    error instanceof Error ? { cause: error } : undefined,
+    failure.cause !== undefined ? { cause: failure.cause } : undefined,
   );
 };

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -36,6 +36,56 @@ export type BuildRespondInput =
   | { action: "approve" }
   | { action: "deny" }
   | { action: "message"; message: string };
+
+type RuntimeEnsureFailureKind = "timeout" | "error";
+
+class RuntimeEnsureError extends Error {
+  readonly failureKind: RuntimeEnsureFailureKind;
+
+  constructor(message: string, failureKind: RuntimeEnsureFailureKind, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RuntimeEnsureError";
+    this.failureKind = failureKind;
+  }
+}
+
+const readUnknownProp = (value: unknown, key: string): unknown => {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  return (value as Record<string, unknown>)[key];
+};
+
+const readStringProp = (value: unknown, key: string): string | undefined => {
+  const candidate = readUnknownProp(value, key);
+  return typeof candidate === "string" && candidate.trim().length > 0 ? candidate : undefined;
+};
+
+const readRuntimeEnsureFailureKind = (value: unknown): RuntimeEnsureFailureKind | undefined => {
+  return value === "timeout" || value === "error" ? value : undefined;
+};
+
+const toRuntimeEnsureError = (error: unknown): RuntimeEnsureError | null => {
+  const payload = error instanceof Error ? error.cause : error;
+  const failureKind = readRuntimeEnsureFailureKind(readUnknownProp(payload, "failureKind"));
+  if (!failureKind) {
+    return null;
+  }
+
+  const message =
+    (error instanceof Error && error.message.trim().length > 0 ? error.message : undefined) ??
+    readStringProp(payload, "message") ??
+    readStringProp(payload, "error") ??
+    "Failed to ensure runtime.";
+
+  return new RuntimeEnsureError(
+    message,
+    failureKind,
+    error instanceof Error ? { cause: error } : undefined,
+  );
+};
+
 const systemCheck = async (invokeFn: InvokeFn, repoPath: string): Promise<SystemCheck> => {
   const payload = await invokeFn("system_check", { repoPath });
   return systemCheckSchema.parse(payload);
@@ -94,11 +144,15 @@ const runtimeEnsure = async (
   repoPath: string,
   runtimeKind: RuntimeKind,
 ): Promise<RuntimeInstanceSummary> => {
-  const payload = await invokeFn("runtime_ensure", {
-    repoPath,
-    runtimeKind,
-  });
-  return runtimeInstanceSummarySchema.parse(payload);
+  try {
+    const payload = await invokeFn("runtime_ensure", {
+      repoPath,
+      runtimeKind,
+    });
+    return runtimeInstanceSummarySchema.parse(payload);
+  } catch (error) {
+    throw toRuntimeEnsureError(error) ?? error;
+  }
 };
 
 const buildStart = async (

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -39,13 +39,22 @@ export type BuildRespondInput =
 
 type RuntimeEnsureFailureKind = "timeout" | "error";
 
+type RuntimeEnsureErrorInit = {
+  failureKind: RuntimeEnsureFailureKind;
+};
+
+type NormalizedRuntimeEnsureFailure = RuntimeEnsureErrorInit & {
+  message: string;
+  cause?: unknown;
+};
+
 class RuntimeEnsureError extends Error {
   readonly failureKind: RuntimeEnsureFailureKind;
 
-  constructor(message: string, failureKind: RuntimeEnsureFailureKind, options?: ErrorOptions) {
+  constructor(message: string, failure: RuntimeEnsureErrorInit, options?: ErrorOptions) {
     super(message, options);
     this.name = "RuntimeEnsureError";
-    this.failureKind = failureKind;
+    this.failureKind = failure.failureKind;
   }
 }
 
@@ -62,27 +71,54 @@ const readStringProp = (value: unknown, key: string): string | undefined => {
   return typeof candidate === "string" && candidate.trim().length > 0 ? candidate : undefined;
 };
 
-const readRuntimeEnsureFailureKind = (value: unknown): RuntimeEnsureFailureKind | undefined => {
-  return value === "timeout" || value === "error" ? value : undefined;
+const readFailureKind = (value: unknown): RuntimeEnsureFailureKind | undefined => {
+  const candidate = readUnknownProp(value, "failureKind");
+  return candidate === "timeout" || candidate === "error" ? candidate : undefined;
 };
 
-const toRuntimeEnsureError = (error: unknown): RuntimeEnsureError | null => {
-  const payload = error instanceof Error ? error.cause : error;
-  const failureKind = readRuntimeEnsureFailureKind(readUnknownProp(payload, "failureKind"));
+const buildRuntimeEnsureFailureSources = (error: unknown): unknown[] => {
+  return [error, readUnknownProp(error, "cause")];
+};
+
+const extractRuntimeEnsureFailure = (error: unknown): NormalizedRuntimeEnsureFailure | null => {
+  if (error instanceof RuntimeEnsureError) {
+    return {
+      message: error.message,
+      failureKind: error.failureKind,
+      ...(error.cause !== undefined ? { cause: error.cause } : {}),
+    };
+  }
+
+  const sources = buildRuntimeEnsureFailureSources(error);
+  const failureSource = sources.find((source) => readFailureKind(source) !== undefined);
+  const failureKind = failureSource ? readFailureKind(failureSource) : undefined;
   if (!failureKind) {
     return null;
   }
 
   const message =
+    readStringProp(failureSource, "message") ??
+    readStringProp(failureSource, "error") ??
     (error instanceof Error && error.message.trim().length > 0 ? error.message : undefined) ??
-    readStringProp(payload, "message") ??
-    readStringProp(payload, "error") ??
     "Failed to ensure runtime.";
 
-  return new RuntimeEnsureError(
+  return {
     message,
     failureKind,
-    error instanceof Error ? { cause: error } : undefined,
+    ...(error !== undefined ? { cause: error } : {}),
+  };
+};
+
+const toRuntimeEnsureError = (error: unknown): RuntimeEnsureError | null => {
+  const failure = extractRuntimeEnsureFailure(error);
+  if (!failure) {
+    return null;
+  }
+
+  return new RuntimeEnsureError(
+    failure.message,
+    { failureKind: failure.failureKind },
+    failure.cause !== undefined ? { cause: failure.cause } : undefined,
   );
 };
 

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1255,10 +1255,63 @@ describe("TauriHostClient", () => {
       await client.runtimeEnsure("/repo", "opencode");
       throw new Error("Expected runtimeEnsure to reject");
     } catch (error) {
-      expect((error as { message?: unknown }).message).toBe(
-        "OpenCode startup probe failed reason=timeout after 15000ms",
-      );
-      expect((error as { failureKind?: unknown }).failureKind).toBe("timeout");
+      expect(error instanceof Error).toBe(true);
+      if (!(error instanceof Error)) {
+        throw new Error("Expected runtimeEnsure to reject with an Error");
+      }
+      expect(error.message).toBe("OpenCode startup probe failed reason=timeout after 15000ms");
+      expect(Reflect.get(error, "failureKind")).toBe("timeout");
+    }
+  });
+
+  test("runtimeEnsure prefers structured cause metadata over generic wrapper errors", async () => {
+    const { client } = createClient((command) => {
+      if (command === "runtime_ensure") {
+        const error = new Error("invoke failed");
+        Reflect.set(error, "cause", {
+          message: "OpenCode runtime is still starting",
+          failureKind: "timeout",
+        });
+        throw error;
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    try {
+      await client.runtimeEnsure("/repo", "opencode");
+      throw new Error("Expected runtimeEnsure to reject");
+    } catch (error) {
+      expect(error instanceof Error).toBe(true);
+      if (!(error instanceof Error)) {
+        throw new Error("Expected runtimeEnsure to reject with an Error");
+      }
+      expect(error.message).toBe("OpenCode runtime is still starting");
+      expect(Reflect.get(error, "failureKind")).toBe("timeout");
+    }
+  });
+
+  test("runtimeEnsure preserves failure metadata attached directly to Error instances", async () => {
+    const { client } = createClient((command) => {
+      if (command === "runtime_ensure") {
+        const error = new Error("OpenCode runtime startup failed");
+        Reflect.set(error, "failureKind", "error");
+        throw error;
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    try {
+      await client.runtimeEnsure("/repo", "opencode");
+      throw new Error("Expected runtimeEnsure to reject");
+    } catch (error) {
+      expect(error instanceof Error).toBe(true);
+      if (!(error instanceof Error)) {
+        throw new Error("Expected runtimeEnsure to reject with an Error");
+      }
+      expect(error.message).toBe("OpenCode runtime startup failed");
+      expect(Reflect.get(error, "failureKind")).toBe("error");
     }
   });
 

--- a/packages/adapters-tauri-host/src/index.test.ts
+++ b/packages/adapters-tauri-host/src/index.test.ts
@@ -1239,6 +1239,29 @@ describe("TauriHostClient", () => {
     );
   });
 
+  test("runtimeEnsure preserves structured timeout metadata from host failures", async () => {
+    const { client } = createClient((command) => {
+      if (command === "runtime_ensure") {
+        throw {
+          message: "OpenCode startup probe failed reason=timeout after 15000ms",
+          failureKind: "timeout",
+        };
+      }
+
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    try {
+      await client.runtimeEnsure("/repo", "opencode");
+      throw new Error("Expected runtimeEnsure to reject");
+    } catch (error) {
+      expect((error as { message?: unknown }).message).toBe(
+        "OpenCode startup probe failed reason=timeout after 15000ms",
+      );
+      expect((error as { failureKind?: unknown }).failureKind).toBe("timeout");
+    }
+  });
+
   test("agent session history commands use expected IPC routes", async () => {
     const { client, calls } = createClient((command) => {
       if (command === "task_metadata_get") {


### PR DESCRIPTION
## Summary
- raise the desktop and Rust diagnostics timeout floor to 15 seconds, distinguish runtime/MCP startup timeouts from hard failures, and automatically retry timeout-classified runtime health checks without duplicate toasts
- keep timeout classification source-owned by runtime health so generic query-layer throws stay hard errors, then reconcile CLI tools, Beads, and runtime diagnostics into consistent retrying or unavailable states instead of leaving checks stuck in Checking
- centralize diagnostics check projection, toast issue derivation, and retry planning into pure workspace helpers while threading explicit CLI and Beads failure kinds through checks state and diagnostics UI consumers

## Testing
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- rtk cargo test -p host-infra-system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup timeout default raised to 15s for more robust launches
  * Automatic retry scheduling for timeout-classified failures
  * Timeout-aware diagnostics toasts with persistent/dismissible behavior

* **Improvements**
  * Timeout-specific blocked readiness messaging (e.g., “Retrying automatically”)
  * Diagnostics panel shows clearer timeout badges (“Starting”, “Retrying”)
  * Deduplicated, targeted toasts preserved/dismissed on recovery and retry actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->