### PR TITLE
fix(desktop): harden composer and approval workflows

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -34,8 +34,8 @@
         "form-action": ["'self'"],
         "script-src": ["'self'"],
         "style-src": ["'self'", "'unsafe-inline'"],
-        "img-src": ["'self'", "data:", "asset:", "http://asset.localhost"],
-        "media-src": ["'self'", "data:", "asset:", "http://asset.localhost"],
+        "img-src": ["'self'", "data:", "blob:", "asset:", "http://asset.localhost"],
+        "media-src": ["'self'", "data:", "blob:", "asset:", "http://asset.localhost"],
         "connect-src": ["ipc:", "http://ipc.localhost", "http://127.0.0.1:*"]
       },
       "devCsp": {
@@ -46,8 +46,8 @@
         "form-action": ["'self'"],
         "script-src": ["'self'", "'unsafe-eval'", "'unsafe-inline'"],
         "style-src": ["'self'", "'unsafe-inline'"],
-        "img-src": ["'self'", "data:", "asset:", "http://asset.localhost"],
-        "media-src": ["'self'", "data:", "asset:", "http://asset.localhost"],
+        "img-src": ["'self'", "data:", "blob:", "asset:", "http://asset.localhost"],
+        "media-src": ["'self'", "data:", "blob:", "asset:", "http://asset.localhost"],
         "connect-src": [
           "'self'",
           "ipc:",

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
@@ -82,7 +82,7 @@ describe("AgentChatAttachmentChip", () => {
     });
   });
 
-  test("does not poison preview opening when the inline thumbnail errors during rerender", async () => {
+  test("surfaces inline thumbnail failures as explicit preview errors", async () => {
     hostClient.workspaceResolveLocalAttachmentPath = mock(async ({ path }) => ({
       path: `/tmp/openducktor-local-attachments/${path}`,
     }));
@@ -104,11 +104,13 @@ describe("AgentChatAttachmentChip", () => {
     const thumbnailImage = await screen.findByAltText("preview-inline.png");
     fireEvent.error(thumbnailImage);
 
-    expect(
-      screen.queryByText(
-        'Attachment preview is unavailable because "preview-inline.png" could not be read from its original local path.',
-      ),
-    ).toBeNull();
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Attachment preview is unavailable because "preview-inline.png" could not be read from its original local path.',
+        ),
+      ).toBeDefined();
+    });
 
     const previewButton = screen
       .getAllByRole("button")
@@ -118,7 +120,9 @@ describe("AgentChatAttachmentChip", () => {
     }
     fireEvent.click(previewButton);
 
-    await screen.findByText("Image preview");
+    await waitFor(() => {
+      expect(screen.queryByText("Image preview")).toBeNull();
+    });
   });
 
   test("renders transcript image previews from the resolved desktop asset url", async () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.test.tsx
@@ -1,13 +1,37 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { hostClient } from "@/lib/host-client";
 import { AgentChatAttachmentChip } from "./agent-chat-attachment-chip";
 
+type TestWindow = Window &
+  typeof globalThis & {
+    __TAURI_INTERNALS__?: {
+      convertFileSrc: (path: string, protocol?: string) => string;
+    };
+  };
+
+const testWindow = window as TestWindow;
 const originalCreateObjectUrl = URL.createObjectURL;
 const originalRevokeObjectUrl = URL.revokeObjectURL;
+const originalResolveLocalAttachmentPath = hostClient.workspaceResolveLocalAttachmentPath;
+const originalTauriInternals = testWindow.__TAURI_INTERNALS__;
+
+const installMockTauriRuntime = (): void => {
+  testWindow.__TAURI_INTERNALS__ = {
+    convertFileSrc: (path: string, protocol = "asset") =>
+      `${protocol}://localhost/${encodeURIComponent(path)}`,
+  };
+};
 
 afterEach(() => {
   URL.createObjectURL = originalCreateObjectUrl;
   URL.revokeObjectURL = originalRevokeObjectUrl;
+  hostClient.workspaceResolveLocalAttachmentPath = originalResolveLocalAttachmentPath;
+  if (originalTauriInternals) {
+    testWindow.__TAURI_INTERNALS__ = originalTauriInternals;
+    return;
+  }
+  delete testWindow.__TAURI_INTERNALS__;
 });
 
 describe("AgentChatAttachmentChip", () => {
@@ -59,15 +83,17 @@ describe("AgentChatAttachmentChip", () => {
   });
 
   test("does not poison preview opening when the inline thumbnail errors during rerender", async () => {
-    URL.createObjectURL = () => "blob:preview-inline.png";
-    URL.revokeObjectURL = () => {};
+    hostClient.workspaceResolveLocalAttachmentPath = mock(async ({ path }) => ({
+      path: `/tmp/openducktor-local-attachments/${path}`,
+    }));
+    installMockTauriRuntime();
 
     render(
       <AgentChatAttachmentChip
         variant="transcript"
         attachment={{
           id: "attachment-3",
-          path: "/tmp/preview-inline.png",
+          path: "uuid-preview-inline.png",
           name: "preview-inline.png",
           kind: "image",
           mime: "image/png",
@@ -93,6 +119,50 @@ describe("AgentChatAttachmentChip", () => {
     fireEvent.click(previewButton);
 
     await screen.findByText("Image preview");
+  });
+
+  test("renders transcript image previews from the resolved desktop asset url", async () => {
+    hostClient.workspaceResolveLocalAttachmentPath = mock(async ({ path }) => ({
+      path: `/tmp/openducktor-local-attachments/${path}`,
+    }));
+    installMockTauriRuntime();
+
+    render(
+      <AgentChatAttachmentChip
+        variant="transcript"
+        attachment={{
+          id: "attachment-4",
+          path: "uuid-preview-dialog.png",
+          name: "preview-dialog.png",
+          kind: "image",
+          mime: "image/png",
+        }}
+      />,
+    );
+
+    const thumbnailImage = await screen.findByAltText("preview-dialog.png");
+    expect(thumbnailImage.getAttribute("src")).toBe(
+      "asset://localhost/%2Ftmp%2Fopenducktor-local-attachments%2Fuuid-preview-dialog.png",
+    );
+
+    const previewButton = screen
+      .getAllByRole("button")
+      .find((button) => button.getAttribute("aria-label") === null);
+    if (!previewButton) {
+      throw new Error("Expected preview button");
+    }
+    fireEvent.click(previewButton);
+
+    await screen.findByText("Image preview");
+    const dialogImage = screen
+      .getAllByAltText("preview-dialog.png")
+      .find((image) => image.className.includes("object-contain"));
+    if (!(dialogImage instanceof HTMLElement)) {
+      throw new Error("Expected fullscreen preview image");
+    }
+    expect(dialogImage.getAttribute("src")).toBe(
+      "asset://localhost/%2Ftmp%2Fopenducktor-local-attachments%2Fuuid-preview-dialog.png",
+    );
   });
 
   test("exposes the full attachment name on hover", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-attachment-chip.tsx
@@ -1,6 +1,6 @@
 import type { AgentAttachmentReference } from "@openducktor/core";
 import { FileAudio2, FileText, Film, Image as ImageIcon, LoaderCircle, X } from "lucide-react";
-import { type ReactElement, type SyntheticEvent, useState } from "react";
+import type { ReactElement, SyntheticEvent } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -78,21 +78,19 @@ export function AgentChatAttachmentChip(
   });
   const removable = variant === "draft";
   const onRemove = draftProps?.onRemove ?? null;
-  const [failedThumbnailSrc, setFailedThumbnailSrc] = useState<string | null>(null);
-  const thumbnailFailed = failedThumbnailSrc !== null && failedThumbnailSrc === resolvedPreviewSrc;
-  const showPreviewImage = showResolvedPreview && !thumbnailFailed && attachment.kind === "image";
-  const showPreviewVideo = showResolvedPreview && !thumbnailFailed && attachment.kind === "video";
+  const showPreviewImage = showResolvedPreview && attachment.kind === "image";
+  const showPreviewVideo = showResolvedPreview && attachment.kind === "video";
   const showPreviewLoader = isResolvingPreview;
 
   const handleThumbnailError = (
     event: SyntheticEvent<HTMLImageElement | HTMLVideoElement>,
   ): void => {
-    setFailedThumbnailSrc(
+    const failingSrc =
       event.currentTarget.currentSrc ||
-        event.currentTarget.getAttribute("src") ||
-        resolvedPreviewSrc ||
-        null,
-    );
+      event.currentTarget.getAttribute("src") ||
+      resolvedPreviewSrc ||
+      undefined;
+    markPreviewUnavailable(failingSrc);
   };
 
   const handleDialogPreviewMediaError = (

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.test.tsx
@@ -1,16 +1,40 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { hostClient } from "@/lib/host-client";
 import { createHookHarness } from "@/test-utils/react-hook-harness";
 import {
   readAttachmentPreviewLoadFailureMessage,
   useAgentChatAttachmentPreview,
 } from "./use-agent-chat-attachment-preview";
 
+type TestWindow = Window &
+  typeof globalThis & {
+    __TAURI_INTERNALS__?: {
+      convertFileSrc: (path: string, protocol?: string) => string;
+    };
+  };
+
+const testWindow = window as TestWindow;
 const originalCreateObjectUrl = URL.createObjectURL;
 const originalRevokeObjectUrl = URL.revokeObjectURL;
+const originalResolveLocalAttachmentPath = hostClient.workspaceResolveLocalAttachmentPath;
+const originalTauriInternals = testWindow.__TAURI_INTERNALS__;
+
+const installMockTauriRuntime = (): void => {
+  testWindow.__TAURI_INTERNALS__ = {
+    convertFileSrc: (path: string, protocol = "asset") =>
+      `${protocol}://localhost/${encodeURIComponent(path)}`,
+  };
+};
 
 afterEach(() => {
   URL.createObjectURL = originalCreateObjectUrl;
   URL.revokeObjectURL = originalRevokeObjectUrl;
+  hostClient.workspaceResolveLocalAttachmentPath = originalResolveLocalAttachmentPath;
+  if (originalTauriInternals) {
+    testWindow.__TAURI_INTERNALS__ = originalTauriInternals;
+    return;
+  }
+  delete testWindow.__TAURI_INTERNALS__;
 });
 
 describe("useAgentChatAttachmentPreview", () => {
@@ -104,6 +128,62 @@ describe("useAgentChatAttachmentPreview", () => {
 
     expect(harness.getLatest().resolvedPreviewSrc).toBe("blob:active-preview");
     expect(harness.getLatest().effectiveError).toBeNull();
+
+    await harness.unmount();
+  });
+
+  test("resolves transcript image previews through the desktop asset protocol", async () => {
+    hostClient.workspaceResolveLocalAttachmentPath = mock(async ({ path }) => ({
+      path: `/tmp/openducktor-local-attachments/${path}`,
+    }));
+    installMockTauriRuntime();
+
+    const harness = createHookHarness(useAgentChatAttachmentPreview, {
+      attachment: {
+        id: "attachment-4",
+        name: "preview.png",
+        kind: "image" as const,
+        mime: "image/png",
+        path: "uuid-preview.png",
+      },
+      externalError: null,
+    });
+
+    await harness.mount();
+    await harness.waitFor((state) => state.showResolvedPreview === true);
+
+    expect(harness.getLatest().resolvedPreviewSrc).toBe(
+      "asset://localhost/%2Ftmp%2Fopenducktor-local-attachments%2Fuuid-preview.png",
+    );
+    expect(harness.getLatest().previewError).toBeNull();
+
+    await harness.unmount();
+  });
+
+  test("surfaces transcript preview resolution failures as explicit errors", async () => {
+    hostClient.workspaceResolveLocalAttachmentPath = mock(async () => {
+      throw new Error("Attachment path is not a staged local attachment.");
+    });
+    installMockTauriRuntime();
+
+    const harness = createHookHarness(useAgentChatAttachmentPreview, {
+      attachment: {
+        id: "attachment-5",
+        name: "preview.png",
+        kind: "image" as const,
+        mime: "image/png",
+        path: "/tmp/preview.png",
+      },
+      externalError: null,
+    });
+
+    await harness.mount();
+    await harness.waitFor((state) => state.isResolvingPreview === false);
+
+    expect(harness.getLatest().resolvedPreviewSrc).toBeNull();
+    expect(harness.getLatest().previewError).toBe(
+      "Attachment path is not a staged local attachment.",
+    );
 
     await harness.unmount();
   });

--- a/apps/desktop/src/lib/local-attachment-files.test.ts
+++ b/apps/desktop/src/lib/local-attachment-files.test.ts
@@ -5,10 +5,33 @@ import {
   resolveLocalAttachmentPreviewSrc,
 } from "./local-attachment-files";
 
+type TestWindow = Window &
+  typeof globalThis & {
+    __TAURI_INTERNALS__?: {
+      convertFileSrc: (path: string, protocol?: string) => string;
+    };
+  };
+
+const testWindow = window as TestWindow;
 const originalResolveLocalAttachmentPath = hostClient.workspaceResolveLocalAttachmentPath;
+const originalTauriInternals = testWindow.__TAURI_INTERNALS__;
+
+const installMockTauriRuntime = (
+  convertFileSrc: (path: string, protocol?: string) => string = (path, protocol = "asset") =>
+    `${protocol}://localhost/${encodeURIComponent(path)}`,
+): void => {
+  testWindow.__TAURI_INTERNALS__ = {
+    convertFileSrc,
+  };
+};
 
 afterEach(() => {
   hostClient.workspaceResolveLocalAttachmentPath = originalResolveLocalAttachmentPath;
+  if (originalTauriInternals) {
+    testWindow.__TAURI_INTERNALS__ = originalTauriInternals;
+    return;
+  }
+  delete testWindow.__TAURI_INTERNALS__;
 });
 
 describe("local-attachment-files", () => {
@@ -24,21 +47,43 @@ describe("local-attachment-files", () => {
     );
   });
 
-  test("resolveLocalAttachmentPreviewSrc treats UNC paths as absolute local paths", async () => {
-    await expect(resolveLocalAttachmentPreviewSrc("\\\\server\\share\\preview.png")).resolves.toBe(
-      "\\\\server\\share\\preview.png",
+  test("resolveLocalAttachmentPreviewSrc validates absolute staged paths before building desktop preview urls", async () => {
+    const stagedPath = "/tmp/openducktor-local-attachments/uuid-preview.png";
+    hostClient.workspaceResolveLocalAttachmentPath = mock(async ({ path }) => ({ path }));
+    installMockTauriRuntime((path, protocol = "asset") => {
+      expect(path).toBe(stagedPath);
+      expect(protocol).toBe("asset");
+      return `${protocol}://localhost/${encodeURIComponent(path)}`;
+    });
+
+    await expect(resolveLocalAttachmentPreviewSrc(stagedPath)).resolves.toBe(
+      "asset://localhost/%2Ftmp%2Fopenducktor-local-attachments%2Fuuid-preview.png",
     );
+    expect(hostClient.workspaceResolveLocalAttachmentPath).toHaveBeenCalledWith({
+      path: stagedPath,
+    });
   });
 
-  test("resolveLocalAttachmentPreviewSrc resolves staged filename tokens before building browser preview urls", async () => {
+  test("resolveLocalAttachmentPreviewSrc resolves staged filename tokens before building desktop preview urls", async () => {
     hostClient.workspaceResolveLocalAttachmentPath = mock(async ({ path }) => ({
       path: `/tmp/openducktor-local-attachments/uuid-${path}`,
     }));
+    installMockTauriRuntime();
 
     await expect(
       resolveLocalAttachmentPreviewSrc("Screenshot-2026-03-16-at-23.48.30.png"),
     ).resolves.toBe(
-      "/tmp/openducktor-local-attachments/uuid-Screenshot-2026-03-16-at-23.48.30.png",
+      "asset://localhost/%2Ftmp%2Fopenducktor-local-attachments%2Fuuid-Screenshot-2026-03-16-at-23.48.30.png",
+    );
+  });
+
+  test("resolveLocalAttachmentPreviewSrc surfaces host validation errors for non-staged absolute paths", async () => {
+    hostClient.workspaceResolveLocalAttachmentPath = mock(async () => {
+      throw new Error("Attachment path is not a staged local attachment.");
+    });
+
+    await expect(resolveLocalAttachmentPreviewSrc("/tmp/preview.png")).rejects.toThrow(
+      "Attachment path is not a staged local attachment.",
     );
   });
 });

--- a/apps/desktop/src/lib/local-attachment-files.ts
+++ b/apps/desktop/src/lib/local-attachment-files.ts
@@ -2,10 +2,6 @@ import { getBrowserBackendUrl, isBrowserAppMode } from "@/lib/browser-mode";
 import { hostClient } from "@/lib/host-client";
 import { isTauriRuntime } from "@/lib/runtime";
 
-const isAbsoluteLocalAttachmentPath = (path: string): boolean => {
-  return path.startsWith("/") || /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\");
-};
-
 const bufferToBase64 = (buffer: ArrayBuffer): string => {
   const bytes = new Uint8Array(buffer);
   let binary = "";
@@ -42,9 +38,8 @@ export const resolveLocalAttachmentPreviewSrc = async (path: string): Promise<st
     throw new Error("Attachment preview is unavailable because the local file path is missing.");
   }
 
-  const resolvedPath = isAbsoluteLocalAttachmentPath(trimmedPath)
-    ? trimmedPath
-    : (await hostClient.workspaceResolveLocalAttachmentPath({ path: trimmedPath })).path;
+  const resolvedPath = (await hostClient.workspaceResolveLocalAttachmentPath({ path: trimmedPath }))
+    .path;
 
   if (isBrowserAppMode()) {
     return buildBrowserLocalAttachmentPreviewUrl(getBrowserBackendUrl(), resolvedPath);
@@ -52,7 +47,7 @@ export const resolveLocalAttachmentPreviewSrc = async (path: string): Promise<st
 
   if (isTauriRuntime()) {
     const api = await import("@tauri-apps/api/core");
-    return api.convertFileSrc(resolvedPath);
+    return api.convertFileSrc(resolvedPath, "asset");
   }
 
   return resolvedPath;

--- a/apps/desktop/src/lib/tauri-csp.contract.test.ts
+++ b/apps/desktop/src/lib/tauri-csp.contract.test.ts
@@ -60,6 +60,20 @@ describe("tauri CSP contract", () => {
     expect(connectSrc).toContain("http://127.0.0.1:*");
     expect(connectSrc).not.toContain("ws://localhost:*");
     expect(connectSrc).not.toContain("ws://127.0.0.1:*");
+
+    const imgSrc = toSourceList(csp["img-src"]);
+    expect(imgSrc).toContain("'self'");
+    expect(imgSrc).toContain("data:");
+    expect(imgSrc).toContain("blob:");
+    expect(imgSrc).toContain("asset:");
+    expect(imgSrc).toContain("http://asset.localhost");
+
+    const mediaSrc = toSourceList(csp["media-src"]);
+    expect(mediaSrc).toContain("'self'");
+    expect(mediaSrc).toContain("data:");
+    expect(mediaSrc).toContain("blob:");
+    expect(mediaSrc).toContain("asset:");
+    expect(mediaSrc).toContain("http://asset.localhost");
   });
 
   test("keeps development CSP compatible with HMR while retaining baseline hardening", () => {
@@ -83,5 +97,19 @@ describe("tauri CSP contract", () => {
     expect(connectSrc).toContain("ws://localhost:*");
     expect(connectSrc).toContain("http://127.0.0.1:*");
     expect(connectSrc).toContain("ws://127.0.0.1:*");
+
+    const imgSrc = toSourceList(devCsp["img-src"]);
+    expect(imgSrc).toContain("'self'");
+    expect(imgSrc).toContain("data:");
+    expect(imgSrc).toContain("blob:");
+    expect(imgSrc).toContain("asset:");
+    expect(imgSrc).toContain("http://asset.localhost");
+
+    const mediaSrc = toSourceList(devCsp["media-src"]);
+    expect(mediaSrc).toContain("'self'");
+    expect(mediaSrc).toContain("data:");
+    expect(mediaSrc).toContain("blob:");
+    expect(mediaSrc).toContain("asset:");
+    expect(mediaSrc).toContain("http://asset.localhost");
   });
 });

--- a/docs/desktop-csp-hardening.md
+++ b/docs/desktop-csp-hardening.md
@@ -1,6 +1,6 @@
 # Desktop CSP Hardening
 
-This document defines the current Content Security Policy baseline for the desktop app and the remaining hardening roadmap.
+This document defines the current Content Security Policy baseline for the desktop app, the attachment preview allowances that depend on it, and the remaining hardening roadmap.
 
 ## Current Baseline
 
@@ -15,12 +15,38 @@ Production CSP constraints:
 - `form-action 'self'`
 - `script-src 'self'`
 - `style-src 'self' 'unsafe-inline'`
-- `img-src 'self' data:`
+- `img-src 'self' data: blob: asset: http://asset.localhost`
+- `media-src 'self' data: blob: asset: http://asset.localhost`
 - `connect-src ipc: http://ipc.localhost http://127.0.0.1:*`
 
-Development CSP retains the same baseline, with only dev-specific allowances for Vite/HMR (`'unsafe-eval'`, `localhost`, and `ws://` endpoints).
+Development CSP retains the same baseline for media loading, with only dev-specific allowances for Vite/HMR (`'unsafe-eval'`, `localhost`, and `ws://` endpoints).
 
 A desktop contract test enforces this baseline in `apps/desktop/src/lib/tauri-csp.contract.test.ts`.
+
+## Attachment Preview Allowances
+
+The desktop attachment preview flow intentionally uses two different transports:
+
+- Composer previews use `blob:` object URLs created from in-memory draft `File` objects in `apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-attachment-preview.ts`.
+- Transcript previews resolve staged local attachment paths through `apps/desktop/src/lib/local-attachment-files.ts` and convert the validated path with Tauri's asset protocol.
+
+That means `img-src` and `media-src` must allow both:
+
+- `blob:` for pre-send composer previews
+- `asset:` and `http://asset.localhost` for staged transcript previews after send
+
+These allowances are intentionally limited to media directives only. The CSP does not broaden `script-src` or add generic fallback transports for attachment rendering.
+
+## Attachment Preview Verification Matrix
+
+The bundled attachment preview fix was validated manually against the real desktop app in all supported desktop targets:
+
+- `bun run tauri:dev`: composer image preview before send, transcript thumbnail after send, and transcript preview dialog render all passed.
+- `bun run tauri:dev:cef`: composer image preview before send, transcript thumbnail after send, and transcript preview dialog render all passed.
+- Packaged default desktop build produced by `bun run tauri:build`: composer image preview before send, transcript thumbnail after send, and transcript preview dialog render all passed.
+- Packaged CEF desktop build produced by `bun run tauri:build:cef`: composer image preview before send, transcript thumbnail after send, and transcript preview dialog render all passed.
+
+Negative-path preview failures remain covered by automated tests in the attachment preview helper, hook, and chip suites.
 
 ## Remaining Risk
 


### PR DESCRIPTION
## Summary
- harden the desktop chat composer by forcing plain-text paste handling, tightening selection/editor behavior, and restoring bundled image preview support for draft attachments and transcript previews
- make human approval flows fail fast and recover cleanly when builder worktree context is missing, while keeping approval errors visible and simplifying the related UI/state wiring across the Tauri host, contracts, and Kanban approval flow
- add focused coverage for the approval workflow changes, desktop attachment preview paths, and CSP/media contract, and record the desktop attachment preview verification matrix in the CSP hardening docs

## Testing
- bun run --filter @openducktor/desktop test
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint
- bun run tauri:build
- bun run tauri:build:cef

## Manual Verification
- verified attachment previews in `bun run tauri:dev`
- verified attachment previews in `bun run tauri:dev:cef`
- verified attachment previews in the packaged default desktop build from `bun run tauri:build`
- verified attachment previews in the packaged CEF desktop build from `bun run tauri:build:cef`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment preview handling for images and videos in agent chat by refactoring thumbnail failure detection logic.

* **Tests**
  * Enhanced test coverage for attachment preview resolution and error handling across multiple test suites.

* **Documentation**
  * Updated Content Security Policy documentation to reflect expanded resource loading permissions for media attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->