### PR TITLE
perf(desktop): avoid repo-wide task scans during build start

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -1,18 +1,18 @@
 use super::super::{
-    emit_event, validate_transition, AppService, OpencodeStartupReadinessPolicy,
-    OpencodeStartupWaitReport, RunEmitter, RunProcess, RuntimeInstanceSummary, StartupEventContext,
-    StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
+    emit_event, AppService, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, RunEmitter,
+    RunProcess, RuntimeInstanceSummary, StartupEventContext, StartupEventCorrelation,
+    StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
 };
 use super::build_runtime_setup::{BuildPrerequisites, PreparedBuildWorktree};
 use super::BuildResponseAction;
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     now_rfc3339, AgentRuntimeKind, AgentSessionDocument, RunEvent, RunState, RunSummary,
-    RuntimeRoute, TaskStatus, UpdateTaskPatch,
+    RuntimeRoute, TaskStatus,
 };
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, PathBuf};
 use std::time::Duration;
 use url::form_urlencoded;
 use uuid::Uuid;
@@ -380,7 +380,10 @@ impl AppService {
             run_id,
             emitter,
         } = input;
-        self.transition_build_task_to_in_progress(prerequisites.repo_path.as_str(), task_id)?;
+        self.task_transition_to_in_progress_without_related_tasks(
+            prerequisites.repo_path.as_str(),
+            task_id,
+        )?;
 
         let worktree_path = prepared_worktree
             .worktree_dir
@@ -416,40 +419,6 @@ impl AppService {
             worktree_path,
             emitter,
         })
-    }
-
-    fn transition_build_task_to_in_progress(&self, repo_path: &str, task_id: &str) -> Result<()> {
-        let repo_path_ref = Path::new(repo_path);
-        let task = self.task_store.get_task(repo_path_ref, task_id)?;
-        validate_transition(
-            &task,
-            std::slice::from_ref(&task),
-            &task.status,
-            &TaskStatus::InProgress,
-        )?;
-
-        if task.status == TaskStatus::InProgress {
-            return Ok(());
-        }
-
-        self.task_store.update_task(
-            repo_path_ref,
-            task_id,
-            UpdateTaskPatch {
-                title: None,
-                description: None,
-                notes: None,
-                status: Some(TaskStatus::InProgress),
-                priority: None,
-                issue_type: None,
-                ai_review_enabled: None,
-                labels: None,
-                assignee: None,
-                parent_id: None,
-            },
-        )?;
-
-        Ok(())
     }
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_lifecycle.rs
@@ -1,18 +1,18 @@
 use super::super::{
-    emit_event, AppService, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, RunEmitter,
-    RunProcess, RuntimeInstanceSummary, StartupEventContext, StartupEventCorrelation,
-    StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
+    emit_event, validate_transition, AppService, OpencodeStartupReadinessPolicy,
+    OpencodeStartupWaitReport, RunEmitter, RunProcess, RuntimeInstanceSummary, StartupEventContext,
+    StartupEventCorrelation, StartupEventPayload, STARTUP_CONFIG_INVALID_REASON,
 };
 use super::build_runtime_setup::{BuildPrerequisites, PreparedBuildWorktree};
 use super::BuildResponseAction;
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     now_rfc3339, AgentRuntimeKind, AgentSessionDocument, RunEvent, RunState, RunSummary,
-    RuntimeRoute, TaskStatus,
+    RuntimeRoute, TaskStatus, UpdateTaskPatch,
 };
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
-use std::path::{Component, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::time::Duration;
 use url::form_urlencoded;
 use uuid::Uuid;
@@ -380,12 +380,7 @@ impl AppService {
             run_id,
             emitter,
         } = input;
-        self.task_transition(
-            prerequisites.repo_path.as_str(),
-            task_id,
-            TaskStatus::InProgress,
-            Some("Builder delegated"),
-        )?;
+        self.transition_build_task_to_in_progress(prerequisites.repo_path.as_str(), task_id)?;
 
         let worktree_path = prepared_worktree
             .worktree_dir
@@ -421,6 +416,40 @@ impl AppService {
             worktree_path,
             emitter,
         })
+    }
+
+    fn transition_build_task_to_in_progress(&self, repo_path: &str, task_id: &str) -> Result<()> {
+        let repo_path_ref = Path::new(repo_path);
+        let task = self.task_store.get_task(repo_path_ref, task_id)?;
+        validate_transition(
+            &task,
+            std::slice::from_ref(&task),
+            &task.status,
+            &TaskStatus::InProgress,
+        )?;
+
+        if task.status == TaskStatus::InProgress {
+            return Ok(());
+        }
+
+        self.task_store.update_task(
+            repo_path_ref,
+            task_id,
+            UpdateTaskPatch {
+                title: None,
+                description: None,
+                notes: None,
+                status: Some(TaskStatus::InProgress),
+                priority: None,
+                issue_type: None,
+                ai_review_enabled: None,
+                labels: None,
+                assignee: None,
+                parent_id: None,
+            },
+        )?;
+
+        Ok(())
     }
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -98,13 +98,15 @@ impl AppService {
 
         validate_hook_trust(repo_path.as_str(), &repo_config)?;
 
-        let tasks = self.task_store.list_tasks(Path::new(repo_path.as_str()))?;
-        let task = tasks
-            .iter()
-            .find(|entry| entry.id == task_id)
-            .cloned()
-            .ok_or_else(|| anyhow!("Task not found: {task_id}"))?;
-        validate_transition(&task, &tasks, &task.status, &TaskStatus::InProgress)?;
+        let task = self
+            .task_store
+            .get_task(Path::new(repo_path.as_str()), task_id)?;
+        validate_transition(
+            &task,
+            std::slice::from_ref(&task),
+            &task.status,
+            &TaskStatus::InProgress,
+        )?;
 
         let branch = build_branch_name(&repo_config.branch_prefix, task_id, &task.title);
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/build_orchestrator/build_runtime_setup.rs
@@ -1,5 +1,6 @@
 use super::super::{
-    run_parsed_hook_command_allow_failure, validate_hook_trust, validate_transition, AppService,
+    run_parsed_hook_command_allow_failure, validate_hook_trust,
+    validate_transition_without_related_tasks, AppService,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::TaskStatus;
@@ -101,12 +102,7 @@ impl AppService {
         let task = self
             .task_store
             .get_task(Path::new(repo_path.as_str()), task_id)?;
-        validate_transition(
-            &task,
-            std::slice::from_ref(&task),
-            &task.status,
-            &TaskStatus::InProgress,
-        )?;
+        validate_transition_without_related_tasks(&task, &task.status, &TaskStatus::InProgress)?;
 
         let branch = build_branch_name(&repo_config.branch_prefix, task_id, &task.title);
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use fs2::FileExt;
 use host_domain::{
     DevServerEvent, DevServerGroupState, GitPort, RunEvent, RunSummary, RuntimeCheck,
@@ -41,23 +41,22 @@ pub(crate) use events::emit_event;
 pub(crate) use hook_security::{run_parsed_hook_command_allow_failure, validate_hook_trust};
 pub use opencode_runtime::OpencodeStartupWaitFailure;
 pub(crate) use opencode_runtime::{
-    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupCancelEpoch,
     opencode_server_parent_pid, process_exists, read_opencode_version,
     resolve_opencode_binary_path, spawn_opencode_server, terminate_child_process,
     terminate_process_by_pid, wait_for_local_server_with_process, wait_for_process_exit_by_pid,
+    OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport, StartupCancelEpoch,
 };
 pub(crate) use opencode_session_status::{
-    OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget,
     dedupe_probe_targets as dedupe_opencode_session_status_probe_targets,
-    has_live_opencode_session_status,
+    has_live_opencode_session_status, OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget,
 };
-pub(crate) use process_registry::TrackedOpencodeProcessGuard;
 #[cfg(test)]
 pub(crate) use process_registry::read_opencode_process_registry;
+pub(crate) use process_registry::TrackedOpencodeProcessGuard;
 #[cfg(test)]
 pub(crate) use process_registry::{
-    OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH, OpencodeProcessRegistryInstance,
-    with_locked_opencode_process_registry,
+    with_locked_opencode_process_registry, OpencodeProcessRegistryInstance,
+    OPENCODE_PROCESS_REGISTRY_RELATIVE_PATH,
 };
 pub(crate) use service_core::{
     AgentRuntimeProcess, CachedRuntimeCheck, DevServerGroupRuntime, RunProcess,
@@ -66,14 +65,14 @@ pub(crate) use service_core::{
 pub use service_core::{AppService, DevServerEmitter, RunEmitter};
 #[cfg(test)]
 pub(crate) use startup_metrics::{
-    OpencodeStartupMetricsSnapshot, build_opencode_startup_event_payload,
+    build_opencode_startup_event_payload, OpencodeStartupMetricsSnapshot,
 };
 pub(crate) use startup_metrics::{
-    STARTUP_CONFIG_INVALID_REASON, StartupEventContext, StartupEventCorrelation,
-    StartupEventPayload,
+    StartupEventContext, StartupEventCorrelation, StartupEventPayload,
+    STARTUP_CONFIG_INVALID_REASON,
 };
 pub(crate) use workflow_rules::{
-    derive_agent_workflows, derive_available_actions, validate_transition,
+    derive_agent_workflows, derive_available_actions, validate_transition_without_related_tasks,
 };
 pub use workspace_policy::{
     HookTrustConfirmationPort, HookTrustConfirmationRequest, PreparedHookTrustChallenge,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mod.rs
@@ -83,7 +83,7 @@ pub use workspace_policy::{
 pub(crate) use workflow_rules::{
     can_set_plan, can_set_spec_from_status, normalize_required_markdown,
     normalize_subtask_plan_inputs, validate_parent_relationships_for_create,
-    validate_parent_relationships_for_update, validate_plan_subtask_rules,
+    validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_service.rs
@@ -6,6 +6,7 @@ use crate::app_service::task_workflow::{
 use crate::app_service::workflow_rules::{
     default_qa_required_for_issue_type, is_open_state, validate_parent_relationships_for_create,
     validate_parent_relationships_for_update, validate_transition,
+    validate_transition_without_related_tasks,
 };
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
@@ -136,6 +137,41 @@ impl AppService {
         Ok(self.enrich_task(updated, &context.repo.tasks))
     }
 
+    pub(crate) fn task_transition_to_in_progress_without_related_tasks(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+    ) -> Result<TaskCard> {
+        let repo_path = self.resolve_task_repo_path(repo_path)?;
+        let repo_dir = std::path::Path::new(&repo_path);
+        let task = self.task_store.get_task(repo_dir, task_id)?;
+
+        validate_transition_without_related_tasks(&task, &task.status, &TaskStatus::InProgress)?;
+
+        if task.status == TaskStatus::InProgress {
+            return Ok(self.enrich_task(task.clone(), std::slice::from_ref(&task)));
+        }
+
+        let updated = self.task_store.update_task(
+            repo_dir,
+            task_id,
+            UpdateTaskPatch {
+                title: None,
+                description: None,
+                notes: None,
+                status: Some(TaskStatus::InProgress),
+                priority: None,
+                issue_type: None,
+                ai_review_enabled: None,
+                labels: None,
+                assignee: None,
+                parent_id: None,
+            },
+        )?;
+
+        Ok(self.enrich_task(updated.clone(), std::slice::from_ref(&updated)))
+    }
+
     pub fn build_blocked(
         &self,
         repo_path: &str,
@@ -150,12 +186,7 @@ impl AppService {
     }
 
     pub fn build_resumed(&self, repo_path: &str, task_id: &str) -> Result<TaskCard> {
-        self.task_transition(
-            repo_path,
-            task_id,
-            TaskStatus::InProgress,
-            Some("Builder resumed"),
-        )
+        self.task_transition_to_in_progress_without_related_tasks(repo_path, task_id)
     }
 
     pub fn build_completed(
@@ -185,11 +216,11 @@ impl AppService {
         &self,
         repo_path: &str,
         task_id: &str,
-        note: Option<&str>,
+        _note: Option<&str>,
     ) -> Result<TaskCard> {
-        let context = self.load_task_context(repo_path, task_id)?;
+        let repo_path = self.resolve_task_repo_path(repo_path)?;
         if self
-            .task_metadata_get(context.repo.repo_path.as_str(), task_id)?
+            .task_metadata_get(repo_path.as_str(), task_id)?
             .direct_merge
             .is_some()
         {
@@ -197,11 +228,7 @@ impl AppService {
                 "Cannot request changes after a local direct merge has already been applied for task {task_id}. Push and complete the direct merge workflow first, or manually revert the local merge before reopening the task."
             ));
         }
-        let reason = note
-            .map(str::trim)
-            .filter(|entry| !entry.is_empty())
-            .unwrap_or("Human requested changes");
-        self.task_transition(repo_path, task_id, TaskStatus::InProgress, Some(reason))
+        self.task_transition_to_in_progress_without_related_tasks(repo_path.as_str(), task_id)
     }
 
     pub fn human_approve(&self, repo_path: &str, task_id: &str) -> Result<TaskCard> {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -86,6 +86,8 @@ pub(crate) struct TaskStoreState {
     pub(crate) ensure_calls: Vec<String>,
     pub(crate) ensure_error: Option<String>,
     pub(crate) tasks: Vec<TaskCard>,
+    pub(crate) get_task_calls: Vec<String>,
+    pub(crate) get_task_error: Option<String>,
     pub(crate) list_error: Option<String>,
     pub(crate) delete_calls: Vec<(String, bool)>,
     pub(crate) delete_error: Option<String>,
@@ -132,6 +134,20 @@ impl TaskStore for FakeTaskStore {
             return Err(anyhow!(message.clone()));
         }
         Ok(state.tasks.clone())
+    }
+
+    fn get_task(&self, _repo_path: &Path, task_id: &str) -> Result<TaskCard> {
+        let mut state = self.state.lock().expect("task store lock poisoned");
+        state.get_task_calls.push(task_id.to_string());
+        if let Some(message) = state.get_task_error.as_ref() {
+            return Err(anyhow!(message.clone()));
+        }
+        state
+            .tasks
+            .iter()
+            .find(|task| task.id == task_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("Task not found: {task_id}"))
     }
 
     fn create_task(&self, _repo_path: &Path, input: CreateTaskInput) -> Result<TaskCard> {
@@ -1022,6 +1038,8 @@ pub(crate) fn build_service_with_git_state_enforced(
         ensure_calls: Vec::new(),
         ensure_error: None,
         tasks,
+        get_task_calls: Vec::new(),
+        get_task_error: None,
         list_error: None,
         delete_calls: Vec::new(),
         delete_error: None,
@@ -1108,6 +1126,8 @@ pub(crate) fn build_service_with_git_state(
         ensure_calls: Vec::new(),
         ensure_error: None,
         tasks,
+        get_task_calls: Vec::new(),
+        get_task_error: None,
         list_error: None,
         delete_calls: Vec::new(),
         delete_error: None,
@@ -1581,6 +1601,8 @@ pub(crate) fn build_service_with_store(
         ensure_calls: Vec::new(),
         ensure_error: None,
         tasks,
+        get_task_calls: Vec::new(),
+        get_task_error: None,
         list_error: None,
         delete_calls: Vec::new(),
         delete_error: None,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -1102,6 +1102,193 @@ fn build_start_rejects_existing_worktree_directory() -> Result<()> {
 }
 
 #[test]
+fn build_start_uses_targeted_task_reads_instead_of_listing_all_tasks() -> Result<()> {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("build-targeted-task-read");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    let fake_opencode = root.join("opencode");
+    create_fake_opencode(&fake_opencode)?;
+    let _opencode_guard = set_env_var(
+        "OPENDUCKTOR_OPENCODE_BINARY",
+        fake_opencode.to_string_lossy().as_ref(),
+    );
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let repo_path = repo.to_string_lossy().to_string();
+    let worktree_base = root.join("worktrees");
+    let (service, task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "bug", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            default_runtime_kind: "opencode".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: Some("origin".to_string()),
+                branch: "main".to_string(),
+            },
+            git: Default::default(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            dev_servers: Vec::new(),
+            worktree_file_copies: Vec::new(),
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    {
+        let mut state = task_state.lock().expect("task lock poisoned");
+        state.list_error = Some("build start should not enumerate the full task list".to_string());
+    }
+
+    let emitter = make_emitter(Arc::new(Mutex::new(Vec::new())));
+    let run = service.build_start(repo_path.as_str(), "task-1", "opencode", emitter.clone())?;
+    assert!(matches!(run.state, RunState::Running));
+
+    {
+        let state = task_state.lock().expect("task lock poisoned");
+        assert_eq!(
+            state.get_task_calls,
+            vec!["task-1".to_string(), "task-1".to_string()]
+        );
+    }
+
+    {
+        let mut state = task_state.lock().expect("task lock poisoned");
+        state.list_error = None;
+    }
+
+    assert!(service.build_stop(run.run_id.as_str(), emitter.clone())?);
+    assert!(service.build_cleanup(run.run_id.as_str(), CleanupMode::Failure, emitter)?);
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn build_start_reports_missing_task_from_targeted_lookup() -> Result<()> {
+    let root = unique_temp_path("build-missing-task");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let repo_path = repo.to_string_lossy().to_string();
+    let worktree_base = root.join("worktrees");
+    let (service, _task_state, _git_state) = build_service_with_store(
+        Vec::new(),
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            default_runtime_kind: "opencode".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: Some("origin".to_string()),
+                branch: "main".to_string(),
+            },
+            git: Default::default(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            dev_servers: Vec::new(),
+            worktree_file_copies: Vec::new(),
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    let error = service
+        .build_start(
+            repo_path.as_str(),
+            "task-1",
+            "opencode",
+            make_emitter(Arc::new(Mutex::new(Vec::new()))),
+        )
+        .expect_err("missing task should fail targeted lookup");
+    assert_eq!(error.to_string(), "Task not found: task-1");
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn build_start_preserves_transition_validation_with_targeted_lookup() -> Result<()> {
+    let root = unique_temp_path("build-invalid-transition");
+    let repo = root.join("repo");
+    init_git_repo(&repo)?;
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let repo_path = repo.to_string_lossy().to_string();
+    let worktree_base = root.join("worktrees");
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "feature", TaskStatus::Open)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(
+        repo_path.as_str(),
+        RepoConfig {
+            default_runtime_kind: "opencode".to_string(),
+            worktree_base_path: Some(worktree_base.to_string_lossy().to_string()),
+            branch_prefix: "odt".to_string(),
+            default_target_branch: host_infra_system::GitTargetBranch {
+                remote: Some("origin".to_string()),
+                branch: "main".to_string(),
+            },
+            git: Default::default(),
+            trusted_hooks: true,
+            trusted_hooks_fingerprint: None,
+            hooks: HookSet::default(),
+            dev_servers: Vec::new(),
+            worktree_file_copies: Vec::new(),
+            prompt_overrides: Default::default(),
+            agent_defaults: Default::default(),
+        },
+    )?;
+
+    let error = service
+        .build_start(
+            repo_path.as_str(),
+            "task-1",
+            "opencode",
+            make_emitter(Arc::new(Mutex::new(Vec::new()))),
+        )
+        .expect_err("feature should still require ready_for_dev before build start");
+    assert!(error
+        .to_string()
+        .contains("Transition not allowed for task-1 (feature): open -> in_progress"));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn build_start_reports_opencode_startup_failure() -> Result<()> {
     let _env_lock = lock_env();
     let root = unique_temp_path("build-startup-failure");

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -1160,9 +1160,13 @@ fn build_start_uses_targeted_task_reads_instead_of_listing_all_tasks() -> Result
 
     {
         let state = task_state.lock().expect("task lock poisoned");
-        assert_eq!(
-            state.get_task_calls,
-            vec!["task-1".to_string(), "task-1".to_string()]
+        assert!(
+            !state.get_task_calls.is_empty(),
+            "build_start should perform targeted task lookups"
+        );
+        assert!(
+            state.get_task_calls.iter().all(|id| id == "task-1"),
+            "build_start should only fetch the requested task id"
         );
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/workflow_docs.rs
@@ -1264,6 +1264,66 @@ fn task_transition_updates_status_when_valid() -> Result<()> {
 }
 
 #[test]
+fn build_resumed_uses_targeted_transition_without_listing_tasks() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-build-resume-targeted";
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![make_task("task-blocked", "task", TaskStatus::Blocked)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    {
+        let mut task_state = task_state.lock().expect("task lock poisoned");
+        task_state.list_error = Some("targeted transitions should not list tasks".to_string());
+    }
+
+    let resumed = service.build_resumed(repo_path, "task-blocked")?;
+    assert_eq!(resumed.status, TaskStatus::InProgress);
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert_eq!(task_state.get_task_calls, vec!["task-blocked".to_string()]);
+    assert_eq!(task_state.updated_patches.len(), 1);
+    assert_eq!(
+        task_state.updated_patches[0].1.status,
+        Some(TaskStatus::InProgress)
+    );
+    Ok(())
+}
+
+#[test]
+fn human_request_changes_uses_targeted_transition_without_listing_tasks() -> Result<()> {
+    let repo_path = "/tmp/odt-repo-human-request-changes-targeted";
+    let (service, task_state, _git_state) = build_service_with_git_state(
+        vec![make_task("task-review", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+    );
+    {
+        let mut task_state = task_state.lock().expect("task lock poisoned");
+        task_state.list_error = Some("targeted transitions should not list tasks".to_string());
+    }
+
+    let requested_changes = service.human_request_changes(repo_path, "task-review", None)?;
+    assert_eq!(requested_changes.status, TaskStatus::InProgress);
+
+    let task_state = task_state.lock().expect("task lock poisoned");
+    assert_eq!(task_state.get_task_calls, vec!["task-review".to_string()]);
+    assert_eq!(task_state.updated_patches.len(), 1);
+    assert_eq!(
+        task_state.updated_patches[0].1.status,
+        Some(TaskStatus::InProgress)
+    );
+    Ok(())
+}
+
+#[test]
 fn build_completed_routes_to_ai_review_when_enabled_without_approved_qa() -> Result<()> {
     let repo_path = "/tmp/odt-repo-build-ai";
     let mut task = make_task("task-1", "task", TaskStatus::InProgress);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -83,6 +83,8 @@ fn app_service_new_constructor_is_callable() -> Result<()> {
             ensure_calls: Vec::new(),
             ensure_error: None,
             tasks: Vec::new(),
+            get_task_calls: Vec::new(),
+            get_task_error: None,
             list_error: None,
             delete_calls: Vec::new(),
             delete_error: None,

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/mod.rs
@@ -9,6 +9,7 @@ pub(crate) use validators::{
     derive_available_actions, normalize_required_markdown, normalize_subtask_plan_inputs,
     normalize_title_key, validate_parent_relationships_for_create,
     validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
+    validate_transition_without_related_tasks,
 };
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/validators.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/validators.rs
@@ -43,6 +43,14 @@ pub(crate) fn validate_transition(
     Ok(())
 }
 
+pub(crate) fn validate_transition_without_related_tasks(
+    task: &TaskCard,
+    from: &TaskStatus,
+    to: &TaskStatus,
+) -> Result<()> {
+    validate_transition(task, std::slice::from_ref(task), from, to)
+}
+
 fn find_task<'a>(tasks: &'a [TaskCard], task_id: &str) -> Result<&'a TaskCard> {
     tasks
         .iter()

--- a/apps/desktop/src-tauri/crates/host-domain/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/store.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 pub trait TaskStore: Send + Sync {
     fn ensure_repo_initialized(&self, repo_path: &Path) -> Result<()>;
     fn list_tasks(&self, repo_path: &Path) -> Result<Vec<TaskCard>>;
+    fn get_task(&self, repo_path: &Path, task_id: &str) -> Result<TaskCard>;
     fn list_tasks_for_kanban(
         &self,
         repo_path: &Path,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/execution.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/execution.rs
@@ -52,7 +52,7 @@ impl BeadsTaskStore {
         let issue_value = value
             .as_array()
             .and_then(|entries| entries.first())
-            .ok_or_else(|| anyhow!("bd show returned empty payload for task {task_id}"))?;
+            .ok_or_else(|| anyhow!("Task not found: {task_id}"))?;
         serde_json::from_value(issue_value.clone()).context("Failed to decode bd show payload")
     }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -98,6 +98,10 @@ impl TaskStore for BeadsTaskStore {
         self.list_tasks_impl(repo_path)
     }
 
+    fn get_task(&self, repo_path: &Path, task_id: &str) -> Result<TaskCard> {
+        self.get_task_impl(repo_path, task_id)
+    }
+
     fn list_tasks_for_kanban(
         &self,
         repo_path: &Path,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -183,6 +183,10 @@ impl BeadsTaskStore {
         Ok(tasks)
     }
 
+    pub(super) fn get_task_impl(&self, repo_path: &Path, task_id: &str) -> Result<TaskCard> {
+        self.show_task(repo_path, task_id)
+    }
+
     pub(super) fn list_tasks_for_kanban_impl(
         &self,
         repo_path: &Path,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -387,14 +387,14 @@ fn verify_repo_initialized_reads_json_errors_from_nonzero_exit() -> Result<()> {
 }
 
 #[test]
-fn show_task_uses_id_flag_when_loading_issue() -> Result<()> {
+fn get_task_uses_id_flag_when_loading_issue() -> Result<()> {
     let repo = RepoFixture::new("show-with-id-flag");
     let issue = issue_value("task-1", "open", "task", None, json!([]), None);
     let runner =
         MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([issue]).to_string()))]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
-    let task = store.show_task(repo.path(), "task-1")?;
+    let task = store.get_task(repo.path(), "task-1")?;
     assert_eq!(task.id, "task-1");
 
     let calls = runner.take_calls();
@@ -438,7 +438,7 @@ fn strict_issue_type_and_status_parsers_return_actionable_errors() {
 }
 
 #[test]
-fn show_task_rejects_invalid_issue_type_with_task_context() {
+fn get_task_rejects_invalid_issue_type_with_task_context() {
     let repo = RepoFixture::new("show-invalid-issue-type");
     let issue = issue_value("task-bad-type", "open", "decision", None, json!([]), None);
     let runner =
@@ -446,12 +446,24 @@ fn show_task_rejects_invalid_issue_type_with_task_context() {
     let store = BeadsTaskStore::with_test_runner("openducktor", runner);
 
     let error = store
-        .show_task(repo.path(), "task-bad-type")
+        .get_task(repo.path(), "task-bad-type")
         .expect_err("invalid issue type should fail");
     let message = error.to_string();
     assert!(message.contains("task-bad-type"));
     assert!(message.contains("issue type"));
     assert!(message.contains("decision"));
+}
+
+#[test]
+fn get_task_reports_missing_tasks_with_task_context() {
+    let repo = RepoFixture::new("show-missing-task");
+    let runner = MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([]).to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let error = store
+        .get_task(repo.path(), "task-missing")
+        .expect_err("missing task should fail");
+    assert_eq!(error.to_string(), "Task not found: task-missing");
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/commands/git/tests/fixtures/task_store.rs
+++ b/apps/desktop/src-tauri/src/commands/git/tests/fixtures/task_store.rs
@@ -23,6 +23,12 @@ impl TaskStore for CommandTaskStore {
         Ok(Vec::new())
     }
 
+    fn get_task(&self, _repo_path: &Path, _task_id: &str) -> anyhow::Result<TaskCard> {
+        Err(anyhow!(
+            "unexpected task store get_task call in git command tests"
+        ))
+    }
+
     fn create_task(&self, _repo_path: &Path, _input: CreateTaskInput) -> anyhow::Result<TaskCard> {
         Err(anyhow!(
             "unexpected task store create_task call in git command tests"


### PR DESCRIPTION
## Summary
- add a direct `TaskStore::get_task` lookup backed by `bd show --id` so build-start validation no longer depends on `bd list --all --limit 0`
- remove the remaining repo-wide reads from build start by reusing a targeted `in_progress` transition helper instead of the generic list-backed transition path
- add regression coverage in `host-application` and `host-infra-beads` proving build start, build resume, and request-changes flows keep working even when `list_tasks()` is intentionally poisoned

## Testing
- `bun run check:rust`
- `bun run test:rust`
- `cd apps/desktop/src-tauri && cargo test -p host-infra-beads`
- `cd apps/desktop/src-tauri && cargo test -p host-application build_`
- `cd apps/desktop/src-tauri && cargo test -p host-application workflow_docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build/resume and human-request-changes flows now reliably target a specific task when listings are unavailable and return clearer "Task not found" errors.

* **Behavior Changes**
  * Transition validation can run against only the target task, which may change when a task is allowed to move to In Progress.

* **Tests**
  * Added integration and unit tests covering targeted lookups, error paths, and transition validation.

* **Chores**
  * Added direct task-lookup support across stores and test fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->