### PR TITLE
fix(desktop): stabilize macos cef quit shutdown

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,8 @@ use tauri::{AppHandle, Emitter, RunEvent as TauriRunEvent};
 
 mod commands;
 mod headless;
+#[cfg(all(feature = "cef", target_os = "macos"))]
+mod macos_cef_quit;
 
 #[cfg(feature = "cef")]
 type TauriRuntime = tauri::Cef;
@@ -36,158 +38,6 @@ pub(crate) struct AppState {
     service: Arc<AppService>,
     #[cfg(test)]
     hook_trust_dialog_test_response: Mutex<Option<bool>>,
-}
-
-#[cfg(all(feature = "cef", target_os = "macos"))]
-mod macos_cef_quit_delegate {
-    use super::TauriRuntime;
-    use anyhow::{Context, Result};
-    use objc2::{
-        DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send,
-        rc::Retained,
-        runtime::{AnyObject, NSObject, NSObjectProtocol, ProtocolObject, Sel},
-        sel,
-    };
-    use objc2_app_kit::{NSApp, NSApplication, NSApplicationDelegate, NSApplicationTerminateReply};
-    use objc2_foundation::NSArray;
-    use std::cell::RefCell;
-    use tauri::{App, AppHandle, Manager};
-
-    thread_local! {
-        static QUIT_DELEGATE: RefCell<Option<Retained<QuitDelegate>>> = const { RefCell::new(None) };
-    }
-
-    struct QuitDelegateIvars {
-        app_handle: AppHandle<TauriRuntime>,
-        original_delegate: Retained<ProtocolObject<dyn NSApplicationDelegate>>,
-    }
-
-    define_class!(
-        #[unsafe(super(NSObject))]
-        #[name = "OpenDucktorCefQuitDelegate"]
-        #[ivars = QuitDelegateIvars]
-        #[thread_kind = MainThreadOnly]
-        struct QuitDelegate;
-
-        unsafe impl NSObjectProtocol for QuitDelegate {}
-
-        #[allow(non_snake_case)]
-        impl QuitDelegate {
-            #[unsafe(method(forwardingTargetForSelector:))]
-            unsafe fn forwardingTargetForSelector(&self, selector: Sel) -> *mut AnyObject {
-                if selector == sel!(applicationShouldTerminate:)
-                    || selector == sel!(application:openURLs:)
-                {
-                    std::ptr::null_mut()
-                } else {
-                    Retained::as_ptr(&self.ivars().original_delegate)
-                        .cast::<AnyObject>()
-                        .cast_mut()
-                }
-            }
-        }
-
-        #[allow(non_snake_case)]
-        unsafe impl NSApplicationDelegate for QuitDelegate {
-            #[unsafe(method(application:openURLs:))]
-            unsafe fn application_openURLs(
-                &self,
-                application: &NSApplication,
-                urls: &NSArray<objc2_foundation::NSURL>,
-            ) {
-                if self
-                    .ivars()
-                    .original_delegate
-                    .respondsToSelector(sel!(application:openURLs:))
-                {
-                    self.ivars().original_delegate.application_openURLs(application, urls);
-                }
-            }
-
-            #[unsafe(method(applicationShouldTerminate:))]
-            unsafe fn applicationShouldTerminate(
-                &self,
-                sender: &NSApplication,
-            ) -> NSApplicationTerminateReply {
-                if should_intercept_quit(self.ivars().app_handle.webview_windows().len()) {
-                    request_orderly_quit(&self.ivars().app_handle);
-                    return NSApplicationTerminateReply::TerminateCancel;
-                }
-
-                if self
-                    .ivars()
-                    .original_delegate
-                    .respondsToSelector(sel!(applicationShouldTerminate:))
-                {
-                    return self.ivars().original_delegate.applicationShouldTerminate(sender);
-                }
-
-                NSApplicationTerminateReply::TerminateNow
-            }
-        }
-    );
-
-    impl QuitDelegate {
-        fn new(
-            mtm: MainThreadMarker,
-            app_handle: AppHandle<TauriRuntime>,
-            original_delegate: Retained<ProtocolObject<dyn NSApplicationDelegate>>,
-        ) -> Retained<Self> {
-            let delegate = Self::alloc(mtm).set_ivars(QuitDelegateIvars {
-                app_handle,
-                original_delegate,
-            });
-            unsafe { msg_send![super(delegate), init] }
-        }
-    }
-
-    fn should_intercept_quit(open_window_count: usize) -> bool {
-        open_window_count > 0
-    }
-
-    fn request_orderly_quit(app_handle: &AppHandle<TauriRuntime>) {
-        for window in app_handle.webview_windows().into_values() {
-            // `destroy()` proved more reliable than `close()` for the macOS CEF
-            // quit path because it completes teardown before the runtime exits.
-            let _ = window.destroy();
-        }
-    }
-
-    pub(super) fn install(app: &mut App<TauriRuntime>) -> Result<()> {
-        let mtm = MainThreadMarker::new().context("macOS quit delegate requires main thread")?;
-        let ns_app = NSApp(mtm);
-        let original_delegate = ns_app
-            .delegate()
-            .context("missing NSApplication delegate for CEF runtime")?;
-        let delegate = QuitDelegate::new(mtm, app.handle().clone(), original_delegate);
-        ns_app.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
-        QUIT_DELEGATE.with(|slot| {
-            slot.replace(Some(delegate));
-        });
-        Ok(())
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn intercepts_first_quit_with_open_windows() {
-            assert!(should_intercept_quit(1));
-        }
-
-        #[test]
-        fn keeps_intercepting_until_windows_are_gone() {
-            assert!(should_intercept_quit(3));
-            assert!(should_intercept_quit(1));
-            assert!(!should_intercept_quit(0));
-        }
-
-        #[test]
-        fn does_not_intercept_when_no_windows_remain() {
-            assert!(!should_intercept_quit(0));
-        }
-    }
 }
 
 static TRACING_INITIALIZED: OnceLock<()> = OnceLock::new();
@@ -552,7 +402,7 @@ fn startup_phase_build_tauri_app(
     let builder = builder
         .setup(|_app| {
             #[cfg(all(feature = "cef", target_os = "macos"))]
-            macos_cef_quit_delegate::install(_app)?;
+            macos_cef_quit::install(_app)?;
             Ok(())
         })
         .plugin(tauri_plugin_dialog::init())

--- a/apps/desktop/src-tauri/src/macos_cef_quit.rs
+++ b/apps/desktop/src-tauri/src/macos_cef_quit.rs
@@ -1,0 +1,303 @@
+use crate::TauriRuntime;
+use anyhow::{anyhow, Context, Result};
+use objc2::{
+    define_class, ffi, msg_send,
+    rc::Retained,
+    runtime::{AnyObject, Imp, NSObject, NSObjectProtocol, ProtocolObject, Sel},
+    sel, DefinedClass, MainThreadMarker, MainThreadOnly,
+};
+use objc2_app_kit::{NSApp, NSApplication, NSApplicationDelegate, NSApplicationTerminateReply};
+use objc2_foundation::NSArray;
+use std::cell::RefCell;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use tauri::{App, AppHandle, Manager};
+
+thread_local! {
+    static QUIT_DELEGATE: RefCell<Option<Retained<QuitDelegate>>> = const { RefCell::new(None) };
+}
+
+static ORDERLY_QUIT_REQUESTED: AtomicBool = AtomicBool::new(false);
+static QUIT_APP_HANDLE: OnceLock<AppHandle<TauriRuntime>> = OnceLock::new();
+static ORIGINAL_TERMINATE_IMP: OnceLock<Imp> = OnceLock::new();
+static TERMINATE_INTERPOSED: OnceLock<()> = OnceLock::new();
+
+struct QuitDelegateIvars {
+    app_handle: AppHandle<TauriRuntime>,
+    original_delegate: Retained<ProtocolObject<dyn NSApplicationDelegate>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuitAction {
+    StartOrderlyQuit,
+    WaitForWindowTeardown,
+    AllowTerminate,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "OpenDucktorCefQuitDelegate"]
+    #[ivars = QuitDelegateIvars]
+    #[thread_kind = MainThreadOnly]
+    struct QuitDelegate;
+
+    unsafe impl NSObjectProtocol for QuitDelegate {}
+
+    #[allow(non_snake_case)]
+    impl QuitDelegate {
+        #[unsafe(method(forwardingTargetForSelector:))]
+        unsafe fn forwardingTargetForSelector(&self, selector: Sel) -> *mut AnyObject {
+            if selector == sel!(applicationShouldTerminate:)
+                || selector == sel!(application:openURLs:)
+            {
+                std::ptr::null_mut()
+            } else {
+                Retained::as_ptr(&self.ivars().original_delegate)
+                    .cast::<AnyObject>()
+                    .cast_mut()
+            }
+        }
+    }
+
+    #[allow(non_snake_case)]
+    unsafe impl NSApplicationDelegate for QuitDelegate {
+        #[unsafe(method(application:openURLs:))]
+        unsafe fn application_openURLs(
+            &self,
+            application: &NSApplication,
+            urls: &NSArray<objc2_foundation::NSURL>,
+        ) {
+            if self
+                .ivars()
+                .original_delegate
+                .respondsToSelector(sel!(application:openURLs:))
+            {
+                self.ivars()
+                    .original_delegate
+                    .application_openURLs(application, urls);
+            }
+        }
+
+        #[unsafe(method(applicationShouldTerminate:))]
+        unsafe fn applicationShouldTerminate(
+            &self,
+            sender: &NSApplication,
+        ) -> NSApplicationTerminateReply {
+            match decide_quit_action(
+                self.ivars().app_handle.webview_windows().len(),
+                ORDERLY_QUIT_REQUESTED.load(Ordering::SeqCst),
+            ) {
+                QuitAction::StartOrderlyQuit => {
+                    ORDERLY_QUIT_REQUESTED.store(true, Ordering::SeqCst);
+                    log_orderly_quit_start(self.ivars().app_handle.webview_windows().len());
+                    request_orderly_quit(&self.ivars().app_handle);
+                    return NSApplicationTerminateReply::TerminateCancel;
+                }
+                QuitAction::WaitForWindowTeardown => {
+                    tracing::debug!(
+                        target: "openducktor.cef.quit",
+                        open_window_count = self.ivars().app_handle.webview_windows().len(),
+                        "Ignoring applicationShouldTerminate while CEF windows are still closing"
+                    );
+                    return NSApplicationTerminateReply::TerminateCancel;
+                }
+                QuitAction::AllowTerminate => {
+                    ORDERLY_QUIT_REQUESTED.store(false, Ordering::SeqCst);
+                    tracing::debug!(
+                        target: "openducktor.cef.quit",
+                        "Allowing applicationShouldTerminate after CEF windows closed"
+                    );
+                }
+            }
+
+            if self
+                .ivars()
+                .original_delegate
+                .respondsToSelector(sel!(applicationShouldTerminate:))
+            {
+                return self
+                    .ivars()
+                    .original_delegate
+                    .applicationShouldTerminate(sender);
+            }
+
+            NSApplicationTerminateReply::TerminateNow
+        }
+    }
+);
+
+impl QuitDelegate {
+    fn new(
+        mtm: MainThreadMarker,
+        app_handle: AppHandle<TauriRuntime>,
+        original_delegate: Retained<ProtocolObject<dyn NSApplicationDelegate>>,
+    ) -> Retained<Self> {
+        let delegate = Self::alloc(mtm).set_ivars(QuitDelegateIvars {
+            app_handle,
+            original_delegate,
+        });
+        unsafe { msg_send![super(delegate), init] }
+    }
+}
+
+type TerminateImp = unsafe extern "C-unwind" fn(&NSApplication, Sel, *mut AnyObject);
+
+unsafe extern "C-unwind" fn intercept_terminate(
+    this: &NSApplication,
+    cmd: Sel,
+    sender: *mut AnyObject,
+) {
+    let Some(app_handle) = QUIT_APP_HANDLE.get() else {
+        call_original_terminate(this, cmd, sender);
+        return;
+    };
+
+    match decide_quit_action(
+        app_handle.webview_windows().len(),
+        ORDERLY_QUIT_REQUESTED.load(Ordering::SeqCst),
+    ) {
+        QuitAction::StartOrderlyQuit => {
+            ORDERLY_QUIT_REQUESTED.store(true, Ordering::SeqCst);
+            log_orderly_quit_start(app_handle.webview_windows().len());
+            request_orderly_quit(app_handle);
+        }
+        QuitAction::WaitForWindowTeardown => {
+            tracing::debug!(
+                target: "openducktor.cef.quit",
+                open_window_count = app_handle.webview_windows().len(),
+                "Ignoring repeated terminate: while CEF windows are still closing"
+            );
+        }
+        QuitAction::AllowTerminate => {
+            ORDERLY_QUIT_REQUESTED.store(false, Ordering::SeqCst);
+            tracing::info!(
+                target: "openducktor.cef.quit",
+                "Forwarding native terminate: after all CEF windows closed"
+            );
+            call_original_terminate(this, cmd, sender);
+        }
+    }
+}
+
+fn log_orderly_quit_start(open_window_count: usize) {
+    tracing::info!(
+        target: "openducktor.cef.quit",
+        open_window_count,
+        "Starting orderly macOS CEF quit from native terminate:"
+    );
+}
+
+fn call_original_terminate(this: &NSApplication, cmd: Sel, sender: *mut AnyObject) {
+    let Some(original_imp) = ORIGINAL_TERMINATE_IMP.get().copied() else {
+        return;
+    };
+    let original: TerminateImp = unsafe { std::mem::transmute(original_imp) };
+    unsafe {
+        original(this, cmd, sender);
+    }
+}
+
+fn install_terminate_interpose(ns_app: &NSApplication) -> Result<()> {
+    if TERMINATE_INTERPOSED.get().is_some() {
+        return Ok(());
+    }
+
+    let app_class = ns_app.class() as *const _ as *mut _;
+    let terminate_sel = sel!(terminate:);
+    let terminate_method = unsafe { ffi::class_getInstanceMethod(app_class, terminate_sel) };
+    let terminate_method = unsafe { terminate_method.as_ref() }
+        .context("missing terminate: method on CEF NSApplication class")?;
+    let original_imp = unsafe { ffi::method_getImplementation(terminate_method) }
+        .context("missing terminate: implementation on CEF NSApplication class")?;
+    let type_encoding = unsafe { ffi::method_getTypeEncoding(terminate_method) };
+
+    ORIGINAL_TERMINATE_IMP
+        .set(original_imp)
+        .map_err(|_| anyhow!("original terminate: implementation already registered"))?;
+
+    let intercept_imp: Imp = unsafe { std::mem::transmute(intercept_terminate as TerminateImp) };
+
+    unsafe {
+        ffi::class_replaceMethod(app_class, terminate_sel, intercept_imp, type_encoding);
+    }
+
+    TERMINATE_INTERPOSED
+        .set(())
+        .map_err(|_| anyhow!("CEF terminate: interpose already installed"))?;
+
+    tracing::info!(
+        target: "openducktor.cef.quit",
+        app_class = %ns_app.class().name().to_string_lossy(),
+        "Installed macOS CEF terminate: interpose"
+    );
+
+    Ok(())
+}
+
+fn decide_quit_action(open_window_count: usize, orderly_quit_requested: bool) -> QuitAction {
+    if open_window_count == 0 {
+        return QuitAction::AllowTerminate;
+    }
+
+    if orderly_quit_requested {
+        QuitAction::WaitForWindowTeardown
+    } else {
+        QuitAction::StartOrderlyQuit
+    }
+}
+
+fn request_orderly_quit(app_handle: &AppHandle<TauriRuntime>) {
+    for window in app_handle.webview_windows().into_values() {
+        if let Err(error) = window.close() {
+            tracing::warn!(
+                target: "openducktor.cef.quit",
+                error = %format!("{error:#}"),
+                "Failed requesting graceful CEF window close during app quit"
+            );
+        }
+    }
+}
+
+pub(crate) fn install(app: &mut App<TauriRuntime>) -> Result<()> {
+    let mtm = MainThreadMarker::new().context("macOS quit delegate requires main thread")?;
+    let ns_app = NSApp(mtm);
+    let _ = QUIT_APP_HANDLE.set(app.handle().clone());
+    install_terminate_interpose(&ns_app)?;
+    let original_delegate = ns_app
+        .delegate()
+        .context("missing NSApplication delegate for CEF runtime")?;
+    let delegate = QuitDelegate::new(mtm, app.handle().clone(), original_delegate);
+    ns_app.setDelegate(Some(ProtocolObject::from_ref(&*delegate)));
+    QUIT_DELEGATE.with(|slot| {
+        slot.replace(Some(delegate));
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intercepts_first_quit_with_open_windows() {
+        assert_eq!(decide_quit_action(1, false), QuitAction::StartOrderlyQuit);
+    }
+
+    #[test]
+    fn waits_for_open_windows_to_finish_closing_after_quit_request() {
+        assert_eq!(
+            decide_quit_action(3, true),
+            QuitAction::WaitForWindowTeardown
+        );
+        assert_eq!(
+            decide_quit_action(1, true),
+            QuitAction::WaitForWindowTeardown
+        );
+    }
+
+    #[test]
+    fn allows_terminate_once_all_windows_are_gone() {
+        assert_eq!(decide_quit_action(0, false), QuitAction::AllowTerminate);
+        assert_eq!(decide_quit_action(0, true), QuitAction::AllowTerminate);
+    }
+}

--- a/apps/desktop/src-tauri/src/macos_cef_quit.rs
+++ b/apps/desktop/src-tauri/src/macos_cef_quit.rs
@@ -90,7 +90,9 @@ define_class!(
                 QuitAction::StartOrderlyQuit => {
                     ORDERLY_QUIT_REQUESTED.store(true, Ordering::SeqCst);
                     log_orderly_quit_start(self.ivars().app_handle.webview_windows().len());
-                    request_orderly_quit(&self.ivars().app_handle);
+                    if !request_orderly_quit(&self.ivars().app_handle) {
+                        ORDERLY_QUIT_REQUESTED.store(false, Ordering::SeqCst);
+                    }
                     return NSApplicationTerminateReply::TerminateCancel;
                 }
                 QuitAction::WaitForWindowTeardown => {
@@ -159,7 +161,9 @@ unsafe extern "C-unwind" fn intercept_terminate(
         QuitAction::StartOrderlyQuit => {
             ORDERLY_QUIT_REQUESTED.store(true, Ordering::SeqCst);
             log_orderly_quit_start(app_handle.webview_windows().len());
-            request_orderly_quit(app_handle);
+            if !request_orderly_quit(app_handle) {
+                ORDERLY_QUIT_REQUESTED.store(false, Ordering::SeqCst);
+            }
         }
         QuitAction::WaitForWindowTeardown => {
             tracing::debug!(
@@ -246,9 +250,15 @@ fn decide_quit_action(open_window_count: usize, orderly_quit_requested: bool) ->
     }
 }
 
-fn request_orderly_quit(app_handle: &AppHandle<TauriRuntime>) {
+fn request_orderly_quit(app_handle: &AppHandle<TauriRuntime>) -> bool {
+    let mut all_close_requests_sent = true;
+
     for window in app_handle.webview_windows().into_values() {
+        // Keep the normal close lifecycle on the Cmd+Q path so the interposed
+        // native terminate flow can wait for orderly teardown instead of
+        // force-destroying windows mid-shutdown.
         if let Err(error) = window.close() {
+            all_close_requests_sent = false;
             tracing::warn!(
                 target: "openducktor.cef.quit",
                 error = %format!("{error:#}"),
@@ -256,6 +266,8 @@ fn request_orderly_quit(app_handle: &AppHandle<TauriRuntime>) {
             );
         }
     }
+
+    all_close_requests_sent
 }
 
 pub(crate) fn install(app: &mut App<TauriRuntime>) -> Result<()> {

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -24,6 +24,7 @@ Current scope note:
 | Tauri command bridge (Rust) | `apps/desktop/src-tauri/src/lib.rs`, `apps/desktop/src-tauri/src/commands/*` | Typed command surface (`tauri::command`), argument mapping, command registration | Deep business policy (kept in `AppService`) |
 | Host application/domain (Rust) | `apps/desktop/src-tauri/crates/host-application/src/app_service/*`, `apps/desktop/src-tauri/crates/host-domain/src/*` | Workflow transition rules, task enrichment (`available_actions`, `agent_workflows`), runtime orchestration, `TaskStore` trait | UI concerns, view-level behavior |
 | Infrastructure/persistence (Rust) | `apps/desktop/src-tauri/crates/host-infra-beads/*`, `apps/desktop/src-tauri/crates/host-infra-system/*` | Beads-backed `TaskStore`, config/worktree/process integrations | UI workflow decisions |
+| MCP workflow service (TS) | `packages/openducktor-mcp/src/index.ts`, `packages/openducktor-mcp/src/lib.ts`, `packages/openducktor-mcp/src/odt-task-store.ts` | public MCP task tools (`create_task`, `search_tasks`, `odt_read_task`) plus `odt_*` workflow execution and validation against Beads metadata/status | Frontend rendering/state |
 
 ## Platform-specific native lifecycle seams
 
@@ -32,7 +33,6 @@ Current scope note:
 - For the CEF runtime on macOS, OpenDucktor must start quit by closing windows from `terminate:` and only forward the original native terminate call after all windows are gone.
 - Keep this behavior isolated from generic app shutdown logic in `lib.rs`; the signal handler and `RunEvent::ExitRequested` cleanup path are still generic, while the CEF quit interpose is a platform/runtime-specific seam.
 - If this area regresses, inspect `openducktor.cef.quit` tracing first and compare Cmd+Q against red-window-close behavior before changing broader shutdown code.
-| MCP workflow service (TS) | `packages/openducktor-mcp/src/index.ts`, `packages/openducktor-mcp/src/lib.ts`, `packages/openducktor-mcp/src/odt-task-store.ts` | public MCP task tools (`create_task`, `search_tasks`, `odt_read_task`) plus `odt_*` workflow execution and validation against Beads metadata/status | Frontend rendering/state |
 
 ## Runtime Data Flows
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -24,6 +24,14 @@ Current scope note:
 | Tauri command bridge (Rust) | `apps/desktop/src-tauri/src/lib.rs`, `apps/desktop/src-tauri/src/commands/*` | Typed command surface (`tauri::command`), argument mapping, command registration | Deep business policy (kept in `AppService`) |
 | Host application/domain (Rust) | `apps/desktop/src-tauri/crates/host-application/src/app_service/*`, `apps/desktop/src-tauri/crates/host-domain/src/*` | Workflow transition rules, task enrichment (`available_actions`, `agent_workflows`), runtime orchestration, `TaskStore` trait | UI concerns, view-level behavior |
 | Infrastructure/persistence (Rust) | `apps/desktop/src-tauri/crates/host-infra-beads/*`, `apps/desktop/src-tauri/crates/host-infra-system/*` | Beads-backed `TaskStore`, config/worktree/process integrations | UI workflow decisions |
+
+## Platform-specific native lifecycle seams
+
+- `apps/desktop/src-tauri/src/macos_cef_quit.rs` owns the macOS CEF quit workaround.
+- That module exists because Cmd+Q enters Cocoa's native `terminate:` path before the normal red-close window teardown finishes.
+- For the CEF runtime on macOS, OpenDucktor must start quit by closing windows from `terminate:` and only forward the original native terminate call after all windows are gone.
+- Keep this behavior isolated from generic app shutdown logic in `lib.rs`; the signal handler and `RunEvent::ExitRequested` cleanup path are still generic, while the CEF quit interpose is a platform/runtime-specific seam.
+- If this area regresses, inspect `openducktor.cef.quit` tracing first and compare Cmd+Q against red-window-close behavior before changing broader shutdown code.
 | MCP workflow service (TS) | `packages/openducktor-mcp/src/index.ts`, `packages/openducktor-mcp/src/lib.ts`, `packages/openducktor-mcp/src/odt-task-store.ts` | public MCP task tools (`create_task`, `search_tasks`, `odt_read_task`) plus `odt_*` workflow execution and validation against Beads metadata/status | Frontend rendering/state |
 
 ## Runtime Data Flows


### PR DESCRIPTION
## Summary
- move the macOS CEF quit workaround out of `src/lib.rs` into a dedicated `macos_cef_quit` module with targeted native quit tracing
- intercept the CEF app `terminate:` path so Cmd+Q closes windows first and only forwards native termination after teardown completes
- document the platform-specific quit seam in the architecture guide and keep the CEF-only Rust verification green

## Verification
- `rtk cargo check --package openducktor-desktop --no-default-features --features cef`
- `rtk cargo test --package openducktor-desktop --no-default-features --features cef`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized macOS-specific quit handling code for improved maintainability.

* **Documentation**
  * Added architecture documentation for platform-specific lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->