### PR TITLE
fix(host-application): keep linked PR refresh and closure reliable

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/linked_pull_request_merge_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/linked_pull_request_merge_service.rs
@@ -31,10 +31,11 @@ impl<'a> LinkedPullRequestMergeService<'a> {
         pull_request: PullRequestRecord,
         cleanup: LinkedPullRequestMergeCleanup,
     ) -> Result<TaskCard> {
-        self.service.task_store.set_pull_request(
+        self.service.task_store.set_delivery_metadata(
             Path::new(repo_path),
             task_id,
             Some(pull_request),
+            None,
         )?;
 
         if let LinkedPullRequestMergeCleanup::BuilderBranches {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/linked_pull_request_merge_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/linked_pull_request_merge_service.rs
@@ -4,27 +4,32 @@ use anyhow::Result;
 use host_domain::{PullRequestRecord, TaskCard, TaskStatus};
 use std::path::Path;
 
+const LINKED_PULL_REQUEST_MERGED_REASON: &str = "Linked pull request merged";
+
 #[derive(Clone, Debug)]
-pub(super) struct MergedPullRequestCleanupContext {
-    pub(super) source_branch: String,
-    pub(super) target_branch: String,
+pub(super) enum LinkedPullRequestMergeCleanup {
+    Skip,
+    BuilderBranches {
+        source_branch: String,
+        target_branch: String,
+    },
 }
 
-pub(super) struct MergedPullRequestCompletionService<'a> {
+pub(super) struct LinkedPullRequestMergeService<'a> {
     service: &'a AppService,
 }
 
-impl<'a> MergedPullRequestCompletionService<'a> {
+impl<'a> LinkedPullRequestMergeService<'a> {
     pub(super) fn new(service: &'a AppService) -> Self {
         Self { service }
     }
 
-    pub(super) fn complete_linked_pull_request_merge(
+    pub(super) fn persist_merge_and_close_task(
         &self,
         repo_path: &str,
         task_id: &str,
         pull_request: PullRequestRecord,
-        cleanup_context: Option<MergedPullRequestCleanupContext>,
+        cleanup: LinkedPullRequestMergeCleanup,
     ) -> Result<TaskCard> {
         self.service.task_store.set_pull_request(
             Path::new(repo_path),
@@ -32,12 +37,16 @@ impl<'a> MergedPullRequestCompletionService<'a> {
             Some(pull_request),
         )?;
 
-        if let Some(cleanup_context) = cleanup_context {
+        if let LinkedPullRequestMergeCleanup::BuilderBranches {
+            source_branch,
+            target_branch,
+        } = cleanup
+        {
             BuilderCleanupService::new(self.service).finalize_direct_merge_cleanup(
                 repo_path,
                 task_id,
-                cleanup_context.source_branch.as_str(),
-                cleanup_context.target_branch.as_str(),
+                source_branch.as_str(),
+                target_branch.as_str(),
             )?;
         }
 
@@ -45,7 +54,7 @@ impl<'a> MergedPullRequestCompletionService<'a> {
             repo_path,
             task_id,
             TaskStatus::Closed,
-            Some("Linked pull request merged"),
+            Some(LINKED_PULL_REQUEST_MERGED_REASON),
         )
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/merged_pull_request_completion_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/merged_pull_request_completion_service.rs
@@ -1,0 +1,51 @@
+use super::builder_cleanup_service::BuilderCleanupService;
+use crate::app_service::service_core::AppService;
+use anyhow::Result;
+use host_domain::{PullRequestRecord, TaskCard, TaskStatus};
+use std::path::Path;
+
+#[derive(Clone, Debug)]
+pub(super) struct MergedPullRequestCleanupContext {
+    pub(super) source_branch: String,
+    pub(super) target_branch: String,
+}
+
+pub(super) struct MergedPullRequestCompletionService<'a> {
+    service: &'a AppService,
+}
+
+impl<'a> MergedPullRequestCompletionService<'a> {
+    pub(super) fn new(service: &'a AppService) -> Self {
+        Self { service }
+    }
+
+    pub(super) fn complete_linked_pull_request_merge(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+        pull_request: PullRequestRecord,
+        cleanup_context: Option<MergedPullRequestCleanupContext>,
+    ) -> Result<TaskCard> {
+        self.service.task_store.set_pull_request(
+            Path::new(repo_path),
+            task_id,
+            Some(pull_request),
+        )?;
+
+        if let Some(cleanup_context) = cleanup_context {
+            BuilderCleanupService::new(self.service).finalize_direct_merge_cleanup(
+                repo_path,
+                task_id,
+                cleanup_context.source_branch.as_str(),
+                cleanup_context.target_branch.as_str(),
+            )?;
+        }
+
+        self.service.task_transition(
+            repo_path,
+            task_id,
+            TaskStatus::Closed,
+            Some("Linked pull request merged"),
+        )
+    }
+}

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/mod.rs
@@ -7,6 +7,7 @@ mod cleanup_plans;
 mod direct_merge_workflow_service;
 mod document_service;
 mod implementation_reset_service;
+mod merged_pull_request_completion_service;
 mod pull_request_provider_service;
 mod pull_request_sync_service;
 mod pull_request_workflow_service;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/mod.rs
@@ -7,7 +7,7 @@ mod cleanup_plans;
 mod direct_merge_workflow_service;
 mod document_service;
 mod implementation_reset_service;
-mod merged_pull_request_completion_service;
+mod linked_pull_request_merge_service;
 mod pull_request_provider_service;
 mod pull_request_sync_service;
 mod pull_request_workflow_service;

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_sync_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_sync_service.rs
@@ -46,16 +46,15 @@ impl<'a> PullRequestSyncService<'a> {
                 continue;
             };
             if updated.record.state == "merged" && task.status != TaskStatus::Closed {
-                let _ = LinkedPullRequestMergeService::new(self.service)
-                    .persist_merge_and_close_task(
-                        repo_path.as_str(),
-                        task.id.as_str(),
-                        updated.record,
-                        LinkedPullRequestMergeCleanup::BuilderBranches {
-                            source_branch: updated.source_branch,
-                            target_branch: updated.target_branch,
-                        },
-                    )?;
+                LinkedPullRequestMergeService::new(self.service).persist_merge_and_close_task(
+                    repo_path.as_str(),
+                    task.id.as_str(),
+                    updated.record,
+                    LinkedPullRequestMergeCleanup::BuilderBranches {
+                        source_branch: updated.source_branch,
+                        target_branch: updated.target_branch,
+                    },
+                )?;
             } else {
                 self.service.task_store.set_pull_request(
                     Path::new(&repo_path),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_sync_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_sync_service.rs
@@ -1,5 +1,7 @@
 use super::approval_support::{is_syncable_pull_request_state, is_terminal_task_status};
-use super::builder_cleanup_service::BuilderCleanupService;
+use super::merged_pull_request_completion_service::{
+    MergedPullRequestCleanupContext, MergedPullRequestCompletionService,
+};
 use super::pull_request_provider_service::PullRequestProviderService;
 use crate::app_service::service_core::AppService;
 use anyhow::Result;
@@ -43,24 +45,22 @@ impl<'a> PullRequestSyncService<'a> {
             else {
                 continue;
             };
-            self.service.task_store.set_pull_request(
-                Path::new(&repo_path),
-                task.id.as_str(),
-                Some(updated.record.clone()),
-            )?;
-
             if updated.record.state == "merged" && task.status != TaskStatus::Closed {
-                BuilderCleanupService::new(self.service).finalize_direct_merge_cleanup(
-                    repo_path.as_str(),
+                let _ = MergedPullRequestCompletionService::new(self.service)
+                    .complete_linked_pull_request_merge(
+                        repo_path.as_str(),
+                        task.id.as_str(),
+                        updated.record,
+                        Some(MergedPullRequestCleanupContext {
+                            source_branch: updated.source_branch,
+                            target_branch: updated.target_branch,
+                        }),
+                    )?;
+            } else {
+                self.service.task_store.set_pull_request(
+                    Path::new(&repo_path),
                     task.id.as_str(),
-                    updated.source_branch.as_str(),
-                    updated.target_branch.as_str(),
-                )?;
-                self.service.task_transition(
-                    repo_path.as_str(),
-                    task.id.as_str(),
-                    TaskStatus::Closed,
-                    Some("Linked pull request merged"),
+                    Some(updated.record),
                 )?;
             }
         }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_sync_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_sync_service.rs
@@ -1,6 +1,6 @@
 use super::approval_support::{is_syncable_pull_request_state, is_terminal_task_status};
-use super::merged_pull_request_completion_service::{
-    MergedPullRequestCleanupContext, MergedPullRequestCompletionService,
+use super::linked_pull_request_merge_service::{
+    LinkedPullRequestMergeCleanup, LinkedPullRequestMergeService,
 };
 use super::pull_request_provider_service::PullRequestProviderService;
 use crate::app_service::service_core::AppService;
@@ -46,15 +46,15 @@ impl<'a> PullRequestSyncService<'a> {
                 continue;
             };
             if updated.record.state == "merged" && task.status != TaskStatus::Closed {
-                let _ = MergedPullRequestCompletionService::new(self.service)
-                    .complete_linked_pull_request_merge(
+                let _ = LinkedPullRequestMergeService::new(self.service)
+                    .persist_merge_and_close_task(
                         repo_path.as_str(),
                         task.id.as_str(),
                         updated.record,
-                        Some(MergedPullRequestCleanupContext {
+                        LinkedPullRequestMergeCleanup::BuilderBranches {
                             source_branch: updated.source_branch,
                             target_branch: updated.target_branch,
-                        }),
+                        },
                     )?;
             } else {
                 self.service.task_store.set_pull_request(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_workflow_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_workflow_service.rs
@@ -3,8 +3,8 @@ use super::approval_support::{
     ensure_clean_builder_worktree, ensure_pull_request_management_status,
 };
 use super::builder_branch_service::BuilderBranchService;
-use super::merged_pull_request_completion_service::{
-    MergedPullRequestCleanupContext, MergedPullRequestCompletionService,
+use super::linked_pull_request_merge_service::{
+    LinkedPullRequestMergeCleanup, LinkedPullRequestMergeService,
 };
 use super::pull_request_provider_service::PullRequestProviderService;
 use crate::app_service::git_provider::ResolvedPullRequest;
@@ -182,7 +182,7 @@ impl<'a> PullRequestWorkflowService<'a> {
         }
 
         let repo_path = self.service.resolve_task_repo_path(repo_path)?;
-        let cleanup_context = if metadata.pull_request.is_none() {
+        let cleanup = if metadata.pull_request.is_none() {
             let builder_context = BuilderBranchService::new(self.service)
                 .load_builder_branch_context(
                     context.repo.repo_path.as_str(),
@@ -192,19 +192,19 @@ impl<'a> PullRequestWorkflowService<'a> {
             let target_branch = BuilderBranchService::new(self.service)
                 .target_branch_for_repo(context.repo.repo_path.as_str())?
                 .checkout_branch();
-            Some(MergedPullRequestCleanupContext {
+            LinkedPullRequestMergeCleanup::BuilderBranches {
                 source_branch: builder_context.source_branch,
                 target_branch,
-            })
+            }
         } else {
-            None
+            LinkedPullRequestMergeCleanup::Skip
         };
 
-        MergedPullRequestCompletionService::new(self.service).complete_linked_pull_request_merge(
+        LinkedPullRequestMergeService::new(self.service).persist_merge_and_close_task(
             repo_path.as_str(),
             task_id,
             pull_request,
-            cleanup_context,
+            cleanup,
         )
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_workflow_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_workflow_service.rs
@@ -3,7 +3,9 @@ use super::approval_support::{
     ensure_clean_builder_worktree, ensure_pull_request_management_status,
 };
 use super::builder_branch_service::BuilderBranchService;
-use super::builder_cleanup_service::BuilderCleanupService;
+use super::merged_pull_request_completion_service::{
+    MergedPullRequestCleanupContext, MergedPullRequestCompletionService,
+};
 use super::pull_request_provider_service::PullRequestProviderService;
 use crate::app_service::git_provider::ResolvedPullRequest;
 use crate::app_service::service_core::AppService;
@@ -180,38 +182,29 @@ impl<'a> PullRequestWorkflowService<'a> {
         }
 
         let repo_path = self.service.resolve_task_repo_path(repo_path)?;
-        let builder_context = BuilderBranchService::new(self.service).load_builder_branch_context(
-            context.repo.repo_path.as_str(),
-            task_id,
-            "Pull request linking",
-        )?;
-        let target_branch = BuilderBranchService::new(self.service)
-            .target_branch_for_repo(context.repo.repo_path.as_str())?
-            .checkout_branch();
+        let cleanup_context = if metadata.pull_request.is_none() {
+            let builder_context = BuilderBranchService::new(self.service)
+                .load_builder_branch_context(
+                    context.repo.repo_path.as_str(),
+                    task_id,
+                    "Pull request linking",
+                )?;
+            let target_branch = BuilderBranchService::new(self.service)
+                .target_branch_for_repo(context.repo.repo_path.as_str())?
+                .checkout_branch();
+            Some(MergedPullRequestCleanupContext {
+                source_branch: builder_context.source_branch,
+                target_branch,
+            })
+        } else {
+            None
+        };
 
-        if metadata.pull_request.is_none() {
-            PullRequestProviderService::new(self.service).store_linked_pull_request_metadata(
-                repo_path.as_str(),
-                task_id,
-                ResolvedPullRequest {
-                    record: pull_request,
-                    source_branch: builder_context.source_branch.clone(),
-                    target_branch: target_branch.clone(),
-                },
-            )?;
-        }
-        BuilderCleanupService::new(self.service).finalize_direct_merge_cleanup(
+        MergedPullRequestCompletionService::new(self.service).complete_linked_pull_request_merge(
             repo_path.as_str(),
             task_id,
-            builder_context.source_branch.as_str(),
-            target_branch.as_str(),
-        )?;
-        let task = self.service.task_transition(
-            repo_path.as_str(),
-            task_id,
-            TaskStatus::Closed,
-            Some("Linked pull request merged"),
-        )?;
-        Ok(task)
+            pull_request,
+            cleanup_context,
+        )
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_workflow_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/pull_request_workflow_service.rs
@@ -7,7 +7,6 @@ use super::linked_pull_request_merge_service::{
     LinkedPullRequestMergeCleanup, LinkedPullRequestMergeService,
 };
 use super::pull_request_provider_service::PullRequestProviderService;
-use crate::app_service::git_provider::ResolvedPullRequest;
 use crate::app_service::service_core::AppService;
 use anyhow::{anyhow, Result};
 use host_domain::{PullRequestRecord, TaskCard, TaskPullRequestDetectResult, TaskStatus};
@@ -164,9 +163,7 @@ impl<'a> PullRequestWorkflowService<'a> {
         if context.task.status == TaskStatus::Closed && same_existing_pull_request {
             return Ok(context.task);
         }
-        if context.task.status != TaskStatus::Closed || !same_existing_pull_request {
-            ensure_pull_request_management_status(&context.task.status)?;
-        }
+        ensure_pull_request_management_status(&context.task.status)?;
         if metadata.direct_merge.is_some() {
             return Err(anyhow!(
                 "A local direct merge is already recorded for task {task_id}. Finish the direct merge workflow before linking a merged pull request."
@@ -183,21 +180,9 @@ impl<'a> PullRequestWorkflowService<'a> {
 
         let repo_path = self.service.resolve_task_repo_path(repo_path)?;
         let cleanup = if metadata.pull_request.is_none() {
-            let builder_context = BuilderBranchService::new(self.service)
-                .load_builder_branch_context(
-                    context.repo.repo_path.as_str(),
-                    task_id,
-                    "Pull request linking",
-                )?;
-            let target_branch = BuilderBranchService::new(self.service)
-                .target_branch_for_repo(context.repo.repo_path.as_str())?
-                .checkout_branch();
-            LinkedPullRequestMergeCleanup::BuilderBranches {
-                source_branch: builder_context.source_branch,
-                target_branch,
-            }
+            self.load_required_cleanup(context.repo.repo_path.as_str(), task_id)?
         } else {
-            LinkedPullRequestMergeCleanup::Skip
+            self.load_retry_cleanup(context.repo.repo_path.as_str(), task_id)?
         };
 
         LinkedPullRequestMergeService::new(self.service).persist_merge_and_close_task(
@@ -207,4 +192,44 @@ impl<'a> PullRequestWorkflowService<'a> {
             cleanup,
         )
     }
+
+    fn load_required_cleanup(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+    ) -> Result<LinkedPullRequestMergeCleanup> {
+        let builder_context = BuilderBranchService::new(self.service).load_builder_branch_context(
+            repo_path,
+            task_id,
+            "Pull request linking",
+        )?;
+        let target_branch = BuilderBranchService::new(self.service)
+            .target_branch_for_repo(repo_path)?
+            .checkout_branch();
+
+        Ok(LinkedPullRequestMergeCleanup::BuilderBranches {
+            source_branch: builder_context.source_branch,
+            target_branch,
+        })
+    }
+
+    fn load_retry_cleanup(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+    ) -> Result<LinkedPullRequestMergeCleanup> {
+        match self.load_required_cleanup(repo_path, task_id) {
+            Ok(cleanup) => Ok(cleanup),
+            Err(error) if can_skip_relinked_pull_request_cleanup(error.to_string().as_str()) => {
+                Ok(LinkedPullRequestMergeCleanup::Skip)
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+fn can_skip_relinked_pull_request_cleanup(message: &str) -> bool {
+    message.contains("requires a builder worktree for task")
+        || message.contains("the latest builder workspace is detached")
+        || message.contains("requires a builder branch name")
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
@@ -3,11 +3,12 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     GitBranch, GitCurrentBranch, GitFileStatus, GitMergeBranchResult, GitMergeMethod,
-    TaskPullRequestDetectResult, TaskStatus,
+    PullRequestRecord, TaskPullRequestDetectResult, TaskStatus,
 };
 use host_infra_system::{
     AppConfigStore, GitProviderConfig, GitProviderRepository, HookSet, RepoConfig,
 };
+use host_test_support::EnvVarGuard;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -17,6 +18,35 @@ use crate::app_service::test_support::{
     set_env_var, unique_temp_path, write_executable_script, GitCall,
 };
 use crate::RepoConfigUpdate;
+
+const TASK_ID: &str = "task-1";
+const TASK_SOURCE_BRANCH: &str = "odt/task-1";
+const LINKED_PULL_REQUEST_NUMBER: u32 = 17;
+const LINKED_PULL_REQUEST_URL: &str = "https://github.com/openai/openducktor/pull/17";
+const LINKED_PULL_REQUEST_CREATED_AT: &str = "2026-03-11T10:00:00Z";
+const LINKED_PULL_REQUEST_MERGED_AT: &str = "2026-03-11T10:10:00Z";
+
+type TaskStateHandle =
+    std::sync::Arc<std::sync::Mutex<crate::app_service::test_support::TaskStoreState>>;
+type GitStateHandle = std::sync::Arc<std::sync::Mutex<crate::app_service::test_support::GitState>>;
+
+struct PullRequestWorkflowFixture {
+    root: PathBuf,
+    repo_path: String,
+    worktree_path: PathBuf,
+    service: crate::app_service::AppService,
+    task_state: TaskStateHandle,
+    git_state: GitStateHandle,
+}
+
+struct FakeMergedPullRequestGitHub {
+    _path_guard: EnvVarGuard,
+    _auth_ok_guard: EnvVarGuard,
+    _auth_login_guard: EnvVarGuard,
+    _create_guard: EnvVarGuard,
+    _update_guard: EnvVarGuard,
+    _fetch_guard: EnvVarGuard,
+}
 
 fn base_repo_config(worktree_base: &Path) -> RepoConfig {
     RepoConfig {
@@ -72,8 +102,8 @@ fn configure_builder_session(
     worktree_path: &Path,
     source_branch: &str,
     service: &crate::app_service::AppService,
-    task_state: &std::sync::Arc<std::sync::Mutex<crate::app_service::test_support::TaskStoreState>>,
-    git_state: &std::sync::Arc<std::sync::Mutex<crate::app_service::test_support::GitState>>,
+    task_state: &TaskStateHandle,
+    git_state: &GitStateHandle,
 ) -> Result<()> {
     fs::create_dir_all(worktree_path)?;
     let repo_root = Path::new(repo_path);
@@ -114,6 +144,140 @@ fn configure_builder_session(
 
     service.workspace_add(repo_path)?;
     Ok(())
+}
+
+fn setup_pull_request_workflow_fixture(
+    test_name: &str,
+    issue_type: &str,
+    task_status: TaskStatus,
+) -> Result<PullRequestWorkflowFixture> {
+    let root = unique_temp_path(test_name);
+    let repo = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    let worktree_path = worktree_base.join(TASK_ID);
+    init_git_repo(&repo)?;
+    fs::create_dir_all(&worktree_path)?;
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, task_state, git_state) = build_service_with_store(
+        vec![make_task(TASK_ID, issue_type, task_status)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    let repo_path = repo.to_string_lossy().to_string();
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
+    configure_builder_session(
+        repo_path.as_str(),
+        &worktree_path,
+        TASK_SOURCE_BRANCH,
+        &service,
+        &task_state,
+        &git_state,
+    )?;
+
+    Ok(PullRequestWorkflowFixture {
+        root,
+        repo_path,
+        worktree_path,
+        service,
+        task_state,
+        git_state,
+    })
+}
+
+fn pull_request_record(state: &str) -> PullRequestRecord {
+    let merged = state == "merged";
+    PullRequestRecord {
+        provider_id: "github".to_string(),
+        number: LINKED_PULL_REQUEST_NUMBER,
+        url: LINKED_PULL_REQUEST_URL.to_string(),
+        state: state.to_string(),
+        created_at: LINKED_PULL_REQUEST_CREATED_AT.to_string(),
+        updated_at: if merged {
+            LINKED_PULL_REQUEST_MERGED_AT.to_string()
+        } else {
+            LINKED_PULL_REQUEST_CREATED_AT.to_string()
+        },
+        last_synced_at: merged.then(|| LINKED_PULL_REQUEST_MERGED_AT.to_string()),
+        merged_at: merged.then(|| LINKED_PULL_REQUEST_MERGED_AT.to_string()),
+        closed_at: merged.then(|| LINKED_PULL_REQUEST_MERGED_AT.to_string()),
+    }
+}
+
+fn open_pull_request_record() -> PullRequestRecord {
+    pull_request_record("open")
+}
+
+fn merged_pull_request_record() -> PullRequestRecord {
+    pull_request_record("merged")
+}
+
+fn insert_task_pull_request(task_state: &TaskStateHandle, pull_request: PullRequestRecord) {
+    task_state
+        .lock()
+        .expect("task state lock poisoned")
+        .pull_requests
+        .insert(TASK_ID.to_string(), pull_request);
+}
+
+fn set_local_task_branch(git_state: &GitStateHandle, branch: &str) {
+    git_state.lock().expect("git state lock poisoned").branches = vec![GitBranch {
+        name: branch.to_string(),
+        is_current: false,
+        is_remote: false,
+    }];
+}
+
+fn write_merged_pull_request_fetch_response(
+    path: &Path,
+    source_branch: &str,
+    target_branch: &str,
+) -> Result<()> {
+    write_json(
+        path,
+        format!(
+            r#"{{"number":{LINKED_PULL_REQUEST_NUMBER},"html_url":"{LINKED_PULL_REQUEST_URL}","title":"Merged PR","draft":false,"state":"closed","created_at":"{LINKED_PULL_REQUEST_CREATED_AT}","updated_at":"{LINKED_PULL_REQUEST_MERGED_AT}","merged_at":"{LINKED_PULL_REQUEST_MERGED_AT}","closed_at":"{LINKED_PULL_REQUEST_MERGED_AT}","head":{{"ref":"{source_branch}"}},"base":{{"ref":"{target_branch}"}}}}"#,
+        )
+        .as_str(),
+    )
+}
+
+fn setup_fake_gh_for_merged_pull_request(
+    root: &Path,
+    source_branch: &str,
+    target_branch: &str,
+) -> Result<FakeMergedPullRequestGitHub> {
+    let create_response = root.join("create.json");
+    let update_response = root.join("update.json");
+    let fetch_response = root.join("fetch.json");
+    write_json(&create_response, "{}")?;
+    write_json(&update_response, "{}")?;
+    write_merged_pull_request_fetch_response(&fetch_response, source_branch, target_branch)?;
+
+    let bin_dir = write_fake_gh(root)?;
+    Ok(FakeMergedPullRequestGitHub {
+        _path_guard: prepend_path(&bin_dir),
+        _auth_ok_guard: set_env_var("ODT_GH_AUTH_OK", "1"),
+        _auth_login_guard: set_env_var("ODT_GH_AUTH_LOGIN", "octocat"),
+        _create_guard: set_env_var(
+            "ODT_GH_CREATE_RESPONSE",
+            create_response.to_string_lossy().as_ref(),
+        ),
+        _update_guard: set_env_var(
+            "ODT_GH_UPDATE_RESPONSE",
+            update_response.to_string_lossy().as_ref(),
+        ),
+        _fetch_guard: set_env_var(
+            "ODT_GH_FETCH_RESPONSE",
+            fetch_response.to_string_lossy().as_ref(),
+        ),
+    })
 }
 
 fn write_fake_gh(root: &Path) -> Result<PathBuf> {
@@ -2013,524 +2177,259 @@ fn task_pull_request_detect_requires_matching_push_remote() -> Result<()> {
 #[test]
 fn repo_pull_request_sync_closes_tasks_when_linked_pull_request_is_merged() -> Result<()> {
     let _env_lock = lock_env();
-    let root = unique_temp_path("approval-pr-sync");
-    let repo = root.join("repo");
-    let worktree_base = root.join("worktrees");
-    let worktree_path = worktree_base.join("task-1");
-    let create_response = root.join("create.json");
-    let update_response = root.join("update.json");
-    let fetch_response = root.join("fetch.json");
-    init_git_repo(&repo)?;
-    fs::create_dir_all(&worktree_path)?;
-    write_json(&create_response, "{}")?;
-    write_json(&update_response, "{}")?;
-    write_json(
-        &fetch_response,
-        r#"{"number":17,"html_url":"https://github.com/openai/openducktor/pull/17","title":"Merged PR","draft":false,"state":"closed","created_at":"2026-03-11T10:00:00Z","updated_at":"2026-03-11T10:10:00Z","merged_at":"2026-03-11T10:10:00Z","closed_at":"2026-03-11T10:10:00Z","head":{"ref":"odt/task-1"},"base":{"ref":"main"}}"#,
-    )?;
+    let fixture =
+        setup_pull_request_workflow_fixture("approval-pr-sync", "task", TaskStatus::HumanReview)?;
+    let _github = setup_fake_gh_for_merged_pull_request(&fixture.root, TASK_SOURCE_BRANCH, "main")?;
+    insert_task_pull_request(&fixture.task_state, open_pull_request_record());
+    set_local_task_branch(&fixture.git_state, TASK_SOURCE_BRANCH);
 
-    let bin_dir = write_fake_gh(&root)?;
-    let _path_guard = prepend_path(&bin_dir);
-    let _auth_ok_guard = set_env_var("ODT_GH_AUTH_OK", "1");
-    let _auth_login_guard = set_env_var("ODT_GH_AUTH_LOGIN", "octocat");
-    let _create_guard = set_env_var(
-        "ODT_GH_CREATE_RESPONSE",
-        create_response.to_string_lossy().as_ref(),
-    );
-    let _update_guard = set_env_var(
-        "ODT_GH_UPDATE_RESPONSE",
-        update_response.to_string_lossy().as_ref(),
-    );
-    let _fetch_guard = set_env_var(
-        "ODT_GH_FETCH_RESPONSE",
-        fetch_response.to_string_lossy().as_ref(),
-    );
+    assert!(fixture
+        .service
+        .repo_pull_request_sync(fixture.repo_path.as_str())?);
 
-    let config_store = AppConfigStore::from_path(root.join("config.json"));
-    let (service, task_state, git_state) = build_service_with_store(
-        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
-        vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-            revision: None,
-        },
-        config_store,
-    );
-    let repo_path = repo.to_string_lossy().to_string();
-    service.workspace_add(repo_path.as_str())?;
-    service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
-    configure_builder_session(
-        repo_path.as_str(),
-        &worktree_path,
-        "odt/task-1",
-        &service,
-        &task_state,
-        &git_state,
-    )?;
-    task_state
-        .lock()
-        .expect("task state lock poisoned")
-        .pull_requests
-        .insert(
-            "task-1".to_string(),
-            host_domain::PullRequestRecord {
-                provider_id: "github".to_string(),
-                number: 17,
-                url: "https://github.com/openai/openducktor/pull/17".to_string(),
-                state: "open".to_string(),
-                created_at: "2026-03-11T10:00:00Z".to_string(),
-                updated_at: "2026-03-11T10:00:00Z".to_string(),
-                last_synced_at: None,
-                merged_at: None,
-                closed_at: None,
-            },
-        );
-    {
-        let mut git = git_state.lock().expect("git state lock poisoned");
-        git.branches = vec![GitBranch {
-            name: "odt/task-1".to_string(),
-            is_current: false,
-            is_remote: false,
-        }];
-    }
-
-    assert!(service.repo_pull_request_sync(repo_path.as_str())?);
-
-    let state = task_state.lock().expect("task state lock poisoned");
+    let state = fixture.task_state.lock().expect("task state lock poisoned");
     let task = state
         .tasks
         .iter()
-        .find(|task| task.id == "task-1")
+        .find(|task| task.id == TASK_ID)
         .ok_or_else(|| anyhow!("task not found after sync"))?;
     assert_eq!(task.status, TaskStatus::Closed);
     assert_eq!(
         state
             .pull_requests
-            .get("task-1")
+            .get(TASK_ID)
             .map(|entry| entry.state.as_str()),
         Some("merged"),
     );
     drop(state);
 
-    let git = git_state.lock().expect("git state lock poisoned");
+    let git = fixture.git_state.lock().expect("git state lock poisoned");
     assert!(git
         .calls
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
     assert!(git.calls.iter().any(
-        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == TASK_SOURCE_BRANCH)
     ));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&fixture.root);
     Ok(())
 }
 
 #[test]
 fn repo_pull_request_sync_closes_tasks_when_builder_worktree_is_already_missing() -> Result<()> {
     let _env_lock = lock_env();
-    let root = unique_temp_path("approval-pr-sync-missing-worktree");
-    let repo = root.join("repo");
-    let worktree_base = root.join("worktrees");
-    let worktree_path = worktree_base.join("task-1");
-    let create_response = root.join("create.json");
-    let update_response = root.join("update.json");
-    let fetch_response = root.join("fetch.json");
-    init_git_repo(&repo)?;
-    fs::create_dir_all(&worktree_path)?;
-    write_json(&create_response, "{}")?;
-    write_json(&update_response, "{}")?;
-    write_json(
-        &fetch_response,
-        r#"{"number":17,"html_url":"https://github.com/openai/openducktor/pull/17","title":"Merged PR","draft":false,"state":"closed","created_at":"2026-03-11T10:00:00Z","updated_at":"2026-03-11T10:10:00Z","merged_at":"2026-03-11T10:10:00Z","closed_at":"2026-03-11T10:10:00Z","head":{"ref":"odt/task-1"},"base":{"ref":"main"}}"#,
+    let fixture = setup_pull_request_workflow_fixture(
+        "approval-pr-sync-missing-worktree",
+        "task",
+        TaskStatus::HumanReview,
     )?;
+    let _github = setup_fake_gh_for_merged_pull_request(&fixture.root, TASK_SOURCE_BRANCH, "main")?;
+    insert_task_pull_request(&fixture.task_state, open_pull_request_record());
+    set_local_task_branch(&fixture.git_state, TASK_SOURCE_BRANCH);
+    fs::remove_dir_all(&fixture.worktree_path)?;
 
-    let bin_dir = write_fake_gh(&root)?;
-    let _path_guard = prepend_path(&bin_dir);
-    let _auth_ok_guard = set_env_var("ODT_GH_AUTH_OK", "1");
-    let _auth_login_guard = set_env_var("ODT_GH_AUTH_LOGIN", "octocat");
-    let _create_guard = set_env_var(
-        "ODT_GH_CREATE_RESPONSE",
-        create_response.to_string_lossy().as_ref(),
-    );
-    let _update_guard = set_env_var(
-        "ODT_GH_UPDATE_RESPONSE",
-        update_response.to_string_lossy().as_ref(),
-    );
-    let _fetch_guard = set_env_var(
-        "ODT_GH_FETCH_RESPONSE",
-        fetch_response.to_string_lossy().as_ref(),
-    );
+    assert!(fixture
+        .service
+        .repo_pull_request_sync(fixture.repo_path.as_str())?);
 
-    let config_store = AppConfigStore::from_path(root.join("config.json"));
-    let (service, task_state, git_state) = build_service_with_store(
-        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
-        vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-            revision: None,
-        },
-        config_store,
-    );
-    let repo_path = repo.to_string_lossy().to_string();
-    service.workspace_add(repo_path.as_str())?;
-    service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
-    configure_builder_session(
-        repo_path.as_str(),
-        &worktree_path,
-        "odt/task-1",
-        &service,
-        &task_state,
-        &git_state,
-    )?;
-    task_state
-        .lock()
-        .expect("task state lock poisoned")
-        .pull_requests
-        .insert(
-            "task-1".to_string(),
-            host_domain::PullRequestRecord {
-                provider_id: "github".to_string(),
-                number: 17,
-                url: "https://github.com/openai/openducktor/pull/17".to_string(),
-                state: "open".to_string(),
-                created_at: "2026-03-11T10:00:00Z".to_string(),
-                updated_at: "2026-03-11T10:00:00Z".to_string(),
-                last_synced_at: None,
-                merged_at: None,
-                closed_at: None,
-            },
-        );
-    {
-        let mut git = git_state.lock().expect("git state lock poisoned");
-        git.branches = vec![GitBranch {
-            name: "odt/task-1".to_string(),
-            is_current: false,
-            is_remote: false,
-        }];
-    }
-    fs::remove_dir_all(&worktree_path)?;
-
-    assert!(service.repo_pull_request_sync(repo_path.as_str())?);
-
-    let state = task_state.lock().expect("task state lock poisoned");
+    let state = fixture.task_state.lock().expect("task state lock poisoned");
     let task = state
         .tasks
         .iter()
-        .find(|task| task.id == "task-1")
+        .find(|task| task.id == TASK_ID)
         .ok_or_else(|| anyhow!("task not found after sync"))?;
     assert_eq!(task.status, TaskStatus::Closed);
     assert_eq!(
         state
             .pull_requests
-            .get("task-1")
+            .get(TASK_ID)
             .map(|entry| entry.state.as_str()),
         Some("merged"),
     );
     drop(state);
 
-    let git = git_state.lock().expect("git state lock poisoned");
+    let git = fixture.git_state.lock().expect("git state lock poisoned");
     assert!(!git
         .calls
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
     assert!(git.calls.iter().any(
-        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == TASK_SOURCE_BRANCH)
     ));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&fixture.root);
     Ok(())
 }
 
 #[test]
 fn repo_pull_request_sync_propagates_close_transition_failures() -> Result<()> {
     let _env_lock = lock_env();
-    let root = unique_temp_path("approval-pr-sync-close-error");
-    let repo = root.join("repo");
-    let worktree_base = root.join("worktrees");
-    let worktree_path = worktree_base.join("task-1");
-    let create_response = root.join("create.json");
-    let update_response = root.join("update.json");
-    let fetch_response = root.join("fetch.json");
-    init_git_repo(&repo)?;
-    fs::create_dir_all(&worktree_path)?;
-    write_json(&create_response, "{}")?;
-    write_json(&update_response, "{}")?;
-    write_json(
-        &fetch_response,
-        r#"{"number":17,"html_url":"https://github.com/openai/openducktor/pull/17","title":"Merged PR","draft":false,"state":"closed","created_at":"2026-03-11T10:00:00Z","updated_at":"2026-03-11T10:10:00Z","merged_at":"2026-03-11T10:10:00Z","closed_at":"2026-03-11T10:10:00Z","head":{"ref":"odt/task-1"},"base":{"ref":"main"}}"#,
+    let fixture = setup_pull_request_workflow_fixture(
+        "approval-pr-sync-close-error",
+        "feature",
+        TaskStatus::Open,
     )?;
+    let _github = setup_fake_gh_for_merged_pull_request(&fixture.root, TASK_SOURCE_BRANCH, "main")?;
+    insert_task_pull_request(&fixture.task_state, open_pull_request_record());
+    set_local_task_branch(&fixture.git_state, TASK_SOURCE_BRANCH);
 
-    let bin_dir = write_fake_gh(&root)?;
-    let _path_guard = prepend_path(&bin_dir);
-    let _auth_ok_guard = set_env_var("ODT_GH_AUTH_OK", "1");
-    let _auth_login_guard = set_env_var("ODT_GH_AUTH_LOGIN", "octocat");
-    let _create_guard = set_env_var(
-        "ODT_GH_CREATE_RESPONSE",
-        create_response.to_string_lossy().as_ref(),
-    );
-    let _update_guard = set_env_var(
-        "ODT_GH_UPDATE_RESPONSE",
-        update_response.to_string_lossy().as_ref(),
-    );
-    let _fetch_guard = set_env_var(
-        "ODT_GH_FETCH_RESPONSE",
-        fetch_response.to_string_lossy().as_ref(),
-    );
-
-    let config_store = AppConfigStore::from_path(root.join("config.json"));
-    let (service, task_state, git_state) = build_service_with_store(
-        vec![make_task("task-1", "feature", TaskStatus::Open)],
-        vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-            revision: None,
-        },
-        config_store,
-    );
-    let repo_path = repo.to_string_lossy().to_string();
-    service.workspace_add(repo_path.as_str())?;
-    service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
-    configure_builder_session(
-        repo_path.as_str(),
-        &worktree_path,
-        "odt/task-1",
-        &service,
-        &task_state,
-        &git_state,
-    )?;
-    task_state
-        .lock()
-        .expect("task state lock poisoned")
-        .pull_requests
-        .insert(
-            "task-1".to_string(),
-            host_domain::PullRequestRecord {
-                provider_id: "github".to_string(),
-                number: 17,
-                url: "https://github.com/openai/openducktor/pull/17".to_string(),
-                state: "open".to_string(),
-                created_at: "2026-03-11T10:00:00Z".to_string(),
-                updated_at: "2026-03-11T10:00:00Z".to_string(),
-                last_synced_at: None,
-                merged_at: None,
-                closed_at: None,
-            },
-        );
-    {
-        let mut git = git_state.lock().expect("git state lock poisoned");
-        git.branches = vec![GitBranch {
-            name: "odt/task-1".to_string(),
-            is_current: false,
-            is_remote: false,
-        }];
-    }
-
-    let error = service
-        .repo_pull_request_sync(repo_path.as_str())
+    let error = fixture
+        .service
+        .repo_pull_request_sync(fixture.repo_path.as_str())
         .expect_err("invalid close transition should fail sync");
     assert!(error.to_string().contains("Transition not allowed"));
 
-    let state = task_state.lock().expect("task state lock poisoned");
+    let state = fixture.task_state.lock().expect("task state lock poisoned");
     assert_eq!(
         state
             .tasks
             .iter()
-            .find(|task| task.id == "task-1")
+            .find(|task| task.id == TASK_ID)
             .map(|task| &task.status),
         Some(&TaskStatus::Open),
     );
     assert_eq!(
         state
             .pull_requests
-            .get("task-1")
+            .get(TASK_ID)
             .map(|pull_request| pull_request.state.as_str()),
         Some("merged"),
     );
     drop(state);
 
-    let git = git_state.lock().expect("git state lock poisoned");
+    let git = fixture.git_state.lock().expect("git state lock poisoned");
     assert!(git
         .calls
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
     assert!(git.calls.iter().any(
-        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == TASK_SOURCE_BRANCH)
     ));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&fixture.root);
     Ok(())
 }
 
 #[test]
 fn task_pull_request_link_merged_closes_task_and_cleans_up_worktree() -> Result<()> {
-    let root = unique_temp_path("approval-pr-link-merged");
-    let repo = root.join("repo");
-    let worktree_base = root.join("worktrees");
-    let worktree_path = worktree_base.join("task-1");
-    init_git_repo(&repo)?;
-    fs::create_dir_all(&worktree_path)?;
-
-    let config_store = AppConfigStore::from_path(root.join("config.json"));
-    let (service, task_state, git_state) = build_service_with_store(
-        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
-        vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-            revision: None,
-        },
-        config_store,
-    );
-    let repo_path = repo.to_string_lossy().to_string();
-    service.workspace_add(repo_path.as_str())?;
-    service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
-    configure_builder_session(
-        repo_path.as_str(),
-        &worktree_path,
-        "odt/task-1",
-        &service,
-        &task_state,
-        &git_state,
+    let fixture = setup_pull_request_workflow_fixture(
+        "approval-pr-link-merged",
+        "task",
+        TaskStatus::HumanReview,
     )?;
-    {
-        let mut git = git_state.lock().expect("git state lock poisoned");
-        git.branches = vec![GitBranch {
-            name: "odt/task-1".to_string(),
-            is_current: false,
-            is_remote: false,
-        }];
-    }
+    set_local_task_branch(&fixture.git_state, TASK_SOURCE_BRANCH);
 
-    let task = service.task_pull_request_link_merged(
-        repo_path.as_str(),
-        "task-1",
-        host_domain::PullRequestRecord {
-            provider_id: "github".to_string(),
-            number: 17,
-            url: "https://github.com/openai/openducktor/pull/17".to_string(),
-            state: "merged".to_string(),
-            created_at: "2026-03-11T10:00:00Z".to_string(),
-            updated_at: "2026-03-11T10:10:00Z".to_string(),
-            last_synced_at: Some("2026-03-11T10:10:00Z".to_string()),
-            merged_at: Some("2026-03-11T10:10:00Z".to_string()),
-            closed_at: Some("2026-03-11T10:10:00Z".to_string()),
-        },
+    let task = fixture.service.task_pull_request_link_merged(
+        fixture.repo_path.as_str(),
+        TASK_ID,
+        merged_pull_request_record(),
     )?;
 
     assert_eq!(task.status, TaskStatus::Closed);
-    let state = task_state.lock().expect("task state lock poisoned");
+    let state = fixture.task_state.lock().expect("task state lock poisoned");
     assert_eq!(
         state
             .pull_requests
-            .get("task-1")
+            .get(TASK_ID)
             .map(|pull_request| pull_request.state.as_str()),
         Some("merged")
     );
     drop(state);
 
-    let git = git_state.lock().expect("git state lock poisoned");
+    let git = fixture.git_state.lock().expect("git state lock poisoned");
     assert!(git
         .calls
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
     assert!(git.calls.iter().any(
-        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == TASK_SOURCE_BRANCH)
     ));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&fixture.root);
     Ok(())
 }
 
 #[test]
 fn task_pull_request_link_merged_closes_already_linked_task_without_live_builder_worktree(
 ) -> Result<()> {
-    let root = unique_temp_path("approval-pr-link-merged-missing-worktree");
-    let repo = root.join("repo");
-    let worktree_base = root.join("worktrees");
-    let worktree_path = worktree_base.join("task-1");
-    init_git_repo(&repo)?;
-    fs::create_dir_all(&worktree_path)?;
-
-    let config_store = AppConfigStore::from_path(root.join("config.json"));
-    let (service, task_state, git_state) = build_service_with_store(
-        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
-        vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-            revision: None,
-        },
-        config_store,
-    );
-    let repo_path = repo.to_string_lossy().to_string();
-    service.workspace_add(repo_path.as_str())?;
-    service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
-    configure_builder_session(
-        repo_path.as_str(),
-        &worktree_path,
-        "odt/task-1",
-        &service,
-        &task_state,
-        &git_state,
+    let fixture = setup_pull_request_workflow_fixture(
+        "approval-pr-link-merged-missing-worktree",
+        "task",
+        TaskStatus::HumanReview,
     )?;
-    task_state
-        .lock()
-        .expect("task state lock poisoned")
-        .pull_requests
-        .insert(
-            "task-1".to_string(),
-            host_domain::PullRequestRecord {
-                provider_id: "github".to_string(),
-                number: 17,
-                url: "https://github.com/openai/openducktor/pull/17".to_string(),
-                state: "merged".to_string(),
-                created_at: "2026-03-11T10:00:00Z".to_string(),
-                updated_at: "2026-03-11T10:10:00Z".to_string(),
-                last_synced_at: Some("2026-03-11T10:10:00Z".to_string()),
-                merged_at: Some("2026-03-11T10:10:00Z".to_string()),
-                closed_at: Some("2026-03-11T10:10:00Z".to_string()),
-            },
-        );
-    {
-        let mut git = git_state.lock().expect("git state lock poisoned");
-        git.branches = vec![GitBranch {
-            name: "odt/task-1".to_string(),
-            is_current: false,
-            is_remote: false,
-        }];
-    }
-    fs::remove_dir_all(&worktree_path)?;
+    insert_task_pull_request(&fixture.task_state, merged_pull_request_record());
+    set_local_task_branch(&fixture.git_state, TASK_SOURCE_BRANCH);
+    fs::remove_dir_all(&fixture.worktree_path)?;
 
-    let task = service.task_pull_request_link_merged(
-        repo_path.as_str(),
-        "task-1",
-        host_domain::PullRequestRecord {
-            provider_id: "github".to_string(),
-            number: 17,
-            url: "https://github.com/openai/openducktor/pull/17".to_string(),
-            state: "merged".to_string(),
-            created_at: "2026-03-11T10:00:00Z".to_string(),
-            updated_at: "2026-03-11T10:10:00Z".to_string(),
-            last_synced_at: Some("2026-03-11T10:10:00Z".to_string()),
-            merged_at: Some("2026-03-11T10:10:00Z".to_string()),
-            closed_at: Some("2026-03-11T10:10:00Z".to_string()),
-        },
+    let task = fixture.service.task_pull_request_link_merged(
+        fixture.repo_path.as_str(),
+        TASK_ID,
+        merged_pull_request_record(),
     )?;
 
     assert_eq!(task.status, TaskStatus::Closed);
-    let git = git_state.lock().expect("git state lock poisoned");
+    let git = fixture.git_state.lock().expect("git state lock poisoned");
     assert!(!git
         .calls
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
     assert!(!git.calls.iter().any(
-        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == TASK_SOURCE_BRANCH)
     ));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&fixture.root);
+    Ok(())
+}
+
+#[test]
+fn task_pull_request_link_merged_persists_metadata_when_close_transition_is_invalid() -> Result<()>
+{
+    let fixture = setup_pull_request_workflow_fixture(
+        "approval-pr-link-merged-close-error",
+        "task",
+        TaskStatus::InProgress,
+    )?;
+    set_local_task_branch(&fixture.git_state, TASK_SOURCE_BRANCH);
+
+    let error = fixture
+        .service
+        .task_pull_request_link_merged(
+            fixture.repo_path.as_str(),
+            TASK_ID,
+            merged_pull_request_record(),
+        )
+        .expect_err("invalid close transition should fail merged PR linking");
+    assert!(error.to_string().contains("Transition not allowed"));
+
+    let state = fixture.task_state.lock().expect("task state lock poisoned");
+    assert_eq!(
+        state
+            .tasks
+            .iter()
+            .find(|task| task.id == TASK_ID)
+            .map(|task| &task.status),
+        Some(&TaskStatus::InProgress),
+    );
+    assert_eq!(
+        state
+            .pull_requests
+            .get(TASK_ID)
+            .map(|pull_request| pull_request.state.as_str()),
+        Some("merged"),
+    );
+    drop(state);
+
+    let git = fixture.git_state.lock().expect("git state lock poisoned");
+    assert!(git
+        .calls
+        .iter()
+        .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
+    assert!(git.calls.iter().any(
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == TASK_SOURCE_BRANCH)
+    ));
+
+    let _ = fs::remove_dir_all(&fixture.root);
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
@@ -2127,6 +2127,123 @@ fn repo_pull_request_sync_closes_tasks_when_linked_pull_request_is_merged() -> R
 }
 
 #[test]
+fn repo_pull_request_sync_closes_tasks_when_builder_worktree_is_already_missing() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("approval-pr-sync-missing-worktree");
+    let repo = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    let worktree_path = worktree_base.join("task-1");
+    let create_response = root.join("create.json");
+    let update_response = root.join("update.json");
+    let fetch_response = root.join("fetch.json");
+    init_git_repo(&repo)?;
+    fs::create_dir_all(&worktree_path)?;
+    write_json(&create_response, "{}")?;
+    write_json(&update_response, "{}")?;
+    write_json(
+        &fetch_response,
+        r#"{"number":17,"html_url":"https://github.com/openai/openducktor/pull/17","title":"Merged PR","draft":false,"state":"closed","created_at":"2026-03-11T10:00:00Z","updated_at":"2026-03-11T10:10:00Z","merged_at":"2026-03-11T10:10:00Z","closed_at":"2026-03-11T10:10:00Z","head":{"ref":"odt/task-1"},"base":{"ref":"main"}}"#,
+    )?;
+
+    let bin_dir = write_fake_gh(&root)?;
+    let _path_guard = prepend_path(&bin_dir);
+    let _auth_ok_guard = set_env_var("ODT_GH_AUTH_OK", "1");
+    let _auth_login_guard = set_env_var("ODT_GH_AUTH_LOGIN", "octocat");
+    let _create_guard = set_env_var(
+        "ODT_GH_CREATE_RESPONSE",
+        create_response.to_string_lossy().as_ref(),
+    );
+    let _update_guard = set_env_var(
+        "ODT_GH_UPDATE_RESPONSE",
+        update_response.to_string_lossy().as_ref(),
+    );
+    let _fetch_guard = set_env_var(
+        "ODT_GH_FETCH_RESPONSE",
+        fetch_response.to_string_lossy().as_ref(),
+    );
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, task_state, git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    let repo_path = repo.to_string_lossy().to_string();
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
+    configure_builder_session(
+        repo_path.as_str(),
+        &worktree_path,
+        "odt/task-1",
+        &service,
+        &task_state,
+        &git_state,
+    )?;
+    task_state
+        .lock()
+        .expect("task state lock poisoned")
+        .pull_requests
+        .insert(
+            "task-1".to_string(),
+            host_domain::PullRequestRecord {
+                provider_id: "github".to_string(),
+                number: 17,
+                url: "https://github.com/openai/openducktor/pull/17".to_string(),
+                state: "open".to_string(),
+                created_at: "2026-03-11T10:00:00Z".to_string(),
+                updated_at: "2026-03-11T10:00:00Z".to_string(),
+                last_synced_at: None,
+                merged_at: None,
+                closed_at: None,
+            },
+        );
+    {
+        let mut git = git_state.lock().expect("git state lock poisoned");
+        git.branches = vec![GitBranch {
+            name: "odt/task-1".to_string(),
+            is_current: false,
+            is_remote: false,
+        }];
+    }
+    fs::remove_dir_all(&worktree_path)?;
+
+    assert!(service.repo_pull_request_sync(repo_path.as_str())?);
+
+    let state = task_state.lock().expect("task state lock poisoned");
+    let task = state
+        .tasks
+        .iter()
+        .find(|task| task.id == "task-1")
+        .ok_or_else(|| anyhow!("task not found after sync"))?;
+    assert_eq!(task.status, TaskStatus::Closed);
+    assert_eq!(
+        state
+            .pull_requests
+            .get("task-1")
+            .map(|entry| entry.state.as_str()),
+        Some("merged"),
+    );
+    drop(state);
+
+    let git = git_state.lock().expect("git state lock poisoned");
+    assert!(!git
+        .calls
+        .iter()
+        .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
+    assert!(git.calls.iter().any(
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
+    ));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn repo_pull_request_sync_propagates_close_transition_failures() -> Result<()> {
     let _env_lock = lock_env();
     let root = unique_temp_path("approval-pr-sync-close-error");
@@ -2320,6 +2437,96 @@ fn task_pull_request_link_merged_closes_task_and_cleans_up_worktree() -> Result<
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
     assert!(git.calls.iter().any(
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
+    ));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn task_pull_request_link_merged_closes_already_linked_task_without_live_builder_worktree(
+) -> Result<()> {
+    let root = unique_temp_path("approval-pr-link-merged-missing-worktree");
+    let repo = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    let worktree_path = worktree_base.join("task-1");
+    init_git_repo(&repo)?;
+    fs::create_dir_all(&worktree_path)?;
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, task_state, git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    let repo_path = repo.to_string_lossy().to_string();
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
+    configure_builder_session(
+        repo_path.as_str(),
+        &worktree_path,
+        "odt/task-1",
+        &service,
+        &task_state,
+        &git_state,
+    )?;
+    task_state
+        .lock()
+        .expect("task state lock poisoned")
+        .pull_requests
+        .insert(
+            "task-1".to_string(),
+            host_domain::PullRequestRecord {
+                provider_id: "github".to_string(),
+                number: 17,
+                url: "https://github.com/openai/openducktor/pull/17".to_string(),
+                state: "merged".to_string(),
+                created_at: "2026-03-11T10:00:00Z".to_string(),
+                updated_at: "2026-03-11T10:10:00Z".to_string(),
+                last_synced_at: Some("2026-03-11T10:10:00Z".to_string()),
+                merged_at: Some("2026-03-11T10:10:00Z".to_string()),
+                closed_at: Some("2026-03-11T10:10:00Z".to_string()),
+            },
+        );
+    {
+        let mut git = git_state.lock().expect("git state lock poisoned");
+        git.branches = vec![GitBranch {
+            name: "odt/task-1".to_string(),
+            is_current: false,
+            is_remote: false,
+        }];
+    }
+    fs::remove_dir_all(&worktree_path)?;
+
+    let task = service.task_pull_request_link_merged(
+        repo_path.as_str(),
+        "task-1",
+        host_domain::PullRequestRecord {
+            provider_id: "github".to_string(),
+            number: 17,
+            url: "https://github.com/openai/openducktor/pull/17".to_string(),
+            state: "merged".to_string(),
+            created_at: "2026-03-11T10:00:00Z".to_string(),
+            updated_at: "2026-03-11T10:10:00Z".to_string(),
+            last_synced_at: Some("2026-03-11T10:10:00Z".to_string()),
+            merged_at: Some("2026-03-11T10:10:00Z".to_string()),
+            closed_at: Some("2026-03-11T10:10:00Z".to_string()),
+        },
+    )?;
+
+    assert_eq!(task.status, TaskStatus::Closed);
+    let git = git_state.lock().expect("git state lock poisoned");
+    assert!(!git
+        .calls
+        .iter()
+        .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
+    assert!(!git.calls.iter().any(
         |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == "odt/task-1")
     ));
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
@@ -226,6 +226,25 @@ fn insert_task_pull_request(task_state: &TaskStateHandle, pull_request: PullRequ
         .insert(TASK_ID.to_string(), pull_request);
 }
 
+fn insert_task_direct_merge_record(task_state: &TaskStateHandle) {
+    task_state
+        .lock()
+        .expect("task state lock poisoned")
+        .direct_merge_records
+        .insert(
+            TASK_ID.to_string(),
+            host_domain::DirectMergeRecord {
+                method: host_domain::GitMergeMethod::MergeCommit,
+                source_branch: TASK_SOURCE_BRANCH.to_string(),
+                target_branch: host_domain::GitTargetBranch {
+                    remote: None,
+                    branch: "main".to_string(),
+                },
+                merged_at: LINKED_PULL_REQUEST_MERGED_AT.to_string(),
+            },
+        );
+}
+
 fn set_local_task_branch(git_state: &GitStateHandle, branch: &str) {
     git_state.lock().expect("git state lock poisoned").branches = vec![GitBranch {
         name: branch.to_string(),
@@ -2181,6 +2200,7 @@ fn repo_pull_request_sync_closes_tasks_when_linked_pull_request_is_merged() -> R
         setup_pull_request_workflow_fixture("approval-pr-sync", "task", TaskStatus::HumanReview)?;
     let _github = setup_fake_gh_for_merged_pull_request(&fixture.root, TASK_SOURCE_BRANCH, "main")?;
     insert_task_pull_request(&fixture.task_state, open_pull_request_record());
+    insert_task_direct_merge_record(&fixture.task_state);
     set_local_task_branch(&fixture.git_state, TASK_SOURCE_BRANCH);
 
     assert!(fixture
@@ -2201,6 +2221,7 @@ fn repo_pull_request_sync_closes_tasks_when_linked_pull_request_is_merged() -> R
             .map(|entry| entry.state.as_str()),
         Some("merged"),
     );
+    assert!(!state.direct_merge_records.contains_key(TASK_ID));
     drop(state);
 
     let git = fixture.git_state.lock().expect("git state lock poisoned");
@@ -2566,85 +2587,31 @@ fn task_pull_request_link_merged_blocks_when_direct_merge_is_pending() -> Result
 
 #[test]
 fn task_pull_request_link_merged_retries_cleanup_for_same_pull_request() -> Result<()> {
-    let root = unique_temp_path("approval-pr-link-merged-retry-cleanup");
-    let repo = root.join("repo");
-    let worktree_base = root.join("worktrees");
-    let worktree_path = worktree_base.join("task-1");
-    init_git_repo(&repo)?;
-    fs::create_dir_all(&worktree_path)?;
-
-    let config_store = AppConfigStore::from_path(root.join("config.json"));
-    let (service, task_state, git_state) = build_service_with_store(
-        vec![make_task("task-1", "task", TaskStatus::Closed)],
-        vec![],
-        GitCurrentBranch {
-            name: Some("main".to_string()),
-            detached: false,
-            revision: None,
-        },
-        config_store,
-    );
-    let repo_path = repo.to_string_lossy().to_string();
-    service.workspace_add(repo_path.as_str())?;
-    service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
-    configure_builder_session(
-        repo_path.as_str(),
-        &worktree_path,
-        "odt/task-1",
-        &service,
-        &task_state,
-        &git_state,
+    let fixture = setup_pull_request_workflow_fixture(
+        "approval-pr-link-merged-retry-cleanup",
+        "task",
+        TaskStatus::HumanReview,
     )?;
-    {
-        let mut state = task_state.lock().expect("task state lock poisoned");
-        state.pull_requests.insert(
-            "task-1".to_string(),
-            host_domain::PullRequestRecord {
-                provider_id: "github".to_string(),
-                number: 17,
-                url: "https://github.com/openai/openducktor/pull/17".to_string(),
-                state: "merged".to_string(),
-                created_at: "2026-03-11T10:00:00Z".to_string(),
-                updated_at: "2026-03-11T10:10:00Z".to_string(),
-                last_synced_at: Some("2026-03-11T10:10:00Z".to_string()),
-                merged_at: Some("2026-03-11T10:10:00Z".to_string()),
-                closed_at: Some("2026-03-11T10:10:00Z".to_string()),
-            },
-        );
-    }
-    {
-        let mut git = git_state.lock().expect("git state lock poisoned");
-        git.branches = vec![GitBranch {
-            name: "odt/task-1".to_string(),
-            is_current: false,
-            is_remote: false,
-        }];
-    }
+    insert_task_pull_request(&fixture.task_state, merged_pull_request_record());
+    set_local_task_branch(&fixture.git_state, TASK_SOURCE_BRANCH);
 
-    let task = service.task_pull_request_link_merged(
-        repo_path.as_str(),
-        "task-1",
-        host_domain::PullRequestRecord {
-            provider_id: "github".to_string(),
-            number: 17,
-            url: "https://github.com/openai/openducktor/pull/17".to_string(),
-            state: "merged".to_string(),
-            created_at: "2026-03-11T10:00:00Z".to_string(),
-            updated_at: "2026-03-11T10:10:00Z".to_string(),
-            last_synced_at: Some("2026-03-11T10:10:00Z".to_string()),
-            merged_at: Some("2026-03-11T10:10:00Z".to_string()),
-            closed_at: Some("2026-03-11T10:10:00Z".to_string()),
-        },
+    let task = fixture.service.task_pull_request_link_merged(
+        fixture.repo_path.as_str(),
+        TASK_ID,
+        merged_pull_request_record(),
     )?;
 
     assert_eq!(task.status, TaskStatus::Closed);
-    let git = git_state.lock().expect("git state lock poisoned");
-    assert!(!git
+    let git = fixture.git_state.lock().expect("git state lock poisoned");
+    assert!(git
         .calls
         .iter()
         .any(|call| matches!(call, GitCall::RemoveWorktree { .. })));
+    assert!(git.calls.iter().any(
+        |call| matches!(call, GitCall::DeleteLocalBranch { branch, .. } if branch == TASK_SOURCE_BRANCH)
+    ));
 
-    let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(&fixture.root);
     Ok(())
 }
 

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -487,6 +487,64 @@ describe("useAppLifecycle", () => {
     }
   });
 
+  test("keeps periodic PR sync active across parent rerenders such as route changes", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTasksWithOptions = mock(async () => {});
+    const baseArgs: HookArgs = {
+      activeRepo: "/repo",
+      setEvents: mock((_updater) => {}),
+      setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+      refreshWorkspaces: mock(async () => {}),
+      refreshBranches: mock(async () => {}),
+      refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+      refreshBeadsCheckForRepo: mock(async () => ({
+        beadsOk: true,
+        beadsPath: "/repo/.beads",
+        beadsError: null,
+      })),
+      refreshTaskData: mock(async () => {}),
+      refreshTasksWithOptions,
+      clearBranchData: mock(() => {}),
+      pullRequestSyncIntervalMs: 20,
+    };
+
+    const Harness = ({ args, route }: { args: HookArgs; route: string }) => {
+      useAppLifecycle(args);
+      return <div data-route={route} />;
+    };
+
+    const intervalController = createIntervalController();
+    const harness = createSharedHookHarness(Harness, {
+      args: baseArgs,
+      route: "/kanban",
+    });
+
+    try {
+      await harness.mount();
+
+      intervalController.tick();
+      await harness.waitFor(() => refreshTasksWithOptions.mock.calls.length === 1, 1000);
+
+      await harness.update({
+        args: baseArgs,
+        route: "/agents",
+      });
+
+      expect(refreshTasksWithOptions).toHaveBeenCalledTimes(1);
+
+      intervalController.tick();
+      await harness.waitFor(() => refreshTasksWithOptions.mock.calls.length === 2, 1000);
+
+      expect(refreshTasksWithOptions).toHaveBeenNthCalledWith(1, { trigger: "scheduled" });
+      expect(refreshTasksWithOptions).toHaveBeenNthCalledWith(2, { trigger: "scheduled" });
+    } finally {
+      await harness.unmount();
+      intervalController.restore();
+    }
+  });
+
   test("does not block repo diagnostics load on branch refresh completion", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = Parameters<typeof useAppLifecycle>[0];


### PR DESCRIPTION
## Problem
Linked pull request refresh was expected to keep working anywhere in the visible app, but merged-task closure could still fail when the Builder worktree had already been removed. The host also handled merged linked PR completion through multiple paths, which made the edge cases harder to keep consistent.

## Summary
- centralize linked merged-PR completion in the host workflow so repo sync and manual merged-PR linking share the same metadata persistence, cleanup, and close-transition path
- allow already-linked merged PRs to close tasks even when the Builder worktree is already gone, while still surfacing real workflow-transition or provider failures
- add lifecycle regression coverage proving scheduled PR sync is route-independent within the visible app, plus host integration coverage for missing-worktree and invalid-transition edge cases

## Implementation Details
- add `LinkedPullRequestMergeService` to own the shared "persist merged PR and close task" workflow
- update `PullRequestSyncService` to use the shared merge-completion path when a linked PR becomes merged
- update `task_pull_request_link_merged` to skip Builder cleanup when the merged PR is already durably linked, instead of failing on missing live worktree state
- refactor `approval_workflow.rs` with small PR test fixtures/helpers so the merged-PR scenarios are easier to read and extend

## Testing
- `bun run --filter @openducktor/desktop test`
- `cargo test -p host-application`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced pull request merge workflow with automatic task closure and branch cleanup handling.

* **Tests**
  * Expanded integration test coverage for approval workflows and app lifecycle management to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->