### PR TITLE
fix(mcp): refresh Kanban after external task creates

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2526,6 +2526,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ chrono = { version = "0.4", features = ["serde"] }
 mime_guess = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 tauri = { version = "2", default-features = false, features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "process", "sync", "macros", "time"] }

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/mcp_bridge_process.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/mcp_bridge_process.rs
@@ -116,6 +116,10 @@ impl AppService {
         self.ensure_mcp_bridge_url().map(|_| ())
     }
 
+    pub fn mcp_bridge_base_url(&self) -> Result<String> {
+        self.ensure_mcp_bridge_url()
+    }
+
     pub(crate) fn ensure_mcp_bridge_url(&self) -> Result<String> {
         let mut bridge = self
             .mcp_bridge_process

--- a/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
+++ b/apps/desktop/src-tauri/crates/host-application/src/app_service/tests/unit.rs
@@ -2967,41 +2967,60 @@ fn wait_for_local_server_with_process_times_out_when_child_stays_alive() {
 
 #[test]
 fn wait_for_local_server_with_process_honors_total_timeout_budget_when_connect_timeout_is_large() {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
-    let port = listener.local_addr().expect("addr").port();
-    drop(listener);
+    const MAX_PORT_RETRY_ATTEMPTS: usize = 5;
 
-    let mut child = Command::new("/bin/sh")
-        .arg("-lc")
-        .arg("sleep 5")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .expect("spawn sleeping process");
-    let cancel_epoch = Arc::new(AtomicU64::new(0));
-    let started_at = Instant::now();
-    let error = wait_for_local_server_with_process(
-        &mut child,
-        port,
-        OpencodeStartupReadinessPolicy {
-            timeout: Duration::from_millis(250),
-            connect_timeout: Duration::from_secs(10),
-            initial_retry_delay: Duration::from_millis(10),
-            max_retry_delay: Duration::from_millis(50),
-            child_state_check_interval: Duration::from_millis(25),
-        },
-        &cancel_epoch,
-        0,
-        |_| {},
-    )
-    .expect_err("total timeout budget should cap each connect attempt");
-    let elapsed = started_at.elapsed();
-    terminate_child_process(&mut child);
-    assert_eq!(error.reason, "timeout");
-    assert!(
-        elapsed < Duration::from_secs(2),
-        "startup wait should not exceed total budget window, elapsed={elapsed:?}"
-    );
+    for attempt in 0..MAX_PORT_RETRY_ATTEMPTS {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+        let port = listener.local_addr().expect("addr").port();
+        drop(listener);
+
+        let mut child = Command::new("/bin/sh")
+            .arg("-lc")
+            .arg("sleep 5")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn sleeping process");
+        let cancel_epoch = Arc::new(AtomicU64::new(0));
+        let started_at = Instant::now();
+        let result = wait_for_local_server_with_process(
+            &mut child,
+            port,
+            OpencodeStartupReadinessPolicy {
+                timeout: Duration::from_millis(250),
+                connect_timeout: Duration::from_secs(10),
+                initial_retry_delay: Duration::from_millis(10),
+                max_retry_delay: Duration::from_millis(50),
+                child_state_check_interval: Duration::from_millis(25),
+            },
+            &cancel_epoch,
+            0,
+            |_| {},
+        );
+        let elapsed = started_at.elapsed();
+        terminate_child_process(&mut child);
+
+        match result {
+            Err(error) => {
+                assert_eq!(error.reason, "timeout");
+                assert!(
+                    elapsed < Duration::from_secs(2),
+                    "startup wait should not exceed total budget window, elapsed={elapsed:?}"
+                );
+                return;
+            }
+            Ok(report) if attempt + 1 < MAX_PORT_RETRY_ATTEMPTS => {
+                // Some CI hosts can immediately rebind a recently released ephemeral port.
+                // Retry with a fresh closed port so the timeout-budget assertion remains deterministic.
+                eprintln!(
+                    "retrying flaky closed-port probe on reused port {port}, report={report:?}"
+                );
+            }
+            Ok(report) => panic!(
+                "total timeout budget should cap each connect attempt; port {port} became reachable in all retries, last report={report:?}"
+            ),
+        }
+    }
 }
 
 #[test]

--- a/apps/desktop/src-tauri/src/external_task_sync.rs
+++ b/apps/desktop/src-tauri/src/external_task_sync.rs
@@ -1,8 +1,8 @@
+use crate::sse_relay::{build_sse_stream_request, read_next_sse_message, SseEventId};
 use anyhow::{Context, Result};
 use host_application::AppService;
 use host_domain::now_rfc3339;
 use reqwest::blocking::{Client, Response};
-use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT};
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -14,7 +14,6 @@ use uuid::Uuid;
 const TASK_EVENT_STREAM_PATH: &str = "task-events";
 const TASK_EVENT_RELAY_RETRY_DELAY: Duration = Duration::from_secs(1);
 const TASK_EVENT_RELAY_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
-const LAST_EVENT_ID_HEADER: HeaderName = HeaderName::from_static("last-event-id");
 pub(crate) const TASK_EVENT_NAME: &str = "openducktor://task-event";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -35,12 +34,6 @@ pub(crate) struct ExternalTaskSyncEvent {
 
 pub(crate) struct TaskEventRelayState {
     pub(crate) stop_requested: Arc<AtomicBool>,
-}
-
-#[derive(Debug, Default, PartialEq, Eq)]
-struct SseMessage {
-    id: Option<u64>,
-    data: String,
 }
 
 pub(crate) fn build_external_task_created_event(
@@ -86,7 +79,7 @@ fn run_task_event_relay<R: tauri::Runtime>(
         .build()
         .context("failed to build task event relay HTTP client")?;
 
-    let mut last_event_id = None;
+    let mut last_event_id: Option<SseEventId> = None;
     while !stop_requested.load(Ordering::SeqCst) {
         let stream_url = match service.mcp_bridge_base_url() {
             Ok(base_url) => format!("{base_url}/{TASK_EVENT_STREAM_PATH}"),
@@ -101,20 +94,19 @@ fn run_task_event_relay<R: tauri::Runtime>(
             }
         };
 
-        let response =
-            match build_task_event_stream_request(&client, &stream_url, last_event_id).send() {
-                Ok(response) => response,
-                Err(error) => {
-                    tracing::error!(
-                        target: "openducktor.task-sync",
-                        stream_url,
-                        error = %error,
-                        "Task event relay failed to connect to the MCP bridge task stream"
-                    );
-                    sleep_before_retry(&stop_requested);
-                    continue;
-                }
-            };
+        let response = match build_sse_stream_request(&client, &stream_url, last_event_id).send() {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::error!(
+                    target: "openducktor.task-sync",
+                    stream_url,
+                    error = %error,
+                    "Task event relay failed to connect to the MCP bridge task stream"
+                );
+                sleep_before_retry(&stop_requested);
+                continue;
+            }
+        };
 
         if let Err(error) =
             relay_task_event_stream(&app, response, &stop_requested, &mut last_event_id)
@@ -137,7 +129,7 @@ fn relay_task_event_stream<R: tauri::Runtime>(
     app: &AppHandle<R>,
     response: Response,
     stop_requested: &AtomicBool,
-    last_event_id: &mut Option<u64>,
+    last_event_id: &mut Option<SseEventId>,
 ) -> Result<()> {
     let status = response.status();
     if !status.is_success() {
@@ -163,7 +155,7 @@ fn relay_task_event_stream<R: tauri::Runtime>(
 fn relay_task_event_reader(
     mut reader: impl BufRead,
     stop_requested: &AtomicBool,
-    last_event_id: &mut Option<u64>,
+    last_event_id: &mut Option<SseEventId>,
     mut emit: impl FnMut(ExternalTaskSyncEvent),
 ) -> Result<()> {
     while !stop_requested.load(Ordering::SeqCst) {
@@ -196,68 +188,6 @@ fn relay_task_event_reader(
     Ok(())
 }
 
-fn read_next_sse_message(reader: &mut impl BufRead) -> Result<Option<SseMessage>> {
-    let mut message = SseMessage::default();
-
-    let mut payload_lines = Vec::new();
-
-    loop {
-        let mut line = String::new();
-        let bytes_read = reader.read_line(&mut line)?;
-
-        if bytes_read == 0 {
-            if payload_lines.is_empty() {
-                return Ok(None);
-            }
-
-            message.data = payload_lines.join("\n");
-            return Ok(Some(message));
-        }
-
-        let trimmed = line.trim_end_matches(['\r', '\n']);
-        if trimmed.is_empty() {
-            if payload_lines.is_empty() {
-                continue;
-            }
-
-            message.data = payload_lines.join("\n");
-            return Ok(Some(message));
-        }
-
-        if let Some(id) = trimmed.strip_prefix("id:") {
-            let parsed_id = id.trim().parse::<u64>().with_context(|| {
-                format!(
-                    "invalid task event stream id received from MCP bridge: {}",
-                    id.trim()
-                )
-            })?;
-            message.id = Some(parsed_id);
-            continue;
-        }
-
-        if let Some(payload) = trimmed.strip_prefix("data:") {
-            payload_lines.push(payload.trim_start().to_string());
-        }
-    }
-}
-
-fn build_task_event_stream_request<'a>(
-    client: &'a Client,
-    stream_url: &'a str,
-    last_event_id: Option<u64>,
-) -> reqwest::blocking::RequestBuilder {
-    let mut headers = HeaderMap::new();
-    headers.insert(ACCEPT, HeaderValue::from_static("text/event-stream"));
-
-    if let Some(last_event_id) = last_event_id {
-        if let Ok(value) = HeaderValue::from_str(&last_event_id.to_string()) {
-            headers.insert(LAST_EVENT_ID_HEADER.clone(), value);
-        }
-    }
-
-    client.get(stream_url).headers(headers)
-}
-
 fn sleep_before_retry(stop_requested: &AtomicBool) {
     if stop_requested.load(Ordering::SeqCst) {
         return;
@@ -280,50 +210,6 @@ mod tests {
         assert_eq!(event.task_id, "task-1");
         assert!(!event.event_id.is_empty());
         assert!(!event.emitted_at.is_empty());
-    }
-
-    #[test]
-    fn read_next_sse_message_collects_multiline_data_events_and_event_id() {
-        let mut reader = Cursor::new(
-            b"id: 7\nevent: message\ndata: {\"one\":1}\ndata: {\"two\":2}\n\n".to_vec(),
-        );
-
-        let message = read_next_sse_message(&mut reader)
-            .expect("payload should parse")
-            .expect("payload should be present");
-
-        assert_eq!(message.id, Some(7));
-        assert_eq!(message.data, "{\"one\":1}\n{\"two\":2}");
-    }
-
-    #[test]
-    fn read_next_sse_message_skips_keepalive_comments() {
-        let mut reader = Cursor::new(b": keepalive\n\ndata: {\"ok\":true}\n\n".to_vec());
-
-        let message = read_next_sse_message(&mut reader)
-            .expect("payload should parse")
-            .expect("payload should be present");
-
-        assert_eq!(message.id, None);
-        assert_eq!(message.data, "{\"ok\":true}");
-    }
-
-    #[test]
-    fn build_task_event_stream_request_includes_last_event_id_for_resume() {
-        let client = Client::builder().build().expect("client should build");
-        let request =
-            build_task_event_stream_request(&client, "http://127.0.0.1:1234/task-events", Some(42))
-                .build()
-                .expect("request should build");
-
-        assert_eq!(
-            request.headers().get(LAST_EVENT_ID_HEADER.clone()),
-            Some(&HeaderValue::from_static("42"))
-        );
-        assert_eq!(
-            request.headers().get(ACCEPT),
-            Some(&HeaderValue::from_static("text/event-stream"))
-        );
     }
 
     #[test]
@@ -351,7 +237,7 @@ mod tests {
 
         assert_eq!(last_event_id, Some(5));
 
-        let request = build_task_event_stream_request(
+        let request = build_sse_stream_request(
             &Client::builder().build().expect("client should build"),
             "http://127.0.0.1:1234/task-events",
             last_event_id,
@@ -359,8 +245,8 @@ mod tests {
         .build()
         .expect("request should build");
         assert_eq!(
-            request.headers().get(LAST_EVENT_ID_HEADER.clone()),
-            Some(&HeaderValue::from_static("5"))
+            request.headers().get("last-event-id"),
+            Some(&"5".parse().expect("header should parse"))
         );
 
         let replay_stream = Cursor::new(format!("id: 6\ndata: {second_event}\n\n").into_bytes());
@@ -397,7 +283,7 @@ mod tests {
         assert_eq!(last_event_id, Some(5));
         assert!(emitted_task_ids.is_empty());
 
-        let request = build_task_event_stream_request(
+        let request = build_sse_stream_request(
             &Client::builder().build().expect("client should build"),
             "http://127.0.0.1:1234/task-events",
             last_event_id,
@@ -405,8 +291,8 @@ mod tests {
         .build()
         .expect("request should build");
         assert_eq!(
-            request.headers().get(LAST_EVENT_ID_HEADER.clone()),
-            Some(&HeaderValue::from_static("5"))
+            request.headers().get("last-event-id"),
+            Some(&"5".parse().expect("header should parse"))
         );
     }
 }

--- a/apps/desktop/src-tauri/src/external_task_sync.rs
+++ b/apps/desktop/src-tauri/src/external_task_sync.rs
@@ -4,6 +4,7 @@ use host_application::AppService;
 use host_domain::now_rfc3339;
 use reqwest::blocking::{Client, Response};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::io::{BufRead, BufReader};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -15,6 +16,16 @@ const TASK_EVENT_STREAM_PATH: &str = "task-events";
 const TASK_EVENT_RELAY_RETRY_DELAY: Duration = Duration::from_secs(1);
 const TASK_EVENT_RELAY_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const TASK_EVENT_NAME: &str = "openducktor://task-event";
+const STREAM_WARNING_EVENT_NAME: &str = "stream-warning";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct TaskEventControlPayload {
+    #[serde(rename = "__openducktorBrowserLive")]
+    browser_live: bool,
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -156,12 +167,17 @@ fn relay_task_event_reader(
     mut reader: impl BufRead,
     stop_requested: &AtomicBool,
     last_event_id: &mut Option<SseEventId>,
-    mut emit: impl FnMut(ExternalTaskSyncEvent),
+    mut emit: impl FnMut(Value),
 ) -> Result<()> {
     while !stop_requested.load(Ordering::SeqCst) {
         let Some(message) = read_next_sse_message(&mut reader)? else {
             return Ok(());
         };
+
+        if message.event.as_deref() == Some(STREAM_WARNING_EVENT_NAME) {
+            emit(task_stream_warning_payload(message.data));
+            continue;
+        }
 
         if message.data.is_empty() {
             continue;
@@ -172,11 +188,12 @@ fn relay_task_event_reader(
                 if let Some(message_id) = message.id {
                     *last_event_id = Some(message_id);
                 }
-                emit(event)
+                emit(serde_json::to_value(event).expect("task sync event should serialize"))
             }
             Err(error) => {
                 tracing::error!(
                     target: "openducktor.task-sync",
+                    event_type = message.event.as_deref().unwrap_or("message"),
                     raw_payload = message.data,
                     error = %error,
                     "Task event relay received an invalid task sync payload"
@@ -186,6 +203,15 @@ fn relay_task_event_reader(
     }
 
     Ok(())
+}
+
+fn task_stream_warning_payload(message: String) -> Value {
+    serde_json::to_value(TaskEventControlPayload {
+        browser_live: true,
+        kind: STREAM_WARNING_EVENT_NAME,
+        message: Some(message),
+    })
+    .expect("task stream warning payload should serialize")
 }
 
 fn sleep_before_retry(stop_requested: &AtomicBool) {
@@ -199,6 +225,7 @@ fn sleep_before_retry(stop_requested: &AtomicBool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
     use std::io::Cursor;
 
     #[test]
@@ -227,12 +254,15 @@ mod tests {
 
         let stop_requested = AtomicBool::new(false);
         let mut last_event_id = None;
-        let mut emitted_task_ids = Vec::new();
+        let mut emitted_payloads = Vec::new();
 
         let first_stream = Cursor::new(format!("id: 5\ndata: {first_event}\n\n").into_bytes());
-        relay_task_event_reader(first_stream, &stop_requested, &mut last_event_id, |event| {
-            emitted_task_ids.push(event.task_id)
-        })
+        relay_task_event_reader(
+            first_stream,
+            &stop_requested,
+            &mut last_event_id,
+            |payload| emitted_payloads.push(payload),
+        )
         .expect("first stream should relay");
 
         assert_eq!(last_event_id, Some(5));
@@ -254,14 +284,33 @@ mod tests {
             replay_stream,
             &stop_requested,
             &mut last_event_id,
-            |event| emitted_task_ids.push(event.task_id),
+            |payload| emitted_payloads.push(payload),
         )
         .expect("replay stream should relay");
 
         assert_eq!(last_event_id, Some(6));
         assert_eq!(
-            emitted_task_ids,
-            vec!["task-1".to_string(), "task-2".to_string()]
+            emitted_payloads,
+            vec![
+                json!({
+                    "eventId": serde_json::from_str::<Value>(&first_event)
+                        .expect("first event should deserialize")["eventId"],
+                    "kind": "external_task_created",
+                    "repoPath": "/repo",
+                    "taskId": "task-1",
+                    "emittedAt": serde_json::from_str::<Value>(&first_event)
+                        .expect("first event should deserialize")["emittedAt"],
+                }),
+                json!({
+                    "eventId": serde_json::from_str::<Value>(&second_event)
+                        .expect("second event should deserialize")["eventId"],
+                    "kind": "external_task_created",
+                    "repoPath": "/repo",
+                    "taskId": "task-2",
+                    "emittedAt": serde_json::from_str::<Value>(&second_event)
+                        .expect("second event should deserialize")["emittedAt"],
+                })
+            ]
         );
     }
 
@@ -269,19 +318,19 @@ mod tests {
     fn relay_task_event_reader_does_not_advance_resume_cursor_for_partial_id_only_eof() {
         let stop_requested = AtomicBool::new(false);
         let mut last_event_id = Some(5);
-        let mut emitted_task_ids = Vec::new();
+        let mut emitted_payloads = Vec::new();
 
         let partial_stream = Cursor::new(b"id: 6\n".to_vec());
         relay_task_event_reader(
             partial_stream,
             &stop_requested,
             &mut last_event_id,
-            |event| emitted_task_ids.push(event.task_id),
+            |payload| emitted_payloads.push(payload),
         )
         .expect("partial stream should be ignored without failing");
 
         assert_eq!(last_event_id, Some(5));
-        assert!(emitted_task_ids.is_empty());
+        assert!(emitted_payloads.is_empty());
 
         let request = build_sse_stream_request(
             &Client::builder().build().expect("client should build"),
@@ -293,6 +342,35 @@ mod tests {
         assert_eq!(
             request.headers().get("last-event-id"),
             Some(&"5".parse().expect("header should parse"))
+        );
+    }
+
+    #[test]
+    fn relay_task_event_reader_emits_stream_warning_control_payload() {
+        let stop_requested = AtomicBool::new(false);
+        let mut last_event_id = Some(5);
+        let mut emitted_payloads = Vec::new();
+
+        let warning_stream = Cursor::new(
+            b"event: stream-warning\ndata: task-events skipped 2 events; reconnect will replay buffered events.\n\n"
+                .to_vec(),
+        );
+        relay_task_event_reader(
+            warning_stream,
+            &stop_requested,
+            &mut last_event_id,
+            |payload| emitted_payloads.push(payload),
+        )
+        .expect("warning stream should relay");
+
+        assert_eq!(last_event_id, Some(5));
+        assert_eq!(
+            emitted_payloads,
+            vec![json!({
+                "__openducktorBrowserLive": true,
+                "kind": "stream-warning",
+                "message": "task-events skipped 2 events; reconnect will replay buffered events.",
+            })]
         );
     }
 }

--- a/apps/desktop/src-tauri/src/external_task_sync.rs
+++ b/apps/desktop/src-tauri/src/external_task_sync.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use host_application::AppService;
 use host_domain::now_rfc3339;
 use reqwest::blocking::{Client, Response};
-use reqwest::header::ACCEPT;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT};
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -14,6 +14,7 @@ use uuid::Uuid;
 const TASK_EVENT_STREAM_PATH: &str = "task-events";
 const TASK_EVENT_RELAY_RETRY_DELAY: Duration = Duration::from_secs(1);
 const TASK_EVENT_RELAY_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const LAST_EVENT_ID_HEADER: HeaderName = HeaderName::from_static("last-event-id");
 pub(crate) const TASK_EVENT_NAME: &str = "openducktor://task-event";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -34,6 +35,12 @@ pub(crate) struct ExternalTaskSyncEvent {
 
 pub(crate) struct TaskEventRelayState {
     pub(crate) stop_requested: Arc<AtomicBool>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SseMessage {
+    id: Option<u64>,
+    data: String,
 }
 
 pub(crate) fn build_external_task_created_event(
@@ -79,6 +86,7 @@ fn run_task_event_relay<R: tauri::Runtime>(
         .build()
         .context("failed to build task event relay HTTP client")?;
 
+    let mut last_event_id = None;
     while !stop_requested.load(Ordering::SeqCst) {
         let stream_url = match service.mcp_bridge_base_url() {
             Ok(base_url) => format!("{base_url}/{TASK_EVENT_STREAM_PATH}"),
@@ -93,25 +101,24 @@ fn run_task_event_relay<R: tauri::Runtime>(
             }
         };
 
-        let response = match client
-            .get(&stream_url)
-            .header(ACCEPT, "text/event-stream")
-            .send()
-        {
-            Ok(response) => response,
-            Err(error) => {
-                tracing::error!(
-                    target: "openducktor.task-sync",
-                    stream_url,
-                    error = %error,
-                    "Task event relay failed to connect to the MCP bridge task stream"
-                );
-                sleep_before_retry(&stop_requested);
-                continue;
-            }
-        };
+        let response =
+            match build_task_event_stream_request(&client, &stream_url, last_event_id).send() {
+                Ok(response) => response,
+                Err(error) => {
+                    tracing::error!(
+                        target: "openducktor.task-sync",
+                        stream_url,
+                        error = %error,
+                        "Task event relay failed to connect to the MCP bridge task stream"
+                    );
+                    sleep_before_retry(&stop_requested);
+                    continue;
+                }
+            };
 
-        if let Err(error) = relay_task_event_stream(&app, response, &stop_requested) {
+        if let Err(error) =
+            relay_task_event_stream(&app, response, &stop_requested, &mut last_event_id)
+        {
             tracing::error!(
                 target: "openducktor.task-sync",
                 stream_url,
@@ -130,36 +137,54 @@ fn relay_task_event_stream<R: tauri::Runtime>(
     app: &AppHandle<R>,
     response: Response,
     stop_requested: &AtomicBool,
+    last_event_id: &mut Option<u64>,
 ) -> Result<()> {
     let status = response.status();
     if !status.is_success() {
         anyhow::bail!("task event stream returned unexpected status {status}");
     }
 
-    let mut reader = BufReader::new(response);
+    relay_task_event_reader(
+        BufReader::new(response),
+        stop_requested,
+        last_event_id,
+        |event| {
+            if let Err(error) = app.emit(TASK_EVENT_NAME, event) {
+                tracing::error!(
+                    target: "openducktor.task-sync",
+                    error = %error,
+                    "Task event relay failed to emit a desktop task event"
+                );
+            }
+        },
+    )
+}
+
+fn relay_task_event_reader(
+    mut reader: impl BufRead,
+    stop_requested: &AtomicBool,
+    last_event_id: &mut Option<u64>,
+    mut emit: impl FnMut(ExternalTaskSyncEvent),
+) -> Result<()> {
     while !stop_requested.load(Ordering::SeqCst) {
-        let Some(payload) = read_next_sse_payload(&mut reader)? else {
+        let Some(message) = read_next_sse_message(&mut reader)? else {
             return Ok(());
         };
 
-        if payload.is_empty() {
+        if let Some(message_id) = message.id {
+            *last_event_id = Some(message_id);
+        }
+
+        if message.data.is_empty() {
             continue;
         }
 
-        match serde_json::from_str::<ExternalTaskSyncEvent>(&payload) {
-            Ok(event) => {
-                if let Err(error) = app.emit(TASK_EVENT_NAME, event) {
-                    tracing::error!(
-                        target: "openducktor.task-sync",
-                        error = %error,
-                        "Task event relay failed to emit a desktop task event"
-                    );
-                }
-            }
+        match serde_json::from_str::<ExternalTaskSyncEvent>(&message.data) {
+            Ok(event) => emit(event),
             Err(error) => {
                 tracing::error!(
                     target: "openducktor.task-sync",
-                    raw_payload = payload,
+                    raw_payload = message.data,
                     error = %error,
                     "Task event relay received an invalid task sync payload"
                 );
@@ -170,7 +195,9 @@ fn relay_task_event_stream<R: tauri::Runtime>(
     Ok(())
 }
 
-fn read_next_sse_payload(reader: &mut impl BufRead) -> Result<Option<String>> {
+fn read_next_sse_message(reader: &mut impl BufRead) -> Result<Option<SseMessage>> {
+    let mut message = SseMessage::default();
+
     let mut payload_lines = Vec::new();
 
     loop {
@@ -178,11 +205,12 @@ fn read_next_sse_payload(reader: &mut impl BufRead) -> Result<Option<String>> {
         let bytes_read = reader.read_line(&mut line)?;
 
         if bytes_read == 0 {
-            if payload_lines.is_empty() {
+            if payload_lines.is_empty() && message.id.is_none() {
                 return Ok(None);
             }
 
-            return Ok(Some(payload_lines.join("\n")));
+            message.data = payload_lines.join("\n");
+            return Ok(Some(message));
         }
 
         let trimmed = line.trim_end_matches(['\r', '\n']);
@@ -191,13 +219,42 @@ fn read_next_sse_payload(reader: &mut impl BufRead) -> Result<Option<String>> {
                 continue;
             }
 
-            return Ok(Some(payload_lines.join("\n")));
+            message.data = payload_lines.join("\n");
+            return Ok(Some(message));
+        }
+
+        if let Some(id) = trimmed.strip_prefix("id:") {
+            let parsed_id = id.trim().parse::<u64>().with_context(|| {
+                format!(
+                    "invalid task event stream id received from MCP bridge: {}",
+                    id.trim()
+                )
+            })?;
+            message.id = Some(parsed_id);
+            continue;
         }
 
         if let Some(payload) = trimmed.strip_prefix("data:") {
             payload_lines.push(payload.trim_start().to_string());
         }
     }
+}
+
+fn build_task_event_stream_request<'a>(
+    client: &'a Client,
+    stream_url: &'a str,
+    last_event_id: Option<u64>,
+) -> reqwest::blocking::RequestBuilder {
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static("text/event-stream"));
+
+    if let Some(last_event_id) = last_event_id {
+        if let Ok(value) = HeaderValue::from_str(&last_event_id.to_string()) {
+            headers.insert(LAST_EVENT_ID_HEADER.clone(), value);
+        }
+    }
+
+    client.get(stream_url).headers(headers)
 }
 
 fn sleep_before_retry(stop_requested: &AtomicBool) {
@@ -225,25 +282,99 @@ mod tests {
     }
 
     #[test]
-    fn read_next_sse_payload_collects_multiline_data_events() {
-        let mut reader =
-            Cursor::new(b"event: message\ndata: {\"one\":1}\ndata: {\"two\":2}\n\n".to_vec());
+    fn read_next_sse_message_collects_multiline_data_events_and_event_id() {
+        let mut reader = Cursor::new(
+            b"id: 7\nevent: message\ndata: {\"one\":1}\ndata: {\"two\":2}\n\n".to_vec(),
+        );
 
-        let payload = read_next_sse_payload(&mut reader)
+        let message = read_next_sse_message(&mut reader)
             .expect("payload should parse")
             .expect("payload should be present");
 
-        assert_eq!(payload, "{\"one\":1}\n{\"two\":2}");
+        assert_eq!(message.id, Some(7));
+        assert_eq!(message.data, "{\"one\":1}\n{\"two\":2}");
     }
 
     #[test]
-    fn read_next_sse_payload_skips_keepalive_comments() {
+    fn read_next_sse_message_skips_keepalive_comments() {
         let mut reader = Cursor::new(b": keepalive\n\ndata: {\"ok\":true}\n\n".to_vec());
 
-        let payload = read_next_sse_payload(&mut reader)
+        let message = read_next_sse_message(&mut reader)
             .expect("payload should parse")
             .expect("payload should be present");
 
-        assert_eq!(payload, "{\"ok\":true}");
+        assert_eq!(message.id, None);
+        assert_eq!(message.data, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn build_task_event_stream_request_includes_last_event_id_for_resume() {
+        let client = Client::builder().build().expect("client should build");
+        let request =
+            build_task_event_stream_request(&client, "http://127.0.0.1:1234/task-events", Some(42))
+                .build()
+                .expect("request should build");
+
+        assert_eq!(
+            request.headers().get(LAST_EVENT_ID_HEADER.clone()),
+            Some(&HeaderValue::from_static("42"))
+        );
+        assert_eq!(
+            request.headers().get(ACCEPT),
+            Some(&HeaderValue::from_static("text/event-stream"))
+        );
+    }
+
+    #[test]
+    fn relay_task_event_reader_updates_resume_cursor_and_replays_follow_up_events() {
+        let first_event = serde_json::to_string(&build_external_task_created_event(
+            "/repo".to_string(),
+            "task-1".to_string(),
+        ))
+        .expect("event should serialize");
+        let second_event = serde_json::to_string(&build_external_task_created_event(
+            "/repo".to_string(),
+            "task-2".to_string(),
+        ))
+        .expect("event should serialize");
+
+        let stop_requested = AtomicBool::new(false);
+        let mut last_event_id = None;
+        let mut emitted_task_ids = Vec::new();
+
+        let first_stream = Cursor::new(format!("id: 5\ndata: {first_event}\n\n").into_bytes());
+        relay_task_event_reader(first_stream, &stop_requested, &mut last_event_id, |event| {
+            emitted_task_ids.push(event.task_id)
+        })
+        .expect("first stream should relay");
+
+        assert_eq!(last_event_id, Some(5));
+
+        let request = build_task_event_stream_request(
+            &Client::builder().build().expect("client should build"),
+            "http://127.0.0.1:1234/task-events",
+            last_event_id,
+        )
+        .build()
+        .expect("request should build");
+        assert_eq!(
+            request.headers().get(LAST_EVENT_ID_HEADER.clone()),
+            Some(&HeaderValue::from_static("5"))
+        );
+
+        let replay_stream = Cursor::new(format!("id: 6\ndata: {second_event}\n\n").into_bytes());
+        relay_task_event_reader(
+            replay_stream,
+            &stop_requested,
+            &mut last_event_id,
+            |event| emitted_task_ids.push(event.task_id),
+        )
+        .expect("replay stream should relay");
+
+        assert_eq!(last_event_id, Some(6));
+        assert_eq!(
+            emitted_task_ids,
+            vec!["task-1".to_string(), "task-2".to_string()]
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/external_task_sync.rs
+++ b/apps/desktop/src-tauri/src/external_task_sync.rs
@@ -171,16 +171,17 @@ fn relay_task_event_reader(
             return Ok(());
         };
 
-        if let Some(message_id) = message.id {
-            *last_event_id = Some(message_id);
-        }
-
         if message.data.is_empty() {
             continue;
         }
 
         match serde_json::from_str::<ExternalTaskSyncEvent>(&message.data) {
-            Ok(event) => emit(event),
+            Ok(event) => {
+                if let Some(message_id) = message.id {
+                    *last_event_id = Some(message_id);
+                }
+                emit(event)
+            }
             Err(error) => {
                 tracing::error!(
                     target: "openducktor.task-sync",
@@ -205,7 +206,7 @@ fn read_next_sse_message(reader: &mut impl BufRead) -> Result<Option<SseMessage>
         let bytes_read = reader.read_line(&mut line)?;
 
         if bytes_read == 0 {
-            if payload_lines.is_empty() && message.id.is_none() {
+            if payload_lines.is_empty() {
                 return Ok(None);
             }
 
@@ -375,6 +376,37 @@ mod tests {
         assert_eq!(
             emitted_task_ids,
             vec!["task-1".to_string(), "task-2".to_string()]
+        );
+    }
+
+    #[test]
+    fn relay_task_event_reader_does_not_advance_resume_cursor_for_partial_id_only_eof() {
+        let stop_requested = AtomicBool::new(false);
+        let mut last_event_id = Some(5);
+        let mut emitted_task_ids = Vec::new();
+
+        let partial_stream = Cursor::new(b"id: 6\n".to_vec());
+        relay_task_event_reader(
+            partial_stream,
+            &stop_requested,
+            &mut last_event_id,
+            |event| emitted_task_ids.push(event.task_id),
+        )
+        .expect("partial stream should be ignored without failing");
+
+        assert_eq!(last_event_id, Some(5));
+        assert!(emitted_task_ids.is_empty());
+
+        let request = build_task_event_stream_request(
+            &Client::builder().build().expect("client should build"),
+            "http://127.0.0.1:1234/task-events",
+            last_event_id,
+        )
+        .build()
+        .expect("request should build");
+        assert_eq!(
+            request.headers().get(LAST_EVENT_ID_HEADER.clone()),
+            Some(&HeaderValue::from_static("5"))
         );
     }
 }

--- a/apps/desktop/src-tauri/src/external_task_sync.rs
+++ b/apps/desktop/src-tauri/src/external_task_sync.rs
@@ -1,0 +1,249 @@
+use anyhow::{Context, Result};
+use host_application::AppService;
+use host_domain::now_rfc3339;
+use reqwest::blocking::{Client, Response};
+use reqwest::header::ACCEPT;
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, BufReader};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+use uuid::Uuid;
+
+const TASK_EVENT_STREAM_PATH: &str = "task-events";
+const TASK_EVENT_RELAY_RETRY_DELAY: Duration = Duration::from_secs(1);
+const TASK_EVENT_RELAY_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const TASK_EVENT_NAME: &str = "openducktor://task-event";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ExternalTaskSyncEventKind {
+    ExternalTaskCreated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ExternalTaskSyncEvent {
+    pub(crate) event_id: String,
+    pub(crate) kind: ExternalTaskSyncEventKind,
+    pub(crate) repo_path: String,
+    pub(crate) task_id: String,
+    pub(crate) emitted_at: String,
+}
+
+pub(crate) struct TaskEventRelayState {
+    pub(crate) stop_requested: Arc<AtomicBool>,
+}
+
+pub(crate) fn build_external_task_created_event(
+    repo_path: String,
+    task_id: String,
+) -> ExternalTaskSyncEvent {
+    ExternalTaskSyncEvent {
+        event_id: Uuid::new_v4().to_string(),
+        kind: ExternalTaskSyncEventKind::ExternalTaskCreated,
+        repo_path,
+        task_id,
+        emitted_at: now_rfc3339(),
+    }
+}
+
+pub(crate) fn start_task_event_relay<R: tauri::Runtime>(
+    service: Arc<AppService>,
+    app: AppHandle<R>,
+) -> Arc<AtomicBool> {
+    let stop_requested = Arc::new(AtomicBool::new(false));
+    let relay_stop_requested = stop_requested.clone();
+
+    std::thread::spawn(move || {
+        if let Err(error) = run_task_event_relay(service, app, relay_stop_requested.clone()) {
+            tracing::error!(
+                target: "openducktor.task-sync",
+                error = %format!("{error:#}"),
+                "Task event relay terminated unexpectedly"
+            );
+        }
+    });
+
+    stop_requested
+}
+
+fn run_task_event_relay<R: tauri::Runtime>(
+    service: Arc<AppService>,
+    app: AppHandle<R>,
+    stop_requested: Arc<AtomicBool>,
+) -> Result<()> {
+    let client = Client::builder()
+        .connect_timeout(TASK_EVENT_RELAY_CONNECT_TIMEOUT)
+        .build()
+        .context("failed to build task event relay HTTP client")?;
+
+    while !stop_requested.load(Ordering::SeqCst) {
+        let stream_url = match service.mcp_bridge_base_url() {
+            Ok(base_url) => format!("{base_url}/{TASK_EVENT_STREAM_PATH}"),
+            Err(error) => {
+                tracing::error!(
+                    target: "openducktor.task-sync",
+                    error = %format!("{error:#}"),
+                    "Task event relay could not resolve the MCP bridge URL"
+                );
+                sleep_before_retry(&stop_requested);
+                continue;
+            }
+        };
+
+        let response = match client
+            .get(&stream_url)
+            .header(ACCEPT, "text/event-stream")
+            .send()
+        {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::error!(
+                    target: "openducktor.task-sync",
+                    stream_url,
+                    error = %error,
+                    "Task event relay failed to connect to the MCP bridge task stream"
+                );
+                sleep_before_retry(&stop_requested);
+                continue;
+            }
+        };
+
+        if let Err(error) = relay_task_event_stream(&app, response, &stop_requested) {
+            tracing::error!(
+                target: "openducktor.task-sync",
+                stream_url,
+                error = %format!("{error:#}"),
+                "Task event relay lost the MCP bridge task stream"
+            );
+        }
+
+        sleep_before_retry(&stop_requested);
+    }
+
+    Ok(())
+}
+
+fn relay_task_event_stream<R: tauri::Runtime>(
+    app: &AppHandle<R>,
+    response: Response,
+    stop_requested: &AtomicBool,
+) -> Result<()> {
+    let status = response.status();
+    if !status.is_success() {
+        anyhow::bail!("task event stream returned unexpected status {status}");
+    }
+
+    let mut reader = BufReader::new(response);
+    while !stop_requested.load(Ordering::SeqCst) {
+        let Some(payload) = read_next_sse_payload(&mut reader)? else {
+            return Ok(());
+        };
+
+        if payload.is_empty() {
+            continue;
+        }
+
+        match serde_json::from_str::<ExternalTaskSyncEvent>(&payload) {
+            Ok(event) => {
+                if let Err(error) = app.emit(TASK_EVENT_NAME, event) {
+                    tracing::error!(
+                        target: "openducktor.task-sync",
+                        error = %error,
+                        "Task event relay failed to emit a desktop task event"
+                    );
+                }
+            }
+            Err(error) => {
+                tracing::error!(
+                    target: "openducktor.task-sync",
+                    raw_payload = payload,
+                    error = %error,
+                    "Task event relay received an invalid task sync payload"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn read_next_sse_payload(reader: &mut impl BufRead) -> Result<Option<String>> {
+    let mut payload_lines = Vec::new();
+
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader.read_line(&mut line)?;
+
+        if bytes_read == 0 {
+            if payload_lines.is_empty() {
+                return Ok(None);
+            }
+
+            return Ok(Some(payload_lines.join("\n")));
+        }
+
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            if payload_lines.is_empty() {
+                continue;
+            }
+
+            return Ok(Some(payload_lines.join("\n")));
+        }
+
+        if let Some(payload) = trimmed.strip_prefix("data:") {
+            payload_lines.push(payload.trim_start().to_string());
+        }
+    }
+}
+
+fn sleep_before_retry(stop_requested: &AtomicBool) {
+    if stop_requested.load(Ordering::SeqCst) {
+        return;
+    }
+
+    std::thread::sleep(TASK_EVENT_RELAY_RETRY_DELAY);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn build_external_task_created_event_sets_expected_payload_shape() {
+        let event = build_external_task_created_event("/repo".to_string(), "task-1".to_string());
+
+        assert_eq!(event.kind, ExternalTaskSyncEventKind::ExternalTaskCreated);
+        assert_eq!(event.repo_path, "/repo");
+        assert_eq!(event.task_id, "task-1");
+        assert!(!event.event_id.is_empty());
+        assert!(!event.emitted_at.is_empty());
+    }
+
+    #[test]
+    fn read_next_sse_payload_collects_multiline_data_events() {
+        let mut reader =
+            Cursor::new(b"event: message\ndata: {\"one\":1}\ndata: {\"two\":2}\n\n".to_vec());
+
+        let payload = read_next_sse_payload(&mut reader)
+            .expect("payload should parse")
+            .expect("payload should be present");
+
+        assert_eq!(payload, "{\"one\":1}\n{\"two\":2}");
+    }
+
+    #[test]
+    fn read_next_sse_payload_skips_keepalive_comments() {
+        let mut reader = Cursor::new(b": keepalive\n\ndata: {\"ok\":true}\n\n".to_vec());
+
+        let payload = read_next_sse_payload(&mut reader)
+            .expect("payload should parse")
+            .expect("payload should be present");
+
+        assert_eq!(payload, "{\"ok\":true}");
+    }
+}

--- a/apps/desktop/src-tauri/src/headless/command_registry.rs
+++ b/apps/desktop/src-tauri/src/headless/command_registry.rs
@@ -123,6 +123,7 @@ mod tests {
                 service,
                 events: HeadlessEventBus::new(1),
                 dev_server_events: HeadlessEventBus::new(1),
+                task_events: HeadlessEventBus::new(1),
                 registry: Arc::new(registry),
                 shutdown_signal: Arc::new(Notify::new()),
                 shutdown_started: Arc::new(AtomicBool::new(false)),

--- a/apps/desktop/src-tauri/src/headless/command_support.rs
+++ b/apps/desktop/src-tauri/src/headless/command_support.rs
@@ -19,6 +19,7 @@ pub(super) struct HeadlessState {
     pub(super) service: Arc<AppService>,
     pub(super) events: HeadlessEventBus,
     pub(super) dev_server_events: HeadlessEventBus,
+    pub(super) task_events: HeadlessEventBus,
     pub(super) registry: Arc<CommandRegistry>,
     pub(super) shutdown_signal: Arc<Notify>,
     pub(super) shutdown_started: Arc<AtomicBool>,

--- a/apps/desktop/src-tauri/src/headless/odt_mcp_commands.rs
+++ b/apps/desktop/src-tauri/src/headless/odt_mcp_commands.rs
@@ -1,8 +1,9 @@
 use super::command_registry::CommandRegistry;
 use super::command_support::{
-    deserialize_args, handle_repo_scoped_input_operation_blocking, request_error, serialize_value,
-    CommandResult, HeadlessState,
+    deserialize_args, request_error, serialize_value, CommandResult, HeadlessState,
 };
+use crate::external_task_sync::build_external_task_created_event;
+use host_application::{OdtCreateTaskInput, OdtSearchTasksInput, OdtTaskSummary};
 use host_domain::PlanSubtaskInput;
 use serde::Deserialize;
 use serde_json::Value;
@@ -177,23 +178,57 @@ async fn handle_odt_read_task_documents(state: &HeadlessState, args: Value) -> C
 }
 
 async fn handle_create_task(state: &HeadlessState, args: Value) -> CommandResult {
-    handle_repo_scoped_input_operation_blocking(
+    let super::command_support::RepoScopedInputArgs { repo_path, input } =
+        deserialize_args::<super::command_support::RepoScopedInputArgs<OdtCreateTaskInput>>(args)?;
+    let repo_path_for_create = repo_path.clone();
+    let service = state.service.clone();
+    let created: OdtTaskSummary =
+        super::command_support::run_headless_blocking("odt_create_task", move || {
+            service.odt_create_task(&repo_path_for_create, input)
+        })
+        .await?;
+
+    emit_task_created_event(state, &repo_path, &created);
+
+    serialize_value(created)
+}
+
+async fn handle_search_tasks(state: &HeadlessState, args: Value) -> CommandResult {
+    super::command_support::handle_repo_scoped_input_operation_blocking(
         state,
         args,
-        "odt_create_task",
-        |service, repo_path, input| service.odt_create_task(&repo_path, input),
+        "odt_search_tasks",
+        |service, repo_path, input: OdtSearchTasksInput| service.odt_search_tasks(&repo_path, input),
     )
     .await
 }
 
-async fn handle_search_tasks(state: &HeadlessState, args: Value) -> CommandResult {
-    handle_repo_scoped_input_operation_blocking(
-        state,
-        args,
-        "odt_search_tasks",
-        |service, repo_path, input| service.odt_search_tasks(&repo_path, input),
-    )
-    .await
+fn emit_task_created_event(state: &HeadlessState, repo_path: &str, created: &OdtTaskSummary) {
+    let canonical_repo_path = match state.service.resolve_authorized_repo_path(repo_path) {
+        Ok(repo_path) => repo_path,
+        Err(error) => {
+            tracing::error!(
+                target: "openducktor.task-sync",
+                repo_path,
+                error = %format!("{error:#}"),
+                "External task create succeeded but canonical repo-path resolution for task sync failed"
+            );
+            return;
+        }
+    };
+
+    let task_id = created.task.task.id.clone();
+    let event = build_external_task_created_event(canonical_repo_path, task_id);
+    match serde_json::to_string(&event) {
+        Ok(payload) => state.task_events.emit(payload),
+        Err(error) => {
+            tracing::error!(
+                target: "openducktor.task-sync",
+                error = %error,
+                "External task create succeeded but task sync event serialization failed"
+            );
+        }
+    }
 }
 
 async fn handle_odt_set_spec(state: &HeadlessState, args: Value) -> CommandResult {

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -74,6 +74,7 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
         Arc::new(build_registry().context("failed to build browser backend command registry")?);
     let events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
     let dev_server_events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
+    let task_events = HeadlessEventBus::new(EVENT_BUFFER_CAPACITY);
     let shutdown_signal = Arc::new(Notify::new());
     let shutdown_started = Arc::new(AtomicBool::new(false));
     startup_phase_shutdown_hooks_with_gate(
@@ -86,6 +87,7 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
         .route("/shutdown", post(shutdown_handler))
         .route("/events", get(events_handler))
         .route("/dev-server-events", get(dev_server_events_handler))
+        .route("/task-events", get(task_events_handler))
         .route(
             "/local-attachment-preview",
             get(local_attachment_preview_handler),
@@ -96,6 +98,7 @@ pub(super) async fn run_browser_backend(port: u16) -> anyhow::Result<()> {
             service,
             events,
             dev_server_events,
+            task_events,
             registry,
             shutdown_signal: shutdown_signal.clone(),
             shutdown_started: shutdown_started.clone(),
@@ -186,6 +189,19 @@ async fn dev_server_events_handler(
         state.dev_server_events,
         last_event_id,
         "Browser dev server event stream",
+    ))
+}
+
+async fn task_events_handler(
+    State(state): State<HeadlessState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, HeadlessCommandError> {
+    reject_when_shutting_down(&state)?;
+    let last_event_id = parse_last_event_id(&headers)?;
+    Ok(build_sse_response(
+        state.task_events,
+        last_event_id,
+        "Browser task event stream",
     ))
 }
 
@@ -710,6 +726,7 @@ mod tests {
                 service,
                 events: HeadlessEventBus::new(EVENT_BUFFER_CAPACITY),
                 dev_server_events: HeadlessEventBus::new(EVENT_BUFFER_CAPACITY),
+                task_events: HeadlessEventBus::new(EVENT_BUFFER_CAPACITY),
                 registry,
                 shutdown_signal: Arc::new(Notify::new()),
                 shutdown_started: Arc::new(AtomicBool::new(false)),
@@ -749,6 +766,7 @@ mod tests {
                     service,
                     events: HeadlessEventBus::new(EVENT_BUFFER_CAPACITY),
                     dev_server_events: HeadlessEventBus::new(EVENT_BUFFER_CAPACITY),
+                    task_events: HeadlessEventBus::new(EVENT_BUFFER_CAPACITY),
                     registry,
                     shutdown_signal: Arc::new(Notify::new()),
                     shutdown_started: Arc::new(AtomicBool::new(false)),
@@ -824,6 +842,19 @@ mod tests {
         let state = task_state.lock().expect("task store lock poisoned");
         assert_eq!(state.created_inputs.len(), 1);
         assert_eq!(state.created_inputs[0].title, "Bridge task");
+
+        let (_receiver, replayed) = fixture.state.task_events.subscribe_with_replay(Some(0));
+        assert_eq!(replayed.len(), 1);
+
+        let task_event: Value =
+            serde_json::from_str(&replayed[0].payload).expect("task event should deserialize");
+        let expected_repo_path = std::fs::canonicalize(&repo_path)
+            .unwrap_or(repo_path.clone())
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(task_event["kind"], json!("external_task_created"));
+        assert_eq!(task_event["repoPath"], json!(expected_repo_path));
+        assert_eq!(task_event["taskId"], json!("generated-1"));
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/headless/server.rs
+++ b/apps/desktop/src-tauri/src/headless/server.rs
@@ -30,6 +30,7 @@ const DEFAULT_BROWSER_FRONTEND_ORIGINS: [&str; 3] = [
     "http://[::1]:1420",
 ];
 const BROWSER_FRONTEND_ORIGIN_ENV: &str = "ODT_BROWSER_FRONTEND_ORIGIN";
+const LAST_EVENT_ID_HEADER: &str = "last-event-id";
 pub(super) const EVENT_BUFFER_CAPACITY: usize = 256;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -301,21 +302,28 @@ fn browser_backend_cors_layer() -> anyhow::Result<CorsLayer> {
             CorsLayer::new()
                 .allow_origin(parse_default_frontend_origins()?)
                 .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
-                .allow_headers([header::CONTENT_TYPE])
+                .allow_headers(browser_backend_allowed_headers())
         } else {
             CorsLayer::new()
                 .allow_origin(parse_origin_header(origin)?)
                 .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
-                .allow_headers([header::CONTENT_TYPE])
+                .allow_headers(browser_backend_allowed_headers())
         }
     } else {
         CorsLayer::new()
             .allow_origin(parse_default_frontend_origins()?)
             .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
-            .allow_headers([header::CONTENT_TYPE])
+            .allow_headers(browser_backend_allowed_headers())
     };
 
     Ok(layer)
+}
+
+fn browser_backend_allowed_headers() -> [header::HeaderName; 2] {
+    [
+        header::CONTENT_TYPE,
+        header::HeaderName::from_static(LAST_EVENT_ID_HEADER),
+    ]
 }
 
 fn parse_default_frontend_origins() -> anyhow::Result<Vec<HeaderValue>> {
@@ -806,6 +814,15 @@ mod tests {
             payload,
             json!({ "error": "Failed to parse the request body as JSON: key must be a string at line 1 column 2" })
         );
+    }
+
+    #[test]
+    fn browser_backend_allowed_headers_include_last_event_id_for_sse_replay() {
+        let headers = browser_backend_allowed_headers();
+
+        assert_eq!(headers.len(), 2);
+        assert!(headers.contains(&header::CONTENT_TYPE));
+        assert!(headers.contains(&header::HeaderName::from_static(LAST_EVENT_ID_HEADER)));
     }
 
     #[tokio::test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Context};
+use external_task_sync::{start_task_event_relay, TaskEventRelayState};
 use host_application::{AppService, DevServerEmitter, RunEmitter};
 #[cfg(test)]
 use host_domain::TaskStatus;
@@ -16,6 +17,7 @@ use std::time::SystemTime;
 use tauri::{AppHandle, Emitter, Manager, RunEvent as TauriRunEvent};
 
 mod commands;
+mod external_task_sync;
 mod headless;
 #[cfg(all(feature = "cef", target_os = "macos"))]
 mod macos_cef_quit;
@@ -427,6 +429,7 @@ fn startup_phase_build_tauri_app(
     service: Arc<AppService>,
 ) -> anyhow::Result<tauri::App<TauriRuntime>> {
     let builder = tauri::Builder::<TauriRuntime>::default();
+    let setup_service = service.clone();
 
     #[cfg(all(feature = "cef", target_os = "macos"))]
     let builder = builder.command_line_args([
@@ -436,17 +439,20 @@ fn startup_phase_build_tauri_app(
     ]);
 
     let builder = builder
-        .setup(|_app| {
-            #[cfg(all(feature = "cef", target_os = "macos"))]
-            macos_cef_quit::install(_app)?;
-            Ok(())
-        })
-        .plugin(tauri_plugin_dialog::init())
         .manage(AppState {
             service,
             #[cfg(test)]
             hook_trust_dialog_test_response: Mutex::new(None),
-        });
+        })
+        .setup(move |app| {
+            #[cfg(all(feature = "cef", target_os = "macos"))]
+            macos_cef_quit::install(app)?;
+
+            let stop_requested = start_task_event_relay(setup_service.clone(), app.handle().clone());
+            app.manage(TaskEventRelayState { stop_requested });
+            Ok(())
+        })
+        .plugin(tauri_plugin_dialog::init());
 
     startup_phase_command_registration(builder)
         .build(tauri::generate_context!())
@@ -473,6 +479,11 @@ fn startup_phase_exit_shutdown_handler(
             {
                 return;
             }
+
+            handle
+                .state::<TaskEventRelayState>()
+                .stop_requested
+                .store(true, Ordering::SeqCst);
 
             for window in handle.webview_windows().into_values() {
                 let _ = window.hide();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ mod external_task_sync;
 mod headless;
 #[cfg(all(feature = "cef", target_os = "macos"))]
 mod macos_cef_quit;
+mod sse_relay;
 
 #[cfg(feature = "cef")]
 type TauriRuntime = tauri::Cef;

--- a/apps/desktop/src-tauri/src/sse_relay.rs
+++ b/apps/desktop/src-tauri/src/sse_relay.rs
@@ -1,0 +1,125 @@
+use anyhow::{Context, Result};
+use reqwest::blocking::Client;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT};
+use std::io::BufRead;
+
+const LAST_EVENT_ID_HEADER: HeaderName = HeaderName::from_static("last-event-id");
+
+pub(crate) type SseEventId = u64;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct SseMessage {
+    pub(crate) id: Option<SseEventId>,
+    pub(crate) data: String,
+}
+
+pub(crate) fn build_sse_stream_request<'a>(
+    client: &'a Client,
+    stream_url: &'a str,
+    last_event_id: Option<SseEventId>,
+) -> reqwest::blocking::RequestBuilder {
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static("text/event-stream"));
+
+    if let Some(last_event_id) = last_event_id {
+        if let Ok(value) = HeaderValue::from_str(&last_event_id.to_string()) {
+            headers.insert(LAST_EVENT_ID_HEADER.clone(), value);
+        }
+    }
+
+    client.get(stream_url).headers(headers)
+}
+
+pub(crate) fn read_next_sse_message(reader: &mut impl BufRead) -> Result<Option<SseMessage>> {
+    let mut message = SseMessage::default();
+    let mut payload_lines = Vec::new();
+
+    loop {
+        let mut line = String::new();
+        let bytes_read = reader.read_line(&mut line)?;
+
+        if bytes_read == 0 {
+            if payload_lines.is_empty() {
+                return Ok(None);
+            }
+
+            message.data = payload_lines.join("\n");
+            return Ok(Some(message));
+        }
+
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            if payload_lines.is_empty() {
+                continue;
+            }
+
+            message.data = payload_lines.join("\n");
+            return Ok(Some(message));
+        }
+
+        if let Some(id) = trimmed.strip_prefix("id:") {
+            let parsed_id = id.trim().parse::<SseEventId>().with_context(|| {
+                format!(
+                    "invalid SSE event id received from relay stream: {}",
+                    id.trim()
+                )
+            })?;
+            message.id = Some(parsed_id);
+            continue;
+        }
+
+        if let Some(payload) = trimmed.strip_prefix("data:") {
+            payload_lines.push(payload.trim_start().to_string());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn read_next_sse_message_collects_multiline_data_events_and_event_id() {
+        let mut reader = Cursor::new(
+            b"id: 7\nevent: message\ndata: {\"one\":1}\ndata: {\"two\":2}\n\n".to_vec(),
+        );
+
+        let message = read_next_sse_message(&mut reader)
+            .expect("payload should parse")
+            .expect("payload should be present");
+
+        assert_eq!(message.id, Some(7));
+        assert_eq!(message.data, "{\"one\":1}\n{\"two\":2}");
+    }
+
+    #[test]
+    fn read_next_sse_message_skips_keepalive_comments() {
+        let mut reader = Cursor::new(b": keepalive\n\ndata: {\"ok\":true}\n\n".to_vec());
+
+        let message = read_next_sse_message(&mut reader)
+            .expect("payload should parse")
+            .expect("payload should be present");
+
+        assert_eq!(message.id, None);
+        assert_eq!(message.data, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn build_sse_stream_request_includes_last_event_id_for_resume() {
+        let client = Client::builder().build().expect("client should build");
+        let request =
+            build_sse_stream_request(&client, "http://127.0.0.1:1234/task-events", Some(42))
+                .build()
+                .expect("request should build");
+
+        assert_eq!(
+            request.headers().get(LAST_EVENT_ID_HEADER.clone()),
+            Some(&HeaderValue::from_static("42"))
+        );
+        assert_eq!(
+            request.headers().get(ACCEPT),
+            Some(&HeaderValue::from_static("text/event-stream"))
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/sse_relay.rs
+++ b/apps/desktop/src-tauri/src/sse_relay.rs
@@ -10,6 +10,7 @@ pub(crate) type SseEventId = u64;
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct SseMessage {
     pub(crate) id: Option<SseEventId>,
+    pub(crate) event: Option<String>,
     pub(crate) data: String,
 }
 
@@ -68,6 +69,11 @@ pub(crate) fn read_next_sse_message(reader: &mut impl BufRead) -> Result<Option<
             continue;
         }
 
+        if let Some(event) = trimmed.strip_prefix("event:") {
+            message.event = Some(event.trim().to_string());
+            continue;
+        }
+
         if let Some(payload) = trimmed.strip_prefix("data:") {
             payload_lines.push(payload.trim_start().to_string());
         }
@@ -90,6 +96,7 @@ mod tests {
             .expect("payload should be present");
 
         assert_eq!(message.id, Some(7));
+        assert_eq!(message.event.as_deref(), Some("message"));
         assert_eq!(message.data, "{\"one\":1}\n{\"two\":2}");
     }
 
@@ -102,7 +109,22 @@ mod tests {
             .expect("payload should be present");
 
         assert_eq!(message.id, None);
+        assert_eq!(message.event, None);
         assert_eq!(message.data, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn read_next_sse_message_preserves_named_event_type() {
+        let mut reader =
+            Cursor::new(b"event: stream-warning\ndata: task-events skipped 2 events\n\n".to_vec());
+
+        let message = read_next_sse_message(&mut reader)
+            .expect("payload should parse")
+            .expect("payload should be present");
+
+        assert_eq!(message.id, None);
+        assert_eq!(message.event.as_deref(), Some("stream-warning"));
+        assert_eq!(message.data, "task-events skipped 2 events");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/sse_relay.rs
+++ b/apps/desktop/src-tauri/src/sse_relay.rs
@@ -54,21 +54,25 @@ pub(crate) fn read_next_sse_message(reader: &mut impl BufRead) -> Result<Option<
         }
 
         if let Some(id) = trimmed.strip_prefix("id:") {
-            if let Ok(parsed_id) = id.trim().parse::<SseEventId>() {
+            if let Ok(parsed_id) = trim_single_optional_leading_space(id).parse::<SseEventId>() {
                 message.id = Some(parsed_id);
             }
             continue;
         }
 
         if let Some(event) = trimmed.strip_prefix("event:") {
-            message.event = Some(event.trim().to_string());
+            message.event = Some(trim_single_optional_leading_space(event).to_string());
             continue;
         }
 
         if let Some(payload) = trimmed.strip_prefix("data:") {
-            payload_lines.push(payload.trim_start().to_string());
+            payload_lines.push(trim_single_optional_leading_space(payload).to_string());
         }
     }
+}
+
+fn trim_single_optional_leading_space(value: &str) -> &str {
+    value.strip_prefix(' ').unwrap_or(value)
 }
 
 #[cfg(test)]
@@ -155,5 +159,24 @@ mod tests {
 
         assert_eq!(message.id, None);
         assert_eq!(message.data, "{\"ok\":true}");
+    }
+
+    #[test]
+    fn read_next_sse_message_trims_only_one_optional_space_per_field() {
+        let mut reader = Cursor::new(
+            b"id: 7\nevent:  stream-warning\ndata:  leading space kept\ndata:   two leading spaces keep one extra\n\n"
+                .to_vec(),
+        );
+
+        let message = read_next_sse_message(&mut reader)
+            .expect("payload should parse")
+            .expect("payload should be present");
+
+        assert_eq!(message.id, Some(7));
+        assert_eq!(message.event.as_deref(), Some(" stream-warning"));
+        assert_eq!(
+            message.data,
+            " leading space kept\n  two leading spaces keep one extra"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/sse_relay.rs
+++ b/apps/desktop/src-tauri/src/sse_relay.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, ACCEPT};
 use std::io::BufRead;
@@ -40,12 +40,7 @@ pub(crate) fn read_next_sse_message(reader: &mut impl BufRead) -> Result<Option<
         let bytes_read = reader.read_line(&mut line)?;
 
         if bytes_read == 0 {
-            if payload_lines.is_empty() {
-                return Ok(None);
-            }
-
-            message.data = payload_lines.join("\n");
-            return Ok(Some(message));
+            return Ok(None);
         }
 
         let trimmed = line.trim_end_matches(['\r', '\n']);
@@ -59,13 +54,9 @@ pub(crate) fn read_next_sse_message(reader: &mut impl BufRead) -> Result<Option<
         }
 
         if let Some(id) = trimmed.strip_prefix("id:") {
-            let parsed_id = id.trim().parse::<SseEventId>().with_context(|| {
-                format!(
-                    "invalid SSE event id received from relay stream: {}",
-                    id.trim()
-                )
-            })?;
-            message.id = Some(parsed_id);
+            if let Ok(parsed_id) = id.trim().parse::<SseEventId>() {
+                message.id = Some(parsed_id);
+            }
             continue;
         }
 
@@ -143,5 +134,26 @@ mod tests {
             request.headers().get(ACCEPT),
             Some(&HeaderValue::from_static("text/event-stream"))
         );
+    }
+
+    #[test]
+    fn read_next_sse_message_discards_unterminated_eof_payloads() {
+        let mut reader = Cursor::new(b"id: 7\ndata: {\"one\":1}\n".to_vec());
+
+        let message = read_next_sse_message(&mut reader).expect("payload should parse");
+
+        assert_eq!(message, None);
+    }
+
+    #[test]
+    fn read_next_sse_message_ignores_non_numeric_event_ids() {
+        let mut reader = Cursor::new(b"id: reset\ndata: {\"ok\":true}\n\n".to_vec());
+
+        let message = read_next_sse_message(&mut reader)
+            .expect("payload should parse")
+            .expect("payload should be present");
+
+        assert_eq!(message.id, None);
+        assert_eq!(message.data, "{\"ok\":true}");
     }
 }

--- a/apps/desktop/src/lib/browser-live-client.test.ts
+++ b/apps/desktop/src/lib/browser-live-client.test.ts
@@ -273,4 +273,32 @@ describe("browser live SSE subscriptions", () => {
     unsubscribeB();
     expect(FakeEventSource.instances[0]?.closed).toBe(true);
   });
+
+  test("emits reconnect and stream-warning control payloads for task-event subscribers", async () => {
+    const { subscribeBrowserLiveTaskEvents } = await loadBrowserLiveClient();
+    const listener = mock(() => {});
+
+    const unsubscribe = await subscribeBrowserLiveTaskEvents(listener);
+
+    FakeEventSource.instances[0]?.emit("open", "");
+    expect(listener).not.toHaveBeenCalled();
+
+    FakeEventSource.instances[0]?.emit("open", "");
+    FakeEventSource.instances[0]?.emit(
+      "stream-warning",
+      "Task stream skipped 2 events; reconnect will replay buffered events.",
+    );
+
+    expect(listener).toHaveBeenNthCalledWith(1, {
+      __openducktorBrowserLive: true,
+      kind: "reconnected",
+    });
+    expect(listener).toHaveBeenNthCalledWith(2, {
+      __openducktorBrowserLive: true,
+      kind: "stream-warning",
+      message: "Task stream skipped 2 events; reconnect will replay buffered events.",
+    });
+
+    unsubscribe();
+  });
 });

--- a/apps/desktop/src/lib/browser-live-client.test.ts
+++ b/apps/desktop/src/lib/browser-live-client.test.ts
@@ -239,4 +239,38 @@ describe("browser live SSE subscriptions", () => {
 
     unsubscribe();
   });
+
+  test("shares one EventSource for multiple task-event subscribers", async () => {
+    const { subscribeBrowserLiveTaskEvents } = await loadBrowserLiveClient();
+    const listenerA = mock(() => {});
+    const listenerB = mock(() => {});
+
+    const unsubscribeA = await subscribeBrowserLiveTaskEvents(listenerA);
+    const unsubscribeB = await subscribeBrowserLiveTaskEvents(listenerB);
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(FakeEventSource.instances[0]?.url).toBe("http://127.0.0.1:14327/task-events");
+
+    FakeEventSource.instances[0]?.emit(
+      "message",
+      JSON.stringify({ kind: "external_task_created", repoPath: "/repo", taskId: "task-1" }),
+    );
+
+    expect(listenerA).toHaveBeenCalledWith({
+      kind: "external_task_created",
+      repoPath: "/repo",
+      taskId: "task-1",
+    });
+    expect(listenerB).toHaveBeenCalledWith({
+      kind: "external_task_created",
+      repoPath: "/repo",
+      taskId: "task-1",
+    });
+
+    unsubscribeA();
+    expect(FakeEventSource.instances[0]?.closed).toBe(false);
+
+    unsubscribeB();
+    expect(FakeEventSource.instances[0]?.closed).toBe(true);
+  });
 });

--- a/apps/desktop/src/lib/browser-live-client.test.ts
+++ b/apps/desktop/src/lib/browser-live-client.test.ts
@@ -253,18 +253,28 @@ describe("browser live SSE subscriptions", () => {
 
     FakeEventSource.instances[0]?.emit(
       "message",
-      JSON.stringify({ kind: "external_task_created", repoPath: "/repo", taskId: "task-1" }),
+      JSON.stringify({
+        eventId: "event-1",
+        kind: "external_task_created",
+        repoPath: "/repo",
+        taskId: "task-1",
+        emittedAt: "2026-04-10T13:00:00.000Z",
+      }),
     );
 
     expect(listenerA).toHaveBeenCalledWith({
+      eventId: "event-1",
       kind: "external_task_created",
       repoPath: "/repo",
       taskId: "task-1",
+      emittedAt: "2026-04-10T13:00:00.000Z",
     });
     expect(listenerB).toHaveBeenCalledWith({
+      eventId: "event-1",
       kind: "external_task_created",
       repoPath: "/repo",
       taskId: "task-1",
+      emittedAt: "2026-04-10T13:00:00.000Z",
     });
 
     unsubscribeA();

--- a/apps/desktop/src/lib/browser-live-client.ts
+++ b/apps/desktop/src/lib/browser-live-client.ts
@@ -181,3 +181,9 @@ export const subscribeBrowserLiveDevServerEvents = async (
 ): Promise<() => void> => {
   return subscribeSseChannel("dev-server-events", listener);
 };
+
+export const subscribeBrowserLiveTaskEvents = async (
+  listener: (payload: unknown) => void,
+): Promise<() => void> => {
+  return subscribeSseChannel("task-events", listener);
+};

--- a/apps/desktop/src/lib/browser-live-client.ts
+++ b/apps/desktop/src/lib/browser-live-client.ts
@@ -9,6 +9,8 @@ type BrowserLiveControlEvent = {
   message?: string;
 };
 
+const CONTROL_EVENT_SSE_PATHS = new Set(["dev-server-events", "task-events"]);
+
 type BrowserSseChannel = {
   eventSource: EventSource;
   listeners: Map<number, BrowserSseListener>;
@@ -93,6 +95,18 @@ const browserLiveControlEvent = (
   ...(message ? { message } : {}),
 });
 
+export const isBrowserLiveControlEvent = (payload: unknown): payload is BrowserLiveControlEvent => {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const record = payload as Record<string, unknown>;
+  return (
+    record.__openducktorBrowserLive === true &&
+    (record.kind === "reconnected" || record.kind === "stream-warning")
+  );
+};
+
 const closeSseChannelIfUnused = (path: string, channel: BrowserSseChannel): void => {
   if (channel.listeners.size > 0) {
     return;
@@ -114,7 +128,7 @@ const subscribeSseChannel = (path: string, listener: BrowserSseListener): (() =>
   if (!channel) {
     const eventSource = new EventSource(`${baseUrl}/${path}`);
     const listeners = new Map<number, BrowserSseListener>();
-    const shouldEmitControlEvents = path === "dev-server-events";
+    const shouldEmitControlEvents = CONTROL_EVENT_SSE_PATHS.has(path);
     let hasOpened = false;
     const handleMessage = (event: MessageEvent<string>): void => {
       const payload = parseSsePayload(event.data);

--- a/apps/desktop/src/lib/browser-live-client.ts
+++ b/apps/desktop/src/lib/browser-live-client.ts
@@ -1,13 +1,11 @@
 import { createTauriHostClient, type TauriHostClient } from "@openducktor/adapters-tauri-host";
+import {
+  browserLiveControlEvent,
+  isBrowserLiveControlEvent,
+} from "@/lib/browser-live-control-events";
 import { getBrowserBackendUrl } from "@/lib/browser-mode";
 
 type BrowserSseListener = (payload: unknown) => void;
-
-type BrowserLiveControlEvent = {
-  __openducktorBrowserLive: true;
-  kind: "reconnected" | "stream-warning";
-  message?: string;
-};
 
 const CONTROL_EVENT_SSE_PATHS = new Set(["dev-server-events", "task-events"]);
 
@@ -86,26 +84,7 @@ const parseSsePayload = (raw: string): unknown => {
   }
 };
 
-const browserLiveControlEvent = (
-  kind: BrowserLiveControlEvent["kind"],
-  message?: string,
-): BrowserLiveControlEvent => ({
-  __openducktorBrowserLive: true,
-  kind,
-  ...(message ? { message } : {}),
-});
-
-export const isBrowserLiveControlEvent = (payload: unknown): payload is BrowserLiveControlEvent => {
-  if (!payload || typeof payload !== "object") {
-    return false;
-  }
-
-  const record = payload as Record<string, unknown>;
-  return (
-    record.__openducktorBrowserLive === true &&
-    (record.kind === "reconnected" || record.kind === "stream-warning")
-  );
-};
+export { isBrowserLiveControlEvent };
 
 const closeSseChannelIfUnused = (path: string, channel: BrowserSseChannel): void => {
   if (channel.listeners.size > 0) {

--- a/apps/desktop/src/lib/browser-live-client.ts
+++ b/apps/desktop/src/lib/browser-live-client.ts
@@ -1,8 +1,9 @@
 import { createTauriHostClient, type TauriHostClient } from "@openducktor/adapters-tauri-host";
 import {
-  browserLiveControlEvent,
-  isBrowserLiveControlEvent,
-} from "@/lib/browser-live-control-events";
+  BROWSER_LIVE_RECONNECTED_EVENT_KIND,
+  BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
+} from "@/lib/browser-live/constants";
+import { browserLiveControlEvent } from "@/lib/browser-live-control-events";
 import { getBrowserBackendUrl } from "@/lib/browser-mode";
 
 type BrowserSseListener = (payload: unknown) => void;
@@ -84,8 +85,6 @@ const parseSsePayload = (raw: string): unknown => {
   }
 };
 
-export { isBrowserLiveControlEvent };
-
 const closeSseChannelIfUnused = (path: string, channel: BrowserSseChannel): void => {
   if (channel.listeners.size > 0) {
     return;
@@ -124,7 +123,7 @@ const subscribeSseChannel = (path: string, listener: BrowserSseListener): (() =>
         return;
       }
       for (const currentListener of listeners.values()) {
-        currentListener(browserLiveControlEvent("reconnected"));
+        currentListener(browserLiveControlEvent(BROWSER_LIVE_RECONNECTED_EVENT_KIND));
       }
     };
     const handleStreamWarning = (event: MessageEvent<string>): void => {
@@ -132,7 +131,9 @@ const subscribeSseChannel = (path: string, listener: BrowserSseListener): (() =>
         return;
       }
       for (const currentListener of listeners.values()) {
-        currentListener(browserLiveControlEvent("stream-warning", event.data));
+        currentListener(
+          browserLiveControlEvent(BROWSER_LIVE_STREAM_WARNING_EVENT_KIND, event.data),
+        );
       }
     };
 

--- a/apps/desktop/src/lib/browser-live-control-events.test.ts
+++ b/apps/desktop/src/lib/browser-live-control-events.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BROWSER_LIVE_RECONNECTED_EVENT_KIND,
+  BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
+} from "@/lib/browser-live/constants";
+import { browserLiveControlEvent, isBrowserLiveControlEvent } from "./browser-live-control-events";
+
+describe("browser-live-control-events", () => {
+  test("preserves empty-string messages", () => {
+    expect(browserLiveControlEvent(BROWSER_LIVE_STREAM_WARNING_EVENT_KIND, "")).toEqual({
+      __openducktorBrowserLive: true,
+      kind: BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
+      message: "",
+    });
+  });
+
+  test("accepts valid control events", () => {
+    expect(
+      isBrowserLiveControlEvent({
+        __openducktorBrowserLive: true,
+        kind: BROWSER_LIVE_RECONNECTED_EVENT_KIND,
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects control events with non-string messages", () => {
+    expect(
+      isBrowserLiveControlEvent({
+        __openducktorBrowserLive: true,
+        kind: BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
+        message: 42,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/browser-live-control-events.ts
+++ b/apps/desktop/src/lib/browser-live-control-events.ts
@@ -1,0 +1,28 @@
+export type BrowserLiveControlEventKind = "reconnected" | "stream-warning";
+
+export type BrowserLiveControlEvent = {
+  __openducktorBrowserLive: true;
+  kind: BrowserLiveControlEventKind;
+  message?: string;
+};
+
+export const browserLiveControlEvent = (
+  kind: BrowserLiveControlEventKind,
+  message?: string,
+): BrowserLiveControlEvent => ({
+  __openducktorBrowserLive: true,
+  kind,
+  ...(message ? { message } : {}),
+});
+
+export const isBrowserLiveControlEvent = (payload: unknown): payload is BrowserLiveControlEvent => {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const record = payload as Record<string, unknown>;
+  return (
+    record.__openducktorBrowserLive === true &&
+    (record.kind === "reconnected" || record.kind === "stream-warning")
+  );
+};

--- a/apps/desktop/src/lib/browser-live-control-events.ts
+++ b/apps/desktop/src/lib/browser-live-control-events.ts
@@ -1,10 +1,8 @@
-export type BrowserLiveControlEventKind = "reconnected" | "stream-warning";
-
-export type BrowserLiveControlEvent = {
-  __openducktorBrowserLive: true;
-  kind: BrowserLiveControlEventKind;
-  message?: string;
-};
+import {
+  BROWSER_LIVE_RECONNECTED_EVENT_KIND,
+  BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
+} from "@/lib/browser-live/constants";
+import type { BrowserLiveControlEvent, BrowserLiveControlEventKind } from "@/types";
 
 export const browserLiveControlEvent = (
   kind: BrowserLiveControlEventKind,
@@ -12,7 +10,7 @@ export const browserLiveControlEvent = (
 ): BrowserLiveControlEvent => ({
   __openducktorBrowserLive: true,
   kind,
-  ...(message ? { message } : {}),
+  ...(message !== undefined ? { message } : {}),
 });
 
 export const isBrowserLiveControlEvent = (payload: unknown): payload is BrowserLiveControlEvent => {
@@ -23,6 +21,8 @@ export const isBrowserLiveControlEvent = (payload: unknown): payload is BrowserL
   const record = payload as Record<string, unknown>;
   return (
     record.__openducktorBrowserLive === true &&
-    (record.kind === "reconnected" || record.kind === "stream-warning")
+    (record.kind === BROWSER_LIVE_RECONNECTED_EVENT_KIND ||
+      record.kind === BROWSER_LIVE_STREAM_WARNING_EVENT_KIND) &&
+    (record.message === undefined || typeof record.message === "string")
   );
 };

--- a/apps/desktop/src/lib/browser-live/constants.ts
+++ b/apps/desktop/src/lib/browser-live/constants.ts
@@ -1,0 +1,2 @@
+export const BROWSER_LIVE_RECONNECTED_EVENT_KIND = "reconnected";
+export const BROWSER_LIVE_STREAM_WARNING_EVENT_KIND = "stream-warning";

--- a/apps/desktop/src/lib/host-client.test.ts
+++ b/apps/desktop/src/lib/host-client.test.ts
@@ -57,6 +57,41 @@ describe("host-client", () => {
     );
   });
 
+  test("fails fast when task-event subscriptions are unavailable in the current runtime", async () => {
+    const { createHostBridge } = await import("./host-client");
+
+    await expect(createHostBridge().subscribeTaskEvents(() => {})).rejects.toThrow(
+      "Task-event subscriptions require the desktop shell or browser live mode.",
+    );
+  });
+
+  test("subscribes to the Tauri task-event channel", async () => {
+    isTauriRuntime = true;
+    const listener = mock(() => {});
+    let listenedEventName = "";
+    let registeredHandler: ((event: { payload: unknown }) => void) | undefined;
+
+    listenImpl = async (event, handler) => {
+      listenedEventName = event;
+      registeredHandler = handler;
+      return () => {};
+    };
+
+    const { createHostBridge } = await import("./host-client");
+    const unsubscribe = await createHostBridge().subscribeTaskEvents(listener);
+
+    if (!registeredHandler) {
+      throw new Error("Expected the Tauri task-event handler to be registered");
+    }
+
+    registeredHandler({ payload: { kind: "external_task_created", taskId: "task-1" } });
+
+    expect(listenedEventName).toBe("openducktor://task-event");
+    expect(listener).toHaveBeenCalledWith({ kind: "external_task_created", taskId: "task-1" });
+
+    unsubscribe();
+  });
+
   test("normalizes Tauri event cleanup into an idempotent callback", async () => {
     isTauriRuntime = true;
     let cleanupCalls = 0;

--- a/apps/desktop/src/lib/host-client.ts
+++ b/apps/desktop/src/lib/host-client.ts
@@ -3,22 +3,26 @@ import {
   createBrowserLiveHostClient,
   subscribeBrowserLiveDevServerEvents,
   subscribeBrowserLiveRunEvents,
+  subscribeBrowserLiveTaskEvents,
 } from "@/lib/browser-live-client";
 import { isBrowserAppMode } from "@/lib/browser-mode";
 import { isTauriRuntime } from "@/lib/runtime";
 
-type RunEventListener = (payload: unknown) => void;
+type HostEventListener = (payload: unknown) => void;
 type AsyncCleanup = (() => void | Promise<void>) | null | undefined;
 type HostBridge = {
   client: TauriHostClient;
-  subscribeRunEvents: (listener: RunEventListener) => Promise<() => void>;
-  subscribeDevServerEvents: (listener: RunEventListener) => Promise<() => void>;
+  subscribeRunEvents: (listener: HostEventListener) => Promise<() => void>;
+  subscribeDevServerEvents: (listener: HostEventListener) => Promise<() => void>;
+  subscribeTaskEvents: (listener: HostEventListener) => Promise<() => void>;
 };
 
 const RUN_EVENT_SUBSCRIPTIONS_UNAVAILABLE_ERROR =
   "Run-event subscriptions require the desktop shell or browser live mode.";
 const DEV_SERVER_EVENT_SUBSCRIPTIONS_UNAVAILABLE_ERROR =
   "Dev-server event subscriptions require the desktop shell or browser live mode.";
+const TASK_EVENT_SUBSCRIPTIONS_UNAVAILABLE_ERROR =
+  "Task-event subscriptions require the desktop shell or browser live mode.";
 const TAURI_EVENT_UNSUBSCRIBE_LOG_PREFIX = "[host-client] Tauri event unsubscribe failed";
 
 let tauriCoreModulePromise: Promise<typeof import("@tauri-apps/api/core")> | null = null;
@@ -109,10 +113,28 @@ const createDevServerEventSubscription =
     return createSafeCleanup(cleanup);
   };
 
+const createTaskEventSubscription = (): HostBridge["subscribeTaskEvents"] => async (listener) => {
+  if (isBrowserAppMode()) {
+    return subscribeBrowserLiveTaskEvents(listener);
+  }
+
+  if (!isTauriRuntime()) {
+    throw new Error(TASK_EVENT_SUBSCRIPTIONS_UNAVAILABLE_ERROR);
+  }
+
+  const events = await import("@tauri-apps/api/event");
+  const cleanup = await events.listen("openducktor://task-event", (event) => {
+    listener(event.payload);
+  });
+
+  return createSafeCleanup(cleanup);
+};
+
 export const createHostBridge = (): HostBridge => ({
   client: createHostCommands(),
   subscribeRunEvents: createRunEventSubscription(),
   subscribeDevServerEvents: createDevServerEventSubscription(),
+  subscribeTaskEvents: createTaskEventSubscription(),
 });
 
 export const hostBridge = createHostBridge();
@@ -120,3 +142,4 @@ export const hostBridge = createHostBridge();
 export const hostClient = hostBridge.client;
 
 export const subscribeDevServerEvents = hostBridge.subscribeDevServerEvents;
+export const subscribeTaskEvents = hostBridge.subscribeTaskEvents;

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
@@ -4,10 +4,9 @@ import type {
   DevServerScriptState,
 } from "@openducktor/contracts";
 import { trimDevServerTerminalChunks } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
-import {
-  isBrowserLiveControlEvent,
-  type BrowserLiveControlEvent as DevServerSubscriptionControlEvent,
-} from "@/lib/browser-live-control-events";
+import { isBrowserLiveControlEvent } from "@/lib/browser-live-control-events";
+
+export type { BrowserLiveControlEvent as DevServerSubscriptionControlEvent } from "@/types";
 
 export const buildTaskMemoryKey = (repoPath: string, taskId: string): string => {
   return `${repoPath}::${taskId}`;

--- a/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
+++ b/apps/desktop/src/pages/agents/right-panel/use-agent-studio-dev-server-panel-helpers.ts
@@ -4,12 +4,10 @@ import type {
   DevServerScriptState,
 } from "@openducktor/contracts";
 import { trimDevServerTerminalChunks } from "@/features/agent-studio-build-tools/dev-server-log-buffer";
-
-export type DevServerSubscriptionControlEvent = {
-  __openducktorBrowserLive: true;
-  kind: "reconnected" | "stream-warning";
-  message?: string;
-};
+import {
+  isBrowserLiveControlEvent,
+  type BrowserLiveControlEvent as DevServerSubscriptionControlEvent,
+} from "@/lib/browser-live-control-events";
 
 export const buildTaskMemoryKey = (repoPath: string, taskId: string): string => {
   return `${repoPath}::${taskId}`;
@@ -41,19 +39,7 @@ export const buildOptimisticStartingState = (state: DevServerGroupState): DevSer
   })),
 });
 
-export const isDevServerSubscriptionControlEvent = (
-  payload: unknown,
-): payload is DevServerSubscriptionControlEvent => {
-  if (!payload || typeof payload !== "object") {
-    return false;
-  }
-
-  const record = payload as Record<string, unknown>;
-  return (
-    record.__openducktorBrowserLive === true &&
-    (record.kind === "reconnected" || record.kind === "stream-warning")
-  );
-};
+export const isDevServerSubscriptionControlEvent = isBrowserLiveControlEvent;
 
 export const applyDevServerEventToState = (
   state: DevServerGroupState | null,

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -480,6 +480,109 @@ describe("useAppLifecycle", () => {
     }
   });
 
+  test("resyncs the active repo when the browser-live task stream reconnects", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTaskData = mock(async (_repoPath: string, _taskId?: string) => {});
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        setEvents: mock((_updater) => {}),
+        setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () => ({
+          beadsOk: true,
+          beadsPath: "/repo/.beads",
+          beadsError: null,
+        })),
+        refreshTaskData,
+        refreshTasksWithOptions: mock(async () => {}),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+    await harness.mount();
+    try {
+      refreshTaskData.mockClear();
+      if (!subscribedTaskListener) {
+        throw new Error("Expected task event listener to be registered");
+      }
+
+      await harness.run(async () => {
+        subscribedTaskListener?.({
+          __openducktorBrowserLive: true,
+          kind: "reconnected",
+        });
+        await Promise.resolve();
+      });
+
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo");
+      expect(toastError).not.toHaveBeenCalledWith("Task sync stream degraded", expect.anything());
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("surfaces browser-live task stream warnings and triggers a resync", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTaskData = mock(async (_repoPath: string, _taskId?: string) => {});
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        setEvents: mock((_updater) => {}),
+        setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () => ({
+          beadsOk: true,
+          beadsPath: "/repo/.beads",
+          beadsError: null,
+        })),
+        refreshTaskData,
+        refreshTasksWithOptions: mock(async () => {}),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+    await harness.mount();
+    try {
+      refreshTaskData.mockClear();
+      if (!subscribedTaskListener) {
+        throw new Error("Expected task event listener to be registered");
+      }
+
+      await harness.run(async () => {
+        subscribedTaskListener?.({
+          __openducktorBrowserLive: true,
+          kind: "stream-warning",
+          message: "Task stream skipped 2 events; reconnect will replay buffered events.",
+        });
+        await Promise.resolve();
+      });
+
+      expect(toastError).toHaveBeenCalledWith("Task sync stream degraded", {
+        description: "Task stream skipped 2 events; reconnect will replay buffered events.",
+      });
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
   test("loads repo task and diagnostics checks when the active repo changes", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = Parameters<typeof useAppLifecycle>[0];

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -6,6 +6,11 @@ import { createHookHarness as createSharedHookHarness } from "@/test-utils/react
 
 let subscribedRunListener: ((payload: unknown) => void) | null = null;
 let subscribedTaskListener: ((payload: unknown) => void) | null = null;
+let subscribeRunEventsImpl: ((listener: (payload: unknown) => void) => Promise<() => void>) | null =
+  null;
+let subscribeTaskEventsImpl:
+  | ((listener: (payload: unknown) => void) => Promise<() => void>)
+  | null = null;
 const toastError = mock((_message: string, _options?: { description?: string }) => "");
 const toastLoading = mock((_message: string, _options?: { description?: string }) => "toast-id");
 const toastSuccess = mock((_message: string, _options?: { description?: string }) => "");
@@ -126,22 +131,34 @@ let visibilityStateController: ReturnType<typeof createVisibilityStateController
 
 beforeEach(() => {
   visibilityStateController = createVisibilityStateController();
+  subscribeRunEventsImpl = async (listener: (payload: unknown) => void) => {
+    subscribedRunListener = listener;
+    return () => {
+      subscribedRunListener = null;
+    };
+  };
+  subscribeTaskEventsImpl = async (listener: (payload: unknown) => void) => {
+    subscribedTaskListener = listener;
+    return () => {
+      subscribedTaskListener = null;
+    };
+  };
   mock.module("@/lib/host-client", () => ({
     createHostBridge: () => ({
       client: createTauriHostClient(async () => {
         throw new Error("Tauri runtime not available. Run inside the desktop shell.");
       }),
       subscribeRunEvents: async (listener: (payload: unknown) => void) => {
-        subscribedRunListener = listener;
-        return () => {
-          subscribedRunListener = null;
-        };
+        if (!subscribeRunEventsImpl) {
+          throw new Error("Expected subscribeRunEventsImpl to be configured");
+        }
+        return subscribeRunEventsImpl(listener);
       },
       subscribeTaskEvents: async (listener: (payload: unknown) => void) => {
-        subscribedTaskListener = listener;
-        return () => {
-          subscribedTaskListener = null;
-        };
+        if (!subscribeTaskEventsImpl) {
+          throw new Error("Expected subscribeTaskEventsImpl to be configured");
+        }
+        return subscribeTaskEventsImpl(listener);
       },
     }),
     createHostClient: () =>
@@ -153,32 +170,32 @@ beforeEach(() => {
         throw new Error("Tauri runtime not available. Run inside the desktop shell.");
       }),
       subscribeRunEvents: async (listener: (payload: unknown) => void) => {
-        subscribedRunListener = listener;
-        return () => {
-          subscribedRunListener = null;
-        };
+        if (!subscribeRunEventsImpl) {
+          throw new Error("Expected subscribeRunEventsImpl to be configured");
+        }
+        return subscribeRunEventsImpl(listener);
       },
       subscribeTaskEvents: async (listener: (payload: unknown) => void) => {
-        subscribedTaskListener = listener;
-        return () => {
-          subscribedTaskListener = null;
-        };
+        if (!subscribeTaskEventsImpl) {
+          throw new Error("Expected subscribeTaskEventsImpl to be configured");
+        }
+        return subscribeTaskEventsImpl(listener);
       },
     },
     hostClient: createTauriHostClient(async () => {
       throw new Error("Tauri runtime not available. Run inside the desktop shell.");
     }),
     subscribeRunEvents: async (listener: (payload: unknown) => void) => {
-      subscribedRunListener = listener;
-      return () => {
-        subscribedRunListener = null;
-      };
+      if (!subscribeRunEventsImpl) {
+        throw new Error("Expected subscribeRunEventsImpl to be configured");
+      }
+      return subscribeRunEventsImpl(listener);
     },
     subscribeTaskEvents: async (listener: (payload: unknown) => void) => {
-      subscribedTaskListener = listener;
-      return () => {
-        subscribedTaskListener = null;
-      };
+      if (!subscribeTaskEventsImpl) {
+        throw new Error("Expected subscribeTaskEventsImpl to be configured");
+      }
+      return subscribeTaskEventsImpl(listener);
     },
   }));
   mock.module("sonner", () => ({
@@ -262,6 +279,55 @@ describe("useAppLifecycle", () => {
     }
   });
 
+  test("cleans up a run-event subscription that resolves after unmount", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const deferred = createDeferred<() => void>();
+    let cleanupCalls = 0;
+    subscribeRunEventsImpl = async (listener: (payload: unknown) => void) => {
+      subscribedRunListener = listener;
+      return deferred.promise;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        setEvents: mock((_updater) => {}),
+        setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () => ({
+          beadsOk: true,
+          beadsPath: "/repo/.beads",
+          beadsError: null,
+        })),
+        refreshTaskData: mock(async () => {}),
+        refreshTasksWithOptions: mock(async () => {}),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+
+    await harness.mount();
+    await harness.unmount();
+
+    deferred.resolve(() => {
+      cleanupCalls += 1;
+      subscribedRunListener = null;
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(cleanupCalls).toBe(1);
+    expect(subscribedRunListener).toBeNull();
+  });
+
   test("refreshes active repo task data when an external task event arrives", async () => {
     const { useAppLifecycle } = await import("./use-app-lifecycle");
     type HookArgs = Parameters<typeof useAppLifecycle>[0];
@@ -311,6 +377,55 @@ describe("useAppLifecycle", () => {
     } finally {
       await harness.unmount();
     }
+  });
+
+  test("cleans up a task-event subscription that resolves after unmount", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const deferred = createDeferred<() => void>();
+    let cleanupCalls = 0;
+    subscribeTaskEventsImpl = async (listener: (payload: unknown) => void) => {
+      subscribedTaskListener = listener;
+      return deferred.promise;
+    };
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        setEvents: mock((_updater) => {}),
+        setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () => ({
+          beadsOk: true,
+          beadsPath: "/repo/.beads",
+          beadsError: null,
+        })),
+        refreshTaskData: mock(async () => {}),
+        refreshTasksWithOptions: mock(async () => {}),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+
+    await harness.mount();
+    await harness.unmount();
+
+    deferred.resolve(() => {
+      cleanupCalls += 1;
+      subscribedTaskListener = null;
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(cleanupCalls).toBe(1);
+    expect(subscribedTaskListener).toBeNull();
   });
 
   test("ignores external task events for a different repo", async () => {

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createTauriHostClient } from "@openducktor/adapters-tauri-host";
 import { act } from "react";
 import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
@@ -216,9 +216,11 @@ beforeEach(() => {
 
 afterEach(() => {
   visibilityStateController.restore();
+  subscribeRunEventsImpl = null;
+  subscribeTaskEventsImpl = null;
 });
 
-afterAll(async () => {
+afterEach(async () => {
   await restoreMockedModules([
     ["@/lib/host-client", () => import("@/lib/host-client")],
     ["sonner", () => import("sonner")],

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx
@@ -5,6 +5,7 @@ import { restoreMockedModules } from "@/test-utils/mock-module-cleanup";
 import { createHookHarness as createSharedHookHarness } from "@/test-utils/react-hook-harness";
 
 let subscribedRunListener: ((payload: unknown) => void) | null = null;
+let subscribedTaskListener: ((payload: unknown) => void) | null = null;
 const toastError = mock((_message: string, _options?: { description?: string }) => "");
 const toastLoading = mock((_message: string, _options?: { description?: string }) => "toast-id");
 const toastSuccess = mock((_message: string, _options?: { description?: string }) => "");
@@ -136,6 +137,12 @@ beforeEach(() => {
           subscribedRunListener = null;
         };
       },
+      subscribeTaskEvents: async (listener: (payload: unknown) => void) => {
+        subscribedTaskListener = listener;
+        return () => {
+          subscribedTaskListener = null;
+        };
+      },
     }),
     createHostClient: () =>
       createTauriHostClient(async () => {
@@ -151,6 +158,12 @@ beforeEach(() => {
           subscribedRunListener = null;
         };
       },
+      subscribeTaskEvents: async (listener: (payload: unknown) => void) => {
+        subscribedTaskListener = listener;
+        return () => {
+          subscribedTaskListener = null;
+        };
+      },
     },
     hostClient: createTauriHostClient(async () => {
       throw new Error("Tauri runtime not available. Run inside the desktop shell.");
@@ -159,6 +172,12 @@ beforeEach(() => {
       subscribedRunListener = listener;
       return () => {
         subscribedRunListener = null;
+      };
+    },
+    subscribeTaskEvents: async (listener: (payload: unknown) => void) => {
+      subscribedTaskListener = listener;
+      return () => {
+        subscribedTaskListener = null;
       };
     },
   }));
@@ -171,6 +190,7 @@ beforeEach(() => {
     },
   }));
   subscribedRunListener = null;
+  subscribedTaskListener = null;
   toastError.mockClear();
   toastLoading.mockClear();
   toastSuccess.mockClear();
@@ -237,6 +257,224 @@ describe("useAppLifecycle", () => {
 
       expect(setRunCompletionSignal).toHaveBeenCalledWith("run-1", "run_finished");
       expect(refreshTaskData).toHaveBeenCalledWith("/repo");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("refreshes active repo task data when an external task event arrives", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTaskData = mock(async (_repoPath: string, _taskId?: string) => {});
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        setEvents: mock((_updater) => {}),
+        setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () => ({
+          beadsOk: true,
+          beadsPath: "/repo/.beads",
+          beadsError: null,
+        })),
+        refreshTaskData,
+        refreshTasksWithOptions: mock(async () => {}),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+    await harness.mount();
+    try {
+      refreshTaskData.mockClear();
+      if (!subscribedTaskListener) {
+        throw new Error("Expected task event listener to be registered");
+      }
+
+      await harness.run(() => {
+        subscribedTaskListener?.({
+          eventId: "event-1",
+          kind: "external_task_created",
+          repoPath: "/repo",
+          taskId: "task-1",
+          emittedAt: "2026-04-10T13:00:00.000Z",
+        });
+      });
+
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo", "task-1");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("ignores external task events for a different repo", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTaskData = mock(async (_repoPath: string, _taskId?: string) => {});
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo-a",
+        setEvents: mock((_updater) => {}),
+        setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () => ({
+          beadsOk: true,
+          beadsPath: "/repo-a/.beads",
+          beadsError: null,
+        })),
+        refreshTaskData,
+        refreshTasksWithOptions: mock(async () => {}),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+    await harness.mount();
+    try {
+      refreshTaskData.mockClear();
+      if (!subscribedTaskListener) {
+        throw new Error("Expected task event listener to be registered");
+      }
+
+      await harness.run(() => {
+        subscribedTaskListener?.({
+          eventId: "event-1",
+          kind: "external_task_created",
+          repoPath: "/repo-b",
+          taskId: "task-1",
+          emittedAt: "2026-04-10T13:00:00.000Z",
+        });
+      });
+
+      expect(refreshTaskData).not.toHaveBeenCalled();
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("deduplicates replayed external task events by event id", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTaskData = mock(async (_repoPath: string, _taskId?: string) => {});
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        setEvents: mock((_updater) => {}),
+        setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () => ({
+          beadsOk: true,
+          beadsPath: "/repo/.beads",
+          beadsError: null,
+        })),
+        refreshTaskData,
+        refreshTasksWithOptions: mock(async () => {}),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+    await harness.mount();
+    try {
+      refreshTaskData.mockClear();
+      if (!subscribedTaskListener) {
+        throw new Error("Expected task event listener to be registered");
+      }
+
+      await harness.run(() => {
+        subscribedTaskListener?.({
+          eventId: "event-1",
+          kind: "external_task_created",
+          repoPath: "/repo",
+          taskId: "task-1",
+          emittedAt: "2026-04-10T13:00:00.000Z",
+        });
+        subscribedTaskListener?.({
+          eventId: "event-1",
+          kind: "external_task_created",
+          repoPath: "/repo",
+          taskId: "task-1",
+          emittedAt: "2026-04-10T13:00:00.000Z",
+        });
+      });
+
+      expect(refreshTaskData).toHaveBeenCalledTimes(1);
+      expect(refreshTaskData).toHaveBeenCalledWith("/repo", "task-1");
+    } finally {
+      await harness.unmount();
+    }
+  });
+
+  test("surfaces task refresh failures triggered by external task events", async () => {
+    const { useAppLifecycle } = await import("./use-app-lifecycle");
+    type HookArgs = Parameters<typeof useAppLifecycle>[0];
+
+    const refreshTaskData = mock(async (_repoPath: string, taskId?: string) => {
+      if (taskId === "task-1") {
+        throw new Error("sync failed");
+      }
+    });
+
+    const Harness = ({ args }: { args: HookArgs }) => {
+      useAppLifecycle(args);
+      return null;
+    };
+    const harness = createSharedHookHarness(Harness, {
+      args: {
+        activeRepo: "/repo",
+        setEvents: mock((_updater) => {}),
+        setRunCompletionSignal: mock((_runId: string, _eventType) => {}),
+        refreshWorkspaces: mock(async () => {}),
+        refreshBranches: mock(async () => {}),
+        refreshRuntimeCheck: mock(async () => ({ runtimeOk: true })),
+        refreshBeadsCheckForRepo: mock(async () => ({
+          beadsOk: true,
+          beadsPath: "/repo/.beads",
+          beadsError: null,
+        })),
+        refreshTaskData,
+        refreshTasksWithOptions: mock(async () => {}),
+        clearBranchData: mock(() => {}),
+      } satisfies HookArgs,
+    });
+    await harness.mount();
+    try {
+      if (!subscribedTaskListener) {
+        throw new Error("Expected task event listener to be registered");
+      }
+
+      await harness.run(async () => {
+        subscribedTaskListener?.({
+          eventId: "event-1",
+          kind: "external_task_created",
+          repoPath: "/repo",
+          taskId: "task-1",
+          emittedAt: "2026-04-10T13:00:00.000Z",
+        });
+        await Promise.resolve();
+      });
+
+      expect(toastError).toHaveBeenCalledWith("Failed to sync external task changes", {
+        description: "Task store unavailable. sync failed",
+      });
     } finally {
       await harness.unmount();
     }

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -1,5 +1,6 @@
 import { externalTaskSyncEventSchema, type RunEvent, runEventSchema } from "@openducktor/contracts";
 import { type Dispatch, type SetStateAction, useEffect, useLayoutEffect, useRef } from "react";
+import { isBrowserLiveControlEvent } from "@/lib/browser-live-client";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
 import { hostBridge } from "@/lib/host-client";
@@ -134,6 +135,28 @@ export function useAppLifecycle({
     let unsubscribe: (() => void) | null = null;
     hostBridge
       .subscribeTaskEvents((payload) => {
+        if (isBrowserLiveControlEvent(payload)) {
+          const activeRepo = activeRepoRef.current;
+          if (!activeRepo) {
+            return;
+          }
+
+          if (payload.kind === "stream-warning") {
+            toast.error("Task sync stream degraded", {
+              description:
+                payload.message ??
+                "The browser-live task event stream fell behind and is reconnecting.",
+            });
+          }
+
+          void refreshTaskDataRef.current(activeRepo).catch((error: unknown) => {
+            toast.error("Failed to resync tasks after task stream reconnect", {
+              description: summarizeTaskLoadError(error),
+            });
+          });
+          return;
+        }
+
         const parsed = externalTaskSyncEventSchema.safeParse(payload);
         if (!parsed.success) {
           toast.error("Task sync event invalid", {

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -1,4 +1,4 @@
-import { type RunEvent, runEventSchema } from "@openducktor/contracts";
+import { externalTaskSyncEventSchema, type RunEvent, runEventSchema } from "@openducktor/contracts";
 import { type Dispatch, type SetStateAction, useEffect, useLayoutEffect, useRef } from "react";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
@@ -9,6 +9,28 @@ import { prependRunEvent } from "./app-lifecycle-model";
 
 const BEADS_PREPARATION_TOAST_DELAY_MS = 1_000;
 const PULL_REQUEST_SYNC_INTERVAL_MS = 5 * 60 * 1_000;
+const MAX_TRACKED_EXTERNAL_TASK_EVENT_IDS = 256;
+
+const rememberProcessedExternalTaskEvent = (
+  eventIds: Set<string>,
+  order: string[],
+  eventId: string,
+): boolean => {
+  if (eventIds.has(eventId)) {
+    return false;
+  }
+
+  eventIds.add(eventId);
+  order.push(eventId);
+  if (order.length > MAX_TRACKED_EXTERNAL_TASK_EVENT_IDS) {
+    const oldestEventId = order.shift();
+    if (oldestEventId) {
+      eventIds.delete(oldestEventId);
+    }
+  }
+
+  return true;
+};
 
 type UseAppLifecycleArgs = {
   activeRepo: string | null;
@@ -49,6 +71,8 @@ export function useAppLifecycle({
   const activeRepoRef = useRef(activeRepo);
   const refreshTaskDataRef = useRef(refreshTaskData);
   const refreshTasksWithOptionsRef = useRef(refreshTasksWithOptions);
+  const processedTaskEventIdsRef = useRef(new Set<string>());
+  const processedTaskEventOrderRef = useRef<string[]>([]);
 
   useLayoutEffect(() => {
     activeRepoRef.current = activeRepo;
@@ -105,6 +129,54 @@ export function useAppLifecycle({
       unsubscribe?.();
     };
   }, [refreshRuntimeCheck, refreshWorkspaces, setEvents, setRunCompletionSignal]);
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | null = null;
+    hostBridge
+      .subscribeTaskEvents((payload) => {
+        const parsed = externalTaskSyncEventSchema.safeParse(payload);
+        if (!parsed.success) {
+          toast.error("Task sync event invalid", {
+            description: "Received an invalid external task sync payload from the host bridge.",
+          });
+          return;
+        }
+
+        if (
+          !rememberProcessedExternalTaskEvent(
+            processedTaskEventIdsRef.current,
+            processedTaskEventOrderRef.current,
+            parsed.data.eventId,
+          )
+        ) {
+          return;
+        }
+
+        if (activeRepoRef.current !== parsed.data.repoPath) {
+          return;
+        }
+
+        void refreshTaskDataRef
+          .current(parsed.data.repoPath, parsed.data.taskId)
+          .catch((error: unknown) => {
+            toast.error("Failed to sync external task changes", {
+              description: summarizeTaskLoadError(error),
+            });
+          });
+      })
+      .then((cleanup) => {
+        unsubscribe = cleanup;
+      })
+      .catch((error: unknown) => {
+        toast.error("Task event subscription failed", {
+          description: errorMessage(error),
+        });
+      });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, []);
 
   useEffect(() => {
     if (!activeRepo) {

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -1,7 +1,8 @@
 import { externalTaskSyncEventSchema, type RunEvent, runEventSchema } from "@openducktor/contracts";
-import { type Dispatch, type SetStateAction, useEffect, useRef } from "react";
-import { isBrowserLiveControlEvent } from "@/lib/browser-live-client";
+import { type Dispatch, type SetStateAction, useEffect, useLayoutEffect, useRef } from "react";
 import { toast } from "sonner";
+import { BROWSER_LIVE_STREAM_WARNING_EVENT_KIND } from "@/lib/browser-live/constants";
+import { isBrowserLiveControlEvent } from "@/lib/browser-live-control-events";
 import { errorMessage } from "@/lib/errors";
 import { hostBridge } from "@/lib/host-client";
 import type { TaskRefreshOptions } from "@/state/app-state-contexts";
@@ -75,9 +76,11 @@ export function useAppLifecycle({
   const processedTaskEventIdsRef = useRef(new Set<string>());
   const processedTaskEventOrderRef = useRef<string[]>([]);
 
-  activeRepoRef.current = activeRepo;
-  refreshTaskDataRef.current = refreshTaskData;
-  refreshTasksWithOptionsRef.current = refreshTasksWithOptions;
+  useLayoutEffect(() => {
+    activeRepoRef.current = activeRepo;
+    refreshTaskDataRef.current = refreshTaskData;
+    refreshTasksWithOptionsRef.current = refreshTasksWithOptions;
+  }, [activeRepo, refreshTaskData, refreshTasksWithOptions]);
 
   useEffect(() => {
     let disposed = false;
@@ -150,7 +153,7 @@ export function useAppLifecycle({
             return;
           }
 
-          if (payload.kind === "stream-warning") {
+          if (payload.kind === BROWSER_LIVE_STREAM_WARNING_EVENT_KIND) {
             toast.error("Task sync stream degraded", {
               description:
                 payload.message ??

--- a/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
+++ b/apps/desktop/src/state/lifecycle/use-app-lifecycle.ts
@@ -1,5 +1,5 @@
 import { externalTaskSyncEventSchema, type RunEvent, runEventSchema } from "@openducktor/contracts";
-import { type Dispatch, type SetStateAction, useEffect, useLayoutEffect, useRef } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useRef } from "react";
 import { isBrowserLiveControlEvent } from "@/lib/browser-live-client";
 import { toast } from "sonner";
 import { errorMessage } from "@/lib/errors";
@@ -75,13 +75,14 @@ export function useAppLifecycle({
   const processedTaskEventIdsRef = useRef(new Set<string>());
   const processedTaskEventOrderRef = useRef<string[]>([]);
 
-  useLayoutEffect(() => {
-    activeRepoRef.current = activeRepo;
-    refreshTaskDataRef.current = refreshTaskData;
-    refreshTasksWithOptionsRef.current = refreshTasksWithOptions;
-  }, [activeRepo, refreshTaskData, refreshTasksWithOptions]);
+  activeRepoRef.current = activeRepo;
+  refreshTaskDataRef.current = refreshTaskData;
+  refreshTasksWithOptionsRef.current = refreshTasksWithOptions;
 
   useEffect(() => {
+    let disposed = false;
+    let unsubscribe: (() => void) | null = null;
+
     Promise.allSettled([refreshWorkspaces(), refreshRuntimeCheck(false)]).then(
       ([workspaceResult]) => {
         if (workspaceResult.status === "rejected") {
@@ -92,7 +93,6 @@ export function useAppLifecycle({
       },
     );
 
-    let unsubscribe: (() => void) | null = null;
     hostBridge
       .subscribeRunEvents((payload) => {
         const parsed = runEventSchema.safeParse(payload);
@@ -118,20 +118,29 @@ export function useAppLifecycle({
         }
       })
       .then((cleanup) => {
+        if (disposed) {
+          cleanup();
+          return;
+        }
         unsubscribe = cleanup;
       })
       .catch((error: unknown) => {
+        if (disposed) {
+          return;
+        }
         toast.error("Run event subscription failed", {
           description: errorMessage(error),
         });
       });
 
     return () => {
+      disposed = true;
       unsubscribe?.();
     };
   }, [refreshRuntimeCheck, refreshWorkspaces, setEvents, setRunCompletionSignal]);
 
   useEffect(() => {
+    let disposed = false;
     let unsubscribe: (() => void) | null = null;
     hostBridge
       .subscribeTaskEvents((payload) => {
@@ -188,15 +197,23 @@ export function useAppLifecycle({
           });
       })
       .then((cleanup) => {
+        if (disposed) {
+          cleanup();
+          return;
+        }
         unsubscribe = cleanup;
       })
       .catch((error: unknown) => {
+        if (disposed) {
+          return;
+        }
         toast.error("Task event subscription failed", {
           description: errorMessage(error),
         });
       });
 
     return () => {
+      disposed = true;
       unsubscribe?.();
     };
   }, []);

--- a/apps/desktop/src/types/browser-live.ts
+++ b/apps/desktop/src/types/browser-live.ts
@@ -1,0 +1,14 @@
+import type {
+  BROWSER_LIVE_RECONNECTED_EVENT_KIND,
+  BROWSER_LIVE_STREAM_WARNING_EVENT_KIND,
+} from "@/lib/browser-live/constants";
+
+export type BrowserLiveControlEventKind =
+  | typeof BROWSER_LIVE_RECONNECTED_EVENT_KIND
+  | typeof BROWSER_LIVE_STREAM_WARNING_EVENT_KIND;
+
+export type BrowserLiveControlEvent = {
+  __openducktorBrowserLive: true;
+  kind: BrowserLiveControlEventKind;
+  message?: string;
+};

--- a/apps/desktop/src/types/index.ts
+++ b/apps/desktop/src/types/index.ts
@@ -1,1 +1,2 @@
 export { AGENT_ROLE_LABELS } from "./agent-role-labels";
+export type { BrowserLiveControlEvent, BrowserLiveControlEventKind } from "./browser-live";

--- a/packages/contracts/src/exports.contract.test.ts
+++ b/packages/contracts/src/exports.contract.test.ts
@@ -23,6 +23,8 @@ import type {
   BuildContinuationTargetSource,
   ChatSettings,
   CommitsAheadBehind,
+  ExternalTaskSyncEvent,
+  ExternalTaskSyncEventKind,
   FailureKind,
   FileDiff,
   FileStatus,
@@ -161,6 +163,8 @@ const EXPECTED_RUNTIME_EXPORTS = [
   "devServerTerminalChunkSchema",
   "devServerScriptStateSchema",
   "devServerScriptStatusSchema",
+  "externalTaskSyncEventKindSchema",
+  "externalTaskSyncEventSchema",
   "DEFAULT_BRANCH_PREFIX",
   "failureKindSchema",
   "gitCommitAllRequestSchema",
@@ -346,6 +350,8 @@ type ExportedTypeContract = {
   BeadsCheck: BeadsCheck;
   ChatSettings: ChatSettings;
   CommitsAheadBehind: CommitsAheadBehind;
+  ExternalTaskSyncEvent: ExternalTaskSyncEvent;
+  ExternalTaskSyncEventKind: ExternalTaskSyncEventKind;
   GitCommitAllRequest: GitCommitAllRequest;
   GitCommitAllResult: GitCommitAllResult;
   GitConflict: GitConflict;

--- a/packages/contracts/src/external-task-sync-schemas.test.ts
+++ b/packages/contracts/src/external-task-sync-schemas.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { externalTaskSyncEventSchema } from "./external-task-sync-schemas";
+
+describe("external-task-sync-schemas", () => {
+  test("parses external task created sync events", () => {
+    const parsed = externalTaskSyncEventSchema.parse({
+      eventId: "event-1",
+      kind: "external_task_created",
+      repoPath: "/repo",
+      taskId: "task-7",
+      emittedAt: "2026-04-10T13:00:00.000Z",
+    });
+
+    expect(parsed.kind).toBe("external_task_created");
+    expect(parsed.repoPath).toBe("/repo");
+    expect(parsed.taskId).toBe("task-7");
+  });
+});

--- a/packages/contracts/src/external-task-sync-schemas.ts
+++ b/packages/contracts/src/external-task-sync-schemas.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const externalTaskSyncEventKindSchema = z.literal("external_task_created");
+export type ExternalTaskSyncEventKind = z.infer<typeof externalTaskSyncEventKindSchema>;
+
+export const externalTaskSyncEventSchema = z.object({
+  eventId: z.string().min(1),
+  kind: externalTaskSyncEventKindSchema,
+  repoPath: z.string().min(1),
+  taskId: z.string().min(1),
+  emittedAt: z.string().min(1),
+});
+export type ExternalTaskSyncEvent = z.infer<typeof externalTaskSyncEventSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,6 +2,7 @@ export * from "./agent-runtime-schemas";
 export * from "./agent-workflow-schemas";
 export * from "./config-schemas";
 export * from "./dev-server-schemas";
+export * from "./external-task-sync-schemas";
 export * from "./failure-schemas";
 export * from "./git-provider-repository";
 export * from "./git-schemas";


### PR DESCRIPTION
## Summary
- add a repo-scoped external task sync path from successful external `odt_create_task` calls through the headless MCP bridge, desktop relay, and frontend lifecycle so the active Kanban refreshes from canonical host/Beads data without waiting for stale-time expiry or the scheduled refresh loop
- harden the transport layer for real stream failures by replaying missed task events after reconnect, preserving partial-frame safety, and relaying task-stream `stream-warning` control events so the desktop path triggers the same compensating resync behavior as browser-live mode
- refactor the implementation for long-term maintainability by extracting shared browser-live control-event helpers, extracting generic SSE relay parsing/resume helpers, and tightening `useAppLifecycle` subscription cleanup to be unmount-safe and more React-idiomatic

## Testing
- `bun run --filter @openducktor/contracts test`
- `bun run --filter @openducktor/desktop typecheck`
- `bun run --filter @openducktor/desktop test`
- `bun test apps/desktop/src/state/lifecycle/use-app-lifecycle.test.tsx`
- `bun run check:rust`
- `cd apps/desktop/src-tauri && cargo test -p host-application`
- `cd apps/desktop/src-tauri && cargo test -p openducktor-desktop --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time external task event streaming: desktop receives external "task created" notifications with reconnection, replay, and host/browser-live subscription support.
  * New public subscription API for task events (works in desktop and browser-live modes).
  * App now starts/stops a background task-event relay on startup/exit.

* **Bug Fixes**
  * Client-side de-duplication prevents duplicate replay handling; degraded stream warnings surface to users.

* **Tests**
  * Added tests for SSE parsing, control events, task-event relay, subscriptions, and related UI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->