### PR TITLE
perf(desktop): move agent session host work to blocking workers

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime.rs
@@ -13,8 +13,8 @@ pub(crate) use process_lifecycle::{
 };
 pub use startup_readiness::OpencodeStartupWaitFailure;
 pub(crate) use startup_readiness::{
-    wait_for_local_server_with_process, OpencodeStartupReadinessPolicy,
-    OpencodeStartupWaitReport, StartupCancelEpoch,
+    wait_for_local_server_with_process, OpencodeStartupReadinessPolicy, OpencodeStartupWaitReport,
+    StartupCancelEpoch,
 };
 
 pub(crate) fn spawn_opencode_server(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_session_status.rs
@@ -3,7 +3,7 @@ use super::service_core::{
     CachedOpencodeSessionStatusProbeOutcome, OpencodeSessionStatusFlight,
     OpencodeSessionStatusFlightState, OpencodeSessionStatusProbeLimiter,
 };
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use host_domain::RuntimeRoute;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
@@ -13,7 +13,7 @@ use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
-use url::{Url, form_urlencoded};
+use url::{form_urlencoded, Url};
 
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -567,10 +567,10 @@ impl AppService {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppService, CachedOpencodeSessionStatusProbe, CachedOpencodeSessionStatusProbeOutcome,
+        has_live_opencode_session_status, load_opencode_session_statuses, AppService,
+        CachedOpencodeSessionStatusProbe, CachedOpencodeSessionStatusProbeOutcome,
         OpencodeSessionStatus, OpencodeSessionStatusFlightGuard, OpencodeSessionStatusMap,
-        OpencodeSessionStatusProbeTarget, has_live_opencode_session_status,
-        load_opencode_session_statuses,
+        OpencodeSessionStatusProbeTarget,
     };
     use crate::app_service::test_support::build_service_with_state;
     use anyhow::Result;
@@ -943,16 +943,12 @@ mod tests {
             .join()
             .expect("status server thread should finish");
 
-        assert!(
-            first_error
-                .to_string()
-                .contains("Failed parsing OpenCode session status response")
-        );
-        assert!(
-            second_error
-                .to_string()
-                .contains("Failed parsing OpenCode session status response")
-        );
+        assert!(first_error
+            .to_string()
+            .contains("Failed parsing OpenCode session status response"));
+        assert!(second_error
+            .to_string()
+            .contains("Failed parsing OpenCode session status response"));
         assert_eq!(connections.load(Ordering::SeqCst), 1);
         Ok(())
     }
@@ -975,18 +971,16 @@ mod tests {
         let error = outcome
             .to_result()
             .expect_err("dropped leader should finish waiters with an error");
-        assert!(
-            error
-                .to_string()
-                .contains("OpenCode session status probe aborted unexpectedly")
-        );
+        assert!(error
+            .to_string()
+            .contains("OpenCode session status probe aborted unexpectedly"));
 
         Ok(())
     }
 
     #[test]
-    fn complete_opencode_session_status_flight_recovers_poisoned_state_and_removes_entry()
-    -> Result<()> {
+    fn complete_opencode_session_status_flight_recovers_poisoned_state_and_removes_entry(
+    ) -> Result<()> {
         let (service, _task_state, _git_state) = build_service_with_state(vec![]);
         let target = OpencodeSessionStatusProbeTarget::for_runtime_route(
             &AgentRuntimeKind::Opencode.route_for_port(1235),
@@ -1014,11 +1008,9 @@ mod tests {
                 &CachedOpencodeSessionStatusProbeOutcome::Statuses(OpencodeSessionStatusMap::new()),
             )
             .expect_err("poisoned completion should surface an error");
-        assert!(
-            error
-                .to_string()
-                .contains("OpenCode session status coordination state lock poisoned")
-        );
+        assert!(error
+            .to_string()
+            .contains("OpenCode session status coordination state lock poisoned"));
 
         let flights = service
             .opencode_session_status_flights

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/task_activity_guard.rs
@@ -1,10 +1,9 @@
 use super::cleanup_plans::{normalize_path_for_comparison, normalize_path_key};
 use crate::app_service::{
-    OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget,
     dedupe_opencode_session_status_probe_targets, has_live_opencode_session_status,
-    service_core::AppService,
+    service_core::AppService, OpencodeSessionStatusMap, OpencodeSessionStatusProbeTarget,
 };
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use host_domain::{AgentRuntimeKind, AgentSessionDocument, RunState, RuntimeRole, RuntimeRoute};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;

--- a/apps/desktop/src-tauri/crates/host-application/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/lib.rs
@@ -3,6 +3,6 @@ mod app_service;
 pub use app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
 pub use app_service::{
     AppService, DevServerEmitter, HookTrustConfirmationPort, HookTrustConfirmationRequest,
-    OpencodeStartupWaitFailure, PreparedHookTrustChallenge, RepoConfigUpdate, RepoSettingsUpdate, RunEmitter,
-    WorkspaceSettingsSnapshotUpdate,
+    OpencodeStartupWaitFailure, PreparedHookTrustChallenge, RepoConfigUpdate, RepoSettingsUpdate,
+    RunEmitter, WorkspaceSettingsSnapshotUpdate,
 };

--- a/apps/desktop/src-tauri/src/commands/agent_sessions.rs
+++ b/apps/desktop/src-tauri/src/commands/agent_sessions.rs
@@ -1,4 +1,4 @@
-use crate::{as_error, AppState};
+use crate::{as_error, run_service_blocking, AppState};
 use host_domain::AgentSessionDocument;
 use std::collections::HashMap;
 use tauri::State;
@@ -9,7 +9,12 @@ pub async fn agent_sessions_list(
     repo_path: String,
     task_id: String,
 ) -> Result<Vec<AgentSessionDocument>, String> {
-    as_error(state.service.agent_sessions_list(&repo_path, &task_id))
+    let service = state.service.clone();
+    let result = run_service_blocking("agent_sessions_list", move || {
+        service.agent_sessions_list(&repo_path, &task_id)
+    })
+    .await;
+    as_error(result)
 }
 
 #[tauri::command]
@@ -19,12 +24,14 @@ pub async fn agent_session_upsert(
     task_id: String,
     session: AgentSessionDocument,
 ) -> Result<serde_json::Value, String> {
-    as_error(
-        state
-            .service
+    let service = state.service.clone();
+    let result = run_service_blocking("agent_session_upsert", move || {
+        service
             .agent_session_upsert(&repo_path, &task_id, session)
-            .map(|ok| serde_json::json!({ "ok": ok })),
-    )
+            .map(|ok| serde_json::json!({ "ok": ok }))
+    })
+    .await;
+    as_error(result)
 }
 
 #[tauri::command]
@@ -33,9 +40,138 @@ pub async fn agent_sessions_list_bulk(
     repo_path: String,
     task_ids: Vec<String>,
 ) -> Result<HashMap<String, Vec<AgentSessionDocument>>, String> {
-    as_error(
-        state
-            .service
-            .agent_sessions_list_bulk(&repo_path, &task_ids),
-    )
+    let service = state.service.clone();
+    let result = run_service_blocking("agent_sessions_list_bulk", move || {
+        service.agent_sessions_list_bulk(&repo_path, &task_ids)
+    })
+    .await;
+    as_error(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use host_domain::AgentSessionDocument;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AgentSessionsListPayload {
+        repo_path: String,
+        task_id: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AgentSessionUpsertPayload {
+        repo_path: String,
+        task_id: String,
+        session: AgentSessionDocument,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AgentSessionsListBulkPayload {
+        repo_path: String,
+        task_ids: Vec<String>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct AgentSessionUpsertResponse {
+        ok: bool,
+    }
+
+    #[test]
+    fn agent_sessions_list_payload_accepts_task_identifier() {
+        let payload = json!({
+            "repoPath": "/repo",
+            "taskId": "task-1",
+        });
+        let parsed: AgentSessionsListPayload =
+            serde_json::from_value(payload).expect("payload should deserialize");
+
+        assert_eq!(parsed.repo_path, "/repo");
+        assert_eq!(parsed.task_id, "task-1");
+    }
+
+    #[test]
+    fn agent_sessions_list_payload_rejects_missing_task_id() {
+        let payload = json!({
+            "repoPath": "/repo",
+        });
+        let error = serde_json::from_value::<AgentSessionsListPayload>(payload)
+            .expect_err("task id should be required at command boundary");
+
+        assert!(error.to_string().contains("taskId"));
+    }
+
+    #[test]
+    fn agent_session_upsert_payload_accepts_session_document() {
+        let payload = json!({
+            "repoPath": "/repo",
+            "taskId": "task-1",
+            "session": {
+                "sessionId": "session-1",
+                "externalSessionId": "external-session-1",
+                "role": "build",
+                "scenario": "build_default",
+                "startedAt": "2026-02-20T12:00:00Z",
+                "runtimeKind": "opencode",
+                "workingDirectory": "/repo/worktree/task-1"
+            }
+        });
+        let parsed: AgentSessionUpsertPayload =
+            serde_json::from_value(payload).expect("payload should deserialize");
+
+        assert_eq!(parsed.repo_path, "/repo");
+        assert_eq!(parsed.task_id, "task-1");
+        assert_eq!(parsed.session.session_id, "session-1");
+        assert_eq!(parsed.session.role, "build");
+        assert_eq!(parsed.session.working_directory, "/repo/worktree/task-1");
+    }
+
+    #[test]
+    fn agent_session_upsert_payload_rejects_missing_session() {
+        let payload = json!({
+            "repoPath": "/repo",
+            "taskId": "task-1",
+        });
+        let error = serde_json::from_value::<AgentSessionUpsertPayload>(payload)
+            .expect_err("session should be required at command boundary");
+
+        assert!(error.to_string().contains("session"));
+    }
+
+    #[test]
+    fn agent_sessions_list_bulk_payload_accepts_task_ids() {
+        let payload = json!({
+            "repoPath": "/repo",
+            "taskIds": ["task-1", "task-2"],
+        });
+        let parsed: AgentSessionsListBulkPayload =
+            serde_json::from_value(payload).expect("payload should deserialize");
+
+        assert_eq!(parsed.repo_path, "/repo");
+        assert_eq!(parsed.task_ids, vec!["task-1", "task-2"]);
+    }
+
+    #[test]
+    fn agent_sessions_list_bulk_payload_rejects_missing_task_ids() {
+        let payload = json!({
+            "repoPath": "/repo",
+        });
+        let error = serde_json::from_value::<AgentSessionsListBulkPayload>(payload)
+            .expect_err("task ids should be required at command boundary");
+
+        assert!(error.to_string().contains("taskIds"));
+    }
+
+    #[test]
+    fn agent_session_upsert_response_keeps_ok_envelope() {
+        let response = json!({ "ok": true });
+        let parsed: AgentSessionUpsertResponse =
+            serde_json::from_value(response).expect("response should deserialize");
+
+        assert!(parsed.ok);
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/build.rs
+++ b/apps/desktop/src-tauri/src/commands/build.rs
@@ -318,6 +318,7 @@ pub async fn runs_list(
     repo_path: Option<String>,
 ) -> Result<Vec<RunSummary>, String> {
     let service = state.service.clone();
-    let result = run_service_blocking("runs_list", move || service.runs_list(repo_path.as_deref())).await;
+    let result =
+        run_service_blocking("runs_list", move || service.runs_list(repo_path.as_deref())).await;
     as_error(result)
 }

--- a/apps/desktop/src-tauri/src/commands/git/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/git/mod.rs
@@ -2,12 +2,12 @@ mod authorization;
 mod command_handlers;
 mod snapshot;
 
-pub(crate) use authorization::{
-    invalidate_worktree_resolution_cache_for_repo, resolve_working_dir,
-};
 #[cfg(test)]
 pub(crate) use authorization::{
     authorized_worktree_cache, cache_key, read_worktree_state_token, AuthorizedWorktreeCacheEntry,
+};
+pub(crate) use authorization::{
+    invalidate_worktree_resolution_cache_for_repo, resolve_working_dir,
 };
 pub use command_handlers::{
     git_abort_conflict, git_commit_all, git_commits_ahead_behind, git_create_worktree,

--- a/apps/desktop/src-tauri/src/commands/tasks.rs
+++ b/apps/desktop/src-tauri/src/commands/tasks.rs
@@ -50,8 +50,10 @@ pub async fn tasks_list(
     let service = state.service.clone();
     let result = match done_visible_days {
         Some(days) => {
-            run_service_blocking("tasks_list", move || service.tasks_list_for_kanban(&repo_path, days))
-                .await
+            run_service_blocking("tasks_list", move || {
+                service.tasks_list_for_kanban(&repo_path, days)
+            })
+            .await
         }
         None => run_service_blocking("tasks_list", move || service.tasks_list(&repo_path)).await,
     };

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -79,7 +79,13 @@ fn sanitize_attachment_lookup_token(path_or_name: &str) -> Result<String, String
 fn format_attachment_lookup_display_name(token: &str) -> String {
     let sanitized = token
         .chars()
-        .map(|character| if character.is_control() { '_' } else { character })
+        .map(|character| {
+            if character.is_control() {
+                '_'
+            } else {
+                character
+            }
+        })
         .collect::<String>();
     if sanitized.len() <= MAX_ATTACHMENT_LOOKUP_DISPLAY_LEN {
         return sanitized;
@@ -104,18 +110,17 @@ fn read_staged_attachment_original_name(path: &Path) -> Option<String> {
     Some(rest[1..].to_string())
 }
 
-pub(crate) fn stage_local_attachment_to_temp(name: &str, base64_data: &str) -> Result<PathBuf, String> {
+pub(crate) fn stage_local_attachment_to_temp(
+    name: &str,
+    base64_data: &str,
+) -> Result<PathBuf, String> {
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(base64_data)
         .map_err(|error| format!("Failed to decode attachment payload: {error}"))?;
     let attachment_dir = local_attachment_stage_dir();
     std::fs::create_dir_all(&attachment_dir)
         .map_err(|error| format!("Failed to prepare attachment staging directory: {error}"))?;
-    let file_name = format!(
-        "{}-{}",
-        Uuid::new_v4(),
-        sanitize_attachment_filename(name)
-    );
+    let file_name = format!("{}-{}", Uuid::new_v4(), sanitize_attachment_filename(name));
     let path = attachment_dir.join(file_name);
     std::fs::write(&path, bytes)
         .map_err(|error| format!("Failed to stage local attachment: {error}"))?;
@@ -143,15 +148,20 @@ pub(crate) fn resolve_staged_local_attachment_path(path_or_name: &str) -> Result
     let entries = match std::fs::read_dir(&attachment_dir) {
         Ok(entries) => entries,
         Err(error) if error.kind() == ErrorKind::NotFound => {
-            return Err(format!("No staged local attachment matches '{display_name}'."))
+            return Err(format!(
+                "No staged local attachment matches '{display_name}'."
+            ))
         }
         Err(error) => {
-            return Err(format!("Failed to read attachment staging directory: {error}"))
+            return Err(format!(
+                "Failed to read attachment staging directory: {error}"
+            ))
         }
     };
     let mut matches = Vec::new();
     for entry in entries {
-        let entry = entry.map_err(|error| format!("Failed to read staged attachment entry: {error}"))?;
+        let entry =
+            entry.map_err(|error| format!("Failed to read staged attachment entry: {error}"))?;
         let path = entry.path();
         let Some(name) = read_staged_attachment_original_name(&path) else {
             continue;
@@ -162,7 +172,9 @@ pub(crate) fn resolve_staged_local_attachment_path(path_or_name: &str) -> Result
     }
 
     match matches.len() {
-        0 => Err(format!("No staged local attachment matches '{display_name}'.")),
+        0 => Err(format!(
+            "No staged local attachment matches '{display_name}'."
+        )),
         1 => Ok(matches.remove(0)),
         _ => {
             let mut ranked_matches = matches
@@ -583,13 +595,10 @@ mod tests {
         stage_local_attachment_to_temp, workspace_detect_github_repository,
         workspace_prepare_trusted_hooks_challenge, workspace_save_repo_settings,
         workspace_save_settings_snapshot, workspace_set_trusted_hooks,
-        workspace_update_repo_config,
-        workspace_update_global_git_config, HookSet,
-    };
-    use crate::commands::git::{
-        authorized_worktree_cache, cache_key, read_worktree_state_token,
+        workspace_update_global_git_config, workspace_update_repo_config, HookSet,
     };
     use crate::commands::git::resolve_working_dir;
+    use crate::commands::git::{authorized_worktree_cache, cache_key, read_worktree_state_token};
     use crate::{AppState, RepoConfigPayload, RepoSettingsPayload, SettingsSnapshotPayload};
     use host_application::{AppService, PreparedHookTrustChallenge};
     use host_domain::{TaskStore, WorkspaceRecord, TASK_METADATA_NAMESPACE};
@@ -648,11 +657,8 @@ mod tests {
                 .expect("system clock should be after unix epoch")
                 .as_nanos()
         );
-        let path = stage_local_attachment_to_temp(
-            &unique_name,
-            "cHJldmlldy1ieXRlcw==",
-        )
-        .expect("attachment should stage");
+        let path = stage_local_attachment_to_temp(&unique_name, "cHJldmlldy1ieXRlcw==")
+            .expect("attachment should stage");
 
         let resolved = resolve_staged_local_attachment_path(&unique_name)
             .expect("filename token should resolve to staged path");
@@ -717,12 +723,15 @@ mod tests {
     }
 
     fn seed_authorized_worktree_cache_with_subset(repo: &Path, allowed_worktrees: &[&Path]) {
-        let canonical_repo = fs::canonicalize(repo).expect("repo should canonicalize for cache seed");
+        let canonical_repo =
+            fs::canonicalize(repo).expect("repo should canonicalize for cache seed");
         let worktree_state_token = read_worktree_state_token(canonical_repo.as_path())
             .expect("worktree state token should be readable for cache seed");
         let seeded_worktrees = allowed_worktrees
             .iter()
-            .map(|path| fs::canonicalize(path).expect("worktree should canonicalize for cache seed"))
+            .map(|path| {
+                fs::canonicalize(path).expect("worktree should canonicalize for cache seed")
+            })
             .collect::<HashSet<_>>();
         let mut cache = authorized_worktree_cache()
             .lock()
@@ -1280,7 +1289,8 @@ mod tests {
 
     #[test]
     fn workspace_update_repo_config_invalidates_authorized_worktree_cache() -> Result<(), String> {
-        let fixture = setup_workspace_command_fixture("update-repo-config-cache", HookSet::default());
+        let fixture =
+            setup_workspace_command_fixture("update-repo-config-cache", HookSet::default());
         let repo_path = PathBuf::from(&fixture.repo_path);
         clear_authorized_worktree_cache_for_repo(repo_path.as_path());
         let worktree_one = fixture.root.join("repo-wt-config-one");
@@ -1313,15 +1323,22 @@ mod tests {
         seed_authorized_worktree_cache_with_subset(repo_path.as_path(), &[worktree_one.as_path()]);
 
         let worktree_two_str = worktree_two.to_string_lossy().to_string();
-        let stale_error = resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
-            .expect_err("seeded cache should reject worktree omitted from subset");
+        let stale_error =
+            resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
+                .expect_err("seeded cache should reject worktree omitted from subset");
         assert!(stale_error.contains("not within authorized repository or linked worktrees"));
 
         run_workspace_update_repo_config(
             &fixture,
             RepoConfigPayload {
                 default_runtime_kind: None,
-                worktree_base_path: Some(fixture.root.join("updated-base").to_string_lossy().to_string()),
+                worktree_base_path: Some(
+                    fixture
+                        .root
+                        .join("updated-base")
+                        .to_string_lossy()
+                        .to_string(),
+                ),
                 branch_prefix: None,
                 default_target_branch: None,
                 git: None,
@@ -1332,8 +1349,9 @@ mod tests {
             },
         )?;
 
-        let resolved = resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
-            .expect("worktree cache should refresh after repo config update invalidation");
+        let resolved =
+            resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
+                .expect("worktree cache should refresh after repo config update invalidation");
         let expected = fs::canonicalize(&worktree_two)
             .expect("worktree should canonicalize")
             .to_string_lossy()
@@ -1346,7 +1364,8 @@ mod tests {
 
     #[test]
     fn workspace_save_repo_settings_invalidates_authorized_worktree_cache() -> Result<(), String> {
-        let fixture = setup_workspace_command_fixture("save-repo-settings-cache", HookSet::default());
+        let fixture =
+            setup_workspace_command_fixture("save-repo-settings-cache", HookSet::default());
         let repo_path = PathBuf::from(&fixture.repo_path);
         clear_authorized_worktree_cache_for_repo(repo_path.as_path());
         let worktree_one = fixture.root.join("repo-wt-settings-one");
@@ -1379,15 +1398,22 @@ mod tests {
         seed_authorized_worktree_cache_with_subset(repo_path.as_path(), &[worktree_one.as_path()]);
 
         let worktree_two_str = worktree_two.to_string_lossy().to_string();
-        let stale_error = resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
-            .expect_err("seeded cache should reject worktree omitted from subset");
+        let stale_error =
+            resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
+                .expect_err("seeded cache should reject worktree omitted from subset");
         assert!(stale_error.contains("not within authorized repository or linked worktrees"));
 
         run_workspace_save_repo_settings(
             &fixture,
             RepoSettingsPayload {
                 default_runtime_kind: None,
-                worktree_base_path: Some(fixture.root.join("updated-settings-base").to_string_lossy().to_string()),
+                worktree_base_path: Some(
+                    fixture
+                        .root
+                        .join("updated-settings-base")
+                        .to_string_lossy()
+                        .to_string(),
+                ),
                 branch_prefix: None,
                 default_target_branch: None,
                 git: None,
@@ -1400,8 +1426,9 @@ mod tests {
             },
         )?;
 
-        let resolved = resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
-            .expect("worktree cache should refresh after repo settings save invalidation");
+        let resolved =
+            resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
+                .expect("worktree cache should refresh after repo settings save invalidation");
         let expected = fs::canonicalize(&worktree_two)
             .expect("worktree should canonicalize")
             .to_string_lossy()
@@ -1413,8 +1440,10 @@ mod tests {
     }
 
     #[test]
-    fn workspace_save_settings_snapshot_invalidates_authorized_worktree_cache() -> Result<(), String> {
-        let fixture = setup_workspace_command_fixture("save-settings-snapshot-cache", HookSet::default());
+    fn workspace_save_settings_snapshot_invalidates_authorized_worktree_cache() -> Result<(), String>
+    {
+        let fixture =
+            setup_workspace_command_fixture("save-settings-snapshot-cache", HookSet::default());
         let repo_path = PathBuf::from(&fixture.repo_path);
         clear_authorized_worktree_cache_for_repo(repo_path.as_path());
         let worktree_one = fixture.root.join("repo-wt-snapshot-one");
@@ -1447,8 +1476,9 @@ mod tests {
         seed_authorized_worktree_cache_with_subset(repo_path.as_path(), &[worktree_one.as_path()]);
 
         let worktree_two_str = worktree_two.to_string_lossy().to_string();
-        let stale_error = resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
-            .expect_err("seeded cache should reject worktree omitted from subset");
+        let stale_error =
+            resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
+                .expect_err("seeded cache should reject worktree omitted from subset");
         assert!(stale_error.contains("not within authorized repository or linked worktrees"));
 
         let (theme, git, chat, kanban, autopilot, repos, global_prompt_overrides) = fixture
@@ -1468,8 +1498,9 @@ mod tests {
             },
         )?;
 
-        let resolved = resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
-            .expect("worktree cache should refresh after snapshot save invalidation");
+        let resolved =
+            resolve_working_dir(fixture.repo_path.as_str(), Some(worktree_two_str.as_str()))
+                .expect("worktree cache should refresh after snapshot save invalidation");
         let expected = fs::canonicalize(&worktree_two)
             .expect("worktree should canonicalize")
             .to_string_lossy()

--- a/apps/desktop/src-tauri/src/headless/command_registry.rs
+++ b/apps/desktop/src-tauri/src/headless/command_registry.rs
@@ -44,14 +44,10 @@ impl CommandRegistry {
 
 pub(super) fn build_registry() -> anyhow::Result<CommandRegistry> {
     let mut registry = CommandRegistry::default();
-    workspace_commands::register_commands(&mut registry)
-        .map_err(|error| anyhow!(error))?;
-    git_commands::register_commands(&mut registry)
-        .map_err(|error| anyhow!(error))?;
-    task_commands::register_commands(&mut registry)
-        .map_err(|error| anyhow!(error))?;
-    runtime_commands::register_commands(&mut registry)
-        .map_err(|error| anyhow!(error))?;
+    workspace_commands::register_commands(&mut registry).map_err(|error| anyhow!(error))?;
+    git_commands::register_commands(&mut registry).map_err(|error| anyhow!(error))?;
+    task_commands::register_commands(&mut registry).map_err(|error| anyhow!(error))?;
+    runtime_commands::register_commands(&mut registry).map_err(|error| anyhow!(error))?;
     Ok(registry)
 }
 
@@ -115,9 +111,8 @@ mod tests {
         let root = unique_temp_path("registry");
         fs::create_dir_all(&root).expect("test root should exist");
         let config_store = AppConfigStore::from_path(root.join("config.json"));
-        let task_store: Arc<dyn TaskStore> = Arc::new(BeadsTaskStore::with_metadata_namespace(
-            "openducktor",
-        ));
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(BeadsTaskStore::with_metadata_namespace("openducktor"));
         let service = Arc::new(AppService::new(task_store, config_store));
 
         TestStateFixture {
@@ -162,7 +157,10 @@ mod tests {
             .register("test_command", |_, _| Box::pin(async { Ok(Value::Null) }))
             .expect_err("duplicate registration should fail");
 
-        assert_eq!(error, "duplicate browser backend command registration: test_command");
+        assert_eq!(
+            error,
+            "duplicate browser backend command registration: test_command"
+        );
         assert!(registry.contains("test_command"));
     }
 
@@ -170,10 +168,14 @@ mod tests {
     async fn duplicate_registration_keeps_original_handler() {
         let mut registry = CommandRegistry::default();
         registry
-            .register("test_command", |_, _| Box::pin(async { Ok(json!({ "value": "first" })) }))
+            .register("test_command", |_, _| {
+                Box::pin(async { Ok(json!({ "value": "first" })) })
+            })
             .expect("first registration should succeed");
         registry
-            .register("test_command", |_, _| Box::pin(async { Ok(json!({ "value": "second" })) }))
+            .register("test_command", |_, _| {
+                Box::pin(async { Ok(json!({ "value": "second" })) })
+            })
             .expect_err("duplicate registration should fail");
 
         let fixture = test_state_fixture(registry);

--- a/apps/desktop/src-tauri/src/headless/command_support.rs
+++ b/apps/desktop/src-tauri/src/headless/command_support.rs
@@ -65,11 +65,7 @@ impl IntoResponse for HeadlessCommandError {
             }),
         };
 
-        (
-            self.status,
-            Json(payload),
-        )
-            .into_response()
+        (self.status, Json(payload)).into_response()
     }
 }
 
@@ -107,12 +103,16 @@ impl HookTrustConfirmationPort for HeadlessHookTrustConfirmationPort {
     }
 }
 
-pub(super) fn deserialize_args<T: DeserializeOwned>(args: Value) -> Result<T, HeadlessCommandError> {
+pub(super) fn deserialize_args<T: DeserializeOwned>(
+    args: Value,
+) -> Result<T, HeadlessCommandError> {
     serde_json::from_value(args)
         .map_err(|error| HeadlessCommandError::bad_request(format!("Invalid arguments: {error}")))
 }
 
-pub(super) fn serialize_value<T: serde::Serialize>(value: T) -> Result<Value, HeadlessCommandError> {
+pub(super) fn serialize_value<T: serde::Serialize>(
+    value: T,
+) -> Result<Value, HeadlessCommandError> {
     serde_json::to_value(value).map_err(|error| {
         HeadlessCommandError::internal(format!("Failed to serialize response: {error}"))
     })
@@ -233,9 +233,7 @@ where
     )
 }
 
-pub(super) fn invalidate_repo_worktree_cache(
-    repo_path: &str,
-) -> Result<(), HeadlessCommandError> {
+pub(super) fn invalidate_repo_worktree_cache(repo_path: &str) -> Result<(), HeadlessCommandError> {
     invalidate_worktree_resolution_cache_for_repo(repo_path)
         .map_err(|error| HeadlessCommandError::internal(error.to_string()))
 }

--- a/apps/desktop/src-tauri/src/headless/events.rs
+++ b/apps/desktop/src-tauri/src/headless/events.rs
@@ -66,7 +66,6 @@ impl HeadlessEventBus {
 
         (receiver, replay)
     }
-
 }
 
 pub(super) fn build_sse_response(
@@ -75,11 +74,9 @@ pub(super) fn build_sse_response(
     stream_name: &'static str,
 ) -> impl IntoResponse {
     let (receiver, replay) = bus.subscribe_with_replay(last_event_id);
-    let replay_stream = tokio_stream::iter(
-        replay.into_iter().map(|event| to_sse_event(&event)),
-    );
-    let live_stream = BroadcastStream::new(receiver)
-        .map(move |message| live_event_to_sse(message, stream_name));
+    let replay_stream = tokio_stream::iter(replay.into_iter().map(|event| to_sse_event(&event)));
+    let live_stream =
+        BroadcastStream::new(receiver).map(move |message| live_event_to_sse(message, stream_name));
     let stream: Pin<Box<dyn Stream<Item = Result<Event, Infallible>> + Send>> =
         Box::pin(replay_stream.chain(live_stream));
 
@@ -225,7 +222,10 @@ mod tests {
 
         bus.emit("third".to_string());
 
-        let live = receiver.recv().await.expect("subscribed receiver should get new events");
+        let live = receiver
+            .recv()
+            .await
+            .expect("subscribed receiver should get new events");
         assert_eq!(live.id, 3);
         assert_eq!(live.payload, "third");
     }

--- a/apps/desktop/src-tauri/src/headless/git_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/git_commands.rs
@@ -1,8 +1,8 @@
 use super::command_registry::CommandRegistry;
 use super::command_support::{
     deserialize_args, handle_repo_path_operation_blocking, invalidate_repo_worktree_cache,
-    request_error, run_headless_blocking, serialize_value, CommandResult,
-    HeadlessCommandError, HeadlessState,
+    request_error, run_headless_blocking, serialize_value, CommandResult, HeadlessCommandError,
+    HeadlessState,
 };
 use crate::commands::git::{
     build_worktree_status_summary_with_snapshot, build_worktree_status_with_snapshot,
@@ -140,9 +140,7 @@ fn resolve_authorized_working_dir(
     resolve_working_dir(repo_path, working_dir).map_err(request_error)
 }
 
-fn require_git_commit_message(
-    message: &str,
-) -> Result<String, HeadlessCommandError> {
+fn require_git_commit_message(message: &str) -> Result<String, HeadlessCommandError> {
     let trimmed = message.trim();
     if trimmed.is_empty() {
         return Err(HeadlessCommandError::bad_request("message is required"));
@@ -150,12 +148,12 @@ fn require_git_commit_message(
     Ok(trimmed.to_string())
 }
 
-fn require_git_rebase_target_branch(
-    target_branch: &str,
-) -> Result<String, HeadlessCommandError> {
+fn require_git_rebase_target_branch(target_branch: &str) -> Result<String, HeadlessCommandError> {
     let trimmed = target_branch.trim();
     if trimmed.is_empty() {
-        return Err(HeadlessCommandError::bad_request("targetBranch is required"));
+        return Err(HeadlessCommandError::bad_request(
+            "targetBranch is required",
+        ));
     }
     Ok(trimmed.to_string())
 }
@@ -181,9 +179,12 @@ fn build_worktree_snapshot_metadata(
 pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), String> {
     registry.register("git_get_branches", |state, args| {
         Box::pin(async move {
-            handle_repo_path_operation_blocking(state, args, "git_get_branches", |service, repo_path| {
-                service.git_get_branches(&repo_path)
-            })
+            handle_repo_path_operation_blocking(
+                state,
+                args,
+                "git_get_branches",
+                |service, repo_path| service.git_get_branches(&repo_path),
+            )
             .await
         })
     })?;
@@ -504,10 +505,7 @@ async fn handle_git_commit_all(state: &HeadlessState, args: Value) -> CommandRes
     )
 }
 
-async fn handle_git_reset_worktree_selection(
-    state: &HeadlessState,
-    args: Value,
-) -> CommandResult {
+async fn handle_git_reset_worktree_selection(state: &HeadlessState, args: Value) -> CommandResult {
     let request: GitResetWorktreeSelectionArgs = deserialize_args(args)?;
     let target_branch = require_target_branch(&request.target_branch)
         .map_err(request_error)?
@@ -630,8 +628,8 @@ mod tests {
 
     #[test]
     fn require_git_rebase_target_branch_rejects_blank_values() {
-        let error = require_git_rebase_target_branch("   ")
-            .expect_err("blank target branch should fail");
+        let error =
+            require_git_rebase_target_branch("   ").expect_err("blank target branch should fail");
 
         assert_eq!(error.status, StatusCode::BAD_REQUEST);
         assert_eq!(error.message, "targetBranch is required");

--- a/apps/desktop/src-tauri/src/headless/runtime_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/runtime_commands.rs
@@ -1,6 +1,6 @@
 use super::command_registry::CommandRegistry;
 use super::command_support::{
-    deserialize_args, handle_repo_task_operation, run_headless_blocking, serialize_value,
+    deserialize_args, handle_repo_task_operation_blocking, run_headless_blocking, serialize_value,
     service_error, CommandResult, HeadlessState, RepoTaskArgs,
 };
 use super::events::{make_dev_server_emitter, make_emitter};
@@ -133,13 +133,13 @@ pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), St
         Box::pin(handle_repo_runtime_health_status(state, args))
     })?;
     registry.register("agent_sessions_list", |state, args| {
-        Box::pin(async move { handle_agent_sessions_list(state, args) })
+        Box::pin(handle_agent_sessions_list(state, args))
     })?;
     registry.register("agent_sessions_list_bulk", |state, args| {
-        Box::pin(async move { handle_agent_sessions_list_bulk(state, args) })
+        Box::pin(handle_agent_sessions_list_bulk(state, args))
     })?;
     registry.register("agent_session_upsert", |state, args| {
-        Box::pin(async move { handle_agent_session_upsert(state, args) })
+        Box::pin(handle_agent_session_upsert(state, args))
     })?;
     Ok(())
 }
@@ -376,36 +376,42 @@ async fn handle_repo_runtime_health_status(state: &HeadlessState, args: Value) -
     )
 }
 
-fn handle_agent_sessions_list(state: &HeadlessState, args: Value) -> CommandResult {
-    handle_repo_task_operation(args, |repo_path, task_id| {
-        state.service.agent_sessions_list(&repo_path, &task_id)
-    })
+async fn handle_agent_sessions_list(state: &HeadlessState, args: Value) -> CommandResult {
+    handle_repo_task_operation_blocking(
+        state,
+        args,
+        "agent_sessions_list",
+        |service, repo_path, task_id| service.agent_sessions_list(&repo_path, &task_id),
+    )
+    .await
 }
 
-fn handle_agent_sessions_list_bulk(state: &HeadlessState, args: Value) -> CommandResult {
+async fn handle_agent_sessions_list_bulk(state: &HeadlessState, args: Value) -> CommandResult {
     let AgentSessionsListBulkArgs {
         repo_path,
         task_ids,
     } = deserialize_args(args)?;
+    let service = state.service.clone();
     serialize_value(
-        state
-            .service
-            .agent_sessions_list_bulk(&repo_path, &task_ids)
-            .map_err(service_error)?,
+        run_headless_blocking("agent_sessions_list_bulk", move || {
+            service.agent_sessions_list_bulk(&repo_path, &task_ids)
+        })
+        .await?,
     )
 }
 
-fn handle_agent_session_upsert(state: &HeadlessState, args: Value) -> CommandResult {
+async fn handle_agent_session_upsert(state: &HeadlessState, args: Value) -> CommandResult {
     let AgentSessionUpsertArgs {
         repo_path,
         task_id,
         session,
     } = deserialize_args(args)?;
+    let service = state.service.clone();
     Ok(json!({
-        "ok": state
-            .service
-            .agent_session_upsert(&repo_path, &task_id, session)
-            .map_err(service_error)?
+        "ok": run_headless_blocking("agent_session_upsert", move || {
+            service.agent_session_upsert(&repo_path, &task_id, session)
+        })
+        .await?
     }))
 }
 
@@ -413,6 +419,97 @@ fn handle_agent_session_upsert(state: &HeadlessState, args: Value) -> CommandRes
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn agent_sessions_list_args_accept_task_identifier() {
+        let parsed = deserialize_args::<RepoTaskArgs>(json!({
+            "repoPath": "/repo",
+            "taskId": "task-1"
+        }))
+        .expect("payload should deserialize");
+
+        assert_eq!(parsed.repo_path, "/repo");
+        assert_eq!(parsed.task_id, "task-1");
+    }
+
+    #[test]
+    fn agent_sessions_list_args_reject_missing_task_id() {
+        let error = deserialize_args::<RepoTaskArgs>(json!({
+            "repoPath": "/repo"
+        }))
+        .expect_err("task id should be required at headless transport boundary");
+
+        assert_eq!(error.status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(error.message.contains("taskId"));
+    }
+
+    #[test]
+    fn agent_sessions_list_bulk_args_accept_task_ids() {
+        let parsed = deserialize_args::<AgentSessionsListBulkArgs>(json!({
+            "repoPath": "/repo",
+            "taskIds": ["task-1", "task-2"]
+        }))
+        .expect("payload should deserialize");
+
+        assert_eq!(parsed.repo_path, "/repo");
+        assert_eq!(parsed.task_ids, vec!["task-1", "task-2"]);
+    }
+
+    #[test]
+    fn agent_sessions_list_bulk_args_reject_missing_task_ids() {
+        let error = deserialize_args::<AgentSessionsListBulkArgs>(json!({
+            "repoPath": "/repo"
+        }))
+        .expect_err("task ids should be required at headless transport boundary");
+
+        assert_eq!(error.status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(error.message.contains("taskIds"));
+    }
+
+    #[test]
+    fn agent_session_upsert_args_accept_session_document() {
+        let parsed = deserialize_args::<AgentSessionUpsertArgs>(json!({
+            "repoPath": "/repo",
+            "taskId": "task-1",
+            "session": {
+                "sessionId": "session-1",
+                "externalSessionId": "external-session-1",
+                "role": "build",
+                "scenario": "build_default",
+                "startedAt": "2026-02-20T12:00:00Z",
+                "runtimeKind": "opencode",
+                "workingDirectory": "/repo/worktree/task-1"
+            }
+        }))
+        .expect("payload should deserialize");
+
+        assert_eq!(parsed.repo_path, "/repo");
+        assert_eq!(parsed.task_id, "task-1");
+        assert_eq!(parsed.session.session_id, "session-1");
+        assert_eq!(parsed.session.working_directory, "/repo/worktree/task-1");
+    }
+
+    #[test]
+    fn agent_session_upsert_args_reject_missing_session() {
+        let error = deserialize_args::<AgentSessionUpsertArgs>(json!({
+            "repoPath": "/repo",
+            "taskId": "task-1"
+        }))
+        .expect_err("session should be required at headless transport boundary");
+
+        assert_eq!(error.status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(error.message.contains("session"));
+    }
+
+    #[test]
+    fn agent_session_upsert_response_keeps_ok_envelope() {
+        let response = serde_json::from_value::<serde_json::Map<String, Value>>(json!({
+            "ok": true
+        }))
+        .expect("response should deserialize");
+
+        assert_eq!(response.get("ok"), Some(&json!(true)));
+    }
 
     #[test]
     fn runtime_list_args_reject_invalid_runtime_kind() {

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -2,9 +2,7 @@ use super::command_registry::{build_registry, dispatch_command};
 use super::command_support::{HeadlessCommandError, HeadlessState};
 use super::events::{build_sse_response, parse_last_event_id, HeadlessEventBus};
 use crate::commands::workspace::is_staged_local_attachment_path;
-use crate::{
-    startup_phase_service_bootstrap, startup_phase_shutdown_hooks, startup_phase_tracing,
-};
+use crate::{startup_phase_service_bootstrap, startup_phase_shutdown_hooks, startup_phase_tracing};
 use anyhow::Context;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, Query, State};
@@ -34,16 +32,18 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
     startup_phase_tracing();
     let service = startup_phase_service_bootstrap()?;
     startup_phase_shutdown_hooks(service.clone());
-    let registry = Arc::new(
-        build_registry().context("failed to build browser backend command registry")?,
-    );
+    let registry =
+        Arc::new(build_registry().context("failed to build browser backend command registry")?);
     let events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
     let dev_server_events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
     let app = Router::new()
         .route("/health", get(health_handler))
         .route("/events", get(events_handler))
         .route("/dev-server-events", get(dev_server_events_handler))
-        .route("/local-attachment-preview", get(local_attachment_preview_handler))
+        .route(
+            "/local-attachment-preview",
+            get(local_attachment_preview_handler),
+        )
         .route("/invoke/{command}", post(invoke_handler))
         .layer(browser_backend_cors_layer()?)
         .with_state(HeadlessState {
@@ -124,11 +124,13 @@ async fn local_attachment_preview_handler(
     Query(query): Query<LocalAttachmentPreviewQuery>,
 ) -> Result<Response, HeadlessCommandError> {
     let path = PathBuf::from(&query.path);
-    let metadata = tokio::fs::metadata(&path).await.map_err(|error| HeadlessCommandError {
-        message: format!("Failed to stat local attachment preview: {error}"),
-        status: StatusCode::NOT_FOUND,
-        failure_kind: None,
-    })?;
+    let metadata = tokio::fs::metadata(&path)
+        .await
+        .map_err(|error| HeadlessCommandError {
+            message: format!("Failed to stat local attachment preview: {error}"),
+            status: StatusCode::NOT_FOUND,
+            failure_kind: None,
+        })?;
     if !metadata.is_file() {
         return Err(HeadlessCommandError {
             message: "Local attachment preview path must reference a file".to_string(),
@@ -143,20 +145,23 @@ async fn local_attachment_preview_handler(
     })?;
     if !allowed {
         return Err(HeadlessCommandError {
-            message:
-                "Local attachment preview is only available for staged attachment files."
-                    .to_string(),
+            message: "Local attachment preview is only available for staged attachment files."
+                .to_string(),
             status: StatusCode::FORBIDDEN,
             failure_kind: None,
         });
     }
 
-    let file = tokio::fs::File::open(&path).await.map_err(|error| HeadlessCommandError {
-        message: format!("Failed to read local attachment preview: {error}"),
-        status: StatusCode::INTERNAL_SERVER_ERROR,
-        failure_kind: None,
-    })?;
-    let mime = mime_guess::from_path(&path).first_or_octet_stream().to_string();
+    let file = tokio::fs::File::open(&path)
+        .await
+        .map_err(|error| HeadlessCommandError {
+            message: format!("Failed to read local attachment preview: {error}"),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            failure_kind: None,
+        })?;
+    let mime = mime_guess::from_path(&path)
+        .first_or_octet_stream()
+        .to_string();
     let stream = ReaderStream::new(file);
 
     Response::builder()
@@ -257,9 +262,8 @@ mod tests {
         let root = unique_temp_path("server");
         fs::create_dir_all(&root).expect("test root should exist");
         let config_store = AppConfigStore::from_path(root.join("config.json"));
-        let task_store: Arc<dyn TaskStore> = Arc::new(BeadsTaskStore::with_metadata_namespace(
-            "openducktor",
-        ));
+        let task_store: Arc<dyn TaskStore> =
+            Arc::new(BeadsTaskStore::with_metadata_namespace("openducktor"));
         let service = Arc::new(AppService::new(task_store, config_store));
         let registry = Arc::new(build_registry().expect("registry should build"));
 
@@ -345,7 +349,9 @@ mod tests {
         .expect_err("missing preview path should fail");
 
         assert_eq!(error.status, StatusCode::NOT_FOUND);
-        assert!(error.message.contains("Failed to stat local attachment preview"));
+        assert!(error
+            .message
+            .contains("Failed to stat local attachment preview"));
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/headless/task_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/task_commands.rs
@@ -116,38 +116,60 @@ struct HumanRequestChangesArgs {
 }
 
 pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), String> {
-    registry.register("tasks_list", |state, args| Box::pin(handle_tasks_list(state, args)))?;
-    registry.register("task_create", |state, args| Box::pin(handle_task_create(state, args)))?;
-    registry.register("task_update", |state, args| Box::pin(handle_task_update(state, args)))?;
-    registry.register("task_delete", |state, args| Box::pin(handle_task_delete(state, args)))?;
+    registry.register("tasks_list", |state, args| {
+        Box::pin(handle_tasks_list(state, args))
+    })?;
+    registry.register("task_create", |state, args| {
+        Box::pin(handle_task_create(state, args))
+    })?;
+    registry.register("task_update", |state, args| {
+        Box::pin(handle_task_update(state, args))
+    })?;
+    registry.register("task_delete", |state, args| {
+        Box::pin(handle_task_delete(state, args))
+    })?;
     registry.register("task_reset_implementation", |state, args| {
         Box::pin(handle_task_reset_implementation(state, args))
     })?;
     registry.register("task_transition", |state, args| {
         Box::pin(handle_task_transition(state, args))
     })?;
-    registry.register("task_defer", |state, args| Box::pin(handle_task_defer(state, args)))?;
+    registry.register("task_defer", |state, args| {
+        Box::pin(handle_task_defer(state, args))
+    })?;
     registry.register("task_resume_deferred", |state, args| {
         Box::pin(handle_task_resume_deferred(state, args))
     })?;
-    registry.register("spec_get", |state, args| Box::pin(handle_spec_get(state, args)))?;
+    registry.register("spec_get", |state, args| {
+        Box::pin(handle_spec_get(state, args))
+    })?;
     registry.register("task_metadata_get", |state, args| {
         Box::pin(handle_task_metadata_get(state, args))
     })?;
-    registry.register("set_spec", |state, args| Box::pin(handle_set_spec(state, args)))?;
+    registry.register("set_spec", |state, args| {
+        Box::pin(handle_set_spec(state, args))
+    })?;
     registry.register("spec_save_document", |state, args| {
         Box::pin(handle_spec_save_document(state, args))
     })?;
-    registry.register("plan_get", |state, args| Box::pin(handle_plan_get(state, args)))?;
-    registry.register("set_plan", |state, args| Box::pin(handle_set_plan(state, args)))?;
+    registry.register("plan_get", |state, args| {
+        Box::pin(handle_plan_get(state, args))
+    })?;
+    registry.register("set_plan", |state, args| {
+        Box::pin(handle_set_plan(state, args))
+    })?;
     registry.register("plan_save_document", |state, args| {
         Box::pin(handle_plan_save_document(state, args))
     })?;
     registry.register("qa_get_report", |state, args| {
         Box::pin(handle_qa_get_report(state, args))
     })?;
-    registry.register("qa_approved", |state, args| Box::pin(handle_qa_approved(state, args)))?;
-    registry.register("qa_rejected", |state, args| Box::pin(handle_qa_rejected(state, args)))?;
+    registry.register("qa_approved", |state, args| {
+        Box::pin(handle_qa_approved(state, args))
+    })?;
+    registry.register("qa_rejected", |state, args| {
+        Box::pin(handle_qa_rejected(state, args))
+    })?;
     registry.register("build_blocked", |state, args| {
         Box::pin(async move { handle_build_blocked(state, args) })
     })?;
@@ -278,16 +300,24 @@ async fn handle_task_transition(state: &HeadlessState, args: Value) -> CommandRe
 }
 
 async fn handle_task_defer(state: &HeadlessState, args: Value) -> CommandResult {
-    handle_repo_task_reason_operation_blocking(state, args, "task_defer", |service, repo_path, task_id, reason| {
-        service.task_defer(&repo_path, &task_id, reason.as_deref())
-    })
+    handle_repo_task_reason_operation_blocking(
+        state,
+        args,
+        "task_defer",
+        |service, repo_path, task_id, reason| {
+            service.task_defer(&repo_path, &task_id, reason.as_deref())
+        },
+    )
     .await
 }
 
 async fn handle_task_resume_deferred(state: &HeadlessState, args: Value) -> CommandResult {
-    handle_repo_task_operation_blocking(state, args, "task_resume_deferred", |service, repo_path, task_id| {
-        service.task_resume_deferred(&repo_path, &task_id)
-    })
+    handle_repo_task_operation_blocking(
+        state,
+        args,
+        "task_resume_deferred",
+        |service, repo_path, task_id| service.task_resume_deferred(&repo_path, &task_id),
+    )
     .await
 }
 
@@ -299,9 +329,12 @@ async fn handle_spec_get(state: &HeadlessState, args: Value) -> CommandResult {
 }
 
 async fn handle_task_metadata_get(state: &HeadlessState, args: Value) -> CommandResult {
-    handle_repo_task_operation_blocking(state, args, "task_metadata_get", |service, repo_path, task_id| {
-        service.task_metadata_get(&repo_path, &task_id)
-    })
+    handle_repo_task_operation_blocking(
+        state,
+        args,
+        "task_metadata_get",
+        |service, repo_path, task_id| service.task_metadata_get(&repo_path, &task_id),
+    )
     .await
 }
 
@@ -375,9 +408,12 @@ async fn handle_plan_save_document(state: &HeadlessState, args: Value) -> Comman
 }
 
 async fn handle_qa_get_report(state: &HeadlessState, args: Value) -> CommandResult {
-    handle_repo_task_operation_blocking(state, args, "qa_get_report", |service, repo_path, task_id| {
-        service.qa_get_report(&repo_path, &task_id)
-    })
+    handle_repo_task_operation_blocking(
+        state,
+        args,
+        "qa_get_report",
+        |service, repo_path, task_id| service.qa_get_report(&repo_path, &task_id),
+    )
     .await
 }
 
@@ -477,10 +513,11 @@ async fn handle_task_direct_merge_complete(state: &HeadlessState, args: Value) -
     let service = state.service.clone();
     let repo_path_for_worker = repo_path.clone();
     let task_id_for_worker = task_id.clone();
-    let result = super::command_support::run_headless_blocking("task_direct_merge_complete", move || {
-        service.task_direct_merge_complete(&repo_path_for_worker, &task_id_for_worker)
-    })
-    .await?;
+    let result =
+        super::command_support::run_headless_blocking("task_direct_merge_complete", move || {
+            service.task_direct_merge_complete(&repo_path_for_worker, &task_id_for_worker)
+        })
+        .await?;
     super::command_support::invalidate_repo_worktree_cache(&repo_path)?;
     serialize_value(result)
 }
@@ -515,10 +552,7 @@ fn handle_task_pull_request_detect(state: &HeadlessState, args: Value) -> Comman
     })
 }
 
-async fn handle_task_pull_request_link_merged(
-    state: &HeadlessState,
-    args: Value,
-) -> CommandResult {
+async fn handle_task_pull_request_link_merged(state: &HeadlessState, args: Value) -> CommandResult {
     #[derive(Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct TaskPullRequestLinkMergedArgs {
@@ -535,14 +569,15 @@ async fn handle_task_pull_request_link_merged(
     let service = state.service.clone();
     let repo_path_for_worker = repo_path.clone();
     let task_id_for_worker = task_id.clone();
-    let result = super::command_support::run_headless_blocking("task_pull_request_link_merged", move || {
-        service.task_pull_request_link_merged(
-            &repo_path_for_worker,
-            &task_id_for_worker,
-            pull_request,
-        )
-    })
-    .await?;
+    let result =
+        super::command_support::run_headless_blocking("task_pull_request_link_merged", move || {
+            service.task_pull_request_link_merged(
+                &repo_path_for_worker,
+                &task_id_for_worker,
+                pull_request,
+            )
+        })
+        .await?;
     super::command_support::invalidate_repo_worktree_cache(&repo_path)?;
     serialize_value(result)
 }

--- a/apps/desktop/src-tauri/src/headless/workspace_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/workspace_commands.rs
@@ -84,9 +84,12 @@ struct WorkspaceResolveLocalAttachmentPathArgs {
 pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), String> {
     registry.register("system_check", |state, args| {
         Box::pin(async move {
-            handle_repo_path_operation_blocking(state, args, "system_check", |service, repo_path| {
-                service.system_check(&repo_path)
-            })
+            handle_repo_path_operation_blocking(
+                state,
+                args,
+                "system_check",
+                |service, repo_path| service.system_check(&repo_path),
+            )
             .await
         })
     })?;
@@ -121,15 +124,18 @@ pub(super) fn register_commands(registry: &mut CommandRegistry) -> Result<(), St
     registry.register("workspace_update_repo_hooks", |state, args| {
         Box::pin(async move { handle_workspace_update_repo_hooks(state, args) })
     })?;
-    registry.register("workspace_prepare_trusted_hooks_challenge", |state, args| {
-        Box::pin(async move {
-            handle_repo_path_operation(args, |repo_path| {
-                state
-                    .service
-                    .workspace_prepare_trusted_hooks_challenge(&repo_path)
+    registry.register(
+        "workspace_prepare_trusted_hooks_challenge",
+        |state, args| {
+            Box::pin(async move {
+                handle_repo_path_operation(args, |repo_path| {
+                    state
+                        .service
+                        .workspace_prepare_trusted_hooks_challenge(&repo_path)
+                })
             })
-        })
-    })?;
+        },
+    )?;
     registry.register("workspace_get_repo_config", |state, args| {
         Box::pin(async move {
             handle_repo_path_operation(args, |repo_path| {
@@ -359,10 +365,7 @@ async fn handle_workspace_save_settings_snapshot(
     serialize_value(updated)
 }
 
-async fn handle_workspace_set_trusted_hooks(
-    state: &HeadlessState,
-    args: Value,
-) -> CommandResult {
+async fn handle_workspace_set_trusted_hooks(state: &HeadlessState, args: Value) -> CommandResult {
     let WorkspaceSetTrustedHooksArgs {
         repo_path,
         trusted,


### PR DESCRIPTION
## Summary
- move the desktop Tauri agent-session commands onto `run_service_blocking(...)` so session reads and writes no longer run synchronous host work on async command threads
- extend the same blocking-worker posture to the matching headless session commands and add command-boundary contract tests for both desktop and headless payloads
- keep the service-layer behavior and IPC envelopes stable while carrying forward the repo's current Rust formatting after the rebase

## Why
Session hydration and persistence paths can hit Beads, metadata, and filesystem validation work. Shifting that work to the existing blocking helpers reduces the risk that session-heavy activity stalls unrelated command handling.

## Implementation Notes
- desktop commands updated in `apps/desktop/src-tauri/src/commands/agent_sessions.rs`
- headless parity updated in `apps/desktop/src-tauri/src/headless/runtime_commands.rs`
- service semantics remain in `apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs`
- rebases preserved newer runtime-health and macOS CEF quit behavior while retaining the intended blocking-worker changes

## Testing
- `cargo test -p host-application runtime_`
- `cargo test -p openducktor-desktop agent_session`
- `bun run check:rust`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted imports and function signatures across multiple files for consistency.

* **Refactor**
  * Refactored command handlers to use blocking execution wrappers, improving command execution stability and reliability.

* **Tests**
  * Added unit tests for agent session and task command serialization/deserialization validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->