### PR TITLE
fix(desktop): preserve context usage for idle sessions

### DIFF
--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
@@ -299,6 +299,33 @@ describe("use-agent-studio-model-selection-model", () => {
     });
   });
 
+  test("prefers selected-model fallback metadata before older assistant-message history", () => {
+    const lookup = toModelDescriptorByKey(CATALOG);
+    const messages: AgentChatMessage[] = [
+      createAssistantMessage({
+        totalTokens: 24,
+        contextWindow: 40_000,
+        outputLimit: 1_000,
+      }),
+    ];
+
+    expect(
+      extractLatestContextUsage({
+        session: createSessionMessageOwner(messages),
+        liveContextUsage: {
+          totalTokens: 31,
+        },
+        modelDescriptorByKey: lookup,
+        fallbackContextWindow: 100_000,
+        fallbackOutputLimit: 4_096,
+      }),
+    ).toEqual({
+      totalTokens: 31,
+      contextWindow: 100_000,
+      outputLimit: 4_096,
+    });
+  });
+
   test("falls back to an older assistant message when the latest tokenized one has no usable context window", () => {
     const lookup = toModelDescriptorByKey(CATALOG);
     const messages: AgentChatMessage[] = [

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.test.ts
@@ -274,6 +274,31 @@ describe("use-agent-studio-model-selection-model", () => {
     });
   });
 
+  test("merges newer live token totals with older assistant-message metadata", () => {
+    const lookup = toModelDescriptorByKey(CATALOG);
+    const messages: AgentChatMessage[] = [
+      createAssistantMessage({
+        totalTokens: 24,
+        contextWindow: 40_000,
+        outputLimit: 1_000,
+      }),
+    ];
+
+    expect(
+      extractLatestContextUsage({
+        session: createSessionMessageOwner(messages),
+        liveContextUsage: {
+          totalTokens: 31,
+        },
+        modelDescriptorByKey: lookup,
+      }),
+    ).toEqual({
+      totalTokens: 31,
+      contextWindow: 40_000,
+      outputLimit: 1_000,
+    });
+  });
+
   test("falls back to an older assistant message when the latest tokenized one has no usable context window", () => {
     const lookup = toModelDescriptorByKey(CATALOG);
     const messages: AgentChatMessage[] = [

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -126,6 +126,80 @@ export const toModelDescriptorByKey = (
   return map;
 };
 
+const pickPositiveNumber = (...values: Array<number | undefined>): number | undefined => {
+  for (const value of values) {
+    if (typeof value === "number" && value > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+const extractFallbackContextUsageEntry = ({
+  session,
+  modelDescriptorByKey,
+  fallbackContextWindow,
+}: {
+  session: SessionMessageOwner | null | undefined;
+  modelDescriptorByKey: ReadonlyMap<string, CatalogModelDescriptor>;
+  fallbackContextWindow: number | undefined;
+}): AgentStudioContextUsageEntry => {
+  if (!session) {
+    return null;
+  }
+
+  return extractLatestContextUsageEntry(
+    fallbackContextWindow === undefined
+      ? {
+          session,
+          modelDescriptorByKey,
+        }
+      : {
+          session,
+          modelDescriptorByKey,
+          fallbackContextWindow,
+        },
+  );
+};
+
+const resolveLiveContextUsageParts = ({
+  liveContextUsage,
+  modelDescriptor,
+  fallbackUsage,
+  fallbackContextWindow,
+}: {
+  liveContextUsage: AgentSessionContextUsage;
+  modelDescriptor: CatalogModelDescriptor | undefined;
+  fallbackUsage: AgentStudioContextUsage;
+  fallbackContextWindow: number | undefined;
+}): ResolvedContextUsageParts | null => {
+  const contextWindow = pickPositiveNumber(
+    liveContextUsage.contextWindow,
+    modelDescriptor?.contextWindow,
+    fallbackUsage?.contextWindow,
+    fallbackContextWindow,
+  );
+  if (contextWindow === undefined) {
+    return null;
+  }
+
+  const outputLimit = pickPositiveNumber(
+    liveContextUsage.outputLimit,
+    modelDescriptor?.outputLimit,
+    fallbackUsage?.outputLimit,
+  );
+
+  if (outputLimit === undefined) {
+    return { contextWindow };
+  }
+
+  return {
+    contextWindow,
+    outputLimit,
+  };
+};
+
 export const extractLatestContextUsage = ({
   session,
   liveContextUsage,
@@ -137,47 +211,32 @@ export const extractLatestContextUsage = ({
   modelDescriptorByKey: ReadonlyMap<string, CatalogModelDescriptor>;
   fallbackContextWindow?: number;
 }): AgentStudioContextUsage => {
-  const fallbackUsageEntry = session
-    ? extractLatestContextUsageEntry({
-        session,
-        modelDescriptorByKey,
-        ...(typeof fallbackContextWindow === "number" ? { fallbackContextWindow } : {}),
-      })
-    : null;
+  const fallbackUsageEntry = extractFallbackContextUsageEntry({
+    session,
+    modelDescriptorByKey,
+    fallbackContextWindow,
+  });
 
   if (liveContextUsage && liveContextUsage.totalTokens > 0) {
     const modelDescriptor = resolveContextUsageDescriptor({
       liveContextUsage,
       modelDescriptorByKey,
     });
-    const resolvedParts: ResolvedContextUsageParts | null = (() => {
-      const contextWindow =
-        liveContextUsage.contextWindow ??
-        modelDescriptor?.contextWindow ??
-        fallbackUsageEntry?.usage.contextWindow ??
-        fallbackContextWindow;
-      if (typeof contextWindow !== "number" || contextWindow <= 0) {
-        return null;
-      }
-
-      const outputLimit =
-        liveContextUsage.outputLimit ??
-        modelDescriptor?.outputLimit ??
-        fallbackUsageEntry?.usage.outputLimit;
-
-      return {
-        contextWindow,
-        ...(typeof outputLimit === "number" ? { outputLimit } : {}),
-      };
-    })();
+    const resolvedParts = resolveLiveContextUsageParts({
+      liveContextUsage,
+      modelDescriptor,
+      fallbackUsage: fallbackUsageEntry?.usage ?? null,
+      fallbackContextWindow,
+    });
     if (resolvedParts) {
-      return {
+      const usage: NonNullable<AgentStudioContextUsage> = {
         totalTokens: liveContextUsage.totalTokens,
         contextWindow: resolvedParts.contextWindow,
-        ...(typeof resolvedParts.outputLimit === "number"
-          ? { outputLimit: resolvedParts.outputLimit }
-          : {}),
       };
+      if (typeof resolvedParts.outputLimit === "number") {
+        usage.outputLimit = resolvedParts.outputLimit;
+      }
+      return usage;
     }
   }
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -147,8 +147,6 @@ export const extractLatestContextUsage = ({
         ...(typeof resolvedOutputLimit === "number" ? { outputLimit: resolvedOutputLimit } : {}),
       };
     }
-
-    return null;
   }
 
   if (!session) {

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -140,27 +140,23 @@ const extractFallbackContextUsageEntry = ({
   session,
   modelDescriptorByKey,
   fallbackContextWindow,
+  fallbackOutputLimit,
 }: {
   session: SessionMessageOwner | null | undefined;
   modelDescriptorByKey: ReadonlyMap<string, CatalogModelDescriptor>;
   fallbackContextWindow: number | undefined;
+  fallbackOutputLimit: number | undefined;
 }): AgentStudioContextUsageEntry => {
   if (!session) {
     return null;
   }
 
-  return extractLatestContextUsageEntry(
-    fallbackContextWindow === undefined
-      ? {
-          session,
-          modelDescriptorByKey,
-        }
-      : {
-          session,
-          modelDescriptorByKey,
-          fallbackContextWindow,
-        },
-  );
+  return extractLatestContextUsageEntry({
+    session,
+    modelDescriptorByKey,
+    ...(fallbackContextWindow !== undefined ? { fallbackContextWindow } : {}),
+    ...(fallbackOutputLimit !== undefined ? { fallbackOutputLimit } : {}),
+  });
 };
 
 const resolveLiveContextUsageParts = ({
@@ -168,17 +164,19 @@ const resolveLiveContextUsageParts = ({
   modelDescriptor,
   fallbackUsage,
   fallbackContextWindow,
+  fallbackOutputLimit,
 }: {
   liveContextUsage: AgentSessionContextUsage;
   modelDescriptor: CatalogModelDescriptor | undefined;
   fallbackUsage: AgentStudioContextUsage;
   fallbackContextWindow: number | undefined;
+  fallbackOutputLimit: number | undefined;
 }): ResolvedContextUsageParts | null => {
   const contextWindow = pickPositiveNumber(
     liveContextUsage.contextWindow,
     modelDescriptor?.contextWindow,
-    fallbackUsage?.contextWindow,
     fallbackContextWindow,
+    fallbackUsage?.contextWindow,
   );
   if (contextWindow === undefined) {
     return null;
@@ -187,6 +185,7 @@ const resolveLiveContextUsageParts = ({
   const outputLimit = pickPositiveNumber(
     liveContextUsage.outputLimit,
     modelDescriptor?.outputLimit,
+    fallbackOutputLimit,
     fallbackUsage?.outputLimit,
   );
 
@@ -205,28 +204,55 @@ export const extractLatestContextUsage = ({
   liveContextUsage,
   modelDescriptorByKey,
   fallbackContextWindow,
+  fallbackOutputLimit,
 }: {
   session: SessionMessageOwner | null | undefined;
   liveContextUsage?: AgentSessionContextUsage | null;
   modelDescriptorByKey: ReadonlyMap<string, CatalogModelDescriptor>;
   fallbackContextWindow?: number;
+  fallbackOutputLimit?: number;
 }): AgentStudioContextUsage => {
-  const fallbackUsageEntry = extractFallbackContextUsageEntry({
-    session,
-    modelDescriptorByKey,
-    fallbackContextWindow,
-  });
+  let fallbackUsageEntry: AgentStudioContextUsageEntry | undefined;
+  const getFallbackUsageEntry = (): AgentStudioContextUsageEntry => {
+    if (fallbackUsageEntry !== undefined) {
+      return fallbackUsageEntry;
+    }
+
+    fallbackUsageEntry = extractFallbackContextUsageEntry({
+      session,
+      modelDescriptorByKey,
+      fallbackContextWindow,
+      fallbackOutputLimit,
+    });
+    return fallbackUsageEntry;
+  };
 
   if (liveContextUsage && liveContextUsage.totalTokens > 0) {
     const modelDescriptor = resolveContextUsageDescriptor({
       liveContextUsage,
       modelDescriptorByKey,
     });
+    let fallbackUsage: AgentStudioContextUsage = null;
+    const needsHistoryFallback =
+      pickPositiveNumber(
+        liveContextUsage.contextWindow,
+        modelDescriptor?.contextWindow,
+        fallbackContextWindow,
+      ) === undefined ||
+      pickPositiveNumber(
+        liveContextUsage.outputLimit,
+        modelDescriptor?.outputLimit,
+        fallbackOutputLimit,
+      ) === undefined;
+    if (needsHistoryFallback) {
+      fallbackUsage = getFallbackUsageEntry()?.usage ?? null;
+    }
     const resolvedParts = resolveLiveContextUsageParts({
       liveContextUsage,
       modelDescriptor,
-      fallbackUsage: fallbackUsageEntry?.usage ?? null,
+      fallbackUsage,
       fallbackContextWindow,
+      fallbackOutputLimit,
     });
     if (resolvedParts) {
       const usage: NonNullable<AgentStudioContextUsage> = {
@@ -240,19 +266,21 @@ export const extractLatestContextUsage = ({
     }
   }
 
-  return fallbackUsageEntry?.usage ?? null;
+  return getFallbackUsageEntry()?.usage ?? null;
 };
 
 export const extractLatestContextUsageEntry = ({
   session,
   modelDescriptorByKey,
   fallbackContextWindow,
+  fallbackOutputLimit,
   startIndex = 0,
   endIndex,
 }: {
   session: SessionMessageOwner | null | undefined;
   modelDescriptorByKey: ReadonlyMap<string, CatalogModelDescriptor>;
   fallbackContextWindow?: number;
+  fallbackOutputLimit?: number;
   startIndex?: number;
   endIndex?: number;
 }): AgentStudioContextUsageEntry => {
@@ -288,7 +316,8 @@ export const extractLatestContextUsageEntry = ({
     if (typeof contextWindow !== "number" || contextWindow <= 0) {
       continue;
     }
-    const outputLimit = message.meta.outputLimit ?? modelDescriptor?.outputLimit;
+    const outputLimit =
+      message.meta.outputLimit ?? modelDescriptor?.outputLimit ?? fallbackOutputLimit;
 
     return {
       usage: {

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection-model.ts
@@ -23,6 +23,11 @@ export type AgentStudioContextUsageEntry = {
   sourceIndex: number;
 } | null;
 
+type ResolvedContextUsageParts = {
+  contextWindow: number;
+  outputLimit?: number;
+};
+
 type CatalogModelDescriptor = AgentModelCatalog["models"][number];
 
 export const toRoleDefaultSelection = (
@@ -132,34 +137,51 @@ export const extractLatestContextUsage = ({
   modelDescriptorByKey: ReadonlyMap<string, CatalogModelDescriptor>;
   fallbackContextWindow?: number;
 }): AgentStudioContextUsage => {
+  const fallbackUsageEntry = session
+    ? extractLatestContextUsageEntry({
+        session,
+        modelDescriptorByKey,
+        ...(typeof fallbackContextWindow === "number" ? { fallbackContextWindow } : {}),
+      })
+    : null;
+
   if (liveContextUsage && liveContextUsage.totalTokens > 0) {
     const modelDescriptor = resolveContextUsageDescriptor({
       liveContextUsage,
       modelDescriptorByKey,
     });
-    const contextWindow =
-      liveContextUsage.contextWindow ?? modelDescriptor?.contextWindow ?? fallbackContextWindow;
-    if (typeof contextWindow === "number" && contextWindow > 0) {
-      const resolvedOutputLimit = liveContextUsage.outputLimit ?? modelDescriptor?.outputLimit;
+    const resolvedParts: ResolvedContextUsageParts | null = (() => {
+      const contextWindow =
+        liveContextUsage.contextWindow ??
+        modelDescriptor?.contextWindow ??
+        fallbackUsageEntry?.usage.contextWindow ??
+        fallbackContextWindow;
+      if (typeof contextWindow !== "number" || contextWindow <= 0) {
+        return null;
+      }
+
+      const outputLimit =
+        liveContextUsage.outputLimit ??
+        modelDescriptor?.outputLimit ??
+        fallbackUsageEntry?.usage.outputLimit;
+
+      return {
+        contextWindow,
+        ...(typeof outputLimit === "number" ? { outputLimit } : {}),
+      };
+    })();
+    if (resolvedParts) {
       return {
         totalTokens: liveContextUsage.totalTokens,
-        contextWindow,
-        ...(typeof resolvedOutputLimit === "number" ? { outputLimit: resolvedOutputLimit } : {}),
+        contextWindow: resolvedParts.contextWindow,
+        ...(typeof resolvedParts.outputLimit === "number"
+          ? { outputLimit: resolvedParts.outputLimit }
+          : {}),
       };
     }
   }
 
-  if (!session) {
-    return null;
-  }
-
-  return (
-    extractLatestContextUsageEntry({
-      session,
-      modelDescriptorByKey,
-      ...(typeof fallbackContextWindow === "number" ? { fallbackContextWindow } : {}),
-    })?.usage ?? null
-  );
+  return fallbackUsageEntry?.usage ?? null;
 };
 
 export const extractLatestContextUsageEntry = ({

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -1002,6 +1002,42 @@ describe("useAgentStudioModelSelection", () => {
     }
   });
 
+  test("keeps live context usage visible when idle appends a final assistant message without token metadata", async () => {
+    const contextUsage = {
+      totalTokens: 44,
+      contextWindow: 150_000,
+      outputLimit: 4_096,
+    };
+    const activeSession = createActiveSession({
+      status: "running",
+      selectedModel: null,
+      modelCatalog: null,
+      contextUsage,
+      messages: [],
+    });
+    const harness = createHookHarness(createBaseProps({ activeSession }));
+
+    try {
+      await harness.mount();
+      const previousUsage = harness.getLatest().activeSessionContextUsage;
+
+      await harness.update(
+        createBaseProps({
+          activeSession: {
+            ...activeSession,
+            status: "idle",
+            contextUsage: null,
+            messages: [createAssistantMessage()],
+          },
+        }),
+      );
+
+      expect(harness.getLatest().activeSessionContextUsage).toBe(previousUsage);
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("keeps fallback context usage stable when unrelated tail messages change", async () => {
     const activeSession = createActiveSession({
       contextUsage: null,

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -869,6 +869,57 @@ describe("useAgentStudioModelSelection", () => {
     }
   });
 
+  test("prefers selected model fallback metadata over older assistant message history", async () => {
+    const primaryModel = CATALOG.models[0];
+    const secondaryModel = CATALOG.models[1];
+    if (!primaryModel || !secondaryModel) {
+      throw new Error("Expected catalog fixture models");
+    }
+    const catalogWithSelectionFallback: AgentModelCatalog = {
+      ...CATALOG,
+      models: [
+        primaryModel,
+        {
+          ...secondaryModel,
+          contextWindow: 100_000,
+          outputLimit: 4_096,
+        },
+      ],
+    };
+    const activeSession = createActiveSession({
+      status: "idle",
+      modelCatalog: catalogWithSelectionFallback,
+      selectedModel: {
+        runtimeKind: "opencode",
+        providerId: "anthropic",
+        modelId: "claude-sonnet",
+      },
+      contextUsage: {
+        totalTokens: 31,
+      },
+      messages: [
+        createAssistantMessage({
+          totalTokens: 24,
+          contextWindow: 40_000,
+          outputLimit: 1_000,
+        }),
+      ],
+    });
+
+    const harness = createHookHarness(createBaseProps({ activeSession }));
+
+    try {
+      await harness.mount();
+      expect(harness.getLatest().activeSessionContextUsage).toEqual({
+        totalTokens: 31,
+        contextWindow: 100_000,
+        outputLimit: 4_096,
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("falls back to the selected model context window when message + descriptor metadata are missing", async () => {
     const primaryModel = CATALOG.models[0];
     const secondaryModel = CATALOG.models[1];

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -830,6 +830,45 @@ describe("useAgentStudioModelSelection", () => {
     }
   });
 
+  test("falls back to assistant message context usage when an idle session has incomplete live usage", async () => {
+    const activeSession = createActiveSession({
+      status: "idle",
+      selectedModel: null,
+      modelCatalog: null,
+      contextUsage: {
+        totalTokens: 24,
+      },
+      messages: [
+        createAssistantMessage({
+          totalTokens: 24,
+          contextWindow: 40_000,
+          outputLimit: 1_000,
+        }),
+      ],
+    });
+
+    const harness = createHookHarness(
+      createBaseProps({
+        activeSession,
+        loadCatalog: async () => {
+          throw new Error("catalog unavailable");
+        },
+      }),
+    );
+
+    try {
+      await harness.mount();
+      await harness.waitFor((state) => state.isSelectionCatalogLoading === false);
+      expect(harness.getLatest().activeSessionContextUsage).toEqual({
+        totalTokens: 24,
+        contextWindow: 40_000,
+        outputLimit: 1_000,
+      });
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("falls back to the selected model context window when message + descriptor metadata are missing", async () => {
     const primaryModel = CATALOG.models[0];
     const secondaryModel = CATALOG.models[1];

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -830,13 +830,13 @@ describe("useAgentStudioModelSelection", () => {
     }
   });
 
-  test("falls back to assistant message context usage when an idle session has incomplete live usage", async () => {
+  test("merges incomplete idle live usage with assistant message metadata", async () => {
     const activeSession = createActiveSession({
       status: "idle",
       selectedModel: null,
       modelCatalog: null,
       contextUsage: {
-        totalTokens: 24,
+        totalTokens: 31,
       },
       messages: [
         createAssistantMessage({
@@ -860,7 +860,7 @@ describe("useAgentStudioModelSelection", () => {
       await harness.mount();
       await harness.waitFor((state) => state.isSelectionCatalogLoading === false);
       expect(harness.getLatest().activeSessionContextUsage).toEqual({
-        totalTokens: 24,
+        totalTokens: 31,
         contextWindow: 40_000,
         outputLimit: 1_000,
       });

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.test.tsx
@@ -1002,42 +1002,6 @@ describe("useAgentStudioModelSelection", () => {
     }
   });
 
-  test("keeps live context usage visible when idle appends a final assistant message without token metadata", async () => {
-    const contextUsage = {
-      totalTokens: 44,
-      contextWindow: 150_000,
-      outputLimit: 4_096,
-    };
-    const activeSession = createActiveSession({
-      status: "running",
-      selectedModel: null,
-      modelCatalog: null,
-      contextUsage,
-      messages: [],
-    });
-    const harness = createHookHarness(createBaseProps({ activeSession }));
-
-    try {
-      await harness.mount();
-      const previousUsage = harness.getLatest().activeSessionContextUsage;
-
-      await harness.update(
-        createBaseProps({
-          activeSession: {
-            ...activeSession,
-            status: "idle",
-            contextUsage: null,
-            messages: [createAssistantMessage()],
-          },
-        }),
-      );
-
-      expect(harness.getLatest().activeSessionContextUsage).toBe(previousUsage);
-    } finally {
-      await harness.unmount();
-    }
-  });
-
   test("keeps fallback context usage stable when unrelated tail messages change", async () => {
     const activeSession = createActiveSession({
       contextUsage: null,

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -18,10 +18,7 @@ import {
 import type { ComboboxOption } from "@/components/ui/combobox";
 import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
-import {
-  findFirstChangedSessionMessageIndex,
-  getSessionMessageCount,
-} from "@/state/operations/agent-orchestrator/support/messages";
+import { findFirstChangedSessionMessageIndex } from "@/state/operations/agent-orchestrator/support/messages";
 import {
   sessionFileSearchQueryOptions,
   sessionSlashCommandsQueryOptions,
@@ -698,22 +695,6 @@ export function useAgentStudioModelSelection({
             metadataKey,
           };
           return cached.value;
-        }
-
-        if (!nextUsageEntry && cached.sourceIndex === Number.MAX_SAFE_INTEGER) {
-          const cachedMessageCount = getSessionMessageCount({
-            sessionId: cached.sessionId,
-            messages: cached.messages,
-          });
-          const onlyAppendedMessages = firstChangedMessageIndex >= cachedMessageCount;
-          if (onlyAppendedMessages) {
-            activeSessionContextUsageCacheRef.current = {
-              ...cached,
-              messages: activeSessionMessageOwnerForContextUsage.messages,
-              metadataKey,
-            };
-            return cached.value;
-          }
         }
 
         if (!nextUsageEntry && firstChangedMessageIndex > 0) {

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -18,7 +18,10 @@ import {
 import type { ComboboxOption } from "@/components/ui/combobox";
 import { DEFAULT_RUNTIME_KIND } from "@/lib/agent-runtime";
 import { useRuntimeDefinitionsContext } from "@/state/app-state-contexts";
-import { findFirstChangedSessionMessageIndex } from "@/state/operations/agent-orchestrator/support/messages";
+import {
+  findFirstChangedSessionMessageIndex,
+  getSessionMessageCount,
+} from "@/state/operations/agent-orchestrator/support/messages";
 import {
   sessionFileSearchQueryOptions,
   sessionSlashCommandsQueryOptions,
@@ -695,6 +698,22 @@ export function useAgentStudioModelSelection({
             metadataKey,
           };
           return cached.value;
+        }
+
+        if (!nextUsageEntry && cached.sourceIndex === Number.MAX_SAFE_INTEGER) {
+          const cachedMessageCount = getSessionMessageCount({
+            sessionId: cached.sessionId,
+            messages: cached.messages,
+          });
+          const onlyAppendedMessages = firstChangedMessageIndex >= cachedMessageCount;
+          if (onlyAppendedMessages) {
+            activeSessionContextUsageCacheRef.current = {
+              ...cached,
+              messages: activeSessionMessageOwnerForContextUsage.messages,
+              metadataKey,
+            };
+            return cached.value;
+          }
         }
 
         if (!nextUsageEntry && firstChangedMessageIndex > 0) {

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -587,8 +587,7 @@ export function useAgentStudioModelSelection({
   }, [selectionCatalog]);
 
   const activeSessionIdForContextUsage = activeSession?.sessionId ?? null;
-  const activeSessionMessagesForContextUsage =
-    activeSession?.sessionId === activeSessionId ? activeSessionMessages : null;
+  const activeSessionMessagesForContextUsage = activeSessionMessages;
   const activeSessionMessageOwnerForContextUsage = useMemo(
     () =>
       activeSessionIdForContextUsage && activeSessionMessagesForContextUsage
@@ -608,6 +607,8 @@ export function useAgentStudioModelSelection({
       typeof selectedModelEntry?.contextWindow === "number"
         ? selectedModelEntry.contextWindow
         : null;
+    const fallbackOutputLimit =
+      typeof selectedModelEntry?.outputLimit === "number" ? selectedModelEntry.outputLimit : null;
     const metadataKey = [
       activeSessionIdForContextUsage ?? "",
       selectedModelSelection?.providerId ?? "",
@@ -651,6 +652,7 @@ export function useAgentStudioModelSelection({
         liveContextUsage: activeSessionLiveContextUsage,
         modelDescriptorByKey: activeSessionModelDescriptorByKey,
         ...(fallbackContextWindow !== null ? { fallbackContextWindow } : {}),
+        ...(fallbackOutputLimit !== null ? { fallbackOutputLimit } : {}),
       });
       if (nextUsage === null) {
         activeSessionContextUsageCacheRef.current = null;
@@ -685,6 +687,7 @@ export function useAgentStudioModelSelection({
           session: activeSessionMessageOwnerForContextUsage,
           modelDescriptorByKey: activeSessionModelDescriptorByKey,
           ...(fallbackContextWindow !== null ? { fallbackContextWindow } : {}),
+          ...(fallbackOutputLimit !== null ? { fallbackOutputLimit } : {}),
           startIndex: firstChangedMessageIndex,
         });
 
@@ -702,6 +705,7 @@ export function useAgentStudioModelSelection({
             session: activeSessionMessageOwnerForContextUsage,
             modelDescriptorByKey: activeSessionModelDescriptorByKey,
             ...(fallbackContextWindow !== null ? { fallbackContextWindow } : {}),
+            ...(fallbackOutputLimit !== null ? { fallbackOutputLimit } : {}),
             endIndex: firstChangedMessageIndex - 1,
           });
         }
@@ -710,6 +714,7 @@ export function useAgentStudioModelSelection({
           session: activeSessionMessageOwnerForContextUsage,
           modelDescriptorByKey: activeSessionModelDescriptorByKey,
           ...(fallbackContextWindow !== null ? { fallbackContextWindow } : {}),
+          ...(fallbackOutputLimit !== null ? { fallbackOutputLimit } : {}),
         });
       }
     }

--- a/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-model-selection.ts
@@ -586,13 +586,9 @@ export function useAgentStudioModelSelection({
     return map;
   }, [selectionCatalog]);
 
-  const activeSessionForContextUsage =
-    activeSessionLiveContextUsage && activeSessionLiveContextUsage.totalTokens > 0
-      ? null
-      : activeSession;
-  const activeSessionIdForContextUsage = activeSessionForContextUsage?.sessionId ?? null;
+  const activeSessionIdForContextUsage = activeSession?.sessionId ?? null;
   const activeSessionMessagesForContextUsage =
-    activeSessionForContextUsage?.sessionId === activeSessionId ? activeSessionMessages : null;
+    activeSession?.sessionId === activeSessionId ? activeSessionMessages : null;
   const activeSessionMessageOwnerForContextUsage = useMemo(
     () =>
       activeSessionIdForContextUsage && activeSessionMessagesForContextUsage

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-event-types.ts
@@ -38,6 +38,7 @@ export type AttachAgentSessionListenerParams = {
   >;
   turnStartedAtBySessionRef: MutableRefObject<Record<string, number>>;
   turnModelBySessionRef?: MutableRefObject<Record<string, AgentSessionState["selectedModel"]>>;
+  contextUsageMessageIdBySessionRef?: MutableRefObject<Record<string, string>>;
   updateSession: UpdateSession;
   resolveTurnDurationMs: ResolveTurnDuration;
   clearTurnDuration: (sessionId: string) => void;
@@ -63,6 +64,7 @@ export type SessionTurnContext = Pick<
   | "sessionId"
   | "turnStartedAtBySessionRef"
   | "turnModelBySessionRef"
+  | "contextUsageMessageIdBySessionRef"
   | "resolveTurnDurationMs"
   | "clearTurnDuration"
 >;
@@ -121,6 +123,9 @@ export const createSessionEventHandlerContext = (
       ...(context.turnModelBySessionRef
         ? { turnModelBySessionRef: context.turnModelBySessionRef }
         : {}),
+      ...(context.contextUsageMessageIdBySessionRef
+        ? { contextUsageMessageIdBySessionRef: context.contextUsageMessageIdBySessionRef }
+        : {}),
       resolveTurnDurationMs: context.resolveTurnDurationMs,
       clearTurnDuration: context.clearTurnDuration,
     },
@@ -150,6 +155,9 @@ export const createSessionEventHandlerContext = (
       turnStartedAtBySessionRef: context.turnStartedAtBySessionRef,
       ...(context.turnModelBySessionRef
         ? { turnModelBySessionRef: context.turnModelBySessionRef }
+        : {}),
+      ...(context.contextUsageMessageIdBySessionRef
+        ? { contextUsageMessageIdBySessionRef: context.contextUsageMessageIdBySessionRef }
         : {}),
       resolveTurnDurationMs: context.resolveTurnDurationMs,
       clearTurnDuration: context.clearTurnDuration,

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -2844,6 +2844,242 @@ describe("agent-orchestrator-session-events", () => {
     });
   });
 
+  test("preserves step-derived context usage even when no assistant transcript row exists yet", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          selectedModel: {
+            runtimeKind: "opencode",
+            providerId: "openai",
+            modelId: "gpt-5",
+            variant: "high",
+            profileId: "Hephaestus",
+          },
+          modelCatalog: {
+            models: [
+              {
+                id: "openai/gpt-5",
+                providerId: "openai",
+                providerName: "OpenAI",
+                modelId: "gpt-5",
+                modelName: "GPT-5",
+                variants: ["high"],
+                contextWindow: 200_000,
+                outputLimit: 8_192,
+              },
+            ],
+            defaultModelsByProvider: { openai: "gpt-5" },
+          },
+        }),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      draftMessageIdBySessionRef: { current: {} },
+      draftFlushTimeoutBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "assistant_part",
+      sessionId: "session-1",
+      timestamp: "2026-02-22T08:00:02.000Z",
+      part: {
+        kind: "step",
+        messageId: "assistant-live-1",
+        partId: "step-finish-1",
+        phase: "finish",
+        reason: "tool-calls",
+        totalTokens: 35_022,
+      },
+    });
+
+    handleEvent({
+      type: "assistant_message",
+      sessionId: "session-1",
+      messageId: "assistant-live-1",
+      timestamp: "2026-02-22T08:00:03.000Z",
+      message: "Final answer",
+    });
+
+    expect(sessionsRef.current["session-1"]?.contextUsage).toEqual({
+      totalTokens: 35_022,
+      contextWindow: 200_000,
+      outputLimit: 8_192,
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "Hephaestus",
+    });
+    expect(sessionMessageAt(getSession(sessionsRef), 0)?.meta).toMatchObject({
+      kind: "assistant",
+      totalTokens: 35_022,
+      contextWindow: 200_000,
+      outputLimit: 8_192,
+    });
+  });
+
+  test("does not carry previous-turn context usage into a new final snapshot without token updates", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          contextUsage: {
+            totalTokens: 35_022,
+            contextWindow: 200_000,
+            outputLimit: 8_192,
+            providerId: "openai",
+            modelId: "gpt-5",
+            variant: "high",
+            profileId: "Hephaestus",
+          },
+          selectedModel: {
+            runtimeKind: "opencode",
+            providerId: "openai",
+            modelId: "gpt-5",
+            variant: "high",
+            profileId: "Hephaestus",
+          },
+          modelCatalog: {
+            models: [
+              {
+                id: "openai/gpt-5",
+                providerId: "openai",
+                providerName: "OpenAI",
+                modelId: "gpt-5",
+                modelName: "GPT-5",
+                variants: ["high"],
+                contextWindow: 200_000,
+                outputLimit: 8_192,
+              },
+            ],
+            defaultModelsByProvider: { openai: "gpt-5" },
+          },
+        }),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      draftMessageIdBySessionRef: { current: {} },
+      draftFlushTimeoutBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "assistant_part",
+      sessionId: "session-1",
+      timestamp: "2026-02-22T08:00:01.000Z",
+      part: {
+        kind: "text",
+        messageId: "assistant-live-2",
+        partId: "text-1",
+        text: "Fresh answer",
+        completed: true,
+      },
+    });
+
+    handleEvent({
+      type: "assistant_message",
+      sessionId: "session-1",
+      messageId: "assistant-live-2",
+      timestamp: "2026-02-22T08:00:02.000Z",
+      message: "Fresh answer",
+    });
+
+    expect(sessionsRef.current["session-1"]?.contextUsage).toBeNull();
+    expect(sessionMessageAt(getSession(sessionsRef), 0)?.meta).toMatchObject({
+      kind: "assistant",
+      agentRole: "spec",
+      isFinal: true,
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "Hephaestus",
+    });
+    expect(sessionMessageAt(getSession(sessionsRef), 0)?.meta).not.toMatchObject({
+      totalTokens: 35_022,
+    });
+  });
+
   test("routes reasoning deltas into thinking draft state without finalizing assistant text", () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const adapter: SessionEventAdapter = {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -2716,6 +2716,134 @@ describe("agent-orchestrator-session-events", () => {
     });
   });
 
+  test("preserves step-derived context usage when the final assistant message omits token metadata", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession({
+          selectedModel: {
+            runtimeKind: "opencode",
+            providerId: "openai",
+            modelId: "gpt-5",
+            variant: "high",
+            profileId: "Hephaestus",
+          },
+          modelCatalog: {
+            models: [
+              {
+                id: "openai/gpt-5",
+                providerId: "openai",
+                providerName: "OpenAI",
+                modelId: "gpt-5",
+                modelName: "GPT-5",
+                variants: ["high"],
+                contextWindow: 200_000,
+                outputLimit: 8_192,
+              },
+            ],
+            defaultModelsByProvider: { openai: "gpt-5" },
+          },
+        }),
+      },
+    };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      draftMessageIdBySessionRef: { current: {} },
+      draftFlushTimeoutBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "assistant_part",
+      sessionId: "session-1",
+      timestamp: "2026-02-22T08:00:01.000Z",
+      part: {
+        kind: "text",
+        messageId: "assistant-live-1",
+        partId: "text-1",
+        text: "Final answer",
+        completed: true,
+      },
+    });
+
+    handleEvent({
+      type: "assistant_part",
+      sessionId: "session-1",
+      timestamp: "2026-02-22T08:00:02.000Z",
+      part: {
+        kind: "step",
+        messageId: "assistant-live-1",
+        partId: "step-finish-1",
+        phase: "finish",
+        reason: "tool-calls",
+        totalTokens: 35_022,
+      },
+    });
+
+    handleEvent({
+      type: "assistant_message",
+      sessionId: "session-1",
+      messageId: "assistant-live-1",
+      timestamp: "2026-02-22T08:00:03.000Z",
+      message: "Final answer",
+    });
+
+    expect(sessionsRef.current["session-1"]?.contextUsage).toEqual({
+      totalTokens: 35_022,
+      contextWindow: 200_000,
+      outputLimit: 8_192,
+      providerId: "openai",
+      modelId: "gpt-5",
+      variant: "high",
+      profileId: "Hephaestus",
+    });
+    expect(sessionMessageAt(getSession(sessionsRef), 0)?.meta).toMatchObject({
+      kind: "assistant",
+      totalTokens: 35_022,
+      contextWindow: 200_000,
+      outputLimit: 8_192,
+    });
+  });
+
   test("routes reasoning deltas into thinking draft state without finalizing assistant text", () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const adapter: SessionEventAdapter = {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.test.ts
@@ -2593,6 +2593,79 @@ describe("agent-orchestrator-session-events", () => {
     });
   });
 
+  test("does not mark a step message as tokenized when the step update is ignored", () => {
+    const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
+    const adapter: SessionEventAdapter = {
+      subscribeEvents: (_sessionId, handler) => {
+        handlers.push(
+          handler as unknown as (event: { type: string; [key: string]: unknown }) => void,
+        );
+        return () => {};
+      },
+      replyPermission: async () => {},
+    };
+
+    const sessionsRef: { current: Record<string, AgentSessionState> } = {
+      current: {
+        "session-1": buildSession(),
+      },
+    };
+    const contextUsageMessageIdBySessionRef = { current: {} as Record<string, string> };
+
+    const updateSession = (
+      sessionId: string,
+      updater: (current: AgentSessionState) => AgentSessionState,
+    ) => {
+      const current = sessionsRef.current[sessionId];
+      if (!current) {
+        return;
+      }
+      sessionsRef.current = {
+        ...sessionsRef.current,
+        [sessionId]: updater(current),
+      };
+    };
+
+    attachAgentSessionListener({
+      adapter,
+      repoPath: "/tmp/repo",
+      sessionId: "session-1",
+      sessionsRef,
+      draftRawBySessionRef: { current: {} },
+      draftSourceBySessionRef: { current: {} },
+      draftMessageIdBySessionRef: { current: {} },
+      draftFlushTimeoutBySessionRef: { current: {} },
+      turnStartedAtBySessionRef: { current: {} },
+      contextUsageMessageIdBySessionRef,
+      updateSession,
+      resolveTurnDurationMs: () => undefined,
+      clearTurnDuration: () => {},
+      refreshTaskData: async () => {},
+    });
+
+    const handleEvent = handlers[0];
+    if (!handleEvent) {
+      throw new Error("Expected session event handler to be registered");
+    }
+
+    handleEvent({
+      type: "assistant_part",
+      sessionId: "session-1",
+      timestamp: "2026-02-22T08:00:02.000Z",
+      part: {
+        kind: "step",
+        messageId: "assistant-live-1",
+        partId: "step-finish-1",
+        phase: "finish",
+        reason: "tool-calls",
+        totalTokens: 0,
+      },
+    });
+
+    expect(sessionsRef.current["session-1"]?.contextUsage).toBeNull();
+    expect(contextUsageMessageIdBySessionRef.current["session-1"]).toBeUndefined();
+  });
+
   test("keeps live context usage bound to the in-flight turn model after selection changes", () => {
     const handlers: Array<(event: { type: string; [key: string]: unknown }) => void> = [];
     const adapter: SessionEventAdapter = {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-events.ts
@@ -78,7 +78,14 @@ const handleSessionEvent = (context: SessionEventHandlerContext, event: SessionE
 export const attachAgentSessionListener = (
   context: AttachAgentSessionListenerParams,
 ): (() => void) => {
-  const handlerContext = createSessionEventHandlerContext(context);
+  const contextUsageMessageIdBySessionRef = context.contextUsageMessageIdBySessionRef ?? {
+    current: {} as Record<string, string>,
+  };
+  const eventContext = {
+    ...context,
+    contextUsageMessageIdBySessionRef,
+  };
+  const handlerContext = createSessionEventHandlerContext(eventContext);
   const batchWindowMs = context.eventBatchWindowMs ?? SESSION_EVENT_BATCH_WINDOW_MS;
   const batcher = createSessionEventBatcher();
   let queuedEvents: SessionEvent[] = [];
@@ -111,7 +118,7 @@ export const attachAgentSessionListener = (
     let shouldPersistBufferedSession = false;
     let hasBufferedSessionUpdate = false;
     const batchedHandlerContext = createSessionEventHandlerContext({
-      ...context,
+      ...eventContext,
       sessionsRef: batchedSessionsRef,
       updateSession: (sessionId, updater, options) => {
         if (sessionId !== context.sessionId) {

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -9,7 +9,11 @@ import {
   toSessionContextUsage,
 } from "../support/assistant-meta";
 import { READ_ONLY_ROLES } from "../support/core";
-import { appendSessionMessage, upsertSessionMessage } from "../support/messages";
+import {
+  appendSessionMessage,
+  findSessionMessageById,
+  upsertSessionMessage,
+} from "../support/messages";
 import { mergeTodoListPreservingOrder } from "../support/todos";
 import {
   isStopAbortSessionErrorMessage,
@@ -164,12 +168,36 @@ export const handleAssistantMessage = (
       event.timestamp,
       settledMessages,
     );
+    const nextContextUsage = toSessionContextUsage(current, event.totalTokens, event.model);
+    const currentAssistantMessage = findSessionMessageById(
+      { sessionId: current.sessionId, messages: settledMessages },
+      event.messageId,
+    );
+    const shouldPreserveContextUsage =
+      nextContextUsage === null && currentAssistantMessage?.role === "assistant";
+    const resolvedContextUsage = shouldPreserveContextUsage
+      ? (current.contextUsage ?? null)
+      : nextContextUsage;
+    const nextAssistantMeta = {
+      ...toAssistantMessageMeta(
+        current,
+        durationMs,
+        event.totalTokens ?? resolvedContextUsage?.totalTokens,
+        event.model,
+      ),
+    };
+    if (typeof resolvedContextUsage?.contextWindow === "number") {
+      nextAssistantMeta.contextWindow = resolvedContextUsage.contextWindow;
+    }
+    if (typeof resolvedContextUsage?.outputLimit === "number") {
+      nextAssistantMeta.outputLimit = resolvedContextUsage.outputLimit;
+    }
     const nextAssistantMessage = {
       id: event.messageId,
       role: "assistant" as const,
       content: event.message,
       timestamp: event.timestamp,
-      meta: toAssistantMessageMeta(current, durationMs, event.totalTokens, event.model),
+      meta: nextAssistantMeta,
     };
     return {
       ...current,
@@ -177,7 +205,7 @@ export const handleAssistantMessage = (
       draftAssistantMessageId: null,
       draftReasoningText: "",
       draftReasoningMessageId: null,
-      contextUsage: toSessionContextUsage(current, event.totalTokens, event.model),
+      contextUsage: resolvedContextUsage,
       messages: upsertSessionMessage(
         {
           sessionId: current.sessionId,

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -10,11 +10,7 @@ import {
   toSessionContextUsage,
 } from "../support/assistant-meta";
 import { READ_ONLY_ROLES } from "../support/core";
-import {
-  appendSessionMessage,
-  findSessionMessageById,
-  upsertSessionMessage,
-} from "../support/messages";
+import { appendSessionMessage, upsertSessionMessage } from "../support/messages";
 import { mergeTodoListPreservingOrder } from "../support/todos";
 import {
   isStopAbortSessionErrorMessage,
@@ -29,12 +25,22 @@ import {
   settleDraftToIdle,
 } from "./session-helpers";
 
-const clearTurnModelSnapshot = (
-  context: Pick<SessionLifecycleEventContext, "turn" | "store">,
-): void => {
+const clearTurnTracking = (context: Pick<SessionLifecycleEventContext, "turn" | "store">): void => {
   if (context.turn.turnModelBySessionRef) {
     delete context.turn.turnModelBySessionRef.current[context.store.sessionId];
   }
+  if (context.turn.contextUsageMessageIdBySessionRef) {
+    delete context.turn.contextUsageMessageIdBySessionRef.current[context.store.sessionId];
+  }
+};
+
+const nextContextUsageWasEstablishedForMessage = (
+  context: Pick<SessionLifecycleEventContext, "turn" | "store">,
+  messageId: string,
+): boolean => {
+  return (
+    context.turn.contextUsageMessageIdBySessionRef?.current[context.store.sessionId] === messageId
+  );
 };
 
 type PermissionRequiredEvent = Extract<SessionEvent, { type: "permission_required" }>;
@@ -143,22 +149,16 @@ const autoRejectMutatingPermission = (
 
 const resolveFinalAssistantSnapshot = ({
   current,
-  settledMessages,
   durationMs,
   event,
+  shouldPreserveContextUsage,
 }: {
   current: AgentSessionState;
-  settledMessages: AgentSessionState["messages"];
   durationMs: number | undefined;
   event: AssistantMessageEvent;
+  shouldPreserveContextUsage: boolean;
 }) => {
   const nextContextUsage = toSessionContextUsage(current, event.totalTokens, event.model);
-  const currentAssistantMessage = findSessionMessageById(
-    { sessionId: current.sessionId, messages: settledMessages },
-    event.messageId,
-  );
-  const shouldPreserveContextUsage =
-    nextContextUsage === null && currentAssistantMessage?.role === "assistant";
   const resolvedContextUsage = shouldPreserveContextUsage
     ? (current.contextUsage ?? null)
     : nextContextUsage;
@@ -219,11 +219,14 @@ export const handleAssistantMessage = (
       event.timestamp,
       settledMessages,
     );
+    const shouldPreserveContextUsage =
+      nextContextUsageWasEstablishedForMessage(context, event.messageId) &&
+      current.contextUsage !== null;
     const nextSnapshot = resolveFinalAssistantSnapshot({
       current,
-      settledMessages,
       durationMs,
       event,
+      shouldPreserveContextUsage,
     });
     return {
       ...current,
@@ -242,7 +245,7 @@ export const handleAssistantMessage = (
     };
   });
   context.turn.clearTurnDuration(context.store.sessionId);
-  clearTurnModelSnapshot(context);
+  clearTurnTracking(context);
 };
 
 export const handleUserMessage = (
@@ -317,7 +320,7 @@ export const handleSessionStatus = (
 
   if (settleDraftToIdle(context, event.timestamp)) {
     context.turn.clearTurnDuration(context.store.sessionId);
-    clearTurnModelSnapshot(context);
+    clearTurnTracking(context);
   }
 };
 
@@ -511,7 +514,7 @@ export const handleSessionError = (
     { persist: true },
   );
   context.turn.clearTurnDuration(context.store.sessionId);
-  clearTurnModelSnapshot(context);
+  clearTurnTracking(context);
 };
 
 export const handleSessionIdle = (
@@ -522,7 +525,7 @@ export const handleSessionIdle = (
   clearDraftBuffers(context);
   if (settleDraftToIdle(context, event.timestamp)) {
     context.turn.clearTurnDuration(context.store.sessionId);
-    clearTurnModelSnapshot(context);
+    clearTurnTracking(context);
   }
 };
 
@@ -565,5 +568,5 @@ export const handleSessionFinished = (
     { persist: true },
   );
   context.turn.clearTurnDuration(context.store.sessionId);
-  clearTurnModelSnapshot(context);
+  clearTurnTracking(context);
 };

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-lifecycle.ts
@@ -1,6 +1,7 @@
 import type { AgentRole } from "@openducktor/core";
 import { buildReadOnlyPermissionRejectionMessage } from "@openducktor/core";
 import { errorMessage } from "@/lib/errors";
+import type { AgentSessionState } from "@/types/agent-orchestrator";
 import { isMutatingPermission } from "../../permission-policy";
 import { settleDanglingTodoToolMessages } from "../agent-tool-messages";
 import {
@@ -37,6 +38,7 @@ const clearTurnModelSnapshot = (
 };
 
 type PermissionRequiredEvent = Extract<SessionEvent, { type: "permission_required" }>;
+type AssistantMessageEvent = Extract<SessionEvent, { type: "assistant_message" }>;
 
 const toPendingPermission = (event: PermissionRequiredEvent) => ({
   requestId: event.requestId,
@@ -139,6 +141,55 @@ const autoRejectMutatingPermission = (
     });
 };
 
+const resolveFinalAssistantSnapshot = ({
+  current,
+  settledMessages,
+  durationMs,
+  event,
+}: {
+  current: AgentSessionState;
+  settledMessages: AgentSessionState["messages"];
+  durationMs: number | undefined;
+  event: AssistantMessageEvent;
+}) => {
+  const nextContextUsage = toSessionContextUsage(current, event.totalTokens, event.model);
+  const currentAssistantMessage = findSessionMessageById(
+    { sessionId: current.sessionId, messages: settledMessages },
+    event.messageId,
+  );
+  const shouldPreserveContextUsage =
+    nextContextUsage === null && currentAssistantMessage?.role === "assistant";
+  const resolvedContextUsage = shouldPreserveContextUsage
+    ? (current.contextUsage ?? null)
+    : nextContextUsage;
+
+  const assistantMeta = {
+    ...toAssistantMessageMeta(
+      current,
+      durationMs,
+      event.totalTokens ?? resolvedContextUsage?.totalTokens,
+      event.model,
+    ),
+  };
+  if (typeof resolvedContextUsage?.contextWindow === "number") {
+    assistantMeta.contextWindow = resolvedContextUsage.contextWindow;
+  }
+  if (typeof resolvedContextUsage?.outputLimit === "number") {
+    assistantMeta.outputLimit = resolvedContextUsage.outputLimit;
+  }
+
+  return {
+    contextUsage: resolvedContextUsage,
+    assistantMessage: {
+      id: event.messageId,
+      role: "assistant" as const,
+      content: event.message,
+      timestamp: event.timestamp,
+      meta: assistantMeta,
+    },
+  };
+};
+
 export const handleSessionStarted = (
   context: Pick<SessionLifecycleEventContext, "store">,
   event: Extract<SessionEvent, { type: "session_started" }>,
@@ -157,7 +208,7 @@ export const handleSessionStarted = (
 
 export const handleAssistantMessage = (
   context: SessionLifecycleEventContext,
-  event: Extract<SessionEvent, { type: "assistant_message" }>,
+  event: AssistantMessageEvent,
 ): void => {
   flushDraftBuffers(context);
   clearDraftBuffers(context);
@@ -168,50 +219,25 @@ export const handleAssistantMessage = (
       event.timestamp,
       settledMessages,
     );
-    const nextContextUsage = toSessionContextUsage(current, event.totalTokens, event.model);
-    const currentAssistantMessage = findSessionMessageById(
-      { sessionId: current.sessionId, messages: settledMessages },
-      event.messageId,
-    );
-    const shouldPreserveContextUsage =
-      nextContextUsage === null && currentAssistantMessage?.role === "assistant";
-    const resolvedContextUsage = shouldPreserveContextUsage
-      ? (current.contextUsage ?? null)
-      : nextContextUsage;
-    const nextAssistantMeta = {
-      ...toAssistantMessageMeta(
-        current,
-        durationMs,
-        event.totalTokens ?? resolvedContextUsage?.totalTokens,
-        event.model,
-      ),
-    };
-    if (typeof resolvedContextUsage?.contextWindow === "number") {
-      nextAssistantMeta.contextWindow = resolvedContextUsage.contextWindow;
-    }
-    if (typeof resolvedContextUsage?.outputLimit === "number") {
-      nextAssistantMeta.outputLimit = resolvedContextUsage.outputLimit;
-    }
-    const nextAssistantMessage = {
-      id: event.messageId,
-      role: "assistant" as const,
-      content: event.message,
-      timestamp: event.timestamp,
-      meta: nextAssistantMeta,
-    };
+    const nextSnapshot = resolveFinalAssistantSnapshot({
+      current,
+      settledMessages,
+      durationMs,
+      event,
+    });
     return {
       ...current,
       draftAssistantText: "",
       draftAssistantMessageId: null,
       draftReasoningText: "",
       draftReasoningMessageId: null,
-      contextUsage: resolvedContextUsage,
+      contextUsage: nextSnapshot.contextUsage,
       messages: upsertSessionMessage(
         {
           sessionId: current.sessionId,
           messages: settledMessages,
         },
-        nextAssistantMessage,
+        nextSnapshot.assistantMessage,
       ),
     };
   });

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-parts.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-parts.ts
@@ -402,6 +402,11 @@ const handleStepPart = (
     },
     { persist: false },
   );
+
+  if (context.turn.contextUsageMessageIdBySessionRef) {
+    context.turn.contextUsageMessageIdBySessionRef.current[context.store.sessionId] =
+      part.messageId;
+  }
 };
 
 export const handleAssistantPart = (

--- a/apps/desktop/src/state/operations/agent-orchestrator/events/session-parts.ts
+++ b/apps/desktop/src/state/operations/agent-orchestrator/events/session-parts.ts
@@ -394,6 +394,11 @@ const handleStepPart = (
             };
       }
 
+      if (context.turn.contextUsageMessageIdBySessionRef) {
+        context.turn.contextUsageMessageIdBySessionRef.current[context.store.sessionId] =
+          part.messageId;
+      }
+
       return {
         ...prepared,
         status: "running",
@@ -402,11 +407,6 @@ const handleStepPart = (
     },
     { persist: false },
   );
-
-  if (context.turn.contextUsageMessageIdBySessionRef) {
-    context.turn.contextUsageMessageIdBySessionRef.current[context.store.sessionId] =
-      part.messageId;
-  }
 };
 
 export const handleAssistantPart = (


### PR DESCRIPTION
## Summary
- preserve session context usage when a session transitions to idle, including the case where the final assistant snapshot omits token metadata after a step-finish token update
- improve context-usage resolution so partial live usage keeps newer token totals while filling missing window and output metadata from assistant-message history or model descriptors
- simplify the final implementation by moving the idle-state preservation to the session event reducer and removing the now-redundant hook-level fallback

## Testing
- bun test src/state/operations/agent-orchestrator/events/session-events.test.ts src/pages/agents/use-agent-studio-model-selection.test.tsx src/pages/agents/use-agent-studio-page-models.test.tsx src/pages/agents/use-agent-studio-model-selection-model.test.ts
- bun run --filter @openducktor/desktop typecheck

## Notes
- the bug reproduced because `assistant_message` could clear `contextUsage` to `null` when the final snapshot arrived without token metadata, even though the same turn had already produced valid usage from a `step` finish part
- the branch now has reducer-level regression coverage for that live event sequence and focused model-selection coverage for incomplete live usage on idle sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit and integration tests verifying context-usage extraction, fallback precedence (including output-limit fallbacks), model-selection context computation, step-derived token propagation, and session event behavior.

* **Improvements**
  * More robust context-usage resolution: live token totals merge with resolved context-window/output-limit fallbacks (including selection-derived fallbacks and explicit output-limit inputs).
  * Improved session lifecycle handling: consistent preservation/clearing of context usage, explicit tracking of context-usage message IDs, and tighter turn cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->