### PR TITLE
fix(desktop): surface blocked builder tasks as warnings

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.test.ts
@@ -392,6 +392,37 @@ describe("AgentStudioHeader", () => {
 
     expect(html).toContain('title="Session is waiting for input"');
     expect(html).toContain("border-warning-border");
+    expect(html).toContain("lucide-circle-dashed");
+  });
+
+  test("renders blocked builder warning with alert icon and blocked-task copy", () => {
+    const html = renderToStaticMarkup(
+      createElement(AgentStudioHeader, {
+        model: {
+          ...buildModel(),
+          selectedRole: "build",
+          workflowSteps: [
+            {
+              role: "build" as const,
+              label: "Builder",
+              icon: roleIcon(2),
+              state: {
+                tone: "waiting_input" as const,
+                availability: "available" as const,
+                completion: "in_progress" as const,
+                liveSession: "stopped" as const,
+              },
+              sessionId: "build-session",
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(html).toContain('title="Task is blocked and waiting for user action"');
+    expect(html).toContain("border-warning-border");
+    expect(html).toContain("lucide-triangle-alert");
+    expect(html).not.toContain("lucide-circle-dashed size-3.5");
   });
 
   test("renders optional workflow step as neutral dashed styling", () => {

--- a/apps/desktop/src/components/features/agents/agent-studio-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.tsx
@@ -38,6 +38,8 @@ type AgentWorkflowStep = {
   sessionId: string | null;
 };
 
+type WorkflowStepAttentionVariant = "none" | "session_waiting_input" | "blocked_task";
+
 type AgentStudioSessionSelectorModel = {
   value: string;
   groups: ComboboxGroup[];
@@ -135,19 +137,27 @@ const workflowBorderStyleClassName = (state: AgentWorkflowStepState): string =>
   // Dashed styling is only for steps that are currently merely optional and available.
   state.tone === "optional" ? "border-dashed" : "";
 
-const isBlockedTaskWarningStep = (entry: AgentWorkflowStep): boolean => {
-  return (
-    entry.role === "build" &&
-    entry.state.tone === "waiting_input" &&
-    entry.state.liveSession !== "waiting_input"
-  );
+const getWorkflowStepAttentionVariant = (
+  entry: AgentWorkflowStep,
+): WorkflowStepAttentionVariant => {
+  if (entry.state.liveSession === "waiting_input") {
+    return "session_waiting_input";
+  }
+
+  if (entry.role === "build" && entry.state.tone === "waiting_input") {
+    return "blocked_task";
+  }
+
+  return "none";
 };
 
 const workflowStepHint = (entry: AgentWorkflowStep): string => {
-  if (entry.state.liveSession === "waiting_input") {
+  const attentionVariant = getWorkflowStepAttentionVariant(entry);
+
+  if (attentionVariant === "session_waiting_input") {
     return "Session is waiting for input";
   }
-  if (isBlockedTaskWarningStep(entry)) {
+  if (attentionVariant === "blocked_task") {
     return "Task is blocked and waiting for user action";
   }
   if (entry.state.liveSession === "running") {
@@ -378,6 +388,7 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
             const Icon = entry.icon;
             const isSelected = selectedRole === entry.role;
             const shouldSpinInProgress = entry.state.liveSession === "running";
+            const attentionVariant = getWorkflowStepAttentionVariant(entry);
             const nextStep = workflowSteps[index + 1] ?? null;
             return (
               <div key={entry.role} className="flex min-w-0 items-center gap-2">
@@ -403,7 +414,7 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
                   {entry.state.tone === "done" ? (
                     <Check className="size-3.5 text-success-accent" />
                   ) : null}
-                  {entry.state.liveSession === "waiting_input" ? (
+                  {attentionVariant === "session_waiting_input" ? (
                     <CircleDashed className="size-3.5" />
                   ) : null}
                   {entry.state.tone === "in_progress" && shouldSpinInProgress ? (
@@ -414,7 +425,9 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
                   ) : null}
                   {entry.state.tone === "available" ? <Circle className="size-3" /> : null}
                   {entry.state.tone === "optional" ? <CircleDashed className="size-3" /> : null}
-                  {isBlockedTaskWarningStep(entry) ? <AlertTriangle className="size-3.5" /> : null}
+                  {attentionVariant === "blocked_task" ? (
+                    <AlertTriangle className="size-3.5" />
+                  ) : null}
                   {entry.state.tone === "rejected" || entry.state.tone === "failed" ? (
                     <AlertTriangle className="size-3.5" />
                   ) : null}

--- a/apps/desktop/src/components/features/agents/agent-studio-header.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-header.tsx
@@ -135,9 +135,20 @@ const workflowBorderStyleClassName = (state: AgentWorkflowStepState): string =>
   // Dashed styling is only for steps that are currently merely optional and available.
   state.tone === "optional" ? "border-dashed" : "";
 
+const isBlockedTaskWarningStep = (entry: AgentWorkflowStep): boolean => {
+  return (
+    entry.role === "build" &&
+    entry.state.tone === "waiting_input" &&
+    entry.state.liveSession !== "waiting_input"
+  );
+};
+
 const workflowStepHint = (entry: AgentWorkflowStep): string => {
   if (entry.state.liveSession === "waiting_input") {
     return "Session is waiting for input";
+  }
+  if (isBlockedTaskWarningStep(entry)) {
+    return "Task is blocked and waiting for user action";
   }
   if (entry.state.liveSession === "running") {
     return "Step in progress";
@@ -403,6 +414,7 @@ export function AgentStudioHeader({ model }: { model: AgentStudioHeaderModel }):
                   ) : null}
                   {entry.state.tone === "available" ? <Circle className="size-3" /> : null}
                   {entry.state.tone === "optional" ? <CircleDashed className="size-3" /> : null}
+                  {isBlockedTaskWarningStep(entry) ? <AlertTriangle className="size-3.5" /> : null}
                   {entry.state.tone === "rejected" || entry.state.tone === "failed" ? (
                     <AlertTriangle className="size-3.5" />
                   ) : null}

--- a/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-studio-task-tabs.test.tsx
@@ -42,6 +42,7 @@ describe("AgentStudioTaskTabs", () => {
     expect(html).toContain("Ship QA checklist");
     expect(html).toContain('aria-label="Working"');
     expect(html).toContain('aria-label="Waiting input"');
+    expect(html).toContain("text-warning-accent");
     expect(html).toContain('aria-label="Open new task tab"');
     expect(html).toContain("Close tab for Add social login");
     expect(html).toContain("bg-secondary");

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
@@ -370,6 +370,52 @@ describe("agents-page-session-tabs", () => {
     });
   });
 
+  test("keeps blocked builder tasks in progress while the live builder session is still running", () => {
+    const roleSessionByRole = buildRoleSessionSummaryMap([
+      buildSession({ role: "build", status: "running", scenario: "build_implementation_start" }),
+    ]);
+    const states = buildWorkflowStateByRole({
+      task: buildTask({ status: "blocked" }),
+      roleWorkflowsByTask: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: true, completed: true },
+        build: { required: true, canSkip: false, available: true, completed: false },
+        qa: { required: false, canSkip: true, available: false, completed: false },
+      },
+      roleSessionByRole,
+    });
+
+    expect(states.build).toEqual({
+      tone: "in_progress",
+      availability: "available",
+      completion: "in_progress",
+      liveSession: "running",
+    });
+  });
+
+  test("keeps blocked builder tasks failed when the latest builder session errored", () => {
+    const roleSessionByRole = buildRoleSessionSummaryMap([
+      buildSession({ role: "build", status: "error", scenario: "build_implementation_start" }),
+    ]);
+    const states = buildWorkflowStateByRole({
+      task: buildTask({ status: "blocked" }),
+      roleWorkflowsByTask: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: true, completed: true },
+        build: { required: true, canSkip: false, available: true, completed: false },
+        qa: { required: false, canSkip: true, available: false, completed: false },
+      },
+      roleSessionByRole,
+    });
+
+    expect(states.build).toEqual({
+      tone: "failed",
+      availability: "available",
+      completion: "in_progress",
+      liveSession: "error",
+    });
+  });
+
   test("marks workflow role as in_progress when latest role session is started but not completed", () => {
     const roleSessionByRole = buildRoleSessionSummaryMap([
       buildSession({ role: "planner", status: "idle" }),

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.test.ts
@@ -15,7 +15,7 @@ import {
   closeTaskTab,
   ensureActiveTaskTab,
   getAvailableTabTasks,
-  getTabStatusFromSession,
+  getTabStatusForTask,
   parsePersistedTaskTabs,
   resolveFallbackTaskId,
   toPersistedTaskTabs,
@@ -74,14 +74,31 @@ describe("agents-page-session-tabs", () => {
   });
 
   test("prioritizes waiting-input status over running", () => {
-    const status = getTabStatusFromSession(
-      buildSession({
+    const status = getTabStatusForTask({
+      task: buildTask(),
+      session: buildSession({
         status: "running",
         pendingQuestions: [{ requestId: "q-1", questions: [] }],
       }),
-    );
+    });
 
     expect(status).toBe("waiting_input");
+  });
+
+  test("treats blocked tasks as waiting for input even without a live waiting session", () => {
+    expect(
+      getTabStatusForTask({
+        task: buildTask({ status: "blocked" }),
+        session: buildSession({ role: "build", status: "stopped" }),
+      }),
+    ).toBe("waiting_input");
+
+    expect(
+      getTabStatusForTask({
+        task: buildTask({ status: "blocked" }),
+        session: null,
+      }),
+    ).toBe("waiting_input");
   });
 
   test("appends active task tab only once", () => {
@@ -304,6 +321,52 @@ describe("agents-page-session-tabs", () => {
       availability: "available",
       completion: "in_progress",
       liveSession: "stopped",
+    });
+  });
+
+  test("uses warning tone for blocked builder tasks even when the latest session is stopped", () => {
+    const roleSessionByRole = buildRoleSessionSummaryMap([
+      buildSession({ role: "build", status: "stopped", scenario: "build_implementation_start" }),
+    ]);
+    const states = buildWorkflowStateByRole({
+      task: buildTask({ status: "blocked" }),
+      roleWorkflowsByTask: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: true, completed: true },
+        build: { required: true, canSkip: false, available: true, completed: false },
+        qa: { required: false, canSkip: true, available: false, completed: false },
+      },
+      roleSessionByRole,
+    });
+
+    expect(states.build).toEqual({
+      tone: "waiting_input",
+      availability: "available",
+      completion: "in_progress",
+      liveSession: "stopped",
+    });
+    expect(states.spec.tone).toBe("done");
+    expect(states.planner.tone).toBe("done");
+    expect(states.qa.tone).toBe("blocked");
+  });
+
+  test("uses warning tone for blocked builder tasks without an existing builder session", () => {
+    const states = buildWorkflowStateByRole({
+      task: buildTask({ status: "blocked" }),
+      roleWorkflowsByTask: {
+        spec: { required: true, canSkip: false, available: true, completed: true },
+        planner: { required: true, canSkip: false, available: true, completed: true },
+        build: { required: true, canSkip: false, available: true, completed: false },
+        qa: { required: false, canSkip: true, available: false, completed: false },
+      },
+      roleSessionByRole: buildRoleSessionSummaryMap([]),
+    });
+
+    expect(states.build).toEqual({
+      tone: "waiting_input",
+      availability: "available",
+      completion: "not_started",
+      liveSession: "none",
     });
   });
 
@@ -928,6 +991,37 @@ describe("agents-page-session-tabs", () => {
         taskId: "task-ghost",
         taskTitle: "task-ghost",
         status: "idle",
+        isActive: false,
+      },
+    ]);
+  });
+
+  test("builds blocked task tabs with warning status even when the latest session is idle or absent", () => {
+    const latestByTask = buildLatestSessionByTaskMap([
+      buildSession({ taskId: "task-1", role: "build", status: "idle" }),
+    ]);
+
+    const tabs = buildTaskTabs({
+      tabTaskIds: ["task-1", "task-2"],
+      tasks: [
+        buildTask({ id: "task-1", title: "Blocked with session", status: "blocked" }),
+        buildTask({ id: "task-2", title: "Blocked without session", status: "blocked" }),
+      ],
+      latestSessionByTaskId: latestByTask,
+      activeTaskId: "task-1",
+    });
+
+    expect(tabs).toEqual([
+      {
+        taskId: "task-1",
+        taskTitle: "Blocked with session",
+        status: "waiting_input",
+        isActive: true,
+      },
+      {
+        taskId: "task-2",
+        taskTitle: "Blocked without session",
+        status: "waiting_input",
         isActive: false,
       },
     ]);

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -162,7 +162,13 @@ const deriveWorkflowToneForRole = (params: {
   completion: AgentWorkflowStepState["completion"];
   liveSession: AgentWorkflowStepLiveSession;
 }): AgentWorkflowStepState["tone"] => {
-  if (params.role === "build" && params.taskAttentionState === "blocked_needs_input") {
+  const allowBlockedTaskWarning =
+    params.role === "build" &&
+    params.taskAttentionState === "blocked_needs_input" &&
+    params.liveSession !== "running" &&
+    params.liveSession !== "error";
+
+  if (allowBlockedTaskWarning) {
     return "waiting_input";
   }
 

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -58,6 +58,8 @@ type RoleSessionSummary = {
   liveSession: AgentWorkflowStepLiveSession;
 };
 
+type TaskAttentionState = "none" | "blocked_needs_input";
+
 const toLiveSessionState = (session: AgentSessionWorkflowSummary): AgentWorkflowStepLiveSession => {
   if (session.pendingPermissions.length > 0 || session.pendingQuestions.length > 0) {
     return "waiting_input";
@@ -122,6 +124,53 @@ const normalizeTaskTabs = (entries: unknown): string[] => {
       ),
     ),
   );
+};
+
+const createRoleRecord = <Value>(build: (role: AgentRole) => Value): Record<AgentRole, Value> => ({
+  spec: build("spec"),
+  planner: build("planner"),
+  build: build("build"),
+  qa: build("qa"),
+});
+
+const buildSessionsByRole = (
+  sessionsForTask: AgentSessionWorkflowSummary[],
+): Record<AgentRole, AgentSessionWorkflowSummary[]> => {
+  const sessionsByRole = createRoleRecord<AgentSessionWorkflowSummary[]>(() => []);
+
+  for (const session of [...sessionsForTask].sort(compareAgentSessionRecency)) {
+    sessionsByRole[session.role].push(session);
+  }
+
+  return sessionsByRole;
+};
+
+const deriveTaskAttentionState = (task: TaskCard | null | undefined): TaskAttentionState => {
+  return task?.status === "blocked" ? "blocked_needs_input" : "none";
+};
+
+const deriveTaskTabStatusFromAttentionState = (
+  attentionState: TaskAttentionState,
+): AgentStudioTaskTab["status"] => {
+  return attentionState === "blocked_needs_input" ? "waiting_input" : "idle";
+};
+
+const deriveWorkflowToneForRole = (params: {
+  role: AgentRole;
+  taskAttentionState: TaskAttentionState;
+  availability: AgentWorkflowStepAvailability;
+  completion: AgentWorkflowStepState["completion"];
+  liveSession: AgentWorkflowStepLiveSession;
+}): AgentWorkflowStepState["tone"] => {
+  if (params.role === "build" && params.taskAttentionState === "blocked_needs_input") {
+    return "waiting_input";
+  }
+
+  return deriveWorkflowTone({
+    availability: params.availability,
+    completion: params.completion,
+    liveSession: params.liveSession,
+  });
 };
 
 export const buildLatestSessionByTaskMap = (
@@ -218,32 +267,13 @@ export const buildWorkflowStateByRole = (params: {
   roleWorkflowsByTask: Record<AgentRole, AgentWorkflowState>;
   roleSessionByRole: Record<AgentRole, RoleSessionSummary>;
 }): Record<AgentRole, AgentWorkflowStepState> => {
-  const stateByRole: Record<AgentRole, AgentWorkflowStepState> = {
-    spec: {
-      tone: "blocked",
-      availability: "blocked",
-      completion: "not_started",
-      liveSession: "none",
-    },
-    planner: {
-      tone: "blocked",
-      availability: "blocked",
-      completion: "not_started",
-      liveSession: "none",
-    },
-    build: {
-      tone: "blocked",
-      availability: "blocked",
-      completion: "not_started",
-      liveSession: "none",
-    },
-    qa: {
-      tone: "blocked",
-      availability: "blocked",
-      completion: "not_started",
-      liveSession: "none",
-    },
-  };
+  const stateByRole = createRoleRecord<AgentWorkflowStepState>(() => ({
+    tone: "blocked",
+    availability: "blocked",
+    completion: "not_started",
+    liveSession: "none",
+  }));
+  const taskAttentionState = deriveTaskAttentionState(params.task);
   const qaRejected = isQaRejectedTask(params.task);
   const qaRejectedInAiReview =
     params.task &&
@@ -284,14 +314,13 @@ export const buildWorkflowStateByRole = (params: {
       completion = "in_progress";
     }
 
-    const tone =
-      role === "build" && params.task?.status === "blocked"
-        ? "waiting_input"
-        : deriveWorkflowTone({
-            availability,
-            completion,
-            liveSession,
-          });
+    const tone = deriveWorkflowToneForRole({
+      role,
+      taskAttentionState,
+      availability,
+      completion,
+      liveSession,
+    });
 
     stateByRole[role] = {
       tone,
@@ -307,62 +336,25 @@ export const buildWorkflowStateByRole = (params: {
 export const buildLatestSessionByRoleMap = (
   sessionsForTask: AgentSessionWorkflowSummary[],
 ): Record<AgentRole, AgentSessionWorkflowSummary | null> => {
-  const map: Record<AgentRole, AgentSessionWorkflowSummary | null> = {
-    spec: null,
-    planner: null,
-    build: null,
-    qa: null,
-  };
-
-  const sortedSessions = [...sessionsForTask].sort(compareAgentSessionRecency);
-
-  for (const role of ALL_AGENT_ROLES) {
-    map[role] = sortedSessions.find((entry) => entry.role === role) ?? null;
-  }
-
-  return map;
+  const sessionsByRole = buildSessionsByRole(sessionsForTask);
+  return createRoleRecord((role) => sessionsByRole[role][0] ?? null);
 };
 
 export const buildRoleSessionSummaryMap = (
   sessionsForTask: AgentSessionWorkflowSummary[],
 ): Record<AgentRole, RoleSessionSummary> => {
-  const sortedSessions = [...sessionsForTask].sort(compareAgentSessionRecency);
-  const map: Record<AgentRole, RoleSessionSummary> = {
-    spec: {
-      latestSession: null,
-      workflowSession: null,
-      liveSession: "none",
-    },
-    planner: {
-      latestSession: null,
-      workflowSession: null,
-      liveSession: "none",
-    },
-    build: {
-      latestSession: null,
-      workflowSession: null,
-      liveSession: "none",
-    },
-    qa: {
-      latestSession: null,
-      workflowSession: null,
-      liveSession: "none",
-    },
-  };
+  const latestSessionByRole = buildLatestSessionByRoleMap(sessionsForTask);
 
-  for (const role of ALL_AGENT_ROLES) {
-    const roleSessions = sortedSessions.filter((entry) => entry.role === role);
-    const latestSession = roleSessions[0] ?? null;
+  return createRoleRecord((role) => {
+    const latestSession = latestSessionByRole[role];
     const workflowSession = latestSession;
 
-    map[role] = {
+    return {
       latestSession,
       workflowSession,
       liveSession: workflowSession ? toLiveSessionState(workflowSession) : "none",
     };
-  }
-
-  return map;
+  });
 };
 
 export const buildSessionSelectorGroups = (params: {
@@ -371,9 +363,10 @@ export const buildSessionSelectorGroups = (params: {
   roleLabelByRole: Record<AgentRole, string>;
 }): ComboboxGroup[] => {
   const groups: ComboboxGroup[] = [];
+  const sessionsByRole = buildSessionsByRole(params.sessionsForTask);
 
   for (const role of ALL_AGENT_ROLES) {
-    const roleSessions = params.sessionsForTask.filter((entry) => entry.role === role);
+    const roleSessions = sessionsByRole[role];
     if (roleSessions.length === 0) {
       continue;
     }
@@ -522,12 +515,12 @@ export const getTabStatusForTask = (params: {
   task: TaskCard | null | undefined;
   session: AgentSessionWorkflowSummary | null | undefined;
 }): AgentStudioTaskTab["status"] => {
-  if (!params.task) {
-    return "idle";
+  const attentionState = deriveTaskAttentionState(params.task);
+
+  if (attentionState !== "none") {
+    return deriveTaskTabStatusFromAttentionState(attentionState);
   }
-  if (params.task.status === "blocked") {
-    return "waiting_input";
-  }
+
   return getTabStatusFromSession(params.session);
 };
 
@@ -537,8 +530,10 @@ export const buildTaskTabs = (params: {
   latestSessionByTaskId: Map<string, AgentSessionWorkflowSummary>;
   activeTaskId: string;
 }): AgentStudioTaskTab[] => {
+  const taskById = new Map(params.tasks.map((task) => [task.id, task]));
+
   return params.tabTaskIds.map((tabTaskId) => {
-    const task = params.tasks.find((entry) => entry.id === tabTaskId);
+    const task = taskById.get(tabTaskId);
     const session = params.latestSessionByTaskId.get(tabTaskId);
 
     return {

--- a/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
+++ b/apps/desktop/src/pages/agents/agents-page-session-tabs.ts
@@ -284,11 +284,14 @@ export const buildWorkflowStateByRole = (params: {
       completion = "in_progress";
     }
 
-    const tone = deriveWorkflowTone({
-      availability,
-      completion,
-      liveSession,
-    });
+    const tone =
+      role === "build" && params.task?.status === "blocked"
+        ? "waiting_input"
+        : deriveWorkflowTone({
+            availability,
+            completion,
+            liveSession,
+          });
 
     stateByRole[role] = {
       tone,
@@ -500,7 +503,7 @@ export const getAvailableTabTasks = (tasks: TaskCard[], tabTaskIds: string[]): T
   return tasks.filter((task) => !tabTaskIds.includes(task.id));
 };
 
-export const getTabStatusFromSession = (
+const getTabStatusFromSession = (
   session: AgentSessionWorkflowSummary | null | undefined,
 ): AgentStudioTaskTab["status"] => {
   if (!session) {
@@ -513,6 +516,19 @@ export const getTabStatusFromSession = (
     return "working";
   }
   return "idle";
+};
+
+export const getTabStatusForTask = (params: {
+  task: TaskCard | null | undefined;
+  session: AgentSessionWorkflowSummary | null | undefined;
+}): AgentStudioTaskTab["status"] => {
+  if (!params.task) {
+    return "idle";
+  }
+  if (params.task.status === "blocked") {
+    return "waiting_input";
+  }
+  return getTabStatusFromSession(params.session);
 };
 
 export const buildTaskTabs = (params: {
@@ -528,7 +544,10 @@ export const buildTaskTabs = (params: {
     return {
       taskId: tabTaskId,
       taskTitle: task?.title ?? tabTaskId,
-      status: getTabStatusFromSession(session),
+      status: getTabStatusForTask({
+        task,
+        session,
+      }),
       isActive: params.activeTaskId === tabTaskId,
     };
   });


### PR DESCRIPTION
## Summary

- surface blocked Builder tasks as warning states in Agent Studio so blocked work no longer looks merely idle or in progress
- preserve true live Builder run/error states even when the task is blocked, so active runs still look in progress and errored runs still look failed
- refactor the Agent Studio page-model helpers to make blocked-task attention state explicit while reducing repeated per-role scans in `agents-page-session-tabs.ts`

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run check:rust`
- [x] `bun run test:rust`
- [ ] Not applicable

## Checklist

- [ ] I updated docs when behavior, workflows, runtime contracts, or setup changed
- [x] I added or updated relevant tests
- [x] I kept failures explicit instead of adding fallback logic
- [x] I linked related issues or context below

## Related Issues

Closes #
Related context: `openducktor-xd3`

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes are described below

## Additional Context

- blocked Builder workflow steps now render the warning treatment with `AlertTriangle` and blocked-task copy when the task is blocked and no live run/error state should take precedence
- blocked task tabs reuse the existing orange warning indicator already used for waiting-input tabs
- focused regressions were added for blocked Builder tasks with stopped, none, running, and error live-session states