### PR TITLE
fix(desktop): enforce plain-text paste in chat composer

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -227,6 +227,20 @@ const selectComposerContentRange = (container: HTMLElement): HTMLElement => {
   return editorRoot;
 };
 
+const createClipboardData = (plainText: string, htmlText: string) => ({
+  getData: (type: string): string => {
+    if (type === "text/plain") {
+      return plainText;
+    }
+
+    if (type === "text/html") {
+      return htmlText;
+    }
+
+    return "";
+  },
+});
+
 describe("AgentChatComposerEditor", () => {
   test("shows the slash-command error state after typing a slash trigger", async () => {
     const rendered = render(
@@ -311,6 +325,42 @@ describe("AgentChatComposerEditor", () => {
       const editable = rendered.container.querySelector("[data-text-segment-id]");
       expect(editable?.textContent).toBe("abc");
     });
+  });
+
+  test("pastes website content as raw text", async () => {
+    const rendered = render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
+
+    typeIntoEditor(rendered.container, "hello ");
+
+    fireEvent.paste(getEditorRoot(rendered.container), {
+      clipboardData: createClipboardData(
+        "bold words",
+        '<strong>bold</strong><span style="color:red"> words</span>',
+      ),
+    });
+
+    await expectComposerText(rendered.container, "hello bold words");
+
+    const contentRoot = rendered.container.querySelector("[data-composer-content-root]");
+    expect(contentRoot?.querySelector("strong")).toBeNull();
+    expect(screen.getByTestId("draft-state").textContent).toContain("hello bold words");
+  });
+
+  test("replaces a full composer selection with pasted plain text", async () => {
+    const rendered = render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
+
+    typeIntoEditor(rendered.container, "existing content");
+    const editorRoot = selectComposerContentRange(rendered.container);
+
+    fireEvent.paste(editorRoot, {
+      clipboardData: createClipboardData(
+        "line one\nline two",
+        "<div>line one</div><div>line two</div>",
+      ),
+    });
+
+    await expectComposerText(rendered.container, "line one\nline two");
+    expect(screen.getByTestId("draft-state").textContent).toContain("line one\\nline two");
   });
 
   test("selects the full composer content with the select-all shortcut", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -3,10 +3,16 @@ import type { AgentFileSearchResult } from "@openducktor/core";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { type ReactElement, useRef, useState } from "react";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
-import { type AgentChatComposerDraft, createComposerAttachment } from "./agent-chat-composer-draft";
+import {
+  type AgentChatComposerDraft,
+  createComposerAttachment,
+  createFileReferenceSegment,
+  createTextSegment,
+} from "./agent-chat-composer-draft";
 import { buildFileSearchResult, createComposerDraft } from "./agent-chat-test-fixtures";
 
 let AgentChatComposerEditor: typeof import("./agent-chat-composer-editor").AgentChatComposerEditor;
+let actualComposerSelectionModule: typeof import("./agent-chat-composer-selection");
 const renderMockEditableTextContent = (text: string): string => {
   if (text.length === 0) {
     return "\u200B";
@@ -58,7 +64,10 @@ const getCaretOffsetWithinElementMock = mock(
 );
 
 beforeAll(async () => {
+  actualComposerSelectionModule = await import("./agent-chat-composer-selection");
+
   mock.module("./agent-chat-composer-selection", () => ({
+    ...actualComposerSelectionModule,
     EMPTY_TEXT_SEGMENT_SENTINEL: "\u200B",
     readEditableTextContent: readMockEditableTextContent,
     renderEditableTextContent: renderMockEditableTextContent,
@@ -227,7 +236,44 @@ const selectComposerContentRange = (container: HTMLElement): HTMLElement => {
   return editorRoot;
 };
 
-const createClipboardData = (plainText: string, htmlText: string) => ({
+const selectRangeAcrossTextSegments = (
+  container: HTMLElement,
+  startOffset: number,
+  endOffset: number,
+): HTMLElement => {
+  const editorRoot = getEditorRoot(container);
+  const textSegments = getTextSegments(container);
+  const startSegment = textSegments[0];
+  const endSegment = textSegments.at(-1);
+  if (!(startSegment instanceof HTMLElement) || !(endSegment instanceof HTMLElement)) {
+    throw new Error("Expected text segments for range selection");
+  }
+
+  const startNode = startSegment.firstChild;
+  const endNode = endSegment.firstChild;
+  if (!(startNode instanceof Text) || !(endNode instanceof Text)) {
+    throw new Error("Expected text nodes for range selection");
+  }
+
+  const range = document.createRange();
+  range.setStart(startNode, startOffset);
+  range.setEnd(endNode, endOffset);
+  const selection = globalThis.getSelection?.();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  return editorRoot;
+};
+
+const createClipboardData = ({
+  plainText = "",
+  htmlText = "",
+  types = ["text/plain", "text/html"],
+}: {
+  plainText?: string;
+  htmlText?: string;
+  types?: string[];
+}) => ({
+  types,
   getData: (type: string): string => {
     if (type === "text/plain") {
       return plainText;
@@ -333,10 +379,10 @@ describe("AgentChatComposerEditor", () => {
     typeIntoEditor(rendered.container, "hello ");
 
     fireEvent.paste(getEditorRoot(rendered.container), {
-      clipboardData: createClipboardData(
-        "bold words",
-        '<strong>bold</strong><span style="color:red"> words</span>',
-      ),
+      clipboardData: createClipboardData({
+        plainText: "bold words",
+        htmlText: '<strong>bold</strong><span style="color:red"> words</span>',
+      }),
     });
 
     await expectComposerText(rendered.container, "hello bold words");
@@ -353,14 +399,58 @@ describe("AgentChatComposerEditor", () => {
     const editorRoot = selectComposerContentRange(rendered.container);
 
     fireEvent.paste(editorRoot, {
-      clipboardData: createClipboardData(
-        "line one\nline two",
-        "<div>line one</div><div>line two</div>",
-      ),
+      clipboardData: createClipboardData({
+        plainText: "line one\nline two",
+        htmlText: "<div>line one</div><div>line two</div>",
+      }),
     });
 
     await expectComposerText(rendered.container, "line one\nline two");
     expect(screen.getByTestId("draft-state").textContent).toContain("line one\\nline two");
+  });
+
+  test("ignores non-text clipboard payloads without clearing the composer", async () => {
+    const rendered = render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
+
+    typeIntoEditor(rendered.container, "keep this");
+    selectComposerContentRange(rendered.container);
+
+    fireEvent.paste(getEditorRoot(rendered.container), {
+      clipboardData: createClipboardData({ types: ["Files"] }),
+    });
+
+    await expectComposerText(rendered.container, "keep this");
+    expect(screen.getByTestId("draft-state").textContent).toContain("keep this");
+  });
+
+  test("replaces selections spanning a file chip with normalized plain text", async () => {
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        initialDraft={{
+          segments: [
+            createTextSegment("before ", "text-before"),
+            createFileReferenceSegment(buildFileSearchResult(), "file-chip"),
+            createTextSegment(" after", "text-after"),
+          ],
+          attachments: [],
+        }}
+      />,
+    );
+
+    const editorRoot = selectRangeAcrossTextSegments(rendered.container, 3, 3);
+
+    fireEvent.paste(editorRoot, {
+      clipboardData: createClipboardData({
+        plainText: "X",
+        htmlText: "<em>X</em>",
+      }),
+    });
+
+    await expectComposerText(rendered.container, "befXter");
+    expect(rendered.container.querySelector("[data-chip-segment-id]")).toBeNull();
+    expect(screen.getByTestId("draft-state").textContent).toContain("befXter");
   });
 
   test("selects the full composer content with the select-all shortcut", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx
@@ -119,6 +119,7 @@ const EditorHarness = ({
   searchFiles = async () => [],
   onSend,
   initialDraft = createComposerDraft(""),
+  disabled = false,
 }: {
   slashCommandsError: string | null;
   slashCommands: typeof COMMANDS;
@@ -126,6 +127,7 @@ const EditorHarness = ({
   searchFiles?: (query: string) => Promise<ReturnType<typeof buildFileSearchResult>[]>;
   onSend?: () => void;
   initialDraft?: AgentChatComposerDraft;
+  disabled?: boolean;
 }): ReactElement => {
   const [draft, setDraft] = useState<AgentChatComposerDraft>(initialDraft);
   const editorRef = useRef<HTMLDivElement>(null);
@@ -136,7 +138,7 @@ const EditorHarness = ({
         draft={draft}
         onDraftChange={setDraft}
         placeholder="Type a message"
-        disabled={false}
+        disabled={disabled}
         editorRef={editorRef}
         onEditorInput={() => {}}
         onSend={onSend ?? (() => {})}
@@ -423,6 +425,32 @@ describe("AgentChatComposerEditor", () => {
     expect(screen.getByTestId("draft-state").textContent).toContain("keep this");
   });
 
+  test("ignores paste while the composer is disabled", async () => {
+    const rendered = render(
+      <EditorHarness
+        slashCommands={COMMANDS}
+        slashCommandsError={null}
+        initialDraft={createComposerDraft("keep this")}
+        disabled
+      />,
+    );
+
+    const editorRoot = rendered.container.querySelector('[aria-disabled="true"]');
+    if (!(editorRoot instanceof HTMLElement)) {
+      throw new Error("Expected disabled composer root");
+    }
+
+    fireEvent.paste(editorRoot, {
+      clipboardData: createClipboardData({
+        plainText: "should not apply",
+        htmlText: "<strong>should not apply</strong>",
+      }),
+    });
+
+    await expectComposerText(rendered.container, "keep this");
+    expect(screen.getByTestId("draft-state").textContent).toContain("keep this");
+  });
+
   test("replaces selections spanning a file chip with normalized plain text", async () => {
     const rendered = render(
       <EditorHarness
@@ -451,6 +479,26 @@ describe("AgentChatComposerEditor", () => {
     await expectComposerText(rendered.container, "befXter");
     expect(rendered.container.querySelector("[data-chip-segment-id]")).toBeNull();
     expect(screen.getByTestId("draft-state").textContent).toContain("befXter");
+  });
+
+  test("repairs shell-level paste selection so the inserted text stays at the remembered caret", async () => {
+    resetSelectionMocks();
+    const rendered = render(<EditorHarness slashCommands={COMMANDS} slashCommandsError={null} />);
+
+    const editable = typeIntoEditor(rendered.container, "hello");
+    fireEvent.keyUp(editable, { key: "o" });
+
+    const editorRoot = collapseSelectionOnEditorRoot(rendered.container);
+    fireEvent.paste(editorRoot, {
+      clipboardData: createClipboardData({
+        plainText: "!",
+        htmlText: "<strong>!</strong>",
+      }),
+    });
+
+    await expectComposerText(rendered.container, "hello!");
+    expect(screen.getByTestId("draft-state").textContent).toContain("hello!");
+    expect(setCaretOffsetWithinElementMock).toHaveBeenCalledWith(editable, 5);
   });
 
   test("selects the full composer content with the select-all shortcut", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.tsx
@@ -276,6 +276,7 @@ export function AgentChatComposerEditor({
     selectFileSearchResult,
     handleEditorInput,
     handleEditorBeforeInput,
+    handleEditorPaste,
     handleEditorFocus,
     handleEditorClick,
     handleEditorKeyUp,
@@ -377,6 +378,7 @@ export function AgentChatComposerEditor({
         )}
         aria-disabled={disabled}
         onBeforeInput={handleEditorBeforeInput}
+        onPaste={handleEditorPaste}
         onInput={(event) => handleEditorInput(event.currentTarget)}
         onFocus={handleEditorFocus}
         onClick={handleEditorClick}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-selection.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-selection.ts
@@ -150,22 +150,19 @@ export const replaceComposerSelectionWithText = (root: HTMLDivElement, text: str
     return false;
   }
 
-  let range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+  const selectionRange = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
   const rangeInsideComposer =
-    range &&
-    (range.commonAncestorContainer === contentRoot ||
-      contentRoot.contains(range.commonAncestorContainer));
-  if (!rangeInsideComposer) {
-    range = createCollapsedRangeAtComposerEnd(root);
-    if (!range) {
-      return false;
-    }
-    selection.removeAllRanges();
-    selection.addRange(range);
-  }
-
+    selectionRange &&
+    (selectionRange.commonAncestorContainer === contentRoot ||
+      contentRoot.contains(selectionRange.commonAncestorContainer));
+  const range = rangeInsideComposer ? selectionRange : createCollapsedRangeAtComposerEnd(root);
   if (!range) {
     return false;
+  }
+
+  if (!rangeInsideComposer) {
+    selection.removeAllRanges();
+    selection.addRange(range);
   }
 
   range.deleteContents();

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-selection.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-selection.ts
@@ -122,3 +122,72 @@ export const insertTextAtCaretWithinElement = (
 
   return getCaretOffsetWithinElement(element);
 };
+
+export const getComposerContentRoot = (root: HTMLElement): HTMLElement | null => {
+  if (root.hasAttribute("data-composer-content-root")) {
+    return root;
+  }
+
+  return root.querySelector<HTMLElement>("[data-composer-content-root]");
+};
+
+const createCollapsedRangeAtComposerEnd = (root: HTMLElement): Range | null => {
+  const contentRoot = getComposerContentRoot(root);
+  if (!contentRoot) {
+    return null;
+  }
+
+  const range = root.ownerDocument.createRange();
+  range.selectNodeContents(contentRoot);
+  range.collapse(false);
+  return range;
+};
+
+export const replaceComposerSelectionWithText = (root: HTMLDivElement, text: string): boolean => {
+  const contentRoot = getComposerContentRoot(root);
+  const selection = root.ownerDocument.defaultView?.getSelection() ?? globalThis.getSelection?.();
+  if (!contentRoot || !selection) {
+    return false;
+  }
+
+  let range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+  const rangeInsideComposer =
+    range &&
+    (range.commonAncestorContainer === contentRoot ||
+      contentRoot.contains(range.commonAncestorContainer));
+  if (!rangeInsideComposer) {
+    range = createCollapsedRangeAtComposerEnd(root);
+    if (!range) {
+      return false;
+    }
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  if (!range) {
+    return false;
+  }
+
+  range.deleteContents();
+
+  if (text.length === 0) {
+    const collapsedRange = root.ownerDocument.createRange();
+    collapsedRange.setStart(range.startContainer, range.startOffset);
+    collapsedRange.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(collapsedRange);
+    root.focus();
+    return true;
+  }
+
+  const textNode = root.ownerDocument.createTextNode(text);
+  range.insertNode(textNode);
+
+  const collapsedRange = root.ownerDocument.createRange();
+  collapsedRange.setStart(textNode, text.length);
+  collapsedRange.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(collapsedRange);
+  root.focus();
+  return true;
+};

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -889,6 +889,10 @@ export const useAgentChatComposerEditor = ({
 
   const handleEditorPaste = useCallback(
     (event: ReactClipboardEvent<HTMLDivElement>) => {
+      if (disabled) {
+        return;
+      }
+
       event.preventDefault();
 
       const clipboardTypes = Array.from(event.clipboardData.types ?? []);
@@ -901,7 +905,11 @@ export const useAgentChatComposerEditor = ({
       const plainText = event.clipboardData.getData("text/plain");
 
       const sourceDraft = latestDraftRef.current;
-      const activeSelection = readActiveTextSelection(event.currentTarget, event.target);
+      const activeSelection = resolveActiveTextSelection(
+        event.currentTarget,
+        sourceDraft,
+        event.target,
+      );
       const selectionTarget = resolveSelectionTargetFromActiveSelection(
         sourceDraft,
         activeSelection,
@@ -923,7 +931,13 @@ export const useAgentChatComposerEditor = ({
       closeFileMenu();
       handleEditorInput(event.currentTarget);
     },
-    [closeFileMenu, handleEditorInput, rememberSelectionTarget],
+    [
+      closeFileMenu,
+      disabled,
+      handleEditorInput,
+      rememberSelectionTarget,
+      resolveActiveTextSelection,
+    ],
   );
 
   const handleEditorBeforeInput = useCallback(

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -26,7 +26,9 @@ import {
 } from "./agent-chat-composer-draft";
 import {
   getCaretOffsetWithinElement,
+  getComposerContentRoot,
   readEditableTextContent,
+  replaceComposerSelectionWithText,
   setCaretOffsetWithinElement,
 } from "./agent-chat-composer-selection";
 
@@ -229,74 +231,6 @@ const filterSlashCommands = (commands: AgentSlashCommand[], query: string): Agen
   }
 
   return commands.filter((command) => command.trigger.toLowerCase().includes(normalizedQuery));
-};
-
-const getComposerContentRoot = (root: HTMLElement): HTMLElement | null => {
-  if (root.hasAttribute("data-composer-content-root")) {
-    return root;
-  }
-  return root.querySelector<HTMLElement>("[data-composer-content-root]");
-};
-
-const createCollapsedRangeAtComposerEnd = (root: HTMLElement): Range | null => {
-  const contentRoot = getComposerContentRoot(root);
-  if (!contentRoot) {
-    return null;
-  }
-
-  const range = root.ownerDocument.createRange();
-  range.selectNodeContents(contentRoot);
-  range.collapse(false);
-  return range;
-};
-
-const replaceComposerSelectionWithText = (root: HTMLDivElement, text: string): boolean => {
-  const contentRoot = getComposerContentRoot(root);
-  const selection = root.ownerDocument.defaultView?.getSelection() ?? globalThis.getSelection?.();
-  if (!contentRoot || !selection) {
-    return false;
-  }
-
-  let range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
-  const rangeInsideComposer =
-    range &&
-    (range.commonAncestorContainer === contentRoot ||
-      contentRoot.contains(range.commonAncestorContainer));
-  if (!rangeInsideComposer) {
-    range = createCollapsedRangeAtComposerEnd(root);
-    if (!range) {
-      return false;
-    }
-    selection.removeAllRanges();
-    selection.addRange(range);
-  }
-
-  if (!range) {
-    return false;
-  }
-
-  range.deleteContents();
-
-  if (text.length === 0) {
-    const collapsedRange = root.ownerDocument.createRange();
-    collapsedRange.setStart(range.startContainer, range.startOffset);
-    collapsedRange.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(collapsedRange);
-    root.focus();
-    return true;
-  }
-
-  const textNode = root.ownerDocument.createTextNode(text);
-  range.insertNode(textNode);
-
-  const collapsedRange = root.ownerDocument.createRange();
-  collapsedRange.setStart(textNode, text.length);
-  collapsedRange.collapse(true);
-  selection.removeAllRanges();
-  selection.addRange(collapsedRange);
-  root.focus();
-  return true;
 };
 
 const selectComposerContents = (root: HTMLElement): boolean => {
@@ -957,6 +891,15 @@ export const useAgentChatComposerEditor = ({
     (event: ReactClipboardEvent<HTMLDivElement>) => {
       event.preventDefault();
 
+      const clipboardTypes = Array.from(event.clipboardData.types ?? []);
+      const hasPlainText = clipboardTypes.includes("text/plain");
+      if (!hasPlainText) {
+        pendingInputStateRef.current = null;
+        return;
+      }
+
+      const plainText = event.clipboardData.getData("text/plain");
+
       const sourceDraft = latestDraftRef.current;
       const activeSelection = readActiveTextSelection(event.currentTarget, event.target);
       const selectionTarget = resolveSelectionTargetFromActiveSelection(
@@ -968,16 +911,11 @@ export const useAgentChatComposerEditor = ({
         ? {
             ...selectionTarget,
             inputType: "insertFromPaste",
-            data: event.clipboardData.getData("text/plain"),
+            data: plainText,
           }
         : null;
 
-      if (
-        !replaceComposerSelectionWithText(
-          event.currentTarget,
-          event.clipboardData.getData("text/plain"),
-        )
-      ) {
+      if (!replaceComposerSelectionWithText(event.currentTarget, plainText)) {
         return;
       }
 

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-composer-editor.ts
@@ -1,5 +1,6 @@
 import type { AgentFileSearchResult, AgentSlashCommand } from "@openducktor/core";
 import {
+  type ClipboardEvent as ReactClipboardEvent,
   type FocusEvent as ReactFocusEvent,
   type FormEvent as ReactFormEvent,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -73,6 +74,7 @@ type UseAgentChatComposerEditorResult = {
   selectFileSearchResult: (result: AgentFileSearchResult) => void;
   handleEditorInput: (root: HTMLDivElement) => void;
   handleEditorBeforeInput: (event: ReactFormEvent<HTMLDivElement>) => void;
+  handleEditorPaste: (event: ReactClipboardEvent<HTMLDivElement>) => void;
   handleEditorFocus: (event: ReactFocusEvent<HTMLDivElement>) => void;
   handleEditorClick: (event: ReactMouseEvent<HTMLDivElement>) => void;
   handleEditorKeyUp: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
@@ -234,6 +236,67 @@ const getComposerContentRoot = (root: HTMLElement): HTMLElement | null => {
     return root;
   }
   return root.querySelector<HTMLElement>("[data-composer-content-root]");
+};
+
+const createCollapsedRangeAtComposerEnd = (root: HTMLElement): Range | null => {
+  const contentRoot = getComposerContentRoot(root);
+  if (!contentRoot) {
+    return null;
+  }
+
+  const range = root.ownerDocument.createRange();
+  range.selectNodeContents(contentRoot);
+  range.collapse(false);
+  return range;
+};
+
+const replaceComposerSelectionWithText = (root: HTMLDivElement, text: string): boolean => {
+  const contentRoot = getComposerContentRoot(root);
+  const selection = root.ownerDocument.defaultView?.getSelection() ?? globalThis.getSelection?.();
+  if (!contentRoot || !selection) {
+    return false;
+  }
+
+  let range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+  const rangeInsideComposer =
+    range &&
+    (range.commonAncestorContainer === contentRoot ||
+      contentRoot.contains(range.commonAncestorContainer));
+  if (!rangeInsideComposer) {
+    range = createCollapsedRangeAtComposerEnd(root);
+    if (!range) {
+      return false;
+    }
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  if (!range) {
+    return false;
+  }
+
+  range.deleteContents();
+
+  if (text.length === 0) {
+    const collapsedRange = root.ownerDocument.createRange();
+    collapsedRange.setStart(range.startContainer, range.startOffset);
+    collapsedRange.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(collapsedRange);
+    root.focus();
+    return true;
+  }
+
+  const textNode = root.ownerDocument.createTextNode(text);
+  range.insertNode(textNode);
+
+  const collapsedRange = root.ownerDocument.createRange();
+  collapsedRange.setStart(textNode, text.length);
+  collapsedRange.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(collapsedRange);
+  root.focus();
+  return true;
 };
 
 const selectComposerContents = (root: HTMLElement): boolean => {
@@ -890,6 +953,41 @@ export const useAgentChatComposerEditor = ({
     ],
   );
 
+  const handleEditorPaste = useCallback(
+    (event: ReactClipboardEvent<HTMLDivElement>) => {
+      event.preventDefault();
+
+      const sourceDraft = latestDraftRef.current;
+      const activeSelection = readActiveTextSelection(event.currentTarget, event.target);
+      const selectionTarget = resolveSelectionTargetFromActiveSelection(
+        sourceDraft,
+        activeSelection,
+      );
+      rememberSelectionTarget(sourceDraft, selectionTarget);
+      pendingInputStateRef.current = selectionTarget
+        ? {
+            ...selectionTarget,
+            inputType: "insertFromPaste",
+            data: event.clipboardData.getData("text/plain"),
+          }
+        : null;
+
+      if (
+        !replaceComposerSelectionWithText(
+          event.currentTarget,
+          event.clipboardData.getData("text/plain"),
+        )
+      ) {
+        return;
+      }
+
+      setSlashMenuState(null);
+      closeFileMenu();
+      handleEditorInput(event.currentTarget);
+    },
+    [closeFileMenu, handleEditorInput, rememberSelectionTarget],
+  );
+
   const handleEditorBeforeInput = useCallback(
     (event: ReactFormEvent<HTMLDivElement>) => {
       const sourceDraft = latestDraftRef.current;
@@ -1164,6 +1262,7 @@ export const useAgentChatComposerEditor = ({
     selectFileSearchResult,
     handleEditorInput,
     handleEditorBeforeInput,
+    handleEditorPaste,
     handleEditorFocus,
     handleEditorClick,
     handleEditorKeyUp,


### PR DESCRIPTION
## Summary
- intercept chat composer paste events and insert only `text/plain`, preventing copied website HTML from corrupting the contenteditable DOM or truncating message content
- move composer selection replacement logic into the shared selection utility layer and treat non-text clipboard payloads as explicit no-ops instead of clearing composer content
- add regression coverage for HTML-origin paste, full-selection multiline replacement, non-text clipboard payloads, and selections that span file chips

## Testing
- `bun test apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer-editor.test.tsx`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer paste handling improved: pastes normalized plain text, replaces selections (including multi-segment and file-chip selections), preserves caret offset, and respects the composer’s disabled state.

* **Bug Fixes**
  * Clipboard payloads without plain-text are ignored without clearing composer content; HTML styling like <strong> is not preserved.

* **Tests**
  * Added comprehensive tests covering paste scenarios, selection spanning, and disabled-composer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->