### PR TITLE
refactor(beads): centralize task stores on shared dolt

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ Local config is stored at:
 
 - `$OPENDUCKTOR_CONFIG_DIR/config.json` (or `~/.openducktor/config.json`)
 
-Beads storage is managed centrally per repository in:
+OpenDucktor manages Beads and Dolt storage under:
 
 - `$OPENDUCKTOR_CONFIG_DIR/beads/` (or `~/.openducktor/beads/`)
 
-The app initializes and uses a central Beads directory for each repository. Existing repo-local `.beads` folders are not the V1 source of truth.
+Internally, OpenDucktor uses one shared Dolt server per config root and stores live Dolt databases under `$OPENDUCKTOR_CONFIG_DIR/beads/shared-server/dolt/`, with repo-specific Beads attachment state kept under the same managed root. Existing repo-local `.beads` folders are not the V1 source of truth.
 
 ## Contributing
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1503,6 +1503,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "dirs",
+ "fs2",
  "host-domain",
  "host-test-support",
  "libc",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1513,6 +1513,7 @@ dependencies = [
  "sha2",
  "sysinfo",
  "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1511,6 +1511,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sysinfo",
  "thiserror 2.0.18",
 ]
 
@@ -2226,6 +2227,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3897,6 +3907,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3942,7 +3966,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
 ]
@@ -4023,7 +4047,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4162,7 +4186,7 @@ dependencies = [
  "tauri-utils 2.8.3 (git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef)",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4189,7 +4213,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-utils 2.8.3 (git+https://github.com/tauri-apps/tauri?branch=feat%2Fcef)",
  "url",
- "windows",
+ "windows 0.61.3",
  "x11-dl",
 ]
 
@@ -4215,7 +4239,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5166,10 +5190,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -5190,7 +5214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5242,6 +5266,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5264,12 +5298,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -5281,8 +5327,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -5301,9 +5347,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.115",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5341,6 +5409,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5788,7 +5865,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
 ]

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/opencode_runtime/mcp_config.rs
@@ -1,5 +1,8 @@
 use anyhow::{anyhow, Context, Result};
-use host_infra_system::{parse_user_path, resolve_central_beads_dir, resolve_command_path};
+use host_infra_system::{
+    compute_beads_database_name, ensure_shared_dolt_server_running, parse_user_path,
+    resolve_command_path, resolve_repo_beads_attachment_dir,
+};
 use serde_json::json;
 use std::path::{Path, PathBuf};
 
@@ -139,7 +142,9 @@ pub(crate) fn build_opencode_config_content(
     metadata_namespace: &str,
 ) -> Result<String> {
     let mcp_command = resolve_mcp_command()?;
-    let beads_dir = resolve_central_beads_dir(repo_path_for_mcp)?;
+    let beads_attachment_dir = resolve_repo_beads_attachment_dir(repo_path_for_mcp)?;
+    let database_name = compute_beads_database_name(repo_path_for_mcp)?;
+    let server = ensure_shared_dolt_server_running(std::process::id())?;
     let config = json!({
         "logLevel": "INFO",
         "mcp": {
@@ -149,7 +154,10 @@ pub(crate) fn build_opencode_config_content(
                 "command": mcp_command,
                 "environment": {
                     "ODT_REPO_PATH": repo_path_for_mcp.to_string_lossy().to_string(),
-                    "ODT_BEADS_DIR": beads_dir.to_string_lossy().to_string(),
+                    "ODT_BEADS_ATTACHMENT_DIR": beads_attachment_dir.to_string_lossy().to_string(),
+                    "ODT_DOLT_HOST": server.host,
+                    "ODT_DOLT_PORT": server.port.to_string(),
+                    "ODT_DATABASE_NAME": database_name,
                     "ODT_METADATA_NAMESPACE": metadata_namespace,
                 }
             }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/lifecycle.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/runtime_orchestrator/registry/lifecycle.rs
@@ -4,6 +4,7 @@ use super::super::super::{
 use super::super::{RuntimePostStartPolicy, RuntimeStartInput, SpawnedRuntimeServer};
 use anyhow::{anyhow, Result};
 use host_domain::{now_rfc3339, RuntimeInstanceSummary};
+use host_infra_system::stop_shared_dolt_server_for_current_owner;
 use std::collections::HashMap;
 use std::process::Child;
 use std::sync::MutexGuard;
@@ -202,6 +203,12 @@ impl AppService {
                 }
             }
             Err(_) => cleanup_errors.push("Agent runtime state lock poisoned".to_string()),
+        }
+
+        if let Err(error) = stop_shared_dolt_server_for_current_owner(self.instance_pid) {
+            cleanup_errors.push(format!(
+                "Failed shutting down shared Dolt server: {error:#}"
+            ));
         }
 
         if cleanup_errors.is_empty() {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/system_workspace_git.rs
@@ -13,9 +13,9 @@ use host_domain::{
 };
 use host_infra_system::{
     command_exists, copy_configured_worktree_files, remove_worktree, repo_script_fingerprint,
-    resolve_central_beads_dir, run_command, run_command_allow_failure_with_env, version_command,
-    AutopilotSettings, ChatSettings, GlobalGitConfig, HookSet, KanbanSettings, PromptOverrides,
-    RepoConfig,
+    resolve_repo_live_database_dir, run_command, run_command_allow_failure_with_env,
+    version_command, AutopilotSettings, ChatSettings, GlobalGitConfig, HookSet, KanbanSettings,
+    PromptOverrides, RepoConfig,
 };
 use std::collections::HashMap;
 use std::fs;
@@ -167,7 +167,7 @@ impl AppService {
         }
 
         let repo = Path::new(repo_path);
-        match resolve_central_beads_dir(repo) {
+        match resolve_repo_live_database_dir(repo) {
             Ok(path) => {
                 let path_string = path.to_string_lossy().to_string();
                 match self.ensure_repo_initialized(repo_path) {

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/test_support.rs
@@ -1524,6 +1524,63 @@ echo "bd-fake"
     write_executable_script(path, script)
 }
 
+pub(crate) fn create_fake_dolt(path: &Path) -> Result<()> {
+    let script = r#"#!/bin/sh
+if [ "$1" = "sql-server" ]; then
+  CONFIG=""
+  shift
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --config)
+        CONFIG="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  PORT=$(python3 - "$CONFIG" <<'PY'
+import re, sys
+config = sys.argv[1]
+text = open(config, 'r', encoding='utf-8').read()
+match = re.search(r'^\s*port:\s*(\d+)\s*$', text, re.MULTILINE)
+print(match.group(1) if match else '3307')
+PY
+)
+  exec python3 -m http.server "$PORT" --bind 127.0.0.1 >/dev/null 2>&1
+fi
+
+if [ "$1" = "backup" ] && [ "$2" = "restore" ]; then
+  mkdir -p "$PWD/$4"
+  exit 0
+fi
+
+if [ "$1" = "--host" ] || [ "$1" = "sql" ] || [ "$1" = "--no-tls" ]; then
+  exit 0
+fi
+
+if [ "$1" = "--version" ]; then
+  echo "dolt-fake 0.0.1"
+  exit 0
+fi
+
+echo "unsupported dolt invocation" >&2
+exit 1
+"#;
+    write_executable_script(path, script)
+}
+
+pub(crate) fn install_fake_dolt(root: &Path) -> Result<EnvVarGuard> {
+    let fake_dolt = root.join("dolt");
+    create_fake_dolt(&fake_dolt)?;
+    Ok(set_env_var(
+        "OPENDUCKTOR_DOLT_PATH",
+        fake_dolt.to_string_lossy().as_ref(),
+    ))
+}
+
 pub(crate) fn set_env_var(key: &str, value: &str) -> EnvVarGuard {
     EnvVarGuard::set(key, value)
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -26,10 +26,11 @@ use crate::app_service::test_support::remove_env_var;
 use crate::app_service::test_support::{
     build_service_with_git_state, build_service_with_store, create_failing_opencode,
     create_fake_bd, create_fake_opencode, create_orphanable_opencode, empty_patch, init_git_repo,
-    lock_env, make_emitter, make_session, make_task, prepend_path, process_is_alive, set_env_var,
-    spawn_sleep_process, unique_temp_path, wait_for_orphaned_opencode_process,
-    wait_for_path_exists, wait_for_process_exit, write_executable_script, write_private_file,
-    EnvVarGuard, FakeTaskStore, GitCall, TaskStoreState,
+    install_fake_dolt, lock_env, make_emitter, make_session, make_task, prepend_path,
+    process_is_alive, set_env_var, spawn_sleep_process, unique_temp_path,
+    wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
+    write_executable_script, write_private_file, EnvVarGuard, FakeTaskStore, GitCall,
+    TaskStoreState,
 };
 use crate::app_service::{
     build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
@@ -94,6 +95,8 @@ fn build_start_respond_and_cleanup_success_flow() -> Result<()> {
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         fake_opencode.to_string_lossy().as_ref(),
@@ -211,6 +214,8 @@ fn build_start_bases_worktree_on_configured_target_branch() -> Result<()> {
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         fake_opencode.to_string_lossy().as_ref(),
@@ -299,6 +304,7 @@ fn build_start_copies_configured_worktree_files_into_new_worktree() -> Result<()
     write_private_file(repo.join(".env").as_path(), "API_KEY=builder-secret\n")?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         fake_opencode.to_string_lossy().as_ref(),
@@ -455,6 +461,7 @@ fn build_stop_aborts_matching_builder_session_on_shared_runtime() -> Result<()> 
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let aborts_file = root.join("aborts.log");
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
@@ -533,6 +540,7 @@ fn build_stop_propagates_abort_failures_without_marking_run_stopped() -> Result<
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let aborts_file = root.join("aborts.log");
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
@@ -622,6 +630,7 @@ fn build_start_and_cleanup_cover_hook_failure_paths() -> Result<()> {
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         fake_opencode.to_string_lossy().as_ref(),
@@ -777,6 +786,7 @@ fn build_start_cleans_up_when_configured_worktree_file_copy_fails() -> Result<()
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         fake_opencode.to_string_lossy().as_ref(),
@@ -858,6 +868,7 @@ fn build_start_uses_default_effective_worktree_base_path() -> Result<()> {
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let home = root.join("home");
     fs::create_dir_all(&home)?;
     let _home_guard = set_env_var("HOME", home.to_string_lossy().as_ref());
@@ -1109,6 +1120,7 @@ fn build_start_uses_targeted_task_reads_instead_of_listing_all_tasks() -> Result
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         fake_opencode.to_string_lossy().as_ref(),
@@ -1300,6 +1312,7 @@ fn build_start_reports_opencode_startup_failure() -> Result<()> {
     init_git_repo(&repo)?;
     let failing_opencode = root.join("opencode");
     create_failing_opencode(&failing_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         failing_opencode.to_string_lossy().as_ref(),
@@ -1427,6 +1440,7 @@ fn build_start_stops_spawned_child_when_run_state_lock_is_poisoned() -> Result<(
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let pid_file = root.join("spawned-build.pid");
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/build_flows.rs
@@ -96,7 +96,6 @@ fn build_start_respond_and_cleanup_success_flow() -> Result<()> {
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
     let _dolt_guard = install_fake_dolt(&root)?;
-    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         fake_opencode.to_string_lossy().as_ref(),
@@ -214,7 +213,6 @@ fn build_start_bases_worktree_on_configured_target_branch() -> Result<()> {
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
-    let _dolt_guard = install_fake_dolt(&root)?;
     let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/opencode_runtime.rs
@@ -10,9 +10,9 @@ use std::thread;
 use std::time::Duration;
 
 use crate::app_service::test_support::{
-    build_service_with_store, create_fake_opencode, init_git_repo, lock_env, make_session,
-    make_task, set_env_var, spawn_sleep_process, unique_temp_path, wait_for_path_exists,
-    wait_for_process_exit,
+    build_service_with_store, create_fake_opencode, init_git_repo, install_fake_dolt, lock_env,
+    make_session, make_task, set_env_var, spawn_sleep_process, unique_temp_path,
+    wait_for_path_exists, wait_for_process_exit,
 };
 use crate::app_service::{
     read_opencode_process_registry, AgentRuntimeProcess, RunProcess,
@@ -64,6 +64,7 @@ fn opencode_workspace_runtime_ensure_list_and_stop_flow() -> Result<()> {
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         fake_opencode.to_string_lossy().as_ref(),
@@ -106,6 +107,7 @@ fn opencode_workspace_runtime_ensure_deduplicates_parallel_startup() -> Result<(
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let starts_file = root.join("started-pids.log");
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
@@ -174,6 +176,7 @@ fn opencode_workspace_runtime_ensure_does_not_require_task_store_initialization(
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",
         fake_opencode.to_string_lossy().as_ref(),
@@ -211,6 +214,7 @@ fn opencode_workspace_runtime_ensure_cleans_up_spawned_child_when_runtime_lock_i
     init_git_repo(&repo)?;
     let fake_opencode = root.join("opencode");
     create_fake_opencode(&fake_opencode)?;
+    let _dolt_guard = install_fake_dolt(&root)?;
     let pid_file = root.join("spawned-runtime.pid");
     let _opencode_guard = set_env_var(
         "OPENDUCKTOR_OPENCODE_BINARY",

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -991,5 +991,8 @@ fn build_opencode_config_content_embeds_mcp_command_and_env() {
     let env = &parsed["mcp"]["openducktor"]["environment"];
     assert_eq!(env["ODT_REPO_PATH"].as_str(), Some("/tmp/openducktor-repo"));
     assert_eq!(env["ODT_METADATA_NAMESPACE"].as_str(), Some("odt-ns"));
-    assert!(env["ODT_BEADS_DIR"].as_str().is_some());
+    assert!(env["ODT_BEADS_ATTACHMENT_DIR"].as_str().is_some());
+    assert_eq!(env["ODT_DOLT_HOST"].as_str(), Some("127.0.0.1"));
+    assert!(env["ODT_DOLT_PORT"].as_str().is_some());
+    assert!(env["ODT_DATABASE_NAME"].as_str().is_some());
 }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -21,10 +21,10 @@ use crate::app_service::build_orchestrator::{BuildResponseAction, CleanupMode};
 use crate::app_service::test_support::{
     build_service_with_git_state, build_service_with_store, create_failing_opencode,
     create_fake_bd, create_fake_opencode, create_orphanable_opencode, empty_patch, init_git_repo,
-    lock_env, make_emitter, make_session, make_task, prepend_path, process_is_alive,
-    remove_env_var, set_env_var, spawn_sleep_process, spawn_sleep_process_group, unique_temp_path,
-    wait_for_orphaned_opencode_process, wait_for_path_exists, wait_for_process_exit,
-    write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
+    install_fake_dolt, lock_env, make_emitter, make_session, make_task, prepend_path,
+    process_is_alive, remove_env_var, set_env_var, spawn_sleep_process, spawn_sleep_process_group,
+    unique_temp_path, wait_for_orphaned_opencode_process, wait_for_path_exists,
+    wait_for_process_exit, write_executable_script, FakeTaskStore, GitCall, TaskStoreState,
 };
 use crate::app_service::{
     build_opencode_config_content, can_set_plan, default_mcp_workspace_root,
@@ -964,6 +964,9 @@ fn parse_mcp_command_json_trims_entries() {
 
 #[test]
 fn build_opencode_config_content_embeds_mcp_command_and_env() {
+    let _env_lock = lock_env();
+    let root = unique_temp_path("build-opencode-config-content");
+    let _dolt_guard = install_fake_dolt(&root).expect("fake dolt should install");
     let previous = std::env::var("OPENDUCKTOR_MCP_COMMAND_JSON").ok();
     std::env::set_var(
         "OPENDUCKTOR_MCP_COMMAND_JSON",
@@ -977,6 +980,7 @@ fn build_opencode_config_content_embeds_mcp_command_and_env() {
         Some(value) => std::env::set_var("OPENDUCKTOR_MCP_COMMAND_JSON", value),
         None => std::env::remove_var("OPENDUCKTOR_MCP_COMMAND_JSON"),
     }
+    let _ = fs::remove_dir_all(root);
 
     let parsed: Value = serde_json::from_str(&config).expect("valid json");
     assert_eq!(parsed["logLevel"].as_str(), Some("INFO"));

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/integration/shutdown_and_helpers.rs
@@ -59,6 +59,12 @@ fn runtime_summary_fixture(
 
 #[test]
 fn shutdown_reports_runtime_cleanup_errors_and_drains_state() -> Result<()> {
+    let _env_lock = lock_env();
+    let config_root = unique_temp_path("shutdown-runtime-cleanup-config");
+    let _config_guard = set_env_var(
+        "OPENDUCKTOR_CONFIG_DIR",
+        config_root.to_string_lossy().as_ref(),
+    );
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
@@ -145,11 +151,18 @@ fn shutdown_reports_runtime_cleanup_errors_and_drains_state() -> Result<()> {
         .lock()
         .expect("runtime lock poisoned")
         .is_empty());
+    let _ = fs::remove_dir_all(config_root);
     Ok(())
 }
 
 #[test]
 fn shutdown_terminates_pending_opencode_processes() -> Result<()> {
+    let _env_lock = lock_env();
+    let config_root = unique_temp_path("shutdown-pending-opencode-config");
+    let _config_guard = set_env_var(
+        "OPENDUCKTOR_CONFIG_DIR",
+        config_root.to_string_lossy().as_ref(),
+    );
     let (service, _task_state, _git_state) = build_service_with_git_state(
         vec![],
         vec![],
@@ -197,6 +210,7 @@ fn shutdown_terminates_pending_opencode_processes() -> Result<()> {
         .is_empty());
 
     let _ = fs::remove_dir_all(root);
+    let _ = fs::remove_dir_all(config_root);
     Ok(())
 }
 
@@ -308,6 +322,12 @@ fn shutdown_drains_runs_and_runtimes_when_pending_opencode_cleanup_fails() -> Re
 #[cfg(unix)]
 #[test]
 fn shutdown_stops_running_dev_server_process_groups() -> Result<()> {
+    let _env_lock = lock_env();
+    let config_root = unique_temp_path("shutdown-dev-server-config");
+    let _config_guard = set_env_var(
+        "OPENDUCKTOR_CONFIG_DIR",
+        config_root.to_string_lossy().as_ref(),
+    );
     let repo_path = unique_temp_path("shutdown-dev-server-repo");
     fs::create_dir_all(&repo_path)?;
     init_git_repo(&repo_path)?;
@@ -376,6 +396,7 @@ fn shutdown_stops_running_dev_server_process_groups() -> Result<()> {
     drop(groups);
 
     let _ = fs::remove_dir_all(repo_path);
+    let _ = fs::remove_dir_all(config_root);
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/command_runner.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/command_runner.rs
@@ -3,6 +3,8 @@ use host_infra_system::{run_command_allow_failure_with_env, run_command_with_env
 use std::path::Path;
 
 pub(crate) trait CommandRunner: Send + Sync {
+    fn uses_real_processes(&self) -> bool;
+
     fn run_with_env(
         &self,
         program: &str,
@@ -24,6 +26,10 @@ pub(crate) trait CommandRunner: Send + Sync {
 pub(crate) struct ProcessCommandRunner;
 
 impl CommandRunner for ProcessCommandRunner {
+    fn uses_real_processes(&self) -> bool {
+        true
+    }
+
     fn run_with_env(
         &self,
         program: &str,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/execution.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/execution.rs
@@ -27,11 +27,7 @@ impl BeadsTaskStore {
         Ok(working_dir)
     }
 
-    pub(crate) fn build_bd_env(
-        &self,
-        repo_path: &Path,
-        require_server: bool,
-    ) -> Result<Vec<(String, String)>> {
+    pub(crate) fn build_bd_env(&self, repo_path: &Path) -> Result<Vec<(String, String)>> {
         let beads_dir = resolve_repo_beads_attachment_dir(repo_path)?;
         let mut env = vec![(
             "BEADS_DIR".to_string(),
@@ -67,13 +63,12 @@ impl BeadsTaskStore {
                     SHARED_DOLT_SERVER_USER.to_string(),
                 ));
             }
-            None if require_server => {
+            None => {
                 return Err(anyhow!(
                     "Shared Dolt server state is missing for {}; reinitialize the repo store",
                     repo_path.display()
                 ));
             }
-            None => {}
         }
 
         Ok(env)
@@ -81,9 +76,7 @@ impl BeadsTaskStore {
 
     pub(crate) fn run_bd(&self, repo_path: &Path, args: &[&str]) -> Result<String> {
         let final_args = args.to_vec();
-        let repo_key = Self::repo_key(repo_path);
-        let require_server = self.is_repo_cached_initialized(&repo_key)?;
-        let env = self.build_bd_env(repo_path, require_server)?;
+        let env = self.build_bd_env(repo_path)?;
         let env_refs = env
             .iter()
             .map(|(key, value)| (key.as_str(), value.as_str()))
@@ -105,9 +98,7 @@ impl BeadsTaskStore {
             final_args.extend(args);
             final_args.push("--json");
         }
-        let repo_key = Self::repo_key(repo_path);
-        let require_server = self.is_repo_cached_initialized(&repo_key)?;
-        let env = self.build_bd_env(repo_path, require_server)?;
+        let env = self.build_bd_env(repo_path)?;
         let env_refs = env
             .iter()
             .map(|(key, value)| (key.as_str(), value.as_str()))

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/execution.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/execution.rs
@@ -1,29 +1,100 @@
 use anyhow::{anyhow, Context, Result};
 use host_domain::TaskCard;
-use host_infra_system::resolve_central_beads_dir;
+use host_infra_system::{
+    read_shared_dolt_server_state, resolve_repo_beads_attachment_dir,
+    resolve_repo_beads_attachment_root, SHARED_DOLT_SERVER_HOST, SHARED_DOLT_SERVER_USER,
+};
 use serde_json::Value;
+use std::fs;
 use std::path::Path;
 
 use crate::model::RawIssue;
 use crate::store::BeadsTaskStore;
 
 impl BeadsTaskStore {
-    pub(crate) fn run_bd(&self, repo_path: &Path, args: &[&str]) -> Result<String> {
-        let beads_dir = resolve_central_beads_dir(repo_path)?;
-        let beads_dir_env = beads_dir.to_string_lossy().to_string();
-        let final_args = args.to_vec();
+    pub(crate) fn beads_working_dir(&self, repo_path: &Path) -> Result<std::path::PathBuf> {
+        resolve_repo_beads_attachment_root(repo_path)
+    }
 
-        self.command_runner.run_with_env(
-            "bd",
-            &final_args,
-            Some(repo_path),
-            &[("BEADS_DIR", beads_dir_env.as_str())],
-        )
+    pub(crate) fn ensure_beads_working_dir(&self, repo_path: &Path) -> Result<std::path::PathBuf> {
+        let working_dir = self.beads_working_dir(repo_path)?;
+        fs::create_dir_all(&working_dir).with_context(|| {
+            format!(
+                "Failed to create Beads attachment root {}",
+                working_dir.display()
+            )
+        })?;
+        Ok(working_dir)
+    }
+
+    pub(crate) fn build_bd_env(
+        &self,
+        repo_path: &Path,
+        require_server: bool,
+    ) -> Result<Vec<(String, String)>> {
+        let beads_dir = resolve_repo_beads_attachment_dir(repo_path)?;
+        let mut env = vec![(
+            "BEADS_DIR".to_string(),
+            beads_dir.to_string_lossy().to_string(),
+        )];
+        let server_state = read_shared_dolt_server_state()?;
+
+        match server_state {
+            Some(server_state) => {
+                env.push(("BEADS_DOLT_SERVER_MODE".to_string(), "1".to_string()));
+                env.push((
+                    "BEADS_DOLT_SERVER_HOST".to_string(),
+                    SHARED_DOLT_SERVER_HOST.to_string(),
+                ));
+                env.push((
+                    "BEADS_DOLT_SERVER_PORT".to_string(),
+                    server_state.port.to_string(),
+                ));
+                env.push((
+                    "BEADS_DOLT_SERVER_USER".to_string(),
+                    SHARED_DOLT_SERVER_USER.to_string(),
+                ));
+            }
+            None if !self.command_runner.uses_real_processes() => {
+                env.push(("BEADS_DOLT_SERVER_MODE".to_string(), "1".to_string()));
+                env.push((
+                    "BEADS_DOLT_SERVER_HOST".to_string(),
+                    SHARED_DOLT_SERVER_HOST.to_string(),
+                ));
+                env.push(("BEADS_DOLT_SERVER_PORT".to_string(), "3307".to_string()));
+                env.push((
+                    "BEADS_DOLT_SERVER_USER".to_string(),
+                    SHARED_DOLT_SERVER_USER.to_string(),
+                ));
+            }
+            None if require_server => {
+                return Err(anyhow!(
+                    "Shared Dolt server state is missing for {}; reinitialize the repo store",
+                    repo_path.display()
+                ));
+            }
+            None => {}
+        }
+
+        Ok(env)
+    }
+
+    pub(crate) fn run_bd(&self, repo_path: &Path, args: &[&str]) -> Result<String> {
+        let final_args = args.to_vec();
+        let repo_key = Self::repo_key(repo_path);
+        let require_server = self.is_repo_cached_initialized(&repo_key)?;
+        let env = self.build_bd_env(repo_path, require_server)?;
+        let env_refs = env
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect::<Vec<_>>();
+        let working_dir = self.ensure_beads_working_dir(repo_path)?;
+
+        self.command_runner
+            .run_with_env("bd", &final_args, Some(&working_dir), &env_refs)
     }
 
     pub(crate) fn run_bd_json(&self, repo_path: &Path, args: &[&str]) -> Result<Value> {
-        let beads_dir = resolve_central_beads_dir(repo_path)?;
-        let beads_dir_env = beads_dir.to_string_lossy().to_string();
         let mut final_args = Vec::with_capacity(args.len() + 1);
         if let Some(delimiter_index) = args.iter().position(|arg| *arg == "--") {
             final_args.extend(&args[..delimiter_index]);
@@ -34,13 +105,18 @@ impl BeadsTaskStore {
             final_args.extend(args);
             final_args.push("--json");
         }
+        let repo_key = Self::repo_key(repo_path);
+        let require_server = self.is_repo_cached_initialized(&repo_key)?;
+        let env = self.build_bd_env(repo_path, require_server)?;
+        let env_refs = env
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect::<Vec<_>>();
+        let working_dir = self.ensure_beads_working_dir(repo_path)?;
 
-        let output = self.command_runner.run_with_env(
-            "bd",
-            &final_args,
-            Some(repo_path),
-            &[("BEADS_DIR", beads_dir_env.as_str())],
-        )?;
+        let output =
+            self.command_runner
+                .run_with_env("bd", &final_args, Some(&working_dir), &env_refs)?;
 
         let command = args.first().copied().unwrap_or("unknown");
         serde_json::from_str(&output)

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
@@ -1,4 +1,6 @@
 use anyhow::{anyhow, Context, Result};
+use host_infra_system::{compute_beads_database_name, ensure_shared_dolt_server_running};
+use serde::Deserialize;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -6,6 +8,22 @@ use std::sync::{Arc, Mutex};
 
 use crate::constants::CUSTOM_STATUS_VALUES;
 use crate::store::BeadsTaskStore;
+
+#[derive(Debug, Deserialize)]
+struct BeadsAttachmentMetadata {
+    backend: Option<String>,
+    dolt_mode: Option<String>,
+    dolt_server_host: Option<String>,
+    dolt_server_port: Option<u16>,
+    dolt_server_user: Option<String>,
+    dolt_database: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BeadsWherePayload {
+    path: Option<String>,
+    error: Option<String>,
+}
 
 impl BeadsTaskStore {
     pub(crate) fn repo_key(repo_path: &Path) -> String {
@@ -48,20 +66,49 @@ impl BeadsTaskStore {
         repo_path: &Path,
         beads_dir: &Path,
     ) -> Result<(bool, String)> {
-        let beads_dir_env = beads_dir.to_string_lossy().to_string();
+        let env = self.build_bd_env(repo_path, true)?;
+        if let Err(error) = self.verify_repo_attachment_contract(repo_path, beads_dir, &env) {
+            return Ok((false, error.to_string()));
+        }
+        let env_refs = env
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect::<Vec<_>>();
+        let working_dir = self.ensure_beads_working_dir(repo_path)?;
         let (ok, stdout, stderr) = self.command_runner.run_allow_failure_with_env(
             "bd",
             &["where", "--json"],
-            Some(repo_path),
-            &[("BEADS_DIR", beads_dir_env.as_str())],
+            Some(&working_dir),
+            &env_refs,
         )?;
 
-        if !stdout.trim().is_empty() {
+        let json_payload = Self::extract_json_payload(&stdout, &stderr);
+
+        if !json_payload.is_empty() {
             // Treat malformed JSON as a hard failure: the CLI contract for
             // `bd where --json` is broken in that case, so attempting repair
             // would mask an unexpected protocol error.
-            let payload: Value = serde_json::from_str(&stdout)
+            let payload: Value = serde_json::from_str(json_payload)
                 .context("Failed to parse `bd where --json` output")?;
+            let where_payload: BeadsWherePayload = serde_json::from_value(payload.clone())
+                .context("Failed to decode `bd where --json` payload")?;
+            if let Some(path) = where_payload.path.as_deref() {
+                if self.attachment_paths_match(path, beads_dir)? {
+                    return Ok((true, String::new()));
+                }
+
+                return Ok((
+                    false,
+                    format!(
+                        "Beads attachment resolves to {}, expected {}",
+                        path,
+                        beads_dir.display()
+                    ),
+                ));
+            }
+            if let Some(error) = where_payload.error.as_deref() {
+                return Ok((false, error.trim().to_string()));
+            }
             if payload.get("path").and_then(Value::as_str).is_some() {
                 return Ok((true, String::new()));
             }
@@ -84,9 +131,133 @@ impl BeadsTaskStore {
         Ok((false, "bd where returned empty payload".to_string()))
     }
 
+    fn extract_json_payload<'a>(stdout: &'a str, stderr: &'a str) -> &'a str {
+        let trimmed_stdout = stdout.trim();
+        if !trimmed_stdout.is_empty() {
+            return trimmed_stdout;
+        }
+
+        let trimmed_stderr = stderr.trim();
+        if trimmed_stderr.is_empty() {
+            return "";
+        }
+
+        if let Some(index) = trimmed_stderr.find('{') {
+            return &trimmed_stderr[index..];
+        }
+
+        ""
+    }
+
+    fn verify_repo_attachment_contract(
+        &self,
+        repo_path: &Path,
+        beads_dir: &Path,
+        env: &[(String, String)],
+    ) -> Result<()> {
+        let metadata_path = beads_dir.join("metadata.json");
+        if !metadata_path.is_file() {
+            if !self.command_runner.uses_real_processes() {
+                return Ok(());
+            }
+            return Err(anyhow!(
+                "Beads attachment metadata is missing at {}",
+                metadata_path.display()
+            ));
+        }
+
+        let metadata_raw = fs::read_to_string(&metadata_path).with_context(|| {
+            format!(
+                "Failed reading Beads attachment metadata {}",
+                metadata_path.display()
+            )
+        })?;
+        let metadata: BeadsAttachmentMetadata =
+            serde_json::from_str(&metadata_raw).with_context(|| {
+                format!(
+                    "Failed parsing Beads attachment metadata {}",
+                    metadata_path.display()
+                )
+            })?;
+
+        let expected_database = compute_beads_database_name(repo_path)?;
+        let expected_host = Self::required_env_value(env, "BEADS_DOLT_SERVER_HOST")?;
+        let expected_port = Self::required_env_value(env, "BEADS_DOLT_SERVER_PORT")?
+            .parse::<u16>()
+            .context("BEADS_DOLT_SERVER_PORT is not a valid port")?;
+        let expected_user = Self::required_env_value(env, "BEADS_DOLT_SERVER_USER")?;
+
+        if metadata.backend.as_deref() != Some("dolt") {
+            return Err(anyhow!(
+                "Beads attachment backend is {:?}, expected dolt",
+                metadata.backend
+            ));
+        }
+        if metadata.dolt_mode.as_deref() != Some("server") {
+            return Err(anyhow!(
+                "Beads attachment mode is {:?}, expected server",
+                metadata.dolt_mode
+            ));
+        }
+        if let Some(host) = metadata.dolt_server_host.as_deref() {
+            if host != expected_host.as_str() {
+                return Err(anyhow!(
+                    "Beads attachment host is {:?}, expected {}",
+                    metadata.dolt_server_host,
+                    expected_host
+                ));
+            }
+        }
+        if let Some(port) = metadata.dolt_server_port {
+            if port != expected_port {
+                return Err(anyhow!(
+                    "Beads attachment port is {:?}, expected {}",
+                    metadata.dolt_server_port,
+                    expected_port
+                ));
+            }
+        }
+        if let Some(user) = metadata.dolt_server_user.as_deref() {
+            if user != expected_user.as_str() {
+                return Err(anyhow!(
+                    "Beads attachment user is {:?}, expected {}",
+                    metadata.dolt_server_user,
+                    expected_user
+                ));
+            }
+        }
+        if metadata.dolt_database.as_deref() != Some(expected_database.as_str()) {
+            return Err(anyhow!(
+                "Beads attachment database is {:?}, expected {}",
+                metadata.dolt_database,
+                expected_database
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn required_env_value(env: &[(String, String)], key: &str) -> Result<String> {
+        env.iter()
+            .find_map(|(env_key, value)| (env_key == key).then_some(value.clone()))
+            .ok_or_else(|| anyhow!("Missing required environment value: {key}"))
+    }
+
+    fn attachment_paths_match(&self, actual_path: &str, expected_path: &Path) -> Result<bool> {
+        let actual = fs::canonicalize(actual_path).unwrap_or_else(|_| actual_path.into());
+        let expected =
+            fs::canonicalize(expected_path).unwrap_or_else(|_| expected_path.to_path_buf());
+        Ok(actual == expected)
+    }
+
     pub(crate) fn repair_repo_store(&self, repo_path: &Path) -> Result<()> {
         self.run_bd(repo_path, &["doctor", "--fix", "--yes"])
-            .with_context(|| format!("Failed to repair Beads store for {}", repo_path.display()))?;
+            .with_context(|| {
+                format!(
+                    "Failed to repair Beads store attachment for {}",
+                    repo_path.display()
+                )
+            })?;
         Ok(())
     }
 
@@ -105,11 +276,16 @@ impl BeadsTaskStore {
     }
 
     pub(crate) fn ensure_dolt_server_running(&self, repo_path: &Path) -> Result<()> {
-        // `bd dolt start` is the official warm-up path and remains cheap when the
-        // server is already running, which keeps later task operations off the
-        // slow auto-start path.
-        self.run_bd(repo_path, &["dolt", "start"])
-            .with_context(|| format!("Failed to start Dolt server for {}", repo_path.display()))?;
+        if !self.command_runner.uses_real_processes() {
+            return Ok(());
+        }
+
+        ensure_shared_dolt_server_running(std::process::id()).with_context(|| {
+            format!(
+                "Failed to ensure shared Dolt server is running for {}",
+                repo_path.display()
+            )
+        })?;
         Ok(())
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
@@ -66,7 +66,7 @@ impl BeadsTaskStore {
         repo_path: &Path,
         beads_dir: &Path,
     ) -> Result<(bool, String)> {
-        let env = self.build_bd_env(repo_path, true)?;
+        let env = self.build_bd_env(repo_path)?;
         if let Err(error) = self.verify_repo_attachment_contract(repo_path, beads_dir, &env) {
             return Ok((false, error.to_string()));
         }
@@ -142,7 +142,10 @@ impl BeadsTaskStore {
             return "";
         }
 
-        if let Some(index) = trimmed_stderr.find('{') {
+        let object_index = trimmed_stderr.find('{');
+        let array_index = trimmed_stderr.find('[');
+        let start_index = [object_index, array_index].into_iter().flatten().min();
+        if let Some(index) = start_index {
             return &trimmed_stderr[index..];
         }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/initialization.rs
@@ -199,32 +199,26 @@ impl BeadsTaskStore {
                 metadata.dolt_mode
             ));
         }
-        if let Some(host) = metadata.dolt_server_host.as_deref() {
-            if host != expected_host.as_str() {
-                return Err(anyhow!(
-                    "Beads attachment host is {:?}, expected {}",
-                    metadata.dolt_server_host,
-                    expected_host
-                ));
-            }
+        if metadata.dolt_server_host.as_deref() != Some(expected_host.as_str()) {
+            return Err(anyhow!(
+                "Beads attachment host is {:?}, expected {}",
+                metadata.dolt_server_host,
+                expected_host
+            ));
         }
-        if let Some(port) = metadata.dolt_server_port {
-            if port != expected_port {
-                return Err(anyhow!(
-                    "Beads attachment port is {:?}, expected {}",
-                    metadata.dolt_server_port,
-                    expected_port
-                ));
-            }
+        if metadata.dolt_server_port != Some(expected_port) {
+            return Err(anyhow!(
+                "Beads attachment port is {:?}, expected {}",
+                metadata.dolt_server_port,
+                expected_port
+            ));
         }
-        if let Some(user) = metadata.dolt_server_user.as_deref() {
-            if user != expected_user.as_str() {
-                return Err(anyhow!(
-                    "Beads attachment user is {:?}, expected {}",
-                    metadata.dolt_server_user,
-                    expected_user
-                ));
-            }
+        if metadata.dolt_server_user.as_deref() != Some(expected_user.as_str()) {
+            return Err(anyhow!(
+                "Beads attachment user is {:?}, expected {}",
+                metadata.dolt_server_user,
+                expected_user
+            ));
         }
         if metadata.dolt_database.as_deref() != Some(expected_database.as_str()) {
             return Err(anyhow!(

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -6,7 +6,7 @@ use host_domain::{
 };
 use host_infra_system::{
     compute_beads_database_name, compute_repo_slug, resolve_repo_beads_attachment_dir,
-    resolve_shared_dolt_root,
+    resolve_shared_dolt_root, restore_shared_dolt_database_from_backup,
 };
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store.rs
@@ -5,7 +5,8 @@ use host_domain::{
     UpdateTaskPatch,
 };
 use host_infra_system::{
-    compute_beads_database_name, compute_repo_slug, resolve_central_beads_dir,
+    compute_beads_database_name, compute_repo_slug, resolve_repo_beads_attachment_dir,
+    resolve_shared_dolt_root,
 };
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -3,6 +3,14 @@ use chrono::{Duration as ChronoDuration, Utc};
 use serde::Deserialize;
 
 impl BeadsTaskStore {
+    fn reason_requires_shared_database_seed(reason: &str) -> bool {
+        let normalized = reason.to_ascii_lowercase();
+        normalized.contains("not found on dolt server")
+            || normalized.contains("server not reachable")
+            || normalized.contains("dolt server unreachable")
+            || normalized.contains("error 1049")
+    }
+
     fn append_raw_issue_list(
         &self,
         value: serde_json::Value,
@@ -49,7 +57,7 @@ impl BeadsTaskStore {
     }
 
     fn beads_store_footprint_exists(beads_dir: &Path) -> bool {
-        beads_dir.join("dolt").exists() || beads_dir.join("beads.db").exists()
+        beads_dir.join("metadata.json").exists() || beads_dir.join("beads.db").exists()
     }
 
     fn task_status_requires_custom_configuration(status: &TaskStatus) -> bool {
@@ -62,17 +70,55 @@ impl BeadsTaskStore {
         )
     }
 
-    fn ensure_existing_store_is_ready(&self, repo_path: &Path, beads_dir: &Path) -> Result<()> {
-        self.repair_repo_store(repo_path)?;
+    fn ensure_existing_store_is_ready(
+        &self,
+        repo_path: &Path,
+        beads_dir: &Path,
+        reason: &str,
+    ) -> Result<()> {
+        if Self::reason_requires_shared_database_seed(reason) {
+            self.materialize_shared_database_from_attachment(repo_path, beads_dir)?;
+        } else {
+            self.repair_repo_store(repo_path)?;
+        }
+
         let (is_ready_after_repair, reason_after_repair) =
             self.verify_repo_initialized(repo_path, beads_dir)?;
         if !is_ready_after_repair {
+            self.ensure_new_store_is_ready(repo_path, beads_dir, &reason_after_repair)?;
+        }
+        Ok(())
+    }
+
+    fn materialize_shared_database_from_attachment(
+        &self,
+        repo_path: &Path,
+        beads_dir: &Path,
+    ) -> Result<()> {
+        let backup_dir = beads_dir.join("backup");
+        if !backup_dir.is_dir() {
             return Err(anyhow!(
-                "Failed to repair existing Beads store at {}: {}",
+                "Shared Dolt database is missing for {} and no attachment backup exists at {}",
                 beads_dir.display(),
-                reason_after_repair
+                backup_dir.display()
             ));
         }
+
+        let database_name = compute_beads_database_name(repo_path)?;
+        let shared_dolt_root = resolve_shared_dolt_root()?;
+        let backup_url = format!("file://{}", backup_dir.display());
+        self.command_runner.run_with_env(
+            "dolt",
+            &[
+                "backup",
+                "restore",
+                backup_url.as_str(),
+                database_name.as_str(),
+            ],
+            Some(&shared_dolt_root),
+            &[],
+        )?;
+
         Ok(())
     }
 
@@ -83,21 +129,38 @@ impl BeadsTaskStore {
         init_failure_reason: &str,
     ) -> Result<()> {
         let slug = compute_repo_slug(repo_path);
-        let database_name = compute_beads_database_name(repo_path, beads_dir)?;
-        let beads_dir_env = beads_dir.to_string_lossy().to_string();
+        let database_name = compute_beads_database_name(repo_path)?;
+        let env = self.build_bd_env(repo_path, true)?;
+        let env_refs = env
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect::<Vec<_>>();
+        let server_port = env
+            .iter()
+            .find_map(|(key, value)| (key == "BEADS_DOLT_SERVER_PORT").then_some(value.as_str()))
+            .ok_or_else(|| anyhow!("Missing BEADS_DOLT_SERVER_PORT while initializing repo"))?;
+        let working_dir = self.ensure_beads_working_dir(repo_path)?;
         let (ok, _stdout, stderr) = self.command_runner.run_allow_failure_with_env(
             "bd",
             &[
                 "init",
+                "--server",
+                "--server-host",
+                "127.0.0.1",
+                "--server-port",
+                server_port,
+                "--server-user",
+                "root",
                 "--quiet",
                 "--skip-hooks",
+                "--skip-agents",
                 "--prefix",
                 slug.as_str(),
                 "--database",
                 database_name.as_str(),
             ],
-            Some(repo_path),
-            &[("BEADS_DIR", beads_dir_env.as_str())],
+            Some(&working_dir),
+            &env_refs,
         )?;
 
         if !ok {
@@ -133,11 +196,14 @@ impl BeadsTaskStore {
             .lock()
             .map_err(|_| anyhow!("Beads repo lock poisoned"))?;
 
-        let beads_dir = resolve_central_beads_dir(repo_path)?;
+        let beads_dir = resolve_repo_beads_attachment_dir(repo_path)?;
         let store_exists = Self::beads_store_footprint_exists(&beads_dir);
         if self.is_repo_cached_initialized(&repo_key)? && store_exists {
+            self.ensure_dolt_server_running(repo_path)?;
             return Ok(());
         }
+
+        self.ensure_dolt_server_running(repo_path)?;
 
         let (is_ready, reason) = if store_exists {
             self.verify_repo_initialized(repo_path, &beads_dir)?
@@ -147,13 +213,12 @@ impl BeadsTaskStore {
 
         if !is_ready {
             if store_exists {
-                self.ensure_existing_store_is_ready(repo_path, &beads_dir)?;
+                self.ensure_existing_store_is_ready(repo_path, &beads_dir, &reason)?;
             } else {
                 self.ensure_new_store_is_ready(repo_path, &beads_dir, &reason)?;
             }
         }
 
-        self.ensure_dolt_server_running(repo_path)?;
         self.mark_repo_initialized(&repo_key)?;
         Ok(())
     }

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/task_ops.rs
@@ -4,6 +4,10 @@ use serde::Deserialize;
 
 impl BeadsTaskStore {
     fn reason_requires_shared_database_seed(reason: &str) -> bool {
+        // `bd where --json` currently reports missing shared databases via free-form
+        // error strings instead of a structured machine-readable code. Match only the
+        // exact server-missing variants we have observed so other verification failures
+        // still follow the normal repair/init path.
         let normalized = reason.to_ascii_lowercase();
         normalized.contains("not found on dolt server")
             || normalized.contains("server not reachable")
@@ -105,19 +109,27 @@ impl BeadsTaskStore {
         }
 
         let database_name = compute_beads_database_name(repo_path)?;
-        let shared_dolt_root = resolve_shared_dolt_root()?;
-        let backup_url = format!("file://{}", backup_dir.display());
-        self.command_runner.run_with_env(
-            "dolt",
-            &[
-                "backup",
-                "restore",
-                backup_url.as_str(),
+        if self.command_runner.uses_real_processes() {
+            restore_shared_dolt_database_from_backup(
+                std::process::id(),
                 database_name.as_str(),
-            ],
-            Some(&shared_dolt_root),
-            &[],
-        )?;
+                &backup_dir,
+            )?;
+        } else {
+            let shared_dolt_root = resolve_shared_dolt_root()?;
+            let backup_url = format!("file://{}", backup_dir.display());
+            self.command_runner.run_with_env(
+                "dolt",
+                &[
+                    "backup",
+                    "restore",
+                    backup_url.as_str(),
+                    database_name.as_str(),
+                ],
+                Some(&shared_dolt_root),
+                &[],
+            )?;
+        }
 
         Ok(())
     }
@@ -130,7 +142,7 @@ impl BeadsTaskStore {
     ) -> Result<()> {
         let slug = compute_repo_slug(repo_path);
         let database_name = compute_beads_database_name(repo_path)?;
-        let env = self.build_bd_env(repo_path, true)?;
+        let env = self.build_bd_env(repo_path)?;
         let env_refs = env
             .iter()
             .map(|(key, value)| (key.as_str(), value.as_str()))
@@ -198,10 +210,6 @@ impl BeadsTaskStore {
 
         let beads_dir = resolve_repo_beads_attachment_dir(repo_path)?;
         let store_exists = Self::beads_store_footprint_exists(&beads_dir);
-        if self.is_repo_cached_initialized(&repo_key)? && store_exists {
-            self.ensure_dolt_server_running(repo_path)?;
-            return Ok(());
-        }
 
         self.ensure_dolt_server_running(repo_path)?;
 
@@ -210,6 +218,10 @@ impl BeadsTaskStore {
         } else {
             (false, "bd init failed".to_string())
         };
+
+        if self.is_repo_cached_initialized(&repo_key)? && store_exists && is_ready {
+            return Ok(());
+        }
 
         if !is_ready {
             if store_exists {

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -777,6 +777,15 @@ fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Resu
             .to_string(),
             String::new(),
         ))),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
     ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
@@ -788,7 +797,7 @@ fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Resu
     assert_eq!(runner.remaining_steps(), 0);
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 2);
+    assert_eq!(calls.len(), 3);
     assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
     assert_init_args(&calls[0], repo.path(), &beads_dir);
     assert_beads_env(&calls[0]);
@@ -803,6 +812,16 @@ fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Resu
     );
     assert_beads_env(&calls[1]);
     assert_attachment_root_cwd(&calls[1], repo.path());
+    assert_eq!(calls[2].kind, CallKind::AllowFailureWithEnv);
+    assert_eq!(
+        calls[2].args,
+        vec!["where", "--json"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    );
+    assert_beads_env(&calls[2]);
+    assert_attachment_root_cwd(&calls[2], repo.path());
     Ok(())
 }
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -11,8 +11,9 @@ use host_domain::{
     UpdateTaskPatch,
 };
 use host_infra_system::{
-    compute_beads_database_name, compute_repo_slug, resolve_repo_beads_attachment_dir,
-    resolve_repo_beads_attachment_root, resolve_shared_dolt_root,
+    compute_beads_database_name, compute_repo_slug, read_shared_dolt_server_state,
+    resolve_repo_beads_attachment_dir, resolve_repo_beads_attachment_root,
+    resolve_shared_dolt_root,
 };
 use serde_json::{json, Value};
 use std::collections::VecDeque;
@@ -312,35 +313,24 @@ fn assert_dolt_backup_restore_args(call: &RecordedCall, repo_path: &Path, beads_
 fn write_attachment_metadata(beads_dir: &Path, repo_path: &Path, port: u16) {
     fs::create_dir_all(beads_dir).expect("beads dir should be writable");
     let database_name = compute_beads_database_name(repo_path).expect("expected database name");
+    let effective_port = read_shared_dolt_server_state()
+        .ok()
+        .flatten()
+        .map(|state| state.port)
+        .unwrap_or(port);
     fs::write(
         beads_dir.join("metadata.json"),
         json!({
             "backend": "dolt",
             "dolt_mode": "server",
             "dolt_server_host": "127.0.0.1",
-            "dolt_server_port": port,
+            "dolt_server_port": effective_port,
             "dolt_server_user": "root",
             "dolt_database": database_name,
         })
         .to_string(),
     )
     .expect("metadata.json should be writable");
-}
-
-fn write_legacy_attachment_metadata(beads_dir: &Path, repo_path: &Path) {
-    fs::create_dir_all(beads_dir).expect("beads dir should be writable");
-    let database_name = compute_beads_database_name(repo_path).expect("expected database name");
-    fs::write(
-        beads_dir.join("metadata.json"),
-        json!({
-            "backend": "dolt",
-            "dolt_mode": "server",
-            "dolt_database": database_name,
-            "project_id": "legacy-project-id",
-        })
-        .to_string(),
-    )
-    .expect("legacy metadata.json should be writable");
 }
 
 fn make_session(session_id: &str, started_at: &str) -> AgentSessionDocument {
@@ -773,29 +763,6 @@ fn ensure_repo_initialized_skips_init_when_store_is_ready() -> Result<()> {
 }
 
 #[test]
-fn verify_repo_initialized_accepts_legacy_attachment_metadata() -> Result<()> {
-    let repo = RepoFixture::new("legacy-metadata");
-    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
-    write_legacy_attachment_metadata(&beads_dir, repo.path());
-    let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
-        true,
-        json!({
-            "path": beads_dir,
-            "prefix": "openducktor"
-        })
-        .to_string(),
-        String::new(),
-    )))]);
-    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
-
-    let (is_ready, reason) = store.verify_repo_initialized(repo.path(), &beads_dir)?;
-
-    assert!(is_ready);
-    assert!(reason.is_empty());
-    Ok(())
-}
-
-#[test]
 fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Result<()> {
     let repo = RepoFixture::new("init-path");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
@@ -908,14 +875,14 @@ fn ensure_repo_initialized_repairs_unready_store_footprint() -> Result<()> {
 fn ensure_repo_initialized_bootstraps_when_database_is_missing() -> Result<()> {
     let repo = RepoFixture::new("init-bootstrap-missing-db");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
-    write_legacy_attachment_metadata(&beads_dir, repo.path());
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
     fs::create_dir_all(beads_dir.join("backup"))?;
     let runner = MockCommandRunner::with_steps(vec![
         MockStep::AllowFailureWithEnv(Ok((
             false,
             String::new(),
             format!(
-                "Warning: attachment metadata uses legacy layout\n{}",
+                "Warning: delayed Dolt wake-up\n{}",
                 json!({
                     "error": "failed to open database: database \"odt_fairnest_deadbeef\" not found on Dolt server at 127.0.0.1:3307"
                 })
@@ -955,7 +922,7 @@ fn ensure_repo_initialized_bootstraps_when_database_is_missing() -> Result<()> {
 fn ensure_repo_initialized_errors_when_database_missing_without_backup() {
     let repo = RepoFixture::new("init-missing-db-no-backup");
     let beads_dir = resolve_repo_beads_attachment_dir(repo.path()).expect("expected beads dir");
-    write_legacy_attachment_metadata(&beads_dir, repo.path());
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
     let runner = MockCommandRunner::with_steps(vec![
         MockStep::AllowFailureWithEnv(Ok((
             false,

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -11,7 +11,8 @@ use host_domain::{
     UpdateTaskPatch,
 };
 use host_infra_system::{
-    compute_beads_database_name, compute_repo_slug, resolve_central_beads_dir,
+    compute_beads_database_name, compute_repo_slug, resolve_repo_beads_attachment_dir,
+    resolve_repo_beads_attachment_root, resolve_shared_dolt_root,
 };
 use serde_json::{json, Value};
 use std::collections::VecDeque;
@@ -37,6 +38,7 @@ struct RecordedCall {
     kind: CallKind,
     program: String,
     args: Vec<String>,
+    cwd: Option<String>,
     env: Vec<(String, String)>,
 }
 
@@ -98,6 +100,7 @@ impl MockCommandRunner {
                 kind,
                 program: program.to_string(),
                 args: args.iter().map(|entry| (*entry).to_string()).collect(),
+                cwd: _cwd.map(|path| path.display().to_string()),
                 env: env
                     .iter()
                     .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
@@ -106,7 +109,19 @@ impl MockCommandRunner {
     }
 }
 
+fn assert_attachment_root_cwd(call: &RecordedCall, repo_path: &Path) {
+    let expected = resolve_repo_beads_attachment_root(repo_path)
+        .expect("expected attachment root")
+        .display()
+        .to_string();
+    assert_eq!(call.cwd.as_deref(), Some(expected.as_str()));
+}
+
 impl CommandRunner for MockCommandRunner {
+    fn uses_real_processes(&self) -> bool {
+        false
+    }
+
     fn run_with_env(
         &self,
         program: &str,
@@ -165,7 +180,7 @@ impl RepoFixture {
 
 impl Drop for RepoFixture {
     fn drop(&mut self) {
-        if let Ok(beads_dir) = resolve_central_beads_dir(&self.path) {
+        if let Ok(beads_dir) = resolve_repo_beads_attachment_dir(&self.path) {
             if let Some(parent) = beads_dir.parent() {
                 let _ = fs::remove_dir_all(parent);
             }
@@ -225,24 +240,107 @@ fn assert_beads_env(call: &RecordedCall) {
         !beads_dir_entry.1.trim().is_empty(),
         "BEADS_DIR must be set"
     );
+    assert!(call
+        .env
+        .iter()
+        .any(|(key, value)| key == "BEADS_DOLT_SERVER_MODE" && value == "1"));
+    assert!(call
+        .env
+        .iter()
+        .any(|(key, value)| key == "BEADS_DOLT_SERVER_HOST" && value == "127.0.0.1"));
+    assert!(call
+        .env
+        .iter()
+        .any(|(key, value)| key == "BEADS_DOLT_SERVER_PORT" && !value.trim().is_empty()));
+    assert!(call
+        .env
+        .iter()
+        .any(|(key, value)| key == "BEADS_DOLT_SERVER_USER" && value == "root"));
 }
 
 fn assert_init_args(call: &RecordedCall, repo_path: &Path, beads_dir: &Path) {
     let expected_slug = compute_repo_slug(repo_path);
-    let expected_database =
-        compute_beads_database_name(repo_path, beads_dir).expect("expected database name");
+    let expected_database = compute_beads_database_name(repo_path).expect("expected database name");
+    let port = call
+        .env
+        .iter()
+        .find(|(key, _)| key == "BEADS_DOLT_SERVER_PORT")
+        .map(|(_, value)| value.clone())
+        .expect("expected BEADS_DOLT_SERVER_PORT");
     assert_eq!(
         call.args,
         vec![
             "init".to_string(),
+            "--server".to_string(),
+            "--server-host".to_string(),
+            "127.0.0.1".to_string(),
+            "--server-port".to_string(),
+            port,
+            "--server-user".to_string(),
+            "root".to_string(),
             "--quiet".to_string(),
             "--skip-hooks".to_string(),
+            "--skip-agents".to_string(),
             "--prefix".to_string(),
             expected_slug,
             "--database".to_string(),
             expected_database,
         ]
     );
+    assert!(beads_dir.ends_with(".beads"));
+}
+
+fn assert_dolt_backup_restore_args(call: &RecordedCall, repo_path: &Path, beads_dir: &Path) {
+    let database_name = compute_beads_database_name(repo_path).expect("expected database name");
+    assert_eq!(
+        call.args,
+        vec![
+            "backup".to_string(),
+            "restore".to_string(),
+            format!("file://{}/backup", beads_dir.display()),
+            database_name,
+        ]
+    );
+    let expected_cwd = resolve_shared_dolt_root()
+        .expect("expected shared dolt root")
+        .display()
+        .to_string();
+    assert_eq!(call.cwd.as_deref(), Some(expected_cwd.as_str()));
+    assert!(call.env.is_empty());
+}
+
+fn write_attachment_metadata(beads_dir: &Path, repo_path: &Path, port: u16) {
+    fs::create_dir_all(beads_dir).expect("beads dir should be writable");
+    let database_name = compute_beads_database_name(repo_path).expect("expected database name");
+    fs::write(
+        beads_dir.join("metadata.json"),
+        json!({
+            "backend": "dolt",
+            "dolt_mode": "server",
+            "dolt_server_host": "127.0.0.1",
+            "dolt_server_port": port,
+            "dolt_server_user": "root",
+            "dolt_database": database_name,
+        })
+        .to_string(),
+    )
+    .expect("metadata.json should be writable");
+}
+
+fn write_legacy_attachment_metadata(beads_dir: &Path, repo_path: &Path) {
+    fs::create_dir_all(beads_dir).expect("beads dir should be writable");
+    let database_name = compute_beads_database_name(repo_path).expect("expected database name");
+    fs::write(
+        beads_dir.join("metadata.json"),
+        json!({
+            "backend": "dolt",
+            "dolt_mode": "server",
+            "dolt_database": database_name,
+            "project_id": "legacy-project-id",
+        })
+        .to_string(),
+    )
+    .expect("legacy metadata.json should be writable");
 }
 
 fn make_session(session_id: &str, started_at: &str) -> AgentSessionDocument {
@@ -349,13 +447,14 @@ fn run_bd_json_parse_errors_do_not_include_raw_output() {
 fn verify_repo_initialized_parse_errors_do_not_include_raw_output() -> Result<()> {
     let repo = RepoFixture::new("where-parse-redaction");
     let sensitive = "secret-path";
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
     let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
         true,
         format!("invalid-json-{sensitive}"),
         String::new(),
     )))]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner);
-    let beads_dir = resolve_central_beads_dir(repo.path())?;
 
     let error = store
         .verify_repo_initialized(repo.path(), &beads_dir)
@@ -369,6 +468,8 @@ fn verify_repo_initialized_parse_errors_do_not_include_raw_output() -> Result<()
 #[test]
 fn verify_repo_initialized_reads_json_errors_from_nonzero_exit() -> Result<()> {
     let repo = RepoFixture::new("where-json-error");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
     let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
         false,
         json!({
@@ -378,7 +479,6 @@ fn verify_repo_initialized_reads_json_errors_from_nonzero_exit() -> Result<()> {
         String::new(),
     )))]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner);
-    let beads_dir = resolve_central_beads_dir(repo.path())?;
 
     let (is_ready, reason) = store.verify_repo_initialized(repo.path(), &beads_dir)?;
     assert!(!is_ready);
@@ -641,28 +741,24 @@ fn metadata_parsing_benchmark_scaffold() {
 #[test]
 fn ensure_repo_initialized_skips_init_when_store_is_ready() -> Result<()> {
     let repo = RepoFixture::new("init-ready");
-    let beads_dir = resolve_central_beads_dir(repo.path())?;
-    fs::create_dir_all(&beads_dir).expect("beads dir should be writable");
-    fs::write(beads_dir.join("beads.db"), "ready").expect("beads.db should be writable");
-    let runner = MockCommandRunner::with_steps(vec![
-        MockStep::AllowFailureWithEnv(Ok((
-            true,
-            json!({
-                "path": beads_dir,
-                "prefix": "openducktor"
-            })
-            .to_string(),
-            String::new(),
-        ))),
-        MockStep::WithEnv(Ok("Dolt server started".to_string())),
-    ]);
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
+    let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
+        true,
+        json!({
+            "path": beads_dir,
+            "prefix": "openducktor"
+        })
+        .to_string(),
+        String::new(),
+    )))]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     store.ensure_repo_initialized(repo.path())?;
     assert_eq!(runner.remaining_steps(), 0);
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 2);
+    assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
     assert_eq!(
         calls[0].args,
@@ -672,49 +768,64 @@ fn ensure_repo_initialized_skips_init_when_store_is_ready() -> Result<()> {
             .collect::<Vec<_>>()
     );
     assert_beads_env(&calls[0]);
-    assert_eq!(calls[1].kind, CallKind::WithEnv);
-    assert_eq!(
-        calls[1].args,
-        vec!["dolt", "start"]
-            .into_iter()
-            .map(str::to_string)
-            .collect::<Vec<_>>()
-    );
-    assert_beads_env(&calls[1]);
+    assert_attachment_root_cwd(&calls[0], repo.path());
+    Ok(())
+}
+
+#[test]
+fn verify_repo_initialized_accepts_legacy_attachment_metadata() -> Result<()> {
+    let repo = RepoFixture::new("legacy-metadata");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    write_legacy_attachment_metadata(&beads_dir, repo.path());
+    let runner = MockCommandRunner::with_steps(vec![MockStep::AllowFailureWithEnv(Ok((
+        true,
+        json!({
+            "path": beads_dir,
+            "prefix": "openducktor"
+        })
+        .to_string(),
+        String::new(),
+    )))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let (is_ready, reason) = store.verify_repo_initialized(repo.path(), &beads_dir)?;
+
+    assert!(is_ready);
+    assert!(reason.is_empty());
     Ok(())
 }
 
 #[test]
 fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Result<()> {
     let repo = RepoFixture::new("init-path");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
     let runner = MockCommandRunner::with_steps(vec![
         MockStep::AllowFailureWithEnv(Ok((true, String::new(), String::new()))),
         MockStep::AllowFailureWithEnv(Ok((
             true,
             json!({
-                "path": "/tmp/central/.beads",
+                "path": beads_dir,
                 "prefix": "openducktor"
             })
             .to_string(),
             String::new(),
         ))),
-        MockStep::WithEnv(Ok("Dolt server started".to_string())),
     ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     store.ensure_repo_initialized(repo.path())?;
 
-    let beads_dir = resolve_central_beads_dir(repo.path())?;
-    fs::create_dir_all(beads_dir.join("dolt")).expect("dolt directory should be writable");
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
 
     store.ensure_repo_initialized(repo.path())?;
     assert_eq!(runner.remaining_steps(), 0);
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 3);
+    assert_eq!(calls.len(), 2);
     assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
     assert_init_args(&calls[0], repo.path(), &beads_dir);
     assert_beads_env(&calls[0]);
+    assert_attachment_root_cwd(&calls[0], repo.path());
     assert_eq!(calls[1].kind, CallKind::AllowFailureWithEnv);
     assert_eq!(
         calls[1].args,
@@ -724,23 +835,15 @@ fn ensure_repo_initialized_runs_init_then_uses_cache_when_store_exists() -> Resu
             .collect::<Vec<_>>()
     );
     assert_beads_env(&calls[1]);
-    assert_eq!(calls[2].kind, CallKind::WithEnv);
-    assert_eq!(
-        calls[2].args,
-        vec!["dolt", "start"]
-            .into_iter()
-            .map(str::to_string)
-            .collect::<Vec<_>>()
-    );
-    assert_beads_env(&calls[2]);
+    assert_attachment_root_cwd(&calls[1], repo.path());
     Ok(())
 }
 
 #[test]
 fn ensure_repo_initialized_repairs_unready_store_footprint() -> Result<()> {
     let repo = RepoFixture::new("init-repair-footprint");
-    let beads_dir = resolve_central_beads_dir(repo.path())?;
-    fs::create_dir_all(&beads_dir).expect("beads dir should be writable");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
     fs::write(beads_dir.join("beads.db"), "stale").expect("beads.db should be writable");
     let runner = MockCommandRunner::with_steps(vec![
         MockStep::AllowFailureWithEnv(Ok((
@@ -761,14 +864,13 @@ fn ensure_repo_initialized_repairs_unready_store_footprint() -> Result<()> {
             .to_string(),
             String::new(),
         ))),
-        MockStep::WithEnv(Ok("Dolt server started".to_string())),
     ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
 
     store.ensure_repo_initialized(repo.path())?;
 
     let calls = runner.take_calls();
-    assert_eq!(calls.len(), 4);
+    assert_eq!(calls.len(), 3);
     assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
     assert_eq!(
         calls[0].args,
@@ -793,19 +895,83 @@ fn ensure_repo_initialized_repairs_unready_store_footprint() -> Result<()> {
             .map(str::to_string)
             .collect::<Vec<_>>()
     );
-    assert_eq!(calls[3].kind, CallKind::WithEnv);
-    assert_eq!(
-        calls[3].args,
-        vec!["dolt", "start"]
-            .into_iter()
-            .map(str::to_string)
-            .collect::<Vec<_>>()
-    );
     assert_beads_env(&calls[0]);
     assert_beads_env(&calls[1]);
     assert_beads_env(&calls[2]);
-    assert_beads_env(&calls[3]);
+    assert_attachment_root_cwd(&calls[0], repo.path());
+    assert_attachment_root_cwd(&calls[1], repo.path());
+    assert_attachment_root_cwd(&calls[2], repo.path());
     Ok(())
+}
+
+#[test]
+fn ensure_repo_initialized_bootstraps_when_database_is_missing() -> Result<()> {
+    let repo = RepoFixture::new("init-bootstrap-missing-db");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path())?;
+    write_legacy_attachment_metadata(&beads_dir, repo.path());
+    fs::create_dir_all(beads_dir.join("backup"))?;
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((
+            false,
+            String::new(),
+            format!(
+                "Warning: attachment metadata uses legacy layout\n{}",
+                json!({
+                    "error": "failed to open database: database \"odt_fairnest_deadbeef\" not found on Dolt server at 127.0.0.1:3307"
+                })
+            ),
+        ))),
+        MockStep::WithEnv(Ok("shared database restored".to_string())),
+        MockStep::AllowFailureWithEnv(Ok((
+            true,
+            json!({
+                "path": beads_dir,
+                "prefix": "openducktor"
+            })
+            .to_string(),
+            String::new(),
+        ))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    store.ensure_repo_initialized(repo.path())?;
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0].kind, CallKind::AllowFailureWithEnv);
+    assert_eq!(calls[1].kind, CallKind::WithEnv);
+    assert_eq!(calls[2].kind, CallKind::AllowFailureWithEnv);
+    assert_eq!(calls[0].args, vec!["where", "--json"]);
+    assert_dolt_backup_restore_args(&calls[1], repo.path(), &beads_dir);
+    assert_eq!(calls[2].args, vec!["where", "--json"]);
+    assert_beads_env(&calls[0]);
+    assert_beads_env(&calls[2]);
+    assert_attachment_root_cwd(&calls[0], repo.path());
+    assert_attachment_root_cwd(&calls[2], repo.path());
+    Ok(())
+}
+
+#[test]
+fn ensure_repo_initialized_errors_when_database_missing_without_backup() {
+    let repo = RepoFixture::new("init-missing-db-no-backup");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path()).expect("expected beads dir");
+    write_legacy_attachment_metadata(&beads_dir, repo.path());
+    let runner = MockCommandRunner::with_steps(vec![
+        MockStep::AllowFailureWithEnv(Ok((
+            false,
+            String::new(),
+            json!({
+                "error": "failed to open database: database \"odt_fairnest_deadbeef\" not found on Dolt server at 127.0.0.1:3307"
+            })
+            .to_string(),
+        ))),
+    ]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
+
+    let error = store
+        .ensure_repo_initialized(repo.path())
+        .expect_err("missing shared database without backup should fail");
+    assert!(error.to_string().contains("no attachment backup exists"));
 }
 
 #[test]
@@ -826,40 +992,16 @@ fn ensure_repo_initialized_returns_error_when_init_fails() {
 }
 
 #[test]
-fn ensure_repo_initialized_returns_error_when_dolt_start_fails() {
-    let repo = RepoFixture::new("dolt-start-fails");
-    let beads_dir = resolve_central_beads_dir(repo.path()).expect("expected beads dir");
-    fs::create_dir_all(&beads_dir).expect("beads dir should be writable");
-    fs::write(beads_dir.join("beads.db"), "ready").expect("beads.db should be writable");
-    let runner = MockCommandRunner::with_steps(vec![
-        MockStep::AllowFailureWithEnv(Ok((
-            true,
-            json!({
-                "path": beads_dir,
-                "prefix": "openducktor"
-            })
-            .to_string(),
-            String::new(),
-        ))),
-        MockStep::WithEnv(Err("port already in use".to_string())),
-    ]);
-    let store = BeadsTaskStore::with_test_runner("openducktor", runner);
-
-    let error = store
-        .ensure_repo_initialized(repo.path())
-        .expect_err("dolt start should fail");
-    assert!(error.to_string().contains("Failed to start Dolt server"));
-}
-
-#[test]
 fn ensure_repo_initialized_errors_when_verification_is_still_not_ready() {
     let repo = RepoFixture::new("init-malformed");
-    let beads_dir = resolve_central_beads_dir(repo.path()).expect("expected beads dir");
-    fs::create_dir_all(&beads_dir).expect("beads dir should be writable");
+    let beads_dir = resolve_repo_beads_attachment_dir(repo.path()).expect("expected beads dir");
+    write_attachment_metadata(&beads_dir, repo.path(), 3307);
     fs::write(beads_dir.join("beads.db"), "stale").expect("beads.db should be writable");
     let runner = MockCommandRunner::with_steps(vec![
         MockStep::AllowFailureWithEnv(Ok((false, String::new(), "bd where failed".to_string()))),
         MockStep::WithEnv(Ok("doctor fixed".to_string())),
+        MockStep::AllowFailureWithEnv(Ok((true, "{}".to_string(), String::new()))),
+        MockStep::AllowFailureWithEnv(Ok((true, String::new(), String::new()))),
         MockStep::AllowFailureWithEnv(Ok((true, "{}".to_string(), String::new()))),
     ]);
     let store = BeadsTaskStore::with_test_runner("openducktor", runner);
@@ -869,7 +1011,7 @@ fn ensure_repo_initialized_errors_when_verification_is_still_not_ready() {
         .expect_err("init should fail when store remains unready");
     assert!(error
         .to_string()
-        .contains("Failed to repair existing Beads store"));
+        .contains("Beads init completed but store is not ready"));
 }
 
 #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
@@ -15,6 +15,7 @@ rayon = "1"
 libc = "0.2"
 fs2 = "0.4"
 sysinfo = "0.33"
+url = "2"
 host-domain = { path = "../host-domain" }
 
 [dev-dependencies]

--- a/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
@@ -14,6 +14,7 @@ sha2 = "0.10"
 rayon = "1"
 libc = "0.2"
 fs2 = "0.4"
+sysinfo = "0.33"
 host-domain = { path = "../host-domain" }
 
 [dev-dependencies]

--- a/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
+++ b/apps/desktop/src-tauri/crates/host-infra-system/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
 rayon = "1"
 libc = "0.2"
+fs2 = "0.4"
 host-domain = { path = "../host-domain" }
 
 [dev-dependencies]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -13,6 +13,9 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
+#[cfg(not(unix))]
+use sysinfo::Signal;
+use sysinfo::{Pid, ProcessesToUpdate, System};
 
 use crate::{
     config::resolve_openducktor_base_dir, parse_user_path, resolve_command_path,
@@ -178,8 +181,11 @@ pub fn ensure_shared_dolt_server_running(owner_pid: u32) -> Result<SharedDoltSer
             return Ok(existing);
         }
 
-        if !is_process_alive(existing.owner_pid) && is_process_alive(existing.pid) {
-            terminate_process_by_pid(existing.pid).with_context(|| {
+        if !is_process_alive(existing.owner_pid)
+            && is_process_alive(existing.pid)
+            && process_matches_expected_dolt_server(existing.pid, &shared_server_root)?
+        {
+            terminate_process_by_pid(existing.pid, &shared_server_root).with_context(|| {
                 format!(
                     "Failed terminating stale shared Dolt server pid {} for {}",
                     existing.pid,
@@ -237,10 +243,76 @@ pub fn stop_shared_dolt_server_for_current_owner(owner_pid: u32) -> Result<bool>
         return Ok(false);
     }
 
-    terminate_process_by_pid(state.pid)?;
+    terminate_process_by_pid(state.pid, &state.shared_server_root)?;
     remove_if_exists(&state_file)
         .with_context(|| format!("Failed removing shared Dolt state {}", state_file.display()))?;
     Ok(true)
+}
+
+pub fn restore_shared_dolt_database_from_backup(
+    owner_pid: u32,
+    database_name: &str,
+    backup_dir: &Path,
+) -> Result<()> {
+    let shared_server_root = resolve_shared_server_root()?;
+    let shared_dolt_root = resolve_shared_dolt_root()?;
+    fs::create_dir_all(&shared_dolt_root).with_context(|| {
+        format!(
+            "Failed creating Dolt data root {}",
+            shared_dolt_root.display()
+        )
+    })?;
+
+    let restart_server = {
+        let _lock = lock_shared_server_state()?;
+        let state_file = resolve_server_state_file()?;
+        let mut restart_server = false;
+        if let Some(existing) = read_server_state_from_path(&state_file)? {
+            let process_alive = is_process_alive(existing.pid);
+            let process_matches =
+                process_matches_expected_dolt_server(existing.pid, &shared_server_root)?;
+            if process_alive && process_matches {
+                if existing.owner_pid != owner_pid {
+                    return Err(anyhow!(
+                        "Shared Dolt server for {} is running under owner pid {} and cannot be stopped for restore by pid {}",
+                        shared_server_root.display(),
+                        existing.owner_pid,
+                        owner_pid
+                    ));
+                }
+
+                terminate_process_by_pid(existing.pid, &existing.shared_server_root)?;
+                restart_server = true;
+            }
+
+            remove_if_exists(&state_file).with_context(|| {
+                format!(
+                    "Failed removing shared Dolt state {} before restore",
+                    state_file.display()
+                )
+            })?;
+        }
+
+        let backup_url = format!("file://{}", backup_dir.display());
+        crate::run_command(
+            "dolt",
+            &["backup", "restore", backup_url.as_str(), database_name],
+            Some(&shared_dolt_root),
+        )
+        .with_context(|| {
+            format!(
+                "Failed restoring shared Dolt database {database_name} from {}",
+                backup_dir.display()
+            )
+        })?;
+        restart_server
+    };
+
+    if restart_server {
+        ensure_shared_dolt_server_running(owner_pid)?;
+    }
+
+    Ok(())
 }
 
 pub fn resolve_default_worktree_base_dir(repo_path: &Path) -> Result<PathBuf> {
@@ -295,6 +367,7 @@ fn lock_shared_server_state() -> Result<File> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(&lock_file)
         .with_context(|| {
             format!(
@@ -320,7 +393,9 @@ fn is_server_state_healthy(
     {
         return Ok(false);
     }
-    if !is_process_alive(state.pid) {
+    if !is_process_alive(state.pid)
+        || !process_matches_expected_dolt_server(state.pid, expected_shared_server_root)?
+    {
         return Ok(false);
     }
     if !tcp_probe(state.port) {
@@ -365,17 +440,37 @@ fn write_dolt_config_file(port: u16) -> Result<()> {
         "log_level: info\nbehavior:\n  autocommit: true\nlistener:\n  host: {host}\n  port: {port}\ndata_dir: {data_dir}\ncfg_dir: {cfg_dir}\nprivilege_file: {privilege_file}\nbranch_control_file: {branch_control_file}\n",
         host = SHARED_DOLT_SERVER_HOST,
         port = port,
-        data_dir = dolt_root.display(),
-        cfg_dir = cfg_dir.display(),
-        privilege_file = privilege_file.display(),
-        branch_control_file = branch_control_file.display(),
+        data_dir = yaml_quote_path(&dolt_root),
+        cfg_dir = yaml_quote_path(&cfg_dir),
+        privilege_file = yaml_quote_path(&privilege_file),
+        branch_control_file = yaml_quote_path(&branch_control_file),
     );
 
-    let mut file = File::create(&config_file)
-        .with_context(|| format!("Failed creating Dolt config {}", config_file.display()))?;
-    file.write_all(config.as_bytes())
-        .with_context(|| format!("Failed writing Dolt config {}", config_file.display()))?;
+    let temp_file = config_file.with_extension(format!("yaml.tmp-{}", std::process::id()));
+    let mut file = File::create(&temp_file).with_context(|| {
+        format!(
+            "Failed creating Dolt config temp file {}",
+            temp_file.display()
+        )
+    })?;
+    file.write_all(config.as_bytes()).with_context(|| {
+        format!(
+            "Failed writing Dolt config temp file {}",
+            temp_file.display()
+        )
+    })?;
+    fs::rename(&temp_file, &config_file).with_context(|| {
+        format!(
+            "Failed replacing Dolt config {} from {}",
+            config_file.display(),
+            temp_file.display()
+        )
+    })?;
     Ok(())
+}
+
+fn yaml_quote_path(path: &Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "''"))
 }
 
 fn spawn_shared_dolt_server(
@@ -509,13 +604,21 @@ fn remove_if_exists(path: &Path) -> Result<()> {
     }
 }
 
-fn terminate_process_by_pid(pid: u32) -> Result<()> {
+fn terminate_process_by_pid(pid: u32, expected_shared_server_root: &Path) -> Result<()> {
+    if !is_process_alive(pid) {
+        return Ok(());
+    }
+    if !process_matches_expected_dolt_server(pid, expected_shared_server_root)? {
+        return Err(anyhow!(
+            "Refusing to terminate pid {} because it no longer matches the expected shared Dolt server under {}",
+            pid,
+            expected_shared_server_root.display()
+        ));
+    }
+
     #[cfg(unix)]
     {
         let raw_pid = pid as i32;
-        if !is_process_alive(pid) {
-            return Ok(());
-        }
         let terminate_status = unsafe { libc::kill(raw_pid, libc::SIGTERM) };
         if terminate_status != 0 {
             return Err(std::io::Error::last_os_error())
@@ -535,7 +638,18 @@ fn terminate_process_by_pid(pid: u32) -> Result<()> {
 
     #[cfg(not(unix))]
     {
-        let _ = pid;
+        let mut system = System::new_all();
+        system.refresh_processes(ProcessesToUpdate::All, true);
+        let Some(process) = system.process(Pid::from_u32(pid)) else {
+            return Ok(());
+        };
+
+        if !process.kill_with(Signal::Term).unwrap_or(false) {
+            if !process.kill() {
+                return Err(anyhow!("Failed terminating Dolt pid {pid}"));
+            }
+        }
+        wait_for_process_exit(pid, Duration::from_secs(3));
         Ok(())
     }
 }
@@ -552,21 +666,49 @@ fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
 }
 
 fn is_process_alive(pid: u32) -> bool {
-    #[cfg(unix)]
-    {
-        let status = unsafe { libc::kill(pid as i32, 0) };
-        if status == 0 {
-            return true;
+    let mut system = System::new_all();
+    system.refresh_processes(ProcessesToUpdate::All, true);
+    system.process(Pid::from_u32(pid)).is_some()
+}
+
+fn process_matches_expected_dolt_server(
+    pid: u32,
+    expected_shared_server_root: &Path,
+) -> Result<bool> {
+    let mut system = System::new_all();
+    system.refresh_processes(ProcessesToUpdate::All, true);
+    let Some(process) = system.process(Pid::from_u32(pid)) else {
+        return Ok(false);
+    };
+
+    let process_name = process.name().to_string_lossy().to_ascii_lowercase();
+    if !process_name.contains("dolt") {
+        return Ok(false);
+    }
+
+    let command_line = process
+        .cmd()
+        .iter()
+        .map(|value| value.to_string_lossy().into_owned())
+        .collect::<Vec<_>>();
+    if !command_line.iter().any(|arg| arg == "sql-server") {
+        return Ok(false);
+    }
+
+    if let Some(cwd) = process.cwd() {
+        if paths_match(cwd, expected_shared_server_root)? {
+            return Ok(true);
         }
-
-        return std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
     }
 
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        false
+    let expected_config = expected_shared_server_root.join("dolt-config.yaml");
+    for args in command_line.windows(2) {
+        if args[0] == "--config" && paths_match(Path::new(&args[1]), &expected_config)? {
+            return Ok(true);
+        }
     }
+
+    Ok(false)
 }
 
 fn canonical_or_absolute(repo_path: &Path) -> Result<PathBuf> {
@@ -642,14 +784,14 @@ mod tests {
     use super::{
         compute_beads_database_name, compute_repo_id, compute_repo_slug,
         deterministic_shared_dolt_port_candidate, ensure_shared_dolt_server_running,
-        is_process_alive, read_shared_dolt_server_state, resolve_beads_root,
-        resolve_default_worktree_base_dir, resolve_dolt_config_dir, resolve_dolt_config_file,
-        resolve_effective_worktree_base_dir, resolve_repo_beads_attachment_dir,
-        resolve_repo_beads_attachment_root, resolve_repo_beads_paths,
-        resolve_repo_live_database_dir, resolve_server_lock_file, resolve_server_state_file,
-        resolve_shared_dolt_root, resolve_shared_server_root,
-        stop_shared_dolt_server_for_current_owner, wrap_port_candidate, SharedDoltServerState,
-        SHARED_DOLT_PORT_RANGE_LEN, SHARED_DOLT_PORT_RANGE_START,
+        is_process_alive, process_matches_expected_dolt_server, read_shared_dolt_server_state,
+        resolve_beads_root, resolve_default_worktree_base_dir, resolve_dolt_config_dir,
+        resolve_dolt_config_file, resolve_effective_worktree_base_dir,
+        resolve_repo_beads_attachment_dir, resolve_repo_beads_attachment_root,
+        resolve_repo_beads_paths, resolve_repo_live_database_dir, resolve_server_lock_file,
+        resolve_server_state_file, resolve_shared_dolt_root, resolve_shared_server_root,
+        stop_shared_dolt_server_for_current_owner, wrap_port_candidate, write_dolt_config_file,
+        SharedDoltServerState, SHARED_DOLT_PORT_RANGE_LEN, SHARED_DOLT_PORT_RANGE_START,
     };
     use anyhow::Result;
     use host_test_support::{lock_env, EnvVarGuard};
@@ -833,6 +975,40 @@ mod tests {
             wrap_port_candidate(port, u32::from(SHARED_DOLT_PORT_RANGE_LEN)),
             port
         );
+    }
+
+    #[test]
+    fn process_liveness_detects_current_process() {
+        assert!(is_process_alive(std::process::id()));
+    }
+
+    #[test]
+    fn current_process_is_not_mistaken_for_shared_dolt_server() {
+        let temp_root = temp_config_root("process-identity");
+        let matches = process_matches_expected_dolt_server(std::process::id(), &temp_root)
+            .expect("process identity check should succeed");
+        assert!(!matches);
+    }
+
+    #[test]
+    fn shared_dolt_config_quotes_paths_with_spaces() {
+        let _env_lock = lock_env();
+        let config_root = temp_config_root("config with spaces");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            config_root.to_string_lossy().as_ref(),
+        );
+
+        write_dolt_config_file(39280).expect("config file should be written");
+        let config_file = resolve_dolt_config_file().expect("config file path should resolve");
+        let contents = fs::read_to_string(config_file).expect("config file should be readable");
+
+        assert!(contents.contains("data_dir: '"));
+        assert!(contents.contains("cfg_dir: '"));
+        assert!(contents.contains("privilege_file: '"));
+        assert!(contents.contains("branch_control_file: '"));
+
+        let _ = fs::remove_dir_all(config_root);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -1,10 +1,54 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
+use chrono::Utc;
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::env;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::net::{TcpListener, TcpStream};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
-use crate::{config::resolve_openducktor_base_dir, parse_user_path};
+use crate::{
+    config::resolve_openducktor_base_dir, parse_user_path, resolve_command_path,
+    subprocess_path_env,
+};
+
+pub const SHARED_DOLT_SERVER_HOST: &str = "127.0.0.1";
+pub const SHARED_DOLT_SERVER_USER: &str = "root";
+
+const SHARED_DOLT_PORT_RANGE_START: u16 = 36_000;
+const SHARED_DOLT_PORT_RANGE_LEN: u16 = 10_000;
+const SHARED_DOLT_HEALTH_TIMEOUT: Duration = Duration::from_secs(5);
+const SHARED_DOLT_HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const SHARED_DOLT_TCP_TIMEOUT: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoBeadsPaths {
+    pub repo_id: String,
+    pub attachment_root: PathBuf,
+    pub attachment_dir: PathBuf,
+    pub database_name: String,
+    pub live_database_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SharedDoltServerState {
+    pub pid: u32,
+    pub owner_pid: u32,
+    pub host: String,
+    pub user: String,
+    pub port: u16,
+    pub shared_server_root: PathBuf,
+    pub dolt_data_dir: PathBuf,
+    pub started_at: String,
+}
 
 pub fn compute_repo_slug(repo_path: &Path) -> String {
     let candidate = repo_path
@@ -27,13 +71,12 @@ pub fn compute_repo_id(repo_path: &Path) -> Result<String> {
     Ok(format!("{slug}-{short_hash}"))
 }
 
-pub fn compute_beads_database_name(repo_path: &Path, beads_dir: &Path) -> Result<String> {
-    let slug = sanitize_database_identifier(&compute_repo_slug(repo_path));
+pub fn compute_beads_database_name(repo_path: &Path) -> Result<String> {
     let resolved_repo_path = canonical_or_absolute(repo_path)?;
-    let resolved_beads_dir = canonical_or_absolute_from(beads_dir, &resolved_repo_path)?;
-    let digest = Sha256::digest(resolved_beads_dir.to_string_lossy().as_bytes());
-    let short_hash = format!("{digest:x}");
-    let hash_suffix = &short_hash[..12];
+    let slug = sanitize_database_identifier(&compute_repo_slug(&resolved_repo_path));
+    let digest = Sha256::digest(resolved_repo_path.to_string_lossy().as_bytes());
+    let hash_suffix = format!("{digest:x}");
+    let hash_suffix = &hash_suffix[..12];
     let max_slug_len = 64usize.saturating_sub("odt__".len() + hash_suffix.len());
     let truncated_slug = if slug.len() > max_slug_len {
         &slug[..max_slug_len]
@@ -44,8 +87,160 @@ pub fn compute_beads_database_name(repo_path: &Path, beads_dir: &Path) -> Result
     Ok(format!("odt_{truncated_slug}_{hash_suffix}"))
 }
 
-pub fn resolve_central_beads_dir(repo_path: &Path) -> Result<PathBuf> {
-    Ok(resolve_repo_scoped_openducktor_dir(repo_path, "beads")?.join(".beads"))
+pub fn resolve_beads_root() -> Result<PathBuf> {
+    Ok(resolve_openducktor_base_dir()?.join("beads"))
+}
+
+pub fn resolve_shared_server_root() -> Result<PathBuf> {
+    Ok(resolve_beads_root()?.join("shared-server"))
+}
+
+pub fn resolve_shared_dolt_root() -> Result<PathBuf> {
+    Ok(resolve_shared_server_root()?.join("dolt"))
+}
+
+pub fn resolve_dolt_config_dir() -> Result<PathBuf> {
+    Ok(resolve_shared_server_root()?.join(".doltcfg"))
+}
+
+pub fn resolve_dolt_config_file() -> Result<PathBuf> {
+    Ok(resolve_shared_server_root()?.join("dolt-config.yaml"))
+}
+
+pub fn resolve_server_state_file() -> Result<PathBuf> {
+    Ok(resolve_shared_server_root()?.join("server.json"))
+}
+
+pub fn resolve_server_lock_file() -> Result<PathBuf> {
+    Ok(resolve_shared_server_root()?.join("server.lock"))
+}
+
+pub fn resolve_repo_beads_attachment_root(repo_path: &Path) -> Result<PathBuf> {
+    Ok(resolve_beads_root()?.join(compute_repo_id(repo_path)?))
+}
+
+pub fn resolve_repo_beads_attachment_dir(repo_path: &Path) -> Result<PathBuf> {
+    Ok(resolve_repo_beads_attachment_root(repo_path)?.join(".beads"))
+}
+
+pub fn resolve_repo_live_database_dir(repo_path: &Path) -> Result<PathBuf> {
+    Ok(resolve_shared_dolt_root()?.join(compute_beads_database_name(repo_path)?))
+}
+
+pub fn resolve_repo_beads_paths(repo_path: &Path) -> Result<RepoBeadsPaths> {
+    let repo_id = compute_repo_id(repo_path)?;
+    let attachment_root = resolve_beads_root()?.join(&repo_id);
+    let attachment_dir = attachment_root.join(".beads");
+    let database_name = compute_beads_database_name(repo_path)?;
+    let live_database_dir = resolve_shared_dolt_root()?.join(&database_name);
+
+    Ok(RepoBeadsPaths {
+        repo_id,
+        attachment_root,
+        attachment_dir,
+        database_name,
+        live_database_dir,
+    })
+}
+
+pub fn read_shared_dolt_server_state() -> Result<Option<SharedDoltServerState>> {
+    let state_file = resolve_server_state_file()?;
+    read_server_state_from_path(&state_file)
+}
+
+pub fn ensure_shared_dolt_server_running(owner_pid: u32) -> Result<SharedDoltServerState> {
+    let shared_server_root = resolve_shared_server_root()?;
+    let dolt_root = resolve_shared_dolt_root()?;
+    let cfg_dir = resolve_dolt_config_dir()?;
+    fs::create_dir_all(&shared_server_root).with_context(|| {
+        format!(
+            "Failed creating shared Dolt server root {}",
+            shared_server_root.display()
+        )
+    })?;
+    fs::create_dir_all(&dolt_root)
+        .with_context(|| format!("Failed creating Dolt data root {}", dolt_root.display()))?;
+    fs::create_dir_all(&cfg_dir)
+        .with_context(|| format!("Failed creating Dolt config dir {}", cfg_dir.display()))?;
+
+    let _lock = lock_shared_server_state()?;
+    let state_file = resolve_server_state_file()?;
+    if let Some(existing) = read_server_state_from_path(&state_file)? {
+        if is_server_state_healthy(&existing, &shared_server_root, &dolt_root)? {
+            if existing.owner_pid != owner_pid && !is_process_alive(existing.owner_pid) {
+                let adopted = SharedDoltServerState {
+                    owner_pid,
+                    ..existing.clone()
+                };
+                write_server_state(&state_file, &adopted)?;
+                return Ok(adopted);
+            }
+            return Ok(existing);
+        }
+
+        if !is_process_alive(existing.owner_pid) && is_process_alive(existing.pid) {
+            terminate_process_by_pid(existing.pid).with_context(|| {
+                format!(
+                    "Failed terminating stale shared Dolt server pid {} for {}",
+                    existing.pid,
+                    shared_server_root.display()
+                )
+            })?;
+        }
+
+        remove_if_exists(&state_file).with_context(|| {
+            format!(
+                "Failed removing stale server state {}",
+                state_file.display()
+            )
+        })?;
+    }
+
+    let base_port = deterministic_shared_dolt_port_candidate()?;
+    for offset in 0..u32::from(SHARED_DOLT_PORT_RANGE_LEN) {
+        let port = wrap_port_candidate(base_port, offset);
+        if !is_port_available(port) {
+            continue;
+        }
+
+        write_dolt_config_file(port)?;
+        match spawn_shared_dolt_server(owner_pid, port, &shared_server_root, &dolt_root) {
+            Ok(state) => {
+                write_server_state(&state_file, &state)?;
+                return Ok(state);
+            }
+            Err(error) if error_should_continue_to_next_port(&error) => continue,
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(anyhow!(
+        "Failed to start a shared Dolt server for {}; no available port in {}-{}",
+        shared_server_root.display(),
+        SHARED_DOLT_PORT_RANGE_START,
+        SHARED_DOLT_PORT_RANGE_START + SHARED_DOLT_PORT_RANGE_LEN - 1
+    ))
+}
+
+pub fn stop_shared_dolt_server_for_current_owner(owner_pid: u32) -> Result<bool> {
+    let state_file = resolve_server_state_file()?;
+    if !state_file.exists() {
+        return Ok(false);
+    }
+
+    let _lock = lock_shared_server_state()?;
+    let Some(state) = read_server_state_from_path(&state_file)? else {
+        return Ok(false);
+    };
+
+    if state.owner_pid != owner_pid {
+        return Ok(false);
+    }
+
+    terminate_process_by_pid(state.pid)?;
+    remove_if_exists(&state_file)
+        .with_context(|| format!("Failed removing shared Dolt state {}", state_file.display()))?;
+    Ok(true)
 }
 
 pub fn resolve_default_worktree_base_dir(repo_path: &Path) -> Result<PathBuf> {
@@ -66,6 +261,312 @@ fn resolve_repo_scoped_openducktor_dir(repo_path: &Path, namespace: &str) -> Res
     let base_dir = resolve_openducktor_base_dir()?;
     let repo_id = compute_repo_id(repo_path)?;
     Ok(base_dir.join(namespace).join(repo_id))
+}
+
+fn read_server_state_from_path(path: &Path) -> Result<Option<SharedDoltServerState>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let payload = fs::read_to_string(path)
+        .with_context(|| format!("Failed reading shared Dolt server state {}", path.display()))?;
+    let state = serde_json::from_str(&payload)
+        .with_context(|| format!("Failed parsing shared Dolt server state {}", path.display()))?;
+    Ok(Some(state))
+}
+
+fn write_server_state(path: &Path, state: &SharedDoltServerState) -> Result<()> {
+    let payload = serde_json::to_string_pretty(state).context("Failed serializing server state")?;
+    fs::write(path, payload)
+        .with_context(|| format!("Failed writing shared Dolt server state {}", path.display()))
+}
+
+fn lock_shared_server_state() -> Result<File> {
+    let lock_file = resolve_server_lock_file()?;
+    if let Some(parent) = lock_file.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "Failed creating shared Dolt lock parent {}",
+                parent.display()
+            )
+        })?;
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(&lock_file)
+        .with_context(|| {
+            format!(
+                "Failed opening shared Dolt lock file {}",
+                lock_file.display()
+            )
+        })?;
+    file.lock_exclusive()
+        .with_context(|| format!("Failed locking shared Dolt state {}", lock_file.display()))?;
+    Ok(file)
+}
+
+fn is_server_state_healthy(
+    state: &SharedDoltServerState,
+    expected_shared_server_root: &Path,
+    expected_dolt_root: &Path,
+) -> Result<bool> {
+    if state.host != SHARED_DOLT_SERVER_HOST || state.user != SHARED_DOLT_SERVER_USER {
+        return Ok(false);
+    }
+    if !paths_match(&state.shared_server_root, expected_shared_server_root)?
+        || !paths_match(&state.dolt_data_dir, expected_dolt_root)?
+    {
+        return Ok(false);
+    }
+    if !is_process_alive(state.pid) {
+        return Ok(false);
+    }
+    if !tcp_probe(state.port) {
+        return Ok(false);
+    }
+    sql_probe(state.port)
+}
+
+fn paths_match(left: &Path, right: &Path) -> Result<bool> {
+    Ok(canonical_or_absolute(left)? == canonical_or_absolute(right)?)
+}
+
+fn deterministic_shared_dolt_port_candidate() -> Result<u16> {
+    let base_dir = canonical_or_absolute(&resolve_openducktor_base_dir()?)?;
+    let digest = Sha256::digest(base_dir.to_string_lossy().as_bytes());
+    let offset = u16::from_be_bytes([digest[0], digest[1]]) % SHARED_DOLT_PORT_RANGE_LEN;
+    Ok(SHARED_DOLT_PORT_RANGE_START + offset)
+}
+
+fn wrap_port_candidate(base: u16, offset: u32) -> u16 {
+    let normalized_base = base - SHARED_DOLT_PORT_RANGE_START;
+    SHARED_DOLT_PORT_RANGE_START
+        + (((u32::from(normalized_base) + offset) % u32::from(SHARED_DOLT_PORT_RANGE_LEN)) as u16)
+}
+
+fn is_port_available(port: u16) -> bool {
+    TcpListener::bind((SHARED_DOLT_SERVER_HOST, port)).is_ok()
+}
+
+fn write_dolt_config_file(port: u16) -> Result<()> {
+    let shared_server_root = resolve_shared_server_root()?;
+    let config_file = resolve_dolt_config_file()?;
+    let dolt_root = resolve_shared_dolt_root()?;
+    let cfg_dir = resolve_dolt_config_dir()?;
+    let privilege_file = cfg_dir.join("privileges.db");
+    let branch_control_file = cfg_dir.join("branch_control.db");
+
+    fs::create_dir_all(&shared_server_root)
+        .with_context(|| format!("Failed creating {}", shared_server_root.display()))?;
+
+    let config = format!(
+        "log_level: info\nbehavior:\n  autocommit: true\nlistener:\n  host: {host}\n  port: {port}\ndata_dir: {data_dir}\ncfg_dir: {cfg_dir}\nprivilege_file: {privilege_file}\nbranch_control_file: {branch_control_file}\n",
+        host = SHARED_DOLT_SERVER_HOST,
+        port = port,
+        data_dir = dolt_root.display(),
+        cfg_dir = cfg_dir.display(),
+        privilege_file = privilege_file.display(),
+        branch_control_file = branch_control_file.display(),
+    );
+
+    let mut file = File::create(&config_file)
+        .with_context(|| format!("Failed creating Dolt config {}", config_file.display()))?;
+    file.write_all(config.as_bytes())
+        .with_context(|| format!("Failed writing Dolt config {}", config_file.display()))?;
+    Ok(())
+}
+
+fn spawn_shared_dolt_server(
+    owner_pid: u32,
+    port: u16,
+    shared_server_root: &Path,
+    dolt_root: &Path,
+) -> Result<SharedDoltServerState> {
+    let config_file = resolve_dolt_config_file()?;
+    let stderr_log = shared_server_root.join("server.stderr.log");
+    let stdout_log = shared_server_root.join("server.stdout.log");
+    let stdout = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&stdout_log)
+        .with_context(|| format!("Failed opening {}", stdout_log.display()))?;
+    let stderr = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&stderr_log)
+        .with_context(|| format!("Failed opening {}", stderr_log.display()))?;
+    let dolt_binary = resolve_command_path("dolt")?.ok_or_else(|| {
+        anyhow!("dolt not found in bundled locations, standard install locations, or PATH")
+    })?;
+
+    let mut command = Command::new(&dolt_binary);
+    command
+        .arg("sql-server")
+        .arg("--config")
+        .arg(&config_file)
+        .current_dir(shared_server_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    if let Some(path_value) = subprocess_path_env() {
+        command.env("PATH", path_value);
+    }
+    #[cfg(unix)]
+    command.process_group(0);
+
+    let mut child = command.spawn().with_context(|| {
+        format!(
+            "Failed starting shared Dolt server with config {}",
+            config_file.display()
+        )
+    })?;
+
+    if wait_for_server_ready(port)? {
+        return Ok(SharedDoltServerState {
+            pid: child.id(),
+            owner_pid,
+            host: SHARED_DOLT_SERVER_HOST.to_string(),
+            user: SHARED_DOLT_SERVER_USER.to_string(),
+            port,
+            shared_server_root: shared_server_root.to_path_buf(),
+            dolt_data_dir: dolt_root.to_path_buf(),
+            started_at: Utc::now().to_rfc3339(),
+        });
+    }
+
+    let status = child
+        .try_wait()
+        .context("Failed checking shared Dolt server process state")?;
+    if status.is_none() {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    let stderr_output = fs::read_to_string(&stderr_log).unwrap_or_default();
+    let stderr_output = stderr_output.trim();
+    let error_message = if stderr_output.is_empty() {
+        format!(
+            "Shared Dolt server on port {port} failed to become ready within {}ms",
+            SHARED_DOLT_HEALTH_TIMEOUT.as_millis()
+        )
+    } else {
+        format!("Shared Dolt server on port {port} failed to become ready: {stderr_output}")
+    };
+
+    Err(anyhow!(error_message))
+}
+
+fn wait_for_server_ready(port: u16) -> Result<bool> {
+    let deadline = Instant::now() + SHARED_DOLT_HEALTH_TIMEOUT;
+    while Instant::now() < deadline {
+        if tcp_probe(port) && sql_probe(port)? {
+            return Ok(true);
+        }
+        thread::sleep(SHARED_DOLT_HEALTH_POLL_INTERVAL);
+    }
+    Ok(false)
+}
+
+fn tcp_probe(port: u16) -> bool {
+    let address = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    TcpStream::connect_timeout(&address, SHARED_DOLT_TCP_TIMEOUT).is_ok()
+}
+
+fn sql_probe(port: u16) -> Result<bool> {
+    let port_string = port.to_string();
+    let args = [
+        "--host",
+        SHARED_DOLT_SERVER_HOST,
+        "--port",
+        port_string.as_str(),
+        "--no-tls",
+        "-u",
+        SHARED_DOLT_SERVER_USER,
+        "-p",
+        "",
+        "sql",
+        "-q",
+        "show databases",
+    ];
+    let (ok, _, _) = crate::run_command_allow_failure("dolt", &args, None)?;
+    Ok(ok)
+}
+
+fn error_should_continue_to_next_port(error: &anyhow::Error) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("address already in use")
+        || message.contains("bind")
+        || message.contains("listen tcp")
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn terminate_process_by_pid(pid: u32) -> Result<()> {
+    #[cfg(unix)]
+    {
+        let raw_pid = pid as i32;
+        if !is_process_alive(pid) {
+            return Ok(());
+        }
+        let terminate_status = unsafe { libc::kill(raw_pid, libc::SIGTERM) };
+        if terminate_status != 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("Failed sending SIGTERM to Dolt pid {pid}"));
+        }
+        wait_for_process_exit(pid, Duration::from_secs(3));
+        if is_process_alive(pid) {
+            let kill_status = unsafe { libc::kill(raw_pid, libc::SIGKILL) };
+            if kill_status != 0 {
+                return Err(std::io::Error::last_os_error())
+                    .with_context(|| format!("Failed sending SIGKILL to Dolt pid {pid}"));
+            }
+            wait_for_process_exit(pid, Duration::from_secs(2));
+        }
+        return Ok(());
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        Ok(())
+    }
+}
+
+fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !is_process_alive(pid) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    !is_process_alive(pid)
+}
+
+fn is_process_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let status = unsafe { libc::kill(pid as i32, 0) };
+        if status == 0 {
+            return true;
+        }
+
+        return std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
 }
 
 fn canonical_or_absolute(repo_path: &Path) -> Result<PathBuf> {
@@ -128,18 +629,47 @@ fn sanitize_database_identifier(input: &str) -> String {
             }
         })
         .collect::<String>();
-    sanitized.trim_matches('_').to_string()
+    let trimmed = sanitized.trim_matches('_').to_string();
+    if trimmed.is_empty() {
+        "repo".to_string()
+    } else {
+        trimmed
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_beads_database_name, compute_repo_id, compute_repo_slug, resolve_central_beads_dir,
-        resolve_default_worktree_base_dir, resolve_effective_worktree_base_dir,
+        compute_beads_database_name, compute_repo_id, compute_repo_slug,
+        deterministic_shared_dolt_port_candidate, ensure_shared_dolt_server_running,
+        is_process_alive, read_shared_dolt_server_state, resolve_beads_root,
+        resolve_default_worktree_base_dir, resolve_dolt_config_dir, resolve_dolt_config_file,
+        resolve_effective_worktree_base_dir, resolve_repo_beads_attachment_dir,
+        resolve_repo_beads_attachment_root, resolve_repo_beads_paths,
+        resolve_repo_live_database_dir, resolve_server_lock_file, resolve_server_state_file,
+        resolve_shared_dolt_root, resolve_shared_server_root,
+        stop_shared_dolt_server_for_current_owner, wrap_port_candidate, SharedDoltServerState,
+        SHARED_DOLT_PORT_RANGE_LEN, SHARED_DOLT_PORT_RANGE_START,
     };
+    use anyhow::Result;
     use host_test_support::{lock_env, EnvVarGuard};
+    use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_config_root(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("odt-shared-dolt-{label}-{nanos}"))
+    }
+
+    fn skip_if_dolt_unavailable() -> bool {
+        crate::resolve_command_path("dolt")
+            .expect("dolt resolution should not fail")
+            .is_none()
+    }
 
     #[test]
     fn slug_sanitizes_to_ascii_and_collapses_separators() {
@@ -169,94 +699,140 @@ mod tests {
     }
 
     #[test]
-    fn beads_database_name_is_stable_for_same_repo_and_store() {
-        let repo_path = Path::new("/tmp/example-project");
-        let beads_dir = Path::new("/tmp/.openducktor/beads/example-project/.beads");
-
-        let first = compute_beads_database_name(repo_path, beads_dir).expect("first database name");
-        let second =
-            compute_beads_database_name(repo_path, beads_dir).expect("second database name");
+    fn beads_database_name_is_stable_for_same_repo() {
+        let repo_path = Path::new("/tmp/OpenDucktor Repo");
+        let first = compute_beads_database_name(repo_path).expect("first database name");
+        let second = compute_beads_database_name(repo_path).expect("second database name");
 
         assert_eq!(first, second);
-        assert!(first.starts_with("odt_example_project_"));
+        assert_eq!(first, "odt_openducktor_repo_d03d54c7be05");
         assert!(first.len() <= 64);
-        assert!(!first.contains('-'));
     }
 
     #[test]
-    fn beads_database_name_differs_for_distinct_store_paths() {
-        let repo_path = Path::new("/tmp/example-project");
-        let first = compute_beads_database_name(
-            repo_path,
-            Path::new("/tmp/.openducktor/beads/example-project/.beads"),
-        )
-        .expect("first database name");
-        let second = compute_beads_database_name(
-            repo_path,
-            Path::new("/tmp/.openducktor-local/beads/example-project/.beads"),
-        )
-        .expect("second database name");
+    fn beads_database_name_differs_for_distinct_repo_paths_with_same_basename() {
+        let first =
+            compute_beads_database_name(Path::new("/tmp/a/project")).expect("first database name");
+        let second =
+            compute_beads_database_name(Path::new("/tmp/b/project")).expect("second database name");
 
+        assert_eq!(first, "odt_project_ee5494991388");
+        assert_eq!(second, "odt_project_11c79766e587");
         assert_ne!(first, second);
     }
 
     #[test]
-    fn beads_database_name_resolves_relative_store_path_from_repo_path() {
-        let repo_path = Path::new("/tmp/example-project");
-        let relative = compute_beads_database_name(repo_path, Path::new("relative/.beads"))
-            .expect("relative database name");
-        let absolute = compute_beads_database_name(
-            repo_path,
-            Path::new("/tmp/example-project/relative/.beads"),
+    fn shared_beads_helpers_use_expected_layouts() {
+        let _env_lock = lock_env();
+        let _override_guard = EnvVarGuard::remove("OPENDUCKTOR_CONFIG_DIR");
+
+        let beads_root = resolve_beads_root().expect("beads root");
+        let shared_root = resolve_shared_server_root().expect("shared root");
+        let dolt_root = resolve_shared_dolt_root().expect("dolt root");
+        let cfg_dir = resolve_dolt_config_dir().expect("cfg dir");
+        let config_file = resolve_dolt_config_file().expect("config file");
+        let state_file = resolve_server_state_file().expect("state file");
+        let lock_file = resolve_server_lock_file().expect("lock file");
+
+        assert!(beads_root
+            .to_string_lossy()
+            .ends_with("/.openducktor/beads"));
+        assert!(shared_root
+            .to_string_lossy()
+            .ends_with("/.openducktor/beads/shared-server"));
+        assert!(dolt_root
+            .to_string_lossy()
+            .ends_with("/.openducktor/beads/shared-server/dolt"));
+        assert!(cfg_dir
+            .to_string_lossy()
+            .ends_with("/.openducktor/beads/shared-server/.doltcfg"));
+        assert!(config_file
+            .to_string_lossy()
+            .ends_with("/.openducktor/beads/shared-server/dolt-config.yaml"));
+        assert!(state_file
+            .to_string_lossy()
+            .ends_with("/.openducktor/beads/shared-server/server.json"));
+        assert!(lock_file
+            .to_string_lossy()
+            .ends_with("/.openducktor/beads/shared-server/server.lock"));
+    }
+
+    #[test]
+    fn repo_attachment_helpers_use_expected_layouts() {
+        let _env_lock = lock_env();
+        let _override_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "/tmp/odt-config-root");
+        let repo_path = Path::new("/tmp/openducktor-test/repo");
+        let repo_id = compute_repo_id(repo_path).expect("repo id");
+
+        let attachment_root =
+            resolve_repo_beads_attachment_root(repo_path).expect("attachment root should resolve");
+        let attachment_dir =
+            resolve_repo_beads_attachment_dir(repo_path).expect("attachment dir should resolve");
+        let live_db_dir =
+            resolve_repo_live_database_dir(repo_path).expect("live db dir should resolve");
+        let paths = resolve_repo_beads_paths(repo_path).expect("repo paths should resolve");
+
+        assert_eq!(
+            attachment_root,
+            PathBuf::from("/tmp/odt-config-root/beads").join(&repo_id)
+        );
+        assert_eq!(attachment_dir, attachment_root.join(".beads"));
+        assert_eq!(
+            live_db_dir,
+            PathBuf::from("/tmp/odt-config-root/beads/shared-server/dolt")
+                .join(&paths.database_name)
+        );
+        assert_eq!(paths.attachment_dir, attachment_dir);
+        assert_eq!(paths.live_database_dir, live_db_dir);
+    }
+
+    #[test]
+    fn server_state_round_trip_reads_serialized_file() {
+        let _env_lock = lock_env();
+        let temp_root = std::env::temp_dir().join("odt-shared-dolt-state-test");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            temp_root.to_string_lossy().as_ref(),
+        );
+        let state_path = resolve_server_state_file().expect("state file should resolve");
+        fs::create_dir_all(state_path.parent().expect("state parent")).expect("create state dir");
+        let payload = SharedDoltServerState {
+            pid: 12,
+            owner_pid: 34,
+            host: "127.0.0.1".to_string(),
+            user: "root".to_string(),
+            port: 36123,
+            shared_server_root: resolve_shared_server_root().expect("shared root"),
+            dolt_data_dir: resolve_shared_dolt_root().expect("dolt root"),
+            started_at: "2026-04-08T00:00:00Z".to_string(),
+        };
+        fs::write(
+            &state_path,
+            serde_json::to_string(&payload).expect("serialize payload"),
         )
-        .expect("absolute database name");
+        .expect("write state payload");
 
-        assert_eq!(relative, absolute);
+        let loaded = read_shared_dolt_server_state()
+            .expect("state should load")
+            .expect("state should exist");
+        assert_eq!(loaded, payload);
+
+        let _ = fs::remove_dir_all(temp_root);
     }
 
     #[test]
-    fn central_beads_dir_uses_expected_layout_suffix() {
+    fn deterministic_port_candidate_stays_in_reserved_range() {
         let _env_lock = lock_env();
-        let _override_guard = EnvVarGuard::remove("OPENDUCKTOR_CONFIG_DIR");
-        let resolved =
-            resolve_central_beads_dir(Path::new("/tmp/openducktor-test/repo")).expect("beads dir");
-        let as_string = resolved.to_string_lossy();
-        assert!(as_string.contains(".openducktor/beads/"));
-        assert!(as_string.ends_with("/.beads"));
-    }
+        let _override_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", "/tmp/odt-config-root");
 
-    #[test]
-    fn central_beads_dir_resolution_does_not_create_directories() {
-        let _env_lock = lock_env();
-        let _override_guard = EnvVarGuard::remove("OPENDUCKTOR_CONFIG_DIR");
-        let home = dirs::home_dir().expect("home directory should resolve");
-
-        for attempt in 0..64 {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("time should be after epoch")
-                .as_nanos();
-            let candidate = PathBuf::from(format!(
-                "/tmp/odt-beads-no-side-effect-{nanos}-{attempt}/repo"
-            ));
-            let repo_id = compute_repo_id(&candidate).expect("repo id should resolve");
-            let repo_root = home.join(".openducktor").join("beads").join(repo_id);
-            if repo_root.exists() {
-                continue;
-            }
-
-            let resolved =
-                resolve_central_beads_dir(&candidate).expect("beads path should resolve");
-            assert_eq!(resolved, repo_root.join(".beads"));
-            assert!(
-                !repo_root.exists(),
-                "resolve_central_beads_dir should not create {}",
-                repo_root.display()
-            );
-            return;
-        }
-
-        panic!("failed to generate unique beads directory candidate path");
+        let port = deterministic_shared_dolt_port_candidate().expect("port candidate");
+        assert!((SHARED_DOLT_PORT_RANGE_START
+            ..(SHARED_DOLT_PORT_RANGE_START + SHARED_DOLT_PORT_RANGE_LEN))
+            .contains(&port));
+        assert_eq!(
+            wrap_port_candidate(port, u32::from(SHARED_DOLT_PORT_RANGE_LEN)),
+            port
+        );
     }
 
     #[test]
@@ -268,23 +844,6 @@ mod tests {
         let as_string = resolved.to_string_lossy();
         assert!(as_string.contains(".openducktor/worktrees/"));
         assert!(!as_string.ends_with("/.beads"));
-    }
-
-    #[test]
-    fn central_beads_dir_uses_env_override_when_set() {
-        let _env_lock = lock_env();
-        let override_base = "/tmp/odt-custom-config-dir";
-        let _override_guard = EnvVarGuard::set("OPENDUCKTOR_CONFIG_DIR", override_base);
-
-        let repo_path = Path::new("/tmp/openducktor-test/repo");
-        let repo_id = compute_repo_id(repo_path).expect("repo id should resolve");
-        let resolved = resolve_central_beads_dir(repo_path).expect("beads dir should resolve");
-        let expected = PathBuf::from(override_base)
-            .join("beads")
-            .join(repo_id)
-            .join(".beads");
-
-        assert_eq!(resolved, expected);
     }
 
     #[test]
@@ -322,5 +881,215 @@ mod tests {
         .expect("effective worktree base dir");
 
         assert_eq!(resolved, home.join("custom-worktrees"));
+    }
+
+    #[test]
+    fn shared_dolt_server_reuses_healthy_state_for_same_root() -> Result<()> {
+        if skip_if_dolt_unavailable() {
+            return Ok(());
+        }
+
+        let _env_lock = lock_env();
+        let config_root = temp_config_root("reuse");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            config_root.to_string_lossy().as_ref(),
+        );
+
+        let first = ensure_shared_dolt_server_running(1001)?;
+        let second = ensure_shared_dolt_server_running(1001)?;
+
+        assert_eq!(first.pid, second.pid);
+        assert_eq!(first.port, second.port);
+        assert!(is_process_alive(first.pid));
+
+        assert!(stop_shared_dolt_server_for_current_owner(1001)?);
+        let _ = fs::remove_dir_all(config_root);
+        Ok(())
+    }
+
+    #[test]
+    fn shared_dolt_server_replaces_stale_state_files() -> Result<()> {
+        if skip_if_dolt_unavailable() {
+            return Ok(());
+        }
+
+        let _env_lock = lock_env();
+        let config_root = temp_config_root("stale-state");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            config_root.to_string_lossy().as_ref(),
+        );
+
+        let shared_root = resolve_shared_server_root()?;
+        let dolt_root = resolve_shared_dolt_root()?;
+        let state_file = resolve_server_state_file()?;
+        fs::create_dir_all(&shared_root)?;
+        fs::write(
+            &state_file,
+            serde_json::to_string(&SharedDoltServerState {
+                pid: 999_999,
+                owner_pid: 2002,
+                host: "127.0.0.1".to_string(),
+                user: "root".to_string(),
+                port: 39999,
+                shared_server_root: shared_root.clone(),
+                dolt_data_dir: dolt_root,
+                started_at: "2026-04-08T00:00:00Z".to_string(),
+            })?,
+        )?;
+
+        let replacement = ensure_shared_dolt_server_running(2002)?;
+        assert_ne!(replacement.pid, 999_999);
+        assert_ne!(replacement.port, 39999);
+        assert!(is_process_alive(replacement.pid));
+
+        assert!(stop_shared_dolt_server_for_current_owner(2002)?);
+        let _ = fs::remove_dir_all(config_root);
+        Ok(())
+    }
+
+    #[test]
+    fn shared_dolt_shutdown_only_stops_matching_owner() -> Result<()> {
+        if skip_if_dolt_unavailable() {
+            return Ok(());
+        }
+
+        let _env_lock = lock_env();
+        let config_root = temp_config_root("owner");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            config_root.to_string_lossy().as_ref(),
+        );
+
+        let state = ensure_shared_dolt_server_running(3003)?;
+        assert!(!stop_shared_dolt_server_for_current_owner(4004)?);
+        assert!(is_process_alive(state.pid));
+        assert!(stop_shared_dolt_server_for_current_owner(3003)?);
+
+        let _ = fs::remove_dir_all(config_root);
+        Ok(())
+    }
+
+    #[test]
+    fn shared_dolt_server_adopts_healthy_state_when_previous_owner_is_gone() -> Result<()> {
+        if skip_if_dolt_unavailable() {
+            return Ok(());
+        }
+
+        let _env_lock = lock_env();
+        let config_root = temp_config_root("adopt-owner");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            config_root.to_string_lossy().as_ref(),
+        );
+
+        let first = ensure_shared_dolt_server_running(6006)?;
+        let state_file = resolve_server_state_file()?;
+        fs::write(
+            &state_file,
+            serde_json::to_string(&SharedDoltServerState {
+                owner_pid: 999_999,
+                ..first.clone()
+            })?,
+        )?;
+
+        let adopted = ensure_shared_dolt_server_running(7007)?;
+        let persisted = read_shared_dolt_server_state()?.expect("expected persisted shared state");
+
+        assert_eq!(adopted.pid, first.pid);
+        assert_eq!(adopted.port, first.port);
+        assert_eq!(adopted.owner_pid, 7007);
+        assert_eq!(persisted.owner_pid, 7007);
+
+        assert!(stop_shared_dolt_server_for_current_owner(7007)?);
+        let _ = fs::remove_dir_all(config_root);
+        Ok(())
+    }
+
+    #[test]
+    fn shared_dolt_server_replaces_unhealthy_process_from_dead_owner() -> Result<()> {
+        if skip_if_dolt_unavailable() {
+            return Ok(());
+        }
+
+        let _env_lock = lock_env();
+        let config_root = temp_config_root("replace-dead-owner");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            config_root.to_string_lossy().as_ref(),
+        );
+
+        let first = ensure_shared_dolt_server_running(8008)?;
+        let state_file = resolve_server_state_file()?;
+        fs::write(
+            &state_file,
+            serde_json::to_string(&SharedDoltServerState {
+                owner_pid: 999_999,
+                port: first.port.saturating_add(1),
+                ..first.clone()
+            })?,
+        )?;
+
+        let replacement = ensure_shared_dolt_server_running(9009)?;
+        let persisted = read_shared_dolt_server_state()?.expect("expected persisted shared state");
+
+        assert_ne!(replacement.pid, first.pid);
+        assert_eq!(replacement.owner_pid, 9009);
+        assert_eq!(persisted.pid, replacement.pid);
+        assert_eq!(persisted.owner_pid, 9009);
+        assert!(stop_shared_dolt_server_for_current_owner(9009)?);
+
+        let _ = fs::remove_dir_all(config_root);
+        Ok(())
+    }
+
+    #[test]
+    fn shared_dolt_server_keeps_roots_and_ports_separate_per_config_dir() -> Result<()> {
+        if skip_if_dolt_unavailable() {
+            return Ok(());
+        }
+
+        let _env_lock = lock_env();
+        let root_one = temp_config_root("root-one");
+        let root_two = temp_config_root("root-two");
+
+        let first = {
+            let _guard = EnvVarGuard::set(
+                "OPENDUCKTOR_CONFIG_DIR",
+                root_one.to_string_lossy().as_ref(),
+            );
+            ensure_shared_dolt_server_running(5005)?
+        };
+        let second = {
+            let _guard = EnvVarGuard::set(
+                "OPENDUCKTOR_CONFIG_DIR",
+                root_two.to_string_lossy().as_ref(),
+            );
+            ensure_shared_dolt_server_running(5005)?
+        };
+
+        assert_ne!(first.shared_server_root, second.shared_server_root);
+        assert_ne!(first.dolt_data_dir, second.dolt_data_dir);
+        assert_ne!(first.port, second.port);
+
+        {
+            let _guard = EnvVarGuard::set(
+                "OPENDUCKTOR_CONFIG_DIR",
+                root_one.to_string_lossy().as_ref(),
+            );
+            assert!(stop_shared_dolt_server_for_current_owner(5005)?);
+        }
+        {
+            let _guard = EnvVarGuard::set(
+                "OPENDUCKTOR_CONFIG_DIR",
+                root_two.to_string_lossy().as_ref(),
+            );
+            assert!(stop_shared_dolt_server_for_current_owner(5005)?);
+        }
+
+        let _ = fs::remove_dir_all(root_one);
+        let _ = fs::remove_dir_all(root_two);
+        Ok(())
     }
 }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -181,17 +181,27 @@ pub fn ensure_shared_dolt_server_running(owner_pid: u32) -> Result<SharedDoltSer
             return Ok(existing);
         }
 
-        if !is_process_alive(existing.owner_pid)
-            && is_process_alive(existing.pid)
-            && process_matches_expected_dolt_server(existing.pid, &shared_server_root)?
-        {
-            terminate_process_by_pid(existing.pid, &shared_server_root).with_context(|| {
-                format!(
-                    "Failed terminating stale shared Dolt server pid {} for {}",
-                    existing.pid,
-                    shared_server_root.display()
-                )
-            })?;
+        let owner_alive = is_process_alive(existing.owner_pid);
+        let server_alive = is_process_alive(existing.pid);
+        let server_matches =
+            process_matches_expected_dolt_server(existing.pid, &shared_server_root)?;
+
+        if server_alive && server_matches {
+            if existing.owner_pid == owner_pid || !owner_alive {
+                terminate_process_by_pid(existing.pid, &shared_server_root).with_context(|| {
+                    format!(
+                        "Failed terminating stale shared Dolt server pid {} for {}",
+                        existing.pid,
+                        shared_server_root.display()
+                    )
+                })?;
+            } else {
+                return Err(anyhow!(
+                    "Shared Dolt server for {} is unhealthy but still owned by live pid {}",
+                    shared_server_root.display(),
+                    existing.owner_pid
+                ));
+            }
         }
 
         remove_if_exists(&state_file).with_context(|| {
@@ -349,8 +359,28 @@ fn read_server_state_from_path(path: &Path) -> Result<Option<SharedDoltServerSta
 
 fn write_server_state(path: &Path, state: &SharedDoltServerState) -> Result<()> {
     let payload = serde_json::to_string_pretty(state).context("Failed serializing server state")?;
-    fs::write(path, payload)
-        .with_context(|| format!("Failed writing shared Dolt server state {}", path.display()))
+    let parent = path.parent().ok_or_else(|| {
+        anyhow!(
+            "Shared Dolt server state path has no parent: {}",
+            path.display()
+        )
+    })?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("Failed creating shared state parent {}", parent.display()))?;
+    let temp_file = parent.join(format!(
+        ".server.json.tmp-{}-{}",
+        std::process::id(),
+        Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    ));
+    fs::write(&temp_file, payload)
+        .with_context(|| format!("Failed writing temp shared state {}", temp_file.display()))?;
+    fs::rename(&temp_file, path).with_context(|| {
+        format!(
+            "Failed replacing shared Dolt server state {} with {}",
+            path.display(),
+            temp_file.display()
+        )
+    })
 }
 
 fn lock_shared_server_state() -> Result<File> {
@@ -842,24 +872,25 @@ mod tests {
 
     #[test]
     fn beads_database_name_is_stable_for_same_repo() {
-        let repo_path = Path::new("/tmp/OpenDucktor Repo");
-        let first = compute_beads_database_name(repo_path).expect("first database name");
-        let second = compute_beads_database_name(repo_path).expect("second database name");
+        let repo_path = temp_config_root("db-name-stable").join("OpenDucktor Repo");
+        let first = compute_beads_database_name(&repo_path).expect("first database name");
+        let second = compute_beads_database_name(&repo_path).expect("second database name");
 
         assert_eq!(first, second);
-        assert_eq!(first, "odt_openducktor_repo_d03d54c7be05");
+        assert!(first.starts_with("odt_openducktor_repo_"));
         assert!(first.len() <= 64);
     }
 
     #[test]
     fn beads_database_name_differs_for_distinct_repo_paths_with_same_basename() {
-        let first =
-            compute_beads_database_name(Path::new("/tmp/a/project")).expect("first database name");
-        let second =
-            compute_beads_database_name(Path::new("/tmp/b/project")).expect("second database name");
+        let temp_root = temp_config_root("db-name-diff");
+        let first = compute_beads_database_name(&temp_root.join("a").join("project"))
+            .expect("first database name");
+        let second = compute_beads_database_name(&temp_root.join("b").join("project"))
+            .expect("second database name");
 
-        assert_eq!(first, "odt_project_ee5494991388");
-        assert_eq!(second, "odt_project_11c79766e587");
+        assert!(first.starts_with("odt_project_"));
+        assert!(second.starts_with("odt_project_"));
         assert_ne!(first, second);
     }
 
@@ -876,27 +907,42 @@ mod tests {
         let state_file = resolve_server_state_file().expect("state file");
         let lock_file = resolve_server_lock_file().expect("lock file");
 
-        assert!(beads_root
-            .to_string_lossy()
-            .ends_with("/.openducktor/beads"));
-        assert!(shared_root
-            .to_string_lossy()
-            .ends_with("/.openducktor/beads/shared-server"));
-        assert!(dolt_root
-            .to_string_lossy()
-            .ends_with("/.openducktor/beads/shared-server/dolt"));
-        assert!(cfg_dir
-            .to_string_lossy()
-            .ends_with("/.openducktor/beads/shared-server/.doltcfg"));
-        assert!(config_file
-            .to_string_lossy()
-            .ends_with("/.openducktor/beads/shared-server/dolt-config.yaml"));
-        assert!(state_file
-            .to_string_lossy()
-            .ends_with("/.openducktor/beads/shared-server/server.json"));
-        assert!(lock_file
-            .to_string_lossy()
-            .ends_with("/.openducktor/beads/shared-server/server.lock"));
+        assert!(beads_root.ends_with(Path::new(".openducktor").join("beads")));
+        assert!(shared_root.ends_with(
+            Path::new(".openducktor")
+                .join("beads")
+                .join("shared-server")
+        ));
+        assert!(dolt_root.ends_with(
+            Path::new(".openducktor")
+                .join("beads")
+                .join("shared-server")
+                .join("dolt")
+        ));
+        assert!(cfg_dir.ends_with(
+            Path::new(".openducktor")
+                .join("beads")
+                .join("shared-server")
+                .join(".doltcfg")
+        ));
+        assert!(config_file.ends_with(
+            Path::new(".openducktor")
+                .join("beads")
+                .join("shared-server")
+                .join("dolt-config.yaml")
+        ));
+        assert!(state_file.ends_with(
+            Path::new(".openducktor")
+                .join("beads")
+                .join("shared-server")
+                .join("server.json")
+        ));
+        assert!(lock_file.ends_with(
+            Path::new(".openducktor")
+                .join("beads")
+                .join("shared-server")
+                .join("server.lock")
+        ));
     }
 
     #[test]
@@ -1216,6 +1262,42 @@ mod tests {
         assert_eq!(persisted.owner_pid, 9009);
         assert!(stop_shared_dolt_server_for_current_owner(9009)?);
 
+        let _ = fs::remove_dir_all(config_root);
+        Ok(())
+    }
+
+    #[test]
+    fn shared_dolt_server_rejects_replacement_when_live_owner_still_controls_process() -> Result<()>
+    {
+        if skip_if_dolt_unavailable() {
+            return Ok(());
+        }
+
+        let _env_lock = lock_env();
+        let config_root = temp_config_root("live-owner-guard");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            config_root.to_string_lossy().as_ref(),
+        );
+
+        let owner_pid = std::process::id();
+        let first = ensure_shared_dolt_server_running(owner_pid)?;
+        let state_file = resolve_server_state_file()?;
+        fs::write(
+            &state_file,
+            serde_json::to_string(&SharedDoltServerState {
+                port: first.port.saturating_add(1),
+                ..first.clone()
+            })?,
+        )?;
+
+        let error = ensure_shared_dolt_server_running(owner_pid.saturating_add(1))
+            .expect_err("live owner should block replacement");
+        assert!(error
+            .to_string()
+            .contains("is unhealthy but still owned by live pid"));
+
+        assert!(stop_shared_dolt_server_for_current_owner(owner_pid)?);
         let _ = fs::remove_dir_all(config_root);
         Ok(())
     }

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -633,7 +633,7 @@ fn terminate_process_by_pid(pid: u32, expected_shared_server_root: &Path) -> Res
             }
             wait_for_process_exit(pid, Duration::from_secs(2));
         }
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, Instant};
 #[cfg(not(unix))]
 use sysinfo::Signal;
 use sysinfo::{Pid, ProcessesToUpdate, System};
+use url::Url;
 
 use crate::{
     config::resolve_openducktor_base_dir, parse_user_path, resolve_command_path,
@@ -303,7 +304,12 @@ pub fn restore_shared_dolt_database_from_backup(
             })?;
         }
 
-        let backup_url = format!("file://{}", backup_dir.display());
+        let backup_url = Url::from_file_path(backup_dir).map_err(|()| {
+            anyhow!(
+                "Failed converting backup path {} into file URL",
+                backup_dir.display()
+            )
+        })?;
         crate::run_command(
             "dolt",
             &["backup", "restore", backup_url.as_str(), database_name],

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/beads.rs
@@ -660,14 +660,24 @@ fn terminate_process_by_pid(pid: u32, expected_shared_server_root: &Path) -> Res
             return Err(std::io::Error::last_os_error())
                 .with_context(|| format!("Failed sending SIGTERM to Dolt pid {pid}"));
         }
-        wait_for_process_exit(pid, Duration::from_secs(3));
+        let terminated_after_term = wait_for_process_exit(pid, Duration::from_secs(3));
         if is_process_alive(pid) {
             let kill_status = unsafe { libc::kill(raw_pid, libc::SIGKILL) };
             if kill_status != 0 {
                 return Err(std::io::Error::last_os_error())
                     .with_context(|| format!("Failed sending SIGKILL to Dolt pid {pid}"));
             }
-            wait_for_process_exit(pid, Duration::from_secs(2));
+            if !wait_for_process_exit(pid, Duration::from_secs(2)) {
+                return Err(anyhow!(
+                    "Dolt pid {} is still alive after SIGKILL timeout",
+                    pid
+                ));
+            }
+        } else if !terminated_after_term {
+            return Err(anyhow!(
+                "Dolt pid {} is still alive after SIGTERM timeout",
+                pid
+            ));
         }
         Ok(())
     }
@@ -685,7 +695,12 @@ fn terminate_process_by_pid(pid: u32, expected_shared_server_root: &Path) -> Res
                 return Err(anyhow!("Failed terminating Dolt pid {pid}"));
             }
         }
-        wait_for_process_exit(pid, Duration::from_secs(3));
+        if !wait_for_process_exit(pid, Duration::from_secs(3)) {
+            return Err(anyhow!(
+                "Dolt pid {} is still alive after termination timeout",
+                pid
+            ));
+        }
         Ok(())
     }
 }
@@ -826,14 +841,17 @@ mod tests {
         resolve_repo_beads_attachment_dir, resolve_repo_beads_attachment_root,
         resolve_repo_beads_paths, resolve_repo_live_database_dir, resolve_server_lock_file,
         resolve_server_state_file, resolve_shared_dolt_root, resolve_shared_server_root,
-        stop_shared_dolt_server_for_current_owner, wrap_port_candidate, write_dolt_config_file,
-        SharedDoltServerState, SHARED_DOLT_PORT_RANGE_LEN, SHARED_DOLT_PORT_RANGE_START,
+        restore_shared_dolt_database_from_backup, stop_shared_dolt_server_for_current_owner,
+        wrap_port_candidate, write_dolt_config_file, SharedDoltServerState,
+        SHARED_DOLT_PORT_RANGE_LEN, SHARED_DOLT_PORT_RANGE_START, SHARED_DOLT_SERVER_HOST,
+        SHARED_DOLT_SERVER_USER,
     };
-    use anyhow::Result;
+    use anyhow::{anyhow, Result};
     use host_test_support::{lock_env, EnvVarGuard};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
+    use url::Url;
 
     fn temp_config_root(label: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -1302,6 +1320,134 @@ mod tests {
         assert!(error
             .to_string()
             .contains("is unhealthy but still owned by live pid"));
+
+        assert!(stop_shared_dolt_server_for_current_owner(owner_pid)?);
+        let _ = fs::remove_dir_all(config_root);
+        Ok(())
+    }
+
+    fn create_test_dolt_backup(backup_root: &Path) -> Result<()> {
+        let source_root = backup_root.join("source");
+        fs::create_dir_all(&source_root)?;
+        crate::run_command("dolt", &["init"], Some(&source_root))?;
+        crate::run_command(
+            "dolt",
+            &["sql", "-q", "create table t (id int primary key)"],
+            Some(&source_root),
+        )?;
+        crate::run_command("dolt", &["add", "."], Some(&source_root))?;
+
+        let commit_env = [
+            ("DOLT_AUTHOR_NAME", "OpenDucktor Test"),
+            ("DOLT_AUTHOR_EMAIL", "test@example.com"),
+        ];
+        crate::run_command_with_env(
+            "dolt",
+            &["commit", "-m", "init"],
+            Some(&source_root),
+            &commit_env,
+        )?;
+
+        let backup_dir = backup_root.join("backup");
+        let backup_url = Url::from_file_path(&backup_dir)
+            .map_err(|()| anyhow!("Failed converting {} into file URL", backup_dir.display()))?;
+        crate::run_command(
+            "dolt",
+            &["backup", "add", "localbackup", backup_url.as_str()],
+            Some(&source_root),
+        )?;
+        crate::run_command(
+            "dolt",
+            &["backup", "sync", "localbackup"],
+            Some(&source_root),
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn restore_shared_dolt_database_rejects_live_owner_mismatch() -> Result<()> {
+        if skip_if_dolt_unavailable() {
+            return Ok(());
+        }
+
+        let _env_lock = lock_env();
+        let config_root = temp_config_root("restore-owner-mismatch");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            config_root.to_string_lossy().as_ref(),
+        );
+
+        let owner_pid = std::process::id();
+        let state = ensure_shared_dolt_server_running(owner_pid)?;
+        let backup_dir = config_root.join("backup-source").join("backup");
+
+        let error = restore_shared_dolt_database_from_backup(
+            owner_pid.saturating_add(1),
+            "odt_restore_owner_mismatch_deadbeef",
+            &backup_dir,
+        )
+        .expect_err("restore should fail when another live owner controls the server");
+        assert!(error
+            .to_string()
+            .contains("cannot be stopped for restore by pid"));
+        assert!(is_process_alive(state.pid));
+
+        assert!(stop_shared_dolt_server_for_current_owner(owner_pid)?);
+        let _ = fs::remove_dir_all(config_root);
+        Ok(())
+    }
+
+    #[test]
+    fn restore_shared_dolt_database_restarts_server_after_successful_restore() -> Result<()> {
+        if skip_if_dolt_unavailable() {
+            return Ok(());
+        }
+
+        let _env_lock = lock_env();
+        let config_root = temp_config_root("restore-restart");
+        let _override_guard = EnvVarGuard::set(
+            "OPENDUCKTOR_CONFIG_DIR",
+            config_root.to_string_lossy().as_ref(),
+        );
+
+        let owner_pid = std::process::id();
+        let initial_state = ensure_shared_dolt_server_running(owner_pid)?;
+        let backup_root = config_root.join("backup-source");
+        create_test_dolt_backup(&backup_root)?;
+        let backup_dir = backup_root.join("backup");
+        let database_name = "odt_restore_restart_deadbeef";
+
+        restore_shared_dolt_database_from_backup(owner_pid, database_name, &backup_dir)?;
+
+        let restored_state = read_shared_dolt_server_state()?.expect("shared state should exist");
+        let restored_db_dir = resolve_shared_dolt_root()?.join(database_name);
+        assert_eq!(restored_state.owner_pid, owner_pid);
+        assert!(is_process_alive(restored_state.pid));
+        assert!(restored_db_dir.exists());
+        assert_ne!(restored_state.pid, initial_state.pid);
+
+        let port = restored_state.port.to_string();
+        let (ok, stdout, stderr) = crate::run_command_allow_failure(
+            "dolt",
+            &[
+                "--host",
+                SHARED_DOLT_SERVER_HOST,
+                "--port",
+                port.as_str(),
+                "--no-tls",
+                "-u",
+                SHARED_DOLT_SERVER_USER,
+                "-p",
+                "",
+                "sql",
+                "-q",
+                "show databases",
+            ],
+            None,
+        )?;
+        assert!(ok, "show databases should succeed: {stderr}");
+        assert!(stdout.contains(database_name));
 
         assert!(stop_shared_dolt_server_for_current_owner(owner_pid)?);
         let _ = fs::remove_dir_all(config_root);

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -12,8 +12,9 @@ pub use beads::{
     resolve_effective_worktree_base_dir, resolve_repo_beads_attachment_dir,
     resolve_repo_beads_attachment_root, resolve_repo_beads_paths, resolve_repo_live_database_dir,
     resolve_server_lock_file, resolve_server_state_file, resolve_shared_dolt_root,
-    resolve_shared_server_root, stop_shared_dolt_server_for_current_owner, RepoBeadsPaths,
-    SharedDoltServerState, SHARED_DOLT_SERVER_HOST, SHARED_DOLT_SERVER_USER,
+    resolve_shared_server_root, restore_shared_dolt_database_from_backup,
+    stop_shared_dolt_server_for_current_owner, RepoBeadsPaths, SharedDoltServerState,
+    SHARED_DOLT_SERVER_HOST, SHARED_DOLT_SERVER_USER,
 };
 pub use config::{
     hook_set_fingerprint, normalize_hook_set, normalize_repo_dev_servers, repo_script_fingerprint,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/lib.rs
@@ -6,8 +6,14 @@ mod user_paths;
 mod worktree;
 
 pub use beads::{
-    compute_beads_database_name, compute_repo_id, compute_repo_slug, resolve_central_beads_dir,
-    resolve_default_worktree_base_dir, resolve_effective_worktree_base_dir,
+    compute_beads_database_name, compute_repo_id, compute_repo_slug,
+    ensure_shared_dolt_server_running, read_shared_dolt_server_state, resolve_beads_root,
+    resolve_default_worktree_base_dir, resolve_dolt_config_dir, resolve_dolt_config_file,
+    resolve_effective_worktree_base_dir, resolve_repo_beads_attachment_dir,
+    resolve_repo_beads_attachment_root, resolve_repo_beads_paths, resolve_repo_live_database_dir,
+    resolve_server_lock_file, resolve_server_state_file, resolve_shared_dolt_root,
+    resolve_shared_server_root, stop_shared_dolt_server_for_current_owner, RepoBeadsPaths,
+    SharedDoltServerState, SHARED_DOLT_SERVER_HOST, SHARED_DOLT_SERVER_USER,
 };
 pub use config::{
     hook_set_fingerprint, normalize_hook_set, normalize_repo_dev_servers, repo_script_fingerprint,

--- a/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-system/src/process.rs
@@ -871,7 +871,7 @@ mod tests {
         let login_bin = root.join("login-bin");
         fs::create_dir_all(&login_bin).expect("login path should exist");
         let shell = root.join("fake-shell");
-        let program = "node";
+        let program = "odt-login-shell-cli";
         let script = login_bin.join(program);
         write_executable(&script, "#!/bin/sh\nprintf 'login-shell-ok'");
         write_fake_login_shell(&shell, &login_bin);

--- a/apps/desktop/src-tauri/src/headless/command_registry.rs
+++ b/apps/desktop/src-tauri/src/headless/command_registry.rs
@@ -80,8 +80,10 @@ mod tests {
     use serde_json::Value;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::sync::Notify;
 
     struct TestStateFixture {
         state: HeadlessState,
@@ -121,6 +123,8 @@ mod tests {
                 events: HeadlessEventBus::new(1),
                 dev_server_events: HeadlessEventBus::new(1),
                 registry: Arc::new(registry),
+                shutdown_signal: Arc::new(Notify::new()),
+                shutdown_started: Arc::new(AtomicBool::new(false)),
             },
             root,
         }

--- a/apps/desktop/src-tauri/src/headless/command_support.rs
+++ b/apps/desktop/src-tauri/src/headless/command_support.rs
@@ -10,7 +10,9 @@ use host_application::{AppService, HookTrustConfirmationPort, HookTrustConfirmat
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::{json, Value};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use tokio::sync::Notify;
 
 #[derive(Clone)]
 pub(super) struct HeadlessState {
@@ -18,6 +20,8 @@ pub(super) struct HeadlessState {
     pub(super) events: HeadlessEventBus,
     pub(super) dev_server_events: HeadlessEventBus,
     pub(super) registry: Arc<CommandRegistry>,
+    pub(super) shutdown_signal: Arc<Notify>,
+    pub(super) shutdown_started: Arc<AtomicBool>,
 }
 
 #[derive(Debug)]

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -2,7 +2,9 @@ use super::command_registry::{build_registry, dispatch_command};
 use super::command_support::{HeadlessCommandError, HeadlessState};
 use super::events::{build_sse_response, parse_last_event_id, HeadlessEventBus};
 use crate::commands::workspace::is_staged_local_attachment_path;
-use crate::{startup_phase_service_bootstrap, startup_phase_shutdown_hooks, startup_phase_tracing};
+use crate::{
+    startup_phase_service_bootstrap, startup_phase_shutdown_hooks_with_gate, startup_phase_tracing,
+};
 use anyhow::Context;
 use axum::extract::rejection::JsonRejection;
 use axum::extract::{Path, Query, State};
@@ -48,16 +50,33 @@ fn shutdown_exit_code(success: bool) -> i32 {
     if success { 0 } else { 1 }
 }
 
+fn reject_when_shutting_down(state: &HeadlessState) -> Result<(), HeadlessCommandError> {
+    if state.shutdown_started.load(Ordering::SeqCst) {
+        Err(HeadlessCommandError {
+            message: "Browser backend is shutting down and is no longer accepting new work."
+                .to_string(),
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            failure_kind: None,
+        })
+    } else {
+        Ok(())
+    }
+}
+
 pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
     startup_phase_tracing();
     let service = startup_phase_service_bootstrap()?;
-    startup_phase_shutdown_hooks(service.clone());
     let registry =
         Arc::new(build_registry().context("failed to build browser backend command registry")?);
     let events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
     let dev_server_events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
     let shutdown_signal = Arc::new(Notify::new());
     let shutdown_started = Arc::new(AtomicBool::new(false));
+    startup_phase_shutdown_hooks_with_gate(
+        service.clone(),
+        shutdown_started.clone(),
+        Some(shutdown_signal.clone()),
+    );
     let app = Router::new()
         .route("/health", get(health_handler))
         .route("/shutdown", post(shutdown_handler))
@@ -113,6 +132,7 @@ async fn shutdown_handler(State(state): State<HeadlessState>) -> impl IntoRespon
     let service = state.service.clone();
     let shutdown_signal = state.shutdown_signal.clone();
     tokio::spawn(async move {
+        shutdown_signal.notify_waiters();
         let exit_code = match tokio::task::spawn_blocking(move || service.shutdown()).await {
             Ok(Ok(())) => shutdown_exit_code(true),
             Ok(Err(error)) => {
@@ -132,7 +152,6 @@ async fn shutdown_handler(State(state): State<HeadlessState>) -> impl IntoRespon
                 shutdown_exit_code(false)
             }
         };
-        shutdown_signal.notify_waiters();
         tokio::task::yield_now().await;
         std::process::exit(exit_code);
     });
@@ -144,6 +163,7 @@ async fn events_handler(
     State(state): State<HeadlessState>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, HeadlessCommandError> {
+    reject_when_shutting_down(&state)?;
     let last_event_id = parse_last_event_id(&headers)?;
     Ok(build_sse_response(
         state.events,
@@ -156,6 +176,7 @@ async fn dev_server_events_handler(
     State(state): State<HeadlessState>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse, HeadlessCommandError> {
+    reject_when_shutting_down(&state)?;
     let last_event_id = parse_last_event_id(&headers)?;
     Ok(build_sse_response(
         state.dev_server_events,
@@ -169,6 +190,10 @@ async fn invoke_handler(
     State(state): State<HeadlessState>,
     args: Result<Json<Value>, JsonRejection>,
 ) -> impl IntoResponse {
+    if let Err(error) = reject_when_shutting_down(&state) {
+        return error.into_response();
+    }
+
     let args = match args {
         Ok(Json(args)) => args,
         Err(error) => return json_rejection_error(error).into_response(),
@@ -337,6 +362,37 @@ mod tests {
 
         assert_eq!(status, StatusCode::ACCEPTED);
         assert_eq!(payload, json!({ "ok": true }));
+    }
+
+    #[tokio::test]
+    async fn invoke_handler_rejects_new_work_when_shutdown_started() {
+        let fixture = test_state_fixture();
+        fixture
+            .state
+            .shutdown_started
+            .store(true, Ordering::SeqCst);
+
+        let response = invoke_handler(
+            Path("workspace_list".to_string()),
+            State(fixture.state.clone()),
+            Ok(Json(json!({}))),
+        )
+        .await
+        .into_response();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should collect");
+        let payload: Value =
+            serde_json::from_slice(&bytes).expect("response body should deserialize");
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            payload,
+            json!({
+                "error": "Browser backend is shutting down and is no longer accepting new work."
+            })
+        );
     }
 
     struct TestStateFixture {

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -14,9 +14,10 @@ use axum::{Json, Router};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::time::{sleep, Duration};
+use tokio::sync::Notify;
 use tokio_util::io::ReaderStream;
 use tower_http::cors::CorsLayer;
 
@@ -37,6 +38,8 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
         Arc::new(build_registry().context("failed to build browser backend command registry")?);
     let events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
     let dev_server_events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
+    let shutdown_signal = Arc::new(Notify::new());
+    let shutdown_started = Arc::new(AtomicBool::new(false));
     let app = Router::new()
         .route("/health", get(health_handler))
         .route("/shutdown", post(shutdown_handler))
@@ -53,6 +56,8 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
             events,
             dev_server_events,
             registry,
+            shutdown_signal: shutdown_signal.clone(),
+            shutdown_started: shutdown_started.clone(),
         });
 
     let listener = TcpListener::bind((DEFAULT_BROWSER_BACKEND_HOST, port))
@@ -69,6 +74,9 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
     );
 
     axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            shutdown_signal.notified().await;
+        })
         .await
         .context("browser backend server terminated unexpectedly")
 }
@@ -78,11 +86,35 @@ async fn health_handler() -> impl IntoResponse {
 }
 
 async fn shutdown_handler(State(state): State<HeadlessState>) -> impl IntoResponse {
+    if state.shutdown_started.swap(true, Ordering::SeqCst) {
+        return (StatusCode::ACCEPTED, Json(json!({ "ok": true })));
+    }
+
     let service = state.service.clone();
+    let shutdown_signal = state.shutdown_signal.clone();
     tokio::spawn(async move {
-        sleep(Duration::from_millis(50)).await;
-        let _ = service.shutdown();
-        std::process::exit(0);
+        let exit_code = match tokio::task::spawn_blocking(move || service.shutdown()).await {
+            Ok(Ok(())) => 0,
+            Ok(Err(error)) => {
+                tracing::error!(
+                    target: "openducktor.browser-backend",
+                    error = %error,
+                    "Browser backend shutdown failed"
+                );
+                1
+            }
+            Err(error) => {
+                tracing::error!(
+                    target: "openducktor.browser-backend",
+                    error = %error,
+                    "Browser backend shutdown task failed"
+                );
+                1
+            }
+        };
+        shutdown_signal.notify_waiters();
+        tokio::task::yield_now().await;
+        std::process::exit(exit_code);
     });
 
     (StatusCode::ACCEPTED, Json(json!({ "ok": true })))
@@ -286,6 +318,8 @@ mod tests {
                 events: HeadlessEventBus::new(EVENT_BUFFER_CAPACITY),
                 dev_server_events: HeadlessEventBus::new(EVENT_BUFFER_CAPACITY),
                 registry,
+                shutdown_signal: Arc::new(Notify::new()),
+                shutdown_started: Arc::new(AtomicBool::new(false)),
             },
             root,
         }

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -16,6 +16,7 @@ use serde_json::{json, Value};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
+use tokio::time::{sleep, Duration};
 use tokio_util::io::ReaderStream;
 use tower_http::cors::CorsLayer;
 
@@ -38,6 +39,7 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
     let dev_server_events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
     let app = Router::new()
         .route("/health", get(health_handler))
+        .route("/shutdown", post(shutdown_handler))
         .route("/events", get(events_handler))
         .route("/dev-server-events", get(dev_server_events_handler))
         .route(
@@ -73,6 +75,17 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
 
 async fn health_handler() -> impl IntoResponse {
     Json(json!({ "ok": true }))
+}
+
+async fn shutdown_handler(State(state): State<HeadlessState>) -> impl IntoResponse {
+    let service = state.service.clone();
+    tokio::spawn(async move {
+        sleep(Duration::from_millis(50)).await;
+        let _ = service.shutdown();
+        std::process::exit(0);
+    });
+
+    (StatusCode::ACCEPTED, Json(json!({ "ok": true })))
 }
 
 async fn events_handler(

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -30,6 +30,24 @@ const DEFAULT_BROWSER_FRONTEND_ORIGINS: [&str; 3] = [
 const BROWSER_FRONTEND_ORIGIN_ENV: &str = "ODT_BROWSER_FRONTEND_ORIGIN";
 pub(super) const EVENT_BUFFER_CAPACITY: usize = 256;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShutdownRequestAction {
+    Start,
+    AlreadyStarted,
+}
+
+fn classify_shutdown_request(already_started: bool) -> ShutdownRequestAction {
+    if already_started {
+        ShutdownRequestAction::AlreadyStarted
+    } else {
+        ShutdownRequestAction::Start
+    }
+}
+
+fn shutdown_exit_code(success: bool) -> i32 {
+    if success { 0 } else { 1 }
+}
+
 pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
     startup_phase_tracing();
     let service = startup_phase_service_bootstrap()?;
@@ -86,7 +104,9 @@ async fn health_handler() -> impl IntoResponse {
 }
 
 async fn shutdown_handler(State(state): State<HeadlessState>) -> impl IntoResponse {
-    if state.shutdown_started.swap(true, Ordering::SeqCst) {
+    if classify_shutdown_request(state.shutdown_started.swap(true, Ordering::SeqCst))
+        == ShutdownRequestAction::AlreadyStarted
+    {
         return (StatusCode::ACCEPTED, Json(json!({ "ok": true })));
     }
 
@@ -94,14 +114,14 @@ async fn shutdown_handler(State(state): State<HeadlessState>) -> impl IntoRespon
     let shutdown_signal = state.shutdown_signal.clone();
     tokio::spawn(async move {
         let exit_code = match tokio::task::spawn_blocking(move || service.shutdown()).await {
-            Ok(Ok(())) => 0,
+            Ok(Ok(())) => shutdown_exit_code(true),
             Ok(Err(error)) => {
                 tracing::error!(
                     target: "openducktor.browser-backend",
                     error = %error,
                     "Browser backend shutdown failed"
                 );
-                1
+                shutdown_exit_code(false)
             }
             Err(error) => {
                 tracing::error!(
@@ -109,7 +129,7 @@ async fn shutdown_handler(State(state): State<HeadlessState>) -> impl IntoRespon
                     error = %error,
                     "Browser backend shutdown task failed"
                 );
-                1
+                shutdown_exit_code(false)
             }
         };
         shutdown_signal.notify_waiters();
@@ -283,6 +303,41 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn classify_shutdown_request_starts_only_once() {
+        assert_eq!(classify_shutdown_request(false), ShutdownRequestAction::Start);
+        assert_eq!(
+            classify_shutdown_request(true),
+            ShutdownRequestAction::AlreadyStarted
+        );
+    }
+
+    #[test]
+    fn shutdown_exit_code_maps_success_and_failure() {
+        assert_eq!(shutdown_exit_code(true), 0);
+        assert_eq!(shutdown_exit_code(false), 1);
+    }
+
+    #[tokio::test]
+    async fn shutdown_handler_returns_accepted_when_shutdown_already_started() {
+        let fixture = test_state_fixture();
+        fixture
+            .state
+            .shutdown_started
+            .store(true, Ordering::SeqCst);
+
+        let response = shutdown_handler(State(fixture.state.clone())).await.into_response();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body should collect");
+        let payload: Value =
+            serde_json::from_slice(&bytes).expect("response body should deserialize");
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(payload, json!({ "ok": true }));
+    }
 
     struct TestStateFixture {
         state: HeadlessState,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -424,13 +424,16 @@ fn startup_phase_exit_shutdown_handler(
 
     move |handle, event| {
         if let TauriRunEvent::ExitRequested { api, code, .. } = event {
-            if code.is_some() {
+            let action = classify_exit_request(code.is_some(), shutdown_started.load(Ordering::SeqCst));
+            if action == ExitRequestAction::AllowProgrammaticExit {
                 return;
             }
 
             api.prevent_exit();
 
-            if shutdown_started.swap(true, Ordering::SeqCst) {
+            if action == ExitRequestAction::IgnoreRepeatedUserExit
+                || shutdown_started.swap(true, Ordering::SeqCst)
+            {
                 return;
             }
 
@@ -441,11 +444,42 @@ fn startup_phase_exit_shutdown_handler(
             let shutdown_service = app_service.clone();
             let exit_handle = handle.clone();
             std::thread::spawn(move || {
-                let _ = shutdown_service.shutdown();
-                exit_handle.exit(0);
+                let exit_code = match shutdown_service.shutdown() {
+                    Ok(()) => shutdown_exit_code(true),
+                    Err(error) => {
+                        tracing::error!(
+                            target: "openducktor.desktop-shutdown",
+                            error = %error,
+                            "Desktop shutdown failed"
+                        );
+                        shutdown_exit_code(false)
+                    }
+                };
+                exit_handle.exit(exit_code);
             });
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExitRequestAction {
+    AllowProgrammaticExit,
+    StartUserShutdown,
+    IgnoreRepeatedUserExit,
+}
+
+fn classify_exit_request(code_present: bool, shutdown_already_started: bool) -> ExitRequestAction {
+    if code_present {
+        ExitRequestAction::AllowProgrammaticExit
+    } else if shutdown_already_started {
+        ExitRequestAction::IgnoreRepeatedUserExit
+    } else {
+        ExitRequestAction::StartUserShutdown
+    }
+}
+
+fn shutdown_exit_code(success: bool) -> i32 {
+    if success { 0 } else { 1 }
 }
 
 pub fn run() -> anyhow::Result<()> {
@@ -494,6 +528,28 @@ mod tests {
         validate_startup_config(&config_store, &runtime_store)?;
         let _ = fs::remove_dir_all(root);
         Ok(())
+    }
+
+    #[test]
+    fn classify_exit_request_distinguishes_programmatic_and_user_paths() {
+        assert_eq!(
+            classify_exit_request(true, false),
+            ExitRequestAction::AllowProgrammaticExit
+        );
+        assert_eq!(
+            classify_exit_request(false, false),
+            ExitRequestAction::StartUserShutdown
+        );
+        assert_eq!(
+            classify_exit_request(false, true),
+            ExitRequestAction::IgnoreRepeatedUserExit
+        );
+    }
+
+    #[test]
+    fn shutdown_exit_code_maps_success_and_failure() {
+        assert_eq!(shutdown_exit_code(true), 0);
+        assert_eq!(shutdown_exit_code(false), 1);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -269,16 +269,33 @@ pub(crate) fn startup_phase_service_bootstrap() -> anyhow::Result<Arc<AppService
     Ok(service)
 }
 
-fn install_shutdown_signal_handler(service: Arc<AppService>) {
-    let shutdown_requested = Arc::new(AtomicBool::new(false));
+fn install_shutdown_signal_handler(
+    service: Arc<AppService>,
+    shutdown_requested: Arc<AtomicBool>,
+    shutdown_signal: Option<Arc<tokio::sync::Notify>>,
+) {
     let shutdown_service = service.clone();
     let shutdown_requested_signal = shutdown_requested.clone();
+    let shutdown_signal_for_handler = shutdown_signal.clone();
     if let Err(error) = ctrlc::set_handler(move || {
         if shutdown_requested_signal.swap(true, Ordering::SeqCst) {
             return;
         }
-        let _ = shutdown_service.shutdown();
-        std::process::exit(0);
+        if let Some(shutdown_signal) = &shutdown_signal_for_handler {
+            shutdown_signal.notify_waiters();
+        }
+        let exit_code = match shutdown_service.shutdown() {
+            Ok(()) => shutdown_exit_code(true),
+            Err(error) => {
+                tracing::error!(
+                    target: "openducktor.startup",
+                    error = %error,
+                    "Signal-triggered shutdown failed"
+                );
+                shutdown_exit_code(false)
+            }
+        };
+        std::process::exit(exit_code);
     }) {
         tracing::warn!(
             target: "openducktor.startup",
@@ -289,7 +306,15 @@ fn install_shutdown_signal_handler(service: Arc<AppService>) {
 }
 
 pub(crate) fn startup_phase_shutdown_hooks(service: Arc<AppService>) {
-    install_shutdown_signal_handler(service);
+    startup_phase_shutdown_hooks_with_gate(service, Arc::new(AtomicBool::new(false)), None);
+}
+
+pub(crate) fn startup_phase_shutdown_hooks_with_gate(
+    service: Arc<AppService>,
+    shutdown_requested: Arc<AtomicBool>,
+    shutdown_signal: Option<Arc<tokio::sync::Notify>>,
+) {
+    install_shutdown_signal_handler(service, shutdown_requested, shutdown_signal);
 }
 
 fn startup_phase_command_registration<R: tauri::Runtime>(
@@ -444,13 +469,22 @@ fn startup_phase_exit_shutdown_handler(
             let shutdown_service = app_service.clone();
             let exit_handle = handle.clone();
             std::thread::spawn(move || {
-                let exit_code = match shutdown_service.shutdown() {
-                    Ok(()) => shutdown_exit_code(true),
-                    Err(error) => {
+                let exit_code = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+                    move || shutdown_service.shutdown(),
+                )) {
+                    Ok(Ok(())) => shutdown_exit_code(true),
+                    Ok(Err(error)) => {
                         tracing::error!(
                             target: "openducktor.desktop-shutdown",
                             error = %error,
                             "Desktop shutdown failed"
+                        );
+                        shutdown_exit_code(false)
+                    }
+                    Err(_) => {
+                        tracing::error!(
+                            target: "openducktor.desktop-shutdown",
+                            "Desktop shutdown panicked"
                         );
                         shutdown_exit_code(false)
                     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ use std::sync::Mutex;
 use std::sync::{Arc, OnceLock};
 #[cfg(test)]
 use std::time::SystemTime;
-use tauri::{AppHandle, Emitter, RunEvent as TauriRunEvent};
+use tauri::{AppHandle, Emitter, Manager, RunEvent as TauriRunEvent};
 
 mod commands;
 mod headless;
@@ -420,12 +420,26 @@ fn startup_phase_build_tauri_app(
 fn startup_phase_exit_shutdown_handler(
     app_service: Arc<AppService>,
 ) -> impl FnMut(&AppHandle<TauriRuntime>, TauriRunEvent) {
-    move |_handle, event| {
-        if matches!(
-            event,
-            TauriRunEvent::ExitRequested { .. } | TauriRunEvent::Exit
-        ) {
-            let _ = app_service.shutdown();
+    let shutdown_started = Arc::new(AtomicBool::new(false));
+
+    move |handle, event| {
+        if let TauriRunEvent::ExitRequested { api, .. } = event {
+            if shutdown_started.swap(true, Ordering::SeqCst) {
+                return;
+            }
+
+            api.prevent_exit();
+
+            for window in handle.webview_windows().into_values() {
+                let _ = window.hide();
+            }
+
+            let shutdown_service = app_service.clone();
+            let exit_handle = handle.clone();
+            std::thread::spawn(move || {
+                let _ = shutdown_service.shutdown();
+                exit_handle.exit(0);
+            });
         }
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -423,12 +423,16 @@ fn startup_phase_exit_shutdown_handler(
     let shutdown_started = Arc::new(AtomicBool::new(false));
 
     move |handle, event| {
-        if let TauriRunEvent::ExitRequested { api, .. } = event {
-            if shutdown_started.swap(true, Ordering::SeqCst) {
+        if let TauriRunEvent::ExitRequested { api, code, .. } = event {
+            if code.is_some() {
                 return;
             }
 
             api.prevent_exit();
+
+            if shutdown_started.swap(true, Ordering::SeqCst) {
+                return;
+            }
 
             for window in handle.webview_windows().into_values() {
                 let _ = window.hide();

--- a/apps/desktop/src/components/features/tasks/task-selector.test.tsx
+++ b/apps/desktop/src/components/features/tasks/task-selector.test.tsx
@@ -45,19 +45,19 @@ describe("TaskSelector", () => {
       fireEvent.input(input, { target: { value: "TASK-123" } });
     });
 
-    expect(screen.queryByText(/TASK-123/)).toBeNull();
+    expect(screen.getByText("No option found.")).toBeTruthy();
 
     await act(async () => {
       fireEvent.input(input, { target: { value: "bug" } });
     });
 
-    expect(screen.queryByText(/TASK-123/)).toBeNull();
+    expect(screen.getByText("No option found.")).toBeTruthy();
 
     await act(async () => {
       fireEvent.input(input, { target: { value: "frontend" } });
     });
 
-    expect(screen.queryByText(/TASK-123/)).toBeNull();
+    expect(screen.getByText("No option found.")).toBeTruthy();
 
     await act(async () => {
       fireEvent.input(input, { target: { value: "GPT-5.4 dropdown" } });

--- a/apps/desktop/src/components/features/tasks/task-selector.test.tsx
+++ b/apps/desktop/src/components/features/tasks/task-selector.test.tsx
@@ -1,14 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { TaskCard } from "@openducktor/contracts";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { act } from "react";
-import {
-  createTaskCardFixture,
-  enableReactActEnvironment,
-} from "@/pages/agents/agent-studio-test-utils";
-import { TaskSelector } from "./task-selector";
-
-enableReactActEnvironment();
+import { createTaskCardFixture } from "@/pages/agents/agent-studio-test-utils";
+import { buildTaskSelectorOptions } from "./task-selector";
 
 const tasks: TaskCard[] = [
   createTaskCardFixture({
@@ -30,40 +23,29 @@ const tasks: TaskCard[] = [
 ];
 
 describe("TaskSelector", () => {
-  test("searches only by task title while keeping the id in the visible label", async () => {
-    render(
-      <TaskSelector tasks={tasks} value="" includeEmptyOption={false} onValueChange={() => {}} />,
-    );
+  test("builds options that search only by title while keeping ids visible", () => {
+    const options = buildTaskSelectorOptions(tasks, false, "Select task");
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button"));
+    expect(options).toHaveLength(2);
+    expect(options[0]).toEqual({
+      value: "TASK-123",
+      label: "TASK-123 · Polish GPT-5.4 dropdown search",
+      searchText: "Polish GPT-5.4 dropdown search",
     });
-
-    const input = screen.getByPlaceholderText("Search tasks...");
-
-    await act(async () => {
-      fireEvent.input(input, { target: { value: "TASK-123" } });
+    expect(options[1]).toEqual({
+      value: "TASK-999",
+      label: "TASK-999 · Refine agent studio layout",
+      searchText: "Refine agent studio layout",
     });
+  });
 
-    expect(screen.getByText("No option found.")).toBeTruthy();
+  test("prepends the empty option when requested", () => {
+    const options = buildTaskSelectorOptions(tasks, true, "Select task");
 
-    await act(async () => {
-      fireEvent.input(input, { target: { value: "bug" } });
+    expect(options[0]).toEqual({
+      value: "__none__",
+      label: "Select task",
+      searchText: "Select task",
     });
-
-    expect(screen.getByText("No option found.")).toBeTruthy();
-
-    await act(async () => {
-      fireEvent.input(input, { target: { value: "frontend" } });
-    });
-
-    expect(screen.getByText("No option found.")).toBeTruthy();
-
-    await act(async () => {
-      fireEvent.input(input, { target: { value: "GPT-5.4 dropdown" } });
-    });
-
-    expect(screen.getByText("TASK-123 · Polish GPT-5.4 dropdown search")).toBeTruthy();
-    expect(screen.queryByText("TASK-999 · Refine agent studio layout")).toBeNull();
   });
 });

--- a/apps/desktop/src/components/features/tasks/task-selector.tsx
+++ b/apps/desktop/src/components/features/tasks/task-selector.tsx
@@ -14,6 +14,24 @@ type TaskSelectorProps = {
 
 const EMPTY_VALUE = "__none__";
 
+export function buildTaskSelectorOptions(
+  tasks: TaskCard[],
+  includeEmptyOption: boolean,
+  emptyLabel: string,
+): ComboboxOption[] {
+  const entries = tasks.map((task) => ({
+    value: task.id,
+    label: `${task.id} · ${task.title}`,
+    searchText: task.title,
+  }));
+
+  if (!includeEmptyOption) {
+    return entries;
+  }
+
+  return [{ value: EMPTY_VALUE, label: emptyLabel, searchText: emptyLabel }, ...entries];
+}
+
 export function TaskSelector({
   tasks,
   value,
@@ -23,19 +41,10 @@ export function TaskSelector({
   searchPlaceholder = "Search tasks...",
   disabled = false,
 }: TaskSelectorProps) {
-  const options = useMemo<ComboboxOption[]>(() => {
-    const entries = tasks.map((task) => ({
-      value: task.id,
-      label: `${task.id} · ${task.title}`,
-      searchText: task.title,
-    }));
-
-    if (!includeEmptyOption) {
-      return entries;
-    }
-
-    return [{ value: EMPTY_VALUE, label: emptyLabel, searchText: emptyLabel }, ...entries];
-  }, [emptyLabel, includeEmptyOption, tasks]);
+  const options = useMemo<ComboboxOption[]>(
+    () => buildTaskSelectorOptions(tasks, includeEmptyOption, emptyLabel),
+    [emptyLabel, includeEmptyOption, tasks],
+  );
 
   return (
     <Combobox

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This folder contains the project documentation that explains how OpenDucktor is 
 - [agent-orchestrator-module-map.md](agent-orchestrator-module-map.md): maintainer map for the desktop agent orchestration modules.
 - [agent-runtime-implementation-plan.md](agent-runtime-implementation-plan.md): runtime abstraction plan and guardrails.
 - [agent-ui-library-evaluation.md](agent-ui-library-evaluation.md): reasoning behind the current agent UI approach.
+- [beads-shared-dolt-lifecycle.md](beads-shared-dolt-lifecycle.md): detailed Beads attachment and shared Dolt lifecycle, command inventory, startup, hydration, and shutdown rules.
 - [external-mcp.md](external-mcp.md): public MCP package usage, install config, and the external task tools.
 - [runtime-integration-guide.md](runtime-integration-guide.md): runtime vocabulary, capability model, integration checklist, and verification path.
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -66,6 +66,8 @@ Key boundary:
 8. On prompt send, adapter applies role-scoped tool gating from `AGENT_ROLE_TOOL_POLICY` (core) and runtime tool IDs, then sends `tools` selection to OpenCode.
 9. Session snapshots are persisted via `host.agentSessionUpsert` into task metadata for restart/reuse continuity.
 
+For the exact Beads attachment and shared Dolt startup/shutdown command sequence, see `docs/beads-shared-dolt-lifecycle.md`.
+
 Critical session invariants:
 - Read-only roles (`spec`, `planner`, `qa`) must auto-reject mutating permission prompts; on auto-reply failure, permission remains actionable and a system error is emitted.
 - Stale workspace protection must roll back newly started/resumed sessions with best-effort `stopSession` cleanup.
@@ -129,6 +131,7 @@ Concrete adapters today:
 
 ## Related Docs
 - `docs/agent-orchestrator-module-map.md`
+- `docs/beads-shared-dolt-lifecycle.md`
 - `docs/runtime-integration-guide.md`
 - `docs/task-workflow-status-model.md`
 - `docs/task-workflow-actions.md`

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -61,7 +61,7 @@ Key boundary:
  - `build` role: `host.buildStart(repo, task, runtimeKind)` creates a build worktree and starts the configured build runtime; today only `opencode` is implemented.
  - `qa` role: `host.runtimeStart(runtimeKind, repo, task, "qa")` creates a task runtime for the selected kind.
  - `spec`/`planner`: `host.runtimeEnsure(runtimeKind, repo)` ensures a shared workspace runtime for the selected kind.
-6. Rust host resolves the requested runtime kind, then runs runtime-specific startup. Today that startup path still spawns OpenCode with `OPENCODE_CONFIG_CONTENT` containing MCP server `openducktor` and env (`ODT_REPO_PATH`, `ODT_BEADS_DIR`, `ODT_METADATA_NAMESPACE`).
+6. Rust host resolves the requested runtime kind, then runs runtime-specific startup. For OpenCode this spawns the MCP server `openducktor` with host-owned Beads attachment and shared Dolt connection env (`ODT_REPO_PATH`, `ODT_BEADS_ATTACHMENT_DIR`, `ODT_DOLT_HOST`, `ODT_DOLT_PORT`, `ODT_DATABASE_NAME`, `ODT_METADATA_NAMESPACE`).
 7. `OpencodeSdkAdapter` (`AgentEnginePort` implementation) starts, resumes, or forks the session and subscribes to OpenCode stream events.
 8. On prompt send, adapter applies role-scoped tool gating from `AGENT_ROLE_TOOL_POLICY` (core) and runtime tool IDs, then sends `tools` selection to OpenCode.
 9. Session snapshots are persisted via `host.agentSessionUpsert` into task metadata for restart/reuse continuity.

--- a/docs/beads-shared-dolt-lifecycle.md
+++ b/docs/beads-shared-dolt-lifecycle.md
@@ -1,0 +1,360 @@
+# Beads, Dolt, And OpenDucktor
+
+## Overview
+
+OpenDucktor uses **Beads** to store tasks and workflow metadata locally for each repository.
+Beads itself uses **Dolt** as its database engine.
+
+That means OpenDucktor needs two things to work well:
+
+- a Beads attachment for each repository
+- a Dolt database that Beads can read and write
+
+The important design choice is that OpenDucktor does **not** run one Dolt process per repository.
+Instead, it runs **one shared local Dolt server per OpenDucktor config directory** and gives each repository its own database inside that server.
+
+This gives us:
+
+- low process count
+- predictable startup and shutdown
+- one place to manage Dolt runtime state
+- per-repo isolation without exposing Dolt internals to users
+
+## What Beads Does
+
+Beads is the task store.
+
+In OpenDucktor, Beads is responsible for:
+
+- tasks
+- task status
+- labels and priorities
+- task metadata
+- agent-authored documents such as spec, plan, and QA reports
+
+OpenDucktor treats Beads as the persisted source of truth for task workflow state.
+
+## Why Dolt Is Involved
+
+Beads stores its structured task data in Dolt.
+
+OpenDucktor therefore has to make sure a Dolt database exists for each repository and that Beads can connect to it.
+
+We use Dolt because it is the database backend Beads is built around. OpenDucktor does not use Dolt for its own sake; it uses Dolt because Beads needs it.
+
+## How OpenDucktor Embeds Them
+
+OpenDucktor wraps Beads and Dolt behind its own lifecycle.
+
+From the user point of view:
+
+- you open a repository in OpenDucktor
+- OpenDucktor makes sure the Beads attachment exists
+- OpenDucktor makes sure the shared Dolt server is running
+- OpenDucktor makes sure the repository's Dolt database exists inside that shared server
+- after that, task reads and writes go through Beads normally
+
+Users should not have to choose between Dolt modes or understand how Dolt is started.
+
+## Storage Layout
+
+For a config directory such as `~/.openducktor` or a custom `OPENDUCKTOR_CONFIG_DIR`, OpenDucktor stores Beads and Dolt under one managed root:
+
+```text
+<config-root>/
+  beads/
+    <repo-id>/
+      .beads/
+        metadata.json
+        config.yaml
+        backup/
+        interactions.jsonl
+    shared-server/
+      server.json
+      server.lock
+      dolt-config.yaml
+      .doltcfg/
+      dolt/
+        <database-name>/
+```
+
+There are two kinds of state here.
+
+### Durable state
+
+This is the part we want to survive app restarts:
+
+- each repository's `.beads/` attachment
+- the attachment metadata
+- the attachment backup
+- task interaction data
+
+### Runtime state
+
+This is the part OpenDucktor can recreate:
+
+- the shared Dolt server process
+- `server.json`
+- `server.lock`
+- the generated Dolt config file
+- the live shared-server `dolt/` data root
+
+That difference matters a lot.
+
+If the shared server state is wiped, that should not mean the repository itself has to be reinitialized from scratch.
+
+## One Repository, Two Names
+
+OpenDucktor derives two different identifiers from the same repo path.
+
+### Attachment id
+
+Example:
+
+```text
+fairnest-265440cf
+```
+
+This is used for the filesystem directory under `beads/`.
+
+It is meant to be short and stable.
+
+### Dolt database name
+
+Example:
+
+```text
+odt_fairnest_265440cf59ae
+```
+
+This is used inside the shared Dolt server.
+
+It is more explicit and uses a longer hash suffix to reduce collisions.
+
+The two names often look similar because they come from the same canonical repo path, but they serve different purposes and should not be confused.
+
+## Shared Dolt Server Model
+
+There is one shared Dolt server per config root.
+
+If you run OpenDucktor against:
+
+- `~/.openducktor`
+- `~/.openducktor-local`
+
+those are treated as two different environments and each gets its own shared Dolt server.
+
+The server listens on `127.0.0.1` and uses a deterministic port derived from the config root. That keeps the route stable for one config directory while preventing different config roots from colliding with each other.
+
+## How The Shared Dolt Server Starts
+
+OpenDucktor starts the shared Dolt server lazily.
+
+It does **not** start it as soon as the application launches. It starts it when something actually needs Beads storage.
+
+The server command is:
+
+```sh
+dolt sql-server --config <shared-server-root>/dolt-config.yaml
+```
+
+OpenDucktor also performs a health check before treating the server as ready.
+
+That check includes:
+
+1. opening a TCP connection to the chosen port
+2. running:
+
+```sh
+dolt --host 127.0.0.1 --port <port> --no-tls -u root -p '' sql -q "show databases"
+```
+
+This makes sure the server is not just listening, but actually ready to answer Dolt SQL requests.
+
+## How Ownership Works
+
+OpenDucktor records which app process currently owns the shared Dolt server.
+
+If a healthy shared server already exists, a later app instance reuses it.
+
+If the original owner process is gone but the server is still healthy, the new app instance adopts ownership.
+
+This prevents two problems:
+
+- starting unnecessary duplicate Dolt servers
+- leaving a reused server orphaned forever because no current process believes it owns it
+
+## How OpenDucktor Talks To Beads
+
+OpenDucktor runs Beads commands with an explicit environment that points Beads at:
+
+- the repository's durable attachment directory
+- the shared Dolt host and port
+- the shared Dolt user
+
+The important point is that OpenDucktor does **not** run Beads commands from the repository root.
+
+Instead, it runs them from the attachment root under the OpenDucktor config directory.
+
+That is deliberate.
+
+It avoids writing Beads side effects or agent integration files into the repository itself.
+
+## What Happens When You Open A Repo
+
+At a high level, OpenDucktor does this:
+
+1. resolve the repository's attachment directory
+2. ensure the shared Dolt server is running
+3. check whether a Beads attachment already exists
+4. if it exists, verify that it points at the expected shared Dolt database
+5. if it does not exist, create it
+6. if the attachment exists but the shared Dolt database is missing, recreate that database from the attachment backup
+
+That is the normal lifecycle.
+
+## Verification For An Existing Attachment
+
+When an attachment already exists, OpenDucktor verifies two things.
+
+### 1. The attachment metadata
+
+It checks that the attachment says:
+
+- backend is Dolt
+- mode is server
+- host is the current shared Dolt host
+- port is the current shared Dolt port
+- user is the current shared Dolt user
+- database name is the exact database OpenDucktor expects for this repo
+
+### 2. The Beads CLI can resolve it
+
+OpenDucktor runs:
+
+```sh
+bd where --json
+```
+
+This confirms that Beads itself can open the attachment and that it resolves to the expected `.beads` directory.
+
+If both checks pass, the repository is ready.
+
+## What Happens For A Brand-New Attachment
+
+If there is no existing Beads footprint yet, OpenDucktor creates one with:
+
+```sh
+bd init \
+  --server \
+  --server-host 127.0.0.1 \
+  --server-port <shared-server-port> \
+  --server-user root \
+  --quiet \
+  --skip-hooks \
+  --skip-agents \
+  --prefix <repo-slug> \
+  --database <database-name>
+```
+
+Why these flags matter:
+
+- `--server` and the server route flags force shared-server mode
+- `--quiet` keeps initialization noise down
+- `--skip-hooks` avoids running repository hooks during internal setup
+- `--skip-agents` avoids Beads adding agent integration side effects during internal setup
+- `--prefix` gives the repo stable Beads issue ids
+- `--database` binds the attachment to the exact shared Dolt database OpenDucktor expects
+
+## What Happens If The Shared Database Is Missing
+
+This is the situation where the attachment still exists, but the runtime Dolt database is gone. For example, the `shared-server/` directory was deleted.
+
+OpenDucktor treats that as missing runtime infrastructure, not as repository corruption.
+
+It restores the missing database from the durable attachment backup with:
+
+```sh
+dolt backup restore file://<attachment-dir>/backup <database-name>
+```
+
+This is why the attachment backup matters.
+
+The attachment is the durable representation of the repo's task store. The shared Dolt database is the live runtime copy that can be recreated from it.
+
+## What Happens If Verification Fails For Other Reasons
+
+If the attachment exists but fails verification for reasons other than a missing shared database, OpenDucktor currently uses:
+
+```sh
+bd doctor --fix --yes
+```
+
+That is the generic attachment-repair path.
+
+## Everyday Beads Commands OpenDucktor Uses
+
+After initialization, most work is ordinary Beads task I/O.
+
+Examples of commands OpenDucktor runs during normal operation:
+
+- `bd list --all --limit 0 --json`
+- `bd list --limit 0 --json`
+- `bd list --status closed --closed-after <date> --limit 0 --json`
+- `bd show --id <task-id> --json`
+- `bd create ...`
+- `bd update ...`
+- `bd delete --force [--cascade] -- <task-id>`
+- `bd config set status.custom spec_ready,ready_for_dev,ai_review,human_review`
+
+The custom status command is needed because OpenDucktor adds workflow states on top of Beads' built-in statuses.
+
+## How MCP Fits In
+
+When OpenDucktor launches its MCP sidecar for OpenCode, it passes the Beads and Dolt context explicitly:
+
+- repo path
+- Beads attachment directory
+- Dolt host
+- Dolt port
+- Dolt database name
+- metadata namespace
+
+These values are passed explicitly because the MCP sidecar must connect to the exact same live shared Dolt server and the exact same repo database as the Rust host.
+
+Today the MCP sidecar still contains its own Beads client logic. That is internal plumbing, and it is one reason these parameters exist. The desktop host injects them automatically.
+
+## What Happens On App Exit
+
+When OpenDucktor shuts down, it cleans up runtime processes in order:
+
+1. pending OpenCode startup processes
+2. dev servers
+3. active run children
+4. active runtime children
+5. the shared Dolt server, if the current app instance owns it
+
+On desktop close, the window is hidden first and cleanup finishes in the background so the UI does not feel frozen while shutdown runs.
+
+## Why This Design Exists
+
+OpenDucktor uses this model because it balances a few goals that matter at the same time:
+
+- Beads stays the persisted task source of truth
+- users do not have to think about Dolt internals
+- one config root gets one shared Dolt server, not one server per repo
+- repositories stay isolated through database naming, not extra processes
+- durable repo state and disposable runtime state are kept separate
+- repo working trees are not modified by internal Beads setup
+
+In short:
+
+- **Beads** is the task system
+- **Dolt** is the database engine behind it
+- **OpenDucktor** owns the lifecycle around both so the setup stays lightweight and mostly invisible
+
+## Related Docs
+
+- `docs/architecture-overview.md`
+- `docs/external-mcp.md`
+- `packages/openducktor-mcp/README.md`

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -6,6 +6,8 @@ This document describes the public OpenDucktor MCP package that can be used outs
 
 Desktop-managed MCP launches receive the Beads attachment path and shared Dolt connection details from the host automatically. Standalone external use must provide those values explicitly.
 
+For the full Beads attachment and shared Dolt lifecycle, including why these parameters exist and how the host currently owns server startup, see [beads-shared-dolt-lifecycle.md](beads-shared-dolt-lifecycle.md).
+
 Package name:
 
 - `@openducktor/mcp`
@@ -64,6 +66,12 @@ Internal workflow tools remain on the same MCP server:
 - `odt_qa_rejected`
 
 Current OpenDucktor Spec/Planner/Builder/QA agents must not receive `create_task` or `search_tasks` in their tool selection.
+
+Maintainer note:
+
+- the TypeScript MCP sidecar still contains its own Beads client today
+- that lifecycle currently duplicates some host-side Beads logic
+- the duplication is temporary, but if you change Beads or shared-Dolt behavior you must review both this package and the Rust host in the same change
 
 ## Shared Response Model
 

--- a/docs/external-mcp.md
+++ b/docs/external-mcp.md
@@ -4,6 +4,8 @@
 
 This document describes the public OpenDucktor MCP package that can be used outside the desktop app.
 
+Desktop-managed MCP launches receive the Beads attachment path and shared Dolt connection details from the host automatically. Standalone external use must provide those values explicitly.
+
 Package name:
 
 - `@openducktor/mcp`
@@ -21,7 +23,14 @@ Example MCP config:
   "mcpServers": {
     "openducktor": {
       "command": "bunx",
-      "args": ["@openducktor/mcp", "--repo", "/absolute/path/to/repo"]
+      "args": [
+        "@openducktor/mcp",
+        "--repo", "/absolute/path/to/repo",
+        "--beads-attachment-dir", "/absolute/path/to/openducktor/beads/<repo-id>/.beads",
+        "--dolt-host", "127.0.0.1",
+        "--dolt-port", "3310",
+        "--database-name", "odt_repo_deadbeefcafe"
+      ]
     }
   }
 }
@@ -29,7 +38,10 @@ Example MCP config:
 
 Optional arguments:
 
-- `--beads-dir <path>`
+- `--beads-attachment-dir <path>`
+- `--dolt-host <host>`
+- `--dolt-port <port>`
+- `--database-name <name>`
 - `--metadata-namespace <name>`
 
 ## Public Tools

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -2,6 +2,8 @@
 
 OpenDucktor MCP server for local repository task workflows.
 
+When OpenDucktor launches this MCP from the desktop app it injects the Beads attachment dir and shared Dolt connection details automatically. For standalone use, you must provide the same contract yourself.
+
 ## Usage
 
 ```json
@@ -9,7 +11,14 @@ OpenDucktor MCP server for local repository task workflows.
   "mcpServers": {
     "openducktor": {
       "command": "bunx",
-      "args": ["@openducktor/mcp", "--repo", "/absolute/path/to/repo"]
+      "args": [
+        "@openducktor/mcp",
+        "--repo", "/absolute/path/to/repo",
+        "--beads-attachment-dir", "/absolute/path/to/openducktor/beads/<repo-id>/.beads",
+        "--dolt-host", "127.0.0.1",
+        "--dolt-port", "3310",
+        "--database-name", "odt_repo_deadbeefcafe"
+      ]
     }
   }
 }
@@ -17,7 +26,10 @@ OpenDucktor MCP server for local repository task workflows.
 
 Optional arguments:
 
-- `--beads-dir <path>`
+- `--beads-attachment-dir <path>`
+- `--dolt-host <host>`
+- `--dolt-port <port>`
+- `--database-name <name>`
 - `--metadata-namespace <name>`
 
 ## Public Tools

--- a/packages/openducktor-mcp/README.md
+++ b/packages/openducktor-mcp/README.md
@@ -4,6 +4,8 @@ OpenDucktor MCP server for local repository task workflows.
 
 When OpenDucktor launches this MCP from the desktop app it injects the Beads attachment dir and shared Dolt connection details automatically. For standalone use, you must provide the same contract yourself.
 
+For the full Beads attachment and shared Dolt lifecycle, including why these parameters exist, see `../../docs/beads-shared-dolt-lifecycle.md`.
+
 ## Usage
 
 ```json

--- a/packages/openducktor-mcp/src/beads-runtime-client.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { computeBeadsDatabaseName } from "./beads-runtime";
 import { BeadsRuntimeClient } from "./beads-runtime-client";
 
@@ -20,6 +20,26 @@ const makeTempBeadsDir = (): string => {
   return join(root, ".beads");
 };
 
+const writeAttachmentMetadata = (
+  beadsDir: string,
+  databaseName: string,
+  port = 3310,
+  includeConnectionFields = true,
+): void => {
+  mkdirSync(beadsDir, { recursive: true });
+  const payload: Record<string, unknown> = {
+    backend: "dolt",
+    dolt_mode: "server",
+    dolt_database: databaseName,
+  };
+  if (includeConnectionFields) {
+    payload.dolt_server_host = "127.0.0.1";
+    payload.dolt_server_port = port;
+    payload.dolt_server_user = "root";
+  }
+  writeFileSync(join(beadsDir, "metadata.json"), JSON.stringify(payload));
+};
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -27,80 +47,293 @@ afterEach(() => {
 });
 
 describe("BeadsRuntimeClient", () => {
-  test("ensureInitialized initializes missing stores and starts dolt", async () => {
+  test("ensureInitialized initializes missing stores against the shared server", async () => {
     const beadsDir = makeTempBeadsDir();
-    const databaseName = await computeBeadsDatabaseName("/repo/fairnest", beadsDir);
+    const databaseName = await computeBeadsDatabaseName("/repo/fairnest");
     const calls: ProcessCall[] = [];
-    const client = new BeadsRuntimeClient("/repo/fairnest", beadsDir, {
-      runProcess: async (command, args, cwd, env) => {
-        calls.push({ command, args: [...args], cwd, env });
-        return { ok: true, stdout: "", stderr: "" };
+    const client = new BeadsRuntimeClient(
+      "/repo/fairnest",
+      {
+        beadsAttachmentDir: beadsDir,
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName,
       },
-    });
+      {
+        runProcess: async (command, args, cwd, env) => {
+          calls.push({ command, args: [...args], cwd, env });
+          if (args[0] === "init") {
+            writeAttachmentMetadata(beadsDir, databaseName);
+          }
+          if (args[0] === "where") {
+            return { ok: true, stdout: JSON.stringify({ path: beadsDir }), stderr: "" };
+          }
+          return { ok: true, stdout: "", stderr: "" };
+        },
+      },
+    );
 
     await client.ensureInitialized();
 
     expect(calls.map((call) => call.args)).toEqual([
-      ["init", "--quiet", "--skip-hooks", "--prefix", "fairnest", "--database", databaseName],
-      ["dolt", "start"],
+      [
+        "init",
+        "--server",
+        "--server-host",
+        "127.0.0.1",
+        "--server-port",
+        "3310",
+        "--server-user",
+        "root",
+        "--quiet",
+        "--skip-hooks",
+        "--prefix",
+        "fairnest",
+        "--database",
+        databaseName,
+      ],
+      ["where", "--json"],
     ]);
     expect(calls.every((call) => call.command === "bd")).toBe(true);
-    expect(calls.every((call) => call.cwd === "/repo/fairnest")).toBe(true);
+    expect(calls.every((call) => call.cwd === dirname(beadsDir))).toBe(true);
     expect(calls.every((call) => call.env.BEADS_DIR === beadsDir)).toBe(true);
+    expect(calls.every((call) => call.env.BEADS_DOLT_SERVER_MODE === "1")).toBe(true);
+    expect(calls.every((call) => call.env.BEADS_DOLT_SERVER_HOST === "127.0.0.1")).toBe(true);
+    expect(calls.every((call) => call.env.BEADS_DOLT_SERVER_PORT === "3310")).toBe(true);
+    expect(calls.every((call) => call.env.BEADS_DOLT_SERVER_USER === "root")).toBe(true);
   });
 
-  test("ensureInitialized skips init when dolt store already exists", async () => {
+  test("ensureInitialized reuses an attachment only when verification passes", async () => {
     const beadsDir = makeTempBeadsDir();
-    mkdirSync(join(beadsDir, "dolt"), { recursive: true });
+    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe", 3310, false);
     const calls: ProcessCall[] = [];
-    const client = new BeadsRuntimeClient("/repo/fairnest", beadsDir, {
-      runProcess: async (command, args, cwd, env) => {
-        calls.push({ command, args: [...args], cwd, env });
-        return { ok: true, stdout: "", stderr: "" };
+    const client = new BeadsRuntimeClient(
+      "/repo/fairnest",
+      {
+        beadsAttachmentDir: beadsDir,
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_fairnest_deadbeefcafe",
       },
-    });
+      {
+        runProcess: async (command, args, cwd, env) => {
+          calls.push({ command, args: [...args], cwd, env });
+          if (args[0] === "where") {
+            return { ok: true, stdout: JSON.stringify({ path: beadsDir }), stderr: "" };
+          }
+          return { ok: true, stdout: "", stderr: "" };
+        },
+      },
+    );
 
     await client.ensureInitialized();
 
-    expect(calls.map((call) => call.args)).toEqual([["dolt", "start"]]);
+    expect(calls.map((call) => call.args)).toEqual([["where", "--json"]]);
+  });
+
+  test("ensureInitialized bootstraps existing attachments when the shared database is missing", async () => {
+    const beadsDir = makeTempBeadsDir();
+    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe", 3310, false);
+    mkdirSync(join(beadsDir, "backup"), { recursive: true });
+    const calls: ProcessCall[] = [];
+    const client = new BeadsRuntimeClient(
+      "/repo/fairnest",
+      {
+        beadsAttachmentDir: beadsDir,
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_fairnest_deadbeefcafe",
+      },
+      {
+        runProcess: async (command, args, cwd, env) => {
+          calls.push({ command, args: [...args], cwd, env });
+          if (args[0] === "where") {
+            if (calls.filter((call) => call.args[0] === "where").length === 1) {
+              return {
+                ok: false,
+                stdout: "",
+                stderr: JSON.stringify({
+                  error:
+                    'failed to open database: database "odt_fairnest_deadbeefcafe" not found on Dolt server at 127.0.0.1:3310',
+                }),
+              };
+            }
+            return { ok: true, stdout: JSON.stringify({ path: beadsDir }), stderr: "" };
+          }
+          return { ok: true, stdout: "", stderr: "" };
+        },
+      },
+    );
+
+    await client.ensureInitialized();
+
+    expect(calls.map((call) => call.args)).toEqual([
+      ["where", "--json"],
+      ["bootstrap", "--yes"],
+      ["where", "--json"],
+    ]);
+  });
+
+  test("ensureInitialized force-restores backups when bootstrap asks for overwrite", async () => {
+    const beadsDir = makeTempBeadsDir();
+    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe", 3310, false);
+    mkdirSync(join(beadsDir, "backup"), { recursive: true });
+    const calls: ProcessCall[] = [];
+    const client = new BeadsRuntimeClient(
+      "/repo/fairnest",
+      {
+        beadsAttachmentDir: beadsDir,
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_fairnest_deadbeefcafe",
+      },
+      {
+        runProcess: async (command, args, cwd, env) => {
+          calls.push({ command, args: [...args], cwd, env });
+          if (args[0] === "where") {
+            if (calls.filter((call) => call.args[0] === "where").length === 1) {
+              return {
+                ok: false,
+                stdout: "",
+                stderr: JSON.stringify({
+                  error:
+                    'failed to open database: database "odt_fairnest_deadbeefcafe" not found on Dolt server at 127.0.0.1:3310',
+                }),
+              };
+            }
+            return { ok: true, stdout: JSON.stringify({ path: beadsDir }), stderr: "" };
+          }
+          if (args[0] === "bootstrap") {
+            return {
+              ok: false,
+              stdout: "",
+              stderr:
+                "Bootstrap failed: restore from backup: Error 1105: database already exists, use '--force' to overwrite",
+            };
+          }
+          return { ok: true, stdout: "", stderr: "" };
+        },
+      },
+    );
+
+    await client.ensureInitialized();
+
+    expect(calls.map((call) => call.args)).toEqual([
+      ["where", "--json"],
+      ["bootstrap", "--yes"],
+      ["backup", "restore", "--force"],
+      ["where", "--json"],
+    ]);
+  });
+
+  test("ensureInitialized repairs mismatched attachment metadata", async () => {
+    const beadsDir = makeTempBeadsDir();
+    writeAttachmentMetadata(beadsDir, "odt_wrong_db");
+    const calls: ProcessCall[] = [];
+    const client = new BeadsRuntimeClient(
+      "/repo/fairnest",
+      {
+        beadsAttachmentDir: beadsDir,
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_fairnest_deadbeefcafe",
+      },
+      {
+        runProcess: async (command, args, cwd, env) => {
+          if (args[0] === "init") {
+            writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe");
+          }
+          if (args[0] === "where") {
+            return { ok: true, stdout: JSON.stringify({ path: beadsDir }), stderr: "" };
+          }
+          calls.push({ command, args: [...args], cwd, env });
+          return { ok: true, stdout: "", stderr: "" };
+        },
+      },
+    );
+
+    await client.ensureInitialized();
+
+    expect(calls.map((call) => call.args)).toEqual([
+      [
+        "init",
+        "--server",
+        "--server-host",
+        "127.0.0.1",
+        "--server-port",
+        "3310",
+        "--server-user",
+        "root",
+        "--quiet",
+        "--skip-hooks",
+        "--prefix",
+        "fairnest",
+        "--database",
+        "odt_fairnest_deadbeefcafe",
+      ],
+    ]);
   });
 
   test("ensureCustomStatuses is lazy and runs once", async () => {
     const beadsDir = makeTempBeadsDir();
-    mkdirSync(join(beadsDir, "dolt"), { recursive: true });
+    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe");
     const calls: ProcessCall[] = [];
-    const client = new BeadsRuntimeClient("/repo/fairnest", beadsDir, {
-      runProcess: async (command, args, cwd, env) => {
-        calls.push({ command, args: [...args], cwd, env });
-        return { ok: true, stdout: "", stderr: "" };
+    const client = new BeadsRuntimeClient(
+      "/repo/fairnest",
+      {
+        beadsAttachmentDir: beadsDir,
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_fairnest_deadbeefcafe",
       },
-    });
+      {
+        runProcess: async (command, args, cwd, env) => {
+          calls.push({ command, args: [...args], cwd, env });
+          if (args[0] === "where") {
+            return { ok: true, stdout: JSON.stringify({ path: beadsDir }), stderr: "" };
+          }
+          return { ok: true, stdout: "", stderr: "" };
+        },
+      },
+    );
 
     await client.ensureCustomStatuses();
     await client.ensureCustomStatuses();
 
     expect(calls.map((call) => call.args)).toEqual([
-      ["dolt", "start"],
+      ["where", "--json"],
       ["config", "set", "status.custom", "spec_ready,ready_for_dev,ai_review,human_review"],
     ]);
   });
 
   test("updateTask configures custom statuses only for custom workflow states", async () => {
     const beadsDir = makeTempBeadsDir();
-    mkdirSync(join(beadsDir, "dolt"), { recursive: true });
+    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe");
     const calls: ProcessCall[] = [];
-    const client = new BeadsRuntimeClient("/repo/fairnest", beadsDir, {
-      runProcess: async (command, args, cwd, env) => {
-        calls.push({ command, args: [...args], cwd, env });
-        return { ok: true, stdout: "{}", stderr: "" };
+    const client = new BeadsRuntimeClient(
+      "/repo/fairnest",
+      {
+        beadsAttachmentDir: beadsDir,
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_fairnest_deadbeefcafe",
       },
-    });
+      {
+        runProcess: async (command, args, cwd, env) => {
+          calls.push({ command, args: [...args], cwd, env });
+          if (args[0] === "where") {
+            return { ok: true, stdout: JSON.stringify({ path: beadsDir }), stderr: "" };
+          }
+          return { ok: true, stdout: "{}", stderr: "" };
+        },
+      },
+    );
 
     await client.updateTask(["update", "task-1", "--status", "spec_ready"]);
     await client.updateTask(["update", "task-1", "--status", "blocked"]);
 
     expect(calls.map((call) => call.args)).toEqual([
-      ["dolt", "start"],
+      ["where", "--json"],
       ["config", "set", "status.custom", "spec_ready,ready_for_dev,ai_review,human_review"],
       ["update", "task-1", "--status", "spec_ready", "--json"],
       ["update", "task-1", "--status", "blocked", "--json"],

--- a/packages/openducktor-mcp/src/beads-runtime-client.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.test.ts
@@ -17,26 +17,26 @@ const tempRoots: string[] = [];
 const makeTempBeadsDir = (): string => {
   const root = mkdtempSync(join(tmpdir(), "odt-beads-runtime-client-"));
   tempRoots.push(root);
-  return join(root, ".beads");
+  return join(root, "beads", "repo-123", ".beads");
 };
+
+const sharedDoltRootFor = (beadsDir: string): string =>
+  join(dirname(dirname(beadsDir)), "shared-server", "dolt");
 
 const writeAttachmentMetadata = (
   beadsDir: string,
   databaseName: string,
   port = 3310,
-  includeConnectionFields = true,
 ): void => {
   mkdirSync(beadsDir, { recursive: true });
   const payload: Record<string, unknown> = {
     backend: "dolt",
     dolt_mode: "server",
+    dolt_server_host: "127.0.0.1",
+    dolt_server_port: port,
+    dolt_server_user: "root",
     dolt_database: databaseName,
   };
-  if (includeConnectionFields) {
-    payload.dolt_server_host = "127.0.0.1";
-    payload.dolt_server_port = port;
-    payload.dolt_server_user = "root";
-  }
   writeFileSync(join(beadsDir, "metadata.json"), JSON.stringify(payload));
 };
 
@@ -87,6 +87,7 @@ describe("BeadsRuntimeClient", () => {
         "root",
         "--quiet",
         "--skip-hooks",
+        "--skip-agents",
         "--prefix",
         "fairnest",
         "--database",
@@ -105,7 +106,7 @@ describe("BeadsRuntimeClient", () => {
 
   test("ensureInitialized reuses an attachment only when verification passes", async () => {
     const beadsDir = makeTempBeadsDir();
-    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe", 3310, false);
+    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe", 3310);
     const calls: ProcessCall[] = [];
     const client = new BeadsRuntimeClient(
       "/repo/fairnest",
@@ -131,9 +132,9 @@ describe("BeadsRuntimeClient", () => {
     expect(calls.map((call) => call.args)).toEqual([["where", "--json"]]);
   });
 
-  test("ensureInitialized bootstraps existing attachments when the shared database is missing", async () => {
+  test("ensureInitialized restores missing shared databases from the attachment backup", async () => {
     const beadsDir = makeTempBeadsDir();
-    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe", 3310, false);
+    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe", 3310);
     mkdirSync(join(beadsDir, "backup"), { recursive: true });
     const calls: ProcessCall[] = [];
     const client = new BeadsRuntimeClient(
@@ -152,10 +153,12 @@ describe("BeadsRuntimeClient", () => {
               return {
                 ok: false,
                 stdout: "",
-                stderr: JSON.stringify({
-                  error:
-                    'failed to open database: database "odt_fairnest_deadbeefcafe" not found on Dolt server at 127.0.0.1:3310',
-                }),
+                stderr:
+                  "Warning: delayed Dolt wake-up\n" +
+                  JSON.stringify({
+                    error:
+                      'failed to open database: database "odt_fairnest_deadbeefcafe" not found on Dolt server at 127.0.0.1:3310',
+                  }),
               };
             }
             return { ok: true, stdout: JSON.stringify({ path: beadsDir }), stderr: "" };
@@ -169,15 +172,17 @@ describe("BeadsRuntimeClient", () => {
 
     expect(calls.map((call) => call.args)).toEqual([
       ["where", "--json"],
-      ["bootstrap", "--yes"],
+      ["backup", "restore", `file://${join(beadsDir, "backup")}`, "odt_fairnest_deadbeefcafe"],
       ["where", "--json"],
     ]);
+    expect(calls[1]?.command).toBe("dolt");
+    expect(calls[1]?.cwd).toBe(sharedDoltRootFor(beadsDir));
+    expect(calls[1]?.env).toEqual({});
   });
 
-  test("ensureInitialized force-restores backups when bootstrap asks for overwrite", async () => {
+  test("ensureInitialized errors when the shared database is missing and no backup exists", async () => {
     const beadsDir = makeTempBeadsDir();
-    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe", 3310, false);
-    mkdirSync(join(beadsDir, "backup"), { recursive: true });
+    writeAttachmentMetadata(beadsDir, "odt_fairnest_deadbeefcafe", 3310);
     const calls: ProcessCall[] = [];
     const client = new BeadsRuntimeClient(
       "/repo/fairnest",
@@ -191,24 +196,13 @@ describe("BeadsRuntimeClient", () => {
         runProcess: async (command, args, cwd, env) => {
           calls.push({ command, args: [...args], cwd, env });
           if (args[0] === "where") {
-            if (calls.filter((call) => call.args[0] === "where").length === 1) {
-              return {
-                ok: false,
-                stdout: "",
-                stderr: JSON.stringify({
-                  error:
-                    'failed to open database: database "odt_fairnest_deadbeefcafe" not found on Dolt server at 127.0.0.1:3310',
-                }),
-              };
-            }
-            return { ok: true, stdout: JSON.stringify({ path: beadsDir }), stderr: "" };
-          }
-          if (args[0] === "bootstrap") {
             return {
               ok: false,
               stdout: "",
-              stderr:
-                "Bootstrap failed: restore from backup: Error 1105: database already exists, use '--force' to overwrite",
+              stderr: JSON.stringify({
+                error:
+                  'failed to open database: database "odt_fairnest_deadbeefcafe" not found on Dolt server at 127.0.0.1:3310',
+              }),
             };
           }
           return { ok: true, stdout: "", stderr: "" };
@@ -216,14 +210,10 @@ describe("BeadsRuntimeClient", () => {
       },
     );
 
-    await client.ensureInitialized();
-
-    expect(calls.map((call) => call.args)).toEqual([
-      ["where", "--json"],
-      ["bootstrap", "--yes"],
-      ["backup", "restore", "--force"],
-      ["where", "--json"],
-    ]);
+    await expect(client.ensureInitialized()).rejects.toThrow(
+      `Shared Dolt database is missing for ${beadsDir} and no attachment backup exists at ${join(beadsDir, "backup")}`,
+    );
+    expect(calls.map((call) => call.args)).toEqual([["where", "--json"]]);
   });
 
   test("ensureInitialized repairs mismatched attachment metadata", async () => {
@@ -266,6 +256,7 @@ describe("BeadsRuntimeClient", () => {
         "root",
         "--quiet",
         "--skip-hooks",
+        "--skip-agents",
         "--prefix",
         "fairnest",
         "--database",

--- a/packages/openducktor-mcp/src/beads-runtime-client.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.test.ts
@@ -23,11 +23,7 @@ const makeTempBeadsDir = (): string => {
 const sharedDoltRootFor = (beadsDir: string): string =>
   join(dirname(dirname(beadsDir)), "shared-server", "dolt");
 
-const writeAttachmentMetadata = (
-  beadsDir: string,
-  databaseName: string,
-  port = 3310,
-): void => {
+const writeAttachmentMetadata = (beadsDir: string, databaseName: string, port = 3310): void => {
   mkdirSync(beadsDir, { recursive: true });
   const payload: Record<string, unknown> = {
     backend: "dolt",

--- a/packages/openducktor-mcp/src/beads-runtime-client.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { computeBeadsDatabaseName } from "./beads-runtime";
 import { BeadsRuntimeClient } from "./beads-runtime-client";
 
@@ -168,7 +169,12 @@ describe("BeadsRuntimeClient", () => {
 
     expect(calls.map((call) => call.args)).toEqual([
       ["where", "--json"],
-      ["backup", "restore", `file://${join(beadsDir, "backup")}`, "odt_fairnest_deadbeefcafe"],
+      [
+        "backup",
+        "restore",
+        pathToFileURL(join(beadsDir, "backup")).toString(),
+        "odt_fairnest_deadbeefcafe",
+      ],
       ["where", "--json"],
     ]);
     expect(calls[1]?.command).toBe("dolt");

--- a/packages/openducktor-mcp/src/beads-runtime-client.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   type BeadsAttachmentDirResolver,
   CUSTOM_STATUS_VALUES,
@@ -197,7 +198,7 @@ export class BeadsRuntimeClient {
     mkdirSync(sharedDoltRoot, { recursive: true });
     await this.runCommand(
       "dolt",
-      ["backup", "restore", `file://${backupPath}`, this.databaseName],
+      ["backup", "restore", pathToFileURL(backupPath).toString(), this.databaseName],
       sharedDoltRoot,
       {},
     );

--- a/packages/openducktor-mcp/src/beads-runtime-client.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.ts
@@ -1,6 +1,6 @@
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { basename, dirname } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
   type BeadsAttachmentDirResolver,
   CUSTOM_STATUS_VALUES,
@@ -117,6 +117,16 @@ export class BeadsRuntimeClient {
     return dirname(beadsAttachmentDir);
   }
 
+  private ensureBeadsWorkingDirectory(beadsAttachmentDir: string): string {
+    const workingDirectory = this.beadsWorkingDirectory(beadsAttachmentDir);
+    mkdirSync(workingDirectory, { recursive: true });
+    return workingDirectory;
+  }
+
+  private sharedDoltDataRoot(beadsAttachmentDir: string): string {
+    return join(dirname(this.beadsWorkingDirectory(beadsAttachmentDir)), "shared-server", "dolt");
+  }
+
   private statusRequiresCustomConfiguration(status: string): boolean {
     return (
       status === "spec_ready" ||
@@ -154,33 +164,72 @@ export class BeadsRuntimeClient {
     return (
       metadata?.backend === "dolt" &&
       metadata?.dolt_mode === "server" &&
-      (metadata?.dolt_server_host === undefined || metadata.dolt_server_host === this.doltHost) &&
-      (metadata?.dolt_server_port === undefined ||
-        metadata.dolt_server_port === Number(this.doltPort)) &&
-      (metadata?.dolt_server_user === undefined || metadata.dolt_server_user === "root") &&
+      metadata?.dolt_server_host === this.doltHost &&
+      metadata?.dolt_server_port === Number(this.doltPort) &&
+      metadata?.dolt_server_user === "root" &&
       metadata?.dolt_database === expectedDatabaseName
     );
   }
 
-  private static reasonRequiresBootstrap(reason: string): boolean {
+  private static reasonRequiresSharedDatabaseSeed(reason: string): boolean {
     const normalized = reason.toLowerCase();
     return (
       normalized.includes("not found on dolt server") ||
       normalized.includes("server not reachable") ||
+      normalized.includes("dolt server unreachable") ||
       normalized.includes("error 1049")
     );
   }
 
-  private shouldForceRestoreBackup(beadsAttachmentDir: string, error: unknown): boolean {
-    if (!existsSync(`${beadsAttachmentDir}/backup`)) {
-      return false;
+  private sharedDatabaseBackupPath(beadsAttachmentDir: string): string {
+    return `${beadsAttachmentDir}/backup`;
+  }
+
+  private async materializeSharedDatabaseFromAttachment(beadsAttachmentDir: string): Promise<void> {
+    const backupPath = this.sharedDatabaseBackupPath(beadsAttachmentDir);
+    if (!existsSync(backupPath)) {
+      throw new Error(
+        `Shared Dolt database is missing for ${beadsAttachmentDir} and no attachment backup exists at ${backupPath}`,
+      );
     }
 
-    const message = error instanceof Error ? error.message : String(error);
-    const normalized = message.toLowerCase();
-    return (
-      normalized.includes("already exists") && normalized.includes("use '--force' to overwrite")
+    const sharedDoltRoot = this.sharedDoltDataRoot(beadsAttachmentDir);
+    mkdirSync(sharedDoltRoot, { recursive: true });
+    await this.runCommand(
+      "dolt",
+      ["backup", "restore", `file://${backupPath}`, this.databaseName],
+      sharedDoltRoot,
+      {},
     );
+  }
+
+  private extractJsonPayload(output: string): string {
+    const trimmed = output.trim();
+    if (trimmed.length === 0) {
+      return trimmed;
+    }
+
+    const objectIndex = trimmed.indexOf("{");
+    const arrayIndex = trimmed.indexOf("[");
+    const candidates = [objectIndex, arrayIndex].filter((index) => index >= 0);
+    if (candidates.length === 0) {
+      return trimmed;
+    }
+
+    return trimmed.slice(Math.min(...candidates));
+  }
+
+  private async runCommand(
+    command: string,
+    args: string[],
+    cwd: string,
+    env: Record<string, string>,
+  ): Promise<void> {
+    const result = await this.runProcess(command, args, cwd, env);
+    if (!result.ok) {
+      const details = result.stderr || result.stdout || `${command} command failed`;
+      throw new Error(`${command} ${args.join(" ")} failed: ${details}`);
+    }
   }
 
   private async inspectAttachment(beadsAttachmentDir: string): Promise<AttachmentStatus> {
@@ -193,13 +242,14 @@ export class BeadsRuntimeClient {
     }
 
     const whereOutput = await this.runBd(["where"], { json: true, allowFailure: true });
-    if (whereOutput.trim().length === 0) {
+    const jsonPayload = this.extractJsonPayload(whereOutput);
+    if (jsonPayload.length === 0) {
       return { ready: false, reason: "bd where returned empty payload" };
     }
 
     let payload: BeadsWherePayload;
     try {
-      payload = JSON.parse(whereOutput) as BeadsWherePayload;
+      payload = JSON.parse(jsonPayload) as BeadsWherePayload;
     } catch {
       throw new Error("Failed to parse bd JSON output for args: where");
     }
@@ -238,7 +288,7 @@ export class BeadsRuntimeClient {
     const result = await this.runProcess(
       "bd",
       finalArgs,
-      this.beadsWorkingDirectory(beadsAttachmentDir),
+      this.ensureBeadsWorkingDirectory(beadsAttachmentDir),
       this.beadsEnv(beadsAttachmentDir),
     );
 
@@ -256,7 +306,7 @@ export class BeadsRuntimeClient {
   async runBdJson(args: string[]): Promise<unknown> {
     const output = await this.runBd(args, { json: true });
     try {
-      return JSON.parse(output);
+      return JSON.parse(this.extractJsonPayload(output));
     } catch {
       throw new Error(`Failed to parse bd JSON output for args: ${args.join(" ")}`);
     }
@@ -278,16 +328,8 @@ export class BeadsRuntimeClient {
         ? await this.inspectAttachment(beadsAttachmentDir)
         : { ready: false, reason: "bd init failed" };
       if (!status.ready) {
-        if (BeadsRuntimeClient.reasonRequiresBootstrap(status.reason)) {
-          try {
-            await this.runBd(["bootstrap", "--yes"]);
-          } catch (error) {
-            if (this.shouldForceRestoreBackup(beadsAttachmentDir, error)) {
-              await this.runBd(["backup", "restore", "--force"]);
-            } else {
-              throw error;
-            }
-          }
+        if (BeadsRuntimeClient.reasonRequiresSharedDatabaseSeed(status.reason)) {
+          await this.materializeSharedDatabaseFromAttachment(beadsAttachmentDir);
         } else {
           const slug = sanitizeSlug(basename(this.repoPath));
           await this.runBd([
@@ -301,6 +343,7 @@ export class BeadsRuntimeClient {
             "root",
             "--quiet",
             "--skip-hooks",
+            "--skip-agents",
             "--prefix",
             slug,
             "--database",

--- a/packages/openducktor-mcp/src/beads-runtime-client.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.ts
@@ -1,50 +1,120 @@
 import { existsSync } from "node:fs";
-import { basename, join } from "node:path";
+import { readFile } from "node:fs/promises";
+import { basename, dirname } from "node:path";
 import {
-  type BeadsDirResolver,
+  type BeadsAttachmentDirResolver,
   CUSTOM_STATUS_VALUES,
-  computeBeadsDatabaseName,
+  normalizeOptionalInput,
   type ProcessRunner,
-  resolveCentralBeadsDir,
+  resolveCanonicalPath,
+  resolveRepoBeadsAttachmentDir,
   runProcess,
   sanitizeSlug,
 } from "./beads-runtime";
 
 export type BeadsRuntimeClientDeps = {
   runProcess?: ProcessRunner;
-  resolveBeadsDir?: BeadsDirResolver;
+  resolveBeadsAttachmentDir?: BeadsAttachmentDirResolver;
+  readAttachmentMetadata?: (beadsAttachmentDir: string) => Promise<BeadsAttachmentMetadata | null>;
+};
+
+type ProcessRunnerWithMetadataReader = ProcessRunner & {
+  readAttachmentMetadata?: (beadsAttachmentDir: string) => Promise<BeadsAttachmentMetadata | null>;
+};
+
+export type BeadsRuntimeClientOptions = {
+  beadsAttachmentDir: string | null;
+  doltHost: string | undefined;
+  doltPort: string | undefined;
+  databaseName: string | undefined;
+};
+
+type BeadsAttachmentMetadata = {
+  backend?: string;
+  dolt_mode?: string;
+  dolt_server_host?: string;
+  dolt_server_port?: number;
+  dolt_server_user?: string;
+  dolt_database?: string;
+};
+
+type BeadsWherePayload = {
+  path?: string;
+  error?: string;
+};
+
+type AttachmentStatus = {
+  ready: boolean;
+  reason: string;
 };
 
 export class BeadsRuntimeClient {
-  private beadsDir: string | null;
+  private beadsAttachmentDir: string | null;
   private readonly runProcess: ProcessRunner;
-  private readonly resolveBeadsDir: BeadsDirResolver;
+  private readonly resolveBeadsAttachmentDir: BeadsAttachmentDirResolver;
+  private readonly readAttachmentMetadataForPath: (
+    beadsAttachmentDir: string,
+  ) => Promise<BeadsAttachmentMetadata | null>;
   private customStatusesConfigured: boolean;
   private initialized: boolean;
   private initializationPromise: Promise<void> | null;
   private readonly repoPath: string;
+  private readonly doltHost: string;
+  private readonly doltPort: string;
+  private readonly databaseName: string;
 
-  constructor(repoPath: string, beadsDir: string | null, deps: BeadsRuntimeClientDeps = {}) {
+  constructor(
+    repoPath: string,
+    options: BeadsRuntimeClientOptions,
+    deps: BeadsRuntimeClientDeps = {},
+  ) {
     this.repoPath = repoPath;
-    this.beadsDir = beadsDir;
-    this.runProcess = deps.runProcess ?? runProcess;
-    this.resolveBeadsDir = deps.resolveBeadsDir ?? resolveCentralBeadsDir;
+    this.beadsAttachmentDir = options.beadsAttachmentDir;
+    this.doltHost =
+      normalizeOptionalInput(options.doltHost) ??
+      BeadsRuntimeClient.missingContractValue("ODT_DOLT_HOST");
+    this.doltPort =
+      normalizeOptionalInput(options.doltPort) ??
+      BeadsRuntimeClient.missingContractValue("ODT_DOLT_PORT");
+    this.databaseName =
+      normalizeOptionalInput(options.databaseName) ??
+      BeadsRuntimeClient.missingContractValue("ODT_DATABASE_NAME");
+    const configuredRunProcess = (deps.runProcess ?? runProcess) as ProcessRunnerWithMetadataReader;
+    this.runProcess = configuredRunProcess;
+    this.resolveBeadsAttachmentDir =
+      deps.resolveBeadsAttachmentDir ?? resolveRepoBeadsAttachmentDir;
+    this.readAttachmentMetadataForPath =
+      deps.readAttachmentMetadata ??
+      configuredRunProcess.readAttachmentMetadata ??
+      ((beadsAttachmentDir) => this.readAttachmentMetadata(beadsAttachmentDir));
     this.customStatusesConfigured = false;
     this.initialized = false;
     this.initializationPromise = null;
   }
 
-  private async ensureBeadsDir(): Promise<string> {
-    if (this.beadsDir) {
-      return this.beadsDir;
-    }
-
-    this.beadsDir = await this.resolveBeadsDir(this.repoPath);
-    return this.beadsDir;
+  private static missingContractValue(name: string): never {
+    throw new Error(`Missing required OpenDucktor MCP contract value: ${name}`);
   }
 
-  private beadsStoreFootprintExists(beadsDir: string): boolean {
-    return existsSync(join(beadsDir, "dolt")) || existsSync(join(beadsDir, "beads.db"));
+  private async ensureBeadsAttachmentDir(): Promise<string> {
+    if (this.beadsAttachmentDir) {
+      return this.beadsAttachmentDir;
+    }
+
+    this.beadsAttachmentDir = await this.resolveBeadsAttachmentDir(this.repoPath);
+    return this.beadsAttachmentDir;
+  }
+
+  private beadsStoreFootprintExists(beadsAttachmentDir: string): boolean {
+    return existsSync(beadsAttachmentDir) || existsSync(`${beadsAttachmentDir}/beads.db`);
+  }
+
+  private beadsMetadataPath(beadsAttachmentDir: string): string {
+    return `${beadsAttachmentDir}/metadata.json`;
+  }
+
+  private beadsWorkingDirectory(beadsAttachmentDir: string): string {
+    return dirname(beadsAttachmentDir);
   }
 
   private statusRequiresCustomConfiguration(status: string): boolean {
@@ -56,26 +126,131 @@ export class BeadsRuntimeClient {
     );
   }
 
+  private beadsEnv(beadsAttachmentDir: string): Record<string, string> {
+    return {
+      BEADS_DIR: beadsAttachmentDir,
+      BEADS_DOLT_SERVER_MODE: "1",
+      BEADS_DOLT_SERVER_HOST: this.doltHost,
+      BEADS_DOLT_SERVER_PORT: this.doltPort,
+      BEADS_DOLT_SERVER_USER: "root",
+    };
+  }
+
+  private async readAttachmentMetadata(
+    beadsAttachmentDir: string,
+  ): Promise<BeadsAttachmentMetadata | null> {
+    try {
+      const raw = await readFile(this.beadsMetadataPath(beadsAttachmentDir), "utf8");
+      return JSON.parse(raw) as BeadsAttachmentMetadata;
+    } catch {
+      return null;
+    }
+  }
+
+  private attachmentMetadataMatches(
+    metadata: BeadsAttachmentMetadata | null,
+    expectedDatabaseName: string,
+  ): boolean {
+    return (
+      metadata?.backend === "dolt" &&
+      metadata?.dolt_mode === "server" &&
+      (metadata?.dolt_server_host === undefined || metadata.dolt_server_host === this.doltHost) &&
+      (metadata?.dolt_server_port === undefined ||
+        metadata.dolt_server_port === Number(this.doltPort)) &&
+      (metadata?.dolt_server_user === undefined || metadata.dolt_server_user === "root") &&
+      metadata?.dolt_database === expectedDatabaseName
+    );
+  }
+
+  private static reasonRequiresBootstrap(reason: string): boolean {
+    const normalized = reason.toLowerCase();
+    return (
+      normalized.includes("not found on dolt server") ||
+      normalized.includes("server not reachable") ||
+      normalized.includes("error 1049")
+    );
+  }
+
+  private shouldForceRestoreBackup(beadsAttachmentDir: string, error: unknown): boolean {
+    if (!existsSync(`${beadsAttachmentDir}/backup`)) {
+      return false;
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    const normalized = message.toLowerCase();
+    return (
+      normalized.includes("already exists") && normalized.includes("use '--force' to overwrite")
+    );
+  }
+
+  private async inspectAttachment(beadsAttachmentDir: string): Promise<AttachmentStatus> {
+    const metadata = await this.readAttachmentMetadataForPath(beadsAttachmentDir);
+    if (!this.attachmentMetadataMatches(metadata, this.databaseName)) {
+      return {
+        ready: false,
+        reason: "Beads attachment metadata does not match the shared-server binding",
+      };
+    }
+
+    const whereOutput = await this.runBd(["where"], { json: true, allowFailure: true });
+    if (whereOutput.trim().length === 0) {
+      return { ready: false, reason: "bd where returned empty payload" };
+    }
+
+    let payload: BeadsWherePayload;
+    try {
+      payload = JSON.parse(whereOutput) as BeadsWherePayload;
+    } catch {
+      throw new Error("Failed to parse bd JSON output for args: where");
+    }
+
+    if (typeof payload.error === "string" && payload.error.trim().length > 0) {
+      return { ready: false, reason: payload.error.trim() };
+    }
+    if (typeof payload.path !== "string" || payload.path.trim().length === 0) {
+      return { ready: false, reason: "bd where returned malformed payload" };
+    }
+
+    const [actualPath, expectedPath] = await Promise.all([
+      resolveCanonicalPath(payload.path),
+      resolveCanonicalPath(beadsAttachmentDir),
+    ]);
+    if (actualPath !== expectedPath) {
+      return {
+        ready: false,
+        reason: `Beads attachment resolves to ${payload.path}, expected ${beadsAttachmentDir}`,
+      };
+    }
+
+    return { ready: true, reason: "" };
+  }
+
   async runBd(
     args: string[],
     options?: { json?: boolean; allowFailure?: boolean },
   ): Promise<string> {
-    const beadsDir = await this.ensureBeadsDir();
+    const beadsAttachmentDir = await this.ensureBeadsAttachmentDir();
     const finalArgs = [...args];
     if (options?.json) {
       finalArgs.push("--json");
     }
 
-    const result = await this.runProcess("bd", finalArgs, this.repoPath, {
-      BEADS_DIR: beadsDir,
-    });
+    const result = await this.runProcess(
+      "bd",
+      finalArgs,
+      this.beadsWorkingDirectory(beadsAttachmentDir),
+      this.beadsEnv(beadsAttachmentDir),
+    );
 
     if (!result.ok && !options?.allowFailure) {
       const details = result.stderr || result.stdout || "bd command failed";
       throw new Error(`bd ${finalArgs.join(" ")} failed: ${details}`);
     }
 
-    return result.stdout;
+    if (result.stdout.trim().length > 0) {
+      return result.stdout;
+    }
+    return result.stderr;
   }
 
   async runBdJson(args: string[]): Promise<unknown> {
@@ -98,22 +273,48 @@ export class BeadsRuntimeClient {
     }
 
     this.initializationPromise = (async () => {
-      const beadsDir = await this.ensureBeadsDir();
-      if (!this.beadsStoreFootprintExists(beadsDir)) {
-        const slug = sanitizeSlug(basename(this.repoPath));
-        const databaseName = await computeBeadsDatabaseName(this.repoPath, beadsDir);
-        await this.runBd([
-          "init",
-          "--quiet",
-          "--skip-hooks",
-          "--prefix",
-          slug,
-          "--database",
-          databaseName,
-        ]);
+      const beadsAttachmentDir = await this.ensureBeadsAttachmentDir();
+      const status = this.beadsStoreFootprintExists(beadsAttachmentDir)
+        ? await this.inspectAttachment(beadsAttachmentDir)
+        : { ready: false, reason: "bd init failed" };
+      if (!status.ready) {
+        if (BeadsRuntimeClient.reasonRequiresBootstrap(status.reason)) {
+          try {
+            await this.runBd(["bootstrap", "--yes"]);
+          } catch (error) {
+            if (this.shouldForceRestoreBackup(beadsAttachmentDir, error)) {
+              await this.runBd(["backup", "restore", "--force"]);
+            } else {
+              throw error;
+            }
+          }
+        } else {
+          const slug = sanitizeSlug(basename(this.repoPath));
+          await this.runBd([
+            "init",
+            "--server",
+            "--server-host",
+            this.doltHost,
+            "--server-port",
+            this.doltPort,
+            "--server-user",
+            "root",
+            "--quiet",
+            "--skip-hooks",
+            "--prefix",
+            slug,
+            "--database",
+            this.databaseName,
+          ]);
+        }
+        const verifiedAfterRecovery = await this.inspectAttachment(beadsAttachmentDir);
+        if (!verifiedAfterRecovery.ready) {
+          throw new Error(
+            `Beads attachment verification failed after recovery for ${beadsAttachmentDir}: ${verifiedAfterRecovery.reason}`,
+          );
+        }
       }
 
-      await this.runBd(["dolt", "start"]);
       this.initialized = true;
     })();
 

--- a/packages/openducktor-mcp/src/beads-runtime-client.ts
+++ b/packages/openducktor-mcp/src/beads-runtime-client.ts
@@ -326,7 +326,7 @@ export class BeadsRuntimeClient {
       const beadsAttachmentDir = await this.ensureBeadsAttachmentDir();
       const status = this.beadsStoreFootprintExists(beadsAttachmentDir)
         ? await this.inspectAttachment(beadsAttachmentDir)
-        : { ready: false, reason: "bd init failed" };
+        : { ready: false, reason: "Beads attachment is missing" };
       if (!status.ready) {
         if (BeadsRuntimeClient.reasonRequiresSharedDatabaseSeed(status.reason)) {
           await this.materializeSharedDatabaseFromAttachment(beadsAttachmentDir);

--- a/packages/openducktor-mcp/src/beads-runtime.test.ts
+++ b/packages/openducktor-mcp/src/beads-runtime.test.ts
@@ -8,12 +8,14 @@ import {
   computeBeadsDatabaseName,
   resolveBundledCommandPath,
   resolveCommandExecutable,
+  resolveRepoBeadsAttachmentDir,
   sanitizeSlug,
 } from "./beads-runtime";
 
 const originalExecPath = process.execPath;
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
+const originalConfigRoot = process.env.OPENDUCKTOR_CONFIG_DIR;
 const tempDirs: string[] = [];
 
 const setExecPath = (value: string): void => {
@@ -35,6 +37,11 @@ afterEach(() => {
     process.env.USERPROFILE = originalUserProfile;
   } else {
     delete process.env.USERPROFILE;
+  }
+  if (typeof originalConfigRoot === "string") {
+    process.env.OPENDUCKTOR_CONFIG_DIR = originalConfigRoot;
+  } else {
+    delete process.env.OPENDUCKTOR_CONFIG_DIR;
   }
   delete process.env[commandEnvOverrideName("bd")];
   for (const dir of tempDirs.splice(0)) {
@@ -143,34 +150,30 @@ describe("beads runtime command resolution", () => {
     expect(sanitizeSlug("___My Repo___")).toBe("my-repo");
   });
 
-  test("computeBeadsDatabaseName is stable and scoped to the beads directory", async () => {
-    const first = await computeBeadsDatabaseName(
-      "/repo/fairnest",
-      "/tmp/.openducktor/beads/fairnest/.beads",
-    );
-    const firstAgain = await computeBeadsDatabaseName(
-      "/repo/fairnest",
-      "/tmp/.openducktor/beads/fairnest/.beads",
-    );
-    const second = await computeBeadsDatabaseName(
-      "/repo/fairnest",
-      "/tmp/.openducktor-local/beads/fairnest/.beads",
-    );
+  test("computeBeadsDatabaseName is stable for the same repo path", async () => {
+    const first = await computeBeadsDatabaseName("/tmp/OpenDucktor Repo");
+    const firstAgain = await computeBeadsDatabaseName("/tmp/OpenDucktor Repo");
+    const second = await computeBeadsDatabaseName("/tmp/b/project");
 
     expect(firstAgain).toBe(first);
-    expect(first).toMatch(/^odt_fairnest_[a-f0-9]{12}$/);
-    expect(second).toMatch(/^odt_fairnest_[a-f0-9]{12}$/);
+    expect(first).toBe("odt_openducktor_repo_d03d54c7be05");
+    expect(second).toBe("odt_project_11c79766e587");
     expect(first).not.toBe(second);
     expect(first.length).toBeLessThanOrEqual(64);
   });
 
-  test("computeBeadsDatabaseName resolves relative store paths from the repo path", async () => {
-    const relative = await computeBeadsDatabaseName("/repo/fairnest", "relative/.beads");
-    const absolute = await computeBeadsDatabaseName(
-      "/repo/fairnest",
-      "/repo/fairnest/relative/.beads",
-    );
+  test("computeBeadsDatabaseName differs for same-basename repos in different paths", async () => {
+    const first = await computeBeadsDatabaseName("/tmp/a/project");
+    const second = await computeBeadsDatabaseName("/tmp/b/project");
 
-    expect(relative).toBe(absolute);
+    expect(first).toBe("odt_project_ee5494991388");
+    expect(second).toBe("odt_project_11c79766e587");
+  });
+
+  test("resolveRepoBeadsAttachmentDir uses the shared config root layout", async () => {
+    process.env.OPENDUCKTOR_CONFIG_DIR = "/tmp/odt-config-root";
+    const attachmentDir = await resolveRepoBeadsAttachmentDir("/tmp/openducktor-test/repo");
+
+    expect(attachmentDir).toMatch(/^\/tmp\/odt-config-root\/beads\/repo-[a-f0-9]{8}\/\.beads$/);
   });
 });

--- a/packages/openducktor-mcp/src/beads-runtime.ts
+++ b/packages/openducktor-mcp/src/beads-runtime.ts
@@ -80,7 +80,7 @@ export type ProcessRunner = (
   cwd: string,
   env: Record<string, string>,
 ) => Promise<ProcessResult>;
-export type BeadsDirResolver = (repoPath: string) => Promise<string>;
+export type BeadsAttachmentDirResolver = (repoPath: string) => Promise<string>;
 export type TimeProvider = () => string;
 
 export const commandEnvOverrideName = (command: string): string => {
@@ -233,21 +233,33 @@ const sanitizeDatabaseIdentifier = (input: string): string => {
   return sanitized.length > 0 ? sanitized : "repo";
 };
 
-export const computeBeadsDatabaseName = async (
-  repoPath: string,
-  beadsDir: string,
-): Promise<string> => {
-  const slug = sanitizeDatabaseIdentifier(sanitizeSlug(basename(repoPath)));
+export const computeBeadsDatabaseName = async (repoPath: string): Promise<string> => {
   const canonicalRepoPath = await resolveCanonicalPath(repoPath);
-  const canonicalBeadsDir = await resolveCanonicalPath(resolve(canonicalRepoPath, beadsDir));
-  const hashSuffix = createHash("sha256").update(canonicalBeadsDir).digest("hex").slice(0, 12);
+  const slug = sanitizeDatabaseIdentifier(sanitizeSlug(basename(canonicalRepoPath)));
+  const hashSuffix = createHash("sha256").update(canonicalRepoPath).digest("hex").slice(0, 12);
   const maxSlugLength = 64 - "odt__".length - hashSuffix.length;
   const truncatedSlug = slug.slice(0, maxSlugLength);
   return `odt_${truncatedSlug}_${hashSuffix}`;
 };
 
-export const resolveCentralBeadsDir = async (repoPath: string): Promise<string> => {
+export const resolveConfigRoot = (): string => {
+  const configuredRoot = normalizeOptionalPathInput(process.env.OPENDUCKTOR_CONFIG_DIR);
+  return configuredRoot ?? resolve(homedir(), ".openducktor");
+};
+
+export const resolveBeadsRoot = (): string => resolve(resolveConfigRoot(), "beads");
+
+export const resolveRepoBeadsAttachmentDir = async (repoPath: string): Promise<string> => {
   const repoId = await computeRepoId(repoPath);
-  const root = resolve(homedir(), ".openducktor", "beads", repoId);
+  const root = resolve(resolveBeadsRoot(), repoId);
   return resolve(root, ".beads");
+};
+
+export const resolveRepoLiveDatabaseDir = async (repoPath: string): Promise<string> => {
+  return resolve(
+    resolveBeadsRoot(),
+    "shared-server",
+    "dolt",
+    await computeBeadsDatabaseName(repoPath),
+  );
 };

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -76,8 +76,26 @@ const parseCliArgs = (argv: string[]): OdtStoreContext => {
       continue;
     }
 
-    if (current === "--beads-dir") {
-      next.beadsDir = value;
+    if (current === "--beads-dir" || current === "--beads-attachment-dir") {
+      next.beadsAttachmentDir = value;
+      index += 1;
+      continue;
+    }
+
+    if (current === "--dolt-host") {
+      next.doltHost = value;
+      index += 1;
+      continue;
+    }
+
+    if (current === "--dolt-port") {
+      next.doltPort = value;
+      index += 1;
+      continue;
+    }
+
+    if (current === "--database-name" || current === "--database") {
+      next.databaseName = value;
       index += 1;
       continue;
     }

--- a/packages/openducktor-mcp/src/index.ts
+++ b/packages/openducktor-mcp/src/index.ts
@@ -76,7 +76,7 @@ const parseCliArgs = (argv: string[]): OdtStoreContext => {
       continue;
     }
 
-    if (current === "--beads-dir" || current === "--beads-attachment-dir") {
+    if (current === "--beads-attachment-dir") {
       next.beadsAttachmentDir = value;
       index += 1;
       continue;

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -7,7 +7,7 @@ import {
   normalizePlanSubtasks,
   ODT_TOOL_SCHEMAS,
   OdtTaskStore,
-  resolveCentralBeadsDir,
+  resolveRepoBeadsAttachmentDir,
   resolveStoreContext,
 } from "./lib";
 
@@ -26,12 +26,23 @@ type ProcessResult = {
 
 const FIXED_TIMESTAMP = "2026-02-28T11:30:00.000Z";
 
-const ENV_KEYS = ["ODT_REPO_PATH", "ODT_METADATA_NAMESPACE", "ODT_BEADS_DIR", "BEADS_DIR"] as const;
+const ENV_KEYS = [
+  "ODT_REPO_PATH",
+  "ODT_METADATA_NAMESPACE",
+  "ODT_BEADS_ATTACHMENT_DIR",
+  "ODT_DOLT_HOST",
+  "ODT_DOLT_PORT",
+  "ODT_DATABASE_NAME",
+  "BEADS_DIR",
+] as const;
 
 const takeEnvSnapshot = (): Record<(typeof ENV_KEYS)[number], string | undefined> => ({
   ODT_REPO_PATH: process.env.ODT_REPO_PATH,
   ODT_METADATA_NAMESPACE: process.env.ODT_METADATA_NAMESPACE,
-  ODT_BEADS_DIR: process.env.ODT_BEADS_DIR,
+  ODT_BEADS_ATTACHMENT_DIR: process.env.ODT_BEADS_ATTACHMENT_DIR,
+  ODT_DOLT_HOST: process.env.ODT_DOLT_HOST,
+  ODT_DOLT_PORT: process.env.ODT_DOLT_PORT,
+  ODT_DATABASE_NAME: process.env.ODT_DATABASE_NAME,
   BEADS_DIR: process.env.BEADS_DIR,
 });
 
@@ -93,41 +104,64 @@ const buildProcessRunner = (
   calls: ProcessCall[];
 } => {
   const calls: ProcessCall[] = [];
+  const metadataByPath = new Map<string, Record<string, unknown>>();
+  const runProcess = async (
+    command: string,
+    args: string[],
+    cwd: string,
+    env: Record<string, string>,
+  ) => {
+    calls.push({
+      command,
+      args: [...args],
+      cwd,
+      env: { ...env },
+    });
+    if (args[0] === "init") {
+      metadataByPath.set(env.BEADS_DIR, {
+        backend: "dolt",
+        dolt_mode: "server",
+        dolt_server_host: env.BEADS_DOLT_SERVER_HOST,
+        dolt_server_port: Number(env.BEADS_DOLT_SERVER_PORT),
+        dolt_server_user: env.BEADS_DOLT_SERVER_USER,
+        dolt_database: args[args.length - 1],
+      });
+      return { ok: true, stdout: "", stderr: "" };
+    }
+    if (args[0] === "config" && args[1] === "set" && args[2] === "status.custom") {
+      return { ok: true, stdout: "{}", stderr: "" };
+    }
+    if (args[0] === "where") {
+      const metadata = metadataByPath.get(env.BEADS_DIR);
+      return metadata
+        ? { ok: true, stdout: JSON.stringify({ path: env.BEADS_DIR }), stderr: "" }
+        : { ok: false, stdout: "", stderr: "attachment missing" };
+    }
+    const result = impl(args);
+    const stdout = result.stdout ?? "";
+    if (typeof result.stdout === "string" && result.stdout.trim().length > 0) {
+      try {
+        const parsed = JSON.parse(result.stdout);
+        assertCompleteIssuePayloads(parsed, args);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Invalid JSON fixture for bd ${args.join(" ")}: ${message}`);
+      }
+    }
+    return {
+      ok: result.ok,
+      stdout,
+      stderr: result.stderr ?? "",
+    };
+  };
+  (
+    runProcess as typeof runProcess & {
+      readAttachmentMetadata?: (path: string) => Promise<Record<string, unknown> | null>;
+    }
+  ).readAttachmentMetadata = async (path) => metadataByPath.get(path) ?? null;
 
   return {
-    runProcess: async (command, args, cwd, env) => {
-      calls.push({
-        command,
-        args: [...args],
-        cwd,
-        env: { ...env },
-      });
-      if (args[0] === "init") {
-        return { ok: true, stdout: "", stderr: "" };
-      }
-      if (args[0] === "dolt" && args[1] === "start") {
-        return { ok: true, stdout: "started", stderr: "" };
-      }
-      if (args[0] === "config" && args[1] === "set" && args[2] === "status.custom") {
-        return { ok: true, stdout: "{}", stderr: "" };
-      }
-      const result = impl(args);
-      const stdout = result.stdout ?? "";
-      if (typeof result.stdout === "string" && result.stdout.trim().length > 0) {
-        try {
-          const parsed = JSON.parse(result.stdout);
-          assertCompleteIssuePayloads(parsed, args);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          throw new Error(`Invalid JSON fixture for bd ${args.join(" ")}: ${message}`);
-        }
-      }
-      return {
-        ok: result.ok,
-        stdout,
-        stderr: result.stderr ?? "",
-      };
-    },
+    runProcess,
     calls,
   };
 };
@@ -136,7 +170,10 @@ afterEach(() => {
   restoreEnvSnapshot({
     ODT_REPO_PATH: undefined,
     ODT_METADATA_NAMESPACE: undefined,
-    ODT_BEADS_DIR: undefined,
+    ODT_BEADS_ATTACHMENT_DIR: undefined,
+    ODT_DOLT_HOST: undefined,
+    ODT_DOLT_PORT: undefined,
+    ODT_DATABASE_NAME: undefined,
     BEADS_DIR: undefined,
   });
 });
@@ -178,35 +215,44 @@ describe("openducktor-mcp lib", () => {
     try {
       process.env.ODT_REPO_PATH = "/tmp/env-repo";
       process.env.ODT_METADATA_NAMESPACE = "env-ns";
-      process.env.ODT_BEADS_DIR = "/tmp/env-beads";
-      process.env.BEADS_DIR = "/tmp/fallback-beads";
+      process.env.ODT_BEADS_ATTACHMENT_DIR = "/tmp/env-beads";
+      process.env.ODT_DOLT_HOST = "127.0.0.1";
+      process.env.ODT_DOLT_PORT = "3310";
+      process.env.ODT_DATABASE_NAME = "odt_env_repo";
 
       const resolved = await resolveStoreContext({
         repoPath: "/tmp/context-repo",
         metadataNamespace: "context-ns",
-        beadsDir: "/tmp/context-beads",
+        beadsAttachmentDir: "/tmp/context-beads",
+        doltHost: "127.0.0.2",
+        doltPort: "3311",
+        databaseName: "odt_context_repo",
       });
 
       expect(resolved.repoPath).toBe("/tmp/context-repo");
       expect(resolved.metadataNamespace).toBe("context-ns");
-      expect(resolved.beadsDir).toBe("/tmp/context-beads");
+      expect(resolved.beadsAttachmentDir).toBe("/tmp/context-beads");
+      expect(resolved.doltHost).toBe("127.0.0.2");
+      expect(resolved.doltPort).toBe("3311");
+      expect(resolved.databaseName).toBe("odt_context_repo");
     } finally {
       restoreEnvSnapshot(snapshot);
     }
   });
 
-  test("resolveStoreContext treats empty/sentinel env values as missing", async () => {
+  test("resolveStoreContext rejects missing shared-server contract values", async () => {
     const snapshot = takeEnvSnapshot();
     try {
       process.env.ODT_REPO_PATH = "undefined";
       process.env.ODT_METADATA_NAMESPACE = "null";
-      process.env.ODT_BEADS_DIR = "  ";
-      process.env.BEADS_DIR = "/tmp/fallback-beads";
+      process.env.ODT_BEADS_ATTACHMENT_DIR = "  ";
+      delete process.env.ODT_DOLT_HOST;
+      delete process.env.ODT_DOLT_PORT;
+      delete process.env.ODT_DATABASE_NAME;
 
-      const resolved = await resolveStoreContext({});
-      expect(resolved.repoPath.length).toBeGreaterThan(0);
-      expect(resolved.metadataNamespace).toBe("openducktor");
-      expect(resolved.beadsDir).toBe("/tmp/fallback-beads");
+      await expect(resolveStoreContext({})).rejects.toThrow(
+        "Missing Beads attachment directory for OpenDucktor MCP",
+      );
     } finally {
       restoreEnvSnapshot(snapshot);
     }
@@ -217,7 +263,7 @@ describe("openducktor-mcp lib", () => {
     expect(id).toMatch(/^openducktor-repo-[a-f0-9]{8}$/);
   });
 
-  test("resolveCentralBeadsDir does not create directory side effects", async () => {
+  test("resolveRepoBeadsAttachmentDir does not create directory side effects", async () => {
     const nonce = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
     const repoPath = `/tmp/odt-beads-no-side-effect-${nonce}/repo`;
     const repoId = await computeRepoId(repoPath);
@@ -225,7 +271,7 @@ describe("openducktor-mcp lib", () => {
 
     expect(existsSync(repoRoot)).toBe(false);
 
-    const resolved = await resolveCentralBeadsDir(repoPath);
+    const resolved = await resolveRepoBeadsAttachmentDir(repoPath);
     expect(resolved).toBe(resolve(repoRoot, ".beads"));
     expect(existsSync(repoRoot)).toBe(false);
   });
@@ -420,7 +466,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       {
         runProcess,
@@ -507,7 +556,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       {
         runProcess,
@@ -563,7 +615,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -614,7 +669,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -626,14 +684,15 @@ describe("openducktor-mcp lib", () => {
     ]);
 
     expect(calls.filter((entry) => entry.args[0] === "init")).toHaveLength(1);
-    expect(
-      calls.filter((entry) => entry.args[0] === "dolt" && entry.args[1] === "start"),
-    ).toHaveLength(1);
     expect(calls.filter((entry) => entry.args[0] === "list")).toHaveLength(1);
     expect(calls.filter((entry) => entry.args[0] === "show")).toHaveLength(3);
     for (const call of calls) {
       expect(call.command).toBe("bd");
       expect(call.env.BEADS_DIR).toBe("/beads");
+      expect(call.env.BEADS_DOLT_SERVER_MODE).toBe("1");
+      expect(call.env.BEADS_DOLT_SERVER_HOST).toBe("127.0.0.1");
+      expect(call.env.BEADS_DOLT_SERVER_PORT).toBe("3310");
+      expect(call.env.BEADS_DOLT_SERVER_USER).toBe("root");
     }
   });
 
@@ -709,7 +768,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -793,7 +855,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -859,7 +924,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -908,7 +976,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -971,7 +1042,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1045,7 +1119,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       {
         runProcess,
@@ -1140,7 +1217,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1216,7 +1296,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1295,7 +1378,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1371,7 +1457,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1444,7 +1533,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1534,7 +1626,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1628,7 +1723,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1725,7 +1823,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1804,7 +1905,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1881,7 +1985,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );
@@ -1960,7 +2067,10 @@ describe("openducktor-mcp lib", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       { runProcess },
     );

--- a/packages/openducktor-mcp/src/lib.test.ts
+++ b/packages/openducktor-mcp/src/lib.test.ts
@@ -240,18 +240,72 @@ describe("openducktor-mcp lib", () => {
     }
   });
 
-  test("resolveStoreContext rejects missing shared-server contract values", async () => {
+  test("resolveStoreContext rejects missing attachment dir", async () => {
     const snapshot = takeEnvSnapshot();
     try {
       process.env.ODT_REPO_PATH = "undefined";
       process.env.ODT_METADATA_NAMESPACE = "null";
       process.env.ODT_BEADS_ATTACHMENT_DIR = "  ";
-      delete process.env.ODT_DOLT_HOST;
-      delete process.env.ODT_DOLT_PORT;
-      delete process.env.ODT_DATABASE_NAME;
+      process.env.ODT_DOLT_HOST = "127.0.0.1";
+      process.env.ODT_DOLT_PORT = "3310";
+      process.env.ODT_DATABASE_NAME = "odt_env_repo";
 
       await expect(resolveStoreContext({})).rejects.toThrow(
         "Missing Beads attachment directory for OpenDucktor MCP",
+      );
+    } finally {
+      restoreEnvSnapshot(snapshot);
+    }
+  });
+
+  test("resolveStoreContext rejects missing dolt host", async () => {
+    const snapshot = takeEnvSnapshot();
+    try {
+      process.env.ODT_REPO_PATH = "/tmp/env-repo";
+      process.env.ODT_METADATA_NAMESPACE = "env-ns";
+      process.env.ODT_BEADS_ATTACHMENT_DIR = "/tmp/env-beads";
+      delete process.env.ODT_DOLT_HOST;
+      process.env.ODT_DOLT_PORT = "3310";
+      process.env.ODT_DATABASE_NAME = "odt_env_repo";
+
+      await expect(resolveStoreContext({})).rejects.toThrow(
+        "Missing Dolt host for OpenDucktor MCP. Provide ODT_DOLT_HOST.",
+      );
+    } finally {
+      restoreEnvSnapshot(snapshot);
+    }
+  });
+
+  test("resolveStoreContext rejects missing dolt port", async () => {
+    const snapshot = takeEnvSnapshot();
+    try {
+      process.env.ODT_REPO_PATH = "/tmp/env-repo";
+      process.env.ODT_METADATA_NAMESPACE = "env-ns";
+      process.env.ODT_BEADS_ATTACHMENT_DIR = "/tmp/env-beads";
+      process.env.ODT_DOLT_HOST = "127.0.0.1";
+      delete process.env.ODT_DOLT_PORT;
+      process.env.ODT_DATABASE_NAME = "odt_env_repo";
+
+      await expect(resolveStoreContext({})).rejects.toThrow(
+        "Missing Dolt port for OpenDucktor MCP. Provide ODT_DOLT_PORT.",
+      );
+    } finally {
+      restoreEnvSnapshot(snapshot);
+    }
+  });
+
+  test("resolveStoreContext rejects missing database name", async () => {
+    const snapshot = takeEnvSnapshot();
+    try {
+      process.env.ODT_REPO_PATH = "/tmp/env-repo";
+      process.env.ODT_METADATA_NAMESPACE = "env-ns";
+      process.env.ODT_BEADS_ATTACHMENT_DIR = "/tmp/env-beads";
+      process.env.ODT_DOLT_HOST = "127.0.0.1";
+      process.env.ODT_DOLT_PORT = "3310";
+      delete process.env.ODT_DATABASE_NAME;
+
+      await expect(resolveStoreContext({})).rejects.toThrow(
+        "Missing Dolt database name for OpenDucktor MCP. Provide ODT_DATABASE_NAME.",
       );
     } finally {
       restoreEnvSnapshot(snapshot);

--- a/packages/openducktor-mcp/src/lib.ts
+++ b/packages/openducktor-mcp/src/lib.ts
@@ -1,4 +1,4 @@
-export { computeRepoId, resolveCentralBeadsDir } from "./beads-runtime";
+export { computeRepoId, resolveRepoBeadsAttachmentDir } from "./beads-runtime";
 export type {
   IssueType,
   PlanSubtaskInput,

--- a/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
@@ -85,7 +85,10 @@ describe("OdtTaskStore composition", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "wrong_namespace",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       {
         persistence,
@@ -162,7 +165,10 @@ describe("OdtTaskStore composition", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       {
         persistence,
@@ -235,7 +241,10 @@ describe("OdtTaskStore composition", () => {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       {
         persistence,

--- a/packages/openducktor-mcp/src/odt-task-store.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.test.ts
@@ -75,6 +75,7 @@ const makeIssue = (input: {
 
 class OdtStoreHarness {
   private readonly issues: Map<string, TestIssue>;
+  private readonly attachmentMetadata = new Map<string, Record<string, unknown>>();
   private readonly listSnapshots: TestIssue[][] | null;
   private listCalls = 0;
   private createCounter = 0;
@@ -94,10 +95,15 @@ class OdtStoreHarness {
       {
         repoPath: "/repo",
         metadataNamespace: "openducktor",
-        beadsDir: "/beads",
+        beadsAttachmentDir: "/beads",
+        doltHost: "127.0.0.1",
+        doltPort: "3310",
+        databaseName: "odt_repo_testdb",
       },
       {
         runProcess: (command, args, cwd, env) => this.runProcess(command, args, cwd, env),
+        readAttachmentMetadata: (beadsAttachmentDir) =>
+          Promise.resolve(this.attachmentMetadata.get(beadsAttachmentDir) ?? null),
         now: this.now,
       },
     );
@@ -151,13 +157,23 @@ class OdtStoreHarness {
 
     switch (subcommand) {
       case "init":
+        this.attachmentMetadata.set(env.BEADS_DIR, {
+          backend: "dolt",
+          dolt_mode: "server",
+          dolt_server_host: env.BEADS_DOLT_SERVER_HOST,
+          dolt_server_port: Number(env.BEADS_DOLT_SERVER_PORT),
+          dolt_server_user: env.BEADS_DOLT_SERVER_USER,
+          dolt_database: args[args.length - 1],
+        });
         result = { ok: true, stdout: "" };
         break;
       case "config":
         result = { ok: true, stdout: "{}" };
         break;
-      case "dolt":
-        result = { ok: true, stdout: "started" };
+      case "where":
+        result = this.attachmentMetadata.has(env.BEADS_DIR)
+          ? { ok: true, stdout: JSON.stringify({ path: env.BEADS_DIR }) }
+          : { ok: false, stderr: "attachment missing" };
         break;
       case "list":
         this.listCalls += 1;

--- a/packages/openducktor-mcp/src/odt-task-store.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.ts
@@ -33,7 +33,8 @@ import {
 
 export type OdtTaskStoreDeps = {
   runProcess?: BeadsRuntimeClientDeps["runProcess"];
-  resolveBeadsDir?: BeadsRuntimeClientDeps["resolveBeadsDir"];
+  resolveBeadsAttachmentDir?: BeadsRuntimeClientDeps["resolveBeadsAttachmentDir"];
+  readAttachmentMetadata?: BeadsRuntimeClientDeps["readAttachmentMetadata"];
   now?: TimeProvider;
   persistence?: TaskPersistencePort;
   documentStore?: TaskDocumentPort;
@@ -97,10 +98,24 @@ export class OdtTaskStore {
     options: OdtStoreOptions,
     deps: OdtTaskStoreDeps,
   ): BeadsPersistence {
-    const beadsClient = new BeadsRuntimeClient(this.repoPath, options.beadsDir ?? null, {
-      ...(deps.runProcess ? { runProcess: deps.runProcess } : {}),
-      ...(deps.resolveBeadsDir ? { resolveBeadsDir: deps.resolveBeadsDir } : {}),
-    });
+    const beadsClient = new BeadsRuntimeClient(
+      this.repoPath,
+      {
+        beadsAttachmentDir: options.beadsAttachmentDir ?? null,
+        doltHost: options.doltHost,
+        doltPort: options.doltPort,
+        databaseName: options.databaseName,
+      },
+      {
+        ...(deps.runProcess ? { runProcess: deps.runProcess } : {}),
+        ...(deps.resolveBeadsAttachmentDir
+          ? { resolveBeadsAttachmentDir: deps.resolveBeadsAttachmentDir }
+          : {}),
+        ...(deps.readAttachmentMetadata
+          ? { readAttachmentMetadata: deps.readAttachmentMetadata }
+          : {}),
+      },
+    );
     return new BeadsPersistence(beadsClient, options.metadataNamespace);
   }
 

--- a/packages/openducktor-mcp/src/store-context.ts
+++ b/packages/openducktor-mcp/src/store-context.ts
@@ -2,13 +2,19 @@ import { normalizeOptionalInput, resolveCanonicalPath } from "./beads-runtime";
 
 export type OdtStoreOptions = {
   repoPath: string;
-  beadsDir?: string;
+  beadsAttachmentDir?: string;
+  doltHost?: string;
+  doltPort?: string;
+  databaseName?: string;
   metadataNamespace: string;
 };
 
 export type OdtStoreContext = {
   repoPath?: string;
-  beadsDir?: string;
+  beadsAttachmentDir?: string;
+  doltHost?: string;
+  doltPort?: string;
+  databaseName?: string;
   metadataNamespace?: string;
 };
 
@@ -27,14 +33,38 @@ export const resolveStoreContext = async (context: OdtStoreContext): Promise<Odt
     normalizeOptionalInput(process.env.ODT_METADATA_NAMESPACE) ??
     "openducktor";
 
-  const beadsDir =
-    normalizeOptionalInput(context.beadsDir) ??
-    normalizeOptionalInput(process.env.ODT_BEADS_DIR) ??
-    normalizeOptionalInput(process.env.BEADS_DIR);
+  const beadsAttachmentDir =
+    normalizeOptionalInput(context.beadsAttachmentDir) ??
+    normalizeOptionalInput(process.env.ODT_BEADS_ATTACHMENT_DIR);
+  const doltHost =
+    normalizeOptionalInput(context.doltHost) ?? normalizeOptionalInput(process.env.ODT_DOLT_HOST);
+  const doltPort =
+    normalizeOptionalInput(context.doltPort) ?? normalizeOptionalInput(process.env.ODT_DOLT_PORT);
+  const databaseName =
+    normalizeOptionalInput(context.databaseName) ??
+    normalizeOptionalInput(process.env.ODT_DATABASE_NAME);
+
+  if (!beadsAttachmentDir) {
+    throw new Error(
+      "Missing Beads attachment directory for OpenDucktor MCP. Provide ODT_BEADS_ATTACHMENT_DIR.",
+    );
+  }
+  if (!doltHost) {
+    throw new Error("Missing Dolt host for OpenDucktor MCP. Provide ODT_DOLT_HOST.");
+  }
+  if (!doltPort) {
+    throw new Error("Missing Dolt port for OpenDucktor MCP. Provide ODT_DOLT_PORT.");
+  }
+  if (!databaseName) {
+    throw new Error("Missing Dolt database name for OpenDucktor MCP. Provide ODT_DATABASE_NAME.");
+  }
 
   return {
     repoPath: normalizedRepoPath,
     metadataNamespace,
-    ...(beadsDir ? { beadsDir } : {}),
+    beadsAttachmentDir,
+    doltHost,
+    doltPort,
+    databaseName,
   };
 };

--- a/scripts/browser-dev.ts
+++ b/scripts/browser-dev.ts
@@ -12,31 +12,80 @@ const backendEnv: Record<string, string> = {
 const backendProcess = Bun.spawn({
   cmd: ["cargo", "run", "--bin", "browser_backend"],
   cwd: `${repoRoot}/apps/desktop/src-tauri`,
+  detached: true,
   env: backendEnv,
   stdout: "inherit",
   stderr: "inherit",
+});
+let backendExited = false;
+void backendProcess.exited.then(() => {
+  backendExited = true;
 });
 
 let frontendProcess: Bun.Subprocess | null = null;
 let stoppingChildren = false;
 
-const stopChildren = () => {
+const requestBackendShutdown = async (): Promise<void> => {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3_000);
+    await fetch(`${backendUrl}/shutdown`, {
+      method: "POST",
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+  } catch {}
+};
+
+const terminateProcessGroup = async (child: Bun.Subprocess | null): Promise<void> => {
+  if (!child) {
+    return;
+  }
+
+  const pid = child.pid;
+  if (typeof pid === "number" && pid > 0) {
+    try {
+      process.kill(-pid, "SIGTERM");
+    } catch {}
+  }
+
+  child.kill();
+  await Promise.race([child.exited, Bun.sleep(3_000)]);
+
+  if (typeof pid === "number" && pid > 0) {
+    try {
+      process.kill(-pid, 0);
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {}
+    } catch {}
+  }
+
+  child.kill(9);
+  await Promise.race([child.exited, Bun.sleep(1_000)]);
+};
+
+const stopChildren = async () => {
   if (stoppingChildren) {
     return;
   }
   stoppingChildren = true;
-  backendProcess.kill();
-  frontendProcess?.kill();
+
+  await Promise.allSettled([requestBackendShutdown(), terminateProcessGroup(frontendProcess)]);
+
+  await Promise.race([backendProcess.exited, Bun.sleep(4_000)]);
+
+  if (!backendExited) {
+    await terminateProcessGroup(backendProcess);
+  }
 };
 
 process.on("SIGINT", () => {
-  stopChildren();
-  process.exit(130);
+  void stopChildren().finally(() => process.exit(130));
 });
 
 process.on("SIGTERM", () => {
-  stopChildren();
-  process.exit(143);
+  void stopChildren().finally(() => process.exit(143));
 });
 
 const waitForBackend = async (): Promise<void> => {
@@ -66,6 +115,7 @@ try {
   frontendProcess = Bun.spawn({
     cmd: ["bun", "run", "--filter", "@openducktor/desktop", "dev:browser"],
     cwd: repoRoot,
+    detached: true,
     env: {
       ...process.env,
       VITE_ODT_BROWSER_BACKEND_URL: backendUrl,
@@ -85,7 +135,7 @@ try {
     })),
   ]);
 
-  stopChildren();
+  await stopChildren();
 
   if (firstExit.processName === "backend") {
     await frontendProcess.exited;
@@ -95,7 +145,7 @@ try {
 
   process.exit(firstExit.exitCode);
 } catch (error) {
-  stopChildren();
+  await stopChildren();
   console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- centralize Beads storage on one shared Dolt server per config root, with explicit repo attachment directories, deterministic shared database naming, strict attachment verification, and shared database hydration from attachment backups
- align the host and MCP launch contract around explicit attachment and shared-Dolt routing details, tighten attachment metadata checks, and remove legacy attachment compatibility from the remaining runtime paths
- improve shutdown behavior for the shared Dolt server and runtime processes, and add Beads/Dolt lifecycle documentation that explains the architecture and command flow in `docs/`

## Testing
- `bun run check:rust`
- `rtk cargo test -p host-infra-system`
- `rtk cargo test -p host-infra-beads`
- `rtk cargo test -p host-application`
- `bun run --filter @openducktor/mcp test`
- `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single shared local Dolt SQL server per config root with per-repo Beads attachments; MCP/runtime and CLI now receive explicit Beads-attachment and Dolt connection params (new flags).
  * Headless server exposes POST /shutdown for coordinated shutdown.  
  * Centralized task-option builder for UI task selector.

* **Bug Fixes**
  * Shutdown flow now stops shared Dolt server and surfaces related cleanup errors.

* **Documentation**
  * Added detailed Beads + shared-Dolt lifecycle docs and updated architecture/MCP guides.

* **Tests**
  * Tests updated to cover shared-server workflows, env/CLI changes, and backup/restore flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->