### PR TITLE
fix(workflow): allow blocked tasks to reset implementation

### DIFF
--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/cleanup_plans.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/cleanup_plans.rs
@@ -1,4 +1,5 @@
 use crate::app_service::service_core::AppService;
+use crate::app_service::workflow_rules::can_reset_implementation_from_status;
 use anyhow::{anyhow, Context, Result};
 use host_domain::{
     AgentSessionDocument, GitWorktreeSummary, TaskCard, TaskStatus, DEFAULT_BRANCH_PREFIX,
@@ -192,13 +193,7 @@ pub(super) fn derive_reset_implementation_status(task: &TaskCard) -> TaskStatus 
 }
 
 pub(super) fn ensure_task_reset_status_allowed(task: &TaskCard) -> Result<()> {
-    if matches!(
-        task.status,
-        TaskStatus::InProgress
-            | TaskStatus::Blocked
-            | TaskStatus::AiReview
-            | TaskStatus::HumanReview
-    ) {
+    if can_reset_implementation_from_status(&task.status) {
         return Ok(());
     }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/cleanup_plans.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/task_workflow/cleanup_plans.rs
@@ -194,13 +194,16 @@ pub(super) fn derive_reset_implementation_status(task: &TaskCard) -> TaskStatus 
 pub(super) fn ensure_task_reset_status_allowed(task: &TaskCard) -> Result<()> {
     if matches!(
         task.status,
-        TaskStatus::InProgress | TaskStatus::AiReview | TaskStatus::HumanReview
+        TaskStatus::InProgress
+            | TaskStatus::Blocked
+            | TaskStatus::AiReview
+            | TaskStatus::HumanReview
     ) {
         return Ok(());
     }
 
     Err(anyhow!(
-        "Implementation reset is only allowed from in_progress, ai_review, or human_review (current: {}).",
+        "Implementation reset is only allowed from in_progress, blocked, ai_review, or human_review (current: {}).",
         task.status.as_cli_value()
     ))
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -416,8 +416,24 @@ fn blocked_tasks_expose_builder_and_reset_implementation_actions() {
 }
 
 #[test]
-fn task_reset_implementation_discards_builder_state_and_rolls_back_to_ready_for_dev() -> Result<()>
-{
+fn task_reset_implementation_discards_builder_state_and_rolls_back_to_ready_for_dev_from_ai_review(
+) -> Result<()> {
+    assert_task_reset_implementation_discards_builder_state_and_rolls_back_to_ready_for_dev(
+        TaskStatus::AiReview,
+    )
+}
+
+#[test]
+fn task_reset_implementation_discards_builder_state_and_rolls_back_to_ready_for_dev_from_blocked(
+) -> Result<()> {
+    assert_task_reset_implementation_discards_builder_state_and_rolls_back_to_ready_for_dev(
+        TaskStatus::Blocked,
+    )
+}
+
+fn assert_task_reset_implementation_discards_builder_state_and_rolls_back_to_ready_for_dev(
+    status: TaskStatus,
+) -> Result<()> {
     let repo_path = unique_temp_path("reset-implementation-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -428,7 +444,7 @@ fn task_reset_implementation_discards_builder_state_and_rolls_back_to_ready_for_
     fs::create_dir_all(&build_worktree)?;
     fs::create_dir_all(&qa_worktree)?;
 
-    let mut task = make_task("task-1", "task", TaskStatus::Blocked);
+    let mut task = make_task("task-1", "task", status);
     task.document_summary.spec.has = true;
     task.document_summary.plan.has = true;
     task.document_summary.qa_report.has = true;
@@ -670,12 +686,10 @@ fn task_reset_implementation_uses_document_presence_for_rollback_target() -> Res
     ready_for_dev.document_summary.spec.has = true;
     ready_for_dev.document_summary.plan.has = true;
 
-    let mut spec_ready = make_task("task-spec", "task", TaskStatus::InProgress);
+    let mut spec_ready = make_task("task-spec", "task", TaskStatus::Blocked);
     spec_ready.document_summary.spec.has = true;
 
-    let mut open = make_task("task-open", "task", TaskStatus::HumanReview);
-    spec_ready.status = TaskStatus::Blocked;
-    open.status = TaskStatus::Blocked;
+    let open = make_task("task-open", "task", TaskStatus::Blocked);
 
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![ready_for_dev, spec_ready, open],
@@ -1257,12 +1271,23 @@ fn task_delete_clears_stale_runs_after_successful_delete() -> Result<()> {
 }
 
 #[test]
-fn task_reset_implementation_rejects_live_build_session_status() -> Result<()> {
+fn task_reset_implementation_rejects_live_build_session_status_for_in_progress() -> Result<()> {
+    assert_task_reset_implementation_rejects_live_build_session_status(TaskStatus::InProgress)
+}
+
+#[test]
+fn task_reset_implementation_rejects_live_build_session_status_for_blocked() -> Result<()> {
+    assert_task_reset_implementation_rejects_live_build_session_status(TaskStatus::Blocked)
+}
+
+fn assert_task_reset_implementation_rejects_live_build_session_status(
+    status: TaskStatus,
+) -> Result<()> {
     let repo_path = unique_temp_path("reset-implementation-live-runtime-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
 
-    let task = make_task("task-1", "task", TaskStatus::Blocked);
+    let task = make_task("task-1", "task", status);
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![task],
         Vec::new(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -407,6 +407,15 @@ fn human_review_tasks_expose_qa_start_and_request_changes() {
 }
 
 #[test]
+fn blocked_tasks_expose_builder_and_reset_implementation_actions() {
+    let task = make_task("task-1", "task", TaskStatus::Blocked);
+    let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+    assert!(actions.contains(&TaskAction::OpenBuilder));
+    assert!(actions.contains(&TaskAction::ResetImplementation));
+    assert!(!actions.contains(&TaskAction::BuildStart));
+}
+
+#[test]
 fn task_reset_implementation_discards_builder_state_and_rolls_back_to_ready_for_dev() -> Result<()>
 {
     let repo_path = unique_temp_path("reset-implementation-repo");
@@ -419,7 +428,7 @@ fn task_reset_implementation_discards_builder_state_and_rolls_back_to_ready_for_
     fs::create_dir_all(&build_worktree)?;
     fs::create_dir_all(&qa_worktree)?;
 
-    let mut task = make_task("task-1", "task", TaskStatus::AiReview);
+    let mut task = make_task("task-1", "task", TaskStatus::Blocked);
     task.document_summary.spec.has = true;
     task.document_summary.plan.has = true;
     task.document_summary.qa_report.has = true;
@@ -657,13 +666,19 @@ fn task_reset_implementation_uses_document_presence_for_rollback_target() -> Res
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
 
+    let mut ready_for_dev = make_task("task-ready", "task", TaskStatus::Blocked);
+    ready_for_dev.document_summary.spec.has = true;
+    ready_for_dev.document_summary.plan.has = true;
+
     let mut spec_ready = make_task("task-spec", "task", TaskStatus::InProgress);
     spec_ready.document_summary.spec.has = true;
 
-    let open = make_task("task-open", "task", TaskStatus::HumanReview);
+    let mut open = make_task("task-open", "task", TaskStatus::HumanReview);
+    spec_ready.status = TaskStatus::Blocked;
+    open.status = TaskStatus::Blocked;
 
     let (service, _task_state, _git_state) = build_service_with_git_state(
-        vec![spec_ready, open],
+        vec![ready_for_dev, spec_ready, open],
         Vec::new(),
         host_domain::GitCurrentBranch {
             name: Some("main".to_string()),
@@ -678,11 +693,14 @@ fn task_reset_implementation_uses_document_presence_for_rollback_target() -> Res
     };
     service.workspace_update_repo_config(&repo_path.to_string_lossy(), repo_config)?;
 
+    let ready_for_dev_result =
+        service.task_reset_implementation(&repo_path.to_string_lossy(), "task-ready")?;
     let spec_ready_result =
         service.task_reset_implementation(&repo_path.to_string_lossy(), "task-spec")?;
     let open_result =
         service.task_reset_implementation(&repo_path.to_string_lossy(), "task-open")?;
 
+    assert_eq!(ready_for_dev_result.status, TaskStatus::ReadyForDev);
     assert_eq!(spec_ready_result.status, TaskStatus::SpecReady);
     assert_eq!(open_result.status, TaskStatus::Open);
     Ok(())
@@ -1244,7 +1262,7 @@ fn task_reset_implementation_rejects_live_build_session_status() -> Result<()> {
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
 
-    let task = make_task("task-1", "task", TaskStatus::InProgress);
+    let task = make_task("task-1", "task", TaskStatus::Blocked);
     let (service, task_state, _git_state) = build_service_with_git_state(
         vec![task],
         Vec::new(),

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/mod.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/mod.rs
@@ -6,8 +6,8 @@ pub(crate) use transitions::{
     default_qa_required_for_issue_type, derive_agent_workflows, is_open_state,
 };
 pub(crate) use validators::{
-    derive_available_actions, normalize_required_markdown, normalize_subtask_plan_inputs,
-    normalize_title_key, validate_parent_relationships_for_create,
+    can_reset_implementation_from_status, derive_available_actions, normalize_required_markdown,
+    normalize_subtask_plan_inputs, normalize_title_key, validate_parent_relationships_for_create,
     validate_parent_relationships_for_update, validate_plan_subtask_rules, validate_transition,
     validate_transition_without_related_tasks,
 };

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
@@ -15,6 +15,7 @@ struct WorkflowContractFixture {
     transitions: BTreeMap<String, BTreeMap<String, Vec<String>>>,
     set_spec_allowed_statuses: Vec<String>,
     set_plan_allowed_statuses: BTreeMap<String, Vec<String>>,
+    reset_implementation_allowed_statuses: Vec<String>,
     epic_subtask_replacement_allowed_statuses: Vec<String>,
 }
 
@@ -85,16 +86,39 @@ fn module_derive_available_actions_exposes_review_actions_during_review_states()
 }
 
 #[test]
-fn module_derive_available_actions_exposes_reset_for_in_progress_only_and_not_blocked() {
-    let in_progress = make_task("task-1", "task", TaskStatus::InProgress);
-    let blocked = make_task("task-2", "task", TaskStatus::Blocked);
+fn module_derive_available_actions_exposes_reset_for_implementation_stage_statuses() {
+    for status in [
+        TaskStatus::InProgress,
+        TaskStatus::Blocked,
+        TaskStatus::AiReview,
+        TaskStatus::HumanReview,
+    ] {
+        let task = make_task("task-1", "task", status);
+        let actions = derive_available_actions(&task, std::slice::from_ref(&task));
 
-    let in_progress_actions =
-        derive_available_actions(&in_progress, std::slice::from_ref(&in_progress));
-    let blocked_actions = derive_available_actions(&blocked, std::slice::from_ref(&blocked));
+        assert!(
+            actions.contains(&TaskAction::ResetImplementation),
+            "expected reset implementation for status {}",
+            task.status.as_cli_value()
+        );
+    }
 
-    assert!(in_progress_actions.contains(&TaskAction::ResetImplementation));
-    assert!(!blocked_actions.contains(&TaskAction::ResetImplementation));
+    for status in [
+        TaskStatus::Open,
+        TaskStatus::SpecReady,
+        TaskStatus::ReadyForDev,
+        TaskStatus::Deferred,
+        TaskStatus::Closed,
+    ] {
+        let task = make_task("task-2", "task", status);
+        let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+
+        assert!(
+            !actions.contains(&TaskAction::ResetImplementation),
+            "unexpected reset implementation for status {}",
+            task.status.as_cli_value()
+        );
+    }
 }
 
 #[test]
@@ -317,6 +341,28 @@ fn workflow_contract_set_plan_statuses_match_fixture() {
                 "set_plan mismatch for issue_type={issue_type} status={status}"
             );
         }
+    }
+}
+
+#[test]
+fn workflow_contract_reset_implementation_statuses_match_fixture() {
+    let fixture = load_workflow_contract_fixture();
+    let expected = fixture
+        .reset_implementation_allowed_statuses
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+
+    for status in &fixture.statuses {
+        let parsed_status = parse_status(status);
+        let task = make_task("fixture-task", "task", parsed_status);
+        let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+        let actual_allowed = actions.contains(&TaskAction::ResetImplementation);
+        let expected_allowed = expected.contains(&status.as_str());
+        assert_eq!(
+            actual_allowed, expected_allowed,
+            "reset_implementation mismatch for status={status}"
+        );
     }
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/tests.rs
@@ -353,16 +353,18 @@ fn workflow_contract_reset_implementation_statuses_match_fixture() {
         .map(String::as_str)
         .collect::<Vec<_>>();
 
-    for status in &fixture.statuses {
-        let parsed_status = parse_status(status);
-        let task = make_task("fixture-task", "task", parsed_status);
-        let actions = derive_available_actions(&task, std::slice::from_ref(&task));
-        let actual_allowed = actions.contains(&TaskAction::ResetImplementation);
-        let expected_allowed = expected.contains(&status.as_str());
-        assert_eq!(
-            actual_allowed, expected_allowed,
-            "reset_implementation mismatch for status={status}"
-        );
+    for issue_type in ["epic", "feature", "task", "bug"] {
+        for status in &fixture.statuses {
+            let parsed_status = parse_status(status);
+            let task = make_task("fixture-task", issue_type, parsed_status);
+            let actions = derive_available_actions(&task, std::slice::from_ref(&task));
+            let actual_allowed = actions.contains(&TaskAction::ResetImplementation);
+            let expected_allowed = expected.contains(&status.as_str());
+            assert_eq!(
+                actual_allowed, expected_allowed,
+                "reset_implementation mismatch for issue_type={issue_type} status={status}"
+            );
+        }
     }
 }
 

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/validators.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/validators.rs
@@ -180,7 +180,10 @@ pub(crate) fn derive_available_actions(task: &TaskCard, all_tasks: &[TaskCard]) 
 
     if matches!(
         task.status,
-        TaskStatus::InProgress | TaskStatus::AiReview | TaskStatus::HumanReview
+        TaskStatus::InProgress
+            | TaskStatus::Blocked
+            | TaskStatus::AiReview
+            | TaskStatus::HumanReview
     ) {
         actions.push(TaskAction::ResetImplementation);
     }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/validators.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/workflow_rules/validators.rs
@@ -148,6 +148,16 @@ fn is_qa_rejected_rework(task: &TaskCard) -> bool {
         && task.document_summary.qa_report.verdict == QaWorkflowVerdict::Rejected
 }
 
+pub(crate) fn can_reset_implementation_from_status(status: &TaskStatus) -> bool {
+    matches!(
+        status,
+        TaskStatus::InProgress
+            | TaskStatus::Blocked
+            | TaskStatus::AiReview
+            | TaskStatus::HumanReview
+    )
+}
+
 pub(crate) fn derive_available_actions(task: &TaskCard, all_tasks: &[TaskCard]) -> Vec<TaskAction> {
     let mut actions = vec![TaskAction::ViewDetails];
 
@@ -178,13 +188,7 @@ pub(crate) fn derive_available_actions(task: &TaskCard, all_tasks: &[TaskCard]) 
         actions.push(TaskAction::OpenBuilder);
     }
 
-    if matches!(
-        task.status,
-        TaskStatus::InProgress
-            | TaskStatus::Blocked
-            | TaskStatus::AiReview
-            | TaskStatus::HumanReview
-    ) {
+    if can_reset_implementation_from_status(&task.status) {
         actions.push(TaskAction::ResetImplementation);
     }
 

--- a/apps/desktop/src/components/features/kanban/kanban-task-workflow.test.ts
+++ b/apps/desktop/src/components/features/kanban/kanban-task-workflow.test.ts
@@ -89,6 +89,19 @@ describe("resolveTaskCardActions", () => {
     expect(result.secondaryActions).toContain("reset_implementation");
   });
 
+  test("keeps reset implementation available for blocked tasks", () => {
+    const task = createTaskCardFixture({
+      status: "blocked",
+      issueType: "task",
+      availableActions: ["open_builder", "reset_implementation"],
+    });
+
+    const result = resolveTaskCardActions(task);
+
+    expect(result.primaryAction).toBe("open_builder");
+    expect(result.secondaryActions).toEqual(["reset_implementation"]);
+  });
+
   test("uses qa_start as primary during ai review when available", () => {
     const task = createTaskCardFixture({
       status: "ai_review",

--- a/docs/contracts/workflow-contract-fixture.json
+++ b/docs/contracts/workflow-contract-fixture.json
@@ -88,5 +88,6 @@
     "task": ["open", "spec_ready", "ready_for_dev"],
     "bug": ["open", "spec_ready", "ready_for_dev"]
   },
+  "resetImplementationAllowedStatuses": ["in_progress", "blocked", "ai_review", "human_review"],
   "epicSubtaskReplacementAllowedStatuses": ["open", "spec_ready", "ready_for_dev"]
 }

--- a/docs/task-workflow-actions.md
+++ b/docs/task-workflow-actions.md
@@ -19,6 +19,7 @@ The backend is the single source of truth for which actions are currently allowe
 - `set_plan`
 - `build_start`
 - `open_builder`
+- `reset_implementation`
 - `qa_start`
 - `open_qa`
 - `defer_issue`
@@ -49,6 +50,18 @@ The backend is the single source of truth for which actions are currently allowe
 ### `open_builder`
 - Purpose: open existing builder context/run UX.
 - Transition: none.
+
+### `reset_implementation`
+- Purpose: discard the current implementation attempt and clean up task-owned build/QA state.
+- Transition: `in_progress`, `blocked`, `ai_review`, or `human_review` -> derived rollback target.
+- Rollback target:
+  - `ready_for_dev` when an implementation plan document is retained.
+  - `spec_ready` when only a spec document is retained.
+  - `open` when neither document is retained.
+- Guardrails:
+  - reject while live build or QA activity still exists for the task.
+  - fail if task-owned branch cleanup is unsafe, including checked-out branches.
+  - preserve retained spec and plan documents.
 
 ### `qa_start`
 - Purpose: request or start a QA review loop for the current task state.
@@ -90,6 +103,7 @@ Current card/detail primary+menu rendering uses workflow actions:
 - `set_plan`
 - `build_start`
 - `open_builder`
+- `reset_implementation`
 - `qa_start`
 - `open_qa`
 - `defer_issue`

--- a/docs/task-workflow-transition-matrix.md
+++ b/docs/task-workflow-transition-matrix.md
@@ -38,6 +38,9 @@ Human actions:
 - `defer_issue(taskId, reason?)`
 - `resume_deferred(taskId)`
 
+Native task actions:
+- `reset_implementation(taskId)`
+
 ## Transition Matrix
 | Trigger | From | Guards | To |
 |---|---|---|---|
@@ -49,6 +52,7 @@ Human actions:
 | `odt_build_resumed` | `ready_for_dev` | feature/epic standard flow | `in_progress` |
 | `odt_build_resumed` | `open`, `spec_ready`, `ready_for_dev`, `blocked` | task/bug optional flow + blocked resume | `in_progress` |
 | `odt_build_blocked` | `in_progress` | reason required | `blocked` |
+| `reset_implementation` | `in_progress`, `blocked`, `ai_review`, `human_review` | reject while live build/QA activity exists; reject on unsafe branch cleanup; retained plan/spec determine rollback target | `ready_for_dev`, `spec_ready`, or `open` |
 | `odt_build_completed` | `in_progress` | `qaRequired=true` and latest QA verdict is not `approved` (including no QA verdict yet) | `ai_review` |
 | `odt_build_completed` | `in_progress` | `qaRequired=false` or latest QA verdict is `approved` | `human_review` |
 | `odt_set_pull_request` | `in_progress`, `ai_review`, `human_review` | provider id and PR number required; OpenDucktor resolves canonical PR metadata | unchanged |


### PR DESCRIPTION
## Summary
- allow the native `reset_implementation` flow for `blocked` tasks by extending the backend eligibility and runtime validation gates
- add host/frontend regression coverage plus workflow-contract fixture checks for blocked reset availability, rollback targets, and guardrails
- document the shipped `reset_implementation` action and centralize the reset-status allowlist to keep derivation and validation aligned

## Verification
- `rtk cargo test -p host-application`
- `rtk cargo fmt --all --check`
- `bun test "apps/desktop/src/components/features/kanban/kanban-task-workflow.test.ts"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks with "Blocked" status can now reset their implementation, enabling rollback to prior development states while clearing associated build/QA activity.
  
* **Documentation**
  * Updated workflow documentation to reflect the expanded availability of the reset implementation action and its transition rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->