### PR TITLE
fix(desktop): keep agent chat pinned on todo and attachment growth

### DIFF
--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createRef } from "react";
 import { AgentChatComposer } from "./agent-chat-composer";
@@ -57,6 +57,7 @@ const buildModel = () => ({
   composerEditorRef: createRef<HTMLDivElement>(),
   onComposerEditorInput: SHARED_CALLBACKS.onComposerEditorInput,
   scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+  syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
 });
 
 describe("AgentChatComposer attachments", () => {
@@ -147,6 +148,38 @@ describe("AgentChatComposer attachments", () => {
 
     await waitFor(() => {
       expect(screen.queryByTitle("brief.pdf")).toBeNull();
+    });
+  });
+
+  test("requests a bottom resync when attachment layout changes", async () => {
+    const syncBottomAfterComposerLayout = { current: mock(() => {}) };
+    const file = new File(["pdf"], "brief.pdf", { type: "application/pdf" });
+    const { container } = render(
+      <AgentChatComposer
+        model={{
+          ...buildModel(),
+          syncBottomAfterComposerLayoutRef: syncBottomAfterComposerLayout,
+        }}
+      />,
+    );
+
+    const attachmentInput = container.querySelector('input[type="file"]');
+    if (!(attachmentInput instanceof HTMLInputElement)) {
+      throw new Error("Expected hidden attachment input");
+    }
+
+    fireEvent.change(attachmentInput, {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(syncBottomAfterComposerLayout.current).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove brief.pdf" }));
+
+    await waitFor(() => {
+      expect(syncBottomAfterComposerLayout.current).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.test.ts
@@ -53,6 +53,7 @@ const buildModel = () => ({
   composerEditorRef: createRef<HTMLDivElement>(),
   onComposerEditorInput: () => {},
   scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+  syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
 });
 
 describe("AgentChatComposer", () => {

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-composer.tsx
@@ -14,6 +14,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -260,6 +261,7 @@ export const AgentChatComposer = forwardRef<
     composerFormRef,
     composerEditorRef,
     onComposerEditorInput,
+    syncBottomAfterComposerLayoutRef,
   } = model;
 
   const [draft, setDraft] = useState(createEmptyComposerDraft);
@@ -340,6 +342,17 @@ export const AgentChatComposer = forwardRef<
   const hasBlockingAttachments = Object.keys(attachmentErrors).length > 0;
   const hasSlashAttachmentConflict =
     (draft.attachments ?? []).length > 0 && draftHasSlashCommandSegment(draft);
+  const attachmentLayoutKey = useMemo(() => {
+    const attachments = draft.attachments ?? [];
+    if (attachments.length === 0) {
+      return null;
+    }
+
+    return attachments
+      .map((attachment) => `${attachment.id}:${attachmentErrors[attachment.id] ?? "ok"}`)
+      .join("|");
+  }, [attachmentErrors, draft.attachments]);
+  const previousAttachmentLayoutKeyRef = useRef<string | null | undefined>(undefined);
 
   const sendDisabled =
     (isSending && !isSessionWorking) ||
@@ -357,6 +370,20 @@ export const AgentChatComposer = forwardRef<
   latestDraftRef.current = draft;
   latestOnSendRef.current = onSend;
   latestSendDisabledRef.current = sendDisabled;
+
+  useLayoutEffect(() => {
+    if (previousAttachmentLayoutKeyRef.current === attachmentLayoutKey) {
+      return;
+    }
+
+    const previousAttachmentLayoutKey = previousAttachmentLayoutKeyRef.current;
+    previousAttachmentLayoutKeyRef.current = attachmentLayoutKey;
+    if (typeof previousAttachmentLayoutKey === "undefined") {
+      return;
+    }
+
+    syncBottomAfterComposerLayoutRef.current?.();
+  }, [attachmentLayoutKey, syncBottomAfterComposerLayoutRef]);
 
   const selectorDisabled =
     !taskId || isSelectionCatalogLoading || isSubmitting || !agentStudioReady || isReadOnly;

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.test.ts
@@ -90,6 +90,59 @@ type ScrollContainerMock = {
   scrollTop: number;
 };
 
+type MockResizeObserverController = {
+  callback: ResizeObserverCallback;
+  observer: ResizeObserver;
+  observedElements: Set<Element>;
+};
+
+const mockResizeObserverControllers = new Set<MockResizeObserverController>();
+
+class MockResizeObserver implements ResizeObserver {
+  private readonly observedElements = new Set<Element>();
+
+  constructor(callback: ResizeObserverCallback) {
+    mockResizeObserverControllers.add({
+      callback,
+      observer: this,
+      observedElements: this.observedElements,
+    });
+  }
+
+  disconnect(): void {
+    this.observedElements.clear();
+  }
+
+  observe(target: Element): void {
+    this.observedElements.add(target);
+  }
+
+  unobserve(target: Element): void {
+    this.observedElements.delete(target);
+  }
+}
+
+const triggerResizeObservers = (heightByElement = new Map<Element, number>()): void => {
+  for (const controller of mockResizeObserverControllers) {
+    if (controller.observedElements.size === 0) {
+      continue;
+    }
+
+    controller.callback(
+      Array.from(controller.observedElements).map((target) => ({
+        borderBoxSize: [] as ResizeObserverSize[],
+        contentBoxSize: [] as ResizeObserverSize[],
+        contentRect: {
+          height: heightByElement.get(target) ?? 0,
+        } as DOMRectReadOnly,
+        devicePixelContentBoxSize: [] as ResizeObserverSize[],
+        target,
+      })),
+      controller.observer,
+    );
+  }
+};
+
 const buildLongSession = (sessionId: string, count = 80) => {
   const messages = Array.from({ length: count }, (_, index) =>
     buildMessage("user", `Message ${index + 1}`, {
@@ -112,8 +165,10 @@ describe("AgentChatThread", () => {
   const originalMatchMedia = globalThis.matchMedia;
   const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
   const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+  const originalResizeObserver = globalThis.ResizeObserver;
 
   beforeEach(() => {
+    mockResizeObserverControllers.clear();
     let nextAnimationFrameTime = 16;
     globalThis.matchMedia = ((query: string) =>
       ({
@@ -135,6 +190,7 @@ describe("AgentChatThread", () => {
       return 1;
     }) as typeof requestAnimationFrame;
     globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
     globalThis.IntersectionObserver = class MockIntersectionObserver {
       disconnect(): void {}
 
@@ -154,6 +210,7 @@ describe("AgentChatThread", () => {
     globalThis.matchMedia = originalMatchMedia;
     globalThis.requestAnimationFrame = originalRequestAnimationFrame;
     globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    globalThis.ResizeObserver = originalResizeObserver;
   });
 
   test("renders empty state when no session is active", () => {
@@ -698,6 +755,119 @@ describe("AgentChatThread", () => {
     await act(flush);
 
     expect(containerNode.scrollTop).toBe(2_000);
+
+    rendered.unmount();
+  });
+
+  test("resyncs the transcript when the todo stack first appears", async () => {
+    const syncBottomAfterComposerLayout = mock(() => {});
+    const syncBottomAfterComposerLayoutRef = {
+      current: null,
+    } as { current: (() => void) | null };
+    const model = {
+      ...buildBaseModel(),
+      syncBottomAfterComposerLayoutRef,
+      session: buildSession({
+        pendingQuestions: [],
+        pendingPermissions: [],
+        todos: [],
+      }),
+    };
+
+    const rendered = render(
+      createElement(AgentChatThread, {
+        model,
+      }),
+    );
+    await act(flush);
+    syncBottomAfterComposerLayoutRef.current = syncBottomAfterComposerLayout;
+
+    rendered.rerender(
+      createElement(AgentChatThread, {
+        model: {
+          ...model,
+          session: buildSession({
+            sessionId: model.session?.sessionId,
+            pendingQuestions: [],
+            pendingPermissions: [],
+            todos: [buildTodoItem({ content: "Keep transcript pinned", status: "in_progress" })],
+          }),
+        },
+      }),
+    );
+    await act(flush);
+
+    const bottomStack = rendered.container.querySelector(".agent-chat-bottom-stack");
+    if (!(bottomStack instanceof HTMLDivElement)) {
+      throw new Error("Expected bottom stack element");
+    }
+    const bottomStackWrapper = bottomStack.parentElement;
+    if (!(bottomStackWrapper instanceof HTMLDivElement)) {
+      throw new Error("Expected bottom stack wrapper element");
+    }
+
+    syncBottomAfterComposerLayoutRef.current = syncBottomAfterComposerLayout;
+    syncBottomAfterComposerLayout.mockClear();
+
+    triggerResizeObservers(new Map([[bottomStackWrapper, 72]]));
+
+    expect(syncBottomAfterComposerLayout).toHaveBeenCalledTimes(1);
+
+    rendered.unmount();
+  });
+
+  test("resyncs the transcript when the todo panel expands", async () => {
+    const syncBottomAfterComposerLayout = mock(() => {});
+    const syncBottomAfterComposerLayoutRef = {
+      current: null,
+    } as { current: (() => void) | null };
+    const session = buildSession({
+      pendingQuestions: [],
+      pendingPermissions: [],
+      todos: [buildTodoItem({ content: "Keep transcript pinned", status: "in_progress" })],
+    });
+    const model = {
+      ...buildBaseModel(),
+      syncBottomAfterComposerLayoutRef,
+      session,
+      todoPanelCollapsed: true,
+    };
+
+    const rendered = render(
+      createElement(AgentChatThread, {
+        model,
+      }),
+    );
+    await act(flush);
+    syncBottomAfterComposerLayoutRef.current = syncBottomAfterComposerLayout;
+
+    const bottomStack = rendered.container.querySelector(".agent-chat-bottom-stack");
+    if (!(bottomStack instanceof HTMLDivElement)) {
+      throw new Error("Expected bottom stack element");
+    }
+    const bottomStackWrapper = bottomStack.parentElement;
+    if (!(bottomStackWrapper instanceof HTMLDivElement)) {
+      throw new Error("Expected bottom stack wrapper element");
+    }
+
+    syncBottomAfterComposerLayout.mockClear();
+    triggerResizeObservers(new Map([[bottomStackWrapper, 56]]));
+    syncBottomAfterComposerLayout.mockClear();
+
+    rendered.rerender(
+      createElement(AgentChatThread, {
+        model: {
+          ...model,
+          todoPanelCollapsed: false,
+        },
+      }),
+    );
+    await act(flush);
+
+    syncBottomAfterComposerLayoutRef.current = syncBottomAfterComposerLayout;
+    triggerResizeObservers(new Map([[bottomStackWrapper, 140]]));
+
+    expect(syncBottomAfterComposerLayout).toHaveBeenCalledTimes(1);
 
     rendered.unmount();
   });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat-thread.tsx
@@ -4,6 +4,7 @@ import {
   type ReactElement,
   type RefObject,
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -646,6 +647,50 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
     }));
   }, [activeTurnKey, stagedTurns]);
   const allowTurnContainment = !hasAttachmentMessages;
+  const bottomStackRef = useRef<HTMLDivElement | null>(null);
+  const bottomStackHeightRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!hasBottomStack) {
+      bottomStackHeightRef.current = null;
+      return;
+    }
+
+    const bottomStack = bottomStackRef.current;
+    if (!bottomStack || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const syncAfterBottomStackResize = (height: number) => {
+      if (!Number.isFinite(height)) {
+        return;
+      }
+
+      if (
+        bottomStackHeightRef.current !== null &&
+        Math.abs(bottomStackHeightRef.current - height) < 0.5
+      ) {
+        return;
+      }
+
+      bottomStackHeightRef.current = height;
+      syncBottomAfterComposerLayoutRef.current?.();
+    };
+
+    const observer = new ResizeObserver((entries) => {
+      const matchingEntry = entries.find((entry) => entry.target === bottomStack) ?? entries[0];
+      const nextHeight =
+        matchingEntry?.contentRect.height ?? bottomStack.getBoundingClientRect().height;
+      syncAfterBottomStackResize(nextHeight);
+    });
+
+    observer.observe(bottomStack);
+    syncAfterBottomStackResize(bottomStack.getBoundingClientRect().height);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasBottomStack, syncBottomAfterComposerLayoutRef]);
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col">
@@ -675,22 +720,24 @@ export function AgentChatThread({ model }: { model: AgentChatThreadModel }): Rea
       />
 
       {hasBottomStack && session ? (
-        <AgentChatBottomStack
-          sessionId={session.sessionId}
-          pendingQuestions={session.pendingQuestions}
-          pendingPermissions={session.pendingPermissions}
-          todos={session.todos}
-          agentStudioReady={agentStudioReady}
-          isSubmittingQuestionByRequestId={isSubmittingQuestionByRequestId}
-          onSubmitQuestionAnswers={onSubmitQuestionAnswers}
-          isSubmittingPermissionByRequestId={isSubmittingPermissionByRequestId}
-          permissionReplyErrorByRequestId={permissionReplyErrorByRequestId}
-          onReplyPermission={onReplyPermission}
-          todoPanelCollapsed={todoPanelCollapsed}
-          isSessionWorking={isSessionWorking}
-          sessionAccentColor={sessionAccentColor}
-          onToggleTodoPanel={onToggleTodoPanel}
-        />
+        <div ref={bottomStackRef}>
+          <AgentChatBottomStack
+            sessionId={session.sessionId}
+            pendingQuestions={session.pendingQuestions}
+            pendingPermissions={session.pendingPermissions}
+            todos={session.todos}
+            agentStudioReady={agentStudioReady}
+            isSubmittingQuestionByRequestId={isSubmittingQuestionByRequestId}
+            onSubmitQuestionAnswers={onSubmitQuestionAnswers}
+            isSubmittingPermissionByRequestId={isSubmittingPermissionByRequestId}
+            permissionReplyErrorByRequestId={permissionReplyErrorByRequestId}
+            onReplyPermission={onReplyPermission}
+            todoPanelCollapsed={todoPanelCollapsed}
+            isSessionWorking={isSessionWorking}
+            sessionAccentColor={sessionAccentColor}
+            onToggleTodoPanel={onToggleTodoPanel}
+          />
+        </div>
       ) : null}
       {session ? <ScrollToTopButton visible={!isNearTop} onClick={scrollToTop} /> : null}
       {session ? <ScrollToBottomButton visible={!isNearBottom} onClick={scrollToBottom} /> : null}

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx
@@ -97,6 +97,7 @@ const buildModel = () => ({
     composerEditorRef: createRef<HTMLDivElement>(),
     onComposerEditorInput: () => {},
     scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+    syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
     sessionAgentColors: {},
   },
 });

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.test.ts
@@ -85,6 +85,7 @@ const buildModel = () => ({
     composerEditorRef: createRef<HTMLDivElement>(),
     onComposerEditorInput: () => {},
     scrollToBottomOnSendRef: { current: null } as { current: (() => void) | null },
+    syncBottomAfterComposerLayoutRef: { current: null } as { current: (() => void) | null },
   },
 });
 

--- a/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/agent-chat.types.ts
@@ -92,6 +92,7 @@ export type AgentChatComposerModel = {
   composerEditorRef: RefObject<HTMLDivElement | null>;
   onComposerEditorInput: () => void;
   scrollToBottomOnSendRef: MutableRefObject<(() => void) | null>;
+  syncBottomAfterComposerLayoutRef: MutableRefObject<(() => void) | null>;
 };
 
 export type AgentChatModel = {

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-layout.ts
@@ -1,6 +1,5 @@
 import type { MutableRefObject } from "react";
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
-import { CHAT_SCROLL_EDGE_THRESHOLD_PX } from "./agent-chat-window-shared";
 
 export const COMPOSER_EDITOR_MIN_HEIGHT_PX = 44;
 export const COMPOSER_EDITOR_MAX_HEIGHT_PX = 220;
@@ -144,12 +143,6 @@ export const useAgentChatLayout = ({
       return;
     }
 
-    const container = messagesContainerRef.current;
-    const wasNearBottom =
-      container !== null
-        ? container.scrollHeight - container.scrollTop - container.clientHeight <=
-          CHAT_SCROLL_EDGE_THRESHOLD_PX
-        : false;
     const { didHeightChange } = resizeComposerEditorElement(
       editor,
       undefined,
@@ -160,7 +153,7 @@ export const useAgentChatLayout = ({
       ((editor.textContent ?? "").length === 0
         ? COMPOSER_EDITOR_MIN_HEIGHT_PX
         : composerEditorHeightRef.current);
-    if (wasNearBottom && didHeightChange) {
+    if (didHeightChange) {
       syncBottomAfterComposerLayoutRef?.current?.();
     }
   }, [syncBottomAfterComposerLayoutRef]);
@@ -188,12 +181,6 @@ export const useAgentChatLayout = ({
       return;
     }
 
-    const container = messagesContainerRef.current;
-    const wasNearBottom =
-      container !== null
-        ? container.scrollHeight - container.scrollTop - container.clientHeight <=
-          CHAT_SCROLL_EDGE_THRESHOLD_PX
-        : false;
     const { didHeightChange } = resizeComposerTextareaElement(
       textarea,
       undefined,
@@ -204,7 +191,7 @@ export const useAgentChatLayout = ({
       (textarea.value.length === 0
         ? COMPOSER_TEXTAREA_MIN_HEIGHT_PX
         : composerTextareaHeightRef.current);
-    if (wasNearBottom && didHeightChange) {
+    if (didHeightChange) {
       syncBottomAfterComposerLayoutRef?.current?.();
     }
   }, [syncBottomAfterComposerLayoutRef]);

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.test.ts
@@ -738,6 +738,91 @@ describe("useAgentChatWindow", () => {
     await harness.unmount();
   });
 
+  test("syncBottomAfterComposerLayoutRef keeps the transcript pinned while following", async () => {
+    const rows = createTurnRows(8);
+    const extraContentHeightPx = { current: 0 };
+    const syncBottomAfterComposerLayoutRef = { current: null as (() => void) | null };
+    const harness = await mountHarness(
+      {
+        rows,
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+        isSessionWorking: true,
+        syncBottomAfterComposerLayoutRef,
+      },
+      { attachDom: true, extraContentHeightPx },
+    );
+
+    const container = harness.messagesContainerRef.current;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+    if (!syncBottomAfterComposerLayoutRef.current) {
+      throw new Error("Expected sync callback");
+    }
+
+    container.scrollTop = getMaxScrollTop(container);
+    await act(async () => {
+      await dispatchScroll(container);
+    });
+    await flushAnimationFrames();
+
+    extraContentHeightPx.current = 200;
+    await act(async () => {
+      syncBottomAfterComposerLayoutRef.current?.();
+      await flush();
+    });
+    await flushAnimationFrames();
+
+    expect(container.scrollTop).toBe(getMaxScrollTop(container));
+    expect(harness.getLatestResult().isNearBottom).toBe(true);
+
+    await harness.unmount();
+  });
+
+  test("syncBottomAfterComposerLayoutRef does not override manual scroll position", async () => {
+    const rows = createTurnRows(8);
+    const extraContentHeightPx = { current: 0 };
+    const syncBottomAfterComposerLayoutRef = { current: null as (() => void) | null };
+    const harness = await mountHarness(
+      {
+        rows,
+        activeSessionId: "session-1",
+        isSessionViewLoading: false,
+        isSessionWorking: true,
+        syncBottomAfterComposerLayoutRef,
+      },
+      { attachDom: true, extraContentHeightPx },
+    );
+
+    const container = harness.messagesContainerRef.current;
+    if (!container) {
+      throw new Error("Expected messages container");
+    }
+    if (!syncBottomAfterComposerLayoutRef.current) {
+      throw new Error("Expected sync callback");
+    }
+
+    container.scrollTop = 120;
+    await act(async () => {
+      await dispatchWheelUp(container);
+      await dispatchScroll(container);
+    });
+    await flushAnimationFrames();
+
+    extraContentHeightPx.current = 200;
+    await act(async () => {
+      syncBottomAfterComposerLayoutRef.current?.();
+      await flush();
+    });
+    await flushAnimationFrames();
+
+    expect(container.scrollTop).toBe(120);
+    expect(harness.getLatestResult().isNearBottom).toBe(false);
+
+    await harness.unmount();
+  });
+
   test("exports the expected turn window constants", () => {
     expect(CHAT_TURN_WINDOW_INIT).toBe(10);
     expect(CHAT_TURN_WINDOW_BATCH).toBe(8);

--- a/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
+++ b/apps/desktop/src/components/features/agents/agent-chat/use-agent-chat-window.ts
@@ -70,6 +70,9 @@ export function useAgentChatWindow({
   });
   const pendingBottomResetRef = useRef(false);
   const visibleWindowKey = `${windowStart}:${windowedRows.length}`;
+  const isFollowingTranscript = useCallback(() => {
+    return !userScrolledRef.current;
+  }, [userScrolledRef]);
 
   const resetLatestTurnsAndPinBottom = useCallback(() => {
     if (turnStart === latestTurnStart) {
@@ -118,6 +121,10 @@ export function useAgentChatWindow({
     };
 
     syncBottomAfterComposerLayoutRef.current = () => {
+      if (!isFollowingTranscript()) {
+        return;
+      }
+
       cancelScheduledComposerLayoutSync();
       const requestAnimationFrameFn = globalThis.requestAnimationFrame;
       if (typeof requestAnimationFrameFn !== "function") {
@@ -151,7 +158,12 @@ export function useAgentChatWindow({
         syncBottomAfterComposerLayoutRef.current = null;
       }
     };
-  }, [forceScrollToBottom, syncBottomAfterComposerLayoutRef, userScrollIntentVersionRef]);
+  }, [
+    forceScrollToBottom,
+    isFollowingTranscript,
+    syncBottomAfterComposerLayoutRef,
+    userScrollIntentVersionRef,
+  ]);
 
   useLayoutEffect(() => {
     if (!pendingBottomResetRef.current) {

--- a/apps/desktop/src/pages/agents/agents-page-view-model.ts
+++ b/apps/desktop/src/pages/agents/agents-page-view-model.ts
@@ -170,6 +170,7 @@ type AgentChatComposerModelArgs = {
   composerEditorRef: RefObject<HTMLDivElement | null>;
   onComposerEditorInput: () => void;
   scrollToBottomOnSendRef: AgentChatModel["composer"]["scrollToBottomOnSendRef"];
+  syncBottomAfterComposerLayoutRef: AgentChatModel["composer"]["syncBottomAfterComposerLayoutRef"];
 };
 
 export const buildAgentChatThreadModel = (
@@ -249,6 +250,7 @@ export const buildAgentChatComposerModel = (
   composerEditorRef: args.composerEditorRef,
   onComposerEditorInput: args.onComposerEditorInput,
   scrollToBottomOnSendRef: args.scrollToBottomOnSendRef,
+  syncBottomAfterComposerLayoutRef: args.syncBottomAfterComposerLayoutRef,
 });
 
 export const buildAgentChatModel = (

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -1,9 +1,6 @@
 import { beforeAll, describe, expect, mock, test } from "bun:test";
 import { act } from "react";
-import {
-  buildTodoItem,
-  createComposerDraft,
-} from "@/components/features/agents/agent-chat/agent-chat-test-fixtures";
+import { createComposerDraft } from "@/components/features/agents/agent-chat/agent-chat-test-fixtures";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
 import { toAgentSessionSummary } from "@/state/agent-sessions-store";
 import { sessionMessageAt } from "@/test-utils/session-message-test-helpers";
@@ -271,62 +268,6 @@ describe("useAgentStudioPageModels", () => {
     }
     sendResolver.current(true);
     await sendPromise;
-    await harness.unmount();
-  });
-
-  test("requests a bottom resync when a todo first appears", async () => {
-    const harness = createHookHarness(createHookArgs());
-
-    await harness.mount();
-
-    const syncBottomAfterComposerLayout = mock(() => {});
-    harness.getLatest().agentChatModel.thread.syncBottomAfterComposerLayoutRef.current =
-      syncBottomAfterComposerLayout;
-
-    const sessionWithTodo = createSession("session-1", "external-1", {
-      todos: [buildTodoItem({ content: "Keep transcript pinned", status: "in_progress" })],
-    });
-
-    await harness.update(
-      createHookArgs({
-        core: {
-          activeSession: sessionWithTodo,
-          sessionsForTask: [toAgentSessionSummary(sessionWithTodo)],
-        },
-      }),
-    );
-
-    expect(syncBottomAfterComposerLayout).toHaveBeenCalledTimes(1);
-
-    await harness.unmount();
-  });
-
-  test("requests a bottom resync when toggling the todo panel", async () => {
-    const sessionWithTodo = createSession("session-1", "external-1", {
-      todos: [buildTodoItem({ content: "Keep transcript pinned", status: "in_progress" })],
-    });
-    const harness = createHookHarness(
-      createHookArgs({
-        core: {
-          activeSession: sessionWithTodo,
-          sessionsForTask: [toAgentSessionSummary(sessionWithTodo)],
-        },
-      }),
-    );
-
-    await harness.mount();
-
-    const syncBottomAfterComposerLayout = mock(() => {});
-    harness.getLatest().agentChatModel.thread.syncBottomAfterComposerLayoutRef.current =
-      syncBottomAfterComposerLayout;
-
-    await act(async () => {
-      harness.getLatest().agentChatModel.thread.onToggleTodoPanel();
-      await Promise.resolve();
-    });
-
-    expect(syncBottomAfterComposerLayout).toHaveBeenCalledTimes(1);
-
     await harness.unmount();
   });
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.test.tsx
@@ -1,6 +1,9 @@
 import { beforeAll, describe, expect, mock, test } from "bun:test";
 import { act } from "react";
-import { createComposerDraft } from "@/components/features/agents/agent-chat/agent-chat-test-fixtures";
+import {
+  buildTodoItem,
+  createComposerDraft,
+} from "@/components/features/agents/agent-chat/agent-chat-test-fixtures";
 import type { TaskDocumentState } from "@/components/features/task-details/use-task-documents";
 import { toAgentSessionSummary } from "@/state/agent-sessions-store";
 import { sessionMessageAt } from "@/test-utils/session-message-test-helpers";
@@ -268,6 +271,62 @@ describe("useAgentStudioPageModels", () => {
     }
     sendResolver.current(true);
     await sendPromise;
+    await harness.unmount();
+  });
+
+  test("requests a bottom resync when a todo first appears", async () => {
+    const harness = createHookHarness(createHookArgs());
+
+    await harness.mount();
+
+    const syncBottomAfterComposerLayout = mock(() => {});
+    harness.getLatest().agentChatModel.thread.syncBottomAfterComposerLayoutRef.current =
+      syncBottomAfterComposerLayout;
+
+    const sessionWithTodo = createSession("session-1", "external-1", {
+      todos: [buildTodoItem({ content: "Keep transcript pinned", status: "in_progress" })],
+    });
+
+    await harness.update(
+      createHookArgs({
+        core: {
+          activeSession: sessionWithTodo,
+          sessionsForTask: [toAgentSessionSummary(sessionWithTodo)],
+        },
+      }),
+    );
+
+    expect(syncBottomAfterComposerLayout).toHaveBeenCalledTimes(1);
+
+    await harness.unmount();
+  });
+
+  test("requests a bottom resync when toggling the todo panel", async () => {
+    const sessionWithTodo = createSession("session-1", "external-1", {
+      todos: [buildTodoItem({ content: "Keep transcript pinned", status: "in_progress" })],
+    });
+    const harness = createHookHarness(
+      createHookArgs({
+        core: {
+          activeSession: sessionWithTodo,
+          sessionsForTask: [toAgentSessionSummary(sessionWithTodo)],
+        },
+      }),
+    );
+
+    await harness.mount();
+
+    const syncBottomAfterComposerLayout = mock(() => {});
+    harness.getLatest().agentChatModel.thread.syncBottomAfterComposerLayoutRef.current =
+      syncBottomAfterComposerLayout;
+
+    await act(async () => {
+      harness.getLatest().agentChatModel.thread.onToggleTodoPanel();
+      await Promise.resolve();
+    });
+
+    expect(syncBottomAfterComposerLayout).toHaveBeenCalledTimes(1);
+
     await harness.unmount();
   });
 

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -1,9 +1,8 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { AgentChatModel } from "@/components/features/agents/agent-chat/agent-chat.types";
 import type { AgentChatComposerDraft } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
-import { getVisibleSessionTodos } from "@/components/features/agents/agent-chat/agent-session-todo-panel";
 import { useAgentChatLayout } from "@/components/features/agents/agent-chat/use-agent-chat-layout";
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents/agent-studio-task-tabs";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
@@ -280,20 +279,6 @@ export function useAgentStudioPageModels({
   const activeTodoPanelCollapsed = activeSessionId
     ? (todoPanelCollapsedBySession[activeSessionId] ?? true)
     : true;
-  const todoLayoutKey = useMemo(() => {
-    if (!threadSession) {
-      return null;
-    }
-
-    const visibleTodos = getVisibleSessionTodos(threadSession.todos);
-    if (visibleTodos.length === 0) {
-      return null;
-    }
-
-    return `${threadSession.sessionId}:${activeTodoPanelCollapsed}:${visibleTodos
-      .map((todo) => `${todo.id}:${todo.status}:${todo.content}`)
-      .join("|")}`;
-  }, [activeTodoPanelCollapsed, threadSession]);
   const composerSessionId = core.activeSession?.sessionId ?? null;
   const composerSelectedModel = core.activeSession?.selectedModel ?? null;
   const composerIsLoadingModelCatalog = core.activeSession?.isLoadingModelCatalog ?? false;
@@ -328,14 +313,6 @@ export function useAgentStudioPageModels({
       [activeSessionId]: !(current[activeSessionId] ?? true),
     }));
   }, [activeSessionId]);
-
-  useLayoutEffect(() => {
-    if (!todoLayoutKey) {
-      return;
-    }
-
-    syncBottomAfterComposerLayoutRef.current?.();
-  }, [todoLayoutKey]);
 
   const agentChatThreadModel = useAgentStudioThreadModel({
     threadSession,

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-models.ts
@@ -1,8 +1,9 @@
 import type { TaskCard } from "@openducktor/contracts";
 import type { AgentModelSelection, AgentRole } from "@openducktor/core";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { AgentChatModel } from "@/components/features/agents/agent-chat/agent-chat.types";
 import type { AgentChatComposerDraft } from "@/components/features/agents/agent-chat/agent-chat-composer-draft";
+import { getVisibleSessionTodos } from "@/components/features/agents/agent-chat/agent-session-todo-panel";
 import { useAgentChatLayout } from "@/components/features/agents/agent-chat/use-agent-chat-layout";
 import type { AgentStudioTaskTabsModel } from "@/components/features/agents/agent-studio-task-tabs";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
@@ -279,6 +280,20 @@ export function useAgentStudioPageModels({
   const activeTodoPanelCollapsed = activeSessionId
     ? (todoPanelCollapsedBySession[activeSessionId] ?? true)
     : true;
+  const todoLayoutKey = useMemo(() => {
+    if (!threadSession) {
+      return null;
+    }
+
+    const visibleTodos = getVisibleSessionTodos(threadSession.todos);
+    if (visibleTodos.length === 0) {
+      return null;
+    }
+
+    return `${threadSession.sessionId}:${activeTodoPanelCollapsed}:${visibleTodos
+      .map((todo) => `${todo.id}:${todo.status}:${todo.content}`)
+      .join("|")}`;
+  }, [activeTodoPanelCollapsed, threadSession]);
   const composerSessionId = core.activeSession?.sessionId ?? null;
   const composerSelectedModel = core.activeSession?.selectedModel ?? null;
   const composerIsLoadingModelCatalog = core.activeSession?.isLoadingModelCatalog ?? false;
@@ -313,6 +328,14 @@ export function useAgentStudioPageModels({
       [activeSessionId]: !(current[activeSessionId] ?? true),
     }));
   }, [activeSessionId]);
+
+  useLayoutEffect(() => {
+    if (!todoLayoutKey) {
+      return;
+    }
+
+    syncBottomAfterComposerLayoutRef.current?.();
+  }, [todoLayoutKey]);
 
   const agentChatThreadModel = useAgentStudioThreadModel({
     threadSession,
@@ -384,6 +407,7 @@ export function useAgentStudioPageModels({
     composerEditorRef,
     resizeComposerEditor,
     scrollToBottomOnSendRef,
+    syncBottomAfterComposerLayoutRef,
   });
 
   const agentChatModel = useMemo(

--- a/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
+++ b/apps/desktop/src/pages/agents/use-agent-studio-page-submodels.ts
@@ -282,6 +282,7 @@ type UseAgentStudioComposerModelArgs = {
   composerEditorRef: RefObject<HTMLDivElement | null>;
   resizeComposerEditor: () => void;
   scrollToBottomOnSendRef: AgentChatModel["composer"]["scrollToBottomOnSendRef"];
+  syncBottomAfterComposerLayoutRef: AgentChatModel["composer"]["syncBottomAfterComposerLayoutRef"];
 };
 
 export const useAgentStudioComposerModel = ({
@@ -322,6 +323,7 @@ export const useAgentStudioComposerModel = ({
   composerEditorRef,
   resizeComposerEditor,
   scrollToBottomOnSendRef,
+  syncBottomAfterComposerLayoutRef,
 }: UseAgentStudioComposerModelArgs): ReturnType<typeof buildAgentChatComposerModel> => {
   const isModelSelectionPending = Boolean(
     activeSession?.isLoadingModelCatalog && !activeSession?.selectedModel,
@@ -388,6 +390,7 @@ export const useAgentStudioComposerModel = ({
         composerEditorRef,
         onComposerEditorInput: resizeComposerEditor,
         scrollToBottomOnSendRef,
+        syncBottomAfterComposerLayoutRef,
       }),
     [
       activeSessionAgentColors,
@@ -416,6 +419,7 @@ export const useAgentStudioComposerModel = ({
       onSelectVariant,
       resizeComposerEditor,
       scrollToBottomOnSendRef,
+      syncBottomAfterComposerLayoutRef,
       selectedModelSelection,
       selectedModelDescriptor,
       selectedRoleAvailable,


### PR DESCRIPTION
## Summary
- keep agent chat pinned to the bottom when composer attachment chips change layout and reduce the chance of clipped transcript content while the session is active
- move todo-triggered repinning to the rendered chat thread so real bottom-stack size changes, including todo appearance and collapse/expand, repin the transcript reliably
- add focused regressions for attachment layout resync, bottom-follow safety, and todo stack resize behavior

## Testing
- bun run --filter @openducktor/desktop test -- src/components/features/agents/agent-chat/agent-chat-thread.test.ts src/components/features/agents/agent-chat/agent-chat-composer.attachments.test.tsx src/components/features/agents/agent-chat/use-agent-chat-window.test.ts src/components/features/agents/agent-chat/agent-chat.attachments.test.tsx src/pages/agents/use-agent-studio-page-models.test.tsx
- bun run --filter @openducktor/desktop typecheck
- bun run --filter @openducktor/desktop lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat scroll position to remain properly synchronized when attachments are added or removed.
  * Improved automatic scroll-to-bottom alignment when the composer interface layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->