### PR TITLE
fix(desktop): restore git panel diff rendering

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/diff-preload-queue.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/diff-preload-queue.tsx
@@ -56,7 +56,11 @@ export const DiffPreloadQueue = memo(function DiffPreloadQueue({
   return (
     <>
       {preloadEntries.map((entry) => (
-        <PierreDiffPreloader key={entry.file} patch={entry.diff} filePath={entry.file} />
+        <PierreDiffPreloader
+          key={`preload:${entry.file}`}
+          patch={entry.diff}
+          filePath={entry.file}
+        />
       ))}
     </>
   );

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx
@@ -53,34 +53,22 @@ function FileDiffEntry({
   const dirName = diff.file.includes("/") ? diff.file.slice(0, diff.file.lastIndexOf("/")) : "";
   const hasDiffContent = diff.diff.trim().length > 0;
   const shouldPersistMountedDiffBody = process.env.NODE_ENV !== "test";
-  const [isDiffBodyMounted, setIsDiffBodyMounted] = useState(process.env.NODE_ENV === "test");
+  const [hasMountedDiffBody, setHasMountedDiffBody] = useState(false);
 
   useEffect(() => {
-    if (!isExpanded || !hasDiffContent) {
-      if (!shouldPersistMountedDiffBody) {
-        setIsDiffBodyMounted(false);
-      }
+    if (isExpanded && hasDiffContent) {
+      setHasMountedDiffBody(true);
       return;
     }
 
-    if (process.env.NODE_ENV === "test") {
-      setIsDiffBodyMounted(true);
-      return;
+    if (!shouldPersistMountedDiffBody) {
+      setHasMountedDiffBody(false);
     }
+  }, [hasDiffContent, isExpanded, shouldPersistMountedDiffBody]);
 
-    if (isDiffBodyMounted) {
-      return;
-    }
-
-    setIsDiffBodyMounted(false);
-    const rafId = globalThis.requestAnimationFrame(() => {
-      setIsDiffBodyMounted(true);
-    });
-
-    return () => {
-      globalThis.cancelAnimationFrame(rafId);
-    };
-  }, [hasDiffContent, isDiffBodyMounted, isExpanded, shouldPersistMountedDiffBody]);
+  const shouldRenderPersistedDiffBody =
+    hasDiffContent && shouldPersistMountedDiffBody && hasMountedDiffBody;
+  const shouldRenderDiffBody = isExpanded || shouldRenderPersistedDiffBody;
 
   return (
     <div className="min-w-0 max-w-full">
@@ -165,37 +153,28 @@ function FileDiffEntry({
         ) : null}
       </div>
 
-      {isExpanded || (hasDiffContent && shouldPersistMountedDiffBody && isDiffBodyMounted) ? (
+      {shouldRenderDiffBody ? (
         <div
           className={cn("border-t border-border/50", !isExpanded && "hidden")}
           style={DIFF_BODY_CONTAINER_STYLE}
         >
           {hasDiffContent ? (
-            isDiffBodyMounted ? (
-              <div>
-                <PierreDiffViewer
-                  patch={diff.diff}
-                  filePath={diff.file}
-                  diffStyle={diffStyle}
-                  enableHunkReset={canReset && onRequestHunkReset != null}
-                  isHunkResetDisabled={isResetDisabled}
-                  onResetHunk={
-                    onRequestHunkReset
-                      ? (hunkIndex) => {
-                          onRequestHunkReset(diff.file, hunkIndex);
-                        }
-                      : undefined
-                  }
-                />
-              </div>
-            ) : (
-              <div
-                className="p-3 text-xs text-muted-foreground"
-                data-testid="agent-studio-git-diff-pending"
-              >
-                Loading diff...
-              </div>
-            )
+            <div>
+              <PierreDiffViewer
+                patch={diff.diff}
+                filePath={diff.file}
+                diffStyle={diffStyle}
+                enableHunkReset={canReset && onRequestHunkReset != null}
+                isHunkResetDisabled={isResetDisabled}
+                onResetHunk={
+                  onRequestHunkReset
+                    ? (hunkIndex) => {
+                        onRequestHunkReset(diff.file, hunkIndex);
+                      }
+                    : undefined
+                }
+              />
+            </div>
           ) : (
             <div className="p-3 text-xs italic text-muted-foreground">
               No diff content available for {diff.file}

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-entry.tsx
@@ -52,6 +52,8 @@ function FileDiffEntry({
   const fileName = diff.file.split("/").pop() ?? diff.file;
   const dirName = diff.file.includes("/") ? diff.file.slice(0, diff.file.lastIndexOf("/")) : "";
   const hasDiffContent = diff.diff.trim().length > 0;
+  // Keep diff subtrees mounted after first expand in production for cheap reopen,
+  // but reset them in tests so assertions stay deterministic.
   const shouldPersistMountedDiffBody = process.env.NODE_ENV !== "test";
   const [hasMountedDiffBody, setHasMountedDiffBody] = useState(false);
 
@@ -76,6 +78,7 @@ function FileDiffEntry({
         <button
           type="button"
           className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 overflow-hidden text-left text-xs"
+          aria-label={`Toggle diff for ${diff.file}`}
           data-testid="agent-studio-git-file-toggle-button"
           onClick={() => onToggle(diff.file)}
         >

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-list.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-list.test.tsx
@@ -30,6 +30,13 @@ beforeAll(async () => {
   }));
 
   ({ FileDiffList } = await import("./file-diff-list"));
+
+  await restoreMockedModules([
+    [
+      "@/components/features/agents/pierre-diff-viewer",
+      () => import("@/components/features/agents/pierre-diff-viewer"),
+    ],
+  ]);
 });
 
 afterEach(() => {
@@ -44,15 +51,6 @@ afterAll(() => {
   } else {
     reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = previousActEnvironmentValue;
   }
-});
-
-afterAll(async () => {
-  await restoreMockedModules([
-    [
-      "@/components/features/agents/pierre-diff-viewer",
-      () => import("@/components/features/agents/pierre-diff-viewer"),
-    ],
-  ]);
 });
 
 function FileDiffListHarness(): ReactElement {
@@ -101,7 +99,7 @@ describe("FileDiffList", () => {
     expect(screen.getByTestId("pierre-diff-preloader").textContent).toBe("src/example.ts");
     expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: /example\.ts/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Toggle diff for src/example.ts" }));
 
     expect(screen.getByTestId("pierre-diff-viewer").textContent).toBe("src/example.ts");
     expect(screen.queryByTestId("pierre-diff-preloader")).toBeNull();

--- a/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-list.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-list.test.tsx
@@ -1,0 +1,109 @@
+import { afterAll, afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { type ReactElement, useState } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+
+type FileDiffListComponent = typeof import("./file-diff-list")["FileDiffList"];
+
+let FileDiffList: FileDiffListComponent;
+
+const reactActEnvironmentGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+const previousActEnvironmentValue = reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+
+const preloaderMock = mock(({ filePath }: { filePath: string }) => (
+  <div data-testid="pierre-diff-preloader">{filePath}</div>
+));
+
+const viewerMock = mock(({ filePath }: { filePath: string }) => (
+  <div data-testid="pierre-diff-viewer">{filePath}</div>
+));
+
+beforeAll(async () => {
+  reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+
+  mock.module("@/components/features/agents/pierre-diff-viewer", () => ({
+    PierreDiffPreloader: preloaderMock,
+    PierreDiffViewer: viewerMock,
+  }));
+
+  ({ FileDiffList } = await import("./file-diff-list"));
+});
+
+afterEach(() => {
+  cleanup();
+  preloaderMock.mockClear();
+  viewerMock.mockClear();
+});
+
+afterAll(() => {
+  if (typeof previousActEnvironmentValue === "undefined") {
+    delete reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT;
+  } else {
+    reactActEnvironmentGlobal.IS_REACT_ACT_ENVIRONMENT = previousActEnvironmentValue;
+  }
+});
+
+afterAll(async () => {
+  await restoreMockedModules([
+    [
+      "@/components/features/agents/pierre-diff-viewer",
+      () => import("@/components/features/agents/pierre-diff-viewer"),
+    ],
+  ]);
+});
+
+function FileDiffListHarness(): ReactElement {
+  const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
+
+  return (
+    <TooltipProvider>
+      <FileDiffList
+        fileDiffs={[
+          {
+            file: "src/example.ts",
+            type: "modified",
+            additions: 1,
+            deletions: 1,
+            diff: "@@ -1 +1 @@\n-old\n+new\n",
+          },
+        ]}
+        conflictedFiles={new Set()}
+        diffStyle="unified"
+        setDiffStyle={() => {}}
+        expandedFiles={expandedFiles}
+        onToggleFile={(filePath) => {
+          setExpandedFiles((previous) => {
+            const next = new Set(previous);
+            if (next.has(filePath)) {
+              next.delete(filePath);
+            } else {
+              next.add(filePath);
+            }
+            return next;
+          });
+        }}
+        preloadLimit={1}
+        canResetFiles={false}
+        isResetDisabled={false}
+        resetDisabledReason={null}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe("FileDiffList", () => {
+  test("keeps row expansion working while preload entries are mounted", () => {
+    render(<FileDiffListHarness />);
+
+    expect(screen.getByTestId("pierre-diff-preloader").textContent).toBe("src/example.ts");
+    expect(screen.queryByTestId("pierre-diff-viewer")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /example\.ts/i }));
+
+    expect(screen.getByTestId("pierre-diff-viewer").textContent).toBe("src/example.ts");
+    expect(screen.queryByTestId("pierre-diff-preloader")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- fix the git panel diff regression by giving hidden preload entries distinct React keys so expanding a file row always mounts the right diff subtree
- simplify file diff row mounting so expanded diffs render immediately while still keeping previously opened diff bodies mounted for cheap reopen performance
- add focused regression coverage for the preload-plus-expansion interaction and keep the existing git panel test suite green

## Verification
- bun test apps/desktop/src/components/features/agents/agent-studio-git-panel/file-diff-list.test.tsx
- bun test apps/desktop/src/components/features/agents/agent-studio-git-panel/diff-preload-queue.test.ts apps/desktop/src/components/features/agents/agent-studio-git-panel.test.tsx
- bun run --filter @openducktor/desktop typecheck