### PR TITLE
Replace bulk agent session N+1 metadata fetches

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentSessionDocument, BuildContinuationTarget, BuildContinuationTargetSource, RunState,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -41,20 +41,26 @@ impl AppService {
 
         let repo_path = self.resolve_task_repo_path(repo_path)?;
         let repo_dir = Path::new(&repo_path);
-        let tasks = self.task_store.list_tasks(repo_dir)?;
-        let available_task_ids = tasks
+        let sessions_by_available_task = self
+            .task_store
+            .list_tasks(repo_dir)?
             .into_iter()
-            .map(|task| task.id)
-            .collect::<HashSet<_>>();
+            .map(|task| (task.id, task.agent_sessions))
+            .collect::<HashMap<_, _>>();
+
+        for task_id in task_ids {
+            if !sessions_by_available_task.contains_key(task_id) {
+                return Err(anyhow!("Task not found: {task_id}"));
+            }
+        }
 
         let mut sessions_by_task = HashMap::new();
         for task_id in task_ids {
-            if !available_task_ids.contains(task_id) {
-                return Err(anyhow!("Task not found: {task_id}"));
-            }
-
-            let metadata = self.task_store.get_task_metadata(repo_dir, task_id)?;
-            sessions_by_task.insert(task_id.clone(), metadata.agent_sessions);
+            let sessions = sessions_by_available_task
+                .get(task_id)
+                .cloned()
+                .ok_or_else(|| anyhow!("Task not found: {task_id}"))?;
+            sessions_by_task.insert(task_id.clone(), sessions);
         }
 
         Ok(sessions_by_task)

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
@@ -48,13 +48,7 @@ impl AppService {
             .map(|task| (task.id, task.agent_sessions))
             .collect::<HashMap<_, _>>();
 
-        for task_id in task_ids {
-            if !sessions_by_available_task.contains_key(task_id) {
-                return Err(anyhow!("Task not found: {task_id}"));
-            }
-        }
-
-        let mut sessions_by_task = HashMap::new();
+        let mut sessions_by_task = HashMap::with_capacity(task_ids.len());
         for task_id in task_ids {
             let sessions = sessions_by_available_task
                 .get(task_id)

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -1984,6 +1984,131 @@ fn agent_sessions_list_and_upsert_flow_through_store() -> Result<()> {
 }
 
 #[test]
+fn agent_sessions_list_bulk_returns_empty_map_without_store_access() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-sessions-bulk-empty";
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    {
+        let mut state = task_state.lock().expect("task lock poisoned");
+        state.list_error = Some("list_tasks should not be called for empty input".to_string());
+    }
+
+    let sessions = service.agent_sessions_list_bulk(repo_path, &[])?;
+
+    assert!(sessions.is_empty());
+    assert!(task_state
+        .lock()
+        .expect("task lock poisoned")
+        .metadata_get_calls
+        .is_empty());
+    Ok(())
+}
+
+#[test]
+fn agent_sessions_list_bulk_reads_task_card_sessions_without_metadata_lookups() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-sessions-bulk";
+    let mut task_one = make_task("task-1", "task", TaskStatus::Open);
+    let mut task_one_newest = make_session("task-1", "session-1-newest");
+    task_one_newest.started_at = "2026-02-20T13:00:00Z".to_string();
+    let mut task_one_oldest = make_session("task-1", "session-1-oldest");
+    task_one_oldest.started_at = "2026-02-20T11:00:00Z".to_string();
+    task_one.agent_sessions = vec![task_one_newest.clone(), task_one_oldest.clone()];
+
+    let task_two = make_task("task-2", "task", TaskStatus::Open);
+
+    let mut task_three = make_task("task-3", "task", TaskStatus::Open);
+    let mut task_three_session = make_session("task-3", "session-3");
+    task_three_session.started_at = "2026-02-20T12:30:00Z".to_string();
+    task_three.agent_sessions = vec![task_three_session.clone()];
+
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![task_one, task_two, task_three],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+
+    let sessions = service.agent_sessions_list_bulk(
+        repo_path,
+        &[
+            "task-1".to_string(),
+            "task-2".to_string(),
+            "task-3".to_string(),
+        ],
+    )?;
+
+    assert_eq!(sessions.len(), 3);
+    assert_eq!(
+        sessions
+            .get("task-1")
+            .expect("task-1 sessions should exist")
+            .iter()
+            .map(|session| session.session_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["session-1-newest", "session-1-oldest"]
+    );
+    assert!(sessions
+        .get("task-2")
+        .expect("task-2 sessions should exist")
+        .is_empty());
+    assert_eq!(
+        sessions
+            .get("task-3")
+            .expect("task-3 sessions should exist")
+            .iter()
+            .map(|session| session.session_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![task_three_session.session_id.as_str()]
+    );
+
+    assert!(task_state
+        .lock()
+        .expect("task lock poisoned")
+        .metadata_get_calls
+        .is_empty());
+    Ok(())
+}
+
+#[test]
+fn agent_sessions_list_bulk_fails_for_missing_task_before_metadata_reads() {
+    let repo_path = "/tmp/odt-repo-sessions-bulk-missing";
+    let present = make_task("task-1", "task", TaskStatus::Open);
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![present],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+
+    let error = service
+        .agent_sessions_list_bulk(
+            repo_path,
+            &["task-1".to_string(), "missing-task".to_string()],
+        )
+        .expect_err("missing task should fail bulk session lookup");
+
+    assert!(error.to_string().contains("Task not found: missing-task"));
+    assert!(task_state
+        .lock()
+        .expect("task lock poisoned")
+        .metadata_get_calls
+        .is_empty());
+}
+
+#[test]
 fn agent_session_upsert_rejects_working_directory_outside_repo_and_worktree_base() -> Result<()> {
     let repo_root = unique_temp_path("session-upsert-invalid-workdir");
     let repo = repo_root.join("repo");

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -2054,6 +2054,62 @@ fn get_latest_qa_report_returns_latest_entry_when_present() -> Result<()> {
 }
 
 #[test]
+fn list_tasks_parses_agent_sessions_for_multiple_tasks_in_single_list_call() -> Result<()> {
+    let repo = RepoFixture::new("list-task-sessions");
+    let task_one = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "agentSessions": [
+                    serde_json::to_value(make_session("session-old", "2026-02-20T09:00:00Z", "idle"))?,
+                    serde_json::to_value(make_session("session-new", "2026-02-20T11:00:00Z", "running"))?
+                ]
+            }
+        })),
+    );
+    let task_two = issue_value(
+        "task-2",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "agentSessions": []
+            }
+        })),
+    );
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(
+            json!([task_one, task_two]).to_string()
+        ))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let tasks = store.list_tasks(repo.path())?;
+
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(
+        tasks[0]
+            .agent_sessions
+            .iter()
+            .map(|session| session.session_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["session-new", "session-old"]
+    );
+    assert!(tasks[1].agent_sessions.is_empty());
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].program, "bd");
+    assert_eq!(calls[0].args[0], "list");
+    Ok(())
+}
+
+#[test]
 fn list_agent_sessions_is_sorted_descending_by_started_at() -> Result<()> {
     let repo = RepoFixture::new("list-sessions");
     let payload = issue_value(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -245,7 +245,7 @@ fn assert_init_args(call: &RecordedCall, repo_path: &Path, beads_dir: &Path) {
     );
 }
 
-fn make_session(session_id: &str, started_at: &str, _status: &str) -> AgentSessionDocument {
+fn make_session(session_id: &str, started_at: &str) -> AgentSessionDocument {
     AgentSessionDocument {
         session_id: session_id.to_string(),
         external_session_id: Some(format!("external-{session_id}")),
@@ -2065,8 +2065,8 @@ fn list_tasks_parses_agent_sessions_for_multiple_tasks_in_single_list_call() -> 
         Some(json!({
             "openducktor": {
                 "agentSessions": [
-                    serde_json::to_value(make_session("session-old", "2026-02-20T09:00:00Z", "idle"))?,
-                    serde_json::to_value(make_session("session-new", "2026-02-20T11:00:00Z", "running"))?
+                    serde_json::to_value(make_session("session-old", "2026-02-20T09:00:00Z"))?,
+                    serde_json::to_value(make_session("session-new", "2026-02-20T11:00:00Z"))?
                 ]
             }
         })),
@@ -2121,8 +2121,8 @@ fn list_agent_sessions_is_sorted_descending_by_started_at() -> Result<()> {
         Some(json!({
             "openducktor": {
                 "agentSessions": [
-                    serde_json::to_value(make_session("session-old", "2026-02-20T09:00:00Z", "idle"))?,
-                    serde_json::to_value(make_session("session-new", "2026-02-20T11:00:00Z", "running"))?
+                    serde_json::to_value(make_session("session-old", "2026-02-20T09:00:00Z"))?,
+                    serde_json::to_value(make_session("session-new", "2026-02-20T11:00:00Z"))?
                 ]
             }
         })),
@@ -2150,8 +2150,8 @@ fn upsert_agent_session_updates_existing_session_without_duplication() -> Result
         Some(json!({
             "openducktor": {
                 "agentSessions": [
-                    serde_json::to_value(make_session("session-1", "2026-02-20T10:00:00Z", "idle"))?,
-                    serde_json::to_value(make_session("session-2", "2026-02-20T09:00:00Z", "idle"))?
+                    serde_json::to_value(make_session("session-1", "2026-02-20T10:00:00Z"))?,
+                    serde_json::to_value(make_session("session-2", "2026-02-20T09:00:00Z"))?
                 ]
             }
         })),
@@ -2162,7 +2162,7 @@ fn upsert_agent_session_updates_existing_session_without_duplication() -> Result
     ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
-    let updated = make_session("session-1", "2026-02-20T12:00:00Z", "running");
+    let updated = make_session("session-1", "2026-02-20T12:00:00Z");
     store.upsert_agent_session(repo.path(), "task-1", updated)?;
 
     let calls = runner.take_calls();
@@ -2197,7 +2197,6 @@ fn upsert_agent_session_truncates_to_latest_100_entries() -> Result<()> {
             serde_json::to_value(make_session(
                 &format!("session-{index:03}"),
                 started_at.as_str(),
-                "idle",
             ))
             .expect("session should serialize")
         })
@@ -2220,7 +2219,7 @@ fn upsert_agent_session_truncates_to_latest_100_entries() -> Result<()> {
     ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
-    let newest = make_session("session-newest", "2026-02-21T00:00:00Z", "running");
+    let newest = make_session("session-newest", "2026-02-21T00:00:00Z");
     store.upsert_agent_session(repo.path(), "task-1", newest)?;
 
     let calls = runner.take_calls();


### PR DESCRIPTION
## Summary
- Reuse the existing `list_tasks(...)` snapshot when hydrating bulk agent sessions so the host no longer performs one metadata lookup per task.
- Preserve fail-fast missing-task validation and keep single-task metadata freshness behavior unchanged.
- Add Rust regressions covering empty bulk input, multi-task session hydration, missing task failures, and Beads list-path session parsing.

## Verification
- `cargo test -p host-application`
- `cargo test -p host-infra-beads`
- `bun run check:rust`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized agent session retrieval from tasks to reduce unnecessary metadata lookups.

* **Tests**
  * Extended test coverage for bulk session listing, including empty task lists, multiple tasks with varying session counts, and missing task error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->