### PR TITLE
refactor(contracts): share structured failure kind

### DIFF
--- a/apps/desktop/src/lib/browser-live-client.test.ts
+++ b/apps/desktop/src/lib/browser-live-client.test.ts
@@ -53,6 +53,7 @@ class FakeEventSource {
 }
 
 const originalEventSource = globalThis.EventSource;
+const originalFetch = globalThis.fetch;
 
 const loadBrowserLiveClient = () => import("./browser-live-client");
 
@@ -65,6 +66,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.EventSource = originalEventSource;
+  globalThis.fetch = originalFetch;
 });
 
 describe("readBrowserLiveErrorMessage", () => {
@@ -97,6 +99,45 @@ describe("readBrowserLiveErrorMessage", () => {
 
     await expect(readBrowserLiveErrorMessage(response)).resolves.toBe(
       "Browser backend request failed with status 502.",
+    );
+  });
+
+  test("preserves structured timeout metadata through browser live runtimeEnsure", async () => {
+    const { createBrowserLiveHostClient } = await loadBrowserLiveClient();
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          error: "OpenCode runtime is still starting",
+          failureKind: "timeout",
+        }),
+        {
+          status: 504,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const client = createBrowserLiveHostClient();
+
+    try {
+      await client.runtimeEnsure("/repo", "opencode");
+      throw new Error("Expected runtimeEnsure to reject");
+    } catch (error) {
+      expect(error instanceof Error).toBe(true);
+      if (!(error instanceof Error)) {
+        throw new Error("Expected runtimeEnsure to reject with an Error");
+      }
+      expect(error.message).toBe("OpenCode runtime is still starting");
+      expect(Reflect.get(error, "failureKind")).toBe("timeout");
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:14327/invoke/runtime_ensure",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      }),
     );
   });
 });

--- a/apps/desktop/src/lib/browser-live-client.test.ts
+++ b/apps/desktop/src/lib/browser-live-client.test.ts
@@ -101,7 +101,9 @@ describe("readBrowserLiveErrorMessage", () => {
       "Browser backend request failed with status 502.",
     );
   });
+});
 
+describe("createBrowserLiveHostClient", () => {
   test("preserves structured timeout metadata through browser live runtimeEnsure", async () => {
     const { createBrowserLiveHostClient } = await loadBrowserLiveClient();
     const fetchMock = mock(async () => {
@@ -119,24 +121,29 @@ describe("readBrowserLiveErrorMessage", () => {
     globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
 
     const client = createBrowserLiveHostClient();
+    const result = await client.runtimeEnsure("/repo", "opencode").then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
 
-    try {
-      await client.runtimeEnsure("/repo", "opencode");
+    if (result.ok) {
       throw new Error("Expected runtimeEnsure to reject");
-    } catch (error) {
-      expect(error instanceof Error).toBe(true);
-      if (!(error instanceof Error)) {
-        throw new Error("Expected runtimeEnsure to reject with an Error");
-      }
-      expect(error.message).toBe("OpenCode runtime is still starting");
-      expect(Reflect.get(error, "failureKind")).toBe("timeout");
     }
+
+    const { error } = result;
+    expect(error instanceof Error).toBe(true);
+    if (!(error instanceof Error)) {
+      throw new Error("Expected runtimeEnsure to reject with an Error");
+    }
+    expect(error.message).toBe("OpenCode runtime is still starting");
+    expect(Reflect.get(error, "failureKind")).toBe("timeout");
 
     expect(fetchMock).toHaveBeenCalledWith(
       "http://127.0.0.1:14327/invoke/runtime_ensure",
       expect.objectContaining({
         method: "POST",
         headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repoPath: "/repo", runtimeKind: "opencode" }),
       }),
     );
   });

--- a/apps/desktop/src/types/diagnostics.ts
+++ b/apps/desktop/src/types/diagnostics.ts
@@ -1,6 +1,6 @@
-import type { RuntimeInstanceSummary } from "@openducktor/contracts";
+import type { FailureKind, RuntimeInstanceSummary } from "@openducktor/contracts";
 
-export type RepoRuntimeFailureKind = "timeout" | "error" | null;
+export type RepoRuntimeFailureKind = FailureKind | null;
 
 export type RepoRuntimeHealthCheck = {
   runtimeOk: boolean;

--- a/packages/adapters-opencode-sdk/src/request-errors.ts
+++ b/packages/adapters-opencode-sdk/src/request-errors.ts
@@ -1,9 +1,11 @@
+import type { FailureKind } from "@openducktor/contracts";
+
 type ResponseMetadata = {
   status?: unknown;
   statusText?: unknown;
 };
 
-export type OpenCodeRequestFailureKind = "timeout" | "error";
+export type OpenCodeRequestFailureKind = FailureKind;
 
 type OpenCodeRequestErrorInit = {
   failureKind: OpenCodeRequestFailureKind;

--- a/packages/adapters-opencode-sdk/src/request-errors.ts
+++ b/packages/adapters-opencode-sdk/src/request-errors.ts
@@ -1,4 +1,4 @@
-import type { FailureKind } from "@openducktor/contracts";
+import { type FailureKind, failureKindSchema } from "@openducktor/contracts";
 
 type ResponseMetadata = {
   status?: unknown;
@@ -109,7 +109,8 @@ const readCodePropFromSources = (sources: unknown[], key: string): string | unde
 
 const readFailureKind = (value: unknown): OpenCodeRequestFailureKind | undefined => {
   const candidate = readUnknownProp(value, "failureKind");
-  return candidate === "timeout" || candidate === "error" ? candidate : undefined;
+  const result = failureKindSchema.safeParse(candidate);
+  return result.success ? result.data : undefined;
 };
 
 const classifyOpenCodeRequestFailureKind = (failure: {

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -6,6 +6,7 @@ import {
   type DevServerGroupState,
   devServerGroupStateSchema,
   type FailureKind,
+  failureKindSchema,
   type PullRequest,
   pullRequestSchema,
   type RunSummary,
@@ -74,7 +75,8 @@ const readStringProp = (value: unknown, key: string): string | undefined => {
 
 const readFailureKind = (value: unknown): RuntimeEnsureFailureKind | undefined => {
   const candidate = readUnknownProp(value, "failureKind");
-  return candidate === "timeout" || candidate === "error" ? candidate : undefined;
+  const result = failureKindSchema.safeParse(candidate);
+  return result.success ? result.data : undefined;
 };
 
 const buildRuntimeEnsureFailureSources = (error: unknown): unknown[] => {

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -5,6 +5,7 @@ import {
   buildContinuationTargetSchema,
   type DevServerGroupState,
   devServerGroupStateSchema,
+  type FailureKind,
   type PullRequest,
   pullRequestSchema,
   type RunSummary,
@@ -37,7 +38,7 @@ export type BuildRespondInput =
   | { action: "deny" }
   | { action: "message"; message: string };
 
-type RuntimeEnsureFailureKind = "timeout" | "error";
+type RuntimeEnsureFailureKind = FailureKind;
 
 type RuntimeEnsureErrorInit = {
   failureKind: RuntimeEnsureFailureKind;

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -23,6 +23,7 @@ import type {
   BuildContinuationTargetSource,
   ChatSettings,
   CommitsAheadBehind,
+  FailureKind,
   FileDiff,
   FileStatus,
   GitBranch,
@@ -305,6 +306,7 @@ type ExportedTypeContract = {
   GitConflictOperation: GitConflictOperation;
   FileDiff: FileDiff;
   FileStatus: FileStatus;
+  FailureKind: FailureKind;
   GitFileStatusCounts: GitFileStatusCounts;
   GitBranch: GitBranch;
   GitCurrentBranch: GitCurrentBranch;

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -147,6 +147,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "devServerScriptStateSchema",
   "devServerScriptStatusSchema",
   "DEFAULT_BRANCH_PREFIX",
+  "failureKindSchema",
   "gitCommitAllRequestSchema",
   "gitCommitAllResultSchema",
   "gitConflictAbortRequestSchema",

--- a/packages/contracts/src/failure-schemas.ts
+++ b/packages/contracts/src/failure-schemas.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const failureKindSchema = z.enum(["timeout", "error"]);
+
+export type FailureKind = z.infer<typeof failureKindSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,6 +2,7 @@ export * from "./agent-runtime-schemas";
 export * from "./agent-workflow-schemas";
 export * from "./config-schemas";
 export * from "./dev-server-schemas";
+export * from "./failure-schemas";
 export * from "./git-provider-repository";
 export * from "./git-schemas";
 export * from "./metadata-schemas";


### PR DESCRIPTION
## Summary
- add a shared `FailureKind` contract so diagnostics, request errors, and runtime-ensure errors reuse the same structured timeout/error type
- add browser-live coverage proving `runtime_ensure` timeout metadata survives the HTTP transport and tauri-host adapter path
- keep the change intentionally small and follow-up scoped on top of the merged diagnostics work

## Verification
- bun run --filter @openducktor/contracts test src/exports.contract.test.ts
- bun run --filter @openducktor/contracts typecheck
- bun run --filter @openducktor/adapters-opencode-sdk test src/request-errors.test.ts src/catalog-and-mcp.test.ts
- bun run --filter @openducktor/adapters-opencode-sdk typecheck
- bun run --filter @openducktor/adapters-tauri-host test src/index.test.ts
- bun run --filter @openducktor/adapters-tauri-host typecheck
- bun run --filter @openducktor/desktop test src/lib/browser-live-client.test.ts src/state/operations/shared/runtime-catalog.test.ts src/state/queries/checks.test.ts
- bun run --filter @openducktor/desktop typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation for timeout error handling in browser-live client, verifying error structure and HTTP request format.
  * Improved test cleanup to properly restore fetch functionality.

* **Refactor**
  * Consolidated failure kind type definitions across multiple modules to use a centralized contract-based type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->