### PR TITLE
fix(desktop): stabilize the CEF worktree workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,24 @@ bun run tauri:setup:cef
 
 That command:
 
-- installs repo-local CEF tools into `.cargo-tools/`
-- exports CEF into the repo-local cache at `.cache/cef/`
+- installs the CEF toolchain into a shared OpenDucktor cache directory
+- exports CEF into a shared OpenDucktor cache directory that is versioned by the resolved `cef` crate version
 - clears the macOS quarantine attribute from the downloaded CEF bundle
 
-The CEF setup uses repo-local tool binaries and a repo-local CEF cache so contributors do not need machine-specific paths in their package scripts. The day-to-day `dev` and `build` commands are thin wrappers around the repo-local `cargo-tauri` binary.
+By default, worktrees share the same contributor-local cache under `~/.openducktor/cache/`, so you do not need to rerun the full CEF bootstrap for every git worktree.
+
+- CEF tools default to `~/.openducktor/cache/cargo-tools/tauri-feat-cef/<tauri-revision>/`
+- Exported CEF bundles default to `~/.openducktor/cache/cef/<cef-version>/`
+
+The setup script installs `cargo-tauri` from the exact Tauri git revision locked in `apps/desktop/src-tauri/Cargo.lock`, so the CEF CLI matches the app runtime instead of following the moving `feat/cef` branch head.
+
+You can override those locations with environment variables:
+
+- `OPENDUCKTOR_CARGO_TOOLS_ROOT` sets the install root for the shared `cargo-tauri` and `export-cef-dir` binaries
+- `OPENDUCKTOR_CEF_PATH` sets the exported CEF bundle directory used by OpenDucktor's setup, dev, and build wrappers
+- `CEF_PATH` is still honored for upstream compatibility when `OPENDUCKTOR_CEF_PATH` is unset
+
+The day-to-day `dev` and `build` commands are thin wrappers around the shared `cargo-tauri` binary.
 
 Then run:
 
@@ -93,7 +106,15 @@ Then run:
 bun run tauri:dev:cef
 ```
 
-If you need a different CEF location temporarily, you can still override `CEF_PATH` when invoking the setup or run script directly.
+If you need a different location temporarily, set `OPENDUCKTOR_CARGO_TOOLS_ROOT` and/or `OPENDUCKTOR_CEF_PATH` for that shell before invoking the scripts.
+
+On macOS, `tauri:dev:cef` uses `src-tauri/tauri.cef-dev.conf.json` so it runs as a separate app identity from your packaged `tauri:build:cef` app.
+
+- app bundle name: `OpenDucktor CEF Dev.app`
+- bundle identifier: `dev.openducktor.desktop.cefdev`
+- main window title: `OpenDucktor CEF Dev`
+
+That separation keeps the CEF dev app from sharing the same CEF profile directory as the packaged app. It does not change frontend UI copy such as the sidebar title.
 
 ### Build A macOS CEF Bundle
 

--- a/apps/desktop/scripts/cef-paths.test.ts
+++ b/apps/desktop/scripts/cef-paths.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import {
@@ -17,6 +17,8 @@ const ENV_KEYS = [
   "OPENDUCKTOR_CONFIG_DIR",
 ] as const;
 
+const originalEnv = new Map<(typeof ENV_KEYS)[number], string | undefined>();
+
 function withTempTauriRoot(lockContents: string): string {
   const root = mkdtempSync(join(tmpdir(), "odt-cef-paths-"));
   writeFileSync(join(root, "Cargo.lock"), lockContents);
@@ -25,9 +27,23 @@ function withTempTauriRoot(lockContents: string): string {
 
 function restoreEnv(): void {
   for (const key of ENV_KEYS) {
-    delete process.env[key];
+    const previousValue = originalEnv.get(key);
+    if (previousValue === undefined) {
+      delete process.env[key];
+      continue;
+    }
+
+    process.env[key] = previousValue;
   }
+
+  originalEnv.clear();
 }
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+  }
+});
 
 afterEach(() => {
   restoreEnv();
@@ -55,7 +71,7 @@ describe("cef-paths", () => {
     try {
       expect(resolveCargoToolsRoot(tauriRoot)).toBe(
         resolve(
-          process.env.HOME ?? "",
+          homedir(),
           ".openducktor-dev",
           "cache",
           "cargo-tools",
@@ -64,7 +80,7 @@ describe("cef-paths", () => {
         ),
       );
       expect(resolveCefPath(tauriRoot)).toBe(
-        resolve(process.env.HOME ?? "", ".openducktor-dev", "cache", "cef", "136.2.1"),
+        resolve(homedir(), ".openducktor-dev", "cache", "cef", "136.2.1"),
       );
     } finally {
       rmSync(tauriRoot, { force: true, recursive: true });
@@ -80,10 +96,8 @@ describe("cef-paths", () => {
     );
 
     try {
-      expect(resolveCargoToolsRoot(tauriRoot)).toBe(
-        resolve(process.env.HOME ?? "", "custom-tools"),
-      );
-      expect(resolveCefPath(tauriRoot)).toBe(resolve(process.env.HOME ?? "", "custom-cef"));
+      expect(resolveCargoToolsRoot(tauriRoot)).toBe(resolve(homedir(), "custom-tools"));
+      expect(resolveCefPath(tauriRoot)).toBe(resolve(homedir(), "custom-cef"));
     } finally {
       rmSync(tauriRoot, { force: true, recursive: true });
     }
@@ -96,6 +110,18 @@ describe("cef-paths", () => {
 
     try {
       expect(readTauriCefRevision(tauriRoot)).toBe("abcdefabcdefabcdefabcdefabcdefabcdefabcd");
+    } finally {
+      rmSync(tauriRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("prefers the git-sourced tauri package when multiple entries exist", () => {
+    const tauriRoot = withTempTauriRoot(
+      '[[package]]\nname = "cef"\nversion = "137.0.0"\n\n[[package]]\nname = "tauri"\nversion = "2.10.3"\nsource = "registry+https://github.com/rust-lang/crates.io-index"\n\n[[package]]\nname = "tauri"\nversion = "2.10.3"\nsource = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#fedcbafedcbafedcbafedcbafedcbafedcbafedc"\n',
+    );
+
+    try {
+      expect(readTauriCefRevision(tauriRoot)).toBe("fedcbafedcbafedcbafedcbafedcbafedcbafedc");
     } finally {
       rmSync(tauriRoot, { force: true, recursive: true });
     }

--- a/apps/desktop/scripts/cef-paths.test.ts
+++ b/apps/desktop/scripts/cef-paths.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  readCefVersion,
+  readTauriCefRevision,
+  resolveCargoToolsRoot,
+  resolveCefPath,
+} from "./cef-paths";
+
+const ENV_KEYS = [
+  "CEF_PATH",
+  "OPENDUCKTOR_CEF_PATH",
+  "OPENDUCKTOR_CARGO_TOOLS_ROOT",
+  "OPENDUCKTOR_CONFIG_DIR",
+] as const;
+
+function withTempTauriRoot(lockContents: string): string {
+  const root = mkdtempSync(join(tmpdir(), "odt-cef-paths-"));
+  writeFileSync(join(root, "Cargo.lock"), lockContents);
+  return root;
+}
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+afterEach(() => {
+  restoreEnv();
+});
+
+describe("cef-paths", () => {
+  test("reads the cef crate version from Cargo.lock", () => {
+    const tauriRoot = withTempTauriRoot(
+      '[package]\nname = "root"\n\n[[package]]\nname = "serde"\nversion = "1.0.0"\n\n[[package]]\nname = "cef"\nversion = "135.0.0"\n\n[[package]]\nname = "tauri"\nversion = "2.10.3"\nsource = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#1234567890abcdef1234567890abcdef12345678"\n',
+    );
+
+    try {
+      expect(readCefVersion(tauriRoot)).toBe("135.0.0");
+    } finally {
+      rmSync(tauriRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("uses the shared config root for default cache paths", () => {
+    process.env.OPENDUCKTOR_CONFIG_DIR = "~/.openducktor-dev";
+    const tauriRoot = withTempTauriRoot(
+      '[[package]]\nname = "cef"\nversion = "136.2.1"\n\n[[package]]\nname = "tauri"\nversion = "2.10.3"\nsource = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#1234567890abcdef1234567890abcdef12345678"\n',
+    );
+
+    try {
+      expect(resolveCargoToolsRoot(tauriRoot)).toBe(
+        resolve(
+          process.env.HOME ?? "",
+          ".openducktor-dev",
+          "cache",
+          "cargo-tools",
+          "tauri-feat-cef",
+          "1234567890ab",
+        ),
+      );
+      expect(resolveCefPath(tauriRoot)).toBe(
+        resolve(process.env.HOME ?? "", ".openducktor-dev", "cache", "cef", "136.2.1"),
+      );
+    } finally {
+      rmSync(tauriRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("prefers explicit OpenDucktor overrides", () => {
+    process.env.CEF_PATH = "/tmp/upstream-cef";
+    process.env.OPENDUCKTOR_CEF_PATH = "~/custom-cef";
+    process.env.OPENDUCKTOR_CARGO_TOOLS_ROOT = "~/custom-tools";
+    const tauriRoot = withTempTauriRoot(
+      '[[package]]\nname = "cef"\nversion = "137.0.0"\n\n[[package]]\nname = "tauri"\nversion = "2.10.3"\nsource = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#abcdefabcdefabcdefabcdefabcdefabcdefabcd"\n',
+    );
+
+    try {
+      expect(resolveCargoToolsRoot(tauriRoot)).toBe(
+        resolve(process.env.HOME ?? "", "custom-tools"),
+      );
+      expect(resolveCefPath(tauriRoot)).toBe(resolve(process.env.HOME ?? "", "custom-cef"));
+    } finally {
+      rmSync(tauriRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("reads the pinned tauri revision from Cargo.lock", () => {
+    const tauriRoot = withTempTauriRoot(
+      '[[package]]\nname = "cef"\nversion = "137.0.0"\n\n[[package]]\nname = "tauri"\nversion = "2.10.3"\nsource = "git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef#abcdefabcdefabcdefabcdefabcdefabcdefabcd"\n',
+    );
+
+    try {
+      expect(readTauriCefRevision(tauriRoot)).toBe("abcdefabcdefabcdefabcdefabcdefabcdefabcd");
+    } finally {
+      rmSync(tauriRoot, { force: true, recursive: true });
+    }
+  });
+
+  test("rejects empty overrides", () => {
+    process.env.OPENDUCKTOR_CARGO_TOOLS_ROOT = "   ";
+
+    expect(() => resolveCargoToolsRoot(process.cwd())).toThrow(
+      "OPENDUCKTOR_CARGO_TOOLS_ROOT is set but empty. Provide a valid directory path.",
+    );
+  });
+});

--- a/apps/desktop/scripts/cef-paths.ts
+++ b/apps/desktop/scripts/cef-paths.ts
@@ -37,14 +37,35 @@ function readCargoLock(tauriRoot: string): string {
   return readFileSync(resolve(tauriRoot, "Cargo.lock"), "utf8");
 }
 
-function findPackageBlock(lockFile: string, packageName: string): string {
-  const packageBlocks = lockFile.split(/\[\[package\]\]\r?\n/);
+type CargoLockPackage = {
+  name?: string;
+  source?: string;
+  version?: string;
+};
 
-  for (const packageBlock of packageBlocks) {
-    const nameMatch = packageBlock.match(/^name = "([^"]+)"/m);
-    if (nameMatch?.[1] === packageName) {
-      return packageBlock;
+function readCargoLockPackages(tauriRoot: string): CargoLockPackage[] {
+  const parsedLock = Bun.TOML.parse(readCargoLock(tauriRoot)) as {
+    package?: CargoLockPackage[];
+  };
+
+  return parsedLock.package ?? [];
+}
+
+function findPackage(
+  packages: CargoLockPackage[],
+  packageName: string,
+  predicate?: (pkg: CargoLockPackage) => boolean,
+): CargoLockPackage {
+  for (const pkg of packages) {
+    if (pkg.name !== packageName) {
+      continue;
     }
+
+    if (predicate && !predicate(pkg)) {
+      continue;
+    }
+
+    return pkg;
   }
 
   throw new Error(`Could not resolve the ${packageName} crate from Cargo.lock`);
@@ -52,11 +73,10 @@ function findPackageBlock(lockFile: string, packageName: string): string {
 
 export function readCefVersion(tauriRoot: string): string {
   const lockFilePath = resolve(tauriRoot, "Cargo.lock");
-  const packageBlock = findPackageBlock(readCargoLock(tauriRoot), "cef");
-  const versionMatch = packageBlock.match(/^version = "([^"]+)"/m);
+  const packageEntry = findPackage(readCargoLockPackages(tauriRoot), "cef");
 
-  if (versionMatch?.[1]) {
-    return versionMatch[1];
+  if (packageEntry.version) {
+    return packageEntry.version;
   }
 
   throw new Error(`Could not resolve the cef crate version from ${lockFilePath}`);
@@ -64,9 +84,13 @@ export function readCefVersion(tauriRoot: string): string {
 
 export function readTauriCefRevision(tauriRoot: string): string {
   const lockFilePath = resolve(tauriRoot, "Cargo.lock");
-  const packageBlock = findPackageBlock(readCargoLock(tauriRoot), "tauri");
-  const sourceMatch = packageBlock.match(
-    /^source = "git\+https:\/\/github\.com\/tauri-apps\/tauri\?[^#]+#([0-9a-f]{40})"/m,
+  const packageEntry = findPackage(
+    readCargoLockPackages(tauriRoot),
+    "tauri",
+    (pkg) => pkg.source?.startsWith("git+https://github.com/tauri-apps/tauri?") ?? false,
+  );
+  const sourceMatch = packageEntry.source?.match(
+    /^git\+https:\/\/github\.com\/tauri-apps\/tauri\?[^#]+#([0-9a-f]{40})$/,
   );
 
   if (sourceMatch?.[1]) {

--- a/apps/desktop/scripts/cef-paths.ts
+++ b/apps/desktop/scripts/cef-paths.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, sep } from "node:path";
+
+const OPENDUCKTOR_CONFIG_DIR_ENV = "OPENDUCKTOR_CONFIG_DIR";
+const OPENDUCKTOR_CARGO_TOOLS_ROOT_ENV = "OPENDUCKTOR_CARGO_TOOLS_ROOT";
+const OPENDUCKTOR_CEF_PATH_ENV = "OPENDUCKTOR_CEF_PATH";
+const UPSTREAM_CEF_PATH_ENV = "CEF_PATH";
+
+function expandHome(path: string): string {
+  if (path === "~") {
+    return homedir();
+  }
+
+  if (path.startsWith(`~${sep}`)) {
+    return resolve(homedir(), path.slice(2));
+  }
+
+  return path;
+}
+
+function resolveConfiguredPath(envName: string): string | undefined {
+  const rawValue = process.env[envName];
+  if (rawValue === undefined) {
+    return undefined;
+  }
+
+  const trimmedValue = rawValue.trim();
+  if (trimmedValue.length === 0) {
+    throw new Error(`${envName} is set but empty. Provide a valid directory path.`);
+  }
+
+  return resolve(expandHome(trimmedValue));
+}
+
+function readCargoLock(tauriRoot: string): string {
+  return readFileSync(resolve(tauriRoot, "Cargo.lock"), "utf8");
+}
+
+function findPackageBlock(lockFile: string, packageName: string): string {
+  const packageBlocks = lockFile.split(/\[\[package\]\]\r?\n/);
+
+  for (const packageBlock of packageBlocks) {
+    const nameMatch = packageBlock.match(/^name = "([^"]+)"/m);
+    if (nameMatch?.[1] === packageName) {
+      return packageBlock;
+    }
+  }
+
+  throw new Error(`Could not resolve the ${packageName} crate from Cargo.lock`);
+}
+
+export function readCefVersion(tauriRoot: string): string {
+  const lockFilePath = resolve(tauriRoot, "Cargo.lock");
+  const packageBlock = findPackageBlock(readCargoLock(tauriRoot), "cef");
+  const versionMatch = packageBlock.match(/^version = "([^"]+)"/m);
+
+  if (versionMatch?.[1]) {
+    return versionMatch[1];
+  }
+
+  throw new Error(`Could not resolve the cef crate version from ${lockFilePath}`);
+}
+
+export function readTauriCefRevision(tauriRoot: string): string {
+  const lockFilePath = resolve(tauriRoot, "Cargo.lock");
+  const packageBlock = findPackageBlock(readCargoLock(tauriRoot), "tauri");
+  const sourceMatch = packageBlock.match(
+    /^source = "git\+https:\/\/github\.com\/tauri-apps\/tauri\?[^#]+#([0-9a-f]{40})"/m,
+  );
+
+  if (sourceMatch?.[1]) {
+    return sourceMatch[1];
+  }
+
+  throw new Error(`Could not resolve the pinned tauri revision from ${lockFilePath}`);
+}
+
+export function resolveOpenducktorDataRoot(): string {
+  return resolveConfiguredPath(OPENDUCKTOR_CONFIG_DIR_ENV) ?? resolve(homedir(), ".openducktor");
+}
+
+export function resolveCargoToolsRoot(tauriRoot: string): string {
+  return (
+    resolveConfiguredPath(OPENDUCKTOR_CARGO_TOOLS_ROOT_ENV) ??
+    resolve(
+      resolveOpenducktorDataRoot(),
+      "cache",
+      "cargo-tools",
+      "tauri-feat-cef",
+      readTauriCefRevision(tauriRoot).slice(0, 12),
+    )
+  );
+}
+
+export function resolveCefPath(tauriRoot: string): string {
+  return (
+    resolveConfiguredPath(OPENDUCKTOR_CEF_PATH_ENV) ??
+    resolveConfiguredPath(UPSTREAM_CEF_PATH_ENV) ??
+    resolve(resolveOpenducktorDataRoot(), "cache", "cef", readCefVersion(tauriRoot))
+  );
+}

--- a/apps/desktop/scripts/setup-cef.ts
+++ b/apps/desktop/scripts/setup-cef.ts
@@ -1,35 +1,23 @@
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
 
+import {
+  readCefVersion,
+  readTauriCefRevision,
+  resolveCargoToolsRoot,
+  resolveCefPath,
+} from "./cef-paths";
+
 const desktopRoot = process.cwd();
-const repoRoot = resolve(desktopRoot, "../..");
 const tauriRoot = resolve(desktopRoot, "src-tauri");
-const toolRoot = resolve(repoRoot, ".cargo-tools");
+const toolRoot = resolveCargoToolsRoot(tauriRoot);
 const toolBinRoot = resolve(toolRoot, "bin");
-const cefPath = process.env.CEF_PATH ?? resolve(repoRoot, ".cache", "cef");
+const cefPath = resolveCefPath(tauriRoot);
+const tauriRevision = readTauriCefRevision(tauriRoot);
 const binaryExtension = process.platform === "win32" ? ".exe" : "";
 const exportCefDirPath = resolve(toolBinRoot, `export-cef-dir${binaryExtension}`);
-
-function cefVersion(): string {
-  const lockFilePath = resolve(tauriRoot, "Cargo.lock");
-  const lockFile = readFileSync(lockFilePath, "utf8");
-  const packageBlocks = lockFile.split(/\[\[package\]\]\r?\n/);
-  for (const packageBlock of packageBlocks) {
-    const nameMatch = packageBlock.match(/^name = "([^"]+)"/m);
-    if (nameMatch?.[1] !== "cef") {
-      continue;
-    }
-
-    const versionMatch = packageBlock.match(/^version = "([^"]+)"/m);
-    if (versionMatch?.[1]) {
-      return versionMatch[1];
-    }
-  }
-
-  throw new Error(`Could not resolve the cef crate version from ${lockFilePath}`);
-}
 
 function cargoHomeBinPath(): string {
   return resolve(process.env.CARGO_HOME ?? join(homedir(), ".cargo"), "bin");
@@ -93,8 +81,8 @@ await (async () => {
     "tauri-cli",
     "--git",
     "https://github.com/tauri-apps/tauri",
-    "--branch",
-    "feat/cef",
+    "--rev",
+    tauriRevision,
     "--force",
   ]);
 
@@ -108,7 +96,7 @@ await (async () => {
     toolRoot,
     "export-cef-dir",
     "--version",
-    cefVersion(),
+    readCefVersion(tauriRoot),
     "--force",
   ]);
 

--- a/apps/desktop/scripts/tauri-cef-build.ts
+++ b/apps/desktop/scripts/tauri-cef-build.ts
@@ -2,14 +2,16 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { resolveCargoToolsRoot, resolveCefPath } from "./cef-paths";
+
 const desktopRoot = process.cwd();
-const repoRoot = resolve(desktopRoot, "../..");
+const tauriRoot = resolve(desktopRoot, "src-tauri");
 const cargoTauriPath = resolve(
-  repoRoot,
-  ".cargo-tools",
+  resolveCargoToolsRoot(tauriRoot),
   "bin",
   process.platform === "win32" ? "cargo-tauri.exe" : "cargo-tauri",
 );
+const cefPath = resolveCefPath(tauriRoot);
 
 if (!existsSync(cargoTauriPath)) {
   console.error("Missing cargo-tauri. Run `bun run tauri:setup:cef` first.");
@@ -32,7 +34,7 @@ const child = spawn(
     cwd: desktopRoot,
     env: {
       ...process.env,
-      CEF_PATH: process.env.CEF_PATH ?? resolve(repoRoot, ".cache", "cef"),
+      CEF_PATH: cefPath,
       OPENDUCKTOR_PREPARE_SIDECARS: "1",
     },
     stdio: "inherit",

--- a/apps/desktop/scripts/tauri-cef-dev.ts
+++ b/apps/desktop/scripts/tauri-cef-dev.ts
@@ -2,36 +2,43 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { resolveCargoToolsRoot, resolveCefPath } from "./cef-paths";
+
 const desktopRoot = process.cwd();
-const repoRoot = resolve(desktopRoot, "../..");
+const tauriRoot = resolve(desktopRoot, "src-tauri");
+const macosCefDevConfigPath = resolve(tauriRoot, "tauri.cef-dev.conf.json");
 const cargoTauriPath = resolve(
-  repoRoot,
-  ".cargo-tools",
+  resolveCargoToolsRoot(tauriRoot),
   "bin",
   process.platform === "win32" ? "cargo-tauri.exe" : "cargo-tauri",
 );
+const cefPath = resolveCefPath(tauriRoot);
 
 if (!existsSync(cargoTauriPath)) {
   console.error("Missing cargo-tauri. Run `bun run tauri:setup:cef` first.");
   process.exit(1);
 }
 
-const child = spawn(
-  cargoTauriPath,
-  ["dev", "--features", "cef", "--", "--no-default-features", ...process.argv.slice(2)],
-  {
-    cwd: desktopRoot,
-    env: {
-      ...process.env,
-      CEF_PATH: process.env.CEF_PATH ?? resolve(repoRoot, ".cache", "cef"),
-      APPLE_SIGNING_IDENTITY:
-        process.platform === "darwin"
-          ? (process.env.APPLE_SIGNING_IDENTITY ?? "-")
-          : process.env.APPLE_SIGNING_IDENTITY,
-    },
-    stdio: "inherit",
+const tauriArgs = ["dev"];
+
+if (process.platform === "darwin") {
+  tauriArgs.push("--config", macosCefDevConfigPath);
+}
+
+tauriArgs.push("--features", "cef", "--", "--no-default-features", ...process.argv.slice(2));
+
+const child = spawn(cargoTauriPath, tauriArgs, {
+  cwd: desktopRoot,
+  env: {
+    ...process.env,
+    CEF_PATH: cefPath,
+    APPLE_SIGNING_IDENTITY:
+      process.platform === "darwin"
+        ? (process.env.APPLE_SIGNING_IDENTITY ?? "-")
+        : process.env.APPLE_SIGNING_IDENTITY,
   },
-);
+  stdio: "inherit",
+});
 
 child.on("exit", (code, signal) => {
   if (signal) {

--- a/apps/desktop/src-tauri/tauri.cef-dev.conf.json
+++ b/apps/desktop/src-tauri/tauri.cef-dev.conf.json
@@ -1,0 +1,15 @@
+{
+  "productName": "OpenDucktor CEF Dev",
+  "identifier": "dev.openducktor.desktop.cefdev",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "OpenDucktor CEF Dev",
+        "width": 1500,
+        "height": 980,
+        "resizable": true
+      }
+    ]
+  }
+}

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -8,5 +8,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "scripts", "vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- share the pinned CEF toolchain and exported CEF bundle across git worktrees by default, with documented environment variable overrides
- install `cargo-tauri` from the exact Tauri revision locked in `apps/desktop/src-tauri/Cargo.lock` so the CEF CLI matches the app runtime
- run macOS `tauri:dev:cef` with a dedicated CEF dev Tauri config so the packaged app and the dev app can coexist without colliding on the same CEF profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Use a shared OpenDucktor cache (~/.openducktor/) for CEF tools and bundles.
  * New env overrides: OPENDUCKTOR_CARGO_TOOLS_ROOT and OPENDUCKTOR_CEF_PATH (CEF_PATH kept for compatibility).
  * Separate CEF dev app identity and window settings on macOS.

* **Documentation**
  * Updated setup guide with cache defaults, pinned tauri CLI revision behavior, env var guidance, and macOS identity notes.

* **Tests**
  * Added tests for CEF path/version and override resolution.

* **Chores**
  * Included scripts in TypeScript project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->