### PR TITLE
fix(beads): keep only latest QA report metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,7 @@ Prefer light shades for backgrounds (`bg-sky-50`) and dark for text (`text-sky-7
   - built-in: `open`, `in_progress`, `blocked`, `deferred`, `closed`
   - custom: `spec_ready`, `ready_for_dev`, `ai_review`, `human_review`
 - UI label mapping: `open` → Backlog, `closed` → Done, `deferred` → hidden from Kanban.
-- Agent-authored docs are metadata under `openducktor` namespace: `documents.spec`, `documents.implementationPlan` (latest-only), `documents.qaReports` (append-only).
+- Agent-authored docs are metadata under `openducktor` namespace: `documents.spec`, `documents.implementationPlan`, `documents.qaReports` (latest-only).
 - Task actions defined in `packages/contracts/src/task-schemas.ts` (`taskActionSchema`).
 - Detailed workflow docs: `docs/task-workflow-*.md`
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
@@ -1,5 +1,44 @@
 use super::*;
 
+fn write_latest_qa_report(
+    documents_map: &mut serde_json::Map<String, Value>,
+    markdown: &str,
+    verdict: QaVerdict,
+) -> Result<QaEntry> {
+    let next_revision = documents_map
+        .get("qaReports")
+        .and_then(parse_qa_entries)
+        .map(|entries| {
+            entries
+                .iter()
+                .map(|entry| entry.revision)
+                .max()
+                .unwrap_or(0)
+                + 1
+        })
+        .unwrap_or(1);
+
+    let source_tool = match verdict {
+        QaVerdict::Approved => "qa_approved",
+        QaVerdict::Rejected => "qa_rejected",
+    };
+    let entry = QaEntry {
+        markdown: markdown.trim().to_string(),
+        verdict,
+        updated_at: now_rfc3339(),
+        updated_by: "qa-agent".to_string(),
+        source_tool: source_tool.to_string(),
+        revision: next_revision,
+    };
+
+    documents_map.insert(
+        "qaReports".to_string(),
+        Value::Array(vec![serde_json::to_value(&entry)?]),
+    );
+
+    Ok(entry)
+}
+
 impl BeadsTaskStore {
     pub(super) fn get_spec_impl(&self, repo_path: &Path, task_id: &str) -> Result<SpecDocument> {
         let issue = self.show_raw_issue(repo_path, task_id)?;
@@ -162,43 +201,14 @@ impl BeadsTaskStore {
             .and_then(Value::as_object)
             .cloned()
             .unwrap_or_default();
-
-        let mut entries = documents_map
-            .get("qaReports")
-            .and_then(parse_qa_entries)
-            .unwrap_or_default();
-        let next_revision = entries.last().map(|entry| entry.revision + 1).unwrap_or(1);
-
-        let timestamp = now_rfc3339();
-        let entry = QaEntry {
-            markdown: markdown.trim().to_string(),
-            verdict: verdict.clone(),
-            updated_at: timestamp.clone(),
-            updated_by: "qa-agent".to_string(),
-            source_tool: match verdict {
-                QaVerdict::Approved => "qa_approved".to_string(),
-                QaVerdict::Rejected => "qa_rejected".to_string(),
-            },
-            revision: next_revision,
-        };
-
-        entries.push(entry.clone());
-        documents_map.insert(
-            "qaReports".to_string(),
-            Value::Array(
-                entries
-                    .iter()
-                    .map(serde_json::to_value)
-                    .collect::<std::result::Result<Vec<_>, _>>()?,
-            ),
-        );
+        let entry = write_latest_qa_report(&mut documents_map, markdown, verdict)?;
         namespace_map.insert("documents".to_string(), Value::Object(documents_map));
 
         self.persist_namespace(repo_path, task_id, &namespace_key, &mut root, namespace_map)?;
         Ok(QaReportDocument {
             markdown: entry.markdown,
             verdict: entry.verdict,
-            updated_at: timestamp,
+            updated_at: entry.updated_at,
             revision: entry.revision,
         })
     }
@@ -220,36 +230,7 @@ impl BeadsTaskStore {
             .and_then(Value::as_object)
             .cloned()
             .unwrap_or_default();
-
-        let mut entries = documents_map
-            .get("qaReports")
-            .and_then(parse_qa_entries)
-            .unwrap_or_default();
-        let next_revision = entries.last().map(|entry| entry.revision + 1).unwrap_or(1);
-
-        let timestamp = now_rfc3339();
-        let entry = QaEntry {
-            markdown: markdown.trim().to_string(),
-            verdict: verdict.clone(),
-            updated_at: timestamp,
-            updated_by: "qa-agent".to_string(),
-            source_tool: match verdict {
-                QaVerdict::Approved => "qa_approved".to_string(),
-                QaVerdict::Rejected => "qa_rejected".to_string(),
-            },
-            revision: next_revision,
-        };
-
-        entries.push(entry);
-        documents_map.insert(
-            "qaReports".to_string(),
-            Value::Array(
-                entries
-                    .iter()
-                    .map(serde_json::to_value)
-                    .collect::<std::result::Result<Vec<_>, _>>()?,
-            ),
-        );
+        let entry = write_latest_qa_report(&mut documents_map, markdown, verdict)?;
         namespace_map.insert("documents".to_string(), Value::Object(documents_map));
         root.insert(namespace_key, Value::Object(namespace_map));
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
@@ -5,18 +5,32 @@ fn write_latest_qa_report(
     markdown: &str,
     verdict: QaVerdict,
 ) -> Result<QaEntry> {
-    let next_revision = documents_map
-        .get("qaReports")
-        .and_then(parse_qa_entries)
-        .map(|entries| {
+    let next_revision = match documents_map.get("qaReports") {
+        None => 1,
+        Some(raw_reports) => {
+            let raw_entries = raw_reports.as_array().ok_or_else(|| {
+                anyhow::Error::msg("Invalid existing qaReports metadata: expected an array")
+            })?;
+            let entries = raw_entries
+                .iter()
+                .enumerate()
+                .map(|(index, entry)| {
+                    serde_json::from_value::<QaEntry>(entry.clone()).map_err(|error| {
+                        anyhow::Error::msg(format!(
+                            "Invalid existing qaReports metadata at index {index}: {error}"
+                        ))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
             entries
                 .iter()
                 .map(|entry| entry.revision)
                 .max()
                 .unwrap_or(0)
                 + 1
-        })
-        .unwrap_or(1);
+        }
+    };
 
     let source_tool = match verdict {
         QaVerdict::Approved => "odt_qa_approved",

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/store/doc_ops.rs
@@ -19,8 +19,8 @@ fn write_latest_qa_report(
         .unwrap_or(1);
 
     let source_tool = match verdict {
-        QaVerdict::Approved => "qa_approved",
-        QaVerdict::Rejected => "qa_rejected",
+        QaVerdict::Approved => "odt_qa_approved",
+        QaVerdict::Rejected => "odt_qa_rejected",
     };
     let entry = QaEntry {
         markdown: markdown.trim().to_string(),
@@ -230,7 +230,7 @@ impl BeadsTaskStore {
             .and_then(Value::as_object)
             .cloned()
             .unwrap_or_default();
-        let entry = write_latest_qa_report(&mut documents_map, markdown, verdict)?;
+        write_latest_qa_report(&mut documents_map, markdown, verdict)?;
         namespace_map.insert("documents".to_string(), Value::Object(documents_map));
         root.insert(namespace_key, Value::Object(namespace_map));
 

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -2042,6 +2042,40 @@ fn qa_reports_store_latest_entry_and_preserve_next_revision() -> Result<()> {
 }
 
 #[test]
+fn append_qa_report_rejects_malformed_existing_metadata() {
+    let repo = RepoFixture::new("qa-docs-invalid");
+    let malformed = issue_value(
+        "task-1",
+        "open",
+        "task",
+        None,
+        json!([]),
+        Some(json!({
+            "openducktor": {
+                "documents": {
+                    "qaReports": {
+                        "unexpected": true
+                    }
+                }
+            }
+        })),
+    );
+    let runner =
+        MockCommandRunner::with_steps(vec![MockStep::WithEnv(Ok(json!([malformed]).to_string()))]);
+    let store = BeadsTaskStore::with_test_runner("openducktor", runner.clone());
+
+    let error = store
+        .append_qa_report(repo.path(), "task-1", "Needs fixes", QaVerdict::Rejected)
+        .expect_err("malformed qaReports metadata should fail");
+    assert!(error
+        .to_string()
+        .contains("Invalid existing qaReports metadata: expected an array"));
+
+    let calls = runner.take_calls();
+    assert_eq!(calls.len(), 1);
+}
+
+#[test]
 fn record_qa_outcome_updates_status_and_metadata_in_one_update_call() -> Result<()> {
     let repo = RepoFixture::new("qa-outcome");
     let current = issue_value(
@@ -2077,14 +2111,6 @@ fn record_qa_outcome_updates_status_and_metadata_in_one_update_call() -> Result<
             "openducktor": {
                 "documents": {
                     "qaReports": [
-                        {
-                            "markdown": "Initial QA",
-                            "verdict": "rejected",
-                            "updatedAt": "2026-02-20T10:00:00Z",
-                            "updatedBy": "qa-agent",
-                            "sourceTool": "odt_qa_rejected",
-                            "revision": 1
-                        },
                         {
                             "markdown": "Looks good",
                             "verdict": "approved",

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -603,7 +603,7 @@ fn markdown_and_qa_entry_parsers_filter_invalid_entries() {
             "verdict": "approved",
             "updatedAt": "2026-02-17T13:10:00Z",
             "updatedBy": "qa-agent",
-            "sourceTool": "qa_approved",
+            "sourceTool": "odt_qa_approved",
             "revision": 2
         },
         {
@@ -682,7 +682,7 @@ fn metadata_parsing_benchmark_scaffold() {
                     "verdict": if index % 2 == 0 { "approved" } else { "rejected" },
                     "updatedAt": "2026-02-17T13:10:00Z",
                     "updatedBy": "qa-agent",
-                    "sourceTool": if index % 2 == 0 { "qa_approved" } else { "qa_rejected" },
+                    "sourceTool": if index % 2 == 0 { "odt_qa_approved" } else { "odt_qa_rejected" },
                     "revision": index + 1
                 })
             })
@@ -1029,7 +1029,7 @@ fn list_tasks_filters_events_and_populates_subtask_ids() -> Result<()> {
                                 "verdict": "approved",
                                 "updatedAt": "2026-02-20T10:00:00Z",
                                 "updatedBy": "qa-agent",
-                                "sourceTool": "qa_approved",
+            "sourceTool": "odt_qa_approved",
                                 "revision": 1
                             }
                         ]
@@ -1112,7 +1112,7 @@ fn list_tasks_keeps_qa_verdict_but_marks_missing_content_when_latest_markdown_is
                             "verdict": "approved",
                             "updatedAt": "2026-02-20T09:00:00Z",
                             "updatedBy": "qa-agent",
-                            "sourceTool": "qa_approved",
+            "sourceTool": "odt_qa_approved",
                             "revision": 1
                         },
                         {
@@ -1120,7 +1120,7 @@ fn list_tasks_keeps_qa_verdict_but_marks_missing_content_when_latest_markdown_is
                             "verdict": "rejected",
                             "updatedAt": "2026-02-20T10:00:00Z",
                             "updatedBy": "qa-agent",
-                            "sourceTool": "qa_rejected",
+            "sourceTool": "odt_qa_rejected",
                             "revision": 2
                         }
                     ]
@@ -1998,7 +1998,7 @@ fn qa_reports_store_latest_entry_and_preserve_next_revision() -> Result<()> {
                             "verdict": "approved",
                             "updatedAt": "2026-02-20T10:00:00Z",
                             "updatedBy": "qa-agent",
-                            "sourceTool": "qa_approved",
+                            "sourceTool": "odt_qa_approved",
                             "revision": 1
                         }
                     ]
@@ -2036,7 +2036,7 @@ fn qa_reports_store_latest_entry_and_preserve_next_revision() -> Result<()> {
     assert_eq!(newest["revision"], Value::Number(2.into()));
     assert_eq!(
         newest["sourceTool"],
-        Value::String("qa_rejected".to_string())
+        Value::String("odt_qa_rejected".to_string())
     );
     Ok(())
 }
@@ -2059,7 +2059,7 @@ fn record_qa_outcome_updates_status_and_metadata_in_one_update_call() -> Result<
                             "verdict": "rejected",
                             "updatedAt": "2026-02-20T10:00:00Z",
                             "updatedBy": "qa-agent",
-                            "sourceTool": "qa_rejected",
+                            "sourceTool": "odt_qa_rejected",
                             "revision": 1
                         }
                     ]
@@ -2082,7 +2082,7 @@ fn record_qa_outcome_updates_status_and_metadata_in_one_update_call() -> Result<
                             "verdict": "rejected",
                             "updatedAt": "2026-02-20T10:00:00Z",
                             "updatedBy": "qa-agent",
-                            "sourceTool": "qa_rejected",
+                            "sourceTool": "odt_qa_rejected",
                             "revision": 1
                         },
                         {
@@ -2090,7 +2090,7 @@ fn record_qa_outcome_updates_status_and_metadata_in_one_update_call() -> Result<
                             "verdict": "approved",
                             "updatedAt": "2026-02-20T12:00:00Z",
                             "updatedBy": "qa-agent",
-                            "sourceTool": "qa_approved",
+                            "sourceTool": "odt_qa_approved",
                             "revision": 2
                         }
                     ]
@@ -2139,7 +2139,7 @@ fn record_qa_outcome_updates_status_and_metadata_in_one_update_call() -> Result<
     assert_eq!(newest["revision"], Value::Number(2.into()));
     assert_eq!(
         newest["sourceTool"],
-        Value::String("qa_approved".to_string())
+        Value::String("odt_qa_approved".to_string())
     );
     Ok(())
 }
@@ -2162,7 +2162,7 @@ fn get_latest_qa_report_returns_latest_entry_when_present() -> Result<()> {
                             "verdict": "rejected",
                             "updatedAt": "2026-02-20T10:00:00Z",
                             "updatedBy": "qa-agent",
-                            "sourceTool": "qa_rejected",
+                            "sourceTool": "odt_qa_rejected",
                             "revision": 1
                         },
                         {
@@ -2170,7 +2170,7 @@ fn get_latest_qa_report_returns_latest_entry_when_present() -> Result<()> {
                             "verdict": "approved",
                             "updatedAt": "2026-02-20T11:00:00Z",
                             "updatedBy": "qa-agent",
-                            "sourceTool": "qa_approved",
+                            "sourceTool": "odt_qa_approved",
                             "revision": 2
                         }
                     ]
@@ -2410,7 +2410,7 @@ fn get_task_metadata_fetches_all_fields_in_single_call() -> Result<()> {
                             "verdict": "approved",
                             "updatedAt": "2026-02-20T12:00:00Z",
                             "updatedBy": "qa-agent",
-                            "sourceTool": "qa_approved",
+            "sourceTool": "odt_qa_approved",
                             "revision": 1
                         }
                     ]

--- a/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
+++ b/apps/desktop/src-tauri/crates/host-infra-beads/src/tests.rs
@@ -1980,7 +1980,7 @@ fn get_and_set_plan_use_implementation_plan_metadata() -> Result<()> {
 }
 
 #[test]
-fn qa_reports_support_latest_lookup_and_append_history() -> Result<()> {
+fn qa_reports_store_latest_entry_and_preserve_next_revision() -> Result<()> {
     let repo = RepoFixture::new("qa-docs");
     let empty = issue_value("task-1", "open", "task", None, json!([]), None);
     let with_reports = issue_value(
@@ -2031,8 +2031,8 @@ fn qa_reports_support_latest_lookup_and_append_history() -> Result<()> {
     let reports = metadata_root["openducktor"]["documents"]["qaReports"]
         .as_array()
         .expect("qaReports should be an array");
-    assert_eq!(reports.len(), 2);
-    let newest = reports.last().expect("newest report missing");
+    assert_eq!(reports.len(), 1);
+    let newest = reports.first().expect("latest report missing");
     assert_eq!(newest["revision"], Value::Number(2.into()));
     assert_eq!(
         newest["sourceTool"],
@@ -2132,8 +2132,8 @@ fn record_qa_outcome_updates_status_and_metadata_in_one_update_call() -> Result<
     let reports = metadata_root["openducktor"]["documents"]["qaReports"]
         .as_array()
         .expect("qaReports should be an array");
-    assert_eq!(reports.len(), 2);
-    let newest = reports.last().expect("newest report missing");
+    assert_eq!(reports.len(), 1);
+    let newest = reports.first().expect("latest report missing");
     assert_eq!(newest["markdown"], Value::String("Looks good".to_string()));
     assert_eq!(newest["verdict"], Value::String("approved".to_string()));
     assert_eq!(newest["revision"], Value::Number(2.into()));

--- a/docs/task-workflow-status-model.md
+++ b/docs/task-workflow-status-model.md
@@ -131,7 +131,7 @@ Root namespace key is fixed to `openducktor`.
 ```
 
 ## Document History Policy
-- `qaReports`: append-only history (full timeline retained).
+- `qaReports`: list structure, but V1 retains only the latest entry in the list (list length = 1).
 - `spec`: list structure, but V1 retains only the latest entry in the list (list length = 1).
 - `implementationPlan`: list structure, but V1 retains only the latest entry in the list (list length = 1).
 

--- a/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.composition.test.ts
@@ -78,7 +78,7 @@ describe("OdtTaskStore composition", () => {
       }),
       persistSpec: async () => ({ issue, updatedAt: "", revision: 1 }),
       persistImplementationPlan: async () => ({ issue, updatedAt: "", revision: 1 }),
-      appendQaReport: async () => {},
+      persistQaReport: async () => {},
     };
 
     const store = new OdtTaskStore(
@@ -158,7 +158,7 @@ describe("OdtTaskStore composition", () => {
       }),
       persistSpec: async () => ({ issue, updatedAt: "", revision: 1 }),
       persistImplementationPlan: async () => ({ issue, updatedAt: "", revision: 1 }),
-      appendQaReport: async () => {},
+      persistQaReport: async () => {},
     };
 
     const store = new OdtTaskStore(
@@ -234,7 +234,7 @@ describe("OdtTaskStore composition", () => {
       }),
       persistSpec: async () => ({ issue, updatedAt: "", revision: 1 }),
       persistImplementationPlan: async () => ({ issue, updatedAt: "", revision: 1 }),
-      appendQaReport: async () => {},
+      persistQaReport: async () => {},
     };
 
     const store = new OdtTaskStore(

--- a/packages/openducktor-mcp/src/odt-task-store.test.ts
+++ b/packages/openducktor-mcp/src/odt-task-store.test.ts
@@ -686,7 +686,7 @@ describe("OdtTaskStore workflow mutation paths", () => {
     expect(harness.getStatusUpdateCalls()[0]?.args).toContain("human_review");
   });
 
-  test("qaRejected appends qa report entries and increments revision", async () => {
+  test("qaRejected stores latest qa report and increments revision", async () => {
     const harness = new OdtStoreHarness({
       issues: [
         makeIssue({
@@ -732,14 +732,6 @@ describe("OdtTaskStore workflow mutation paths", () => {
     const documents = getNamespaceDocuments(harness.getIssue("task-1"));
     const qaReports = Array.isArray(documents.qaReports) ? documents.qaReports : [];
     expect(qaReports).toEqual([
-      {
-        markdown: "Initial QA report",
-        verdict: "approved",
-        updatedAt: "2026-02-20T00:00:00.000Z",
-        updatedBy: "qa-agent",
-        sourceTool: "odt_qa_approved",
-        revision: 1,
-      },
       {
         markdown: "## Needs fixes",
         verdict: "rejected",

--- a/packages/openducktor-mcp/src/task-document-store.test.ts
+++ b/packages/openducktor-mcp/src/task-document-store.test.ts
@@ -348,7 +348,7 @@ describe("TaskDocumentStore", () => {
     });
   });
 
-  test("appendQaReport stores only latest report and uses max revision + 1", async () => {
+  test("persistQaReport stores only latest report and uses max revision + 1", async () => {
     const harness = createPersistenceHarness({
       id: "task-1",
       title: "Task 1",
@@ -384,7 +384,7 @@ describe("TaskDocumentStore", () => {
     });
 
     const documents = new TaskDocumentStore(harness.persistence, () => FIXED_NOW);
-    await documents.appendQaReport("task-1", "needs changes", "rejected");
+    await documents.persistQaReport("task-1", "needs changes", "rejected");
 
     const updatedIssue = harness.getIssue();
     expect(updatedIssue.metadata).toEqual({

--- a/packages/openducktor-mcp/src/task-document-store.test.ts
+++ b/packages/openducktor-mcp/src/task-document-store.test.ts
@@ -348,7 +348,7 @@ describe("TaskDocumentStore", () => {
     });
   });
 
-  test("appendQaReport appends new report and uses max revision + 1", async () => {
+  test("appendQaReport stores only latest report and uses max revision + 1", async () => {
     const harness = createPersistenceHarness({
       id: "task-1",
       title: "Task 1",
@@ -391,22 +391,6 @@ describe("TaskDocumentStore", () => {
       openducktor: {
         documents: {
           qaReports: [
-            {
-              markdown: "initial",
-              verdict: "approved",
-              updatedAt: "2026-02-22T00:00:00.000Z",
-              updatedBy: "qa-agent",
-              sourceTool: "odt_qa_approved",
-              revision: 4,
-            },
-            {
-              markdown: "older",
-              verdict: "rejected",
-              updatedAt: "2026-02-20T00:00:00.000Z",
-              updatedBy: "qa-agent",
-              sourceTool: "odt_qa_rejected",
-              revision: 2,
-            },
             {
               markdown: "needs changes",
               verdict: "rejected",

--- a/packages/openducktor-mcp/src/task-document-store.ts
+++ b/packages/openducktor-mcp/src/task-document-store.ts
@@ -70,7 +70,7 @@ export type TaskDocumentPort = {
   readDocuments(issue: RawIssue, input: ReadTaskDocumentsInput): ReadTaskDocumentsResult;
   persistSpec(taskId: string, markdown: string): Promise<PersistedTaskDocumentResult>;
   persistImplementationPlan(taskId: string, markdown: string): Promise<PersistedTaskDocumentResult>;
-  appendQaReport(taskId: string, markdown: string, verdict: QaReportVerdict): Promise<void>;
+  persistQaReport(taskId: string, markdown: string, verdict: QaReportVerdict): Promise<void>;
   prepareQaReportWrite(
     issue: RawIssue,
     markdown: string,
@@ -121,7 +121,7 @@ export class TaskDocumentStore implements TaskDocumentPort {
     });
   }
 
-  async appendQaReport(taskId: string, markdown: string, verdict: QaReportVerdict): Promise<void> {
+  async persistQaReport(taskId: string, markdown: string, verdict: QaReportVerdict): Promise<void> {
     const issue = await this.persistence.showRawIssue(taskId);
     const preparedWrite = this.prepareQaReportWrite(issue, markdown, verdict);
     await this.persistence.writeNamespace(taskId, preparedWrite.root, preparedWrite.namespace);

--- a/packages/openducktor-mcp/src/task-document-store.ts
+++ b/packages/openducktor-mcp/src/task-document-store.ts
@@ -150,7 +150,7 @@ export class TaskDocumentStore implements TaskDocumentPort {
       ...namespace,
       documents: {
         ...documents,
-        qaReports: [...entries, entry],
+        qaReports: [entry],
       },
     };
 


### PR DESCRIPTION
## Summary
- store only the latest QA report entry in Beads metadata across the Rust host and MCP layers
- preserve monotonically increasing QA revisions while aligning persistence with the app's latest-only QA consumption
- update tests and workflow docs to reflect latest-only `qaReports` behavior

## Verification
- rtk cargo test -p host-infra-beads
- bun run --filter @openducktor/mcp test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * QA reports now persist only the latest entry (no longer append historical entries) while preserving correct revision numbering.

* **Documentation**
  * Updated QA report storage policy to document the latest-only versioning behavior.

* **Tests**
  * Test suite updated to reflect latest-only QA report behavior and includes a new test validating error handling for malformed existing QA metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->