### PR TITLE
fix(desktop): recover approval when the builder worktree is missing

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_context_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_context_service.rs
@@ -57,7 +57,7 @@ impl<'a> ApprovalContextService<'a> {
                 });
 
             return Ok(TaskApprovalContextLoadResult::Ready {
-                approval_context: TaskApprovalContext {
+                approval_context: Box::new(TaskApprovalContext {
                     task_id: task_id.to_string(),
                     task_status: context.task.status.as_cli_value().to_string(),
                     working_directory,
@@ -72,7 +72,7 @@ impl<'a> ApprovalContextService<'a> {
                     suggested_squash_commit_message: None,
                     providers: PullRequestProviderService::new(self.service)
                         .provider_statuses(Path::new(&context.repo.repo_path), &repo_config),
-                },
+                }),
             });
         }
 
@@ -94,7 +94,7 @@ impl<'a> ApprovalContextService<'a> {
                 approval.target_branch.canonical().as_str(),
             )?;
         Ok(TaskApprovalContextLoadResult::Ready {
-            approval_context: approval,
+            approval_context: Box::new(approval),
         })
     }
 
@@ -133,6 +133,11 @@ impl<'a> ApprovalContextService<'a> {
                 "Human approval",
             )? {
             BuilderBranchContextLoadResult::Ready(context) => context,
+            BuilderBranchContextLoadResult::MissingContext => {
+                return Err(ApprovalContextLoadError::Other(anyhow::anyhow!(
+                    "Human approval requires a builder worktree for task {task_id}. Start Builder first."
+                )));
+            }
             BuilderBranchContextLoadResult::MissingWorktree(missing) => {
                 return Err(ApprovalContextLoadError::MissingBuilderWorktree(missing));
             }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_context_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_context_service.rs
@@ -2,11 +2,15 @@ use super::approval_support::{
     ensure_human_approval_status, is_terminal_task_status, normalize_recorded_target_branch,
     publish_recorded_target_branch, publish_target_branch, to_domain_merge_method,
 };
-use super::builder_branch_service::BuilderBranchService;
+use super::builder_branch_service::{
+    BuilderBranchContextLoadResult, BuilderBranchService, MissingBuilderWorktree,
+};
 use super::pull_request_provider_service::PullRequestProviderService;
 use crate::app_service::service_core::AppService;
 use anyhow::Result;
 use host_domain::{GitDiffScope, TaskApprovalContext, TaskApprovalContextLoadResult};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 
 pub(super) struct ApprovalContextService<'a> {
@@ -72,18 +76,17 @@ impl<'a> ApprovalContextService<'a> {
             });
         }
 
-        let mut approval = match self.load_open_task_approval_context(repo_path, task_id) {
-            Ok(approval) => approval,
-            Err(error) => {
-                if BuilderBranchService::missing_builder_worktree_error(&error).is_some() {
+        let mut approval =
+            match self.load_open_task_approval_context_with_recovery(repo_path, task_id) {
+                Ok(approval) => approval,
+                Err(ApprovalContextLoadError::MissingBuilderWorktree(_missing)) => {
                     return Ok(TaskApprovalContextLoadResult::MissingBuilderWorktree {
                         task_id: task_id.to_string(),
                         task_status: context.task.status.as_cli_value().to_string(),
                     });
                 }
-                return Err(error);
-            }
-        };
+                Err(ApprovalContextLoadError::Other(error)) => return Err(error),
+            };
         approval.suggested_squash_commit_message =
             self.service.git_port.suggested_squash_commit_message(
                 Path::new(&context.repo.repo_path),
@@ -100,6 +103,20 @@ impl<'a> ApprovalContextService<'a> {
         repo_path: &str,
         task_id: &str,
     ) -> Result<TaskApprovalContext> {
+        self.load_open_task_approval_context_with_recovery(repo_path, task_id)
+            .map_err(|error| match error {
+                ApprovalContextLoadError::MissingBuilderWorktree(missing) => {
+                    anyhow::anyhow!(missing)
+                }
+                ApprovalContextLoadError::Other(error) => error,
+            })
+    }
+
+    fn load_open_task_approval_context_with_recovery(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+    ) -> Result<TaskApprovalContext, ApprovalContextLoadError> {
         let context = self.service.load_task_context(repo_path, task_id)?;
         ensure_human_approval_status(&context.task.status)?;
         let repo_config = self
@@ -109,11 +126,17 @@ impl<'a> ApprovalContextService<'a> {
             .service
             .task_metadata_get(context.repo.repo_path.as_str(), task_id)?;
         let config = self.service.config_store.load()?;
-        let builder_context = BuilderBranchService::new(self.service).load_builder_branch_context(
-            context.repo.repo_path.as_str(),
-            task_id,
-            "Human approval",
-        )?;
+        let builder_context = match BuilderBranchService::new(self.service)
+            .load_builder_branch_context_result(
+                context.repo.repo_path.as_str(),
+                task_id,
+                "Human approval",
+            )? {
+            BuilderBranchContextLoadResult::Ready(context) => context,
+            BuilderBranchContextLoadResult::MissingWorktree(missing) => {
+                return Err(ApprovalContextLoadError::MissingBuilderWorktree(missing));
+            }
+        };
         let target_branch = BuilderBranchService::new(self.service)
             .target_branch_for_repo(context.repo.repo_path.as_str())?;
         let publish_target = publish_target_branch(&repo_config.default_target_branch)?;
@@ -139,5 +162,35 @@ impl<'a> ApprovalContextService<'a> {
             providers: PullRequestProviderService::new(self.service)
                 .provider_statuses(Path::new(&context.repo.repo_path), &repo_config),
         })
+    }
+}
+
+#[derive(Debug)]
+enum ApprovalContextLoadError {
+    MissingBuilderWorktree(MissingBuilderWorktree),
+    Other(anyhow::Error),
+}
+
+impl Display for ApprovalContextLoadError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingBuilderWorktree(missing) => Display::fmt(missing, f),
+            Self::Other(error) => Display::fmt(error, f),
+        }
+    }
+}
+
+impl Error for ApprovalContextLoadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::MissingBuilderWorktree(missing) => Some(missing),
+            Self::Other(error) => Some(error.root_cause()),
+        }
+    }
+}
+
+impl From<anyhow::Error> for ApprovalContextLoadError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Other(error)
     }
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_context_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_context_service.rs
@@ -6,7 +6,7 @@ use super::builder_branch_service::BuilderBranchService;
 use super::pull_request_provider_service::PullRequestProviderService;
 use crate::app_service::service_core::AppService;
 use anyhow::Result;
-use host_domain::{GitDiffScope, TaskApprovalContext};
+use host_domain::{GitDiffScope, TaskApprovalContext, TaskApprovalContextLoadResult};
 use std::path::Path;
 
 pub(super) struct ApprovalContextService<'a> {
@@ -22,7 +22,7 @@ impl<'a> ApprovalContextService<'a> {
         &self,
         repo_path: &str,
         task_id: &str,
-    ) -> Result<TaskApprovalContext> {
+    ) -> Result<TaskApprovalContextLoadResult> {
         let context = self.service.load_task_context(repo_path, task_id)?;
         ensure_human_approval_status(&context.task.status)?;
         let repo_config = self
@@ -52,32 +52,47 @@ impl<'a> ApprovalContextService<'a> {
                         .then_some(target.working_directory)
                 });
 
-            return Ok(TaskApprovalContext {
-                task_id: task_id.to_string(),
-                task_status: context.task.status.as_cli_value().to_string(),
-                working_directory,
-                source_branch: direct_merge.source_branch.clone(),
-                target_branch,
-                publish_target,
-                default_merge_method: to_domain_merge_method(config.git.default_merge_method),
-                has_uncommitted_changes: false,
-                uncommitted_file_count: 0,
-                pull_request: metadata.pull_request,
-                direct_merge: Some(direct_merge),
-                suggested_squash_commit_message: None,
-                providers: PullRequestProviderService::new(self.service)
-                    .provider_statuses(Path::new(&context.repo.repo_path), &repo_config),
+            return Ok(TaskApprovalContextLoadResult::Ready {
+                approval_context: TaskApprovalContext {
+                    task_id: task_id.to_string(),
+                    task_status: context.task.status.as_cli_value().to_string(),
+                    working_directory,
+                    source_branch: direct_merge.source_branch.clone(),
+                    target_branch,
+                    publish_target,
+                    default_merge_method: to_domain_merge_method(config.git.default_merge_method),
+                    has_uncommitted_changes: false,
+                    uncommitted_file_count: 0,
+                    pull_request: metadata.pull_request,
+                    direct_merge: Some(direct_merge),
+                    suggested_squash_commit_message: None,
+                    providers: PullRequestProviderService::new(self.service)
+                        .provider_statuses(Path::new(&context.repo.repo_path), &repo_config),
+                },
             });
         }
 
-        let mut approval = self.load_open_task_approval_context(repo_path, task_id)?;
+        let mut approval = match self.load_open_task_approval_context(repo_path, task_id) {
+            Ok(approval) => approval,
+            Err(error) => {
+                if BuilderBranchService::missing_builder_worktree_error(&error).is_some() {
+                    return Ok(TaskApprovalContextLoadResult::MissingBuilderWorktree {
+                        task_id: task_id.to_string(),
+                        task_status: context.task.status.as_cli_value().to_string(),
+                    });
+                }
+                return Err(error);
+            }
+        };
         approval.suggested_squash_commit_message =
             self.service.git_port.suggested_squash_commit_message(
                 Path::new(&context.repo.repo_path),
                 approval.source_branch.as_str(),
                 approval.target_branch.canonical().as_str(),
             )?;
-        Ok(approval)
+        Ok(TaskApprovalContextLoadResult::Ready {
+            approval_context: approval,
+        })
     }
 
     pub(super) fn load_open_task_approval_context(

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/approval_service.rs
@@ -6,8 +6,8 @@ use super::pull_request_workflow_service::PullRequestWorkflowService;
 use crate::app_service::service_core::AppService;
 use anyhow::Result;
 use host_domain::{
-    GitMergeMethod, PullRequestRecord, TaskApprovalContext, TaskCard, TaskDirectMergeResult,
-    TaskPullRequestDetectResult,
+    GitMergeMethod, PullRequestRecord, TaskApprovalContextLoadResult, TaskCard,
+    TaskDirectMergeResult, TaskPullRequestDetectResult,
 };
 
 impl AppService {
@@ -15,7 +15,7 @@ impl AppService {
         &self,
         repo_path: &str,
         task_id: &str,
-    ) -> Result<TaskApprovalContext> {
+    ) -> Result<TaskApprovalContextLoadResult> {
         ApprovalContextService::new(self).task_approval_context_get(repo_path, task_id)
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/builder_branch_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/builder_branch_service.rs
@@ -2,6 +2,8 @@ use super::approval_support::normalize_approval_target_branch;
 use crate::app_service::service_core::AppService;
 use anyhow::{anyhow, Result};
 use host_domain::{BuildContinuationTargetSource, GitTargetBranch};
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 
 #[derive(Debug)]
@@ -15,6 +17,33 @@ pub(super) struct BuilderCleanupTarget {
     pub(super) working_directory: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct MissingBuilderWorktreeError {
+    task_id: String,
+    operation_label: String,
+}
+
+impl MissingBuilderWorktreeError {
+    fn new(task_id: &str, operation_label: &str) -> Self {
+        Self {
+            task_id: task_id.to_string(),
+            operation_label: operation_label.to_string(),
+        }
+    }
+}
+
+impl Display for MissingBuilderWorktreeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} requires a builder worktree for task {}. Start Builder first.",
+            self.operation_label, self.task_id
+        )
+    }
+}
+
+impl Error for MissingBuilderWorktreeError {}
+
 pub(super) struct BuilderBranchService<'a> {
     service: &'a AppService,
 }
@@ -22,6 +51,12 @@ pub(super) struct BuilderBranchService<'a> {
 impl<'a> BuilderBranchService<'a> {
     pub(super) fn new(service: &'a AppService) -> Self {
         Self { service }
+    }
+
+    pub(super) fn missing_builder_worktree_error(
+        error: &anyhow::Error,
+    ) -> Option<&MissingBuilderWorktreeError> {
+        error.downcast_ref::<MissingBuilderWorktreeError>()
     }
 
     pub(super) fn load_builder_branch_context(
@@ -33,11 +68,7 @@ impl<'a> BuilderBranchService<'a> {
         let working_directory = self
             .service
             .build_continuation_target_get(repo_path, task_id)?
-            .ok_or_else(|| {
-                anyhow!(
-                    "{operation_label} requires a builder worktree for task {task_id}. Start Builder first."
-                )
-            })?
+            .ok_or_else(|| MissingBuilderWorktreeError::new(task_id, operation_label))?
             .working_directory;
         let current_branch = self
             .service
@@ -233,6 +264,7 @@ mod tests {
         let error = BuilderBranchService::new(&service)
             .load_builder_branch_context(repo_path.as_str(), "task-1", "Pull request detection")
             .expect_err("missing builder worktree should be rejected");
+        assert!(BuilderBranchService::missing_builder_worktree_error(&error).is_some());
         assert_eq!(
             error.to_string(),
             "Pull request detection requires a builder worktree for task task-1. Start Builder first."

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/builder_branch_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/builder_branch_service.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::path::Path;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct BuilderBranchContext {
     pub(super) working_directory: String,
     pub(super) source_branch: String,
@@ -18,12 +18,12 @@ pub(super) struct BuilderCleanupTarget {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct MissingBuilderWorktreeError {
+pub(super) struct MissingBuilderWorktree {
     task_id: String,
     operation_label: String,
 }
 
-impl MissingBuilderWorktreeError {
+impl MissingBuilderWorktree {
     fn new(task_id: &str, operation_label: &str) -> Self {
         Self {
             task_id: task_id.to_string(),
@@ -32,7 +32,7 @@ impl MissingBuilderWorktreeError {
     }
 }
 
-impl Display for MissingBuilderWorktreeError {
+impl Display for MissingBuilderWorktree {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -42,7 +42,13 @@ impl Display for MissingBuilderWorktreeError {
     }
 }
 
-impl Error for MissingBuilderWorktreeError {}
+impl Error for MissingBuilderWorktree {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum BuilderBranchContextLoadResult {
+    Ready(BuilderBranchContext),
+    MissingWorktree(MissingBuilderWorktree),
+}
 
 pub(super) struct BuilderBranchService<'a> {
     service: &'a AppService,
@@ -53,23 +59,35 @@ impl<'a> BuilderBranchService<'a> {
         Self { service }
     }
 
-    pub(super) fn missing_builder_worktree_error(
-        error: &anyhow::Error,
-    ) -> Option<&MissingBuilderWorktreeError> {
-        error.downcast_ref::<MissingBuilderWorktreeError>()
-    }
-
     pub(super) fn load_builder_branch_context(
         &self,
         repo_path: &str,
         task_id: &str,
         operation_label: &str,
     ) -> Result<BuilderBranchContext> {
-        let working_directory = self
+        match self.load_builder_branch_context_result(repo_path, task_id, operation_label)? {
+            BuilderBranchContextLoadResult::Ready(context) => Ok(context),
+            BuilderBranchContextLoadResult::MissingWorktree(missing) => {
+                Err(anyhow!(missing.to_string()))
+            }
+        }
+    }
+
+    pub(super) fn load_builder_branch_context_result(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+        operation_label: &str,
+    ) -> Result<BuilderBranchContextLoadResult> {
+        let Some(target) = self
             .service
             .build_continuation_target_get(repo_path, task_id)?
-            .ok_or_else(|| MissingBuilderWorktreeError::new(task_id, operation_label))?
-            .working_directory;
+        else {
+            return Ok(BuilderBranchContextLoadResult::MissingWorktree(
+                MissingBuilderWorktree::new(task_id, operation_label),
+            ));
+        };
+        let working_directory = target.working_directory;
         let current_branch = self
             .service
             .git_port
@@ -83,10 +101,12 @@ impl<'a> BuilderBranchService<'a> {
             .name
             .ok_or_else(|| anyhow!("{operation_label} requires a builder branch name."))?;
 
-        Ok(BuilderBranchContext {
-            working_directory,
-            source_branch,
-        })
+        Ok(BuilderBranchContextLoadResult::Ready(
+            BuilderBranchContext {
+                working_directory,
+                source_branch,
+            },
+        ))
     }
 
     pub(super) fn target_branch_for_repo(&self, repo_path: &str) -> Result<GitTargetBranch> {
@@ -261,10 +281,21 @@ mod tests {
         let repo_path = repo.to_string_lossy().to_string();
         service.workspace_add(repo_path.as_str())?;
 
+        let result = BuilderBranchService::new(&service).load_builder_branch_context_result(
+            repo_path.as_str(),
+            "task-1",
+            "Pull request detection",
+        )?;
+        assert_eq!(
+            result,
+            super::BuilderBranchContextLoadResult::MissingWorktree(
+                super::MissingBuilderWorktree::new("task-1", "Pull request detection")
+            )
+        );
+
         let error = BuilderBranchService::new(&service)
             .load_builder_branch_context(repo_path.as_str(), "task-1", "Pull request detection")
             .expect_err("missing builder worktree should be rejected");
-        assert!(BuilderBranchService::missing_builder_worktree_error(&error).is_some());
         assert_eq!(
             error.to_string(),
             "Pull request detection requires a builder worktree for task task-1. Start Builder first."

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/builder_branch_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/builder_branch_service.rs
@@ -1,5 +1,6 @@
 use super::approval_support::normalize_approval_target_branch;
 use crate::app_service::service_core::AppService;
+use crate::app_service::task_workflow::session_service::BuildContinuationTargetLookup;
 use anyhow::{anyhow, Result};
 use host_domain::{BuildContinuationTargetSource, GitTargetBranch};
 use std::error::Error;
@@ -47,6 +48,7 @@ impl Error for MissingBuilderWorktree {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum BuilderBranchContextLoadResult {
     Ready(BuilderBranchContext),
+    MissingContext,
     MissingWorktree(MissingBuilderWorktree),
 }
 
@@ -67,6 +69,9 @@ impl<'a> BuilderBranchService<'a> {
     ) -> Result<BuilderBranchContext> {
         match self.load_builder_branch_context_result(repo_path, task_id, operation_label)? {
             BuilderBranchContextLoadResult::Ready(context) => Ok(context),
+            BuilderBranchContextLoadResult::MissingContext => Err(anyhow!(
+                "{operation_label} requires a builder worktree for task {task_id}. Start Builder first."
+            )),
             BuilderBranchContextLoadResult::MissingWorktree(missing) => {
                 Err(anyhow!(missing.to_string()))
             }
@@ -79,13 +84,19 @@ impl<'a> BuilderBranchService<'a> {
         task_id: &str,
         operation_label: &str,
     ) -> Result<BuilderBranchContextLoadResult> {
-        let Some(target) = self
+        let target = match self
             .service
-            .build_continuation_target_get(repo_path, task_id)?
-        else {
-            return Ok(BuilderBranchContextLoadResult::MissingWorktree(
-                MissingBuilderWorktree::new(task_id, operation_label),
-            ));
+            .build_continuation_target_lookup(repo_path, task_id)?
+        {
+            BuildContinuationTargetLookup::Found(target) => target,
+            BuildContinuationTargetLookup::NoBuilderContext => {
+                return Ok(BuilderBranchContextLoadResult::MissingContext);
+            }
+            BuildContinuationTargetLookup::MissingBuilderWorktree => {
+                return Ok(BuilderBranchContextLoadResult::MissingWorktree(
+                    MissingBuilderWorktree::new(task_id, operation_label),
+                ));
+            }
         };
         let working_directory = target.working_directory;
         let current_branch = self
@@ -265,6 +276,63 @@ mod tests {
     fn load_builder_branch_context_uses_operation_label_when_worktree_is_missing() -> Result<()> {
         let root = unique_temp_path("builder-branch-missing");
         let repo = root.join("repo");
+        let missing_worktree = root.join("missing-worktree");
+        init_git_repo(&repo)?;
+
+        let config_store = AppConfigStore::from_path(root.join("config.json"));
+        let (service, task_state, _git_state) = build_service_with_store(
+            vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+            vec![],
+            GitCurrentBranch {
+                name: Some("main".to_string()),
+                detached: false,
+                revision: None,
+            },
+            config_store,
+        );
+        let repo_path = repo.to_string_lossy().to_string();
+        service.workspace_add(repo_path.as_str())?;
+
+        fs::create_dir_all(&missing_worktree)?;
+        let mut session = make_session("task-1", "session-build");
+        session.role = " build ".to_string();
+        session.working_directory = missing_worktree.to_string_lossy().to_string();
+        task_state
+            .lock()
+            .expect("task state lock poisoned")
+            .agent_sessions
+            .push(session);
+        let _ = fs::remove_dir_all(&missing_worktree);
+
+        let result = BuilderBranchService::new(&service).load_builder_branch_context_result(
+            repo_path.as_str(),
+            "task-1",
+            "Pull request detection",
+        )?;
+        assert_eq!(
+            result,
+            super::BuilderBranchContextLoadResult::MissingWorktree(
+                super::MissingBuilderWorktree::new("task-1", "Pull request detection")
+            )
+        );
+
+        let error = BuilderBranchService::new(&service)
+            .load_builder_branch_context(repo_path.as_str(), "task-1", "Pull request detection")
+            .expect_err("missing builder worktree should be rejected");
+        assert_eq!(
+            error.to_string(),
+            "Pull request detection requires a builder worktree for task task-1. Start Builder first."
+        );
+
+        let _ = fs::remove_dir_all(root);
+        Ok(())
+    }
+
+    #[test]
+    fn load_builder_branch_context_reports_missing_context_when_no_builder_session_exists(
+    ) -> Result<()> {
+        let root = unique_temp_path("builder-branch-no-context");
+        let repo = root.join("repo");
         init_git_repo(&repo)?;
 
         let config_store = AppConfigStore::from_path(root.join("config.json"));
@@ -288,14 +356,12 @@ mod tests {
         )?;
         assert_eq!(
             result,
-            super::BuilderBranchContextLoadResult::MissingWorktree(
-                super::MissingBuilderWorktree::new("task-1", "Pull request detection")
-            )
+            super::BuilderBranchContextLoadResult::MissingContext
         );
 
         let error = BuilderBranchService::new(&service)
             .load_builder_branch_context(repo_path.as_str(), "task-1", "Pull request detection")
-            .expect_err("missing builder worktree should be rejected");
+            .expect_err("missing builder context should fail fast");
         assert_eq!(
             error.to_string(),
             "Pull request detection requires a builder worktree for task task-1. Start Builder first."
@@ -335,6 +401,7 @@ mod tests {
         older.working_directory = older_worktree.to_string_lossy().to_string();
         let mut newer = make_session("task-1", "session-2");
         newer.started_at = "2026-03-11T11:00:00Z".to_string();
+        newer.role = " build ".to_string();
         newer.working_directory = newer_worktree.to_string_lossy().to_string();
         task_state
             .lock()

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/session_service.rs
@@ -8,6 +8,82 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 impl AppService {
+    pub(super) fn build_continuation_target_lookup(
+        &self,
+        repo_path: &str,
+        task_id: &str,
+    ) -> Result<BuildContinuationTargetLookup> {
+        let repo_path = self.resolve_task_repo_path(repo_path)?;
+        let normalized_repo_path = normalize_path_for_comparison(repo_path.as_str());
+
+        let active_worktree_path: Option<String> = {
+            let runs = self
+                .runs
+                .lock()
+                .map_err(|_| anyhow!("Run state lock poisoned"))?;
+            runs.values()
+                .filter(|run| {
+                    normalize_path_for_comparison(run.repo_path.as_str()) == normalized_repo_path
+                        && run.task_id == task_id
+                        && matches!(
+                            run.summary.state,
+                            RunState::Starting
+                                | RunState::Running
+                                | RunState::Blocked
+                                | RunState::AwaitingDoneConfirmation
+                        )
+                })
+                .max_by(|left, right| left.summary.started_at.cmp(&right.summary.started_at))
+                .map(|run| run.worktree_path.clone())
+        };
+
+        if let Some(worktree_path) = active_worktree_path {
+            let working_directory = validate_build_continuation_working_directory(
+                repo_path.as_str(),
+                task_id,
+                &worktree_path,
+            )?;
+            return Ok(BuildContinuationTargetLookup::Found(
+                BuildContinuationTarget {
+                    working_directory,
+                    source: BuildContinuationTargetSource::ActiveBuildRun,
+                },
+            ));
+        }
+
+        let sessions = self.agent_sessions_list(repo_path.as_str(), task_id)?;
+        let latest_builder_session = sessions
+            .into_iter()
+            .filter(|session| {
+                TaskAgentRole::parse(session.role.trim()) == Some(TaskAgentRole::Build)
+            })
+            .max_by(|left, right| session_sort_key(left).cmp(&session_sort_key(right)));
+        let Some(latest_builder_session) = latest_builder_session else {
+            return Ok(BuildContinuationTargetLookup::NoBuilderContext);
+        };
+
+        let working_directory = match validate_build_continuation_working_directory(
+            repo_path.as_str(),
+            task_id,
+            &latest_builder_session.working_directory,
+        ) {
+            Ok(working_directory) => working_directory,
+            Err(error) => {
+                let message = error.to_string();
+                if message.contains("The latest builder workspace does not exist") {
+                    return Ok(BuildContinuationTargetLookup::MissingBuilderWorktree);
+                }
+                return Err(error);
+            }
+        };
+        Ok(BuildContinuationTargetLookup::Found(
+            BuildContinuationTarget {
+                working_directory,
+                source: BuildContinuationTargetSource::BuilderSession,
+            },
+        ))
+    }
+
     pub fn agent_sessions_list(
         &self,
         repo_path: &str,
@@ -65,72 +141,19 @@ impl AppService {
         repo_path: &str,
         task_id: &str,
     ) -> Result<Option<BuildContinuationTarget>> {
-        let repo_path = self.resolve_task_repo_path(repo_path)?;
-        let normalized_repo_path = normalize_path_for_comparison(repo_path.as_str());
-
-        let active_worktree_path: Option<String> = {
-            let runs = self
-                .runs
-                .lock()
-                .map_err(|_| anyhow!("Run state lock poisoned"))?;
-            runs.values()
-                .filter(|run| {
-                    normalize_path_for_comparison(run.repo_path.as_str()) == normalized_repo_path
-                        && run.task_id == task_id
-                        && matches!(
-                            run.summary.state,
-                            RunState::Starting
-                                | RunState::Running
-                                | RunState::Blocked
-                                | RunState::AwaitingDoneConfirmation
-                        )
-                })
-                .max_by(|left, right| left.summary.started_at.cmp(&right.summary.started_at))
-                .map(|run| run.worktree_path.clone())
-        };
-
-        if let Some(worktree_path) = active_worktree_path {
-            let working_directory = validate_build_continuation_working_directory(
-                repo_path.as_str(),
-                task_id,
-                &worktree_path,
-            )?;
-            return Ok(Some(BuildContinuationTarget {
-                working_directory,
-                source: BuildContinuationTargetSource::ActiveBuildRun,
-            }));
+        match self.build_continuation_target_lookup(repo_path, task_id)? {
+            BuildContinuationTargetLookup::Found(target) => Ok(Some(target)),
+            BuildContinuationTargetLookup::NoBuilderContext
+            | BuildContinuationTargetLookup::MissingBuilderWorktree => Ok(None),
         }
-
-        let sessions = self.agent_sessions_list(repo_path.as_str(), task_id)?;
-        let latest_builder_session = sessions
-            .into_iter()
-            .filter(|session| {
-                TaskAgentRole::parse(session.role.trim()) == Some(TaskAgentRole::Build)
-            })
-            .max_by(|left, right| session_sort_key(left).cmp(&session_sort_key(right)));
-        let Some(latest_builder_session) = latest_builder_session else {
-            return Ok(None);
-        };
-
-        let working_directory = match validate_build_continuation_working_directory(
-            repo_path.as_str(),
-            task_id,
-            &latest_builder_session.working_directory,
-        ) {
-            Ok(working_directory) => working_directory,
-            Err(error) => {
-                let message = error.to_string();
-                if message.contains("The latest builder workspace does not exist") {
-                    return Ok(None);
-                }
-                return Err(error);
-            }
-        };
-        Ok(Some(BuildContinuationTarget {
-            working_directory,
-            source: BuildContinuationTargetSource::BuilderSession,
-        }))
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum BuildContinuationTargetLookup {
+    Found(BuildContinuationTarget),
+    NoBuilderContext,
+    MissingBuilderWorktree,
 }
 
 fn session_sort_key(session: &AgentSessionDocument) -> (&str, &str) {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
@@ -151,7 +151,7 @@ fn expect_ready_approval_context(
     result: TaskApprovalContextLoadResult,
 ) -> Result<TaskApprovalContext> {
     match result {
-        TaskApprovalContextLoadResult::Ready { approval_context } => Ok(approval_context),
+        TaskApprovalContextLoadResult::Ready { approval_context } => Ok(*approval_context),
         TaskApprovalContextLoadResult::MissingBuilderWorktree { task_id, .. } => Err(anyhow!(
             "expected ready approval context for task {task_id}, got missing builder worktree"
         )),
@@ -874,6 +874,40 @@ fn task_approval_context_reports_missing_builder_worktree_for_review_tasks() -> 
             task_id: "task-1".to_string(),
             task_status: TaskStatus::HumanReview.as_cli_value().to_string(),
         }
+    );
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn task_approval_context_still_errors_when_builder_context_is_missing() -> Result<()> {
+    let root = unique_temp_path("approval-context-missing-builder-context");
+    let repo = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    init_git_repo(&repo)?;
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, _task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    let repo_path = repo.to_string_lossy().to_string();
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(repo_path.as_str(), base_repo_config(&worktree_base))?;
+
+    let error = service
+        .task_approval_context_get(repo_path.as_str(), "task-1")
+        .expect_err("missing builder context should fail fast");
+    assert_eq!(
+        error.to_string(),
+        "Human approval requires a builder worktree for task task-1. Start Builder first."
     );
 
     let _ = fs::remove_dir_all(root);

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/approval_workflow.rs
@@ -3,7 +3,8 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     GitBranch, GitCurrentBranch, GitFileStatus, GitMergeBranchResult, GitMergeMethod,
-    PullRequestRecord, TaskPullRequestDetectResult, TaskStatus,
+    PullRequestRecord, TaskApprovalContext, TaskApprovalContextLoadResult,
+    TaskPullRequestDetectResult, TaskStatus,
 };
 use host_infra_system::{
     AppConfigStore, GitProviderConfig, GitProviderRepository, HookSet, RepoConfig,
@@ -144,6 +145,17 @@ fn configure_builder_session(
 
     service.workspace_add(repo_path)?;
     Ok(())
+}
+
+fn expect_ready_approval_context(
+    result: TaskApprovalContextLoadResult,
+) -> Result<TaskApprovalContext> {
+    match result {
+        TaskApprovalContextLoadResult::Ready { approval_context } => Ok(approval_context),
+        TaskApprovalContextLoadResult::MissingBuilderWorktree { task_id, .. } => Err(anyhow!(
+            "expected ready approval context for task {task_id}, got missing builder worktree"
+        )),
+    }
 }
 
 fn setup_pull_request_workflow_fixture(
@@ -822,6 +834,106 @@ fn task_direct_merge_complete_skips_ancestry_probe_when_squash_source_branch_is_
 }
 
 #[test]
+fn task_approval_context_reports_missing_builder_worktree_for_review_tasks() -> Result<()> {
+    let root = unique_temp_path("approval-context-missing-builder-worktree");
+    let repo = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    let missing_worktree_path = worktree_base.join("task-1");
+    init_git_repo(&repo)?;
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, task_state, _git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    let repo_path = repo.to_string_lossy().to_string();
+    service.workspace_add(repo_path.as_str())?;
+    service.workspace_update_repo_config(repo_path.as_str(), base_repo_config(&worktree_base))?;
+
+    fs::create_dir_all(&missing_worktree_path)?;
+    let mut session = make_session("task-1", "session-build");
+    session.working_directory = missing_worktree_path.to_string_lossy().to_string();
+    task_state
+        .lock()
+        .expect("task state lock poisoned")
+        .agent_sessions
+        .push(session);
+    let _ = fs::remove_dir_all(&missing_worktree_path);
+    assert!(!missing_worktree_path.exists());
+
+    let approval = service.task_approval_context_get(repo_path.as_str(), "task-1")?;
+    assert_eq!(
+        approval,
+        TaskApprovalContextLoadResult::MissingBuilderWorktree {
+            task_id: "task-1".to_string(),
+            task_status: TaskStatus::HumanReview.as_cli_value().to_string(),
+        }
+    );
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
+fn task_approval_context_still_errors_for_detached_builder_branch() -> Result<()> {
+    let root = unique_temp_path("approval-context-detached-builder-branch");
+    let repo = root.join("repo");
+    let worktree_base = root.join("worktrees");
+    let worktree_path = worktree_base.join("task-1");
+    init_git_repo(&repo)?;
+
+    let config_store = AppConfigStore::from_path(root.join("config.json"));
+    let (service, task_state, git_state) = build_service_with_store(
+        vec![make_task("task-1", "task", TaskStatus::HumanReview)],
+        vec![],
+        GitCurrentBranch {
+            name: Some("main".to_string()),
+            detached: false,
+            revision: None,
+        },
+        config_store,
+    );
+    let repo_path = repo.to_string_lossy().to_string();
+    configure_builder_session(
+        repo_path.as_str(),
+        &worktree_path,
+        "odt/task-1",
+        &service,
+        &task_state,
+        &git_state,
+    )?;
+    service.workspace_update_repo_config(repo_path.as_str(), base_repo_config(&worktree_base))?;
+    git_state
+        .lock()
+        .expect("git state lock poisoned")
+        .current_branches_by_path
+        .insert(
+            worktree_path.to_string_lossy().to_string(),
+            GitCurrentBranch {
+                name: None,
+                detached: true,
+                revision: None,
+            },
+        );
+
+    let error = service
+        .task_approval_context_get(repo_path.as_str(), "task-1")
+        .expect_err("detached builder branch should still fail");
+    assert!(error
+        .to_string()
+        .contains("requires a builder branch, but the latest builder workspace is detached"));
+
+    let _ = fs::remove_dir_all(root);
+    Ok(())
+}
+
+#[test]
 fn task_approval_context_uses_pending_direct_merge_metadata_without_builder_worktree() -> Result<()>
 {
     let root = unique_temp_path("approval-direct-merge-reopen");
@@ -875,7 +987,9 @@ fn task_approval_context_uses_pending_direct_merge_metadata_without_builder_work
     let _ = fs::remove_dir_all(&missing_worktree_path);
     assert!(!missing_worktree_path.exists());
 
-    let approval = service.task_approval_context_get(repo_path.as_str(), "task-1")?;
+    let approval = expect_ready_approval_context(
+        service.task_approval_context_get(repo_path.as_str(), "task-1")?,
+    )?;
     assert_eq!(approval.working_directory, None);
     assert_eq!(approval.source_branch, "odt/task-1");
     assert_eq!(approval.target_branch.checkout_branch(), "main");
@@ -952,7 +1066,9 @@ fn task_approval_context_reports_global_merge_default_and_dirty_worktree() -> Re
         });
     }
 
-    let approval = service.task_approval_context_get(repo_path.as_str(), "task-1")?;
+    let approval = expect_ready_approval_context(
+        service.task_approval_context_get(repo_path.as_str(), "task-1")?,
+    )?;
     assert_eq!(approval.default_merge_method, GitMergeMethod::Rebase);
     assert!(approval.has_uncommitted_changes);
     assert_eq!(approval.uncommitted_file_count, 1);
@@ -1158,7 +1274,9 @@ fn task_approval_context_reports_pull_request_unavailable_when_github_auth_is_mi
     )?;
     service.workspace_update_repo_config(repo_path.as_str(), github_repo_config(&worktree_base))?;
 
-    let context = service.task_approval_context_get(repo_path.as_str(), "task-1")?;
+    let context = expect_ready_approval_context(
+        service.task_approval_context_get(repo_path.as_str(), "task-1")?,
+    )?;
     let github = context
         .providers
         .iter()
@@ -1215,7 +1333,9 @@ fn task_approval_context_uses_configured_github_host_for_auth_status() -> Result
         github_repo_config_for_host(&worktree_base, "github.mycorp.com"),
     )?;
 
-    let context = service.task_approval_context_get(repo_path.as_str(), "task-1")?;
+    let context = expect_ready_approval_context(
+        service.task_approval_context_get(repo_path.as_str(), "task-1")?,
+    )?;
     let github = context
         .providers
         .iter()

--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -161,7 +161,7 @@ pub struct TaskApprovalContext {
 pub enum TaskApprovalContextLoadResult {
     Ready {
         #[serde(rename = "approvalContext")]
-        approval_context: TaskApprovalContext,
+        approval_context: Box<TaskApprovalContext>,
     },
     MissingBuilderWorktree {
         #[serde(rename = "taskId")]

--- a/apps/desktop/src-tauri/crates/host-domain/src/git.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/git.rs
@@ -158,6 +158,21 @@ pub struct TaskApprovalContext {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum TaskApprovalContextLoadResult {
+    Ready {
+        #[serde(rename = "approvalContext")]
+        approval_context: TaskApprovalContext,
+    },
+    MissingBuilderWorktree {
+        #[serde(rename = "taskId")]
+        task_id: String,
+        #[serde(rename = "taskStatus")]
+        task_status: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum GitPushResult {
     Pushed {
         remote: String,

--- a/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-domain/src/lib.rs
@@ -20,7 +20,8 @@ pub use git::{
     GitResetWorktreeSelection, GitResetWorktreeSelectionRequest, GitResetWorktreeSelectionResult,
     GitTargetBranch, GitUpstreamAheadBehind, GitWorktreeStatus, GitWorktreeStatusData,
     GitWorktreeStatusSnapshot, GitWorktreeStatusSummary, GitWorktreeStatusSummaryData,
-    GitWorktreeSummary, PullRequestRecord, TaskApprovalContext, TaskPullRequestDetectResult,
+    GitWorktreeSummary, PullRequestRecord, TaskApprovalContext, TaskApprovalContextLoadResult,
+    TaskPullRequestDetectResult,
 };
 pub use runtime::{
     AgentRuntimeKind, BuildContinuationTarget, BuildContinuationTargetSource, DevServerEvent,

--- a/apps/desktop/src-tauri/src/commands/build.rs
+++ b/apps/desktop/src-tauri/src/commands/build.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use host_application::{BuildResponseAction, CleanupMode};
 use host_domain::{
-    AgentRuntimeKind, DevServerGroupState, PullRequestRecord, RunSummary, TaskApprovalContext,
-    TaskCard, TaskDirectMergeResult, TaskPullRequestDetectResult,
+    AgentRuntimeKind, DevServerGroupState, PullRequestRecord, RunSummary,
+    TaskApprovalContextLoadResult, TaskCard, TaskDirectMergeResult, TaskPullRequestDetectResult,
 };
 use tauri::{AppHandle, State};
 
@@ -179,7 +179,7 @@ pub async fn task_approval_context_get(
     state: State<'_, AppState>,
     repo_path: String,
     task_id: String,
-) -> Result<TaskApprovalContext, String> {
+) -> Result<TaskApprovalContextLoadResult, String> {
     as_error(
         state
             .service

--- a/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
+++ b/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
@@ -44,7 +44,7 @@ export type PullRequestDraftMode = "manual" | "generate_ai";
 
 export type TaskApprovalModalModel = {
   open: boolean;
-  stage: "approval" | "complete_direct_merge";
+  stage: "approval" | "complete_direct_merge" | "missing_builder_worktree";
   taskId: string;
   isLoading: boolean;
   mode: TaskApprovalMode;
@@ -72,6 +72,8 @@ export type TaskApprovalModalModel = {
   onBodyChange: (value: string) => void;
   onSquashCommitMessageChange: (value: string) => void;
   onConfirm: () => void;
+  onCompleteMissingBuilderWorktree: () => void;
+  onResetMissingBuilderWorktree: () => void;
   onSkipDirectMergeCompletion: () => void;
   onCompleteDirectMerge: () => void;
 };

--- a/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
+++ b/apps/desktop/src/pages/kanban/kanban-page-model-types.ts
@@ -42,10 +42,16 @@ export type KanbanResolvedSessionStartIntent = KanbanSessionStartIntent & {
 export type TaskApprovalMode = "direct_merge" | "pull_request";
 export type PullRequestDraftMode = "manual" | "generate_ai";
 
-export type TaskApprovalModalModel = {
+type TaskApprovalModalBase = {
   open: boolean;
-  stage: "approval" | "complete_direct_merge" | "missing_builder_worktree";
   taskId: string;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+export type TaskApprovalApprovalModalModel = TaskApprovalModalBase & {
+  stage: "approval";
   isLoading: boolean;
   mode: TaskApprovalMode;
   mergeMethod: "merge_commit" | "squash" | "rebase";
@@ -61,10 +67,6 @@ export type TaskApprovalModalModel = {
   squashCommitMessageTouched: boolean;
   hasSuggestedSquashCommitMessage: boolean;
   targetBranch: GitTargetBranch | null;
-  publishTarget: GitTargetBranch | null;
-  isSubmitting: boolean;
-  errorMessage: string | null;
-  onOpenChange: (open: boolean) => void;
   onModeChange: (mode: TaskApprovalMode) => void;
   onMergeMethodChange: (mergeMethod: "merge_commit" | "squash" | "rebase") => void;
   onPullRequestDraftModeChange: (mode: PullRequestDraftMode) => void;
@@ -72,11 +74,26 @@ export type TaskApprovalModalModel = {
   onBodyChange: (value: string) => void;
   onSquashCommitMessageChange: (value: string) => void;
   onConfirm: () => void;
+};
+
+export type TaskApprovalMissingBuilderWorktreeModalModel = TaskApprovalModalBase & {
+  stage: "missing_builder_worktree";
   onCompleteMissingBuilderWorktree: () => void;
   onResetMissingBuilderWorktree: () => void;
+};
+
+export type TaskApprovalCompletionModalModel = TaskApprovalModalBase & {
+  stage: "complete_direct_merge";
+  targetBranch: GitTargetBranch | null;
+  publishTarget: GitTargetBranch | null;
   onSkipDirectMergeCompletion: () => void;
   onCompleteDirectMerge: () => void;
 };
+
+export type TaskApprovalModalModel =
+  | TaskApprovalApprovalModalModel
+  | TaskApprovalMissingBuilderWorktreeModalModel
+  | TaskApprovalCompletionModalModel;
 
 export type KanbanPageHeaderModel = {
   isLoadingTasks: boolean;

--- a/apps/desktop/src/pages/kanban/task-approval-flow-direct-merge.ts
+++ b/apps/desktop/src/pages/kanban/task-approval-flow-direct-merge.ts
@@ -88,7 +88,14 @@ export async function submitDirectMergeApproval({
     repoPath,
     approval.taskId,
   );
-  if (!nextApprovalContext.directMerge) {
+  if (nextApprovalContext.outcome !== "ready") {
+    throw new Error(
+      "Local direct merge completed, but the builder worktree disappeared before completion could resume.",
+    );
+  }
+
+  const resumedApprovalContext = nextApprovalContext.approvalContext;
+  if (!resumedApprovalContext.directMerge) {
     throw new Error(
       "Local direct merge completed, but the task did not enter a resumable completion state.",
     );
@@ -96,7 +103,7 @@ export async function submitDirectMergeApproval({
 
   return {
     outcome: "await_completion",
-    approvalContext: nextApprovalContext,
+    approvalContext: resumedApprovalContext,
   };
 }
 

--- a/apps/desktop/src/pages/kanban/task-approval-flow-state.ts
+++ b/apps/desktop/src/pages/kanban/task-approval-flow-state.ts
@@ -1,7 +1,10 @@
 import type { TaskApprovalContext } from "@openducktor/contracts";
 import type { PullRequestDraftMode, TaskApprovalMode } from "./kanban-page-model-types";
 
-export type TaskApprovalFlowStage = "approval" | "complete_direct_merge";
+export type TaskApprovalFlowStage =
+  | "approval"
+  | "complete_direct_merge"
+  | "missing_builder_worktree";
 export type TaskApprovalMergeMethod = "merge_commit" | "squash" | "rebase";
 
 export type TaskApprovalFlowOpenState = {
@@ -25,6 +28,10 @@ export type TaskApprovalFlowReadyState = TaskApprovalFlowOpenState & {
   approvalContext: TaskApprovalContext;
 };
 
+export type TaskApprovalFlowInteractiveState = TaskApprovalFlowOpenState & {
+  phase: "ready";
+};
+
 export type TaskApprovalFlowState = { kind: "closed" } | TaskApprovalFlowOpenState;
 
 type TaskApprovalFlowOpenPayload = {
@@ -42,6 +49,7 @@ type TaskApprovalFlowAction =
       type: "load_succeeded";
       approvalContext: TaskApprovalContext;
     } & TaskApprovalFlowOpenPayload)
+  | ({ type: "load_missing_builder_worktree" } & TaskApprovalFlowOpenPayload)
   | { type: "close" }
   | { type: "start_submitting" }
   | { type: "return_to_editable"; errorMessage: string | null }
@@ -81,6 +89,10 @@ export const isTaskApprovalReady = (
 ): state is TaskApprovalFlowReadyState =>
   state.kind === "open" && state.phase === "ready" && state.approvalContext !== null;
 
+export const isTaskApprovalInteractive = (
+  state: TaskApprovalFlowState,
+): state is TaskApprovalFlowInteractiveState => state.kind === "open" && state.phase === "ready";
+
 const buildTaskApprovalLoadingState = (
   payload: TaskApprovalFlowOpenPayload,
 ): TaskApprovalFlowOpenState => ({
@@ -117,6 +129,24 @@ const buildTaskApprovalLoadedState = (
   approvalContext: payload.approvalContext,
 });
 
+const buildMissingBuilderWorktreeState = (
+  payload: TaskApprovalFlowOpenPayload,
+): TaskApprovalFlowOpenState => ({
+  kind: "open",
+  phase: "ready",
+  stage: "missing_builder_worktree",
+  taskId: payload.taskId,
+  mode: payload.mode,
+  mergeMethod: "merge_commit",
+  pullRequestDraftMode: payload.pullRequestDraftMode,
+  title: payload.title,
+  body: payload.body,
+  squashCommitMessage: "",
+  squashCommitMessageTouched: false,
+  errorMessage: payload.errorMessage,
+  approvalContext: null,
+});
+
 export function taskApprovalFlowReducer(
   state: TaskApprovalFlowState,
   action: TaskApprovalFlowAction,
@@ -126,6 +156,8 @@ export function taskApprovalFlowReducer(
       return buildTaskApprovalLoadingState(action);
     case "load_succeeded":
       return buildTaskApprovalLoadedState(action);
+    case "load_missing_builder_worktree":
+      return buildMissingBuilderWorktreeState(action);
     case "close":
       return CLOSED_TASK_APPROVAL_STATE;
     case "start_submitting":

--- a/apps/desktop/src/pages/kanban/task-approval-modal-panel.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal-panel.tsx
@@ -241,6 +241,56 @@ export function TaskApprovalModalPanel({
   );
 }
 
+function getDirectMergeCompletionContextError(
+  model: TaskApprovalCompletionModalModel,
+): string | null {
+  return model.targetBranch === null
+    ? "Missing target branch for direct-merge completion. Refresh approval context and retry."
+    : null;
+}
+
+function getApprovalSubmitValidation(model: TaskApprovalApprovalModalModel): {
+  hasManualPullRequestValidationError: boolean;
+  hasSquashCommitMessageSubmitError: boolean;
+  showSquashCommitMessageValidationError: boolean;
+  confirmDisabled: boolean;
+  confirmLabel: string;
+} {
+  const hasManualPullRequestValidationError =
+    model.mode === "pull_request" &&
+    model.pullRequestAvailable &&
+    model.pullRequestDraftMode === "manual" &&
+    (model.title.trim().length === 0 || model.body.trim().length === 0);
+  const hasSquashCommitMessageSubmitError =
+    model.mode === "direct_merge" &&
+    model.mergeMethod === "squash" &&
+    model.squashCommitMessage.trim().length === 0;
+  const showSquashCommitMessageValidationError =
+    hasSquashCommitMessageSubmitError &&
+    (model.hasSuggestedSquashCommitMessage || model.squashCommitMessageTouched);
+
+  let confirmLabel = "Merge Locally";
+  if (model.mode === "pull_request" && model.pullRequestDraftMode === "manual") {
+    confirmLabel = "Create Pull Request";
+  } else if (model.mode === "pull_request") {
+    confirmLabel = "Start PR Generation";
+  }
+
+  return {
+    hasManualPullRequestValidationError,
+    hasSquashCommitMessageSubmitError,
+    showSquashCommitMessageValidationError,
+    confirmDisabled:
+      model.isLoading ||
+      model.isSubmitting ||
+      model.hasUncommittedChanges ||
+      (model.mode === "pull_request" && !model.pullRequestAvailable) ||
+      hasManualPullRequestValidationError ||
+      hasSquashCommitMessageSubmitError,
+    confirmLabel,
+  };
+}
+
 function TaskApprovalApprovalStage({
   model,
   sectionLabelClass,
@@ -248,6 +298,7 @@ function TaskApprovalApprovalStage({
   model: TaskApprovalApprovalModalModel;
   sectionLabelClass: string;
 }): ReactElement {
+  const { showSquashCommitMessageValidationError } = getApprovalSubmitValidation(model);
   const actionOptions = APPROVAL_ACTION_OPTIONS.map((option) => ({
     value: option.value,
     label: option.label,
@@ -257,13 +308,6 @@ function TaskApprovalApprovalStage({
     model.uncommittedFileCount === 1
       ? "The builder worktree has 1 uncommitted file. Commit or discard it before approving this task."
       : `The builder worktree has ${model.uncommittedFileCount} uncommitted files. Commit or discard them before approving this task.`;
-  const hasSquashCommitMessageSubmitError =
-    model.mode === "direct_merge" &&
-    model.mergeMethod === "squash" &&
-    model.squashCommitMessage.trim().length === 0;
-  const showSquashCommitMessageValidationError =
-    hasSquashCommitMessageSubmitError &&
-    (model.hasSuggestedSquashCommitMessage || model.squashCommitMessageTouched);
 
   if (model.isLoading) {
     return (
@@ -506,10 +550,7 @@ function TaskApprovalCompletionStage({
   sectionLabelClass: string;
 }): ReactElement {
   const hasPublishTarget = model.publishTarget !== null;
-  const completionContextError =
-    model.targetBranch === null
-      ? "Missing target branch for direct-merge completion. Refresh approval context and retry."
-      : null;
+  const completionContextError = getDirectMergeCompletionContextError(model);
   const completionErrorMessage = completionContextError ?? model.errorMessage;
   const localBranchName = model.targetBranch?.branch ?? "";
   const publishTargetLabel = model.publishTarget ? canonicalTargetBranch(model.publishTarget) : "";
@@ -605,10 +646,7 @@ function TaskApprovalModalFooter({ model }: { model: TaskApprovalModalModel }): 
   );
 
   if (model.stage === "complete_direct_merge") {
-    const completionContextError =
-      model.targetBranch === null
-        ? "Missing target branch for direct-merge completion. Refresh approval context and retry."
-        : null;
+    const completionContextError = getDirectMergeCompletionContextError(model);
     const completionActionDisabled = model.isSubmitting || completionContextError !== null;
     const finishLaterDisabled = model.isSubmitting;
     const publishTargetBranchName = model.publishTarget?.branch ?? "";
@@ -683,28 +721,7 @@ function TaskApprovalModalFooter({ model }: { model: TaskApprovalModalModel }): 
     );
   }
 
-  const hasManualPullRequestValidationError =
-    model.mode === "pull_request" &&
-    model.pullRequestAvailable &&
-    model.pullRequestDraftMode === "manual" &&
-    (model.title.trim().length === 0 || model.body.trim().length === 0);
-  const hasSquashCommitMessageSubmitError =
-    model.mode === "direct_merge" &&
-    model.mergeMethod === "squash" &&
-    model.squashCommitMessage.trim().length === 0;
-  const confirmDisabled =
-    model.isLoading ||
-    model.isSubmitting ||
-    model.hasUncommittedChanges ||
-    (model.mode === "pull_request" && !model.pullRequestAvailable) ||
-    hasManualPullRequestValidationError ||
-    hasSquashCommitMessageSubmitError;
-  const confirmLabel =
-    model.mode === "pull_request"
-      ? model.pullRequestDraftMode === "manual"
-        ? "Create Pull Request"
-        : "Start PR Generation"
-      : "Merge Locally";
+  const { confirmDisabled, confirmLabel } = getApprovalSubmitValidation(model);
 
   return (
     <DialogFooter className={footerClassName}>

--- a/apps/desktop/src/pages/kanban/task-approval-modal-panel.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal-panel.tsx
@@ -9,6 +9,9 @@ import { canonicalTargetBranch } from "@/lib/target-branch";
 import { cn } from "@/lib/utils";
 import type {
   PullRequestDraftMode,
+  TaskApprovalApprovalModalModel,
+  TaskApprovalCompletionModalModel,
+  TaskApprovalMissingBuilderWorktreeModalModel,
   TaskApprovalModalModel,
   TaskApprovalMode,
 } from "./kanban-page-model-types";
@@ -28,7 +31,7 @@ const APPROVAL_ACTION_OPTIONS: Array<{
 ];
 
 const MERGE_METHOD_OPTIONS: Array<{
-  value: TaskApprovalModalModel["mergeMethod"];
+  value: TaskApprovalApprovalModalModel["mergeMethod"];
   label: string;
   description: string;
 }> = [
@@ -177,10 +180,7 @@ export function getTaskApprovalModalHeader(model: TaskApprovalModalModel): {
     };
   }
 
-  const isCompletionStage = model.stage === "complete_direct_merge";
-  const hasPublishTarget = model.publishTarget !== null;
-
-  if (isCompletionStage && hasPublishTarget) {
+  if (model.stage === "complete_direct_merge" && model.publishTarget !== null) {
     const publishTargetLabel = canonicalTargetBranch(model.publishTarget);
     return {
       title: "Publish And Mark Done",
@@ -188,7 +188,7 @@ export function getTaskApprovalModalHeader(model: TaskApprovalModalModel): {
     };
   }
 
-  if (isCompletionStage) {
+  if (model.stage === "complete_direct_merge") {
     return {
       title: "Complete Direct Merge",
       description:
@@ -211,72 +211,8 @@ export function TaskApprovalModalPanel({
   showHeader?: boolean;
 }): ReactElement {
   const { title, description } = getTaskApprovalModalHeader(model);
-
-  const hasManualPullRequestValidationError =
-    model.stage === "approval" &&
-    model.mode === "pull_request" &&
-    model.pullRequestAvailable &&
-    model.pullRequestDraftMode === "manual" &&
-    (model.title.trim().length === 0 || model.body.trim().length === 0);
-  const hasSquashCommitMessageSubmitError =
-    model.stage === "approval" &&
-    model.mode === "direct_merge" &&
-    model.mergeMethod === "squash" &&
-    model.squashCommitMessage.trim().length === 0;
-  const showSquashCommitMessageValidationError =
-    hasSquashCommitMessageSubmitError &&
-    (model.hasSuggestedSquashCommitMessage || model.squashCommitMessageTouched);
-  const confirmDisabled =
-    model.isLoading ||
-    model.isSubmitting ||
-    model.hasUncommittedChanges ||
-    (model.mode === "pull_request" && !model.pullRequestAvailable) ||
-    hasManualPullRequestValidationError ||
-    hasSquashCommitMessageSubmitError;
-  const isCompletionStage = model.stage === "complete_direct_merge";
-  const isMissingBuilderWorktreeStage = model.stage === "missing_builder_worktree";
-  const hasPublishTarget = model.publishTarget !== null;
-  const hasCompletionBranchContext = model.targetBranch !== null;
-  const completionContextError =
-    isCompletionStage && !hasCompletionBranchContext
-      ? "Missing target branch for direct-merge completion. Refresh approval context and retry."
-      : null;
-  const localBranchName = model.targetBranch ? model.targetBranch.branch : "";
-  const publishTargetLabel = model.publishTarget ? canonicalTargetBranch(model.publishTarget) : "";
-  const publishTargetBranchName = model.publishTarget?.branch ?? "";
-  const dirtyWorktreeMessage =
-    model.uncommittedFileCount === 1
-      ? "The builder worktree has 1 uncommitted file. Commit or discard it before approving this task."
-      : `The builder worktree has ${model.uncommittedFileCount} uncommitted files. Commit or discard them before approving this task.`;
   const sectionLabelClass =
     "text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground";
-  const actionOptions = APPROVAL_ACTION_OPTIONS.map((option) => ({
-    value: option.value,
-    label: option.label,
-    disabled: option.value === "pull_request" && !model.pullRequestAvailable,
-  }));
-  let confirmLabel = "Merge Locally";
-  if (model.mode === "pull_request") {
-    confirmLabel =
-      model.pullRequestDraftMode === "manual" ? "Create Pull Request" : "Start PR Generation";
-  }
-  let completionButtonLabel = "Mark Task Done";
-  if (model.isSubmitting && hasPublishTarget) {
-    completionButtonLabel = `Publishing ${publishTargetBranchName}`;
-  } else if (model.isSubmitting) {
-    completionButtonLabel = "Completing Direct Merge";
-  } else if (hasPublishTarget) {
-    completionButtonLabel = `Push ${publishTargetBranchName} And Mark Done`;
-  }
-  let completionStageDescription =
-    "Finish later to keep the task in Human Review until you are ready to close it and clean up the builder workspace.";
-  if (hasPublishTarget) {
-    completionStageDescription =
-      "Finish later to keep the task in Human Review while the local merge stays ready to publish.";
-  }
-  const completionActionDisabled = model.isSubmitting || completionContextError !== null;
-  const finishLaterDisabled = model.isSubmitting;
-  const completionErrorMessage = completionContextError ?? model.errorMessage;
 
   return (
     <>
@@ -289,58 +225,46 @@ export function TaskApprovalModalPanel({
 
       <DialogBody>
         {model.stage === "approval" ? (
-          <TaskApprovalApprovalStage
-            model={model}
-            actionOptions={actionOptions}
-            dirtyWorktreeMessage={dirtyWorktreeMessage}
-            sectionLabelClass={sectionLabelClass}
-            showSquashCommitMessageValidationError={showSquashCommitMessageValidationError}
-          />
+          <TaskApprovalApprovalStage model={model} sectionLabelClass={sectionLabelClass} />
         ) : null}
 
-        {isMissingBuilderWorktreeStage ? (
+        {model.stage === "missing_builder_worktree" ? (
           <TaskApprovalMissingBuilderWorktreeStage model={model} />
         ) : null}
 
-        {isCompletionStage ? (
-          <TaskApprovalCompletionStage
-            completionContextError={completionContextError}
-            completionErrorMessage={completionErrorMessage}
-            hasPublishTarget={hasPublishTarget}
-            localBranchName={localBranchName}
-            publishTargetLabel={publishTargetLabel}
-            sectionLabelClass={sectionLabelClass}
-          />
+        {model.stage === "complete_direct_merge" ? (
+          <TaskApprovalCompletionStage model={model} sectionLabelClass={sectionLabelClass} />
         ) : null}
       </DialogBody>
-      <TaskApprovalModalFooter
-        model={model}
-        completionActionDisabled={completionActionDisabled}
-        completionButtonLabel={completionButtonLabel}
-        completionStageDescription={completionStageDescription}
-        confirmDisabled={confirmDisabled}
-        confirmLabel={confirmLabel}
-        finishLaterDisabled={finishLaterDisabled}
-        isCompletionStage={isCompletionStage}
-        isMissingBuilderWorktreeStage={isMissingBuilderWorktreeStage}
-      />
+      <TaskApprovalModalFooter model={model} />
     </>
   );
 }
 
 function TaskApprovalApprovalStage({
   model,
-  actionOptions,
-  dirtyWorktreeMessage,
   sectionLabelClass,
-  showSquashCommitMessageValidationError,
 }: {
-  model: TaskApprovalModalModel;
-  actionOptions: Array<{ value: TaskApprovalMode; label: string; disabled: boolean }>;
-  dirtyWorktreeMessage: string;
+  model: TaskApprovalApprovalModalModel;
   sectionLabelClass: string;
-  showSquashCommitMessageValidationError: boolean;
 }): ReactElement {
+  const actionOptions = APPROVAL_ACTION_OPTIONS.map((option) => ({
+    value: option.value,
+    label: option.label,
+    disabled: option.value === "pull_request" && !model.pullRequestAvailable,
+  }));
+  const dirtyWorktreeMessage =
+    model.uncommittedFileCount === 1
+      ? "The builder worktree has 1 uncommitted file. Commit or discard it before approving this task."
+      : `The builder worktree has ${model.uncommittedFileCount} uncommitted files. Commit or discard them before approving this task.`;
+  const hasSquashCommitMessageSubmitError =
+    model.mode === "direct_merge" &&
+    model.mergeMethod === "squash" &&
+    model.squashCommitMessage.trim().length === 0;
+  const showSquashCommitMessageValidationError =
+    hasSquashCommitMessageSubmitError &&
+    (model.hasSuggestedSquashCommitMessage || model.squashCommitMessageTouched);
+
   if (model.isLoading) {
     return (
       <div className="space-y-6 px-6 py-6 sm:px-8">
@@ -407,7 +331,7 @@ function TaskApprovalApprovalStage({
 function TaskApprovalMissingBuilderWorktreeStage({
   model,
 }: {
-  model: TaskApprovalModalModel;
+  model: TaskApprovalMissingBuilderWorktreeModalModel;
 }): ReactElement {
   return (
     <div className="space-y-4 px-6 py-6 sm:px-8">
@@ -453,7 +377,7 @@ function TaskApprovalDirectMergeSection({
   sectionLabelClass,
   showSquashCommitMessageValidationError,
 }: {
-  model: TaskApprovalModalModel;
+  model: TaskApprovalApprovalModalModel;
   sectionLabelClass: string;
   showSquashCommitMessageValidationError: boolean;
 }): ReactElement {
@@ -508,7 +432,7 @@ function TaskApprovalPullRequestSection({
   model,
   sectionLabelClass,
 }: {
-  model: TaskApprovalModalModel;
+  model: TaskApprovalApprovalModalModel;
   sectionLabelClass: string;
 }): ReactElement {
   return (
@@ -575,20 +499,21 @@ function TaskApprovalPullRequestSection({
 }
 
 function TaskApprovalCompletionStage({
-  completionContextError,
-  completionErrorMessage,
-  hasPublishTarget,
-  localBranchName,
-  publishTargetLabel,
+  model,
   sectionLabelClass,
 }: {
-  completionContextError: string | null;
-  completionErrorMessage: string | null;
-  hasPublishTarget: boolean;
-  localBranchName: string;
-  publishTargetLabel: string;
+  model: TaskApprovalCompletionModalModel;
   sectionLabelClass: string;
 }): ReactElement {
+  const hasPublishTarget = model.publishTarget !== null;
+  const completionContextError =
+    model.targetBranch === null
+      ? "Missing target branch for direct-merge completion. Refresh approval context and retry."
+      : null;
+  const completionErrorMessage = completionContextError ?? model.errorMessage;
+  const localBranchName = model.targetBranch?.branch ?? "";
+  const publishTargetLabel = model.publishTarget ? canonicalTargetBranch(model.publishTarget) : "";
+
   return (
     <div className="grid gap-4 px-6 py-6 sm:px-8">
       {completionErrorMessage ? (
@@ -670,27 +595,8 @@ function TaskApprovalCompletionStage({
   );
 }
 
-function TaskApprovalModalFooter({
-  model,
-  completionActionDisabled,
-  completionButtonLabel,
-  completionStageDescription,
-  confirmDisabled,
-  confirmLabel,
-  finishLaterDisabled,
-  isCompletionStage,
-  isMissingBuilderWorktreeStage,
-}: {
-  model: TaskApprovalModalModel;
-  completionActionDisabled: boolean;
-  completionButtonLabel: string;
-  completionStageDescription: string;
-  confirmDisabled: boolean;
-  confirmLabel: string;
-  finishLaterDisabled: boolean;
-  isCompletionStage: boolean;
-  isMissingBuilderWorktreeStage: boolean;
-}): ReactElement {
+function TaskApprovalModalFooter({ model }: { model: TaskApprovalModalModel }): ReactElement {
+  const isCompletionStage = model.stage === "complete_direct_merge";
   const footerClassName = cn(
     "mt-0 border-t border-border/80 bg-muted/20 px-6 py-4 sm:px-8",
     isCompletionStage
@@ -698,7 +604,26 @@ function TaskApprovalModalFooter({
       : "flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between",
   );
 
-  if (isCompletionStage) {
+  if (model.stage === "complete_direct_merge") {
+    const completionContextError =
+      model.targetBranch === null
+        ? "Missing target branch for direct-merge completion. Refresh approval context and retry."
+        : null;
+    const completionActionDisabled = model.isSubmitting || completionContextError !== null;
+    const finishLaterDisabled = model.isSubmitting;
+    const publishTargetBranchName = model.publishTarget?.branch ?? "";
+    let completionButtonLabel = "Mark Task Done";
+    if (model.isSubmitting && model.publishTarget) {
+      completionButtonLabel = `Publishing ${publishTargetBranchName}`;
+    } else if (model.isSubmitting) {
+      completionButtonLabel = "Completing Direct Merge";
+    } else if (model.publishTarget) {
+      completionButtonLabel = `Push ${publishTargetBranchName} And Mark Done`;
+    }
+    const completionStageDescription = model.publishTarget
+      ? "Finish later to keep the task in Human Review while the local merge stays ready to publish."
+      : "Finish later to keep the task in Human Review until you are ready to close it and clean up the builder workspace.";
+
     return (
       <DialogFooter className={footerClassName}>
         <p className="text-sm text-muted-foreground">{completionStageDescription}</p>
@@ -725,7 +650,7 @@ function TaskApprovalModalFooter({
     );
   }
 
-  if (isMissingBuilderWorktreeStage) {
+  if (model.stage === "missing_builder_worktree") {
     return (
       <DialogFooter className="mt-0 flex-col-reverse gap-3 border-t border-border/80 bg-muted/20 px-6 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-8">
         <Button
@@ -757,6 +682,29 @@ function TaskApprovalModalFooter({
       </DialogFooter>
     );
   }
+
+  const hasManualPullRequestValidationError =
+    model.mode === "pull_request" &&
+    model.pullRequestAvailable &&
+    model.pullRequestDraftMode === "manual" &&
+    (model.title.trim().length === 0 || model.body.trim().length === 0);
+  const hasSquashCommitMessageSubmitError =
+    model.mode === "direct_merge" &&
+    model.mergeMethod === "squash" &&
+    model.squashCommitMessage.trim().length === 0;
+  const confirmDisabled =
+    model.isLoading ||
+    model.isSubmitting ||
+    model.hasUncommittedChanges ||
+    (model.mode === "pull_request" && !model.pullRequestAvailable) ||
+    hasManualPullRequestValidationError ||
+    hasSquashCommitMessageSubmitError;
+  const confirmLabel =
+    model.mode === "pull_request"
+      ? model.pullRequestDraftMode === "manual"
+        ? "Create Pull Request"
+        : "Start PR Generation"
+      : "Merge Locally";
 
   return (
     <DialogFooter className={footerClassName}>

--- a/apps/desktop/src/pages/kanban/task-approval-modal-panel.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal-panel.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, Check, LoaderCircle } from "lucide-react";
+import { AlertTriangle, ArrowRight, Check, LoaderCircle } from "lucide-react";
 import type { ReactElement } from "react";
 import { Button } from "@/components/ui/button";
 import { DialogBody, DialogFooter } from "@/components/ui/dialog";
@@ -169,6 +169,14 @@ export function getTaskApprovalModalHeader(model: TaskApprovalModalModel): {
   title: string;
   description: string;
 } {
+  if (model.stage === "missing_builder_worktree") {
+    return {
+      title: "Builder Worktree Missing",
+      description:
+        "The builder worktree for this task is no longer available. You can still complete the task or reset the implementation from here.",
+    };
+  }
+
   const isCompletionStage = model.stage === "complete_direct_merge";
   const hasPublishTarget = model.publishTarget !== null;
 
@@ -226,6 +234,7 @@ export function TaskApprovalModalPanel({
     hasManualPullRequestValidationError ||
     hasSquashCommitMessageSubmitError;
   const isCompletionStage = model.stage === "complete_direct_merge";
+  const isMissingBuilderWorktreeStage = model.stage === "missing_builder_worktree";
   const hasPublishTarget = model.publishTarget !== null;
   const hasCompletionBranchContext = model.targetBranch !== null;
   const completionContextError =
@@ -289,6 +298,10 @@ export function TaskApprovalModalPanel({
           />
         ) : null}
 
+        {isMissingBuilderWorktreeStage ? (
+          <TaskApprovalMissingBuilderWorktreeStage model={model} />
+        ) : null}
+
         {isCompletionStage ? (
           <TaskApprovalCompletionStage
             completionContextError={completionContextError}
@@ -309,6 +322,7 @@ export function TaskApprovalModalPanel({
         confirmLabel={confirmLabel}
         finishLaterDisabled={finishLaterDisabled}
         isCompletionStage={isCompletionStage}
+        isMissingBuilderWorktreeStage={isMissingBuilderWorktreeStage}
       />
     </>
   );
@@ -386,6 +400,50 @@ function TaskApprovalApprovalStage({
       ) : (
         <TaskApprovalPullRequestSection model={model} sectionLabelClass={sectionLabelClass} />
       )}
+    </div>
+  );
+}
+
+function TaskApprovalMissingBuilderWorktreeStage({
+  model,
+}: {
+  model: TaskApprovalModalModel;
+}): ReactElement {
+  return (
+    <div className="space-y-4 px-6 py-6 sm:px-8">
+      <div className="rounded-2xl border border-warning-border bg-warning-surface p-5 text-warning-surface-foreground">
+        <div className="flex items-start gap-4">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-warning-border/60 bg-card/70 text-warning-muted">
+            <AlertTriangle className="size-5" />
+          </div>
+          <div className="space-y-1.5">
+            <p className="text-sm font-semibold text-warning-surface-foreground">
+              Builder worktree not found
+            </p>
+            <p className="text-sm leading-6 text-warning-surface-foreground">
+              OpenDucktor could not load the latest builder worktree for this task. Normal direct
+              merge and pull request approval options are unavailable without that workspace.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {model.errorMessage ? (
+        <div className="grid gap-1 rounded-2xl border border-destructive-border bg-destructive-surface p-4 text-destructive-surface-foreground">
+          <p className="text-sm font-semibold">Recovery action failed</p>
+          <p className="text-sm text-destructive-muted">{model.errorMessage}</p>
+        </div>
+      ) : null}
+
+      <div className="rounded-2xl border border-border bg-card p-5">
+        <div className="space-y-1.5">
+          <p className="text-sm font-semibold text-foreground">Choose the next step</p>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Complete task closes the review and moves this task to Done. Reset implementation opens
+            the existing reset workflow so you can send the task back for more work.
+          </p>
+        </div>
+      </div>
     </div>
   );
 }
@@ -621,6 +679,7 @@ function TaskApprovalModalFooter({
   confirmLabel,
   finishLaterDisabled,
   isCompletionStage,
+  isMissingBuilderWorktreeStage,
 }: {
   model: TaskApprovalModalModel;
   completionActionDisabled: boolean;
@@ -630,6 +689,7 @@ function TaskApprovalModalFooter({
   confirmLabel: string;
   finishLaterDisabled: boolean;
   isCompletionStage: boolean;
+  isMissingBuilderWorktreeStage: boolean;
 }): ReactElement {
   const footerClassName = cn(
     "mt-0 border-t border-border/80 bg-muted/20 px-6 py-4 sm:px-8",
@@ -659,6 +719,39 @@ function TaskApprovalModalFooter({
           >
             {model.isSubmitting ? <LoaderCircle className="size-4 animate-spin" /> : null}
             {completionButtonLabel}
+          </Button>
+        </div>
+      </DialogFooter>
+    );
+  }
+
+  if (isMissingBuilderWorktreeStage) {
+    return (
+      <DialogFooter className="mt-0 flex-col-reverse gap-3 border-t border-border/80 bg-muted/20 px-6 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-8">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={model.isSubmitting}
+          onClick={() => model.onOpenChange(false)}
+        >
+          Cancel
+        </Button>
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={model.isSubmitting}
+            onClick={model.onResetMissingBuilderWorktree}
+          >
+            Reset Implementation
+          </Button>
+          <Button
+            type="button"
+            disabled={model.isSubmitting}
+            onClick={model.onCompleteMissingBuilderWorktree}
+          >
+            {model.isSubmitting ? <LoaderCircle className="size-4 animate-spin" /> : null}
+            {model.isSubmitting ? "Completing Task" : "Complete Task"}
           </Button>
         </div>
       </DialogFooter>

--- a/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
@@ -38,6 +38,8 @@ const createModel = (overrides: Partial<TaskApprovalModalModel> = {}): TaskAppro
   onBodyChange: noop,
   onSquashCommitMessageChange: noop,
   onConfirm: noop,
+  onCompleteMissingBuilderWorktree: noop,
+  onResetMissingBuilderWorktree: noop,
   onSkipDirectMergeCompletion: noop,
   onCompleteDirectMerge: noop,
   ...overrides,
@@ -77,6 +79,24 @@ describe("TaskApprovalModal", () => {
 
     expect(html).toContain("Publishing beta");
     expect(html).toContain("animate-spin");
+  });
+
+  test("renders recovery copy when the builder worktree is missing", () => {
+    const html = renderToStaticMarkup(
+      createElement(TaskApprovalModalPanel, {
+        model: createModel({
+          stage: "missing_builder_worktree",
+          targetBranch: null,
+          publishTarget: null,
+        }),
+      }),
+    );
+
+    expect(html).toContain("Builder Worktree Missing");
+    expect(html).toContain("Builder worktree not found");
+    expect(html).toContain("Normal direct merge and pull request approval options are unavailable");
+    expect(html).toContain("Reset Implementation");
+    expect(html).toContain("Complete Task");
   });
 
   test("shows a loading indicator for approval submission actions", () => {

--- a/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
+++ b/apps/desktop/src/pages/kanban/task-approval-modal.test.tsx
@@ -2,15 +2,37 @@ import { describe, expect, test } from "bun:test";
 import { render, screen } from "@testing-library/react";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { TaskApprovalModalModel } from "./kanban-page-model-types";
+import type {
+  TaskApprovalApprovalModalModel,
+  TaskApprovalCompletionModalModel,
+  TaskApprovalMissingBuilderWorktreeModalModel,
+} from "./kanban-page-model-types";
 import { TaskApprovalModal } from "./task-approval-modal";
 import { TaskApprovalModalPanel } from "./task-approval-modal-panel";
 
 const noop = () => {};
 
-const createModel = (overrides: Partial<TaskApprovalModalModel> = {}): TaskApprovalModalModel => ({
+const createCompletionModel = (
+  overrides: Partial<TaskApprovalCompletionModalModel> = {},
+): TaskApprovalCompletionModalModel => ({
   open: true,
   stage: "complete_direct_merge",
+  taskId: "TASK-1",
+  targetBranch: { remote: "origin", branch: "beta" },
+  publishTarget: { remote: "origin", branch: "beta" },
+  isSubmitting: false,
+  errorMessage: null,
+  onOpenChange: noop,
+  onSkipDirectMergeCompletion: noop,
+  onCompleteDirectMerge: noop,
+  ...overrides,
+});
+
+const createApprovalModel = (
+  overrides: Partial<TaskApprovalApprovalModalModel> = {},
+): TaskApprovalApprovalModalModel => ({
+  open: true,
+  stage: "approval",
   taskId: "TASK-1",
   isLoading: false,
   mode: "direct_merge",
@@ -27,7 +49,6 @@ const createModel = (overrides: Partial<TaskApprovalModalModel> = {}): TaskAppro
   squashCommitMessageTouched: false,
   hasSuggestedSquashCommitMessage: true,
   targetBranch: { remote: "origin", branch: "beta" },
-  publishTarget: { remote: "origin", branch: "beta" },
   isSubmitting: false,
   errorMessage: null,
   onOpenChange: noop,
@@ -38,16 +59,26 @@ const createModel = (overrides: Partial<TaskApprovalModalModel> = {}): TaskAppro
   onBodyChange: noop,
   onSquashCommitMessageChange: noop,
   onConfirm: noop,
+  ...overrides,
+});
+
+const createMissingBuilderWorktreeModel = (
+  overrides: Partial<TaskApprovalMissingBuilderWorktreeModalModel> = {},
+): TaskApprovalMissingBuilderWorktreeModalModel => ({
+  open: true,
+  stage: "missing_builder_worktree",
+  taskId: "TASK-1",
+  isSubmitting: false,
+  errorMessage: null,
+  onOpenChange: noop,
   onCompleteMissingBuilderWorktree: noop,
   onResetMissingBuilderWorktree: noop,
-  onSkipDirectMergeCompletion: noop,
-  onCompleteDirectMerge: noop,
   ...overrides,
 });
 
 describe("TaskApprovalModal", () => {
   test("renders the wrapper dialog title and description", () => {
-    const rendered = render(createElement(TaskApprovalModal, { model: createModel() }));
+    const rendered = render(createElement(TaskApprovalModal, { model: createCompletionModel() }));
 
     expect(screen.getByText("Publish And Mark Done")).toBeTruthy();
     expect(
@@ -61,7 +92,7 @@ describe("TaskApprovalModal", () => {
 
   test("renders explicit completion copy for merged local branches", () => {
     const html = renderToStaticMarkup(
-      createElement(TaskApprovalModalPanel, { model: createModel() }),
+      createElement(TaskApprovalModalPanel, { model: createCompletionModel() }),
     );
 
     expect(html).toContain("Publish And Mark Done");
@@ -73,7 +104,7 @@ describe("TaskApprovalModal", () => {
   test("shows a loading label while direct merge completion is pending", () => {
     const html = renderToStaticMarkup(
       createElement(TaskApprovalModalPanel, {
-        model: createModel({ isSubmitting: true }),
+        model: createCompletionModel({ isSubmitting: true }),
       }),
     );
 
@@ -84,11 +115,7 @@ describe("TaskApprovalModal", () => {
   test("renders recovery copy when the builder worktree is missing", () => {
     const html = renderToStaticMarkup(
       createElement(TaskApprovalModalPanel, {
-        model: createModel({
-          stage: "missing_builder_worktree",
-          targetBranch: null,
-          publishTarget: null,
-        }),
+        model: createMissingBuilderWorktreeModel(),
       }),
     );
 
@@ -102,11 +129,7 @@ describe("TaskApprovalModal", () => {
   test("shows a loading indicator for approval submission actions", () => {
     const html = renderToStaticMarkup(
       createElement(TaskApprovalModalPanel, {
-        model: createModel({
-          stage: "approval",
-          isSubmitting: true,
-          publishTarget: null,
-        }),
+        model: createApprovalModel({ isSubmitting: true }),
       }),
     );
 
@@ -117,11 +140,7 @@ describe("TaskApprovalModal", () => {
   test("renders the squash commit message editor when squash is selected", () => {
     const html = renderToStaticMarkup(
       createElement(TaskApprovalModalPanel, {
-        model: createModel({
-          stage: "approval",
-          mergeMethod: "squash",
-          publishTarget: null,
-        }),
+        model: createApprovalModel({ mergeMethod: "squash" }),
       }),
     );
 
@@ -133,11 +152,9 @@ describe("TaskApprovalModal", () => {
   test("disables direct merge confirmation when the squash commit message is empty", () => {
     const html = renderToStaticMarkup(
       createElement(TaskApprovalModalPanel, {
-        model: createModel({
-          stage: "approval",
+        model: createApprovalModel({
           mergeMethod: "squash",
           squashCommitMessage: "",
-          publishTarget: null,
         }),
       }),
     );
@@ -149,13 +166,11 @@ describe("TaskApprovalModal", () => {
   test("does not show a squash validation error before the user interacts when no suggestion exists", () => {
     const html = renderToStaticMarkup(
       createElement(TaskApprovalModalPanel, {
-        model: createModel({
-          stage: "approval",
+        model: createApprovalModel({
           mergeMethod: "squash",
           squashCommitMessage: "",
           squashCommitMessageTouched: false,
           hasSuggestedSquashCommitMessage: false,
-          publishTarget: null,
         }),
       }),
     );
@@ -168,7 +183,7 @@ describe("TaskApprovalModal", () => {
   test("fails fast when direct-merge completion branch context is missing", () => {
     const html = renderToStaticMarkup(
       createElement(TaskApprovalModalPanel, {
-        model: createModel({
+        model: createCompletionModel({
           targetBranch: null,
           publishTarget: null,
         }),
@@ -187,11 +202,9 @@ describe("TaskApprovalModal", () => {
   test("renders AI pull request copy for the forked builder workflow", () => {
     const html = renderToStaticMarkup(
       createElement(TaskApprovalModalPanel, {
-        model: createModel({
-          stage: "approval",
+        model: createApprovalModel({
           mode: "pull_request",
           pullRequestDraftMode: "generate_ai",
-          publishTarget: null,
         }),
       }),
     );
@@ -210,10 +223,8 @@ describe("TaskApprovalModal", () => {
   test("disables pull request confirmation when the provider is unavailable", () => {
     const html = renderToStaticMarkup(
       createElement(TaskApprovalModalPanel, {
-        model: createModel({
-          stage: "approval",
+        model: createApprovalModel({
           mode: "pull_request",
-          publishTarget: null,
           pullRequestAvailable: false,
           pullRequestUnavailableReason: "GitHub is not configured for this repository.",
         }),

--- a/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
+++ b/apps/desktop/src/pages/kanban/use-kanban-page-models.ts
@@ -71,6 +71,7 @@ export function useKanbanPageModels({
     resetTaskImplementation,
     deferTask,
     resumeDeferredTask,
+    humanApproveTask,
     humanRequestChangesTask,
   } = useTasksState();
   const reportedSettingsErrorRef = useRef<string | null>(null);
@@ -206,11 +207,22 @@ export function useKanbanPageModels({
     },
     [handleResolveGitConflict, kanbanTasks, navigate, sessions],
   );
+  const { resetImplementationModal, openResetImplementation } = useTaskResetFlow({
+    tasks: kanbanTasks,
+    sessions,
+    loadAgentSessions,
+    removeAgentSessions,
+    resetTaskImplementation,
+    closeTaskDetails: onCloseDetails,
+  });
+
   const { taskApprovalModal, taskGitConflictDialog, openTaskApproval } = useTaskApprovalFlow({
     activeRepo,
     tasks: kanbanTasks,
     requestPullRequestGeneration: onPullRequestGenerate,
     refreshTasks,
+    humanApproveTask,
+    openResetImplementation,
     onResolveGitConflict: handleResolveKanbanGitConflict,
   });
 
@@ -220,15 +232,6 @@ export function useKanbanPageModels({
     },
     [openTaskApproval],
   );
-
-  const { resetImplementationModal, openResetImplementation } = useTaskResetFlow({
-    tasks: kanbanTasks,
-    sessions,
-    loadAgentSessions,
-    removeAgentSessions,
-    resetTaskImplementation,
-    closeTaskDetails: onCloseDetails,
-  });
 
   const taskDialogs = useKanbanTaskDialogs({
     tasks: kanbanTasks,

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createTauriHostClient } from "@openducktor/adapters-tauri-host";
-import type { TaskApprovalContext } from "@openducktor/contracts";
+import type { TaskApprovalContext, TaskApprovalContextLoadResult } from "@openducktor/contracts";
 import { waitFor } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { act } from "react";
@@ -43,6 +43,8 @@ const defaultGitPushBranch = async () => ({
   output: "",
 });
 const defaultGitAbortConflict = async () => {};
+const defaultHumanApproveTask = async () => {};
+const defaultOpenResetImplementation = (_taskId: string) => true;
 
 const taskApprovalContextGetMock = mock(defaultTaskApprovalContextGet);
 const taskDirectMergeMock = mock(defaultTaskDirectMerge);
@@ -50,6 +52,8 @@ const taskDirectMergeCompleteMock = mock(defaultTaskDirectMergeComplete);
 const taskPullRequestUpsertMock = mock(defaultTaskPullRequestUpsert);
 const gitPushBranchMock = mock(defaultGitPushBranch);
 const gitAbortConflictMock = mock(defaultGitAbortConflict);
+const humanApproveTaskMock = mock(defaultHumanApproveTask);
+const openResetImplementationMock = mock(defaultOpenResetImplementation);
 const toastLoadingMock = mock(() => "toast-id");
 const toastSuccessMock = mock(() => {});
 const toastErrorMock = mock(() => {});
@@ -203,6 +207,24 @@ const createTaskApprovalContextFixture = (
   ...overrides,
 });
 
+const createReadyTaskApprovalContextResult = (
+  overrides: Partial<TaskApprovalContext> = {},
+): TaskApprovalContextLoadResult => ({
+  outcome: "ready",
+  approvalContext: createTaskApprovalContextFixture(overrides),
+});
+
+const createMissingBuilderWorktreeApprovalContextResult = (
+  overrides: Partial<
+    Extract<TaskApprovalContextLoadResult, { outcome: "missing_builder_worktree" }>
+  > = {},
+): TaskApprovalContextLoadResult => ({
+  outcome: "missing_builder_worktree",
+  taskId: "TASK-1",
+  taskStatus: "human_review",
+  ...overrides,
+});
+
 const createConflictDirectMergeResult = (
   overrides: { currentBranch?: string; workingDir?: string } = {},
 ) =>
@@ -243,6 +265,10 @@ describe("useTaskApprovalFlow", () => {
     gitPushBranchMock.mockImplementation(defaultGitPushBranch);
     gitAbortConflictMock.mockClear();
     gitAbortConflictMock.mockImplementation(defaultGitAbortConflict);
+    humanApproveTaskMock.mockClear();
+    humanApproveTaskMock.mockImplementation(defaultHumanApproveTask);
+    openResetImplementationMock.mockClear();
+    openResetImplementationMock.mockImplementation(defaultOpenResetImplementation);
   });
 
   afterAll(async () => {
@@ -253,7 +279,7 @@ describe("useTaskApprovalFlow", () => {
   });
 
   test("opens immediately in loading state and does not fetch the settings snapshot", async () => {
-    const pendingApprovalContext = createDeferred<TaskApprovalContext>();
+    const pendingApprovalContext = createDeferred<TaskApprovalContextLoadResult>();
     taskApprovalContextGetMock.mockImplementationOnce(
       (async () => pendingApprovalContext.promise) as unknown as never,
     );
@@ -285,20 +311,14 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.mergeMethod).toBe("merge_commit");
 
-    pendingApprovalContext.resolve({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "origin", branch: "main" },
-      publishTarget: { remote: "origin", branch: "main" },
-      defaultMergeMethod: "squash",
-      hasUncommittedChanges: true,
-      uncommittedFileCount: 2,
-      pullRequest: undefined,
-      suggestedSquashCommitMessage: "feat: builder change",
-      providers: [],
-    });
+    pendingApprovalContext.resolve(
+      createReadyTaskApprovalContextResult({
+        defaultMergeMethod: "squash",
+        hasUncommittedChanges: true,
+        uncommittedFileCount: 2,
+        suggestedSquashCommitMessage: "feat: builder change",
+      }),
+    );
 
     await act(async () => {
       await pendingApprovalContext.promise;
@@ -317,7 +337,7 @@ describe("useTaskApprovalFlow", () => {
   });
 
   test("defaults to pull_request mode when GitHub provider is available", async () => {
-    const pendingApprovalContext = createDeferred<TaskApprovalContext>();
+    const pendingApprovalContext = createDeferred<TaskApprovalContextLoadResult>();
     taskApprovalContextGetMock.mockImplementationOnce(
       (async () => pendingApprovalContext.promise) as unknown as never,
     );
@@ -348,27 +368,19 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
 
-    pendingApprovalContext.resolve({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "origin", branch: "main" },
-      publishTarget: undefined,
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      suggestedSquashCommitMessage: undefined,
-      providers: [
-        {
-          providerId: "github",
-          enabled: true,
-          available: true,
-          reason: undefined,
-        },
-      ],
-    });
+    pendingApprovalContext.resolve(
+      createReadyTaskApprovalContextResult({
+        publishTarget: undefined,
+        providers: [
+          {
+            providerId: "github",
+            enabled: true,
+            available: true,
+            reason: undefined,
+          },
+        ],
+      }),
+    );
 
     await act(async () => {
       await pendingApprovalContext.promise;
@@ -385,7 +397,7 @@ describe("useTaskApprovalFlow", () => {
   });
 
   test("defaults to direct_merge mode when no git provider is available", async () => {
-    const pendingApprovalContext = createDeferred<TaskApprovalContext>();
+    const pendingApprovalContext = createDeferred<TaskApprovalContextLoadResult>();
     taskApprovalContextGetMock.mockImplementationOnce(
       (async () => pendingApprovalContext.promise) as unknown as never,
     );
@@ -416,20 +428,11 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
 
-    pendingApprovalContext.resolve({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "origin", branch: "main" },
-      publishTarget: undefined,
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      suggestedSquashCommitMessage: undefined,
-      providers: [],
-    });
+    pendingApprovalContext.resolve(
+      createReadyTaskApprovalContextResult({
+        publishTarget: undefined,
+      }),
+    );
 
     await act(async () => {
       await pendingApprovalContext.promise;
@@ -446,25 +449,18 @@ describe("useTaskApprovalFlow", () => {
   });
 
   test("reopens in direct merge completion stage when a local merge is already recorded", async () => {
-    taskApprovalContextGetMock.mockResolvedValueOnce({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: undefined,
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "origin", branch: "main" },
-      publishTarget: { remote: "origin", branch: "main" },
-      defaultMergeMethod: "rebase",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      directMerge: {
-        method: "rebase",
-        sourceBranch: "odt/TASK-1",
-        targetBranch: { remote: "origin", branch: "main" },
-        mergedAt: "2026-03-12T12:00:00Z",
-      },
-      providers: [],
-    } satisfies TaskApprovalContext as unknown as never);
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createReadyTaskApprovalContextResult({
+        workingDirectory: undefined,
+        defaultMergeMethod: "rebase",
+        directMerge: {
+          method: "rebase",
+          sourceBranch: "odt/TASK-1",
+          targetBranch: { remote: "origin", branch: "main" },
+          mergedAt: "2026-03-12T12:00:00Z",
+        },
+      }) as unknown as never,
+    );
 
     const Harness = (): ReactElement | null => {
       latestHarnessValue = useTaskApprovalFlow({
@@ -490,35 +486,214 @@ describe("useTaskApprovalFlow", () => {
     });
   });
 
+  test("opens the recovery modal when the builder worktree is missing", async () => {
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createMissingBuilderWorktreeApprovalContextResult() as unknown as never,
+    );
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("missing_builder_worktree");
+    expect(latestHarnessValue?.taskApprovalModal?.pullRequestAvailable).toBe(false);
+    expect(toastErrorMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("completes the task from missing-builder-worktree recovery and closes the modal", async () => {
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createMissingBuilderWorktreeApprovalContextResult() as unknown as never,
+    );
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+        humanApproveTask: humanApproveTaskMock,
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onCompleteMissingBuilderWorktree();
+      await Promise.resolve();
+    });
+
+    expect(humanApproveTaskMock).toHaveBeenCalledWith("TASK-1");
+    await waitForTaskApprovalModalClosed();
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("keeps the recovery modal open when completion fails from missing-builder-worktree recovery", async () => {
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createMissingBuilderWorktreeApprovalContextResult() as unknown as never,
+    );
+    humanApproveTaskMock.mockImplementationOnce(async () => {
+      throw new Error("Task is no longer reviewable");
+    });
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+        humanApproveTask: humanApproveTaskMock,
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onCompleteMissingBuilderWorktree();
+      await Promise.resolve();
+    });
+
+    expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("missing_builder_worktree");
+    expect(latestHarnessValue?.taskApprovalModal?.isSubmitting).toBe(false);
+    expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBe(
+      "Task is no longer reviewable",
+    );
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Approval failed",
+      expect.objectContaining({ description: "Task is no longer reviewable" }),
+    );
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("only closes the recovery modal after reset handoff succeeds", async () => {
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createMissingBuilderWorktreeApprovalContextResult() as unknown as never,
+    );
+    openResetImplementationMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+        openResetImplementation: openResetImplementationMock,
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+    await waitForTaskApprovalModalLoaded();
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onResetMissingBuilderWorktree();
+      await Promise.resolve();
+    });
+
+    expect(openResetImplementationMock).toHaveBeenNthCalledWith(1, "TASK-1");
+    expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
+
+    await act(async () => {
+      latestHarnessValue?.taskApprovalModal?.onResetMissingBuilderWorktree();
+      await Promise.resolve();
+    });
+
+    expect(openResetImplementationMock).toHaveBeenNthCalledWith(2, "TASK-1");
+    await waitForTaskApprovalModalClosed();
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
+  test("keeps non-recoverable approval-context failures fail-fast", async () => {
+    taskApprovalContextGetMock.mockImplementationOnce(async () => {
+      throw new Error("Builder branch is detached");
+    });
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow({
+        activeRepo: "/repo",
+        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+        requestPullRequestGeneration: async () => undefined,
+        refreshTasks: async () => {},
+      });
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+
+    await waitForTaskApprovalModalClosed();
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Failed to open approval flow",
+      expect.objectContaining({ description: "Builder branch is detached" }),
+    );
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
   test("refetches approval context on reopen so worktree status is current", async () => {
-    taskApprovalContextGetMock.mockResolvedValueOnce({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "origin", branch: "main" },
-      publishTarget: { remote: "origin", branch: "main" },
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: true,
-      uncommittedFileCount: 2,
-      pullRequest: undefined,
-      directMerge: undefined,
-      providers: [],
-    } satisfies TaskApprovalContext as unknown as never);
-    taskApprovalContextGetMock.mockResolvedValueOnce({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "origin", branch: "main" },
-      publishTarget: { remote: "origin", branch: "main" },
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      directMerge: undefined,
-      providers: [],
-    } satisfies TaskApprovalContext as unknown as never);
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createReadyTaskApprovalContextResult({
+        hasUncommittedChanges: true,
+        uncommittedFileCount: 2,
+      }) as unknown as never,
+    );
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createReadyTaskApprovalContextResult({
+        hasUncommittedChanges: false,
+        uncommittedFileCount: 0,
+      }) as unknown as never,
+    );
 
     const Harness = (): ReactElement | null => {
       latestHarnessValue = useTaskApprovalFlow({
@@ -559,12 +734,12 @@ describe("useTaskApprovalFlow", () => {
   });
 
   test("ignores a stale approval-context response from a superseded open cycle", async () => {
-    const firstContext = createDeferred<TaskApprovalContext>();
+    const firstContext = createDeferred<TaskApprovalContextLoadResult>();
     taskApprovalContextGetMock.mockImplementationOnce(
       (async () => firstContext.promise) as unknown as never,
     );
     taskApprovalContextGetMock.mockResolvedValueOnce(
-      createTaskApprovalContextFixture({
+      createReadyTaskApprovalContextResult({
         taskId: "TASK-2",
         defaultMergeMethod: "rebase",
         hasUncommittedChanges: false,
@@ -602,7 +777,7 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(false);
 
     firstContext.resolve(
-      createTaskApprovalContextFixture({
+      createReadyTaskApprovalContextResult({
         defaultMergeMethod: "squash",
         hasUncommittedChanges: true,
         uncommittedFileCount: 3,
@@ -629,39 +804,24 @@ describe("useTaskApprovalFlow", () => {
       outcome: "completed" as const,
       task: createTaskCardFixture({ id: "TASK-1", status: "human_review" }),
     });
-    taskApprovalContextGetMock.mockResolvedValueOnce({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "upstream", branch: "main" },
-      publishTarget: { remote: "upstream", branch: "main" },
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      directMerge: undefined,
-      providers: [],
-    } satisfies TaskApprovalContext as unknown as never);
-    taskApprovalContextGetMock.mockResolvedValueOnce({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "upstream", branch: "main" },
-      publishTarget: { remote: "upstream", branch: "main" },
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      directMerge: {
-        method: "merge_commit",
-        sourceBranch: "odt/TASK-1",
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createReadyTaskApprovalContextResult({
         targetBranch: { remote: "upstream", branch: "main" },
-        mergedAt: "2026-03-12T12:00:00Z",
-      },
-      providers: [],
-    } satisfies TaskApprovalContext as unknown as never);
+        publishTarget: { remote: "upstream", branch: "main" },
+      }) as unknown as never,
+    );
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createReadyTaskApprovalContextResult({
+        targetBranch: { remote: "upstream", branch: "main" },
+        publishTarget: { remote: "upstream", branch: "main" },
+        directMerge: {
+          method: "merge_commit",
+          sourceBranch: "odt/TASK-1",
+          targetBranch: { remote: "upstream", branch: "main" },
+          mergedAt: "2026-03-12T12:00:00Z",
+        },
+      }) as unknown as never,
+    );
 
     const Harness = (): ReactElement | null => {
       latestHarnessValue = useTaskApprovalFlow({
@@ -717,19 +877,12 @@ describe("useTaskApprovalFlow", () => {
 
   test("closes after direct merge without offering a push step for local-only target branches", async () => {
     const refreshTasksMock = mock(async () => {});
-    taskApprovalContextGetMock.mockResolvedValueOnce({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { branch: "release/2026.03" },
-      publishTarget: undefined,
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      providers: [],
-    } satisfies TaskApprovalContext as unknown as never);
+    taskApprovalContextGetMock.mockResolvedValueOnce(
+      createReadyTaskApprovalContextResult({
+        targetBranch: { branch: "release/2026.03" },
+        publishTarget: undefined,
+      }) as unknown as never,
+    );
 
     const Harness = (): ReactElement | null => {
       latestHarnessValue = useTaskApprovalFlow({
@@ -771,7 +924,7 @@ describe("useTaskApprovalFlow", () => {
 
   test("opens the git conflict dialog when direct merge returns conflicts", async () => {
     taskApprovalContextGetMock.mockResolvedValueOnce(
-      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+      createReadyTaskApprovalContextResult({ publishTarget: undefined }) as unknown as never,
     );
     taskDirectMergeMock.mockResolvedValueOnce(createConflictDirectMergeResult());
 
@@ -816,10 +969,10 @@ describe("useTaskApprovalFlow", () => {
 
   test("reopens approval in direct_merge mode after aborting a git conflict", async () => {
     taskApprovalContextGetMock.mockResolvedValueOnce(
-      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+      createReadyTaskApprovalContextResult({ publishTarget: undefined }) as unknown as never,
     );
     taskApprovalContextGetMock.mockResolvedValueOnce(
-      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+      createReadyTaskApprovalContextResult({ publishTarget: undefined }) as unknown as never,
     );
     taskDirectMergeMock.mockResolvedValueOnce(
       createConflictDirectMergeResult({
@@ -872,7 +1025,7 @@ describe("useTaskApprovalFlow", () => {
 
   test("keeps the git conflict dialog open when Ask Builder does not start a resolution session", async () => {
     taskApprovalContextGetMock.mockResolvedValueOnce(
-      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+      createReadyTaskApprovalContextResult({ publishTarget: undefined }) as unknown as never,
     );
     taskDirectMergeMock.mockResolvedValueOnce(
       createConflictDirectMergeResult({
@@ -926,7 +1079,7 @@ describe("useTaskApprovalFlow", () => {
 
   test("surfaces Ask Builder failures without closing the git conflict dialog", async () => {
     taskApprovalContextGetMock.mockResolvedValueOnce(
-      createTaskApprovalContextFixture({ publishTarget: undefined }) as unknown as never,
+      createReadyTaskApprovalContextResult({ publishTarget: undefined }) as unknown as never,
     );
     taskDirectMergeMock.mockResolvedValueOnce(
       createConflictDirectMergeResult({
@@ -983,7 +1136,7 @@ describe("useTaskApprovalFlow", () => {
   test("creates a pull request manually, refreshes tasks, and closes the modal", async () => {
     const refreshTasksMock = mock(async () => {});
     taskApprovalContextGetMock.mockResolvedValueOnce(
-      createTaskApprovalContextFixture({
+      createReadyTaskApprovalContextResult({
         providers: [
           {
             providerId: "github",
@@ -1049,26 +1202,18 @@ describe("useTaskApprovalFlow", () => {
     const requestPullRequestGenerationMock = mock(
       async () => requestPullRequestGenerationDeferred.promise,
     );
-    taskApprovalContextGetMock.mockResolvedValue({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "origin", branch: "main" },
-      publishTarget: { remote: "origin", branch: "main" },
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      providers: [
-        {
-          providerId: "github",
-          enabled: true,
-          available: true,
-          reason: undefined,
-        },
-      ],
-    } satisfies TaskApprovalContext as unknown as never);
+    taskApprovalContextGetMock.mockResolvedValue(
+      createReadyTaskApprovalContextResult({
+        providers: [
+          {
+            providerId: "github",
+            enabled: true,
+            available: true,
+            reason: undefined,
+          },
+        ],
+      }) as unknown as never,
+    );
 
     const Harness = (): ReactElement | null => {
       latestHarnessValue = useTaskApprovalFlow({
@@ -1121,26 +1266,18 @@ describe("useTaskApprovalFlow", () => {
 
   test("keeps the approval modal open when AI pull request generation is cancelled", async () => {
     const requestPullRequestGenerationMock = mock(async () => undefined);
-    taskApprovalContextGetMock.mockResolvedValue({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "origin", branch: "main" },
-      publishTarget: { remote: "origin", branch: "main" },
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      providers: [
-        {
-          providerId: "github",
-          enabled: true,
-          available: true,
-          reason: undefined,
-        },
-      ],
-    } satisfies TaskApprovalContext as unknown as never);
+    taskApprovalContextGetMock.mockResolvedValue(
+      createReadyTaskApprovalContextResult({
+        providers: [
+          {
+            providerId: "github",
+            enabled: true,
+            available: true,
+            reason: undefined,
+          },
+        ],
+      }) as unknown as never,
+    );
 
     const { useTaskApprovalFlow } = await import("./use-task-approval-flow");
 
@@ -1191,11 +1328,11 @@ describe("useTaskApprovalFlow", () => {
     const requestPullRequestGenerationMock = mock(
       async () => requestPullRequestGenerationDeferred.promise,
     );
-    const secondApprovalContext = createDeferred<TaskApprovalContext>();
+    const secondApprovalContext = createDeferred<TaskApprovalContextLoadResult>();
 
     taskApprovalContextGetMock.mockImplementation((async (_repoPath: string, taskId: string) => {
       if (taskId === "TASK-1") {
-        return createTaskApprovalContextFixture({
+        return createReadyTaskApprovalContextResult({
           taskId,
           providers: [
             {
@@ -1266,7 +1403,7 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.isSubmitting).toBe(false);
 
     secondApprovalContext.resolve(
-      createTaskApprovalContextFixture({
+      createReadyTaskApprovalContextResult({
         taskId: "TASK-2",
         providers: [],
       }),
@@ -1287,26 +1424,18 @@ describe("useTaskApprovalFlow", () => {
   });
 
   test("keeps the modal open when pull request generation cannot start", async () => {
-    taskApprovalContextGetMock.mockResolvedValue({
-      taskId: "TASK-1",
-      taskStatus: "human_review",
-      workingDirectory: "/repo/.worktrees/task-1",
-      sourceBranch: "odt/TASK-1",
-      targetBranch: { remote: "origin", branch: "main" },
-      publishTarget: { remote: "origin", branch: "main" },
-      defaultMergeMethod: "merge_commit",
-      hasUncommittedChanges: false,
-      uncommittedFileCount: 0,
-      pullRequest: undefined,
-      providers: [
-        {
-          providerId: "github",
-          enabled: true,
-          available: true,
-          reason: undefined,
-        },
-      ],
-    } satisfies TaskApprovalContext as unknown as never);
+    taskApprovalContextGetMock.mockResolvedValue(
+      createReadyTaskApprovalContextResult({
+        providers: [
+          {
+            providerId: "github",
+            enabled: true,
+            available: true,
+            reason: undefined,
+          },
+        ],
+      }) as unknown as never,
+    );
     const requestPullRequestGenerationMock = mock(async () => {
       throw new Error("Generation crashed");
     });
@@ -1358,7 +1487,7 @@ describe("useTaskApprovalFlow", () => {
 
   test("keeps direct-merge completion recoverable when publish configuration is incomplete", async () => {
     taskApprovalContextGetMock.mockResolvedValueOnce(
-      createTaskApprovalContextFixture({
+      createReadyTaskApprovalContextResult({
         publishTarget: { branch: "main" },
         directMerge: {
           method: "merge_commit",
@@ -1420,7 +1549,7 @@ describe("useTaskApprovalFlow", () => {
       output: "",
     } as unknown as never);
     taskApprovalContextGetMock.mockResolvedValueOnce(
-      createTaskApprovalContextFixture({
+      createReadyTaskApprovalContextResult({
         directMerge: {
           method: "merge_commit",
           sourceBranch: "odt/TASK-1",

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -573,6 +573,46 @@ describe("useTaskApprovalFlow", () => {
     });
   });
 
+  test("keeps missing builder context as a fail-fast approval-loading error", async () => {
+    taskApprovalContextGetMock.mockImplementationOnce(async () => {
+      throw new Error(
+        "Human approval requires a builder worktree for task TASK-1. Start Builder first.",
+      );
+    });
+
+    const Harness = (): ReactElement | null => {
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
+      return null;
+    };
+
+    const harness = await mountApprovalHarness(Harness);
+
+    await act(async () => {
+      latestHarnessValue?.openTaskApproval("TASK-1");
+      await Promise.resolve();
+    });
+
+    await waitForTaskApprovalModalClosed();
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "Failed to open approval flow",
+      expect.objectContaining({
+        description:
+          "Human approval requires a builder worktree for task TASK-1. Start Builder first.",
+      }),
+    );
+
+    await act(async () => {
+      await harness.unmount();
+    });
+  });
+
   test("completes the task from missing-builder-worktree recovery and closes the modal", async () => {
     taskApprovalContextGetMock.mockResolvedValueOnce(
       createMissingBuilderWorktreeApprovalContextResult() as unknown as never,
@@ -1562,7 +1602,7 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.isSubmitting).toBe(false);
     expect(expectApprovalModal().mode).toBe("pull_request");
-    expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBeNull();
+    expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBe("Generation crashed");
     expect(toastErrorMock).toHaveBeenCalledWith(
       "Approval failed",
       expect.objectContaining({ description: "Generation crashed" }),

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx
@@ -12,6 +12,11 @@ import {
   createTaskCardFixture,
   enableReactActEnvironment,
 } from "../agents/agent-studio-test-utils";
+import type {
+  TaskApprovalApprovalModalModel,
+  TaskApprovalCompletionModalModel,
+  TaskApprovalMissingBuilderWorktreeModalModel,
+} from "./kanban-page-model-types";
 import { useTaskApprovalFlow } from "./use-task-approval-flow";
 
 enableReactActEnvironment();
@@ -178,7 +183,9 @@ const mountApprovalHarness = async (Harness: () => ReactElement | null) => {
 const waitForTaskApprovalModalLoaded = async (): Promise<void> => {
   await waitFor(() => {
     expect(latestHarnessValue?.taskApprovalModal).toBeTruthy();
-    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(false);
+    if (latestHarnessValue?.taskApprovalModal?.stage === "approval") {
+      expect(latestHarnessValue.taskApprovalModal.isLoading).toBe(false);
+    }
   });
 };
 
@@ -240,6 +247,45 @@ const createConflictDirectMergeResult = (
     },
   }) as unknown as Awaited<ReturnType<typeof defaultTaskDirectMerge>>;
 
+const createUseTaskApprovalFlowArgs = (
+  overrides: Partial<Parameters<typeof useTaskApprovalFlow>[0]>,
+): Parameters<typeof useTaskApprovalFlow>[0] => ({
+  activeRepo: "/repo",
+  tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+  requestPullRequestGeneration: async () => undefined,
+  refreshTasks: async () => {},
+  humanApproveTask: humanApproveTaskMock,
+  openResetImplementation: openResetImplementationMock,
+  ...overrides,
+});
+
+const expectApprovalModal = (): TaskApprovalApprovalModalModel => {
+  const modal = latestHarnessValue?.taskApprovalModal;
+  expect(modal?.stage).toBe("approval");
+  if (!modal || modal.stage !== "approval") {
+    throw new Error("Expected approval modal");
+  }
+  return modal;
+};
+
+const expectCompletionModal = (): TaskApprovalCompletionModalModel => {
+  const modal = latestHarnessValue?.taskApprovalModal;
+  expect(modal?.stage).toBe("complete_direct_merge");
+  if (!modal || modal.stage !== "complete_direct_merge") {
+    throw new Error("Expected direct-merge completion modal");
+  }
+  return modal;
+};
+
+const expectMissingBuilderWorktreeModal = (): TaskApprovalMissingBuilderWorktreeModalModel => {
+  const modal = latestHarnessValue?.taskApprovalModal;
+  expect(modal?.stage).toBe("missing_builder_worktree");
+  if (!modal || modal.stage !== "missing_builder_worktree") {
+    throw new Error("Expected missing-builder-worktree modal");
+  }
+  return modal;
+};
+
 describe("useTaskApprovalFlow", () => {
   beforeEach(async () => {
     await applyHostMocks();
@@ -285,18 +331,20 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [
-          createTaskCardFixture({
-            id: "TASK-1",
-            title: "Ship approval flow",
-            description: "Task description",
-          }),
-        ],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [
+            createTaskCardFixture({
+              id: "TASK-1",
+              title: "Ship approval flow",
+              description: "Task description",
+            }),
+          ],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -308,8 +356,8 @@ describe("useTaskApprovalFlow", () => {
 
     expect(taskApprovalContextGetMock).toHaveBeenCalledWith("/repo", "TASK-1");
     expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
-    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
-    expect(latestHarnessValue?.taskApprovalModal?.mergeMethod).toBe("merge_commit");
+    expect(expectApprovalModal().isLoading).toBe(true);
+    expect(expectApprovalModal().mergeMethod).toBe("merge_commit");
 
     pendingApprovalContext.resolve(
       createReadyTaskApprovalContextResult({
@@ -325,11 +373,11 @@ describe("useTaskApprovalFlow", () => {
       await Promise.resolve();
     });
 
-    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(false);
-    expect(latestHarnessValue?.taskApprovalModal?.mergeMethod).toBe("squash");
-    expect(latestHarnessValue?.taskApprovalModal?.squashCommitMessage).toBe("feat: builder change");
-    expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(true);
-    expect(latestHarnessValue?.taskApprovalModal?.uncommittedFileCount).toBe(2);
+    expect(expectApprovalModal().isLoading).toBe(false);
+    expect(expectApprovalModal().mergeMethod).toBe("squash");
+    expect(expectApprovalModal().squashCommitMessage).toBe("feat: builder change");
+    expect(expectApprovalModal().hasUncommittedChanges).toBe(true);
+    expect(expectApprovalModal().uncommittedFileCount).toBe(2);
 
     await act(async () => {
       await harness.unmount();
@@ -343,18 +391,20 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [
-          createTaskCardFixture({
-            id: "TASK-1",
-            title: "Ship approval flow",
-            description: "Task description",
-          }),
-        ],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [
+            createTaskCardFixture({
+              id: "TASK-1",
+              title: "Ship approval flow",
+              description: "Task description",
+            }),
+          ],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -365,8 +415,8 @@ describe("useTaskApprovalFlow", () => {
     });
 
     expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
-    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
-    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
+    expect(expectApprovalModal().isLoading).toBe(true);
+    expect(expectApprovalModal().mode).toBe("direct_merge");
 
     pendingApprovalContext.resolve(
       createReadyTaskApprovalContextResult({
@@ -387,9 +437,9 @@ describe("useTaskApprovalFlow", () => {
       await Promise.resolve();
     });
 
-    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(false);
-    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("pull_request");
-    expect(latestHarnessValue?.taskApprovalModal?.pullRequestAvailable).toBe(true);
+    expect(expectApprovalModal().isLoading).toBe(false);
+    expect(expectApprovalModal().mode).toBe("pull_request");
+    expect(expectApprovalModal().pullRequestAvailable).toBe(true);
 
     await act(async () => {
       await harness.unmount();
@@ -403,18 +453,20 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [
-          createTaskCardFixture({
-            id: "TASK-1",
-            title: "Ship approval flow",
-            description: "Task description",
-          }),
-        ],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [
+            createTaskCardFixture({
+              id: "TASK-1",
+              title: "Ship approval flow",
+              description: "Task description",
+            }),
+          ],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -425,8 +477,8 @@ describe("useTaskApprovalFlow", () => {
     });
 
     expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
-    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
-    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
+    expect(expectApprovalModal().isLoading).toBe(true);
+    expect(expectApprovalModal().mode).toBe("direct_merge");
 
     pendingApprovalContext.resolve(
       createReadyTaskApprovalContextResult({
@@ -439,9 +491,9 @@ describe("useTaskApprovalFlow", () => {
       await Promise.resolve();
     });
 
-    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(false);
-    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
-    expect(latestHarnessValue?.taskApprovalModal?.pullRequestAvailable).toBe(false);
+    expect(expectApprovalModal().isLoading).toBe(false);
+    expect(expectApprovalModal().mode).toBe("direct_merge");
+    expect(expectApprovalModal().pullRequestAvailable).toBe(false);
 
     await act(async () => {
       await harness.unmount();
@@ -463,12 +515,14 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -492,12 +546,14 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -510,7 +566,6 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("missing_builder_worktree");
-    expect(latestHarnessValue?.taskApprovalModal?.pullRequestAvailable).toBe(false);
     expect(toastErrorMock).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -524,13 +579,15 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-        humanApproveTask: humanApproveTaskMock,
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+          humanApproveTask: humanApproveTaskMock,
+        }),
+      );
       return null;
     };
 
@@ -543,7 +600,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onCompleteMissingBuilderWorktree();
+      expectMissingBuilderWorktreeModal().onCompleteMissingBuilderWorktree();
       await Promise.resolve();
     });
 
@@ -564,13 +621,15 @@ describe("useTaskApprovalFlow", () => {
     });
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-        humanApproveTask: humanApproveTaskMock,
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+          humanApproveTask: humanApproveTaskMock,
+        }),
+      );
       return null;
     };
 
@@ -583,7 +642,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onCompleteMissingBuilderWorktree();
+      expectMissingBuilderWorktreeModal().onCompleteMissingBuilderWorktree();
       await Promise.resolve();
     });
 
@@ -609,13 +668,15 @@ describe("useTaskApprovalFlow", () => {
     openResetImplementationMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-        openResetImplementation: openResetImplementationMock,
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+          openResetImplementation: openResetImplementationMock,
+        }),
+      );
       return null;
     };
 
@@ -628,7 +689,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onResetMissingBuilderWorktree();
+      expectMissingBuilderWorktreeModal().onResetMissingBuilderWorktree();
       await Promise.resolve();
     });
 
@@ -636,7 +697,7 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onResetMissingBuilderWorktree();
+      expectMissingBuilderWorktreeModal().onResetMissingBuilderWorktree();
       await Promise.resolve();
     });
 
@@ -654,12 +715,14 @@ describe("useTaskApprovalFlow", () => {
     });
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -696,12 +759,14 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -712,7 +777,7 @@ describe("useTaskApprovalFlow", () => {
       await Promise.resolve();
     });
 
-    expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(true);
+    expect(expectApprovalModal().hasUncommittedChanges).toBe(true);
 
     await act(async () => {
       latestHarnessValue?.taskApprovalModal?.onOpenChange(false);
@@ -725,8 +790,8 @@ describe("useTaskApprovalFlow", () => {
     });
 
     expect(taskApprovalContextGetMock).toHaveBeenCalledTimes(2);
-    expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(false);
-    expect(latestHarnessValue?.taskApprovalModal?.uncommittedFileCount).toBe(0);
+    expect(expectApprovalModal().hasUncommittedChanges).toBe(false);
+    expect(expectApprovalModal().uncommittedFileCount).toBe(0);
 
     await act(async () => {
       await harness.unmount();
@@ -748,15 +813,17 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [
-          createTaskCardFixture({ id: "TASK-1", title: "Task 1" }),
-          createTaskCardFixture({ id: "TASK-2", title: "Task 2" }),
-        ],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [
+            createTaskCardFixture({ id: "TASK-1", title: "Task 1" }),
+            createTaskCardFixture({ id: "TASK-2", title: "Task 2" }),
+          ],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -773,8 +840,8 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
-    expect(latestHarnessValue?.taskApprovalModal?.mergeMethod).toBe("rebase");
-    expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(false);
+    expect(expectApprovalModal().mergeMethod).toBe("rebase");
+    expect(expectApprovalModal().hasUncommittedChanges).toBe(false);
 
     firstContext.resolve(
       createReadyTaskApprovalContextResult({
@@ -790,9 +857,9 @@ describe("useTaskApprovalFlow", () => {
     });
 
     expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
-    expect(latestHarnessValue?.taskApprovalModal?.mergeMethod).toBe("rebase");
-    expect(latestHarnessValue?.taskApprovalModal?.hasUncommittedChanges).toBe(false);
-    expect(latestHarnessValue?.taskApprovalModal?.uncommittedFileCount).toBe(0);
+    expect(expectApprovalModal().mergeMethod).toBe("rebase");
+    expect(expectApprovalModal().hasUncommittedChanges).toBe(false);
+    expect(expectApprovalModal().uncommittedFileCount).toBe(0);
 
     await act(async () => {
       await harness.unmount();
@@ -824,12 +891,14 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -842,13 +911,13 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onMergeMethodChange("squash");
-      latestHarnessValue?.taskApprovalModal?.onSquashCommitMessageChange("feat: merged task");
+      expectApprovalModal().onMergeMethodChange("squash");
+      expectApprovalModal().onSquashCommitMessageChange("feat: merged task");
       await Promise.resolve();
     });
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
@@ -857,7 +926,7 @@ describe("useTaskApprovalFlow", () => {
     });
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onCompleteDirectMerge();
+      expectCompletionModal().onCompleteDirectMerge();
       await Promise.resolve();
     });
 
@@ -885,12 +954,14 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: refreshTasksMock,
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: refreshTasksMock,
+        }),
+      );
       return null;
     };
 
@@ -903,7 +974,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
@@ -929,12 +1000,14 @@ describe("useTaskApprovalFlow", () => {
     taskDirectMergeMock.mockResolvedValueOnce(createConflictDirectMergeResult());
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -947,7 +1020,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
@@ -982,12 +1055,14 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -1000,7 +1075,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
@@ -1015,7 +1090,7 @@ describe("useTaskApprovalFlow", () => {
       "direct_merge_merge_commit",
       "/repo/.worktrees/task-1",
     );
-    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
+    expect(expectApprovalModal().mode).toBe("direct_merge");
     expect(latestHarnessValue?.taskGitConflictDialog).toBeNull();
 
     await act(async () => {
@@ -1036,13 +1111,15 @@ describe("useTaskApprovalFlow", () => {
     const onResolveGitConflictMock = mock(async () => false);
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-        onResolveGitConflict: onResolveGitConflictMock,
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+          onResolveGitConflict: onResolveGitConflictMock,
+        }),
+      );
       return null;
     };
 
@@ -1055,7 +1132,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
@@ -1092,13 +1169,15 @@ describe("useTaskApprovalFlow", () => {
     });
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-        onResolveGitConflict: onResolveGitConflictMock,
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+          onResolveGitConflict: onResolveGitConflictMock,
+        }),
+      );
       return null;
     };
 
@@ -1111,7 +1190,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
@@ -1149,18 +1228,20 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [
-          createTaskCardFixture({
-            id: "TASK-1",
-            title: "Ship approval flow",
-            description: "Task description",
-          }),
-        ],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: refreshTasksMock,
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [
+            createTaskCardFixture({
+              id: "TASK-1",
+              title: "Ship approval flow",
+              description: "Task description",
+            }),
+          ],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: refreshTasksMock,
+        }),
+      );
       return null;
     };
 
@@ -1173,7 +1254,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
@@ -1216,12 +1297,14 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: requestPullRequestGenerationMock,
-        refreshTasks: refreshTasksMock,
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: requestPullRequestGenerationMock,
+          refreshTasks: refreshTasksMock,
+        }),
+      );
       return null;
     };
 
@@ -1234,13 +1317,13 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onModeChange("pull_request");
-      latestHarnessValue?.taskApprovalModal?.onPullRequestDraftModeChange("generate_ai");
+      expectApprovalModal().onModeChange("pull_request");
+      expectApprovalModal().onPullRequestDraftModeChange("generate_ai");
       await Promise.resolve();
     });
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
@@ -1282,12 +1365,14 @@ describe("useTaskApprovalFlow", () => {
     const { useTaskApprovalFlow } = await import("./use-task-approval-flow");
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: requestPullRequestGenerationMock,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: requestPullRequestGenerationMock,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -1300,20 +1385,20 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onModeChange("pull_request");
-      latestHarnessValue?.taskApprovalModal?.onPullRequestDraftModeChange("generate_ai");
+      expectApprovalModal().onModeChange("pull_request");
+      expectApprovalModal().onPullRequestDraftModeChange("generate_ai");
       await Promise.resolve();
     });
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
     expect(requestPullRequestGenerationMock).toHaveBeenCalledWith("TASK-1");
     expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.isSubmitting).toBe(false);
-    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("pull_request");
+    expect(expectApprovalModal().mode).toBe("pull_request");
     expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBeNull();
     expect(toastErrorMock).not.toHaveBeenCalled();
     expect(taskPullRequestUpsertMock).not.toHaveBeenCalled();
@@ -1349,15 +1434,17 @@ describe("useTaskApprovalFlow", () => {
     }) as unknown as never);
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [
-          createTaskCardFixture({ id: "TASK-1", title: "Task 1" }),
-          createTaskCardFixture({ id: "TASK-2", title: "Task 2" }),
-        ],
-        requestPullRequestGeneration: requestPullRequestGenerationMock,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [
+            createTaskCardFixture({ id: "TASK-1", title: "Task 1" }),
+            createTaskCardFixture({ id: "TASK-2", title: "Task 2" }),
+          ],
+          requestPullRequestGeneration: requestPullRequestGenerationMock,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -1370,13 +1457,13 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onModeChange("pull_request");
-      latestHarnessValue?.taskApprovalModal?.onPullRequestDraftModeChange("generate_ai");
+      expectApprovalModal().onModeChange("pull_request");
+      expectApprovalModal().onPullRequestDraftModeChange("generate_ai");
       await Promise.resolve();
     });
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
@@ -1389,7 +1476,7 @@ describe("useTaskApprovalFlow", () => {
     });
 
     expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
-    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
+    expect(expectApprovalModal().isLoading).toBe(true);
 
     requestPullRequestGenerationDeferred.resolve(undefined);
 
@@ -1399,7 +1486,7 @@ describe("useTaskApprovalFlow", () => {
     });
 
     expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
-    expect(latestHarnessValue?.taskApprovalModal?.isLoading).toBe(true);
+    expect(expectApprovalModal().isLoading).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.isSubmitting).toBe(false);
 
     secondApprovalContext.resolve(
@@ -1416,7 +1503,7 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     expect(latestHarnessValue?.taskApprovalModal?.taskId).toBe("TASK-2");
-    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("direct_merge");
+    expect(expectApprovalModal().mode).toBe("direct_merge");
 
     await act(async () => {
       await harness.unmount();
@@ -1441,12 +1528,14 @@ describe("useTaskApprovalFlow", () => {
     });
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: requestPullRequestGenerationMock,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: requestPullRequestGenerationMock,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -1459,20 +1548,20 @@ describe("useTaskApprovalFlow", () => {
     await waitForTaskApprovalModalLoaded();
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onModeChange("pull_request");
-      latestHarnessValue?.taskApprovalModal?.onPullRequestDraftModeChange("generate_ai");
+      expectApprovalModal().onModeChange("pull_request");
+      expectApprovalModal().onPullRequestDraftModeChange("generate_ai");
       await Promise.resolve();
     });
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onConfirm();
+      expectApprovalModal().onConfirm();
       await Promise.resolve();
     });
 
     expect(requestPullRequestGenerationMock).toHaveBeenCalledTimes(1);
     expect(latestHarnessValue?.taskApprovalModal?.open).toBe(true);
     expect(latestHarnessValue?.taskApprovalModal?.isSubmitting).toBe(false);
-    expect(latestHarnessValue?.taskApprovalModal?.mode).toBe("pull_request");
+    expect(expectApprovalModal().mode).toBe("pull_request");
     expect(latestHarnessValue?.taskApprovalModal?.errorMessage).toBeNull();
     expect(toastErrorMock).toHaveBeenCalledWith(
       "Approval failed",
@@ -1499,12 +1588,14 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -1519,7 +1610,7 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onCompleteDirectMerge();
+      expectCompletionModal().onCompleteDirectMerge();
       await Promise.resolve();
     });
 
@@ -1560,12 +1651,14 @@ describe("useTaskApprovalFlow", () => {
     );
 
     const Harness = (): ReactElement | null => {
-      latestHarnessValue = useTaskApprovalFlow({
-        activeRepo: "/repo",
-        tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
-        requestPullRequestGeneration: async () => undefined,
-        refreshTasks: async () => {},
-      });
+      latestHarnessValue = useTaskApprovalFlow(
+        createUseTaskApprovalFlowArgs({
+          activeRepo: "/repo",
+          tasks: [createTaskCardFixture({ id: "TASK-1", title: "Task" })],
+          requestPullRequestGeneration: async () => undefined,
+          refreshTasks: async () => {},
+        }),
+      );
       return null;
     };
 
@@ -1580,7 +1673,7 @@ describe("useTaskApprovalFlow", () => {
     expect(latestHarnessValue?.taskApprovalModal?.stage).toBe("complete_direct_merge");
 
     await act(async () => {
-      latestHarnessValue?.taskApprovalModal?.onCompleteDirectMerge();
+      expectCompletionModal().onCompleteDirectMerge();
       await Promise.resolve();
     });
 

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -1,4 +1,4 @@
-import type { TaskApprovalContext, TaskCard } from "@openducktor/contracts";
+import type { TaskApprovalContextLoadResult, TaskCard } from "@openducktor/contracts";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useReducer, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -23,6 +23,7 @@ import { submitPullRequestApproval } from "./task-approval-flow-pull-request";
 import {
   CLOSED_TASK_APPROVAL_STATE,
   determineDefaultTaskApprovalMode,
+  isTaskApprovalInteractive,
   isTaskApprovalOpen,
   isTaskApprovalReady,
   taskApprovalFlowReducer,
@@ -33,6 +34,8 @@ type UseTaskApprovalFlowArgs = {
   tasks: TaskCard[];
   requestPullRequestGeneration: (taskId: string) => Promise<string | undefined>;
   refreshTasks: () => Promise<void>;
+  humanApproveTask?: (taskId: string) => Promise<void>;
+  openResetImplementation?: (taskId: string) => boolean;
   onResolveGitConflict?: (conflict: GitConflict, taskId: string) => Promise<boolean>;
 };
 
@@ -55,6 +58,14 @@ export function useTaskApprovalFlow({
   tasks,
   requestPullRequestGeneration,
   refreshTasks,
+  humanApproveTask = async (): Promise<void> => {
+    throw new Error("humanApproveTask handler is required for missing-builder-worktree recovery.");
+  },
+  openResetImplementation = (): boolean => {
+    throw new Error(
+      "openResetImplementation handler is required for missing-builder-worktree recovery.",
+    );
+  },
   onResolveGitConflict = async (): Promise<boolean> => {
     throw new Error(
       "onResolveGitConflict handler is required to use the Ask Builder conflict-resolution path.",
@@ -112,8 +123,11 @@ export function useTaskApprovalFlow({
 
       const cachedContext = queryClient.getQueryData(
         taskApprovalQueryKeys.context(activeRepo, taskId),
-      ) as TaskApprovalContext | undefined;
-      const effectiveMode = options?.mode ?? determineDefaultTaskApprovalMode(cachedContext);
+      ) as TaskApprovalContextLoadResult | undefined;
+      const cachedApprovalContext =
+        cachedContext?.outcome === "ready" ? cachedContext.approvalContext : undefined;
+      const effectiveMode =
+        options?.mode ?? determineDefaultTaskApprovalMode(cachedApprovalContext);
       const title = task?.title ?? "";
       const body = task?.description ?? "";
       const pullRequestDraftMode = options?.pullRequestDraftMode ?? "manual";
@@ -131,7 +145,7 @@ export function useTaskApprovalFlow({
 
       void (async () => {
         try {
-          const approvalContext = await loadTaskApprovalContextFromQuery(
+          const approvalContextResult = await loadTaskApprovalContextFromQuery(
             queryClient,
             activeRepo,
             taskId,
@@ -139,6 +153,20 @@ export function useTaskApprovalFlow({
           if (approvalRequestVersionRef.current !== requestVersion) {
             return;
           }
+          if (approvalContextResult.outcome === "missing_builder_worktree") {
+            dispatch({
+              type: "load_missing_builder_worktree",
+              taskId,
+              mode: effectiveMode,
+              pullRequestDraftMode,
+              title,
+              body,
+              errorMessage: openErrorMessage,
+            });
+            return;
+          }
+
+          const approvalContext = approvalContextResult.approvalContext;
           const updatedEffectiveMode =
             options?.mode ?? determineDefaultTaskApprovalMode(approvalContext);
           dispatch({
@@ -166,10 +194,32 @@ export function useTaskApprovalFlow({
   );
 
   const confirm = useCallback((): void => {
-    if (!activeRepo || !isTaskApprovalReady(state)) {
+    if (!isTaskApprovalInteractive(state)) {
       return;
     }
     const approvalState = state;
+
+    if (approvalState.stage === "missing_builder_worktree") {
+      void (async () => {
+        dispatch({ type: "clear_error" });
+        dispatch({ type: "start_submitting" });
+        try {
+          await humanApproveTask(approvalState.taskId);
+          reset();
+        } catch (error) {
+          const description = errorMessage(error);
+          dispatch({ type: "return_to_editable", errorMessage: description });
+          toast.error("Approval failed", {
+            description,
+          });
+        }
+      })();
+      return;
+    }
+
+    if (!activeRepo || !isTaskApprovalReady(approvalState)) {
+      return;
+    }
 
     void (async () => {
       dispatch({ type: "start_submitting" });
@@ -244,7 +294,25 @@ export function useTaskApprovalFlow({
         });
       }
     })();
-  }, [activeRepo, queryClient, refreshTasks, requestPullRequestGeneration, reset, state]);
+  }, [
+    activeRepo,
+    humanApproveTask,
+    queryClient,
+    refreshTasks,
+    requestPullRequestGeneration,
+    reset,
+    state,
+  ]);
+
+  const resetMissingBuilderWorktree = useCallback((): void => {
+    if (!isTaskApprovalInteractive(state) || state.stage !== "missing_builder_worktree") {
+      return;
+    }
+
+    if (openResetImplementation(state.taskId)) {
+      reset();
+    }
+  }, [openResetImplementation, reset, state]);
 
   const abortGitConflict = useCallback((): void => {
     if (!activeRepo || !gitConflictState.conflict || gitConflictState.isHandlingConflict) {
@@ -422,6 +490,8 @@ export function useTaskApprovalFlow({
       onSquashCommitMessageChange: (squashCommitMessage) =>
         dispatch({ type: "set_squash_commit_message", squashCommitMessage }),
       onConfirm: confirm,
+      onCompleteMissingBuilderWorktree: confirm,
+      onResetMissingBuilderWorktree: resetMissingBuilderWorktree,
       onSkipDirectMergeCompletion: reset,
       onCompleteDirectMerge: completeDirectMerge,
     },

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -287,9 +287,10 @@ export function useTaskApprovalFlow({
         });
         reset();
       } catch (error) {
-        dispatch({ type: "return_to_editable", errorMessage: null });
+        const description = errorMessage(error);
+        dispatch({ type: "return_to_editable", errorMessage: description });
         toast.error("Approval failed", {
-          description: errorMessage(error),
+          description,
         });
       }
     })();

--- a/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-approval-flow.ts
@@ -10,7 +10,12 @@ import {
   loadTaskApprovalContextFromQuery,
   taskApprovalQueryKeys,
 } from "@/state/queries/task-approval";
-import type { TaskApprovalModalModel } from "./kanban-page-model-types";
+import type {
+  TaskApprovalApprovalModalModel,
+  TaskApprovalCompletionModalModel,
+  TaskApprovalMissingBuilderWorktreeModalModel,
+  TaskApprovalModalModel,
+} from "./kanban-page-model-types";
 import {
   completeDirectMergeApproval,
   submitDirectMergeApproval,
@@ -34,8 +39,8 @@ type UseTaskApprovalFlowArgs = {
   tasks: TaskCard[];
   requestPullRequestGeneration: (taskId: string) => Promise<string | undefined>;
   refreshTasks: () => Promise<void>;
-  humanApproveTask?: (taskId: string) => Promise<void>;
-  openResetImplementation?: (taskId: string) => boolean;
+  humanApproveTask: (taskId: string) => Promise<void>;
+  openResetImplementation: (taskId: string) => boolean;
   onResolveGitConflict?: (conflict: GitConflict, taskId: string) => Promise<boolean>;
 };
 
@@ -58,14 +63,8 @@ export function useTaskApprovalFlow({
   tasks,
   requestPullRequestGeneration,
   refreshTasks,
-  humanApproveTask = async (): Promise<void> => {
-    throw new Error("humanApproveTask handler is required for missing-builder-worktree recovery.");
-  },
-  openResetImplementation = (): boolean => {
-    throw new Error(
-      "openResetImplementation handler is required for missing-builder-worktree recovery.",
-    );
-  },
+  humanApproveTask,
+  openResetImplementation,
   onResolveGitConflict = async (): Promise<boolean> => {
     throw new Error(
       "onResolveGitConflict handler is required to use the Ask Builder conflict-resolution path.",
@@ -452,12 +451,39 @@ export function useTaskApprovalFlow({
 
   const approvalContext = state.approvalContext;
   const githubProvider = approvalContext?.providers.find((entry) => entry.providerId === "github");
+  const baseModal = {
+    open: true,
+    taskId: state.taskId,
+    isSubmitting: state.phase === "submitting",
+    errorMessage: state.errorMessage,
+    onOpenChange: (open: boolean) => {
+      if (!open) {
+        reset();
+      }
+    },
+  };
 
-  return {
-    taskApprovalModal: {
-      open: true,
-      stage: state.stage,
-      taskId: state.taskId,
+  let taskApprovalModal: TaskApprovalModalModel;
+  if (state.stage === "missing_builder_worktree") {
+    taskApprovalModal = {
+      ...baseModal,
+      stage: "missing_builder_worktree",
+      onCompleteMissingBuilderWorktree: confirm,
+      onResetMissingBuilderWorktree: resetMissingBuilderWorktree,
+    } satisfies TaskApprovalMissingBuilderWorktreeModalModel;
+  } else if (state.stage === "complete_direct_merge") {
+    taskApprovalModal = {
+      ...baseModal,
+      stage: "complete_direct_merge",
+      targetBranch: approvalContext?.targetBranch ?? null,
+      publishTarget: approvalContext?.publishTarget ?? null,
+      onSkipDirectMergeCompletion: reset,
+      onCompleteDirectMerge: completeDirectMerge,
+    } satisfies TaskApprovalCompletionModalModel;
+  } else {
+    taskApprovalModal = {
+      ...baseModal,
+      stage: "approval",
       isLoading: state.phase === "loading",
       mode: state.mode,
       mergeMethod: state.mergeMethod,
@@ -469,18 +495,10 @@ export function useTaskApprovalFlow({
       pullRequestUrl: approvalContext?.pullRequest?.url ?? null,
       title: state.title,
       body: state.body,
-      targetBranch: approvalContext?.targetBranch ?? null,
-      publishTarget: approvalContext?.publishTarget ?? null,
       squashCommitMessage: state.squashCommitMessage,
       squashCommitMessageTouched: state.squashCommitMessageTouched,
       hasSuggestedSquashCommitMessage: approvalContext?.suggestedSquashCommitMessage != null,
-      isSubmitting: state.phase === "submitting",
-      errorMessage: state.errorMessage,
-      onOpenChange: (open) => {
-        if (!open) {
-          reset();
-        }
-      },
+      targetBranch: approvalContext?.targetBranch ?? null,
       onModeChange: (mode) => dispatch({ type: "set_mode", mode }),
       onMergeMethodChange: (mergeMethod) => dispatch({ type: "set_merge_method", mergeMethod }),
       onPullRequestDraftModeChange: (pullRequestDraftMode) =>
@@ -490,11 +508,11 @@ export function useTaskApprovalFlow({
       onSquashCommitMessageChange: (squashCommitMessage) =>
         dispatch({ type: "set_squash_commit_message", squashCommitMessage }),
       onConfirm: confirm,
-      onCompleteMissingBuilderWorktree: confirm,
-      onResetMissingBuilderWorktree: resetMissingBuilderWorktree,
-      onSkipDirectMergeCompletion: reset,
-      onCompleteDirectMerge: completeDirectMerge,
-    },
+    } satisfies TaskApprovalApprovalModalModel;
+  }
+
+  return {
+    taskApprovalModal,
     taskGitConflictDialog,
     openTaskApproval,
   };

--- a/apps/desktop/src/pages/kanban/use-task-reset-flow.ts
+++ b/apps/desktop/src/pages/kanban/use-task-reset-flow.ts
@@ -44,7 +44,7 @@ export function useTaskResetFlow({
   closeTaskDetails,
 }: UseTaskResetFlowArgs): {
   resetImplementationModal: ResetImplementationModalModel;
-  openResetImplementation: (taskId: string, options?: ResetImplementationOptions) => void;
+  openResetImplementation: (taskId: string, options?: ResetImplementationOptions) => boolean;
 } {
   const [taskId, setTaskId] = useState<string | null>(null);
   const [closeDetailsAfterReset, setCloseDetailsAfterReset] = useState(false);
@@ -69,13 +69,13 @@ export function useTaskResetFlow({
   }, [isSubmitting]);
 
   const openResetImplementation = useCallback(
-    (nextTaskId: string, options?: ResetImplementationOptions): void => {
+    (nextTaskId: string, options?: ResetImplementationOptions): boolean => {
       const nextTask = tasks.find((entry) => entry.id === nextTaskId);
       if (!nextTask) {
         toast.error("Unable to reset implementation", {
           description: `Task ${nextTaskId} was not found. Refresh tasks and try again.`,
         });
-        return;
+        return false;
       }
 
       const hasActiveSession = sessions.some(
@@ -85,12 +85,13 @@ export function useTaskResetFlow({
         toast.error("Stop active work first", {
           description: `Builder or QA is still running for ${nextTaskId}. Stop the active session before resetting the implementation.`,
         });
-        return;
+        return false;
       }
 
       setModalError(null);
       setTaskId(nextTaskId);
       setCloseDetailsAfterReset(options?.closeDetailsAfterReset ?? false);
+      return true;
     },
     [sessions, tasks],
   );

--- a/apps/desktop/src/state/queries/task-approval.ts
+++ b/apps/desktop/src/state/queries/task-approval.ts
@@ -1,4 +1,4 @@
-import type { TaskApprovalContext } from "@openducktor/contracts";
+import type { TaskApprovalContextLoadResult } from "@openducktor/contracts";
 import { type QueryClient, queryOptions } from "@tanstack/react-query";
 import { host } from "../operations/host";
 
@@ -11,7 +11,8 @@ export const taskApprovalQueryKeys = {
 const taskApprovalContextQueryOptions = (repoPath: string, taskId: string) =>
   queryOptions({
     queryKey: taskApprovalQueryKeys.context(repoPath, taskId),
-    queryFn: (): Promise<TaskApprovalContext> => host.taskApprovalContextGet(repoPath, taskId),
+    queryFn: (): Promise<TaskApprovalContextLoadResult> =>
+      host.taskApprovalContextGet(repoPath, taskId),
     staleTime: 0,
   });
 
@@ -19,7 +20,7 @@ export const loadTaskApprovalContextFromQuery = (
   queryClient: QueryClient,
   repoPath: string,
   taskId: string,
-): Promise<TaskApprovalContext> =>
+): Promise<TaskApprovalContextLoadResult> =>
   queryClient.fetchQuery(taskApprovalContextQueryOptions(repoPath, taskId));
 
 export const invalidateTaskApprovalContextQuery = (

--- a/packages/adapters-tauri-host/src/build-runtime-client.ts
+++ b/packages/adapters-tauri-host/src/build-runtime-client.ts
@@ -24,10 +24,11 @@ import {
   runtimeInstanceSummarySchema,
   type SystemCheck,
   systemCheckSchema,
+  type TaskApprovalContextLoadResult,
   type TaskCard,
   type TaskDirectMergeInput,
   type TaskDirectMergeResult,
-  taskApprovalContextSchema,
+  taskApprovalContextLoadResultSchema,
   taskCardSchema,
   taskDirectMergeInputSchema,
   taskDirectMergeResultSchema,
@@ -346,12 +347,16 @@ const humanApprove = async (
   return taskCardSchema.parse(payload);
 };
 
-const taskApprovalContextGet = async (invokeFn: InvokeFn, repoPath: string, taskId: string) => {
+const taskApprovalContextGet = async (
+  invokeFn: InvokeFn,
+  repoPath: string,
+  taskId: string,
+): Promise<TaskApprovalContextLoadResult> => {
   const payload = await invokeFn("task_approval_context_get", {
     repoPath,
     taskId,
   });
-  return taskApprovalContextSchema.parse(payload);
+  return taskApprovalContextLoadResultSchema.parse(payload);
 };
 
 const taskDirectMerge = async (
@@ -572,7 +577,10 @@ export class TauriAgentClient {
     return humanApprove(this.invokeFn, repoPath, taskId);
   }
 
-  async taskApprovalContextGet(repoPath: string, taskId: string) {
+  async taskApprovalContextGet(
+    repoPath: string,
+    taskId: string,
+  ): Promise<TaskApprovalContextLoadResult> {
     return taskApprovalContextGet(this.invokeFn, repoPath, taskId);
   }
 

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -269,6 +269,7 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "planSubtaskPrioritySchema",
   "taskActionSchema",
   "taskApprovalContextSchema",
+  "taskApprovalContextLoadResultSchema",
   "taskCardSchema",
   "taskCreateInputSchema",
   "taskDirectMergeInputSchema",

--- a/packages/contracts/src/git-schemas.ts
+++ b/packages/contracts/src/git-schemas.ts
@@ -174,6 +174,19 @@ export const taskApprovalContextSchema = z.object({
 });
 export type TaskApprovalContext = z.infer<typeof taskApprovalContextSchema>;
 
+export const taskApprovalContextLoadResultSchema = z.discriminatedUnion("outcome", [
+  z.object({
+    outcome: z.literal("ready"),
+    approvalContext: taskApprovalContextSchema,
+  }),
+  z.object({
+    outcome: z.literal("missing_builder_worktree"),
+    taskId: z.string(),
+    taskStatus: z.string(),
+  }),
+]);
+export type TaskApprovalContextLoadResult = z.infer<typeof taskApprovalContextLoadResultSchema>;
+
 export const gitPushBranchResultSchema = z.discriminatedUnion("outcome", [
   z.object({
     outcome: z.literal("pushed"),


### PR DESCRIPTION
## Summary
- recover the human-approval flow when a task reaches review after its builder worktree was deleted outside OpenDucktor by returning a typed `missing_builder_worktree` approval-context outcome from the host instead of hard-failing the modal open path
- add a dedicated warning-state approval modal that lets reviewers either complete the task directly or hand off to the existing reset implementation workflow while keeping other approval failures fail-fast
- tighten the follow-up implementation by replacing the Rust `anyhow` downcast recovery seam with an explicit typed outcome, making approval recovery dependencies required in the hook wiring, and modeling approval modal stages as a discriminated union

## Changes
- add `TaskApprovalContextLoadResult` to the shared contracts, Tauri host domain, build runtime client, and approval-context query path
- update Rust approval-context loading so only the explicit missing-builder-worktree case is recoverable, while detached branches and other approval errors still surface normally
- update the Kanban approval flow state machine, modal model, and modal panel to support a missing-builder-worktree recovery stage with dedicated actions and warning copy
- reuse the existing reset implementation workflow from the recovery modal and complete the task through the existing human-approval operation when the user chooses to finish without a worktree
- harden the direct-merge follow-up path so it rejects if the builder worktree disappears before completion resumes
- add frontend coverage for the new recovery stage and fail-fast behavior, plus Rust approval workflow coverage for missing-worktree and detached-branch scenarios

## Verification
- `bun test apps/desktop/src/pages/kanban/use-task-approval-flow.test.tsx apps/desktop/src/pages/kanban/task-approval-modal.test.tsx`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop lint`
- `rtk cargo test -p host-application approval_workflow`
- `bun run test:rust`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery flow for missing builder worktree in task approval, plus a dedicated "Missing Builder Worktree" modal with Reset and Complete actions.

* **Bug Fixes**
  * Approval flow now detects and blocks progression when builder worktree disappears, showing recovery UI instead of failing.
  * Improved error handling and user-facing messages for missing or detached builder contexts.

* **Refactor**
  * Approval modal split into stage-specific components for clearer UI and behavior separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->