### PR TITLE
fix(desktop): use Pierre portable diff worker asset

### DIFF
--- a/apps/desktop/src/lib/diff/pierre-diff-worker.ts
+++ b/apps/desktop/src/lib/diff/pierre-diff-worker.ts
@@ -1,1 +1,0 @@
-import "@pierre/diffs/worker/worker.js";

--- a/apps/desktop/src/lib/diff/workerFactory.ts
+++ b/apps/desktop/src/lib/diff/workerFactory.ts
@@ -1,4 +1,4 @@
-const workerUrl = new URL("./pierre-diff-worker.ts", import.meta.url);
+const workerUrl = new URL("@pierre/diffs/worker/worker-portable.js", import.meta.url);
 
 export function workerFactory(): Worker {
   return new Worker(workerUrl, { type: "module" });


### PR DESCRIPTION
## Summary
- switch the Git Panel diff worker factory to use Pierre's bundled `worker-portable.js` asset directly instead of routing through a local shim
- remove the obsolete shim worker file so packaged Tauri and CEF builds use the same worker-backed diff path that still preserves large-diff performance
- verify the full repo checks plus both packaged desktop build variants stay green, and confirm the bundled app renders Git Panel diffs again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized worker initialization for improved application modularity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->