### PR TITLE
fix(desktop): harden tauri event unsubscription

### DIFF
--- a/apps/desktop/src/lib/host-client.test.ts
+++ b/apps/desktop/src/lib/host-client.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 
 let isBrowserAppMode = false;
@@ -7,33 +7,33 @@ let listenImpl:
   | ((event: string, handler: (event: { payload: unknown }) => void) => unknown)
   | null = null;
 
-mock.module("@/lib/browser-mode", () => ({
-  isBrowserAppMode: () => isBrowserAppMode,
-  getBrowserBackendUrl: () => "http://127.0.0.1:14327",
-}));
-
-mock.module("@/lib/runtime", () => ({
-  isTauriRuntime: () => isTauriRuntime,
-}));
-
-mock.module("@tauri-apps/api/event", () => ({
-  listen: (event: string, handler: (event: { payload: unknown }) => void) => {
-    if (!listenImpl) {
-      throw new Error("listenImpl not configured");
-    }
-
-    return listenImpl(event, handler);
-  },
-}));
-
 describe("host-client", () => {
   beforeEach(() => {
     isBrowserAppMode = false;
     isTauriRuntime = false;
     listenImpl = null;
+
+    mock.module("@/lib/browser-mode", () => ({
+      isBrowserAppMode: () => isBrowserAppMode,
+      getBrowserBackendUrl: () => "http://127.0.0.1:14327",
+    }));
+
+    mock.module("@/lib/runtime", () => ({
+      isTauriRuntime: () => isTauriRuntime,
+    }));
+
+    mock.module("@tauri-apps/api/event", () => ({
+      listen: (event: string, handler: (event: { payload: unknown }) => void) => {
+        if (!listenImpl) {
+          throw new Error("listenImpl not configured");
+        }
+
+        return listenImpl(event, handler);
+      },
+    }));
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await restoreMockedModules([
       ["@/lib/browser-mode", () => import("@/lib/browser-mode")],
       ["@/lib/runtime", () => import("@/lib/runtime")],

--- a/apps/desktop/src/lib/host-client.test.ts
+++ b/apps/desktop/src/lib/host-client.test.ts
@@ -1,16 +1,99 @@
-import { describe, expect, test } from "bun:test";
-import { createHostBridge } from "./host-client";
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
+
+let isBrowserAppMode = false;
+let isTauriRuntime = false;
+let listenImpl:
+  | ((event: string, handler: (event: { payload: unknown }) => void) => unknown)
+  | null = null;
+
+mock.module("@/lib/browser-mode", () => ({
+  isBrowserAppMode: () => isBrowserAppMode,
+  getBrowserBackendUrl: () => "http://127.0.0.1:14327",
+}));
+
+mock.module("@/lib/runtime", () => ({
+  isTauriRuntime: () => isTauriRuntime,
+}));
+
+mock.module("@tauri-apps/api/event", () => ({
+  listen: (event: string, handler: (event: { payload: unknown }) => void) => {
+    if (!listenImpl) {
+      throw new Error("listenImpl not configured");
+    }
+
+    return listenImpl(event, handler);
+  },
+}));
 
 describe("host-client", () => {
+  beforeEach(() => {
+    isBrowserAppMode = false;
+    isTauriRuntime = false;
+    listenImpl = null;
+  });
+
+  afterAll(async () => {
+    await restoreMockedModules([
+      ["@/lib/browser-mode", () => import("@/lib/browser-mode")],
+      ["@/lib/runtime", () => import("@/lib/runtime")],
+      ["@tauri-apps/api/event", () => import("@tauri-apps/api/event")],
+    ]);
+  });
+
   test("fails fast when run-event subscriptions are unavailable in the current runtime", async () => {
+    const { createHostBridge } = await import("./host-client");
+
     await expect(createHostBridge().subscribeRunEvents(() => {})).rejects.toThrow(
       "Run-event subscriptions require the desktop shell or browser live mode.",
     );
   });
 
   test("fails fast when dev-server event subscriptions are unavailable in the current runtime", async () => {
+    const { createHostBridge } = await import("./host-client");
+
     await expect(createHostBridge().subscribeDevServerEvents(() => {})).rejects.toThrow(
       "Dev-server event subscriptions require the desktop shell or browser live mode.",
     );
+  });
+
+  test("normalizes Tauri event cleanup into an idempotent callback", async () => {
+    isTauriRuntime = true;
+    let cleanupCalls = 0;
+    listenImpl = async () => () => {
+      cleanupCalls += 1;
+    };
+
+    const { createHostBridge } = await import("./host-client");
+    const unsubscribe = await createHostBridge().subscribeDevServerEvents(() => {});
+
+    unsubscribe();
+    unsubscribe();
+
+    expect(cleanupCalls).toBe(1);
+  });
+
+  test("handles rejected async Tauri cleanup without surfacing an unhandled rejection", async () => {
+    isTauriRuntime = true;
+    const cleanupError = new Error("listener already removed");
+    const consoleWarn = spyOn(console, "warn").mockImplementation(() => {});
+    listenImpl = async () => async () => {
+      throw cleanupError;
+    };
+
+    try {
+      const { createHostBridge } = await import("./host-client");
+      const unsubscribe = await createHostBridge().subscribeRunEvents(() => {});
+
+      unsubscribe();
+      await Promise.resolve();
+
+      expect(consoleWarn).toHaveBeenCalledWith(
+        "[host-client] Tauri event unsubscribe failed",
+        cleanupError,
+      );
+    } finally {
+      consoleWarn.mockRestore();
+    }
   });
 });

--- a/apps/desktop/src/lib/host-client.ts
+++ b/apps/desktop/src/lib/host-client.ts
@@ -35,17 +35,17 @@ const notAvailable = async <T>(): Promise<T> => {
 };
 
 const createSafeCleanup = (cleanup: AsyncCleanup): (() => void) => {
-  let settledCleanup = cleanup;
+  let pendingCleanup = cleanup;
   let called = false;
 
   return () => {
-    if (called || !settledCleanup) {
+    if (called || !pendingCleanup) {
       return;
     }
 
     called = true;
-    const currentCleanup = settledCleanup;
-    settledCleanup = null;
+    const currentCleanup = pendingCleanup;
+    pendingCleanup = null;
 
     try {
       const result = currentCleanup();

--- a/apps/desktop/src/lib/host-client.ts
+++ b/apps/desktop/src/lib/host-client.ts
@@ -8,6 +8,7 @@ import { isBrowserAppMode } from "@/lib/browser-mode";
 import { isTauriRuntime } from "@/lib/runtime";
 
 type RunEventListener = (payload: unknown) => void;
+type AsyncCleanup = (() => void | Promise<void>) | null | undefined;
 type HostBridge = {
   client: TauriHostClient;
   subscribeRunEvents: (listener: RunEventListener) => Promise<() => void>;
@@ -18,6 +19,7 @@ const RUN_EVENT_SUBSCRIPTIONS_UNAVAILABLE_ERROR =
   "Run-event subscriptions require the desktop shell or browser live mode.";
 const DEV_SERVER_EVENT_SUBSCRIPTIONS_UNAVAILABLE_ERROR =
   "Dev-server event subscriptions require the desktop shell or browser live mode.";
+const TAURI_EVENT_UNSUBSCRIBE_LOG_PREFIX = "[host-client] Tauri event unsubscribe failed";
 
 let tauriCoreModulePromise: Promise<typeof import("@tauri-apps/api/core")> | null = null;
 
@@ -30,6 +32,32 @@ const getTauriCoreModule = (): Promise<typeof import("@tauri-apps/api/core")> =>
 
 const notAvailable = async <T>(): Promise<T> => {
   throw new Error("Tauri runtime not available. Run inside the desktop shell.");
+};
+
+const createSafeCleanup = (cleanup: AsyncCleanup): (() => void) => {
+  let settledCleanup = cleanup;
+  let called = false;
+
+  return () => {
+    if (called || !settledCleanup) {
+      return;
+    }
+
+    called = true;
+    const currentCleanup = settledCleanup;
+    settledCleanup = null;
+
+    try {
+      const result = currentCleanup();
+      if (result && typeof result.then === "function") {
+        void result.catch((error: unknown) => {
+          console.warn(TAURI_EVENT_UNSUBSCRIBE_LOG_PREFIX, error);
+        });
+      }
+    } catch (error) {
+      console.warn(TAURI_EVENT_UNSUBSCRIBE_LOG_PREFIX, error);
+    }
+  };
 };
 
 const createHostCommands = (): TauriHostClient => {
@@ -56,9 +84,11 @@ const createRunEventSubscription = (): HostBridge["subscribeRunEvents"] => async
   }
 
   const events = await import("@tauri-apps/api/event");
-  return events.listen("openducktor://run-event", (event) => {
+  const cleanup = await events.listen("openducktor://run-event", (event) => {
     listener(event.payload);
   });
+
+  return createSafeCleanup(cleanup);
 };
 
 const createDevServerEventSubscription =
@@ -72,9 +102,11 @@ const createDevServerEventSubscription =
     }
 
     const events = await import("@tauri-apps/api/event");
-    return events.listen("openducktor://dev-server-event", (event) => {
+    const cleanup = await events.listen("openducktor://dev-server-event", (event) => {
       listener(event.payload);
     });
+
+    return createSafeCleanup(cleanup);
   };
 
 export const createHostBridge = (): HostBridge => ({


### PR DESCRIPTION
## Summary
- harden Tauri event unsubscribe handling in `host-client` so listener cleanup stays idempotent and rejected async unlisten calls no longer surface as unhandled promise rejections
- downgrade handled unsubscribe race logging from error to warning because the app now treats this path as tolerated cleanup noise
- add focused `host-client` coverage for unavailable runtimes, double cleanup, and rejected async cleanup behavior

## Verification
- `bun test src/lib/host-client.test.ts`
- `bun run --filter @openducktor/desktop test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable event unsubscription: cleanup runs at most once and errors during unsubscribe are caught and logged to avoid unhandled rejections.

* **Tests**
  * Added tests covering idempotent unsubscribe behavior and proper error handling during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->